### PR TITLE
Supply content category field when deploying

### DIFF
--- a/src/cpp/core/include/core/json/JsonRpc.hpp
+++ b/src/cpp/core/include/core/json/JsonRpc.hpp
@@ -412,6 +412,40 @@ core::Error readParams(const json::Array& params,
    return readParam(params, 10, pValue11) ;
 }
 
+template <typename T1, typename T2, typename T3, typename T4, typename T5,
+typename T6, typename T7, typename T8, typename T9, typename T10, typename T11,
+typename T12>
+core::Error readParams(const json::Array& params,
+                       T1* pValue1,
+                       T2* pValue2,
+                       T3* pValue3,
+                       T4* pValue4,
+                       T5* pValue5,
+                       T6* pValue6,
+                       T7* pValue7,
+                       T8* pValue8,
+                       T9* pValue9,
+                       T10* pValue10,
+                       T11* pValue11,
+                       T12* pValue12)
+{
+   core::Error error = readParams(params,
+                                  pValue1,
+                                  pValue2,
+                                  pValue3,
+                                  pValue4,
+                                  pValue5,
+                                  pValue6,
+                                  pValue7,
+                                  pValue8,
+                                  pValue9,
+                                  pValue10,
+                                  pValue11) ;
+   if (error)
+      return error ;
+
+   return readParam(params, 11, pValue12) ;
+}
 namespace errors {
 
 inline Error paramMissing(const std::string& name,
@@ -928,6 +962,39 @@ core::Error readObject(const json::Object& object,
       return error;
 
    return readObject(object, name11, pValue11);
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12>
+core::Error readObject(const json::Object& object,
+                       const std::string& name1, T1* pValue1,
+                       const std::string& name2, T2* pValue2,
+                       const std::string& name3, T3* pValue3,
+                       const std::string& name4, T4* pValue4,
+                       const std::string& name5, T5* pValue5,
+                       const std::string& name6, T6* pValue6,
+                       const std::string& name7, T7* pValue7,
+                       const std::string& name8, T8* pValue8,
+                       const std::string& name9, T9* pValue9,
+                       const std::string& name10, T10* pValue10,
+                       const std::string& name11, T11* pValue11,
+                       const std::string& name12, T12* pValue12)
+{
+   Error error = readObject(object,
+                            name1, pValue1,
+                            name2, pValue2,
+                            name3, pValue3,
+                            name4, pValue4,
+                            name5, pValue5,
+                            name6, pValue6,
+                            name7, pValue7,
+                            name8, pValue8,
+                            name9, pValue9,
+                            name10, pValue10,
+                            name11, pValue11);
+   if (error)
+      return error;
+
+   return readObject(object, name12, pValue12);
 }
 
 // json rpc response

--- a/src/cpp/session/modules/SessionRSConnect.cpp
+++ b/src/cpp/session/modules/SessionRSConnect.cpp
@@ -71,6 +71,7 @@ public:
          const std::string& account,
          const std::string& server,
          const std::string& app,
+         const std::string& contentCategory,
          const json::Array& additionalFilesList,
          const json::Array& ignoredFilesList,
          bool asMultiple,
@@ -112,7 +113,9 @@ public:
                 sourceDoc + "', ") + 
              "account = '" + account + "',"
              "server = '" + server + "', "
-             "appName = '" + app + "', "
+             "appName = '" + app + "', " + 
+             (contentCategory.empty() ? "" : "contentCategory = '" + 
+                contentCategory + "', ") +
              "launch.browser = function (url) { "
              "   message('" kFinishedMarker "', url) "
              "}, "
@@ -188,11 +191,13 @@ Error rsconnectPublish(const json::JsonRpcRequest& request,
                        json::JsonRpcResponse* pResponse)
 {
    json::Array sourceFiles, additionalFiles, ignoredFiles;
-   std::string sourceDir, sourceFile, sourceDoc, account, server, appName;
+   std::string sourceDir, sourceFile, sourceDoc, account, server, appName,
+               contentCategory;
    bool asMultiple = false, asStatic = false;
    Error error = json::readParams(request.params, &sourceDir, &sourceFiles,
                                    &sourceFile, &sourceDoc, &account, &server, 
-                                   &appName, &additionalFiles, &ignoredFiles, 
+                                   &appName, &contentCategory, 
+                                   &additionalFiles, &ignoredFiles, 
                                    &asMultiple, &asStatic);
    if (error)
       return error;
@@ -207,6 +212,7 @@ Error rsconnectPublish(const json::JsonRpcRequest& request,
       s_pRSConnectPublish_ = RSConnectPublish::create(sourceDir, sourceFiles, 
                                                   sourceFile, sourceDoc, 
                                                   account, server, appName, 
+                                                  contentCategory,
                                                   additionalFiles,
                                                   ignoredFiles, asMultiple,
                                                   asStatic);

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
@@ -205,7 +205,8 @@ public class RSConnect implements SessionInitHandler,
                               new RSConnectPublishSource(event.getPath(), 
                                     event.getHtmlFile(), 
                                     arg.isSelfContained(), 
-                                    arg.getDescription()));
+                                    arg.getDescription(),
+                                    event.getContentType()));
                      else
                         publishAsCode(event);
                   }
@@ -335,7 +336,7 @@ public class RSConnect implements SessionInitHandler,
       else
       {
          source = new RSConnectPublishSource(event.getPath(), 
-            false, null);
+            false, null, event.getContentType());
       }
          
       publishAsFiles(event, source);
@@ -356,7 +357,8 @@ public class RSConnect implements SessionInitHandler,
          source = new RSConnectPublishSource(
                input.getOriginatingEvent().getHtmlFile(),
                input.isSelfContained(), 
-               input.getDescription());
+               input.getDescription(),
+               input.getContentType());
       }
       publishAsFiles(input.getOriginatingEvent(), source);
    }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSource.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSource.java
@@ -16,6 +16,7 @@ package org.rstudio.studio.client.rsconnect.model;
 
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.files.FileSystemItem;
+import org.rstudio.studio.client.rsconnect.RSConnect;
 
 public class RSConnectPublishSource
 {
@@ -26,21 +27,29 @@ public class RSConnectPublishSource
       isSelfContained_ = false;
       description_ = null;
       deployDir_ = sourceDir;
+      contentCategory_ = null;
    }
 
    public RSConnectPublishSource(String sourceFile, boolean isSelfContained, 
-         String description)
+         String description, int type)
    {
-      this(sourceFile, sourceFile, isSelfContained, description);
+      this(sourceFile, sourceFile, isSelfContained, description,
+            type);
    }
    
    public RSConnectPublishSource(String sourceFile, String outputFile, 
-         boolean isSelfContained, String description)
+         boolean isSelfContained, String description, int type)
    {
       deployFile_ = outputFile;
       sourceFile_ = sourceFile;
       description_ = description;
       isSelfContained_ = isSelfContained;
+
+      // consider plots and raw HTML published from the viewer pane to be 
+      // plots 
+      contentCategory_ = (type == RSConnect.CONTENT_TYPE_PLOT  ||
+            type == RSConnect.CONTENT_TYPE_HTML) ? "plot" : null;
+
       deployDir_ = FileSystemItem.createFile(outputFile).getParentPathString();
    }
    
@@ -51,6 +60,7 @@ public class RSConnectPublishSource
       sourceFile_ = preview.getSourceFile();
       description_ = description;
       isSelfContained_ = isSelfContained;
+      contentCategory_ = null;
       deployDir_ = FileSystemItem.createFile(preview.getOutputFile())
             .getParentPathString();
    }
@@ -63,6 +73,7 @@ public class RSConnectPublishSource
       deployFile_ = deployFile;
       isSelfContained_ = isSelfContained;
       description_ = description;
+      contentCategory_ = null;
    }
    
    public String getDeployFile()
@@ -111,9 +122,15 @@ public class RSConnectPublishSource
       return isSelfContained_;
    }
    
+   public String getContentCategory()
+   {
+      return contentCategory_;
+   }
+   
    private final String deployFile_;
    private final String deployDir_;
    private final String sourceFile_;
    private final String description_;
+   private final String contentCategory_;
    private final boolean isSelfContained_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishFilesPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishFilesPage.java
@@ -52,7 +52,8 @@ public class PublishFilesPage
                               input.getOriginatingEvent().getPath(),
                               input.getOriginatingEvent().getHtmlFile(),
                               input.isSelfContained() && asStatic,
-                              input.getDescription());
+                              input.getDescription(),
+                              input.getContentType());
             }
             contents_.setPublishSource(source, input.getContentType(), 
                   asMultiple, true);
@@ -61,7 +62,8 @@ public class PublishFilesPage
             contents_.setPublishSource(
                   new RSConnectPublishSource(input.getSourceRmd().getPath(),
                         input.isSelfContained() && asStatic,
-                        input.getDescription()),
+                        input.getDescription(),
+                        input.getContentType()),
                   input.getContentType(),
                   asMultiple, false);
       }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishRPubsPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishRPubsPage.java
@@ -57,7 +57,8 @@ public class PublishRPubsPage
                   initialData_.getOriginatingEvent().getPath(), 
                   initialData_.getOriginatingEvent().getHtmlFile(),
                   initialData_.isSelfContained(),
-                  initialData_.getDescription()));
+                  initialData_.getDescription(),
+                  initialData_.getContentType()));
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -3676,10 +3676,12 @@ public class RemoteServer implements Server
       params.set(4, new JSONString(account));
       params.set(5, new JSONString(server));
       params.set(6, new JSONString(appName));
-      params.set(7, JSONUtils.toJSONStringArray(settings.getAdditionalFiles()));
-      params.set(8, JSONUtils.toJSONStringArray(settings.getIgnoredFiles()));
-      params.set(9, JSONBoolean.getInstance(settings.getAsMultiple()));
-      params.set(10, JSONBoolean.getInstance(settings.getAsStatic()));
+      params.set(7, new JSONString(source.getContentCategory() == null ? "" :
+            source.getContentCategory()));
+      params.set(8, JSONUtils.toJSONStringArray(settings.getAdditionalFiles()));
+      params.set(9, JSONUtils.toJSONStringArray(settings.getIgnoredFiles()));
+      params.set(10, JSONBoolean.getInstance(settings.getAsMultiple()));
+      params.set(11, JSONBoolean.getInstance(settings.getAsStatic()));
       sendRequest(RPC_SCOPE,
             RSCONNECT_PUBLISH,
             params,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/rsconnectdeploy/RSConnectDeployOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/rsconnectdeploy/RSConnectDeployOutputPresenter.java
@@ -67,7 +67,11 @@ public class RSConnectDeployOutputPresenter extends BusyPresenter
       // HTML file for which we know the title--this may very well be a
       // temporary file
       String title = event.getPath();
-      if ((title.toLowerCase().endsWith(".htm") || 
+      if (title == null)
+         title = "";
+      
+      if ((title.isEmpty() ||
+           title.toLowerCase().endsWith(".htm") || 
            title.toLowerCase().endsWith(".html") &&
            !StringUtil.isNullOrEmpty(event.getTitle())))
       {


### PR DESCRIPTION
This change supplies the content category field when deploying static content from the IDE. 

The new field is intended to help the server distinguish among different kinds of static HTML content (for instance, plots and documents).