### PR TITLE
Add missing | characters in cpp highlighting rules

### DIFF
--- a/src/gwt/acesupport/acemode/c_cpp_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/c_cpp_highlight_rules.js
@@ -38,16 +38,16 @@ var RHighlightRules = require("mode/r_highlight_rules").RHighlightRules;
 var c_cppHighlightRules = function() {
 
     var keywords = lang.arrayToMap(
-        ("alignas|alignof|and|and_eq|asm|auto|bitand|bitor|bool|break" +
-        "case|catch|char|char16_t|char32_t|class|compl|const" +
-        "constexpr|const_cast|continue|decltype|default|delete|do" +
-        "double|dynamic_cast|else|enum|explicit|export|extern|false" +
-        "float|for|friend|goto|if|inline|int|long|mutable|namespace" +
-        "new|noexcept|not|not_eq|nullptr|operator|or|or_eq|private" +
-        "protected|public|register|reinterpret_cast|return|short" +
-        "signed|sizeof|static|static_assert|static_cast|struct" +
-        "switch|template|this|thread_local|throw|true|try|typedef" +
-        "typeid|typename|union|unsigned|using|virtual|void|volatile" +
+        ("alignas|alignof|and|and_eq|asm|auto|bitand|bitor|bool|break|" +
+        "case|catch|char|char16_t|char32_t|class|compl|const|" +
+        "constexpr|const_cast|continue|decltype|default|delete|do|" +
+        "double|dynamic_cast|else|enum|explicit|export|extern|false|" +
+        "float|for|friend|goto|if|inline|int|long|mutable|namespace|" +
+        "new|noexcept|not|not_eq|nullptr|operator|or|or_eq|private|" +
+        "protected|public|register|reinterpret_cast|return|short|" +
+        "signed|sizeof|static|static_assert|static_cast|struct|" +
+        "switch|template|this|thread_local|throw|true|try|typedef|" +
+        "typeid|typename|union|unsigned|using|virtual|void|volatile|" +
         "wchar_t|while|xor|xor_eq").split("|")
     );
 


### PR DESCRIPTION
These were missed in the earlier commit.
