### PR TITLE
reduce staggering in help display

### DIFF
--- a/src/cpp/session/resources/R.css
+++ b/src/cpp/session/resources/R.css
@@ -95,3 +95,8 @@ div.vignettes a:hover {
    background: rgb(85%, 85%, 85%);
 }
 
+table p {
+   margin-top: 0;
+   margin-bottom: 6px;
+}
+


### PR DESCRIPTION
This improves the completion display by removing the staggering in argument help.

Before:

![screen shot 2015-04-24 at 2 06 37 pm](https://cloud.githubusercontent.com/assets/1976582/7328862/c2775756-ea8d-11e4-97c8-3003663f9a93.png)

After:

![screen shot 2015-04-24 at 2 25 40 pm](https://cloud.githubusercontent.com/assets/1976582/7328868/cebbf684-ea8d-11e4-85ab-2862c5cf0d61.png)
