### PR TITLE
Avoid `.packages` call when packages pane disabled

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -62,7 +62,14 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
       .Call(.rs.routines$rs_packageUnloaded, pkgname)
    }
    
-   sapply(.packages(TRUE), function(packageName) 
+   # NOTE: `list.dirs()` was introduced with R 2.13 but was buggy until 3.0
+   # (the 'full.names' argument was not properly respected)
+   pkgNames <- if (getRversion() >= "3.0.0")
+      base::list.dirs(.libPaths(), full.names = FALSE, recursive = FALSE)
+   else
+      .packages(TRUE)
+   
+   sapply(pkgNames, function(packageName)
    {
       if ( !(packageName %in% .rs.hookedPackages) )
       {


### PR DESCRIPTION
Not quite ready for merge -- just putting it up there for now...

## TODO

- [x] Avoid calling `updatePackageEvents()` when packages pane disabled
- [x] Rip out `onPackageLoaded` handler in `SessionShiny`
- [ ] Provide a new event, `onProjectPackageLoaded`, for use in `BreakpointManager`
- [ ] Verify no other code paths use this (check `onPackageStatusChanged`, `onPackageLoaded`, `onPackageUnloaded` -- e.g. `ag -Q " onPackage"`)