### PR TITLE
Add support for filtering boolean columns

### DIFF
--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -116,6 +116,11 @@
         col_type <- "character"
         col_search_type <- "character"
       }
+      else if (is.logical(val))
+      {
+        col_type <- "boolean"
+        col_search_type <- "boolean"
+      }
     }
     list(
       col_name        = .rs.scalar(col_name),
@@ -321,6 +326,13 @@
         else
           # equality filter
           x <- x[is.finite(x[[i]]) & x[[i]] == filterval, , drop = FALSE]
+      }
+      else if (identical(filtertype, "boolean")) 
+      {
+        filterval <- isTRUE(filterval == "TRUE")
+        matches <- x[[i]] == filterval
+        matches[is.na(matches)] <- FALSE
+        x <- x[matches, , drop = FALSE]
       }
     }
   }

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -160,9 +160,9 @@ bool isFilterSubset(const std::string& outer, const std::string& inner)
       if (boost::regex_search(innerValue, innerMatch, numFilter) &&
           boost::regex_search(outerValue, outerMatch, numFilter))
       {
-         // for numeric filters, the inner is a subset if its lower bound (1) is 
-         // larger than the outer lower bound, and the upper bound (2) is smaller
-         // than the outer upper bound
+         // for numeric filters, the inner is a subset if its lower bound (1)
+         // is larger than the outer lower bound, and the upper bound (2) is
+         // smaller than the outer upper bound
          return safe_convert::stringTo<double>(innerMatch[1], 0) >= 
                 safe_convert::stringTo<double>(outerMatch[1], 0) &&
                 safe_convert::stringTo<double>(innerMatch[2], 0) <= 
@@ -172,10 +172,10 @@ bool isFilterSubset(const std::string& outer, const std::string& inner)
       // if not identical and not a range, then not a subset
       return false;
    } 
-   else if (outerType == "factor")
+   else if (outerType == "factor" || outerType == "boolean")
    {
-      // factors have to be identical for subsetting, and we already checked
-      // above
+      // factors and boolean values have to be identical for subsetting, and we
+      // already checked above
       return false;
    }
    else if (outerType == "character")

--- a/src/cpp/session/resources/grid/gridstyles.css
+++ b/src/cpp/session/resources/grid/gridstyles.css
@@ -1,3 +1,17 @@
+/*
+ * gridstyles.css
+ *
+ * Copyright (C) 2009-15 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
 
 body {
     height: 100%;
@@ -137,7 +151,7 @@ table.dataTable {
     padding-bottom: 8px;
 }
 
-.factorList {
+.choiceList {
     max-height: 300px;
     max-width: 400px;
     min-width: 50px;
@@ -145,7 +159,7 @@ table.dataTable {
     overflow-x: hidden;
 }
 
-.factorListItem {
+.choiceListItem {
     padding-top: 4px;
     padding-bottom: 4px;
     padding-right: 8px;
@@ -153,7 +167,7 @@ table.dataTable {
     cursor: pointer;
 }
 
-.factorListItem:hover {
+.choiceListItem:hover {
     background-color: #bce0fc;
 }
 

--- a/src/cpp/session/resources/grid/gridviewer.html
+++ b/src/cpp/session/resources/grid/gridviewer.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="datatables/css/jquery.dataTables.min.css" />
     <link rel="stylesheet" href="datatables/css/dataTables.scroller.min.css" />
     <link rel="stylesheet" href="jquery/ui/jquery-ui.min.css" />
-    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="gridstyles.css" />
     <script type="text/javascript" src="datatables/js/jquery.js"></script>
     <script type="text/javascript" src="datatables/js/jquery.dataTables.min.js"></script>
     <script type="text/javascript" src="datatables/js/dataTables.scroller.min.js"></script>

--- a/src/cpp/session/resources/grid/gridviewer.js
+++ b/src/cpp/session/resources/grid/gridviewer.js
@@ -1,7 +1,9 @@
+/*jshint browser:true, strict:false, curly:false, indent:3*/
+
 /*
  * gridviewer.js
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-15 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -353,13 +355,13 @@ var createFactorFilterUI = function(idx, col, onDismiss) {
   };
   invokeFilterPopup(ele, function(popup) {
     var list = document.createElement("div");
-    list.className = "factorList";
+    list.className = "choiceList";
     var val = parseSearchVal(idx);
     var current = val.length > 0 ? parseInt(val) : 0;
     for (var i = 0; i < col.col_vals.length; i++) {
       var opt = document.createElement("div");
       opt.textContent = col.col_vals[i];
-      opt.className = "factorListItem";
+      opt.className = "choiceListItem";
       opt.addEventListener("click", setValHandler(i + 1, col.col_vals[i]));
       list.appendChild(opt);
     }
@@ -399,6 +401,37 @@ var createTextFilterUI = function(idx, col, onDismiss) {
     evt.stopPropagation();
   });
   ele.appendChild(input);
+  return ele;
+};
+
+var createBooleanFilterUI = function(idx, col, onDismiss) {
+  var ele = document.createElement("div");
+  var display = document.createElement("span");
+  display.innerHTML = "&nbsp;";
+  ele.appendChild(display);
+
+  var setBoolValHandler = function(text) {
+      return function(evt) {
+        var searchText = "boolean|" + text;
+        table.columns(idx).search(searchText).draw();
+        display.textContent = text;
+      };
+  };
+
+  invokeFilterPopup(ele, function(popup) {
+    var list = document.createElement("div");
+    list.className = "choiceList";
+    var values = ["TRUE", "FALSE"];
+    for (logical in values) {
+      var opt = document.createElement("div");
+      opt.textContent = values[logical];
+      opt.className = "choiceListItem";
+      opt.addEventListener("click", setBoolValHandler(values[logical]));
+      list.appendChild(opt);
+    }
+    popup.appendChild(list);
+  }, onDismiss, false);
+
   return ele;
 };
 
@@ -505,6 +538,8 @@ var createFilterUI = function(idx, col) {
       ui = createFactorFilterUI(idx, col, onDismiss);
     } else if (col.col_search_type === "character") {
       ui = createTextFilterUI(idx, col, onDismiss);
+    } else if (col.col_search_type === "boolean") {
+      ui = createBooleanFilterUI(idx, col, onDismiss);
     }
     if (ui) {
       ui.className += " filterValue";
@@ -769,7 +804,8 @@ window.setFilterUIVisible = function(visible) {
     var th = thead.children[i];
     if (col.col_search_type === "numeric" || 
         col.col_search_type === "character" ||
-        col.col_search_type === "factor")  {
+        col.col_search_type === "factor" ||
+        col.col_search_type === "boolean")  {
       if (visible) {
         var filter = createFilterUI(i, col);
         th.appendChild(filter);


### PR DESCRIPTION
This change adds support for filtering columns that contain logical values; like factors, these now get a pop-up with possible values, of which there are always two:

![image](https://cloud.githubusercontent.com/assets/470418/6901768/563ed906-d6c4-11e4-8346-a49e047b9562.png)

