### PR TITLE
highlight + scope tree fixes for 'operator', 'const', 'noexcept'

### DIFF
--- a/src/gwt/acesupport/acemode/c_cpp_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/c_cpp_highlight_rules.js
@@ -69,8 +69,8 @@ var c_cppHighlightRules = function() {
    );
 
    var operatorTokens = [
-      
-      ">>=", "<<=", "new",
+
+      ">>=", "<<=", "new", "delete",
       
       "<<", ">>", "&&", "||", "==", "!=", "<=", ">=", "::",
       "*=", "+=", "-=", "/=", "++", "--", "<>", "&=", "^=",
@@ -84,9 +84,15 @@ var c_cppHighlightRules = function() {
       return escapeRegExp(x);
    }).join("|");
 
-   var reOperator = operatorTokens.map(function(x) {
-      return "operator\\s*" + escapeRegExp(x);
-   }).join("|");
+   var reOperator =
+      [",", "()", "[]", "->*", "->"]
+      .concat(operatorTokens)
+      .map(function(x) {
+         return escapeRegExp(x);
+      });
+
+   reOperator = ["new\\s*\\[\\]", "delete\\s*\\[\\]"].concat(reOperator);
+   reOperator = "operator\\s*(?:" + reOperator.join("|") + ")|operator\\s+[\\w_]+";
 
    // regexp must not have capturing parentheses. Use (?:) instead.
    // regexps are ordered -> the first match is used

--- a/src/gwt/acesupport/acemode/token_cursor.js
+++ b/src/gwt/acesupport/acemode/token_cursor.js
@@ -441,6 +441,60 @@ oop.mixin(CppTokenCursor.prototype, TokenCursor.prototype);
 
 (function() {
 
+   // Move the tokne cursor backwards from an open brace over const, noexcept,
+   // for function definitions.
+   //
+   // E.g.
+   //
+   //     int foo(int a) const noexcept(...) {
+   //                    ^~~~~~~~~~~~~~~~~~~~^
+   //
+   // Places the token cursor on the first token following a closing paren.
+   this.bwdOverConstNoexcept = function() {
+
+      var clone = this.cloneCursor();
+      if (clone.currentValue() !== "{") {
+         return false;
+      }
+
+      // Move off of the open brace
+      if (!clone.moveToPreviousToken())
+         return false;
+      
+      // Try moving over a 'noexcept()'.
+      var cloneTwo = clone.cloneCursor();
+      if (cloneTwo.currentValue() === ")") {
+         if (cloneTwo.bwdToMatchingToken()) {
+            if (cloneTwo.moveToPreviousToken()) {
+               if (cloneTwo.currentValue() === "noexcept") {
+                  clone.$row = cloneTwo.$row;
+                  clone.$offset = cloneTwo.$offset;
+               }
+            }
+         }
+      }
+
+      // Try moving over a 'noexcept'.
+      if (clone.currentValue() === "noexcept")
+         if (!clone.moveToPreviousToken())
+            return false;
+
+      // Try moving over the 'const'
+      if (clone.currentValue() === "const")
+         if (!clone.moveToPreviousToken())
+            return false;
+
+      // Move back up one if we landed on the closing paren
+      if (clone.currentValue() === ")")
+         if (!clone.moveToNextToken())
+            return false;
+
+      this.$row = clone.$row;
+      this.$offset = clone.$offset;
+      return true;
+
+   };
+
    this.bwdToMatchingArrow = function() {
 
       var thisValue = ">";


### PR DESCRIPTION
A couple more fixes + tweaks:
1. Member functions with `const`, `const noexcept()` were not properly added in the scope tree.
2. More tweaks for `operator` function definitions; this is mainly done by rolling `operator X` into a single symbol. This also provides syntax highlighting that might be a bit contentious (IMO it makes things easier to read for e.g. definitions of `operator()`, though)

![screen shot 2014-10-24 at 12 44 37 pm](https://cloud.githubusercontent.com/assets/1976582/4775428/c5cd54ce-5bb7-11e4-9a20-0f5245bd2a2a.png)
