### PR TITLE
resolve 'Ctrl+Shift+P' conflict

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -434,8 +434,8 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="jumpTo" value="Shift+Alt+J" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="jumpTo" value="Cmd+Shift+Alt+J" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="jumpToMatching" value="Ctrl+P"/>
-         <shortcut refid="selectToMatching" value="Ctrl+Shift+P"/>
-         <shortcut refid="expandToMatching" value="Cmd+Shift+Alt+P"/>
+         <shortcut refid="selectToMatching" value="Ctrl+Shift+E"/>
+         <shortcut refid="expandToMatching" value="Ctrl+Shift+Alt+E"/>
          <shortcut value="Ctrl+Alt+Up" title="Add cursor above current cursor"/>
          <shortcut value="Ctrl+Alt+Down" title="Add cursor below current cursor"/>
          <shortcut value="Ctrl+Alt+Shift+Up" title="Move active cursor up"/>

--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -346,13 +346,13 @@
   </tr>
   <tr>
     <td>Select to Matching Brace/Paren</td>
-    <td>Ctrl+Shift+P</td>
-    <td>Ctrl+Shift+P</td>
+    <td>Ctrl+Shift+E</td>
+    <td>Ctrl+Shift+E</td>
   </tr>
   <tr>
     <td>Expand to Matching Brace/Paren</td>
-    <td>Ctrl+Shift+Alt+P</td>
-    <td>Command+Shift+Alt+P</td>
+    <td>Ctrl+Shift+Alt+E</td>
+    <td>Ctrl+Shift+Alt+E</td>
   </tr>
   <tr>
     <td>Add Cursor Above Current Cursor</td>


### PR DESCRIPTION
Changes the select/expand to matching keyboard shortcuts to 'Ctrl+Shift+<Alt>+E' instead, to avoid overriding 'run previous chunk'.