### PR TITLE
Fix parentheses in shortcut check

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -534,10 +534,10 @@ public class Shell implements ConsoleInputHandler,
                }
             }
             else if (
-                  BrowseCap.hasMetaKey() && 
-                  (mod == (KeyboardShortcut.META + KeyboardShortcut.SHIFT)) ||
-                  !BrowseCap.hasMetaKey() && 
-                  (mod == (KeyboardShortcut.CTRL + KeyboardShortcut.SHIFT)))
+                  (BrowseCap.hasMetaKey() && 
+                   (mod == (KeyboardShortcut.META + KeyboardShortcut.SHIFT))) ||
+                  (!BrowseCap.hasMetaKey() && 
+                   (mod == (KeyboardShortcut.CTRL + KeyboardShortcut.SHIFT))))
             {
                switch (keyCode)
                {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -432,11 +432,11 @@ public class TextEditingTarget implements
                event.stopPropagation();
                commands_.interruptR().execute();
             }
-            else if (ne.getKeyCode() == KeyCodes.KEY_M &&
+            else if (ne.getKeyCode() == KeyCodes.KEY_M && (
                   (BrowseCap.hasMetaKey() &&
                    mod == (KeyboardShortcut.META + KeyboardShortcut.SHIFT)) ||
                   (!BrowseCap.hasMetaKey() &&
-                   mod == (KeyboardShortcut.CTRL + KeyboardShortcut.SHIFT)))
+                   mod == (KeyboardShortcut.CTRL + KeyboardShortcut.SHIFT))))
             {
                event.preventDefault();
                event.stopPropagation();


### PR DESCRIPTION
On keyboard layouts without a meta key, the magrittr shortcut path was being triggered on CTRL + SHIFT + (any key) due to operator precedence / lack of parentheses in check.
