### PR TITLE
hide completion popup on paste

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManager.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.views.console.shell.assist;
 import com.google.gwt.dom.client.NativeEvent;
 import org.rstudio.studio.client.workbench.views.console.shell.KeyDownPreviewHandler;
 import org.rstudio.studio.client.workbench.views.console.shell.KeyPressPreviewHandler;
+import org.rstudio.studio.client.workbench.views.source.editors.text.events.PasteEvent;
 
 public interface CompletionManager extends KeyDownPreviewHandler,
                                            KeyPressPreviewHandler
@@ -32,5 +33,7 @@ public interface CompletionManager extends KeyDownPreviewHandler,
    void codeCompletion();
    
    void close();
+   
+   void onPaste(PasteEvent event);
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
@@ -83,7 +83,7 @@ public class CompletionPopupPanel extends ThemedPopupPanel
                }
             }
          }
-      }; 
+      };
    }
    
    private void hideAll()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/NullCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/NullCompletionManager.java
@@ -14,10 +14,16 @@
  */
 package org.rstudio.studio.client.workbench.views.console.shell.assist;
 
+import org.rstudio.studio.client.workbench.views.source.editors.text.events.PasteEvent;
+
 import com.google.gwt.dom.client.NativeEvent;
 
 public class NullCompletionManager implements CompletionManager
 {
+   public void onPaste(PasteEvent event)
+   {
+   }
+   
    public void close()
    {
    }
@@ -43,4 +49,5 @@ public class NullCompletionManager implements CompletionManager
    {
       return false;
    }
+
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -69,6 +69,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Positio
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.RInfixData;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.TokenCursor;
+import org.rstudio.studio.client.workbench.views.source.editors.text.events.PasteEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.r.RCompletionToolTip;
 import org.rstudio.studio.client.workbench.views.source.events.CodeBrowserNavigationEvent;
 import org.rstudio.studio.client.workbench.views.source.model.RnwCompletionContext;
@@ -99,7 +100,12 @@ public class RCompletionManager implements CompletionManager
                }
             }
          }
-      });   
+      });
+   }
+   
+   public void onPaste(PasteEvent event)
+   {
+      popup_.hide();
    }
    
    public RCompletionManager(InputEditorDisplay input,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.java
@@ -59,6 +59,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.EditingTargetToo
 import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditor;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetFindReplace;
+import org.rstudio.studio.client.workbench.views.source.editors.text.events.PasteEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.findreplace.FindReplaceBar;
 import org.rstudio.studio.client.workbench.views.source.events.CodeBrowserNavigationEvent;
 import org.rstudio.studio.client.workbench.views.source.model.SourcePosition;
@@ -117,6 +118,12 @@ public class CodeBrowserEditingTargetWidget extends ResizeComposite
        
       // setup custom completion manager for executing F1 and F2 actions
       docDisplay_.setFileType(FileTypeRegistry.R, new CompletionManager() {
+         
+         @Override
+         public void onPaste(PasteEvent event)
+         {
+            // read-only; this can be a no-op
+         }
 
          @Override
          public boolean previewKeyDown(NativeEvent event)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -277,6 +277,9 @@ public class AceEditor implements DocDisplay,
          @Override
          public void onPaste(PasteEvent event)
          {
+            if (completionManager_ != null)
+               completionManager_.onPaste(event);
+            
             final Position start = getSelectionStart();
 
             Scheduler.get().scheduleDeferred(new ScheduledCommand()
@@ -290,16 +293,6 @@ public class AceEditor implements DocDisplay,
             });
          }
       });
-      
-      widget_.addHandler(new PasteEvent.Handler()
-      {
-         @Override
-         public void onPaste(PasteEvent event)
-         {
-            if (completionManager_ != null)
-               completionManager_.onPaste(event);
-         }
-      }, PasteEvent.TYPE);
       
       // handle click events
       addAceClickHandler(new AceClickEvent.Handler()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -291,6 +291,16 @@ public class AceEditor implements DocDisplay,
          }
       });
       
+      widget_.addHandler(new PasteEvent.Handler()
+      {
+         @Override
+         public void onPaste(PasteEvent event)
+         {
+            if (completionManager_ != null)
+               completionManager_.onPaste(event);
+         }
+      }, PasteEvent.TYPE);
+      
       // handle click events
       addAceClickHandler(new AceClickEvent.Handler()
       {    
@@ -1755,7 +1765,7 @@ public class AceEditor implements DocDisplay,
       widget_.getEditor().getRenderer().updateFontSize();
       widget_.forceResize();
    }
-
+   
    public HandlerRegistration addValueChangeHandler(
          ValueChangeHandler<Void> handler)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
@@ -30,6 +30,7 @@ import org.rstudio.studio.client.workbench.views.console.shell.assist.Completion
 import org.rstudio.studio.client.workbench.views.console.shell.editor.InputEditorSelection;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
+import org.rstudio.studio.client.workbench.views.source.editors.text.events.PasteEvent;
 import org.rstudio.studio.client.workbench.views.source.model.CppServerOperations;
 import org.rstudio.studio.client.workbench.views.source.model.CppSourceLocation;
 
@@ -43,6 +44,13 @@ import com.google.inject.Inject;
 
 public class CppCompletionManager implements CompletionManager
 {
+   public void onPaste(PasteEvent event)
+   {
+      CppCompletionPopupMenu popup = getCompletionPopup();
+      if (popup != null)
+         popup.hide();
+   }
+   
    public CppCompletionManager(DocDisplay docDisplay,
                                InitCompletionFilter initFilter,
                                CppCompletionContext completionContext,


### PR DESCRIPTION
@jjallaire, can you do a quick sanity check? (I thought I could implement a handler directly on the `CompletionPopupDisplay` but the paste event never reaches there; so I manually added plumbing to send an `onPaste()` call to the completion manager)