### PR TITLE
Move ACE textarea behind rather than in front of content (for editor)

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -483,7 +483,17 @@ pre {
    -webkit-font-smoothing: subpixel-antialiased;
 }
 
-.ace_editor > textarea {
+/* on the Mac specifically, keeping the ACE input textarea on the same z-index
+ * as the text causes rendering problems in Safari (see case 4093), and lifting
+ * it above the text causes it to intercept unwanted events (e.g. clicks for
+ * double-click), so send it beneath the text. */
+.macintosh #rstudio_source_text_editor.ace_editor > textarea {
+   z-index: -5;
+}
+
+/* the opposite must be done for the console due to the z-indices of the
+ * elements it contains */
+.macintosh #rstudio_console_input.ace_editor > textarea {
    z-index: 5;
 }
 


### PR DESCRIPTION
@hadley noticed that double-clicking to select words doesn't work very well in 0.99, and @kevinushey tracked the problem down as a regression of yesterday's `z-index` fix. :-/ This change improves that fix in two ways:
1. For the source editor specifically, the `z-index` of the text area is now beneath rather than above the editing surface. Having it above the editing surface caused it to absorb some mouse click events, which lead to the inconsistent double-click behavior.
2. As a precautionary measure, the fix has been scoped to Mac browsers, to limit the risk of regression on other platforms.
