### PR TITLE
add vim close all

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -452,6 +452,7 @@ public class Source implements InsertSourceHandler,
       vimOnNextTab(this);
       vimOnPreviousTab(this);
       vimOnCloseTab(this);
+      vimOnCloseAll(this);
       vimOnNewDoc(this);
       vimOnSaveAndCloseTab(this);
       
@@ -522,6 +523,19 @@ public class Source implements InsertSourceHandler,
        
       $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("bdelete", "bd", callback);
       $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("quit", "q", callback);
+   }-*/;
+   
+   private native final void vimOnCloseAll(Source source) /*-{
+      var callback = $entry(function(cm, params) {
+      
+         var interactive = true;
+         if (params.argString && params.argString === "!")
+            interactive = false;
+         
+         source.@org.rstudio.studio.client.workbench.views.source.Source::closeAllSourceDocs(Z)(interactive);
+      });
+       
+      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("qall", "qa", callback);
    }-*/;
    
    private native final void vimOnNewDoc(Source source) /*-{
@@ -1324,6 +1338,15 @@ public class Source implements InsertSourceHandler,
          return;
       
       view_.closeTab(view_.getActiveTabIndex(), interactive);
+   }
+   
+   void closeAllSourceDocs(boolean interactive)
+   {
+      if (view_.getTabCount() == 0)
+         return;
+      
+      for (int i = 0; i < view_.getTabCount(); i++)
+         view_.closeTab(i, interactive);
    }
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -152,7 +152,6 @@ public class Source implements InsertSourceHandler,
       void closeTab(Widget widget, boolean interactive, Command onClosed);
       void closeTab(int index, boolean interactive);
       void closeTab(int index, boolean interactive, Command onClosed);
-      void closeAllTabs();
       void setDirty(Widget widget, boolean dirty);
       void manageChevronVisibility();
       void showOverflowPopup();
@@ -555,7 +554,19 @@ public class Source implements InsertSourceHandler,
             public void execute()
             {
                // documents have been reverted; we can close
-               view_.closeAllTabs();
+               cpsExecuteForEachEditor(editors_,
+                     new CPSEditingTargetCommand()
+               {
+                  @Override
+                  public void execute(EditingTarget editingTarget,
+                                      Command continuation)
+                  {
+                     view_.closeTab(
+                           editingTarget.asWidget(),
+                           false,
+                           continuation);
+                  }
+               });
             }
          });
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourcePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourcePane.java
@@ -150,11 +150,6 @@ public class SourcePane extends Composite implements Display,
          tabPanel_.closeTab(index, onClosed);
    }
    
-   public void closeAllTabs()
-   {
-      tabPanel_.clear();
-   }
-   
    public void setDirty(Widget widget, boolean dirty)
    {
       Widget tab = tabPanel_.getTabWidget(widget);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourcePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourcePane.java
@@ -150,6 +150,11 @@ public class SourcePane extends Composite implements Display,
          tabPanel_.closeTab(index, onClosed);
    }
    
+   public void closeAllTabs()
+   {
+      tabPanel_.clear();
+   }
+   
    public void setDirty(Widget widget, boolean dirty)
    {
       Widget tab = tabPanel_.getTabWidget(widget);


### PR DESCRIPTION
Adds `:qa` and `:qa!` as methods for closing all documents (interactively or non-interactively).