### PR TITLE
Respect package load order in diagnostics

### DIFF
--- a/src/cpp/core/include/core/r_util/RSourceIndex.hpp
+++ b/src/cpp/core/include/core/r_util/RSourceIndex.hpp
@@ -401,6 +401,11 @@ public:
       return s_importFromDirectives_;
    }
    
+   void addSourceItem(const RSourceItem& item)
+   {
+      items_.push_back(item);
+   }
+   
    const std::vector<RSourceItem>& items() const
    {
       return items_;

--- a/src/cpp/core/include/core/r_util/RSourceIndex.hpp
+++ b/src/cpp/core/include/core/r_util/RSourceIndex.hpp
@@ -291,7 +291,7 @@ public:
       return s_allInferredPkgNames_;
    }
 
-   const std::set<std::string>& getInferredPackages()
+   const std::vector<std::string>& getInferredPackages()
    {
       return inferredPkgNames_;
    }
@@ -333,15 +333,20 @@ public:
    
    static const FunctionInformation& getFunctionInformationAnywhere(
          const std::string& func,
+         const std::vector<std::string>& inferredPkgs,
          bool* pLookupFailed)
    {
-      for (PackageInformationDatabase::const_iterator it = s_packageInformation_.begin();
-           it != s_packageInformation_.end();
+      for (std::vector<std::string>::const_reverse_iterator it = inferredPkgs.rbegin();
+           it != inferredPkgs.rend();
            ++it)
       {
-         const PackageInformation& pkgInfo = it->second;
-         if (pkgInfo.functionInfo.count(func))
-            return const_cast<FunctionInformationMap&>(pkgInfo.functionInfo)[func];
+         const std::string& pkg = *it;
+         if (s_packageInformation_.count(pkg))
+         {
+            const PackageInformation& pkgInfo = s_packageInformation_[pkg];
+            if (pkgInfo.functionInfo.count(func))
+               return const_cast<FunctionInformationMap&>(pkgInfo.functionInfo)[func];
+         }
       }
       
       *pLookupFailed = true;
@@ -364,7 +369,7 @@ public:
 
    void addInferredPackage(const std::string& packageName)
    {
-      inferredPkgNames_.insert(packageName);
+      inferredPkgNames_.push_back(packageName);
       s_allInferredPkgNames_.insert(packageName);
    }
    
@@ -419,7 +424,7 @@ private:
    // NOTE: each index tracks the 'library' calls encountered within,
    // but we share that state in a static variable (so that we can
    // cache and share across all indexes)
-   std::set<std::string> inferredPkgNames_;
+   std::vector<std::string> inferredPkgNames_;
    static std::set<std::string> s_importedPackages_;
    static ImportFromMap s_importFromDirectives_;
    static std::set<std::string> s_allInferredPkgNames_;

--- a/src/cpp/core/include/core/r_util/RTokenCursor.hpp
+++ b/src/cpp/core/include/core/r_util/RTokenCursor.hpp
@@ -18,21 +18,17 @@
 
 #include <iostream>
 
+#include <core/Macros.hpp>
 #include <core/r_util/RTokenizer.hpp>
-#include "SessionRParser.hpp"
+#include <core/collection/Position.hpp>
 
 #include <boost/function.hpp>
 
-#include <core/collection/Position.hpp>
-
-#include <core/Macros.hpp>
-
 namespace rstudio {
-namespace session {
-namespace modules {
+namespace core {
+namespace r_util {
 namespace token_cursor {
 
-using namespace rparser;
 using namespace core::collection;
 using namespace core::r_util;
 using namespace core::r_util::token_utils;
@@ -245,13 +241,6 @@ public:
    operator const RToken&() const
    {
       return rTokens_.at(offset_);
-   }
-   
-   operator ParseItem() const
-   {
-      return ParseItem(contentAsUtf8(),
-                       currentPosition(),
-                       NULL);
    }
    
    std::wstring content() const
@@ -561,11 +550,6 @@ public:
   {
      return isValidAsIdentifier(*this) &&
             nextSignificantToken().contentEquals(L"=");
-  }
-  
-  bool isAtEndOfStatement(const ParseStatus& status)
-  {
-     return isAtEndOfStatement(status.isInParentheticalScope());
   }
   
   bool appearsToBeBinaryOperator() const
@@ -988,8 +972,8 @@ PIPE_START:
      if (isPipeOperator(cursor.previousSignificantToken()))
         goto PIPE_START;
 
-     return string_utils::wideToUtf8(std::wstring(
-                                        cursor.begin(), endCursor.end()));
+     return core::string_utils::wideToUtf8(
+              std::wstring(cursor.begin(), endCursor.end()));
      
      return onFailure;
      
@@ -1004,7 +988,7 @@ private:
    std::size_t n_;
 };
 
-} // namespace token_utils
+} // namespace token_cursor
 } // namespace r_util
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/include/core/r_util/RTokenCursor.hpp
+++ b/src/cpp/core/include/core/r_util/RTokenCursor.hpp
@@ -17,6 +17,7 @@
 #define SESSION_MODULES_RTOKENCURSOR_HPP
 
 #include <iostream>
+#include <string>
 
 #include <core/Macros.hpp>
 #include <core/r_util/RTokenizer.hpp>
@@ -182,6 +183,16 @@ public:
       return rTokens_.atUnsafe(offset_);
    }
    
+   std::size_t currentRow() const
+   {
+      return currentToken().row();
+   }
+   
+   std::size_t currentColumn() const
+   {
+      return currentToken().column();
+   }
+   
    Position currentPosition(bool endOfToken = false) const
    {
       const RToken& token = currentToken();
@@ -198,14 +209,14 @@ public:
       return currentToken().end();
    }
    
-   const RToken& nextToken() const
+   const RToken& nextToken(std::size_t offset = 1) const
    {
-      return rTokens_.at(offset_ + 1);
+      return rTokens_.at(offset_ + offset);
    }
    
-   const RToken& previousToken() const
+   const RToken& previousToken(std::size_t offset = 1) const
    {
-      return rTokens_.at(offset_ - 1);
+      return rTokens_.at(offset_ - offset);
    }
    
    const RToken& nextSignificantToken(std::size_t times = 1) const

--- a/src/cpp/core/r_util/RSourceIndex.cpp
+++ b/src/cpp/core/r_util/RSourceIndex.cpp
@@ -16,20 +16,24 @@
 #define RSTUDIO_DEBUG_LABEL "source_index"
 // #define RSTUDIO_ENABLE_DEBUG_MACROS
 
-#include <core/r_util/RSourceIndex.hpp>
-
-#include <boost/algorithm/string.hpp>
+#include <iostream>
 
 #include <core/StringUtils.hpp>
-
-#include <core/r_util/RTokenizer.hpp>
 #include <core/Macros.hpp>
+
+#include <core/r_util/RSourceIndex.hpp>
+#include <core/r_util/RTokenizer.hpp>
+#include <core/r_util/RTokenCursor.hpp>
+
+#include <boost/bind.hpp>
+#include <boost/algorithm/string.hpp>
 
 namespace rstudio {
 namespace core {
 namespace r_util {
 
 using namespace token_utils;
+using namespace token_cursor;
 
 // static members
 std::set<std::string> RSourceIndex::s_allInferredPkgNames_;
@@ -214,351 +218,258 @@ bool isMethodOrClassDefinition(const RToken& token)
             token.contentEquals(L"setRefClass"));
 }
 
+class IndexStatus
+{
+public:
+   
+   IndexStatus()
+      : braceLevel_(0),
+        parenLevel_(0),
+        bracketLevel_(0),
+        doubleBracketLevel_(0)
+   {}
+   
+   void update(const RTokenCursor& cursor)
+   {
+      switch (cursor.type())
+      {
+      
+      case RToken::LBRACE: ++braceLevel_; break;
+      case RToken::LPAREN: ++parenLevel_; break;
+      case RToken::LBRACKET: ++bracketLevel_; break;
+      case RToken::LDBRACKET: ++doubleBracketLevel_; break;
+         
+      case RToken::RBRACE: --braceLevel_; break;
+      case RToken::RPAREN: --parenLevel_; break;
+      case RToken::RBRACKET: --bracketLevel_; break;
+      case RToken::RDBRACKET: --doubleBracketLevel_; break;
+         
+      default:
+         ; // no-op
+         
+      }
+   }
+   
+   int braceLevel() const { return braceLevel_; }
+   int parenLevel() const { return parenLevel_; }
+   int bracketLevel() const { return bracketLevel_; }
+   int doubleBracketLevel() const { return doubleBracketLevel_; }
+   
+private:
+   
+   // NOTE: We use 'int' here to accomodate documents
+   // where we might have more closing than opening parens.
+   int braceLevel_;            // '{'
+   int parenLevel_;            // '('
+   int bracketLevel_;          // '['
+   int doubleBracketLevel_;    // '[['
+};
+
+void addSourceItem(RSourceItem::Type type,
+                   const std::vector<RS4MethodParam>& signature,
+                   const RToken& token,
+                   const IndexStatus& status,
+                   RSourceIndex* pIndex)
+{
+   pIndex->addSourceItem(RSourceItem(
+                            type,
+                            string_utils::strippedOfQuotes(token.contentAsUtf8()),
+                            signature,
+                            status.braceLevel(),
+                            token.row() + 1,
+                            token.column() + 1));
+}
+
+void addSourceItem(RSourceItem::Type type,
+                   const RToken& token,
+                   const IndexStatus& status,
+                   RSourceIndex* pIndex)
+{
+   addSourceItem(type,
+                 std::vector<RS4MethodParam>(),
+                 token,
+                 status,
+                 pIndex);
+}
+
+typedef boost::function<void(const RTokenCursor&, const IndexStatus&, RSourceIndex*)> Indexer;
+
+void libraryCallIndexer(const RTokenCursor& cursor, const IndexStatus& status, RSourceIndex* pIndex)
+{
+   if (!cursor.isType(RToken::ID))
+      return;
+   
+   if (!(cursor.contentEquals(L"library") || cursor.contentEquals(L"require")))
+      return;
+   
+   RTokenCursor clone = cursor.clone();
+   if (!clone.moveToNextToken())
+      return;
+   
+   if (!clone.isType(RToken::LPAREN))
+      return;
+   
+   if (!clone.moveToNextToken())
+      return;
+   
+   // If the package name is supplied as a string, then we're done.
+   if (clone.isType(RToken::STRING))
+   {
+      std::string pkgName = string_utils::strippedOfQuotes(clone.contentAsUtf8());
+      pIndex->addInferredPackage(pkgName);
+   }
+   
+   // If the package name is a symbol, then look forward and check for
+   // the 'character.only' argument.
+   else if (clone.isType(RToken::ID))
+   {
+      std::string pkgName = clone.contentAsUtf8();
+      pIndex->addInferredPackage(pkgName);
+   }
+}
+
+void functionIndexer(const RTokenCursor& cursor, const IndexStatus& status, RSourceIndex* pIndex)
+{
+   if (cursor.isType(RToken::ID) && cursor.contentEquals(L"function"))
+   {
+      RTokenCursor clone = cursor.clone();
+      if (!clone.moveToPreviousToken())
+         return;
+      
+      if (!isLeftAssign(clone))
+         return;
+      
+      if (!clone.moveToPreviousToken())
+         return;
+      
+      if (clone.isType(RToken::ID) || clone.isType(RToken::STRING))
+      {
+         addSourceItem(RSourceItem::Function,
+                       clone,
+                       status,
+                       pIndex);
+      }
+   }
+}
+
+void s4MethodIndexer(const RTokenCursor& cursor, const IndexStatus& status, RSourceIndex* pIndex)
+{
+   if (isMethodOrClassDefinition(cursor))
+   {
+      bool isSetMethod = false;
+      RSourceItem::Type setType = RSourceItem::None;
+
+      if (cursor.contentEquals(L"setMethod"))
+      {
+         isSetMethod = true;
+         setType = RSourceItem::Method;
+      }
+      else if (cursor.contentEquals(L"setGeneric") ||
+               cursor.contentEquals(L"setGroupGeneric"))
+      {
+         setType = RSourceItem::Method;
+      }
+      else if (cursor.contentEquals(L"setClass") ||
+               cursor.contentEquals(L"setClassUnion") ||
+               cursor.contentEquals(L"setRefClass"))
+      {
+         setType = RSourceItem::Class;
+      }
+      else
+      {
+         return;
+      }
+
+      // make sure there are at least 4 more tokens
+      const RTokens& rTokens = cursor.tokens();
+      std::size_t i = cursor.offset();
+      
+      if (i + 3 >= rTokens.size())
+         return;
+      
+      if ( (rTokens.at(i + 1).type() != RToken::LPAREN) ||
+           (rTokens.at(i + 2).type() != RToken::STRING) ||
+           (rTokens.at(i + 3).type() != RToken::COMMA))
+         return;
+
+      // if this was a setMethod then try to lookahead for the signature
+      std::vector<RS4MethodParam> signature;
+      if (isSetMethod)
+      {
+         parseSignature(rTokens.begin() + (i + 4),
+                        rTokens.end(),
+                        &signature);
+      }
+      
+      addSourceItem(setType,
+                    signature,
+                    rTokens.at(i + 2),
+                    status,
+                    pIndex);
+   }
+}
+
+void variableAssignmentIndexer(const RTokenCursor& cursor, const IndexStatus& status, RSourceIndex* pIndex)
+{
+   if (status.braceLevel() == 0 && isLeftAssign(cursor) && cursor.offset() >= 2)
+   {
+      const RToken& prevToken = cursor.previousToken();
+      if (prevToken.isType(RToken::ID) || prevToken.isType(RToken::STRING))
+      {
+         const RToken& prevPrevToken = cursor.previousToken(2);
+         if (isBinaryOp(prevPrevToken))
+            return;
+         
+         addSourceItem(RSourceItem::Variable,
+                       prevToken,
+                       status,
+                       pIndex);
+      }
+   }
+}
+
+std::vector<Indexer> makeIndexers()
+{
+   std::vector<Indexer> indexers;
+   
+   indexers.push_back(libraryCallIndexer);
+   indexers.push_back(functionIndexer);
+   indexers.push_back(s4MethodIndexer);
+   indexers.push_back(variableAssignmentIndexer);
+   
+   return indexers;
+}
+
 }  // anonymous namespace
 
-RSourceIndex::RSourceIndex(const std::string& context,
-                           const std::string& code)
+RSourceIndex::RSourceIndex(const std::string& context, const std::string& code)
    : context_(context)
 {
+   static std::vector<Indexer> indexers = makeIndexers();
+   
    // clear any (source-local) inferred packages
    inferredPkgNames_.clear();
 
-   // convert code to wide
+   // tokenize and create token cursor
    std::wstring wCode = string_utils::utf8ToWide(code, context);
-
-   // determine where the linebreaks are and initialize an iterator
-   // used for scanning them
-   std::vector<std::size_t> newlineLocs;
-   std::size_t nextNL = 0;
-   while ( (nextNL = wCode.find(L'\n', nextNL)) != std::string::npos )
-      newlineLocs.push_back(nextNL++);
-   std::vector<std::size_t>::const_iterator newlineIter = newlineLocs.begin();
-   std::vector<std::size_t>::const_iterator endNewlines = newlineLocs.end();
-
-   // tokenize
    RTokens rTokens(wCode, RTokens::StripWhitespace | RTokens::StripComments);
+   if (rTokens.empty())
+      return;
    
-   // track nest level
-   int braceLevel = 0;
-   int parenLevel = 0;
-   int bracketLevel = 0;
-   int doubleBracketLevel = 0;
+   RTokenCursor cursor(rTokens);
    
-   // scan for function, method, and class definitions
-   std::wstring function(L"function");
-   std::wstring set(L"set");
-   std::wstring setGeneric(L"setGeneric");
-   std::wstring setGroupGeneric(L"setGroupGeneric");
-   std::wstring setMethod(L"setMethod");
-   std::wstring setClass(L"setClass");
-   std::wstring setClassUnion(L"setClassUnion");
-   std::wstring setRefClass(L"setRefClass");
+   // run over tokens and apply indexers
+   IndexStatus status;
    
-   // operator tokens
-   std::wstring eqOp(L"=");
-   std::wstring assignOp(L"<-");
-   std::wstring parentAssignOp(L"<<-");
-   
-   // library, require (requireNamespace?)
-   std::wstring package(L"package");
-   std::wstring library(L"library");
-   std::wstring require(L"require");
-   
-   std::size_t n = rTokens.size();
-   for (std::size_t i = 0; i < n; ++i)
+   do
    {
-      // initial name, qualifer, and type are nil
-      RSourceItem::Type type = RSourceItem::None;
-      std::wstring name;
-      std::size_t tokenOffset = -1;
-      bool isSetMethod = false;
-      std::vector<RS4MethodParam> signature;
-
-      // alias the token
-      const RToken& token = rTokens.at(i);
-      DEBUG("Current token: " << token);
-      
-      // update brace nesting levels
-      braceLevel += token.isType(RToken::LBRACE);
-      braceLevel -= token.isType(RToken::RBRACE);
-      
-      parenLevel += token.isType(RToken::LPAREN);
-      parenLevel -= token.isType(RToken::RPAREN);
-      
-      bracketLevel += token.isType(RToken::LBRACKET);
-      bracketLevel -= token.isType(RToken::RBRACKET);
-      
-      doubleBracketLevel += token.isType(RToken::LDBRACKET);
-      doubleBracketLevel -= token.isType(RToken::RDBRACKET);
-
-      // is this a potential method or class definition?
-      if (isMethodOrClassDefinition(token))
+      status.update(cursor);
+      BOOST_FOREACH(const Indexer& indexer, indexers)
       {
-         RSourceItem::Type setType = RSourceItem::None;
-
-         if (token.contentEquals(setMethod))
-         {
-            isSetMethod = true;
-            setType = RSourceItem::Method;
-         }
-         else if (token.contentEquals(setGeneric) ||
-                  token.contentEquals(setGroupGeneric))
-         {
-            setType = RSourceItem::Method;
-         }
-         else if (token.contentEquals(setClass) ||
-                  token.contentEquals(setClassUnion) ||
-                  token.contentEquals(setRefClass))
-         {
-            setType = RSourceItem::Class;
-         }
-         else
-         {
-            continue;
-         }
-
-         // make sure there are at least 4 more tokens
-         if ( (i + 3) >= rTokens.size())
-            continue;
-
-         // check for the rest of the token sequene for a valid call to set*
-         if ( (rTokens.at(i+1).type() != RToken::LPAREN) ||
-              (rTokens.at(i+2).type() != RToken::STRING) ||
-              (rTokens.at(i+3).type() != RToken::COMMA))
-            continue;
-
-         // found a class or method definition (will find location below)
-         type = setType;
-         name = removeQuoteDelims(rTokens.at(i+2).content());
-         tokenOffset = token.offset();
-
-         // if this was a setMethod then try to lookahead for the signature
-         if (isSetMethod)
-         {
-            parseSignature(rTokens.begin() + (i+4),
-                           rTokens.end(),
-                           &signature);
-         }
+         indexer(cursor, status, this);
       }
-
-      // is this a function?
-      else if (token.contentEquals(function))
-      {
-         // if there is no room for an operator and identifier prior
-         // to the function then bail
-         if (i < 2)
-            continue;
-
-         // check for an assignment operator
-         const RToken& opToken = rTokens.at(i-1);
-         if ( opToken.type() != RToken::OPER)
-            continue;
-         if (!opToken.isOperator(eqOp) &&
-             !opToken.isOperator(assignOp) &&
-             !opToken.isOperator(parentAssignOp))
-            continue;
-
-         // check for an identifier or string
-         const RToken& idToken = rTokens.at(i-2);
-         if (!(idToken.type() == RToken::ID ||
-               idToken.type() == RToken::STRING))
-            continue;
-
-         // if there is another previous token make sure it isn't a
-         // comma or an open paren
-         if ( i > 2 )
-         {
-            const RToken& prevToken = rTokens.at(i-3);
-            if (prevToken.type() == RToken::LPAREN ||
-                prevToken.type() == RToken::COMMA)
-               continue;
-         }
-
-         // if we got this far then this is a function definition
-         type = RSourceItem::Function;
-         name = idToken.content();
-         tokenOffset = idToken.offset();
-      }
-      
-      // is this a library / require call?
-      else if (token.contentEquals(library) ||
-               token.contentEquals(require))
-      {
-         DEBUG("** Checking library token!");
-         
-         // make sure we have enough tokens available
-         if (i + 3 >= rTokens.size())
-            continue;
-         
-         // check for an open paren following
-         const RToken& lParenToken = rTokens.at(i + 1);
-         if (lParenToken.type() != RToken::LPAREN)
-            continue;
-         
-         // ensure that the following token is not a closing paren
-         if (static_cast<const RToken&>(rTokens.at(i + 2)).type() == RToken::RPAREN)
-            continue;
-         
-         // walk forward until we find an associated closing paren -- we'll have to
-         // look ahead a bit, and count parens as we go. also attempt to figure out
-         // what the 'package' and 'character.only' arguments resolve to
-         bool characterOnly = false;
-         
-         // assume that the package token is the first argument (but change our minds later
-         // if necessary)
-         RToken packageToken = rTokens.at(i + 2);
-         
-         std::size_t endParenIndex = i + 2;
-         bool foundRightParen = false;
-         int parenCount = 0;
-         for (int count = 0; count < 30; ++count)
-         {
-            if (endParenIndex + count >= rTokens.size())
-               break;
-            
-            const RToken& currentToken = rTokens.at(endParenIndex + count);
-            DEBUG("- Current token: '" << string_utils::wideToUtf8(currentToken.content()) << "'");
-            
-            if (currentToken.type() == RToken::LPAREN)
-               ++parenCount;
-            
-            if (currentToken.type() == RToken::RPAREN)
-            {
-               if (parenCount == 0)
-               {
-                  DEBUG("- Found closing right paren");
-                  foundRightParen = true;
-                  break;
-               }
-               --parenCount;
-            }
-            
-            // if we encounter 'package =', update the package setting
-            if (currentToken.contentEquals(package) &&
-                endParenIndex + count + 2 < rTokens.size())
-            {
-               const RToken& nextToken = rTokens.at(endParenIndex + count + 1);
-               if (nextToken.contentEquals(eqOp))
-               {
-                  // note -- validate later whether this is appropriate as a package name
-                  packageToken = rTokens.at(endParenIndex + count + 2);
-               }
-            }
-            
-            // if we encounter the token 'character.only', assume that it's
-            // set to TRUE, ie,
-            //
-            //    library("foo", character.only = TRUE)
-            //
-            // it would be unlikely someone would set character.only = FALSE
-            // which is the default
-            if (currentToken.contentEquals(L"character.only"))
-            {
-               DEBUG("- - Setting 'characterOnly' to true");
-               characterOnly = true;
-            }
-            
-         }
-         
-         if (!foundRightParen)
-            continue;
-         
-         // if 'character.only' is TRUE and 'package' is not a string, bail
-         if (characterOnly && packageToken.type() != RToken::STRING)
-         {
-            DEBUG("* characterOnly is true but package token'"
-                  << string_utils::wideToUtf8(packageToken.content())
-                  << "' is not a string");
-            continue;
-         }
-         
-         // otherwise, take the name of the package and cache it
-         std::wstring packageName = packageToken.type() == RToken::STRING ?
-                  removeQuoteDelims(packageToken.content()) :
-                  packageToken.content();
-         
-         DEBUG("** Adding package '" << string_utils::wideToUtf8(packageName) << "'");
-         DEBUG("");
-
-         addInferredPackage(string_utils::wideToUtf8(packageName));
-
-         continue;
-      }
-      
-      // is this some other kind of assignment?
-      // we want to add e.g.
-      //
-      //    foo <- 1
-      //
-      // to the source index here
-      else if (i >= 1 && isLeftAssign(rTokens.at(i - 1)))
-      {
-         // bail if we're not at the top level
-         if (braceLevel || parenLevel || bracketLevel || doubleBracketLevel)
-         {
-            DEBUG("Bailing: [" << braceLevel << ", " << parenLevel << ", " <<
-                  bracketLevel << ", " << doubleBracketLevel << "]");
-            continue;
-         }
-         
-         // ensure the token previous to the left assign is
-         // an identifier or string
-         const RToken& idToken = rTokens.at(i - 2);
-         DEBUG("- Token: " << idToken);
-         
-         if (!(isId(idToken) || isString(idToken)))
-         {
-            DEBUG("* Not an id or string");
-            continue;
-         }
-         
-         // ensure the token previous to the assignment token
-         // is not a binary operator
-         if (i > 2)
-         {
-            const RToken& beforeId = rTokens.at(i - 3);
-            if (isBinaryOp(beforeId))
-            {
-               DEBUG("* Has binary op before; skipping");
-               continue;
-            }
-         }
-            
-         // if we get this far then it's a variable def'n
-         type = RSourceItem::Variable;
-         name = idToken.content();
-         tokenOffset = idToken.offset();
-      }
-      
-      else
-      {
-         continue;
-      }
-
-      // compute the line by starting at the current line index and
-      // finding the first newline which is after the idToken offset
-      newlineIter = std::upper_bound(newlineIter,
-                                     endNewlines,
-                                     tokenOffset);
-      std::size_t line = newlineIter - newlineLocs.begin() + 1;
-
-      // compute column by comparing the offset to the PREVIOUS newline
-      // (guard against no previous newline)
-      std::size_t column;
-      if (line > 1)
-         column = tokenOffset - *(newlineIter - 1);
-      else
-         column = tokenOffset;
-
-      // add to index
-      items_.push_back(RSourceItem(type,
-                                   string_utils::wideToUtf8(name),
-                                   signature,
-                                   braceLevel,
-                                   line,
-                                   column));
-
-   }
+   } while (cursor.moveToNextToken());
+   
 }
 
 } // namespace r_util

--- a/src/cpp/core/r_util/RTokenCursorTests.cpp
+++ b/src/cpp/core/r_util/RTokenCursorTests.cpp
@@ -14,13 +14,12 @@
  */
 
 #include <tests/TestThat.hpp>
-
-#include "SessionRTokenCursor.hpp"
+#include <core/r_util/RTokenCursor.hpp>
 
 namespace rstudio {
 namespace unit_tests {
 
-using namespace session::modules::token_cursor;
+using namespace core::r_util::token_cursor;
 
 bool isPipeOperator(const std::wstring& string)
 {

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -942,8 +942,7 @@ void RSourceIndexes::initialize()
        boost::bind(&RSourceIndexes::removeAll, this));
 }
 
-void RSourceIndexes::update(
-    boost::shared_ptr<session::source_database::SourceDocument> pDoc)
+void RSourceIndexes::update(const boost::shared_ptr<SourceDocument>& pDoc)
 {
    // is this indexable? if not then bail
    if (!pDoc->canContainRCode())
@@ -972,7 +971,11 @@ void RSourceIndexes::update(
    }
    
    // insert it
-   indexes_[pDoc->id()] = pIndex;
+   idMap_[pDoc->id()] = pIndex;
+   
+   // create aliases
+   filePathMap_[filePath.absolutePath()] = pIndex;
+   idToFilePathMap_[pDoc->id()] = filePath;
    
    // kick off an update if necessary
    r_packages::AsyncPackageInformationProcess::update();
@@ -980,12 +983,18 @@ void RSourceIndexes::update(
 
 void RSourceIndexes::remove(const std::string& id)
 {
-   indexes_.erase(id);
+   FilePath filePath = idToFilePathMap_[id];
+   
+   idMap_.erase(id);
+   filePathMap_.erase(filePath.absolutePath());
+   idToFilePathMap_.erase(id);
 }
 
 void RSourceIndexes::removeAll()
 {
-   indexes_.clear();
+   idMap_.clear();
+   filePathMap_.clear();
+   idToFilePathMap_.clear();
 }
 
 RSourceIndexes& rSourceIndex()

--- a/src/cpp/session/modules/SessionCodeSearch.hpp
+++ b/src/cpp/session/modules/SessionCodeSearch.hpp
@@ -42,11 +42,9 @@ private:
    
 public:
    
-   typedef std::string DocumentId;
-   typedef std::string AbsolutePath;
-   
    // maps document id (as string) to associated index
-   typedef std::map< DocumentId, boost::shared_ptr<RSourceIndex> > IndexMap;
+   typedef std::map< std::string, boost::shared_ptr<RSourceIndex> > IDMap;
+   typedef std::map< std::string, boost::shared_ptr<RSourceIndex> > FilePathMap;
    
    RSourceIndexes() {}
    virtual ~RSourceIndexes() {}
@@ -54,11 +52,19 @@ public:
    // COPYING: boost::noncopyable
 
    void initialize();
-   void update(boost::shared_ptr<SourceDocument> pDoc);
+   void update(const boost::shared_ptr<SourceDocument>& pDoc);
    boost::shared_ptr<RSourceIndex> get(const std::string& id)
    {
-      if (indexes_.find(id) != indexes_.end())
-         return indexes_[id];
+      if (idMap_.count(id))
+         return idMap_[id];
+      return boost::shared_ptr<RSourceIndex>();
+   }
+   
+   boost::shared_ptr<RSourceIndex> get(const core::FilePath& filePath)
+   {
+      std::string absPath = filePath.absolutePath();
+      if (filePathMap_.count(absPath))
+         return filePathMap_[absPath];
       return boost::shared_ptr<RSourceIndex>();
    }
    
@@ -68,20 +74,28 @@ public:
    std::vector< boost::shared_ptr<RSourceIndex> > indexes()
    {
       std::vector< boost::shared_ptr<RSourceIndex> > indexes;
-      BOOST_FOREACH(const IndexMap::value_type& index, indexes_)
+      BOOST_FOREACH(const IDMap::value_type& index, idMap_)
       {
          indexes.push_back(index.second);
       }
       return indexes;
    }
    
-   const IndexMap& indexMap() const
+   const IDMap& indexMap() const
    {
-      return indexes_;
+      return idMap_;
+   }
+   
+   const FilePathMap& filePathMap() const
+   {
+      return filePathMap_;
    }
 
 private:
-  IndexMap indexes_;
+   
+  IDMap idMap_;
+  FilePathMap filePathMap_;
+  std::map<std::string, core::FilePath> idToFilePathMap_;
   
 };
 

--- a/src/cpp/session/modules/SessionDiagnostics.cpp
+++ b/src/cpp/session/modules/SessionDiagnostics.cpp
@@ -611,7 +611,7 @@ ParseResults parse(const std::wstring& rCode,
    if (noLint)
       return ParseResults();
    
-   results = rparser::parse(rCode, options);
+   results = rparser::parse(origin, rCode, options);
    
    ParseNode* pRoot = results.parseTree();
    if (!pRoot)

--- a/src/cpp/session/modules/SessionDiagnosticsTests.cpp
+++ b/src/cpp/session/modules/SessionDiagnosticsTests.cpp
@@ -104,8 +104,8 @@ void lintRFilesInSubdirectory(const FilePath& path)
       if (!isRFile(info))
          continue;
       
-      std::string content = file_utils::readFile(core::toFilePath(info));
-      ParseResults results = parse(content);
+      FilePath filePath = core::toFilePath(info);
+      ParseResults results = parse(filePath);
       
       if (results.lint().hasErrors())
       {

--- a/src/cpp/session/modules/SessionRCompletions.cpp
+++ b/src/cpp/session/modules/SessionRCompletions.cpp
@@ -360,7 +360,7 @@ SEXP rs_getNAMESPACEImportedSymbols(SEXP documentIdSEXP)
       
       // If the inferred package is listed _only_ in the NAMESPACE 'importFrom',
       // then we want to selectively return symbols.
-      if ((index && index->getInferredPackages().count(pkg) == 0) &&
+      if ((index && core::algorithm::contains(index->getInferredPackages(), pkg)) &&
           RSourceIndex::getImportedPackages().count(pkg) == 0 &&
           RSourceIndex::getImportFromDirectives().count(pkg) != 0)
       {
@@ -440,9 +440,11 @@ SEXP rs_listInferredPackages(SEXP documentIdSEXP)
    if (index == NULL)
       return R_NilValue;
    
-   std::set<std::string> pkgs = index->getInferredPackages();
-   pkgs.insert(index->getImportedPackages().begin(),
-               index->getImportedPackages().end());
+   std::vector<std::string> pkgs = index->getInferredPackages();
+   pkgs.insert(
+            pkgs.end(),
+            index->getImportedPackages().begin(),
+            index->getImportedPackages().end());
    
    r::sexp::Protect protect;
    return r::sexp::create(pkgs, &protect);

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -27,8 +27,9 @@
 #include <core/StringUtils.hpp>
 #include <core/FileSerializer.hpp>
 
+#include <core/r_util/RTokenCursor.hpp>
+
 #include "SessionRParser.hpp"
-#include "SessionRTokenCursor.hpp"
 #include "SessionCodeSearch.hpp"
 #include "SessionAsyncPackageInformation.hpp"
 
@@ -795,7 +796,7 @@ void handleIdentifier(RTokenCursor& cursor,
          RTokenCursor clone = cursor.clone();
          if (clone.moveToNextSignificantToken() &&
              clone.moveToNextSignificantToken() &&
-             !clone.isAtEndOfStatement(status))
+             !clone.isAtEndOfStatement(status.isInParentheticalScope()))
          {
             lookAheadAndWarnOnUsagesOfSymbol(cursor, clone, status);
          }
@@ -2006,7 +2007,7 @@ START:
             
             // Check to see if this paren closes the current statement.
             // If so, it effectively closes any parent conditional statements.
-            if (cursor.isAtEndOfStatement(status))
+            if (cursor.isAtEndOfStatement(status.isInParentheticalScope()))
                while (status.isInControlFlowStatement())
                   status.popState();
             
@@ -2327,7 +2328,7 @@ ARGUMENT_LIST_END:
          goto START;
       
       // Pop out of control flow statements if this ends the statement.
-      if (cursor.isAtEndOfStatement(status))
+      if (cursor.isAtEndOfStatement(status.isInParentheticalScope()))
          while (status.isInControlFlowStatement())
             status.popState();
       

--- a/src/cpp/session/modules/SessionRParser.hpp
+++ b/src/cpp/session/modules/SessionRParser.hpp
@@ -992,11 +992,12 @@ class ParseStatus
    
 public:
    
-   explicit ParseStatus(const ParseOptions& parseOptions)
+   explicit ParseStatus(const FilePath& filePath, const ParseOptions& parseOptions)
       : pRoot_(ParseNode::createRootNode()),
         pNode_(pRoot_.get()),
         lint_(parseOptions),
-        parseOptions_(parseOptions)
+        parseOptions_(parseOptions),
+        filePath_(filePath)
    {
       parseStateStack_.push(ParseStateTopLevel);
       functionNames_.push(std::wstring(L""));
@@ -1358,6 +1359,11 @@ public:
                begin,
                end);
    }
+   
+   const FilePath& filePath() const
+   {
+      return filePath_;
+   }
 
 private:
    boost::shared_ptr<ParseNode> pRoot_;
@@ -1383,6 +1389,8 @@ private:
    // given ranges.
    typedef std::map< Range, std::set<std::string> > SymbolRanges;
    SymbolRanges symbolRanges_;
+   
+   FilePath filePath_;
 };
 
 class ParseResults {
@@ -1425,6 +1433,15 @@ private:
    LintItems lint_;
    std::set<std::string> globals_;
 };
+
+// Primary method ----
+ParseResults parse(const core::FilePath& filePath,
+                   const std::wstring& rCode,
+                   const ParseOptions& parseOptions = ParseOptions());
+
+// Useful aliases ----
+ParseResults parse(const core::FilePath& filePath,
+                   const ParseOptions& parseOptions = ParseOptions());
 
 ParseResults parse(const std::string& rCode,
                    const ParseOptions& parseOptions = ParseOptions());

--- a/src/cpp/session/modules/SessionRParser.hpp
+++ b/src/cpp/session/modules/SessionRParser.hpp
@@ -32,6 +32,7 @@
 
 #include <core/Algorithm.hpp>
 #include <core/r_util/RTokenizer.hpp>
+#include <core/r_util/RTokenCursor.hpp>
 #include <core/collection/Position.hpp>
 #include <core/collection/Stack.hpp>
 
@@ -317,6 +318,16 @@ public:
       addLintItem(token,
                   LintTypeError,
                   "unexpected end of document");
+   }
+   
+   void noSymbolNamed(const core::r_util::token_cursor::RTokenCursor& cursor,
+                      const std::string& candidate = std::string())
+   {
+      ParseItem item(
+               cursor.contentAsUtf8(),
+               cursor.currentPosition(),
+               NULL);
+      noSymbolNamed(item, candidate);
    }
    
    void noSymbolNamed(const ParseItem& item,


### PR DESCRIPTION
This PR augments diagnostics to respect package load order, so that when two packages export a function of the same name, the package loaded last is used in diagnostics.

This fixes diagnostic errors in e.g.

```R
library(MASS)
library(dplyr)

mtcars %>% select(mpg, cyl)
```

Two mechanisms were added to make this possible:

1) We can now recover the source index for a particular file from the file path (not just the ID), and
2) We store inferred packages as a vector (hence retaining order) and loop through the set of inferred packages in reverse order when resolving dependencies.

The source indexer has also been refactored to be much more modular -- rather than embedding each action within a complex for loop, we instead run a token cursor through the document and run a set of registered 'indexers' over each token in the document.