### PR TITLE
update Cobalt style to make strings green

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/cobalt.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/cobalt.css
@@ -1,4 +1,3 @@
-
 .ace_editor {
   border: 2px solid rgb(159, 159, 159);
 }
@@ -109,6 +108,10 @@ background-color:#800F00;
 .ace_storage {
   color:#FFEE80;
 }
+
+.ace_string {
+  color:#24D406;
+} 
 
 .ace_string.ace_regexp {
   color:#80FFC2;


### PR DESCRIPTION
This patch allows Cobalt style to better differenciate between Strings and variables.
Like the Cobalt style of Gedit, Strings now appear in green.
