### PR TITLE
wire 'select all' in 'Find/Replace bar' to various options

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -2120,6 +2120,11 @@ public class AceEditor implements DocDisplay,
       widget_.getEditor().findAll(needle);
    }
    
+   public void selectAll(String needle, Range range, boolean wholeWord, boolean caseSensitive)
+   {
+      widget_.getEditor().findAll(needle, range, wholeWord, caseSensitive);
+   }
+   
    public void moveCursorLeft()
    {
       moveCursorLeft(1);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -286,6 +286,10 @@ public class AceEditorNative extends JavaScriptObject {
       return this.findAll(needle);
    }-*/;
    
+   public final native int findAll(String needle, Range range, boolean wholeWord, boolean caseSensitive) /*-{
+      return this.findAll(needle, {range: range, wholeWord: wholeWord, caseSensitive: caseSensitive});
+   }-*/;
+   
    public final native void insert(String text) /*-{
       var that = this;
       this.forEachSelection(function() {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplace.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplace.java
@@ -205,10 +205,18 @@ public class FindReplace
    
    public void selectAll()
    {
+      // NOTE: 'null' range here implies whole document
+      Range range = null;
+      if (targetSelection_ != null)
+         range = targetSelection_.getRange();
+      
+      boolean wholeWord = display_.getWholeWord().getValue();
+      boolean caseSensitive = display_.getCaseSensitive().getValue();
+      
       String searchString = display_.getFindValue().getValue();
       if (searchString.length() != 0)
       {
-         editor_.selectAll(searchString);
+         editor_.selectAll(searchString, range, wholeWord, caseSensitive);
          editor_.focus();
       }
    }


### PR DESCRIPTION
This PR wires up the `All` Find / Replace button to the various options / checkboxes we have. (Previously, it ignored all the set options)