### PR TITLE
safely get function body

### DIFF
--- a/src/cpp/r/include/r/RInternal.hpp
+++ b/src/cpp/r/include/r/RInternal.hpp
@@ -42,9 +42,16 @@
 #define R_NO_REMAP
 #include <Rinternals.h>
 
+// Hide macros that are always unsafe for us to use, because their
+// interface has changed between versions of R
+#undef BODY_EXPR
+#define BODY_EXPR UNSAFE_R_FUNCTION
+
+#undef PREXPR
+#define PREXPR    UNSAFE_R_FUNCTION
+
 #ifndef R_INTERNAL_FUNCTIONS
 
-// force compiler error if the client tries to call an R internal function
 // force compiler error if the client tries to call an R internal function
 #define Rf_asChar INTERNAL_R_FUNCTION
 #define Rf_coerceVector INTERNAL_R_FUNCTION

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -81,12 +81,14 @@ bool setNames(SEXP sexp, const std::vector<std::string>& names);
 core::Error getNames(SEXP sexp, std::vector<std::string>* pNames);  
 bool isActiveBinding(const std::string&, const SEXP);
 
+// function introspection
+SEXP functionBody(SEXP functionSEXP);
+
 // type checking
 bool isString(SEXP object);
 bool isLanguage(SEXP object);
 bool isMatrix(SEXP object);
 bool isDataFrame(SEXP object);   
-     
 bool isNull(SEXP object);
 
 // type coercions


### PR DESCRIPTION
This PR avoids using the `BODY_EXPR` macro, and instead goes through R to get the function body.
