### PR TITLE
make the R completion engine more unicode-aware

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/RegexUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/RegexUtil.java
@@ -1,0 +1,65 @@
+/*
+ * RegexUtil.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client;
+
+// We do lazy initialization of all the regex singleton strings here
+public class RegexUtil
+{
+   public static final String letter()
+   {
+      if (LETTER == null)
+         LETTER = constructLetter();
+      return LETTER;
+   }
+   
+   public static final String wordCharacter()
+   {
+      if (WORD_CHARACTER == null)
+         WORD_CHARACTER = constructWordCharacter();
+      return WORD_CHARACTER;
+   }
+   
+   public static boolean isSyntacticRIdentifier(String identifier)
+   {
+      if (SYNTACTIC_R_IDENTIFIER == null)
+         SYNTACTIC_R_IDENTIFIER = constructSyntacticRIdentifierRegex();
+      
+      return identifier.matches(SYNTACTIC_R_IDENTIFIER);
+   }
+   
+   
+   private static final native String constructLetter() /*-{
+      var unicode = $wnd.require("ace/unicode");
+      return unicode.packages.L;
+   }-*/;
+   
+   private static final native String constructWordCharacter() /*-{
+      var unicode = $wnd.require("ace/unicode");
+      return unicode.packages.L +
+             unicode.packages.N;
+   }-*/;
+   
+   private static final String constructSyntacticRIdentifierRegex()
+   {
+      return
+            "[" + letter() + ".]" +
+            "[" + wordCharacter() + "._]*";
+   }
+   
+   private static String WORD_CHARACTER = null;
+   private static String LETTER = null;
+   
+   private static String SYNTACTIC_R_IDENTIFIER = null;
+}

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -193,11 +193,8 @@ public class StringUtil
 
    public static String toRSymbolName(String name)
    {
-      if (!name.matches("^[a-zA-Z_.][a-zA-Z0-9_.]*$")
-          || isRKeyword(name))
-      {
+      if (!RegexUtil.isSyntacticRIdentifier(name) || isRKeyword(name))
          return "`" + name + "`";
-      }
       else
          return name;
    }


### PR DESCRIPTION
This PR adds some provisioning for unicode support (piggybacking on the `ace/unicode` package).

Fixes completions following unicode characters:

![screen shot 2015-04-30 at 3 51 53 pm](https://cloud.githubusercontent.com/assets/1976582/7423994/dc2d6f24-ef50-11e4-9d2e-6b463f3b4a65.png)

Also ensures that such variables containing unicode letters are 'syntactic' (and so does not quote the completion, as it would be successfully parsed by R even without backticks). Other unicode symbols will style require quoting (e.g. ∞).