### PR TITLE
Minor tweaks to R mode indentation

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -81,7 +81,7 @@ assign(x = ".rs.acCompletionTypes",
    else if (isS4(object))
    {
       if (inherits(object, "standardGeneric") ||
-             inherits(object, "nonstandardGenericFunction"))
+          inherits(object, "nonstandardGenericFunction"))
          .rs.acCompletionTypes$S4_GENERIC
       else if (inherits(object, "MethodDefinition"))
          .rs.acCompletionTypes$S4_METHOD
@@ -1120,7 +1120,7 @@ assign(x = ".rs.acCompletionTypes",
          if (identical(currentEnv, encounteredEnvs[[i]]))
             return(.rs.emptyCompletions())
       }
-         
+      
       objects <- objects(currentEnv, all.names = TRUE)
       
       completions <- c(completions, objects)
@@ -1328,8 +1328,8 @@ assign(x = ".rs.acCompletionTypes",
    
    # data
    if (.rs.acContextTypes$FUNCTION %in% type &&
-          string[[1]] == "data" &&
-          numCommas[[1]] == 0)
+       string[[1]] == "data" &&
+       numCommas[[1]] == 0)
       return(.rs.getCompletionsData(token))
    
    # No information on completions other than token
@@ -1391,7 +1391,7 @@ assign(x = ".rs.acCompletionTypes",
    
    # library, require, requireNamespace, loadNamespace
    if (string[[1]] %in% c("library", "require", "requireNamespace") &&
-          numCommas[[1]] == 0)
+       numCommas[[1]] == 0)
    {
       return(.rs.getCompletionsPackages(token, excludeOtherCompletions = TRUE))
    }
@@ -1434,8 +1434,8 @@ assign(x = ".rs.acCompletionTypes",
    ## Completions for server.r (from ui.r)
    if (type[[1]] %in% c(.rs.acContextTypes$DOLLAR,
                         .rs.acContextTypes$DOUBLE_BRACKET) &&
-          tolower(basename(filePath)) == "server.r" &&
-          string[[1]] %in% c("input", "output"))
+       tolower(basename(filePath)) == "server.r" &&
+       string[[1]] %in% c("input", "output"))
    {
       completions <- .rs.getCompletionsFromShinyUI(token, filePath, string[[1]], type[[1]])
       if (!is.null(completions))
@@ -1444,8 +1444,8 @@ assign(x = ".rs.acCompletionTypes",
    
    ## Completions for server.r, on session
    if (type[[1]] == .rs.acContextTypes$DOLLAR &&
-          tolower(basename(filePath)) == "server.r" &&
-          string[[1]] == "session")
+       tolower(basename(filePath)) == "server.r" &&
+       string[[1]] == "session")
    {
       completions <- rs.getCompletionsShinySession(token)
       if (!is.null(completions))
@@ -1454,9 +1454,9 @@ assign(x = ".rs.acCompletionTypes",
    
    ## Completions for ui.r (from server.r)
    if (type[[1]] == .rs.acContextTypes$FUNCTION &&
-          tolower(basename(filePath)) == "ui.r" &&
-          numCommas[[1]] == 0 &&
-          (.rs.endsWith(string[[1]], "Input") || .rs.endsWith(string[[1]], "Output")))
+       tolower(basename(filePath)) == "ui.r" &&
+       numCommas[[1]] == 0 &&
+       (.rs.endsWith(string[[1]], "Input") || .rs.endsWith(string[[1]], "Output")))
    {
       completions <- .rs.getCompletionsFromShinyServer(token, filePath, string[[1]], type[[1]])
       if (!is.null(completions))
@@ -1550,11 +1550,11 @@ assign(x = ".rs.acCompletionTypes",
    
    # get completions from the search path for the 'generic' contexts
    if (token != "" &&
-          type[[1]] %in% c(.rs.acContextTypes$UNKNOWN,
-                           .rs.acContextTypes$FUNCTION,
-                           .rs.acContextTypes$ARGUMENT,
-                           .rs.acContextTypes$SINGLE_BRACKET,
-                           .rs.acContextTypes$DOUBLE_BRACKET))
+       type[[1]] %in% c(.rs.acContextTypes$UNKNOWN,
+                        .rs.acContextTypes$FUNCTION,
+                        .rs.acContextTypes$ARGUMENT,
+                        .rs.acContextTypes$SINGLE_BRACKET,
+                        .rs.acContextTypes$DOUBLE_BRACKET))
    {
       completions <- Reduce(.rs.appendCompletions, list(
          completions,
@@ -1979,7 +1979,7 @@ assign(x = ".rs.acCompletionTypes",
    info <- file.info(file)
    mtime <- info[1, "mtime"]
    if (identical(mtime, .rs.get(fileCacheName)) &&
-          !is.null(.rs.get(completionsCacheName)))
+       !is.null(.rs.get(completionsCacheName)))
    {
       return(.rs.get(completionsCacheName))
    }
@@ -2070,7 +2070,7 @@ assign(x = ".rs.acCompletionTypes",
    info <- file.info(file)
    mtime <- info[1, "mtime"]
    if (identical(mtime, .rs.get(fileCacheName)) &&
-          !is.null(.rs.get(completionsCacheName)))
+       !is.null(.rs.get(completionsCacheName)))
    {
       return(.rs.get(completionsCacheName))
    }
@@ -2285,7 +2285,7 @@ assign(x = ".rs.acCompletionTypes",
       # Bail if we couldn't find anything
       if (is.null(pkg))
          return(.rs.emptyCompletions())
-         
+      
       ## Make a dummy function to match a call against
       argsText <- paste(args, collapse = ", ")
       dummyFunction <- tryCatch(

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1368,7 +1368,8 @@ var RCodeModel = function(doc, tokenizer, statePattern, codeBeginPattern) {
                   // Technically repeat would be legal too,
                   // as rare as it would be...
                   var clone = tokenCursor.cloneCursor();
-                  if (clone.moveToPreviousToken())
+                  if (clone.findStartOfEvaluationContext() &&
+                      clone.moveToPreviousToken())
                   {
                      if (clone.currentValue() === "else" ||
                          clone.currentValue() === "repeat")

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1318,7 +1318,7 @@ var RCodeModel = function(doc, tokenizer, statePattern, codeBeginPattern) {
             {
                return this.getIndentForOpenBrace(
                   tokenCursor.currentPosition()
-               ) + tab;
+               ) + tab + continuationIndent;
             }
                   
             // If we found an assignment token, use that for indentation

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1089,7 +1089,6 @@ var RCodeModel = function(doc, tokenizer, statePattern, codeBeginPattern) {
          // previous line (i.e. the last significant token is a binary operator).
          var continuationIndent = "";
          var startedOnOperator = false;
-         var startedOnAssign = false;
 
          if (prevToken &&
              /\boperator\b/.test(prevToken.token.type) &&
@@ -1103,10 +1102,6 @@ var RCodeModel = function(doc, tokenizer, statePattern, codeBeginPattern) {
             continuationIndent = tab;
             startedOnOperator = true;
             var tokenValue = prevToken.token.value;
-            startedOnAssign = ["<-", "->", "=", "<<-"].some(function(x) {
-               return x === tokenValue;
-            });
-             
          }
 
          else if (prevToken

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1430,29 +1430,6 @@ var RCodeModel = function(doc, tokenizer, statePattern, codeBeginPattern) {
                // We broke out of the loop; we should be on the
                // appropriate line to provide for indentation now.
 
-               // If the line we ended on ends with an assignment
-               // token, but the line we started on did not, then add
-               // an extra continuation indent.
-               //
-               // Ie, support:
-               //
-               //     x <-
-               //         1 +
-               //             |
-               //             ^
-               if (tokenCursor.$row !== startPos.row)
-               {
-                  var rowTokens = tokenCursor.$tokens[tokenCursor.$row];
-                  if (rowTokens != null)
-                  {
-                     tokenCursor.$offset = rowTokens.length - 1;
-                     if (pAssign(tokenCursor.currentToken()))
-                     {
-                        continuationIndent += continuationIndent;
-                     }
-                  }
-               }
-
                return this.$getIndent(
                   this.$getLine(tokenCursor.$row)
                ) + continuationIndent;

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1158,11 +1158,9 @@ var RCodeModel = function(doc, tokenizer, statePattern, codeBeginPattern) {
          tokenCursor.moveToPosition(startPos);
 
          // The first loop looks for an open brace for indentation.
-         var encounteredBrace = false;
          do
          {
             var currentValue = tokenCursor.currentValue();
-            encounteredBrace = encounteredBrace || currentValue === "}";
              
             // Walk over matching braces ('()', '{}', '[]')
             if (tokenCursor.bwdToMatchingToken())
@@ -1173,25 +1171,6 @@ var RCodeModel = function(doc, tokenizer, statePattern, codeBeginPattern) {
             // token.
             if (currentValue === "{")
                break;
-
-            // If we hit a keyword like 'if', 'else' and so on,
-            // use that line's indentation.
-            if (!encounteredBrace &&["if", "else", "repeat", "while", "for"].some(function(x) {
-               return x === currentValue;
-            }))
-            {
-               // NOTE: We add the continuation indent twice as we
-               // may have seen e.g.
-               //
-               //     if (foo)
-               //         x +
-               //
-               // in which case we want to use the indentation of
-               // the 'if' statement, with _two_ tabs.
-               return this.$getIndent(
-                  this.$doc.getLine(tokenCursor.$row)
-               ) + continuationIndent + continuationIndent;
-            }
 
             // If we find an open parenthesis or bracket, we
             // can use this to provide the indentation context.

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1168,7 +1168,7 @@ var RCodeModel = function(doc, tokenizer, statePattern, codeBeginPattern) {
                {
                   return this.getIndentForOpenBrace(
                      tokenCursor.currentPosition()
-                  );
+                  ) + continuationIndent;
                }
 
                // Otherwise, move backwards one and keep going

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1158,33 +1158,25 @@ var RCodeModel = function(doc, tokenizer, statePattern, codeBeginPattern) {
          tokenCursor.moveToPosition(startPos);
 
          // The first loop looks for an open brace for indentation.
+         var encounteredBrace = false;
          do
          {
+            var currentValue = tokenCursor.currentValue();
+            encounteredBrace = encounteredBrace || currentValue === "}";
+             
             // Walk over matching braces ('()', '{}', '[]')
             if (tokenCursor.bwdToMatchingToken())
-            {
-               // If we ended up on a '{', we want to get its indentation.
-               if (tokenCursor.currentValue() === "{")
-               {
-                  return this.getIndentForOpenBrace(
-                     tokenCursor.currentPosition()
-                  ) + continuationIndent;
-               }
-
-               // Otherwise, move backwards one and keep going
                continue;
-            }
 
             // If we found a '{', we break out and loop back -- this is because
             // we may want to indent either on a '<-' token or on a '{'
             // token.
-            var currentValue = tokenCursor.currentValue();
             if (currentValue === "{")
                break;
 
             // If we hit a keyword like 'if', 'else' and so on,
             // use that line's indentation.
-            if (["if", "else", "repeat", "while", "for"].some(function(x) {
+            if (!encounteredBrace &&["if", "else", "repeat", "while", "for"].some(function(x) {
                return x === currentValue;
             }))
             {

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1347,6 +1347,9 @@ var RCodeModel = function(doc, tokenizer, statePattern, codeBeginPattern) {
                   //
                   //    if (foo)
                   //        x <- 1
+                  //
+                  // In such cases, we rely on the 'naked' control identifier
+                  // to provide the appropriate indentation.
                   var clone = tokenCursor.cloneCursor();
                   if (clone.moveToPreviousToken())
                   {

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1329,10 +1329,6 @@ var RCodeModel = function(doc, tokenizer, statePattern, codeBeginPattern) {
             // If we found an assignment token, use that for indentation
             if (pAssign(tokenCursor.currentToken()))
             {
-               // boolean to indicate whether we can successfully indent
-               // for an assignment token
-               var success = true;
-               
                while (pAssign(tokenCursor.currentToken()))
                {
                   // Move off of the assignment token
@@ -1387,7 +1383,6 @@ var RCodeModel = function(doc, tokenizer, statePattern, codeBeginPattern) {
 
                // We broke out of the loop; we should be on the
                // appropriate line to provide for indentation now.
-
                return this.$getIndent(
                   this.$getLine(tokenCursor.$row)
                ) + continuationIndent;
@@ -1465,6 +1460,7 @@ var RCodeModel = function(doc, tokenizer, statePattern, codeBeginPattern) {
                      count++ < maxTokensToWalk);
          }
 
+         // All else fails -- just indent based on the first token.
          var firstToken = this.$findNextSignificantToken(
             {row: 0, column: 0},
             lastRow

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1360,13 +1360,10 @@ var RCodeModel = function(doc, tokenizer, statePattern, codeBeginPattern) {
                         break;
 
                   // Make sure this isn't the only assignment within a 'naked'
-                  // if or else, e.g.
+                  // control flow section
                   //
                   //    if (foo)
                   //        x <- 1
-                  //
-                  // Technically repeat would be legal too,
-                  // as rare as it would be...
                   var clone = tokenCursor.cloneCursor();
                   if (clone.findStartOfEvaluationContext() &&
                       clone.moveToPreviousToken())
@@ -1379,11 +1376,16 @@ var RCodeModel = function(doc, tokenizer, statePattern, codeBeginPattern) {
                      }
 
                      if (clone.bwdToMatchingToken() &&
-                         clone.moveToPreviousToken() &&
-                         clone.currentValue() === "if")
+                         clone.moveToPreviousToken())
                      {
-                        success = false;
-                        break;
+                        var currentValue = clone.currentValue();
+                        if (["if", "for", "while", "repeat", "else"].some(function(x) {
+                           return x === currentValue;
+                        }))
+                        {
+                           success = false;
+                           break;
+                        }
                      }
                   }
 

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1178,8 +1178,28 @@ var RCodeModel = function(doc, tokenizer, statePattern, codeBeginPattern) {
             // If we found a '{', we break out and loop back -- this is because
             // we may want to indent either on a '<-' token or on a '{'
             // token.
-            if (tokenCursor.currentValue() === "{")
+            var currentValue = tokenCursor.currentValue();
+            if (currentValue === "{")
                break;
+
+            // If we hit a keyword like 'if', 'else' and so on,
+            // use that line's indentation.
+            if (["if", "else", "repeat", "while", "for"].some(function(x) {
+               return x === currentValue;
+            }))
+            {
+               // NOTE: We add the continuation indent twice as we
+               // may have seen e.g.
+               //
+               //     if (foo)
+               //         x +
+               //
+               // in which case we want to use the indentation of
+               // the 'if' statement, with _two_ tabs.
+               return this.$getIndent(
+                  this.$doc.getLine(tokenCursor.$row)
+               ) + continuationIndent + continuationIndent;
+            }
 
             // If we find an open parenthesis or bracket, we
             // can use this to provide the indentation context.

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -115,7 +115,7 @@ define("mode/r_highlight_rules", function(require, exports, module)
             },
             {
                token : "keyword.operator",
-               regex : "%%|>=|<=|==|!=|\\->|<\\-|\\|\\||&&|=|\\+|\\-|\\*|/|\\^|>|<|!|&|\\||~|\\$|:|@"
+               regex : "%%|>=|<=|==|!=|\\->|<\\-|<<\\-|\\|\\||&&|=|\\+|\\-|\\*|/|\\^|>|<|!|&|\\||~|\\$|:|@"
             },
             {
                token : "keyword.operator.infix", // infix operators

--- a/src/gwt/test/autoindent_test_r.html
+++ b/src/gwt/test/autoindent_test_r.html
@@ -306,6 +306,11 @@ if (length(foo))
     x <- bar()
 </pre></li>
 
+<li><pre data-expected="2">
+if () {}
+foo <- foo &
+</pre></li>
+
 </ol>
 
 <script type="text/javascript">

--- a/src/gwt/test/autoindent_test_r.html
+++ b/src/gwt/test/autoindent_test_r.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <!script type="text/javascript" src="../tools/ace/build_support/mini_require.js"></script>
-  <script type="text/javascript" src="../tools/ace/build/src/ace.js"></script>
+  <script type="text/javascript" src="../src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/ace.js"></script>
   <script type="text/javascript" src="../acesupport/acemode/auto_brace_insert.js"></script>
   <script type="text/javascript" src="../acesupport/acemode/tex_highlight_rules.js"></script>
   <script type="text/javascript" src="../acesupport/acemode/token_cursor.js"></script>
@@ -338,6 +338,12 @@ while ()
   else {}
   foo$bar <- x &
 </pre></li>
+
+<li><pre data-expected="4">
+{
+  x %in%
+</pre></li>
+
 
 </ol>
 

--- a/src/gwt/test/autoindent_test_r.html
+++ b/src/gwt/test/autoindent_test_r.html
@@ -321,6 +321,11 @@ foo <- function(x, y)
    if (x) y else x
 </pre></li>
 
+<li><pre data-expected="0">
+if ()
+  x$y <- 1
+</pre></li>
+
 </ol>
 
 <script type="text/javascript">

--- a/src/gwt/test/autoindent_test_r.html
+++ b/src/gwt/test/autoindent_test_r.html
@@ -265,6 +265,42 @@ x[1,
   3] <- 1
 </pre></li>
 
+<li><pre data-expected="4">
+if (foo) {
+  x <-
+</pre></li>
+
+<li><pre data-expected="4">
+x <-
+  y <-
+</pre></li>
+
+<li><pre data-expected="4">
+x <-
+  1 +
+</pre></li>
+
+<li><pre data-expected="4">
+{
+  x <-
+</pre></li>
+
+<li><pre data-expected="6">
+{
+  x <-
+    1 +
+</pre></li>
+
+<li><pre data-expected="4">
+plot(
+  x +
+</pre></li>
+
+<li><pre data-expected="2">
+foo(bar, function(x)
+{
+</pre></li>
+
 </ol>
 
 <script type="text/javascript">

--- a/src/gwt/test/autoindent_test_r.html
+++ b/src/gwt/test/autoindent_test_r.html
@@ -270,12 +270,12 @@ if (foo) {
   x <-
 </pre></li>
 
-<li><pre data-expected="4">
+<li><pre data-expected="2">
 x <-
   y <-
 </pre></li>
 
-<li><pre data-expected="4">
+<li><pre data-expected="2">
 x <-
   1 +
 </pre></li>
@@ -285,7 +285,7 @@ x <-
   x <-
 </pre></li>
 
-<li><pre data-expected="6">
+<li><pre data-expected="4">
 {
   x <-
     1 +

--- a/src/gwt/test/autoindent_test_r.html
+++ b/src/gwt/test/autoindent_test_r.html
@@ -311,6 +311,11 @@ if () {}
 foo <- foo &
 </pre></li>
 
+<li><pre data-expected="0">
+foo <- function()
+  function() {}
+</pre></li>
+
 </ol>
 
 <script type="text/javascript">

--- a/src/gwt/test/autoindent_test_r.html
+++ b/src/gwt/test/autoindent_test_r.html
@@ -326,6 +326,14 @@ if ()
   x$y <- 1
 </pre></li>
 
+<li><pre data-expected="0">
+while ()
+  x[
+    1, 2, 3
+  ] <- 1
+</pre></li>
+
+
 </ol>
 
 <script type="text/javascript">

--- a/src/gwt/test/autoindent_test_r.html
+++ b/src/gwt/test/autoindent_test_r.html
@@ -316,6 +316,11 @@ foo <- function()
   function() {}
 </pre></li>
 
+<li><pre data-expected="0">
+foo <- function(x, y)
+   if (x) y else x
+</pre></li>
+
 </ol>
 
 <script type="text/javascript">

--- a/src/gwt/test/autoindent_test_r.html
+++ b/src/gwt/test/autoindent_test_r.html
@@ -333,6 +333,11 @@ while ()
   ] <- 1
 </pre></li>
 
+<li><pre data-expected="4">
+{
+  else {}
+  foo$bar <- x &
+</pre></li>
 
 </ol>
 

--- a/src/gwt/test/autoindent_test_r.html
+++ b/src/gwt/test/autoindent_test_r.html
@@ -301,6 +301,11 @@ foo(bar, function(x)
 {
 </pre></li>
 
+<li><pre data-expected="0">
+if (length(foo))
+    x <- bar()
+</pre></li>
+
 </ol>
 
 <script type="text/javascript">


### PR DESCRIPTION
This PR further refines indentation in R modes, by conditionally indenting on assignment operators when appropriate.

Briefly, the indentation code works as follows:

1. Find an opening `[`, `(`, or `{` to provide for indentation.
2. If we find a `(` or `[`, we can use that for indentation (re-using pre-existing indentation code),
3. If we find a `{`, then we backtrack and attempt to first indent on an assignment operator (`=`, `<-`) first; otherwise, we indent based on the found `{` (plus indentation).

I also added some new tests to the R auto-indent and we now pass on all tests.

One of the main 'features' in this PR -- if we choose to vertically align, then we indent:

```R
if (a &&
    b &&
    c)
```

and

```R
plot(x = x +
         1,
     y = y +
         2
)
```

; ie, we can better discriminate on what is providing the 'scope' for a current expression.