### PR TITLE
Fix problems related to breakpoints in packages

### DIFF
--- a/src/cpp/session/modules/SessionBreakpoints.R
+++ b/src/cpp/session/modules/SessionBreakpoints.R
@@ -15,9 +15,13 @@
 
 # given a function name and filename, find the environment that contains a
 # function with the given name that originated from the given file.
-.rs.addFunction("getEnvironmentOfFunction", function(objName, fileName)
+.rs.addFunction("getEnvironmentOfFunction", function(
+   objName, fileName, packageName)
 {
-   env <- globalenv()
+   env <- if (nchar(packageName) > 0)
+         asNamespace(packageName)
+      else
+         globalenv()
    while (environmentName(env) != "R_EmptyEnv")
    {
       # if the function with the given name exists in this environment...
@@ -133,9 +137,10 @@
 .rs.addFunction("getFunctionSteps", function(
    functionName,
    fileName,
+   packageName,
    lineNumbers)
 {
-   fun <- .rs.getUntracedFunction(functionName, fileName)
+   fun <- .rs.getUntracedFunction(functionName, fileName, packageName)
    funBody <- body(fun)
 
    # attempt to find the end line of the function
@@ -185,9 +190,10 @@
 .rs.addFunction("setFunctionBreakpoints", function(
    functionName,
    fileName,
+   packageName,
    steps)
 {
-   envir <- .rs.getEnvironmentOfFunction(functionName, fileName)
+   envir <- .rs.getEnvironmentOfFunction(functionName, fileName, packageName)
    if (is.null(envir))
    {
       return (NULL)
@@ -242,9 +248,10 @@
    return(functionName)
 })
 
-.rs.addFunction("getUntracedFunction", function(functionName, fileName)
+.rs.addFunction("getUntracedFunction", function(
+   functionName, fileName, packageName)
 {
-   envir <- .rs.getEnvironmentOfFunction(functionName, fileName)
+   envir <- .rs.getEnvironmentOfFunction(functionName, fileName, packageName)
    if (is.null(envir))
    {
       return(NULL)
@@ -257,9 +264,10 @@
    return(fun)
 })
 
-.rs.addFunction("getFunctionSourceRefs", function(functionName, fileName)
+.rs.addFunction("getFunctionSourceRefs", function(
+   functionName, fileName, packageName)
 {
-   fun <- .rs.getUntracedFunction(functionName, fileName)
+   fun <- .rs.getUntracedFunction(functionName, fileName, packageName)
    if (is.null(fun))
    {
       return(NULL)
@@ -267,10 +275,12 @@
    attr(fun, "srcref")
 })
 
-.rs.addFunction("getFunctionSourceCode", function(functionName, fileName)
+.rs.addFunction("getFunctionSourceCode", function(
+   functionName, fileName, packageName)
 {
    paste(capture.output(
-      .rs.getFunctionSourceRefs(functionName, fileName)), collapse="\n")
+      .rs.getFunctionSourceRefs(functionName, fileName, packageName)),
+      collapse="\n")
 })
 
 .rs.addGlobalFunction("debugSource", function(
@@ -431,17 +441,19 @@
 .rs.addJsonRpcHandler("set_function_breakpoints", function(
    functionName,
    fileName,
+   packageName,
    steps)
 {
-   .rs.setFunctionBreakpoints(functionName, fileName, steps)
+   .rs.setFunctionBreakpoints(functionName, fileName, packageName, steps)
 })
 
 .rs.addJsonRpcHandler("get_function_steps", function(
    functionName,
    fileName,
+   packageName,
    lineNumbers)
 {
-   .rs.getFunctionSteps(functionName, fileName, lineNumbers)
+   .rs.getFunctionSteps(functionName, fileName, packageName, lineNumbers)
 })
 
 .rs.addJsonRpcHandler("execute_debug_source", function(

--- a/src/cpp/session/modules/SessionBreakpoints.cpp
+++ b/src/cpp/session/modules/SessionBreakpoints.cpp
@@ -73,7 +73,8 @@ Error getFunctionState(const json::JsonRpcRequest& request,
    Protect protect;
    error = r::exec::RFunction(".rs.getFunctionSourceRefs",
                               functionName,
-                              fileName)
+                              fileName,
+                              packageName)
          .call(&srcRefs, &protect);
    if (error)
    {
@@ -83,7 +84,8 @@ Error getFunctionState(const json::JsonRpcRequest& request,
    std::string functionCode;
    error = r::exec::RFunction(".rs.getFunctionSourceCode",
                               functionName,
-                              fileName)
+                              fileName,
+                              packageName)
          .call(&functionCode);
    if (error)
    {

--- a/src/gwt/src/org/rstudio/studio/client/common/debugging/DebuggingServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/debugging/DebuggingServerOperations.java
@@ -30,12 +30,14 @@ public interface DebuggingServerOperations
    public void getFunctionSteps(
          String functionName,
          String fileName,
+         String packageName,
          int[] lineNumbers,
          ServerRequestCallback<JsArray<FunctionSteps>> requestCallback);
    
    public void setFunctionBreakpoints(
          String functionName,
          String fileName,
+         String packageName,
          ArrayList<String> steps,
          ServerRequestCallback<Void> requestCallback);
    

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -2841,6 +2841,7 @@ public class RemoteServer implements Server
    public void getFunctionSteps(
                  String functionName,
                  String fileName,
+                 String packageName,
                  int[] lineNumbers,
                  ServerRequestCallback<JsArray<FunctionSteps>> requestCallback)
    {
@@ -2852,7 +2853,8 @@ public class RemoteServer implements Server
       JSONArray params = new JSONArray();
       params.set(0, new JSONString(functionName));
       params.set(1, new JSONString(fileName));
-      params.set(2, lineNums);
+      params.set(2, new JSONString(packageName));
+      params.set(3, lineNums);
       sendRequest(RPC_SCOPE,
                   GET_FUNCTION_STEPS,
                   params,
@@ -2863,6 +2865,7 @@ public class RemoteServer implements Server
    public void setFunctionBreakpoints(
          String functionName,
          String fileName,
+         String packageName,
          ArrayList<String> steps,
          ServerRequestCallback<Void> requestCallback)
    {
@@ -2874,7 +2877,8 @@ public class RemoteServer implements Server
       JSONArray params = new JSONArray();
       params.set(0, new JSONString(functionName));
       params.set(1, new JSONString(fileName));
-      params.set(2, breakSteps);
+      params.set(2, new JSONString(packageName));
+      params.set(3, breakSteps);
       sendRequest(RPC_SCOPE,
                   SET_FUNCTION_BREAKPOINTS,
                   params,


### PR DESCRIPTION
- Fix: Console warnings sometimes appear on package load
- Fix: It isn't possible to set a breakpoint in packages that aren't on the search path

After talking with Joe and Hadley, I believe that there is still one more fix needed to make foreign package breakpoints feel seamless: we need to set breakpoints on every copy of the function if more than one copy exists, so that the breakpoint will get hit no matter which copy is invoked. This fix is nontrivial and will require a few hours of coding and testing. If you'd prefer to wait for that fix to merge the branch, I should have it in by EOD today. 
