### PR TITLE
re-size signature tooltip for large signatures

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionToolTip.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionToolTip.java
@@ -46,7 +46,6 @@ public class CppCompletionToolTip extends PopupPanel
    public CppCompletionToolTip(String text, String comment)
    {
       super(true);
-      
       CppCompletionResources.Styles styles = 
                               CppCompletionResources.INSTANCE.styles();
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/RCompletionToolTip.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/RCompletionToolTip.java
@@ -54,13 +54,34 @@ public class RCompletionToolTip extends CppCompletionToolTip
             rectangle.getTop());
    }
    
+   public void resolvePositionAndShow(String signature)
+   {
+      setCursorAnchor();
+      resolvePositionAndShow(signature, docDisplay_.getCursorBounds());
+   }
+   
+   private String truncateSignature(String signature)
+   {
+      return truncateSignature(signature, 500);
+   }
+   
+   private String truncateSignature(String signature, int length)
+   {
+      if (signature.length() > length)
+         return signature.substring(0, length) + "<...truncated...> )";
+      else
+         return signature;
+   }
+   
    public void resolvePositionAndShow(String signature,
                                       int left,
                                       int top)
    {
+      signature = truncateSignature(signature);
       if (signature != null)
          setText(signature);
       
+      resolveWidth(signature);
       resolvePositionRelativeTo(left, top);
       
       setVisible(true);
@@ -68,10 +89,16 @@ public class RCompletionToolTip extends CppCompletionToolTip
       
    }
    
-   public void resolvePositionAndShow(String signature)
+   private void resolveWidth(String signature)
    {
-      setCursorAnchor();
-      resolvePositionAndShow(signature, docDisplay_.getCursorBounds());
+      if (signature.length() > 400)
+         setWidth("800px");
+      else if (signature.length() > 300)
+         setWidth("700px");
+      else if (signature.length() > 200)
+         setWidth("600px");
+      else
+         setWidth(getOffsetWidth() + "px");
    }
    
    private void resolvePositionRelativeTo(final int left,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/RCompletionToolTip.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/RCompletionToolTip.java
@@ -1,6 +1,9 @@
 package org.rstudio.studio.client.workbench.views.source.editors.text.r;
 
+import java.util.ArrayList;
+
 import org.rstudio.core.client.Rectangle;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay.AnchoredSelection;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
@@ -62,15 +65,36 @@ public class RCompletionToolTip extends CppCompletionToolTip
    
    private String truncateSignature(String signature)
    {
-      return truncateSignature(signature, 500);
+      return truncateSignature(signature, 200);
    }
    
    private String truncateSignature(String signature, int length)
    {
+      // Perform smart truncation -- look for a comma at or after the
+      // length specified (so we don't cut argument names in half)
       if (signature.length() > length)
-         return signature.substring(0, length) + "<...truncated...> )";
-      else
-         return signature;
+      {
+         String truncated = signature;
+         ArrayList<Integer> commaIndices = StringUtil.indicesOf(signature, ',');
+         if (commaIndices.size() == 0)
+         {
+            truncated = signature.substring(0, length);
+         }
+         
+         for (int i = 0; i < commaIndices.size(); i++)
+         {
+            int index = commaIndices.get(i);
+            if (index >= length)
+            {
+               truncated = signature.substring(0, index + 1);
+               break;
+            }
+         }
+         
+         return truncated + " <...truncated...> )";
+      }
+      
+      return signature;
    }
    
    public void resolvePositionAndShow(String signature,


### PR DESCRIPTION
This PR attempts to improve the display of very long signatures in the signature tooltip (e.g. `read.table`):

1. We truncate overly-long signatures (>500 characters),
2. We increase the width of the signature tooltip when we have many characters (to decrease vertical space used)

Net result is this:

![screen shot 2015-05-04 at 12 53 37 pm](https://cloud.githubusercontent.com/assets/1976582/7461084/9fc1230a-f25c-11e4-9c8b-da72f65c69c9.png)

I'm not sure if we'd rather still truncate (because that is a load of information; probably too much?) or at least we're happy with the popup not going off screen.