### PR TITLE
allow prefix matches for snippets

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/snippets/SnippetHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/snippets/SnippetHelper.java
@@ -168,11 +168,8 @@ public class SnippetHelper
       
    }-*/;
    
-   public void applySnippet(String token, String snippetName)
+   private void selectToken(String token)
    {
-      // Set the selection based on what we want to replace. For auto-paired
-      // insertions, e.g. `[|]`, we want to replace both characters; typically
-      // we only want to replace the token.
       int offset = token.length();
       if (StringUtil.isComplementOf(
             token.substring(offset - 1),
@@ -182,7 +179,14 @@ public class SnippetHelper
          offset++;
       }
       editor_.expandSelectionLeft(offset);
-      
+   }
+   
+   public void applySnippet(final String token,
+                            final String snippetName)
+   {
+      // Set the selection based on what we want to replace. For auto-paired
+      // insertions, e.g. `[|]`, we want to replace both characters; typically
+      // we only want to replace the token.
       String snippetContent = transformMacros(
             getSnippetContents(snippetName),
             token,
@@ -203,12 +207,14 @@ public class SnippetHelper
             @Override
             public void onResponseReceived(String transformed)
             {
+               selectToken(token);
                applySnippetImpl(transformed, manager_, editor_.getWidget().getEditor());
             }
          });
       }
       else
       {
+         selectToken(token);
          applySnippetImpl(snippetContent, manager_, editor_.getWidget().getEditor());
       }
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -418,7 +418,7 @@ public class RCompletionManager implements CompletionManager
          else if (event.getKeyCode() == KeyCodes.KEY_TAB &&
                   modifier == KeyboardShortcut.SHIFT)
          {
-            return snippets_.attemptSnippetInsertion();
+            return snippets_.attemptSnippetInsertion(true);
          }
          else if (keycode == 112 // F1
                   && modifier == KeyboardShortcut.NONE)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
@@ -200,7 +200,7 @@ public class CppCompletionManager implements CompletionManager
          else if (event.getKeyCode() == KeyCodes.KEY_TAB &&
                   modifier == KeyboardShortcut.SHIFT)
          {
-            return snippets_.attemptSnippetInsertion();
+            return snippets_.attemptSnippetInsertion(true);
          }
          else if (event.getKeyCode() == 112 // F1
                   && modifier == KeyboardShortcut.NONE)


### PR DESCRIPTION
This PR extends the snippets framework to allow for prefix matches and 'dynamic' snippet usage, which IMO increases the potential utility of the snippets framework 100 fold.

For example, given the snippet:

```
snippet $
    `r function_template("$$")`
```

(Note that `$$` is replaced with the contents of the token at the cursor, excluding the snippet name)

We can do the following snippet insertion:

![snippet](https://cloud.githubusercontent.com/assets/1976582/7662684/750136c6-fb14-11e4-8c13-94c168362674.gif)

