### PR TITLE
use 'system.file' to query package existence

### DIFF
--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -103,7 +103,10 @@
 
 .rs.addFunction("isPackageInstalled", function(name, libLoc = NULL)
 {
-  name %in% .packages(all.available = TRUE, lib.loc = libLoc)
+   paths <- vapply(name, FUN.VALUE = character(1), USE.NAMES = FALSE, function(pkg) {
+      system.file(package = pkg, lib.loc = libLoc)
+   })
+   nzchar(paths)
 })
 
 .rs.addFunction("isPackageVersionInstalled", function(name, version) {  


### PR DESCRIPTION
This PR will encompass various optimizations to ensure RStudio startup is speedy whether or not the packages pane is enabled.