### PR TITLE
add 'go to working dir' to 'More...' dropdown

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FileCommandToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FileCommandToolbar.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.workbench.views.files.ui;
 
 import com.google.inject.Inject;
+
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
@@ -45,6 +46,7 @@ public class FileCommandToolbar extends Toolbar
       moreMenu.addItem(commands.exportFiles().createMenuItem(false));
       moreMenu.addSeparator();
       moreMenu.addItem(commands.setAsWorkingDir().createMenuItem(false));
+      moreMenu.addItem(commands.goToWorkingDir().createMenuItem(false));
       moreMenu.addSeparator();
       moreMenu.addItem(commands.showFolder().createMenuItem(false));
 


### PR DESCRIPTION
This adds the `goToWorkingDir` command to the `More...` dropdown in the files pane:

![screen shot 2015-07-24 at 11 37 37 am](https://cloud.githubusercontent.com/assets/1976582/8881970/7dba4364-31f8-11e5-831d-7b814b0d1fb3.png)

@jjallaire, I know we have an icon already on the `Console` pane but I think it makes sense to have this present in the Files pane as well -- what do you think?

(I also feel it's a bit awkward that it's the only item with an associated icon, but it looks like we don't have a simple way of creating a menu bar item sans the icon...)