### PR TITLE
Fix a few issues related to multibyte chars in R Markdown

### DIFF
--- a/src/cpp/session/modules/SessionDiagnostics.R
+++ b/src/cpp/session/modules/SessionDiagnostics.R
@@ -105,6 +105,7 @@
                                          reStart,
                                          reEnd)
 {
+   Encoding(content) <- "UTF-8"
    splat <- strsplit(content, "\n", fixed = TRUE)[[1]]
    starts <- grep(reStart, splat, perl = TRUE)
    ends <- grep(reEnd, splat, perl = TRUE)

--- a/src/cpp/session/modules/SessionSource.R
+++ b/src/cpp/session/modules/SessionSource.R
@@ -31,9 +31,8 @@
    # when the source command is issued by the client for
    # "~/active-rstudio-document" UTF-8 is specified explicitly
    # (see TextEditingTarget.sourceActiveDocument)
-   writeChar(contents, activeRStudioDoc, 
-             nchars = nchar(contents, type = "bytes"),
-             eos=NULL, useBytes = TRUE)
+   Encoding(contents) <- "UTF-8"
+   writeLines(contents, activeRStudioDoc, useBytes = TRUE)
   
    if (sweave)
    {

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -460,7 +460,7 @@ private:
       r::sexp::Protect protect;
       SEXP sexpOutputFormat;
       Error error = r::exec::RFunction("rmarkdown:::default_output_format",
-                                       path, encoding)
+                                       string_utils::utf8ToSystem(path), encoding)
                                       .call(&sexpOutputFormat, &protect);
       if (error)
       {


### PR DESCRIPTION
I'm not sure if I used `string_utils::utf8ToSystem()` correctly. At least the two commits in R worked for me on Windows.

For the third commit, I experimented with `Encoding(input) = 'UTF-8'` inside `rmarkdown::default_output_format` and it also worked, which means the path should have been either marked with UTF-8 or converted to system native encoding. This will make this error go away:

```
Error in file.exists(epath <- path.expand(x)) :
  file name conversion problem -- name too long?
```