### PR TITLE
indentation heuristics to detect statement-level indentation

### DIFF
--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -95,7 +95,59 @@ var RCodeModel = function(session, tokenizer,
    var $normalizeAndTruncate = function(text, width) {
       return $truncate($normalizeWhitespace(text), width);
    };
-   
+
+   function isOpenBracket(bracket)
+   {
+      return bracket === '(' ||
+             bracket === '[' ||
+             bracket === '{';
+   }
+
+   function isClosingBracket(bracket)
+   {
+      return bracket === ')' ||
+             bracket === ']' ||
+             bracket === '}';
+   }
+
+   // NOTE: A lot of the ugliness here stems from the fact that
+   // both open and closing brackets have the same type; that is,
+   //
+   //    paren.keyword.operator
+   //
+   // and so we need to be careful when testing for the 'keyword'
+   // or 'operator' types.
+   function isValidForEndOfStatement(token)
+   {
+      if (!token) return false;
+      
+      var value = token.value;
+      var type  = token.type;
+
+      if (type === "paren.keyword.operator")
+         return isClosingBracket(value);
+
+      return type === "string" ||
+             type === "identifier" ||
+             type.indexOf("constant") !== -1 ||
+             type.indexOf("variable") !== -1;
+   }
+
+   function isValidForStartOfStatement(token)
+   {
+      if (!token) return false;
+      
+      var value = token.value;
+      var type = token.type;
+
+      if (type === "paren.keyword.operator")
+         return isOpenBracket(value);
+
+      return type === "string" ||
+             type === "identifier" ||
+             type.indexOf("constant") !== -1 ||
+             type.indexOf("variable") !== -1;
+   }
 
    function pFunction(t)
    {
@@ -1344,10 +1396,11 @@ var RCodeModel = function(session, tokenizer,
          // pass through here.
          if (!tokenCursor.moveToPosition(startPos))
             return "";
-         
+
+         var prevCursor = tokenCursor.cloneCursor(); // updated by loop below
          do
          {
-            // Walk over matching parens
+            // Walk over matching parens.
             if (tokenCursor.bwdToMatchingToken())
                continue;
             
@@ -1358,6 +1411,23 @@ var RCodeModel = function(session, tokenizer,
                return this.getIndentForOpenBrace(
                   tokenCursor.currentPosition()
                ) + tab + continuationIndent;
+            }
+
+            // Try to detect statements. This is somewhat ad-hoc, but
+            // the idea is basically to look for token streams of the
+            // form:
+            //
+            //    (valid-for-end-of-statement) (newline) (valid-for-start-of-statement)
+            //
+            // Once detected, we use the indentation of the line
+            // following that newline.
+            if (isValidForEndOfStatement(tokenCursor.currentToken()) &&
+                isValidForStartOfStatement(prevCursor.currentToken()) &&
+                prevCursor.$row > tokenCursor.$row)
+            {
+               return this.$getIndent(
+                  this.$doc.getLine(prevCursor.$row)
+               ) + continuationIndent;
             }
                   
             // If we found an assignment token, use that for indentation
@@ -1422,7 +1492,9 @@ var RCodeModel = function(session, tokenizer,
                ) + continuationIndent;
             }
 
-         } while (tokenCursor.moveToPreviousToken());
+         } while (
+            (prevCursor = tokenCursor.cloneCursor()) &&
+               tokenCursor.moveToPreviousToken());
 
          // Fix some edge-case indentation issues, mainly for naked
          // 'if' and 'else' blocks.

--- a/src/gwt/test/autoindent_test_r.html
+++ b/src/gwt/test/autoindent_test_r.html
@@ -4,6 +4,7 @@
   <link rel="stylesheet" type="text/css" href="../src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_bright.css" />
   <!script type="text/javascript" src="../tools/ace/build_support/mini_require.js"></script>
   <script type="text/javascript" src="../src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/ace-uncompressed.js"></script>
+  <script type="text/javascript" src="../acesupport/acemode/utils.js"></script>
   <script type="text/javascript" src="../acesupport/acemode/auto_brace_insert.js"></script>
   <script type="text/javascript" src="../acesupport/acemode/tex_highlight_rules.js"></script>
   <script type="text/javascript" src="../acesupport/acemode/token_cursor.js"></script>
@@ -365,6 +366,11 @@ if ()
 <li><pre data-expected="4" data-expected-vertical-args="4">
 else
   x <-
+</pre></li>
+
+<li><pre data-expected="0">
+    x <- 1
+y
 </pre></li>
 
 </ol>


### PR DESCRIPTION
This PR fixes a minor indentation issue where single-level indentation (without assignment operators) wouldn't be respected; e.g. previously indentation produced this:

```
x <- 1
    y
|
```

Now, the cursor is appropriately indented to match the indentation of `y`. 