### PR TITLE
Add 'refactor in scope' functionality

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * Enhanced display of sections in R scope navigator
 * Added document outline display to R and C++ documents
 * New Close All Except Current command
+* Rename variable in scope (Cmd+Shift+Alt+M)
 
 ### R Markdown
 

--- a/src/gwt/src/org/rstudio/core/client/Mutable.java
+++ b/src/gwt/src/org/rstudio/core/client/Mutable.java
@@ -1,0 +1,36 @@
+/*
+ * Mutable.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client;
+
+// A utility class primarily used for creating mutable integers etc.
+public class Mutable<T>
+{
+   public Mutable(T data)
+   {
+      data_ = data;
+   }
+   
+   public T get()
+   {
+      return data_;
+   }
+   
+   public void set(T data)
+   {
+      data_ = data;
+   }
+   
+   private T data_;
+}

--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -791,6 +791,14 @@ public class DomUtils
       return result;
    }-*/;
    
+   public static final Element getFirstElementWithClassName(Element parent, String classes)
+   {
+      Element[] elements = getElementsByClassName(parent, classes);
+      if (elements.length == 0)
+   	   return null;
+      return elements[0];
+   }
+   
    public static final Element getParent(Element element, int times)
    {
       Element parent = element;
@@ -853,6 +861,25 @@ public class DomUtils
             handler.onNativeEvent(event.getNativeEvent());
          }
       });
+   }
+   
+   public interface ElementPredicate
+   {
+      public boolean test(Element el);
+   }
+   
+   public static Element findParentElement(Element el,
+   	                                     ElementPredicate predicate)
+   {
+      Element parent = el.getParentElement();
+      while (parent != null)
+      {
+         if (predicate.test(parent))
+            return parent;
+
+         parent = parent.getParentElement();
+      }
+      return null;
    }
    
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -288,6 +288,7 @@ public class TextFileType extends EditableFileType
       results.add(commands.goToLine());
       results.add(commands.expandSelection());
       results.add(commands.shrinkSelection());
+      results.add(commands.renameInFile());
       if (canExecuteCode() || isC())
       {
          results.add(commands.reindent());

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -288,7 +288,6 @@ public class TextFileType extends EditableFileType
       results.add(commands.goToLine());
       results.add(commands.expandSelection());
       results.add(commands.shrinkSelection());
-      results.add(commands.renameInFile());
       if (canExecuteCode() || isC())
       {
          results.add(commands.reindent());
@@ -303,6 +302,7 @@ public class TextFileType extends EditableFileType
          results.add(commands.commentUncomment());
          results.add(commands.reflowComment());
          results.add(commands.reformatCode());
+         results.add(commands.renameInFile());
       }
       if (canExecuteAllCode())
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -164,6 +164,7 @@ well as menu structures (for main menu and popup menus).
          <separator/>
          <cmd refid="extractFunction"/>
          <cmd refid="extractLocalVariable"/>
+         <cmd refid="renameInFile"/>
          <separator/>
          <cmd refid="reflowComment"/>
          <cmd refid="commentUncomment"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -439,6 +439,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut value="Ctrl+T" title="Transpose Letters" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut value="Alt+-" title="Insert Assignment Operator"/>
          <shortcut value="Cmd+Shift+M" title="Insert Pipe Operator" />
+         <shortcut refid="renameInFile" value="Cmd+Alt+Shift+M" />
          <shortcut refid="insertRoxygenSkeleton" value="Cmd+Shift+Alt+R" title="Insert Roxygen Skeleton" />
          <shortcut refid="insertSnippet" value="Shift+Tab" title="Insert Snippet"/>
       </shortcutgroup>
@@ -963,6 +964,9 @@ well as menu structures (for main menu and popup menus).
    <cmd id="reflowComment"
         menuLabel="Reflow Co_mment"
         desc="Reflow selected comment lines so they wrap evenly"/>
+   <cmd id="renameInFile"
+        menuLabel="Rename in File"
+        desc="Rename symbol in current file"/>
    <cmd id="insertRoxygenSkeleton"
         menuLabel="Insert Ro_xygen Skeleton"
         desc="Insert a roxygen comment for the current function"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -116,6 +116,7 @@ public abstract class
    public abstract AppCommand codeCompletion();
    public abstract AppCommand findUsages();
    public abstract AppCommand editRmdFormatOptions();
+   public abstract AppCommand renameInFile();
    public abstract AppCommand insertRoxygenSkeleton();
    public abstract AppCommand insertSnippet();
  

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -529,7 +529,8 @@ public class RCompletionManager implements CompletionManager
          }
          
          // continue showing completions on backspace
-         if (keycode == KeyCodes.KEY_BACKSPACE && modifier == KeyboardShortcut.NONE)
+         if (keycode == KeyCodes.KEY_BACKSPACE && modifier == KeyboardShortcut.NONE &&
+             !docDisplay_.inMultiSelectMode())
          {
             int cursorColumn = input_.getCursorPosition().getColumn();
             String currentLine = docDisplay_.getCurrentLine();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -299,6 +299,7 @@ public class Source implements InsertSourceHandler,
       dynamicCommands_.add(commands.editRmdFormatOptions());
       dynamicCommands_.add(commands.reformatCode());
       dynamicCommands_.add(commands.showDiagnosticsActiveDocument());
+      dynamicCommands_.add(commands.renameInFile());
       dynamicCommands_.add(commands.insertRoxygenSkeleton());
       dynamicCommands_.add(commands.expandSelection());
       dynamicCommands_.add(commands.shrinkSelection());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -2319,6 +2319,27 @@ public class AceEditor implements DocDisplay,
    {
       widget_.clearLint();
    }
+   
+   @Override
+   public void showInfoBar(String message)
+   {
+      if (infoBar_ == null)
+      {
+         infoBar_ = new AceInfoBar(widget_);
+         widget_.addKeyDownHandler(new KeyDownHandler()
+         {
+            @Override
+            public void onKeyDown(KeyDownEvent event)
+            {
+               if (event.getNativeKeyCode() == KeyCodes.KEY_ESCAPE)
+                  infoBar_.hide();
+            }
+         });
+      }
+         
+      infoBar_.setText(message);
+      infoBar_.show();
+   }
 
    public Range createAnchoredRange(Position start,
                                     Position end)
@@ -2404,6 +2425,7 @@ public class AceEditor implements DocDisplay,
    private Integer lineDebugMarkerId_ = null;
    private Integer executionLine_ = null;
    private boolean valueChangeSuppressed_ = false;
+   private AceInfoBar infoBar_;
     
    private static final ExternalJavaScriptLoader aceLoader_ =
          new ExternalJavaScriptLoader(AceResources.INSTANCE.acejs().getSafeUri().asString());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -1671,6 +1671,13 @@ public class AceEditor implements DocDisplay,
    {
       return hasCodeModel() && getCodeModel().hasScopes();
    }
+   
+   public void buildScopeTree()
+   {
+      // Builds the scope tree as a side effect
+      if (hasScopeTree())
+         getScopeTree();
+   }
 
    public JsArray<Scope> getScopeTree()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -1084,6 +1084,11 @@ public class AceEditor implements DocDisplay,
       setCode("", false);
    }
    
+   public boolean inMultiSelectMode()
+   {
+      return widget_.getEditor().inMultiSelectMode();
+   }
+   
    public void exitMultiSelectMode()
    {
       widget_.getEditor().exitMultiSelectMode();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -1083,6 +1083,11 @@ public class AceEditor implements DocDisplay,
    {
       setCode("", false);
    }
+   
+   public void clearSelection()
+   {
+      widget_.getEditor().clearSelection();
+   }
 
    public void collapseSelection(boolean collapseToStart)
    {
@@ -1525,6 +1530,11 @@ public class AceEditor implements DocDisplay,
    {
       return getSession().getMode().getCodeModel().getCurrentScope(
             getCursorPosition());
+   }
+   
+   public Scope getScopeAtPosition(Position position)
+   {
+      return getSession().getMode().getCodeModel().getCurrentScope(position);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -1084,6 +1084,11 @@ public class AceEditor implements DocDisplay,
       setCode("", false);
    }
    
+   public void exitMultiSelectMode()
+   {
+      widget_.getEditor().exitMultiSelectMode();
+   }
+   
    public void clearSelection()
    {
       widget_.getEditor().clearSelection();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -67,8 +67,7 @@ public class AceEditorWidget extends Composite
       implements RequiresResize,
                  HasValueChangeHandlers<Void>,
                  HasFoldChangeHandlers,
-                 HasKeyDownHandlers,
-                 HasKeyPressHandlers
+                 HasAllKeyHandlers
 {
    
    public AceEditorWidget()
@@ -411,6 +410,11 @@ public class AceEditorWidget extends Composite
    public HandlerRegistration addKeyPressHandler(KeyPressHandler handler)
    {
       return addHandler(handler, KeyPressEvent.getType());
+   }
+   
+   public HandlerRegistration addKeyUpHandler(KeyUpHandler handler)
+   {
+      return addHandler(handler, KeyUpEvent.getType());
    }
 
    public HandlerRegistration addCapturingKeyDownHandler(KeyDownHandler handler)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceInfoBar.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceInfoBar.css
@@ -1,0 +1,14 @@
+.container {
+    width: 100%;
+    height: 20px;
+    color: black;
+    background-color: rgb(232, 232, 232);
+    position: absolute;
+    bottom: 0px;
+    z-index: 20;
+    cursor: pointer;
+    padding: 2px 5px;
+}
+
+.label {
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceInfoBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceInfoBar.java
@@ -1,0 +1,92 @@
+/*
+ * AceInfoBar.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text;
+
+import org.rstudio.core.client.dom.DomUtils;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.resources.client.ClientBundle;
+import com.google.gwt.resources.client.CssResource;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.Label;
+
+public class AceInfoBar extends Composite
+{
+   public AceInfoBar(AceEditorWidget parent)
+   {
+   	container_ = new FlowPanel();
+   	container_.addStyleName(RES.styles().container());
+   	
+   	label_ = new Label();
+   	label_.addStyleName(RES.styles().label());
+   	
+   	container_.add(label_);
+   	
+   	initWidget(container_);
+   	attachTo(parent);
+   }
+   
+   public void setText(String text)
+   {
+      label_.setText(text);
+   }
+   
+   private boolean attachTo(AceEditorWidget widget)
+   {
+      Element aceScroller = DomUtils.getFirstElementWithClassName(
+            widget.getElement(),
+            "ace_scroller");
+      
+      if (aceScroller == null)
+         return false;
+      
+      aceScroller.appendChild(getElement());
+      return true;
+   }
+   
+   public void show()
+   {
+      setVisible(true);
+   }
+   
+   public void hide()
+   {
+      setVisible(false);
+   }
+   
+   private final FlowPanel container_;
+   private final Label label_;
+   
+   // Styling boilerplate ----
+   public interface Styles extends CssResource
+   {
+      String container();
+      String label();
+   }
+
+   public interface Resources extends ClientBundle
+   {
+   	@Source("AceInfoBar.css")
+   	Styles styles();
+   }
+
+   private static Resources RES = GWT.create(Resources.class);
+   static {
+   	RES.styles().ensureInjected();
+   }
+
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -98,6 +98,8 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    // This returns null for most file types, but for Sweave it returns "R" or
    // "TeX". Use SweaveFileType constants to test for these values.
    String getLanguageMode(Position position);
+   
+   void clearSelection();
    void replaceSelection(String code);
    boolean moveSelectionToNextLine(boolean skipBlankLines);
    boolean moveSelectionToBlankLine(); 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -99,6 +99,8 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    // "TeX". Use SweaveFileType constants to test for these values.
    String getLanguageMode(Position position);
    
+   void exitMultiSelectMode();
+   
    void clearSelection();
    void replaceSelection(String code);
    boolean moveSelectionToNextLine(boolean skipBlankLines);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -99,6 +99,7 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    // "TeX". Use SweaveFileType constants to test for these values.
    String getLanguageMode(Position position);
    
+   boolean inMultiSelectMode();
    void exitMultiSelectMode();
    
    void clearSelection();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -294,4 +294,6 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    
    void forceImmediateRender();
    boolean isPositionVisible(Position position);
+   
+   void showInfoBar(String message);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/InfoBarDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/InfoBarDisplay.java
@@ -1,0 +1,23 @@
+/*
+ * InfoBarDisplay.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text;
+
+import com.google.gwt.user.client.ui.IsWidget;
+
+public interface InfoBarDisplay extends IsWidget
+{
+   void showInfoBar(String message);
+   void hideInfoBar();
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2234,12 +2234,21 @@ public class TextEditingTarget implements
             @Override
             public boolean onNativePreviewEvent(NativePreviewEvent preview)
             {
+               if (!docDisplay_.isFocused())
+               {
+                  docDisplay_.exitMultiSelectMode();
+                  docDisplay_.clearSelection();
+                  return true;
+               }
+               
                if (preview.getTypeInt() == Event.ONKEYDOWN)
                {
                   switch (preview.getNativeEvent().getKeyCode())
                   {
                   case KeyCodes.KEY_ENTER:
                      preview.cancel();
+                  case KeyCodes.KEY_UP:
+                  case KeyCodes.KEY_DOWN:
                   case KeyCodes.KEY_ESCAPE:
                      docDisplay_.exitMultiSelectMode();
                      docDisplay_.clearSelection();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2234,7 +2234,7 @@ public class TextEditingTarget implements
             @Override
             public boolean onNativePreviewEvent(NativePreviewEvent preview)
             {
-               if (!docDisplay_.isFocused())
+               if (!docDisplay_.isFocused() || !docDisplay_.inMultiSelectMode())
                {
                   docDisplay_.exitMultiSelectMode();
                   docDisplay_.clearSelection();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2225,8 +2225,7 @@ public class TextEditingTarget implements
          
          String selectedItem = docDisplay_.getSelectionValue();
          message += " for '" + selectedItem + "'";
-         
-         docDisplay_.showInfoBar(message);
+         view_.getStatusBar().showMessage(message);
       }
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -394,6 +394,7 @@ public class TextEditingTarget implements
                                                                   docDisplay_);
       reformatHelper_ = new TextEditingTargetReformatHelper(docDisplay_);
       snippets_ = new SnippetHelper((AceEditor) docDisplay_);
+      renameHelper_ = new TextEditingTargetRenameHelper(docDisplay_);
       
       docDisplay_.setRnwCompletionContext(compilePdfHelper_);
       docDisplay_.setCppCompletionContext(cppCompletionContext_);
@@ -2208,6 +2209,12 @@ public class TextEditingTarget implements
       }
       
       reformatHelper_.insertPrettyNewlines();
+   }
+   
+   @Handler
+   void onRenameInFile()
+   {
+      renameHelper_.renameInFile();
    }
    
    @Handler
@@ -5059,6 +5066,7 @@ public class TextEditingTarget implements
    private BreakpointManager breakpointManager_;
    private final LintManager lintManager_;
    private final SnippetHelper snippets_;
+   private final TextEditingTargetRenameHelper renameHelper_;
    private CollabEditStartParams queuedCollabParams_;
 
    // Allows external edit checks to supercede one another

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -31,6 +31,8 @@ import com.google.gwt.http.client.URL;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.ui.HasValue;
 import com.google.gwt.user.client.ui.MenuItem;
 import com.google.gwt.user.client.ui.UIObject;
@@ -131,6 +133,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppComp
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionOperation;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.*;
 import org.rstudio.studio.client.workbench.views.source.editors.text.status.StatusBar;
+import org.rstudio.studio.client.workbench.views.source.editors.text.status.StatusBar.HideMessageHandler;
 import org.rstudio.studio.client.workbench.views.source.editors.text.status.StatusBarPopupMenu;
 import org.rstudio.studio.client.workbench.views.source.editors.text.status.StatusBarPopupRequest;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ui.ChooseEncodingDialog;
@@ -2225,7 +2228,27 @@ public class TextEditingTarget implements
          
          String selectedItem = docDisplay_.getSelectionValue();
          message += " for '" + selectedItem + "'";
-         view_.getStatusBar().showMessage(message);
+         
+         view_.getStatusBar().showMessage(message, new HideMessageHandler()
+         {
+            @Override
+            public boolean onNativePreviewEvent(NativePreviewEvent preview)
+            {
+               if (preview.getTypeInt() == Event.ONKEYDOWN)
+               {
+                  switch (preview.getNativeEvent().getKeyCode())
+                  {
+                  case KeyCodes.KEY_ENTER:
+                     preview.cancel();
+                  case KeyCodes.KEY_ESCAPE:
+                     docDisplay_.exitMultiSelectMode();
+                     docDisplay_.clearSelection();
+                     return true;
+                  }
+               }
+               return false;
+            }
+         });
       }
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2214,7 +2214,20 @@ public class TextEditingTarget implements
    @Handler
    void onRenameInFile()
    {
-      renameHelper_.renameInFile();
+      int matches = renameHelper_.renameInFile();
+      if (matches > 0)
+      {
+         String message = "Found " + matches;
+         if (matches == 1)
+            message += " match";
+         else
+            message += " matches";
+         
+         String selectedItem = docDisplay_.getSelectionValue();
+         message += " for '" + selectedItem + "'";
+         
+         docDisplay_.showInfoBar(message);
+      }
    }
    
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetReformatHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetReformatHelper.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Stack;
 
+import org.rstudio.core.client.Mutable;
 import org.rstudio.core.client.Pair;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.regex.Match;
@@ -34,26 +35,6 @@ public class TextEditingTargetReformatHelper
    public TextEditingTargetReformatHelper(DocDisplay docDisplay)
    {
       docDisplay_ = docDisplay;
-   }
-   
-   class MutableInteger {
-      
-      public MutableInteger(int data)
-      {
-         data_ = data;
-      }
-      
-      public void set(int data)
-      {
-         data_ = data;
-      }
-      
-      public int get()
-      {
-         return data_;
-      }
-      
-      private int data_;
    }
    
    private static final Pattern ENDS_WITH_NEWLINE =
@@ -223,7 +204,7 @@ public class TextEditingTargetReformatHelper
          return fwdToMatchingToken(null);
       }
       
-      public boolean fwdToMatchingToken(MutableInteger counter)
+      public boolean fwdToMatchingToken(Mutable<Integer> counter)
       {
          String lhs = this.currentValue();
          if (!isLeftBrace())
@@ -679,7 +660,7 @@ public class TextEditingTargetReformatHelper
                   clone.fwdToMatchingToken();
                else
                {
-                  MutableInteger counter = new MutableInteger(0);
+                  Mutable<Integer> counter = new Mutable<Integer>(0);
                   clone.fwdToMatchingToken(counter);
                   accumulatedLength += counter.get();
                }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRenameHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRenameHelper.java
@@ -1,0 +1,252 @@
+package org.rstudio.studio.client.workbench.views.source.editors.text;
+
+import com.google.gwt.core.client.JsArrayString;
+
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.TokenCursor;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.Stack;
+
+public class TextEditingTargetRenameHelper
+{
+   public TextEditingTargetRenameHelper(DocDisplay docDisplay)
+   {
+      editor_ = (AceEditor) docDisplay;
+      state_ = new Stack<Integer>();
+      newFnArgNames_ = new HashSet<String>();
+      ranges_ = new ArrayList<Range>();
+   }
+   
+   public void renameInFile()
+   {
+      init();
+      if (editor_.getFileType().isR())
+         renameInFileR();
+   }
+   
+   private int renameInFileR()
+   {
+      Position position = editor_.hasSelection() ?
+            editor_.getSelectionStart() :
+            editor_.getCursorPosition();
+            
+      TokenCursor cursor = editor_.getSession().getMode().getCodeModel().getTokenCursor();
+      if (!cursor.moveToPosition(position, true))
+         return 0;
+      
+      editor_.setCursorPosition(position);
+      
+      // Validate that we're looking at an R identifier (TODO: refactor strings?)
+      String targetValue = cursor.currentValue();
+      String targetType = cursor.currentType();
+      
+      boolean isVariableType =
+            targetType.equals("identifier") ||
+            targetType.equals("keyword") ||
+            targetType.equals("constant.language");
+      
+      if (!isVariableType)
+         return 0;
+      
+      // Check to see if this is the name of a function argument. If so, we only want
+      // to rename within that scope.
+      Scope scope = editor_.getCurrentScope();
+      while (!scope.isTopLevel())
+      {
+         if (scope.isFunction())
+         {
+            boolean isCursorOnFunctionDefn =
+                  cursor.peek(1).isLeftAssign() &&
+                  cursor.peek(2).getValue().equals("function");
+            
+            if (!isCursorOnFunctionDefn)
+            {
+               ScopeFunction scopeFunction = (ScopeFunction) scope;
+               JsArrayString args = scopeFunction.getFunctionArgs();
+               for (int i = 0; i < args.length(); i++)
+                  if (args.get(i).equals(targetValue))
+                     return renameVariablesInScope(scope, targetValue, targetType);
+            }
+         }
+         scope = scope.getParentScope();
+      }
+      
+      return 0;
+   }
+   
+   private int renameVariablesInScope(Scope scope, String targetValue, String targetType)
+   {
+      Position startPos = scope.getPreamble();
+      Position endPos = scope.getEnd();
+      
+      TokenCursor cursor = editor_.getSession().getMode().getCodeModel().getTokenCursor();
+      if (!cursor.moveToPosition(startPos, true))
+         return 0;
+      
+      // Workaround 'moveToPosition' not handling forward searches (yet)
+      if (cursor.getRow() < startPos.getRow())
+         if (!cursor.moveToNextToken())
+            return 0;
+      
+      // NOTE: The token associated with the current cursor position
+      // is added last, to ensure that after the 'multi-select' session has
+      // ended the cursor remains where it started.
+      Position cursorPos = editor_.getCursorPosition();
+      
+      while (cursor.moveToNextToken())
+      {
+         // Left brackets push on the stack.
+         if (cursor.isLeftBracket())
+         {
+            // Update state.
+            if (cursor.valueEquals("("))
+            {
+               if (cursor.peekBwd(1).valueEquals("function"))
+                  pushState(STATE_FUNCTION_DEFINITION);
+               else
+                  pushState(STATE_FUNCTION_CALL);
+            }
+            else
+            {
+               pushState(STATE_DEFAULT);
+            }
+            
+            // Update protected names.
+            updateProtectedNames(cursor.currentPosition(), scope, false);
+         }
+         
+         // Right brackets pop the stack.
+         if (cursor.isRightBracket())
+         {
+            popState();
+            updateProtectedNames(cursor.currentPosition(), scope, true);
+         }
+         
+         if (cursor.currentPosition().isAfterOrEqualTo(endPos))
+            break;
+         
+         if (cursor.currentType().equals(targetType) &&
+             cursor.currentValue().equals(targetValue))
+         {
+            // Skip 'protected' names. These are names that have been overwritten
+            // either as assignments, or exist as names to newly defined functions.
+            if (newFnArgNames_.contains(cursor.currentValue()))
+               continue;
+            
+            // Don't rename the argument names for named function calls.
+            // For example, if we're refactoring a variable named 'bar', we
+            // only want to refactor the underlined pieces:
+            //
+            //    bar <- bar + 1; foo(bar = bar)
+            //    ~~~    ~~~                ~~~
+            if (peekState() == STATE_FUNCTION_CALL && cursor.nextValue().equals("="))
+               continue;
+            
+            // Don't rename argument names in function definitions.
+            // For example, if we're refactoring a variable named 'bar', we
+            // only want to refactor the underlined pieces:
+            //
+            //    bar <- bar + 1; foo <- function(bar) { ... }
+            //    ~~~    ~~~        
+            //
+            if (peekState() == STATE_FUNCTION_DEFINITION)
+            {
+               String prevValue = cursor.peekBwd(1).getValue();
+               if (prevValue.equals("(") ||
+                   prevValue.equals(",") ||
+                   prevValue.equals("="))
+               {
+                  continue;
+               }
+            }
+            
+            Range tokenRange = getTokenRange(cursor);
+            if (!tokenRange.contains(cursorPos))
+               ranges_.add(tokenRange);
+         }
+      }
+      
+      if (cursor.moveToPosition(cursorPos, true))
+         ranges_.add(getTokenRange(cursor));
+      
+      if (ranges_.size() > 0)
+         editor_.clearSelection();
+      
+      for (Range range : ranges_)
+         editor_.getNativeSelection().addRange(range, false);
+      
+      return ranges_.size();
+         
+   }
+   
+   private void init()
+   {
+      ranges_.clear();
+      state_.clear();
+   }
+   
+   private int peekState()
+   {
+      return state_.empty() ?
+            STATE_TOP_LEVEL :
+            state_.peek();
+   }
+   
+   private void pushState(int state)
+   {
+      state_.push(state);
+   }
+   
+   private int popState()
+   {
+      return state_.empty() ?
+            STATE_TOP_LEVEL :
+            state_.pop();
+   }
+   
+   private Range getTokenRange(TokenCursor cursor)
+   {
+      Position startPos = cursor.currentPosition();
+      Position endPos = Position.create(
+            startPos.getRow(), startPos.getColumn() + cursor.currentValue().length());
+      return Range.fromPoints(startPos, endPos);
+   }
+   
+   private void updateProtectedNames(Position position,
+                                     Scope parentScope,
+                                     boolean excludeCurrentState)
+   {
+      newFnArgNames_.clear();
+      
+      Scope scope = editor_.getScopeAtPosition(position);
+      if (excludeCurrentState)
+         scope = scope.getParentScope();
+      
+      while (scope != parentScope && !(scope.isTopLevel()))
+      {
+         if (scope.isFunction())
+         {
+            JsArrayString argNames = ((ScopeFunction) scope).getFunctionArgs();
+            for (int i = 0; i < argNames.length(); i++)
+               newFnArgNames_.add(argNames.get(i));
+         }
+         scope = scope.getParentScope();
+      }
+   }
+   
+   private final AceEditor editor_;
+   private final List<Range> ranges_;
+   private final Stack<Integer> state_;
+   private final Set<String> newFnArgNames_;
+   
+   private static final int STATE_TOP_LEVEL = 1;
+   private static final int STATE_DEFAULT = 2;
+   private static final int STATE_FUNCTION_CALL = 3;
+   private static final int STATE_FUNCTION_DEFINITION = 4;
+
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRenameHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRenameHelper.java
@@ -89,6 +89,10 @@ public class TextEditingTargetRenameHelper
       Position startPos = scope.getPreamble();
       Position endPos = scope.getEnd();
       
+      // NOTE: Top-level scope does not have 'end' position
+      if (scope.isTopLevel())
+         endPos = Position.create(editor_.getSession().getLength(), 0);
+      
       TokenCursor cursor = editor_.getSession().getMode().getCodeModel().getTokenCursor();
       if (!cursor.moveToPosition(startPos, true))
          return 0;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRenameHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRenameHelper.java
@@ -44,6 +44,10 @@ public class TextEditingTargetRenameHelper
       
       editor_.setCursorPosition(position);
       
+      // Ensure the scope tree is built, since we use that for determining
+      // the scope for the current refactor.
+      editor_.buildScopeTree();
+      
       // Validate that we're looking at an R identifier
       String targetValue = cursor.currentValue();
       String targetType = cursor.currentType();
@@ -83,6 +87,7 @@ public class TextEditingTargetRenameHelper
       // Check to see if this is the name of a function argument. If so, we only want
       // to rename within that scope.
       Scope scope = editor_.getCurrentScope();
+      
       while (!scope.isTopLevel())
       {
          if (scope.isFunction())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRenameHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRenameHelper.java
@@ -23,12 +23,13 @@ public class TextEditingTargetRenameHelper
       ranges_ = new ArrayList<Range>();
    }
    
-   public void renameInFile()
+   public int renameInFile()
    {
       init();
       TextFileType type = editor_.getFileType();
       if (type.isR() || type.isRhtml() || type.isRmd() || type.isRnw() || type.isRpres())
-         renameInFileR();
+         return renameInFileR();
+      return -1;
    }
    
    private int renameInFileR()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRenameHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRenameHelper.java
@@ -44,7 +44,7 @@ public class TextEditingTargetRenameHelper
       
       editor_.setCursorPosition(position);
       
-      // Validate that we're looking at an R identifier (TODO: refactor strings?)
+      // Validate that we're looking at an R identifier
       String targetValue = cursor.currentValue();
       String targetType = cursor.currentType();
       
@@ -104,7 +104,6 @@ public class TextEditingTargetRenameHelper
       }
       
       // Otherwise, just rename the variable within the current scope.
-      // TODO: Do we need to look into parent scopes?
       return renameVariablesInScope(
             editor_.getCurrentScope(),
             targetValue,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -436,6 +436,7 @@ public class TextEditingTargetWidget
          menu.addSeparator();
          menu.addItem(commands_.extractFunction().createMenuItem(false));
          menu.addItem(commands_.extractLocalVariable().createMenuItem(false));
+         menu.addItem(commands_.renameInFile().createMenuItem(false));
          menu.addSeparator();
          menu.addItem(commands_.reflowComment().createMenuItem(false));
          menu.addItem(commands_.commentUncomment().createMenuItem(false));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -309,6 +309,7 @@ public class AceEditorNative extends JavaScriptObject {
       });
    }-*/;
    
+   public final native boolean inMultiSelectMode() /*-{ return this.inMultiSelectMode === true; }-*/;
    public final native void exitMultiSelectMode() /*-{ this.exitMultiSelectMode(); }-*/;
    public final native void clearSelection() /*-{ return this.clearSelection(); }-*/;
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -309,6 +309,7 @@ public class AceEditorNative extends JavaScriptObject {
       });
    }-*/;
    
+   public final native void exitMultiSelectMode() /*-{ this.exitMultiSelectMode(); }-*/;
    public final native void clearSelection() /*-{ return this.clearSelection(); }-*/;
    
    public final native void moveCursorTo(int row, int column) /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Selection.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Selection.java
@@ -25,6 +25,10 @@ public class Selection extends JavaScriptObject
    public native final Range getRange() /*-{
       return this.getRange();
    }-*/;
+   
+   public native final void addRange(Range range, boolean blockChangeEvents) /*-{
+      this.addRange(range, blockChangeEvents);
+   }-*/;
 
    public native final void setSelectionRange(Range range) /*-{
       this.session.unfold(range, true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Token.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Token.java
@@ -83,6 +83,23 @@ public class Token extends JavaScriptObject
       );
    }-*/;
    
+   public native final boolean isValidForFunctionCall() /*-{
+      return this.type && (
+         this.type === "identifier" ||
+         this.type === "string" ||
+         this.type === "keyword"
+      );
+   }-*/;
+   
+   public native final boolean isExtractionOperator() /*-{
+      return this.value && (
+         this.value === "$" ||
+         this.value === "@" ||
+         this.value === "?" ||
+         this.value === "~"
+      );
+   }-*/;
+   
    // NOTE: Tokens attached to a document should be considered immutable;
    // use setters only when applying to a tokenized line separate from an
    // active editor!

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Token.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Token.java
@@ -50,6 +50,39 @@ public class Token extends JavaScriptObject
       return this.column;
    }-*/;
    
+   public final boolean valueEquals(String value)
+   {
+      return value.equals(getValue());
+   }
+   
+   public final boolean typeEquals(String type)
+   {
+      return type.equals(getType());
+   }
+   
+   public native final boolean isLeftBracket() /*-{
+      return this.value && (
+         this.value === "{" ||
+         this.value === "(" ||
+         this.value === "["
+      );
+   }-*/;
+   
+   public native final boolean isRightBracket() /*-{
+      return this.value && (
+         this.value === "}" ||
+         this.value === ")" ||
+         this.value === "]"
+      );
+   }-*/;
+   
+   public native final boolean isLeftAssign() /*-{
+      return this.value && (
+         this.value === "=" ||
+         this.value === "<-"
+      );
+   }-*/;
+   
    // NOTE: Tokens attached to a document should be considered immutable;
    // use setters only when applying to a tokenized line separate from an
    // active editor!

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/TokenCursor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/TokenCursor.java
@@ -40,6 +40,39 @@ public class TokenCursor extends JavaScriptObject
       return this.currentValue();
    }-*/;
    
+   public final boolean valueEquals(String value)
+   {
+      return currentToken().valueEquals(value);
+   }
+   
+   public final boolean typeEquals(String type)
+   {
+      return currentToken().typeEquals(type);
+   }
+   
+   public final Token peek(int offset)
+   {
+      return offset > 0 ? peekFwd(offset) : peekBwd(-offset);
+   }
+   
+   public final Token peekFwd(int offset)
+   {
+      TokenCursor clone = cloneCursor();
+      for (int i = 0; i < offset; i++)
+         if (!clone.moveToNextToken())
+            return Token.create();
+      return clone.currentToken();
+   }
+   
+   public final Token peekBwd(int offset)
+   {
+      TokenCursor clone = cloneCursor();
+      for (int i = 0; i < offset; i++)
+         if (!clone.moveToPreviousToken())
+            return Token.create();
+      return clone.currentToken();
+   }
+   
    public final String nextValue(int offset)
    {
       TokenCursor clone = cloneCursor();
@@ -157,12 +190,17 @@ public class TokenCursor extends JavaScriptObject
    
    public native final boolean isLeftBracket() /*-{
       var value = this.currentValue();
-      return ["(", "[", "{"].some(function(x) { return x === value; });
+      return value === "(" || value === "[" || value === "{";
+   }-*/;
+   
+   public native final boolean isRightBracket() /*-{
+      var value = this.currentValue();
+      return value === ")" || value === "]" || value === "}";
    }-*/;
    
    public native final boolean isExtractionOperator() /*-{
       var value = this.currentValue();
-      return ["$", "@", "?", "~"].some(function(x) { return x === value; });
+      return value === "$" || value === "@" || value === "?" || value === "~";
    }-*/;
    
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/TokenCursor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/TokenCursor.java
@@ -203,5 +203,20 @@ public class TokenCursor extends JavaScriptObject
       return value === "$" || value === "@" || value === "?" || value === "~";
    }-*/;
    
+   public final boolean isWithinFunctionCall()
+   {
+      TokenCursor clone = cloneCursor();
+      do
+      {
+         if (clone.peekBwd(1).isValidForFunctionCall())
+            return true;
+         
+         if (!clone.moveToPreviousToken())
+            return false;
+         
+      } while (clone.findOpeningBracket("(", false));
+      return false;
+   }
+   
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBar.java
@@ -14,8 +14,16 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.text.status;
 
+import com.google.gwt.user.client.Event.NativePreviewEvent;
+
 public interface StatusBar
 {
+   public static interface HideMessageHandler
+   {
+      // return 'true' to indicate message should be hidden
+      public boolean onNativePreviewEvent(NativePreviewEvent preview);
+   }
+   
    public static final int SCOPE_FUNCTION   = 1;
    public static final int SCOPE_CHUNK      = 2;
    public static final int SCOPE_SECTION    = 3;
@@ -26,11 +34,11 @@ public interface StatusBar
    public static final int SCOPE_ANON       = 8;
    public static final int SCOPE_TOP_LEVEL  = 9;
    
-   
    StatusBarElement getPosition();
    StatusBarElement getScope();
    StatusBarElement getLanguage();
    void setScopeVisible(boolean visible);
    void setScopeType(int type);
-   void showMessage(String message);
+   
+   void showMessage(String message, HideMessageHandler handler);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBar.java
@@ -32,4 +32,5 @@ public interface StatusBar
    StatusBarElement getLanguage();
    void setScopeVisible(boolean visible);
    void setScopeType(int type);
+   void showMessage(String message);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarWidget.java
@@ -152,8 +152,9 @@ public class StatusBarWidget extends Composite
    {
       show(scope_);
       show(scopeIcon_);
-      
       hide(message_);
+      
+      setScopeType(scopeType_);
    }
    
    public void hideMessage()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarWidget.java
@@ -90,7 +90,7 @@ public class StatusBarWidget extends Composite
    
    public void setScopeType(int type)
    {
-      if (type == StatusBar.SCOPE_TOP_LEVEL)
+      if (type == StatusBar.SCOPE_TOP_LEVEL || message_.isVisible())
          scopeIcon_.setVisible(false);
       else
          scopeIcon_.setVisible(true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarWidget.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarWidget.ui.xml
@@ -57,9 +57,15 @@
                                  showArrows="false"/>
       <g:Image ui:field="scopeIcon_"
                styleName="{style.scopeIcon}"/>
+               
       <sb:StatusBarElementWidget ui:field="scope_"
                                  styleName="{style.element}"
                                  showArrows="true"/>
+                                 
+      <sb:StatusBarElementWidget ui:field="message_"
+                                 styleName="{style.element}"
+                                 showArrows="false"/>
+                                 
       <sb:StatusBarElementWidget ui:field="language_"
                                  styleName="{style.element} {style.last}"
                                  showArrows="true"/>


### PR DESCRIPTION
NOTE: Not quite ready for merge (needs implementation for multi-mode documents, e.g. `.Rmd`)

This PR adds functionality for refactoring symbol names within a given scope (single-file only). See the gif for an example -- multiple variables named `item` exist (and shadow each other) at different scopes; the refactor utility is smart enough to figure out which `item` each particular variable refers to.

![refactor-in-scope](https://cloud.githubusercontent.com/assets/1976582/8437605/ef217578-1f14-11e5-8cda-8770130be8eb.gif)

TODO:

- [x] Non-R documents (e.g. C / C++)? Could probably use `clang` to provide symbol positions, or just our own scope tree.
- [x] Multi-mode documents
- [x] Correct behaviour when renaming a function argument name (e.g. in `call(arg = 1)`, if a user attempts to refactor the argument name `arg`, we should instead attempt to locate all calls to `call` with that argument supplied?