### PR TITLE
Continuous Integration with TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: cpp
+install:
+  - cd dependencies/linux
+  - ./install-dependencies-debian
+  - cd ../..
+  - sudo apt-get install --no-install-recommends r-base-dev r-recommended qpdf
+  - sudo chmod 2777 /usr/local/lib/R /usr/local/lib/R/site-library
+script:
+  - mkdir build
+  - mkdir build_install
+  - cd build
+  - cmake .. -DRSTUDIO_TARGET=Desktop -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=`$TRAVIS_BUILD_DIR/build_install`.
+  - make install


### PR DESCRIPTION
Adds a first TravisCi configuration. It currently just makes sure RStudio Desktop can be successfully built.
The script part can of course be extended to compile other variants of the project and to also execute some tests.

It currently takes about 40 minutes to build the project from scratch.
Problem though is that the test fails if the build time exceeds 50 minutes and that can sometimes happen. But maybe this all does not make sense for the project and you have your own CI solution somewhere.
