### PR TITLE
Add support for per-document deployment

### DIFF
--- a/src/cpp/session/SessionSourceDatabase.cpp
+++ b/src/cpp/session/SessionSourceDatabase.cpp
@@ -48,7 +48,7 @@
 // deleted. this has two implications:
 //
 //   - storage is not reclaimed
-//   - the properties can be "resurreced" and re-attached to another
+//   - the properties can be "resurrected" and re-attached to another
 //     file with the same path
 //
 // One way to overcome this might be to use filesystem metadata to store

--- a/src/cpp/session/modules/SessionRSConnect.R
+++ b/src/cpp/session/modules/SessionRSConnect.R
@@ -172,10 +172,26 @@
                       subdir_contents))
 })
 
-.rs.addFunction("rsconnectDeployList", function(dir) {
+.rs.addFunction("rmdDeployList", function(target) {
+  deploy_frame <- rmarkdown::find_external_resources(target) 
+  file_list <- c(deploy_frame$path, basename(target))
+  list (
+    contents = paste("./", file_list),
+    cur_size = sum(
+       file.info(file.path(dirname(target), file_list))$size))
+})
+
+.rs.addFunction("makeDeploymentList", function(target, max_size) {
+   if (identical(tolower(tools::file_ext(target)), "rmd")) 
+     .rs.rmdDeployList(target)
+   else
+     .rs.maxDirectoryList(dir, ".", 0, max_size, 
+                          c("rsconnect", "packrat"), "Rproj")
+})
+
+.rs.addFunction("rsconnectDeployList", function(target) {
   max_size <- 104857600   # 100MB
-  dirlist <- .rs.maxDirectoryList(dir, ".", 0, max_size, 
-                                  c("rsconnect", "packrat"), "Rproj")
+  dirlist <- .rs.makeDeploymentList(target, max_size)
   list (
     # if the directory is too large, no need to bother sending a potentially
     # large blob of data to the client
@@ -193,8 +209,8 @@
   invisible(enable)
 })
 
-.rs.addJsonRpcHandler("get_deployment_files", function(dir) {
-   .rs.rsconnectDeployList(dir)
+.rs.addJsonRpcHandler("get_deployment_files", function(target) {
+  .rs.rsconnectDeployList(target)
 })
 
 # The parameter to this function is a string containing the R command from

--- a/src/cpp/session/modules/SessionRSConnect.R
+++ b/src/cpp/session/modules/SessionRSConnect.R
@@ -176,7 +176,7 @@
   deploy_frame <- rmarkdown::find_external_resources(target) 
   file_list <- c(deploy_frame$path, basename(target))
   list (
-    contents = paste("./", file_list),
+    contents = paste("./", file_list, sep = ""),
     cur_size = sum(
        file.info(file.path(dirname(target), file_list))$size))
 })

--- a/src/cpp/session/modules/SessionRSConnect.R
+++ b/src/cpp/session/modules/SessionRSConnect.R
@@ -34,13 +34,6 @@
    return(ret)
 })
 
-.rs.addFunction("scalarListFromList", function(l) {
-   if (is.null(l))
-     NULL
-   else
-     lapply(l, function(x) { if (is.null(x)) x else .rs.scalar(x) })
-})
-
 .rs.addJsonRpcHandler("get_rsconnect_account_list", function() {
    accounts <- list()
    # safely return an empty list--we want to consider there to be 0 connected

--- a/src/cpp/session/modules/SessionRSConnect.R
+++ b/src/cpp/session/modules/SessionRSConnect.R
@@ -53,8 +53,8 @@
    .rs.scalarListFromFrame(rsconnect::applications(account, server))
 })
 
-.rs.addJsonRpcHandler("get_rsconnect_deployments", function(dir) {
-   .rs.scalarListFromFrame(rsconnect::deployments(dir))
+.rs.addJsonRpcHandler("get_rsconnect_deployments", function(path) {
+   .rs.scalarListFromFrame(rsconnect::deployments(path))
 })
 
 .rs.addJsonRpcHandler("validate_server_url", function(url) {

--- a/src/cpp/session/modules/SessionRSConnect.R
+++ b/src/cpp/session/modules/SessionRSConnect.R
@@ -185,7 +185,7 @@
    if (identical(tolower(tools::file_ext(target)), "rmd")) 
      .rs.rmdDeployList(target)
    else
-     .rs.maxDirectoryList(dir, ".", 0, max_size, 
+     .rs.maxDirectoryList(target, ".", 0, max_size, 
                           c("rsconnect", "packrat"), "Rproj")
 })
 

--- a/src/cpp/session/modules/SessionRSConnect.cpp
+++ b/src/cpp/session/modules/SessionRSConnect.cpp
@@ -47,6 +47,7 @@ class ShinyAppDeploy : public async_r::AsyncRProcess
 public:
    static boost::shared_ptr<ShinyAppDeploy> create(
          const std::string& dir,
+         const json::Array& fileList, 
          const std::string& file, 
          const std::string& account,
          const std::string& server,
@@ -57,8 +58,19 @@ public:
       std::string cmd("{ options(repos = c(CRAN='" +
                        module_context::CRANReposURL() + "')); ");
 
+      // join and quote incoming filenames to deploy
+      std::string files;
+      for (size_t i = 0; i < fileList.size(); i++) 
+      {
+         files += "'" + fileList[i].get_str() + "'";
+         if (i < fileList.size() - 1) 
+            files += ", ";
+      }
+
+      // form the deploy command to hand off to the async deploy process
       cmd += "rsconnect::deployApp("
-             "appDir = '" + dir + "',"
+             "appDir = '" + dir + "'," +
+             (files.empty() ? "" : "appFiles = c(" + files + "), ") +
              "account = '" + account + "',"
              "server = '" + server + "', "
              "appName = '" + app + "', "
@@ -142,9 +154,10 @@ boost::shared_ptr<ShinyAppDeploy> s_pShinyAppDeploy_;
 Error deployShinyApp(const json::JsonRpcRequest& request,
                      json::JsonRpcResponse* pResponse)
 {
+   json::Array sourceFiles;
    std::string sourceDir, sourceFile, account, server, appName;
-   Error error = json::readParams(request.params, &sourceDir, &sourceFile, 
-                                  &account, &server, &appName);
+   Error error = json::readParams(request.params, &sourceDir, &sourceFiles,
+                                   &sourceFile, &account, &server, &appName);
    if (error)
       return error;
 
@@ -155,8 +168,9 @@ Error deployShinyApp(const json::JsonRpcRequest& request,
    }
    else
    {
-      s_pShinyAppDeploy_ = ShinyAppDeploy::create(sourceDir, sourceFile, 
-                                                  account, server, appName);
+      s_pShinyAppDeploy_ = ShinyAppDeploy::create(sourceDir, sourceFiles, 
+                                                  sourceFile, account, server, 
+                                                  appName);
       pResponse->setResult(true);
    }
 

--- a/src/cpp/session/modules/SessionRSConnect.cpp
+++ b/src/cpp/session/modules/SessionRSConnect.cpp
@@ -67,10 +67,23 @@ public:
             files += ", ";
       }
 
+      // if a R Markdown document is being deployed, mark it as the primary
+      // file 
+      std::string primaryRmd;
+      if (!file.empty())
+      {
+         FilePath sourceFile = module_context::resolveAliasedPath(file);
+         if (sourceFile.extensionLowerCase() == ".rmd") 
+         {
+            primaryRmd = file;
+         }
+      }
+
       // form the deploy command to hand off to the async deploy process
       cmd += "rsconnect::deployApp("
              "appDir = '" + dir + "'," +
              (files.empty() ? "" : "appFiles = c(" + files + "), ") +
+             (primaryRmd.empty() ? "" : "appPrimaryRmd = '" + primaryRmd + "', ") + 
              "account = '" + account + "',"
              "server = '" + server + "', "
              "appName = '" + app + "', "

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -634,6 +634,24 @@ Error modifyDocumentProperties(const json::JsonRpcRequest& request,
    return source_database::put(pDoc);
 }
 
+Error getDocumentProperties(const json::JsonRpcRequest& request,
+                            json::JsonRpcResponse* pResponse)
+{
+   std::string path; 
+   json::Object properties;
+   Error error = json::readParams(request.params, &path);
+   if (error)
+      return error;
+
+   error = source_database::getDurableProperties(path, &properties);
+   if (error)
+      return error;
+
+   pResponse->setResult(properties);
+
+   return Success();
+}
+
 Error closeDocument(const json::JsonRpcRequest& request,
                     json::JsonRpcResponse* pResponse)
 {
@@ -1098,6 +1116,7 @@ Error initialize()
       (bind(registerRpcMethod, "ignore_external_edit", ignoreExternalEdit))
       (bind(registerRpcMethod, "set_source_document_on_save", setSourceDocumentOnSave))
       (bind(registerRpcMethod, "modify_document_properties", modifyDocumentProperties))
+      (bind(registerRpcMethod, "get_document_properties", getDocumentProperties))
       (bind(registerRpcMethod, "revert_document", revertDocument))
       (bind(registerRpcMethod, "reopen_with_encoding", reopenWithEncoding))
       (bind(registerRpcMethod, "close_document", closeDocument))

--- a/src/gwt/src/org/rstudio/core/client/JsArrayUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/JsArrayUtil.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.core.client;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.google.gwt.core.client.JavaScriptObject;
@@ -50,5 +51,25 @@ public class JsArrayUtil
       for (int i = 0; i < jsArray.length(); ++i) {
          list.add(jsArray.get(i));
       }
+   }
+   
+   public static JsArrayString toJsArrayString(List<String> in)
+   {
+      JsArrayString out = JavaScriptObject.createArray().cast();
+      for (int i = 0; i < in.size(); i ++)
+      {
+         out.push(in.get(i));
+      }
+      return out;
+   }
+   
+   public static ArrayList<String> fromJsArrayString(JsArrayString in)
+   {
+      ArrayList<String> out = new ArrayList<String>();
+      for (int i = 0; i < in.length(); i++)
+      {
+         out.add(in.get(i));
+      }
+      return out;
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdFrontMatter.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdFrontMatter.java
@@ -45,6 +45,18 @@ public class RmdFrontMatter extends JavaScriptObject
       this.date = (new Date()).toLocaleDateString();
    }-*/;
    
+   public final native void addResourceFile(String file) /*-{
+      if (typeof this.resource_files === "undefined")
+         this.resource_files = [];
+      this.resource_files.push(file);
+   }-*/;
+   
+   public final native JsArrayString getResourceFiles() /*-{
+      if (typeof this.resource_files === "undefined")
+         return [];
+      return this.resource_files;
+   }-*/;
+   
    public final native JsArrayString getFormatList() /*-{
       if (typeof this.output === "undefined")
          return [ "html_document" ];

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdFrontMatter.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdFrontMatter.java
@@ -48,12 +48,16 @@ public class RmdFrontMatter extends JavaScriptObject
    public final native void addResourceFile(String file) /*-{
       if (typeof this.resource_files === "undefined")
          this.resource_files = [];
+      else if (typeof this.resource_files === "string")
+         this.resource_files = [ this.resource_files ];
       this.resource_files.push(file);
    }-*/;
    
    public final native JsArrayString getResourceFiles() /*-{
       if (typeof this.resource_files === "undefined")
          return [];
+      else if (typeof this.resource_files === "string")
+         return [ this.resource_files ];
       return this.resource_files;
    }-*/;
    

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
@@ -302,10 +302,11 @@ public class RSConnect implements SessionInitHandler,
    public static native void deployFromSatellite(
          String path,
          JsArrayString deployFiles,
+         JsArrayString additionalFiles,
          String file, 
          boolean launch, 
          JavaScriptObject record) /*-{
-      $wnd.opener.deployToRSConnect(path, deployFiles, file, launch, record);
+      $wnd.opener.deployToRSConnect(path, deployFiles, additionalFiles, file, launch, record);
    }-*/;
    
    // Private methods ---------------------------------------------------------
@@ -452,13 +453,14 @@ public class RSConnect implements SessionInitHandler,
    private final native void exportNativeCallbacks() /*-{
       var thiz = this;     
       $wnd.deployToRSConnect = $entry(
-         function(path, deployFiles, file, launch, record) {
-            thiz.@org.rstudio.studio.client.rsconnect.RSConnect::deployToRSConnect(Ljava/lang/String;Lcom/google/gwt/core/client/JsArrayString;Ljava/lang/String;ZLcom/google/gwt/core/client/JavaScriptObject;)(path, deployFiles, file, launch, record);
+         function(path, deployFiles, additionalFiles, file, launch, record) {
+            thiz.@org.rstudio.studio.client.rsconnect.RSConnect::deployToRSConnect(Ljava/lang/String;Lcom/google/gwt/core/client/JsArrayString;Lcom/google/gwt/core/client/JsArrayString;Ljava/lang/String;ZLcom/google/gwt/core/client/JavaScriptObject;)(path, deployFiles, file, launch, record);
          }
       ); 
    }-*/;
    
    private void deployToRSConnect(String path, JsArrayString deployFiles, 
+                                  JsArrayString additionalFiles, 
                                   String file, boolean launch, 
                                   JavaScriptObject jsoRecord)
    {
@@ -471,10 +473,12 @@ public class RSConnect implements SessionInitHandler,
       
       ArrayList<String> deployFilesList = 
             JsArrayUtil.fromJsArrayString(deployFiles);
+      ArrayList<String> additionalFilesList = 
+            JsArrayUtil.fromJsArrayString(additionalFiles);
       
       RSConnectDeploymentRecord record = jsoRecord.cast();
       events_.fireEvent(new RSConnectDeployInitiatedEvent(
-            path, deployFilesList, file, launch, record));
+            path, deployFilesList, additionalFilesList, file, launch, record));
    }
    
    private final Commands commands_;

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
@@ -18,8 +18,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.rstudio.core.client.JsArrayUtil;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.dom.WindowEx;
+import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.widget.ModalDialogTracker;
 import org.rstudio.core.client.widget.OperationWithInput;
@@ -206,7 +208,15 @@ public class RSConnect implements SessionInitHandler,
    public void onRSConnectDeployInitiated(
          final RSConnectDeployInitiatedEvent event)
    {
-      server_.getLintResults(event.getPath(), 
+      // get lint results for the file or directory being deployed, as appropriate
+      String deployTarget = event.getPath();
+      if (StringUtil.getExtension(event.getSourceFile()).toLowerCase().equals("rmd")) 
+      {
+         FileSystemItem sourceFSI = FileSystemItem.createDir(deployTarget);
+         deployTarget = sourceFSI.completePath(event.getSourceFile());
+      }
+
+      server_.getLintResults(deployTarget, 
             new ServerRequestCallback<RSConnectLintResults>()
       {
          @Override

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
@@ -22,6 +22,7 @@ import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.widget.ModalDialogTracker;
+import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.ProgressOperation;
 import org.rstudio.studio.client.application.Desktop;
@@ -52,6 +53,7 @@ import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.SessionUtils;
 import org.rstudio.studio.client.workbench.model.helper.JSObjectStateValue;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
+import org.rstudio.studio.client.workbench.views.source.model.SourceServerOperations;
 
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
@@ -79,6 +81,7 @@ public class RSConnect implements SessionInitHandler,
                     DependencyManager dependencyManager,
                     Binder binder, 
                     RSConnectServerOperations server,
+                    SourceServerOperations sourceServer,
                     RSAccountConnector connector,
                     Provider<UIPrefs> pUiPrefs)
                     
@@ -88,6 +91,7 @@ public class RSConnect implements SessionInitHandler,
       dependencyManager_ = dependencyManager;
       session_ = session;
       server_ = server;
+      sourceServer_ = sourceServer;
       events_ = events;
       satellite_ = satellite;
       connector_ = connector;
@@ -138,19 +142,59 @@ public class RSConnect implements SessionInitHandler,
          
          // don't consider this to be a deployment of a specific file unless
          // we're deploying R Markdown content
-         String file = "";
-         if (event.getPath().toLowerCase().endsWith(".rmd"))
+         final String file = event.getPath().toLowerCase().endsWith(".rmd") ? 
+            FilePathUtils.friendlyFileName(event.getPath()) : "";
+            
+         final OperationWithInput<String[]> showDeployDialog = 
+               new OperationWithInput<String[]>()
          {
-            file = FilePathUtils.friendlyFileName(event.getPath());
+            @Override
+            public void execute(String[] ignoredFiles)
+            {
+               RSConnectDeployDialog dialog = 
+                     new RSConnectDeployDialog(
+                               server_, connector_, display_, session_, events_, 
+                               dir, file, ignoredFiles, 
+                               lastAccount, lastAppName,
+                               satellite_.isCurrentWindowSatellite());
+               dialog.showModal();
+            }
+         };
+         
+         if (file.isEmpty())
+         {
+            // if we're deploying a directory, show the dialog right away
+            showDeployDialog.execute(null);
+         }
+         else
+         {
+            sourceServer_.getDocumentProperties(event.getPath(), 
+                  new ServerRequestCallback<JsObject>()
+            {
+               @Override
+               public void onResponseReceived(JsObject properties)
+               {
+                  String files = properties.getString(IGNORED_RESOURCES);
+                  if (files != null && !files.isEmpty())
+                  {
+                     showDeployDialog.execute(files.split("\\|"));
+                  }
+                  else
+                  {
+                     showDeployDialog.execute(null);
+                  }
+               }
+
+               @Override
+               public void onError(ServerError error)
+               {
+                  // recover gracefully--the worst case here is that we won't
+                  // remember which files were unchecked
+                  showDeployDialog.execute(null);
+               }
+            });
          }
 
-         RSConnectDeployDialog dialog = 
-               new RSConnectDeployDialog(
-                         server_, connector_, display_, session_, events_, 
-                         dir, file, event.getIgnoredResources(), 
-                         lastAccount, lastAppName,
-                         satellite_.isCurrentWindowSatellite());
-         dialog.showModal();
       }
       else if (event.getAction() == RSConnectActionEvent.ACTION_TYPE_CONFIGURE)
       {
@@ -491,6 +535,7 @@ public class RSConnect implements SessionInitHandler,
    private final GlobalDisplay display_;
    private final Session session_;
    private final RSConnectServerOperations server_;
+   private final SourceServerOperations sourceServer_;
    private final DependencyManager dependencyManager_;
    private final EventBus events_;
    private final Satellite satellite_;
@@ -504,4 +549,5 @@ public class RSConnect implements SessionInitHandler,
    private boolean dirStateDirty_ = false;
    
    public final static String CLOUD_SERVICE_NAME = "ShinyApps.io";
+   public static final String IGNORED_RESOURCES = "ignored_resources";
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
@@ -147,7 +147,8 @@ public class RSConnect implements SessionInitHandler,
          RSConnectDeployDialog dialog = 
                new RSConnectDeployDialog(
                          server_, connector_, display_, session_, events_, 
-                         dir, file, lastAccount, lastAppName,
+                         dir, file, event.getIgnoredResources(), 
+                         lastAccount, lastAppName,
                          satellite_.isCurrentWindowSatellite());
          dialog.showModal();
       }
@@ -303,10 +304,11 @@ public class RSConnect implements SessionInitHandler,
          String path,
          JsArrayString deployFiles,
          JsArrayString additionalFiles,
+         JsArrayString ignoredFiles,
          String file, 
          boolean launch, 
          JavaScriptObject record) /*-{
-      $wnd.opener.deployToRSConnect(path, deployFiles, additionalFiles, file, launch, record);
+      $wnd.opener.deployToRSConnect(path, deployFiles, additionalFiles, ignoredFiles, file, launch, record);
    }-*/;
    
    // Private methods ---------------------------------------------------------
@@ -453,14 +455,15 @@ public class RSConnect implements SessionInitHandler,
    private final native void exportNativeCallbacks() /*-{
       var thiz = this;     
       $wnd.deployToRSConnect = $entry(
-         function(path, deployFiles, additionalFiles, file, launch, record) {
-            thiz.@org.rstudio.studio.client.rsconnect.RSConnect::deployToRSConnect(Ljava/lang/String;Lcom/google/gwt/core/client/JsArrayString;Lcom/google/gwt/core/client/JsArrayString;Ljava/lang/String;ZLcom/google/gwt/core/client/JavaScriptObject;)(path, deployFiles, additionalFiles, file, launch, record);
+         function(path, deployFiles, additionalFiles, ignoredFiles, file, launch, record) {
+            thiz.@org.rstudio.studio.client.rsconnect.RSConnect::deployToRSConnect(Ljava/lang/String;Lcom/google/gwt/core/client/JsArrayString;Lcom/google/gwt/core/client/JsArrayString;Lcom/google/gwt/core/client/JsArrayString;Ljava/lang/String;ZLcom/google/gwt/core/client/JavaScriptObject;)(path, deployFiles, additionalFiles, ignoredFiles, file, launch, record);
          }
       ); 
    }-*/;
    
    private void deployToRSConnect(String path, JsArrayString deployFiles, 
                                   JsArrayString additionalFiles, 
+                                  JsArrayString ignoredFiles, 
                                   String file, boolean launch, 
                                   JavaScriptObject jsoRecord)
    {
@@ -475,10 +478,13 @@ public class RSConnect implements SessionInitHandler,
             JsArrayUtil.fromJsArrayString(deployFiles);
       ArrayList<String> additionalFilesList = 
             JsArrayUtil.fromJsArrayString(additionalFiles);
+      ArrayList<String> ignoredFilesList = 
+            JsArrayUtil.fromJsArrayString(ignoredFiles);
       
       RSConnectDeploymentRecord record = jsoRecord.cast();
       events_.fireEvent(new RSConnectDeployInitiatedEvent(
-            path, deployFilesList, additionalFilesList, file, launch, record));
+            path, deployFilesList, additionalFilesList, ignoredFilesList, 
+            file, launch, record));
    }
    
    private final Commands commands_;

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
@@ -454,7 +454,7 @@ public class RSConnect implements SessionInitHandler,
       var thiz = this;     
       $wnd.deployToRSConnect = $entry(
          function(path, deployFiles, additionalFiles, file, launch, record) {
-            thiz.@org.rstudio.studio.client.rsconnect.RSConnect::deployToRSConnect(Ljava/lang/String;Lcom/google/gwt/core/client/JsArrayString;Lcom/google/gwt/core/client/JsArrayString;Ljava/lang/String;ZLcom/google/gwt/core/client/JavaScriptObject;)(path, deployFiles, file, launch, record);
+            thiz.@org.rstudio.studio.client.rsconnect.RSConnect::deployToRSConnect(Ljava/lang/String;Lcom/google/gwt/core/client/JsArrayString;Lcom/google/gwt/core/client/JsArrayString;Ljava/lang/String;ZLcom/google/gwt/core/client/JavaScriptObject;)(path, deployFiles, additionalFiles, file, launch, record);
          }
       ); 
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectActionEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectActionEvent.java
@@ -43,6 +43,16 @@ public class RSConnectActionEvent extends GwtEvent<RSConnectActionEvent.Handler>
       return action_;
    }
    
+   public void setIgnoredResources(String[] ignoredResources)
+   {
+      ignoredResources_ = ignoredResources;
+   }
+   
+   public String[] getIgnoredResources()
+   {
+      return ignoredResources_;
+   }
+   
    @Override
    protected void dispatch(RSConnectActionEvent.Handler handler)
    {
@@ -60,4 +70,5 @@ public class RSConnectActionEvent extends GwtEvent<RSConnectActionEvent.Handler>
    
    private String path_;
    private int action_;
+   private String[] ignoredResources_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectActionEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectActionEvent.java
@@ -43,16 +43,6 @@ public class RSConnectActionEvent extends GwtEvent<RSConnectActionEvent.Handler>
       return action_;
    }
    
-   public void setIgnoredResources(String[] ignoredResources)
-   {
-      ignoredResources_ = ignoredResources;
-   }
-   
-   public String[] getIgnoredResources()
-   {
-      return ignoredResources_;
-   }
-   
    @Override
    protected void dispatch(RSConnectActionEvent.Handler handler)
    {
@@ -70,5 +60,4 @@ public class RSConnectActionEvent extends GwtEvent<RSConnectActionEvent.Handler>
    
    private String path_;
    private int action_;
-   private String[] ignoredResources_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeployInitiatedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeployInitiatedEvent.java
@@ -34,6 +34,7 @@ public class RSConnectDeployInitiatedEvent extends GwtEvent<RSConnectDeployIniti
    public RSConnectDeployInitiatedEvent(String path, 
                                         ArrayList<String> deployFiles,
                                         ArrayList<String> additionalFiles,
+                                        ArrayList<String> ignoredFiles,
                                         String sourceFile,
                                         boolean launchBrowser, 
                                         RSConnectDeploymentRecord record)
@@ -41,6 +42,7 @@ public class RSConnectDeployInitiatedEvent extends GwtEvent<RSConnectDeployIniti
       path_ = path;
       deployFiles_ = deployFiles;
       additionalFiles_ = additionalFiles;
+      ignoredFiles_ = ignoredFiles;
       sourceFile_ = sourceFile;
       launchBrowser_ = launchBrowser;
       record_ = record;
@@ -71,6 +73,11 @@ public class RSConnectDeployInitiatedEvent extends GwtEvent<RSConnectDeployIniti
       return additionalFiles_;
    }
    
+   public ArrayList<String> getIgnoredFiles()
+   {
+      return ignoredFiles_;
+   }
+   
    public boolean getLaunchBrowser()
    {
       return launchBrowser_; 
@@ -94,4 +101,5 @@ public class RSConnectDeployInitiatedEvent extends GwtEvent<RSConnectDeployIniti
    private final boolean launchBrowser_;
    private final ArrayList<String> deployFiles_;
    private final ArrayList<String> additionalFiles_;
+   private final ArrayList<String> ignoredFiles_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeployInitiatedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeployInitiatedEvent.java
@@ -41,9 +41,9 @@ public class RSConnectDeployInitiatedEvent extends GwtEvent<RSConnectDeployIniti
       path_ = path;
       deployFiles_ = deployFiles;
       additionalFiles_ = additionalFiles;
-      record_ = record;
       sourceFile_ = sourceFile;
       launchBrowser_ = launchBrowser;
+      record_ = record;
    }
    
    public RSConnectDeploymentRecord getRecord()

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeployInitiatedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeployInitiatedEvent.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.studio.client.rsconnect.events;
 
+import java.util.ArrayList;
+
 import org.rstudio.studio.client.rsconnect.model.RSConnectDeploymentRecord;
 
 import com.google.gwt.event.shared.EventHandler;
@@ -30,11 +32,13 @@ public class RSConnectDeployInitiatedEvent extends GwtEvent<RSConnectDeployIniti
       new GwtEvent.Type<RSConnectDeployInitiatedEvent.Handler>();
    
    public RSConnectDeployInitiatedEvent(String path, 
+                                        ArrayList<String> deployFiles,
                                         String sourceFile,
                                         boolean launchBrowser, 
                                         RSConnectDeploymentRecord record)
    {
       path_ = path;
+      deployFiles_ = deployFiles;
       record_ = record;
       sourceFile_ = sourceFile;
       launchBrowser_ = launchBrowser;
@@ -55,6 +59,11 @@ public class RSConnectDeployInitiatedEvent extends GwtEvent<RSConnectDeployIniti
       return sourceFile_;
    }
    
+   public ArrayList<String> getDeployFiles()
+   {
+      return deployFiles_;
+   }
+   
    public boolean getLaunchBrowser()
    {
       return launchBrowser_; 
@@ -72,8 +81,9 @@ public class RSConnectDeployInitiatedEvent extends GwtEvent<RSConnectDeployIniti
       return TYPE;
    }
    
-   private RSConnectDeploymentRecord record_;
-   private String path_;
-   private String sourceFile_;
-   private boolean launchBrowser_;
+   private final RSConnectDeploymentRecord record_;
+   private final String path_;
+   private final String sourceFile_;
+   private final boolean launchBrowser_;
+   private final ArrayList<String> deployFiles_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeployInitiatedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeployInitiatedEvent.java
@@ -33,12 +33,14 @@ public class RSConnectDeployInitiatedEvent extends GwtEvent<RSConnectDeployIniti
    
    public RSConnectDeployInitiatedEvent(String path, 
                                         ArrayList<String> deployFiles,
+                                        ArrayList<String> additionalFiles,
                                         String sourceFile,
                                         boolean launchBrowser, 
                                         RSConnectDeploymentRecord record)
    {
       path_ = path;
       deployFiles_ = deployFiles;
+      additionalFiles_ = additionalFiles;
       record_ = record;
       sourceFile_ = sourceFile;
       launchBrowser_ = launchBrowser;
@@ -64,6 +66,11 @@ public class RSConnectDeployInitiatedEvent extends GwtEvent<RSConnectDeployIniti
       return deployFiles_;
    }
    
+   public ArrayList<String> getAdditionalFiles()
+   {
+      return additionalFiles_;
+   }
+   
    public boolean getLaunchBrowser()
    {
       return launchBrowser_; 
@@ -86,4 +93,5 @@ public class RSConnectDeployInitiatedEvent extends GwtEvent<RSConnectDeployIniti
    private final String sourceFile_;
    private final boolean launchBrowser_;
    private final ArrayList<String> deployFiles_;
+   private final ArrayList<String> additionalFiles_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectServerOperations.java
@@ -35,7 +35,7 @@ public interface RSConnectServerOperations
    void getRSConnectAppList(String accountName, String server,
                ServerRequestCallback<JsArray<RSConnectApplicationInfo>> requestCallback);
    
-   void getRSConnectDeployments(String dir, 
+   void getRSConnectDeployments(String target, 
                ServerRequestCallback<JsArray<RSConnectDeploymentRecord>> requestCallback); 
    
    void getDeploymentFiles (String target, 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectServerOperations.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.studio.client.rsconnect.model;
 
+import java.util.ArrayList;
+
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
 
@@ -39,7 +41,8 @@ public interface RSConnectServerOperations
    void getDeploymentFiles (String target, 
                ServerRequestCallback<RSConnectDeploymentFiles> requestCallback);
    
-   void deployShinyApp(String dir, String file, String account, String server, String appName, 
+   void deployShinyApp(String dir, ArrayList<String> deployFiles, String file, 
+               String account, String server, String appName, 
                ServerRequestCallback<Boolean> requestCallback);
 
    void validateServerUrl (String url, 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectServerOperations.java
@@ -36,7 +36,7 @@ public interface RSConnectServerOperations
    void getRSConnectDeployments(String dir, 
                ServerRequestCallback<JsArray<RSConnectDeploymentRecord>> requestCallback); 
    
-   void getDeploymentFiles (String dir, 
+   void getDeploymentFiles (String target, 
                ServerRequestCallback<RSConnectDeploymentFiles> requestCallback);
    
    void deployShinyApp(String dir, String file, String account, String server, String appName, 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -187,7 +187,7 @@ public class RSConnectDeploy extends Composite
       appList.setSelectedIndex(selectedIdx);
    }
    
-   public void setFileList(JsArrayString files)
+   public void setFileList(JsArrayString files, String[] unchecked)
    {
       if (forDocument_)
       {
@@ -196,13 +196,25 @@ public class RSConnectDeploy extends Composite
       
       for (int i = 0; i < files.length(); i++)
       {
-         addFile(files.get(i));
+         boolean checked = true;
+         if (unchecked != null)
+         {
+            for (int j = 0; j < unchecked.length; j++)
+            {
+               if (unchecked[j].equals(files.get(i)))
+               {
+                  checked = false; 
+                  break;
+               }
+            }
+         }
+         addFile(files.get(i), checked);
       }
    }
    
    public void addFileToList(String path)
    {
-      addFile(path);
+      addFile(path, true);
    }
    
    public void setFileCheckEnabled(String path, boolean enabled)
@@ -221,17 +233,12 @@ public class RSConnectDeploy extends Composite
    
    public ArrayList<String> getFileList()
    {
-      ArrayList<String> files = new ArrayList<String>();
-      if (fileChecks_ == null)
-         return files;
-      for (int i = 0; i < fileChecks_.size(); i++)
-      {
-         if (fileChecks_.get(i).getValue())
-         {
-            files.add(fileChecks_.get(i).getText());
-         }
-      }
-      return files;
+      return getCheckedFileList(true);
+   }
+   
+   public ArrayList<String> getIgnoredFileList()
+   {
+      return getCheckedFileList(false);
    }
    
    public String getNewAppName()
@@ -312,12 +319,12 @@ public class RSConnectDeploy extends Composite
          onDeployDisabled_.execute();
    }
 
-   private void addFile(String path)
+   private void addFile(String path, boolean checked)
    {
       if (forDocument_)
       {
          CheckBox fileCheck = new CheckBox(path);
-         fileCheck.setValue(true);
+         fileCheck.setValue(checked);
          fileListPanel_.add(fileCheck);
          fileChecks_.add(fileCheck);
       }
@@ -325,6 +332,21 @@ public class RSConnectDeploy extends Composite
       {
          fileListPanel_.add(new Label(path));
       }
+   }
+   
+   private ArrayList<String> getCheckedFileList(boolean checked)
+   {
+      ArrayList<String> files = new ArrayList<String>();
+      if (fileChecks_ == null)
+         return files;
+      for (int i = 0; i < fileChecks_.size(); i++)
+      {
+         if (fileChecks_.get(i).getValue() == checked)
+         {
+            files.add(fileChecks_.get(i).getText());
+         }
+      }
+      return files;
    }
    
    @UiField Anchor urlAnchor;

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -21,8 +21,6 @@ import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ThemedButton;
-import org.rstudio.studio.client.RStudioGinjector;
-import org.rstudio.studio.client.common.FileDialogs;
 import org.rstudio.studio.client.common.FilePathUtils;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.rsconnect.model.RSConnectAccount;

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -20,8 +20,6 @@ import java.util.List;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.OperationWithInput;
-import org.rstudio.core.client.widget.ProgressIndicator;
-import org.rstudio.core.client.widget.ProgressOperationWithInput;
 import org.rstudio.core.client.widget.ThemedButton;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.FileDialogs;
@@ -91,7 +89,6 @@ public class RSConnectDeploy extends Composite
       forDocument_ = forDocument;
       accountList = new RSConnectAccountList(server, display, false);
       initWidget(uiBinder.createAndBindUi(this));
-      final FileDialogs fileDialogs = RStudioGinjector.INSTANCE.getFileDialogs();
 
       // Validate the application name on every keystroke
       appName.addKeyUpHandler(new KeyUpHandler()
@@ -130,19 +127,10 @@ public class RSConnectDeploy extends Composite
          @Override
          public void onClick(ClickEvent arg0)
          {
-            fileDialogs.openFile(
-                  "Select File", 
-                  RStudioGinjector.INSTANCE.getRemoteFileSystemContext(), 
-                  null, // initial location
-                  new ProgressOperationWithInput<FileSystemItem>() 
-                  {
-                     @Override
-                     public void execute(FileSystemItem input,
-                           ProgressIndicator indicator)
-                     {
-                        // TODO: add file
-                     }
-                  });
+            if (onFileAddClick_ != null) 
+            {
+               onFileAddClick_.execute();
+            }
          }
       });
    }
@@ -208,18 +196,13 @@ public class RSConnectDeploy extends Composite
       
       for (int i = 0; i < files.length(); i++)
       {
-         if (forDocument_)
-         {
-            CheckBox fileCheck = new CheckBox(files.get(i));
-            fileCheck.setValue(true);
-            fileListPanel_.add(fileCheck);
-            fileChecks_.add(fileCheck);
-         }
-         else
-         {
-            fileListPanel_.add(new Label(files.get(i)));
-         }
+         addFile(files.get(i));
       }
+   }
+   
+   public void addFileToList(String path)
+   {
+      addFile(path);
    }
    
    public ArrayList<String> getFileList()
@@ -289,6 +272,11 @@ public class RSConnectDeploy extends Composite
       onDeployDisabled_ = cmd;
    }
    
+   public void setOnFileAddClick(Command cmd)
+   {
+      onFileAddClick_ = cmd;
+   }
+   
    public DeployStyle getStyle()
    {
       return style;
@@ -309,6 +297,21 @@ public class RSConnectDeploy extends Composite
       else if (!isValid && onDeployDisabled_ != null)
          onDeployDisabled_.execute();
    }
+
+   private void addFile(String path)
+   {
+      if (forDocument_)
+      {
+         CheckBox fileCheck = new CheckBox(path);
+         fileCheck.setValue(true);
+         fileListPanel_.add(fileCheck);
+         fileChecks_.add(fileCheck);
+      }
+      else
+      {
+         fileListPanel_.add(new Label(path));
+      }
+   }
    
    @UiField Anchor urlAnchor;
    @UiField Anchor addAccountAnchor;
@@ -328,5 +331,6 @@ public class RSConnectDeploy extends Composite
    
    private Command onDeployEnabled_;
    private Command onDeployDisabled_;
+   private Command onFileAddClick_;
    private final boolean forDocument_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.rsconnect.ui;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.rstudio.core.client.StringUtil;
@@ -43,13 +44,14 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.Anchor;
+import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.InlineLabel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.TextBox;
+import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 
 public class RSConnectDeploy extends Composite
@@ -78,8 +80,10 @@ public class RSConnectDeploy extends Composite
    public RSConnectDeploy(final RSConnectServerOperations server, 
                           final RSAccountConnector connector,    
                           final GlobalDisplay display,
-                          final Session session)
+                          final Session session, 
+                          boolean forDocument)
    {
+      forDocument_ = forDocument;
       accountList = new RSConnectAccountList(server, display, false);
       initWidget(uiBinder.createAndBindUi(this));
 
@@ -170,10 +174,24 @@ public class RSConnectDeploy extends Composite
    
    public void setFileList(JsArrayString files)
    {
+      if (forDocument_)
+      {
+         fileChecks_ = new ArrayList<CheckBox>();
+      }
+      
       for (int i = 0; i < files.length(); i++)
       {
-         Label fileLabel = new Label(files.get(i));
-         fileListPanel_.add(fileLabel);
+         if (forDocument_)
+         {
+            CheckBox fileCheck = new CheckBox(files.get(i));
+            fileCheck.setValue(true);
+            fileListPanel_.add(fileCheck);
+            fileChecks_.add(fileCheck);
+         }
+         else
+         {
+            fileListPanel_.add(new Label(files.get(i)));
+         }
       }
    }
    
@@ -260,9 +278,12 @@ public class RSConnectDeploy extends Composite
    @UiField HTMLPanel appInfoPanel;
    @UiField HTMLPanel nameValidatePanel;
    @UiField DeployStyle style;
-   @UiField FlowPanel fileListPanel_;
+   @UiField VerticalPanel fileListPanel_;
    @UiField InlineLabel deployLabel_;
+   
+   private ArrayList<CheckBox> fileChecks_;
    
    private Command onDeployEnabled_;
    private Command onDeployDisabled_;
+   private final boolean forDocument_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -195,6 +195,21 @@ public class RSConnectDeploy extends Composite
       }
    }
    
+   public ArrayList<String> getFileList()
+   {
+      ArrayList<String> files = new ArrayList<String>();
+      if (fileChecks_ == null)
+         return files;
+      for (int i = 0; i < fileChecks_.size(); i++)
+      {
+         if (fileChecks_.get(i).getValue())
+         {
+            files.add(fileChecks_.get(i).getText());
+         }
+      }
+      return files;
+   }
+   
    public String getNewAppName()
    {
       return appName.getText();

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -31,6 +31,7 @@ import org.rstudio.studio.client.workbench.model.Session;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
@@ -120,6 +121,7 @@ public class RSConnectDeploy extends Composite
          }
       });
       addFileButton_.setVisible(forDocument);
+      addFileButton_.getElement().getStyle().setMarginLeft(0, Unit.PX);
       addFileButton_.addClickHandler(new ClickHandler()
       {
          @Override
@@ -201,6 +203,20 @@ public class RSConnectDeploy extends Composite
    public void addFileToList(String path)
    {
       addFile(path);
+   }
+   
+   public void setFileCheckEnabled(String path, boolean enabled)
+   {
+      if (fileChecks_ == null)
+         return;
+
+      for (int i = 0; i < fileChecks_.size(); i++)
+      {
+         if (fileChecks_.get(i).getText().equals(path))
+         {
+            fileChecks_.get(i).setEnabled(enabled);
+         }
+      }
    }
    
    public ArrayList<String> getFileList()

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -20,6 +20,11 @@ import java.util.List;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.core.client.widget.ProgressIndicator;
+import org.rstudio.core.client.widget.ProgressOperationWithInput;
+import org.rstudio.core.client.widget.ThemedButton;
+import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.common.FileDialogs;
 import org.rstudio.studio.client.common.FilePathUtils;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.rsconnect.model.RSConnectAccount;
@@ -86,6 +91,7 @@ public class RSConnectDeploy extends Composite
       forDocument_ = forDocument;
       accountList = new RSConnectAccountList(server, display, false);
       initWidget(uiBinder.createAndBindUi(this));
+      final FileDialogs fileDialogs = RStudioGinjector.INSTANCE.getFileDialogs();
 
       // Validate the application name on every keystroke
       appName.addKeyUpHandler(new KeyUpHandler()
@@ -116,6 +122,27 @@ public class RSConnectDeploy extends Composite
             
             event.preventDefault();
             event.stopPropagation();
+         }
+      });
+      addFileButton_.setVisible(forDocument);
+      addFileButton_.addClickHandler(new ClickHandler()
+      {
+         @Override
+         public void onClick(ClickEvent arg0)
+         {
+            fileDialogs.openFile(
+                  "Select File", 
+                  RStudioGinjector.INSTANCE.getRemoteFileSystemContext(), 
+                  null, // initial location
+                  new ProgressOperationWithInput<FileSystemItem>() 
+                  {
+                     @Override
+                     public void execute(FileSystemItem input,
+                           ProgressIndicator indicator)
+                     {
+                        // TODO: add file
+                     }
+                  });
          }
       });
    }
@@ -295,6 +322,7 @@ public class RSConnectDeploy extends Composite
    @UiField DeployStyle style;
    @UiField VerticalPanel fileListPanel_;
    @UiField InlineLabel deployLabel_;
+   @UiField ThemedButton addFileButton_;
    
    private ArrayList<CheckBox> fileChecks_;
    

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
@@ -87,6 +87,7 @@
 	.controlLabel
 	{
 	  margin-top: 5px;
+	  margin-bottom: 3px;
 	}
 	
 	.urlAnchor
@@ -114,7 +115,10 @@
 	<g:Grid><g:row>
     <g:customCell styleName="{style.rootCell}">
       <g:VerticalPanel>
-        <g:InlineLabel styleName="{style.deployLabel}" ui:field="deployLabel_"></g:InlineLabel>
+        <g:HTMLPanel>
+          <g:InlineLabel text="Deploy Files From:"></g:InlineLabel>
+          <g:InlineLabel styleName="{style.deployLabel}" ui:field="deployLabel_"></g:InlineLabel>
+        </g:HTMLPanel>
         <g:ScrollPanel styleName="{style.fileList}">
           <g:VerticalPanel ui:field="fileListPanel_">
           </g:VerticalPanel>

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
@@ -109,6 +109,11 @@
 	  cursor: pointer;
 	}
 	
+	.firstControlLabel
+	{
+	  margin-bottom: 5px;
+	}
+	
 	</ui:style>
 	<g:HTMLPanel>
 	<g:Image resource="{res.deployIllustration}"></g:Image>
@@ -131,7 +136,7 @@
      <g:customCell styleName="{style.rootCell}">
       <g:HTMLPanel>
          <g:HorizontalPanel width="100%">
-         <g:Label styleName="{style.controlLabel}" text="Destination Account:"></g:Label>
+         <g:Label styleName="{style.firstControlLabel}" text="Destination Account:"></g:Label>
          <g:Anchor styleName="rstudio-HyperlinkLabel {style.accountAnchor}" ui:field="addAccountAnchor" text="Add New Account"></g:Anchor>
          </g:HorizontalPanel>
          <rsc:RSConnectAccountList styleName="{style.accountList}" ui:field="accountList"></rsc:RSConnectAccountList>

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
@@ -115,8 +115,8 @@
       <g:FlowPanel>
         <g:InlineLabel styleName="{style.deployLabel}" ui:field="deployLabel_"></g:InlineLabel>
         <g:ScrollPanel styleName="{style.fileList}">
-          <g:FlowPanel ui:field="fileListPanel_">
-          </g:FlowPanel>
+          <g:VerticalPanel ui:field="fileListPanel_">
+          </g:VerticalPanel>
         </g:ScrollPanel>
       </g:FlowPanel>
      </g:customCell>

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
@@ -1,7 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
 	xmlns:g="urn:import:com.google.gwt.user.client.ui"
-	xmlns:rsc="urn:import:org.rstudio.studio.client.rsconnect.ui">
+	xmlns:rsc="urn:import:org.rstudio.studio.client.rsconnect.ui"
+	xmlns:rw="urn:import:org.rstudio.core.client.widget">
 	<ui:with field="res" type="org.rstudio.studio.client.rsconnect.ui.RSConnectDeploy.DeployResources" />
 	<ui:with field="projRes" type="org.rstudio.studio.client.projects.ui.newproject.NewProjectResources" />
 	<ui:style type="org.rstudio.studio.client.rsconnect.ui.RSConnectDeploy.DeployStyle">
@@ -112,13 +113,16 @@
 	<g:Image resource="{res.deployIllustration}"></g:Image>
 	<g:Grid><g:row>
     <g:customCell styleName="{style.rootCell}">
-      <g:FlowPanel>
+      <g:VerticalPanel>
         <g:InlineLabel styleName="{style.deployLabel}" ui:field="deployLabel_"></g:InlineLabel>
         <g:ScrollPanel styleName="{style.fileList}">
           <g:VerticalPanel ui:field="fileListPanel_">
           </g:VerticalPanel>
         </g:ScrollPanel>
-      </g:FlowPanel>
+        <rw:ThemedButton ui:field="addFileButton_" 
+                         text="Add More..."
+                         visible="false"></rw:ThemedButton>
+      </g:VerticalPanel>
      </g:customCell>
      <g:customCell styleName="{style.rootCell}">
       <g:HTMLPanel>

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployDialog.java
@@ -60,7 +60,8 @@ public class RSConnectDeployDialog
                                 boolean isSatellite)
                                 
    {
-      super(server, display, new RSConnectDeploy(server, connector, display, session));
+      super(server, display, new RSConnectDeploy(server, connector, display, session,
+            StringUtil.getExtension(sourceFile).toLowerCase().equals("rmd")));
       setText("Publish to Server");
       setWidth("350px");
       deployButton_ = new ThemedButton("Publish");
@@ -96,7 +97,10 @@ public class RSConnectDeployDialog
       indicator_ = addProgressIndicator(false);
 
       // Get the files to be deployed
-      server_.getDeploymentFiles(sourceDir,
+      server_.getDeploymentFiles(
+            StringUtil.getExtension(sourceFile).toLowerCase() == "rmd" ?
+                  sourceDir + "/" + sourceFile : 
+                  sourceDir,
             new ServerRequestCallback<RSConnectDeploymentFiles>()
             {
                @Override 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployDialog.java
@@ -60,6 +60,7 @@ public class RSConnectDeployDialog
                                 EventBus events,
                                 final String sourceDir, 
                                 String sourceFile,
+                                String[] ignoredFiles,
                                 final RSConnectAccount lastAccount, 
                                 String lastAppName, 
                                 boolean isSatellite)
@@ -79,6 +80,7 @@ public class RSConnectDeployDialog
       isSatellite_ = isSatellite;
       defaultAccount_ = lastAccount;
       connector_ = connector;
+      ignoredFiles_ = ignoredFiles;
 
       String deployTarget = sourceDir;
       if (StringUtil.getExtension(sourceFile).toLowerCase().equals("rmd")) 
@@ -137,7 +139,7 @@ public class RSConnectDeployDialog
                   }
                   else
                   {
-                     contents_.setFileList(files.getDirList());
+                     contents_.setFileList(files.getDirList(), ignoredFiles_);
                      contents_.setFileCheckEnabled(sourceFile_, false);
                      deployButton_.setEnabled(true);
                   }
@@ -402,6 +404,7 @@ public class RSConnectDeployDialog
                sourceDir_, 
                JsArrayUtil.toJsArrayString(contents_.getFileList()),
                JsArrayUtil.toJsArrayString(additionalFiles),
+               JsArrayUtil.toJsArrayString(contents_.getIgnoredFileList()),
                sourceFile_, 
                launchCheck_.getValue(), 
                RSConnectDeploymentRecord.create(appName, account, ""));
@@ -423,6 +426,7 @@ public class RSConnectDeployDialog
                sourceDir_,
                contents_.getFileList(),
                additionalFiles,
+               contents_.getIgnoredFileList(),
                sourceFile_,
                launchCheck_.getValue(),
                RSConnectDeploymentRecord.create(appName, account, "")));
@@ -503,6 +507,8 @@ public class RSConnectDeployDialog
    private RSConnectAccount defaultAccount_;
    private ArrayList<String> filesAddedManually_ =
          new ArrayList<String>();
+   
+   private String[] ignoredFiles_;
    
    // Map of account to a list of applications owned by that account
    private Map<RSConnectAccount, JsArray<RSConnectApplicationInfo>> apps_ = 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployDialog.java
@@ -80,6 +80,13 @@ public class RSConnectDeployDialog
       defaultAccount_ = lastAccount;
       connector_ = connector;
 
+      String deployTarget = sourceDir;
+      if (StringUtil.getExtension(sourceFile).toLowerCase().equals("rmd")) 
+      {
+         FileSystemItem sourceFSI = FileSystemItem.createDir(sourceDir);
+         deployTarget = sourceFSI.completePath(sourceFile);
+      }
+
       launchCheck_ = new CheckBox("Launch browser");
       launchCheck_.setValue(true);
       launchCheck_.setStyleName(contents_.getStyle().launchCheck());
@@ -112,9 +119,7 @@ public class RSConnectDeployDialog
 
       // Get the files to be deployed
       server_.getDeploymentFiles(
-            StringUtil.getExtension(sourceFile).toLowerCase() == "rmd" ?
-                  sourceDir + "/" + sourceFile : 
-                  sourceDir,
+            deployTarget,
             new ServerRequestCallback<RSConnectDeploymentFiles>()
             {
                @Override 
@@ -146,7 +151,7 @@ public class RSConnectDeployDialog
 
       // Get the deployments of this directory from any account (should be fast,
       // since this information is stored locally in the directory). 
-      server_.getRSConnectDeployments(sourceDir, 
+      server_.getRSConnectDeployments(deployTarget, 
             new ServerRequestCallback<JsArray<RSConnectDeploymentRecord>>()
       {
          @Override

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployDialog.java
@@ -133,6 +133,7 @@ public class RSConnectDeployDialog
                   else
                   {
                      contents_.setFileList(files.getDirList());
+                     contents_.setFileCheckEnabled(sourceFile_, false);
                      deployButton_.setEnabled(true);
                   }
                }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployDialog.java
@@ -382,7 +382,7 @@ public class RSConnectDeployDialog
       ArrayList<String> additionalFiles = new ArrayList<String>();
       for (String filePath: filesAddedManually_)
       {
-         if (deployFiles.contains(filePath))
+         if (!deployFiles.contains(filePath))
          {
             additionalFiles.add(filePath);
          }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployDialog.java
@@ -382,7 +382,7 @@ public class RSConnectDeployDialog
       ArrayList<String> additionalFiles = new ArrayList<String>();
       for (String filePath: filesAddedManually_)
       {
-         if (!deployFiles.contains(filePath))
+         if (deployFiles.contains(filePath))
          {
             additionalFiles.add(filePath);
          }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployDialog.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ProgressIndicator;
@@ -367,6 +368,7 @@ public class RSConnectDeployDialog
          // deployment
          RSConnect.deployFromSatellite(
                sourceDir_, 
+               JsArrayUtil.toJsArrayString(contents_.getFileList()),
                sourceFile_, 
                launchCheck_.getValue(), 
                RSConnectDeploymentRecord.create(appName, account, ""));
@@ -386,6 +388,7 @@ public class RSConnectDeployDialog
          // in the main window, initiate the deployment directly
          events_.fireEvent(new RSConnectDeployInitiatedEvent(
                sourceDir_,
+               contents_.getFileList(),
                sourceFile_,
                launchCheck_.getValue(),
                RSConnectDeploymentRecord.create(appName, account, "")));

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1516,6 +1516,16 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, MODIFY_DOCUMENT_PROPERTIES, params, requestCallback);
    }
 
+   public void getDocumentProperties(
+         String path,
+         ServerRequestCallback<JsObject> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(path));
+
+      sendRequest(RPC_SCOPE, GET_DOCUMENT_PROPERTIES, params, requestCallback);
+   }
+
    public void revertDocument(String id,
                               String fileType,
                               ServerRequestCallback<SourceDocument> requestCallback)
@@ -4087,6 +4097,7 @@ public class RemoteServer implements Server
    private static final String SET_SOURCE_DOCUMENT_ON_SAVE = "set_source_document_on_save";
    private static final String SAVE_ACTIVE_DOCUMENT = "save_active_document";
    private static final String MODIFY_DOCUMENT_PROPERTIES = "modify_document_properties";
+   private static final String GET_DOCUMENT_PROPERTIES = "get_document_properties";
    private static final String REVERT_DOCUMENT = "revert_document";
    private static final String REOPEN_WITH_ENCODING = "reopen_with_encoding";
    private static final String REMOVE_CONTENT_URL = "remove_content_url";

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -3626,15 +3626,17 @@ public class RemoteServer implements Server
    }
    
    @Override
-   public void deployShinyApp(String dir, String file, String account, 
+   public void deployShinyApp(String dir, ArrayList<String> deployFiles, 
+         String file, String account, 
          String server, String appName, ServerRequestCallback<Boolean> requestCallback)
    {
       JSONArray params = new JSONArray();
       params.set(0, new JSONString(dir));
-      params.set(1, new JSONString(file));
-      params.set(2, new JSONString(account));
-      params.set(3, new JSONString(server));
-      params.set(4, new JSONString(appName));
+      params.set(1, JSONUtils.toJSONStringArray(deployFiles));
+      params.set(2, new JSONString(file));
+      params.set(3, new JSONString(account));
+      params.set(4, new JSONString(server));
+      params.set(5, new JSONString(appName));
       sendRequest(RPC_SCOPE,
             DEPLOY_SHINY_APP,
             params,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -86,6 +86,7 @@ import org.rstudio.studio.client.rmarkdown.model.RmdTemplateFormat;
 import org.rstudio.studio.client.rmarkdown.model.RmdYamlData;
 import org.rstudio.studio.client.rmarkdown.model.YamlFrontMatter;
 import org.rstudio.studio.client.rmarkdown.ui.RmdTemplateOptionsDialog;
+import org.rstudio.studio.client.rsconnect.RSConnect;
 import org.rstudio.studio.client.rsconnect.events.RSConnectActionEvent;
 import org.rstudio.studio.client.rsconnect.events.RSConnectDeployInitiatedEvent;
 import org.rstudio.studio.client.server.ServerError;
@@ -154,7 +155,6 @@ public class TextEditingTarget implements
    private static final String NOTEBOOK_TITLE = "notebook_title";
    private static final String NOTEBOOK_AUTHOR = "notebook_author";
    private static final String NOTEBOOK_TYPE = "notebook_type";
-   private static final String IGNORED_RESOURCES = "ignored_resources";
 
    private static final MyCommandBinder commandBinder =
          GWT.create(MyCommandBinder.class);
@@ -2513,20 +2513,6 @@ public class TextEditingTarget implements
       RSConnectActionEvent evt = new RSConnectActionEvent(
             RSConnectActionEvent.ACTION_TYPE_DEPLOY, 
             docUpdateSentinel_.getPath());
-
-      // see if there are any resources that we want to ignore--these are files
-      // that we would ordinarily deploy with this document, but that the user
-      // has asked us in the past to ignore
-      String ignored = docUpdateSentinel_.getProperty(IGNORED_RESOURCES);
-      if (ignored != null && !ignored.isEmpty())
-      {
-         evt.setIgnoredResources(ignored.split("\\|"));
-      }
-      else
-      {
-         evt.setIgnoredResources(new String[]{});
-      }
-
       events_.fireEvent(evt);
    }
 
@@ -4603,7 +4589,8 @@ public class TextEditingTarget implements
    private void setIgnoredFiles(ArrayList<String> ignoredFiles)
    {
       String ignoredFileList =  StringUtil.joinStrings(ignoredFiles, "|");
-      docUpdateSentinel_.setProperty(IGNORED_RESOURCES, ignoredFileList, null);
+      docUpdateSentinel_.setProperty(RSConnect.IGNORED_RESOURCES, 
+            ignoredFileList, null);
    }
    
    private void addAdditionalResourceFiles(ArrayList<String> additionalFiles)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
@@ -538,6 +538,24 @@ public class TextEditingTargetRMarkdownHelper
          });
    }
    
+   public void addAdditionalResourceFiles(String yaml, 
+         final ArrayList<String> files, 
+         final CommandWithArg<String> onCompleted)
+   {
+      convertFromYaml(yaml, new CommandWithArg<RmdYamlData>() 
+      {
+         @Override
+         public void execute(RmdYamlData arg)
+         {
+            if (!arg.parseSucceeded())
+               onCompleted.execute(null);
+            else
+               addAdditionalResourceFiles(arg.getFrontMatter(), files, 
+                     onCompleted);
+         }
+      });
+   }
+
    // Private methods ---------------------------------------------------------
    
    private void cleanAndCreateTemplate(final RmdChosenTemplate template, 
@@ -669,6 +687,18 @@ public class TextEditingTargetRMarkdownHelper
       display.showWarningBar(feature + " requires the " +
                              "knitr package (version " + requiredVersion + 
                              " or higher)");
+   }
+   
+   private void addAdditionalResourceFiles(RmdFrontMatter frontMatter,
+         ArrayList<String> additionalFiles, 
+         CommandWithArg<String> onCompleted)
+   {
+      for (String file: additionalFiles)
+      {
+         frontMatter.addResourceFile(file);
+      }
+
+      frontMatterToYAML(frontMatter, null, onCompleted);
    }
    
    private Session session_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceServerOperations.java
@@ -151,6 +151,9 @@ public interface SourceServerOperations extends FilesServerOperations,
     */
    void modifyDocumentProperties(String id, HashMap<String, String> properties,
                                  ServerRequestCallback<Void> requestCallback);
+   
+   void getDocumentProperties(String path, 
+                              ServerRequestCallback<JsObject> requestCallback);
 
    void revertDocument(String id,
                        String fileType,


### PR DESCRIPTION
This change integrates RStudio with recent changes to the `rsconnect` and `rmarkdown` packages to improve the experience of deploying individual interactive R Markdown documents. In particular:

When an R Markdown document is deployed, only those resources that it actually uses (rather than all the content in its containing directory) are deployed along with it. This feature is supported by `rmarkdown::find_external_resources`. 

![image](https://cloud.githubusercontent.com/assets/470418/6338657/4770b860-bb65-11e4-8162-eb088dfd2763.png)

It is possible to both add and remove files from the auto-discovered list. Files that are added to the list are automatically inserted into the document's YAML header as additional resources; files that are removed (by unchecking) are automatically unchecked on subsequent deployments.

Documents now have their own deployment records, too (due to recent changes in `rsconnect`), so the dialog's information about prior deployments applies specifically to deployments of the current document rather than to any deployment made from the directory.
