### PR TITLE
refine shortcut handling for completion popup

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -322,7 +322,7 @@ public class RCompletionManager implements CompletionManager
        * 
        * When popup showing:
        * Esc - dismiss popup
-       * Enter - accept current selection
+       * Enter/Tab - accept current selection
        * Up-arrow/Down-arrow - change selected item
        * [identifier] - narrow suggestions--or if we're lame, just dismiss
        * All others - dismiss popup
@@ -422,16 +422,10 @@ public class RCompletionManager implements CompletionManager
                   if (value != null)
                   {
                      if (value.type == RCompletionType.DIRECTORY)
-                     {
                         context_.suggestOnAccept_ = true;
                      
-                        context_.onSelection(value);
-                        return true;
-                     }
-                     else
-                     {
-                        return false;
-                     }
+                     context_.onSelection(value);
+                     return true;
                   }
                }
                

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
@@ -241,6 +241,13 @@ public class CppCompletionManager implements CompletionManager
             return false;
          }
          
+         // tab accepts the current selection (popup handles Enter)
+         else if (event.getKeyCode() == KeyCodes.KEY_TAB)
+         {
+            popup.acceptSelected();
+            return true;
+         }
+         
          // non c++ identifier keys (that aren't navigational) close the popup
          else if (!CppCompletionUtils.isCppIdentifierKey(event))
          {


### PR DESCRIPTION
- No special handling for Left/Right/Home/End
- Tab only accepts for case of continuing a directory completion into a it's subdirectory
