### PR TITLE
Autocompletion for install.packages

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -542,3 +542,12 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    return(NULL)
 })
 
+.rs.addFunction("getCachedAvailablePackages", function(contribUrl)
+{
+   .Call("rs_getCachedAvailablePackages", contribUrl)
+})
+
+.rs.addFunction("downloadAvailablePackages", function(contribUrl)
+{
+   .Call("rs_downloadAvailablePackages", contribUrl)
+})


### PR DESCRIPTION
Note that I had already written the install.packages completions infrastructure code; this PR just wires that up to the pre-existing package cache.

You should double-check that I am properly handling mutexes and whatnot on the (singleton) packages cache -- all calls to the cache are locked through a mutex so I do believe that it should be safe, but let me know if you think I missed anything.
