### PR TITLE
Update keyboard.htm

### DIFF
--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -45,7 +45,7 @@
   <tr>
     <td>Clear console</td>
     <td>Ctrl+L</td>
-    <td>Command+L</td>
+    <td>Ctrl+L</td>
   </tr>
   <tr>
     <td>Move cursor to beginning of line</td>


### PR DESCRIPTION
Updating since Ctrl+L is actually the correct command for clearing the console in OS X RStudio