### PR TITLE
Use absolute URL to open rendered PDFs

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/pdfviewer/PDFViewer.java
+++ b/src/gwt/src/org/rstudio/studio/client/pdfviewer/PDFViewer.java
@@ -214,7 +214,6 @@ public class PDFViewer implements CompilePdfCompletedEvent.Handler,
       int width = 1070;
       int height = 1200;
       Point pos = null;
-      final String pdfUrl = url.startsWith("/") ? url : "/" + url;
       
       // if there's a window open, restore the position when we're done
       if (restorePosition && 
@@ -234,7 +233,7 @@ public class PDFViewer implements CompilePdfCompletedEvent.Handler,
          @Override
          public void execute()
          {
-            pdfJsWindow_.openPdf(pdfUrl, 0, synctex);
+            pdfJsWindow_.openPdf(server_.getApplicationURL(url), 0, synctex);
             lastSuccessfulPdfUrl_ = url;
          }
       };


### PR DESCRIPTION
This fixes a bug wherein PDFs were not displayed when RStudio Server is serving pages behind a path other than `/`. Formerly, the PDF.js viewer was loading a server-relative URL (e.g. `/rmd_output/1/`); this change makes that URL absolute (e.g. when RStudio Server is running behind `/rstudio/`, `http://server/rstudio/rmd_output/1`). 
