### PR TITLE
improve shortcut editting UI

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
@@ -570,7 +570,7 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
    public KeySequence getKeySequence()
    {
       if (shortcut_ == null)
-         return null;
+         return new KeySequence();
       
       return shortcut_.getKeySequence();
    }

--- a/src/gwt/src/org/rstudio/core/client/command/KeyboardShortcut.java
+++ b/src/gwt/src/org/rstudio/core/client/command/KeyboardShortcut.java
@@ -18,6 +18,8 @@ import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.dom.client.KeyCodes;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.StringUtil;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -158,6 +160,9 @@ public class KeyboardShortcut
       public static KeySequence fromShortcutString(String shortcut)
       {
          KeySequence sequence = new KeySequence();
+         if (StringUtil.isNullOrEmpty(shortcut))
+            return sequence;
+         
          String[] splat = shortcut.split("\\s+");
          for (int i = 0; i < splat.length; i++)
          {
@@ -193,6 +198,12 @@ public class KeyboardShortcut
          }
          
          return sequence;
+      }
+      
+      public void set(KeySequence others)
+      {
+         keyCombinations_.clear();
+         keyCombinations_.addAll(others.keyCombinations_);
       }
       
       public void clear()

--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
@@ -218,10 +218,13 @@ public class ShortcutManager implements NativePreviewHandler,
       return returnValue;
    }
    
-   // Returns 'true' if the event is canceled.
+   // Returns 'true' if the keyBuffer was reset, or is already empty.
    private boolean updateKeyBuffer(NativeEvent event)
    {
       if (keyBuffer_.isEmpty())
+         return true;
+      
+      if (!isEnabled())
          return false;
       
       // We need to let the Ace editor see prefix matches.

--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -889,4 +889,10 @@ public class DomUtils
    public final static native Element elementFromPoint(int x, int y) /*-{
       return $doc.elementFromPoint(x, y);
    }-*/;
+   
+   public static final native void setSelectionRange(Element el, int start, int end)
+   /*-{
+      if (el.setSelectionRange)
+         el.setSelectionRange(start, end);
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.css
@@ -1,22 +1,7 @@
 @def MODIFIED_COLOUR #cdefcd;
 @def CUSTOM_COLOUR #EFF;
 
-.modifiedRow {
-	background-color: MODIFIED_COLOUR !important;
-}
-
-.modifiedRow td {
-	border-color: MODIFIED_COLOUR !important;
-}
-
-.customBindingRow {
-	background-color: CUSTOM_COLOUR !important;
-}
-
-.customBindingRow td {
-	border-color: CUSTOM_COLOUR !important;
-}
-
+/* DataGrid styling / overrides */
 /* Avoid GWT's inset styling for selected cells */
 .dataGridKeyboardSelectedRowCell, .dataGridKeyboardSelectedRowCell:active,
 .dataGridKeyboardSelectedRowCell:hover, .dataGridKeyboardSelectedRowCell:focus {
@@ -25,8 +10,12 @@
 	border-right: 1px solid #FFF !important;
 }
 
-.dataGridKeyboardSelectedCell {
-	background: #def;
+.dataGridKeyboardSelectedRowCell:first-child {
+	border-left: 2px solid #0AF !important;
+}
+
+.dataGridKeyboardSelectedRowCell:first-child div {
+	margin-left: -1px;
 }
 
 .dataGridWidget > div {
@@ -45,12 +34,35 @@
 	outline: 0;
 }
 
+/* Other styling */
+
+.modifiedRow {
+	background-color: MODIFIED_COLOUR !important;
+}
+
+.modifiedRow td {
+	border-color: MODIFIED_COLOUR !important;
+}
+
+.customBindingRow {
+	background-color: CUSTOM_COLOUR !important;
+}
+
+.customBindingRow td {
+	border-color: CUSTOM_COLOUR !important;
+}
+
 .maskedEditorCommandCell div {
 	text-decoration: line-through;
 }
 
 .conflictRow {
 	background-color: #FED;
+}
+
+.shortcutInput {
+	border: 1px solid #CCC;
+	border-radius: 5px;
 }
 
 .icon {

--- a/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.css
@@ -34,6 +34,10 @@
 	outline: 0;
 }
 
+.dataGridWidget input {
+	height: 14px !important;
+}
+
 /* Other styling */
 
 .modifiedRow {

--- a/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
@@ -782,6 +782,9 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
          String bufferString = buffer_.toString();
          input.setAttribute("value", bufferString);
          input.setInnerHTML(bufferString);
+         
+         // Move the cursor to the end of the selection.
+         DomUtils.setSelectionRange(input, bufferString.length(), bufferString.length());
       }
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -957,7 +957,8 @@ well as menu structures (for main menu and popup menus).
         
    <cmd id="jumpTo"
         label="Jump To..."
-        menuLabel="_Jump To..."/>
+        menuLabel="_Jump To..."
+        context="editor"/>
         
    <cmd id="switchToTab"
         label="Switch to Tab..."


### PR DESCRIPTION
This PR attempts to improve the general UI / usability of the keyboard shortcuts widget.

![shortcut-ui](https://cloud.githubusercontent.com/assets/1976582/9119218/6713e35e-3c2a-11e5-82d2-067e39c98fcb.gif)

Main changes:

- Small blue line on left side used to indicate currently selected row in table
- Use `EditTextCell` so that the cell is replaced with an input when the current shortcut is active for editing
- When not editing, pressing Enter begins editing a particular shortcut.
- When editing, pressing Enter confirms a shortcut (pressing escape cancels the current edit).

Any thoughts on other tweaks we could make? (Is the blue line too lightweight for row selection?)