### PR TITLE
don't allow width collapsing in completion popup

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.css
@@ -38,6 +38,10 @@
 .themedPopupPanel .popupMiddleCenter, .menuPopupMiddleCenter, .suggestPopupMiddleCenter {
    background-color: white;
 }
+
+.themedPopupPanel .popupMiddleLeft {
+	min-width: value('popupMiddleLeft.getWidth', 'px'); /* don't let the browser collapse the table cell if there's no space */
+}
 @sprite .themedPopupPanel .popupMiddleRight, .menuPopupMiddleRight, .suggestPopupMiddleRight {
    gwt-image: 'popupMiddleRight';
    width: value('popupMiddleRight.getWidth', 'px');


### PR DESCRIPTION
This fixes a visual 'bug' where the left cell of the popup would collapse when the window width was too small, producing a display like:

![screen shot 2014-11-22 at 4 00 27 pm](https://cloud.githubusercontent.com/assets/1976582/5156111/b86ef390-7260-11e4-9a74-c2a433b789c4.png)

We set the `min-width` property to ensure that table cell resizing rules don't override our width setting.
