### PR TITLE
eliminate overwrite check in viewer export

### DIFF
--- a/src/cpp/desktop-mac/GwtCallbacks.mm
+++ b/src/cpp/desktop-mac/GwtCallbacks.mm
@@ -591,18 +591,15 @@ private:
 }
 
 
-- (Boolean) exportPageRegionToFile: (NSString*) targetPath
-                            format: (NSString*) format
-                              left: (int) left
-                               top: (int) top
-                             width: (int) width
-                            height: (int) height
-                         overwrite: (Boolean) overwrite
+- (void) exportPageRegionToFile: (NSString*) targetPath
+                         format: (NSString*) format
+                           left: (int) left
+                            top: (int) top
+                          width: (int) width
+                         height: (int) height
 {
-   // resolve path and check for overwrite
+   // resolve path
    targetPath = resolveAliasedPath(targetPath);
-   if (FilePath([targetPath UTF8String]).exists() && !overwrite)
-      return false;
    
    // get an image for the specified region
    NSRect regionRect = NSMakeRect(left, top, width, height);
@@ -640,9 +637,6 @@ private:
    
    // release the image
    [image release];
-  
-   // success
-   return true;
 }
 
 
@@ -1056,7 +1050,7 @@ enum RS_NSActivityOptions : uint64_t
       return @"copyImageToClipboard";
    else if (sel == @selector(copyPageRegionToClipboard:top:width:height:))
       return @"copyPageRegionToClipboard";
-   else if (sel == @selector(exportPageRegionToFile:format:left:top:width:height:overwrite:))
+   else if (sel == @selector(exportPageRegionToFile:format:left:top:width:height:))
       return @"exportPageRegionToFile";
    else if (sel == @selector(showMessageBox:caption:message:buttons:defaultButton:cancelButton:))
       return @"showMessageBox";

--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -478,18 +478,15 @@ void GwtCallback::copyPageRegionToClipboard(int left, int top, int width, int he
    QApplication::clipboard()->setPixmap(pixmap);
 }
 
-bool GwtCallback::exportPageRegionToFile(QString targetPath,
+void GwtCallback::exportPageRegionToFile(QString targetPath,
                                          QString format,
                                          int left,
                                          int top,
                                          int width,
-                                         int height,
-                                         bool overwrite)
+                                         int height)
 {
-   // resolve target path and check for existence
+   // resolve target path
    targetPath = resolveAliasedPath(targetPath);
-   if (QFile::exists(targetPath) && !overwrite)
-      return false;
 
    // get the pixmap
    QPixmap pixmap = QPixmap::grabWidget(pMainWindow_->webView(),
@@ -500,9 +497,6 @@ bool GwtCallback::exportPageRegionToFile(QString targetPath,
 
    // save the file
    pixmap.save(targetPath, format.toUtf8().constData(), 100);
-
-   // return success
-   return true;
 }
 
 

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -94,13 +94,12 @@ public slots:
 
    // coordinates are relative to entire containing web page
    void copyPageRegionToClipboard(int left, int top, int width, int height);
-   bool exportPageRegionToFile(QString targetPath,
+   void exportPageRegionToFile(QString targetPath,
                                QString format,
                                int left,
                                int top,
                                int width,
-                               int height,
-                               bool overwrite);
+                               int height);
 
    bool supportsClipboardMetafile();
 

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -58,13 +58,12 @@ public interface DesktopFrame extends JavaScriptPassthrough
    
    void copyPageRegionToClipboard(int left, int top, int width, int height);
    
-   boolean exportPageRegionToFile(String targetPath, 
-                                  String format, 
-                                  int left, 
-                                  int top, 
-                                  int width, 
-                                  int height,
-                                  boolean overwrite);
+   void exportPageRegionToFile(String targetPath, 
+                               String format, 
+                               int left, 
+                               int top, 
+                               int width, 
+                               int height);
    
    boolean supportsClipboardMetafile();
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/export/SaveViewerPlotAsImageDesktopDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/export/SaveViewerPlotAsImageDesktopDialog.java
@@ -33,7 +33,7 @@ public class SaveViewerPlotAsImageDesktopDialog extends SavePlotAsImageDialog
                      OperationWithInput<ExportPlotOptions> onClose)
    {
       super(globalDisplay, 
-            new ViewerPaneSaveAsImageDesktopOperation(globalDisplay), 
+            new ViewerPaneSaveAsImageDesktopOperation(), 
             new ViewerPanePreviewer(viewerUrl), 
             context, 
             options, 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/export/ViewerPaneSaveAsImageDesktopOperation.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/export/ViewerPaneSaveAsImageDesktopOperation.java
@@ -17,28 +17,21 @@ package org.rstudio.studio.client.workbench.views.viewer.export;
 
 import org.rstudio.core.client.Rectangle;
 import org.rstudio.core.client.files.FileSystemItem;
-import org.rstudio.core.client.widget.MessageDialog;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.studio.client.application.Desktop;
-import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.workbench.exportplot.ExportPlotSizeEditor;
 import org.rstudio.studio.client.workbench.exportplot.SavePlotAsImageOperation;
 
 public class ViewerPaneSaveAsImageDesktopOperation implements SavePlotAsImageOperation
 {
-   public ViewerPaneSaveAsImageDesktopOperation(GlobalDisplay globalDisplay)
-   {
-      globalDisplay_ = globalDisplay;
-   }
-   
    @Override
    public void attemptSave(final ProgressIndicator progressIndicator, 
                            final FileSystemItem targetPath,
                            final String format, 
                            final ExportPlotSizeEditor sizeEditor,
-                           final boolean overwrite, 
+                           final boolean overwrite,
                            final boolean viewAfterSave,
                            final Operation onCompleted)
    {
@@ -48,48 +41,20 @@ public class ViewerPaneSaveAsImageDesktopOperation implements SavePlotAsImageOpe
                @Override
                public void execute(Rectangle viewerRect)
                {
-                  // attempt the export
-                  boolean exported = Desktop.getFrame().exportPageRegionToFile(
+                  // perform the export
+                  Desktop.getFrame().exportPageRegionToFile(
                         targetPath.getPath(), 
                         format, 
                         viewerRect.getLeft(),
                         viewerRect.getTop(),
                         viewerRect.getWidth(),
-                        viewerRect.getHeight(),
-                        overwrite);
+                        viewerRect.getHeight());
                     
-                  if (exported) 
-                  {
-                     if (viewAfterSave)
-                        Desktop.getFrame().showFile(targetPath.getPath());
-                  }
-                  else if (!overwrite)
-                  {
-                     globalDisplay_.showYesNoMessage(
-                        MessageDialog.WARNING, 
-                        "File Exists", 
-                        "The specified file name already exists. " +
-                        "Do you want to overwrite it?", 
-                        new Operation() {
-                           @Override
-                           public void execute()
-                           {
-                              attemptSave(progressIndicator,
-                                          targetPath,
-                                          format,
-                                          sizeEditor,
-                                          true,
-                                          viewAfterSave,
-                                          onCompleted);
-                           }
-                        }, 
-                        true);
-                  }
+                  if (viewAfterSave) 
+                     Desktop.getFrame().showFile(targetPath.getPath());
                }
             },
             onCompleted
-         );  
+         );
    }
-   
-   private final GlobalDisplay globalDisplay_;
 }


### PR DESCRIPTION
this was causing many undesirable interactions including re-setting of the iframe to size 0,0
