### PR TITLE
Prefix uint typedefs with boost:: as necessary

### DIFF
--- a/src/cpp/core/http/Util.cpp
+++ b/src/cpp/core/http/Util.cpp
@@ -236,7 +236,7 @@ std::string urlEncode(const std::string& in, bool queryStringSpaces)
          std::ostringstream ostr ;
          ostr << "%" ;
          ostr << std::setw(2) << std::setfill('0') << std::hex << std::uppercase
-              << (int)(uint8_t)ch ;
+              << (int)(boost::uint8_t)ch ;
          std::string charAsHex = ostr.str();
          encodedURL += charAsHex;
       }

--- a/src/cpp/core/r_util/RSessionLaunchProfile.cpp
+++ b/src/cpp/core/r_util/RSessionLaunchProfile.cpp
@@ -69,7 +69,7 @@ Error cpuAffinityFromJson(const json::Array& affinityJson,
 
 json::Value toJson(RLimitType limit)
 {
-   uint64_t value = safe_convert::numberTo<uint64_t>(limit, 0);
+   boost::uint64_t value = safe_convert::numberTo<boost::uint64_t>(limit, 0);
    return json::Value(value);
 }
 

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1104,7 +1104,7 @@ json::Object createFileSystemItem(const FileInfo& fileInfo)
    // length requires cast
    try
    {
-      entry["length"] = boost::numeric_cast<uint64_t>(fileInfo.size());
+      entry["length"] = boost::numeric_cast<boost::uint64_t>(fileInfo.size());
    }
    catch (const boost::bad_numeric_cast& e)
    {

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -1581,7 +1581,7 @@ Error vcsDiffFile(const json::JsonRpcRequest& request,
       error = systemError(boost::system::errc::file_too_large,
                           ERROR_LOCATION);
       pResponse->setError(error,
-                          json::Value(static_cast<uint64_t>(output.size())));
+                          json::Value(static_cast<boost::uint64_t>(output.size())));
    }
    else
    {
@@ -1941,7 +1941,7 @@ Error vcsShow(const json::JsonRpcRequest& request,
       error = systemError(boost::system::errc::file_too_large,
                           ERROR_LOCATION);
       pResponse->setError(error,
-                          json::Value(static_cast<uint64_t>(output.size())));
+                          json::Value(static_cast<boost::uint64_t>(output.size())));
    }
    else
    {

--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -1059,7 +1059,7 @@ Error svnDiffFile(const json::JsonRpcRequest& request,
       error = systemError(boost::system::errc::file_too_large,
                           ERROR_LOCATION);
       pResponse->setError(error,
-                          json::Value(static_cast<uint64_t>(stdOut.size())));
+                          json::Value(static_cast<boost::uint64_t>(stdOut.size())));
    }
    else
    {
@@ -1484,7 +1484,7 @@ void svnShowEnd(bool noSizeWarning,
    {
       response.setError(
             systemError(boost::system::errc::file_too_large, ERROR_LOCATION),
-            json::Value(static_cast<uint64_t>(result.stdOut.size())));
+            json::Value(static_cast<boost::uint64_t>(result.stdOut.size())));
    }
    else
    {


### PR DESCRIPTION
This fixes build errors (for me) on Ubuntu 14.04 with gcc-4.7.3. I've confirmed this also works on my Mac system + Windows 7 VM. IIUC, for some reason, there are type incompatibilities between boost's `uint` types and the ones contained in `<stdint.h>` for some (newer?) gcc compilers.
