### PR TITLE
respect 'focus console' pref on execution

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3679,7 +3679,7 @@ public class TextEditingTarget implements
                         "UTF-8",
                         activeCodeIsAscii(),
                         forceEcho ? true : echo,
-                        true,
+                        prefs_.focusConsoleAfterExec().getValue(),
                         docDisplay_.hasBreakpoints()); 
                }
             });
@@ -3700,7 +3700,7 @@ public class TextEditingTarget implements
                            docUpdateSentinel_.getEncoding(),
                            activeCodeIsAscii(),
                            forceEcho ? true : echo,
-                           true,
+                           prefs_.focusConsoleAfterExec().getValue(),
                            docDisplay_.hasBreakpoints());   
                   }
                };


### PR DESCRIPTION
With this PR, if the 'focusConsoleAfterExec' pref is unchecked, commands like 'Source Document' will no longer focus the console after execution.