### PR TITLE
don't merge text tokens

### DIFF
--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -147,7 +147,7 @@ define("mode/r_highlight_rules", function(require, exports, module)
             {
                token : "text",
                regex : "\\s+",
-               merge : true
+               merge : false // needs to be false so e.g. ',' not merged with spaces
             }
          ],
          "qqstring" : [


### PR DESCRIPTION
This PR turns of merging of 'text' tokens -- this ensures that, for example, commas and semi-colons are tokenized separately from whitespace. (This is what was causing the matching quote insertion problem).

The auto-indentation R code appears to be unaffected by this change, so as far as I can see it is safe to perform.