### PR TITLE
Improve internal match.call; provide optimizations for hot code paths

### DIFF
--- a/src/cpp/core/include/core/Algorithm.hpp
+++ b/src/cpp/core/include/core/Algorithm.hpp
@@ -17,6 +17,9 @@
 #ifndef CORE_ALGORITHM_HPP
 #define CORE_ALGORITHM_HPP
 
+#include <vector>
+#include <algorithm>
+
 namespace rstudio {
 namespace core {
 namespace algorithm {
@@ -65,11 +68,20 @@ bool contains(const Container& container,
 
 template <typename Container, typename ValueType>
 bool contains(const Container& container,
-              const ValueType& type)
+              const ValueType& value)
 {
-   return std::find(container.begin(), container.end(), type) != container.end();
+   return std::find(container.begin(), container.end(), value) != container.end();
 }
 
+template <typename T>
+std::vector<T> seq(T length)
+{
+   std::vector<T> result;
+   result.reserve(length);
+   for (std::size_t i = 0; i < length; ++i)
+      result.push_back(i);
+   return result;
+}
 
 } // namespace algorithm
 } // namespace core

--- a/src/cpp/core/include/core/Algorithm.hpp
+++ b/src/cpp/core/include/core/Algorithm.hpp
@@ -55,6 +55,21 @@ OutputIterator copy_transformed_if(InputIterator begin,
    return destBegin;
 }
 
+template <typename Container, typename ValueType>
+bool contains(const Container& container,
+              const ValueType& type,
+              typename Container::key_type* SFINAE__key_type = 0)
+{
+   return container.count(type);
+}
+
+template <typename Container, typename ValueType>
+bool contains(const Container& container,
+              const ValueType& type)
+{
+   return std::find(container.begin(), container.end(), type) != container.end();
+}
+
 
 } // namespace algorithm
 } // namespace core

--- a/src/cpp/core/include/core/Debug.hpp
+++ b/src/cpp/core/include/core/Debug.hpp
@@ -1,0 +1,54 @@
+/*
+ * Debug.hpp
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef CORE_DEBUG_HPP
+#define CORE_DEBUG_HPP
+
+#include <iostream>
+#include <core/json/Json.hpp>
+#include <vector>
+#include <map>
+
+namespace rstudio {
+namespace core {
+namespace debug {
+
+template <typename K, typename V>
+void print(const std::map<K, V>& map, std::ostream& os = std::cerr)
+{
+   json::Object object;
+   for (typename std::map<K, V>::const_iterator it = map.begin();
+        it != map.end();
+        ++it)
+   {
+      object[it->first] = json::toJsonValue(it->second);
+   }
+   json::writeFormatted(object, os);
+   os << std::endl;
+}
+
+template <typename T>
+void print(const std::vector<T>& object, std::ostream& os = std::cerr)
+{
+   json::writeFormatted(json::toJsonArray(object), os);
+   os << std::endl;
+}
+
+} // namespace debug
+} // namespace core
+} // namespace rstudio
+
+#endif /* CORE_DEBUG_HPP */
+

--- a/src/cpp/core/include/core/Debug.hpp
+++ b/src/cpp/core/include/core/Debug.hpp
@@ -39,10 +39,12 @@ void print(const std::map<K, V>& map, std::ostream& os = std::cerr)
    os << std::endl;
 }
 
-template <typename T>
-void print(const std::vector<T>& object, std::ostream& os = std::cerr)
+template <typename ConvertibleToArray>
+void print(const ConvertibleToArray& object, std::ostream& os = std::cerr)
 {
-   json::writeFormatted(json::toJsonArray(object), os);
+   typedef typename ConvertibleToArray::value_type value_type;
+   std::vector<value_type> asVector(object.begin(), object.end());
+   json::writeFormatted(json::toJsonArray(asVector), os);
    os << std::endl;
 }
 

--- a/src/cpp/core/include/core/Macros.hpp
+++ b/src/cpp/core/include/core/Macros.hpp
@@ -42,8 +42,11 @@
 # define RSTUDIO_DEBUG(x) do {} while (0)
 # define RSTUDIO_DEBUG_LINE(x) do {} while (0)
 # define RSTUDIO_DEBUG_BLOCK(x) if (false)
+# define RSTUDIO_LOG_OBJECT(x)
 
 #else
+
+#include <core/Debug.hpp>
 
 #define RSTUDIO_DEBUG(x)                                                       \
    do                                                                          \
@@ -69,6 +72,12 @@
                 << std::setfill('0') << __LINE__ << "): " << x << std::endl;   \
    if (true)
 
+# define RSTUDIO_LOG_OBJECT(x)                                                 \
+   do                                                                          \
+   {                                                                           \
+      ::rstudio::core::debug::print(x);                                        \
+   } while (0)
+
 #endif /* Debug logging macros */
 
 #ifndef DEBUG
@@ -81,6 +90,10 @@
 
 #ifndef DEBUG_BLOCK
 # define DEBUG_BLOCK RSTUDIO_DEBUG_BLOCK
+#endif
+
+#ifndef LOG_OBJECT
+# define LOG_OBJECT RSTUDIO_LOG_OBJECT
 #endif
 
 #endif

--- a/src/cpp/core/include/core/Macros.hpp
+++ b/src/cpp/core/include/core/Macros.hpp
@@ -66,7 +66,7 @@
                 << x << std::endl;                                             \
    } while (0)
 
-#define RSTUDIO_DEBUG_BLOCK(x)                                                 \
+# define RSTUDIO_DEBUG_BLOCK(x)                                                \
    if (strlen(x))                                                              \
       std::cerr << "(" << RSTUDIO_DEBUG_LABEL << ":" << std::setw(4)           \
                 << std::setfill('0') << __LINE__ << "): " << x << std::endl;   \
@@ -93,7 +93,7 @@
 #endif
 
 #ifndef LOG_OBJECT
-# define LOG_OBJECT RSTUDIO_LOG_OBJECT
+# define LOG_OBJECT(x) RSTUDIO_LOG_OBJECT(x)
 #endif
 
 #endif

--- a/src/cpp/core/include/core/Macros.hpp
+++ b/src/cpp/core/include/core/Macros.hpp
@@ -45,12 +45,12 @@
 
 #else
 
-# define RSTUDIO_DEBUG(x)                                                      \
+#define RSTUDIO_DEBUG(x)                                                       \
    do                                                                          \
    {                                                                           \
-      std::cerr << "(" << RSTUDIO_DEBUG_LABEL << ":"                           \
-                << std::setw(4) << std::setfill('0') << __LINE__ << "): "      \
-                << x << std::endl;                                             \
+         std::cerr << "(" << RSTUDIO_DEBUG_LABEL << ":" << std::setw(4)        \
+                   << std::setfill('0') << __LINE__ << "): " << x              \
+                   << std::endl;                                               \
    } while (0)
 
 # define RSTUDIO_DEBUG_LINE(x)                                                 \
@@ -64,8 +64,9 @@
    } while (0)
 
 #define RSTUDIO_DEBUG_BLOCK(x)                                                 \
-   std::cerr << "(" << RSTUDIO_DEBUG_LABEL << ":" << std::setw(4)              \
-             << std::setfill('0') << __LINE__ << "): " << x << std::endl;      \
+   if (strlen(x))                                                              \
+      std::cerr << "(" << RSTUDIO_DEBUG_LABEL << ":" << std::setw(4)           \
+                << std::setfill('0') << __LINE__ << "): " << x << std::endl;   \
    if (true)
 
 #endif /* Debug logging macros */

--- a/src/cpp/core/include/core/algorithm/Map.hpp
+++ b/src/cpp/core/include/core/algorithm/Map.hpp
@@ -1,0 +1,62 @@
+/*
+ * Map.hpp
+ *
+ * Copyright (C) 2009-2015 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+#ifndef CORE_ALGORITHM_MAP_HPP
+#define CORE_ALGORITHM_MAP_HPP
+
+// Convenience algorithms -- not necessarily as fast as just
+// using the STL + iterators, but often easier to use.
+
+#include <vector>
+#include <map>
+#include <algorithm>
+
+namespace rstudio {
+namespace core {
+namespace algorithm {
+
+template <typename key_type, typename mapped_type>
+std::vector<key_type> map_keys(const std::map<key_type, mapped_type>& map)
+{
+   std::vector<key_type> result;
+   result.reserve(map.size());
+   for (typename std::map<key_type, mapped_type>::const_iterator it = map.begin();
+        it != map.end();
+        ++it)
+   {
+      result.push_back(it->first);
+   }
+   return result;
+}
+
+template <typename key_type, typename mapped_type>
+std::vector<mapped_type> map_values(const std::map<key_type, mapped_type>& map)
+{
+   std::vector<key_type> result;
+   result.reserve(map.size());
+   for (typename std::map<key_type, mapped_type>::const_iterator it = map.begin();
+        it != map.end();
+        ++it)
+   {
+      result.push_back(it->second);
+   }
+   return result;
+}
+
+} // namespace algorithm
+} // namespace core
+} // namespace rstudio
+
+#endif
+

--- a/src/cpp/core/include/core/algorithm/Set.hpp
+++ b/src/cpp/core/include/core/algorithm/Set.hpp
@@ -25,30 +25,16 @@ namespace core {
 namespace algorithm {
 
 #define RS_SET_OPERATION(__OPERATION__)                                        \
-   template <typename Container>                                               \
-   Container __OPERATION__(Container c1, Container c2)                         \
+   template <typename C1, typename C2>                                         \
+   C1 __OPERATION__(C1 c1, C2 c2)                                              \
    {                                                                           \
                                                                                \
       std::sort(c1.begin(), c1.end());                                         \
       std::sort(c2.begin(), c2.end());                                         \
                                                                                \
-      Container result;                                                        \
+      C1 result;                                                               \
       std::__OPERATION__(c1.begin(), c1.end(), c2.begin(), c2.end(),           \
                          std::back_inserter(result));                          \
-                                                                               \
-      return result;                                                           \
-   }                                                                           \
-                                                                               \
-   template <typename Container, typename Comparator>                          \
-   Container __OPERATION__(Container c1, Container c2, Comparator comp)        \
-   {                                                                           \
-                                                                               \
-      std::sort(c1.begin(), c1.end(), comp);                                   \
-      std::sort(c2.begin(), c2.end(), comp);                                   \
-                                                                               \
-      Container result;                                                        \
-      std::__OPERATION__(c1.begin(), c1.end(), c2.begin(), c2.end(),           \
-                         std::back_inserter(result), comp);                    \
                                                                                \
       return result;                                                           \
    }

--- a/src/cpp/core/include/core/r_util/RTokenizer.hpp
+++ b/src/cpp/core/include/core/r_util/RTokenizer.hpp
@@ -107,7 +107,7 @@ public:
    // accessors
    TokenType type() const { return type_; }
    std::wstring content() const { return std::wstring(begin_, end_); }
-   std::string contentAsUtf8() const;
+   const std::string& contentAsUtf8() const;
    std::size_t offset() const { return offset_; }
    std::size_t length() const { return end_ - begin_; }
    std::size_t row() const { return row_; }

--- a/src/cpp/core/r_util/RTokenizer.cpp
+++ b/src/cpp/core/r_util/RTokenizer.cpp
@@ -495,7 +495,7 @@ ConversionCache& conversionCache()
    return instance;
 }
 
-std::string RToken::contentAsUtf8() const
+const std::string& RToken::contentAsUtf8() const
 {
    ConversionCache& cache = conversionCache();
    if (cache.contains(*this))
@@ -503,7 +503,7 @@ std::string RToken::contentAsUtf8() const
    
    std::string result = string_utils::wideToUtf8(content());
    cache.put(*this, result);
-   return result;
+   return cache.get(*this);
 }
 
 std::string RToken::asString() const

--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -14,6 +14,9 @@
  */
 
 #define R_INTERNAL_FUNCTIONS
+#define RSTUDIO_DEBUG_LABEL "rsexp"
+#define RSTUDIO_ENABLE_DEBUG_MACROS
+
 #include <r/RSexp.hpp>
 #include <r/RInternal.hpp>
 
@@ -1047,6 +1050,7 @@ bool addSymbolCheckedForMissingness(
        CDDR(nodeSEXP) == R_NilValue &&
        strcmp(CHAR(PRINTNAME(CAR(nodeSEXP))), "missing") == 0)
    {
+      DEBUG("Handling 'missing(" << CHAR(PRINTNAME(CADR(nodeSEXP))) << ")'");
       pSymbolsCheckedForMissingness->insert(CHAR(PRINTNAME(CADR(nodeSEXP))));
    }
    return false;
@@ -1057,7 +1061,10 @@ bool addSymbols(
       std::set<const char*>* pSymbolsUsed)
 {
    if (TYPEOF(nodeSEXP) == SYMSXP)
+   {
+      DEBUG("Reporting symbol '" << CHAR(PRINTNAME(nodeSEXP)) << "' as used");
       pSymbolsUsed->insert(CHAR(PRINTNAME(nodeSEXP)));
+   }
    return false;
 }
 
@@ -1201,7 +1208,7 @@ core::Error extractFormals(
       FormalInformation formalInfo(CHAR(PRINTNAME(TAG(formals))));
       if (extractDefaultArguments)
       {
-         if (CAR(formals) == R_MissingArg)
+         if (CAR(formals) != R_MissingArg)
          {
             formalInfo.defaultValue = 
                   boost::optional<std::string>(CHAR(STRING_ELT(defaultValues, index)));

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -437,23 +437,18 @@ public:
       return formals_;
    }
    
-   const std::vector<FormalInformation>& formals() const
-   {
-      return formals_;
-   }
-   
-   const std::vector<std::string>& getFormalNames() const
+   std::vector<std::string>& getFormalNames()
    {
       return formalNames_;
    }
    
-   const boost::optional<std::string>& defaultValueForFormal(
+   boost::optional<std::string>& defaultValueForFormal(
          const std::string& formalName)
    {
       return infoForFormal(formalName).defaultValue;
    }
    
-   const FormalInformation& infoForFormal(const std::string& formalName) const
+   FormalInformation& infoForFormal(const std::string& formalName)
    {
       std::size_t n = formals_.size();
       for (std::size_t i = 0; i < n; ++i)

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -33,6 +33,7 @@
 #include <boost/logic/tribool.hpp>
 
 #include <core/Error.hpp>
+#include <core/Log.hpp>
 #include <core/json/Json.hpp>
 
 #include <r/RErrorCategory.hpp>
@@ -459,6 +460,7 @@ public:
          if (formals_[i].name == formalName)
             return formals_[i];
       
+      LOG_WARNING_MESSAGE("No such formal '" + formalName + "'");
       return noSuchFormal_;
    }
    

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -384,10 +384,6 @@ private:
       {
          while (nodeSEXP != R_NilValue)
          {
-            for (std::size_t i = 0; i < n; ++i)
-               if (operations[i](CAR(nodeSEXP)))
-                  return;
-            
             runImpl(CAR(nodeSEXP), operations, n);
             nodeSEXP = CDR(nodeSEXP);
          }

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -137,6 +137,7 @@ SEXP create(const std::set<std::string>& value, Protect* pProtect);
 SEXP create(const core::json::Array& value, Protect* pProtect);
 SEXP create(const core::json::Object& value, Protect* pProtect);
 SEXP create(const ListBuilder& builder, Protect* pProtect);
+SEXP create(const std::map<std::string, std::string>& value, Protect* pProtect);
 
 // Create a named list
 SEXP createList(const std::vector<std::string>& names, Protect* pProtect);
@@ -342,8 +343,8 @@ core::Error objects(SEXP environment,
 core::Error getNamespaceExports(SEXP ns,
                                 std::vector<std::string>* pNames);
 
-core::Error extractFormalNames(SEXP functionSEXP,
-                               std::vector<std::string>* pNames);
+core::Error extractFormals(SEXP functionSEXP,
+                           std::map<std::string, std::string>* pFormals);
 
 const std::set<std::string>& nsePrimitives();
 

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -450,7 +450,7 @@
          )
       )
       
-      object <- if (!(length(evaled)) && length(output))
+      object <- if (length(output))
          output
       else
          evaled

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -562,7 +562,7 @@
 
 .rs.addFunction("selectIsSubsequence", function(strings, string)
 {
-   .subset(strings, .rs.isSubsequence(strings))
+   .subset(strings, .rs.isSubsequence(strings, string))
 })
 
 .rs.addFunction("escapeForRegex", function(regex)

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1244,3 +1244,7 @@
    
    object
 })
+
+.rs.addFunction("makePrimitiveWrapper", function(x) {
+   wrapper <- eval(parse(text = capture.output(x)), envir = parent.frame(1))
+})

--- a/src/cpp/session/modules/SessionLinter.cpp
+++ b/src/cpp/session/modules/SessionLinter.cpp
@@ -526,7 +526,7 @@ SEXP rs_lintRFile(SEXP filePathSEXP)
    }
    
    std::string rCode;
-   Error error = core::readStringFromFile(filePath, &rCode);
+   error = core::readStringFromFile(filePath, &rCode);
    if (error)
    {
       LOG_ERROR(error);

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -21,6 +21,7 @@
 // simple accessors (which we know will not longjmp)
 #define R_INTERNAL_FUNCTIONS
 
+#include <core/Debug.hpp>
 #include <core/Macros.hpp>
 #include <core/algorithm/Set.hpp>
 #include <core/algorithm/Map.hpp>
@@ -923,6 +924,12 @@ public:
       std::vector<std::string> unnamedArguments;
       getNamedUnnamedArguments(cursor, &namedArguments, &unnamedArguments);
       
+      DEBUG_BLOCK("Named, Unnamed Arguments")
+      {
+         LOG_OBJECT(namedArguments);
+         LOG_OBJECT(unnamedArguments);
+      }
+      
       // Generate a matched call -- figure out what underlying call will
       // actually be made. We'll get the set of formals, and match them in
       // the same order that R would.
@@ -1345,6 +1352,8 @@ void validateFunctionCall(RTokenCursor cursor,
       
       std::map<std::string, boost::optional<std::string> >& matchedCall =
             matched.matchedCall();
+      
+      debug::print(matchedCall);
       
       if (!matchedCall[formalName] && !info.missingnessHandled)
       {

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -13,9 +13,8 @@
  *
  */
 
-// #define RSTUDIO_ENABLE_PROFILING
-#define RSTUDIO_ENABLE_DEBUG_MACROS
 #define RSTUDIO_DEBUG_LABEL "parser"
+// #define RSTUDIO_ENABLE_DEBUG_MACROS
 
 // We use a couple internal R functions here; in particular,
 // simple accessors (which we know will not longjmp)
@@ -1353,7 +1352,10 @@ void validateFunctionCall(RTokenCursor cursor,
       std::map<std::string, boost::optional<std::string> >& matchedCall =
             matched.matchedCall();
       
-      debug::print(matchedCall);
+      DEBUG_BLOCK("")
+      {
+         debug::print(matchedCall);
+      }
       
       if (!matchedCall[formalName] && !info.missingnessHandled)
       {

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -183,6 +183,7 @@ SEXP resolveFunctionAtCursor(RTokenCursor cursor,
    
    if (cursor.isSimpleCall())
    {
+      DEBUG("Resolving as 'simple' call");
       std::string symbol = string_utils::strippedOfQuotes(
                cursor.contentAsUtf8());
       
@@ -190,6 +191,7 @@ SEXP resolveFunctionAtCursor(RTokenCursor cursor,
    }
    else if (cursor.isSimpleNamespaceCall())
    {
+      DEBUG("Resolving as 'namespaced' call");
       std::string symbol = string_utils::strippedOfQuotes(
                cursor.contentAsUtf8());
       
@@ -200,6 +202,7 @@ SEXP resolveFunctionAtCursor(RTokenCursor cursor,
    }
    else
    {
+      DEBUG("Resolving as generic evaluation");
       if (pCacheable) *pCacheable = false;
       
       std::string call = string_utils::wideToUtf8(cursor.getCallingString());

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -828,9 +828,10 @@ bool extractFormalsFromFunctionDefinition(
    while (cursor.isType(RToken::ID))
       extractFormal(cursor, pInfo);
    
-   // TODO: Extract body information as well.
+   // TODO: Extract body information as well, so we can figure out
+   // whether a particular formal is used or not.
    
-   return false;
+   return true;
 }
 
 // Extract formals from the underlying object mapped by the symbol, or expression,

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -967,7 +967,10 @@ public:
       
       // Trim
       formalIndices = core::algorithm::set_difference(formalIndices, matchedIndices);
+      userSuppliedArgNames = core::algorithm::set_difference(userSuppliedArgNames, matchedArgNames);
+      
       matchedIndices.clear();
+      matchedArgNames.clear();
       
       /*
        * 2. Identify prefix matches in the set of remaining formals.
@@ -992,7 +995,10 @@ public:
       
       // Trim
       formalIndices = core::algorithm::set_difference(formalIndices, matchedIndices);
+      userSuppliedArgNames = core::algorithm::set_difference(userSuppliedArgNames, matchedArgNames);
+      
       matchedIndices.clear();
+      matchedArgNames.clear();
       
       /*
        * 3. Match other formals positionally.
@@ -1045,7 +1051,18 @@ public:
       call.unmatchedArgNames_ = core::algorithm::set_difference(
                userSuppliedArgNames, matchedArgNames);
       call.info_ = info;
+      
+      applyFixups(cursor, &call);
       return call;
+   }
+   
+   // Fixups for things that we cannot reasonably infer.
+   static void applyFixups(RTokenCursor cursor,
+                           MatchedCall* pCall)
+   {
+      // `old.packages()` delegates the 'method' formal even when missing
+      if (cursor.contentEquals(L"old.packages"))
+         pCall->functionInfo().infoForFormal("method").missingnessHandled = true;
    }
 
    // Accessors
@@ -1074,7 +1091,7 @@ public:
       return unmatchedArgNames_;
    }
    
-   const r::sexp::FunctionInformation& functionInfo() const
+   r::sexp::FunctionInformation& functionInfo()
    {
       return info_;
    }

--- a/src/cpp/session/modules/SessionRTokenCursor.hpp
+++ b/src/cpp/session/modules/SessionRTokenCursor.hpp
@@ -228,7 +228,7 @@ public:
       return currentToken().content();
    }
    
-   std::string contentAsUtf8() const
+   const std::string& contentAsUtf8() const
    {
       return currentToken().contentAsUtf8();
    }

--- a/src/cpp/session/modules/SessionRTokenCursor.hpp
+++ b/src/cpp/session/modules/SessionRTokenCursor.hpp
@@ -152,7 +152,7 @@ public:
    
    const RToken& currentToken() const
    {
-      return rTokens_.at(offset_);
+      return rTokens_.atUnsafe(offset_);
    }
    
    const Position currentPosition() const

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
@@ -181,7 +181,7 @@ public class UIPrefs extends UIPrefsAccessor implements UiPrefsChangedHandler
          // Configure R Linter
          
          enableStyleDiagnostics().setGlobalValue(
-               newUiPrefs.enableBackgroundDiagnostics().getGlobalValue());
+               newUiPrefs.enableStyleDiagnostics().getGlobalValue());
          
          diagnosticsInRFunctionCalls().setGlobalValue(
                newUiPrefs.diagnosticsInRFunctionCalls().getGlobalValue());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetReformatHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetReformatHelper.java
@@ -829,9 +829,14 @@ public class TextEditingTargetReformatHelper
          if (!rootState && cursor.isRightBrace())
             break;
          
-         // Ensure whitespace following 'if'
-         if (cursor.currentValue().equals("if"))
+         // Ensure a single space follows control flow statements
+         if (cursor.currentValue().equals("if") ||
+             cursor.currentValue().equals("for") ||
+             cursor.currentValue().equals("while") ||
+             cursor.currentValue().equals("repeat"))
+         {
             cursor.ensureSingleSpaceFollows();
+         }
          
          // Ensure newlines around 'naked' else
          if (cursor.currentValue().equals("else"))


### PR DESCRIPTION
NOTE: Not quite ready for merge.

This PR encompasses an improved internal `match.call()` that provides information on function calls both in-source and in-session, and allows us to use the results from both.