### PR TITLE
change .path.package() to path.package()

### DIFF
--- a/src/cpp/r/session/RSearchPath.cpp
+++ b/src/cpp/r/session/RSearchPath.cpp
@@ -276,7 +276,7 @@ Error save(const FilePath& statePath)
                                                                  "package:",
                                                                  "");
          std::string path;
-         Error error = r::exec::RFunction(".path.package", name).call(&path);
+         Error error = r::exec::RFunction("path.package", name).call(&path);
          if (error)
             LOG_ERROR(error);
 

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -19,7 +19,7 @@
       function(pkgname, ...)
       {
          packageStatus = list(name=pkgname,
-                              path=.path.package(pkgname, quiet=TRUE),
+                              path=path.package(pkgname, quiet=TRUE),
                               loaded=status)
          .rs.enqueClientEvent("package_status_changed", packageStatus)
       }
@@ -149,7 +149,7 @@
 .rs.addJsonRpcHandler( "is_package_loaded", function(packageName, libName)
 {
    .rs.scalar( (packageName %in% .packages()) &&
-               identical(.path.package(packageName, quiet=TRUE),
+               identical(path.package(packageName, quiet=TRUE),
                          paste(libName, packageName, sep="/"))
              )
 })
@@ -208,7 +208,7 @@
                          pkgs.name, 
                          "html", 
                          "00Index.html")
-   loaded.pkgs <- .path.package()
+   loaded.pkgs <- path.package()
    pkgs.loaded <- !is.na(match(paste(pkgs.library,pkgs.name, sep="/"),
                                loaded.pkgs))
    


### PR DESCRIPTION
With 

> R.version.string
> [1] "R Under development (unstable) (2013-02-26 r62077)"

I was getting a number of warnings like this when buidi/reloading a package in an RStudio project:
Warning messages:
1: '.path.package' is deprecated.
Use 'path.package' instead.
See help("Deprecated") 

I didn't get these warnings in plain old R, and my code doesn't call either function, so I thought the warnings were coming from RStudio. Here I've changed RStudio's code to use path.packages() instead of .path.packages(). 

Thanks.
Dan
