### PR TITLE
add facility for custom R code eval in snippets

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2751,3 +2751,58 @@ assign(x = ".rs.acCompletionTypes",
    
    return(FALSE)
 })
+
+.rs.addJsonRpcHandler("transform_snippet", function(snippet)
+{
+   # Extract any R code from the snippet
+   reRCode <- "`[Rr]\\s+[^`]+`"
+   matches <- gregexpr(reRCode, snippet, perl = TRUE)[[1]]
+   if (matches == -1)
+      return(snippet)
+   
+   match.length <- attr(matches, "match.length")
+   if (is.null(match.length))
+      return(snippet)
+   
+   ranges <- lapply(seq_along(matches), function(i) {
+      c(matches[[i]], matches[[i]] + match.length[[i]])
+   })
+   
+   extracted <- lapply(ranges, function(range) {
+      substring(
+         snippet,
+         range[[1]] + 2, # skip "`r "
+         range[[2]] - 2 # leave out trailing "`"
+      )
+   })
+   
+   frame <- parent.frame()
+   evaluated <- lapply(extracted, function(code) {
+      tryCatch({
+         captured <- capture.output(
+            result <- paste(collapse = " ", as.character(suppressWarnings(
+               eval(parse(text = code), envir = frame)
+            )))
+         )
+         
+         if (!length(result) && length(captured))
+            paste(captured, collapse = " ")
+         else
+            result
+         
+      }, error = function(e) ""
+      )
+   })
+   
+   newSnippet <- snippet
+   for (i in seq_along(evaluated))
+   {
+      range <- ranges[[i]]
+      text <- substring(snippet, range[[1]], range[[2]] - 1)
+      replacement <- evaluated[[i]]
+      newSnippet <- gsub(text, replacement, newSnippet, fixed = TRUE)
+   }
+   
+   .rs.scalar(newSnippet)
+})
+

--- a/src/gwt/acesupport/snippets/snippets/r.js
+++ b/src/gwt/acesupport/snippets/snippets/r.js
@@ -152,6 +152,25 @@ var snippets = [
    {
       name: "rapply",
       content: "rapply(${1:list}, ${2:function})"
+   },
+
+   /* Utilities */
+
+   {
+      name: "today",
+      content: "Sys.Date()"
+   },
+   {
+      name: "today!",
+      content: "`r Sys.Date()`"
+   },
+   {
+      name: "now",
+      content: "Sys.time()"
+   },
+   {
+      name: "now!",
+      content: "`r Sys.time()`"
    }
 ];
 

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinModule.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinModule.java
@@ -103,6 +103,7 @@ import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.WorkbenchListsServerOperations;
 import org.rstudio.studio.client.workbench.model.WorkbenchServerOperations;
 import org.rstudio.studio.client.workbench.prefs.model.PrefsServerOperations;
+import org.rstudio.studio.client.workbench.snippets.SnippetServerOperations;
 import org.rstudio.studio.client.workbench.ui.WorkbenchScreen;
 import org.rstudio.studio.client.workbench.ui.WorkbenchTab;
 import org.rstudio.studio.client.workbench.views.buildtools.BuildPresenter;
@@ -358,6 +359,7 @@ public class RStudioGinModule extends AbstractGinModule
       bind(MarkersServerOperations.class).to(RemoteServer.class);
       bind(LintServerOperations.class).to(RemoteServer.class);
       bind(RoxygenServerOperations.class).to(RemoteServer.class);
+      bind(SnippetServerOperations.class).to(RemoteServer.class);
 
       bind(WorkbenchMainView.class).to(WorkbenchScreen.class) ;
 

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -59,6 +59,7 @@ import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.RemoteFileSystemContext;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
+import org.rstudio.studio.client.workbench.snippets.SnippetHelper;
 import org.rstudio.studio.client.workbench.snippets.ui.EditSnippetsDialog;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.CompletionRequester;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.HelpStrategy;
@@ -115,6 +116,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(CompletionRequester requester);
    void injectMembers(EditSnippetsDialog dialog);
    void injectMembers(RoxygenHelper helper);
+   void injectMembers(SnippetHelper helper);
    
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);
 

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4020,6 +4020,15 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, GET_SET_REF_CLASS_CALL, params, requestCallback);
    }
    
+   @Override
+   public void transformSnippet(String snippetContent,
+                                ServerRequestCallback<String> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(snippetContent));
+      sendRequest(RPC_SCOPE, TRANSFORM_SNIPPET, params, requestCallback);
+   }
+   
    private String clientId_;
    private double clientVersion_ = 0;
    private boolean listeningForEvents_;
@@ -4349,6 +4358,6 @@ public class RemoteServer implements Server
    private static final String GET_SET_METHOD_CALL = "get_set_method_call";
    private static final String GET_SET_REF_CLASS_CALL = "get_set_ref_class_call";
    
-   
+   private static final String TRANSFORM_SNIPPET = "transform_snippet";
   
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchServerOperations.java
@@ -35,6 +35,7 @@ import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.codesearch.model.CodeSearchServerOperations;
 import org.rstudio.studio.client.workbench.prefs.model.PrefsServerOperations;
 import org.rstudio.studio.client.workbench.prefs.model.RPrefs;
+import org.rstudio.studio.client.workbench.snippets.SnippetServerOperations;
 import org.rstudio.studio.client.workbench.views.buildtools.model.BuildServerOperations;
 import org.rstudio.studio.client.workbench.views.choosefile.model.ChooseFileServerOperations;
 import org.rstudio.studio.client.workbench.views.console.model.ConsoleServerOperations;
@@ -88,7 +89,8 @@ public interface WorkbenchServerOperations extends ConsoleServerOperations,
                                                    PackratServerOperations,
                                                    MarkersServerOperations,
                                                    LintServerOperations,
-                                                   RoxygenServerOperations
+                                                   RoxygenServerOperations,
+                                                   SnippetServerOperations
 {   
    void initializeForMainWorkbench();
    void disconnect();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/snippets/SnippetHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/snippets/SnippetHelper.java
@@ -208,9 +208,9 @@ public class SnippetHelper
             }
             
             @Override
-            public void onResponseReceived(String snippetContent)
+            public void onResponseReceived(String transformed)
             {
-               applySnippetImpl(snippetContent, manager_, editor_.getWidget().getEditor());
+               applySnippetImpl(transformed, manager_, editor_.getWidget().getEditor());
             }
          });
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/snippets/SnippetHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/snippets/SnippetHelper.java
@@ -19,9 +19,15 @@ import com.google.gwt.core.client.JavaScriptException;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.JsArrayString;
+import com.google.inject.Inject;
 
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.JsArrayUtil;
+import org.rstudio.core.client.regex.Pattern;
+import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.FilePathUtils;
+import org.rstudio.studio.client.server.ServerError;
+import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.workbench.snippets.model.Snippet;
 import org.rstudio.studio.client.workbench.snippets.model.SnippetData;
 import org.rstudio.studio.client.workbench.snippets.model.SnippetsChangedEvent;
@@ -48,6 +54,14 @@ public class SnippetHelper
       native_ = editor.getWidget().getEditor();
       manager_ = getSnippetManager();
       path_ = path;
+      
+      RStudioGinjector.INSTANCE.injectMembers(this);
+   }
+   
+   @Inject
+   public void initialize(SnippetServerOperations server)
+   {
+      server_ = server;
    }
    
    private static final native SnippetManager getSnippetManager() /*-{
@@ -180,7 +194,35 @@ public class SnippetHelper
       editor_.expandSelectionLeft(token.length());
       String snippetContent = transformMacros(
             getSnippetContents(snippetName));
-      applySnippetImpl(snippetContent, manager_, editor_.getWidget().getEditor());
+      
+      // For snippets that contain code we want to execute in R, we pass the
+      // snippet down to the server and then apply the response.
+      if (containsExecutableRCode(snippetContent))
+      {
+         server_.transformSnippet(snippetContent, new ServerRequestCallback<String>()
+         {
+            @Override
+            public void onError(ServerError error)
+            {
+               Debug.logError(error);
+            }
+            
+            @Override
+            public void onResponseReceived(String snippetContent)
+            {
+               applySnippetImpl(snippetContent, manager_, editor_.getWidget().getEditor());
+            }
+         });
+      }
+      else
+      {
+         applySnippetImpl(snippetContent, manager_, editor_.getWidget().getEditor());
+      }
+   }
+   
+   private boolean containsExecutableRCode(String snippetContent)
+   {
+      return RE_R_CODE.test(snippetContent);
    }
    
    private String replaceFilename(String snippet)
@@ -285,6 +327,11 @@ public class SnippetHelper
    private final SnippetManager manager_;
    private final String path_;
    
+   private SnippetServerOperations server_;
+   
    private static boolean customCppSnippetsLoaded_;
    private static boolean customRSnippetsLoaded_;
+   
+   private static final Pattern RE_R_CODE =
+         Pattern.create("`[Rr]\\s+[^`]+`", "");
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/snippets/SnippetServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/snippets/SnippetServerOperations.java
@@ -1,0 +1,23 @@
+/*
+ * SnippetServerOperations.java
+ *
+ * Copyright (C) 2009-15 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.snippets;
+
+import org.rstudio.studio.client.server.ServerRequestCallback;
+
+public interface SnippetServerOperations
+{
+   void transformSnippet(String snippetContent,
+                         ServerRequestCallback<String> callBack);
+}


### PR DESCRIPTION
This PR allows users to include custom R code similar to inline R code for RMarkdown documents, e.g.

    `r Sys.Date()`

If the snippet helper encounters any R snippets of this form, it sends it down to the server, which then pulls out that R code, evaluates it, and replaces that string with the output of the call.