### PR TITLE
Bugfix/no namespace autocomplete

### DIFF
--- a/src/gwt/test/autoindent_test_cpp.html
+++ b/src/gwt/test/autoindent_test_cpp.html
@@ -3,6 +3,7 @@
 <head>
   <!script type="text/javascript" src="../tools/ace/build_support/mini_require.js"></script>
   <script type="text/javascript" src="../tools/ace/build/src/ace.js"></script>
+  <script type="text/javascript" src="../acesupport/acemode/utils.js"></script>
   <script type="text/javascript" src="../acesupport/acemode/auto_brace_insert.js"></script>
   <script type="text/javascript" src="../acesupport/acemode/doc_comment_highlight_rules.js"></script>
   <script type="text/javascript" src="../acesupport/acemode/tex_highlight_rules.js"></script>


### PR DESCRIPTION
This disables the automatic insertion of `// end namespace <ns>`.

We could consider bringing this behaviour back in the future as part of snippets.