### PR TITLE
smarter highlight rules for R keyword functions

### DIFF
--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -198,7 +198,7 @@ var RCodeModel = function(session, tokenizer,
       var clone = cursor.cloneCursor();
       
       var token = "";
-      if (clone.currentType() === "identifier")
+      if (clone.hasType("identifier"))
          token = clone.currentValue();
       
       // We're expecting to be within e.g.
@@ -212,7 +212,7 @@ var RCodeModel = function(session, tokenizer,
       if (clone.currentValue() === "=")
          cursorPos = "right";
 
-      if (clone.currentType() === "identifier")
+      if (clone.hasType("identifier"))
       {
          if (!clone.moveToPreviousToken())
             return null;
@@ -322,7 +322,7 @@ var RCodeModel = function(session, tokenizer,
       if (cursor.currentValue() === ")")
          return false;
 
-      if (cursor.currentType() === "identifier")
+      if (cursor.hasType("identifier"))
          data.additionalArgs.push(cursor.currentValue());
       
       if (fnName === "rename")
@@ -358,7 +358,7 @@ var RCodeModel = function(session, tokenizer,
             if (!cursor.moveToNextToken())
                return false;
 
-            if (cursor.currentType() === "identifier")
+            if (cursor.hasType("identifier"))
                data.additionalArgs.push(cursor.currentValue());
             
             if (!cursor.moveToNextToken())
@@ -370,7 +370,7 @@ var RCodeModel = function(session, tokenizer,
                {
                   if (!cursor.moveToNextToken())
                      return false;
-                  if (cursor.currentType() === "identifier")
+                  if (cursor.hasType("identifier"))
                      data.excludeArgs.push(cursor.currentValue());
                }
 
@@ -1359,7 +1359,7 @@ var RCodeModel = function(session, tokenizer,
             {
                if (currentValue === "{")
                   continuationIndent = tab;
-               
+
                return this.$getIndent(
                   this.$doc.getLine(tokenCursor.$row)
                ) + continuationIndent;
@@ -1619,7 +1619,7 @@ var RCodeModel = function(session, tokenizer,
                
                // If we're on a constant, then we need to find an
                // operator beforehand, or give up.
-               if (/\bconstant\b|\bidentifier\b/.test(tokenCursor.currentType()))
+               if (tokenCursor.hasType("constant", "identifier"))
                {
 
                   if (!tokenCursor.moveToPreviousToken())
@@ -1649,7 +1649,7 @@ var RCodeModel = function(session, tokenizer,
 
                   }
 
-                  if (!/\boperator\b/.test(tokenCursor.currentType()))
+                  if (!tokenCursor.hasType("operator"))
                      break;
 
                   continue;
@@ -1712,8 +1712,7 @@ var RCodeModel = function(session, tokenizer,
       }
       else if (isOneOf(tokenCursor.currentValue(),
                        ["else", "repeat", "<-", "<<-", "="]) ||
-        tokenCursor.currentType().indexOf("infix") !== -1 ||
-        tokenCursor.currentType() === "keyword.operator")
+               tokenCursor.hasType("infix", "keyword.operator"))
       {
          return this.$getIndent(this.$getLine(tokenCursor.$row));
       }

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1357,6 +1357,9 @@ var RCodeModel = function(session, tokenizer,
 
             if (tokenCursor.isAtStartOfNewExpression(false))
             {
+               if (currentValue === "{")
+                  continuationIndent = tab;
+               
                return this.$getIndent(
                   this.$doc.getLine(tokenCursor.$row)
                ) + continuationIndent;

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1712,7 +1712,8 @@ var RCodeModel = function(session, tokenizer,
       }
       else if (isOneOf(tokenCursor.currentValue(),
                        ["else", "repeat", "<-", "<<-", "="]) ||
-               tokenCursor.hasType("infix", "keyword.operator"))
+               tokenCursor.hasType("infix") ||
+               tokenCursor.currentType() === "keyword.operator")
       {
          return this.$getIndent(this.$getLine(tokenCursor.$row));
       }

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -186,7 +186,7 @@ define("mode/r_highlight_rules", function(require, exports, module)
          {
             token : function(value) {
                if ($colorFunctionCalls)
-                  return "support.function.identifier";
+                  return "identifier.support.function";
                else
                   return "identifier";
             },
@@ -201,7 +201,7 @@ define("mode/r_highlight_rules", function(require, exports, module)
                if (specialFunctions[value] || keywords[value])
                   return "keyword";
                else if ($colorFunctionCalls)
-                  return "support.function.identifier";
+                  return "identifier.support.function";
                else
                   return "identifier";
             },

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -46,7 +46,7 @@ define("mode/r_highlight_rules", function(require, exports, module)
          "return", "switch", "try", "tryCatch", "stop",
          "warning", "require", "library", "attach", "detach",
          "source", "setMethod", "setGeneric", "setGroupGeneric",
-         "setClass", "setRefClass", "R6Class"
+         "setClass", "setRefClass", "R6Class", "UseMethod", "NextMethod"
       ]);
 
       var builtinConstants = lang.arrayToMap([

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -55,6 +55,8 @@ define("mode/r_highlight_rules", function(require, exports, module)
          "NA_complex_"
       ]);
 
+      var reIdentifier = "[a-zA-Z.][a-zA-Z0-9._]*";
+
       var rules = {};
 
       // Define rule sub-blocks that can be included to create
@@ -141,7 +143,20 @@ define("mode/r_highlight_rules", function(require, exports, module)
                else
                   return "identifier";
             },
-            regex : "[a-zA-Z.][a-zA-Z0-9._]*",
+            regex : reIdentifier,
+            next  : "start"
+         }
+      ];
+
+      rules["#package-access"] = [
+         {
+            token : function(value) {
+               if ($colorFunctionCalls)
+                  return "identifier.support.class";
+               else
+                  return "identifier";
+            },
+            regex : reIdentifier + "(?=\\s*::)",
             next  : "start"
          }
       ];
@@ -156,7 +171,7 @@ define("mode/r_highlight_rules", function(require, exports, module)
                else
                   return "identifier";
             },
-            regex : "[a-zA-Z.][a-zA-Z0-9._]*(?=\\s*\\()",
+            regex : reIdentifier + "(?=\\s*\\()",
             next  : "start"
          }
       ];
@@ -164,7 +179,7 @@ define("mode/r_highlight_rules", function(require, exports, module)
       rules["#variable-assignment"] = [
          {
             token : "variable.identifier",
-            regex : "[a-zA-Z.][a-zA-Z0-9._]*(?=\\s*=)",
+            regex : reIdentifier + "(?=\\s*=)",
             next  : "start"
          }
       ];
@@ -174,7 +189,7 @@ define("mode/r_highlight_rules", function(require, exports, module)
             token : "keyword.operator",
             regex : "\\$|@",
             merge : false,
-            next  : "after-dollar"
+            next  : "start"
          },
          {
             token : "keyword.operator",
@@ -230,14 +245,7 @@ define("mode/r_highlight_rules", function(require, exports, module)
       // Construct rules from previously defined blocks.
       rules["start"] = include(
          "#comment", "#string", "#number",
-         "#function-call", "#identifier",
-         "#operator", "#text"
-      );
-
-      // We don't highlight '#special-functions'
-      // following '$' or '@'.
-      rules["after-dollar"] = include(
-         "#comment", "#string", "#number",
+         "#package-access", "#function-call",
          "#identifier", "#operator", "#text"
       );
 

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -17,9 +17,11 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
+
+var $colorFunctionCalls = false;
+
 define("mode/r_highlight_rules", function(require, exports, module)
 {
-
    function include(/*...*/) {
       var result = [];
       for (var i = 0; i < arguments.length; i++) {
@@ -149,8 +151,10 @@ define("mode/r_highlight_rules", function(require, exports, module)
             token : function(value) {
                if (keywordFunctions[value] || specialFunctions[value])
                   return "keyword";
-               else
+               else if ($colorFunctionCalls)
                   return "support.function.identifier";
+               else
+                  return "identifier";
             },
             regex : "[a-zA-Z.][a-zA-Z0-9._]*(?=\\s*\\()",
             next  : "start"
@@ -299,4 +303,8 @@ define("mode/r_highlight_rules", function(require, exports, module)
    oop.inherits(RHighlightRules, TextHighlightRules);
 
    exports.RHighlightRules = RHighlightRules;
+   exports.setHighlightRFunctionCalls = function(value) {
+      $colorFunctionCalls = value;
+   };
+
 });

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -23,9 +23,9 @@ var $colorFunctionCalls = false;
 define("mode/r_highlight_rules", function(require, exports, module)
 {
    function include(/*...*/) {
-      var result = [];
+      var result = new Array(arguments.length);
       for (var i = 0; i < arguments.length; i++) {
-         result.push({include: arguments[i]});
+         result[i] = {include: arguments[i]};
       }
       return result;
    }
@@ -49,7 +49,7 @@ define("mode/r_highlight_rules", function(require, exports, module)
          "setClass", "setRefClass", "R6Class"
       ]);
 
-      var buildinConstants = lang.arrayToMap([
+      var builtinConstants = lang.arrayToMap([
          "NULL", "NA", "TRUE", "FALSE", "T", "F", "Inf",
          "NaN", "NA_integer_", "NA_real_", "NA_character_",
          "NA_complex_"
@@ -126,17 +126,20 @@ define("mode/r_highlight_rules", function(require, exports, module)
          }
       ];
 
-      rules["#identifier"] = [
+      rules["#quoted-identifier"] = [
          {
             token : "identifier",
             regex : "`.*?`",
             merge : false,
             next  : "start"
-         },
+         }
+      ];
+
+      rules["#identifier"] = [
          {
             token : function(value)
             {
-               if (buildinConstants[value])
+               if (builtinConstants[value])
                   return "constant.language";
                else if (value.match(/^\.\.\d+$/))
                   return "variable.language";
@@ -150,15 +153,9 @@ define("mode/r_highlight_rules", function(require, exports, module)
 
       rules["#keyword-or-identifier"] = [
          {
-            token : "identifier",
-            regex : "`.*?`",
-            merge : false,
-            next  : "start"
-         },
-         {
             token : function(value)
             {
-               if (buildinConstants[value])
+               if (builtinConstants[value])
                   return "constant.language";
                else if (keywords[value])
                   return "keyword";
@@ -209,14 +206,6 @@ define("mode/r_highlight_rules", function(require, exports, module)
                   return "identifier";
             },
             regex : reIdentifier + "(?=\\s*\\()",
-            next  : "start"
-         }
-      ];
-
-      rules["#variable-assignment"] = [
-         {
-            token : "variable.identifier",
-            regex : reIdentifier + "(?=\\s*=)",
             next  : "start"
          }
       ];
@@ -290,13 +279,15 @@ define("mode/r_highlight_rules", function(require, exports, module)
       // Construct rules from previously defined blocks.
       rules["start"] = include(
          "#comment", "#string", "#number",
-         "#package-access", "#function-call-or-keyword", "#keyword-or-identifier",
+         "#package-access", "#quoted-identifier",
+         "#function-call-or-keyword", "#keyword-or-identifier",
          "#operator", "#text"
       );
 
       rules["after-dollar"] = include(
          "#comment", "#string", "#number",
-         "#function-call", "#identifier",
+         "#quoted-identifier",
+         "#function-call", "#keyword-or-identifier",
          "#operator", "#text"
       );
 

--- a/src/gwt/acesupport/acemode/token_cursor.js
+++ b/src/gwt/acesupport/acemode/token_cursor.js
@@ -877,7 +877,7 @@ oop.mixin(RTokenCursor.prototype, TokenCursor.prototype);
              type === "symbol" ||
              type === "keyword" ||
              type === "string" ||
-             type === "constant";
+             this.hasType("constant");
    };
 
    this.isExtractionOperator = function()

--- a/src/gwt/acesupport/acemode/token_cursor.js
+++ b/src/gwt/acesupport/acemode/token_cursor.js
@@ -872,10 +872,12 @@ oop.mixin(RTokenCursor.prototype, TokenCursor.prototype);
 
    this.isValidAsIdentifier = function()
    {
-      return this.hasType(
-         "identifier", "symbol", "keyword",
-         "string", "constant"
-      );
+      var type = this.currentType();
+      return this.hasType("identifier") ||
+             type === "symbol" ||
+             type === "keyword" ||
+             type === "string" ||
+             type === "constant";
    };
 
    this.isExtractionOperator = function()

--- a/src/gwt/acesupport/acemode/token_cursor.js
+++ b/src/gwt/acesupport/acemode/token_cursor.js
@@ -384,6 +384,21 @@ var TokenCursor = function(tokens, row, offset) {
       return this.currentToken().type;
    };
 
+   this.hasType = function(/*...*/)
+   {
+      var tokenType = this.currentType();
+      for (var i = 0; i < arguments.length; i++) {
+         var type = arguments[i];
+         if (tokenType === type ||
+             tokenType.indexOf(type + ".") !== -1 ||
+             tokenType.indexOf("." + type) !== -1)
+         {
+            return true;
+         }
+      }
+      return false;
+   };
+
    this.currentPosition = function()
    {
       var token = this.currentToken();
@@ -812,13 +827,9 @@ oop.mixin(CppTokenCursor.prototype, TokenCursor.prototype);
       }
 
       // Chomp keywords
-      while (clonedCursor.currentType() === "keyword") {
-         
-         if (!clonedCursor.moveToPreviousToken()) {
+      while (clonedCursor.currentType() === "keyword")
+         if (!clonedCursor.moveToPreviousToken())
             return false;
-         }
-         
-      }
       
       // Move backwards over the name of the element initialized
       if (clonedCursor.moveToPreviousToken()) {
@@ -859,13 +870,12 @@ oop.mixin(RTokenCursor.prototype, TokenCursor.prototype);
 
    var contains = Utils.contains;
 
-   this.isValidAsIdentifier = function() {
-      var type = this.currentType();
-      return type === "identifier" ||
-             type === "symbol" ||
-             type === "keyword" ||
-             type === "string" ||
-             type.indexOf("constant") !== -1;
+   this.isValidAsIdentifier = function()
+   {
+      return this.hasType(
+         "identifier", "symbol", "keyword",
+         "string", "constant"
+      );
    };
 
    this.isExtractionOperator = function()
@@ -922,8 +932,9 @@ oop.mixin(RTokenCursor.prototype, TokenCursor.prototype);
 
    this.isLookingAtBinaryOp = function()
    {
-      return this.currentType() === "keyword.operator" ||
-             this.currentType() === "keyword.operator.infix";
+      var type = this.currentType();
+      return type === "keyword.operator" ||
+             type === "keyword.operator.infix";
    };
 
    this.moveToStartOfCurrentStatement = function()
@@ -1067,35 +1078,25 @@ oop.mixin(RTokenCursor.prototype, TokenCursor.prototype);
    // or 'operator' types.
    this.isValidForEndOfStatement = function()
    {
-      var token = this.currentToken();
-      if (!token) return false;
-      
-      var value = token.value;
-      var type  = token.type;
-
+      var type = this.currentType();
       if (type === "paren.keyword.operator")
-         return isRightBracket(value);
+         return isRightBracket(this.currentValue());
+
+      var value = this.currentValue();
 
       return isSingleLineString(value) ||
-             type === "identifier" ||
-             type.indexOf("constant") !== -1 ||
-             type.indexOf("variable") !== -1;
+             this.hasType("identifier", "constant", "variable");
    };
 
    this.isValidForStartOfStatement = function()
    {
-      var token = this.currentToken();
-      
-      var value = token.value;
-      var type = token.type;
-
+      var type = this.currentType();
       if (type === "paren.keyword.operator")
-         return isLeftBracket(value);
+         return isLeftBracket(this.currentValue());
 
+      var value = this.currentValue();
       return isSingleLineString(value) ||
-             type === "identifier" ||
-             type.indexOf("constant") !== -1 ||
-             type.indexOf("variable") !== -1;
+             this.hasType("identifier", "constant", "variable");
    };
 
    // NOTE: By 'conditional' we mean following by a parenthetical

--- a/src/gwt/acesupport/acemode/token_cursor.js
+++ b/src/gwt/acesupport/acemode/token_cursor.js
@@ -873,11 +873,10 @@ oop.mixin(RTokenCursor.prototype, TokenCursor.prototype);
    this.isValidAsIdentifier = function()
    {
       var type = this.currentType();
-      return this.hasType("identifier") ||
+      return this.hasType("identifier", "constant") ||
              type === "symbol" ||
              type === "keyword" ||
-             type === "string" ||
-             this.hasType("constant");
+             type === "string";
    };
 
    this.isExtractionOperator = function()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
@@ -264,6 +264,9 @@ public class UIPrefs extends UIPrefsAccessor implements UiPrefsChangedHandler
          syntaxColorConsole().setGlobalValue(
                              newUiPrefs.syntaxColorConsole().getGlobalValue());
          
+         highlightRFunctionCalls().setGlobalValue(
+                             newUiPrefs.highlightRFunctionCalls().getGlobalValue());
+         
          // chunk toolbar
          showInlineToolbarForRCodeChunks().setGlobalValue(
                newUiPrefs.showInlineToolbarForRCodeChunks().getGlobalValue());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -266,6 +266,11 @@ public class UIPrefsAccessor extends Prefs
       return bool("syntax_color_console", false);
    }
    
+   public PrefValue<Boolean> highlightRFunctionCalls()
+   {
+      return bool("highlight_r_function_calls", false);
+   }
+   
    public PrefValue<Boolean> showInlineToolbarForRCodeChunks()
    {
       return bool("show_inline_toolbar_for_r_code_chunks", true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -132,6 +132,7 @@ public class EditingPreferencesPane extends PreferencesPane
       displayPanel.add(checkboxPref("Show indent guides", prefs_.showIndentGuides()));
       displayPanel.add(checkboxPref("Blinking cursor", prefs_.blinkingCursor()));
       displayPanel.add(checkboxPref("Show syntax highlighting in console input", prefs_.syntaxColorConsole()));
+      displayPanel.add(checkboxPref("Highlight R function calls", prefs_.highlightRFunctionCalls()));
       displayPanel.add(checkboxPref("Allow multiple source windows", prefs_.enableSourceWindows()));
       
       Label rMarkdownLabel = headerLabel("R Markdown");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1099,7 +1099,7 @@ public class RCompletionManager implements CompletionManager
          if (cursor.moveToPosition(input_.getCursorPosition()))
          {
             String token = "";
-            if (cursor.currentType() == "identifier")
+            if (cursor.hasType("identifier"))
                token = cursor.currentValue();
             
             String cursorPos = "left";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -553,12 +553,14 @@ public class AceEditor implements DocDisplay,
                                        UIPrefsAccessor.COMPLETION_ALWAYS);
       int characterThreshold = uiPrefs_.alwaysCompleteCharacters().getValue();
       int delay = uiPrefs_.alwaysCompleteDelayMs().getValue();
+      
       widget_.getEditor().setCompletionOptions(
             enabled,
             uiPrefs_.enableSnippets().getValue(),
             live,
             characterThreshold,
             delay);
+      
    }
 
    @Override
@@ -1447,6 +1449,18 @@ public class AceEditor implements DocDisplay,
    {
       getSession().setUseSoftTabs(on);
    }
+   
+   public void setHighlightRFunctionCalls(boolean highlight)
+   {
+      _setHighlightRFunctionCallsImpl(highlight);
+      widget_.getEditor().retokenizeDocument();
+   }
+   
+   private native final void _setHighlightRFunctionCallsImpl(boolean highlight)
+   /*-{
+      var Mode = $wnd.require("mode/r_highlight_rules");
+      Mode.setHighlightRFunctionCalls(highlight);
+   }-*/;
 
    /**
     * Warning: This will be overridden whenever the file type is set
@@ -2508,7 +2522,7 @@ public class AceEditor implements DocDisplay,
    {
       return snippets_.onInsertSnippet();
    }
-
+   
    private static final int DEBUG_CONTEXT_LINES = 2;
    private final HandlerManager handlers_ = new HandlerManager(this);
    private final AceEditorWidget widget_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -149,6 +149,7 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    void setShowInvisibles(boolean show);
    void setShowIndentGuides(boolean show);
    void setBlinkingCursor(boolean blinking);
+   void setHighlightRFunctionCalls(boolean highlight);
    
    void setUseEmacsKeybindings(boolean use);
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -5022,6 +5022,11 @@ public class TextEditingTarget implements
                public void execute(Boolean arg) {
                   docDisplay.setShowIndentGuides(arg);
                }}));
+      releaseOnDismiss.add(prefs.highlightRFunctionCalls().bind(
+            new CommandWithArg<Boolean>() {
+               public void execute(Boolean arg) {
+                  docDisplay.setHighlightRFunctionCalls(arg);
+               }}));
       releaseOnDismiss.add(prefs.useVimMode().bind(
             new CommandWithArg<Boolean>() {
                public void execute(Boolean arg) {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetReformatHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetReformatHelper.java
@@ -410,6 +410,21 @@ public class TextEditingTargetReformatHelper
          return tokens_.get(index).getValue();
       }
       
+      public boolean hasType(String... targetTypes)
+      {
+         String tokenType = tokens_.get(offset_).getType();
+         for (String targetType : targetTypes)
+         {
+            if (tokenType.equals(targetType) ||
+                tokenType.contains(targetType + ".") ||
+                tokenType.contains("." + targetType))
+            {
+               return true;
+            }
+         }
+         return false;
+      }
+      
       public String currentType()
       {
          return tokens_.get(offset_).getType();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRenameHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRenameHelper.java
@@ -51,13 +51,8 @@ public class TextEditingTargetRenameHelper
       // Validate that we're looking at an R identifier
       String targetValue = cursor.currentValue();
       String targetType = cursor.currentType();
-      
-      boolean isVariableType =
-            targetType.equals("identifier") ||
-            targetType.equals("keyword") ||
-            targetType.equals("constant.language");
-      
-      if (!isVariableType)
+
+      if (!cursor.hasType("identifier", "keyword", "constant.language"))
          return -1;
       
       // Check to see if we're refactoring the name of an argument in a function call,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -383,7 +383,9 @@ public class AceEditorNative extends JavaScriptObject {
    }-*/;
    
    public final native void retokenizeDocument() /*-{
-      this.session.bgTokenizer.start(0);
+      this.session.bgTokenizer &&
+         this.session.bgTokenizer.start &&
+         this.session.bgTokenizer.start(0);
    }-*/;
    
    public final native void setCommandManager(AceCommandManager commands)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -382,8 +382,13 @@ public class AceEditorNative extends JavaScriptObject {
       return this.commands;
    }-*/;
    
+   public final native void retokenizeDocument() /*-{
+      this.session.bgTokenizer.start(0);
+   }-*/;
+   
    public final native void setCommandManager(AceCommandManager commands)
    /*-{
       this.commands = commands;
    }-*/;
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Mode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Mode.java
@@ -82,4 +82,9 @@ public class Mode extends JavaScriptObject
    }-*/;
    
    public native final String getId() /*-{ return this.$id; }-*/;
+   
+   public native final void setHighlightRFunctionCalls(boolean show) /*-{
+      this.setHighlightRFunctionCalls && this.setHighlightRFunctionCalls(show);
+   }-*/;
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Token.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Token.java
@@ -100,7 +100,7 @@ public class Token extends JavaScriptObject
    
    public native final boolean isValidForFunctionCall() /*-{
       return this.type && (
-         this.type === "identifier" ||
+         this.type.indexOf("identifier") !== -1 ||
          this.type === "string" ||
          this.type === "keyword"
       );

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Token.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Token.java
@@ -55,6 +55,21 @@ public class Token extends JavaScriptObject
       return value.equals(getValue());
    }
    
+   public final boolean hasType(String... types)
+   {
+      String tokenType = getType();
+      for (String type : types)
+      {
+         if (tokenType.equals(type) ||
+             tokenType.contains(type + ".") ||
+             tokenType.contains("." + type))
+         {
+            return true;
+         }
+      }
+      return false;
+   }
+   
    public final boolean typeEquals(String type)
    {
       return type.equals(getType());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/TokenCursor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/TokenCursor.java
@@ -50,6 +50,11 @@ public class TokenCursor extends JavaScriptObject
       return currentToken().typeEquals(type);
    }
    
+   public final boolean hasType(String... types)
+   {
+      return currentToken().hasType(types);
+   }
+   
    public final Token peek(int offset)
    {
       return offset > 0 ? peekFwd(offset) : peekBwd(-offset);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Tokenizer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Tokenizer.java
@@ -161,9 +161,4 @@ public class Tokenizer extends JavaScriptObject
       
       return tokens;
    }
-   
-   public final native void retokenizeDocument()
-   /*-{
-      return this.start(0);
-   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Tokenizer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Tokenizer.java
@@ -161,4 +161,9 @@ public class Tokenizer extends JavaScriptObject
       
       return tokens;
    }
+   
+   public final native void retokenizeDocument()
+   /*-{
+      return this.start(0);
+   }-*/;
 }

--- a/src/gwt/test/autoindent_test_r.html
+++ b/src/gwt/test/autoindent_test_r.html
@@ -383,6 +383,10 @@ foo()
     "bar"()
 </pre></li>
 
+<li><pre data-expected="2">
+()
+{
+</pre></li>
 
 </ol>
 


### PR DESCRIPTION
NOTE: don't merge quite yet; needs further testing + want to confirm that we agree this is an overall positive change (or if we would take this in a tweaked form)

This PR attempts to be a bit smarter about tokenization of keywords. I find it somewhat annoying that certain 'key' functions, e.g. `library`, would be highlighted even when not used as a function, e.g. in this screenshot:

<img width="276" alt="screen shot 2015-07-24 at 5 00 17 pm" src="https://cloud.githubusercontent.com/assets/1976582/8886813/7eac2f3a-3225-11e5-8951-f9304653c035.png">

In my mind, the highlighting in each of these cases is 'wrong'; we can do better with the updated Ace tokenizer.

Here's the current state of this PR:

<img width="280" alt="screen shot 2015-07-24 at 5 01 49 pm" src="https://cloud.githubusercontent.com/assets/1976582/8886826/b4df26ac-3225-11e5-8880-f31b1f1ee803.png">

Note that `source` is only highlighted in the first line, where it's used as a function (and not following a `$`). In other words, the idea behind the PR is to preserve the current highlight rules but only highlight 'special' functions when an open `(` follows and they are not preceded by a `$` or `@`.