### PR TITLE
Address pipe read errors on startup for multi-user configs

### DIFF
--- a/src/cpp/core/system/Win32OutputCapture.cpp
+++ b/src/cpp/core/system/Win32OutputCapture.cpp
@@ -21,6 +21,8 @@
 #include <stdio.h>
 #include <fcntl.h>
 
+#include <boost/lexical_cast.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <core/Log.hpp>
 #include <core/Error.hpp>
@@ -30,46 +32,7 @@
 namespace rstudio {
 namespace core {
 namespace system {
-
-
 namespace {
-
-void standardStreamCaptureThread(
-       int readFd,
-       const boost::function<void(const std::string&)>& outputHandler)
-{
-   try
-   {
-      while(true)
-      {
-         const int kBufferSize = 512;
-         char buffer[kBufferSize];
-         // read from the descriptor; this descriptor is attached to a pipe,
-         // and this _read call blocks until we have some bytes or until the
-         // descriptor is closed
-         DWORD bytesRead = ::_read(readFd, &buffer, kBufferSize);
-         if (bytesRead > 0)
-         {
-            // if we got some bytes, invoke the output handler
-            outputHandler(std::string(buffer, bytesRead));
-         }
-         else if (bytesRead == 0)
-         {
-            // reading 0 bytes indicates that we've reached EOF, so we can
-            // quit capturing (we don't expect this to happen)
-            LOG_WARNING_MESSAGE("Reached end of input on standard stream");
-            break;
-         }
-         else if (bytesRead < 0)
-         {
-            // we don't expect errors to ever occur (since the standard
-            // streams are never closed) so log any that do and continue
-            LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
-         }
-      }
-   }
-   CATCH_UNEXPECTED_EXCEPTION
-}
 
 Error ioError(const std::string& description, const ErrorLocation& location)
 {
@@ -93,7 +56,7 @@ Error redirectToPipe(DWORD stdHandle,
    // this way when more than one user has RStudio open (see case 4230).
    int pdfs[2];
    if (!::_pipe(pdfs, 4096, O_TEXT))
-      return systemError(::GetLastError(), ERROR_LOCATION);
+      return systemError(errno, ERROR_LOCATION);
 
    // reset win32 standard handle
    hWritePipe = reinterpret_cast<HANDLE>(::_get_osfhandle(pdfs[1]));
@@ -119,6 +82,85 @@ Error redirectToPipe(DWORD stdHandle,
    return Success();
 }
 
+void standardStreamCaptureThread(
+       int outputHandle,
+       FILE* outputStream,
+       int readFd,
+       const boost::function<void(const std::string&)>& outputHandler)
+{
+   const int kBufferSize = 512;
+   const int kMaxRetries = 16;
+   char buffer[kBufferSize];
+   int redirectTries = 0;
+   try
+   {
+      while(true)
+      {
+         // read from the descriptor; this descriptor is attached to a pipe,
+         // and this _read call blocks until we have some bytes or until the
+         // descriptor is closed
+         int bytesRead = ::_read(readFd, &buffer, kBufferSize);
+         if (bytesRead > 0)
+         {
+            // if we got some bytes, invoke the output handler
+            if (bytesRead > kBufferSize)
+            {
+               // this should never happen, but just to be safe, don't try to
+               // alloc a std::string if we get more bytes than we asked for
+               LOG_WARNING_MESSAGE("Requested " +
+                  boost::lexical_cast<std::string>(kBufferSize) + " bytes, "
+                  "but received " +
+                  boost::lexical_cast<std::string>(bytesRead) + "bytes; "
+                  "ignoring");
+            }
+            else
+            {
+               outputHandler(std::string(buffer, bytesRead));
+            }
+         }
+         else if (bytesRead == 0)
+         {
+            // reading 0 bytes indicates that we've reached EOF, so we can
+            // quit capturing (we don't expect this to happen)
+            LOG_WARNING_MESSAGE("Reached end of input on standard stream");
+            break;
+         }
+         else if (bytesRead < 0)
+         {
+            // if we've already used up all our retries, just stop trying
+            // (we don't want to spin and fill the logs with errors)
+            if (redirectTries++ >= kMaxRetries)
+            {
+               LOG_ERROR_MESSAGE("Could not redirect standard stream after " +
+                  boost::lexical_cast<std::string>(redirectTries) + " tries; "
+                  "giving up.");
+               break;
+            }
+
+            // if we hit an error, attempt to recover by closing the pipe
+            // we were reading from ...
+            if (!_close(readFd))
+            {
+               LOG_ERROR(systemError(errno, ERROR_LOCATION));
+
+               // wait just a few ms to yield to other threads/processes before
+               // trying again
+               boost::this_thread::sleep(boost::posix_time::milliseconds(10));
+               continue;
+            }
+            // ... and establishing a new redirection pipe in its place.
+            Error error = redirectToPipe(outputHandle, outputStream, &readFd);
+            if (error)
+            {
+               LOG_ERROR(error);
+               boost::this_thread::sleep(boost::posix_time::milliseconds(10));
+               continue;
+            }
+         }
+      }
+   }
+   CATCH_UNEXPECTED_EXCEPTION
+}
 
 } // anonymous namespace
 
@@ -136,6 +178,8 @@ Error captureStandardStreams(
 
       // capture stdout
       boost::thread stdoutThread(boost::bind(standardStreamCaptureThread,
+                                             STD_OUTPUT_HANDLE,
+                                             stdout,
                                              stdoutFd,
                                              stdoutHandler));
 
@@ -150,6 +194,8 @@ Error captureStandardStreams(
 
          // capture stderr
          boost::thread stderrThread(boost::bind(standardStreamCaptureThread,
+                                                STD_ERROR_HANDLE,
+                                                stderr,
                                                 stderrFd,
                                                 stderrHandler));
       }
@@ -165,4 +211,3 @@ Error captureStandardStreams(
 } // namespace system
 } // namespace core
 } // namespace rstudio
-


### PR DESCRIPTION
This change fixes an intermittent error on startup for the 2nd (and following) users on multi-user Windows systems. 

For the 2nd user, the file descriptor on the read end of the pipe for `stderr` appears to become invalid during boot in some situations (due to invalidation of the underlying operating system handle, for reasons which are unclear). This causes `_read` to fail every time it attempts to read the descriptor. Since we just keep trying this can result in either a crash (when the `-1` return value from `_read` is interpreted as a large number of bytes read due to an implicit cast to `unsigned`), or a spin (since we log the error and continue, then encounter it again). 

The fix is to implement some fault tolerance: if we can't read from the pipe, we close it, and try to establish a new pipe on the output stream. In practice this new pipe works almost all the time; in the case where it doesn't, we wait very briefly and try again, up to 16 times. 

In my testing I was only able to observe a retry once, and only during boot (i.e. it doesn't seem that the descriptor is invalidated during the normal course of operations). My guess is that there's a boot timing issue here (which might also explain the intermittency).

@jjallaire , could you give this a sanity review? We should probably backport this as soon as we feel comfortable with it; we only have one report of the associated crash in the wild but my guess is that it's because not enough users have tried 448 yet.