### PR TITLE
wire in completions for reference classes

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/RCompletionType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/RCompletionType.java
@@ -30,15 +30,16 @@ public class RCompletionType
    public static final int S4_METHOD = 11;
    public static final int R5_CLASS = 12;
    public static final int R5_OBJECT = 13;
-   public static final int FILE = 14;
-   public static final int CHUNK = 15;
-   public static final int ROXYGEN = 16;
-   public static final int HELP = 17;
-   public static final int STRING = 18;
-   public static final int PACKAGE = 19;
-   public static final int KEYWORD = 20;
-   public static final int OPTION = 21;
-   public static final int DATASET = 22;
+   public static final int R5_METHOD = 14;
+   public static final int FILE = 15;
+   public static final int CHUNK = 16;
+   public static final int ROXYGEN = 17;
+   public static final int HELP = 18;
+   public static final int STRING = 19;
+   public static final int PACKAGE = 20;
+   public static final int KEYWORD = 21;
+   public static final int OPTION = 22;
+   public static final int DATASET = 23;
    
    public static final int CONTEXT = 99;
    
@@ -46,6 +47,7 @@ public class RCompletionType
    {
       return type == FUNCTION ||
              type == S4_GENERIC ||
-             type == S4_METHOD;
+             type == S4_METHOD ||
+             type == R5_METHOD;
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -616,13 +616,6 @@ public class CompletionRequester
          this.type = RCompletionType.UNKNOWN;
       }
       
-      public boolean isFunctionType()
-      {
-         return this.type == RCompletionType.FUNCTION ||
-                this.type == RCompletionType.S4_GENERIC ||
-                this.type == RCompletionType.S4_METHOD;
-      }
-      
       @Override
       public String toString()
       {
@@ -654,16 +647,15 @@ public class CompletionRequester
       
       private ImageResource getIcon()
       {
+         if (RCompletionType.isFunctionType(type))
+            return ICONS.function();
+         
          switch(type)
          {
          case RCompletionType.UNKNOWN:
             return ICONS.variable();
          case RCompletionType.VECTOR:
             return ICONS.variable();
-         case RCompletionType.FUNCTION:
-         case RCompletionType.S4_GENERIC:
-         case RCompletionType.S4_METHOD:
-            return ICONS.function();
          case RCompletionType.ARGUMENT:
             return ICONS.variable();
          case RCompletionType.ARRAY:

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -41,6 +41,7 @@ import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.GlobalProgressDelayer;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.codetools.CodeToolsServerOperations;
+import org.rstudio.studio.client.common.codetools.RCompletionType;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
@@ -1505,7 +1506,7 @@ public class RCompletionManager implements CompletionManager
             return;
          }
          
-         boolean insertParen = qualifiedName.isFunctionType();
+         boolean insertParen = RCompletionType.isFunctionType(qualifiedName.type);
          
          // Don't insert a paren if there is already a '(' following
          // the cursor


### PR DESCRIPTION
This gives us completions on `$` and `@` for reference classes and reference object generators.
