### PR TITLE
Ensure 'defined but not used' warnings only displayed on 'explicit' actions

### DIFF
--- a/src/cpp/session/modules/SessionDiagnostics.cpp
+++ b/src/cpp/session/modules/SessionDiagnostics.cpp
@@ -599,10 +599,12 @@ Error lintRSourceDocument(const json::JsonRpcRequest& request,
    std::string documentId;
    std::string documentPath;
    bool showMarkersTab = false;
+   bool isExplicit = false;
    Error error = json::readParams(request.params,
                                   &documentId,
                                   &documentPath,
-                                  &showMarkersTab);
+                                  &showMarkersTab,
+                                  &isExplicit);
    
    if (error)
    {
@@ -658,7 +660,7 @@ Error lintRSourceDocument(const json::JsonRpcRequest& request,
             string_utils::utf8ToWide(content),
             origin,
             documentId,
-            showMarkersTab);
+            isExplicit);
    
    pResponse->setResult(lintAsJson(results.lint()));
    

--- a/src/cpp/session/modules/SessionDiagnostics.cpp
+++ b/src/cpp/session/modules/SessionDiagnostics.cpp
@@ -446,7 +446,8 @@ void checkNoDefinitionInScope(const FilePath& origin,
 
 ParseResults parse(const std::wstring& rCode,
                    const FilePath& origin,
-                   const std::string& documentId = std::string())
+                   const std::string& documentId = std::string(),
+                   bool isExplicit = false)
 {
    ParseResults results;
    
@@ -459,7 +460,7 @@ ParseResults parse(const std::wstring& rCode,
             userSettings().checkArgumentsToRFunctionCalls());
    
    options.setWarnIfVariableIsDefinedButNotUsed(
-            userSettings().warnIfVariableDefinedButNotUsed());
+            isExplicit && userSettings().warnIfVariableDefinedButNotUsed());
    
    options.setWarnIfNoSuchVariableInScope(
             userSettings().warnIfNoSuchVariableInScope());
@@ -653,7 +654,11 @@ Error lintRSourceDocument(const json::JsonRpcRequest& request,
       return error;
    }
    
-   ParseResults results = parse(content, origin, documentId);
+   ParseResults results = diagnostics::parse(
+            string_utils::utf8ToWide(content),
+            origin,
+            documentId,
+            showMarkersTab);
    
    pResponse->setResult(lintAsJson(results.lint()));
    
@@ -819,7 +824,9 @@ bool collectLint(int depth,
    
    ParseResults results = diagnostics::parse(
             string_utils::utf8ToWide(contents),
-            path);
+            path,
+            std::string(),
+            true);
    
    (*pLint)[path] = results.lint();
    return true;

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -3975,12 +3975,14 @@ public class RemoteServer implements Server
    public void lintRSourceDocument(String documentId,
                                    String documentPath,
                                    boolean showMarkersPane,
+                                   boolean explicit,
                                    ServerRequestCallback<JsArray<LintItem>> requestCallback)
    {
       JSONArray params = new JSONArray();
       params.set(0, new JSONString(documentId));
       params.set(1, new JSONString(documentPath));
       params.set(2, JSONBoolean.getInstance(showMarkersPane));
+      params.set(3, JSONBoolean.getInstance(explicit));
       sendRequest(RPC_SCOPE, LINT_R_SOURCE_DOCUMENT, params, requestCallback);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
@@ -51,23 +51,27 @@ public class LintManager
       public LintContext(Invalidation.Token token,
                          Position cursorPosition,
                          boolean showMarkers,
+                         boolean explicit,
                          boolean excludeCurrentStatement)
       {
          this.cursorPosition = cursorPosition;
          this.token = token;
          this.showMarkers = showMarkers;
+         this.explicit = explicit;
          this.excludeCurrentStatement = excludeCurrentStatement;
       }
       
       public final Invalidation.Token token;
       public final Position cursorPosition;
       public final boolean showMarkers;
+      public final boolean explicit;
       public final boolean excludeCurrentStatement;
    }
    
    private void reset()
    {
       showMarkers_ = false;
+      explicit_ = false;
       excludeCurrentStatement_ = true;
    }
    
@@ -86,6 +90,7 @@ public class LintManager
       target_ = target;
       docDisplay_ = target.getDocDisplay();
       showMarkers_ = false;
+      explicit_ = false;
       invalidation_ = new Invalidation();
       timer_ = new Timer()
       {
@@ -104,6 +109,7 @@ public class LintManager
                   invalidation_.getInvalidationToken(),
                   docDisplay_.getCursorPosition(),
                   showMarkers_,
+                  explicit_,
                   excludeCurrentStatement_);
             reset();
             lintActiveDocument(context);
@@ -133,6 +139,7 @@ public class LintManager
                   docDisplay_.removeMarkersOnCursorLine();
                   showMarkers_ = false;
                   excludeCurrentStatement_ = true;
+                  explicit_ = false;
                   timer_.schedule(uiPrefs_.backgroundDiagnosticsDelayMs().getValue());
                }
             });
@@ -151,7 +158,7 @@ public class LintManager
                return;
             
             if (uiPrefs_.diagnosticsOnSave().getValue())
-               lint(false, false);
+               lint(false, true, false);
          }
       });
    }
@@ -228,6 +235,7 @@ public class LintManager
                         target_.getId(),
                         target_.getPath(),
                         context.showMarkers,
+                        context.explicit,
                         new ServerRequestCallback<JsArray<LintItem>>()
                         {
                            @Override
@@ -267,6 +275,7 @@ public class LintManager
             target_.getId(),
             target_.getPath(),
             context.showMarkers,
+            context.explicit,
             new ServerRequestCallback<JsArray<LintItem>>()
             {
                @Override
@@ -318,9 +327,11 @@ public class LintManager
    }
    
    public void lint(boolean showMarkers,
+                    boolean explicit,
                     boolean excludeCurrentStatement)
    {
       showMarkers_ = showMarkers;
+      explicit_ = explicit;
       excludeCurrentStatement_ = excludeCurrentStatement;
       
       // Add tiny delay to ensure lint not cleared by other concurrent events
@@ -355,6 +366,7 @@ public class LintManager
    private final DocDisplay docDisplay_;
    private final Invalidation invalidation_;
    
+   private boolean explicit_;
    private boolean showMarkers_;
    private boolean excludeCurrentStatement_;
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/LintServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/LintServerOperations.java
@@ -25,6 +25,7 @@ public interface LintServerOperations
    void lintRSourceDocument(String documentId,
                             String documentPath,
                             boolean showMarkersPane,
+                            boolean explicit,
                             ServerRequestCallback<JsArray<LintItem>> requestCallback);
    
    void getCppDiagnostics(

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2073,7 +2073,7 @@ public class TextEditingTarget implements
    @Handler
    void onShowDiagnosticsActiveDocument()
    {
-      lintManager_.lint(true, false);
+      lintManager_.lint(true, true, false);
    }
    
    public void withSavedDoc(Command onsaved)


### PR DESCRIPTION
This ensures the background lint task does not show 'defined but not used' warnings, to help avoid showing false positives while the user is working.