### PR TITLE
provide file-local mechanism for controlling linter

### DIFF
--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -585,7 +585,6 @@ bool isPrefixOf(const std::string& self, const std::string& prefix)
    return boost::algorithm::starts_with(self, prefix);
 }
 
-
 } // namespace string_utils
 } // namespace core 
 } // namespace rstudio

--- a/src/cpp/core/StringUtilsTests.cpp
+++ b/src/cpp/core/StringUtilsTests.cpp
@@ -41,6 +41,20 @@ context("isSubsequence")
       expect_true(strippedOfBackQuotes("abc") == "abc");
       
    }
+   
+   test_that("substring works")
+   {
+      std::string string("  abc  ");
+      expect_true(substring(string, 2, 5) == "abc");
+   }
+   
+   test_that("trimWhitespace works")
+   {
+      std::string string("   abc   ");
+      expect_true(trimWhitespace(string) == "abc");
+      expect_true(trimWhitespace("abc") == "abc");
+      expect_true(trimWhitespace("") == "");
+   }
 }
 
 } // end namespace string_utils

--- a/src/cpp/core/include/core/StringUtils.hpp
+++ b/src/cpp/core/include/core/StringUtils.hpp
@@ -218,6 +218,40 @@ std::wstring::const_iterator countNewlines(std::wstring::const_iterator begin,
 
 bool isPrefixOf(const std::string& self, const std::string& prefix);
 
+template <typename StringType>
+inline StringType substring(const StringType& string,
+                            std::size_t startPos,
+                            std::size_t endPos)
+{
+   return string.substr(startPos, endPos - startPos);
+}
+
+namespace detail {
+
+template <typename StringType>
+inline StringType trimWhitespace(const StringType& string,
+                                 const StringType& whitespace)
+{
+   std::size_t start = string.find_first_not_of(whitespace);
+   if (start == StringType::npos)
+      return StringType();
+   
+   std::size_t end = string.find_last_not_of(whitespace);
+   return substring(string, start, end + 1);
+}
+
+} // namespace detail
+
+inline std::string trimWhitespace(const std::string& string)
+{
+   return detail::trimWhitespace(string, std::string(" \t\n\r\f\v"));
+}
+
+inline std::wstring trimWhitespace(const std::wstring& string)
+{
+   return detail::trimWhitespace(string, std::wstring(L" \t\n\r\f\v"));
+}
+
 } // namespace string_utils
 } // namespace core 
 } // namespace rstudio

--- a/src/cpp/core/include/core/text/CsvParser.hpp
+++ b/src/cpp/core/include/core/text/CsvParser.hpp
@@ -42,9 +42,12 @@ incomplete CSV data that do not end with a line break, the
 returned iterator will never move past the beginning of the
 last line.)
 */
-template<typename InputIterator>
-std::pair<std::vector<std::string>, InputIterator> parseCsvLine(InputIterator begin,
-                                                                InputIterator end)
+
+template <typename InputIterator>
+std::pair<std::vector<std::string>, InputIterator> parseCsvLine(
+      InputIterator begin,
+      InputIterator end,
+      bool allowMissingEOL = false)
 {
    std::vector<std::string> line;
 
@@ -122,7 +125,14 @@ std::pair<std::vector<std::string>, InputIterator> parseCsvLine(InputIterator be
       if (!noIncrement)
          ++pos;
    }
-
+   
+   // if we got here, we failed to find a (terminating) newline
+   if (allowMissingEOL)
+   {
+      line.push_back(element);
+      return std::pair<std::vector<std::string>, InputIterator>(line, end);
+   }
+   
    return std::pair<std::vector<std::string>, InputIterator>(
          std::vector<std::string>(), begin);
 }

--- a/src/cpp/session/modules/SessionDiagnostics.cpp
+++ b/src/cpp/session/modules/SessionDiagnostics.cpp
@@ -493,7 +493,7 @@ void parseLintOption(const std::string& text, FileLocalLintOptions* pOptions)
 {
    using namespace core::text;
    
-   boost::regex reGlobals("^\\s*globals\\s*=");
+   boost::regex reGlobals("^\\s*suppress\\s*=");
    if (boost::regex_search(text, reGlobals))
       return parseLintOptionGlobals(text, pOptions);
    

--- a/src/cpp/session/modules/SessionDiagnostics.cpp
+++ b/src/cpp/session/modules/SessionDiagnostics.cpp
@@ -493,7 +493,8 @@ void parseLintOption(const std::string& text, FileLocalLintOptions* pOptions)
 {
    using namespace core::text;
    
-   if (boost::algorithm::starts_with(text, "globals="))
+   boost::regex reGlobals("^\\s*globals\\s*=");
+   if (boost::regex_search(text, reGlobals))
       return parseLintOptionGlobals(text, pOptions);
    
    ParsedCSVLine line = parseCsvLine(text.begin(), text.end(), true);

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -1313,80 +1313,6 @@ private:
    FunctionInformation info_;
 };
 
-bool lintOptionValueAsBool(const std::wstring& value)
-{
-   if (value.empty())
-      return false;
-   
-   std::wstring lower = boost::algorithm::to_lower_copy(value);
-   if (lower[0] == 'n' || lower[0] == 'f')
-      return false;
-   
-   if (lower[0] == 'y' || lower[0] == 't')
-      return true;
-   
-   return false;
-}
-
-void applyOptionPair(const std::wstring& name,
-                     const std::wstring& value,
-                     ParseOptions* pOptions,
-                     bool* pNoLint)
-{
-   std::wcout << "Name:  '" << name << "'\n";
-   std::wcout << "Value: '" << value << "'\n";
-   
-   bool valueBool = lintOptionValueAsBool(value);
-   if (name == L"style")
-      pOptions->setRecordStyleLint(valueBool);
-   
-   if (name == L"lint")
-   {
-      if (value == L"core")
-      {
-         pOptions->setCheckArgumentsToRFunctionCalls(false);
-         pOptions->setLintRFunctions(false);
-         pOptions->setRecordStyleLint(false);
-         pOptions->setWarnIfNoSuchVariableInScope(false);
-         pOptions->setWarnIfVariableIsDefinedButNotUsed(false);
-      }
-   }
-}
-
-void setFileLocalParseOptions(const std::wstring& rCode,
-                              ParseOptions* pOptions,
-                              bool* pNoLint)
-{
-   using namespace string_utils;
-   
-   static const boost::regex reLintComments("^[\\s\\n]*#+>");
-   
-   if (boost::regex_search(rCode.begin(), rCode.end(), reLintComments))
-   {
-      std::size_t startPos = rCode.find(L"#>") + 2;
-      std::size_t endPos = rCode.find(L'\n', startPos);
-      
-      std::wstring line = substring(rCode, startPos, endPos);
-      std::size_t startIndex = 0;
-      while (true)
-      {
-         std::size_t colonIndex = line.find(L':', startIndex);
-         if (colonIndex == std::wstring::npos)
-            break;
-         
-         std::size_t endIndex = line.find(L',', colonIndex);
-         if (endIndex == std::wstring::npos)
-            endIndex = line.size();
-         
-         std::wstring name = trimWhitespace(substring(line, startIndex, colonIndex));
-         std::wstring value = trimWhitespace(substring(line, colonIndex + 1, endIndex));
-         
-         applyOptionPair(name, value, pOptions, pNoLint);
-         startIndex = endIndex + 1;
-      }
-   }
-}
-
 } // anonymous namespace
 
 void doParse(RTokenCursor&, ParseStatus&);
@@ -1420,7 +1346,7 @@ ParseResults parse(const std::wstring& rCode,
    
    status.addLintIfBracketStackNotEmpty();
    
-   return ParseResults(status.root(), status.lint());
+   return ParseResults(status.root(), status.lint(), parseOptions.globals());
 }
 
 namespace {
@@ -2299,24 +2225,21 @@ ARGUMENT_START:
       
       if (cursor.isType(RToken::COMMA))
       {
-         if (status.parseOptions().checkArgumentsToRFunctionCalls())
-            if (cursor.previousSignificantToken().isType(RToken::LPAREN))
-               status.lint().missingArgumentToFunctionCall(cursor);
+         if (cursor.previousSignificantToken().isType(RToken::LPAREN))
+            status.lint().missingArgumentToFunctionCall(cursor);
          
          MOVE_TO_NEXT_SIGNIFICANT_TOKEN(cursor, status);
          while (cursor.isType(RToken::COMMA))
          {
-            if (status.parseOptions().checkArgumentsToRFunctionCalls())
-               if (status.isWithinParenFunctionCall())
-                  status.lint().missingArgumentToFunctionCall(cursor);
+            if (status.isWithinParenFunctionCall())
+               status.lint().missingArgumentToFunctionCall(cursor);
             MOVE_TO_NEXT_SIGNIFICANT_TOKEN(cursor, status);
          }
       }
       
       if (closesArgumentList(cursor, status))
       {
-         if (status.parseOptions().checkArgumentsToRFunctionCalls() &&
-             status.isWithinParenFunctionCall() &&
+         if (status.isWithinParenFunctionCall() &&
              cursor.previousSignificantToken().isType(RToken::COMMA))
          {
             status.lint().missingArgumentToFunctionCall(cursor.previousSignificantToken());

--- a/src/cpp/session/modules/SessionRParser.hpp
+++ b/src/cpp/session/modules/SessionRParser.hpp
@@ -118,6 +118,33 @@ public:
    {
       warnIfVariableIsDefinedButNotUsed_ = warnIfVariableIsDefinedButNotUsed;
    }
+   
+   void setSyntaxOnly()
+   {
+      lintRFunctions_ = false;
+      checkArgumentsToRFunctionCalls_ = false;
+      warnIfNoSuchVariableInScope_ = false;
+      warnIfVariableIsDefinedButNotUsed_ = false;
+   }
+   
+   void setCoreDiagnostics()
+   {
+      lintRFunctions_ = true;
+      checkArgumentsToRFunctionCalls_ = false;
+      warnIfNoSuchVariableInScope_ = false;
+      warnIfVariableIsDefinedButNotUsed_ = false;
+   }
+   
+   void enableAllDiagnostics()
+   {
+      lintRFunctions_ = true;
+      checkArgumentsToRFunctionCalls_ = true;
+      warnIfNoSuchVariableInScope_ = true;
+      warnIfVariableIsDefinedButNotUsed_ = true;
+   }
+   
+   std::set<std::string>& globals() { return globals_; }
+   const std::set<std::string>& globals() const { return globals_; }
 
 private:
    bool lintRFunctions_;
@@ -125,6 +152,8 @@ private:
    bool warnIfNoSuchVariableInScope_;
    bool warnIfVariableIsDefinedButNotUsed_;
    bool recordStyleLint_;
+   
+   std::set<std::string> globals_;
 };
 
 struct ParseItem;
@@ -1349,9 +1378,16 @@ public:
    {}
    
    ParseResults(boost::shared_ptr<ParseNode> parseTree,
-                LintItems lint)
+                const LintItems& lint)
       : parseTree_(parseTree),
         lint_(lint)
+   {}
+   ParseResults(boost::shared_ptr<ParseNode> parseTree,
+                const LintItems& lint,
+                const std::set<std::string>& globals)
+      : parseTree_(parseTree),
+        lint_(lint),
+        globals_(globals)
    {}
    
    // copy ctor: copyable members
@@ -1364,10 +1400,14 @@ public:
    const LintItems& lint() const { return lint_; }
    LintItems& lint() { return lint_; }
    
+   const std::set<std::string>& globals() const { return globals_; }
+   std::set<std::string>& globals() { return globals_; }
+   
 private:
    
    boost::shared_ptr<ParseNode> parseTree_;
    LintItems lint_;
+   std::set<std::string> globals_;
 };
 
 ParseResults parse(const std::string& rCode,

--- a/src/gwt/src/org/rstudio/studio/client/common/DiagnosticsHelpLink.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/DiagnosticsHelpLink.java
@@ -1,0 +1,26 @@
+/*
+ * DiagnosticsHelpLink.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.common;
+
+import org.rstudio.studio.client.common.HelpLink;
+
+public class DiagnosticsHelpLink extends HelpLink
+{
+   public DiagnosticsHelpLink()
+   {
+      super("Code Diagnostics", "code_diagnostics");
+   }
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -34,6 +34,8 @@ import org.rstudio.core.client.widget.HelpButton;
 import org.rstudio.core.client.widget.NumericValueWidget;
 import org.rstudio.core.client.widget.SelectWidget;
 import org.rstudio.core.client.widget.SmallButton;
+import org.rstudio.studio.client.common.DiagnosticsHelpLink;
+import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.workbench.prefs.model.RPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefsAccessor;
@@ -244,6 +246,11 @@ public class EditingPreferencesPane extends PreferencesPane
       diagnosticsPanel.add(tight(checkboxPref("Show diagnostics after keyboard is idle for a period of time", prefs.enableBackgroundDiagnostics())));
       diagnosticsPanel.add(indent(backgroundDiagnosticsDelayMs_ =
             numericPref("Keyboard idle time (ms):", prefs.backgroundDiagnosticsDelayMs())));
+      
+      HelpLink diagnosticsHelpLink = new DiagnosticsHelpLink();
+      diagnosticsHelpLink.getElement().getStyle().setMarginTop(12, Unit.PX);
+      nudgeRight(diagnosticsHelpLink); 
+      diagnosticsPanel.add(diagnosticsHelpLink);
       
       
       DialogTabLayoutPanel tabPanel = new DialogTabLayoutPanel();


### PR DESCRIPTION
There were a couple requests for this based on the initial preview release containing diagnostics, so I thought I would go ahead and put in the scaffolding for this.

This PR allows for file-local settings to be applied to the linter -- currently, only `style` is recognized.

The goal is to allow a syntax like e.g.

```R
#> style: false

if(1){}   ## doesn't complain about style warnings now
```

to control various settings in the linter. It'd be good to hear some ideas for different options we could specify; e.g. I think it would be useful to have something like (open to better names):

    style: true/false
    syntax: true/false
    diagnostics: syntax/core/all

Thoughts? I'd really like some version of this to be part of v0.99 just so that even for users who opt into the 'heavier' diagnostics, they have a simple file-local mechanism for adjusting if desired.

We could also add something like `suppress: [foo, bar, baz]`, to allow users to suppress various warnings for symbols with some names.