### PR TITLE
Fixes for indentation in multi-mode documents

### DIFF
--- a/src/gwt/acesupport/acemode/c_cpp.js
+++ b/src/gwt/acesupport/acemode/c_cpp.js
@@ -66,7 +66,13 @@ var Mode = function(suppressHighlighting, session) {
    // R-related tokenization
    this.$r_outdent = {};
    oop.implement(this.$r_outdent, RMatchingBraceOutdent);
-   this.r_codeModel = new RCodeModel(session, this.$tokenizer, /^r-/, /^\s*\/\*{3,}\s*([Rr])\s*$/);
+   this.r_codeModel = new RCodeModel(
+      session,
+      this.$tokenizer,
+      /^r-/,
+      /^\s*\/\*{3,}\s*([Rr])\s*$/,
+      /^\s*\*+\//
+   );
 
    // C/C++ related tokenization
    this.codeModel = new CppCodeModel(session, this.$tokenizer);

--- a/src/gwt/acesupport/acemode/c_cpp.js
+++ b/src/gwt/acesupport/acemode/c_cpp.js
@@ -35,7 +35,7 @@ var Range = require("ace/range").Range;
 var RHighlightRules = require("mode/r_highlight_rules").RHighlightRules;
 var c_cppHighlightRules = require("mode/c_cpp_highlight_rules").c_cppHighlightRules;
 
-var MatchingBraceOutdent = require("mode/c_cpp_matching_brace_outdent").MatchingBraceOutdent;
+var CppMatchingBraceOutdent = require("mode/c_cpp_matching_brace_outdent").CppMatchingBraceOutdent;
 var CStyleBehaviour = require("mode/behaviour/cstyle").CStyleBehaviour;
 
 var CppStyleFoldMode = null;
@@ -64,8 +64,6 @@ var Mode = function(suppressHighlighting, session) {
    this.$tokenizer = new Tokenizer(new c_cppHighlightRules().getRules());
 
    // R-related tokenization
-   this.$r_outdent = {};
-   oop.implement(this.$r_outdent, RMatchingBraceOutdent);
    this.r_codeModel = new RCodeModel(
       session,
       this.$tokenizer,
@@ -73,12 +71,13 @@ var Mode = function(suppressHighlighting, session) {
       /^\s*\/\*{3,}\s*([Rr])\s*$/,
       /^\s*\*+\//
    );
+   this.$r_outdent = new RMatchingBraceOutdent(this.r_codeModel);
 
    // C/C++ related tokenization
    this.codeModel = new CppCodeModel(session, this.$tokenizer);
    
    this.$behaviour = new CStyleBehaviour(this.codeModel);
-   this.$outdent = new MatchingBraceOutdent(this.codeModel);
+   this.$cpp_outdent = new CppMatchingBraceOutdent(this.codeModel);
    
    this.$sweaveBackgroundHighlighter = new SweaveBackgroundHighlighter(
       session,
@@ -182,14 +181,14 @@ oop.inherits(Mode, TextMode);
       if (this.inRLanguageMode(state))
          return this.$r_outdent.checkOutdent(state, line, input);
       else
-         return this.$outdent.checkOutdent(state, line, input);
+         return this.$cpp_outdent.checkOutdent(state, line, input);
    };
 
    this.autoOutdent = function(state, doc, row) {
       if (this.inRLanguageMode(state))
          return this.$r_outdent.autoOutdent(state, doc, row, this.r_codeModel);
       else
-         return this.$outdent.autoOutdent(state, doc, row);
+         return this.$cpp_outdent.autoOutdent(state, doc, row);
    };
 
    this.$transformAction = this.transformAction;

--- a/src/gwt/acesupport/acemode/c_cpp_matching_brace_outdent.js
+++ b/src/gwt/acesupport/acemode/c_cpp_matching_brace_outdent.js
@@ -3,9 +3,10 @@ define("mode/c_cpp_matching_brace_outdent", function(require, exports, module) {
 var Range = require("ace/range").Range;
 
 var CppTokenCursor = require("mode/token_cursor").CppTokenCursor;
-var MatchingBraceOutdent = function(codeModel) {
+var CppMatchingBraceOutdent = function(codeModel) {
    this.codeModel = codeModel;
 };
+var Utils = require("mode/utils");
 
 // Allow the user to control various levels of outdenting if desired
 var $outdentColon              = true; // : (initializer list)
@@ -54,8 +55,7 @@ var $alignCase                 = true; // case 'a':
    };
 
    this.checkOutdent = function(state, line, input) {
-
-      if (state == "start") {
+      if (Utils.endsWith(state, "start")) {
 
          // private: / public: / protected
          // also class initializer lists
@@ -75,7 +75,7 @@ var $alignCase                 = true; // case 'a':
       }
 
       // check for nudging of '/' to the left (?)
-      if (state == "comment") {
+      if (Utils.endsWith(state, "comment")) {
 
          if (input == "/") {
             return true;
@@ -493,9 +493,9 @@ var $alignCase                 = true; // case 'a':
       return "";
    };
 
-}).call(MatchingBraceOutdent.prototype);
+}).call(CppMatchingBraceOutdent.prototype);
 
-exports.MatchingBraceOutdent = MatchingBraceOutdent;
+exports.CppMatchingBraceOutdent = CppMatchingBraceOutdent;
 
 exports.getOutdentColon = function() { return $outdentColon; };
 exports.setOutdentColon = function(x) { $outdentColon = x; };

--- a/src/gwt/acesupport/acemode/c_cpp_style_behaviour.js
+++ b/src/gwt/acesupport/acemode/c_cpp_style_behaviour.js
@@ -34,6 +34,7 @@ var Behaviour = require("ace/mode/behaviour").Behaviour;
 var CppCodeModel = require("mode/cpp_code_model").CppCodeModel;
 var CppTokenCursor = require("mode/token_cursor").CppTokenCursor;
 var TextMode = require("ace/mode/text").Mode;
+var Utils = require("mode/utils");
 
 var $fillinDoWhile = true;
 
@@ -143,9 +144,9 @@ var CStyleBehaviour = function(codeModel) {
             };
 
          // Comment indentation rules
-         if (state == "comment" || state == "doc-start") {
-         
-
+         if (Utils.endsWith(state, "comment") ||
+             Utils.endsWith(state, "doc-start"))
+         {
             // Choose indentation for the current line based on the position
             // of the cursor -- but make sure we only apply this if the
             // cursor is on the same row as the line being indented

--- a/src/gwt/acesupport/acemode/r.js
+++ b/src/gwt/acesupport/acemode/r.js
@@ -42,8 +42,7 @@ define("mode/r", function(require, exports, module)
 
       this.codeModel = new RCodeModel(session, this.$tokenizer);
       this.foldingRules = this.codeModel;
-      this.$outdent = {};
-      oop.implement(this.$outdent, RMatchingBraceOutdent);
+      this.$outdent = new RMatchingBraceOutdent(this.codeModel);
    };
    oop.inherits(Mode, TextMode);
 
@@ -54,8 +53,8 @@ define("mode/r", function(require, exports, module)
          return this.$outdent.checkOutdent(state, line, input);
       };
 
-      this.autoOutdent = function(state, doc, row) {
-         return this.$outdent.autoOutdent(state, doc, row, this.codeModel);
+      this.autoOutdent = function(state, session, row) {
+         return this.$outdent.autoOutdent(state, session, row);
       };
       
       this.tokenRe = new RegExp("^["
@@ -69,7 +68,7 @@ define("mode/r", function(require, exports, module)
           + unicode.packages.L
           + unicode.packages.Mn + unicode.packages.Mc
           + unicode.packages.Nd
-          + unicode.packages.Pc + "._]|\s])+", "g"
+          + unicode.packages.Pc + "._]|\\s])+", "g"
       );
 
       this.$complements = {

--- a/src/gwt/acesupport/acemode/r.js
+++ b/src/gwt/acesupport/acemode/r.js
@@ -40,7 +40,7 @@ define("mode/r", function(require, exports, module)
       else
          this.$tokenizer = new Tokenizer(new RHighlightRules().getRules());
 
-      this.codeModel = new RCodeModel(session, this.$tokenizer, null);
+      this.codeModel = new RCodeModel(session, this.$tokenizer);
       this.foldingRules = this.codeModel;
       this.$outdent = {};
       oop.implement(this.$outdent, RMatchingBraceOutdent);

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1586,23 +1586,6 @@ var RCodeModel = function(session, tokenizer,
       return null;
    };
 
-   function isChunkHeaderOrFooter(line)
-   {
-      if (this.$codeBeginPattern &&
-          this.$codeBeginPattern.test(line))
-      {
-         return true;
-      }
-
-      if (this.$codeEndPattern &&
-          this.$codeEndPattern.test(line))
-      {
-         return true;
-      }
-
-      return false;
-   }
-
    this.$tokenizeUpToRow = function(lastRow)
    {
 
@@ -1624,15 +1607,6 @@ var RCodeModel = function(session, tokenizer,
          var line = this.$getLine(row);
          var lineTokens = this.$tokenizer.getLineTokens(line, state);
 
-         // Don't tokenize the beginning, or end, of chunks. This is necessary
-         // for when R is embedded as part of a multi-mode document.
-         if (isChunkHeaderOrFooter.call(this, line))
-         {
-            this.$tokens[row] = [];
-            this.$endStates[row] = lineTokens.state;
-            continue;
-         }
-         
          if (!this.$statePattern ||
              this.$statePattern.test(lineTokens.state) ||
              this.$statePattern.test(state))

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -18,6 +18,7 @@ define("mode/r_code_model", function(require, exports, module) {
 var Range = require("ace/range").Range;
 var TokenIterator = require("ace/token_iterator").TokenIterator;
 var RTokenCursor = require("mode/token_cursor").RTokenCursor;
+var Utils = require("mode/utils");
 
 var $verticallyAlignFunctionArgs = false;
 
@@ -1068,7 +1069,7 @@ var RCodeModel = function(session, tokenizer,
    // we wish to reindent.
    this.getNextLineIndent = function(state, line, tab, row)
    {
-      if (/qstring$/.test(state))
+      if (Utils.endsWith(state, "qstring"))
          return "";
 
       // NOTE: Pressing enter will already have moved the cursor to

--- a/src/gwt/acesupport/acemode/r_matching_brace_outdent.js
+++ b/src/gwt/acesupport/acemode/r_matching_brace_outdent.js
@@ -21,9 +21,9 @@ define("mode/r_matching_brace_outdent", function(require, exports, module)
 {
    var Range = require("ace/range").Range;
 
-   // This is a mixin that enables proper brace outdent behavior for R code.
-
-   var RMatchingBraceOutdent = {};
+   var RMatchingBraceOutdent = function(codeModel) {
+      this.codeModel = codeModel;
+   };
 
    (function()
    {
@@ -51,7 +51,7 @@ define("mode/r_matching_brace_outdent", function(require, exports, module)
          return false;
       };
 
-      this.autoOutdent = function(state, session, row, codeModel) {
+      this.autoOutdent = function(state, session, row) {
          if (row === 0)
             return 0;
 
@@ -65,7 +65,7 @@ define("mode/r_matching_brace_outdent", function(require, exports, module)
 
             if (!openBracePos || openBracePos.row == row) return 0;
 
-            var indent = codeModel.getIndentForOpenBrace(openBracePos);
+            var indent = this.codeModel.getIndentForOpenBrace(openBracePos);
             session.replace(new Range(row, 0, row, column-1), indent);
          }
 
@@ -73,10 +73,10 @@ define("mode/r_matching_brace_outdent", function(require, exports, module)
          if (match)
          {
             var column = match[1].length;
-            var indent = codeModel.getBraceIndent(row - 1);
+            var indent = this.codeModel.getBraceIndent(row - 1);
             session.replace(new Range(row, 0, row, column - 1), indent);
          }
       };
-   }).call(RMatchingBraceOutdent);
+   }).call(RMatchingBraceOutdent.prototype);
    exports.RMatchingBraceOutdent = RMatchingBraceOutdent;
 });

--- a/src/gwt/acesupport/acemode/rhtml.js
+++ b/src/gwt/acesupport/acemode/rhtml.js
@@ -50,6 +50,7 @@ var Mode = function(suppressHighlighting, session) {
 oop.inherits(Mode, HtmlMode);
 
 (function() {
+
    this.insertChunkInfo = {
       value: "<!--begin.rcode\n\nend.rcode-->\n",
       position: {row: 0, column: 15}
@@ -61,9 +62,14 @@ oop.inherits(Mode, HtmlMode);
       return state.match(/^r-/) ? 'R' : 'HTML';
    };
 
-   this.getNextLineIndent = function(state, line, tab)
+   this.$getNextLineIndent = this.getNextLineIndent;
+   this.getNextLineIndent = function(state, line, tab, row)
    {
-      return this.codeModel.getNextLineIndent(state, line, tab);
+      var mode = Utils.getLanguageMode(state, "html");
+      if (mode === "r")
+         return this.codeModel.getNextLineIndent(state, line, tab, row);
+      else
+         return this.$getNextLineIndent(state, line, tab);
    };
 
 }).call(Mode.prototype);

--- a/src/gwt/acesupport/acemode/rhtml.js
+++ b/src/gwt/acesupport/acemode/rhtml.js
@@ -32,8 +32,14 @@ var Mode = function(suppressHighlighting, session) {
    this.$session = session;
    this.$tokenizer = new Tokenizer(new RHtmlHighlightRules().getRules());
 
-   this.codeModel = new RCodeModel(session, this.$tokenizer, /^r-/,
-                                   /^<!--\s*begin.rcode\s*(.*)/);
+   this.codeModel = new RCodeModel(
+      session,
+      this.$tokenizer,
+      /^r-/,
+      /^<!--\s*begin.rcode\s*(.*)/,
+      /^\s*end.rcode\s*-->/
+   );
+   
    this.foldingRules = this.codeModel;
    this.$sweaveBackgroundHighlighter = new SweaveBackgroundHighlighter(
          session,

--- a/src/gwt/acesupport/acemode/rmarkdown.js
+++ b/src/gwt/acesupport/acemode/rmarkdown.js
@@ -42,8 +42,13 @@ var Mode = function(suppressHighlighting, session) {
    this.$r_outdent = {};
    oop.implement(this.$r_outdent, RMatchingBraceOutdent);
 
-   this.codeModel = new RCodeModel(session, this.$tokenizer, /^r-/,
-                                   /^(?:[ ]{4})?`{3,}\s*\{r(.*)\}\s*$/);
+   this.codeModel = new RCodeModel(
+      session,
+      this.$tokenizer,
+      /^r-/,
+      /^(?:[ ]{4})?`{3,}\s*\{r(.*)\}\s*$/,
+      /^\s*```\s*$/
+   );
 
    var markdownFoldingRules = new MarkdownFoldMode();
 

--- a/src/gwt/acesupport/acemode/rmarkdown.js
+++ b/src/gwt/acesupport/acemode/rmarkdown.js
@@ -53,7 +53,7 @@ var Mode = function(suppressHighlighting, session) {
    this.cpp_codeModel = new CppCodeModel(
       session,
       this.$tokenizer,
-      /^cpp-/,
+      /^r-cpp-/,
       new RegExp(RMarkdownHighlightRules.prototype.$reCppChunkStartString),
       new RegExp(RMarkdownHighlightRules.prototype.$reChunkEndString)
    );
@@ -105,7 +105,7 @@ oop.inherits(Mode, MarkdownMode);
       var mode = activeMode(state);
       if (mode === "r")
          return "R";
-      else if (mode === "cpp")
+      else if (mode === "r-cpp")
          return "C_CPP";
       else
          return "Markdown";
@@ -117,7 +117,7 @@ oop.inherits(Mode, MarkdownMode);
       var mode = activeMode(state);
       if (mode === "r")
          return this.codeModel.getNextLineIndent(state, line, tab, row);
-      else if (mode === "cpp")
+      else if (mode === "r-cpp")
          return this.cpp_codeModel.getNextLineIndent(state, line, tab, row, dontSubset);
       else
          return this.$getNextLineIndent(state, line, tab);
@@ -128,7 +128,7 @@ oop.inherits(Mode, MarkdownMode);
       var mode = activeMode(state);
       if (mode === "r")
          return this.$r_outdent.checkOutdent(state, line, input);
-      else if (mode === "cpp")
+      else if (mode === "r-cpp")
          return this.$cpp_outdent.checkOutdent(state, line, input);
       else
          return this.$outdent.checkOutdent(line, input);
@@ -139,7 +139,7 @@ oop.inherits(Mode, MarkdownMode);
       var mode = activeMode(state);
       if (mode === "r")
          return this.$r_outdent.autoOutdent(state, session, row);
-      else if (mode === "cpp")
+      else if (mode === "r-cpp")
          return this.$cpp_outdent.autoOutdent(state, session, row);
       else
          return this.$outdent.autoOutdent(session, row);
@@ -149,7 +149,7 @@ oop.inherits(Mode, MarkdownMode);
       var mode = activeMode(state);
       // from c_cpp.js
       if (action === 'insertion') {
-         if ((text === "\n") && (mode === "cpp")) {
+         if ((text === "\n") && (mode === "r-cpp")) {
             // If newline in a doxygen comment, continue the comment
             var pos = editor.getSelectionRange().start;
             var match = /^((\s*\/\/+')\s*)/.exec(session.doc.getLine(pos.row));
@@ -158,7 +158,7 @@ oop.inherits(Mode, MarkdownMode);
             }
          }
 
-         else if ((text === "R") && (mode === "cpp")) {
+         else if ((text === "R") && (mode === "r-cpp")) {
             // If newline to start and embedded R chunk complete the chunk
             var pos = editor.getSelectionRange().start;
             var match = /^(\s*\/\*{3,}\s*)/.exec(session.doc.getLine(pos.row));

--- a/src/gwt/acesupport/acemode/rmarkdown.js
+++ b/src/gwt/acesupport/acemode/rmarkdown.js
@@ -112,13 +112,13 @@ oop.inherits(Mode, MarkdownMode);
    };
 
    this.$getNextLineIndent = this.getNextLineIndent;
-   this.getNextLineIndent = function(state, line, tab, row)
+   this.getNextLineIndent = function(state, line, tab, row, dontSubset)
    {
       var mode = activeMode(state);
       if (mode === "r")
          return this.codeModel.getNextLineIndent(state, line, tab, row);
       else if (mode === "cpp")
-         return this.cpp_codeModel.getNextLineIndent(state, line, tab, row);
+         return this.cpp_codeModel.getNextLineIndent(state, line, tab, row, dontSubset);
       else
          return this.$getNextLineIndent(state, line, tab);
    };

--- a/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
@@ -47,7 +47,7 @@ var RMarkdownHighlightRules = function() {
 
     this.$rules["start"].unshift({
         token: "support.function.codebegin",
-        regex: "^(?:[ ]{4})?`{3,}\\s*\\{r(?:.*)engine\\='Rcpp'(?:.*)\\}\\s*$",
+        regex: "^(?:[ ]{4})?`{3,}\\s*\\{r(?:.*)engine\\s*\\=\\s*['\"]Rcpp['\"](?:.*)\\}\\s*$",
         next: "r-cpp-start"
     });
 

--- a/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
@@ -24,42 +24,46 @@ var RHighlightRules = require("mode/r_highlight_rules").RHighlightRules;
 var c_cppHighlightRules = require("mode/c_cpp_highlight_rules").c_cppHighlightRules;
 var MarkdownHighlightRules = require("mode/markdown_highlight_rules").MarkdownHighlightRules;
 var TextHighlightRules = require("ace/mode/text_highlight_rules").TextHighlightRules;
+var Utils = require("mode/utils");
 
 var RMarkdownHighlightRules = function() {
 
-    // regexp must not have capturing parentheses
-    // regexps are ordered -> the first match is used
+   // Base rule set (markdown)
+   this.$rules = new MarkdownHighlightRules().getRules();
 
-    this.$rules = new MarkdownHighlightRules().getRules();
-    this.$rules["start"].unshift({
-        token: "support.function.codebegin",
-        regex: "^(?:[ ]{4})?`{3,}\\s*\\{r(?:.*)\\}\\s*$",
-        next: "r-start"
-    });
+   // Embed R highlight rules
+   Utils.embedRules(
+      this,
+      RHighlightRules,
+      "r",
+      this.$reRChunkStartString,
+      this.$reChunkEndString
+   );
 
-    var rRules = new RHighlightRules().getRules();
-    this.addRules(rRules, "r-");
-    this.$rules["r-start"].unshift({
-        token: "support.function.codeend",
-        regex: "^(?:[ ]{4})?`{3,}\\s*$",
-        next: "start"
-    });
-
-    this.$rules["start"].unshift({
-        token: "support.function.codebegin",
-        regex: "^(?:[ ]{4})?`{3,}\\s*\\{r(?:.*)engine\\s*\\=\\s*['\"]Rcpp['\"](?:.*)\\}\\s*$",
-        next: "r-cpp-start"
-    });
-
-    var cppRules = new c_cppHighlightRules().getRules();
-    this.addRules(cppRules, "r-cpp-");
-    this.$rules["r-cpp-start"].unshift({
-        token: "support.function.codeend",
-        regex: "^(?:[ ]{4})?`{3,}\\s*$",
-        next: "start"
-    });
+   // Embed C++ highlight rules
+   Utils.embedRules(
+      this,
+      c_cppHighlightRules,
+      "cpp",
+      this.$reCppChunkStartString,
+      this.$reChunkEndString
+   );
 };
 oop.inherits(RMarkdownHighlightRules, TextHighlightRules);
+
+(function() {
+   
+   this.$reRChunkStartString =
+      "^(?:[ ]{4})?`{3,}\\s*\\{[Rr](.*)\\}\\s*$";
+
+   this.$reCppChunkStartString =
+      "^(?:[ ]{4})?`{3,}\\s*\\{[Rr](?:.*)engine\\s*\\=\\s*['\"]Rcpp['\"](?:.*)\\}\\s*$|" +
+      "^(?:[ ]{4})?`{3,}\\s*\\{[Rr]cpp(?:.*)\\}\\s*$";
+
+   this.$reChunkEndString =
+      "^(?:[ ]{4})?`{3,}\\s*$";
+   
+}).call(RMarkdownHighlightRules.prototype);
 
 exports.RMarkdownHighlightRules = RMarkdownHighlightRules;
 });

--- a/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
@@ -44,7 +44,7 @@ var RMarkdownHighlightRules = function() {
    Utils.embedRules(
       this,
       c_cppHighlightRules,
-      "cpp",
+      "r-cpp",
       this.$reCppChunkStartString,
       this.$reChunkEndString
    );

--- a/src/gwt/acesupport/acemode/sweave.js
+++ b/src/gwt/acesupport/acemode/sweave.js
@@ -36,7 +36,14 @@ var Mode = function(suppressHighlighting, session) {
    else
       this.$tokenizer = new Tokenizer(new SweaveHighlightRules().getRules());
 
-   this.codeModel = new RCodeModel(session, this.$tokenizer, /^r-/, /<<(.*?)>>/);
+   this.codeModel = new RCodeModel(
+      session,
+      this.$tokenizer,
+      /^r-/,
+      /<<(.*?)>>/,
+      /^\s*@\s*$/
+   );
+   
    this.foldingRules = this.codeModel;
    this.$sweaveBackgroundHighlighter = new SweaveBackgroundHighlighter(
          session,

--- a/src/gwt/acesupport/acemode/sweave.js
+++ b/src/gwt/acesupport/acemode/sweave.js
@@ -26,6 +26,7 @@ var TextHighlightRules = require("ace/mode/text_highlight_rules").TextHighlightR
 var SweaveBackgroundHighlighter = require("mode/sweave_background_highlighter").SweaveBackgroundHighlighter;
 var SweaveHighlightRules = require("mode/sweave_highlight_rules").SweaveHighlightRules;
 var RCodeModel = require("mode/r_code_model").RCodeModel;
+var MatchingBraceOutdent = require("ace/mode/matching_brace_outdent").MatchingBraceOutdent;
 var RMatchingBraceOutdent = require("mode/r_matching_brace_outdent").RMatchingBraceOutdent;
 var unicode = require("ace/unicode");
 var Utils = require("mode/utils");
@@ -36,6 +37,8 @@ var Mode = function(suppressHighlighting, session) {
    else
       this.$tokenizer = new Tokenizer(new SweaveHighlightRules().getRules());
 
+   this.$outdent = new MatchingBraceOutdent();
+
    this.codeModel = new RCodeModel(
       session,
       this.$tokenizer,
@@ -43,11 +46,12 @@ var Mode = function(suppressHighlighting, session) {
       /<<(.*?)>>/,
       /^\s*@\s*$/
    );
-   
+   this.$r_outdent = new RMatchingBraceOutdent(this.codeModel);
+
    this.foldingRules = this.codeModel;
    this.$sweaveBackgroundHighlighter = new SweaveBackgroundHighlighter(
          session,
-         /^\s*\<\<.*\>\>=.*$/,
+         /^\s*<<.*>>=.*$/,
          /^\s*@(?:\s.*)?$/,
          false);
    this.$session = session;
@@ -56,20 +60,18 @@ oop.inherits(Mode, TextMode);
 
 (function() {
 
-   oop.implement(this, RMatchingBraceOutdent);
-
    this.tokenRe = new RegExp("^["
        + unicode.packages.L
        + unicode.packages.Mn + unicode.packages.Mc
        + unicode.packages.Nd
-       + unicode.packages.Pc + "_]+", "g"
+       + unicode.packages.Pc + "._]+", "g"
    );
 
    this.nonTokenRe = new RegExp("^(?:[^"
        + unicode.packages.L
        + unicode.packages.Mn + unicode.packages.Mc
        + unicode.packages.Nd
-       + unicode.packages.Pc + "_]|\s])+", "g"
+       + unicode.packages.Pc + "._]|\\s])+", "g"
    );
 
    this.$complements = {
@@ -93,10 +95,32 @@ oop.inherits(Mode, TextMode);
       return state.match(/^r-/) ? 'R' : 'TeX';
    };
 
-   this.getNextLineIndent = function(state, line, tab)
+   this.$getNextLineIndent = this.getNextLineIndent;
+   this.getNextLineIndent = function(state, line, tab, row)
    {
-      state = Utils.primaryState(state);
-      return this.codeModel.getNextLineIndent(state, line, tab);
+      var mode = Utils.getLanguageMode(state, "tex");
+      if (mode === "r")
+         return this.codeModel.getNextLineIndent(state, line, tab, row);
+      else
+         return this.$getNextLineIndent(state, line, tab);
+   };
+
+   this.checkOutdent = function(state, line, input)
+   {
+      var mode = Utils.getLanguageMode(state, "tex");
+      if (mode === "r")
+         return this.$r_outdent.checkOutdent(state, line, input);
+      else
+         return this.$outdent.checkOutdent(line, input);
+   };
+
+   this.autoOutdent = function(state, session, row)
+   {
+      var mode = Utils.getLanguageMode(state, "tex");
+      if (mode === "r")
+         return this.$r_outdent.autoOutdent(state, session, row);
+      else
+         return this.$outdent.autoOutdent(session, row);
    };
 
    this.allowAutoInsert = this.smartAllowAutoInsert;

--- a/src/gwt/acesupport/acemode/token_utils.js
+++ b/src/gwt/acesupport/acemode/token_utils.js
@@ -28,23 +28,6 @@ var TokenUtils = function(doc, tokenizer, tokens,
 
 (function() {
 
-   function isChunkHeaderOrFooter(line)
-   {
-      if (this.$codeBeginPattern &&
-          this.$codeBeginPattern.test(line))
-      {
-         return true;
-      }
-
-      if (this.$codeEndPattern &&
-          this.$codeEndPattern.test(line))
-      {
-         return true;
-      }
-
-      return false;
-   }
-
    function isWhitespaceOrComment(token)
    {
       // virtual-comment is for roxygen content that needs to be highlighted
@@ -117,14 +100,6 @@ var TokenUtils = function(doc, tokenizer, tokens,
          var line = this.$doc.getLine(row);
          var lineTokens = this.$tokenizer.getLineTokens(line, state);
 
-         // Don't tokenize chunk header / footers.
-         if (isChunkHeaderOrFooter.call(this, line))
-         {
-            this.$tokens[row] = [];
-            this.$endStates[row] = lineTokens.state;
-            continue;
-         }
-         
          if (!this.$statePattern ||
              this.$statePattern.test(lineTokens.state) ||
              this.$statePattern.test(state))

--- a/src/gwt/acesupport/acemode/utils.js
+++ b/src/gwt/acesupport/acemode/utils.js
@@ -33,14 +33,9 @@ define("mode/utils", function(require, exports, module) {
       return Object.prototype.toString.call(object) === '[object Array]';
    };
 
-   this.getPrimaryState = function(session, row, state)
+   this.getPrimaryState = function(session, row)
    {
-      var result = session.getState(row);
-      if (that.isArray(result))
-      {
-         return result[0];
-      }
-      return result;
+      return that.primaryState(session.getState(row));
    };
 
    this.primaryState = function(states)
@@ -48,6 +43,25 @@ define("mode/utils", function(require, exports, module) {
       if (that.isArray(states))
          return states[0];
       return states;
+   };
+
+   this.getLanguageMode = function(state, major)
+   {
+      var primary = that.primaryState(state);
+      var modeIdx = primary.lastIndexOf("-");
+      if (modeIdx === -1)
+         return major;
+      return state.substring(0, modeIdx).toLowerCase();
+   };
+
+   this.endsWith = function(string, suffix)
+   {
+      return string.indexOf(suffix, string.length - suffix.length) !== -1;
+   };
+
+   this.escapeRegExp = function(string)
+   {
+      return string.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
    };
    
 }).call(exports);

--- a/src/gwt/acesupport/acemode/utils.js
+++ b/src/gwt/acesupport/acemode/utils.js
@@ -45,7 +45,7 @@ define("mode/utils", function(require, exports, module) {
       return states;
    };
 
-   this.getLanguageMode = function(state, major)
+   this.activeMode = function(state, major)
    {
       var primary = that.primaryState(state);
       var modeIdx = primary.lastIndexOf("-");
@@ -62,6 +62,26 @@ define("mode/utils", function(require, exports, module) {
    this.escapeRegExp = function(string)
    {
       return string.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+   };
+
+   this.embedRules = function(HighlightRules, EmbedRules,
+                              prefix, reStart, reEnd)
+   {
+      var rules = HighlightRules.$rules;
+      rules["start"].unshift({
+         token: "support.function.codebegin",
+         regex: reStart,
+         next : prefix + "-start"
+      });
+
+      var embed = new EmbedRules().getRules();
+      HighlightRules.addRules(embed, prefix + "-");
+      
+      rules[prefix + "-start"].unshift({
+         token: "support.function.codeend",
+         regex: reEnd,
+         next : "start"
+      });
    };
    
 }).call(exports);

--- a/src/gwt/acesupport/loader.js
+++ b/src/gwt/acesupport/loader.js
@@ -75,33 +75,34 @@ oop.inherits(RStudioEditSession, EditSession);
    };
 
    this.reindent = function(range) {
+      
       var mode = this.getMode();
       if (!mode.getNextLineIndent)
          return;
+      
       var start = range.start.row;
       var end = range.end.row;
-      for (var i = start; i <= end; i++) {
-         // First line is always unindented
-         if (i === 0) {
-            this.applyIndent(i, "");
-         }
-         else {
-            var state = Utils.getPrimaryState(this, i - 1);
-            if (state == 'qstring' || state == 'qqstring')
-               continue;
 
-            var line = this.getLine(i - 1);
-            var newline = this.getLine(i);
+      // First line is always unindented
+      if (start === 0) {
+         this.applyIndent(0, "");
+         start++;
+      }
+      
+      for (var i = start; i <= end; i++)
+      {
+         var state = Utils.getPrimaryState(this, i - 1);
+         if (/qstring$/.test(state))
+            continue;
 
-            var newIndent = mode.getNextLineIndent(state,
-                                                   line,
-                                                   this.getTabString(),
-                                                   i - 1,
-                                                   true);
+         var newIndent = mode.getNextLineIndent(state,
+                                                this.getLine(i - 1),
+                                                this.getTabString(),
+                                                i - 1,
+                                                true);
 
-            this.applyIndent(i, newIndent);
-            mode.autoOutdent(state, this, i);
-         }
+         this.applyIndent(i, newIndent);
+         mode.autoOutdent(state, this, i);
       }
 
       // optional outdenting (currently hard-wired for C++ modes)

--- a/src/gwt/acesupport/loader.js
+++ b/src/gwt/acesupport/loader.js
@@ -92,7 +92,7 @@ oop.inherits(RStudioEditSession, EditSession);
       for (var i = start; i <= end; i++)
       {
          var state = Utils.getPrimaryState(this, i - 1);
-         if (/qstring$/.test(state))
+         if (Utils.endsWith(state, "qstring"))
             continue;
 
          var newIndent = mode.getNextLineIndent(state,

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -101,7 +101,15 @@
             <file name="default.js"/>
          </sources>
       </jscomp>
+   </target>
 
+   <target name="acesupport" description="Compile (debugging) Ace support">
+      <exec executable="R">
+         <arg value="--vanilla" />
+         <arg value="--slave" />
+         <arg value="-f" />
+         <arg value="tools/compile-ext.R" />
+      </exec>
    </target>
 
    <target name="javac" description="Compile java source">
@@ -191,8 +199,7 @@
       </java>
    </target>
 
-	
-   <target name="debugmode" depends="javac" description="Run debug-development mode">
+   <target name="debugmode" depends="acesupport,javac" description="Run debug-development mode">
       <java failonerror="true" fork="true" classname="com.google.gwt.dev.DevMode">
          <classpath>
             <pathelement location="src"/>

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -190,6 +190,26 @@
          <arg value="org.rstudio.studio.RStudioSuperDevMode"/>
       </java>
    </target>
+
+	
+   <target name="debugmode" depends="javac" description="Run debug-development mode">
+      <java failonerror="true" fork="true" classname="com.google.gwt.dev.DevMode">
+         <classpath>
+            <pathelement location="src"/>
+            <path refid="project.class.path"/>
+         </classpath>
+         <jvmarg value="-Xmx2048M"/>
+         <arg value="-war"/>
+         <arg value="www"/>
+         <arg value="-noserver"/>
+         <arg value="-startupUrl"/>
+         <arg value="http://localhost:8787"/>
+         <arg line="-bindAddress 127.0.0.1"/>
+         <!-- Additional arguments like -logLevel DEBUG -->
+         <arg value="org.rstudio.studio.RStudioSuperDevMode"/>
+      </java>
+   </target>
+
    
    <target name="superdevmode" description="Run super dev mode">
    	<antcall target="gwtc">

--- a/src/gwt/debugmode
+++ b/src/gwt/debugmode
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+ant clean
+R --vanilla --slave -f tools/compile-ext.R
+ant debugmode

--- a/src/gwt/debugmode
+++ b/src/gwt/debugmode
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-
-ant clean
-R --vanilla --slave -f tools/compile-ext.R
-ant debugmode

--- a/src/gwt/tools/compile-ext.R
+++ b/src/gwt/tools/compile-ext.R
@@ -1,0 +1,34 @@
+#!/usr/bin/env Rscript
+library(methods, quietly = TRUE)
+
+if (!require("rvest", quietly = TRUE))
+   stop("This script requires 'rvest' to run.")
+
+# Ensure we're in the `src/gwt/` directory
+workingDirectory <- getwd()
+if (regexpr("src/gwt$", workingDirectory) == -1)
+   stop("This script must be run from the `src/gwt` subdirectory")
+
+# Scrape out the 'js' build files
+doc <- xml("build.xml")
+jscomp <- xml_node(doc, "jscomp")
+
+extractFiles <- function(node) {
+   if (identical(xml_tag(node), "externs"))
+      return(NULL)
+   
+   dir <- xml_attr(node, "dir")
+   children <- xml_children(node)
+   paths <- unlist(lapply(children, function(child) {
+      xml_attr(child, "name")
+   }))
+   file.path(dir, paths)
+}
+
+sources <- unname(unlist(lapply(xml_children(jscomp), extractFiles)))
+
+# Collect all of the sources into a single file, and write them out
+outputPath <- "src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/acesupport.js"
+
+contents <- unlist(lapply(sources, readLines))
+cat(contents, file = outputPath, sep = "\n")

--- a/src/gwt/tools/compile-ext.R
+++ b/src/gwt/tools/compile-ext.R
@@ -32,3 +32,4 @@ outputPath <- "src/org/rstudio/studio/client/workbench/views/source/editors/text
 
 contents <- unlist(lapply(sources, readLines))
 cat(contents, file = outputPath, sep = "\n")
+cat("- Successfully compiled 'acesupport.js'")


### PR DESCRIPTION
NOTE: Let this brew a day or two to think about whether this really is the best solution...

This PR brings a couple of fixes:

It ensures that chunk headers and footers are _not_ tokenized into the underlying code model, e.g.

    - ```{r}
    + foo <- function(x) {
    +     x + 1
    + }
    - ```

Previously, the header / footer bits were entering the code model, and so the indentation logic would get confused (and believe that e.g. there was an un-finished symbol, `` ` ``, hanging around.)

The reindent logic is moved into GWT code. This was necessary for one main reason -- one change in the Ace default mode API that we tried to step over was the fact that the `getNextLineIndent()` prototype changed -- it is now, by default,

    getNextLineIndent(state, line, tab)

rather than

    getNextLineIndent(state, line, tab, tabSize, row)

However, we rely quite heavily on more than just the current line for computing the current indent (we needed that row parameter), so we work around this by fudging the cursor position (so that, in the context of a `getNextLineIndent()` call, we can assume the cursor is at least on that line).