### PR TITLE
Add subscript syntax to Markdown Quick Reference.

### DIFF
--- a/src/cpp/session/resources/markdown_help.html
+++ b/src/cpp/session/resources/markdown_help.html
@@ -186,6 +186,8 @@ At the bottom of the document:
 <h4>Miscellaneous</h4>
 <pre><code>superscript^2^
 
+subscript~2~
+
 ~~strikethrough~~
 </code></pre>
 


### PR DESCRIPTION
I find myself writing a subscript, e.g. "log~2~ transformation", much more often than either a superscript or strikethrough.

If you approve of this change, I'll sign and email you the individual contributor agreement.