### PR TITLE
don't show diagnostics for R or C/C++ files in a project that isn't the current one

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1066,6 +1066,49 @@ std::string packageNameForSourceFile(const core::FilePath& sourceFilePath)
    }
 }
 
+bool isUnmonitoredPackageSourceFile(const FilePath& filePath)
+{
+   // if it's in the current package then it's fine
+   using namespace projects;
+   if (projectContext().hasProject() &&
+      (projectContext().config().buildType == r_util::kBuildTypePackage) &&
+       filePath.isWithin(projectContext().buildTargetPath()))
+   {
+      return false;
+   }
+
+   // ensure we are dealing with a directory
+   FilePath dir = filePath;
+   if (!dir.isDirectory())
+      dir = filePath.parent();
+
+   // see if one the file's parent directories has a DESCRIPTION
+   while (dir != dir.parent())
+   {
+      FilePath descPath = dir.childPath("DESCRIPTION");
+      if (descPath.exists())
+      {
+         // get path relative to package dir
+         std::string relative = filePath.relativePath(dir);
+         if (boost::algorithm::starts_with(relative, "R/") ||
+             boost::algorithm::starts_with(relative, "src/") ||
+             boost::algorithm::starts_with(relative, "inst/include/"))
+         {
+            return true;
+         }
+         else
+         {
+            return false;
+         }
+      }
+
+      dir = dir.parent();
+   }
+
+   return false;
+}
+
+
 SEXP rs_packageNameForSourceFile(SEXP sourceFilePathSEXP)
 {
    r::sexp::Protect protect;

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -143,6 +143,9 @@ core::Error installEmbeddedPackage(const std::string& name);
 // find the package name for a source file
 std::string packageNameForSourceFile(const core::FilePath& sourceFilePath);
 
+// is this R or C++ source file part of another (unmonitored) package?
+bool isUnmonitoredPackageSourceFile(const core::FilePath& filePath);
+
 // register a handler for rBrowseUrl
 typedef boost::function<bool(const std::string&)> RBrowseUrlHandler;
 core::Error registerRBrowseUrlHandler(const RBrowseUrlHandler& handler);

--- a/src/cpp/session/modules/SessionLinter.cpp
+++ b/src/cpp/session/modules/SessionLinter.cpp
@@ -242,31 +242,6 @@ Error extractRCode(const std::string& contents,
    return error;
 }
 
-bool belongsToUnmonitoredRPackage(FilePath self)
-{
-   // Check to see if this file is the descendent of a path
-   // containing a 'DESCRIPTION' file.
-   if (!self.isDirectory())
-      self = self.parent();
-   
-   while (!self.empty())
-   {
-      FilePath descPath = self.complete("DESCRIPTION");
-      if (descPath.exists())
-      {
-         if (!projects::projectContext().hasProject())
-            return true;
-         
-         if (!self.isEquivalentTo(projects::projectContext().directory()))
-            return true;
-      }
-      
-      self = self.parent();
-   }
-   
-   return false;
-}
-
 Error lintRSourceDocument(const json::JsonRpcRequest& request,
                           json::JsonRpcResponse* pResponse)
 {
@@ -301,7 +276,7 @@ Error lintRSourceDocument(const json::JsonRpcRequest& request,
    FilePath origin = module_context::resolveAliasedPath(documentPath);
    
    // Don't lint files that belong to unmonitored projects
-   if (belongsToUnmonitoredRPackage(origin))
+   if (module_context::isUnmonitoredPackageSourceFile(origin))
       return Success();
    
    // Extract R code from various R-code-containing filetypes.

--- a/src/cpp/session/modules/clang/Diagnostics.cpp
+++ b/src/cpp/session/modules/clang/Diagnostics.cpp
@@ -169,6 +169,13 @@ Error getCppDiagnostics(const core::json::JsonRpcRequest& request,
    // resolve the docPath if it's aliased
    FilePath filePath = module_context::resolveAliasedPath(docPath);
 
+   // don't lint files that belong to unmonitored projects
+   if (module_context::isUnmonitoredPackageSourceFile(filePath))
+   {
+      pResponse->setResult(json::Array());
+      return Success();
+   }
+
    pResponse->setResult(getCppDiagnosticsJson(filePath));
    return Success();
 }


### PR DESCRIPTION
This unifies the logic for R and C/C++ files as well as only qualifies a file as "unmonitored" if it's in the src/, R/, or inst/include/ directories (as other files might be in examples or tests and stand alone perfectly well).

@kevinushey Could you review and merge if this looks okay?