### PR TITLE
Further refine document outline widget

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -498,7 +498,7 @@ public class UIPrefsAccessor extends Prefs
    
    public PrefValue<Boolean> showUnnamedEntriesInDocumentOutline()
    {
-      return bool("show_unnamed_entries_in_document_outline", false);
+      return bool("show_unnamed_chunks_in_document_outline", true);
    }
    
    public PrefValue<Boolean> enableSourceWindows()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
@@ -112,6 +112,10 @@ public class DocumentOutlineWidget extends Composite
             ScopeFunction asFunctionNode = (ScopeFunction) node;
             text = asFunctionNode.getFunctionName();
          }
+         else if (node.isYaml())
+         {
+            text = "Title";
+         }
          else
          {
             text = node.getLabel();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkIconsManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkIconsManager.java
@@ -114,7 +114,12 @@ public class ChunkIconsManager
    
    private void manageChunkIcons(AceEditorNative editor)
    {
+      Element container = editor.getContainer();
+      if (container == null)
+         return;
+      
       Element[] icons = DomUtils.getElementsByClassName(
+            container,
             ThemeStyles.INSTANCE.inlineChunkToolbar());
       
       for (Element icon : icons)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkIconsManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkIconsManager.java
@@ -142,7 +142,7 @@ public class ChunkIconsManager
          if (el.getChildCount() > 0)
             el.removeAllChildren();
          
-         addToolbar(el, isSetupChunk(el, editor));
+         addToolbar(el, isSetupChunk(el, editor), editor);
       }
    }
    
@@ -159,7 +159,7 @@ public class ChunkIconsManager
       return line.contains("r setup");
    }
    
-   private void addToolbar(Element el, boolean isSetupChunk)
+   private void addToolbar(Element el, boolean isSetupChunk, AceEditorNative editor)
    {
       FlowPanel toolbarPanel = new FlowPanel();
       toolbarPanel.addStyleName(ThemeStyles.INSTANCE.inlineChunkToolbar());
@@ -178,9 +178,12 @@ public class ChunkIconsManager
          optionsIcon.getElement().getStyle().setMarginRight(5, Unit.PX);
          toolbarPanel.add(optionsIcon);
 
-         Image runIcon = createRunIcon();
-         toolbarPanel.add(runIcon);
-
+         // Note that 'run current chunk' currently only operates within Rmd
+         if (editor.getSession().getMode().getId().equals("mode/rmarkdown"))
+         {
+            Image runIcon = createRunIcon();
+            toolbarPanel.add(runIcon);
+         }
       }
       
       display(toolbarPanel, el);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOptionsPopupPanel.java
@@ -578,19 +578,19 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
    protected Position position_;
    
    private static final String OUTPUT_USE_DOCUMENT_DEFAULT =
-         "(Use Document Default)";
+         "(Use document default)";
 
    private static final String OUTPUT_SHOW_OUTPUT_ONLY =
-         "Show Output Only";
+         "Show output only";
    
    private static final String OUTPUT_SHOW_CODE_AND_OUTPUT =
-         "Show Code and Output";
+         "Show code and output";
    
    private static final String OUTPUT_SHOW_NOTHING =
-         "Show Nothing (Run Code)";
+         "Show nothing (run code)";
    
    private static final String OUTPUT_SKIP_THIS_CHUNK =
-         "Show Nothing (Don't Run Code)";
+         "Show nothing (don't run code)";
    
    public interface Styles extends CssResource
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -536,11 +536,14 @@ public class TextEditingTargetWidget
       
       // set the content type based on the extended type
       setPublishPath(extendedType_, publishPath_);
-      toggleDocOutlineButton_.setVisible(
-            target_.getDocDisplay().hasScopeTree());
       
       // make toggle outline visible if we have a scope tree
       toggleDocOutlineButton_.setVisible(fileType.canShowScopeTree());
+      if (!fileType.canShowScopeTree())
+      {
+         editorPanel_.setWidgetSize(docOutlineWidget_, 0);
+         toggleDocOutlineButton_.setLatched(false);
+      }
       
       toolbar_.invalidateSeparators();
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -371,4 +371,8 @@ public class AceEditorNative extends JavaScriptObject {
       return this.$clearSelectionHistory();
    }-*/;
    
+   public final native Element getContainer() /*-{
+      return this.container;
+   }-*/;
+   
 }


### PR DESCRIPTION
Almost ready to merge -- there's just one open question...

Currently, 'Run All Chunks' works by tangling the document (ie, extracting all code and writing it out to file, then sourcing that).

The problem with this method is that we don't really have good control over which chunks are / aren't emitted to the generated R document, and so it's difficult to exclude certain chunks.

As an alternative, we could just weave the document ourselves -- run through all chunks, extract those that don't have a custom engine attached, emit that to file and then source it. It seems like this shouldn't be too difficult. Any thoughts?