### PR TITLE
fix bug where help might display in corner

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
@@ -134,8 +134,12 @@ public class CompletionPopupPanel extends ThemedPopupPanel
          setPopupPositionAndShow(callback) ;
       else
          show() ;
+      
       if (help_ != null)
-         resolveHelpPosition(help_.isVisible());
+         if (completionListIsOnScreen())
+            resolveHelpPosition(help_.isVisible());
+         else
+            help_.hide();
    }
    
    public QualifiedName getSelectedValue()
@@ -190,11 +194,17 @@ public class CompletionPopupPanel extends ThemedPopupPanel
    {
       help_.setVisible(visible);
    }
+   
+   private boolean completionListIsOnScreen()
+   {
+      return list_ != null && list_.isAttached() &&
+             getAbsoluteLeft() >= 0 && getAbsoluteTop() >= 0;
+   }
 
    @Override
    public void displayHelp(ParsedInfo help)
    {
-      if (list_ == null || !list_.isAttached())
+      if (!completionListIsOnScreen())
          return;
       
       help_.displayHelp(help) ;
@@ -204,7 +214,7 @@ public class CompletionPopupPanel extends ThemedPopupPanel
    @Override
    public void displayParameterHelp(Map<String, String> map, String parameterName)
    {
-      if (list_ == null || !list_.isAttached())
+      if (!completionListIsOnScreen())
          return;
       
       help_.displayParameterHelp(map, parameterName) ;
@@ -214,7 +224,7 @@ public class CompletionPopupPanel extends ThemedPopupPanel
    @Override
    public void displayPackageHelp(ParsedInfo help)
    {
-      if (list_ == null || !list_.isAttached())
+      if (!completionListIsOnScreen())
          return;
       
       help_.displayPackageHelp(help);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1478,7 +1478,7 @@ public class RCompletionManager implements CompletionManager
                // Show an empty popup message offscreen -- this is a hack to
                // ensure that we can get completion results on backspace after a
                // failed completion, e.g. 'stats::rna' -> 'stats::rn'
-               Rectangle offScreen = new Rectangle(-100, -100, 0, 0);
+               Rectangle offScreen = new Rectangle(-1000, -1000, 0, 0);
                popup_.showErrorMessage(
                      "",
                      new PopupPositioner(offScreen, popup_));


### PR DESCRIPTION
This fixed a bug that might cause the help to display in the top left corner of the screen.

As part of a 'hack' to handle backspace in the completion list, we display the popup off-screen, but allow the current 'completion context' to remain active. This ensures that the current set of completions can be displayed if you mistype a token and later hit backspace.

We now double-check that the completion list is actually on-screen before displaying help.
