### PR TITLE
fix compiler error in OS X Yosemite

### DIFF
--- a/src/cpp/desktop-mac/Main.mm
+++ b/src/cpp/desktop-mac/Main.mm
@@ -36,7 +36,7 @@ int main(int argc, char* argv[])
    
    // create our app delegate
    AppDelegate* appDelegate = [[[AppDelegate alloc] init] autorelease];
-   [NSApp setDelegate: appDelegate];
+   [NSApp setDelegate: (id) appDelegate];
    
    // run the event loop
    [NSApp run];


### PR DESCRIPTION
Not sure if this is the most appropriate fix, but -- when building RStudio with OS X Yosemite, I get the error:

```
/Users/kevin/git/rstudio/src/cpp/desktop-mac/Main.mm:39:24: error: cannot initialize a parameter of type 'id<NSFileManagerDelegate>' with an lvalue of type 'AppDelegate *'
   [NSApp setDelegate: appDelegate];
                       ^~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSFileManager.h:109:47: note: 
      passing argument to parameter 'delegate' here
@property (assign) id <NSFileManagerDelegate> delegate NS_AVAILABLE(10_5, 2_0);
                                              ^
```

It looks like pointer casting checks got stricter in the latest XCode.

cc: @jmcphers 
