### PR TITLE
Fix IDE hang regression caused by previous fix

### DIFF
--- a/src/gwt/acesupport/acemode/cpp_code_model.js
+++ b/src/gwt/acesupport/acemode/cpp_code_model.js
@@ -612,7 +612,8 @@ var CppCodeModel = function(session, tokenizer, statePattern, codeBeginPattern) 
             var tokenCursor = this.getTokenCursor();
             if (useCursor) {
                var cursor = session.getSelection().getCursor();
-               tokenCursor.moveToPosition(cursor);
+               if (!tokenCursor.moveToPosition(cursor))
+                  return 0;
             } else {
                tokenCursor.$row = row;
 

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -60,7 +60,7 @@ var RCodeModel = function(session, tokenizer, statePattern, codeBeginPattern) {
 (function () {
 
    this.getTokenCursor = function() {
-      return new RTokenCursor(this.$tokens, this);
+      return new RTokenCursor(this.$tokens, 0, 0, this);
    };
 
    this.$complements = {
@@ -1184,7 +1184,11 @@ var RCodeModel = function(session, tokenizer, statePattern, codeBeginPattern) {
          // brace, or assignment token. We use the first found token to provide
          // context for the indentation.
          var tokenCursor = this.getTokenCursor();
-         tokenCursor.moveToPosition(startPos);
+
+         // moveToPosition can fail if there are no tokens previous to
+         // the cursor
+         if (!tokenCursor.moveToPosition(startPos))
+            return "";
 
          // The first loop looks for an open brace for indentation.
          do
@@ -1339,7 +1343,9 @@ var RCodeModel = function(session, tokenizer, statePattern, codeBeginPattern) {
          // or we failed otherwise. For '{' scopes, we may want to
          // short-circuit and indent based on a '<-', hence the second
          // pass through here.
-         tokenCursor.moveToPosition(startPos);
+         if (!tokenCursor.moveToPosition(startPos))
+            return "";
+         
          do
          {
             // Walk over matching parens
@@ -1515,11 +1521,13 @@ var RCodeModel = function(session, tokenizer, statePattern, codeBeginPattern) {
    this.getBraceIndent = function(row)
    {
       var tokenCursor = this.getTokenCursor();
-      
-      tokenCursor.moveToPosition({
+      var pos = {
          row: row,
          column: this.$getLine(row).length
-      });
+      };
+
+      if (!tokenCursor.moveToPosition(pos))
+         return "";
 
       if (tokenCursor.currentValue() === ")")
       {

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -60,7 +60,7 @@ var RCodeModel = function(session, tokenizer, statePattern, codeBeginPattern) {
 (function () {
 
    this.getTokenCursor = function() {
-      return new RTokenCursor(this.$tokens);
+      return new RTokenCursor(this.$tokens, this);
    };
 
    this.$complements = {
@@ -564,9 +564,7 @@ var RCodeModel = function(session, tokenizer, statePattern, codeBeginPattern) {
    };
 
    this.getVariablesInScope = function(pos) {
-      
-      this.$tokenizeUpToRow(pos.row);
-      
+
       var tokenCursor = this.getTokenCursor();
       if (!tokenCursor.moveToPosition(pos))
          return [];
@@ -642,10 +640,12 @@ var RCodeModel = function(session, tokenizer, statePattern, codeBeginPattern) {
    function $getFunctionArgs(tokenCursor)
    {
       if (pFunction(tokenCursor.currentToken()))
-         tokenCursor.moveToNextToken();
+         if (!tokenCursor.moveToNextToken())
+            return [];
 
       if (tokenCursor.currentValue() === "(")
-         tokenCursor.moveToNextToken();
+         if (!tokenCursor.moveToNextToken())
+            return [];
 
       if (tokenCursor.currentValue() === ")")
          return [];
@@ -670,7 +670,8 @@ var RCodeModel = function(session, tokenizer, statePattern, codeBeginPattern) {
          if (lookingAtComma(tokenCursor))
          {
             while (lookingAtComma(tokenCursor))
-               tokenCursor.moveToNextToken();
+               if (!tokenCursor.moveToNextToken())
+                  break;
             
             if (pIdentifier(tokenCursor.currentToken()))
                functionArgs.push(tokenCursor.currentValue());
@@ -1513,7 +1514,6 @@ var RCodeModel = function(session, tokenizer, statePattern, codeBeginPattern) {
 
    this.getBraceIndent = function(row)
    {
-      this.$tokenizeUpToRow(row);
       var tokenCursor = this.getTokenCursor();
       
       tokenCursor.moveToPosition({

--- a/src/gwt/acesupport/acemode/token_cursor.js
+++ b/src/gwt/acesupport/acemode/token_cursor.js
@@ -71,9 +71,14 @@ var TokenCursor = function(tokens, row, offset) {
    // on failure.
    this.moveToPreviousToken = function()
    {
-      // Bail if we're at the start of the document
-      if (this.$row === 0 && this.$offset === 0)
+      // Bail if we're at the start of the document (protect against
+      // invalid token cursors)
+      if (this.$row <= 0 && this.$offset <= 0)
+      {
+         this.$row = 0;
+         this.$offset = 0;
          return false;
+      }
 
       // If the offset is greater than zero, we know we can safely
       // decrement it
@@ -132,7 +137,7 @@ var TokenCursor = function(tokens, row, offset) {
          if (this.$codeModel &&
              this.$codeModel.$tokenizeUpToRow)
          {
-            this.$codeModel.$tokenizeUpToRow(maxRow);
+            this.$codeModel.$tokenizeUpToRow.call(this.$codeModel, maxRow);
          }
       }
 
@@ -508,7 +513,7 @@ var TokenCursor = function(tokens, row, offset) {
           this.$codeModel &&
           this.$codeModel.$tokenizeUpToRow)
       {
-         this.$codeModel.$tokenizeUpToRow(row);
+         this.$codeModel.$tokenizeUpToRow.call(this.$codeModel, row);
          rowTokens = this.$tokens[row];
       }
 

--- a/src/gwt/acesupport/acemode/token_cursor.js
+++ b/src/gwt/acesupport/acemode/token_cursor.js
@@ -36,6 +36,19 @@ var TokenCursor = function(tokens, row, offset) {
       return /,\s*$/.test(cursor.currentValue()) && cursor.currentType() === "text";
    }
 
+   // Simulate 'new Foo([args])'; ie, construction of an
+   // object from an array of arguments
+   function construct(constructor, args)
+   {
+      function F()
+      {
+         return constructor.apply(this, args);
+      }
+
+      F.prototype = constructor.prototype;
+      return new F();
+   }
+
    var $complements = {
       "(" : ")",
       "{" : "}",
@@ -53,6 +66,9 @@ var TokenCursor = function(tokens, row, offset) {
       this.$offset = 0;
    };
 
+   // Move the cursor to the previous token. Returns true (and moves the
+   // the cursor) on success; returns false (and does not move the cursor)
+   // on failure.
    this.moveToPreviousToken = function()
    {
       // Bail if we're at the start of the document
@@ -96,6 +112,9 @@ var TokenCursor = function(tokens, row, offset) {
       return true;
    };
 
+   // Move the cursor to the next token. Returns true (and moves the
+   // the cursor) on success; returns false (and does not move the cursor)
+   // on failure.
    this.moveToNextToken = function(maxRow)
    {
       // If maxRow is undefined, we'll iterate up to the length of
@@ -106,6 +125,16 @@ var TokenCursor = function(tokens, row, offset) {
       // If we're already past the maxRow bound, fail
       if (this.$row > maxRow)
          return false;
+
+      // Tokenize ahead, if appropriate
+      if (this.$tokens[this.$row] == null)
+      {
+         if (this.$codeModel &&
+             this.$codeModel.$tokenizeUpToRow)
+         {
+            this.$codeModel.$tokenizeUpToRow(maxRow);
+         }
+      }
 
       // If the number of tokens on the current row is greater than
       // the offset, we can just increment and return true
@@ -416,9 +445,17 @@ var TokenCursor = function(tokens, row, offset) {
          return {row: this.$row, column: token.column};
    };
 
+   // Perform a (shallow) copy of a cursor. This is sufficient as
+   // long as the new cursor has its own $row and $offset (which
+   // is ensured by their being primtive types)
    this.cloneCursor = function()
    {
-      return new this.constructor(this.$tokens, this.$row, this.$offset);
+      var args = [];
+      for (var item in this)
+         if (this.hasOwnProperty(item))
+            args.push(this[item]);
+
+      return construct(this.constructor, args);
    };
 
    this.isFirstSignificantTokenOnLine = function()
@@ -464,6 +501,16 @@ var TokenCursor = function(tokens, row, offset) {
       var column = pos.column;
       
       var rowTokens = this.$tokens[row];
+
+      // Ensure that we have tokenized up to the current position,
+      // if a code model is available.
+      if (rowTokens == null &&
+          this.$codeModel &&
+          this.$codeModel.$tokenizeUpToRow)
+      {
+         this.$codeModel.$tokenizeUpToRow(row);
+         rowTokens = this.$tokens[row];
+      }
 
       // If there are tokens on this row, we can move to the first token
       // on that line before the cursor position.
@@ -849,10 +896,11 @@ oop.mixin(CppTokenCursor.prototype, TokenCursor.prototype);
    
 }).call(CppTokenCursor.prototype);
 
-var RTokenCursor = function(tokens, row, offset) {
+var RTokenCursor = function(tokens, row, offset, codeModel) {
    this.$tokens = tokens;
    this.$row = row || 0;
    this.$offset = offset || 0;
+   this.$codeModel = codeModel;
 };
 oop.mixin(RTokenCursor.prototype, TokenCursor.prototype);
 


### PR DESCRIPTION
This augments the previous fix (which introduced a separate, latent bug) to prevent a hang when attempting to press enter while the cursor is at the start of the document.

Briefly, the `RTokenCursor` was not properly being constructed -- in the fix, I had augmented the constructor to also accept the code model itself, so that the token cursor could attempt to tokenize ahead if moving further ahead in the document. However, I was passing it to the `row` argument (because I had implicitly let those initialize to zero previously). In other words, the constructor looks like this:

```js
var RTokenCursor = function(tokens, row, offset, codeModel) {
   this.$tokens = tokens;
   this.$row = row || 0;
   this.$offset = offset || 0;
   this.$codeModel = codeModel;
};
oop.mixin(RTokenCursor.prototype, TokenCursor.prototype);
```

but the R code model had a wrapper for that constructor like this:

```js
this.getTokenCursor = function() {
   return new RTokenCursor(this.$tokens, this);
};
```

which is obviously wrong; however, prior to the introduction of the code model the constructor looked simply like:

```js
this.getTokenCursor = function() {
   return new RTokenCursor(this.$tokens);
};
```

which was 'correct' since `row` and `column` would have been initialized to zero.

There were also a number of spots in which the return value of `moveToPosition()` was not being checked. A failure in `moveToPosition()` implies there are no tokens lying prior to the cursor (and so the cursor position is not changed); although the cursor is normally still left in a valid state, the new constructor exacerbated this problem by generating invalid token cursors with the improper constructor. Still, it is better to check the success of these calls.