### PR TITLE
ensure namespace loaded in 'find*' functions

### DIFF
--- a/src/cpp/r/RExec.cpp
+++ b/src/cpp/r/RExec.cpp
@@ -309,7 +309,6 @@ void RFunction::commonInit(const std::string& functionName)
    {
       ns = functionName_.substr(0, pos);
       name = functionName_.substr(pos + nsQual.size());
-      
    }
    else
    {
@@ -350,6 +349,7 @@ Error RFunction::call(SEXP evalNS, bool safely, SEXP* pResultSEXP,
    // verify the function
    if (functionSEXP_ == R_UnboundValue)
    {
+      LOG_ERROR_MESSAGE("Failed to find function: '" + functionName_ + "'");
       Error error(errc::SymbolNotFoundError, ERROR_LOCATION);
       if (!functionName_.empty())
          error.addProperty("symbol", functionName_);


### PR DESCRIPTION
The bug we encountered re: `Run All` failing was due to the fact that the `knitr` namespace was not loaded, and the new code introduced for `findFunction` did not validate the namespace was loaded before calling `findNamespace` (which does not load unloaded namespaces).

This PR ensures any namespace we attempt to use for lookup is loaded before starting our lookup.