### PR TITLE
fix bug: restarting R after closing a project applies project state

### DIFF
--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -610,6 +610,10 @@ void startup()
       if (nextSessionProject == kNextSessionProjectNone)
       {
          projectFilePath = FilePath();
+
+         // flush the last project path so restarts won't put us back into
+         // project context (see case 4015)
+         s_projectContext.setLastProjectPath(FilePath());
       }
       else
       {


### PR DESCRIPTION
RStudio saves the last project opened, so it can be restored when the IDE boots up (if the user has "Restore most recently opened project" set in their UI prefs). When a project is closed, this setting's value can persist, and when the R session is coming back after a restart, the value is applied, putting some parts of the IDE into project state while others remain outside project state.
