### PR TITLE
Respect values of new completion options

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -86,7 +86,7 @@ public class EditingPreferencesPane extends PreferencesPane
       completionPanel.add(showCompletions_);
       
       final CheckBox alwaysCompleteInConsole = checkboxPref(
-                       "Always show code completions in the console",
+                       "Allow automatic completions in console",
                        prefs.alwaysCompleteInConsole());
       completionPanel.add(alwaysCompleteInConsole);
       showCompletions_.addChangeHandler(new ChangeHandler() {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -144,7 +144,8 @@ public class Shell implements ConsoleInputHandler,
                                           null,
                                           null,
                                           null,
-                                          (DocDisplay) view_.getInputEditorDisplay());
+                                          (DocDisplay) view_.getInputEditorDisplay(),
+                                          true);
       addKeyDownPreviewHandler(completionManager) ;
       addKeyPressPreviewHandler(completionManager) ;
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -109,7 +109,8 @@ public class RCompletionManager implements CompletionManager
                              InitCompletionFilter initFilter,
                              RCompletionContext rContext,
                              RnwCompletionContext rnwContext,
-                             DocDisplay docDisplay)
+                             DocDisplay docDisplay,
+                             boolean isConsole)
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
       
@@ -122,6 +123,7 @@ public class RCompletionManager implements CompletionManager
       rContext_ = rContext;
       rnwContext_ = rnwContext;
       docDisplay_ = docDisplay;
+      isConsole_ = isConsole;
       sigTip_ = new RCompletionToolTip(docDisplay_);
       
       input_.addBlurHandler(new BlurHandler() {
@@ -306,7 +308,8 @@ public class RCompletionManager implements CompletionManager
    public boolean previewKeyDown(NativeEvent event)
    {
       if (sigTip_ != null)
-         sigTip_.previewKeyDown(event);
+         if (sigTip_.previewKeyDown(event))
+            return true;
       
       /**
        * KEYS THAT MATTER
@@ -540,23 +543,25 @@ public class RCompletionManager implements CompletionManager
          if (keyword.substring(0, currentToken.length()).equals(currentToken))
             return false;
       
-      boolean canAutocomplete =
-            uiPrefs_.alwaysCompleteInConsole().getValue() && 
+      boolean canAutoPopup =
             (currentLine.length() > lookbackLimit - 1 && isValidForRIdentifier(c));
+      
+      if (isConsole_ && !uiPrefs_.alwaysCompleteInConsole().getValue())
+         canAutoPopup = false;
 
-      if (canAutocomplete)
+      if (canAutoPopup)
       {
          for (int i = 0; i < lookbackLimit; i++)
          {
             if (!isValidForRIdentifier(currentLine.charAt(cursorColumn - i - 1)))
             {
-               canAutocomplete = false;
+               canAutoPopup = false;
                break;
             }
          }
       }
 
-      return canAutocomplete;
+      return canAutoPopup;
       
    }
    
@@ -1723,6 +1728,10 @@ public class RCompletionManager implements CompletionManager
    
    private void displaySignatureToolTip(final QualifiedName qualifiedName)
    {
+      // Bail on lack of UI prefs
+      if (!uiPrefs_.showSignatureTooltips().getValue())
+         return;
+      
       // We want to find the cursor position, and place the popup
       // above the cursor.
       server_.getArgs(
@@ -1799,6 +1808,7 @@ public class RCompletionManager implements CompletionManager
    private String token_ ;
    
    private final DocDisplay docDisplay_;
+   private final boolean isConsole_;
 
    private final Invalidation invalidation_ = new Invalidation();
    private CompletionRequestContext context_ ;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -431,7 +431,8 @@ public class AceEditor implements DocDisplay,
                   new Filter(),
                   rContext_,
                   fileType_.canExecuteChunks() ? rnwContext_ : null,
-                  this);
+                  this,
+                  false);
             
             // if this is cpp then we use our own completion manager
             // that can optionally delegate to the R completion manager

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/RCompletionToolTip.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/RCompletionToolTip.java
@@ -29,16 +29,20 @@ public class RCompletionToolTip extends CppCompletionToolTip
       
    }
    
-   public void previewKeyDown(NativeEvent event)
+   public boolean previewKeyDown(NativeEvent event)
    {
       if (!isShowing())
-         return;
+         return false;
       
       if (event.getKeyCode() == KeyCodes.KEY_ESCAPE)
       {
+         event.stopPropagation();
+         event.preventDefault();
          hide();
-         return;
+         return true;
       }
+      
+      return false;
    }
    
    public void resolvePositionAndShow(String signature,


### PR DESCRIPTION
This has a couple changes:
1. Minor copy edit to the UI pref for console 'automatic' completions
2.  Add `isConsole` parameter to the `RCompletionManager` constructor -- this is necessary for us to respect the 'console automatic' completions option; as it was the option disabled automatic completions both in source and console pane.
3. Respect the 'show signature tips' option.
4. Don't let event propagate on escape when sigtip is showing (this ensures that e.g. if the sigtip is showing in the console and we hit escape, we dismiss the tip without clearing the console)
