### PR TITLE
fudge completion width to avoid staggered display

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
@@ -187,6 +187,15 @@ public class CompletionPopupPanel extends ThemedPopupPanel
       else
          show() ;
       
+      
+      // Fudge the completion width when the scrollbar is visible. This has
+      // to be done before help is shown since the help display is offset
+      // from the completion list. This also (implicitly) adds padding between
+      // the completion item and the package name (if it exists)
+      if (list_.getOffsetWidth() > list_.getElement().getClientWidth())
+         list_.setWidth(list_.getOffsetWidth() + 30 + "px");
+      
+      // Show help.
       if (help_ != null)
       {
          if (completionListIsOnScreen())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
@@ -192,7 +192,7 @@ public class CompletionPopupPanel extends ThemedPopupPanel
       // to be done before help is shown since the help display is offset
       // from the completion list. This also (implicitly) adds padding between
       // the completion item and the package name (if it exists)
-      if (list_.getOffsetWidth() > list_.getElement().getClientWidth())
+      if (list_ != null && list_.getOffsetWidth() > list_.getElement().getClientWidth())
          list_.setWidth(list_.getOffsetWidth() + 30 + "px");
       
       // Show help.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.css
@@ -1,21 +1,23 @@
 .completionIcon {
-	margin-bottom: -1px;
+	float: left;
+	margin-top: 4px;
 	padding-left: 2px;
 	padding-right: 6px;
 }
 
 .fileIcon {
-	margin-bottom: -3px;
+	float: left;
+	margin-top: 2px;
 	padding-left: 2px;
 	padding-right: 6px;
 }
 
 .completion {
-	
+	float: left;
 }
 
 .packageName {
-	padding-right: 8px;
 	float: right;
+	padding-right: 8px;
 	color: #999;
 }


### PR DESCRIPTION
This PR fixes two bugs:

1. The completion list was always staggered when displayed on FireFox. We avoid this by floating all content within the popup display (icons + completion item to left, package to right)

2. The completion list could become staggered when the scrollbar is visible. We avoid this by fudging the width of the completion list if the scrollbar is visible.