### PR TITLE
Fix reported issues in debugger and error management

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/FilePathUtils.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/FilePathUtils.java
@@ -33,10 +33,10 @@ public class FilePathUtils
    public static String normalizePath (String path, String workingDirectory)
    {
       // Examine the path to see if it appears to be absolute. An absolute path
-	  // - begins with ~ , or 
-	  // - begins with / (Unix-like systems), or
-	  // - begins with F:/ (Windows systems), where F is an alphabetic drive 
-	  //   letter.
+      // - begins with ~ , or 
+      // - begins with / (Unix-like systems), or
+      // - begins with F:/ (Windows systems), where F is an alphabetic drive 
+      //   letter.
       if (path.startsWith(FileSystemItem.HOME_PREFIX) || 
           path.startsWith("/") ||                        
           path.matches("^[a-zA-Z]:\\/.*"))


### PR DESCRIPTION
- debugSource of some specific kinds of paths under Windows shows an error message: correctly detect absolute paths on the Windows desktop platform
- setting `options(error = NULL)` permanently disables the RStudio error handler: don't record the error handler in user settings unless it was set during startup 
