### PR TITLE
more fixes for markdown mode(s)

### DIFF
--- a/src/gwt/acesupport/acemode/markdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/markdown_highlight_rules.js
@@ -321,7 +321,69 @@ var MarkdownHighlightRules = function() {
         }, {
             token : "support.function",
             regex : ".+"
+        }],
+
+         "fieldblock" : [{
+            token : function(value) {
+                var field = value.slice(0,-1);
+                if (slideFields[field])
+                    return "comment.doc.tag";
+                else
+                    return "text";
+            },
+            regex : "^" +"[\\w-]+\\:",
+            next  : "fieldblockvalue"
+        }, {
+            token : "text",
+            regex : "(?=.+)",
+            next  : "start"
+        }],
+
+        "fieldblockvalue" : [{
+            token : "text",
+            regex : "$",
+            next  : "fieldblock"
+        }, {
+            token : "text",
+            regex : ".+"
+        }],
+
+        "mathjaxdisplay" : [{
+            token : "markup.list",
+            regex : "\\${2}",
+            next  : "start"
+        }, {
+            token : "support.function",
+            regex : "[^\\$]+"
+        }],
+        
+        "mathjaxnativedisplay" : [{
+            token : "markup.list",
+            regex : "\\\\\\]",
+            next  : "start"
+        }, {
+            token : "support.function",
+            regex : "[\\s\\S]+?"
+        }],
+        
+        "mathjaxinline" : [{
+            token : "markup.list",
+            regex : "\\$",
+            next  : "start"
+        }, {
+            token : "support.function",
+            regex : "[^\\$]+"
+        }],
+
+        "mathjaxnativeinline" : [{
+            token : "markup.list",
+            regex : "\\\\\\)",
+            next  : "start"
+        }, {
+            token : "support.function",
+            regex : "[\\s\\S]+?"
         }]
+
     };
 
     this.embedRules(JavaScriptHighlightRules, "jscode-", [{

--- a/src/gwt/acesupport/acemode/rmarkdown_folding.js
+++ b/src/gwt/acesupport/acemode/rmarkdown_folding.js
@@ -40,7 +40,10 @@ oop.inherits(FoldMode, BaseFoldMode);
       var line = session.getLine(row);
       var state = session.getState(row);
 
-      if (state === "$start")
+      // Check for header starts. Note that we don't check the state
+      // explicitly here as not all headers will occur at the 'start' state;
+      // this is done to support YAML blocks and R Presentation features.
+      if (Utils.startsWith(line, "===") || Utils.startsWith(line, "---"))
       {
          if (line[0] === "#")
             return "start";
@@ -174,7 +177,7 @@ oop.inherits(FoldMode, BaseFoldMode);
          depth = match[1].length;
       }
 
-      if (depth == null)
+      if (depth === null)
          return;
 
       var endRow = $findNextHeader(session, row, depth);


### PR DESCRIPTION
This PR fixes a number of things:

- A number of custom states in the Markdown highlight rules, primarily used for Rpres, had been omitted (likely missed somehow with the move to new Ace). This was causing 'error no such state' JavaScript warnings in R presentation documents.

- The 'start' and 'preamble' for Markdown scopes is now set separately -- this is necessary to properly support incremental building of the scope tree; without this you can see a scope added multiple times when attempting to edit it (or near it).

- Minor tweak for R Markdown fold widget locations -- since `===` can occur in more states than just the start state, we allow `===` at the start of the line to generate fold widgets regardless of state.

I think this PR is a candidate for the patch release, and so I've rebased everything into a single commit.