### PR TITLE
Provide a mechanism for getting project-level diagnostics

### DIFF
--- a/src/cpp/core/include/core/FilePath.hpp
+++ b/src/cpp/core/include/core/FilePath.hpp
@@ -40,6 +40,9 @@ class Error ;
 class FilePath
 {
 public:
+   
+   // NOTE: function returns 'true' if computation can continue;
+   // false if computation should stop
    typedef boost::function<bool(int, const FilePath&)>  
                                                 RecursiveIterationFunction;
 

--- a/src/cpp/core/include/core/r_util/RSourceIndex.hpp
+++ b/src/cpp/core/include/core/r_util/RSourceIndex.hpp
@@ -378,10 +378,6 @@ private:
    // NOTE: All source indexes share a set of completions
    static std::map<std::string, AsyncLibraryCompletions> s_completions_;
    
-   // Cache the links between file paths and the associated source index
-   // for easy lookup
-   static std::map<std::string, std::string> s_absPathToIdMap_;
-   
 };
 
 } // namespace r_util

--- a/src/cpp/core/include/core/r_util/RSourceIndex.hpp
+++ b/src/cpp/core/include/core/r_util/RSourceIndex.hpp
@@ -378,6 +378,10 @@ private:
    // NOTE: All source indexes share a set of completions
    static std::map<std::string, AsyncLibraryCompletions> s_completions_;
    
+   // Cache the links between file paths and the associated source index
+   // for easy lookup
+   static std::map<std::string, std::string> s_absPathToIdMap_;
+   
 };
 
 } // namespace r_util

--- a/src/cpp/core/include/core/r_util/RTokenizer.hpp
+++ b/src/cpp/core/include/core/r_util/RTokenizer.hpp
@@ -511,6 +511,28 @@ inline bool canContinueStatement(const RToken& rToken)
            canOpenArgumentList(rToken);
 }
 
+inline bool isSymbolNamed(const RToken& rToken,
+                          const std::wstring& name)
+{
+   // For strings, check if the content within the quotes
+   // is equal to the name provided. TODO: handle escaped
+   // quotes within
+   if (rToken.isType(RToken::STRING) ||
+       (rToken.isType(RToken::ID) && *rToken.begin() == '`'))
+   {
+      std::size_t distance = std::distance(
+               rToken.begin(), rToken.end());
+      if (distance < 2) return false;
+      return distance - 2 == name.size() &&
+            std::equal(
+               rToken.begin() + 1,
+               rToken.end() - 1,
+               name.begin());
+   }
+   
+   return rToken.contentEquals(name);
+}
+
 } // end namespace token_utils
 
 } // namespace r_util

--- a/src/cpp/core/r_util/RSourceIndex.cpp
+++ b/src/cpp/core/r_util/RSourceIndex.cpp
@@ -33,7 +33,6 @@ std::set<std::string> RSourceIndex::s_allInferredPkgNames_;
 std::set<std::string> RSourceIndex::s_importedPackages_;
 RSourceIndex::ImportFromMap RSourceIndex::s_importFromDirectives_;
 std::map<std::string, AsyncLibraryCompletions> RSourceIndex::s_completions_;
-std::map<std::string, std::string> RSourceIndex::s_absPathToIdMap_;
 
 namespace {
 

--- a/src/cpp/core/r_util/RSourceIndex.cpp
+++ b/src/cpp/core/r_util/RSourceIndex.cpp
@@ -33,6 +33,7 @@ std::set<std::string> RSourceIndex::s_allInferredPkgNames_;
 std::set<std::string> RSourceIndex::s_importedPackages_;
 RSourceIndex::ImportFromMap RSourceIndex::s_importFromDirectives_;
 std::map<std::string, AsyncLibraryCompletions> RSourceIndex::s_completions_;
+std::map<std::string, std::string> RSourceIndex::s_absPathToIdMap_;
 
 namespace {
 

--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -1022,8 +1022,6 @@ std::set<std::string> makeNsePrimitives()
    nsePrimitives.insert("evalq");
    nsePrimitives.insert("subset");
    nsePrimitives.insert("eval.parent");
-   nsePrimitives.insert("::");
-   nsePrimitives.insert(":::");
    return nsePrimitives;
 }
 

--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -1022,6 +1022,8 @@ std::set<std::string> makeNsePrimitives()
    nsePrimitives.insert("evalq");
    nsePrimitives.insert("subset");
    nsePrimitives.insert("eval.parent");
+   nsePrimitives.insert("::");
+   nsePrimitives.insert(":::");
    return nsePrimitives;
 }
 
@@ -1034,7 +1036,7 @@ const std::set<std::string>& nsePrimitives()
 // NOTE: returns 'false' to signal item found; 'true' to signal item
 // not found
 bool isCallToNSEFunction(SEXP node,
-                         std::set<std::string>* pNsePrimitives,
+                         const std::set<std::string>* pNsePrimitives,
                          bool* pResult)
 {
    if (TYPEOF(node) != LANGSXP)
@@ -1058,7 +1060,7 @@ bool isCallToNSEFunction(SEXP node,
 bool maybePerformsNSEImpl(SEXP node,
                           const std::set<std::string>& nsePrimitives)
 {
-   r::sexp::CallRecurser recurser;
+   r::sexp::CallRecurser recurser(node);
    bool result = false;
    recurser.add(boost::bind(isCallToNSEFunction, _1, &nsePrimitives, &result));
    recurser.run();

--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -171,6 +171,47 @@ bool fillSetString(SEXP object, std::set<std::string>* pSet)
    return true;
 }
 
+SEXP asEnvironment(std::string name)
+{
+   if (name == "base")
+      return R_BaseEnv;
+   
+   name = "package:" + name;
+   
+   SEXP envSEXP = ENCLOS(R_GlobalEnv);
+   while (envSEXP != R_EmptyEnv)
+   {
+      SEXP nameSEXP = Rf_getAttrib(envSEXP, R_NameSymbol);
+      if (TYPEOF(nameSEXP) == STRSXP &&
+          name == CHAR(STRING_ELT(nameSEXP, 0)))
+      {
+         return envSEXP;
+      }
+      envSEXP = ENCLOS(envSEXP);
+   }
+   
+   LOG_ERROR_MESSAGE("No environment named '" + name + "' on search path");
+   return envSEXP;
+}
+
+namespace {
+
+bool ensureNamespaceLoaded(const std::string& ns)
+{
+   if (ns.empty()) return false;
+   SEXP nsSEXP = findNamespace(ns);
+   if (nsSEXP == R_UnboundValue)
+   {
+      r::exec::RFunction loadNamespace("base:::loadNamespace");
+      loadNamespace.addParam(ns);
+      Error error = loadNamespace.call();
+      if (error) return false;
+   }
+   return true;
+}
+
+} // anonymous namespace
+
 std::vector<std::string> getLoadedNamespaces()
 {
    std::vector<std::string> result;
@@ -179,6 +220,14 @@ std::vector<std::string> getLoadedNamespaces()
    if (error)
       LOG_ERROR(error);
    return result;
+}
+
+SEXP asNamespace(const std::string& name)
+{
+   if (!ensureNamespaceLoaded(name))
+      return R_EmptyEnv;
+   
+   return findNamespace(name);
 }
 
 SEXP findNamespace(const std::string& name)
@@ -251,23 +300,6 @@ SEXP findVar(const std::string &name, const SEXP env)
    return Rf_findVar(Rf_install(name.c_str()), env);
 }
 
-namespace {
-
-void ensureNamespaceLoaded(const std::string& ns)
-{
-   if (ns.empty()) return;
-   SEXP nsSEXP = findNamespace(ns);
-   if (nsSEXP == R_UnboundValue)
-   {
-      r::exec::RFunction loadNamespace("base:::loadNamespace");
-      loadNamespace.addParam(ns);
-      Error error = loadNamespace.call();
-      if (error)
-         LOG_ERROR(error);
-   }
-}
-
-} // anonymous namespace
 
 
 SEXP findVar(const std::string& name, const std::string& ns)
@@ -275,7 +307,9 @@ SEXP findVar(const std::string& name, const std::string& ns)
    if (name.empty())
       return R_UnboundValue;
    
-   ensureNamespaceLoaded(ns);
+   if (!ensureNamespaceLoaded(ns))
+      return R_UnboundValue;
+   
    SEXP env = ns.empty() ? R_GlobalEnv : findNamespace(ns);
    
    return findVar(name, env);

--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -1033,26 +1033,23 @@ const std::set<std::string>& nsePrimitives()
    return set;
 }
 
-// NOTE: returns 'false' to signal item found; 'true' to signal item
-// not found
 bool isCallToNSEFunction(SEXP node,
-                         const std::set<std::string>* pNsePrimitives,
+                         const std::set<std::string>& nsePrimitives,
                          bool* pResult)
 {
    if (TYPEOF(node) != LANGSXP)
-      return true;
+      return false;
    
-   SEXP head = CAR(node);
-   while (TYPEOF(head) == LANGSXP)
-      head = CAR(head);
+   while (TYPEOF(node) == LANGSXP)
+      node = CAR(node);
    
-   if (TYPEOF(head) == SYMSXP && pNsePrimitives->count(CHAR(PRINTNAME(head))))
+   if (TYPEOF(node) == SYMSXP && nsePrimitives.count(CHAR(PRINTNAME(node))))
    {
       *pResult = true;
-      return false;
+      return true;
    }
    
-   return true;
+   return false;
    
 }
 
@@ -1062,7 +1059,8 @@ bool maybePerformsNSEImpl(SEXP node,
 {
    r::sexp::CallRecurser recurser(node);
    bool result = false;
-   recurser.add(boost::bind(isCallToNSEFunction, _1, &nsePrimitives, &result));
+   recurser.add(boost::bind(
+                   isCallToNSEFunction, _1, boost::cref(nsePrimitives), &result));
    recurser.run();
    return result;
 }

--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -1031,6 +1031,8 @@ const std::set<std::string>& nsePrimitives()
    return set;
 }
 
+// NOTE: returns 'false' to signal item found; 'true' to signal item
+// not found
 bool isCallToNSEFunction(SEXP node,
                          std::set<std::string>* pNsePrimitives,
                          bool* pResult)

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -52,8 +52,10 @@ class ListBuilder;
 class Protect;
    
 // environments and namespaces
+SEXP asEnvironment(std::string name);
 std::vector<std::string> getLoadedNamespaces();
 SEXP findNamespace(const std::string& name);
+SEXP asNamespace(const std::string& name);
    
 // variables within an environment
 typedef std::pair<std::string,SEXP> Variable ;

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -925,9 +925,26 @@ void RSourceIndexes::update(
             pDoc->path()).absolutePath();
    
    pathToIdMap_[absPath] = pDoc->id();
+   idToPathMap_[pDoc->id()] = absPath;
 
    // kick off an update if necessary
    r_completions::AsyncRCompletions::update();
+}
+
+void RSourceIndexes::remove(const std::string& id)
+{
+   std::string absPath = idToPathMap_[id];
+   
+   indexes_.erase(id);
+   pathToIdMap_.erase(absPath);
+   idToPathMap_.erase(id);
+}
+
+void RSourceIndexes::removeAll()
+{
+   indexes_.clear();
+   pathToIdMap_.clear();
+   idToPathMap_.clear();
 }
 
 RSourceIndexes& rSourceIndex()

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -919,6 +919,12 @@ void RSourceIndexes::update(
 
    // insert it
    indexes_[pDoc->id()] = pIndex;
+   
+   // cache a link between the document path and the id
+   std::string absPath = module_context::resolveAliasedPath(
+            pDoc->path()).absolutePath();
+   
+   pathToIdMap_[absPath] = pDoc->id();
 
    // kick off an update if necessary
    r_completions::AsyncRCompletions::update();

--- a/src/cpp/session/modules/SessionCodeSearch.hpp
+++ b/src/cpp/session/modules/SessionCodeSearch.hpp
@@ -69,9 +69,8 @@ public:
       return get(id);
    }
 
-   void remove(const std::string& id) { indexes_.erase(id); }
-
-   void removeAll() { indexes_.clear(); }
+   void remove(const std::string& id);
+   void removeAll();
 
    std::vector< boost::shared_ptr<RSourceIndex> > indexes()
    {
@@ -91,6 +90,7 @@ public:
 private:
   IndexMap indexes_;
   std::map<AbsolutePath, DocumentId> pathToIdMap_;
+  std::map<DocumentId, AbsolutePath> idToPathMap_;
   
 };
 

--- a/src/cpp/session/modules/SessionCodeSearch.hpp
+++ b/src/cpp/session/modules/SessionCodeSearch.hpp
@@ -42,7 +42,11 @@ private:
    
 public:
    
-  typedef std::map< std::string, boost::shared_ptr<RSourceIndex> > IndexMap;
+   typedef std::string DocumentId;
+   typedef std::string AbsolutePath;
+   
+   // maps document id (as string) to associated index
+   typedef std::map< DocumentId, boost::shared_ptr<RSourceIndex> > IndexMap;
    
    RSourceIndexes() {}
    virtual ~RSourceIndexes() {}
@@ -56,6 +60,13 @@ public:
       if (indexes_.find(id) != indexes_.end())
          return indexes_[id];
       return boost::shared_ptr<RSourceIndex>();
+   }
+   
+   boost::shared_ptr<RSourceIndex> get(const core::FilePath& filePath)
+   {
+      const std::string& id = pathToIdMap_[filePath.absolutePath()];
+      if (id.empty()) return boost::shared_ptr<RSourceIndex>();
+      return get(id);
    }
 
    void remove(const std::string& id) { indexes_.erase(id); }
@@ -79,6 +90,8 @@ public:
 
 private:
   IndexMap indexes_;
+  std::map<AbsolutePath, DocumentId> pathToIdMap_;
+  
 };
 
 RSourceIndexes& rSourceIndex();

--- a/src/cpp/session/modules/SessionLinter.R
+++ b/src/cpp/session/modules/SessionLinter.R
@@ -139,12 +139,12 @@
    .rs.scalar(paste(new, collapse = "\n"))
 })
 
-.rs.addFunction("lintProject", function()
+.rs.addFunction("lintDirectory", function(directory = .rs.getProjectDirectory())
 {
-   .Call(.rs.routines$rs_lintProject)
+   .Call(.rs.routines$rs_lintDirectory, directory)
 })
 
-.rs.addJsonRpcHandler("analyze_project", function()
+.rs.addJsonRpcHandler("analyze_project", function(directory = .rs.getProjectDirectory())
 {
-   .rs.lintProject()
+   .rs.lintDirectory(directory)
 })

--- a/src/cpp/session/modules/SessionLinter.R
+++ b/src/cpp/session/modules/SessionLinter.R
@@ -138,3 +138,8 @@
    
    .rs.scalar(paste(new, collapse = "\n"))
 })
+
+.rs.addFunction("lintProject", function()
+{
+   .Call(.rs.routines$rs_lintProject)
+})

--- a/src/cpp/session/modules/SessionLinter.R
+++ b/src/cpp/session/modules/SessionLinter.R
@@ -143,3 +143,8 @@
 {
    .Call(.rs.routines$rs_lintProject)
 })
+
+.rs.addJsonRpcHandler("analyze_project", function()
+{
+   .rs.lintProject()
+})

--- a/src/cpp/session/modules/SessionLinter.cpp
+++ b/src/cpp/session/modules/SessionLinter.cpp
@@ -98,25 +98,11 @@ void addInferredSymbols(const FilePath& filePath,
    boost::shared_ptr<RSourceIndex> index =
          rSourceIndex().get(documentId);
    
-   // If that failed for some reason, just re-read and re-parse
-   // the document from that file path
+   // If we were unable to get the R source index for
+   // some reason, try re-resolving the documentId based
+   // on the file path
    if (!index)
-   {
-      LOG_WARNING_MESSAGE("Failed to locate document with id '" + documentId + "'");
-      // Get the source index associated with this filepath.
-      // We have to round trip to map this filePath to a source
-      // document, grab that ID, and then get the index.
-      boost::shared_ptr<SourceDocument> pDoc(new SourceDocument());
-      Error error = source_database::get(filePath.filename(), pDoc);
-      if (error)
-      {
-         LOG_ERROR(error);
-         return;
-      }
-
-      const std::string& id = pDoc->id();
-      index = rSourceIndex().get(id);
-   }
+      index = rSourceIndex().get(filePath);
    
    // If we still don't have an index, bail
    if (!index)

--- a/src/cpp/session/modules/SessionLinter.cpp
+++ b/src/cpp/session/modules/SessionLinter.cpp
@@ -290,7 +290,7 @@ Error getAllAvailableRSymbols(const FilePath& filePath,
       registry.fillExportedSymbols("testthat", pSymbols);
    }
    
-   return Success();
+   return error;
       
 }
 

--- a/src/cpp/session/modules/SessionLinter.cpp
+++ b/src/cpp/session/modules/SessionLinter.cpp
@@ -834,9 +834,9 @@ SEXP rs_lintProject()
    if (!projects::projectContext().hasProject())
       return R_NilValue;
    
-   FilePath buildPath = projects::projectContext().buildTargetPath();
+   FilePath projDir = projects::projectContext().directory();
    std::map<FilePath, LintItems> lint;
-   Error error = buildPath.childrenRecursive(
+   Error error = projDir.childrenRecursive(
             boost::bind(collectLint, _1, _2, &lint));
    if (error)
    {

--- a/src/cpp/session/modules/SessionLinter.cpp
+++ b/src/cpp/session/modules/SessionLinter.cpp
@@ -844,14 +844,15 @@ bool collectLint(int depth,
    return true;
 }
 
-SEXP rs_lintProject()
+SEXP rs_lintDirectory(SEXP directorySEXP)
 {
-   if (!projects::projectContext().hasProject())
+   std::string directory = r::sexp::asString(directorySEXP);
+   FilePath dirPath = module_context::resolveAliasedPath(directory);
+   if (!dirPath.exists())
       return R_NilValue;
    
-   FilePath projDir = projects::projectContext().directory();
    std::map<FilePath, LintItems> lint;
-   Error error = projDir.childrenRecursive(
+   Error error = dirPath.childrenRecursive(
             boost::bind(collectLint, _1, _2, &lint));
    if (error)
    {
@@ -881,7 +882,7 @@ core::Error initialize()
    projects::projectContext().subscribeToFileMonitor("Diagnostics", cb);
    
    RS_REGISTER_CALL_METHOD(rs_lintRFile, 1);
-   RS_REGISTER_CALL_METHOD(rs_lintProject, 0);
+   RS_REGISTER_CALL_METHOD(rs_lintDirectory, 1);
    
    ExecBlock initBlock;
    initBlock.addFunctions()

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -754,9 +754,20 @@ assign(x = ".rs.acCompletionTypes",
       objectNames <- if (exportsOnly)
          getNamespaceExports(namespace)
       else
-         objects(namespace, all.names = TRUE)
+      {
+         # Take advantage of 'sorted' argument if 
+         # available -- we only want to sort a filtered
+         # subset
+         arguments <- list()
+         arguments[["name"]] <- namespace
+         arguments[["all.names"]] <- TRUE
+         if ("sorted" %in% names(formals(objects)))
+            arguments[["sorted"]] <- FALSE
+         
+         do.call(objects, arguments)
+      }
       
-      completions <- .rs.selectFuzzyMatches(objectNames, token)
+      completions <- sort(.rs.selectFuzzyMatches(objectNames, token))
       objects <- mget(completions, envir = namespace, inherits = TRUE)
       type <- vapply(objects, FUN.VALUE = numeric(1), USE.NAMES = FALSE, .rs.getCompletionType)
       

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -150,6 +150,12 @@ public:
    
 private:
    
+   void addNseFunction(const std::string& name,
+                       const std::string& ns)
+   {
+      add(r::sexp::findFunction(name, ns), true);
+   }
+   
    uintptr_t address(SEXP objectSEXP)
    {
       return reinterpret_cast<uintptr_t>(objectSEXP);

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -311,6 +311,10 @@ bool mightPerformNonstandardEvaluation(const RTokenCursor& origin,
             return true;
    }
    
+   // Handle some special cases first.
+   if (isSymbolNamed(cursor, L"::") || isSymbolNamed(cursor, L":::"))
+      return true;
+   
    bool cacheable = true;
    r::sexp::Protect protect;
    SEXP symbolSEXP = resolveFunctionAtCursor(cursor, &protect, &cacheable);
@@ -1236,6 +1240,11 @@ public:
    CustomFunctionValidators()
    {
       // initialize our own custom validators here?
+   }
+   
+   void add(const std::wstring& symbol, Validator validator)
+   {
+      database_[symbol].push_back(validator);
    }
    
    bool applyValidators(RTokenCursor cursor,

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -1064,8 +1064,12 @@ public:
                            MatchedCall* pCall)
    {
       // `old.packages()` delegates the 'method' formal even when missing
-      if (cursor.contentEquals(L"old.packages"))
+      // same with `available.packages()`
+      if (cursor.contentEquals(L"old.packages") ||
+          cursor.contentEquals(L"available.packages"))
+      {
          pCall->functionInfo().infoForFormal("method").missingnessHandled = true;
+      }
    }
 
    // Accessors

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -124,6 +124,10 @@ public:
    
    NSEDatabase()
    {
+      BOOST_FOREACH(const std::string& name, r::sexp::nsePrimitives())
+      {
+         addNseFunction(name, "base");
+      }
    }
    
    void add(SEXP symbolSEXP, bool performsNse)

--- a/src/cpp/session/modules/SessionRParser.hpp
+++ b/src/cpp/session/modules/SessionRParser.hpp
@@ -362,6 +362,12 @@ public:
       lintItems_.push_back(item);
    }
    
+   void push_back(const LintItems& items)
+   {
+      for (std::size_t i = 0, n = items.size(); i < n; ++i)
+         lintItems_.push_back(items.get()[i]);
+   }
+   
    typedef std::vector<LintItem>::iterator iterator;
    typedef std::vector<LintItem>::const_iterator const_iterator;
    

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -289,7 +289,7 @@ public class TextFileType extends EditableFileType
       if (canExecuteCode() || isC())
       {
          results.add(commands.reindent());
-         results.add(commands.lintActiveDocument());
+         results.add(commands.showDiagnosticsActiveDocument());
       }
       if (canExecuteCode()) {
          results.add(commands.executeCode());

--- a/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
@@ -763,7 +763,7 @@ public class Projects implements OpenProjectFileHandler,
    }
    
    @Handler
-   public void onAnalyzeProject()
+   public void onShowDiagnosticsProject()
    {
       projServer_.analyzeProject(new ServerRequestCallback<Void>()
       {

--- a/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
@@ -766,7 +766,7 @@ public class Projects implements OpenProjectFileHandler,
    public void onShowDiagnosticsProject()
    {
       final ProgressIndicator indicator = globalDisplay_.getProgressIndicator("Lint");
-      indicator.onProgress("Linting...");
+      indicator.onProgress("Analyzing project sources...");
       projServer_.analyzeProject(new ServerRequestCallback<Void>()
       {
          @Override

--- a/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
@@ -765,12 +765,21 @@ public class Projects implements OpenProjectFileHandler,
    @Handler
    public void onShowDiagnosticsProject()
    {
+      final ProgressIndicator indicator = globalDisplay_.getProgressIndicator("Lint");
+      indicator.onProgress("Linting...");
       projServer_.analyzeProject(new ServerRequestCallback<Void>()
       {
+         @Override
+         public void onResponseReceived(Void response)
+         {
+            indicator.onCompleted();
+         }
+         
          @Override
          public void onError(ServerError error)
          {
             Debug.logError(error);
+            indicator.onCompleted();
          }
       });
    }

--- a/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
@@ -762,6 +762,19 @@ public class Projects implements OpenProjectFileHandler,
          onCompleted);  
    }
    
+   @Handler
+   public void onAnalyzeProject()
+   {
+      projServer_.analyzeProject(new ServerRequestCallback<Void>()
+      {
+         @Override
+         public void onError(ServerError error)
+         {
+            Debug.logError(error);
+         }
+      });
+   }
+   
    private final Provider<ProjectMRUList> pMRUList_;
    private final ApplicationQuit applicationQuit_;
    private final ProjectsServerOperations projServer_;

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/ProjectsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/ProjectsServerOperations.java
@@ -45,4 +45,6 @@ public interface ProjectsServerOperations extends PrefsServerOperations,
    
    void writeProjectVcsOptions(RProjectVcsOptions options,
                                ServerRequestCallback<Void> callback);
+   
+   void analyzeProject(ServerRequestCallback<Void> callback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -3985,6 +3985,12 @@ public class RemoteServer implements Server
    }
    
    @Override
+   public void analyzeProject(ServerRequestCallback<Void> requestCallback)
+   {
+      sendRequest(RPC_SCOPE, ANALYZE_PROJECT, requestCallback);
+   }
+   
+   @Override
    public void getSetClassCall(String call,
                                ServerRequestCallback<SetClassCall> requestCallback)
    {
@@ -4352,6 +4358,7 @@ public class RemoteServer implements Server
    private static final String GET_PENDING_ACTIONS = "get_pending_actions";
    
    private static final String LINT_R_SOURCE_DOCUMENT = "lint_r_source_document";
+   private static final String ANALYZE_PROJECT = "analyze_project";
    
    private static final String GET_SET_CLASS_CALL = "get_set_class_slots";
    private static final String GET_SET_GENERIC_CALL = "get_set_generic_call";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -158,7 +158,10 @@ well as menu structures (for main menu and popup menus).
          <separator/>
          <cmd refid="reindent"/>
          <cmd refid="reformatCode"/>
-         <cmd refid="lintActiveDocument"/>
+         <menu label="Diagnostics">
+            <cmd refid="lintActiveDocument"/>
+            <cmd refid="analyzeProject"/>
+         </menu>
          <separator/>
          <cmd refid="executeCode"/>
          <cmd refid="executeLastCode"/>
@@ -902,6 +905,9 @@ well as menu structures (for main menu and popup menus).
    <cmd id="lintActiveDocument"
         menuLabel="Show _Diagnostics"
         desc="Show diagnostics for the active document"/>
+   <cmd id="analyzeProject"
+        menuLabel="_Analyze Project"
+        desc="Identify errors in the current project"/>
    <cmd id="reindent"
         menuLabel="_Reindent Lines"
         desc="Reindent the current line/selection"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -158,10 +158,9 @@ well as menu structures (for main menu and popup menus).
          <separator/>
          <cmd refid="reindent"/>
          <cmd refid="reformatCode"/>
-         <menu label="Diagnostics">
-            <cmd refid="lintActiveDocument"/>
-            <cmd refid="analyzeProject"/>
-         </menu>
+         <separator/>
+         <cmd refid="showDiagnosticsActiveDocument"/>
+         <cmd refid="showDiagnosticsProject"/>
          <separator/>
          <cmd refid="executeCode"/>
          <cmd refid="executeLastCode"/>
@@ -395,7 +394,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="reflowComment" value="Cmd+Shift+/" if="!(org.rstudio.core.client.BrowseCap.isMacintosh() &amp;&amp; org.rstudio.core.client.BrowseCap.isChrome())"/>
          <shortcut refid="reflowComment" value="Cmd+Alt+Shift+/" if="org.rstudio.core.client.BrowseCap.isMacintosh() &amp;&amp; org.rstudio.core.client.BrowseCap.isChrome()"/>
          <shortcut refid="reformatCode" value="Cmd+Shift+A"/>
-         <shortcut refid="lintActiveDocument" value="Cmd+Shift+Alt+P"/>
+         <shortcut refid="showDiagnosticsProject" value="Cmd+Shift+Alt+P"/>
          <shortcut refid="fold" value="Alt+L" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" title="Collapse Fold"/>
          <shortcut refid="fold" value="Cmd+Alt+L" if="org.rstudio.core.client.BrowseCap.isMacintosh()" title="Collapse Fold"/>
          <shortcut refid="unfold" value="Shift+Alt+L" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" title="Expand Fold"/>
@@ -902,12 +901,12 @@ well as menu structures (for main menu and popup menus).
    <cmd id="reformatCode"
         menuLabel="Re_format Code"
         desc="Reformat the current line/selection"/>
-   <cmd id="lintActiveDocument"
+   <cmd id="showDiagnosticsActiveDocument"
         menuLabel="Show _Diagnostics"
         desc="Show diagnostics for the active document"/>
-   <cmd id="analyzeProject"
-        menuLabel="_Analyze Project"
-        desc="Identify errors in the current project"/>
+   <cmd id="showDiagnosticsProject"
+        menuLabel="Show _Diagnostics (Project)"
+        desc="Show diagnostics for all source files in the current project"/>
    <cmd id="reindent"
         menuLabel="_Reindent Lines"
         desc="Reindent the current line/selection"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -367,8 +367,8 @@ public abstract class
    public abstract AppCommand errorsMessage();
    public abstract AppCommand errorsTraceback();
    public abstract AppCommand errorsBreak();
-   public abstract AppCommand lintActiveDocument();
-   public abstract AppCommand analyzeProject();
+   public abstract AppCommand showDiagnosticsActiveDocument();
+   public abstract AppCommand showDiagnosticsProject();
    
    // Shiny IDE features
    public abstract AppCommand reloadShinyApp();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -368,6 +368,7 @@ public abstract class
    public abstract AppCommand errorsTraceback();
    public abstract AppCommand errorsBreak();
    public abstract AppCommand lintActiveDocument();
+   public abstract AppCommand analyzeProject();
    
    // Shiny IDE features
    public abstract AppCommand reloadShinyApp();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -285,7 +285,7 @@ public class Source implements InsertSourceHandler,
       dynamicCommands_.add(commands.vcsBlameOnGitHub());
       dynamicCommands_.add(commands.editRmdFormatOptions());
       dynamicCommands_.add(commands.reformatCode());
-      dynamicCommands_.add(commands.lintActiveDocument());
+      dynamicCommands_.add(commands.showDiagnosticsActiveDocument());
       dynamicCommands_.add(commands.insertRoxygenSkeleton());
       for (AppCommand command : dynamicCommands_)
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2071,7 +2071,7 @@ public class TextEditingTarget implements
    }
    
    @Handler
-   void onLintActiveDocument()
+   void onShowDiagnosticsActiveDocument()
    {
       lintManager_.lint(true, false);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -294,6 +294,7 @@ public class TextEditingTargetWidget
          menu.addItem(commands_.reindent().createMenuItem(false));
          menu.addItem(commands_.reformatCode().createMenuItem(false));
          menu.addItem(commands_.lintActiveDocument().createMenuItem(false));
+         menu.addItem(commands_.analyzeProject().createMenuItem(false));
          codeTransform_ = new ToolbarButton("", icon, menu);
          codeTransform_.setTitle("Code Tools");
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -293,6 +293,7 @@ public class TextEditingTargetWidget
          menu.addSeparator();
          menu.addItem(commands_.reindent().createMenuItem(false));
          menu.addItem(commands_.reformatCode().createMenuItem(false));
+         menu.addSeparator();
          menu.addItem(commands_.showDiagnosticsActiveDocument().createMenuItem(false));
          menu.addItem(commands_.showDiagnosticsProject().createMenuItem(false));
          codeTransform_ = new ToolbarButton("", icon, menu);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -293,8 +293,8 @@ public class TextEditingTargetWidget
          menu.addSeparator();
          menu.addItem(commands_.reindent().createMenuItem(false));
          menu.addItem(commands_.reformatCode().createMenuItem(false));
-         menu.addItem(commands_.lintActiveDocument().createMenuItem(false));
-         menu.addItem(commands_.analyzeProject().createMenuItem(false));
+         menu.addItem(commands_.showDiagnosticsActiveDocument().createMenuItem(false));
+         menu.addItem(commands_.showDiagnosticsProject().createMenuItem(false));
          codeTransform_ = new ToolbarButton("", icon, menu);
          codeTransform_.setTitle("Code Tools");
       }


### PR DESCRIPTION
This PR provides `.rs.lintProject()` as an (internal) entry-point for linting all R files within a package and displaying the source marker output. For example, here's what I see on linting `packrat`:

![screen shot 2015-04-06 at 4 18 04 pm](https://cloud.githubusercontent.com/assets/1976582/7014334/88d28476-dc78-11e4-8f22-90b9fd784b5e.png)

I think this is the 'minimal' bit of work we should put in for project linting (we may want to wire up a button somewhere to perform this action as well; perhaps in the `Build` tools or something to that effect)