### PR TITLE
always update completions after inserting characters when popup visible

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -660,6 +660,9 @@ public class RCompletionManager implements CompletionManager
             return false;
          }
          
+         // Always update the current set of completions following
+         // a key insertion. Defer execution so the key insertion can
+         // enter the document.
          Scheduler.get().scheduleDeferred(new ScheduledCommand()
          {
             @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -653,22 +653,23 @@ public class RCompletionManager implements CompletionManager
             }
          }
          
-         if (isValidForRIdentifier(c))
-         {
-            Scheduler.get().scheduleDeferred(new ScheduledCommand()
-            {
-               @Override
-               public void execute()
-               {
-                  beginSuggest(false, true, false);
-               }
-            });
-         }
-         
+         // 
          if (c == ':')
          {
             suggestTimer_.schedule(false, true, false);
+            return false;
          }
+         
+         Scheduler.get().scheduleDeferred(new ScheduledCommand()
+         {
+            @Override
+            public void execute()
+            {
+               beginSuggest(false, true, false);
+            }
+         });
+         return false;
+         
       }
       else
       {


### PR DESCRIPTION
This fixes a bug whereby characters which weren't valid R identifiers wouldn't update the current set of completions, thereby causing odd behaviours when completing filenames or syntactically invalid names.

To repro: try typing

    rn<TAB>---<ENTER>

you should see the completion list remain 'stale' after insertion of `-` characters, and then the token improperly replaced after pressing `<ENTER>`. This PR fixes that by ensuring the completion list is always updated after new presses.