### PR TITLE
update SyncTeX shortcut for PDF viewer Toolbar 

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/pdfviewer/ui/PDFViewerToolbar.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/pdfviewer/ui/PDFViewerToolbar.ui.xml
@@ -103,7 +103,7 @@
                <widget:InlineToolbarButton ui:field="btnJumpToSource_"
                                            icon="{res.jumpToSourceIcon}"
                                            label=""
-                                           description="Sync editor location to PDF view (Ctrl+Click) (Ctrl+F9)"/> 
+                                           description="Sync editor location to PDF view (Ctrl+Click) (Ctrl+F8)"/> 
                           
             </td>
             <td class="{style.alignCell}" align="center" nowrap="nowrap" style="min-width: 400px">


### PR DESCRIPTION
F8 is consistent across the IDE, this is the only reference I could find that was marked wrong.

Orignal Discussion:

http://support.rstudio.org/help/discussions/problems/3679-wrong-hint-in-pdf-viewer-delete-to-line-end-on-mac
