### PR TITLE
add HTML comments to markdown

### DIFF
--- a/src/gwt/acesupport/acemode/markdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/markdown_highlight_rules.js
@@ -240,8 +240,20 @@ var MarkdownHighlightRules = function() {
             token : "text",
             regex : "^\\s{0,3}(?:[*+-]|\\d+\\.)\\s+",
             next  : "listblock-start"
+        }, { // html comment
+            token : "comment",
+            regex : "<\\!--",
+            next  : "html-comment"
         }, {
             include : "basic"
+        }],
+
+        "html-comment" : [{
+           token: "comment",
+           regex: "-->",
+           next: "start"
+        }, {
+           defaultToken: "comment"
         }],
        
         // code block


### PR DESCRIPTION
This enables comment syntax highlighting for HTML comments in Markdown / RMarkdown documents.