### PR TITLE
delay auto-popup; don't show if token matches only possible completion

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupDisplay.java
@@ -41,6 +41,8 @@ public interface CompletionPopupDisplay
    boolean isShowing() ;
 
    void setPopupPosition(int x, int y) ;
+   void placeOffscreen();
+   boolean isOffscreen();
    int getPopupLeft();
    int getPopupTop();
    
@@ -72,4 +74,5 @@ public interface CompletionPopupDisplay
    boolean isHelpVisible() ;
    
    boolean hasCompletions();
+   int numAvailableCompletions();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
@@ -66,6 +66,17 @@ public class CompletionPopupPanel extends ThemedPopupPanel
       setVisible(false);
       help_.setVisible(false);
    }
+   
+   public void placeOffscreen()
+   {
+      setPopupPosition(-10000, -10000);
+   }
+   
+   public boolean isOffscreen()
+   {
+      return getAbsoluteLeft() + getOffsetWidth() < 0 &&
+             getAbsoluteTop() + getOffsetHeight() < 0;
+   }
 
    public void showProgress(String progress, PositionCallback callback)
    {
@@ -122,10 +133,16 @@ public class CompletionPopupPanel extends ThemedPopupPanel
       show(callback) ;
    }
    
-   public boolean hasCompletions() {
+   public boolean hasCompletions()
+   {
       if (list_ == null)
          return false;
       return list_.getItemCount() > 0;
+   }
+   
+   public int numAvailableCompletions()
+   {
+      return list_.getItemCount();
    }
 
    private void show(PositionCallback callback)


### PR DESCRIPTION
This PR tweaks the presentation of automatic popups a bit. We use a single timer that is re-scheduled and cancelled as necessary, and if we see more than 400ms of inactivity from the user then we go ahead with an auto-popup.

We also forego displaying the completion list if there is only one available completion and the token matches that exactly.
