### PR TITLE
Avoid duplication of environment variables (for Yosemite)

### DIFF
--- a/src/cpp/core/system/PosixEnvironment.cpp
+++ b/src/cpp/core/system/PosixEnvironment.cpp
@@ -54,12 +54,15 @@ std::string getenv(const std::string& name)
 
 void setenv(const std::string& name, const std::string& value)
 {
+   while (::getenv(name.c_str()))
+      ::unsetenv(name.c_str());
    ::setenv(name.c_str(), value.c_str(), 1);
 }
 
 void unsetenv(const std::string& name)
 {
-   ::unsetenv(name.c_str());
+   while (::getenv(name.c_str()))
+      ::unsetenv(name.c_str());
 }
 
 


### PR DESCRIPTION
(Maybe overkill, but gives a place to start)

This works around duplicate environment variable issues (specifically `PATH`) on OS X. This ensures that, when setting an environment variable, all environment variables with that name are removed and then the new one is set.
