### PR TITLE
tweak error / find-line bg colors

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/ambiance.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/ambiance.css
@@ -232,15 +232,15 @@
   z-index: -1;
   background-color: #333332;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #474645;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #8F7F2C;
+}
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #474645;
 }
 .ace_console_error {
   background-color: #474645;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chaos.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chaos.css
@@ -165,15 +165,15 @@
   z-index: -1;
   background-color: #2A2A29;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #3F3E3D;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #8A7A27;
+}
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #3F3E3D;
 }
 .ace_console_error {
   background-color: #3F3E3D;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chrome.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chrome.css
@@ -165,16 +165,16 @@
   z-index: -1;
   background-color: #F2F2F2;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #CCCCCC;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #FFEE9B;
 }
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #E5E5E5;
+}
 .ace_console_error {
-  background-color: #CCCCCC;
+  background-color: #E5E5E5;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds.css
@@ -123,18 +123,18 @@
   z-index: -1;
   background-color: #F2F2F2;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #CCCCCC;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #FFEE9B;
 }
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #E5E5E5;
+}
 .ace_console_error {
-  background-color: #CCCCCC;
+  background-color: #E5E5E5;
 }
 .ace_keyword.ace_operator {
   color: #888888 !important;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds_midnight.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds_midnight.css
@@ -124,15 +124,15 @@
   z-index: -1;
   background-color: #252525;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #313131;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #8C7B28;
+}
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #313131;
 }
 .ace_console_error {
   background-color: #313131;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/cobalt.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/cobalt.css
@@ -145,15 +145,15 @@
   z-index: -1;
   background-color: #193853;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #324E66;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #7F803C;
+}
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #324E66;
 }
 .ace_console_error {
   background-color: #324E66;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/crimson_editor.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/crimson_editor.css
@@ -154,16 +154,16 @@
   z-index: -1;
   background-color: #F5F5F5;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #D8D8D8;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #FFEE9B;
 }
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #EBEBEB;
+}
 .ace_console_error {
-  background-color: #D8D8D8;
+  background-color: #EBEBEB;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dawn.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dawn.css
@@ -138,18 +138,18 @@
   z-index: -1;
   background-color: #ECECEC;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #C8C8C8;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #FCEB98;
 }
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #E0E0E0;
+}
 .ace_console_error {
-  background-color: #C8C8C8;
+  background-color: #E0E0E0;
 }
 .ace_keyword.ace_operator {
   color: #888888 !important;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dreamweaver.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dreamweaver.css
@@ -187,16 +187,16 @@
   z-index: -1;
   background-color: #F2F2F2;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #CCCCCC;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #FFEE9B;
 }
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #E5E5E5;
+}
 .ace_console_error {
-  background-color: #CCCCCC;
+  background-color: #E5E5E5;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/eclipse.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/eclipse.css
@@ -124,18 +124,18 @@
   z-index: -1;
   background-color: #F2F2F2;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #CCCCCC;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #FFEE9B;
 }
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #E5E5E5;
+}
 .ace_console_error {
-  background-color: #CCCCCC;
+  background-color: #E5E5E5;
 }
 .ace_keyword.ace_operator {
   color: #888888 !important;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/idle_fingers.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/idle_fingers.css
@@ -124,15 +124,15 @@
   z-index: -1;
   background-color: #464646;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #5A5A5A;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #988835;
+}
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #5A5A5A;
 }
 .ace_console_error {
   background-color: #5A5A5A;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/katzenmilch.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/katzenmilch.css
@@ -151,18 +151,18 @@
   z-index: -1;
   background-color: #E6E5E6;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #C2C1C2;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #F9E895;
 }
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #DAD9DA;
+}
 .ace_console_error {
-  background-color: #C2C1C2;
+  background-color: #DAD9DA;
 }
 .ace_keyword.ace_operator {
   color: #888888 !important;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/kr_theme.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/kr_theme.css
@@ -135,15 +135,15 @@
   z-index: -1;
   background-color: #23221E;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #3B3A33;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #857420;
+}
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #3B3A33;
 }
 .ace_console_error {
   background-color: #3B3A33;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore.css
@@ -121,15 +121,15 @@
   z-index: -1;
   background-color: #2A2A29;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #3F3E3D;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #8A7A27;
+}
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #3F3E3D;
 }
 .ace_console_error {
   background-color: #3F3E3D;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore_soft.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore_soft.css
@@ -122,15 +122,15 @@
   z-index: -1;
   background-color: #302F2F;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #444342;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #8D7D2A;
+}
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #444342;
 }
 .ace_console_error {
   background-color: #444342;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/mono_industrial.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/mono_industrial.css
@@ -137,15 +137,15 @@
   z-index: -1;
   background-color: #38413D;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #4E5652;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #908530;
+}
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #4E5652;
 }
 .ace_console_error {
   background-color: #4E5652;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/monokai.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/monokai.css
@@ -133,15 +133,15 @@
   z-index: -1;
   background-color: #3B3C36;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #50514B;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #93832D;
+}
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #50514B;
 }
 .ace_console_error {
   background-color: #50514B;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/pastel_on_dark.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/pastel_on_dark.css
@@ -143,15 +143,15 @@
   z-index: -1;
   background-color: #3F3B3B;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #524E4E;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #958330;
+}
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #524E4E;
 }
 .ace_console_error {
   background-color: #524E4E;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_dark.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_dark.css
@@ -112,15 +112,15 @@
   z-index: -1;
   background-color: #0E3640;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #1D424B;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #7F8437;
+}
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #1D424B;
 }
 .ace_console_error {
   background-color: #1D424B;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_light.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_light.css
@@ -117,18 +117,18 @@
   z-index: -1;
   background-color: #F4EFDD;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #DCDACD;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #FEEA8D;
 }
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #ECE8D8;
+}
 .ace_console_error {
-  background-color: #DCDACD;
+  background-color: #ECE8D8;
 }
 .ace_keyword.ace_operator {
   color: #93A1A1 !important;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/textmate.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/textmate.css
@@ -166,16 +166,16 @@
   z-index: -1;
   background-color: #F2F2F2;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #CCCCCC;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #FFEE9B;
 }
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #E5E5E5;
+}
 .ace_console_error {
-  background-color: #CCCCCC;
+  background-color: #E5E5E5;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow.css
@@ -136,16 +136,16 @@
   z-index: -1;
   background-color: #F6F6F6;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #DBDBDB;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #FFEE9B;
 }
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #EDEDED;
+}
 .ace_console_error {
-  background-color: #DBDBDB;
+  background-color: #EDEDED;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night.css
@@ -136,15 +136,15 @@
   z-index: -1;
   background-color: #2D2F31;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #3E4042;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #8E7E2C;
+}
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #3E4042;
 }
 .ace_console_error {
   background-color: #3E4042;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_blue.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_blue.css
@@ -133,15 +133,15 @@
   z-index: -1;
   background-color: #193962;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #324F73;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #7F8144;
+}
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #324F73;
 }
 .ace_console_error {
   background-color: #324F73;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_bright.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_bright.css
@@ -152,15 +152,15 @@
   z-index: -1;
   background-color: #212121;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #2C2C2C;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #7F6F1C;
+}
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #2C2C2C;
 }
 .ace_console_error {
   background-color: #2C2C2C;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_eighties.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_eighties.css
@@ -136,15 +136,15 @@
   z-index: -1;
   background-color: #3C3C3C;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #4C4C4C;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #968532;
+}
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #4C4C4C;
 }
 .ace_console_error {
   background-color: #4C4C4C;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/twilight.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/twilight.css
@@ -139,15 +139,15 @@
   z-index: -1;
   background-color: #2A2A2A;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #414141;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #897926;
+}
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #414141;
 }
 .ace_console_error {
   background-color: #414141;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/vibrant_ink.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/vibrant_ink.css
@@ -121,15 +121,15 @@
   z-index: -1;
   background-color: #262626;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #3E3E3E;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #877623;
+}
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #3E3E3E;
 }
 .ace_console_error {
   background-color: #3E3E3E;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/xcode.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/xcode.css
@@ -114,18 +114,18 @@
   z-index: -1;
   background-color: #F2F2F2;
 }
-.ace_marker-layer .ace_find_line {
-  position: absolute;
-  z-index: -1;
-  background-color: #CCCCCC;
-}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
   background-color: #FFEE9B;
 }
+.ace_marker-layer .ace_find_line {
+  position: absolute;
+  z-index: -1;
+  background-color: #E5E5E5;
+}
 .ace_console_error {
-  background-color: #CCCCCC;
+  background-color: #E5E5E5;
 }
 .ace_keyword.ace_operator {
   color: #888888 !important;

--- a/src/gwt/tools/compile-themes.R
+++ b/src/gwt/tools/compile-themes.R
@@ -317,15 +317,6 @@ for (file in themeFiles) {
       create_line_marker_rule(".ace_foreign_line", color_as_hex(mergedColor))
    )
    
-   ## Generate a background used for 'find_line'; most
-   ## promently used for highlighting lines after a failed
-   ## compile
-   findBackground <- color_as_hex(mix_colors(backgroundRgb, foregroundRgb, 0.8))
-   content <- c(
-      content,
-      create_line_marker_rule(".ace_find_line", findBackground)
-   )
-   
    ## Generate a color used for 'debugging' backgrounds.
    debugPrimary <- parse_css_color("#FFDE38")
    debugBg <- color_as_hex(mix_colors(backgroundRgb, debugPrimary, 0.5))
@@ -335,14 +326,26 @@ for (file in themeFiles) {
       create_line_marker_rule(".ace_active_debug_line", debugBg)
    )
    
-   ## Generate a background for console errors.
-   errorBg <- color_as_hex(mix_colors(backgroundRgb, foregroundRgb, 0.8))
+   ## Generate a background color used for console errors, as well as
+   ## 'find_line' (used for highlighting e.g. 'sourceCpp' errors).
+   
+   ## Dark backgrounds need a bit more contrast than light ones for
+   ## a nice visual display.
+   mixingProportion <- if (isDark) 0.8 else 0.9
+   errorBgColor <-
+      color_as_hex(mix_colors(backgroundRgb, foregroundRgb, mixingProportion))
+   
+   content <- c(
+      content,
+      create_line_marker_rule(".ace_find_line", errorBgColor)
+   )
+   
    content <- add_content(
       content,
       ".ace_console_error {",
       "  background-color: %s;",
       "}",
-      replace = errorBg
+      replace = errorBgColor
    )
    
    ## Add operator colors if necessary.


### PR DESCRIPTION
This tweaks the error highlight coloring for light backgrounds -- we now use a larger proportion of the background color when mixing relative to dark backgrounds.

Sorry for the somewhat noisy diffs in the `.css` files -- this is due to me re-organizing the code in `compile-themes.R`. For the dark themes, you'll notice that the `.ace_find_line` and `.ace_active_debug_line` rules have simply been reordered; for 'light' themes you should see a lighter colour for those rules.