### PR TITLE
Put Qt cmake modules to CMAKE_MODULE_PATH

### DIFF
--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -65,9 +65,17 @@ else()
    endif()
 endif()
 
+if (NOT EXISTS ${QT_QMAKE_EXECUTABLE})
+    message( SEND_ERROR "Qt qmake not found" )
+endif()
 # set the cmake prefix path based on the location of the qmake executable
 get_filename_component(QT_BIN_DIR ${QT_QMAKE_EXECUTABLE} PATH)
-set(CMAKE_PREFIX_PATH "${QT_BIN_DIR}//..//lib//cmake")
+set(QT_CMAKE_MODULE_PATH "${QT_BIN_DIR}//..//lib//cmake")
+if (EXISTS ${QT_CMAKE_MODULE_PATH})
+    list(APPEND CMAKE_MODULE_PATH ${QT_CMAKE_MODULE_PATH})
+else()
+    message( WARNING "Qt Cmake modules not found" )
+endif()
 
 # find and include Qt
 add_definitions(-DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII)


### PR DESCRIPTION
Don't overwrite `CMAKE_PREFIX_PATH` as it's used for locating binaries and libraries.
Tested on Gentoo Prefix and Archlinux.

See also the comments to 6c7b139c2f8e167a1a2ff0df9ad3e15a3b5acf15