### PR TITLE
remove alternating handler

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.java
@@ -224,11 +224,8 @@ public class SearchWidget extends Composite implements SearchDisplay
       {
          public void onKeyDown(KeyDownEvent event)
          {
-            if (ignore_ = !ignore_)
-               handler.onKeyDown(event);
+            handler.onKeyDown(event);
          }
-
-         private boolean ignore_ = false;
       });
    }
 


### PR DESCRIPTION
This one seems a bit bizarre -- I am not sure why we would have a keydown handler that ignores half of the events, but...

The rationale for this: in the fuzzy finder (CTRL + .), only half of the up events were 'eaten' -- see https://github.com/rstudio/rstudio/blob/master/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearch.java#L174-L191 -- which implies that, half the time, pressing up would in fact allow the up command to go back to the text box and hence move the cursor from the end to the start.

This probably needs a more targetted fix, though -- any idea why we want to ignore half of the keydown events here?
