### PR TITLE
add pref to show/hide unnamed chunks

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -496,6 +496,11 @@ public class UIPrefsAccessor extends Prefs
       return bool("show_document_outline_rmd", true);
    }
    
+   public PrefValue<Boolean> showUnnamedEntriesInDocumentOutline()
+   {
+      return bool("show_unnamed_entries_in_document_outline", false);
+   }
+   
    private String getDefaultPdfPreview()
    {
       if (Desktop.isDesktop())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -120,6 +120,7 @@ public class EditingPreferencesPane extends PreferencesPane
       displayPanel.add(rMarkdownLabel);
       displayPanel.add(checkboxPref("Show inline toolbar for R code chunks", prefs_.showInlineToolbarForRCodeChunks()));
       displayPanel.add(checkboxPref("Show document outline by default", prefs_.showDocumentOutlineRmd()));
+      displayPanel.add(checkboxPref("Show unnamed entries in document outline", prefs_.showUnnamedEntriesInDocumentOutline()));
       
       VerticalPanel completionPanel = new VerticalPanel();
       


### PR DESCRIPTION
This PR adds a pref to control whether unnamed chunks are shown in the scope tree (with the option off by default).

A picture is worth a 1000 words here -- from Hadley's ggplot2 book,

![screen shot 2015-06-19 at 3 39 22 pm](https://cloud.githubusercontent.com/assets/1976582/8264317/68e1bbae-1699-11e5-9d7c-5945f485625b.png)

IMHO The `untitled` chunk entries are just noise, compared to the other items included.

We might even want to exclude having a UI pref and just never show unnamed chunks in the scope tree.

@jjallaire what do you think?