### PR TITLE
fix r completions in cpp mode

### DIFF
--- a/src/gwt/acesupport/acemode/c_cpp.js
+++ b/src/gwt/acesupport/acemode/c_cpp.js
@@ -64,7 +64,7 @@ var Mode = function(suppressHighlighting, doc, session) {
    // R-related tokenization
    this.$r_outdent = {};
    oop.implement(this.$r_outdent, RMatchingBraceOutdent);
-   this.$r_codeModel = new RCodeModel(doc, this.$tokenizer, /^r-/, /^\s*\/\*{3,}\s+[Rr]\s*$/);
+   this.r_codeModel = new RCodeModel(doc, this.$tokenizer, /^r-/, /^\s*\/\*{3,}\s+(.*)\s*$/);
 
    // C/C++ related tokenization
    this.codeModel = new CppCodeModel(session, this.$tokenizer);
@@ -163,7 +163,7 @@ oop.inherits(Mode, TextMode);
 
       // Defer to the R language indentation rules when in R language mode
       if (this.inRLanguageMode(state))
-         return this.$r_codeModel.getNextLineIndent(row, line, state, tab, tabSize);
+         return this.r_codeModel.getNextLineIndent(row, line, state, tab, tabSize);
       else
          return this.codeModel.getNextLineIndent(row, line, state, tab, tabSize, dontSubset);
 
@@ -178,7 +178,7 @@ oop.inherits(Mode, TextMode);
 
    this.autoOutdent = function(state, doc, row) {
       if (this.inRLanguageMode(state))
-         return this.$r_outdent.autoOutdent(state, doc, row, this.$r_codeModel);
+         return this.$r_outdent.autoOutdent(state, doc, row, this.r_codeModel);
       else
          return this.$outdent.autoOutdent(state, doc, row);
    };

--- a/src/gwt/acesupport/acemode/cpp_code_model.js
+++ b/src/gwt/acesupport/acemode/cpp_code_model.js
@@ -289,31 +289,6 @@ var CppCodeModel = function(session, tokenizer, statePattern, codeBeginPattern) 
             return match[2];
       }
 
-      function getChunkLabel(reOptions, comment) {
-         var match = reOptions.exec(comment);
-         if (!match)
-            return null;
-         var value = match[1];
-         var values = value.split(',');
-         if (values.length == 0)
-            return null;
-
-         // If first arg has no =, it's a label
-         if (!/=/.test(values[0])) {
-            return values[0].replace(/(^\s+)|(\s+$)/g, '');
-         }
-
-         for (var i = 0; i < values.length; i++) {
-            match = /^\s*label\s*=\s*(.*)$/.exec(values[i]);
-            if (match) {
-               return maybeEvaluateLiteralString(
-                                        match[1].replace(/(^\s+)|(\s+$)/g, ''));
-            }
-         }
-
-         return null;
-      }
-
       var maxRow = Math.min(maxrow + 30, this.$doc.getLength() - 1);
       this.$tokenUtils.$tokenizeUpToRow(maxRow);
 
@@ -342,18 +317,15 @@ var CppCodeModel = function(session, tokenizer, statePattern, codeBeginPattern) 
 
             this.$scopes.onSectionHead(label, tokenCursor.currentPosition());
          }
+         
          else if (/\bcodebegin\b/.test(tokenType))
          {
             var chunkStartPos = tokenCursor.currentPosition();
             var chunkPos = {row: chunkStartPos.row + 1, column: 0};
             var chunkNum = this.$scopes.getTopLevelScopeCount()+1;
-            var chunkLabel = getChunkLabel(this.$codeBeginPattern,
-                                           tokenCursor.currentValue());
-            var scopeName = "Chunk " + chunkNum;
-            if (chunkLabel)
-               scopeName += ": " + chunkLabel;
+            var chunkLabel = "(R Code Chunk)";
             this.$scopes.onChunkStart(chunkLabel,
-                                      scopeName,
+                                      chunkLabel,
                                       chunkStartPos,
                                       chunkPos);
          }

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1126,6 +1126,10 @@ var RCodeModel = function(doc, tokenizer, statePattern, codeBeginPattern) {
       }
 
       function getChunkLabel(reOptions, comment) {
+
+         if (typeof reOptions === "undefined")
+            return "";
+         
          var match = reOptions.exec(comment);
          if (!match)
             return null;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -360,7 +360,7 @@ public class CompletionRequester
       {
          Position cursorPosition =
                editor.getSession().getSelection().getCursor();
-         CodeModel codeModel = editor.getSession().getMode().getCodeModel();
+         CodeModel codeModel = editor.getSession().getMode().getRCodeModel();
          JsArray<RFunction> scopedFunctions =
                codeModel.getFunctionsInScope(cursorPosition);
          
@@ -416,7 +416,7 @@ public class CompletionRequester
       {
          Position cursorPosition =
                editor.getSession().getSelection().getCursor();
-         CodeModel codeModel = editor.getSession().getMode().getCodeModel();
+         CodeModel codeModel = editor.getSession().getMode().getRCodeModel();
       
          JsArray<RScopeObject> scopeVariables =
                codeModel.getVariablesInScope(cursorPosition);
@@ -447,7 +447,7 @@ public class CompletionRequester
       {
          Position cursorPosition =
                editor.getSession().getSelection().getCursor();
-         CodeModel codeModel = editor.getSession().getMode().getCodeModel();
+         CodeModel codeModel = editor.getSession().getMode().getRCodeModel();
          
          // Try to see if we can find a function name
          TokenCursor cursor = codeModel.getTokenCursor();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -964,7 +964,7 @@ public class RCompletionManager implements CompletionManager
       AceEditor editor = (AceEditor) docDisplay_;
       if (editor != null)
       {
-         CodeModel codeModel = editor.getSession().getMode().getCodeModel();
+         CodeModel codeModel = editor.getSession().getMode().getRCodeModel();
          TokenCursor cursor = codeModel.getTokenCursor();
          
          if (cursor.moveToPosition(input_.getCursorPosition()))
@@ -1136,7 +1136,7 @@ public class RCompletionManager implements CompletionManager
       if (editor == null)
          return false;
       
-      CodeModel codeModel = editor.getSession().getMode().getCodeModel();
+      CodeModel codeModel = editor.getSession().getMode().getRCodeModel();
       codeModel.tokenizeUpToRow(input_.getCursorPosition().getRow());
       
       TokenCursor cursor = codeModel.getTokenCursor();
@@ -1241,7 +1241,7 @@ public class RCompletionManager implements CompletionManager
       if (editor == null)
          return context;
       
-      CodeModel codeModel = editor.getSession().getMode().getCodeModel();
+      CodeModel codeModel = editor.getSession().getMode().getRCodeModel();
       
       // We might need to grab content from further up in the document than
       // the current cursor position -- so tokenize ahead.
@@ -1640,7 +1640,7 @@ public class RCompletionManager implements CompletionManager
          if (editor != null)
          {
             TokenCursor cursor =
-                  editor.getSession().getMode().getCodeModel().getTokenCursor();
+                  editor.getSession().getMode().getRCodeModel().getTokenCursor();
             cursor.moveToPosition(editor.getCursorPosition());
             if (cursor.moveToNextToken())
             {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Mode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Mode.java
@@ -42,6 +42,13 @@ public class Mode extends JavaScriptObject
    public native final CodeModel getCodeModel() /*-{
       return this.codeModel || {};
    }-*/;
+   
+   public native final CodeModel getRCodeModel() /*-{
+      if (typeof this.r_codeModel !== "undefined")
+         return this.r_codeModel;
+      else
+         return this.codeModel || {};
+   }-*/;
 
    public native final String getLanguageMode(Position position) /*-{
       if (!this.getLanguageMode)


### PR DESCRIPTION
Completions inside of R chunks in C++ mode, e.g.

```
/*** R

*/
```

were broken in C++ mode -- there, we were erroneously grabbing the C++ code model, rather than the R code model, and attempting to use that for completions. We now ensure that anything using the R completion frameworks grabs the R code model, rather than the 'primary' code model.

Somewhere along the line (e.g. if we plan on adding any more code models, or more embedded modes) we should consider making `CodeModel` an abstract class with e.g. `RCodeModel`, `CppCodeModel` extending those.
