### PR TITLE
Remap magrittr keyboard shortcut

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -407,7 +407,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut value="Ctrl+Y" title="Insert Yanked Text" />
          <shortcut value="Ctrl+T" title="Transpose Letters" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut value="Alt+-" title="Insert Assignment Operator"/>
-         <shortcut value="Shift+Alt+." title="Insert Pipe Operator" />
+         <shortcut value="Cmd+Shift+M" title="Insert Pipe Operator" />
       </shortcutgroup>
       <shortcutgroup name="Source Navigation">
          <shortcut refid="sourceNavigateBack" value="Cmd+F9"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -22,6 +22,8 @@ import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.event.dom.client.*;
 import com.google.gwt.user.client.Command;
 import com.google.inject.Inject;
+
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.CommandBinder;
@@ -531,13 +533,19 @@ public class Shell implements ConsoleInputHandler,
                      break;
                }
             }
-            else if (mod == (KeyboardShortcut.ALT + KeyboardShortcut.SHIFT))
+            else if (
+                  BrowseCap.hasMetaKey() && 
+                  (mod == (KeyboardShortcut.META + KeyboardShortcut.SHIFT)) ||
+                  !BrowseCap.hasMetaKey() && 
+                  (mod == (KeyboardShortcut.CTRL + KeyboardShortcut.SHIFT)))
             {
-               if (keyCode == 190)
+               switch (keyCode)
                {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  input_.replaceSelection(" %>% ", true);
+                  case KeyCodes.KEY_M:
+                     event.preventDefault();
+                     event.stopPropagation();
+                     input_.replaceSelection(" %>% ", true);
+                     break;
                }
             }
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -386,6 +386,7 @@ public class TextEditingTarget implements
          {
             NativeEvent ne = event.getNativeEvent();
             int mod = KeyboardShortcut.getModifierValue(ne);
+            
             if ((mod == KeyboardShortcut.META || (mod == KeyboardShortcut.CTRL && !BrowseCap.hasMetaKey()))
                 && ne.getKeyCode() == 'F')
             {
@@ -431,9 +432,11 @@ public class TextEditingTarget implements
                event.stopPropagation();
                commands_.interruptR().execute();
             }
-            
-            else if (mod == (KeyboardShortcut.ALT + KeyboardShortcut.SHIFT)
-                  && ne.getKeyCode() == 190) // period
+            else if (ne.getKeyCode() == KeyCodes.KEY_M &&
+                  (BrowseCap.hasMetaKey() &&
+                   mod == (KeyboardShortcut.META + KeyboardShortcut.SHIFT)) ||
+                  (!BrowseCap.hasMetaKey() &&
+                   mod == (KeyboardShortcut.CTRL + KeyboardShortcut.SHIFT)))
             {
                event.preventDefault();
                event.stopPropagation();

--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -493,8 +493,8 @@
   </tr>
   <tr>
     <td>Insert pipe operator</td>
-    <td>Shift+Alt+.</td>
-    <td>Option+Alt+.</td>
+    <td>Ctrl+Shift+M</td>
+    <td>Cmd+Shift+M</td>
   </tr>
   <tr>
     <td>Show help for function at cursor</td>


### PR DESCRIPTION
This PR remaps insertion of the magrittr pipe operator to META + SHIFT + M (CTRL + SHIFT + M on Windows). The key `M` should be mapped unambiguously across international keyboard layouts (double-checked with Danish, German, French)

I didn't place this in `Commands.java` because AFAICS that forces insertion only in the current source document (and can't be inserted in the console window). I imagine this is also why the `<-` insertion shortcut is not in there.
