### PR TITLE
various workarounds for older versions of R

### DIFF
--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -102,6 +102,9 @@ options(help_type = "html")
       # Strip out the irrelevant bits of the package name. We'd like
       # to just use 'regexpr' but its output is funky with older versions
       # of R.
+      if (!grepl("namespace:", envString))
+         return()
+      
       namespace <- sub(".*namespace:", "", envString)
       namespace <- sub(">.*", "", namespace)
    }

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -277,14 +277,43 @@ assign(x = ".rs.acCompletionTypes",
       pattern <- if (nzchar(tokenName))
          paste("^", .rs.asCaseInsensitiveRegex(.rs.escapeForRegex(tokenName)), sep = "")
       
-      # NOTE: We would like to use 'list.dirs' here but it does not accept
-      # a pattern argument
-      absolutePaths <- gsub("/+", "/", list.files(path = directory,
-                                                  all.files = TRUE,
-                                                  pattern = pattern,
-                                                  no.. = TRUE,
-                                                  full.names = TRUE,
-                                                  include.dirs = TRUE))
+      # Manually construct a call to `list.files` which should work across
+      # versions of R >= 2.11.
+      formals <- as.list(formals(base::list.files))
+      
+      formals$path <- directory
+      formals$pattern <- pattern
+      formals$all.files <- TRUE
+      formals$full.names <- TRUE
+      
+      # NOTE: not available in older versions of R, but defaults to FALSE
+      # with newer versions.
+      if ("include.dirs" %in% names(formals))
+         fomals[["include.dirs"]] <- TRUE
+      
+      # NOTE: not available with older versions of R, but defaults to FALSE
+      if ("no.." %in% names(formals))
+         formals[["no.."]] <- TRUE
+      
+      # Generate the call, and evaluate it.
+      result <- do.call(base::list.files, formals)
+      
+      # Clean up duplicated '/'.
+      absolutePaths <- gsub("/+", "/", result)
+      
+      # Remove un-needed `.` paths. These paths will look like
+      #
+      #     <path>/.
+      #     <path>/..
+      #
+      # This is only unnecessary if we couldn't use 'no..'.
+      if (!("no.." %in% names(formals)))
+      {
+         absolutePaths <- grep("/\\.+$",
+                               absolutePaths,
+                               invert = TRUE,
+                               value = TRUE)
+      }
       
    }
    


### PR DESCRIPTION
This works around some bugs in older versions of R, e.g.

1. `regexpr` doesn't put `capture.*` attributes on the output, so we cannot use that;
2. The `list.files` and `identical` functions have evolved over time, so we manually construct calls.

Tested with R 2.12 on Windows.