### PR TITLE
remap shortcuts for previous/next tab & plot commands

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -114,6 +114,7 @@
 * Diagram previews using the DiagrammeR package (requires recent version from GitHub).
 * Added Markers pane and sourceMarker API for externals tools (e.g. linters)
 * Enable specification of Sweave driver in Rnw magic comment
+* Re-map prev/next tab shortcuts to eliminate conflicts with window managers
 
 ### Server
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -445,12 +445,11 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="activateVcs" value="Ctrl+9"/>
          <shortcut refid="activateBuild" value="Ctrl+0"/>
          <shortcut refid="switchToTab" value="Ctrl+Shift+."/>
-         <shortcut refid="previousTab" value="Ctrl+Alt+Left" if="!org.rstudio.core.client.BrowseCap.isLinux()"/>
-         <shortcut refid="nextTab" value="Ctrl+Alt+Right" if="!org.rstudio.core.client.BrowseCap.isLinux()"/>
-         <shortcut refid="previousTab" value="Ctrl+PageUp" if="org.rstudio.core.client.BrowseCap.isLinux()"/>
-         <shortcut refid="nextTab" value="Ctrl+PageDown" if="org.rstudio.core.client.BrowseCap.isLinux()"/>
-         <shortcut refid="firstTab" value="Ctrl+Alt+Shift+Left"/>
-         <shortcut refid="lastTab" value="Ctrl+Alt+Shift+Right"/>
+         <shortcut refid="previousTab" value="Ctrl+F11"/>
+         <shortcut refid="nextTab" value="Ctrl+F12"/>
+         <shortcut refid="firstTab" value="Ctrl+Shift+F11"/>
+         <shortcut refid="lastTab" value="Ctrl+Shift+F12"/>
+         
       </shortcutgroup>
       <shortcutgroup name="Files">
          <shortcut refid="saveSourceDoc" value="Cmd+S"/>
@@ -507,15 +506,15 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="quitSession" value="Cmd+Q" if="org.rstudio.studio.client.application.Desktop.isDesktop()"/>
          <shortcut refid="restartR" value="Cmd+Shift+0" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="restartR" value="Cmd+Shift+F10"/>
-         <shortcut refid="previousPlot" value="Cmd+Shift+PageUp" />
-         <shortcut refid="nextPlot" value="Cmd+Shift+PageDown" />
+         <shortcut refid="previousPlot" value="Cmd+Alt+F11" />
+         <shortcut refid="nextPlot" value="Cmd+Alt+F12" />
          <shortcut refid="showRequestLog" value="Ctrl+`" />
          <shortcut refid="logFocusedElement" value="Ctrl+Shift+`" />
          <shortcut refid="setWorkingDir" value="Ctrl+Shift+H" />
          <shortcut refid="synctexSearch" value="Cmd+F8" />
          <shortcut refid="checkSpelling" value="F7" />
-         <shortcut refid="refreshSuperDevMode" value="Cmd+Shift+F5"/>
-         <shortcut refid="viewerSaveAllAndRefresh" value="Cmd+Shift+F12"/>
+         <shortcut refid="refreshSuperDevMode" value="Cmd+Shift+F9"/>
+         <shortcut refid="viewerSaveAllAndRefresh" value="Cmd+Shift+F5"/>
          <shortcut refid="helpKeyboardShortcuts" value="Alt+Shift+K"/>
          <shortcut refid="toggleFullScreen" value="Ctrl+Meta+F" if="org.rstudio.core.client.BrowseCap.isMacintoshDesktop()"/>
       </shortcutgroup>

--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -261,23 +261,23 @@
   </tr>
   <tr>
     <td>Previous tab</td>
-    <td>Win: Ctrl+Alt+Left, Linux: Ctrl+PageUp</td>
-    <td>Ctrl+Option+Left</td>
+    <td>Ctrl+F11</td>
+    <td>Ctrl+F11</td>
   </tr>
   <tr>
     <td>Next tab</td>
-    <td>Win: Ctrl+Alt+Right, Linux: Ctrl+PageDown</td>
-    <td>Ctrl+Option+Right</td>
+    <td>Ctrl+F12</td>
+    <td>Ctrl+F12</td>
   </tr>
   <tr>
     <td>First tab</td>
-    <td>Ctrl+Shift+Alt+Left</td>
-    <td>Ctrl+Shift+Option+Left</td>
+    <td>Ctrl+Shift+F11</td>
+    <td>Ctrl+Shift+F11</td>
   </tr>
   <tr>
     <td>Last tab</td>
-    <td>Ctrl+Shift+Alt+Right</td>
-    <td>Ctrl+Shift+Option+Right</td>
+    <td>Ctrl+Shift+F12</td>
+    <td>Ctrl+Shift+F12</td>
   </tr>
   <tr>
      <td>Navigate back</td>
@@ -686,13 +686,13 @@
   <tr><td colspan="3"><h3>Plots</h3></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
   <tr>
     <td>Previous plot</td>
-    <td>Ctrl+Shift+PageUp</td>
-    <td>Command+Shift+PageUp</td>
+    <td>Ctrl+Alt+F11</td>
+    <td>Command+Option+F11</td>
   </tr>
   <tr>
     <td>Next plot</td>
-    <td>Ctrl+Shift+PageDown</td>
-    <td>Command+Shift+PageDown</td>
+    <td>Ctrl+Alt+F12</td>
+    <td>Command+Option+F12</td>
   </tr>
   <tr><td><br/></td></tr>
   <tr><td colspan="3"><h3>Git/SVN</h3></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>


### PR DESCRIPTION
We are in a losing battle with desktop window managers around attempting to use the arrow keys in shortcuts. Recently found out that arrow keys were being used by Windows 8 for switching workspaces. This PR uses the F11 and F12 keys rather than the arrow keys (logic being that they are still conveniently located and are not used at all by browsers or desktops).