### PR TITLE
new shortcut for run current chunk (Cmd+Shift+Enter)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 ### R Markdown
 
 * New run chunk button overlaid at the top right of chunks in the editor
+* New shortcut for run current chunk (Cmd+Shift+Enter)
 
 
 ### Miscellaneous

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -305,7 +305,10 @@ public class TextFileType extends EditableFileType
       {
          results.add(commands.executeAllCode());
          results.add(commands.sourceActiveDocument());
-         results.add(commands.sourceActiveDocumentWithEcho());
+         // file types with chunks take the Cmd+Shift+Enter shortcut
+         // for run current chunk
+         if (!canExecuteChunks())
+            results.add(commands.sourceActiveDocumentWithEcho());
       }
       if (canExecuteToCurrentLine())
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -512,6 +512,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="executeCurrentSection" value="Cmd+Alt+T"/>
          <shortcut refid="executePreviousChunks" value="Cmd+Alt+P"/>
          <shortcut refid="executeCurrentChunk" value="Cmd+Alt+C"/>
+         <shortcut refid="executeCurrentChunk" value="Cmd+Shift+Enter"/>
          <shortcut refid="executeNextChunk" value="Cmd+Alt+N"/>
       </shortcutgroup>
       <shortcutgroup name="Debug">


### PR DESCRIPTION
@kevinushey @jmcphers 

Cmd+Shift+Enter is an easier to access and much more familiar code execution shortcut than Cmd+Alt+C. Formerly this shortcut did a stangle/purl (extract all the code in the document and run it). This is an infrequent operation (considering that Knit does the same thing but actually shows you the output in a document rather than just in the console). Furthermore, Cmd+Shift+S (Source) still provides keyboard access to stangle/purl.

@jmcphers I know that you added support for multiple commands being bound to the same shortcut recently. Does this PR handle things correctly on that front?
