### PR TITLE
use KeyboardHelper for checking keys pressed

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/KeyboardHelper.java
+++ b/src/gwt/src/org/rstudio/core/client/command/KeyboardHelper.java
@@ -1,0 +1,59 @@
+/*
+ * KeyboardHelper.java
+ *
+ * Copyright (C) 2009-15 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.command;
+
+import org.rstudio.core.client.BrowseCap;
+
+import com.google.gwt.dom.client.NativeEvent;
+
+public class KeyboardHelper
+{
+   public static boolean isHyphen(NativeEvent event)
+   {
+      if (KeyboardShortcut.getModifierValue(event) != KeyboardShortcut.NONE)
+         return false;
+      
+      return isHyphenKeycode(event.getKeyCode());
+   }
+   
+   public static boolean isHyphenKeycode(NativeEvent event)
+   {
+      return isHyphenKeycode(event.getKeyCode());
+   }
+   
+   public static boolean isHyphenKeycode(int keyCode)
+   {
+      if (BrowseCap.isFirefox())
+         return keyCode == 173;
+      else
+         return keyCode == 189;
+   }
+   
+   public static boolean isUnderscore(NativeEvent event)
+   {
+      return event.getShiftKey() && isHyphenKeycode(event.getKeyCode());
+   }
+   
+   public static boolean isPeriod(NativeEvent event)
+   {
+      return !event.getShiftKey() && isPeriodKeycode(event.getKeyCode());
+   }
+   
+   public static boolean isPeriodKeycode(int keyCode)
+   {
+      return keyCode == 190;
+   }
+
+}

--- a/src/gwt/src/org/rstudio/core/client/command/KeyboardShortcut.java
+++ b/src/gwt/src/org/rstudio/core/client/command/KeyboardShortcut.java
@@ -147,13 +147,12 @@ public class KeyboardShortcut
          return "=";
       else if (keycode_ == 188)
          return "<";
-      else if (keycode_ == 189)
+      else if (KeyboardHelper.isHyphenKeycode(keycode_))
          return "-";
       else if (keycode_ >= 112 && keycode_ <= 123)
          return "F" + (keycode_ - 111);
       else if (keycode_ == 8)
          return macStyle ? "&#9003;" : "Backspace";
-
 
       return Character.toUpperCase((char)keycode_) + "";
    }

--- a/src/gwt/src/org/rstudio/core/rebind/command/ShortcutsEmitter.java
+++ b/src/gwt/src/org/rstudio/core/rebind/command/ShortcutsEmitter.java
@@ -18,6 +18,8 @@ import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.core.ext.TreeLogger.Type;
 import com.google.gwt.core.ext.UnableToCompleteException;
 import com.google.gwt.user.rebind.SourceWriter;
+
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -26,6 +28,7 @@ import org.w3c.dom.NodeList;
 import javax.xml.transform.Result;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
+
 import java.io.StringWriter;
 
 public class ShortcutsEmitter
@@ -212,7 +215,7 @@ public class ShortcutsEmitter
       if (val.equals("<"))
          return "188";
       if (val.equals("-"))
-         return "189";
+         return BrowseCap.isFirefox() ? "173" : "189";
       if (val.equals("Backspace"))
          return "8";
       return null;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -28,6 +28,7 @@ import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
+import org.rstudio.core.client.command.KeyboardHelper;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.jsonrpc.RpcObjectList;
 import org.rstudio.studio.client.application.events.EventBus;
@@ -516,13 +517,11 @@ public class Shell implements ConsoleInputHandler,
             }
             else if (mod == KeyboardShortcut.ALT)
             {
-               switch (keyCode)
+               if (KeyboardHelper.isHyphenKeycode(keyCode))
                {
-                  case 189: // hyphen
-                     event.preventDefault();
-                     event.stopPropagation();
-                     input_.replaceSelection(" <- ", true);
-                     break;
+                  event.preventDefault();
+                  event.stopPropagation();
+                  input_.replaceSelection(" <- ", true);
                }
             }
             else if (

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -33,6 +33,7 @@ import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.Invalidation;
 import org.rstudio.core.client.Rectangle;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.command.KeyboardHelper;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.events.SelectionCommitEvent;
 import org.rstudio.core.client.events.SelectionCommitHandler;
@@ -802,16 +803,17 @@ public class RCompletionManager implements CompletionManager
       }
       
       int keyCode = event.getKeyCode() ;
+      
       if (keyCode >= 'a' && keyCode <= 'z')
          return true ;
-      if (keyCode >= 'A' && keyCode <= 'Z')
+      else if (keyCode >= 'A' && keyCode <= 'Z')
          return true ;
-      if (keyCode == ' ')
+      else if (keyCode == ' ')
          return true ;
-      if (keyCode == 189) // dash
+      else if (KeyboardHelper.isHyphen(event))
          return true ;
-      if (keyCode == 189 && event.getShiftKey()) // underscore
-         return true ;
+      else if (KeyboardHelper.isUnderscore(event))
+         return true;
       
       if (event.getShiftKey())
          return false ;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -41,6 +41,7 @@ import org.rstudio.core.client.*;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
+import org.rstudio.core.client.command.KeyboardHelper;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.events.EnsureHeightHandler;
 import org.rstudio.core.client.events.EnsureVisibleHandler;
@@ -412,8 +413,8 @@ public class TextEditingTarget implements
                event.stopPropagation();
                commands_.findFromSelection().execute();
             }
-            else if (mod == KeyboardShortcut.ALT
-                     && ne.getKeyCode() == 189) // hyphen
+            else if (mod == KeyboardShortcut.ALT &&
+                     KeyboardHelper.isHyphenKeycode(ne.getKeyCode()))
             {
                event.preventDefault();
                event.stopPropagation();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionUtils.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionUtils.java
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client.workbench.views.source.editors.text.cpp;
 
+import org.rstudio.core.client.command.KeyboardHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 
@@ -32,7 +33,7 @@ public class CppCompletionUtils
          return true ;
       if (keyCode >= 'A' && keyCode <= 'Z')
          return true ;
-      if (keyCode == 189 && event.getShiftKey()) // underscore
+      if (KeyboardHelper.isUnderscore(event))
          return true ;
      
       if (event.getShiftKey())


### PR DESCRIPTION
This PR adds a simple abstraction for checking the key pressed, which should allow us to handle cases where browsers return separate keycodes for the same key. In particular, we use this to detect the hyphen keycode (173 on FireFox, 189 otherwise)

Note: in the future we would want to use the `key` and `code` items for detecting the key pressed, but this is unimplemented in most browsers (and due to bugs in the standard, everyone is moving quite slow, see e.g. https://bugzilla.mozilla.org/show_bug.cgi?id=680830)