### PR TITLE
treat objects of type data.table and cast_df as data in the workspace view

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/workspace/table/WorkspaceObjectTable.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/workspace/table/WorkspaceObjectTable.java
@@ -363,7 +363,7 @@ public class WorkspaceObjectTable
 
    private boolean isData(String type)
    {
-      return "data.frame".equals(type) || "matrix".equals(type);
+      return "data.frame".equals(type) || "matrix".equals(type) || "data.table".equals(type) || "cast_df".equals(type);
    }
 
    private RowManager rowManager_ ;


### PR DESCRIPTION
This has come up quite a few times:

http://support.rstudio.org/help/discussions/suggestions/2077-1-for-datatable-support
http://support.rstudio.org/help/discussions/suggestions/1619-datatable-as-data-in-workspace-browser
http://support.rstudio.org/help/discussions/suggestions/2373-datatable-in-data-section-of-workspace-window
http://support.rstudio.org/help/discussions/suggestions/3201-default-workspace-datatables-to-view-instead-of-fix
http://support.rstudio.org/help/discussions/suggestions/600-could-you-treat-datatable-like-dataframe-in-the-workspace-browser
http://support.rstudio.org/help/discussions/suggestions/1825-treat-a-data-table-object-the-same-as-a-data-frame-in-the-browser

The hack presented here just cures the symptoms instead of solving the problem. However, please consider merging it, as implementing a real solution might take some time indeed.

I understand that properly deciding if an object is a data frame requires checking all `class` members, not only the first (cf. `getSingleClass()`). This in turn would either require passing all inherited classes to the `WorkspaceObjectInfo` or passing the information "the object inherits from `data.frame`". This is beyond my understanding of the RStudio infrastructure.
