### PR TITLE
inject params into global environment prior to Rmd chunk execution

### DIFF
--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -97,6 +97,24 @@
    templateDetails
 })
 
+
+.rs.addFunction("evaluateRmdParams", function(contents) {
+
+   # extract the params using knitr::knit_params
+   knitParams <- knitr::knit_params(contents)
+
+   if (length(knitParams) > 0)
+   {
+      # turn them into a named list
+      params <- list()
+      for (param in knitParams)
+         params[[param$name]] <- param$value
+
+      # inject into global environment
+      assign("params", params, envir = globalenv())
+   }
+})
+
 .rs.addJsonRpcHandler("convert_to_yaml", function(input)
 {
    yaml <- yaml::as.yaml(input)

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RMarkdownServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RMarkdownServerOperations.java
@@ -56,4 +56,7 @@ public interface RMarkdownServerOperations extends CryptoServerOperations
                        ServerRequestCallback<RmdTemplateContent> requestCallback);
    
    public String getApplicationURL(String pathName);
+   
+   void prepareForRmdChunkExecution(String id,
+                                    ServerRequestCallback<Void> requestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/VoidServerRequestCallback.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/VoidServerRequestCallback.java
@@ -35,6 +35,7 @@ public class VoidServerRequestCallback extends ServerRequestCallback<Void>
          progress_.onCompleted();
       
       onSuccess();
+      onCompleted();
    }
    
    public void onError(ServerError error)
@@ -45,6 +46,7 @@ public class VoidServerRequestCallback extends ServerRequestCallback<Void>
          progress_.onError(error.getUserMessage());
       
       onFailure();
+      onCompleted();
    }
    
    protected void onSuccess()
@@ -53,6 +55,11 @@ public class VoidServerRequestCallback extends ServerRequestCallback<Void>
    }
    
    protected void onFailure()
+   {
+      
+   }
+   
+   protected void onCompleted()
    {
       
    }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -3894,6 +3894,17 @@ public class RemoteServer implements Server
    }
    
    @Override
+   public void prepareForRmdChunkExecution(
+                                String id,
+                                ServerRequestCallback<Void> requestCallback)
+   {
+      sendRequest(RPC_SCOPE, 
+                  "prepare_for_rmd_chunk_execution", 
+                  id, 
+                  requestCallback);
+   }
+   
+   @Override
    public void unsatisfiedDependencies(
       JsArray<Dependency> dependencies,
       boolean silentUpdate,


### PR DESCRIPTION
This PR ensures that when individual Rmd chunks are executed that any `params` declared in the YAML are available within the global environment. Note that even if they already exist the `params` are always overwritten. This is guaranteed to be correct behavior because of the constraint that the `params` list is immutable (as of this commit to rmarkdown: https://github.com/rstudio/rmarkdown/commit/6d89520ae5b98274a213f84e11dd29774b8a368a).

@jmcphers @yihui Could you both review this?
