### PR TITLE
refine + refactor expand selection code

### DIFF
--- a/src/gwt/acesupport/acemixins/token_iterator.js
+++ b/src/gwt/acesupport/acemixins/token_iterator.js
@@ -176,15 +176,16 @@ var Range = require("ace/range").Range;
     * If no such token exists at that position, then we instead
     * move to the first token lying previous to that token.
     */
-   this.moveToPosition = function(rowOrPosition, column, seekForward)
+   this.moveToPosition = function(position, seekForward)
    {
-      var position = rowOrPosition;
-      if (typeof column !== "undefined")
-         position = {row: rowOrPosition, column: column};
-         
-      // Try to get a token at the position supplied.
+      // Try to get a token at the position supplied. Note that the
+      // default behaviour of 'session.getTokenAt' is to return the first
+      // token prior to the position supplied; for 'seekForward' behaviour
+      // this is undesired.
       var token = this.$session.getTokenAt(position.row, position.column);
- 
+      if (token && seekForward && token.column < position.column)
+         token = this.$session.getTokenAt(position.row, position.column + 1);
+
       // If no token was returned, place a token cursor at the first
       // cursor previous to that token.
       //

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -754,7 +754,7 @@ var RCodeModel = function(session, tokenizer,
       var row = this.$scopes.parsePos.row;
       var column = this.$scopes.parsePos.column;
 
-      iterator.moveToPosition(row, column, true);
+      iterator.moveToPosition({row: row, column: column}, true);
 
       var token = iterator.getCurrentToken();
       
@@ -853,7 +853,7 @@ var RCodeModel = function(session, tokenizer,
             if (braceIdx !== -1)
                label = label.substr(0, braceIdx).trim();
 
-            this.$scopes.onMarkdownHead(label, labelEndPos, labelStartPos, depth);
+            this.$scopes.onMarkdownHead(label, labelStartPos, labelEndPos, depth);
          }
 
          // Add R-comment sections; e.g.

--- a/src/gwt/acesupport/acemode/r_scope_tree.js
+++ b/src/gwt/acesupport/acemode/r_scope_tree.js
@@ -272,27 +272,40 @@ define('mode/r_scope_tree', function(require, exports, module) {
       // For example, given the function definition:
       //
       //    foo <- function(a, b, c) {
-      //    ^ -- start
+      //    ^ -- preamble
       //                             ^ -- start
       //
       // In general, these should be supplied separately -- otherwise, the
       // scope tree builder runs the risk of improperly adding duplicates of a
       // node when change events are emitted.
       this.start = start;
+
+      // Validate that the preamble lies before the start.
+      if (start && preamble)
+      {
+         if (preamble.row > start.row ||
+             (preamble.row === start.row && preamble.column > start.column))
+         {
+            throw new Error("Malformed preamble: should lie before start position");
+         }
+      }
+
       this.preamble = preamble || start;
 
       // The end position of the scope.
       this.end = null;
 
-      // Whether this scope is
+      // The type of this scope (e.g. a braced scope, a section, and so on)
       this.scopeType = scopeType;
       
-      // A pointer to the parent scope (if any) 
+      // A pointer to the parent scope (if any; only the root scope should
+      // have no parent)
       this.parentScope = null;
 
       // Generalized attributes (an object with names)
       this.attributes = attributes || {};
 
+      // Child nodes
       this.$children = [];
    };
 

--- a/src/gwt/test/acesupport/token_iterator.js
+++ b/src/gwt/test/acesupport/token_iterator.js
@@ -23,7 +23,7 @@ Editor.prototype.clear = function() {
    var end = {
       row: this.getSession().getLength(),
       column: 0
-   }
+   };
 
    this.getSession().remove(Range.fromPoints(start, end));
 }
@@ -35,7 +35,7 @@ Editor.prototype.getContents = function() {
 Editor.prototype.setContents = function(text) {
     this.clear();
     this.insert(text);
-}
+};
 
 // Initialize editor + provide aliases
 var editor = ace.edit("editor");
@@ -68,7 +68,7 @@ QUnit.test("TokenIterator works as expected", function(assert) {
     editor.insert("foo <- function(x) {\n  print(x)\n}");
     var iterator = new TokenIterator(editor.getSession());
 
-    iterator.moveToPosition(0, 0);
+    iterator.moveToPosition({row: 0, column: 0});
     assert.equal(iterator.getCurrentTokenRow(), 0, "First token lies at row 0");
     assert.equal(iterator.getCurrentTokenColumn(), 0, "First token lies on column 0");
 
@@ -94,5 +94,44 @@ QUnit.test("TokenIterator works as expected", function(assert) {
 
     assert.ok(prevToken.value === "}", "The final token is a closing bracket (was '" + prevToken.value + "')");
 
-})
+});
+
+QUnit.test("TokenIterator moves to position as expected", function(assert) {
+
+    // NOTE: The column indices are written above the text just
+    // as a means of double-checking the test.
+    //
+    //             012345678
+    editor.insert("(((abc)))");
+
+    var iterator = new TokenIterator(editor.getSession());
+
+    iterator.moveToPosition({row: 0, column: 0});
+    assert.equal(iterator.getCurrentToken().value, "(");
+
+    iterator.moveToPosition({row: 0, column: 3});
+    assert.equal(iterator.getCurrentToken().value, "(");
+
+    iterator.moveToPosition({row: 0, column: 3}, true);
+    assert.equal(iterator.getCurrentToken().value, "abc");
+
+    iterator.moveToPosition({row: 0, column: 4});
+    assert.equal(iterator.getCurrentToken().value, "abc");
+
+    iterator.moveToPosition({row: 0, column: 4}, true);
+    assert.equal(iterator.getCurrentToken().value, "abc");
+
+    iterator.moveToPosition({row: 0, column: 5});
+    assert.equal(iterator.getCurrentToken().value, "abc");
+
+    iterator.moveToPosition({row: 0, column: 5}, true);
+    assert.equal(iterator.getCurrentToken().value, "abc");
+
+    iterator.moveToPosition({row: 0, column: 6});
+    assert.equal(iterator.getCurrentToken().value, "abc");
+
+    iterator.moveToPosition({row: 0, column: 6}, true);
+    assert.equal(iterator.getCurrentToken().value, ")");
+
+});
 


### PR DESCRIPTION
This PR does a lot to tidy up + make the expand/contract selection more extensible:

1. A notion of an expansion 'rule' is defined; all applicable rules are executed and the smallest applicable expansion is chosen, unless a particular rule is 'safe' for immediate expansion.

1. A couple new expansion rules based on non-blank lines, comment blocks, scopes, etc. are added, making expansion easier in more contexts.

The over-arching goal is that, if you mash the 'expand' keybinding enough, you'll eventually get the selection you want -- it should also be easy for modes to define custom expansion rules in the future, if we wanted to further refine this.

![expand-contract](https://cloud.githubusercontent.com/assets/1976582/8469178/10b1c794-202b-11e5-8f34-579750542cb7.gif)
