### PR TITLE
add simple code formatter

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -274,6 +274,7 @@ public class TextFileType extends EditableFileType
       if (canExecuteCode() || isC())
       {
          results.add(commands.reindent());
+         results.add(commands.reformatCode());
       }
       if (canExecuteCode()) {
          results.add(commands.executeCode());
@@ -283,7 +284,6 @@ public class TextFileType extends EditableFileType
          results.add(commands.extractLocalVariable());
          results.add(commands.commentUncomment());
          results.add(commands.reflowComment());
-         results.add(commands.alignAssignment());
       }
       if (canExecuteAllCode())
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -152,7 +152,7 @@ well as menu structures (for main menu and popup menus).
          <cmd refid="reindent"/>
          <cmd refid="reflowComment"/>
          <cmd refid="commentUncomment"/>
-         <cmd refid="alignAssignment"/>
+         <cmd refid="reformatCode"/>
          <separator/>
          <cmd refid="executeCode"/>
          <cmd refid="executeLastCode"/>
@@ -391,7 +391,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="commentUncomment" value="Cmd+Shift+C"/>
          <shortcut refid="reindent" value="Cmd+I"/>
          <shortcut refid="reflowComment" value="Cmd+Shift+/"/>
-         <shortcut refid="alignAssignment" value="Cmd+Shift+A"/>
+         <shortcut refid="reformatCode" value="Cmd+Shift+A"/>
          <shortcut refid="fold" value="Alt+L" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" title="Collapse Fold"/>
          <shortcut refid="fold" value="Cmd+Alt+L" if="org.rstudio.core.client.BrowseCap.isMacintosh()" title="Collapse Fold"/>
          <shortcut refid="unfold" value="Shift+Alt+L" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" title="Expand Fold"/>
@@ -875,9 +875,9 @@ well as menu structures (for main menu and popup menus).
    <cmd id="commentUncomment"
         menuLabel="_Comment/Uncomment Lines"
         desc="Comment or uncomment the current line/selection"/>
-   <cmd id="alignAssignment"
-        menuLabel="_Align Assignment"
-        desc="Vertically align assignment operators in the current selection"/>
+   <cmd id="reformatCode"
+        menuLabel="Reformat Code"
+        desc="Re-format and indent the current line/selection"/>
    <cmd id="reindent"
         menuLabel="_Reindent Lines"
         desc="Reindent the current line/selection"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -27,7 +27,7 @@ public abstract class
    public abstract AppCommand setWorkingDir();
    
    // Source
-   public abstract AppCommand alignAssignment();
+   public abstract AppCommand reformatCode();
    public abstract AppCommand newSourceDoc();
    public abstract AppCommand newTextDoc();
    public abstract AppCommand newCppDoc();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -276,7 +276,7 @@ public class Source implements InsertSourceHandler,
       dynamicCommands_.add(commands.vcsViewOnGitHub());
       dynamicCommands_.add(commands.vcsBlameOnGitHub());
       dynamicCommands_.add(commands.editRmdFormatOptions());
-      dynamicCommands_.add(commands.alignAssignment());
+      dynamicCommands_.add(commands.reformatCode());
       for (AppCommand command : dynamicCommands_)
       {
          command.setVisible(false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -288,7 +288,7 @@ public class TextEditingTargetWidget
          menu.addItem(commands_.reindent().createMenuItem(false));
          menu.addItem(commands_.reflowComment().createMenuItem(false));
          menu.addItem(commands_.commentUncomment().createMenuItem(false));
-         menu.addItem(commands_.alignAssignment().createMenuItem(false));
+         menu.addItem(commands_.reformatCode().createMenuItem(false));
          codeTransform_ = new ToolbarButton("", icon, menu);
          codeTransform_.setTitle("Code Tools");
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Mode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Mode.java
@@ -72,4 +72,8 @@ public class Mode extends JavaScriptObject
          int row) /*-{
       return this.getNextLineIndent(state, line, tab, tabSize, row);
    }-*/;
+   
+   public native final Tokenizer getTokenizer() /*-{
+      return this.$tokenizer;
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Token.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Token.java
@@ -19,6 +19,14 @@ import com.google.gwt.core.client.JavaScriptObject;
 public class Token extends JavaScriptObject
 {
    protected Token() {}
+   
+   public static native final Token create() /*-{
+      return {
+         "value": "",
+         "type": "",
+         "column": 0
+      };
+   }-*/;
 
    public native final String getValue() /*-{
       return this.value;
@@ -26,5 +34,9 @@ public class Token extends JavaScriptObject
 
    public native final String getType() /*-{
       return this.type;
+   }-*/;
+   
+   public native final int getColumn() /*-{
+      return this.column;
    }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Tokenizer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Tokenizer.java
@@ -1,0 +1,14 @@
+package org.rstudio.studio.client.workbench.views.source.editors.text.ace;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+public class Tokenizer extends JavaScriptObject
+{
+   protected Tokenizer()
+   {
+   }
+   
+   public final native Token[] getLineTokens(String line) /*-{
+      return this.getLineTokens(line, "start").tokens;
+   }-*/;
+}


### PR DESCRIPTION
This extends the previous 'align assignment' code to add a simple re-formatter as well. In this video, I use vim mode plus `J` to join the selection into a single line, and then `CMD + SHIFT + A` to reformat the selected text.

![reformat-code](https://cloud.githubusercontent.com/assets/1976582/5868321/80c85ebe-a25c-11e4-856c-6cb8e66f1d06.gif)

We might consider wiring this up to `formatr` as well.