### PR TITLE
Workaround for Safari 8 text antialiasing

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -479,6 +479,14 @@ pre {
    display: none;
 }
 
+.windowframe {
+   -webkit-font-smoothing: subpixel-antialiased;
+}
+
+.ace_editor > textarea {
+   z-index: 5;
+}
+
 .C  { background-color: white; }
 .N  { background-image: PODTOP; }
 .NE { background-image: PODTOPRIGHT; }


### PR DESCRIPTION
Yosemite comes with a new version of Safari that causes text to be composited on the GPU more frequently. When text is composited on the GPU the antialiasing is done with an algorithm that produces a much lighter font weight.  

![image](https://cloud.githubusercontent.com/assets/470418/4741018/aac3e0d6-5a12-11e4-8491-6c066ddf297f.png)

Elements with `position: fixed;` are particularly prone to trigger this behavior; in fact, the presence of a single visible fixed-position element is enough to trigger the poor behavior for any element it may overlap. The workaround implemented here is to slightly raise the `z-index` of the ACE editor's input `textarea`, which has `position: fixed`:

![image](https://cloud.githubusercontent.com/assets/470418/4741027/c0aba35c-5a12-11e4-9cc9-0de88ca27596.png)
