### PR TITLE
Check for reparse points (links / junctions) that point to directories

### DIFF
--- a/src/cpp/core/FilePath.cpp
+++ b/src/cpp/core/FilePath.cpp
@@ -676,9 +676,11 @@ bool FilePath::isHidden() const
    return system::isHiddenFile(*this) ;
 }
 
-#ifdef _WIN32
 bool FilePath::isJunction() const
 {
+#ifndef _WIN32
+   return false;
+#else
    if (!exists())
       return false;
 
@@ -697,8 +699,8 @@ bool FilePath::isJunction() const
    {
       return false;
    }
-}
 #endif
+}
 
 bool FilePath::isDirectory() const
 {

--- a/src/cpp/core/include/core/FilePath.hpp
+++ b/src/cpp/core/include/core/FilePath.hpp
@@ -135,9 +135,7 @@ public:
    bool isHidden() const ;
 
    // is this a Windows junction point?
-#ifdef _WIN32
-  bool isJunction() const ;
-#endif
+   bool isJunction() const ;
    
    // is this a directory?
    bool isDirectory() const ;


### PR DESCRIPTION
This change allows reparse points that point to directories to be handled in RStudio on Windows.
