### PR TITLE
Fix some bugs in the outdenting for R code in non-R modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ rstudio*.Rproj
 NEWS.html
 CMakeLists.txt.user
 .idea/
+*.tern-port

--- a/src/gwt/acesupport/acemode/c_cpp.js
+++ b/src/gwt/acesupport/acemode/c_cpp.js
@@ -149,14 +149,14 @@ oop.inherits(Mode, TextMode);
 
     this.checkOutdent = function(state, line, input) {
         if (this.inRLanguageMode(state))
-            return this.$r_outdent.checkOutdent(line,input);
+            return this.$r_outdent.checkOutdent(state, line, input);
         else
             return this.$outdent.checkOutdent(line, input);
     };
 
     this.autoOutdent = function(state, doc, row) {
         if (this.inRLanguageMode(state))
-            return this.$r_outdent.autoOutdent(state, doc, row);
+            return this.$r_outdent.autoOutdent(state, doc, row, this.codeModel);
         else
             return this.$outdent.autoOutdent(doc, row);
     };

--- a/src/gwt/acesupport/acemode/r.js
+++ b/src/gwt/acesupport/acemode/r.js
@@ -42,12 +42,22 @@ define("mode/r", function(require, exports, module)
 
       this.codeModel = new RCodeModel(doc, this.$tokenizer, null);
       this.foldingRules = this.codeModel;
+      this.$outdent = {};
+      oop.implement(this.$outdent, RMatchingBraceOutdent);
+      
    };
+   
    oop.inherits(Mode, TextMode);
 
    (function()
    {
-      oop.implement(this, RMatchingBraceOutdent);
+      this.checkOutdent = function(state, line, input) {
+         return this.$outdent.checkOutdent(state, line, input);
+      }
+
+      this.autoOutdent = function(state, doc, row) {
+         return this.$outdent.autoOutdent(state, doc, row, this.codeModel);
+      };
 
       this.tokenRe = new RegExp("^["
           + unicode.packages.L

--- a/src/gwt/acesupport/acemode/r_matching_brace_outdent.js
+++ b/src/gwt/acesupport/acemode/r_matching_brace_outdent.js
@@ -51,7 +51,7 @@ define("mode/r_matching_brace_outdent", function(require, exports, module)
          return false;
       };
 
-      this.autoOutdent = function(state, session, row) {
+      this.autoOutdent = function(state, session, row, codeModel) {
          if (row == 0)
             return 0;
 
@@ -65,7 +65,7 @@ define("mode/r_matching_brace_outdent", function(require, exports, module)
 
             if (!openBracePos || openBracePos.row == row) return 0;
 
-            var indent = this.codeModel.getIndentForOpenBrace(openBracePos);
+            var indent = codeModel.getIndentForOpenBrace(openBracePos);
             session.replace(new Range(row, 0, row, column-1), indent);
          }
 
@@ -73,7 +73,7 @@ define("mode/r_matching_brace_outdent", function(require, exports, module)
          if (match)
          {
             var column = match[1].length;
-            var indent = this.codeModel.getBraceIndent(row-1);
+            var indent = codeModel.getBraceIndent(row-1);
             session.replace(new Range(row, 0, row, column-1), indent);
          }
       };

--- a/src/gwt/acesupport/acemode/rmarkdown.js
+++ b/src/gwt/acesupport/acemode/rmarkdown.js
@@ -139,14 +139,14 @@ oop.inherits(Mode, MarkdownMode);
         if (this.inCppLanguageMode(state))
             return this.$outdent.checkOutdent(line, input);
         else
-            return this.$r_outdent.checkOutdent(line,input);
+            return this.$r_outdent.checkOutdent(state, line, input);
     };
 
     this.autoOutdent = function(state, doc, row) {
         if (this.inCppLanguageMode(state))
             return this.$outdent.autoOutdent(doc, row);
         else
-            return this.$r_outdent.autoOutdent(state, doc, row);
+            return this.$r_outdent.autoOutdent(state, doc, row, this.codeModel);
     };
 
     this.transformAction = function(state, action, editor, session, text) {


### PR DESCRIPTION
NOTE: Definitely leave this one for later as it touches the code indentation and may have broken things I haven't been able to test yet...

This fix has a few components:
1. In 'r_matching_brace_outdent', the autoOutdent method attempted to
   access the code model through 'this'. Unfortunately, 'codeModel' is not
   actually available through 'this' since the reference is bound before it
   ever gets to know about the code model. A simple fix here is to add
   the code model to those function signature. (from what I see, before, an
   exception would be thrown but silently swallowed up by its caller)
2. The 'checkOutdent' and 'autoOutdent' were not matching the signatures
   correctly. This is understandable since the signature in our
   RMatchingBraceOutdent diverged from that of Ace's MatchingBraceOutdent.
   This is now fixed.
3. Although I don't really know why, the way that the
   RMatchingBraceOutdent was mixed in to 'r.js' didn't seem to work (?), so
   I followed the pattern in the other files.

Ironically, the combination of the two bugs above made R code
indentation for closing '}' work fine, but broke it in other modes.

Ultimately, this fixes a bug where reindenting R code within an .Rmd,
.Rnw, or .cpp file would produce formatted e.g. like:

```
for (i in 1:10) {

    }
```

ie, the closing brace offset is now properly aligned in these files. It
(should) preserve indentation behaviour in vanilla R modes.
