### PR TITLE
Fix bug: debugger can show base environment on launch

### DIFF
--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -165,6 +165,7 @@ RCNTXT* getFunctionContext(const int depth,
    RCNTXT* pRContext = r::getGlobalContext();
    RCNTXT* pSrcContext = pRContext;
    int currentDepth = 0;
+   bool foundUserCode = false;
    while (pRContext->callflag)
    {
       if (isDebugHiddenContext(pRContext))
@@ -189,7 +190,8 @@ RCNTXT* getFunctionContext(const int depth,
                                  (pRContext != pSrcContext &&
                                   pRContext->srcref == pSrcContext->srcref))))
          {
-             break;
+            foundUserCode = true;
+            break;
          }
          pSrcContext = pRContext;
       }
@@ -205,6 +207,16 @@ RCNTXT* getFunctionContext(const int depth,
    if (pEnvironment)
    {
       *pEnvironment = currentDepth == 0 ? R_GlobalEnv : pRContext->cloenv;
+   }
+   if (depth == TOP_FUNCTION && findUserCode && !foundUserCode)
+   {
+      // if we were looking for the top user-mode function on the stack but
+      // found nothing, return the top of the stack rather than the bottom.
+      if (pEnvironment)
+         *pEnvironment = r::getGlobalContext()->cloenv;
+      if (pFoundDepth)
+         *pFoundDepth = 1;
+      pRContext = r::getGlobalContext();
    }
    return pRContext;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/CallFramePanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/CallFramePanel.java
@@ -124,13 +124,27 @@ public class CallFramePanel extends ResizeComposite
    {
       clearCallFrames();
       
+      // Check to see whether every function on the stack is internal. 
+      // If it is, the traceback window may appear empty, so show everything
+      // to give the user some context.
+      boolean allInternal = true;
+      for (int idx = 0; idx < frameList.length(); idx++)
+      {
+         if (frameList.get(idx).isNavigable()) {
+            allInternal = false;
+            break;
+         }
+      }
+      
       for (int idx = frameList.length() - 1; idx >= 0; idx--)
       {
          CallFrame frame = frameList.get(idx);
          CallFrameItem item = new CallFrameItem(
                frame, 
                observer_, 
-               !panelHost_.getShowInternalFunctions() && !frame.isNavigable());
+               !panelHost_.getShowInternalFunctions() && 
+                  !frame.isNavigable() &&
+                  !allInternal);
          if (contextDepth == frame.getContextDepth())
          {
             item.setActive();


### PR DESCRIPTION
This bug occurs when no function on the callstack has source references; the easiest way to repro is to call debug(foo::bar); foo::bar(), where foo is a package for which source references are not available, and bar is a function in that package.

The problem is that RStudio walks the callstack looking for a function containing source references, and when it reaches the end and still hasn't found one, it returns the last function it examined. In this specific case what we actually want it to do is to return the top of the stack, so that the user has some context for the debugger (even if they don't have sources available).

The fix is to detect when we're in this case (no sourcerefs anywhere), and to:

a) debug in the context of the top function on the stack, and

b) show internal functions in the UI (since there are no other kind on the stack)
