### PR TITLE
workaround quoting bugs for async procs on Windows

### DIFF
--- a/src/cpp/session/modules/SessionAsyncRCompletions.cpp
+++ b/src/cpp/session/modules/SessionAsyncRCompletions.cpp
@@ -208,7 +208,7 @@ void AsyncRCompletions::update()
    // Construct a call to .rs.getAsyncExports
    std::stringstream ss;
    ss << ".rs.getAsyncExports(";
-   ss << "\"" << pkgs[0] << "\"";
+   ss << "'" << pkgs[0] << "'";
    
    if (pkgs.size() > 0)
    {
@@ -216,7 +216,7 @@ void AsyncRCompletions::update()
            it != pkgs.end();
            ++it)
       {
-         ss << ",\"" << *it << "\"";
+         ss << ",'" << *it << "'";
       }
    }
    ss << ");";

--- a/src/cpp/session/modules/SessionRSConnect.cpp
+++ b/src/cpp/session/modules/SessionRSConnect.cpp
@@ -53,8 +53,8 @@ public:
    {
       boost::shared_ptr<ShinyAppDeploy> pDeploy(new ShinyAppDeploy(file));
 
-      std::string cmd("{ options(repos = c(CRAN=\"" +
-                       module_context::CRANReposURL() + "\")); ");
+      std::string cmd("{ options(repos = c(CRAN='" +
+                       module_context::CRANReposURL() + "')); ");
 
       cmd += "rsconnect::deployApp("
              "appDir = '" + dir + "',"


### PR DESCRIPTION
On Windows, a single string is constructed and sent as a command line argument with `::CreateProcess`. To ensure that all of the argument(s) following `-e` are actually captured by that, we must ensure they are quoted.

It might be best to handle this in `Win32ChildProcess`, but I am not familiar enough with that code to tread within.