### PR TITLE
allow completions for threshold < 3; tweak heuristics

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -208,7 +208,7 @@ public class EditingPreferencesPane extends PreferencesPane
    {
       return (!spacesForTab_.getValue() || tabWidth_.validatePositive("Tab width")) && 
              (!showMargin_.getValue() || marginCol_.validate("Margin column")) &&
-             alwaysCompleteChars_.validateRange("Characters entered", 3, 100) &&
+             alwaysCompleteChars_.validateRange("Characters entered", 1, 100) &&
              alwaysCompleteDelayMs_.validateRange("Keyboard idle (ms)", 0, 10000);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -558,21 +558,32 @@ public class RCompletionManager implements CompletionManager
       if (isValidForRIdentifier(docDisplay_.getCharacterAtCursor()))
          return false;
       
-      // Grab the current token on the line
-      String currentToken = StringUtil.getToken(
-            currentLine, cursorColumn, "^[a-zA-Z0-9._'\"`]$", false, false);
-      
-      // Don't auto-popup for common keywords + symbols
-      String[] keywords = {
-            "for", "if", "in", "function", "while", "repeat",
-            "break", "switch", "return", "library", "require",
-            "TRUE", "FALSE"
-      };
-      
-      for (String keyword : keywords)
-         if (currentToken.length() <= keyword.length() &&
-             keyword.substring(0, currentToken.length()).equals(currentToken))
-            return false;
+      // Check to see if the token forms the start of common keywords -- we
+      // want to limit popups in those cases.
+      //
+      // If the complete character theshold is low, however, we go ahead and
+      // provide completions anyway (since the user has somewhat implicitly
+      // opted into 'noisier' completions)
+      int completeChars = uiPrefs_.alwaysCompleteCharacters().getValue();
+      if (completeChars >= 2)
+      {
+         // Grab the current token on the line
+         String currentToken = StringUtil.getToken(
+               currentLine, cursorColumn, "^[a-zA-Z0-9._'\"`]$", false, false);
+
+         // Don't auto-popup for common keywords + symbols
+         String[] keywords = {
+               "for", "if", "in", "function", "while", "repeat",
+               "break", "switch", "return", "library", "require",
+               "TRUE", "FALSE"
+         };
+
+         for (String keyword : keywords)
+            if (currentToken.length() <= keyword.length() &&
+            keyword.substring(0, currentToken.length()).equals(currentToken))
+               return false;
+
+      }
       
       boolean canAutoPopup =
             (currentLine.length() > lookbackLimit - 1 && isValidForRIdentifier(c));


### PR DESCRIPTION
This allows for 'noisy' completions with low character thresholds by avoiding the 'keyword' checks that disable automatic popups when it appears that the user is typing a keyword.