### PR TITLE
clean up 'else' ugliness in the parser

### DIFF
--- a/src/cpp/core/include/core/RegexUtils.hpp
+++ b/src/cpp/core/include/core/RegexUtils.hpp
@@ -54,7 +54,6 @@ core::Error filterString(
                 const boost::iostreams::regex_filter& filter,
                 std::string* pOutput);
 
-
 } // namespace regex_utils
 } // namespace core 
 } // namespace rstudio

--- a/src/cpp/session/modules/SessionDiagnosticsTests.cpp
+++ b/src/cpp/session/modules/SessionDiagnosticsTests.cpp
@@ -183,7 +183,8 @@ context("Diagnostics")
 
       EXPECT_NO_ERRORS("{if(!(a)){};if(b){}}");
       EXPECT_NO_ERRORS("if (1) foo(1) <- 1 else 2; 1 + 2");
-      EXPECT_NO_ERRORS("if (1)\nfoo(1) <- 1\nelse 2; 4 + 8");
+      EXPECT_ERRORS("if (1)\nfoo(1) <- 1\nelse 2; 4 + 8"); // invalid 'else' at top level
+      EXPECT_NO_ERRORS("{if (1)\nfoo(1) <- 1\nelse 2\n4 + 8}");
       EXPECT_NO_ERRORS("if (1) (foo(1) <- {{1}})\n2 + 1");
       EXPECT_NO_ERRORS("if (1) function() 1 else 2");
       EXPECT_NO_ERRORS("if (1) function() b()() else 2");
@@ -210,7 +211,7 @@ context("Diagnostics")
       // EXPECT_ERRORS("if (1) (1)\nelse (2)");
       EXPECT_NO_ERRORS("{if (1) (1)\nelse (2)}");
       
-      EXPECT_NO_ERRORS("if (a)\nF(b) <- 'c'\nelse if (d) e");
+      EXPECT_NO_ERRORS("{if (a)\nF(b) <- 'c'\nelse if (d) e}");
 
       EXPECT_NO_ERRORS("lapply(x, `[[`, 1)");
 
@@ -248,6 +249,12 @@ context("Diagnostics")
       EXPECT_NO_LINT("f <- function(x) {\n  TRUE\n  !grepl(':$', x)\n}");
       
       EXPECT_NO_ERRORS("# ouch"); // previously segfaulted due to lack of significant tokens
+      
+      EXPECT_NO_ERRORS("if(1)while(2)while(3)while(4)foo() else 5");
+      
+      EXPECT_NO_ERRORS("{\nif (1) {} else if (2) {}\nif (1)\n1\nelse if (2)\n2}");
+      
+      EXPECT_NO_ERRORS("({if (1) for(i in 1) {}})");
    }
    
    lintRStudioRFiles();

--- a/src/cpp/session/modules/SessionRParser.hpp
+++ b/src/cpp/session/modules/SessionRParser.hpp
@@ -1157,6 +1157,18 @@ public:
       }
    }
    
+   bool isInIfStatementOrExpression() const
+   {
+      switch (currentState())
+      {
+      case ParseStateIfStatement:
+      case ParseStateIfExpression:
+         return true;
+      default:
+         return false;
+      }
+   }
+   
    bool isInControlFlowStatement() const
    {
       switch (currentState())
@@ -1253,14 +1265,18 @@ public:
    
    void pushBracket(const RToken& token)
    {
+      DEBUG("===== Pushing bracket: " << token);
       bracketStack_.push(token);
    }
    
    void popBracket(const RToken& rhs)
    {
+      DEBUG("===== Popping bracket; cursor: " << rhs);
+      
       using namespace token_utils;
       if (bracketStack_.empty())
       {
+         DEBUG("===== Attempted to pop bracket from empty stack: " << rhs);
          lint_.unexpectedClosingBracket(rhs);
          return;
       }
@@ -1268,6 +1284,7 @@ public:
       const RToken& lhs = bracketStack_.peek();
       if (typeComplement(lhs.type()) != rhs.type())
       {
+         DEBUG("===== Incorrect closing bracket [" << lhs << " : " << rhs << "]");
          lint_.unexpectedClosingBracket(rhs);
          lint_.expectedMatchForOpenBracket(lhs);
       }

--- a/src/cpp/session/modules/SessionRTokenCursor.hpp
+++ b/src/cpp/session/modules/SessionRTokenCursor.hpp
@@ -510,6 +510,16 @@ public:
      return cursor.row() > row();
   }
   
+  bool isFirstSignificantTokenOnLine()
+  {
+     RTokenCursor cursor = clone();
+     
+     if (!cursor.moveToPreviousSignificantToken())
+        return true;
+     
+     return cursor.row() < row();
+  }
+  
   bool isAtEndOfStatement(bool inParentheticalScope)
   {
      if (isBinaryOp(*this) || isLeftBracket(*this))

--- a/src/gwt/acesupport/snippets/snippets/c_cpp.js
+++ b/src/gwt/acesupport/snippets/snippets/c_cpp.js
@@ -64,6 +64,10 @@ var snippets = [
          "    ${0}",
          "};"
       ].join("\n")
+   },
+   {
+      name: "ept",
+      content: "// [[Rcpp::export]]"
    }
 ];
 


### PR DESCRIPTION
This PR cleans up a lot of the (inconsistent) inline `else` handling code, and places it into a separate function which is then called whenever the end of a statement is reached.

Some new tests were added, and they all pass.