### PR TITLE
Highlight integer literals using exp. notation

### DIFF
--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -74,16 +74,12 @@ define("mode/r_highlight_rules", function(require, exports, module)
                regex : "0[xX][0-9a-fA-F]+[Li]?\\b"
             },
             {
-               token : "constant.numeric", // explicit integer
-               regex : "\\d+L\\b"
+               token : "constant.numeric", // number + integer
+               regex : "\\d+(?:\\.\\d*)?(?:[eE][+\\-]?\\d*)?[iL]?\\b"
             },
             {
-               token : "constant.numeric", // number
-               regex : "\\d+(?:\\.\\d*)?(?:[eE][+\\-]?\\d*)?i?\\b"
-            },
-            {
-               token : "constant.numeric", // number with leading decimal
-               regex : "\\.\\d+(?:[eE][+\\-]?\\d*)?i?\\b"
+               token : "constant.numeric", // number + integer with leading decimal
+               regex : "\\.\\d+(?:[eE][+\\-]?\\d*)?[iL]?\\b"
             },
             {
                token : "constant.language.boolean",


### PR DESCRIPTION
We extend the existing rules for identifying a numeric in a simply way -- allow a `L` character following a 'numeric' value. Hence, values like `1E5L`, `0.1E5L`, `1.5E5L` will now be highlighted.

Modifying the highlight rules in this way obviates the explicit integer highlighting rule.

(Essentially, my modification just changes the `i?` check to `[iL]?`.)
