### PR TITLE
better handling of preproc statement indentation

### DIFF
--- a/src/gwt/acesupport/acemode/c_cpp_matching_brace_outdent.js
+++ b/src/gwt/acesupport/acemode/c_cpp_matching_brace_outdent.js
@@ -64,9 +64,9 @@ var $alignCase                 = true; // case 'a':
          }
 
          // outdenting for lines starting with 'closers' and 'openers'
-         if (/^\s*[\{\}\>\]\)<.:]/.test(input)) {
+         // also preproc lines
+         if (/^\s*[#\{\}\>\]\)<.:]/.test(input))
             return true;
-         }
 
          // outdenting for '='
          if (input === "=")
@@ -387,7 +387,9 @@ var $alignCase                 = true; // case 'a':
       }
 
       // Similar lookback for 'case foo:'.
-      if ($alignCase && /^\s*case.+:/.test(line)) {
+      if ($alignCase &&
+          (/^\s*case.+:/.test(line) || /^\s*default\s*:/.test(line)))
+      {
 
          // Find the associated open bracket.
          var openBracePos = session.$findOpeningBracket(
@@ -468,6 +470,17 @@ var $alignCase                 = true; // case 'a':
 
          }
 
+      }
+
+      // For lines intended for the preprocessor, trim off the indentation.
+      if (/^\s*#/.test(line))
+      {
+         var oldIndent = this.$getIndent(line);
+         doc.replace(
+            new Range(row, 0, row, oldIndent.length),
+            ""
+         );
+         return;
       }
 
    };

--- a/src/gwt/test/autoindent_test_cpp.html
+++ b/src/gwt/test/autoindent_test_cpp.html
@@ -102,10 +102,15 @@ struct some_tag_struct_with_block_comment_above{} ;
 </pre></li>
 
 <li><pre data-expected="0">
-template <
+template &lt;
     int RTYPE
-> class
+&gt; class
 foo;
+</pre></li>
+
+<li><pre data-expected="4">
+template &lt;
+    int RTYPE,
 </pre></li>
 
 <li><pre data-expected="4">


### PR DESCRIPTION
This PR does a few minor things:
1. Preprocessor lines are pushed to the start of line, so they don't have their own indent, and are skipped for the purposes of determining the indentation of other lines.
2. `default:` is properly aligned as with `case 'x':` statements (it had been left out)
