### PR TITLE
enable explicit paste action

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -16,8 +16,10 @@ package org.rstudio.studio.client.application.ui.impl;
 
 import java.util.ArrayList;
 
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
+import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.command.impl.DesktopMenuCallback;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.theme.res.ThemeResources;
@@ -36,6 +38,8 @@ import org.rstudio.studio.client.application.ui.ApplicationHeader;
 import org.rstudio.studio.client.application.ui.GlobalToolbar;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.debugging.ErrorManager;
+import org.rstudio.studio.client.events.BeginPasteEvent;
+import org.rstudio.studio.client.events.EndPasteEvent;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.workbench.codesearch.CodeSearch;
@@ -55,7 +59,13 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.Event.NativePreviewHandler;
 import com.google.gwt.user.client.Timer;
+import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -214,6 +224,28 @@ public class DesktopApplicationHeader implements ApplicationHeader
    @Handler
    void onPasteDummy()
    {
+      eventBus_.fireEvent(new BeginPasteEvent());
+      keyListener_ = Event.addNativePreviewHandler(new NativePreviewHandler()
+      {
+         
+         @Override
+         public void onPreviewNativeEvent(NativePreviewEvent event)
+         {
+            // Defer so that this event can go through and execute unabated
+            Scheduler.get().scheduleDeferred(new ScheduledCommand()
+            {
+               
+               @Override
+               public void execute()
+               {
+                  eventBus_.fireEvent(new EndPasteEvent());
+                  keyListener_.removeHandler();
+                  keyListener_ = null;
+               }
+            });
+         }
+      });
+      
       Desktop.getFrame().clipboardPaste();
    }
 
@@ -364,4 +396,5 @@ public class DesktopApplicationHeader implements ApplicationHeader
    private IgnoredUpdates ignoredUpdates_;
    private boolean ignoredUpdatesDirty_ = false;
    private ApplicationQuit appQuit_; 
+   private HandlerRegistration keyListener_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/events/BeginPasteEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/events/BeginPasteEvent.java
@@ -1,0 +1,40 @@
+/*
+ * BeginPasteEvent.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class BeginPasteEvent extends GwtEvent<BeginPasteEvent.Handler>
+{
+   public interface Handler extends EventHandler
+   {
+      void onBeginPaste(BeginPasteEvent event);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onBeginPaste(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/events/EndPasteEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/events/EndPasteEvent.java
@@ -1,0 +1,40 @@
+/*
+ * EndPasteEvent.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class EndPasteEvent extends GwtEvent<EndPasteEvent.Handler>
+{
+   public interface Handler extends EventHandler
+   {
+      void onEndPaste(EndPasteEvent event);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onEndPaste(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -43,6 +43,8 @@ import org.rstudio.core.client.widget.FontSizer;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.debugging.model.Breakpoint;
+import org.rstudio.studio.client.events.BeginPasteEvent;
+import org.rstudio.studio.client.events.EndPasteEvent;
 import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.output.lint.LintResources;
@@ -234,7 +236,53 @@ public class AceEditorWidget extends Composite
                   events_.fireEvent(new AfterAceRenderEvent());
                }
             });
+      
+      events_.addHandler(
+            BeginPasteEvent.TYPE,
+            new BeginPasteEvent.Handler()
+            {
+               
+               @Override
+               public void onBeginPaste(BeginPasteEvent event)
+               {
+                  maybeUnmapCtrlV();
+               }
+            });
+      
+      events_.addHandler(
+            EndPasteEvent.TYPE,
+            new EndPasteEvent.Handler()
+            {
+               
+               @Override
+               public void onEndPaste(EndPasteEvent event)
+               {
+                  maybeRemapCtrlV();
+               }
+            });
    }
+   
+   private static native final void maybeUnmapCtrlV() /*-{
+      var Vim = $wnd.require("ace/keyboard/vim").handler;
+      var keymap = Vim.defaultKeymap;
+      for (var i = 0; i < keymap.length; i++) {
+         if (keymap[i].keys === "<C-v>") {
+            keymap[i].keys = "<DISABLED:C-v>";
+            break;
+         }
+      }
+   }-*/;
+   
+   private static native final void maybeRemapCtrlV() /*-{
+      var Vim = $wnd.require("ace/keyboard/vim").handler;
+      var keymap = Vim.defaultKeymap;
+      for (var i = 0; i < keymap.length; i++) {
+         if (keymap[i].keys === "<DISABLED:C-v>") {
+            keymap[i].keys = "<C-v>";
+            break;
+         }
+      }
+   }-*/;
    
    @Inject
    private void initialize(EventBus events, ChunkIconsManager manager)


### PR DESCRIPTION
Previously, with Qt, paste events were constructed by manually sending `CTRL + V` back up to the client. This is a problem when in Vim mode on Windows or Linux, as `CTRL + V` is bound to enter visual mode.

I experimented with a model where we disabled and re-enabled those keyboard handlers, but due to the asynchronous nature of event handling here that seemed to be a more dangerous method.

This PR alleviates this behavior by instead extracting the clipboard contents and calling a JavaScript callback that then pasted the associated text.

@jjallaire, can you sanity check that I'm extracting + handling encodings properly at the Qt level, and that the event is handled at the appropriate location (within `TextEditingTarget`)?