### PR TITLE
Convert .Rproj file extension to associated UTI on 'Open Project'

### DIFF
--- a/src/cpp/desktop-mac/GwtCallbacks.mm
+++ b/src/cpp/desktop-mac/GwtCallbacks.mm
@@ -141,6 +141,14 @@ private:
                          [filter rangeOfString: @"*."].location + 2];
       NSString* fromExt = [toExt substringToIndex:
                            [toExt rangeOfString: @")"].location];
+      
+      // If we have the extension equal to 'Rproj', then use the
+      // Uniform Type Identifier (UTI) associated with it
+      if ([[fromExt lowercaseString] isEqualTo: @"rproj"])
+      {
+         fromExt = @"dyn.ah62d4rv4ge81e6dwr7za";
+      }
+      
       [open setAllowedFileTypes: [NSArray arrayWithObject: fromExt]];
    }
    return [self runSheetFileDialog: open];


### PR DESCRIPTION
This fixes a bug wherein spotlight search failed within 'Open Project'... dialogs. If the file extension is `.Rproj`, we pass the associated Uniform Type Identifier, rather than the extension itself, so that search functions correctly.

NOTE: I took the UTI from a sample `.Rproj` file with e.g. `mdls devtools.Rproj`, which gave back:

```
<...>
kMDItemContentType             = "dyn.ah62d4rv4ge81e6dwr7za"
kMDItemContentTypeTree         = (
    "dyn.ah62d4rv4ge81e6dwr7za",
    "public.data",
    "public.item"
)
<...>
```

and so that is how I obtained the ID; however, I think there must be some better method of programmatically getting the UTI, but I haven't been able to figure it out. But we should double-check that it's consistent across different OS X versions.

EDIT: Using a [custom base32 decoder](http://play.golang.org/p/sW5oTXs4Bl), we can see that the string encodes:

```
?0=6:1=rproj
```

which is a compact way of storing from identifier information, alongside the extension (hence why it works)
