### PR TITLE
user options for automatic completions

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
@@ -129,6 +129,12 @@ public class UIPrefs extends UIPrefsAccessor implements UiPrefsChangedHandler
          alwaysCompleteInConsole().setGlobalValue(
                                  newUiPrefs.alwaysCompleteInConsole().getGlobalValue());
          
+         alwaysCompleteDelayMs().setGlobalValue(
+                                 newUiPrefs.alwaysCompleteDelayMs().getGlobalValue());
+         
+         alwaysCompleteCharacters().setGlobalValue(
+                                 newUiPrefs.alwaysCompleteCharacters().getGlobalValue());
+         
          insertParensAfterFunctionCompletion().setGlobalValue(
                                  newUiPrefs.insertParensAfterFunctionCompletion().getGlobalValue());
          

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -128,7 +128,7 @@ public class UIPrefsAccessor extends Prefs
    
    public PrefValue<Integer> alwaysCompleteDelayMs()
    {
-      return integer("always_complete_delay", 200);
+      return integer("always_complete_delay", 250);
    }
    
    public PrefValue<Integer> alwaysCompleteCharacters()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -126,6 +126,16 @@ public class UIPrefsAccessor extends Prefs
       return bool("always_complete_console", true);
    }
    
+   public PrefValue<Integer> alwaysCompleteDelayMs()
+   {
+      return integer("always_complete_delay", 200);
+   }
+   
+   public PrefValue<Integer> alwaysCompleteCharacters()
+   {
+      return integer("always_complete_characters", 3);
+   }
+   
    public PrefValue<Boolean> insertParensAfterFunctionCompletion()
    {
       return bool("insert_parens_after_function_completion", true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -89,10 +89,10 @@ public class EditingPreferencesPane extends PreferencesPane
       final VerticalPanel alwaysCompletePanel = new VerticalPanel();
       alwaysCompletePanel.addStyleName(res.styles().alwaysCompletePanel());
       alwaysCompletePanel.add(indent(alwaysCompleteChars_ = 
-          numericPref("Automatically complete after characters entered:",
+          numericPref("Show completions after characters entered:",
                       prefs.alwaysCompleteCharacters())));
       alwaysCompletePanel.add(indent(alwaysCompleteDelayMs_ = 
-          numericPref("Automatically complete after keyboard idle (ms):",
+          numericPref("Show completions after keyboard idle (ms):",
                       prefs.alwaysCompleteDelayMs())));
       CheckBox alwaysCompleteInConsole = checkboxPref(
             "Allow automatic completions in console",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -34,7 +34,8 @@ import org.rstudio.studio.client.workbench.prefs.model.UIPrefsAccessor;
 public class EditingPreferencesPane extends PreferencesPane
 {
    @Inject
-   public EditingPreferencesPane(UIPrefs prefs)
+   public EditingPreferencesPane(UIPrefs prefs,
+                                 PreferencesDialogResources res)
    {
       prefs_ = prefs;
       
@@ -69,8 +70,8 @@ public class EditingPreferencesPane extends PreferencesPane
       showCompletions_ = new SelectWidget(
             "Show code completions:",
             new String[] {
-                  "Always",
-                  "When Triggered",
+                  "Automatically",
+                  "When Triggered ($, ::)",
                   "Manually (Tab)"
             },
             new String[] {
@@ -84,17 +85,28 @@ public class EditingPreferencesPane extends PreferencesPane
       
       spaced(showCompletions_);
       completionPanel.add(showCompletions_);
-      
-      final CheckBox alwaysCompleteInConsole = checkboxPref(
-                       "Allow automatic completions in console",
-                       prefs.alwaysCompleteInConsole());
-      completionPanel.add(alwaysCompleteInConsole);
-      showCompletions_.addChangeHandler(new ChangeHandler() {
 
+      final VerticalPanel alwaysCompletePanel = new VerticalPanel();
+      alwaysCompletePanel.addStyleName(res.styles().alwaysCompletePanel());
+      alwaysCompletePanel.add(indent(alwaysCompleteChars_ = 
+          numericPref("Automatically complete after characters entered:",
+                      prefs.alwaysCompleteCharacters())));
+      alwaysCompletePanel.add(indent(alwaysCompleteDelayMs_ = 
+          numericPref("Automatically complete after keyboard idle (ms):",
+                      prefs.alwaysCompleteDelayMs())));
+      CheckBox alwaysCompleteInConsole = checkboxPref(
+            "Allow automatic completions in console",
+            prefs.alwaysCompleteInConsole());
+      indent(alwaysCompleteInConsole);
+      alwaysCompletePanel.add(alwaysCompleteInConsole);
+      
+      completionPanel.add(alwaysCompletePanel);
+      showCompletions_.addChangeHandler(new ChangeHandler()
+      {
          @Override
          public void onChange(ChangeEvent event)
          {
-            alwaysCompleteInConsole.setVisible(
+            alwaysCompletePanel.setVisible(
                    showCompletions_.getValue().equals(
                                         UIPrefsAccessor.COMPLETION_ALWAYS));
             
@@ -194,8 +206,10 @@ public class EditingPreferencesPane extends PreferencesPane
    @Override
    public boolean validate()
    {
-      return (!spacesForTab_.getValue() || tabWidth_.validatePositive("Tab width")) &&
-             (!showMargin_.getValue() || marginCol_.validate("Margin column"));
+      return (!spacesForTab_.getValue() || tabWidth_.validatePositive("Tab width")) && 
+             (!showMargin_.getValue() || marginCol_.validate("Margin column")) &&
+             alwaysCompleteChars_.validateRange("Characters entered", 3, 100) &&
+             alwaysCompleteDelayMs_.validateRange("Keyboard idle (ms)", 0, 10000);
    }
 
    @Override
@@ -207,6 +221,8 @@ public class EditingPreferencesPane extends PreferencesPane
    private final UIPrefs prefs_;
    private final NumericValueWidget tabWidth_;
    private final NumericValueWidget marginCol_;
+   private final NumericValueWidget alwaysCompleteChars_;
+   private final NumericValueWidget alwaysCompleteDelayMs_;
    private final CheckBox spacesForTab_;
    private final CheckBox showMargin_;
    private final SelectWidget showCompletions_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.css
@@ -18,6 +18,9 @@
    margin-top: 25px;	
 }
 
+.alwaysCompletePanel {
+   margin-bottom: 11px;
+}
 
 .paneLayoutTable td.paneLayoutTable {
    background-color: white;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialogResources.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialogResources.java
@@ -28,6 +28,7 @@ public interface PreferencesDialogResources extends ClientBundle
       String sshKeyWidget();
       String usingVcsHelp();
       String newSection();
+      String alwaysCompletePanel();
    }
 
    @Source("PreferencesDialog.css")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -706,7 +706,7 @@ public class RCompletionManager implements CompletionManager
          }
          
          // Check for a valid number of R identifier characters for autopopup
-         boolean canAutoPopup = checkCanAutoPopup(c, 2);
+         boolean canAutoPopup = checkCanAutoPopup(c, uiPrefs_.alwaysCompleteCharacters().getValue() - 1);
          
          // Automatically popup completions after certain function calls
          if (c == '(' && !isLineInComment(docDisplay_.getCurrentLine()))
@@ -2018,7 +2018,7 @@ public class RCompletionManager implements CompletionManager
          flushCache_ = flushCache;
          implicit_ = implicit;
          canAutoInsert_ = canAutoInsert;
-         timer_.schedule(400);
+         timer_.schedule(uiPrefs_.alwaysCompleteDelayMs().getValue());
       }
       
       public void cancel()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
@@ -328,10 +328,12 @@ public class CppCompletionManager implements CompletionManager
       // see if we even have a completion position
       boolean alwaysComplete = uiPrefs_.codeComplete().getValue().equals(
                                             UIPrefsAccessor.COMPLETION_ALWAYS);
+      int autoChars = uiPrefs_.alwaysCompleteCharacters().getValue();
       final CompletionPosition completionPosition = 
             CppCompletionUtils.getCompletionPosition(docDisplay_,
                                                      positionExplicit,
-                                                     alwaysComplete);
+                                                     alwaysComplete,
+                                                     autoChars);
       if (completionPosition == null)
       {
          terminateCompletionRequest();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
@@ -38,6 +38,8 @@ import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Timer;
 import com.google.inject.Inject;
 
 public class CppCompletionManager implements CompletionManager
@@ -171,6 +173,8 @@ public class CppCompletionManager implements CompletionManager
    @Override
    public boolean previewKeyDown(NativeEvent event)
    {
+      suggestionTimer_.cancel();
+      
       // delegate to R mode if appropriate
       if (DocumentMode.isCursorInRMode(docDisplay_) ||
             DocumentMode.isCursorInMarkdownMode(docDisplay_))
@@ -240,7 +244,7 @@ public class CppCompletionManager implements CompletionManager
          // backspace triggers completion if the popup is visible
          if (keyCode == KeyCodes.KEY_BACKSPACE)
          {
-            delayedSuggestCompletions(false);
+            deferredSuggestCompletions(false, false);
             return false;
          }
          
@@ -270,6 +274,8 @@ public class CppCompletionManager implements CompletionManager
    @Override
    public boolean previewKeyPress(char c)
    {
+      suggestionTimer_.cancel();
+      
       // delegate to R mode if necessary
       if (DocumentMode.isCursorInRMode(docDisplay_) || 
             DocumentMode.isCursorInMarkdownMode(docDisplay_))
@@ -287,26 +293,34 @@ public class CppCompletionManager implements CompletionManager
          if (!uiPrefs_.codeComplete().getValue().equals(UIPrefsAccessor.COMPLETION_MANUAL) ||
              isCompletionPopupVisible())
          {
-            delayedSuggestCompletions(false);
+            deferredSuggestCompletions(false, true);
          }
          
          return false;
       }
    }
    
-   private void delayedSuggestCompletions(final boolean explicit)
+   private void deferredSuggestCompletions(final boolean explicit, 
+                                           final boolean canDelay)
    {
       Scheduler.get().scheduleDeferred(new ScheduledCommand() {
          @Override
          public void execute()
          {
-            suggestCompletions(explicit);  
+            suggestCompletions(explicit, canDelay);  
          }
       });
    }
    
    private boolean suggestCompletions(final boolean explicit)
    {
+      return suggestCompletions(explicit, false);
+   }
+   
+   private boolean suggestCompletions(final boolean explicit, boolean canDelay)
+   {
+      suggestionTimer_.cancel();
+      
       // check for completions disabled
       if (!completionContext_.isCompletionEnabled())
          return false;
@@ -339,41 +353,88 @@ public class CppCompletionManager implements CompletionManager
          terminateCompletionRequest();
          return false;
       }
-      
-      if ((request_ != null) &&
-          !request_.isTerminated() &&
-          request_.getCompletionPosition().isSupersetOf(completionPosition))
+      else if ((request_ != null) &&
+               !request_.isTerminated() &&
+               request_.getCompletionPosition().isSupersetOf(completionPosition))
       {
          request_.updateUI(false);
       }
+      else if (canDelay && 
+               completionPosition.getScope() == CompletionPosition.Scope.Global)
+      {
+         suggestionTimer_.schedule(completionPosition);
+      }
       else
       {
-         terminateCompletionRequest();
-         
-         final Invalidation.Token invalidationToken = 
-               completionRequestInvalidation_.getInvalidationToken();
-         
-         completionContext_.withUpdatedDoc(new CommandWithArg<String>() {
-
-            @Override
-            public void execute(String docPath)
-            {
-               if (invalidationToken.isInvalid())
-                  return;
-               
-               request_ = new CppCompletionRequest(
-                  docPath,
-                  completionPosition,
-                  docDisplay_,
-                  invalidationToken,
-                  explicit);
-            }
-         });
-         
+         performCompletionRequest(completionPosition, explicit);
       }
       
       return true;
    }
+
+   private void performCompletionRequest(
+         final CompletionPosition completionPosition, final boolean explicit)
+   {  
+      terminateCompletionRequest();
+      
+      final Invalidation.Token invalidationToken = 
+            completionRequestInvalidation_.getInvalidationToken();
+      
+      completionContext_.withUpdatedDoc(new CommandWithArg<String>() {
+
+         @Override
+         public void execute(String docPath)
+         {
+            if (invalidationToken.isInvalid())
+               return;
+            
+            request_ = new CppCompletionRequest(
+               docPath,
+               completionPosition,
+               docDisplay_,
+               invalidationToken,
+               explicit,
+               new Command() {
+                  @Override
+                  public void execute()
+                  {
+                     suggestionTimer_.cancel();
+                  }
+               });
+         }
+      });
+   }
+   
+   private class SuggestionTimer
+   {
+      SuggestionTimer()
+      {
+         timer_ = new Timer()
+         {
+            @Override
+            public void run()
+            {
+               performCompletionRequest(completionPosition_, false);
+            }
+         };
+      }
+      
+      public void schedule(CompletionPosition completionPosition)
+      {
+         completionPosition_ = completionPosition;
+         timer_.schedule(uiPrefs_.alwaysCompleteDelayMs().getValue());
+      }
+      
+      public void cancel()
+      {
+         timer_.cancel();
+      }
+      
+      private final Timer timer_;
+      private CompletionPosition completionPosition_;
+   }
+   private SuggestionTimer suggestionTimer_ = new SuggestionTimer();
+   
      
    private CppCompletionPopupMenu getCompletionPopup()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
@@ -451,6 +451,7 @@ public class CppCompletionManager implements CompletionManager
    
    private void terminateCompletionRequest()
    {
+      suggestionTimer_.cancel();
       completionRequestInvalidation_.invalidate();
       if (request_ != null)
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionRequest.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionRequest.java
@@ -34,6 +34,7 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.CloseHandler;
+import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.PopupPanel;
 import com.google.inject.Inject;
 
@@ -44,7 +45,8 @@ public class CppCompletionRequest
                                CompletionPosition completionPosition,
                                DocDisplay docDisplay, 
                                Invalidation.Token token,
-                               boolean explicit)
+                               boolean explicit,
+                               Command onTerminated)
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
       
@@ -52,6 +54,7 @@ public class CppCompletionRequest
       completionPosition_ = completionPosition;
       invalidationToken_ = token;
       explicit_ = explicit;
+      onTerminated_ = onTerminated;
       
       Position pos = completionPosition_.getPosition();
       
@@ -149,6 +152,8 @@ public class CppCompletionRequest
    {
       closeCompletionPopup();
       terminated_ = true;
+      if (onTerminated_ != null)
+         onTerminated_.execute();
    }
    
    public boolean isTerminated()
@@ -321,4 +326,5 @@ public class CppCompletionRequest
    private JsArray<CppCompletion> completions_;
    
    private boolean terminated_ = false;
+   private Command onTerminated_ = null;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionUtils.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionUtils.java
@@ -54,8 +54,9 @@ public class CppCompletionUtils
    
    public static CompletionPosition getCompletionPosition(DocDisplay docDisplay,
                                                           boolean explicit,
-                                                          boolean alwaysComplete)
-   {
+                                                          boolean alwaysComplete,
+                                                          int autoChars)
+   {      
       // get the current line of code
       String line = docDisplay.getCurrentLine();
       
@@ -107,9 +108,9 @@ public class CppCompletionUtils
       }
       
       // minimum character threshold
-      else if ((alwaysComplete || explicit) &&             // either always completing or explicit
-               ((inputCol - col) >= (explicit ? 1 : 5)) && // meets the character threshold
-               (ch != '"'))                                // not a quote character
+      else if ((alwaysComplete || explicit) &&                     // either always completing or explicit
+               ((inputCol - col) >= (explicit ? 1 : autoChars)) && // meets the character threshold
+               (ch != '"'))                                        // not a quote character
       {
          // calculate user text (up to two characters of additional
          // server side filter)


### PR DESCRIPTION
This PR introduces two options for controlling automatic completions:

1. Minimum number of characters required before automatic completion (defaults to 3)

2. Keyboard idle time required before automatic completion (defaults to 250ms)

Note this is for R mode only, will work on applying these to C++ mode next.

@kevinushey One thing I noticed was that even if I set the minimum character threshold lower than 3 completions never kicked in until I got to 3 characters. Perhaps there is another place in the code where this preference needs to be reflected?  I guess it's also worth discussing what an appropriate minimum should be (3 doesn't seem out of the question given that most users have already typed three characters by the time completions pop up). Let me know what you think.