### PR TITLE
Fix debug stepping problems when debugger is invoked from R RPC calls

### DIFF
--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -171,8 +171,8 @@ bool inBrowseContext()
    return false;
 }
 
-// return whether the current context is being evaluated inside a hidden
-// (debugger internal) function.
+// Return whether the current context is being evaluated inside a hidden
+// (debugger internal) function at the top level.
 bool insideDebugHiddenFunction()
 {
    RCNTXT* pRContext = r::getGlobalContext();
@@ -180,8 +180,15 @@ bool insideDebugHiddenFunction()
    {
       if (pRContext->callflag & CTXT_FUNCTION)
       {
+         // If we find a debugger internal function before any user function,
+         // hide it from the user callstack.
          if (isDebugHiddenContext(pRContext))
             return true;
+
+         // If we find a user function before we encounter a debugger internal
+         // function, don't hide the user code it invokes.
+         if (hasSourceRefs(pRContext))
+             return false;
       }
       pRContext = pRContext->nextcontext;
    }


### PR DESCRIPTION
A recent change for error management broke this scenario. We don't want to see error management functions on the callstack, so we hide them (and in fact all `addRpcHandler` functions). We also don't update line numbers in this case since we don't want the editor to show the RStudio error handler, which is technically the function on top of the stack. 

The fix is just to avoid treating user functions as hidden when they are invoked _by_ a debugger internal function. 
