### PR TITLE
add explicit hotkeys for 'cmd+up', 'cmd+down'

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -382,6 +382,8 @@ well as menu structures (for main menu and popup menus).
       <!-- Valid modifiers are Ctrl, Alt, Meta, Shift, and Cmd -->
       <!-- "Cmd" means Ctrl OR Meta -->
       <shortcutgroup name="Source Editor">
+         <shortcut refid="moveCursorToStartOfDocument" value="Cmd+Up"/>
+         <shortcut refid="moveCursorToEndOfDocument" value="Cmd+Down"/>
          <shortcut refid="insertChunk" value="Cmd+Alt+I"/>
          <shortcut refid="insertSection" value="Cmd+Shift+R"/>
          <shortcut refid="extractFunction" value="Cmd+Alt+X"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -55,6 +55,8 @@ public abstract class
    public abstract AppCommand executeCurrentFunction();
    public abstract AppCommand executeCurrentSection();
    public abstract AppCommand executeLastCode();
+   public abstract AppCommand moveCursorToStartOfDocument();
+   public abstract AppCommand moveCursorToEndOfDocument();
    public abstract AppCommand insertChunk();
    public abstract AppCommand insertSection();
    public abstract AppCommand executePreviousChunks();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1959,6 +1959,21 @@ public class TextEditingTarget implements
    {
       return fileType_;
    }
+   
+   @Handler
+   void onMoveCursorToStartOfDocument()
+   {
+      docDisplay_.setCursorPosition(Position.create(0, 0));
+   }
+   
+   @Handler
+   void onMoveCursorToEndOfDocument()
+   {
+      int row = docDisplay_.getRowCount();
+      int column = docDisplay_.getLength(row - 1);
+      docDisplay_.setCursorPosition(
+            Position.create(row, column));
+   }
 
    @Handler
    void onCheckSpelling()


### PR DESCRIPTION
This adds explicit hotkeys for moving the cursor to the start / end of the document with CTRL (CMD) + Up, Down.
