### PR TITLE
Avoid popup flickering on new suggestions

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1337,8 +1337,6 @@ public class RCompletionManager implements CompletionManager
          if (invalidationToken_.isInvalid())
             return ;
          
-         popup_.hide() ;
-         popup_.clearHelp(false);
          requester_.flushCache() ;
          helpStrategy_.clearCache();
          
@@ -1359,6 +1357,12 @@ public class RCompletionManager implements CompletionManager
                   beginSuggest(true, true, false);
                }
             });
+         }
+         else
+         {
+            popup_.hide() ;
+            popup_.clearHelp(false);
+            popup_.setHelpVisible(false);
          }
          
       }


### PR DESCRIPTION
This fixes the popup flickering in a simple way -- we do not hide an existing popup window when we go to get new suggestions from the server. This ensures that:
1. The old popup should remain for the duration of the RPC call, and
2. The popup will automatically be cleared and updated once that RPC call has returned.
