### PR TITLE
use longer pulse for environment changes and include name column

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.css
@@ -38,7 +38,8 @@
    overflow-x: hidden;
    border: 1px solid #f0f0f0;
    border-left: none;
-   background: none;
+   background-color: #ffffff;
+   transition: background-color 10s;
 }
 
 .objectGrid td.expandCol
@@ -56,7 +57,7 @@
    overflow-x: hidden;
    padding-right: 20px;
    background-color: #ffffff;
-   transition: background-color 0.3s;
+   transition: background-color 10s;
 }
 
 .objectGrid td.valueColNew

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.java
@@ -178,6 +178,8 @@ public class EnvironmentObjects extends ResizeComposite
                @Override
                public void execute()
                {
+                  oldEntry.getNameElement().addClassName(
+                        style.valueColNew());
                   oldEntry.getDescriptionElement().addClassName(
                         style.valueColNew());
                   Scheduler.get().scheduleDeferred(new ScheduledCommand()
@@ -185,6 +187,8 @@ public class EnvironmentObjects extends ResizeComposite
                      @Override
                      public void execute()
                      {
+                        oldEntry.getNameElement().removeClassName(
+                              style.valueColNew());
                         oldEntry.getDescriptionElement().removeClassName(
                               style.valueColNew());
                      }
@@ -776,6 +780,7 @@ public class EnvironmentObjects extends ResizeComposite
          nameCol.title(
                  rowValue.rObject.getName() +
                  " (" + rowValue.rObject.getType() + size + ")");
+         nameCol.id(rowValue.getNameId());
          renderCell(nameCol, createContext(1), objectNameColumn_, rowValue);
          nameCol.endTD();
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/RObjectEntry.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/RObjectEntry.java
@@ -86,10 +86,21 @@ public class RObjectEntry
       return rObject.getType() == "promise";
    }
    
+   public String getNameId()
+   {
+      return getIdPrefix() + "name";
+   }
+   
    public String getDescriptionId()
    {
       return getIdPrefix() + "desc";
    }
+
+   public Element getNameElement()
+   {
+      return Document.get().getElementById(getNameId());
+   }
+
    
    public Element getDescriptionElement()
    {


### PR DESCRIPTION
I tried a 10 second pulse for the environment pane and because it starts fading right away I think it actually works pretty well. Let me know if there are issues in the way I implemented this.
