### PR TITLE
Unload packrat after calling it to check project context

### DIFF
--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -108,11 +108,15 @@
 )
 
 .rs.addFunction("getPackageRStudioProtocol", function(name) {
-   if (exists(".RStudio_protocol_version", envir = asNamespace(name),
+   needsUnloadAfter <- !(name %in% loadedNamespaces())
+   result <- if (exists(".RStudio_protocol_version", envir = asNamespace(name),
               mode = "integer")) 
       get(".RStudio_protocol_version", envir = asNamespace(name))
    else 
       0
+   if (needsUnloadAfter)
+      unloadNamespace(name)
+   result
 })
 
 .rs.addFunction("rstudioIDEPackageRequiresUpdate", function(name, sha1) {

--- a/src/cpp/session/modules/SessionPackrat.cpp
+++ b/src/cpp/session/modules/SessionPackrat.cpp
@@ -1028,18 +1028,15 @@ PackratContext packratContext()
       FilePath projectDir = projects::projectContext().directory();
       std::string projectPath =
          string_utils::utf8ToSystem(projectDir.absolutePath());
-      Error error = r::exec::RFunction(
-                           "packrat:::checkPackified",
-                           /* project = */ projectPath,
-                           /* silent = */ true).call(&context.packified);
-      if (error)
-         LOG_ERROR(error);
+      
+      // a project is packified if a lockfile exists (same logic used in packrat)
+      context.packified = projectDir.complete("packrat").complete("packrat.lock").exists();
 
       if (context.packified)
       {
-         error = r::exec::RFunction(
-                            ".rs.isPackratModeOn",
-                            projectPath).call(&context.modeOn);
+         Error error = r::exec::RFunction(
+                  ".rs.isPackratModeOn",
+                  projectPath).call(&context.modeOn);
          if (error)
             LOG_ERROR(error);
       }


### PR DESCRIPTION
This fixes a bug whereby RStudio would _always_ load packrat into the current session, even if the project was not using packrat.

NOTE: I feel a little bit uncomfortable about this change; I wonder if instead we should have our own shims that check the 'packrat status' of a project without calling into packrat itself (which forces a packrat load)
