### PR TITLE
fix ace preview load on firefox (thanks, @jmcphers!)

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/DynamicIFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/DynamicIFrame.java
@@ -32,7 +32,7 @@ public abstract class DynamicIFrame extends Frame
          @Override
          public boolean execute()
          {
-            if (getIFrame() == null || getWindow() == null)
+            if (getIFrame() == null || getWindow() == null || getDocument() == null)
                return true;
             onFrameLoaded();
             return false;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AceEditorPreview.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AceEditorPreview.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.prefs.views;
 import com.google.gwt.dom.client.*;
 import com.google.gwt.dom.client.Style.BorderStyle;
 import com.google.gwt.dom.client.Style.Unit;
+
 import org.rstudio.core.client.ExternalJavaScriptLoader;
 import org.rstudio.core.client.ExternalJavaScriptLoader.Callback;
 import org.rstudio.core.client.theme.ThemeFonts;
@@ -39,47 +40,71 @@ public class AceEditorPreview extends DynamicIFrame
    protected void onFrameLoaded()
    {
       isFrameLoaded_ = true;
-      if (themeUrl_ != null)
-         setTheme(themeUrl_);
-      if (fontSize_ != null)
-         setFontSize(fontSize_);
-      if (zoomLevel_ != null)
-         setZoomLevel(zoomLevel_);
-
       final Document doc = getDocument();
-      final BodyElement body = doc.getBody();
-      body.getStyle().setMargin(0, Unit.PX);
-      body.getStyle().setBackgroundColor("white");
-
-      StyleElement style = doc.createStyleElement();
-      style.setType("text/css");
-      style.setInnerText(
-            ".ace_editor {\n" +
-            "border: none !important;\n" +
-            "}");
-      setFont(ThemeFonts.getFixedWidthFont());
-      body.appendChild(style);
-
-      DivElement div = doc.createDivElement();
-      div.setId("editor");
-      div.getStyle().setWidth(100, Unit.PCT);
-      div.getStyle().setHeight(100, Unit.PCT);
-      div.setInnerText(code_);
-      body.appendChild(div);
-
-      FontSizer.injectStylesIntoDocument(doc);
-      FontSizer.applyNormalFontSize(div);
-
-      new ExternalJavaScriptLoader(doc, AceResources.INSTANCE.acejs().getSafeUri().asString())
+      
+      // NOTE: There is an interesting 'feature' in Firefox whereby an
+      // initialized IFrame will report that it has successfully initialized the
+      // window / underlying document (readyState is 'complete') but, in fact,
+      // there is still some initialization left to occur and any changes made
+      // before complete initialization will cause it to be swept out from under
+      // our feet. To work around this, we double-check that the document we are
+      // working with is the _same document_ after each JavaScript load
+      // iteration.
+      new ExternalJavaScriptLoader(getDocument(), AceResources.INSTANCE.acejs().getSafeUri().asString())
             .addCallback(new Callback()
       {
          public void onLoaded()
          {
-            new ExternalJavaScriptLoader(doc, AceResources.INSTANCE.acesupportjs().getSafeUri().asString())
+            if (getDocument() != doc) 
+            {
+               onFrameLoaded();
+               return;
+            }
+            
+            new ExternalJavaScriptLoader(getDocument(), AceResources.INSTANCE.acesupportjs().getSafeUri().asString())
                   .addCallback(new Callback()
                   {
                      public void onLoaded()
                      {
+                        
+                        if (getDocument() != doc)
+                        {
+                           onFrameLoaded();
+                           return;
+                        }
+                        
+                        final Document doc = getDocument();
+                        final BodyElement body = doc.getBody();
+                        
+                        if (themeUrl_ != null)
+                           setTheme(themeUrl_);
+                        if (fontSize_ != null)
+                           setFontSize(fontSize_);
+                        if (zoomLevel_ != null)
+                           setZoomLevel(zoomLevel_);
+
+                        body.getStyle().setMargin(0, Unit.PX);
+                        body.getStyle().setBackgroundColor("white");
+
+                        StyleElement style = doc.createStyleElement();
+                        style.setType("text/css");
+                        style.setInnerText(
+                              ".ace_editor {\n" +
+                                    "border: none !important;\n" +
+                              "}");
+                        setFont(ThemeFonts.getFixedWidthFont());
+                        body.appendChild(style);
+
+                        DivElement div = doc.createDivElement();
+                        div.setId("editor");
+                        div.getStyle().setWidth(100, Unit.PCT);
+                        div.getStyle().setHeight(100, Unit.PCT);
+                        div.setInnerText(code_);
+                        body.appendChild(div);
+
+                        FontSizer.injectStylesIntoDocument(doc);
+                        FontSizer.applyNormalFontSize(div);
+                        
                         body.appendChild(doc.createScriptElement(
                               "var event = require('ace/lib/event');\n" +
                               "var Editor = require('ace/editor').Editor;\n" +


### PR DESCRIPTION
Firefox has a very strange behaviour whereby, for a newly created IFrame, it will report that the underlying window / document are ready before a full initialization has been completed. If we attempt to modify the document before the full initialization has complete, those changes will be discarded later when Firefox finishes initialization of the document.

We work around this by ensuring that the document does not change while we load and apply new scripts for the previewer; if they do change, we attempt a restart.

@jjallaire, do you have any thoughts on a more appropriate solution? Is there a better way we could be detecting whether the IFrame / document is _truly_ ready?