### PR TITLE
Fix user-reported data viewer errors 

### DIFF
--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -76,11 +76,21 @@
       }
       else if (is.numeric(val))
       {
-        # ignore missing values when computing min/max
-        col_type <- "numeric"
-        col_search_type <- "numeric"
-        col_min <- min(x[[idx]], na.rm = TRUE)
-        col_max <- max(x[[idx]], na.rm = TRUE)
+        # ignore missing and infinite values (i.e. let any filter applied
+        # implicitly remove those values); if that leaves us with nothing,
+        # treat this column as untyped since we can do no meaningful filtering
+        # on it
+        minmax_vals <- x[[idx]][!is.na(x[[idx]]) & !is.infinite(x[[idx]])]
+        if (length(minmax_vals) > 1)
+        {
+          col_min <- min(minmax_vals)
+          col_max <- max(minmax_vals)
+          if (col_min < col_max) 
+          {
+            col_type <- "numeric"
+            col_search_type <- "numeric"
+          }
+        }
       }
       else if (is.character(val))
       {

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -361,7 +361,7 @@
    # coerce to data frame before assigning, and don't assign if we can't coerce
    frame <- .rs.toDataFrame(obj, objName)
    if (!is.null(frame))
-      assign(cacheKey, obj, .rs.CachedDataEnv)
+      assign(cacheKey, frame, .rs.CachedDataEnv)
 })
 
 .rs.addFunction("removeCachedData", function(cacheKey, cacheDir)

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -80,7 +80,7 @@
         # implicitly remove those values); if that leaves us with nothing,
         # treat this column as untyped since we can do no meaningful filtering
         # on it
-        minmax_vals <- x[[idx]][!is.na(x[[idx]]) & !is.infinite(x[[idx]])]
+        minmax_vals <- x[[idx]][is.finite(x[[idx]])]
         if (length(minmax_vals) > 1)
         {
           col_min <- min(minmax_vals)


### PR DESCRIPTION
Fixes the following problems:

- When a restoring a session containing data open in viewer tabs for which both (a) the original objects no longer exist, and (b) the original objects are not data frames, the tabs can come up blank. Happens because the original object rather than the version coerced to a frame is stored in the cached environment; the fix is to store the coerced object.

- The data viewer can come up blank when a numeric column contains `-Inf`. Happens because this value is passed back to the client as the column's minimum value, and can't be parsed on the client. The fix is to filter all non-finite values (inc. `NA`, `NaN`, and `+/- Inf`) before computing a column's min/max values for the range sliders, and to treat the column as untyped for  the purposes of filtering if it doesn't contain enough values to form a valid range.