### PR TITLE
fix rare hangs caused by infinite 'moveToNextToken()' calls

### DIFF
--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -60,7 +60,7 @@ var RCodeModel = function(session, tokenizer, statePattern, codeBeginPattern) {
 (function () {
 
    this.getTokenCursor = function() {
-      return new RTokenCursor(this.$tokens);
+      return new RTokenCursor(this.$tokens, this);
    };
 
    this.$complements = {
@@ -564,9 +564,7 @@ var RCodeModel = function(session, tokenizer, statePattern, codeBeginPattern) {
    };
 
    this.getVariablesInScope = function(pos) {
-      
-      this.$tokenizeUpToRow(pos.row);
-      
+
       var tokenCursor = this.getTokenCursor();
       if (!tokenCursor.moveToPosition(pos))
          return [];
@@ -642,10 +640,12 @@ var RCodeModel = function(session, tokenizer, statePattern, codeBeginPattern) {
    function $getFunctionArgs(tokenCursor)
    {
       if (pFunction(tokenCursor.currentToken()))
-         tokenCursor.moveToNextToken();
+         if (!tokenCursor.moveToNextToken())
+            return [];
 
       if (tokenCursor.currentValue() === "(")
-         tokenCursor.moveToNextToken();
+         if (!tokenCursor.moveToNextToken())
+            return [];
 
       if (tokenCursor.currentValue() === ")")
          return [];
@@ -670,7 +670,8 @@ var RCodeModel = function(session, tokenizer, statePattern, codeBeginPattern) {
          if (lookingAtComma(tokenCursor))
          {
             while (lookingAtComma(tokenCursor))
-               tokenCursor.moveToNextToken();
+               if (!tokenCursor.moveToNextToken())
+                  break;
             
             if (pIdentifier(tokenCursor.currentToken()))
                functionArgs.push(tokenCursor.currentValue());
@@ -1513,7 +1514,6 @@ var RCodeModel = function(session, tokenizer, statePattern, codeBeginPattern) {
 
    this.getBraceIndent = function(row)
    {
-      this.$tokenizeUpToRow(row);
       var tokenCursor = this.getTokenCursor();
       
       tokenCursor.moveToPosition({

--- a/src/gwt/acesupport/acemode/token_cursor.js
+++ b/src/gwt/acesupport/acemode/token_cursor.js
@@ -36,6 +36,19 @@ var TokenCursor = function(tokens, row, offset) {
       return /,\s*$/.test(cursor.currentValue()) && cursor.currentType() === "text";
    }
 
+   // Simulate 'new Foo([args])'; ie, construction of an
+   // object from an array of arguments
+   function construct(constructor, args)
+   {
+      function F()
+      {
+         return constructor.apply(this, args);
+      }
+
+      F.prototype = constructor.prototype;
+      return new F();
+   }
+
    var $complements = {
       "(" : ")",
       "{" : "}",
@@ -53,6 +66,9 @@ var TokenCursor = function(tokens, row, offset) {
       this.$offset = 0;
    };
 
+   // Move the cursor to the previous token. Returns true (and moves the
+   // the cursor) on success; returns false (and does not move the cursor)
+   // on failure.
    this.moveToPreviousToken = function()
    {
       // Bail if we're at the start of the document
@@ -96,6 +112,9 @@ var TokenCursor = function(tokens, row, offset) {
       return true;
    };
 
+   // Move the cursor to the next token. Returns true (and moves the
+   // the cursor) on success; returns false (and does not move the cursor)
+   // on failure.
    this.moveToNextToken = function(maxRow)
    {
       // If maxRow is undefined, we'll iterate up to the length of
@@ -106,6 +125,16 @@ var TokenCursor = function(tokens, row, offset) {
       // If we're already past the maxRow bound, fail
       if (this.$row > maxRow)
          return false;
+
+      // Tokenize ahead, if appropriate
+      if (this.$tokens[this.$row] == null)
+      {
+         if (this.$codeModel &&
+             this.$codeModel.$tokenizeUpToRow)
+         {
+            this.$codeModel.$tokenizeUpToRow(maxRow);
+         }
+      }
 
       // If the number of tokens on the current row is greater than
       // the offset, we can just increment and return true
@@ -416,9 +445,17 @@ var TokenCursor = function(tokens, row, offset) {
          return {row: this.$row, column: token.column};
    };
 
+   // Perform a (shallow) copy of a cursor. This is sufficient as
+   // long as the new cursor has its own $row and $offset (which
+   // is ensured by their being primtive types)
    this.cloneCursor = function()
    {
-      return new this.constructor(this.$tokens, this.$row, this.$offset);
+      var args = [];
+      for (var item in this)
+         if (this.hasOwnProperty(item))
+            args.push(this[item]);
+
+      return construct(this.constructor, args);
    };
 
    this.isFirstSignificantTokenOnLine = function()
@@ -464,6 +501,16 @@ var TokenCursor = function(tokens, row, offset) {
       var column = pos.column;
       
       var rowTokens = this.$tokens[row];
+
+      // Ensure that we have tokenized up to the current position,
+      // if a code model is available.
+      if (rowTokens == null &&
+          this.$codeModel &&
+          this.$codeModel.$tokenizeUpToRow)
+      {
+         this.$codeModel.$tokenizeUpToRow(row);
+         rowTokens = this.$tokens[row];
+      }
 
       // If there are tokens on this row, we can move to the first token
       // on that line before the cursor position.
@@ -849,10 +896,11 @@ oop.mixin(CppTokenCursor.prototype, TokenCursor.prototype);
    
 }).call(CppTokenCursor.prototype);
 
-var RTokenCursor = function(tokens, row, offset) {
+var RTokenCursor = function(tokens, row, offset, codeModel) {
    this.$tokens = tokens;
    this.$row = row || 0;
    this.$offset = offset || 0;
+   this.$codeModel = codeModel;
 };
 oop.mixin(RTokenCursor.prototype, TokenCursor.prototype);
 


### PR DESCRIPTION
This PR fixes a rare hang in the editor (finally made reproducible by @jjallaire).

The issue here -- in `$getFunctionArgs()`, we were not checking the success of `moveToNextToken()` -- it was possible for us to be caught in an infinite loop calling `moveToNextToken()` without actually moving the token.

I've fixed this in `$getFunctionArgs()`, and also added some extra provisioning to the `RTokenCursor` class -- it now accepts a `codeModel` (optionally), and can use that to tokenize ahead if necessary, on calls that move the cursor forward.