### PR TITLE
snippet insertion respects current language mode for cursor

### DIFF
--- a/src/gwt/acesupport/snippets/snippets/c_cpp.js
+++ b/src/gwt/acesupport/snippets/snippets/c_cpp.js
@@ -35,7 +35,7 @@ var snippets = [
       content: [
          "namespace {",
          "${0}",
-         "] // anonymous namespace"
+         "} // anonymous namespace"
       ].join("\n")
    },
    {
@@ -43,7 +43,7 @@ var snippets = [
       content: [
          "namespace ${1:ns} {",
          "${0}",
-         "] // namespace ${1:ns}"
+         "} // namespace ${1:ns}"
       ].join("\n")
    },
    {
@@ -54,7 +54,7 @@ var snippets = [
          "    ${2}",
          "private:",
          "    ${3}",
-         "}"
+         "};"
       ].join("\n")
    },
    {
@@ -62,7 +62,7 @@ var snippets = [
       content: [
          "struct ${1} {",
          "    ${0}",
-         "}"
+         "};"
       ].join("\n")
    }
 ];

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -413,6 +413,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut value="Alt+-" title="Insert Assignment Operator"/>
          <shortcut value="Cmd+Shift+M" title="Insert Pipe Operator" />
          <shortcut refid="insertRoxygenSkeleton" value="Cmd+Shift+Alt+R" title="Insert Roxygen Skeleton" />
+         <shortcut refid="insertSnippet" value="Shift+Tab" title="Insert Snippet"/>
       </shortcutgroup>
       <shortcutgroup name="Source Navigation">
          <shortcut refid="sourceNavigateBack" value="Cmd+F9"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -105,6 +105,7 @@ public abstract class
    public abstract AppCommand findUsages();
    public abstract AppCommand editRmdFormatOptions();
    public abstract AppCommand insertRoxygenSkeleton();
+   public abstract AppCommand insertSnippet();
  
    // Projects
    public abstract AppCommand newProject();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/snippets/SnippetHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/snippets/SnippetHelper.java
@@ -24,6 +24,8 @@ import com.google.inject.Inject;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.regex.Pattern;
+import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.FilePathUtils;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
@@ -312,6 +314,11 @@ public class SnippetHelper
             editor_.getWidget().getEditor(),
             editor_.getCursorPosition(),
             getMajorMode());
+      
+      // TODO: Find a way to unify 'mode names' and 'state names' we use as
+      // prefixes for multi-mode documents
+      if (mode == "r-cpp" || mode == "c" || mode == "cpp")
+         mode = "c_cpp";
       
       return mode.toLowerCase();
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/snippets/SnippetHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/snippets/SnippetHelper.java
@@ -23,8 +23,7 @@ import com.google.inject.Inject;
 
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.JsArrayUtil;
-import org.rstudio.core.client.regex.Pattern;
-import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.common.FilePathUtils;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
@@ -33,6 +32,7 @@ import org.rstudio.studio.client.workbench.snippets.model.SnippetData;
 import org.rstudio.studio.client.workbench.snippets.model.SnippetsChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditor;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEditorNative;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 
 import java.util.ArrayList;
 
@@ -68,40 +68,17 @@ public class SnippetHelper
       return $wnd.require("ace/snippets").snippetManager;
    }-*/;
    
-   public ArrayList<String> getCppSnippets()
-   {
-      ensureSnippetsLoaded();
-      return JsArrayUtil.fromJsArrayString(
-            getAvailableSnippetsImpl(manager_, "c_cpp"));
-   }
-   
-   public Snippet getCppSnippet(String name)
-   {    
-      return getSnippet(manager_, "c_cpp", name);
-   }
-   
    public ArrayList<String> getAvailableSnippets()
    {
       ensureSnippetsLoaded();
-      
       return JsArrayUtil.fromJsArrayString(
-            getAvailableSnippetsImpl(manager_, getEditorMode()));
+            getAvailableSnippetsImpl(manager_, getActiveMode()));
    }
    
    private final void ensureSnippetsLoaded()
    {
-      ensureRSnippetsLoaded();
-      ensureCppSnippetsLoaded();
-   }
-   
-   private void ensureRSnippetsLoaded()
-   {
-      ensureSnippetsLoaded("r", manager_);
-   }
-   
-   private void ensureCppSnippetsLoaded()
-   {
-      ensureSnippetsLoaded("c_cpp", manager_);
+      ensureSnippetsLoadedImpl(
+            getActiveMode(), manager_);
    }
    
    // Parse a snippet file and apply the parsed snippets for
@@ -154,7 +131,7 @@ public class SnippetHelper
             getSnippetManager());
    }
    
-   private static final native void ensureSnippetsLoaded(
+   private static final native void ensureSnippetsLoadedImpl(
          String mode,
          SnippetManager manager) /*-{
 
@@ -165,7 +142,7 @@ public class SnippetHelper
          // automatically register the snippets as necessary.
          var m = null;
          m = $wnd.require("rstudio/snippets/" + mode);
-         if (m !== null)
+         if (m != null)
             return;
             
          // Try loading internal Ace snippets. We need to pull the snippet
@@ -277,8 +254,18 @@ public class SnippetHelper
          return Object.keys(snippetsForMode);
       return [];
    }-*/;
-
-   private static final native Snippet getSnippet(
+   
+   public Snippet getSnippet(String name)
+   {
+      return getSnippet(name, getActiveMode());
+   }
+   
+   public Snippet getSnippet(String name, String mode)
+   {
+      return getSnippetImpl(manager_, mode, name);
+   }
+   
+   private static final native Snippet getSnippetImpl(
          SnippetManager manager,
          String mode,
          String name) /*-{
@@ -294,16 +281,37 @@ public class SnippetHelper
    // you need to call the ensure* functions)
    public String getSnippetContents(String snippetName)
    {
-      return getSnippet(manager_, getEditorMode(), snippetName).getContent();
+      return getSnippetImpl(manager_, getActiveMode(), snippetName).getContent();
    }
    
-   private String getEditorMode()
+   private static final native String getActiveModeImpl(AceEditorNative editor,
+                                                        Position position,
+                                                        String major)
+   /*-{
+      var Utils = $wnd.require("mode/utils");
+      var state = Utils.primaryState(editor.getSession().getState(position.row));
+      return Utils.activeMode(state, major);
+   }-*/;
+   
+   private String getMajorMode()
    {
-      String mode = editor_.getLanguageMode(
-            editor_.getCursorPosition());
-      
-      if (mode == null)
-         mode = "r";
+      String modeName = editor_.getFileType().getEditorLanguage().getModeName();
+      if (modeName == "rmarkdown")
+         return "markdown";
+      else if (modeName == "sweave")
+         return "tex";
+      else if (modeName == "rhtml")
+         return "html";
+      else
+         return modeName;
+   }
+   
+   private String getActiveMode()
+   {
+      String mode = getActiveModeImpl(
+            editor_.getWidget().getEditor(),
+            editor_.getCursorPosition(),
+            getMajorMode());
       
       return mode.toLowerCase();
    }
@@ -320,6 +328,33 @@ public class SnippetHelper
                snippetData.getContents(),
                manager);
       }
+   }
+   
+   public boolean onInsertSnippet()
+   {
+      return attemptSnippetInsertion();
+   }
+   
+   public boolean attemptSnippetInsertion()
+   {
+      if (!editor_.getSelection().isEmpty())
+         return false;
+      
+      String token = StringUtil.getToken(
+            editor_.getCurrentLine(),
+            editor_.getCursorPosition().getColumn(),
+            "[^ \\s\\n\\t\\r\\v]",
+            false,
+            false);
+      
+      ArrayList<String> snippets = getAvailableSnippets();
+      if (snippets.contains(token))
+      {
+         applySnippet(token, token);
+         return true;
+      }
+      
+      return false;
    }
    
    private final AceEditor editor_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -372,7 +372,7 @@ public class RCompletionManager implements CompletionManager
          else if (event.getKeyCode() == KeyCodes.KEY_TAB &&
                   modifier == KeyboardShortcut.SHIFT)
          {
-            return attemptImmediateSnippetInsertion();
+            return snippets_.attemptSnippetInsertion();
          }
          else if (keycode == 112 // F1
                   && modifier == KeyboardShortcut.NONE)
@@ -2071,28 +2071,6 @@ public class RCompletionManager implements CompletionManager
          }
       };
       helpRequest_.schedule(milliseconds);
-   }
-   
-   private boolean attemptImmediateSnippetInsertion()
-   {
-      if (!docDisplay_.getSelection().isEmpty())
-         return false;
-      
-      String token = StringUtil.getToken(
-            docDisplay_.getCurrentLine(),
-            docDisplay_.getCursorPosition().getColumn(),
-            "[^ \\s\\n\\t\\r\\v]",
-            false,
-            false);
-      
-      ArrayList<String> snippets = snippets_.getAvailableSnippets();
-      if (snippets.contains(token))
-      {
-         snippets_.applySnippet(token, token);
-         return true;
-      }
-      
-      return false;
    }
    
    private GlobalDisplay globalDisplay_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -2221,6 +2221,10 @@ public class AceEditor implements DocDisplay,
       return lastCursorChangedTime_;
    }
    
+   public void blockOutdent()
+   {
+      widget_.getEditor().blockOutdent();
+   }
    
    private static final int DEBUG_CONTEXT_LINES = 2;
    private final HandlerManager handlers_ = new HandlerManager(this);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -261,4 +261,6 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    
    long getLastModifiedTime();
    long getLastCursorChangedTime();
+   
+   void blockOutdent();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -102,6 +102,7 @@ import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.SessionInfo;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefsAccessor;
+import org.rstudio.studio.client.workbench.snippets.SnippetHelper;
 import org.rstudio.studio.client.workbench.ui.FontSizeManager;
 import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
 import org.rstudio.studio.client.workbench.views.console.shell.editor.InputEditorPosition;
@@ -383,6 +384,7 @@ public class TextEditingTarget implements
       presentationHelper_ = new TextEditingTargetPresentationHelper(
                                                                   docDisplay_);
       reformatHelper_ = new TextEditingTargetReformatHelper(docDisplay_);
+      snippets_ = new SnippetHelper((AceEditor) docDisplay_);
       
       docDisplay_.setRnwCompletionContext(compilePdfHelper_);
       docDisplay_.setCppCompletionContext(cppCompletionContext_);
@@ -2057,6 +2059,15 @@ public class TextEditingTarget implements
    void onInsertRoxygenSkeleton()
    {
       roxygenHelper_.insertRoxygenSkeleton();
+   }
+   
+   @Handler
+   void onInsertSnippet()
+   {
+      // NOTE: Bound to Shift + Tab so we delegate back there
+      // if this isn't dispatched
+      if (!snippets_.onInsertSnippet())
+         docDisplay_.blockOutdent();
    }
    
    @Handler
@@ -4787,6 +4798,7 @@ public class TextEditingTarget implements
    private TextEditingTargetSpelling spelling_;
    private BreakpointManager breakpointManager_;
    private final LintManager lintManager_;
+   private final SnippetHelper snippets_;
 
    // Allows external edit checks to supercede one another
    private final Invalidation externalEditCheckInvalidation_ =

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -313,4 +313,8 @@ public class AceEditorNative extends JavaScriptObject {
       return this.getCursorPosition();
    }-*/;
    
+   public final native void blockOutdent() /*-{
+      return this.blockOutdent();
+   }-*/;
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
@@ -16,11 +16,8 @@
 package org.rstudio.studio.client.workbench.views.source.editors.text.cpp;
 
 
-import java.util.ArrayList;
-
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Invalidation;
-import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.filetypes.DocumentMode;
@@ -203,7 +200,7 @@ public class CppCompletionManager implements CompletionManager
          else if (event.getKeyCode() == KeyCodes.KEY_TAB &&
                   modifier == KeyboardShortcut.SHIFT)
          {
-            return attemptImmediateSnippetInsertion();
+            return snippets_.attemptSnippetInsertion();
          }
          else if (event.getKeyCode() == 112 // F1
                   && modifier == KeyboardShortcut.NONE)
@@ -473,28 +470,6 @@ public class CppCompletionManager implements CompletionManager
    private boolean shouldComplete(NativeEvent event)
    {
       return initFilter_ == null || initFilter_.shouldComplete(event);
-   }
-   
-   private boolean attemptImmediateSnippetInsertion()
-   {
-      if (!docDisplay_.getSelection().isEmpty())
-         return false;
-      
-      String token = StringUtil.getToken(
-            docDisplay_.getCurrentLine(),
-            docDisplay_.getCursorPosition().getColumn(),
-            "[^ \\s\\n\\t\\r\\v]",
-            false,
-            false);
-      
-      ArrayList<String> snippets = snippets_.getCppSnippets();
-      if (snippets.contains(token))
-      {
-         snippets_.applySnippet(token, token);
-         return true;
-      }
-      
-      return false;
    }
    
    private CppServerOperations server_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionRequest.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionRequest.java
@@ -144,11 +144,11 @@ public class CppCompletionRequest
       if (uiPrefs_.enableSnippets().getValue() &&
           (completionPosition_.getScope() == CompletionPosition.Scope.Global))
       {
-         ArrayList<String> snippets = snippets_.getCppSnippets();
+         ArrayList<String> snippets = snippets_.getAvailableSnippets();
          for (String snippet : snippets)
             if (snippet.startsWith(userTypedText))
             {
-               String content = snippets_.getCppSnippet(snippet).getContent();
+               String content = snippets_.getSnippet(snippet).getContent();
                content = content.replace("\t", "  ");
                filtered.unshift(CppCompletion.createSnippetCompletion(snippet,
                                                                       content));


### PR DESCRIPTION
This PR cleans up the SnippetHelper class, by allowing it to automatically infer the current mode based on the cursor position.

This means that, e.g. in R Markdown documents, we can appropriately select markdown vs. R vs. C++ snippets, depending on where the cursor currently lives.