### PR TITLE
delete 'Ctrl + Shift + M' keybinding in Ace

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -69,6 +69,7 @@ public class AceEditorWidget extends Composite
       addStyleName("loading");
 
       editor_ = AceEditorNative.createEditor(getElement());
+      editor_.manageDefaultKeybindings();
       editor_.getRenderer().setHScrollBarAlwaysVisible(false);
       editor_.setShowPrintMargin(false);
       editor_.setPrintMarginColumn(0);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -170,6 +170,11 @@ public class AceEditorNative extends JavaScriptObject {
       var loader = require("rstudio/loader");
       return loader.loadEditor(container);
    }-*/;
+   
+   public final native void manageDefaultKeybindings() /*-{
+      // We bind 'Ctrl + Shift + M' to insert a magrittr shortcut on Windows
+      delete this.commands.commandKeyBinding["ctrl-shift-m"];
+   }-*/;
 
    public static <T> HandlerRegistration addEventListener(
          JavaScriptObject target,


### PR DESCRIPTION
This PR adds a `manageDefaultKeybindings` command wherein we can play with, or modify, the default keybindings used by Ace. We delete the default keybinding that maps `Ctrl + Shift + M` to Ace's 'expand-selection' (which we should consider binding to something new)