### PR TITLE
default to working dir on 'new project from existing dir'

### DIFF
--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -65,6 +65,8 @@ Error getNewProjectContext(const json::JsonRpcRequest& request,
    contextJson["packrat_available"] =
          module_context::packratContext().available &&
          module_context::canBuildCpp();
+   contextJson["working_directory"] = module_context::createAliasedPath(
+         r::session::utils::safeCurrentPath());
 
    pResponse->setResult(contextJson);
 

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/NewProjectContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/NewProjectContext.java
@@ -29,4 +29,8 @@ public class NewProjectContext extends JavaScriptObject
    public native final boolean isPackratAvailable() /*-{
       return this.packrat_available;
    }-*/;
+   
+   public native final String getWorkingDirectory() /*-{
+      return this.working_directory;
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/ExistingDirectoryPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/ExistingDirectoryPage.java
@@ -14,8 +14,10 @@
  */
 package org.rstudio.studio.client.projects.ui.newproject;
 
+import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.DirectoryChooserTextBox;
 import org.rstudio.core.client.widget.MessageDialog;
+import org.rstudio.studio.client.projects.model.NewProjectInput;
 import org.rstudio.studio.client.projects.model.NewProjectResult;
 
 
@@ -39,12 +41,16 @@ public class ExistingDirectoryPage extends NewProjectWizardPage
    
       existingProjectDir_ = new DirectoryChooserTextBox(
             "Project working directory:", null);
-
       addWidget(existingProjectDir_);
-      
    }
    
-
+   @Override 
+   protected void initialize(NewProjectInput input)
+   {
+      defaultNewProjectLocation_ = input.getDefaultNewProjectLocation();
+      existingProjectDir_.setText(input.getContext().getWorkingDirectory());
+   }
+   
    @Override
    protected NewProjectResult collectInput()
    {


### PR DESCRIPTION
Minor change: this changes the default directory used under `Create Project from Existing Directory` to the current working directory, e.g.:

![screen shot 2015-04-04 at 4 37 29 pm](https://cloud.githubusercontent.com/assets/1976582/6995121/ed224d8a-dae8-11e4-9834-2653937c04b0.png)

This seems like a better default for someone who might be working in a particular directory and wants to turn it into a project.
