### PR TITLE
Tweaks for autopopup + autocompletion of namespaces

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -30,7 +30,8 @@ assign(x = ".rs.acContextTypes",
           CHUNK              =  9,
           ROXYGEN            = 10,
           HELP               = 11,
-          ARGUMENT           = 12
+          ARGUMENT           = 12,
+          PACKAGE            = 13
        )
 )
 
@@ -1331,6 +1332,12 @@ assign(x = ".rs.acCompletionTypes",
           string[[1]] == "data" &&
           numCommas[[1]] == 0)
       return(.rs.getCompletionsData(token))
+   
+   # package name
+   if (.rs.acContextTypes$PACKAGE %in% type)
+      return(.rs.getCompletionsPackages(token = token,
+                                        appendColons = TRUE,
+                                        excludeOtherCompletions = TRUE))
    
    # No information on completions other than token
    if (!length(string))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -826,6 +826,7 @@ public class RCompletionManager implements CompletionManager
       public static final int TYPE_ROXYGEN = 10;
       public static final int TYPE_HELP = 11;
       public static final int TYPE_ARGUMENT = 12;
+      public static final int TYPE_PACKAGE = 13;
       
       public AutocompletionContext(
             String token,
@@ -1317,6 +1318,22 @@ public class RCompletionManager implements CompletionManager
       TokenCursor tokenCursor = codeModel.getTokenCursor();
       if (!tokenCursor.moveToPosition(input_.getCursorPosition()))
          return context;
+      
+      // Check to see if the token following the cursor is a `::` or `:::`.
+      // If that's the case, then we probably only want to complete package
+      // names.
+      if (tokenCursor.moveToNextToken())
+      {
+         if (tokenCursor.currentValue() == ":" ||
+             tokenCursor.currentValue() == "::" ||
+             tokenCursor.currentValue() == ":::")
+         {
+            return new AutocompletionContext(
+                  token,
+                  AutocompletionContext.TYPE_PACKAGE);
+         }
+         tokenCursor.moveToPreviousToken();
+      }
       
       TokenCursor startCursor = tokenCursor.cloneCursor();
       


### PR DESCRIPTION
- Don't auto-popup if there is an alphanumeric character following the cursor
- If the token following the cursor is `::` or `:::`, only display package name completions
- If the user is editing a package name, e.g. `<foo>::` with `::` following the cursor, on accept, don't insert the trailing `::` (ie, don't duplicate the `::`)