### PR TITLE
preview/check for stan files

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/StanFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/StanFileType.java
@@ -21,14 +21,17 @@ import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.studio.client.common.reditor.EditorLanguage;
 import org.rstudio.studio.client.workbench.commands.Commands;
 
-public class StanFileType extends TextFileType
+public class StanFileType extends PreviewableFromRFileType
 {
    public StanFileType()
    {
       super("stan", "Stan", EditorLanguage.LANG_STAN, ".stan",
-            FileIconResources.INSTANCE.iconStan(), 
-            false, false, false, false, false,
-            false, false, false, false, false, false, false, false);
+            FileIconResources.INSTANCE.iconStan(), "rstan::stanc");
+   }
+   
+   public String getPreviewButtonText()
+   {
+      return "Check";
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -247,6 +247,11 @@ public class TextFileType extends EditableFileType
       return EditorLanguage.LANG_STAN.equals(getEditorLanguage());
    }
    
+   public String getPreviewButtonText()
+   {
+      return "Preview";
+   }
+   
    public String createPreviewCommand(String file)
    {
       return null;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -330,7 +330,7 @@ public class TextEditingTargetWidget
       sourceOnSave_.setVisible(canSourceOnSave);
       srcOnSaveLabel_.setVisible(canSourceOnSave);
       if (fileType.isRd() || canPreviewFromR)
-         srcOnSaveLabel_.setText("Preview on Save");
+         srcOnSaveLabel_.setText(fileType.getPreviewButtonText() + " on Save");
       else
          srcOnSaveLabel_.setText("Source on Save");
       codeTransform_.setVisible(
@@ -372,7 +372,9 @@ public class TextEditingTargetWidget
       }
       else
       {
-         setSourceButtonFromScriptState(isScript, canPreviewFromR);
+         setSourceButtonFromScriptState(isScript, 
+                                        canPreviewFromR,
+                                        fileType.getPreviewButtonText());
       }
       
       toolbar_.invalidateSeparators();
@@ -416,7 +418,10 @@ public class TextEditingTargetWidget
       knitDocumentButton_.setText(width < 450 ? "" : knitCommandText_);
       
       if (editor_.getFileType().isRd() || editor_.getFileType().canPreviewFromR())
-         srcOnSaveLabel_.setText(width < 450 ? "Preview" : "Preview on Save");
+      {
+         String preview = editor_.getFileType().getPreviewButtonText();
+         srcOnSaveLabel_.setText(width < 450 ? preview : preview + " on Save");
+      }
       else
          srcOnSaveLabel_.setText(width < 450 ? "Source" : "Source on Save");
       sourceButton_.setText(width < 400 ? "" : sourceCommandText_);
@@ -654,7 +659,9 @@ public class TextEditingTargetWidget
       previewHTMLButton_.setText(previewCommandText_);
    }
    
-   private void setSourceButtonFromScriptState(boolean isScript, boolean isMermaid)
+   private void setSourceButtonFromScriptState(boolean isScript, 
+                                               boolean canPreviewFromR,
+                                               String previewButtonText)
    {
       sourceCommandText_ = commands_.sourceActiveDocument().getButtonLabel();
       String sourceCommandDesc = commands_.sourceActiveDocument().getDesc();
@@ -665,10 +672,10 @@ public class TextEditingTargetWidget
          sourceButton_.setLeftImage(
                            commands_.debugContinue().getImageResource());
       }
-      else if (isMermaid)
+      else if (canPreviewFromR)
       {
-         sourceCommandText_ = "Preview";
-         sourceCommandDesc = "Save changes and preview the diagram";
+         sourceCommandText_ = previewButtonText;
+         sourceCommandDesc = "Save changes and preview";
          sourceButton_.setLeftImage(
                            commands_.debugContinue().getImageResource());
       }


### PR DESCRIPTION
This PR adds a "Check" button for Stan files (previously this same code-path was used for previewing graphviz diagrams). There is also a "Check on Save" option which will run the check every time the file is saved. Currently this executes the following:

```r
rstan::stanc('filename.stan')
```

Here's a demonstration:

![stancheck](https://cloud.githubusercontent.com/assets/104391/6399860/269cfa08-bdc3-11e4-8845-18acad49be01.gif)

Would be interested in feedback on:

1. Is `rstan::stanc` the best function to call?

2. Is "Check" the best name to use in the UI.

@jrnold @maverickg @syclik @bgoodri @bob-carpenter @rtrangucci

