### PR TITLE
c++ mode: update rules for embedded R chunks to allow for no space between *** and R

### DIFF
--- a/src/gwt/acesupport/acemode/c_cpp.js
+++ b/src/gwt/acesupport/acemode/c_cpp.js
@@ -66,7 +66,7 @@ var Mode = function(suppressHighlighting, session) {
    // R-related tokenization
    this.$r_outdent = {};
    oop.implement(this.$r_outdent, RMatchingBraceOutdent);
-   this.r_codeModel = new RCodeModel(session, this.$tokenizer, /^r-/, /^\s*\/\*{3,}\s+(.*)\s*$/);
+   this.r_codeModel = new RCodeModel(session, this.$tokenizer, /^r-/, /^\s*\/\*{3,}\s*[Rr]\s*$/);
 
    // C/C++ related tokenization
    this.codeModel = new CppCodeModel(session, this.$tokenizer);
@@ -76,7 +76,7 @@ var Mode = function(suppressHighlighting, session) {
    
    this.$sweaveBackgroundHighlighter = new SweaveBackgroundHighlighter(
       session,
-         /^\s*\/\*{3,}\s+[Rr]\s*$/,
+         /^\s*\/\*{3,}\s*[Rr]\s*$/,
          /^\s*\*\/$/,
       true
    );

--- a/src/gwt/acesupport/acemode/c_cpp.js
+++ b/src/gwt/acesupport/acemode/c_cpp.js
@@ -66,7 +66,7 @@ var Mode = function(suppressHighlighting, session) {
    // R-related tokenization
    this.$r_outdent = {};
    oop.implement(this.$r_outdent, RMatchingBraceOutdent);
-   this.r_codeModel = new RCodeModel(session, this.$tokenizer, /^r-/, /^\s*\/\*{3,}\s*[Rr]\s*$/);
+   this.r_codeModel = new RCodeModel(session, this.$tokenizer, /^r-/, /^\s*\/\*{3,}\s*([Rr])\s*$/);
 
    // C/C++ related tokenization
    this.codeModel = new CppCodeModel(session, this.$tokenizer);

--- a/src/gwt/acesupport/acemode/c_cpp_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/c_cpp_highlight_rules.js
@@ -277,7 +277,7 @@ var c_cppHighlightRules = function() {
    // Embed R syntax highlighting
    this.$rules["start"].unshift({
       token: "support.function.codebegin",
-      regex: "^\\s*\\/\\*{3,}\\s+[Rr]\\s*$",
+      regex: "^\\s*\\/\\*{3,}\\s*[Rr]\\s*$",
       next: "r-start"
    });
 

--- a/src/gwt/acesupport/acemode/c_cpp_style_behaviour.js
+++ b/src/gwt/acesupport/acemode/c_cpp_style_behaviour.js
@@ -107,7 +107,7 @@ var CStyleBehaviour = function(codeModel) {
 
          var cursor = editor.getCursorPosition();
          var line = new String(session.doc.getLine(cursor.row));
-         var match = line.match(/^(\s*)\/\*{3,}\s/);
+         var match = line.match(/^(\s*)\/\*{3,}\s*/);
          if (match) {
             return {
                text: "R\n" + match[1] + "\n" + match[1] + "*/",


### PR DESCRIPTION
@kevinushey Could you review this? 

One change I'm not 100% certain about is the change to the regex passed to the RCodeModel. I actually changed it back to what it was when we first checked this feature in:

https://github.com/rstudio/rstudio/commit/80a6c25cd96f92edf7932a6bdafe6d61b8c44ee2

The way I was reading the regex you had in there was /***<space> (then any characters) <eol>. That doesn't seem right to me (as we require an r or R) but then it occurred to me that you may have changed it to that for a reason I don't understand. This checkin reverts to the original regex, let me know if you think that is okay.