### PR TITLE
Check for 'rstudio-protocol' file before attempting to check namespace

### DIFF
--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -110,7 +110,7 @@
 .rs.addFunction("getPackageRStudioProtocol", function(name) {
 
    ## First check to see if the package has a 'rstudio-protocol' file
-   path <- system.file("rstudio-protocol", package = name)
+   path <- system.file("rstudio/rstudio-protocol", package = name)
    if (path != "") {
       tryCatch(
          expr = {


### PR DESCRIPTION
(not necessary for this release)

This modifies the protocol lookup to also attempt to read a `.rstudio-protocol` file included with the installed package. If that file is not available, we fall back to looking within the package namespace.
