### PR TITLE
separate completion list and help into separate popups

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleResources.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleResources.java
@@ -34,6 +34,7 @@ public interface ConsoleResources extends ClientBundle
       String command();
       String completionPopup();
       String completionGrid();
+      String helpPopup();
       String functionInfo();
       String functionInfoSignature();
       String functionInfoSummary();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/consoleStyles.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/consoleStyles.css
@@ -60,6 +60,11 @@
    padding: 0;
 }
 
+.helpPopup {
+   background: white;
+   z-index: 1003;
+}
+
 .completionGrid td {
    font-family: fixedWidthFont;
    font-size: 12px;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionList.java
@@ -111,7 +111,7 @@ class CompletionList<TItem> extends Composite
       scrollPanel_ = new ScrollPanel() ;
       scrollPanel_.getElement().getStyle().setProperty("overflowX", "hidden");
       scrollPanel_.add(grid) ;
-      scrollPanel_.setHeight((visibleItems * 20) + "px") ;
+      scrollPanel_.setHeight((visibleItems * 26) + "px") ;
       
       initWidget(scrollPanel_) ;
       grid_ = grid ;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.java
@@ -24,10 +24,11 @@ import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.workbench.views.console.ConsoleResources;
 import org.rstudio.studio.client.workbench.views.help.model.HelpInfo;
 
-public class HelpInfoPane extends Composite
+public class HelpInfoPopupPanel extends PopupPanel
 {
-   public HelpInfoPane()
+   public HelpInfoPopupPanel()
    {
+      super();
       styles_ = ConsoleResources.INSTANCE.consoleStyles();
 
       DockLayoutPanel outer = new DockLayoutPanel(Unit.PX);
@@ -41,7 +42,8 @@ public class HelpInfoPane extends Composite
       vpanel_.setWidth("100%") ;
       outer.add(scrollPanel_);
 
-      initWidget(outer) ;
+      setWidget(outer) ;
+      show();
       
       timer_ = new Timer() {
          public void run()
@@ -75,8 +77,10 @@ public class HelpInfoPane extends Composite
       htmlDesc.setStylePrimaryName(styles_.functionInfoSummary()) ;
       vpanel_.add(htmlDesc) ;
 
+      vpanel_.setVisible(true);
       f1prompt_.setVisible(true);
-      scrollPanel_.setVisible(true) ;
+      scrollPanel_.setVisible(true);
+      setVisible(true);
       
    }
    


### PR DESCRIPTION
NOTE: not quite ready for merge, as I haven't yet accommodated code handling correct positioning of help.

![popup](https://cloud.githubusercontent.com/assets/1976582/5080524/2cad7626-6e76-11e4-94c2-5e8a2c8d8f04.gif)

@jjallaire: any thoughts on improving the styling for the help popup?
