### PR TITLE
Disable auto-popup within strings

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -627,6 +627,60 @@ public class StringUtil
       return result.toString();
    }
    
+   public static boolean isEndOfLineInRStringState(String string)
+   {
+      if (string == null)
+         return false;
+      
+      if (string == "")
+         return false;
+      
+      boolean inSingleQuotes = false;
+      boolean inDoubleQuotes = false;
+      boolean inQuotes = false;
+
+      int stringStart = 0;
+
+      char currentChar = '\0';
+      char previousChar = '\0';
+
+      for (int i = 0; i < string.length(); i++)
+      {
+         currentChar = string.charAt(i);
+         inQuotes = inSingleQuotes || inDoubleQuotes;
+
+         if (i > 0)
+         {
+            previousChar = string.charAt(i - 1);
+         }
+
+         if (currentChar == '\'' && !inQuotes)
+         {
+            inSingleQuotes = true;
+            continue;
+         }
+
+         if (currentChar == '\'' && previousChar != '\\' && inSingleQuotes)
+         {
+            inSingleQuotes = false;
+            continue;
+         }
+
+         if (currentChar == '"' && !inQuotes)
+         {
+            inDoubleQuotes = true;
+            continue;
+         }
+
+         if (currentChar == '"' && previousChar != '\\' && inDoubleQuotes)
+         {
+            inDoubleQuotes = false;
+            continue;
+         }
+      }
+      
+      return inSingleQuotes || inDoubleQuotes;
+   }
    
    public static boolean isSubsequence(String self,
          String other,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -526,6 +526,10 @@ public class RCompletionManager implements CompletionManager
       Position cursorPos = input_.getCursorPosition();
       int cursorColumn = cursorPos.getColumn();
       
+      // Don't auto-popup when the cursor is within a string
+      if (docDisplay_.isCursorInSingleLineString())
+         return false;
+      
       // Grab the current token on the line
       String currentToken = StringUtil.getToken(
             currentLine, cursorColumn, "^[a-zA-Z0-9._'\"`]$", false, false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -1484,6 +1484,12 @@ public class AceEditor implements DocDisplay,
          moveCursorNearTop();
    }
    
+   @Override
+   public boolean isCursorInSingleLineString()
+   {
+      return StringUtil.isEndOfLineInRStringState(getCurrentLineUpToCursor());
+   }
+   
    public void scrollToBottom()
    { 
       SourcePosition pos = SourcePosition.create(getCurrentLineCount() - 1, 0);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -146,7 +146,7 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    void moveCursorNearTop();
    void moveCursorNearTop(int rowOffset);
    void ensureCursorVisible();
-
+   boolean isCursorInSingleLineString();
    
    InputEditorSelection search(String needle,
                                boolean backwards,


### PR DESCRIPTION
This disables automatic popups within (single-line) strings.

Note that the `isEndOfLineInRStringState` is a trimmed version of `stripBalancedQuotes`, so we have some rough guarantees that the algorithm there is correct (we've been using it for a while in the IDE already)
