### PR TITLE
have 'reflowComment' respect mode of current selection

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2668,7 +2668,9 @@ public class TextEditingTarget implements
    @Handler
    void onReflowComment()
    {
-      if (fileType_.isCpp())
+      if (DocumentMode.isSelectionInRMode(docDisplay_))
+         doReflowComment("(#)");
+      else if (DocumentMode.isSelectionInCppMode(docDisplay_))
       {
          String currentLine = docDisplay_.getLine(
                                     docDisplay_.getCursorPosition().getRow());
@@ -2677,9 +2679,8 @@ public class TextEditingTarget implements
          else
             doReflowComment("(//)");
       }
-         
-      else
-         doReflowComment("(#)");
+      else if (DocumentMode.isSelectionInTexMode(docDisplay_))
+         doReflowComment("(%)");
    }
    
    @Handler


### PR DESCRIPTION
This allows the reflow comments command to work for e.g. C++ comments within a C++ chunk in R Markdown.

Down the line somewhere, we should make it possible to just reflow an entire document -- identify the comment 'chunks' and run this code across it.