### PR TITLE
various minor improvements to cpp mode

### DIFF
--- a/src/cpp/core/include/core/libclang/Cursor.hpp
+++ b/src/cpp/core/include/core/libclang/Cursor.hpp
@@ -67,6 +67,7 @@ public:
    Cursor getSemanticParent() const;
 
    CXLinkageKind getLinkageKind() const;
+   bool hasLinkage() const;
    bool hasExternalLinkage() const;
 
    std::string getUSR() const;

--- a/src/cpp/core/libclang/Cursor.cpp
+++ b/src/cpp/core/libclang/Cursor.cpp
@@ -122,6 +122,14 @@ CXLinkageKind Cursor::getLinkageKind() const
    return clang().getCursorLinkage(cursor_);
 }
 
+bool Cursor::hasLinkage() const
+{
+   CXLinkageKind kind = getLinkageKind();
+   return kind == CXLinkage_Internal ||
+          kind == CXLinkage_External ||
+          kind == CXLinkage_UniqueExternal;
+}
+
 bool Cursor::hasExternalLinkage() const
 {
    CXLinkageKind kind = getLinkageKind();

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -1431,6 +1431,7 @@ SourceItem fromCppDefinition(const clang::CppDefinition& cppDefinition)
       break;
    case CppClassDefinition:
    case CppStructDefinition:
+   case CppTypedefDefinition:
       type = SourceItem::Class;
       break;
    case CppEnumDefinition:
@@ -1447,6 +1448,7 @@ SourceItem fromCppDefinition(const clang::CppDefinition& cppDefinition)
       break;
    default:
       type = SourceItem::None;
+      break;
    }
 
    // return source item

--- a/src/cpp/session/modules/clang/DefinitionIndex.hpp
+++ b/src/cpp/session/modules/clang/DefinitionIndex.hpp
@@ -43,7 +43,8 @@ enum CppDefinitionKind
    CppEnumDefinition = 4,
    CppEnumValue = 5,
    CppFunctionDefinition = 6,
-   CppMemberFunctionDefinition = 7
+   CppMemberFunctionDefinition = 7,
+   CppTypedefDefinition = 8
 };
 
 // C++ symbol definition

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -77,11 +77,6 @@ SourceCppFileInfo sourceCppFileInfo(const core::FilePath& srcPath)
       return SourceCppFileInfo();
    }
 
-   // ensure that have at least one Rcpp include
-   boost::regex reRcpp("#include\\s+<Rcpp");
-   if (!boost::regex_search(contents, reRcpp))
-      return SourceCppFileInfo();
-
    // info to return
    SourceCppFileInfo info;
 

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/PathBreadcrumbWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/PathBreadcrumbWidget.java
@@ -112,6 +112,7 @@ public class PathBreadcrumbWidget
             browse();
          }
       });
+      browse.setTitle("Go to directory");
       eastFrame_.add(browse);
       frame_.addEast(eastFrame_, browse.getWidth());
       
@@ -151,6 +152,8 @@ public class PathBreadcrumbWidget
             }
          });
          projIcon.addStyleName(RES.styles().project());
+         projIcon.setTitle(
+               "Go to project directory");
          
          eastFrame_.insert(projIcon, 0);
          

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -120,6 +120,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Mode.In
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionContext;
+import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionOperation;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.*;
 import org.rstudio.studio.client.workbench.views.source.editors.text.status.StatusBar;
 import org.rstudio.studio.client.workbench.views.source.editors.text.status.StatusBarPopupMenu;
@@ -4370,6 +4371,26 @@ public class TextEditingTarget implements
             }
          });
 
+      }
+
+      @Override
+      public void cppCompletionOperation(final CppCompletionOperation operation)
+      {
+         if (isCompletionEnabled())
+         {
+            withUpdatedDoc(new CommandWithArg<String>() {
+               @Override
+               public void execute(String docPath)
+               {
+                  Position pos = docDisplay_.getSelectionStart();
+                  
+                  operation.execute(docPath, 
+                                    pos.getRow() + 1, 
+                                    pos.getColumn() + 1);
+               }
+            });
+         }
+         
       }   
    };
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
@@ -20,7 +20,6 @@ import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Invalidation;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.studio.client.RStudioGinjector;
-import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.filetypes.DocumentMode;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
@@ -29,7 +28,6 @@ import org.rstudio.studio.client.workbench.views.console.shell.assist.Completion
 import org.rstudio.studio.client.workbench.views.console.shell.assist.CompletionUtils;
 import org.rstudio.studio.client.workbench.views.console.shell.editor.InputEditorSelection;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
-import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.PasteEvent;
 import org.rstudio.studio.client.workbench.views.source.model.CppServerOperations;
 import org.rstudio.studio.client.workbench.views.source.model.CppSourceLocation;
@@ -142,33 +140,30 @@ public class CppCompletionManager implements CompletionManager
       }
       else
       {
-         if (completionContext_.isCompletionEnabled())
-         {
-            completionContext_.withUpdatedDoc(new CommandWithArg<String>() {
-               @Override
-               public void execute(final String docPath)
-               {
-                  Position pos = docDisplay_.getCursorPosition();
-                  
-                  server_.goToCppDefinition(
-                      docPath, 
-                      pos.getRow() + 1, 
-                      pos.getColumn() + 1, 
-                      new SimpleRequestCallback<CppSourceLocation>() {
-                         @Override
-                         public void onResponseReceived(CppSourceLocation loc)
-                         {
-                            if (loc != null)
-                            {
-                               fileTypeRegistry_.editFile(loc.getFile(), 
-                                                          loc.getPosition());  
-                            }
-                         }
-                      });
-                  
-               }
-            });
-         }
+         completionContext_.cppCompletionOperation(new CppCompletionOperation(){
+
+            @Override
+            public void execute(String docPath, int line, int column)
+            {
+               server_.goToCppDefinition(
+                     docPath, 
+                     line, 
+                     column, 
+                     new CppCompletionServerRequestCallback<CppSourceLocation>(
+                                                     "Finding definition...") {
+                        @Override
+                        public void onSuccess(CppSourceLocation loc)
+                        {
+                           if (loc != null)
+                           {
+                              fileTypeRegistry_.editFile(loc.getFile(), 
+                                                         loc.getPosition());  
+                           }
+                        }
+                     });
+            }
+            
+         });
       }
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionOperation.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionOperation.java
@@ -1,5 +1,5 @@
 /*
- * CppCompletionContext.java
+ * CppCompletionOperation.java
  *
  * Copyright (C) 2009-12 by RStudio, Inc.
  *
@@ -15,11 +15,7 @@
 
 package org.rstudio.studio.client.workbench.views.source.editors.text.cpp;
 
-import org.rstudio.core.client.CommandWithArg;
-
-public interface CppCompletionContext
+public interface CppCompletionOperation
 {
-   boolean isCompletionEnabled();
-   void withUpdatedDoc(CommandWithArg<String> onUpdated);
-   void cppCompletionOperation(CppCompletionOperation operation);
+   void execute(String docPath, int line, int column);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionServerRequestCallback.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionServerRequestCallback.java
@@ -1,0 +1,56 @@
+/*
+ * CppCompletionServerRequestCallback.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.source.editors.text.cpp;
+
+import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.common.GlobalProgressDelayer;
+import org.rstudio.studio.client.server.ServerError;
+import org.rstudio.studio.client.server.ServerRequestCallback;
+
+public class CppCompletionServerRequestCallback<T> 
+                            extends ServerRequestCallback<T>
+{
+   public CppCompletionServerRequestCallback(String message)
+   {
+      super();
+      progressDelayer_ =  new GlobalProgressDelayer(
+            RStudioGinjector.INSTANCE.getGlobalDisplay(), 1000, message);
+   }
+   
+   @Override
+   public void onResponseReceived(T result)
+   {
+      progressDelayer_.dismiss();
+      onSuccess(result);
+   }
+   
+   @Override
+   public void onError(ServerError error)
+   {
+      progressDelayer_.dismiss();
+      onFailure(error);
+   }
+   
+   protected void onSuccess(T result)
+   {
+   }
+
+   protected void onFailure(ServerError error)
+   {
+   }
+
+   private final GlobalProgressDelayer progressDelayer_;
+}


### PR DESCRIPTION
- Show client progress for go to definition
- Use Rcpp completion for sourceCpp translation units that don't directly include Rcpp (they may include it in one of their headers)
- Recurse into namespaces for definition index
- Include typedefs in definition index
- Tooltips for file pane directory navigation (in this PR by happenstance)

This shouldn't be merged until master is back open (it's here as a placeholder/reminder)