### PR TITLE
Don't strip extension from project names in dropdown

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/projects/ProjectMRUList.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ProjectMRUList.java
@@ -14,6 +14,9 @@
  */
 package org.rstudio.studio.client.projects;
 
+import java.util.ArrayList;
+
+import org.rstudio.core.client.DuplicateHelper;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.OperationWithInput;
@@ -64,5 +67,13 @@ public class ProjectMRUList extends MRUList
    {
       return FileSystemItem.createFile(entryPath).getParentPathString();
    }
+   
+   @Override
+   protected ArrayList<String> generateLabels(
+		   ArrayList<String> mruEntries, boolean includeExt)
+   {
+	   return DuplicateHelper.getPathLabels(mruEntries, true);
+   }
+   
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/MRUList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/MRUList.java
@@ -92,6 +92,12 @@ public class MRUList
       mruList_.clear();
    }
    
+   protected ArrayList<String> generateLabels(
+		   ArrayList<String> entries, boolean includeExt)
+   {
+	   return DuplicateHelper.getPathLabels(entries, includeExt);
+   }
+   
    public String getQualifiedLabel(String mruEntry)
    { 
       // make a copy of the existing mru entries and prepend the specified
@@ -110,7 +116,7 @@ public class MRUList
          mruEntries.set(i, transformMruEntryPath(mruEntries.get(i)));
       
       // generate labels
-      mruEntries = DuplicateHelper.getPathLabels(mruEntries, includeExt_);
+      mruEntries = generateLabels(mruEntries, includeExt_);
       
       // return the label
       return mruEntries.get(index);    
@@ -129,8 +135,7 @@ public class MRUList
          entries.add(transformMruEntryPath(entry));
       
       // generate labels
-      ArrayList<String> labels = DuplicateHelper.getPathLabels(entries,
-                                                               includeExt_);
+      ArrayList<String> labels = generateLabels(entries, includeExt_);
 
       for (int i = 0; i < mruCmds_.length; i++)
       {


### PR DESCRIPTION
This fixes a bug where, e.g. for projects named `foo.bar.baz`, the `.bar` (ostensibly, the file extension) would be stripped. We just override the label generator and make sure we're not stripping extensions for the `ProjectMRUList` class.

Let me know if there's anything subtle I'm missing; the MRU code was tricky to navigate.
