### PR TITLE
call packrat::init rather than packrat::bootstrap

### DIFF
--- a/src/cpp/session/modules/SessionPackrat.cpp
+++ b/src/cpp/session/modules/SessionPackrat.cpp
@@ -60,7 +60,7 @@ namespace {
 
 bool isRequiredPackratInstalled()
 {
-   return module_context::isPackageVersionInstalled("packrat", "0.2.0.109");
+   return module_context::isPackageVersionInstalled("packrat", "0.2.0.120");
 }
 
 } // anonymous namespace
@@ -555,7 +555,7 @@ Error packratBootstrap(const json::JsonRpcRequest& request,
    dir = string_utils::utf8ToSystem(dirPath.absolutePath());
 
    // bootstrap
-   r::exec::RFunction bootstrap("packrat:::bootstrap");
+   r::exec::RFunction bootstrap("packrat:::init");
    bootstrap.addParam("project", dir);
    bootstrap.addParam("enter", enter);
    bootstrap.addParam("restart", false);

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPackratPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPackratPreferencesPane.java
@@ -239,7 +239,7 @@ public class ProjectPackratPreferencesPane extends ProjectPreferencesPane
          @Override
          public void execute()  
          {
-            packratUtil_.executePackratFunction("bootstrap");
+            packratUtil_.executePackratFunction("init");
          }
       };
 


### PR DESCRIPTION
Hold this until the change to packrat::init is made in packrat. Note that this assumes that the packrat version number has been bumped to >= 0.2.0.120.
