### PR TITLE
allow sub-sections within scope tree; bold text in popup

### DIFF
--- a/src/gwt/acesupport/acemode/r_scope_tree.js
+++ b/src/gwt/acesupport/acemode/r_scope_tree.js
@@ -43,11 +43,22 @@ define('mode/r_scope_tree', function(require, exports, module) {
 
       this.onSectionHead = function(sectionLabel, sectionPos) {
          var existingScopes = this.getActiveScopes(sectionPos);
-         if (existingScopes.length == 2 && existingScopes[1].isSection()) {
-            this.$root.closeScope(sectionPos, ScopeNode.TYPE_SECTION);
+
+         // A section will close a previous section that exists as part
+         // of that parent node (if it exists).
+         if (existingScopes.length > 1)
+         {
+            var parentNode = existingScopes[existingScopes.length - 2];
+            var children = parentNode.$children;
+            for (var i = children.length - 1; i >= 0; i--)
+            {
+               if (children[i].isSection())
+               {
+                  this.$root.closeScope(sectionPos, ScopeNode.TYPE_SECTION);
+                  break;
+               }
+            }
          }
-         else if (existingScopes.length != 1)
-            return;
 
          this.$root.addNode(new this.$ScopeNodeFactory(sectionLabel, sectionPos, sectionPos,
                                           ScopeNode.TYPE_SECTION));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -21,6 +21,7 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.RepeatingCommand;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.dom.client.Style.FontWeight;
 import com.google.gwt.event.dom.client.*;
 import com.google.gwt.event.logical.shared.*;
 import com.google.gwt.event.shared.GwtEvent;
@@ -52,6 +53,7 @@ import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.js.JsUtil;
 import org.rstudio.core.client.regex.Match;
 import org.rstudio.core.client.regex.Pattern;
+import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.*;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.Desktop;
@@ -1317,6 +1319,12 @@ public class TextEditingTarget implements
       
       return menuItem;
    }
+   
+   private void addScopeStyle(MenuItem item, Scope scope)
+   {
+      if (scope.isSection())
+         item.getElement().getStyle().setFontWeight(FontWeight.BOLD);
+   }
 
    private MenuItem addFunctionsToMenu(StatusBarPopupMenu menu,
                                        final JsArray<Scope> funcs,
@@ -1358,6 +1366,7 @@ public class TextEditingTarget implements
                                                        true);
                      }
                   });
+            addScopeStyle(menuItem, func);
             menu.addItem(menuItem);
 
             childIndent = indent + "&nbsp;&nbsp;";


### PR DESCRIPTION
This PR seeks to allow for sub-sections in the scope tree, and also bolds their text in the scope tree display:

![screen shot 2015-05-27 at 6 22 08 pm](https://cloud.githubusercontent.com/assets/1976582/7850952/5a5b2d44-049d-11e5-9d79-1b3430157864.png)

More globally, I think the display of the scope tree could use an overhaul. What do you think about prefixing each entry with the associated icon as well? (This might be too heavy-weight as well, but I feel like we need a bit more visual 'stuff' to separate sections from functions etc.)