### PR TITLE
use R mode token boundaries in R markdown

### DIFF
--- a/src/gwt/acesupport/acemode/rmarkdown.js
+++ b/src/gwt/acesupport/acemode/rmarkdown.js
@@ -30,6 +30,7 @@ var SweaveBackgroundHighlighter = require("mode/sweave_background_highlighter").
 var RCodeModel = require("mode/r_code_model").RCodeModel;
 var MarkdownFoldMode = require("ace/mode/folding/markdown").FoldMode;
 var Utils = require("mode/utils");
+var unicode = require("ace/unicode");
 
 var Mode = function(suppressHighlighting, session) {
    var that = this;
@@ -179,6 +180,21 @@ oop.inherits(Mode, MarkdownMode);
         }
         return false;
     };
+
+    this.tokenRe = new RegExp("^["
+        + unicode.packages.L
+        + unicode.packages.Mn + unicode.packages.Mc
+        + unicode.packages.Nd
+        + unicode.packages.Pc + "._]+", "g"
+    );
+
+    this.nonTokenRe = new RegExp("^(?:[^"
+        + unicode.packages.L
+        + unicode.packages.Mn + unicode.packages.Mc
+        + unicode.packages.Nd
+        + unicode.packages.Pc + "._]|\s])+", "g"
+    );
+   
 
 }).call(Mode.prototype);
 


### PR DESCRIPTION
This PR copies over the `tokenRe` rules to `rmarkdown.js`, thereby causing 'move/select to next/previous word' to behave uniformly across those modes (at least, with respect to R code) -- this implies that, for example, 'select to next word' will stop at `$` or `@` boundaries.

A more full-fledged solution would delegate these actions to the appropriate modes, but I am not yet sure if Ace provides a mechanism for allowing something like this (I suspect not, at this point)