### PR TITLE
Show ShinyApps deployment dialog in preview window for Shiny docs/apps

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApps.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApps.java
@@ -27,6 +27,7 @@ import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.FilePathUtils;
 import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.common.shiny.model.ShinyAppsServerOperations;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
@@ -47,6 +48,7 @@ import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.helper.JSObjectStateValue;
 import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
 
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -64,6 +66,7 @@ public class ShinyApps implements SessionInitHandler,
    public ShinyApps(EventBus events, 
                     Commands commands, 
                     Session session,
+                    Satellite satellite,
                     GlobalDisplay display, 
                     Binder binder, 
                     ShinyAppsServerOperations server)
@@ -74,6 +77,7 @@ public class ShinyApps implements SessionInitHandler,
       session_ = session;
       server_ = server;
       events_ = events;
+      satellite_ = satellite;
 
       binder.bind(commands, this);
 
@@ -88,43 +92,7 @@ public class ShinyApps implements SessionInitHandler,
    @Override
    public void onSessionInit(SessionInitEvent sie)
    {
-      // "Manage accounts" can be invoked any time the package is available
-      commands_.shinyAppsManageAccounts().setVisible(
-            session_.getSessionInfo().getShinyappsInstalled());
-      
-      // This object keeps track of the most recent deployment we made of each
-      // directory, and is used to default directory deployments to last-used
-      // settings.
-      new JSObjectStateValue(
-            "shinyapps",
-            "shinyAppsDirectories",
-            ClientState.PERSISTENT,
-            session_.getSessionInfo().getClientState(),
-            false)
-       {
-          @Override
-          protected void onInit(JsObject value)
-          {
-             dirState_ = (ShinyAppsDirectoryState) (value == null ?
-                   ShinyAppsDirectoryState.create() :
-                   value.cast());
-          }
-   
-          @Override
-          protected JsObject getValue()
-          {
-             dirStateDirty_ = false;
-             return (JsObject) (dirState_ == null ?
-                   ShinyAppsDirectoryState.create().cast() :
-                   dirState_.cast());
-          }
-   
-          @Override
-          protected boolean hasChanged()
-          {
-             return dirStateDirty_;
-          }
-       };
+      ensureSessionInit();
    }
    
    @Override
@@ -132,13 +100,10 @@ public class ShinyApps implements SessionInitHandler,
    {
       if (event.getAction() == ShinyAppsActionEvent.ACTION_TYPE_DEPLOY)
       {
-         // ignore this request if there's already a modal up (we particularly
-         // don't want to stack this modal with itself since the deploy request
-         // can be initiated from a satellite window, which has no knowledge of
-         // whether there's already a dialog up)
+         // ignore this request if there's already a modal up 
          if (ModalDialogTracker.numModalsShowing() > 0)
-            return;
-         
+            return;    
+
          final String dir = FilePathUtils.dirFromFile(event.getPath());
          ShinyAppsDeploymentRecord record = dirState_.getLastDeployment(dir);
          final String lastAccount = record == null ? null : record.getAccount();
@@ -155,7 +120,8 @@ public class ShinyApps implements SessionInitHandler,
          ShinyAppsDeployDialog dialog = 
                new ShinyAppsDeployDialog(
                          server_, display_, events_, 
-                         dir, file, lastAccount, lastAppName);
+                         dir, file, lastAccount, lastAppName,
+                         satellite_.isCurrentWindowSatellite());
          dialog.showModal();
       }
       else if (event.getAction() == ShinyAppsActionEvent.ACTION_TYPE_TERMINATE)
@@ -222,8 +188,58 @@ public class ShinyApps implements SessionInitHandler,
       dialog.showModal();
    }
    
-   public static native void deployFromSatellite(String filename) /*-{
-      $wnd.opener.deployToShinyApps(filename);
+   public void ensureSessionInit()
+   {
+      if (sessionInited_)
+         return;
+      
+      // "Manage accounts" can be invoked any time the package is available
+      commands_.shinyAppsManageAccounts().setVisible(
+            session_.getSessionInfo().getShinyappsInstalled());
+      
+      // This object keeps track of the most recent deployment we made of each
+      // directory, and is used to default directory deployments to last-used
+      // settings.
+      new JSObjectStateValue(
+            "shinyapps",
+            "shinyAppsDirectories",
+            ClientState.PERSISTENT,
+            session_.getSessionInfo().getClientState(),
+            false)
+       {
+          @Override
+          protected void onInit(JsObject value)
+          {
+             dirState_ = (ShinyAppsDirectoryState) (value == null ?
+                   ShinyAppsDirectoryState.create() :
+                   value.cast());
+          }
+   
+          @Override
+          protected JsObject getValue()
+          {
+             dirStateDirty_ = false;
+             return (JsObject) (dirState_ == null ?
+                   ShinyAppsDirectoryState.create().cast() :
+                   dirState_.cast());
+          }
+   
+          @Override
+          protected boolean hasChanged()
+          {
+             return dirStateDirty_;
+          }
+       };
+       
+       sessionInited_ = true;
+   }
+   
+   public static native void deployFromSatellite(
+         String path,
+         String file, 
+         boolean launch, 
+         JavaScriptObject record) /*-{
+      $wnd.opener.deployToShinyApps(path, file, launch, record);
    }-*/;
    
    // Private methods ---------------------------------------------------------
@@ -357,13 +373,14 @@ public class ShinyApps implements SessionInitHandler,
    private final native void exportNativeCallbacks() /*-{
       var thiz = this;     
       $wnd.deployToShinyApps = $entry(
-         function(file) {
-            thiz.@org.rstudio.studio.client.shiny.ShinyApps::deployToShinyApps(Ljava/lang/String;)(file);
+         function(path, file, launch, record) {
+            thiz.@org.rstudio.studio.client.shiny.ShinyApps::deployToShinyApps(Ljava/lang/String;Ljava/lang/String;ZLcom/google/gwt/core/client/JavaScriptObject;)(path, file, launch, record);
          }
       ); 
    }-*/;
    
-   private void deployToShinyApps(String file)
+   private void deployToShinyApps(String path, String file, boolean launch, 
+                                  JavaScriptObject jsoRecord)
    {
       // this can be invoked by a satellite, so bring the main frame to the
       // front if we can
@@ -372,8 +389,9 @@ public class ShinyApps implements SessionInitHandler,
       else
          WindowEx.get().focus();
       
-      events_.fireEvent(new ShinyAppsActionEvent(
-            ShinyAppsActionEvent.ACTION_TYPE_DEPLOY, file));
+      ShinyAppsDeploymentRecord record = jsoRecord.cast();
+      events_.fireEvent(new ShinyAppsDeployInitiatedEvent(
+            path, file, launch, record));
    }
    
    private final Commands commands_;
@@ -381,7 +399,9 @@ public class ShinyApps implements SessionInitHandler,
    private final Session session_;
    private final ShinyAppsServerOperations server_;
    private final EventBus events_;
+   private final Satellite satellite_;
    private boolean launchBrowser_ = false;
+   private boolean sessionInited_ = false;
    
    private ShinyAppsDirectoryState dirState_;
    private boolean dirStateDirty_ = false;

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ui/ShinyApplicationPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ui/ShinyApplicationPanel.java
@@ -30,17 +30,22 @@ import org.rstudio.core.client.widget.SatelliteFramePanel;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.shiny.ShinyApplicationPresenter;
 import org.rstudio.studio.client.shiny.ShinyApps;
+import org.rstudio.studio.client.shiny.events.ShinyAppsActionEvent;
 import org.rstudio.studio.client.shiny.model.ShinyApplicationParams;
 
 public class ShinyApplicationPanel extends SatelliteFramePanel<RStudioFrame>
                                    implements ShinyApplicationPresenter.Display
 {
    @Inject
-   public ShinyApplicationPanel(Commands commands)
+   public ShinyApplicationPanel(Commands commands, EventBus events,
+                                ShinyApps shinyApps)
    {
       super(commands);
+      events_ = events;
+      shinyApps.ensureSessionInit();
    }
    
    @Override 
@@ -76,7 +81,9 @@ public class ShinyApplicationPanel extends SatelliteFramePanel<RStudioFrame>
                if (!deployPath.endsWith("/"))
                   deployPath += "/";
                deployPath += "server.R";
-               ShinyApps.deployFromSatellite(deployPath);
+               events_.fireEvent(new ShinyAppsActionEvent(
+                     ShinyAppsActionEvent.ACTION_TYPE_DEPLOY,
+                     deployPath));
             }
          }
       });
@@ -143,4 +150,6 @@ public class ShinyApplicationPanel extends SatelliteFramePanel<RStudioFrame>
    private ShinyApplicationParams appParams_;
    private ToolbarButton deployButton_;
    private Widget deployButtonSeparator_;
+   
+   private final EventBus events_; 
 }


### PR DESCRIPTION
This change makes it possible to initiate a deployment to ShinyApps directly from the preview windows for Shiny docs and Shiny apps. 

The change works as follows:
- The ShinyApps singleton (which knows how to show the dialog and fire corresponding events) is now initialized in these specific satellite windows 
- The main frame is now passed (via JS callbacks) the output of the deployment dialog (chosen account, app name, etc.), which it uses to fire the same deployment initiation event fired by the dialog when it's running in the main frame. 
