### PR TITLE
use ::strcmp to avoid LC_COLLATE access race conditions

### DIFF
--- a/src/cpp/core/include/core/FileInfo.hpp
+++ b/src/cpp/core/include/core/FileInfo.hpp
@@ -105,9 +105,7 @@ private:
    
 inline int fileInfoPathCompare(const FileInfo& a, const FileInfo& b)
 {
-   // use stcoll because that is what alphasort (comp function passed to
-   // scandir) uses for its sorting)
-   int result = ::strcoll(a.absolutePath().c_str(), b.absolutePath().c_str());
+   int result = ::strcmp(a.absolutePath().c_str(), b.absolutePath().c_str());
 
    if (result != 0)
       return result;

--- a/src/cpp/core/system/PosixFileScanner.cpp
+++ b/src/cpp/core/system/PosixFileScanner.cpp
@@ -32,6 +32,7 @@ namespace core {
 namespace system {
 
 namespace {
+
 #if defined(__APPLE__) && !defined(HAVE_SCANDIR_POSIX)
 int entryFilter(struct dirent *entry)
 #else
@@ -44,6 +45,16 @@ int entryFilter(const struct dirent *entry)
       return 1;
 }
 
+// note: because R may change LC_COLLATE, we cannot
+// use strcoll (otherwise we run into race issues where
+// the file monitor attempts to access LC_COLLATE just as
+// R is replacing it). to avoid this, we use strcmp and
+// don't sort according to locale.
+int alphasort(const dirent** lhs, const dirent** rhs)
+{
+   return strcmp((*lhs)->d_name, (*rhs)->d_name);
+}
+
 // wrapper for scandir api
 Error scanDir(const std::string& dirPath, std::vector<std::string>* pNames)
 {
@@ -52,7 +63,7 @@ Error scanDir(const std::string& dirPath, std::vector<std::string>* pNames)
    int entries = ::scandir(dirPath.c_str(),
                            &namelist,
                            entryFilter,
-                           ::alphasort);
+                           alphasort);
    if (entries == -1)
    {
       Error error = systemError(errno, ERROR_LOCATION);


### PR DESCRIPTION
Tested and this fixes the crash caused when e.g. calling `install.packages("BH")` within a Packrat project.