### PR TITLE
Clean up vim commands

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -210,6 +210,8 @@ public class Source implements InsertSourceHandler,
       pMruList_ = pMruList;
       uiPrefs_ = uiPrefs;
       rnwWeaveRegistry_ = rnwWeaveRegistry;
+      
+      vimCommands_ = new SourceVimCommands();
 
       view_.addTabClosingHandler(this);
       view_.addTabCloseHandler(this);
@@ -448,97 +450,18 @@ public class Source implements InsertSourceHandler,
    
    private void initVimCommands()
    {
-      vimOnSave(this);
-      vimOnNextTab(this);
-      vimOnPreviousTab(this);
-      vimOnCloseTab(this);
-      vimOnCloseAll(this);
-      vimOnNewDoc(this);
-      vimOnSaveAndCloseTab(this);
-      
-      // TODO: Infer encoding from source document?
-      vimOnReadFile(this, uiPrefs_.defaultEncoding().getValue());
-      
-      vimOnRunRScript(this);
+      vimCommands_.save(this);
+      vimCommands_.selectNextTab(this);
+      vimCommands_.selectPreviousTab(this);
+      vimCommands_.closeActiveTab(this);
+      vimCommands_.closeAllTabs(this);
+      vimCommands_.createNewDocument(this);
+      vimCommands_.saveAndCloseActiveTab(this);
+      vimCommands_.readFile(this, uiPrefs_.defaultEncoding().getValue());
+      vimCommands_.runRScript(this);
    }
    
-   private final native void vimOnSave(Source source) /*-{
-      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("write", "w",
-         $entry(function(cm, params) {
-            source.@org.rstudio.studio.client.workbench.views.source.Source::saveActiveSourceDoc()();
-         })
-      );
-   }-*/;
-   
-   private void saveActiveSourceDoc()
-   {
-      if (activeEditor_ != null && activeEditor_ instanceof TextEditingTarget)
-      {
-         TextEditingTarget target = (TextEditingTarget) activeEditor_;
-         target.save();
-      }
-   }
-   
-   private void saveAndCloseActiveSourceDoc()
-   {
-      if (activeEditor_ != null && activeEditor_ instanceof TextEditingTarget)
-      {
-         TextEditingTarget target = (TextEditingTarget) activeEditor_;
-         target.save(new Command()
-         {
-            @Override
-            public void execute()
-            {
-               onCloseSourceDoc();
-            }
-         });
-      }
-   }
-   
-   private native final void vimOnNextTab(Source source) /*-{
-      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("bnext", "bn",
-         $entry(function(cm, params) {
-            source.@org.rstudio.studio.client.workbench.views.source.Source::onNextTab()();
-         })
-      );
-   }-*/;
-   
-   private native final void vimOnPreviousTab(Source source) /*-{
-      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("bprev", "bp",
-         $entry(function(cm, params) {
-            source.@org.rstudio.studio.client.workbench.views.source.Source::onPreviousTab()();
-         })
-      );
-   }-*/;
-   
-   private native final void vimOnCloseTab(Source source) /*-{
-      var callback = $entry(function(cm, params) {
-      
-         var interactive = true;
-         if (params.argString && params.argString === "!")
-            interactive = false;
-         
-         source.@org.rstudio.studio.client.workbench.views.source.Source::closeSourceDoc(Z)(interactive);
-      });
-       
-      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("bdelete", "bd", callback);
-      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("quit", "q", callback);
-   }-*/;
-   
-   private native final void vimOnCloseAll(Source source) /*-{
-      var callback = $entry(function(cm, params) {
-      
-         var interactive = true;
-         if (params.argString && params.argString === "!")
-            interactive = false;
-         
-         source.@org.rstudio.studio.client.workbench.views.source.Source::doVimOnCloseAll(Z)(interactive);
-      });
-       
-      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("qall", "qa", callback);
-   }-*/;
-   
-   private void doVimOnCloseAll(boolean interactive)
+   private void closeAllTabs(boolean interactive)
    {
       if (interactive)
       {
@@ -572,57 +495,30 @@ public class Source implements InsertSourceHandler,
       }
    }
    
-   private native final void vimOnNewDoc(Source source) /*-{
+   private void saveActiveSourceDoc()
+   {
+      if (activeEditor_ != null && activeEditor_ instanceof TextEditingTarget)
+      {
+         TextEditingTarget target = (TextEditingTarget) activeEditor_;
+         target.save();
+      }
+   }
    
-      var callback = $entry(function(cm, params) {
-         if (params.args) {
-            if (params.args.length === 1) {
-               source.@org.rstudio.studio.client.workbench.views.source.Source::editFile(Ljava/lang/String;)(params.args[0]);
+   private void saveAndCloseActiveSourceDoc()
+   {
+      if (activeEditor_ != null && activeEditor_ instanceof TextEditingTarget)
+      {
+         TextEditingTarget target = (TextEditingTarget) activeEditor_;
+         target.save(new Command()
+         {
+            @Override
+            public void execute()
+            {
+               onCloseSourceDoc();
             }
-            // TODO: on error?
-         } else {
-            source.@org.rstudio.studio.client.workbench.views.source.Source::onNewSourceDoc()();
-         }
-      });
-      
-      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("badd", "bad", callback);
-      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("edit", "e", callback);
-      
-   }-*/;
-   
-   private native final void vimOnSaveAndCloseTab(Source source) /*-{
-   
-      var callback = $entry(function(cm, params) {
-         source.@org.rstudio.studio.client.workbench.views.source.Source::saveAndCloseActiveSourceDoc()();
-      });
-      
-      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("wq", "wq", callback);
-      
-   }-*/;
-   
-   private native final void vimOnReadFile(Source source, String encoding) /*-{
-   
-      var callback = $entry(function(cm, params) {
-         if (params.args && params.args.length === 1) {
-            source.@org.rstudio.studio.client.workbench.views.source.Source::pasteFileContentsAtCursor(Ljava/lang/String;Ljava/lang/String;)(params.args[0], encoding);
-         }
-      });
-      
-      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("read", "r", callback);
-   
-   }-*/;
-   
-   private native final void vimOnRunRScript(Source source) /*-{
-      
-      var callback = $entry(function(cm, params) {
-         if (params.args) {
-            source.@org.rstudio.studio.client.workbench.views.source.Source::pasteRCodeExecutionResult(Ljava/lang/String;)(params.argString);
-         }
-      });
-      
-      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("Rscript", "R", callback);
-   
-   }-*/;
+         });
+      }
+   }
    
    /**
     * @param isNewTabPending True if a new tab is about to be created. (If
@@ -3002,6 +2898,7 @@ public class Source implements InsertSourceHandler,
    private final HashSet<AppCommand> dynamicCommands_;
    private final SourceNavigationHistory sourceNavigationHistory_ = 
                                               new SourceNavigationHistory(30);
+   private final SourceVimCommands vimCommands_;
 
    private boolean suspendSourceNavigationAdding_;
   

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -1511,6 +1511,18 @@ public class Source implements InsertSourceHandler,
       });   
    }
    
+   private void revertActiveDocument()
+   {
+      if (activeEditor_ == null)
+         return;
+      
+      if (activeEditor_.getPath() != null)
+         activeEditor_.revertChanges(null);
+      
+      // Ensure that the document is in view
+      activeEditor_.ensureCursorVisible();
+   }
+   
    private void revertUnsavedTargets(Command onCompleted)
    {
       // collect up unsaved targets

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceVimCommands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceVimCommands.java
@@ -70,7 +70,13 @@ public class SourceVimCommands
    public native final void createNewDocument(Source source) /*-{
    
       var callback = $entry(function(cm, params) {
-         if (params.args) {
+         
+         // Handle 'e!'
+         if (params.argString && params.argString === "!")
+            source.@org.rstudio.studio.client.workbench.views.source.Source::revertActiveDocument()();
+            
+         // Handle other editing targets
+         else if (params.args) {
             if (params.args.length === 1) {
                source.@org.rstudio.studio.client.workbench.views.source.Source::editFile(Ljava/lang/String;)(params.args[0]);
             }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceVimCommands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceVimCommands.java
@@ -1,0 +1,122 @@
+/*
+ * Source.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source;
+
+public class SourceVimCommands
+{
+   public final native void save(Source source) /*-{
+      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("write", "w",
+         $entry(function(cm, params) {
+            source.@org.rstudio.studio.client.workbench.views.source.Source::saveActiveSourceDoc()();
+         })
+      );
+   }-*/;
+   
+   public native final void selectNextTab(Source source) /*-{
+      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("bnext", "bn",
+         $entry(function(cm, params) {
+            source.@org.rstudio.studio.client.workbench.views.source.Source::onNextTab()();
+         })
+      );
+   }-*/;
+   
+   public native final void selectPreviousTab(Source source) /*-{
+      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("bprev", "bp",
+         $entry(function(cm, params) {
+            source.@org.rstudio.studio.client.workbench.views.source.Source::onPreviousTab()();
+         })
+      );
+   }-*/;
+   
+   public native final void closeActiveTab(Source source) /*-{
+      var callback = $entry(function(cm, params) {
+      
+         var interactive = true;
+         if (params.argString && params.argString === "!")
+            interactive = false;
+         
+         source.@org.rstudio.studio.client.workbench.views.source.Source::closeSourceDoc(Z)(interactive);
+      });
+       
+      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("bdelete", "bd", callback);
+      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("quit", "q", callback);
+   }-*/;
+   
+   public native final void closeAllTabs(Source source) /*-{
+      var callback = $entry(function(cm, params) {
+      
+         var interactive = true;
+         if (params.argString && params.argString === "!")
+            interactive = false;
+         
+         source.@org.rstudio.studio.client.workbench.views.source.Source::closeAllTabs(Z)(interactive);
+      });
+       
+      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("qall", "qa", callback);
+   }-*/;
+   
+   public native final void createNewDocument(Source source) /*-{
+   
+      var callback = $entry(function(cm, params) {
+         if (params.args) {
+            if (params.args.length === 1) {
+               source.@org.rstudio.studio.client.workbench.views.source.Source::editFile(Ljava/lang/String;)(params.args[0]);
+            }
+            // TODO: on error?
+         } else {
+            source.@org.rstudio.studio.client.workbench.views.source.Source::onNewSourceDoc()();
+         }
+      });
+      
+      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("badd", "bad", callback);
+      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("edit", "e", callback);
+      
+   }-*/;
+   
+   public native final void saveAndCloseActiveTab(Source source) /*-{
+   
+      var callback = $entry(function(cm, params) {
+         source.@org.rstudio.studio.client.workbench.views.source.Source::saveAndCloseActiveSourceDoc()();
+      });
+      
+      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("wq", "wq", callback);
+      
+   }-*/;
+   
+   public native final void readFile(Source source, String encoding) /*-{
+   
+      var callback = $entry(function(cm, params) {
+         if (params.args && params.args.length === 1) {
+            source.@org.rstudio.studio.client.workbench.views.source.Source::pasteFileContentsAtCursor(Ljava/lang/String;Ljava/lang/String;)(params.args[0], encoding);
+         }
+      });
+      
+      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("read", "r", callback);
+   
+   }-*/;
+   
+   public native final void runRScript(Source source) /*-{
+      
+      var callback = $entry(function(cm, params) {
+         if (params.args) {
+            source.@org.rstudio.studio.client.workbench.views.source.Source::pasteRCodeExecutionResult(Ljava/lang/String;)(params.argString);
+         }
+      });
+      
+      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("Rscript", "R", callback);
+   
+   }-*/;
+
+}


### PR DESCRIPTION
This moves the Vim command work to a helper class `SourceVimCommands`, and also adds support for `e!` (revert current document if possible).