### PR TITLE
Add keyboard shortcut card for Vim mode

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutViewer.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutViewer.java
@@ -17,6 +17,7 @@ package org.rstudio.core.client.command;
 
 
 import org.rstudio.core.client.widget.ShortcutInfoPanel;
+import org.rstudio.core.client.widget.VimKeyInfoPanel;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.workbench.commands.Commands;
@@ -58,7 +59,7 @@ public class ShortcutViewer implements NativePreviewHandler
       {
          return;
       }
-      shortcutInfo_ = new ShortcutInfoPanel(new Command()
+      showShortcutInfoPanel(new ShortcutInfoPanel(new Command()
       {
          @Override
          public void execute()
@@ -68,7 +69,22 @@ public class ShortcutViewer implements NativePreviewHandler
             else 
                openApplicationURL("docs/keyboard.htm");
          }
-      });
+      }));
+   }
+   
+   public void showVimKeyboardShortcuts()
+   {
+      // prevent reentry
+      if (shortcutInfo_ != null)
+      {
+         return;
+      }
+      showShortcutInfoPanel(new VimKeyInfoPanel());
+   }
+   
+   private void showShortcutInfoPanel(ShortcutInfoPanel panel)
+   {
+      shortcutInfo_ = panel;
       RootLayoutPanel.get().add(shortcutInfo_);
       preview_ = Event.addNativePreviewHandler(this);
    }

--- a/src/gwt/src/org/rstudio/core/client/widget/ShortcutInfoPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ShortcutInfoPanel.java
@@ -32,6 +32,7 @@ import com.google.gwt.user.client.ui.Anchor;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FocusPanel;
 import com.google.gwt.user.client.ui.HTMLPanel;
+import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
 
 public class ShortcutInfoPanel extends Composite
@@ -47,6 +48,34 @@ public class ShortcutInfoPanel extends Composite
    public ShortcutInfoPanel(final Command onShowFullDocs)
    {
       initWidget(uiBinder.createAndBindUi(this));
+
+      if (onShowFullDocs == null)
+      {
+         shortcutDocLink.setVisible(false);
+      }
+      else
+      {
+         shortcutDocLink.addClickHandler(new ClickHandler()
+         {
+            @Override
+            public void onClick(ClickEvent event)
+            {
+               onShowFullDocs.execute();
+            }
+         });
+      }
+      
+      headerLabel.setText(getHeaderText());
+      shortcutPanel.add(getShortcutContent());
+   }
+   
+   protected String getHeaderText()
+   {
+      return "Keyboard Shortcut Quick Reference";
+   }
+   
+   protected Widget getShortcutContent()
+   {
       SafeHtmlBuilder sb = new SafeHtmlBuilder();
       List<ShortcutInfo> shortcuts = 
             ShortcutManager.INSTANCE.getActiveShortcutInfo();
@@ -88,16 +117,7 @@ public class ShortcutInfoPanel extends Composite
       }
       sb.appendHtmlConstant("</td></tr></table>");
       HTMLPanel panel = new HTMLPanel(sb.toSafeHtml());
-      shortcutPanel.add(panel);
-      
-      shortcutDocLink.addClickHandler(new ClickHandler()
-      {
-         @Override
-         public void onClick(ClickEvent event)
-         {
-            onShowFullDocs.execute();
-         }
-      });
+      return panel;
    }
    
    public Element getRootElement()
@@ -108,4 +128,5 @@ public class ShortcutInfoPanel extends Composite
    @UiField HTMLPanel shortcutPanel;
    @UiField FocusPanel focusPanel;
    @UiField Anchor shortcutDocLink;
+   @UiField Label headerLabel;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ShortcutInfoPanel.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/ShortcutInfoPanel.ui.xml
@@ -68,7 +68,7 @@
 			             text="See All Shortcuts..."
 			             ui:field="shortcutDocLink"></g:Anchor>
 			   <g:Label styleName="{style.shortcutHeader}" 
-			            text="Keyboard Shortcut Quick Reference"></g:Label>
+			            ui:field="headerLabel"></g:Label>
 				<g:HTMLPanel ui:field="shortcutPanel">
 				</g:HTMLPanel>
 			</g:HTMLPanel>

--- a/src/gwt/src/org/rstudio/core/client/widget/VimKeyInfo.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/VimKeyInfo.java
@@ -1,0 +1,23 @@
+package org.rstudio.core.client.widget;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.user.client.ui.UIObject;
+
+public class VimKeyInfo extends UIObject
+{
+
+   private static VimKeyInfoUiBinder uiBinder = GWT
+         .create(VimKeyInfoUiBinder.class);
+
+   interface VimKeyInfoUiBinder extends UiBinder<Element, VimKeyInfo>
+   {
+   }
+
+   public VimKeyInfo()
+   {
+      setElement(uiBinder.createAndBindUi(this));
+   }
+
+}

--- a/src/gwt/src/org/rstudio/core/client/widget/VimKeyInfo.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/VimKeyInfo.ui.xml
@@ -1,12 +1,14 @@
-<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
-<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder">
+<ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
+             xmlns:g='urn:import:com.google.gwt.user.client.ui'>
 	<ui:style>
 	
 	</ui:style>
-	<div>
-	<table>
+<g:HTMLPanel>
+<g:HTML>
+<table width="100%">
 	<tr>
-	<td><h2>Motions</h2>
+	<td width="33%">
+	<h2>Motions</h2>
 		<table>
 			<tr>
 			<td><strong>h, j, k, l</strong></td>
@@ -52,6 +54,14 @@
 			<td><strong>'x, `x</strong></td>
 			<td>To mark x</td>
 			</tr>
+			<tr>
+			<td><strong>H, M, L</strong></td>
+			<td>To top, middle, bottom of screen</td>
+			</tr>
+			<tr>
+			<td><strong>Ctrl+U, Ctrl+D</strong></td>
+			<td>Up, down by 1/2 screen</td>
+			</tr>
 		</table>
 
         <h2>Operators</h2>
@@ -89,8 +99,8 @@
 			<td>Indent, unindent lines</td>
 			</tr>
         </table>
-        
-        
+   </td>
+   <td width="33%">
         <h2>Operator Motions</h2>
         <table>
 			<tr>
@@ -133,6 +143,11 @@
         	<td><strong>o, O</strong></td>
         	<td>Insert line after, before current</td>
         	</tr>
+        	<tr>
+        	<td><strong>zz, zt, zb</strong></td>
+        	<td>Scroll current line to center, top, bottom</td>
+        	</tr>
+
         </table>
 
         <h2>Other</h2>
@@ -153,20 +168,87 @@
 			<td><strong>r</strong></td>
 			<td>Replace character</td>
 			</tr>
+			<tr>
+			<td><strong>J</strong></td>
+			<td>Join line with next</td>
+			</tr>
+			<tr>
+			<td><strong>u, Ctrl+R</strong></td>
+			<td>Undo, redo</td>
+			</tr>
+			<tr>
+			<td><strong>mx</strong></td>
+			<td>Create mark x at cursor</td>
+			</tr>
+			<tr>
+			<td><strong>K</strong></td>
+			<td>Show help for topic under cursor</td>
+			</tr>
+			<tr>
+			<td><strong>.</strong></td>
+			<td>Repeat last operation</td>
+			</tr>
+			<tr>
+			<td><strong>N{operation}</strong></td>
+			<td>Perform <i>operation</i> N times</td>
+			</tr>
+			<tr>
+			<td><strong>Esc, Ctrl+[</strong></td>
+			<td>Leave insert mode</td>
+			</tr>
+        </table>
+   </td>
+   <td width="33%">
+        <h2>Searching</h2>
+        <table>
+			<tr>
+			<td><strong>/text, ?text</strong></td>
+			<td>Search forward, back for <i>text</i></td>
+			</tr>
+			<tr>
+			<td><strong>*</strong></td>
+			<td>Search for text under cursor</td>
+			</tr>
+			<tr>
+			<td><strong>n</strong></td>
+			<td>Go to next search match</td>
+			</tr>
+        </table>
+
+        <h2>Ex Commands</h2>
+        <table>
+			<tr>
+			<td><strong>:w, :wq, wq!</strong></td>
+			<td>Save, save and quit, without prompt</td>
+			</tr>
+			<tr>
+			<td><strong>:bn, :bp</strong></td>
+			<td>Go to previous, next tab</td>
+			</tr>
+			<tr>
+			<td><strong>:N</strong></td>
+			<td>Go to line N</td>
+			</tr>
+			<tr>
+			<td><strong>:R expr</strong></td>
+			<td>Evaluate R expression</td>
+			</tr>
+			<tr>
+			<td><strong>:r file</strong></td>
+			<td>Insert contents of file</td>
+			</tr>
+			<tr>
+			<td><strong>:%s/text/rep/g</strong></td>
+			<td>Search and replace text with rep</td>
+			</tr>
+			<tr>
+			<td><strong>:help</strong></td>
+			<td>Show this screen</td>
+			</tr>
         </table>
 	</td>
  </tr>
- *   Action:
- *   a, i, s, A, I, S, o, O
- *   zz, z., z<CR>, zt, zb, z-
- *   J
- *   u, Ctrl-r
- *   m<character>
- *   r<character>
- *
- *   Modes:
- *   ESC - leave insert mode, visual mode, and clear input state.
- *   Ctrl-[, Ctrl-c - same as ESC.
 </table>
-	</div>
+</g:HTML>
+</g:HTMLPanel>
 </ui:UiBinder>

--- a/src/gwt/src/org/rstudio/core/client/widget/VimKeyInfo.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/VimKeyInfo.ui.xml
@@ -5,6 +5,12 @@
 	</ui:style>
 <g:HTMLPanel>
 <g:HTML>
+<!-- 
+RStudio's Vim support comes from the ACE editor. Documentation on which keys
+it supports can be found here:
+
+https://github.com/ajaxorg/ace/blob/master/lib/ace/keyboard/vim.js
+-->
 <table width="100%">
 	<tr>
 	<td width="33%">
@@ -27,8 +33,12 @@
 			<td>Back to beginning, end of previous word</td>
 			</tr>
 			<tr>
-			<td><strong>fx, Fx, tx, Tx</strong></td>
-			<td>To, to before character x</td>
+			<td><strong>f<i>x</i>, F<i>x</i></strong></td>
+			<td>Forward, backward to character <i>x</i></td>
+			</tr>
+			<tr>
+			<td><strong>t<i>x</i>, T<i>x</i></strong></td>
+			<td>Forward, backward to before character <i>x</i></td>
 			</tr>
 			<tr>
 			<td><strong>^, $</strong></td>
@@ -45,6 +55,10 @@
 			<tr>
 			<td><strong>gg, G</strong></td>
 			<td>To first, last line</td>
+			</tr>
+			<tr>
+			<td><strong><i>{number}</i>G</strong></td>
+			<td>To line <i>number</i></td>
 			</tr>
 			<tr>
 			<td><strong>%</strong></td>
@@ -67,19 +81,19 @@
         <h2>Operators</h2>
         <table>
 			<tr>
-			<td><strong>d{motion}</strong></td>
+			<td><strong>d<i>{motion}</i></strong></td>
 			<td>Delete (cut) text</td>
 			</tr>
 			<tr>
-			<td><strong>y{motion}</strong></td>
+			<td><strong>y<i>{motion}</i></strong></td>
 			<td>Yank (copy) text</td>
 			</tr>
 			<tr>
-			<td><strong>c{motion}</strong></td>
+			<td><strong>c<i>{motion}</i></strong></td>
 			<td>Change (cut, insert) text</td>
 			</tr>
 			<tr>
-			<td><strong>g~{motion}</strong></td>
+			<td><strong>g~<i>{motion}</i></strong></td>
 			<td>Invert text case</td>
 			</tr>
 			<tr>
@@ -87,11 +101,11 @@
 			<td>Invert current line case</td>
 			</tr>
 			<tr>
-			<td><strong>&gt;{motion}</strong></td>
+			<td><strong>&gt;<i>{motion}</i></strong></td>
 			<td>Indent text</td>
 			</tr>
 			<tr>
-			<td><strong>&lt;{motion}</strong></td>
+			<td><strong>&lt;<i>{motion}</i></strong></td>
 			<td>Unindent text</td>
 			</tr>
 			<tr>
@@ -147,7 +161,14 @@
         	<td><strong>zz, zt, zb</strong></td>
         	<td>Scroll current line to center, top, bottom</td>
         	</tr>
-
+        	<tr>
+        	<td><strong>dd</strong></td>
+        	<td>Delete current line</td>
+        	</tr>
+        	<tr>
+        	<td><strong>cc</strong></td>
+        	<td>Change current line</td>
+        	</tr>
         </table>
 
         <h2>Other</h2>
@@ -157,8 +178,8 @@
 			<td>Select characters, lines, blocks</td>
 			</tr>
 			<tr>
-			<td><strong>p</strong></td>
-			<td>Paste</td>
+			<td><strong>p, P</strong></td>
+			<td>Paste after, before cursor</td>
 			</tr>
 			<tr>
 			<td><strong>R</strong></td>
@@ -189,8 +210,12 @@
 			<td>Repeat last operation</td>
 			</tr>
 			<tr>
-			<td><strong>N{operation}</strong></td>
+			<td><strong>N<i>{operation}</i></strong></td>
 			<td>Perform <i>operation</i> N times</td>
+			</tr>
+			<tr>
+			<td><strong>"<i>{register}</i></strong></td>
+			<td>Copy/paste to/from <i>register</i></td>
 			</tr>
 			<tr>
 			<td><strong>Esc, Ctrl+[</strong></td>
@@ -215,6 +240,18 @@
 			</tr>
         </table>
 
+        <h2>Macros</h2>
+        <table>
+			<tr>
+			<td><strong>q<i>{register}</i>, q</strong></td>
+			<td>Begin, end recording macro to <i>register</i></td>
+			</tr>
+			<tr>
+			<td><strong>@<i>{register}</i></strong></td>
+			<td>Replay macro in <i>register</i></td>
+			</tr>
+        </table>
+
         <h2>Ex Commands</h2>
         <table>
 			<tr>
@@ -230,22 +267,32 @@
 			<td>Go to line N</td>
 			</tr>
 			<tr>
-			<td><strong>:R expr</strong></td>
+			<td><strong>:R <i>expr</i></strong></td>
 			<td>Evaluate R expression</td>
 			</tr>
 			<tr>
-			<td><strong>:r file</strong></td>
-			<td>Insert contents of file</td>
+			<td><strong>:r <i>file</i></strong></td>
+			<td>Insert contents of <i>file</i></td>
 			</tr>
 			<tr>
-			<td><strong>:%s/text/rep/g</strong></td>
-			<td>Search and replace text with rep</td>
+			<td><strong>:%s/<i>text</i>/<i>rep</i>/g</strong></td>
+			<td>Replace <i>text</i> with <i>rep</i> in file</td>
+			</tr>
+			<tr>
+			<td><strong>:'&lt;,'&gt;s/<i>text</i>/<i>rep</i>/g</strong></td>
+			<td>Replace in selection</td>
 			</tr>
 			<tr>
 			<td><strong>:help</strong></td>
 			<td>Show this screen</td>
 			</tr>
         </table>
+        
+        <h2>Registers</h2>
+        <p>
+        The registers <strong>-</strong>, <strong>a-z</strong>, <strong>A-Z</strong>, 
+        and <strong>0-9</strong> are available.
+        </p>
 	</td>
  </tr>
 </table>

--- a/src/gwt/src/org/rstudio/core/client/widget/VimKeyInfo.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/VimKeyInfo.ui.xml
@@ -1,0 +1,172 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder">
+	<ui:style>
+	
+	</ui:style>
+	<div>
+	<table>
+	<tr>
+	<td><h2>Motions</h2>
+		<table>
+			<tr>
+			<td><strong>h, j, k, l</strong></td>
+			<td>Left, down, up, right</td>
+			</tr>
+			<tr>
+			<td><strong>gj, gk</strong></td>
+			<td>Down, up (by screen lines)</td>
+			</tr>
+			<tr>
+			<td><strong>w, W, e, E</strong></td>
+			<td>Forward to beginning, end of next word</td>
+			</tr>
+			<tr>
+			<td><strong>b, B, ge, gE</strong></td>
+			<td>Back to beginning, end of previous word</td>
+			</tr>
+			<tr>
+			<td><strong>fx, Fx, tx, Tx</strong></td>
+			<td>To, to before character x</td>
+			</tr>
+			<tr>
+			<td><strong>^, $</strong></td>
+			<td>To first, last character on line</td>
+			</tr>
+			<tr>
+			<td><strong>0, _</strong></td>
+			<td>To first column</td>
+			</tr>
+			<tr>
+			<td><strong>-, +</strong></td>
+			<td>To first character on previous, next line</td>
+			</tr>
+			<tr>
+			<td><strong>gg, G</strong></td>
+			<td>To first, last line</td>
+			</tr>
+			<tr>
+			<td><strong>%</strong></td>
+			<td>To matching brace/bracket</td>
+			</tr>
+			<tr>
+			<td><strong>'x, `x</strong></td>
+			<td>To mark x</td>
+			</tr>
+		</table>
+
+        <h2>Operators</h2>
+        <table>
+			<tr>
+			<td><strong>d{motion}</strong></td>
+			<td>Delete (cut) text</td>
+			</tr>
+			<tr>
+			<td><strong>y{motion}</strong></td>
+			<td>Yank (copy) text</td>
+			</tr>
+			<tr>
+			<td><strong>c{motion}</strong></td>
+			<td>Change (cut, insert) text</td>
+			</tr>
+			<tr>
+			<td><strong>g~{motion}</strong></td>
+			<td>Invert text case</td>
+			</tr>
+			<tr>
+			<td><strong>g~g~</strong></td>
+			<td>Invert current line case</td>
+			</tr>
+			<tr>
+			<td><strong>&gt;{motion}</strong></td>
+			<td>Indent text</td>
+			</tr>
+			<tr>
+			<td><strong>&lt;{motion}</strong></td>
+			<td>Unindent text</td>
+			</tr>
+			<tr>
+			<td><strong>&gt;&gt;, &lt;&lt;</strong></td>
+			<td>Indent, unindent lines</td>
+			</tr>
+        </table>
+        
+        
+        <h2>Operator Motions</h2>
+        <table>
+			<tr>
+			<td><strong>x, X</strong></td>
+			<td>Delete current, previous character</td>
+			</tr>
+			<tr>
+			<td><strong>D</strong></td>
+			<td>Delete to end of line</td>
+			</tr>
+			<tr>
+			<td><strong>Y</strong></td>
+			<td>Yank to end of line</td>
+			</tr>
+			<tr>
+			<td><strong>C</strong></td>
+			<td>Change to end of line</td>
+			</tr>
+			<tr>
+			<td><strong>~</strong></td>
+			<td>Switch case</td>
+			</tr>
+        </table>
+
+        <h2>Actions</h2>
+        <table>
+        	<tr>
+        	<td><strong>a, A</strong></td>
+        	<td>Insert text after cursor, line</td>
+        	</tr>
+        	<tr>
+        	<td><strong>i, I</strong></td>
+        	<td>Insert text before cursor, line</td>
+        	</tr>
+        	<tr>
+        	<td><strong>s, S</strong></td>
+        	<td>Change character, line</td>
+        	</tr>
+        	<tr>
+        	<td><strong>o, O</strong></td>
+        	<td>Insert line after, before current</td>
+        	</tr>
+        </table>
+
+        <h2>Other</h2>
+        <table>
+			<tr>
+			<td><strong>v, V, Ctrl+V</strong></td>
+			<td>Select characters, lines, blocks</td>
+			</tr>
+			<tr>
+			<td><strong>p</strong></td>
+			<td>Paste</td>
+			</tr>
+			<tr>
+			<td><strong>R</strong></td>
+			<td>Replace (overwrite) mode</td>
+			</tr>
+			<tr>
+			<td><strong>r</strong></td>
+			<td>Replace character</td>
+			</tr>
+        </table>
+	</td>
+ </tr>
+ *   Action:
+ *   a, i, s, A, I, S, o, O
+ *   zz, z., z<CR>, zt, zb, z-
+ *   J
+ *   u, Ctrl-r
+ *   m<character>
+ *   r<character>
+ *
+ *   Modes:
+ *   ESC - leave insert mode, visual mode, and clear input state.
+ *   Ctrl-[, Ctrl-c - same as ESC.
+</table>
+	</div>
+</ui:UiBinder>

--- a/src/gwt/src/org/rstudio/core/client/widget/VimKeyInfoPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/VimKeyInfoPanel.java
@@ -1,5 +1,5 @@
 /*
- * VimKeyInfo.java
+ * VimKeyInfoPanel.java
  *
  * Copyright (C) 2009-15 by RStudio, Inc.
  *
@@ -14,22 +14,24 @@
  */
 package org.rstudio.core.client.widget;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.uibinder.client.UiBinder;
-import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
 
-public class VimKeyInfo extends Composite
+public class VimKeyInfoPanel extends ShortcutInfoPanel
 {
-   private static VimKeyInfoUiBinder uiBinder = GWT
-         .create(VimKeyInfoUiBinder.class);
-
-   interface VimKeyInfoUiBinder extends UiBinder<Widget, VimKeyInfo>
+   public VimKeyInfoPanel()
    {
+      super(null);
    }
-
-   public VimKeyInfo()
+   
+   @Override
+   protected String getHeaderText()
    {
-      initWidget(uiBinder.createAndBindUi(this));
+      return "Vim Keyboard Shortcuts";
+   }
+   
+   @Override
+   protected Widget getShortcutContent()
+   {
+     return new VimKeyInfo();
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -18,6 +18,7 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.inject.client.GinModules;
 import com.google.gwt.inject.client.Ginjector;
 
+import org.rstudio.core.client.command.ShortcutViewer;
 import org.rstudio.core.client.files.filedialog.PathBreadcrumbWidget;
 import org.rstudio.core.client.widget.CaptionWithHelp;
 import org.rstudio.core.client.widget.LocalRepositoriesWidget;
@@ -131,4 +132,5 @@ public interface RStudioGinjector extends Ginjector
    UIPrefs getUIPrefs();
    Session getSession();
    HelpStrategy getHelpStrategy();
+   ShortcutViewer getShortcutViewer();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -45,6 +45,7 @@ import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.ProgressOperationWithInput;
+import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.FileDialogs;
@@ -461,6 +462,8 @@ public class Source implements InsertSourceHandler,
       vimCommands_.saveAndCloseActiveTab(this);
       vimCommands_.readFile(this, uiPrefs_.defaultEncoding().getValue());
       vimCommands_.runRScript(this);
+      vimCommands_.showVimHelp(
+            RStudioGinjector.INSTANCE.getShortcutViewer());
    }
    
    private void closeAllTabs(boolean interactive)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceVimCommands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceVimCommands.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.studio.client.workbench.views.source;
 
+import org.rstudio.core.client.command.ShortcutViewer;
+
 public class SourceVimCommands
 {
    public final native void save(Source source) /*-{
@@ -124,5 +126,13 @@ public class SourceVimCommands
       $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("Rscript", "R", callback);
    
    }-*/;
+   
+   public native final void showVimHelp(ShortcutViewer viewer) /*-{
 
+      var callback = $entry(function(cm, params) {
+         viewer.@org.rstudio.core.client.command.ShortcutViewer::showVimKeyboardShortcuts()();
+      });
+      
+      $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("help", "help", callback);
+   }-*/;
 }


### PR DESCRIPTION
This change adds a keyboard shortcut card for Vim mode, similar to the global keyboard shortcut card `Alt+Shift+K`. The goal is to document what's specifically supported in RStudio's Vim mode and to provide discoverability for RStudio-specific extensions (such as `:R expr`). 

The card is accessed by typing `:help` at the Vim commandline.

![image](https://cloud.githubusercontent.com/assets/470418/6305115/bd5a4c7e-b8dd-11e4-9519-d39638b889fb.png)



