### PR TITLE
focus editor on Cmd+E find next

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3943,6 +3943,7 @@ public class TextEditingTarget implements
    void onFindFromSelection()
    {
       view_.findFromSelection();
+      docDisplay_.focus();
    }
    
    @Handler


### PR DESCRIPTION
This focuses the editor after pressing `Cmd + E` to find the next search result, rather than keeping focus in the find + replace bar, as per a FR from @hadley.