### PR TITLE
Fixing typo

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
@@ -312,7 +312,7 @@ public class Projects implements OpenProjectFileHandler,
                VcsCloneOptions cloneOptions = newProject.getVcsCloneOptions();
                
                if (cloneOptions.getVcsName().equals((VCSConstants.GIT_ID)))
-                  indicator.onProgress("Cloning Git repoistory...");
+                  indicator.onProgress("Cloning Git repository...");
                else
                   indicator.onProgress("Checking out SVN repository...");
                


### PR DESCRIPTION
The message shown across the screen used to read "Cloning Git repoistory", I changed it to "Cloning Git repository"