### PR TITLE
Add additional parameters to data import wizard

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -153,6 +153,7 @@
 * Run App command for single file Shiny applications
 * Deprecated 'source.with.encoding' in favor of source(..., encoding = "...")
 * Make source code compatible with -std=c++11
+* Allow specifying character encoding, row name source, and comment character when importing data
 
 
 ### Server

--- a/src/cpp/session/modules/SessionDataImport.R
+++ b/src/cpp/session/modules/SessionDataImport.R
@@ -121,6 +121,7 @@
         separator=sep,
         decimal=dec,
         quote=quote,
+        comment=comment,
         defaultStringsAsFactors=default.stringsAsFactors())
 })
 

--- a/src/cpp/session/modules/SessionDataImport.R
+++ b/src/cpp/session/modules/SessionDataImport.R
@@ -13,16 +13,19 @@
 #
 #
 
-.rs.addFunction("parseDataFile", function(path, header, sep, dec, quote, nrows) {
+.rs.addFunction("parseDataFile", function(path, encoding, header, sep, dec, 
+                                          quote, comment, nrows) {
    data <- tryCatch(
       # try to use read.csv directly if possible (since this is a common case
       # and since LibreOffice spreadsheet exports produce files unparsable
       # by read.table). check Workspace.makeCommand if we want to deduce
       # other more concrete read calls.
       if (identical(sep,",") && identical(dec,".") && identical(quote,"\""))
-         read.csv(path, header=header, nrows=nrows)
+         read.csv(path, encoding=encoding, header=header, nrows=nrows,
+                  comment.char=comment)
       else
-         read.table(path, header=header, sep=sep, dec=dec, quote=quote, nrows=nrows),
+         read.table(path, encoding=encoding, header=header, sep=sep, dec=dec, 
+                    quote=quote, comment.char=comment, nrows=nrows),
       error=function(e) {
          data.frame(Error=e$message)
       })
@@ -67,6 +70,13 @@
 
    # Drop comment lines, leaving the significant ones
    siglines <- grep("^[^#].*", lines, value=TRUE)
+
+   # If any comment lines were found, presume # to be the comment character
+   comment <- ""
+   if (length(siglines) < length(lines)) {
+     comment <- "#"
+   } 
+
    firstline <- siglines[1]
 
    dataline <- siglines[2]
@@ -95,15 +105,18 @@
    quote <- "\""
 
    output <- .rs.parseDataFile(path,
+                               encoding="unknown",
                                header=header,
                                sep=sep,
                                dec=dec,
                                quote=quote,
+                               comment=comment,
                                nrows=nrows)
 
    list(inputLines=paste(lines, collapse="\n"),
         output=output,
         outputNames=names(output),
+        encoding="unknown",
         header=header,
         separator=sep,
         decimal=dec,
@@ -111,15 +124,21 @@
         defaultStringsAsFactors=default.stringsAsFactors())
 })
 
-.rs.addJsonRpcHandler("get_output_preview", function(path, header, sep, decimal, quote)
+.rs.addJsonRpcHandler("get_output_preview", function(path, encoding, header,
+                                                     sep, decimal, quote, 
+                                                     comment)
 {
    nrows <- 20
-   output <- .rs.parseDataFile(path, header=header, sep=sep, dec=decimal, quote=quote, nrows=nrows)
+   output <- .rs.parseDataFile(path, encoding=encoding, header=header, sep=sep, 
+                               dec=decimal, quote=quote, comment=comment, 
+                               nrows=nrows)
 
    list(output=output,
         outputNames=names(output),
         header=header,
+        encoding=encoding,
         separator=sep,
         quote=quote,
+        comment=comment,
         defaultStringsAsFactors=default.stringsAsFactors())
 })

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -779,18 +779,22 @@ public class RemoteServer implements Server
    }
 
    public void getOutputPreview(String dataFilePath,
+                                String encoding,
                                 boolean heading,
                                 String separator,
                                 String decimal,
                                 String quote,
+                                String comment,
                                 ServerRequestCallback<DataPreviewResult> requestCallback)
    {
       JSONArray params = new JSONArray();
       params.set(0, new JSONString(dataFilePath));
-      params.set(1, JSONBoolean.getInstance(heading));
-      params.set(2, new JSONString(separator));
-      params.set(3, new JSONString(decimal));
-      params.set(4, new JSONString(quote));
+      params.set(1, new JSONString(encoding));
+      params.set(2, JSONBoolean.getInstance(heading));
+      params.set(3, new JSONString(separator));
+      params.set(4, new JSONString(decimal));
+      params.set(5, new JSONString(quote));
+      params.set(6, new JSONString(comment));
 
       sendRequest(RPC_SCOPE,
                   GET_OUTPUT_PREVIEW,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/ImportFileSettings.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/ImportFileSettings.java
@@ -20,19 +20,25 @@ public class ImportFileSettings
 {
    public ImportFileSettings(FileSystemItem file,
                              String varname,
+                             String encoding,
                              boolean header,
+                             String rowNames,
                              String sep,
                              String decimal,
                              String quote,
+                             String comment,
                              String naStrings,
                              boolean stringsAsFactors)
    {
       file_ = file;
       varname_ = varname;
+      encoding_ = encoding;
       header_ = header;
+      rowNames_ = rowNames;
       sep_ = sep;
       decimal_ = decimal;
       quote_ = quote;
+      comment_ = comment;
       naStrings_ = naStrings;
       stringsAsFactors_ = stringsAsFactors;
    }
@@ -46,10 +52,20 @@ public class ImportFileSettings
    {
       return varname_;
    }
+   
+   public String getEncoding()
+   {
+      return encoding_;
+   }
 
    public boolean isHeader()
    {
       return header_;
+   }
+   
+   public String getRowNames()
+   {
+      return rowNames_;
    }
 
    public String getSep()
@@ -67,6 +83,11 @@ public class ImportFileSettings
       return quote_;
    }
    
+   public String getComment()
+   {
+      return comment_;
+   }
+   
    public String getNAStrings()
    {
       return naStrings_;
@@ -82,21 +103,28 @@ public class ImportFileSettings
       int score = 0;
       if (isHeader() == other.isHeader())
          score++;
+      if (getRowNames().equals(other.getRowNames()))
+         score++;
       if (getSep().equals(other.getSep()))
          score += 2;
       if (getDec().equals(other.getDec()))
          score += 2;
       if (getQuote().equals(other.getQuote()))
          score++;
+      if (getComment().equals(other.getComment()))
+         score++;
       return score;
    }
 
    private final FileSystemItem file_;
    private final String varname_;
+   private final String encoding_;
    private final boolean header_;
+   private final String rowNames_;
    private final String sep_;
    private final String decimal_;
    private final String quote_;
+   private final String comment_;
    private final String naStrings_;
    private final boolean stringsAsFactors_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/ImportFileSettingsDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/ImportFileSettingsDialog.java
@@ -27,6 +27,7 @@ import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.*;
+
 import org.rstudio.core.client.Invalidation;
 import org.rstudio.core.client.Invalidation.Token;
 import org.rstudio.core.client.files.FileSystemItem;
@@ -39,6 +40,8 @@ import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.workbench.views.environment.model.DataPreviewResult;
 import org.rstudio.studio.client.workbench.views.environment.model.EnvironmentServerOperations;
+import org.rstudio.studio.client.workbench.views.source.editors.text.IconvListResult;
+import org.rstudio.studio.client.workbench.views.source.model.SourceServerOperations;
 
 public class ImportFileSettingsDialog extends ModalDialog<ImportFileSettingsDialogResult>
 {
@@ -66,6 +69,7 @@ public class ImportFileSettingsDialog extends ModalDialog<ImportFileSettingsDial
    
    public ImportFileSettingsDialog(
          EnvironmentServerOperations server,
+         SourceServerOperations sourceServer,
          FileSystemItem dataFile,
          String varname,
          String caption,
@@ -74,6 +78,7 @@ public class ImportFileSettingsDialog extends ModalDialog<ImportFileSettingsDial
    {
       super(caption, operation);
       server_ = server;
+      sourceServer_ = sourceServer;
       dataFile_ = dataFile;
       globalDisplay_ = globalDisplay;
 
@@ -101,6 +106,38 @@ public class ImportFileSettingsDialog extends ModalDialog<ImportFileSettingsDial
       quote_.addItem("Double quote (\")", "\"");
       quote_.addItem("Single quote (')", "'");
       quote_.addItem("None", "");
+      
+      comment_.addItem("None", "");
+      comment_.addItem("#", "#");
+      comment_.addItem("!", "!");
+      comment_.addItem("%", "%");
+      comment_.addItem("@", "@");
+      comment_.addItem("/", "/");
+      comment_.addItem("~", "~");
+      
+      rowNames_.addItem("Automatic", autoValue);
+      rowNames_.addItem("Use first column", "1");
+      rowNames_.addItem("Use numbers", "NULL");
+      
+      encoding_.addItem("Automatic", "unknown");
+      sourceServer_.iconvlist(new ServerRequestCallback<IconvListResult>()
+      {
+         @Override
+         public void onResponseReceived(IconvListResult result)
+         {
+            JsArrayString encodings = result.getAll();
+            for (int i = 0; i < encodings.length(); i++)
+            {
+               encoding_.addItem(encodings.get(i), encodings.get(i));
+            }
+         }
+
+         @Override
+         public void onError(ServerError error)
+         {
+            // not fatal; we'll just leave Automatic as the only option
+         }
+      });
 
       hookChangeEvents();
 
@@ -158,14 +195,15 @@ public class ImportFileSettingsDialog extends ModalDialog<ImportFileSettingsDial
 
       updateRequest_.invalidate();
       final Token invalidationToken = updateRequest_.getInvalidationToken();
-
       progress_.onProgress("Updating preview");
       server_.getOutputPreview(
             dataFile_.getPath(),
+            encoding_.getValue(encoding_.getSelectedIndex()),
             headingYes_.getValue().booleanValue(),
             separator_.getValue(separator_.getSelectedIndex()),
             decimal_.getValue(decimal_.getSelectedIndex()),
             quote_.getValue(quote_.getSelectedIndex()),
+            comment_.getValue(comment_.getSelectedIndex()),
             new ServerRequestCallback<DataPreviewResult>()
             {
                @Override
@@ -302,14 +340,19 @@ public class ImportFileSettingsDialog extends ModalDialog<ImportFileSettingsDial
    @Override
    protected ImportFileSettingsDialogResult collectInput()
    {
+      String rowNames = rowNames_.getValue(rowNames_.getSelectedIndex());
+
       return new ImportFileSettingsDialogResult(
          new ImportFileSettings(
             dataFile_,
             varname_.getText().trim(),
+            encoding_.getValue(encoding_.getSelectedIndex()),
             headingYes_.getValue(),
+            rowNames.equals(autoValue) ? null : rowNames,
             separator_.getValue(separator_.getSelectedIndex()),
             decimal_.getValue(decimal_.getSelectedIndex()),
             quote_.getValue(quote_.getSelectedIndex()),
+            comment_.getValue(comment_.getSelectedIndex()),
             naStrings_.getText().trim(),
             stringsAsFactors_.getValue()),
          defaultStringsAsFactors_);
@@ -363,13 +406,22 @@ public class ImportFileSettingsDialog extends ModalDialog<ImportFileSettingsDial
    TextBox naStrings_;
    @UiField
    CheckBox stringsAsFactors_;
+   @UiField
+   ListBox encoding_;
+   @UiField
+   ListBox rowNames_;
+   @UiField
+   ListBox comment_;
 
    private final Widget widget_;
    private final EnvironmentServerOperations server_;
    private final FileSystemItem dataFile_;
+   private final SourceServerOperations sourceServer_;
    private boolean defaultStringsAsFactors_ = true;
    private final GlobalDisplay globalDisplay_;
    private ProgressIndicator progress_;
    private final Invalidation updateRequest_ = new Invalidation();
    private final Styles styles_;
+   
+   private static final String autoValue = "Auto";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/ImportFileSettingsDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/ImportFileSettingsDialog.java
@@ -182,6 +182,8 @@ public class ImportFileSettingsDialog extends ModalDialog<ImportFileSettingsDial
       separator_.addChangeHandler(changeHandler);
       decimal_.addChangeHandler(changeHandler);
       quote_.addChangeHandler(changeHandler);
+      encoding_.addChangeHandler(changeHandler);
+      comment_.addChangeHandler(changeHandler);
    }
 
    private void updateOutput()
@@ -257,6 +259,7 @@ public class ImportFileSettingsDialog extends ModalDialog<ImportFileSettingsDial
                   selectByValue(separator_, response.getSeparator());
                   selectByValue(decimal_, response.getDecimal());
                   selectByValue(quote_, response.getQuote());
+                  selectByValue(comment_, response.getComment());
                   
                   defaultStringsAsFactors_ = response.getDefaultStringsAsFactors();
                   stringsAsFactors_.setValue(defaultStringsAsFactors_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/ImportFileSettingsDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/ImportFileSettingsDialog.ui.xml
@@ -14,11 +14,19 @@
                   </td>
                </tr>
                <tr>
+                  <td>Encoding</td>
+                  <td><g:ListBox ui:field="encoding_" styleName="{res.styles.list}" /></td>
+               </tr>
+               <tr>
                   <td>Heading</td>
                   <td>
                      <g:RadioButton ui:field="headingYes_" name="importFileSettingsHeading" text="Yes"/>
                      <g:RadioButton ui:field="headingNo_" name="importFileSettingsHeading" text="No"/>
                   </td>
+               </tr>
+               <tr>
+                  <td>Row names</td>
+                  <td><g:ListBox ui:field="rowNames_" styleName="{res.styles.list}" /></td>
                </tr>
                <tr>
                   <td>Separator</td>
@@ -33,11 +41,15 @@
                   <td><g:ListBox ui:field="quote_" styleName="{res.styles.list}" /></td>
                </tr>
                <tr>
+                  <td>Comment</td>
+                  <td><g:ListBox ui:field="comment_" styleName="{res.styles.list}" /></td>
+               </tr>
+               <tr>
                   <td>na.strings</td>
                   <td><g:TextBox ui:field="naStrings_" styleName="{res.styles.nastrings}"></g:TextBox></td>
                </tr>
                <tr>
-                  <td><g:CheckBox ui:field="stringsAsFactors_" text="Strings as factors"></g:CheckBox></td>
+                  <td colspan="2"><g:CheckBox ui:field="stringsAsFactors_" text="Strings as factors"></g:CheckBox></td>
                </tr>
             </table>
          </g:HTMLPanel>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/model/DataPreviewResult.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/model/DataPreviewResult.java
@@ -33,6 +33,10 @@ public class DataPreviewResult extends JavaScriptObject
       return this.output;
    }-*/;
 
+   public final native String getEncoding() /*-{
+      return this.encoding[0];
+   }-*/;
+
    public final native JsArrayString getOutputNames() /*-{
       return this.outputNames;
    }-*/;
@@ -51,6 +55,10 @@ public class DataPreviewResult extends JavaScriptObject
 
    public final native String getQuote() /*-{
       return this.quote[0];
+   }-*/;
+   
+   public final native String getComment() /*-{
+      return this.comment[0];
    }-*/;
    
    public final native boolean getDefaultStringsAsFactors() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/model/EnvironmentServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/model/EnvironmentServerOperations.java
@@ -40,10 +40,12 @@ public interface EnvironmentServerOperations
 
    void getOutputPreview(
            String dataFilePath,
+           String encoding,
            boolean heading,
            String separator,
            String decimal,
            String quote,
+           String comment,
            ServerRequestCallback<DataPreviewResult> requestCallback);
 
    void setContextDepth(int newContextDepth,


### PR DESCRIPTION
This change adds several commonly requested parameters to the data import wizard:

* **Encoding** `encoding` specifies the encoding of the input file. It is specified by a droplist populated from `iconvlist()`. 
* **Comment** `comment.char` specifies the character considered to mark comments in the input file; formerly this was left at its default value (which differs between read methods). We now auto-detect `#` as a comment character if it appears in the first few lines, but presume that there's no comment character otherwise. 
* **Row names** `row.names` specifies whether to assign row names automatically, from the first column, or to always use numbers. 