### PR TITLE
fix cpp indentation (place cursor at appropriate location)

### DIFF
--- a/src/gwt/acesupport/acemode/cpp_code_model.js
+++ b/src/gwt/acesupport/acemode/cpp_code_model.js
@@ -1255,9 +1255,17 @@ var CppCodeModel = function(session, tokenizer, statePattern, codeBeginPattern) 
                var tokenCursor = this.getTokenCursor();
                
                // If 'dontSubset' is false, then we want to plonk the token cursor
-               // on the first token before the cursor.
+               // on the first token before the cursor. Otherwise, we place it at
+               // the end of the current line
                if (!dontSubset)
+               {
                   tokenCursor.moveToPosition(cursor);
+               }
+               else
+               {
+                  tokenCursor.$row = row;
+                  tokenCursor.$offset = this.$tokens[row].length - 1;
+               }
 
                // If there is no token on this current line (this can occur when this code
                // is accessed by e.g. the matching brace offset code) then move back

--- a/src/gwt/test/autoindent_test_cpp.html
+++ b/src/gwt/test/autoindent_test_cpp.html
@@ -35,8 +35,6 @@
 <div id="editor" style="width: 600px; height: 200px; border: 1px solid #999" onkeypress="doIndent()"></div>
 <div id="testEditor" style="display: none;"></div>
 
-<div style="height: 200px;"></div>
-
 <h2>Configure Editor</h2>
 <button id="setBehavioursEnabled" onclick="editor.setBehavioursEnabled(!editor.getBehavioursEnabled())">Toggle Behaviour</button>
 <button onclick="require('mode/r_code_model').setVerticallyAlignFunctionArgs(!require('mode/r_code_model').getVerticallyAlignFunctionArgs())">Toggle Vertical Alignment</button>
@@ -712,8 +710,7 @@ var session = editor.getSession();
         var newIndent = mode.getNextLineIndent(state,
                                                line,
                                                this.getTabString(),
-                                               this.getTabSize(),
-                                               i-1,
+                                               i - 1,
                                                true);
 
         this.applyIndent(i, newIndent);


### PR DESCRIPTION
This fixes the broken C++ indentation noticed by Hadley. The issue here is that in this commit:

https://github.com/rstudio/rstudio/commit/a194d1461cbbfba04cd91ab22982be8817bd2286#diff-a2f565cac38a14977cfd9971ea91c642L1251

Previously, we were getting a token cursor and placing it at the correct location in one go; I missed that when moving to the `getTokenCursor()` interface.