### PR TITLE
Add emacs keybindings

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
@@ -116,6 +116,9 @@ public class UIPrefs extends UIPrefsAccessor implements UiPrefsChangedHandler
          useVimMode().setGlobalValue(
                               newUiPrefs.useVimMode().getGlobalValue());
          
+         enableEmacsKeybindings().setGlobalValue(
+                              newUiPrefs.enableEmacsKeybindings().getGlobalValue());
+         
          continueCommentsOnNewline().setGlobalValue(
                               newUiPrefs.continueCommentsOnNewline().getGlobalValue());
          

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -102,6 +102,11 @@ public class UIPrefsAccessor extends Prefs
       return bool("use_vim_mode", false);
    }
    
+   public PrefValue<Boolean> enableEmacsKeybindings()
+   {
+      return bool("enable_emacs_keybindings", false);
+   }
+   
    public PrefValue<Boolean> insertMatching()
    {
       return bool("insert_matching", true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -52,7 +52,15 @@ public class EditingPreferencesPane extends PreferencesPane
       editingPanel.add(checkboxPref("Ensure that source files end with newline", prefs_.autoAppendNewline()));
       editingPanel.add(checkboxPref("Strip trailing horizontal whitespace when saving", prefs_.stripTrailingWhitespace()));
       editingPanel.add(checkboxPref("Focus console after executing from source", prefs_.focusConsoleAfterExec()));
-      editingPanel.add(checkboxPref("Enable vim editing mode", prefs_.useVimMode()));
+      
+      vim_ = checkboxPref("Enable vim editing mode", prefs_.useVimMode());
+      emacs_ = checkboxPref("Enable Emacs keybindings", prefs_.enableEmacsKeybindings());
+      
+      canOnlyEnableOnePref(vim_, emacs_);
+      
+      editingPanel.add(vim_);
+      editingPanel.add(emacs_);
+      
       editingPanel.add(checkboxPref(
             "Continue comment when inserting new line",
             prefs_.continueCommentsOnNewline(),
@@ -197,6 +205,31 @@ public class EditingPreferencesPane extends PreferencesPane
       checkBox.setVisible(true);
    }
    
+   private void canOnlyEnableOnePref(final CheckBox cb1,
+                                     final CheckBox cb2)
+   {
+      cb1.addValueChangeHandler(new ValueChangeHandler<Boolean>()
+      {
+         @Override
+         public void onValueChange(ValueChangeEvent<Boolean> event)
+         {
+            if (event.getValue())
+               cb2.setValue(false);
+         }
+      });
+      
+      cb2.addValueChangeHandler(new ValueChangeHandler<Boolean>()
+      {
+         @Override
+         public void onValueChange(ValueChangeEvent<Boolean> event)
+         {
+            if (event.getValue())
+               cb1.setValue(false);
+         }
+      });
+      
+   }
+   
    private void addEnabledDependency(final CheckBox speaker,
                                      final CheckBox listener)
    {
@@ -265,6 +298,8 @@ public class EditingPreferencesPane extends PreferencesPane
    private final NumericValueWidget alwaysCompleteDelayMs_;
    private final CheckBox spacesForTab_;
    private final CheckBox showMargin_;
+   private CheckBox vim_;
+   private CheckBox emacs_;
    private final SelectWidget showCompletions_;
    private final SelectWidget showCompletionsOther_;
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -571,11 +571,10 @@ public class AceEditor implements DocDisplay,
       // reset keyboard handlers
       widget_.getEditor().setKeyboardHandler(null);
       
-      // if required add vim handlers to main editor
       if (useVimMode_)
-      {
          widget_.getEditor().addKeyboardHandler(KeyboardHandler.vim());
-      }
+      else if (useEmacsKeybindings_)
+         widget_.getEditor().addKeyboardHandler(KeyboardHandler.emacs());
       
       // add the previewer's handler
       widget_.getEditor().addKeyboardHandler(previewer.getKeyboardHandler());
@@ -1364,6 +1363,16 @@ public class AceEditor implements DocDisplay,
    }
    
    @Override
+   public void setUseEmacsKeybindings(boolean use)
+   {
+      if (widget_.getEditor().getReadOnly())
+         return;
+      
+      useEmacsKeybindings_ = use;
+      updateKeyboardHandlers();
+   }
+   
+   @Override
    public boolean isVimModeOn()
    {
       return useVimMode_;
@@ -2084,6 +2093,7 @@ public class AceEditor implements DocDisplay,
    private TextFileType fileType_;
    private boolean passwordMode_;
    private boolean useVimMode_ = false;
+   private boolean useEmacsKeybindings_ = false;
    private RnwCompletionContext rnwContext_;
    private CppCompletionContext cppContext_;
    private RCompletionContext rContext_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -128,6 +128,8 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    void setUseVimMode(boolean use);
    boolean isVimModeOn();
    boolean isVimInInsertMode();
+   
+   void setUseEmacsKeybindings(boolean use);
 
    JsArray<AceFold> getFolds();
    void addFold(Range range);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/KeyboardHandler.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/KeyboardHandler.java
@@ -24,4 +24,9 @@ public class KeyboardHandler extends JavaScriptObject
       var vim = $wnd.require('ace/keyboard/vim').handler;
       return vim;
    }-*/;
+   
+   public static native KeyboardHandler emacs() /*-{
+      var emacs = $wnd.require('ace/keyboard/emacs').handler;
+      return emacs;
+   }-*/;
 }


### PR DESCRIPTION
NOTE: not ready for merge -- if we do merge we need to think about how to resolve keybinding conflicts. My initial thought (after playing around + testing a bit here is that):

1. We don't really gain that much from the base set of available Emacs keybindings, and
2. There's a bunch of work to be done to resolve conflicts + otherwise.

So we might want to let this sit for a while (unless we can get an Emacs expert to look at the enabled keybindings and say, "yes, that's basically what I want from Emacs, I think it'd be worth it")

-----

This PR allows users to enable Emacs keybindings (those bundled with Ace) for the IDE.

The set of Emacs keybindings available: https://github.com/ajaxorg/ace/blob/master/lib/ace/keyboard/emacs.js#L358-L437

## Conflicts

No `C-x` keybindings seem to work -- not yet sure why.

None of the keybindings involving the `M` key (alt / option key on OSX) seem to work in RStudio, although they do work in the kitchen sink.

    "Up|C-p"      : {command: "goorselect", args: ["golineup","selectup"]},

We take over `C-p` for `moveToMatching`. We might be able to just get rid of that (since Ace supports it natively now), and that means it would appropriately go through the layer of keyboard handlers.

    "C-l" : "recenterTopBottom",

Bound to clear console.

    "C-Space": "setMark",

Bound to display completions.

      "C-w|C-S-W": "killRegion",

Bound to save / close.