### PR TITLE
Fix breakpoint issues on Windows with non-ASCII paths

### DIFF
--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -375,21 +375,21 @@ Error extract(SEXP valueSEXP, std::vector<int>* pVector)
    return Success(); 
 }
    
-   
-Error extract(SEXP valueSEXP, std::string* pString)
+Error extract(SEXP valueSEXP, std::string* pString, bool asUtf8)
 {
    if (TYPEOF(valueSEXP) != STRSXP)
       return Error(errc::UnexpectedDataTypeError, ERROR_LOCATION);
-   
+
    if (Rf_length(valueSEXP) < 1)
       return Error(errc::NoDataAvailableError, ERROR_LOCATION);
-      
-   *pString = std::string(Rf_translateChar(STRING_ELT(valueSEXP, 0)));
-   
+
+   *pString = std::string(asUtf8 ?
+                  Rf_translateCharUTF8(STRING_ELT(valueSEXP, 0)) :
+                  Rf_translateChar(STRING_ELT(valueSEXP, 0)));
+
    return Success();
 }
-   
-   
+
 Error extract(SEXP valueSEXP, std::vector<std::string>* pVector)
 {
    if (TYPEOF(valueSEXP) != STRSXP)

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -105,7 +105,7 @@ core::Error extract(SEXP valueSEXP, int* pInt);
 core::Error extract(SEXP valueSEXP, bool* pBool);
 core::Error extract(SEXP valueSEXP, double* pDouble);
 core::Error extract(SEXP valueSEXP, std::vector<int>* pVector);   
-core::Error extract(SEXP valueSEXP, std::string* pString);
+core::Error extract(SEXP valueSEXP, std::string* pString, bool asUtf8 = false);
 core::Error extract(SEXP valueSEXP, std::vector<std::string>* pVector);
       
 // create SEXP from c++ type

--- a/src/cpp/session/modules/SessionBreakpoints.R
+++ b/src/cpp/session/modules/SessionBreakpoints.R
@@ -18,6 +18,12 @@
 .rs.addFunction("getEnvironmentOfFunction", function(
    objName, fileName, packageName)
 {
+   # assume fileName is UTF-8 encoded unless it's already got a labelled
+   # encoding
+   if (Encoding(fileName) == "unknown") {
+      Encoding(fileName) <- "UTF-8"
+   }
+
    isPackage <- nchar(packageName) > 0
 
    # when searching specifically for a function in a package, search from the
@@ -479,7 +485,10 @@
    # NYI: Consider whether we need to implement source with echo for debugging.
    # This would likely involve injecting print statements into the generated
    # source-equivalent function.
-   invisible(.Call("rs_debugSourceFile", fileName, encoding, local))
+
+   # filenames are all UTF-8 in C-land and aren't transformed automatically,
+   # so convert to UTF-8 here
+   invisible(.Call("rs_debugSourceFile", enc2utf8(fileName), encoding, local))
 })
 
 # Parameters expected to be in environment:

--- a/src/cpp/session/modules/SessionBreakpoints.R
+++ b/src/cpp/session/modules/SessionBreakpoints.R
@@ -486,8 +486,7 @@
    # This would likely involve injecting print statements into the generated
    # source-equivalent function.
 
-   # filenames are all UTF-8 in C-land and aren't transformed automatically,
-   # so convert to UTF-8 here
+   # convert filename to UTF-8 before proceeding 
    invisible(.Call("rs_debugSourceFile", enc2utf8(fileName), encoding, local))
 })
 

--- a/src/cpp/session/modules/SessionBreakpoints.cpp
+++ b/src/cpp/session/modules/SessionBreakpoints.cpp
@@ -449,7 +449,7 @@ SEXP rs_debugSourceFile(SEXP filename, SEXP encoding, SEXP local)
 {
    // Get the file that was sourced
    std::string path;
-   Error error = r::sexp::extract(filename, &path);
+   Error error = r::sexp::extract(filename, &path, true);
    if (error)
    {
       LOG_ERROR(error);

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -130,7 +130,7 @@
    if (!is.null(srcref))
    {
       fileattr <- attr(srcref, "srcfile")
-      fileattr$filename
+      enc2utf8(fileattr$filename)
    }
    else
       ""

--- a/src/cpp/session/modules/environment/EnvironmentUtils.cpp
+++ b/src/cpp/session/modules/environment/EnvironmentUtils.cpp
@@ -152,7 +152,10 @@ bool functionDiffersFromSource(
    std::string fileName;
    Error error = sourceFileFromRef(srcRef, &fileName);
    if (error)
+   {
+      LOG_ERROR(error);
       return true;
+   }
 
    // check for ~/.active-rstudio-document -- we never want to match sources
    // in this file, as it's used to source unsaved changes from RStudio

--- a/src/cpp/session/modules/environment/EnvironmentUtils.cpp
+++ b/src/cpp/session/modules/environment/EnvironmentUtils.cpp
@@ -150,13 +150,9 @@ bool functionDiffersFromSource(
       const std::string& functionCode)
 {
    std::string fileName;
-   Error error = r::exec::RFunction(".rs.sourceFileFromRef", srcRef)
-                 .call(&fileName);
+   Error error = sourceFileFromRef(srcRef, &fileName);
    if (error)
-   {
-      LOG_ERROR(error);
       return true;
-   }
 
    // check for ~/.active-rstudio-document -- we never want to match sources
    // in this file, as it's used to source unsaved changes from RStudio
@@ -217,6 +213,18 @@ void sourceRefToJson(const SEXP srcref, json::Object* pObject)
       (*pObject)["character_number"] = INTEGER(srcref)[4];
       (*pObject)["end_character_number"] = INTEGER(srcref)[5];
    }
+}
+
+Error sourceFileFromRef(const SEXP srcref, std::string* pFileName)
+{
+   r::sexp::Protect protect;
+   SEXP fileName;
+   Error error = r::exec::RFunction(".rs.sourceFileFromRef", srcref)
+                 .call(&fileName, &protect);
+   if (error)
+       return error;
+
+   return r::sexp::extract(fileName, pFileName, true);
 }
 
 } // namespace environment

--- a/src/cpp/session/modules/environment/EnvironmentUtils.hpp
+++ b/src/cpp/session/modules/environment/EnvironmentUtils.hpp
@@ -25,6 +25,7 @@ core::json::Value varToJson(SEXP env, const r::sexp::Variable& var);
 bool isUnevaluatedPromise(SEXP var);
 bool functionDiffersFromSource(SEXP srcRef, const std::string& functionCode);
 void sourceRefToJson(const SEXP srcref, core::json::Object* pObject);
+core::Error sourceFileFromRef(const SEXP srcref, std::string* pFileName);
 
 } // namespace environment
 } // namespace modules

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -136,8 +136,7 @@ Error getFileNameFromContext(const RCNTXT* pContext,
    SEXP srcref = pContext->srcref;
    if (isValidSrcref(srcref))
    {
-      return r::exec::RFunction(".rs.sourceFileFromRef", srcref)
-                    .call(pFileName);
+      return sourceFileFromRef(srcref, pFileName);
    }
    else
    {


### PR DESCRIPTION
This change resolves an issue reported on the forums with breakpoints on Windows when the path includes non-ASCII characters.

The underlying problem is that data coming from some sources (e.g. RPCs) is UTF-8 encoded, but data coming from other sources (e.g. extracted from SEXPs) is in the system default encoding, such as `latin1`. When we attempt to compare filenames from these two sources, they don't match. 

The fix (scoped to breakpoint-related code):
- R -> RStudio: Have R encode filenames as UTF-8, and extract filenames from SEXPs as UTF-8
- RStudio -> R: Mark filename parameters with UTF-8 encoding (unless they already have one set)
