### PR TITLE
Refine 'run previous chunks' and only re-render icons in view

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkIconsManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkIconsManager.java
@@ -142,6 +142,9 @@ public class ChunkIconsManager
          if (!isRunnableChunk(el, editor))
             continue;
          
+         if (!DomUtils.isVisibleVert(container, el))
+            continue;
+         
          if (el.getChildCount() > 0)
             el.removeAllChildren();
          

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3493,12 +3493,16 @@ public class TextEditingTarget implements
    private boolean isRChunk(Scope scope)
    {
       String labelText = docDisplay_.getLine(scope.getPreamble().getRow());
-      Pattern reEngine = Pattern.create(".*engine\\s*=['\"]([^'\"]*)['\"]");
+      Pattern reEngine = Pattern.create(".*engine\\s*=\\s*['\"]([^'\"]*)['\"]");
       Match match = reEngine.match(labelText, 0);
       if (match == null)
          return true;
       
       String engine = match.getGroup(1).toLowerCase();
+      
+      // NOTE: We might want to include 'Rscript' but such chunks are typically
+      // intended to be run in their own process so it might not make sense to
+      // collect those here.
       return engine.equals("r");
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -124,7 +124,6 @@ import org.rstudio.studio.client.workbench.views.presentation.model.Presentation
 import org.rstudio.studio.client.workbench.views.source.SourceBuildHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.EditingTarget;
 import org.rstudio.studio.client.workbench.views.source.editors.EditingTargetCodeExecution;
-import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay.AnchoredSelection;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ScopeList.ContainsFoldPredicate;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetRMarkdownHelper.RmdSelectedTemplate;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceFold;
@@ -3479,40 +3478,25 @@ public class TextEditingTarget implements
    
    public void executePreviousChunks(final Position position)
    {  
-      withPreservedSelection(new Command() {
-
-         @Override
-         public void execute()
-         {
-            // HACK: This is just to force the entire function tree to be built.
-            // It's the easiest way to make sure getCurrentScope() returns
-            // a Scope with an end.
-            docDisplay_.getScopeTree();
-            // execute the previous chunks
-            Scope[] previousScopes = scopeHelper_.getPreviousSweaveChunks(position);
-            for (Scope scope : previousScopes)
-               executeSweaveChunk(scope, false);
-         }
-      });    
+      // HACK: This is just to force the entire function tree to be built.
+      // It's the easiest way to make sure getCurrentScope() returns
+      // a Scope with an end.
+      docDisplay_.getScopeTree();
+      
+      // execute the previous chunks
+      Scope[] previousScopes = scopeHelper_.getPreviousSweaveChunks(position);
+      for (Scope scope : previousScopes)
+         if (isRChunk(scope))
+            executeSweaveChunk(scope, false);
    }
    
-   private void withPreservedSelection(Command command)
-   { 
-      // save the selection and scroll position for restoration
-      int scrollPosition = docDisplay_.getScrollTop();
-      Position start = docDisplay_.getSelectionStart();
-      Position end = docDisplay_.getSelectionEnd();
-      AnchoredSelection anchoredSelection = 
-                           docDisplay_.createAnchoredSelection(start,end);
-      
-      // execute the command
-      command.execute();
-      
-      // restore the selection and scroll position
-      anchoredSelection.apply();
-      docDisplay_.scrollToY(scrollPosition);
+   private boolean isRChunk(Scope scope)
+   {
+      String labelText = docDisplay_.getLine(scope.getPreamble().getRow());
+      Pattern reEngine = Pattern.create("engine\\s*=");
+      return !reEngine.test(labelText);
    }
-
+   
    private void executeSweaveChunk(final Scope chunk, 
                                    final boolean scrollNearTop)
    {
@@ -3533,14 +3517,11 @@ public class TextEditingTarget implements
                                            range.getStart().getColumn()),
                      true);
             }
-            docDisplay_.setSelection(
-                docDisplay_.createSelection(range.getStart(), range.getEnd()));
             if (!range.isEmpty())
             {
                codeExecution_.setLastExecuted(range.getStart(), range.getEnd());
                String code = scopeHelper_.getSweaveChunkText(chunk);
                events_.fireEvent(new SendToConsoleEvent(code, true));
-
                docDisplay_.collapseSelection(true);
             }
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3493,8 +3493,13 @@ public class TextEditingTarget implements
    private boolean isRChunk(Scope scope)
    {
       String labelText = docDisplay_.getLine(scope.getPreamble().getRow());
-      Pattern reEngine = Pattern.create("engine\\s*=");
-      return !reEngine.test(labelText);
+      Pattern reEngine = Pattern.create(".*engine\\s*=['\"]([^'\"]*)['\"]");
+      Match match = reEngine.match(labelText, 0);
+      if (match == null)
+         return true;
+      
+      String engine = match.getGroup(1).toLowerCase();
+      return engine.equals("r");
    }
    
    private void executeSweaveChunk(final Scope chunk, 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3467,7 +3467,10 @@ public class TextEditingTarget implements
       // a Scope with an end.
       docDisplay_.getScopeTree();
       
-      executeSweaveChunk(scopeHelper_.getNextSweaveChunk(), true);
+      Scope nextChunk = scopeHelper_.getNextSweaveChunk();
+      executeSweaveChunk(nextChunk, true);
+      docDisplay_.setCursorPosition(nextChunk.getBodyStart());
+      docDisplay_.ensureCursorVisible();
    }
    
    @Handler


### PR DESCRIPTION
- Don't set a new selection when running chunks (it seems this action is unnecessary and orthogonal to how everything else runs)
- Only run R code chunks
- Only render chunk toolbars that are visible within their container.

This still involves destructing and re-constructing all visible toolbars on each Ace render (which happens per-keystroke) but I'm not yet sure how we could best 'link' a particular toolbar to the associated chunk.