### PR TITLE
append, rather than replace, available packages

### DIFF
--- a/src/cpp/core/include/core/Algorithm.hpp
+++ b/src/cpp/core/include/core/Algorithm.hpp
@@ -187,6 +187,15 @@ bool get(const AssociativeContainer& container,
    return true;
 }
 
+template <typename ContainerType>
+void append(ContainerType* pContainer, const ContainerType& other)
+{
+   pContainer->insert(
+            pContainer->end(),
+            other.begin(),
+            other.end());
+}
+
 } // namespace algorithm
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/session/modules/SessionPackages.cpp
+++ b/src/cpp/session/modules/SessionPackages.cpp
@@ -110,7 +110,7 @@ public:
                                                          cache_.find(contribUrl);
          if (it != cache_.end())
          {
-            *pAvailablePackages = it->second;
+            core::algorithm::append(pAvailablePackages, it->second);
             return true;
          }
          else


### PR DESCRIPTION
This fixes a bug where, if the user has multiple repositories specified, only packages from the final listed repository were available for autocompletion in the 'Install Packages' dialog.

@jjallaire, this actually affects a lot of users in the current RStudio release because by default R on Windows now includes the 'CRANextra' repo:

```
> getOption("repos")
                                CRAN 
           "http://cran.rstudio.com" 
                           CRANextra 
"http://www.stats.ox.ac.uk/pub/RWin" 
```

which implies only the (very limited) set of packages from 'CRANextra' are enumerated. We might want to backport this to the current release.