### PR TITLE
Fix ThemeFonts.java for personal preferences

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/ThemeFonts.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ThemeFonts.java
@@ -57,18 +57,12 @@ public class ThemeFonts
    {
       public String getProportionalFont()
       {
-         String font = BrowseCap.hasUbuntuFonts() ? "Ubuntu, " : "";
-         return font + "\"Lucida Sans\", \"DejaVu Sans\", \"Lucida Grande\", \"Segoe UI\", Verdana, Helvetica, sans-serif"; 
+         return "sans-serif"; 
       }
 
       public String getFixedWidthFont()
       {
-         if (BrowseCap.isMacintosh())
-            return "Monaco, monospace";
-         else if (BrowseCap.isLinux())
-            return "\"Ubuntu Mono\", \"Droid Sans Mono\", \"DejaVu Sans Mono\", monospace";
-         else
-            return "Consolas, \"Lucida Console\", monospace";
+         return "monospace";
       }
    }
 }


### PR DESCRIPTION
Rstudio assumes the user wants Monospace font to be Ubuntu Mono on Linux systems and Monaco on Mac systems and such. There is no inherent reason why this choice has to be enforced: The user indeed should be able to change it when they set the browser preferences.

This is to fix so that the interface respects the browser's settings on Proportional and Fixed-width fonts.