### PR TITLE
improve semi-colon insertion rules

### DIFF
--- a/src/gwt/acesupport/acemode/cpp_code_model.js
+++ b/src/gwt/acesupport/acemode/cpp_code_model.js
@@ -58,7 +58,11 @@ var CppCodeModel = function(session, tokenizer, statePattern, codeBeginPattern) 
 (function() {
 
    this.getTokenCursor = function() {
-      return new CppTokenCursor(this.$tokens);
+      return new CppTokenCursor(this.$tokens, 0, 0, this);
+   };
+
+   this.$tokenizeUpToRow = function(row) {
+      this.$tokenUtils.$tokenizeUpToRow(row);
    };
 
    var $walkBackForScope = function(cursor, that) {
@@ -1248,12 +1252,8 @@ var CppCodeModel = function(session, tokenizer, statePattern, codeBeginPattern) 
                   } 
                }
 
-               var tokenCursor = new CppTokenCursor(
-                  this.$tokens,
-                  row,
-                  this.$tokens[row].length - 1
-               );
-
+               var tokenCursor = this.getTokenCursor();
+               
                // If 'dontSubset' is false, then we want to plonk the token cursor
                // on the first token before the cursor.
                if (!dontSubset)

--- a/src/gwt/acesupport/acemode/token_cursor.js
+++ b/src/gwt/acesupport/acemode/token_cursor.js
@@ -647,10 +647,11 @@ var TokenCursor = function(tokens, row, offset) {
 }).call(TokenCursor.prototype);
 
 
-var CppTokenCursor = function(tokens, row, offset) {
+var CppTokenCursor = function(tokens, row, offset, codeModel) {
    this.$tokens = tokens;
    this.$row = row || 0;
    this.$offset = offset || 0;
+   this.$codeModel = codeModel;
 };
 oop.mixin(CppTokenCursor.prototype, TokenCursor.prototype);
 


### PR DESCRIPTION
This improves upon the old semi-colon insertion rules by using the tokenizer + token cursor rules for C++ mode. The rewritten heuristics are far more readable and easier to reason about, and should lead to fewer 'false positives' wherein we insert undesired semi-colons.