### PR TITLE
bugfix for 'else-if' in parser

### DIFF
--- a/src/cpp/core/include/core/r_util/RTokenizer.hpp
+++ b/src/cpp/core/include/core/r_util/RTokenizer.hpp
@@ -487,6 +487,12 @@ inline RToken::TokenType typeComplement(RToken::TokenType lhsType)
    }
 }
 
+inline bool canContinueStatement(const RToken& rToken)
+{
+   return isBinaryOp(rToken) ||
+           canOpenArgumentList(rToken);
+}
+
 } // end namespace token_utils
 
 } // namespace r_util

--- a/src/cpp/session/modules/SessionLinterTests.cpp
+++ b/src/cpp/session/modules/SessionLinterTests.cpp
@@ -173,6 +173,14 @@ context("Linter")
       EXPECT_NO_ERRORS("function(a)\nfor (i in 1) 1\n");
 
       EXPECT_NO_ERRORS("{if(!(a)){};if(b){}}");
+      EXPECT_NO_ERRORS("if (1) foo(1) <- 1 else 2; 1 + 2");
+      EXPECT_NO_ERRORS("if (1)\nfoo(1) <- 1\nelse 2; 4 + 8");
+      EXPECT_NO_ERRORS("if (1) (foo(1) <- {{1}})\n2 + 1");
+      
+      // EXPECT_ERRORS("if (1) (1)\nelse (2)");
+      EXPECT_NO_ERRORS("{if (1) (1)\nelse (2)}");
+      
+      EXPECT_NO_ERRORS("if (a)\nF(b) <- 'c'\nelse if (d) e");
 
       EXPECT_NO_ERRORS("lapply(x, `[[`, 1)");
 

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -16,6 +16,7 @@
 // #define RSTUDIO_ENABLE_PROFILING
 // #define RSTUDIO_ENABLE_DEBUG_MACROS
 #define RSTUDIO_DEBUG_LABEL "parser"
+
 #include <core/Macros.hpp>
 #include <core/FileSerializer.hpp>
 
@@ -705,6 +706,8 @@ void doParse(RTokenCursor& cursor,
       
 START:
       
+      DEBUG("== Current state: " << status.currentStateAsString());
+      
       // We want to skip over formulas if necessary.
       if (skipFormulas(cursor, status))
       {
@@ -734,6 +737,22 @@ START:
          goto IF_START;
       else if (cursor.contentEquals(L"repeat"))
          goto REPEAT_START;
+      
+      // 'else'. Implicitly ending an 'if' statement.
+      if (cursor.contentEquals(L"else"))
+      {
+         // Ensure that we're in an 'if' statement or expression.
+         if (status.currentState() == ParseStatus::ParseStateIfStatement ||
+             status.currentState() == ParseStatus::ParseStateIfExpression)
+         {
+            MOVE_TO_NEXT_SIGNIFICANT_TOKEN(cursor, status);
+            goto START;
+         }
+         else
+         {
+            GOTO_INVALID_TOKEN(cursor);
+         }
+      }
       
       // Left paren.
       if (cursor.isType(RToken::LPAREN))
@@ -802,15 +821,33 @@ START:
          case ParseStatus::ParseStateWhileCondition:
             goto WHILE_CONDITION_END;
          case ParseStatus::ParseStateWithinParens:
-            DEBUG("Within parens");
             status.popState();
-            while (status.isInControlFlowStatement()) status.popState();
-            if (cursor.isAtEndOfDocument()) return;
+            
+            if (cursor.isAtEndOfDocument())
+               return;
+            
+            // Handle an 'else' following when we are closing an 'if' statement
+            if (status.currentState() == ParseStatus::ParseStateIfStatement &&
+                cursor.nextSignificantToken().contentEquals(L"else"))
+            {
+               status.popState();
+               MOVE_TO_NEXT_SIGNIFICANT_TOKEN(cursor, status);
+               MOVE_TO_NEXT_SIGNIFICANT_TOKEN(cursor, status);
+               goto START;
+            }
+            
+            // Check to see if this paren closes the current statement.
+            // If so, it effectively closes any parent conditional statements.
+            if (cursor.isAtEndOfStatement(status))
+               while (status.isInControlFlowStatement())
+                  status.popState();
+            
             MOVE_TO_NEXT_SIGNIFICANT_TOKEN(cursor, status);
             if (isBinaryOp(cursor))
                goto BINARY_OPERATOR;
             else if (canOpenArgumentList(cursor))
                goto ARGUMENT_LIST;
+            
             goto START;
          default:
             GOTO_INVALID_TOKEN(cursor);
@@ -1089,15 +1126,20 @@ ARGUMENT_START:
 ARGUMENT_LIST_END:
       
       DEBUG("Argument list end: " << cursor);
+      DEBUG("== State: " << status.currentStateAsString());
+      
       status.popState();
       status.popNseCall();
+      
+      DEBUG("== State: " << status.currentStateAsString());
       
       // An argument list may end _two_ states, e.g. in this:
       //
       //    if (foo) a() else if (b()) b()
       //
       // We need to close both the 'if' and the argument list.
-      if (status.isInControlFlowStatement())
+      if (status.isInControlFlowStatement() &&
+          !canContinueStatement(cursor.nextSignificantToken()))
       {
          bool hasElse =
                status.currentState() == ParseStatus::ParseStateIfStatement &&
@@ -1112,8 +1154,10 @@ ARGUMENT_LIST_END:
          }
       }
       
-      while (status.isInControlFlowStatement())
-         status.popState();
+      // Pop out of control flow statements if this ends the statement.
+      if (cursor.isAtEndOfStatement(status))
+         while (status.isInControlFlowStatement())
+            status.popState();
       
       // Following the end of an argument list, we may see:
       //

--- a/src/cpp/session/modules/SessionRParser.hpp
+++ b/src/cpp/session/modules/SessionRParser.hpp
@@ -21,6 +21,9 @@
 #ifndef SESSION_MODULES_RPARSER_HPP
 #define SESSION_MODULES_RPARSER_HPP
 
+// #define RSTUDIO_DEBUG_LABEL "parser"
+// #define RSTUDIO_ENABLE_DEBUG_MACROS
+
 #include <vector>
 #include <map>
 #include <set>
@@ -798,6 +801,7 @@ public:
    void pushFunctionCallState(ParseState state,
                               const std::wstring& functionName)
    {
+      DEBUG("Pushing state: " << stateAsString(state));
       parseStateStack_.push(state);
       functionNames_.push(functionName);
    }
@@ -847,7 +851,14 @@ public:
       }
 
       if (currentState() != ParseStateTopLevel)
+      {
+         DEBUG("Popping state: " << currentStateAsString());
          parseStateStack_.pop();
+      }
+      else
+      {
+         DEBUG("Already at top level; no state to pop");
+      }
    }
    
    ParseState peekState(std::size_t depth = 0) const
@@ -893,12 +904,12 @@ public:
    
    std::string currentStateAsString() const { return stateAsString(currentState()); }
    
-   bool isAtTopLevel()
+   bool isAtTopLevel() const
    {
       return currentState() == ParseStateTopLevel;
    }
    
-   bool isInArgumentList()
+   bool isInArgumentList() const
    {
       switch (currentState())
       {
@@ -912,7 +923,7 @@ public:
       }
    }
    
-   bool isInControlFlowStatement()
+   bool isInControlFlowStatement() const
    {
       switch (currentState())
       {
@@ -927,7 +938,7 @@ public:
       }
    }
    
-   bool isInControlFlowExpression()
+   bool isInControlFlowExpression() const
    {
       switch (currentState())
       {
@@ -942,7 +953,7 @@ public:
       }
    }
    
-   bool isInControlFlowCondition()
+   bool isInControlFlowCondition() const
    {
       switch (currentState())
       {
@@ -955,7 +966,7 @@ public:
       }
    }
    
-   bool isInParentheticalScope()
+   bool isInParentheticalScope() const
    {
       switch (currentState())
       {

--- a/src/cpp/session/modules/SessionRTokenCursor.hpp
+++ b/src/cpp/session/modules/SessionRTokenCursor.hpp
@@ -416,6 +416,33 @@ public:
             isType(RToken::COMMA);
   }
   
+  bool isAtEndOfStatement(const ParseStatus& status)
+  {
+     // Whether we're in a parenthetical scope is important!
+     // For example, these parse the same:
+     //
+     //     (foo\n(1))
+     //     (foo  (1))
+     //
+     // while these parse differently:
+     //
+     //      foo\n(1)
+     //      foo  (1)
+     //
+     if (!status.isInParentheticalScope() &&
+         isWhitespaceWithNewline(nextToken()))
+     {
+        return true;
+     }
+     
+     const RToken& next = nextSignificantToken();
+     return !(
+              isBinaryOp(next) ||
+              next.isType(RToken::LPAREN) ||
+              next.isType(RToken::LBRACKET) ||
+              next.isType(RToken::LDBRACKET));
+  }
+  
   bool appearsToBeBinaryOperator() const
   {
      return isBinaryOp(currentToken()) &&


### PR DESCRIPTION
This fixes a bug where the parser incorrectly flagged and `else` following an `if` statement as erroneous, e.g.

![screen shot 2015-03-31 at 10 18 49 am](https://cloud.githubusercontent.com/assets/1976582/6928084/76dbabca-d7a6-11e4-8734-4fc44b78f3c0.png)

The issue here is that the parser was jumping out of the if statement too soon -- it believed the end of the expressions was here:

```R
Encoding(object) <- "UTF-8"
               ^
```
