### PR TITLE
Ensure rsession process is created with stdout/stderr

### DIFF
--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -51,7 +51,7 @@ void launchProcess(std::string absPath,
    if (options().runDiagnostics())
       pProcess->setProcessChannelMode(QProcess::ForwardedChannels);
    else
-      pProcess->setProcessChannelMode(QProcess::SeparateChannels);
+      pProcess->setProcessChannelMode(QProcess::ForwardedOutputChannel);
    pProcess->start(QString::fromUtf8(absPath.c_str()), argList);
    *ppProc = pProcess;
 }


### PR DESCRIPTION
This is a fix for the `ERROR_INVALID_BLOCK` issue seen by second Remote Desktop users and probably deserves some explanation.

The call which is actually failing for RDP users is this one:

https://github.com/rstudio/rstudio/blob/01329097a054c48dd3f2ddee9ef600b9c420dc62/src/cpp/core/system/Win32OutputCapture.cpp#L90

      if (::_dup2(fd, _fileno(fpStdFile)) != 0)
          return systemError(errno, ERROR_LOCATION);

Some careful disassembly indicates that for the first RDP user, `_fileno(fpStdFile)` returns 1 and 2 for stdout and stderr, respectively. For the second user, however, it returns -2 for both! 

According to https://msdn.microsoft.com/en-us/library/zs6wbdhx.aspx: "If stdout or stderr is not associated with an output stream (for example, in a Windows application without a console window), the file descriptor returned is -2."

So it doesn't seem to have anything to do with pipes at all--the problem is simply that the second user's rsession doesn't *have* stdout or stderr streams, which is why it's so exceedingly difficult to redirect them. 

Why might this be? Well, Qt added some options in 5.4 around managing child process output; compare:

http://doc.qt.io/qt-4.8/qprocess.html#ProcessChannelMode-enum
http://doc.qt.io/qt-5/qprocess.html#ProcessChannelMode-enum

It's hard to tell without a deep dive into the `QProcess` internals, but it appears that there's a bug in Qt 5.4 wherein `QProcess::SeparateChannels` doesn't allocate stdout/stderr streams for the 2nd RDP user. Somewhat unintuitively, then, forwarding the streams for the parent process makes them consistently available for the child process (rsession) to capture. 