### PR TITLE
Escape library names on package load

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -651,7 +651,7 @@ public class Packages
       command.append(packageName);
       command.append("\"");
       command.append(", lib.loc=\"");
-      command.append(libName);
+      command.append(libName.replaceAll("\\\\", "\\\\\\\\"));
       command.append("\"");
       command.append(")");
       events_.fireEvent(new SendToConsoleEvent(command.toString(), true));


### PR DESCRIPTION
Fixes a bug whereby the library location includes a single `\`, as reported at https://support.rstudio.com/hc/communities/public/questions/203008586--no-library-trees-found-in-lib-loc-due-to-missing-escapes.
