### PR TITLE
avoid evaluation (and copying) of data in completion

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -103,6 +103,8 @@ assign(x = ".rs.acCompletionTypes",
       .rs.acCompletionTypes$ENVIRONMENT
    else if (is.vector(object))
       .rs.acCompletionTypes$VECTOR
+   else if (is.factor(object))
+      .rs.acCompletionTypes$VECTOR
    else
       .rs.acCompletionTypes$UNKNOWN
 })
@@ -985,10 +987,12 @@ assign(x = ".rs.acCompletionTypes",
                {
                   type <- numeric(length(names))
                   for (i in seq_along(names))
+                  {
                      type[[i]] <- tryCatch(
-                        .rs.getCompletionType(eval(call("@", object, names[[i]]), envir = envir)),
+                        .rs.getCompletionType(eval(call("@", quote(object), names[[i]]))),
                         error = function(e) .rs.acCompletionTypes$UNKNOWN
                      )
+                  }
                }
             }, error = function(e) NULL
             )
@@ -1042,10 +1046,12 @@ assign(x = ".rs.acCompletionTypes",
          {
             type <- numeric(length(names))
             for (i in seq_along(names))
+            {
                type[[i]] <- tryCatch(
-                  .rs.getCompletionType(eval(call("$", object, names[[i]]), envir = envir)),
+                  .rs.getCompletionType(eval(call("$", quote(object), names[[i]]))),
                   error = function(e) .rs.acCompletionTypes$UNKNOWN
                )
+            }
          }
       }
       


### PR DESCRIPTION
A user reported that completions were slow following `$` for large data.frames, e.g. `diamonds$`. This PR fixes that.

Outline: for a large object, the call

    call("$", object, name)

will force a copy of `object` (and `name`, but that is less important), which can be prohibitively expensive for large datasets. This PR fixes this by instead passing a quoted symbol, rather than 'the real object', to ensure that we don't force a copy of the data when getting completions.