### PR TITLE
don't embed HTML rules in Markdown

### DIFF
--- a/src/gwt/acesupport/acemode/markdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/markdown_highlight_rules.js
@@ -71,7 +71,6 @@ function github_embed(tag, prefix) {
 }
 
 var MarkdownHighlightRules = function() {
-    HtmlHighlightRules.call(this);
 
     var slideFields = lang.arrayToMap(
         ("title|author|date|rtl|depends|autosize|width|height|transition|transition-speed|font-family|css|class|navigation|incremental|left|right|id|audio|video|type|at|help-doc|help-topic|source|console|console-input|execute|pause")
@@ -81,134 +80,8 @@ var MarkdownHighlightRules = function() {
     // regexp must not have capturing parentheses
     // regexps are ordered -> the first match is used
 
-    this.$rules["start"].unshift({
-        token : "empty_line",
-        regex : '^$',
-        next: "allowBlock"
-    }, { // code span
-        token : ["support.function", "support.function", "support.function"],
-        regex : "(`+)([^\\r]*?[^`])(\\1)"
-    }, { // h1 with equals
-        token: "markup.heading.1",
-        regex: "^\\={3,}\\s*$",
-        next: "fieldblock"
-    }, { // h1
-        token: "markup.heading.1",
-        regex: "^=+(?=\\s*$)"
-    }, { // h2
-        token: "markup.heading.2",
-        regex: "^\\-+(?=\\s*$)"
-    }, {
-        token : function(value) {
-            return "markup.heading." + value.length;
-        },
-        regex : /^#{1,6}(?=\s*[^ #]|\s+#.)/,
-        next : "header"
-    },
-                                 
-    github_embed("(?:javascript|js)", "jscode-"),
-    github_embed("xml", "xmlcode-"),
-    github_embed("html", "htmlcode-"),
-    github_embed("css", "csscode-"),
-    
-    { // Github style block
-        token : "support.function",
-        regex : "^\\s*```\\s*\\S*(?:{.*?\\})?\\s*$",
-        next  : "githubblock"
-    }, { // block quote
-        token : "string.blockquote",
-        regex : "^\\s*>\\s*(?:[*+-]|\\d+\\.)?\\s+",
-        next  : "blockquote"
-    },
-    { // reference
-        token : ["text", "constant", "text", "url", "string", "text"],
-        regex : "^([ ]{0,3}\\[)([^\\]]+)(\\]:\\s*)([^ ]+)(\\s*(?:[\"][^\"]+[\"])?(\\s*))$"
-    }, { // link by reference
-        token : ["text", "keyword", "text", "constant", "text"],
-        regex : "(\\[)((?:[[^\\]]*\\]|[^\\[\\]])*)(\\][ ]?(?:\\n[ ]*)?\\[)(.*?)(\\])"
-    }, { // link by url
-        token : ["text", "keyword", "text", "markup.underline", "string", "text"],
-        regex : "(\\[)"+
-            "(\\[[^\\]]*\\]|[^\\[\\]]*)"+
-            "(\\]\\([ \\t]*)"+
-            "(<?(?:(?:[^\\(]*?\\([^\\)]*?\\)\\S*?)|(?:.*?))>?)"+
-            "((?:[ \t]*\"(?:.*?)\"[ \\t]*)?)"+
-            "(\\))"
-    }, { // HR *
-        token : "constant",
-        regex : "^[ ]{0,2}(?:[ ]?\\*[ ]?){3,}\\s*$"
-    }, { // HR -
-        token : "constant",
-        regex : "^[ ]{0,2}(?:[ ]?\\-[ ]?){3,}\\s*$"
-    }, { // HR _
-        token : "constant",
-        regex : "^[ ]{0,2}(?:[ ]?\\_[ ]?){3,}\\s*$"
-    }, { // MathJax native display \[ ... \]
-        token : "markup.list",
-        regex : "\\\\\\[",
-        next  : "mathjaxnativedisplay"
-    }, { // MathJax native inline \( ... \)
-        token : "markup.list",
-        regex : "\\\\\\(",
-        next  : "mathjaxnativeinline"
-    }, { // $ escape
-        token : "text",
-        regex : "\\\\\\$"
-    }, { // MathJax $$
-        token : "markup.list",
-        regex : "\\${2}",
-        next  : "mathjaxdisplay"
-    }, { // MathJax $...$ (org-mode style)
-        token : ["markup.list","support.function","markup.list"],
-        regex : "(\\$)" + "((?!\\s)[^$]*[^$\\s])" + "(\\$)" + "(?![\\w\\d`])"
-    }, { // strong ** __
-        token : ["constant.numeric", "constant.numeric", "constant.numeric"],
-        regex : "([*]{2}|[_]{2}(?=\\S))([^\\r]*?\\S[*_]*)(\\1)"
-    }, { // emphasis * _
-        token : ["constant.language.boolean", "constant.language.boolean", "constant.language.boolean"],
-        regex : "([*]|[_](?=\\S))([^\\r]*?\\S[*_]*)(\\1)"
-    }, { // simple links <url>
-        token : ["text", "keyword", "text"],
-        regex : "(<)("+
-            "(?:https?|ftp|dict):[^'\">\\s]+"+
-            "|"+
-            "(?:mailto:)?[-.\\w]+\\@[-a-z0-9]+(?:\\.[-a-z0-9]+)*\\.[a-z]+"+
-            ")(>)"
-    }, {
-        // embedded latex command
-        token : "keyword",
-        regex : "\\\\(?:[a-zA-z0-9]+|[^a-zA-z0-9])"
-    }, {
-        // embedded latex arg
-        token : ["paren.keyword.operator", "text", "paren.keyword.operator"],
-        regex : "(\\{)([^\\}]*)(\\})"
-    }, {
-        // pandoc citation with brackets
-        token : "markup.list",
-        regex : "\\[-?\\@[\\w\\d-]+\\]"
-    }, {
-        // pandoc citation
-        token : "markup.list",
-        regex : "-?\\@[\\w\\d-]+"
-    }, {
-        token : "text",
-        regex : "[^\\*_%$`\\[#<>\\\\]+"
-    }, {
-        token : "text",
-        regex : "\\\\"
-    }, { // HR * - _
-        token : "constant",
-        regex : "^ {0,2}(?:(?: ?\\* ?){3,}|(?: ?\\- ?){3,}|(?: ?\\_ ?){3,})\\s*$",
-        next: "allowBlock"
-    }, { // list
-        token : "text",
-        regex : "^\\s{0,3}(?:[*+-]|\\d+\\.)\\s+",
-        next  : "listblock-start"
-    }, {
-        include : "basic"
-    });
+    this.$rules = {
 
-    this.addRules({
         "basic" : [{
             token : "constant.language.escape",
             regex : /\\[\\`*_{}\[\]()#+\-.!]/
@@ -243,12 +116,144 @@ var MarkdownHighlightRules = function() {
                 "(?:mailto:)?[-.\\w]+\\@[-a-z0-9]+(?:\\.[-a-z0-9]+)*\\.[a-z]+"+
                 ")(>)"
         }],
-
+       
+        start: [{
+           token : "empty_line",
+           regex : '^$',
+           next: "allowBlock"
+        }, { // code span
+            token : ["support.function", "support.function", "support.function"],
+            regex : "(`+)([^\\r]*?[^`])(\\1)"
+        }, { // h1 with equals
+            token: "markup.heading.1",
+            regex: "^\\={3,}\\s*$",
+            next: "fieldblock"
+        }, { // h1
+            token: "markup.heading.1",
+            regex: "^=+(?=\\s*$)"
+        }, { // h2
+            token: "markup.heading.2",
+            regex: "^\\-+(?=\\s*$)"
+        }, {
+            token : function(value) {
+                return "markup.heading." + value.length;
+            },
+            regex : /^#{1,6}(?=\s*[^ #]|\s+#.)/,
+            next : "header"
+        },
+                                     
+        github_embed("(?:javascript|js)", "jscode-"),
+        github_embed("xml", "xmlcode-"),
+        github_embed("html", "htmlcode-"),
+        github_embed("css", "csscode-"),
+        
+        { // Github style block
+            token : "support.function",
+            regex : "^\\s*```\\s*\\S*(?:{.*?\\})?\\s*$",
+            next  : "githubblock"
+        }, { // block quote
+            token : "string.blockquote",
+            regex : "^\\s*>\\s*(?:[*+-]|\\d+\\.)?\\s+",
+            next  : "blockquote"
+        },
+        { // reference
+            token : ["text", "constant", "text", "url", "string", "text"],
+            regex : "^([ ]{0,3}\\[)([^\\]]+)(\\]:\\s*)([^ ]+)(\\s*(?:[\"][^\"]+[\"])?(\\s*))$"
+        }, { // link by reference
+            token : ["text", "keyword", "text", "constant", "text"],
+            regex : "(\\[)((?:[[^\\]]*\\]|[^\\[\\]])*)(\\][ ]?(?:\\n[ ]*)?\\[)(.*?)(\\])"
+        }, { // link by url
+            token : ["text", "keyword", "text", "markup.underline", "string", "text"],
+            regex : "(\\[)"+
+                "(\\[[^\\]]*\\]|[^\\[\\]]*)"+
+                "(\\]\\([ \\t]*)"+
+                "(<?(?:(?:[^\\(]*?\\([^\\)]*?\\)\\S*?)|(?:.*?))>?)"+
+                "((?:[ \t]*\"(?:.*?)\"[ \\t]*)?)"+
+                "(\\))"
+        }, { // HR *
+            token : "constant",
+            regex : "^[ ]{0,2}(?:[ ]?\\*[ ]?){3,}\\s*$"
+        }, { // HR -
+            token : "constant",
+            regex : "^[ ]{0,2}(?:[ ]?\\-[ ]?){3,}\\s*$"
+        }, { // HR _
+            token : "constant",
+            regex : "^[ ]{0,2}(?:[ ]?\\_[ ]?){3,}\\s*$"
+        }, { // MathJax native display \[ ... \]
+            token : "markup.list",
+            regex : "\\\\\\[",
+            next  : "mathjaxnativedisplay"
+        }, { // MathJax native inline \( ... \)
+            token : "markup.list",
+            regex : "\\\\\\(",
+            next  : "mathjaxnativeinline"
+        }, { // $ escape
+            token : "text",
+            regex : "\\\\\\$"
+        }, { // MathJax $$
+            token : "markup.list",
+            regex : "\\${2}",
+            next  : "mathjaxdisplay"
+        }, { // MathJax $...$ (org-mode style)
+            token : ["markup.list","support.function","markup.list"],
+            regex : "(\\$)" + "((?!\\s)[^$]*[^$\\s])" + "(\\$)" + "(?![\\w\\d`])"
+        }, { // strong ** __
+            token : ["constant.numeric", "constant.numeric", "constant.numeric"],
+            regex : "([*]{2}|[_]{2}(?=\\S))([^\\r]*?\\S[*_]*)(\\1)"
+        }, { // emphasis * _
+            token : ["constant.language.boolean", "constant.language.boolean", "constant.language.boolean"],
+            regex : "([*]|[_](?=\\S))([^\\r]*?\\S[*_]*)(\\1)"
+        }, { // simple links <url>
+            token : ["text", "keyword", "text"],
+            regex : "(<)("+
+                "(?:https?|ftp|dict):[^'\">\\s]+"+
+                "|"+
+                "(?:mailto:)?[-.\\w]+\\@[-a-z0-9]+(?:\\.[-a-z0-9]+)*\\.[a-z]+"+
+                ")(>)"
+        }, {
+            // embedded latex command
+            token : "keyword",
+            regex : "\\\\(?:[a-zA-z0-9]+|[^a-zA-z0-9])"
+        }, {
+            // embedded latex arg
+            token : ["paren.keyword.operator", "text", "paren.keyword.operator"],
+            regex : "(\\{)([^\\}]*)(\\})"
+        }, {
+            // pandoc citation with brackets
+            token : "markup.list",
+            regex : "\\[-?\\@[\\w\\d-]+\\]"
+        }, {
+            // pandoc citation
+            token : "markup.list",
+            regex : "-?\\@[\\w\\d-]+"
+        }, {
+            token : "text",
+            regex : "[^\\*_%$`\\[#<>\\\\]+"
+        }, {
+            token : "text",
+            regex : "\\\\"
+        }, { // HR * - _
+            token : "constant",
+            regex : "^ {0,2}(?:(?: ?\\* ?){3,}|(?: ?\\- ?){3,}|(?: ?\\_ ?){3,})\\s*$",
+            next: "allowBlock"
+        }, { // list
+            token : "text",
+            regex : "^\\s{0,3}(?:[*+-]|\\d+\\.)\\s+",
+            next  : "listblock-start"
+        }, {
+            include : "basic"
+        }],
+       
         // code block
-        "allowBlock": [
-            {token : "support.function", regex : "^ {4}.+", next : "allowBlock"},
-            {token : "empty", regex : "", next : "start"}
-        ],
+        "allowBlock": [{
+           token : "support.function",
+           regex : "^ {4}.+",
+           next : "allowBlock"
+        }, {
+           token : "empty",
+           regex : "",
+           next : "start"
+        }],
 
         "header" : [{
             regex: "$",
@@ -257,7 +262,7 @@ var MarkdownHighlightRules = function() {
             include: "basic"
         }, {
             defaultToken : "heading"
-        } ],
+        }],
 
         "listblock-start" : [{
             token : "text",
@@ -281,7 +286,7 @@ var MarkdownHighlightRules = function() {
             next  : "githubblock"
         }, {
             defaultToken : "text" //do not use markup.list to allow stling leading `*` differntly
-        } ],
+        }],
 
         "blockquote" : [ { // Blockquotes only escape on blank lines.
             token : "empty_line",
@@ -295,7 +300,7 @@ var MarkdownHighlightRules = function() {
             include : "basic", noEscape: true
         }, {
             defaultToken : "string.blockquote"
-        } ],
+        }],
 
         "githubblock" : [ {
             token : "support.function",
@@ -304,8 +309,8 @@ var MarkdownHighlightRules = function() {
         }, {
             token : "support.function",
             regex : ".+"
-        } ]
-    });
+        }]
+    };
 
     this.embedRules(JavaScriptHighlightRules, "jscode-", [{
         token : "support.function",


### PR DESCRIPTION
This ensures that our Markdown mode does not directly embed the HTML highlight rules.

Note that the other changes beyond the removal of:

    HtmlHighlightRules.call(this);

are purely cosmetic.