### PR TITLE
don't auto-popup following '(' in comment

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -602,7 +602,7 @@ public class RCompletionManager implements CompletionManager
                input_.getCursorPosition().getColumn() - 1); 
          
          // Automatically popup completions after certain function calls
-         if (c == '(')
+         if (c == '(' && !isLineInComment(docDisplay_.getCurrentLine()))
          {
             String token = StringUtil.getToken(
                   docDisplay_.getCurrentLine(),


### PR DESCRIPTION
This fixes an issue where e.g. `#' @param data(` could trigger autocompletions.
