### PR TITLE
Break on Error: improve heuristics for locating the error origin

### DIFF
--- a/src/cpp/session/modules/SessionErrors.R
+++ b/src/cpp/session/modules/SessionErrors.R
@@ -134,14 +134,23 @@
    }
    if (foundUserCode || !userOnly)
    {
-      # The magic values 2 and 2 here are derived from the position in the
+      # The magic value 2 here is derived from the position in the
       # stack where this error handler resides relative to where we expect
       # the user code that raised the error to be. These will need to be
       # adjusted if evaluation layers are added or removed between the
       # root error handler (set in options(error=...)) and this function.
-      frame <- length(sys.frames()) - 2
+      errorFrameOffset <- 2
+
+      # move the frame backwards if it's on stop or stopifnot
+      if (identical(deparse(sys.call(errorFrameOffset)[[1]]), "stop"))
+         errorFrameOffset <- errorFrameOffset + 1
+      if (identical(deparse(sys.call(errorFrameOffset)[[1]]), "stopifnot"))
+         errorFrameOffset <- errorFrameOffset + 1
+
+      frame <- length(sys.frames()) - errorFrameOffset
+
       eval(substitute(browser(skipCalls = pos), 
-                      list(pos = length(calls) - (frame - 2))),
+                      list(pos = errorFrameOffset + 2)),
            envir = sys.frame(frame))
    }
 },

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -140,6 +140,36 @@ Error getFileNameFromContext(const RCNTXT* pContext,
    }
 }
 
+// call objects can't be passed as primary values through our R interface
+// (early evaluation can be triggered) so we wrap them in an attribute attached
+// to a dummy value when we need to pass them through
+Error invokeFunctionOnCall(const char* rFunction,
+                           SEXP call, std::string* pResult)
+{
+   SEXP result;
+   r::sexp::Protect protect;
+   SEXP val = r::sexp::create("_rs_callval", &protect);
+   r::sexp::setAttrib(val, "_rs_call", call);
+   Error error = r::exec::RFunction(rFunction, val)
+                            .call(&result, &protect);
+   if (!error && r::sexp::length(result) > 0)
+   {
+      error = r::sexp::extract(result, pResult);
+   }
+   else
+   {
+      pResult->clear();
+   }
+   return error;
+}
+
+Error functionNameFromContext(const RCNTXT* pContext,
+                              std::string* pFunctionName)
+{
+   return invokeFunctionOnCall(".rs.functionNameFromCall", pContext->call,
+                               pFunctionName);
+}
+
 // Construct a simulated source reference from a context containing a
 // function being debugged, and either the context containing the current
 // invocation or a string containing the last debug ouput from R.
@@ -208,6 +238,31 @@ bool isErrorHandlerContext(RCNTXT* pContext)
    return TYPEOF(errFlag) == INTSXP;
 }
 
+// Given a context at which an error handler was found, return the context at
+// which we should presume the error originated. 
+RCNTXT* errorOriginatorContext(RCNTXT* handlerCtx, int* dist) 
+{
+   (*dist)++;
+   RCNTXT* originator = firstFunctionContext(handlerCtx->nextcontext);
+   std::string functionName;
+
+   // skip "stop" if present
+   Error err = functionNameFromContext(originator, &functionName);
+   if (!err && functionName == "stop")
+   {
+      (*dist)++;
+      originator = firstFunctionContext(originator->nextcontext);
+   }
+   // skip "stopifnot" if present
+   err = functionNameFromContext(originator, &functionName);
+   if (!err && functionName == "stopifnot")
+   {
+      (*dist)++;
+      originator = firstFunctionContext(originator->nextcontext);
+   }
+   return originator;
+}
+
 // return the function context at the given depth
 RCNTXT* getFunctionContext(const int depth,
                            bool findUserCode = false,
@@ -246,11 +301,11 @@ RCNTXT* getFunctionContext(const int depth,
          }
          // Record the depth at which the error handler was found (if at all);
          // we will default to reporting code at the function that invoked
-         // the handler, which is one function down.
+         // the handler
          if (findUserCode && isErrorHandlerContext(pRContext))
          {
-            pErrContext = getFunctionContext(currentDepth + 1, false,
-                                             &errorDepth);
+            errorDepth = currentDepth;
+            pErrContext = errorOriginatorContext(pRContext, &errorDepth);
          }
       }
       pRContext = pRContext->nextcontext;
@@ -341,36 +396,6 @@ bool insideDebugHiddenFunction()
       pRContext = pRContext->nextcontext;
    }
    return false;
-}
-
-// call objects can't be passed as primary values through our R interface
-// (early evaluation can be triggered) so we wrap them in an attribute attached
-// to a dummy value when we need to pass them through
-Error invokeFunctionOnCall(const char* rFunction,
-                           SEXP call, std::string* pResult)
-{
-   SEXP result;
-   r::sexp::Protect protect;
-   SEXP val = r::sexp::create("_rs_callval", &protect);
-   r::sexp::setAttrib(val, "_rs_call", call);
-   Error error = r::exec::RFunction(rFunction, val)
-                            .call(&result, &protect);
-   if (!error && r::sexp::length(result) > 0)
-   {
-      error = r::sexp::extract(result, pResult);
-   }
-   else
-   {
-      pResult->clear();
-   }
-   return error;
-}
-
-Error functionNameFromContext(const RCNTXT* pContext,
-                              std::string* pFunctionName)
-{
-   return invokeFunctionOnCall(".rs.functionNameFromCall", pContext->call,
-                               pFunctionName);
 }
 
 // Return the call frames and debug information as a JSON object.


### PR DESCRIPTION
This change fixes a recently reported bug in which the wrong frame in the callstack is chosen as the source of the error.

Today, the Break on Error code presumes that the error is raised with `stop(...)`. In this situation, we don't want to show the frame for `stop` itself; we want to show the frame that invoked `stop`. RStudio uses a baked-in offset that correctly locates this frame.

However, primitive functions can raise an error _without_ calling `stop`. In this situation, there are fewer frames on the stack between the error handler and the frame that we want to show, and the baked-in offset is wrong.

The fix is to presume that the function raising the error is the very last one before we reach error-handling code. Most of the time, this will be `stop`, and when it is, we'll go one frame further. (We'll now also deal more gracefully with `stopifnot`). 
