### PR TITLE
Enable autocompletions for some knitr `opts_*` functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
     - Completions for dimension names in `[`, `[[` calls
     - Completions from packages in `library`, `require` calls automatically
       inferred and supplied even when not loaded
+    - Completions for knitr options, e.g. in `opts_chunk$get()`, are now supplied
 * Improvements to C/C++ editing mode:
     - Code completion
     - F2 code navigation (go to definition)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1306,22 +1306,6 @@ public class RCompletionManager implements CompletionManager
       
       TokenCursor startCursor = tokenCursor.cloneCursor();
       
-      // If this is an argument, return auto-completions tuned to that argument
-      TokenCursor argsCursor = startCursor.cloneCursor();
-      if (argsCursor.currentType() == "identifier")
-         argsCursor.moveToPreviousToken();
-      
-      if (argsCursor.currentValue() == "=")
-      {
-         if (argsCursor.moveToPreviousToken())
-         {
-            return new AutocompletionContext(
-                  token,
-                  argsCursor.currentValue(),
-                  AutocompletionContext.TYPE_ARGUMENT);
-         }
-      }
-      
       // Find an opening '(' or '[' -- this provides the function or object
       // for completion.
       int initialNumCommas = 0;
@@ -1416,6 +1400,33 @@ public class RCompletionManager implements CompletionManager
       
       context.setFunctionCallString(
             (beforeText + afterText).trim());
+      
+      // If this is an argument, return auto-completions tuned to that argument
+      TokenCursor argsCursor = startCursor.cloneCursor();
+      if (argsCursor.currentType() == "identifier")
+         argsCursor.moveToPreviousToken();
+      
+      if (argsCursor.currentValue() == "=")
+      {
+         if (argsCursor.moveToPreviousToken())
+         {
+            context.setToken(token);
+            
+            ArrayList<String> argData = new ArrayList<String>();
+            argData.add(argsCursor.currentValue());
+            context.setAssocData(argData);
+            
+            ArrayList<Integer> dataType = new ArrayList<Integer>();
+            dataType.add(AutocompletionContext.TYPE_ARGUMENT);
+            context.setDataType(dataType);
+            
+            ArrayList<Integer> numCommas = new ArrayList<Integer>();
+            numCommas.add(0);
+            context.setNumCommas(numCommas);
+            
+            return context;
+         }
+      }
       
       String initialData =
             docDisplay_.getTextForRange(Range.fromPoints(


### PR DESCRIPTION
This enables autocompletions for `knitr::opts_*$get` and arguments within `knitr::opts_*$set` (when possible).

We might want to hold off on merging this until after the preview release just because there is a bit of risk; there was a bit of new logic introduced for function argument completions.