### PR TITLE
Fix unnecessary display of data frame icon in name column

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.css
@@ -39,6 +39,7 @@
    border: 1px solid #f0f0f0;
    border-left: none;
    background-color: #ffffff;
+   background-image: none;
    transition: background-color 10s;
 }
 


### PR DESCRIPTION
One more to consider for the preview update. Without it data frames show two icons:

![image](https://f.cloud.github.com/assets/470418/1018399/215fe0a8-0c28-11e3-9d3b-8272fc47a704.png)

Happened when switching `background: none` [which cleared the inherited image] to `background-color: #ffffff`, which did not. 
