### PR TITLE
Improve horizontal popup positioning for completions

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
@@ -310,22 +310,38 @@ public class CompletionPopupPanel extends ThemedPopupPanel
       int bottom = top + getOffsetHeight();
       int width = getOffsetWidth();
       
-      // If displaying the help with the top aligned to the completion list
-      // would place the help offscreen, then re-align it so that the bottom of the
-      // help is aligned with the completion popup.
-      
       if (!help_.isShowing())
          help_.show();
       
+      // If displaying the help with the top aligned to the completion list
+      // would place the help offscreen, then re-align it so that the bottom of the
+      // help is aligned with the completion popup.
+      //
       // NOTE: Help has not been positioned yet so what we're really asking is,
       // 'if we align the top of help with the top of the completion list, will
       // it flow offscreen?'
       
       if (top + help_.getOffsetHeight() + 20 > Window.getClientHeight())
-         top = bottom - help_.getOffsetHeight()
-               - 9; // fudge factor
+         top = bottom - help_.getOffsetHeight() - 9;
       
-      help_.setPopupPosition(left + width - 4, top + 3);
+      // It is also possible that the help could flow offscreen to the right,
+      // e.g. if the user has decided to place the source / console windows on
+      // the right. Check for this and position help to the left if it prevents
+      // overflow.
+      //
+      // It's a bit strange having help to the left of the completion list but
+      // it's better than the alternative (having help overflow on the right)
+      int destinationLeft = left + width - 4;
+      int destinationTop = top + 3;
+      
+      if (destinationLeft + help_.getOffsetWidth() > Window.getClientWidth())
+      {
+         int potentialLeft = left - help_.getOffsetWidth();
+         if (potentialLeft > 0)
+            destinationLeft = potentialLeft;
+      }
+      
+      help_.setPopupPosition(destinationLeft, destinationTop);
       help_.setVisible(setVisible);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/PopupPositioner.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/PopupPositioner.java
@@ -35,18 +35,61 @@ public class PopupPositioner implements PositionCallback
    {
       if (cursorBounds_ == null)
       {
-         assert false : "Positioning popup but no cursor bounds available" ;
+         assert false : "Positioning popup but no cursor bounds available";
          return;
       }
       
-      int windowBottom = Window.getScrollTop() + Window.getClientHeight() ;
-      int cursorBottom = cursorBounds_.getBottom() ;
+      Coordinates coords = getPopupPosition(
+            popupWidth,
+            popupHeight,
+            cursorBounds_.getLeft(),
+            cursorBounds_.getBottom(),
+            5);
       
-      if (windowBottom - cursorBottom >= popupHeight)
-         popup_.setPopupPosition(cursorBounds_.getLeft(), cursorBottom) ;
-      else
-         popup_.setPopupPosition(cursorBounds_.getLeft(), 
-                                 cursorBounds_.getTop() - popupHeight) ;
+      popup_.setPopupPosition(coords.getLeft(), coords.getTop());
+   }
+   
+   private static class Coordinates
+   {
+      public Coordinates(int left, int top)
+      {
+         left_ = left;
+         top_ = top;
+      }
+      
+      public int getLeft() { return left_; }
+      public int getTop() { return top_; }
+      
+      private final int left_;
+      private final int top_;
+   }
+   
+   public static Coordinates getPopupPosition(int width,
+                                              int height,
+                                              int pageX,
+                                              int pageY,
+                                              int fudgeFactor)
+   {
+      int windowTop = Window.getScrollTop();
+      int windowLeft = Window.getScrollLeft();
+      int windowRight = windowLeft + Window.getClientWidth();
+      int windowBottom = windowTop + Window.getClientHeight();
+      
+      boolean positionRight =
+            pageX + width + fudgeFactor < windowRight;
+      
+      boolean positionBottom =
+            pageY + height + fudgeFactor < windowBottom;
+      
+      int left = positionRight ?
+            pageX + fudgeFactor :
+            pageX - width - fudgeFactor;
+      
+      int top = positionBottom ?
+            pageY + fudgeFactor :
+            pageY - height - fudgeFactor;
+      
+      return new Coordinates(left, top);
    }
    
    public static void setPopupPosition(PopupPanel panel,
@@ -54,29 +97,15 @@ public class PopupPositioner implements PositionCallback
                                        int pageY,
                                        int fudgeFactor)
    {
-      int windowTop = Window.getScrollTop();
-      int windowLeft = Window.getScrollLeft();
-      int windowRight = windowLeft + Window.getClientWidth();
-      int windowBottom = windowTop + Window.getClientHeight();
+      Coordinates transformed = getPopupPosition(
+            panel.getOffsetWidth(),
+            panel.getOffsetHeight(),
+            pageX,
+            pageY,
+            fudgeFactor);
       
-      int panelWidth = panel.getOffsetWidth();
-      int panelHeight = panel.getOffsetHeight();
-      
-      boolean positionRight =
-            pageX + panelWidth + fudgeFactor < windowRight;
-      
-      boolean positionBottom =
-            pageY + panelHeight + fudgeFactor < windowBottom;
-      
-      int left = positionRight ?
-            pageX + fudgeFactor :
-            pageX - panelWidth - fudgeFactor;
-      
-      int top = positionBottom ?
-            pageY + fudgeFactor :
-            pageY - panelHeight - fudgeFactor;
-      
-      panel.setPopupPosition(left, top);
-
+      panel.setPopupPosition(
+            transformed.getLeft(),
+            transformed.getTop());
    }
 }


### PR DESCRIPTION
This PR improves popup positioning for users who place the source editor / console on the right of the editor.

![screen shot 2015-06-25 at 10 24 06 am](https://cloud.githubusercontent.com/assets/1976582/8360861/5c3eca10-1b24-11e5-864f-94951d627368.png)

In this example, to prevent the help popup from overflowing off the page, the help is instead positioned to the left of the completion list.