### PR TITLE
Fix for 'run current function definition'

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -1528,16 +1528,17 @@ public class AceEditor implements DocDisplay,
    }
 
    @Override
-   public Scope getCurrentFunction()
+   public ScopeFunction getCurrentFunction(boolean allowAnonymous)
    {
-      return getFunctionAtPosition(getCursorPosition());
+      return getFunctionAtPosition(getCursorPosition(), allowAnonymous);
    }
    
    @Override
-   public ScopeFunction getFunctionAtPosition(Position position)
+   public ScopeFunction getFunctionAtPosition(Position position,
+                                              boolean allowAnonymous)
    {
       return getSession().getMode().getCodeModel().getCurrentFunction(
-            position);
+            position, allowAnonymous);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -175,9 +175,9 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    Scope getCurrentScope();
    Scope getCurrentChunk();
    Scope getCurrentChunk(Position position);
-   Scope getCurrentFunction();
+   ScopeFunction getCurrentFunction(boolean allowAnonymous);
    Scope getCurrentSection();
-   ScopeFunction getFunctionAtPosition(Position position);
+   ScopeFunction getFunctionAtPosition(Position position, boolean allowAnonymous);
    Scope getSectionAtPosition(Position position);
    boolean hasScopeTree();
    JsArray<Scope> getScopeTree();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -912,8 +912,8 @@ public class TextEditingTarget implements
                         Position.create(event.getLineNumber() - 1, 1);
                   
                   // if we're not in function scope, set a top-level breakpoint
-                  ScopeFunction innerFunction = 
-                        docDisplay_.getFunctionAtPosition(breakpointPosition);
+                  ScopeFunction innerFunction =
+                        docDisplay_.getFunctionAtPosition(breakpointPosition, false);
                   if (innerFunction == null || !innerFunction.isFunction() ||
                       StringUtil.isNullOrEmpty(innerFunction.getFunctionName()))
                   {
@@ -3055,13 +3055,13 @@ public class TextEditingTarget implements
       // It's the easiest way to make sure getCurrentScope() returns
       // a Scope with an end.
       docDisplay_.getScopeTree();
-      Scope currentFunction = docDisplay_.getCurrentFunction();
+      Scope currentFunction = docDisplay_.getCurrentFunction(false);
 
       // Check if we're at the top level (i.e. not in a function), or in
       // an unclosed function
       if (currentFunction == null || currentFunction.getEnd() == null)
          return;
-
+      
       Position start = currentFunction.getPreamble();
       Position end = currentFunction.getEnd();
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/CodeModel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/CodeModel.java
@@ -45,11 +45,13 @@ public class CodeModel extends JavaScriptObject
       });
    }-*/;
 
-   public native final ScopeFunction getCurrentFunction(Position position) /*-{
+   public native final ScopeFunction getCurrentFunction(Position position,
+                                                        boolean allowAnonymous) /*-{
       if (!this.getCurrentScope)
          return null;
       return this.getCurrentScope(position, function(scope) {
-         return scope.isBrace() && scope.label;
+         return scope.isBrace() && scope.label &&
+                (allowAnonymous || scope.label.indexOf("<function>") === -1);
       });
    }-*/;
 


### PR DESCRIPTION
The introduction of anonymous functions into the scope tree had a minor regression -- it caused 'run current function definition' to pick up only the inner anonymous function, and not the whole enclosing named function.

This PR fixes that by adding an `allowAnonymous` to the `getCurrentFunction()` calls, and ensuring they're `false` in the two respective places they're used.