### PR TITLE
properly update current value

### DIFF
--- a/src/gwt/acesupport/acemode/token_cursor.js
+++ b/src/gwt/acesupport/acemode/token_cursor.js
@@ -319,7 +319,7 @@ var TokenCursor = function(tokens, row, offset) {
       var parenCount = 0;
       while (this.moveToPreviousToken())
       {
-         var currentValue = "(";
+         var currentValue = this.currentValue();
          if (currentValue === "(")
          {
             if (parenCount === 0)


### PR DESCRIPTION
This fixes the bug seen with incorrect formatting, e.g.

```
foo <- function(x,
                y) {
```