### PR TITLE
don't override 'Ctrl+Shift+E' on non-OSX platforms

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -444,8 +444,8 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="jumpTo" value="Shift+Alt+J" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="jumpTo" value="Cmd+Shift+Alt+J" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="jumpToMatching" value="Ctrl+P"/>
-         <shortcut refid="selectToMatching" value="Ctrl+Shift+Alt+E"/>
-         <shortcut refid="expandToMatching" value="Ctrl+Shift+E"/>
+         <shortcut refid="expandToMatching" value="Ctrl+Shift+E" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="expandToMatching" value="Ctrl+Shift+Alt+E" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="splitIntoLines" value="Cmd+Alt+A"/>
          <shortcut value="Ctrl+Alt+Up" title="Add cursor above current cursor"/>
          <shortcut value="Ctrl+Alt+Down" title="Add cursor below current cursor"/>


### PR DESCRIPTION
This PR removes the `Ctrl + Shift + E` keybinding on non-OSX platforms (to avoid colliding with the pre-existing `Check` keybinding).

This PR should probably become part of the patch release. Note that it removes access to the `selectToMatching` binding but my view is that this option is far less useful and we are essentially out of keyboard real estate to provide a usable mapping for it, and since it has only been part of the editor for a tiny amount of time it's unlikely that we will be breaking too many hearts there.