### PR TITLE
Open R processes with --vanilla

### DIFF
--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -580,9 +580,9 @@ public:
       : shellCmd_(buildRCmd(rBinDir))
    {
 #ifdef _WIN32
-      cmdString_ = "Rcmd.exe";
+      cmdString_ = "R.exe --vanilla CMD";
 #else
-      cmdString_ = "R CMD";
+      cmdString_ = "R --vanilla CMD";
 #endif
 
       // set escape mode to files-only. this is so that when we


### PR DESCRIPTION
I'm not sure if there's ever a situation where RStudio wants to open an R process _not_ using `--vanilla` -- if so, this should probably be added as a parameter, but I do think the most sensible default is always launching as `--vanilla`.

@jmcphers and I bumped into this with testing out packrat bootstrapping -- it turns out that R processes started to install `manipulate` and `rstudio` were also running the `.Rprofile` in the current working directory, which is rather undesirable.
