### PR TITLE
Avoid comment insertion behaviour when popup showing

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -1943,6 +1943,16 @@ public class AceEditor implements DocDisplay,
          executionLine_ = null;
       }
    }
+   
+   public void setPopupVisible(boolean visible)
+   {
+      popupVisible_ = visible;
+   }
+   
+   public boolean isPopupVisible()
+   {
+      return popupVisible_;
+   }
 
    private static final int DEBUG_CONTEXT_LINES = 2;
    private final HandlerManager handlers_ = new HandlerManager(this);
@@ -1963,4 +1973,5 @@ public class AceEditor implements DocDisplay,
          new ExternalJavaScriptLoader(AceResources.INSTANCE.acejs().getSafeUri().asString());
    private static final ExternalJavaScriptLoader aceSupportLoader_ =
          new ExternalJavaScriptLoader(AceResources.INSTANCE.acesupportjs().getSafeUri().asString());
+   private boolean popupVisible_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -229,4 +229,7 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    void removeAllBreakpoints();
    void toggleBreakpointAtCursor();
    boolean hasBreakpoints();
+   
+   void setPopupVisible(boolean visible);
+   boolean isPopupVisible();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -471,6 +471,7 @@ public class TextEditingTarget implements
             }
             else if (
                   prefs_.continueCommentsOnNewline().getValue() && 
+                  !docDisplay_.isPopupVisible() &&
                   ne.getKeyCode() == KeyCodes.KEY_ENTER && mod == 0 &&
                     (fileType_.isC() || isCursorInRMode() || isCursorInTexMode()))
             {
@@ -501,6 +502,7 @@ public class TextEditingTarget implements
             }
             else if (
                   prefs_.continueCommentsOnNewline().getValue() &&
+                  !docDisplay_.isPopupVisible() &&
                   ne.getKeyCode() == KeyCodes.KEY_ENTER &&
                   mod == KeyboardShortcut.SHIFT)
             {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
@@ -228,6 +228,9 @@ public class CppCompletionManager implements CompletionManager
          if ((popup == null) || !popup.isVisible())
             return false;
          
+         // let the document know that a popup is showing
+         docDisplay_.setPopupVisible(true);
+         
          // backspace triggers completion if the popup is visible
          if (keyCode == KeyCodes.KEY_BACKSPACE)
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionRequest.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionRequest.java
@@ -30,6 +30,8 @@ import org.rstudio.studio.client.workbench.views.source.model.CppCompletionResul
 import org.rstudio.studio.client.workbench.views.source.model.CppServerOperations;
 
 import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.user.client.ui.PopupPanel;
@@ -217,6 +219,14 @@ public class CppCompletionRequest
          {
             popup_ = null; 
             terminated_ = true;
+            Scheduler.get().scheduleDeferred(new ScheduledCommand()
+            {
+               @Override
+               public void execute()
+               {
+                  docDisplay_.setPopupVisible(false);
+               }
+            });
          } 
       });
       


### PR DESCRIPTION
This fixes a bug with the recent addition where completion of an Roxygen autocompletion would both complete the Roxygen tag, and also automatically go ahead and insert an Roxygen comment continuation.

It also fixes tab insertion (if the cursor is at `#' |`, then TAB should insert a literal tab rather than do completion -- we automatically pop up completions on `@` anyhow.)
