### PR TITLE
fix formula skipper

### DIFF
--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -1650,13 +1650,13 @@ void validateFunctionCall(RTokenCursor cursor,
 //
 //    foo$bar$log(1 + y) + log(2 + y) ~ ({1 ~ 2}) ^ 5
 //
-bool skipFormulas(RTokenCursor& origin,
-                  ParseStatus& status)
+bool skipFormulas(RTokenCursor& origin, ParseStatus& status)
 {
    RTokenCursor cursor = origin.clone();
+
    bool foundTilde = false;
    
-   while (cursor.moveToEndOfStatement(false))
+   while (cursor.moveToEndOfEvaluation())
    {
       if (!cursor.moveToNextSignificantToken())
          break;
@@ -1881,11 +1881,7 @@ START:
       checkIncorrectComparison(cursor, status);
       
       // We want to skip over formulas if necessary.
-      if (skipFormulas(cursor, status))
-      {
-         if (cursor.isAtEndOfDocument())
-            return;
-      }
+      skipFormulas(cursor, status);
       
       DEBUG("Start: " << cursor);
       // Move over unary operators -- any sequence is valid,
@@ -2206,6 +2202,10 @@ START:
          goto START;
          
       }
+
+      // End of document. Let's go home.
+      if (cursor.isAtEndOfDocument())
+         return;
       
       GOTO_INVALID_TOKEN(cursor);
       

--- a/src/cpp/session/modules/SessionRTokenCursor.hpp
+++ b/src/cpp/session/modules/SessionRTokenCursor.hpp
@@ -574,7 +574,51 @@ public:
             isValidAsIdentifier(previousSignificantToken()) &&
             isValidAsIdentifier(nextSignificantToken());
   }
-  
+
+  // Move to the end of an 'evaluation', e.g.
+  //
+  //    x$foo[[1]]$bar(1, 2, 3)$baz
+  //
+  // Note that we don't move to the start of a _statement_; e.g., we don't
+  // walk over all binary operators. For example:
+  //
+  //    foo + x$foo$bar(1)[1]
+  //          ^   <--       ^
+  //
+  // We only move over extraction operators.
+  bool moveToEndOfEvaluation()
+  {
+     RTokenCursor cursor = clone();
+     while (true)
+     {
+        while (isRightBracket(cursor))
+        {
+           if (!cursor.fwdToMatchingToken())
+              return false;
+
+           if (!cursor.moveToNextSignificantToken())
+              return false;
+        }
+
+        if (isExtractionOperator(cursor.nextSignificantToken()))
+        {
+           if (!cursor.moveToNextSignificantToken())
+              return false;
+
+           if (!cursor.moveToNextSignificantToken())
+              return false;
+
+           continue;
+        }
+
+        break;
+
+     }
+
+     setOffset(cursor.offset());
+     return true;
+  }
+
   // Move to the start of an 'evaluation' (from the end of a statement), e.g.
   //
   //    x$foo[[1]]$bar(1, 2, 3)$baz

--- a/src/cpp/session/modules/SessionRTokenCursorTests.cpp
+++ b/src/cpp/session/modules/SessionRTokenCursorTests.cpp
@@ -100,6 +100,21 @@ context("RTokenCursor")
       cursor.moveToEndOfTokenStream();
       expect_true(cursor.getHeadOfPipeChain().empty());
    }
+   
+   test_that("evaluation lookarounds work")
+   {
+      RTokens rTokens(L"foo$bar$baz[[1]]$bam");
+      RTokenCursor cursor(rTokens);
+      
+      expect_true(cursor.contentEquals(L"foo"));
+      expect_true(cursor.moveToEndOfEvaluation());
+      expect_true(cursor.contentEquals(L"baz"));
+      expect_true(cursor.moveToStartOfEvaluation());
+      expect_true(cursor.contentEquals(L"foo"));
+      
+      expect_true(cursor.moveToEndOfStatement(false));
+      expect_true(cursor.contentEquals(L"bam"));
+   }
 }
 
 } // namespace unit_tests


### PR DESCRIPTION
This fixes an issue @hadley saw re: erroneous lint in formulas, e.g.

    classifly(data, variable ~ other)

I think this PR is safe enough to take for v0.99 but am fine leaving it for the next release as well if we prefer to be conservative.