### PR TITLE
don't complete package names with quotes for library and require

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1148,7 +1148,8 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("getCompletionsPackages", function(token,
                                                    appendColons = FALSE,
-                                                   excludeOtherCompletions = FALSE)
+                                                   excludeOtherCompletions = FALSE,
+                                                   quote = !appendColons)
 {
    allPackages <- Reduce(union, lapply(.libPaths(), list.files))
    
@@ -1162,7 +1163,7 @@ assign(x = ".rs.acCompletionTypes",
                        else
                           completions,
                        packages = completions,
-                       quote = !appendColons,
+                       quote = quote,
                        type = .rs.acCompletionTypes$PACKAGE,
                        excludeOtherCompletions = excludeOtherCompletions)
 })
@@ -1572,7 +1573,10 @@ assign(x = ".rs.acCompletionTypes",
    if (string[[1]] %in% c("library", "require", "requireNamespace") &&
        numCommas[[1]] == 0)
    {
-      return(.rs.getCompletionsPackages(token, excludeOtherCompletions = TRUE))
+      quote <- ! (string[[1]] %in% c("library", "require"))
+      return(.rs.getCompletionsPackages(token, 
+                                        excludeOtherCompletions = TRUE,
+                                        quote = quote))
    }
    
    ## File-based completions


### PR DESCRIPTION
This has bugged me for a while since it's uncommon to see library and require used with quoted strings in the wild and none of our vignettes, tutorials, or examples use this form. @kevinushey could you review and merge this if you have time and agree with the change (I'd like to incorporate it into the preview release that we blog about next week).