### PR TITLE
use dynamic commands for managing availability of toggle outline

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -352,6 +352,10 @@ public class TextFileType extends EditableFileType
       {
          results.add(commands.checkSpelling());
       }
+      if (canShowScopeTree())
+      {
+         results.add(commands.toggleDocumentOutline());
+      }
       results.add(commands.findReplace());
       results.add(commands.findNext());
       results.add(commands.findPrevious());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -299,6 +299,7 @@ public class Source implements InsertSourceHandler,
       dynamicCommands_.add(commands.insertRoxygenSkeleton());
       dynamicCommands_.add(commands.expandSelection());
       dynamicCommands_.add(commands.shrinkSelection());
+      dynamicCommands_.add(commands.toggleDocumentOutline());
       for (AppCommand command : dynamicCommands_)
       {
          command.setVisible(false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -1957,11 +1957,6 @@ public class AceEditor implements DocDisplay,
    {
       return widget_.addHandler(handler, DocumentChangedEvent.TYPE);
    }
-   
-   public HandlerRegistration addEditorLoadedHandler(EditorLoadedHandler handler)
-   {
-      return widget_.addHandler(handler, EditorLoadedEvent.TYPE);
-   }
 
    public HandlerRegistration addCapturingKeyDownHandler(KeyDownHandler handler)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -36,7 +36,6 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.events.Brea
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.BreakpointSetEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.CommandClickEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.CursorChangedHandler;
-import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorLoadedHandler;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.FindRequestedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.HasDocumentChangedHandlers;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.HasFoldChangeHandlers;
@@ -290,8 +289,6 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    void splitIntoLines();
    
    Position screenCoordinatesToDocumentPosition(int pageX, int pageY);
-   
-   HandlerRegistration addEditorLoadedHandler(EditorLoadedHandler handler);
    
    void forceImmediateRender();
    boolean isPositionVisible(Position position);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2193,8 +2193,7 @@ public class TextEditingTarget implements
    @Handler
    void onToggleDocumentOutline()
    {
-      if (getDocDisplay().hasScopeTree())
-         view_.toggleDocumentOutline();
+     view_.toggleDocumentOutline();
    }
    
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -64,8 +64,6 @@ import org.rstudio.studio.client.workbench.views.source.DocumentOutlineWidget;
 import org.rstudio.studio.client.workbench.views.source.PanelWithToolbars;
 import org.rstudio.studio.client.workbench.views.source.editors.EditingTargetToolbar;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTarget.Display;
-import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorLoadedEvent;
-import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorLoadedHandler;
 import org.rstudio.studio.client.workbench.views.source.editors.text.findreplace.FindReplaceBar;
 import org.rstudio.studio.client.workbench.views.source.editors.text.status.StatusBar;
 import org.rstudio.studio.client.workbench.views.source.editors.text.status.StatusBarWidget;
@@ -189,21 +187,8 @@ public class TextEditingTargetWidget
             statusBar_);
       
       adaptToFileType(fileType);
-      addHandlers();
+
       initWidget(panel_);
-   }
-   
-   private void addHandlers()
-   {
-      target_.getDocDisplay().addEditorLoadedHandler(new EditorLoadedHandler()
-      {
-         @Override
-         public void onEditorLoaded(EditorLoadedEvent event)
-         {
-            toggleDocOutlineButton_.setVisible(
-                  target_.getDocDisplay().hasScopeTree());
-         }
-      });
    }
    
    public void initWidgetSize()
@@ -541,6 +526,9 @@ public class TextEditingTargetWidget
       setPublishPath(extendedType_, publishPath_);
       toggleDocOutlineButton_.setVisible(
             target_.getDocDisplay().hasScopeTree());
+      
+      // make toggle outline visible if we have a scope tree
+      toggleDocOutlineButton_.setVisible(fileType.canShowScopeTree());
       
       toolbar_.invalidateSeparators();
    }


### PR DESCRIPTION
@kevinushey I think that our existing infrastructure for managing editor command states can handle ensuring that toggle outline is available only when appropriate. This PR makes that change, take a look and let me know if I may have missed something that requires us to have a more custom implementation.
