### PR TITLE
fix data.table completions; provide column name completions in 'row' spot

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -900,41 +900,39 @@ assign(x = ".rs.acCompletionTypes",
    .rs.subsetCompletions(completions, order)
 })
 
-.rs.addFunction("blackListEvaluationDataTable", function(token, string, envir)
+.rs.addFunction("blackListEvaluationDataTable", function(token, string, functionCall, envir)
 {
    tryCatch({
-      parsed <- suppressWarnings(parse(text = string))
-      if (is.expression(parsed))
-      {
-         call <- parsed[[1]][[1]]
-         if (as.character(call[[1]]) == "[")
-         {
-            objectName <- parsed[[1]][[2]]
-            object <- .rs.getAnywhere(objectName, envir = envir)
-            if (inherits(object, "data.table"))
-            {
-               .rs.makeCompletions(
-                  token = token,
-                  results = names(object),
-                  packages = string,
-                  quote = FALSE,
-                  type = vapply(object, FUN.VALUE = numeric(1), USE.NAMES = FALSE, .rs.getCompletionType)
-               )
-            }
-         }
-      }
+      # NOTE: We don't retrieve the name from the function call as this could
+      # be a complex parse tree (e.g. dt[, y := 1][, y]$x); it is substantially
+      # easier to strip the object name from the 'string' constituting the parsed object
+      bracketIdx <- c(regexpr("[", string, fixed = TRUE))
+      objectName <- if (bracketIdx == -1)
+         string
       else
+         substring(string, 1L, bracketIdx - 1L)
+      
+      object <- .rs.getAnywhere(objectName, envir = envir)
+      if (inherits(object, "data.table"))
       {
-         NULL
+         names <- names(object)
+         results <- .rs.selectFuzzyMatches(names, token)
+         .rs.makeCompletions(
+            token = token,
+            results = results,
+            packages = string,
+            quote = FALSE,
+            type = vapply(object, FUN.VALUE = numeric(1), USE.NAMES = FALSE, .rs.getCompletionType)
+         )
       }
    }, error = function(e) NULL
    )
    
 })
 
-.rs.addFunction("blackListEvaluation", function(token, string, envir)
+.rs.addFunction("blackListEvaluation", function(token, string, functionCall, envir)
 {
-   if (!is.null(result <- .rs.blackListEvaluationDataTable(token, string, envir)))
+   if (!is.null(result <- .rs.blackListEvaluationDataTable(token, string, functionCall, envir)))
       return(result)
    
    NULL
@@ -942,12 +940,12 @@ assign(x = ".rs.acCompletionTypes",
 })
 
 ## NOTE: for '@' as well (set in the 'isAt' parameter)
-.rs.addFunction("getCompletionsDollar", function(token, string, envir, isAt)
+.rs.addFunction("getCompletionsDollar", function(token, string, functionCall, envir, isAt)
 {
    result <- .rs.emptyCompletions(excludeOtherCompletions = TRUE)
    
    ## Blacklist certain evaluations
-   if (!is.null(blacklist <- .rs.blackListEvaluation(token, string, envir)))
+   if (!is.null(blacklist <- .rs.blackListEvaluation(token, string, functionCall, envir)))
       return(blacklist)
    
    object <- .rs.getAnywhere(string, envir)
@@ -1053,13 +1051,14 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("getCompletionsSingleBracket", function(token,
                                                         string,
+                                                        functionCall,
                                                         numCommas,
                                                         envir)
 {
    result <- .rs.emptyCompletions()
    
    ## Blacklist certain evaluations
-   if (!is.null(result <- .rs.blackListEvaluation(token, string, envir)))
+   if (!is.null(result <- .rs.blackListEvaluation(token, string, functionCall, envir)))
       return(result)
    
    object <- .rs.getAnywhere(string, envir)
@@ -1115,12 +1114,13 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("getCompletionsDoubleBracket", function(token,
                                                         string,
+                                                        functionCall,
                                                         envir = parent.frame())
 {
    result <- .rs.emptyCompletions()
    
    ## Blacklist certain evaluations
-   if (!is.null(result <- .rs.blackListEvaluation(token, string, envir)))
+   if (!is.null(result <- .rs.blackListEvaluation(token, string, functionCall, envir)))
       return(result)
    
    object <- .rs.getAnywhere(string, envir)
@@ -1690,6 +1690,7 @@ assign(x = ".rs.acCompletionTypes",
          completions <- .rs.getCompletionsDollar(
             token,
             string[[1]],
+            functionCall,
             envir,
             type[[1]] == .rs.acContextTypes$AT
          )
@@ -1979,9 +1980,9 @@ assign(x = ".rs.acCompletionTypes",
       else if (type == .rs.acContextTypes$ARGUMENT)
          .rs.getCompletionsArgument(token, string, functionCall, envir)
       else if (type == .rs.acContextTypes$SINGLE_BRACKET)
-         .rs.getCompletionsSingleBracket(token, string, numCommas, envir)
+         .rs.getCompletionsSingleBracket(token, string, functionCall, numCommas, envir)
       else if (type == .rs.acContextTypes$DOUBLE_BRACKET)
-         .rs.getCompletionsDoubleBracket(token, string, envir)
+         .rs.getCompletionsDoubleBracket(token, string, functionCall, envir)
       else
          .rs.emptyCompletions()
    )


### PR DESCRIPTION
Previously, the `data.table` blacklist evaluation was not functioning as intended -- in the current version of RStudio, writing e.g.

    library(data.table)
    dt <- data.table(mtcars)
    dt[, y := 1]$<TAB>

will evaluate the full statement preceding the `$`, and hence cause a new variable named `y` to be inserted by reference. In fact, the current blacklist evaluation semantics used for `data.table` were not actually being touched, and so the 'regular' evaluation semantics kicked in.

This PR fixes that by checking to see if a particular completion is a `data.table` completion (properly), and also provides the completions in the 'row' spot for `data.table` objects (and so only the symbol name `dt` is evaluated).