### PR TITLE
Fix getpwuid errors on systems using winbind

### DIFF
--- a/src/cpp/server/util/system/PosixSystem.cpp
+++ b/src/cpp/server/util/system/PosixSystem.cpp
@@ -393,6 +393,16 @@ Error launchChildProcess(std::string path,
          ::exit(EXIT_FAILURE);
       }
 
+      // get current user (before closing file handles since 
+      // we might be using a PAM module that has open FDs...)
+      util::system::user::User user;
+      error = util::system::user::currentUser(&user);
+      if (error)
+      {
+         LOG_ERROR(error);
+         ::exit(EXIT_FAILURE);
+      }
+
       // close all open file descriptors other than std streams
       error = closeNonStdFileDescriptors();
       if (error)
@@ -417,15 +427,6 @@ Error launchChildProcess(std::string path,
          default:
             // do nothing to inherit the streams
             break;
-      }
-
-      // get current user
-      util::system::user::User user;
-      error = util::system::user::currentUser(&user);
-      if (error)
-      {
-         LOG_ERROR(error);
-         ::exit(EXIT_FAILURE);
       }
 
       // setup environment


### PR DESCRIPTION
Hi,

I've been trying to get RStudio Server to run in an enterprise environment where users are authenticated via pam_winbind. I have the same problems that others have already reported, see this thread and the one linked from there:

http://support.rstudio.org/help/discussions/problems/914-pam-authentication-and-winbind-revisited

What was going wrong here is that pam_winbind talks to winbindd through a socket, and you close all open file descriptors - https://github.com/rstudio/rstudio/blob/master/src/cpp/server/util/system/PosixSystem.cpp#L396 - before determining the current user a few lines later. Simply moving the getpwuid call before the file descriptor closing worked around the issue at hand for me, but of course getpwuid will remain broken in the child process, so maybe a more general fix should be considered...

ciao,
Thomas
