### PR TITLE
handle encoding correctly for run all chunks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -133,6 +133,7 @@
 * Syntax highlighting for comments in markdown documents
 * Make publishing UI easier to discover
 * Require save before previewing Rmd file
+* Handle encoding correctly for Run All Chunks on Windows
 * Support for deploying single interactive documents (not just directories)
 * Updated internal PDF viewer (PDF.js) to version 1.0.1040 
 

--- a/src/cpp/session/modules/SessionAuthoring.cpp
+++ b/src/cpp/session/modules/SessionAuthoring.cpp
@@ -149,11 +149,14 @@ Error compilePdfClosed(const json::JsonRpcRequest& request,
    return Success();
 }
 
-SEXP rs_rnwTangle(SEXP filePathSEXP, SEXP rnwWeaveSEXP)
+SEXP rs_rnwTangle(SEXP filePathSEXP,
+                  SEXP encodingSEXP,
+                  SEXP rnwWeaveSEXP)
 {
    try
    {
       modules::tex::rnw_weave::runTangle(r::sexp::asString(filePathSEXP),
+                                         r::sexp::asString(encodingSEXP),
                                          r::sexp::asString(rnwWeaveSEXP));
    }
    catch(const r::exec::RErrorException& e)
@@ -208,7 +211,7 @@ Error initialize()
    R_CallMethodDef methodDef ;
    methodDef.name = "rs_rnwTangle" ;
    methodDef.fun = (DL_FUNC) rs_rnwTangle ;
-   methodDef.numArgs = 2;
+   methodDef.numArgs = 3;
    r::routines::addCallMethod(methodDef);
 
    // install rpc methods

--- a/src/cpp/session/modules/SessionSource.R
+++ b/src/cpp/session/modules/SessionSource.R
@@ -26,12 +26,17 @@
    if (file.exists(activeRStudioDoc))
       file.remove(activeRStudioDoc)
 
-   writeChar(contents, activeRStudioDoc, eos=NULL)
+   # The contents are always passed as UTF-8 from the client and
+   # we want to make sure this is preserved on disk. Note that
+   # when the source command is issued by the client for
+   # "~/active-rstudio-document" UTF-8 is specified explicitly
+   # (see TextEditingTarget.sourceActiveDocument)
+   writeChar(contents, activeRStudioDoc, eos=NULL, useBytes = TRUE)
 
    if (sweave)
    {
       op <- function() {
-         .Call(.rs.routines$rs_rnwTangle, activeRStudioDoc, rnwWeave)
+         .Call(.rs.routines$rs_rnwTangle, activeRStudioDoc, "UTF-8", rnwWeave)
          file.remove(activeRStudioDoc)
          file.rename(paste(activeRStudioDoc, ".R", sep=""), activeRStudioDoc)
       }

--- a/src/cpp/session/modules/tex/SessionRnwWeave.hpp
+++ b/src/cpp/session/modules/tex/SessionRnwWeave.hpp
@@ -79,7 +79,9 @@ struct Result
 
 typedef boost::function<void(const Result&)> CompletedFunction;
 
-void runTangle(const std::string& filePath, const std::string& rnwWeave);
+void runTangle(const std::string& filePath,
+               const std::string& encoding,
+               const std::string& rnwWeave);
 
 void runWeave(const core::FilePath& filePath,
               const std::string& encoding,


### PR DESCRIPTION
This passes the encoding through to knitr::purl and Utils::Stangle when we do a Run All Chunks in the IDE. It's intended to address issues @yihui has seen in doing Run All Chunks with Chinese characters however as of yet I haven't been able to repro his error or confirm that this addresses the error.

@jmcphers Could you review as a sanity check and lend whatever perspective you have. @yihui Could you provide a more detailed repro (including sessionInfo, etc.) so I can see whether this fixes the issue.
