### PR TITLE
Fix rstudio Desktop compilation with GCC 4.7

### DIFF
--- a/src/cpp/core/include/core/StringUtils.hpp
+++ b/src/cpp/core/include/core/StringUtils.hpp
@@ -58,36 +58,6 @@ T hashStable(const std::string& str)
    return hash;
 }
 
-std::string wideToUtf8(const std::wstring& value);
-std::wstring utf8ToWide(const std::string& value,
-                        const std::string& context = std::string());
-
-template <typename Iterator, typename InputIterator>
-Error utf8Clean(Iterator begin,
-                InputIterator end,
-                unsigned char replacementChar)
-{
-   using namespace boost::system;
-
-   if (replacementChar > 0x7F)
-      return systemError(errc::invalid_argument,
-                         "Invalid UTF-8 replacement character",
-                         ERROR_LOCATION);
-
-   Error error;
-
-   while (begin != end)
-   {
-      error = utf8Advance(begin, 1, end, &begin);
-      if (error)
-      {
-         *begin = replacementChar;
-      }
-   }
-
-   return Success();
-}
-
 // Moves the begin pointer the specified number of UTF8
 // characters.
 template <typename InputIterator>
@@ -139,6 +109,37 @@ Error utf8Advance(InputIterator begin,
    *pResult = begin;
    return Success();
 }
+std::string wideToUtf8(const std::wstring& value);
+std::wstring utf8ToWide(const std::string& value,
+                        const std::string& context = std::string());
+
+template <typename Iterator, typename InputIterator>
+Error utf8Clean(Iterator begin,
+                InputIterator end,
+                unsigned char replacementChar)
+
+{
+   using namespace boost::system;
+
+   if (replacementChar > 0x7F)
+      return systemError(errc::invalid_argument,
+                         "Invalid UTF-8 replacement character",
+                         ERROR_LOCATION);
+
+   Error error;
+
+   while (begin != end)
+   {
+      error = utf8Advance(begin, 1, end, &begin);
+      if (error)
+      {
+         *begin = replacementChar;
+      }
+   }
+
+   return Success();
+}
+
 
 template <typename InputIterator>
 Error utf8Distance(InputIterator begin,

--- a/src/cpp/core/include/core/system/PosixUser.hpp
+++ b/src/cpp/core/include/core/system/PosixUser.hpp
@@ -15,6 +15,7 @@
 #define CORE_SYSTEM_POSIX_USER_HPP
 
 #include <string>
+#include <unistd.h>
 
 namespace core {
    class Error;

--- a/src/cpp/desktop/3rdparty/qtsingleapplication/qtlocalpeer.cpp
+++ b/src/cpp/desktop/3rdparty/qtsingleapplication/qtlocalpeer.cpp
@@ -48,6 +48,7 @@
 #include "qtlocalpeer.h"
 #include <QtCore/QCoreApplication>
 #include <QtCore/QTime>
+#include <unistd.h>
 
 #if defined(Q_OS_WIN)
 #include <QtCore/QLibrary>


### PR DESCRIPTION
Fixes according to http://gcc.gnu.org/gcc-4.7/porting_to.html
Might break every other compiler :)
