### PR TITLE
Ensure Ace anchors detached in diagnostics + other contexts

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -55,6 +55,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceDocu
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEditorNative;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceMouseEventNative;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Anchor;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AnchoredRange;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.ExecuteChunksEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Marker;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
@@ -749,20 +750,34 @@ public class AceEditorWidget extends Composite
    
    // ---- Annotation related methods
    
-   private Range createAnchoredRange(Position start,
-                                     Position end)
+   private AnchoredRange createAnchoredRange(Position start,
+                                             Position end)
    {
       return getEditor().getSession().createAnchoredRange(start, end);
    }
    
    // This class binds an ace annotation (used for the gutter) with an
-   // inline marker (the underlining for associated lint)
-   class AnchoredAceAnnotation
+   // inline marker (the underlining for associated lint). We also store
+   // the associated marker. Ie, with some beautiful ASCII art:
+   //
+   //
+   //   1. | 
+   //   2. | foo <- function(apple) {    
+   //  /!\ |   print(Apple)
+   //   3. | }       ~~~~~
+   //   4. |
+   //
+   // The 'anchor' is associated with the position of the warning icon
+   // /!\; while the anchored range is associated with the underlying
+   // '~~~~~'. The marker id is needed to detach the annotation later.
+   private class AnchoredAceAnnotation
    {
       public AnchoredAceAnnotation(AceAnnotation annotation,
+                                   AnchoredRange range,
                                    int markerId)
       {
          annotation_ = annotation;
+         range_ = range;
          anchor_ = Anchor.createAnchor(
                editor_.getSession().getDocument(),
                annotation.row(),
@@ -771,8 +786,17 @@ public class AceEditorWidget extends Composite
       }
       
       public int getMarkerId() { return markerId_; }
-      public int row() { return anchor_.getRow(); }
-      public int column() { return anchor_.getColumn(); }
+      
+      public void detach()
+      {
+         if (range_ != null)
+            range_.detach();
+         
+         if (anchor_ != null)
+            anchor_.detach();
+         
+         editor_.getSession().removeMarker(markerId_);
+      }
       
       public AceAnnotation asAceAnnotation()
       {
@@ -784,6 +808,7 @@ public class AceEditorWidget extends Composite
       }
       
       private final AceAnnotation annotation_;
+      private final AnchoredRange range_;
       private final Anchor anchor_;
       private final int markerId_;
    }
@@ -816,7 +841,7 @@ public class AceEditorWidget extends Composite
       for (int i = 0; i < lint.length(); i++)
       {
          LintItem item = lint.get(i);
-         Range range = createAnchoredRange(
+         AnchoredRange range = createAnchoredRange(
                Position.create(item.getStartRow(), item.getStartColumn()),
                Position.create(item.getEndRow(), item.getEndColumn()));
          
@@ -830,11 +855,11 @@ public class AceEditorWidget extends Composite
          else if (item.getType() == "style")
             clazz = lintStyles_.style();
          
-         int id = editor_.getSession().addMarker(
-               range, clazz, "text", true);
+         int id = editor_.getSession().addMarker(range, clazz, "text", true);
          
          annotations_.add(new AnchoredAceAnnotation(
                annotations.get(i),
+               range,
                id));
       }
    }
@@ -860,7 +885,7 @@ public class AceEditorWidget extends Composite
          if (!range.contains(pos))
             annotations.add(annotation);
          else
-            editor_.getSession().removeMarker(annotation.getMarkerId());
+            annotation.detach();
       }
       annotations_ = annotations;
    }
@@ -868,7 +893,7 @@ public class AceEditorWidget extends Composite
    public void clearAnnotations()
    {
       for (int i = 0; i < annotations_.size(); i++)
-         editor_.getSession().removeMarker(annotations_.get(i).getMarkerId());
+         annotations_.get(i).detach();
       annotations_.clear();
    }
    
@@ -937,13 +962,9 @@ public class AceEditorWidget extends Composite
                
                Range range = marker.getRange();
                if (!range.contains(cursor))
-               {
                   newAnnotations.push(annotation.asAceAnnotation());
-               }
                else
-               {
                   editor_.getSession().removeMarker(markerId);
-               }
             }
             
             editor_.getSession().setAnnotations(newAnnotations);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AnchoredRange.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AnchoredRange.java
@@ -1,6 +1,0 @@
-package org.rstudio.studio.client.workbench.views.source.editors.text;
-
-public class AnchoredRange
-{
-
-}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -54,6 +54,7 @@ import com.google.gwt.event.dom.client.HasKeyDownHandlers;
 import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
 
 import org.rstudio.studio.client.workbench.views.source.model.DirtyState;
 import org.rstudio.studio.client.workbench.views.source.model.RnwCompletionContext;
@@ -124,8 +125,11 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    ChangeTracker getChangeTracker();
 
    String getCode(Position start, Position end);
+   DocDisplay.AnchoredSelection createAnchoredSelection(Widget hostWidget,
+                                                        Position start,
+                                                        Position end);
    DocDisplay.AnchoredSelection createAnchoredSelection(Position start,
-                                             Position end);
+                                                        Position end);
    String getCode(InputEditorSelection selection);
 
    void fitSelectionToLines(boolean expand);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AnchoredRange.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AnchoredRange.java
@@ -1,0 +1,27 @@
+/*
+ * AnchoredRange.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text.ace;
+
+public class AnchoredRange extends Range
+{
+   protected AnchoredRange() {}
+   
+   public final native void detach() /*-{
+      if (this.start && this.start.detach)
+         this.start.detach();
+      if (this.end && this.end.detach)
+         this.end.detach();
+   }-*/;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/EditSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/EditSession.java
@@ -214,8 +214,8 @@ public class EditSession extends JavaScriptObject
       return this.getMarkers(true)[id];
    }-*/;
    
-   public final native Range createAnchoredRange(Position start,
-                                                 Position end) /*-{
+   public final native AnchoredRange createAnchoredRange(Position start,
+                                                         Position end) /*-{
       var Range = $wnd.require("ace/range").Range;
       var result = new Range();
       result.start = this.doc.createAnchor(start.row, start.column);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionSignatureTip.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionSignatureTip.java
@@ -40,7 +40,7 @@ public class CppCompletionSignatureTip extends CppCompletionToolTip
       start = Position.create(start.getRow(), start.getColumn() - 1);
       Position end = docDisplay_.getSelectionEnd();
       end = Position.create(end.getRow(), end.getColumn() + 1);
-      anchor_ = docDisplay_.createAnchoredSelection(start, end);
+      anchor_ = docDisplay_.createAnchoredSelection(this, start, end);
      
       // set the max width
       setMaxWidth(Window.getClientWidth() - 200);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplace.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplace.java
@@ -23,6 +23,7 @@ import com.google.gwt.event.dom.client.KeyUpHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.user.client.ui.HasValue;
+import com.google.gwt.user.client.ui.Widget;
 
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.regex.Match;
@@ -57,6 +58,7 @@ public class FindReplace
                     boolean inSelection);
       
       void focusFindField(boolean selectAll);
+      Widget getUnderlyingWidget();
    }
 
    public FindReplace(AceEditor editor,
@@ -533,8 +535,10 @@ public class FindReplace
          editor_.fitSelectionToLines(true);
          Position start = editor_.getSelectionStart();
          Position end = editor_.getSelectionEnd();
-         anchoredSelection_ = editor_.createAnchoredSelection(start,end);
-         
+         anchoredSelection_ = editor_.createAnchoredSelection(
+               display_.getUnderlyingWidget(),
+               start,
+               end);
          // collapse the cursor to the beginning or end
          editor_.collapseSelection(defaultForward_);
          
@@ -559,6 +563,9 @@ public class FindReplace
       
       public void clear()
       {
+         if (anchoredSelection_ != null)
+            anchoredSelection_.detach();
+         
          if (markerId_ != null)
             editor_.getSession().removeMarker(markerId_);
       }
@@ -581,7 +588,6 @@ public class FindReplace
       clearTargetSelection();
       targetSelection_ = new TargetSelectionTracker();
    }
-   
    
    private static boolean defaultCaseSensitive_ = false;
    private static boolean defaultWrapSearch_ = true;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.java
@@ -325,6 +325,12 @@ public class FindReplaceBar extends Composite implements Display, RequiresResize
    {
       return RES.findReplaceLatched();
    }
+   
+   @Override
+   public Widget getUnderlyingWidget()
+   {
+      return getWidget();
+   }
 
    private FindTextBox txtFind_;
    private FindTextBox txtReplace_;


### PR DESCRIPTION
This PR adds some extra provisioning to ensure that generated anchors are detached when they are cleared.

Primarily, this fixes an issue where event handlers would accumulate when diagnostics added new inline annotations -- now, we ensure the anchors associated with those annotations get detached.

We can rebase this into a single commit for back-porting after review.

cc: @jjallaire, @jmcphers 