### PR TITLE
ensure UTF8 encoding in completion routines

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1381,9 +1381,9 @@
    routineEnv
 })
 
-.rs.addFunction("setEncodingUTF8", function(object)
+.rs.addFunction("setEncodingUnknownToUTF8", function(object)
 {
-   if (is.character(object))
+   if (is.character(object) && Encoding(object) == "unknown")
       Encoding(object) <- "UTF-8"
    else if (is.list(object))
       return(lapply(object, .rs.setEncodingUTF8))

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1380,3 +1380,13 @@
    assign(".rs.routines", routineEnv, pos = which(search() == "tools:rstudio"))
    routineEnv
 })
+
+.rs.addFunction("setEncodingUTF8", function(object)
+{
+   if (is.character(object))
+      Encoding(object) <- "UTF-8"
+   else if (is.list(object))
+      return(lapply(object, .rs.setEncodingUTF8))
+   
+   object
+})

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1494,14 +1494,14 @@ assign(x = ".rs.acCompletionTypes",
 {
    # Ensure UTF-8 encoding, as that's the encoding set when passed down from
    # the client
-   token <- .rs.setEncodingUTF8(token)
-   string <- .rs.setEncodingUTF8(string)
-   functionCallString <- .rs.setEncodingUTF8(functionCallString)
-   chainObjectName <- .rs.setEncodingUTF8(chainObjectName)
-   additionalArgs <- .rs.setEncodingUTF8(additionalArgs)
-   excludeArgs <- .rs.setEncodingUTF8(excludeArgs)
-   excludeArgsFromObject <- .rs.setEncodingUTF8(excludeArgsFromObject)
-   filePath <- .rs.setEncodingUTF8(filePath)
+   token <- .rs.setEncodingUnknownToUTF8(token)
+   string <- .rs.setEncodingUnknownToUTF8(string)
+   functionCallString <- .rs.setEncodingUnknownToUTF8(functionCallString)
+   chainObjectName <- .rs.setEncodingUnknownToUTF8(chainObjectName)
+   additionalArgs <- .rs.setEncodingUnknownToUTF8(additionalArgs)
+   excludeArgs <- .rs.setEncodingUnknownToUTF8(excludeArgs)
+   excludeArgsFromObject <- .rs.setEncodingUnknownToUTF8(excludeArgsFromObject)
+   filePath <- .rs.setEncodingUnknownToUTF8(filePath)
    
    # Get the currently active frame
    envir <- .rs.getActiveFrame(1L)

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1492,6 +1492,17 @@ assign(x = ".rs.acCompletionTypes",
                                                   filePath,
                                                   documentId)
 {
+   # Ensure UTF-8 encoding, as that's the encoding set when passed down from
+   # the client
+   token <- .rs.setEncodingUTF8(token)
+   string <- .rs.setEncodingUTF8(string)
+   functionCallString <- .rs.setEncodingUTF8(functionCallString)
+   chainObjectName <- .rs.setEncodingUTF8(chainObjectName)
+   additionalArgs <- .rs.setEncodingUTF8(additionalArgs)
+   excludeArgs <- .rs.setEncodingUTF8(excludeArgs)
+   excludeArgsFromObject <- .rs.setEncodingUTF8(excludeArgsFromObject)
+   filePath <- .rs.setEncodingUTF8(filePath)
+   
    # Get the currently active frame
    envir <- .rs.getActiveFrame(1L)
    


### PR DESCRIPTION
This PR fixes a problem in autocompletion of items with non-ASCII characters -- we ensure that all character vectors are re-marked with UTF-8 encoding.

Without this PR, entries like `CAFÉ` were interpretted as `CAFÃ‰/`, and so autocompletion couldn't properly resolve the path.