### PR TITLE
fix for 'perfect match' completions

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1616,10 +1616,13 @@ public class RCompletionManager implements CompletionManager
          }
          
          // If there is only one result and the name is identical to the
-         // current token, then don't display anything
+         // current token, then implicitly accept that completion. we hide
+         // the popup to ensure that backspace can re-load completions from
+         // the cache
          if (results.length == 1 &&
              completions.token.equals(results[0].name.replaceAll(":*", "")))
          {
+            popup_.placeOffscreen();
             return;
          }
 


### PR DESCRIPTION
This fixes a bug where the autocompletion popup list could become out of sync, if multiple 'perfect matches' were encountered in the same completion 'session'. To reproduce the bug, try executing this in the console (to get references to these variables)

    foobar <- 1
    foobar1 <- 2

If you type `foo`, request completions, and then write the rest of the name for `foobar1`, you should see that the completion list is not properly dismissed / narrowed; even worse, if you attempt to select a completion it is not properly inserted. This change fixes that by hiding the popup (which acts as an implicit acceptance of the completion, but allows for backspacing to 're-open' that completion session).