### PR TITLE
Auto insert closing grave accent

### DIFF
--- a/src/gwt/acesupport/acemode/auto_brace_insert.js
+++ b/src/gwt/acesupport/acemode/auto_brace_insert.js
@@ -110,7 +110,7 @@ define("mode/auto_brace_insert", function(require, exports, module)
       // in the mode subclass
       this.smartAllowAutoInsert = function(session, pos, text)
       {
-         if (text !== "'" && text !== '"')
+         if (text !== "'" && text !== '"' && text !== "`")
             return true;
 
          // Only allow auto-insertion of a quote char if the actual character
@@ -121,7 +121,7 @@ define("mode/auto_brace_insert", function(require, exports, module)
 
          var token = this.codeModel.getTokenForPos(pos, false, true);
          return token &&
-                token.type === 'string' &&
+                (token.type === 'string' || token.type == 'symbol') &&
                 token.column === pos.column-1;
       };
 

--- a/src/gwt/acesupport/acemode/r.js
+++ b/src/gwt/acesupport/acemode/r.js
@@ -77,10 +77,11 @@ define("mode/r", function(require, exports, module)
                "[": "]",
                '"': '"',
                "'": "'",
+               "`": "`",
                "{": "}"
             };
-      this.$reOpen = /^[(["'{]$/;
-      this.$reClose = /^[)\]"'}]$/;
+      this.$reOpen = /^[(["'`{]$/;
+      this.$reClose = /^[)\]"'`}]$/;
 
       this.getNextLineIndent = function(state, line, tab, tabSize, row)
       {

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -70,6 +70,11 @@ define("mode/r_highlight_rules", function(require, exports, module)
                next : "qstring"
             },
             {
+               token : "symbol",
+               regex : "[`]",
+               next : "symbol"
+            },
+            {
                token : "constant.numeric", // hex
                regex : "0[xX][0-9a-fA-F]+[Li]?\\b"
             },
@@ -151,7 +156,19 @@ define("mode/r_highlight_rules", function(require, exports, module)
                token : "string",
                regex : '.+'
             }
+         ],
+         "symbol" : [
+            {
+               token : "symbol",
+               regex : "(?:(?:\\\\.)|(?:[^`\\\\]))*?`",
+               next : "start"
+            },
+            {
+               token : "symbol",
+               regex : '.+'
+            }
          ]
+         
       };
 
       var rdRules = new TexHighlightRules("comment").getRules();


### PR DESCRIPTION
This change essentially treats insertion / deletion of ``` as other 'balanced' characters (`'`, `"`, `{`, `[`, `(`)
