### PR TITLE
add keyboard shortcut to toggle toolbar visibility

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -180,6 +180,11 @@ public class Application implements ApplicationEventHandlers
       setToolbarPref(false);
    }
    
+   @Handler
+   public void onToggleToolbar()
+   {
+      setToolbarPref(!view_.isToolbarShowing());
+   }
    
    @Handler
    void onShowAboutDialog()

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationView.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationView.java
@@ -31,6 +31,7 @@ public interface ApplicationView
    
    // toolbar
    void showToolbar(boolean showToolbar);
+   boolean isToolbarShowing();
    
    // go to function
    void performGoToFunction();

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
@@ -74,6 +74,11 @@ public class ApplicationWindow extends Composite
       applicationPanel_.forceLayout();  
    }
    
+   public boolean isToolbarShowing()
+   {
+      return applicationHeader_.isToolbarVisible();
+   }
+   
    public void performGoToFunction()
    {
       new CodeSearchDialog(pCodeSearch_).showModal();  

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -547,6 +547,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="viewerSaveAllAndRefresh" value="Cmd+Shift+F5"/>
          <shortcut refid="helpKeyboardShortcuts" value="Alt+Shift+K"/>
          <shortcut refid="toggleFullScreen" value="Ctrl+Meta+F" if="org.rstudio.core.client.BrowseCap.isMacintoshDesktop()"/>
+         <shortcut refid="toggleToolbar" value="Ctrl+Alt+`"/>
       </shortcutgroup>
       <shortcutgroup name="Console">
          <shortcut refid="consoleClear" value="Ctrl+L"/>
@@ -740,6 +741,8 @@ well as menu structures (for main menu and popup menus).
         menuLabel="Show _Toolbar"/>
    <cmd id="hideToolbar"
         menuLabel="Hide _Toolbar"/>
+   <cmd id="toggleToolbar"
+        menuLabel="Toggle Toolbar"/>
    <cmd id="zoomActualSize"
         menuLabel="Actual Size"/>
    <cmd id="zoomIn"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -202,6 +202,7 @@ public abstract class
    // View
    public abstract AppCommand showToolbar();
    public abstract AppCommand hideToolbar();
+   public abstract AppCommand toggleToolbar();
    public abstract AppCommand zoomActualSize();
    public abstract AppCommand zoomIn();
    public abstract AppCommand zoomOut();


### PR DESCRIPTION
This PR binds `` CTRL + ALT + ` `` to toggle the main toolbar's visibility.