### PR TITLE
better completion popup key handling

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupDisplay.java
@@ -33,6 +33,7 @@ public interface CompletionPopupDisplay
                              HasCloseHandlers<PopupPanel>,
                              HasMouseDownHandlers
 {
+   void clearCompletions();
    void showCompletionValues(QualifiedName[] results,
                              PositionCallback callback) ;
    void showErrorMessage(String userMessage, PositionCallback callback) ;
@@ -64,4 +65,5 @@ public interface CompletionPopupDisplay
     *    Implementations may choose to show a progress indicator in this case.
     */
    void clearHelp(boolean downloadOperationPending) ;
+   boolean hasCompletions();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
@@ -70,6 +70,12 @@ public class CompletionPopupPanel extends ThemedPopupPanel
       setText(error) ;
       show(callback) ;
    }
+   
+   @Override
+   public void clearCompletions()
+   {
+      list_ = null;
+   }
 
    @Override
    public void showCompletionValues(QualifiedName[] values, 
@@ -107,6 +113,12 @@ public class CompletionPopupPanel extends ThemedPopupPanel
             ElementIds.POPUP_COMPLETIONS);
       
       show(callback) ;
+   }
+   
+   public boolean hasCompletions() {
+      if (list_ == null)
+         return false;
+      return list_.getItemCount() > 0;
    }
 
    private void show(PositionCallback callback)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -361,44 +361,56 @@ public class RCompletionManager implements CompletionManager
                invalidatePendingRequests() ;
                return true ;
             }
-            else if (keycode == KeyCodes.KEY_TAB
-                  || keycode == KeyCodes.KEY_ENTER
-                  || keycode == KeyCodes.KEY_RIGHT)
+            
+            // NOTE: It is possible for the popup to still be showing, but
+            // showing offscreen with no values. We only grab these keys
+            // when the popup is both showing, and has completions.
+            // This functionality is here to ensure backspace works properly;
+            // e.g "stats::rna" -> "stats::rn" brings completions if the user
+            // had originally requested completions at e.g. "stats::".
+            if (popup_.hasCompletions())
             {
-               QualifiedName value = popup_.getSelectedValue() ;
-               if (value != null)
+               if (keycode == KeyCodes.KEY_TAB
+                     || keycode == KeyCodes.KEY_ENTER
+                     || keycode == KeyCodes.KEY_RIGHT)
                {
-                  context_.onSelection(value) ;
+                  QualifiedName value = popup_.getSelectedValue() ;
+                  if (value != null)
+                  {
+                     context_.onSelection(value) ;
+                     return true ;
+                  }
+               }
+               
+               else if (keycode == KeyCodes.KEY_UP)
+                  return popup_.selectPrev() ;
+               else if (keycode == KeyCodes.KEY_DOWN)
+                  return popup_.selectNext() ;
+               else if (keycode == KeyCodes.KEY_PAGEUP)
+                  return popup_.selectPrevPage() ;
+               else if (keycode == KeyCodes.KEY_PAGEDOWN)
+                  return popup_.selectNextPage() ;
+               else if (keycode == KeyCodes.KEY_HOME)
+                  return popup_.selectFirst() ;
+               else if (keycode == KeyCodes.KEY_END)
+                  return popup_.selectLast() ;
+               else if (keycode == KeyCodes.KEY_LEFT)
+               {
+                  invalidatePendingRequests() ;
                   return true ;
                }
+               if (keycode == 112) // F1
+               {
+                  context_.showHelpTopic() ;
+                  return true ;
+               }
+               else if (keycode == 113) // F2
+               {
+                  goToFunctionDefinition();
+                  return true;
+               }
             }
-            else if (keycode == KeyCodes.KEY_UP)
-               return popup_.selectPrev() ;
-            else if (keycode == KeyCodes.KEY_DOWN)
-               return popup_.selectNext() ;
-            else if (keycode == KeyCodes.KEY_PAGEUP)
-               return popup_.selectPrevPage() ;
-            else if (keycode == KeyCodes.KEY_PAGEDOWN)
-               return popup_.selectNextPage() ;
-            else if (keycode == KeyCodes.KEY_HOME)
-               return popup_.selectFirst() ;
-            else if (keycode == KeyCodes.KEY_END)
-               return popup_.selectLast() ;
-            else if (keycode == KeyCodes.KEY_LEFT)
-            {
-               invalidatePendingRequests() ;
-               return true ;
-            }
-            else if (keycode == 112) // F1
-            {
-               context_.showHelpTopic() ;
-               return true ;
-            }
-            else if (keycode == 113) // F2
-            {
-               goToFunctionDefinition();
-               return true;
-            }
+            
          }
          
          if (canContinueCompletions(event))
@@ -1341,6 +1353,7 @@ public class RCompletionManager implements CompletionManager
          
          if (results.length == 0)
          {
+            popup_.clearCompletions();
             boolean lastInputWasTab =
                   (nativeEvent_ != null && nativeEvent_.getKeyCode() == KeyCodes.KEY_TAB);
             


### PR DESCRIPTION
This fixes a bug whereby movement keys would 'get stuck' by the auto-popup mechanism when no completions were actually available. We alleviate this problem by only grabbing those key events and sending them to the completion popup if it actually has completion values.
