### PR TITLE
Limit max.print to be at most 10000

### DIFF
--- a/src/cpp/r/R/Options.R
+++ b/src/cpp/r/R/Options.R
@@ -46,7 +46,9 @@ options(pager = .rs.pager)
 options(menu.graphics = FALSE)
 
 # set max print so that the DOM won't go haywire showing large datasets
-options(max.print = 10000)
+if (getOption("max.print") > 10000) {
+   options(max.print = 10000)
+}
 
 # set RStudio as the GUI
 local({


### PR DESCRIPTION
If .Rprofile has max.print set to a low value like 100 (common if the user routinely works with datasets that lock up the screen for minutes at a time even with 10000 rows), then just calling options(max.print = 10000) will silently override their wishes.
