### PR TITLE
Feature/formula completions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
    inferred and supplied even when not loaded
  - Completions for knitr options, e.g. in opts_chunk$get(), are now supplied
  - Completions for dynamic symbols within .C, .Call, .Fortran, .External
+ - Completions for object names for 'formula' arguments, e.g. lm(|, data = mtcars)
 
 ### Source Editor
 

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -681,9 +681,33 @@ assign(x = ".rs.acCompletionTypes",
          }
       }
       
+      # Get completions from a data object name if the active argument is 'formula'.
+      # Useful for formula incantations in e.g.
+      #
+      #    lm(|, data = mtcars)
+      #
+      # In this special case, we _override_ argument completions (since they
+      # are often less interesting in this special case)
+      if (.rs.startsWith(activeArg, "form") &&
+          !is.null(matchedCall[["data"]]))
+      {
+         dataObject <- .rs.getAnywhere(matchedCall[["data"]])
+         if (!is.null(dataObject))
+         {
+            dataNames <- .rs.getNames(dataObject)
+            return(.rs.makeCompletions(
+               token = token,
+               results = .rs.selectFuzzyMatches(dataNames, token),
+               quote = FALSE
+            ))
+         }
+      }
+      
       # Get completions for the current active argument
-      argCompletions <- .rs.getCompletionsArgument(token,
-                                                   activeArg)
+      argCompletions <- .rs.getCompletionsArgument(
+         token = token,
+         activeArg = activeArg,
+      )
       
       fguess <- if (length(formals$methods))
          formals$methods[[1]]

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -145,9 +145,13 @@ define("mode/r_highlight_rules", function(require, exports, module)
                regex : "[\\])}]"
             },
             {
+               token : "punctuation",
+               regex : "[;,]",
+               merge : false
+            },
+            {
                token : "text",
-               regex : "\\s+",
-               merge : false // needs to be false so e.g. ',' not merged with spaces
+               regex : "\\s+"
             }
          ],
          "qqstring" : [

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1492,20 +1492,34 @@ public class RCompletionManager implements CompletionManager
       // Now, attempt to find the end of the current statement.
       // Look for the ',' or ')' that ends the statement for the 
       // currently active argument.
-      // the ',' or ')' that ends the statement for this argument.
+      boolean lookupSucceeded = false;
       while (clone.moveToNextToken())
       {
          String value = clone.currentValue();
          if (value.indexOf(",") != -1 || value.equals(")"))
+         {
+            lookupSucceeded = true;
             break;
+         }
+         
+         // Bail if we find a closing paren (we should walk over matched
+         // pairs properly, so finding one implies that we have a parse error).
+         if (value.equals("]") || value.equals("]]") || value.equals("}"))
+         {
+            break;
+         }
          
          if (clone.fwdToMatchingToken())
             continue;
       }
       
-      String afterText = editor.getTextForRange(Range.fromPoints(
-            clone.currentPosition(),
-            endPos));
+      String afterText = "";
+      if (lookupSucceeded)
+      {
+         afterText = editor.getTextForRange(Range.fromPoints(
+               clone.currentPosition(),
+               endPos));
+      }
       
       context.setFunctionCallString(
             (beforeText + afterText).trim());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1443,9 +1443,11 @@ public class RCompletionManager implements CompletionManager
       
       // Try to get the function call string -- either there's
       // an associated closing paren we can use, or we should just go up
-      // to the current cursor position
+      // to the current cursor position.
       
-      // default case: use start cursor
+      // First, attempt to determine where the closing paren is located. If
+      // this fails, we'll just use the start cursor's position (and later
+      // attempt to finish the expression to make it parsable)
       Position endPos = startCursor.currentPosition();
       endPos.setColumn(endPos.getColumn() + startCursor.currentValue().length());
       
@@ -1460,21 +1462,50 @@ public class RCompletionManager implements CompletionManager
          }
       }
       
-      // We can now set the function call string
-      // We strip the current token so that the matched.call work later on
-      // can properly resolve the current argument
-      Position startPosition = startCursor.currentPosition();
+      // We can now set the function call string.
+      //
+      // We strip out the current statement under the cursor, so that
+      // match.call() can later properly resolve the current argument.
+      //
+      // Attempt to find the start of the current statement.
+      TokenCursor clone = startCursor.cloneCursor();
+      do
+      {
+         String value = clone.currentValue();
+         if (value.indexOf(",") != -1 || value.equals("("))
+            break;
+         
+         if (clone.bwdToMatchingToken())
+            continue;
+         
+      } while (clone.moveToPreviousToken());
+      Position startPosition = clone.currentPosition();
+      
+      // Include the opening paren if that's what we found
+      if (clone.currentValue().equals("("))
+         startPosition.setColumn(startPosition.getColumn() + 1);
+      
       String beforeText = editor.getTextForRange(Range.fromPoints(
             tokenCursor.currentPosition(),
             startPosition));
       
-      Position afterTokenPos = startCursor.currentPosition();
-      if (startCursor.currentType() == "identifier")
-         afterTokenPos.setColumn(afterTokenPos.getColumn() +
-               startCursor.currentValue().length());
+      // Now, attempt to find the end of the current statement.
+      // Look for the ',' or ')' that ends the statement for the 
+      // currently active argument.
+      // the ',' or ')' that ends the statement for this argument.
+      while (clone.moveToNextToken())
+      {
+         String value = clone.currentValue();
+         if (value.indexOf(",") != -1 || value.equals(")"))
+            break;
+         
+         if (clone.fwdToMatchingToken())
+            continue;
+      }
       
       String afterText = editor.getTextForRange(Range.fromPoints(
-            afterTokenPos, endPos));
+            clone.currentPosition(),
+            endPos));
       
       context.setFunctionCallString(
             (beforeText + afterText).trim());

--- a/src/gwt/test/autoindent_test_r.html
+++ b/src/gwt/test/autoindent_test_r.html
@@ -379,6 +379,7 @@ var Range = require('ace/range').Range;
 require('mode/auto_brace_insert').setInsertMatching(true);
 
 var editor = ace.edit('editor');
+editor.$blockScrolling = Infinity;
 editor.renderer.setHScrollBarAlwaysVisible(false);
 editor.setHighlightActiveLine(false);
 editor.getSession().setTabSize(2);
@@ -444,6 +445,7 @@ editor.getSession().setMode(
 
 // A test editor that is used for the indent tests
 testEditor = ace.edit('testEditor');
+testEditor.$blockScrolling = Infinity;
 testEditor.getSession().setMode(
   new RMode(false, testEditor.getSession())
 );


### PR DESCRIPTION
This PR enables completions for object names when within a function call which accepts a `data` argument and the active argument is named `formula` (or starts with `form`).

With this PR, when we have:

    lm(|, data = mtcars)

RStudio will provide the names of `mtcars` as completions.

TODO is to enable this in nested function calls, e.g.

    lm(y ~ x + I(|), data = mtcars)

but I think it's okay to leave that for later (this should cover ~90% of cases).

There is a bit of regression risk in this PR -- we now explicitly tokenize semicolons and commas as `punctuation` tokens rather than `text` tokens. I noticed that even still, punctuation and spaces were getting tokenized and merged together, so I finally decided we should go ahead and tokenize them separately. This was necessary as, e.g. in this case,:

    lm( |, data = mtcars)

the token cursor was placed on a token ` ,`, which is unexpected (we would want to placed initially on the `(`).