### PR TITLE
fix packrat initialization order

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1731,9 +1731,12 @@ Error rInit(const r::session::RInitInfo& rInitInfo)
 void rDeferredInit(bool newSession)
 {
    module_context::events().onDeferredInit(newSession);
-
+   
    // allow any packages listening to complete initialization
    modules::rhooks::invokeHook(kSessionInitHook, newSession);
+   
+   // finish off initialization
+   module_context::events().afterDeferredInit(newSession);
    
    // fire an event to the client
    ClientEvent event(client_events::kDeferredInitCompleted);

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -289,6 +289,7 @@ struct Events : boost::noncopyable
    boost::signal<void (ChangeSource)>        onDetectChanges;
    boost::signal<void (core::FilePath)>      onSourceEditorFileSaved;
    boost::signal<void(bool)>                 onDeferredInit;
+   boost::signal<void(bool)>                 afterDeferredInit;
    boost::signal<void(bool)>                 onBackgroundProcessing;
    boost::signal<void(bool)>                 onShutdown;
    boost::signal<void ()>                    onQuit;

--- a/src/cpp/session/modules/SessionPackrat.cpp
+++ b/src/cpp/session/modules/SessionPackrat.cpp
@@ -860,7 +860,7 @@ void activatePackagesIfPendingActions()
    }
 }
 
-void onDeferredInit(bool newSession)
+void afterDeferredInit(bool newSession)
 {
    // additional stuff if we are in packrat mode
    if (module_context::packratContext().modeOn)
@@ -980,7 +980,10 @@ Error initialize()
    // we need to wait until all other modules initialize and all R routines
    // are initialized -- otherwise the package load hook attempts to call
    // rs_packageLoaded and can't find it
-   module_context::events().onDeferredInit.connect(onDeferredInit);
+   //
+   // we want this to occur _after_ packrat has done its own initialization,
+   // so we ensure that the package hooks are run before this
+   module_context::events().afterDeferredInit.connect(afterDeferredInit);
 
    // register packrat action hook
    R_CallMethodDef onPackratActionMethodDef ;


### PR DESCRIPTION
This one is subtle -- the 'deferred initialization' in SessionPackrat.cpp needs to occur _after_ Packrat's init script has run, as this does some work of e.g. setting environment variables and so on. If that isn't set, then the deferred init believes that Packrat mode is not on, and doesn't hook up any of the file monitors and so on.

In other words, previously, we would:
1. Call `SessionPackrat`'s `onDeferredInit`. Because `packrat/init.R` had not yet been run, the initialization believed Packrat was not available.
2. Call `packrat/init.R` -- the rest of the RStudio wiring turns on.

This PR ensures that package hooks are run before things registered on `afterDeferredInit` -- and I am somewhat confused as to why it ever worked before.
