### PR TITLE
save/load Vim folds on document save

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/js/JsMap.java
+++ b/src/gwt/src/org/rstudio/core/client/js/JsMap.java
@@ -1,0 +1,42 @@
+/*
+ * JsMap.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.js;
+
+/* Used for JsObject containers where all objects are of the same type.
+ * Has a simpler interface than `JsObject` which allows objects with
+ * arbitrarily typed elements.
+ */
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArrayString;
+
+public class JsMap<T> extends JavaScriptObject
+{
+   protected JsMap() {}
+   
+   public static native final JsMap create() /*-{ return {}; }-*/;
+   
+   public native final T get(String key) /*-{
+      return this[key];
+   }-*/;
+   
+   public native final void set(String key, T value) /*-{
+      this[key] = value;
+   }-*/;
+   
+   public native final JsArrayString keys() /*-{
+      return Object.keys(this);
+   }-*/;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -47,6 +47,7 @@ import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.WindowEx;
+import org.rstudio.core.client.js.JsMap;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.js.JsUtil;
 import org.rstudio.core.client.regex.Match;
@@ -628,6 +629,14 @@ public class AceEditor implements DocDisplay,
 
    private void updateKeyboardHandlers()
    {
+      // save and restore Vim marks as they can be lost when refreshing
+      // the keyboard handlers. this is necessary as keyboard handlers are
+      // regenerated on each document save, and clearing the Vim handler will
+      // clear any local Vim state.
+      JsMap<Position> marks = JsMap.create().cast();
+      if (useVimMode_)
+         marks = widget_.getEditor().getMarks();
+      
       // create a keyboard previewer for our special hooks
       AceKeyboardPreviewer previewer = new AceKeyboardPreviewer(completionManager_);
 
@@ -641,6 +650,9 @@ public class AceEditor implements DocDisplay,
       
       // add the previewer
       widget_.getEditor().addKeyboardHandler(previewer.getKeyboardHandler());
+      
+      if (useVimMode_)
+         widget_.getEditor().setMarks(marks);
    }
 
    public String getCode()
@@ -1898,6 +1910,18 @@ public class AceEditor implements DocDisplay,
    public void toggleFold()
    {
       getSession().toggleFold();
+   }
+   
+   @Override
+   public JsMap<Position> getMarks()
+   {
+      return widget_.getEditor().getMarks();
+   }
+   
+   @Override
+   public void setMarks(JsMap<Position> marks)
+   {
+      widget_.getEditor().setMarks(marks);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.workbench.views.source.editors.text;
 
 import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
+import org.rstudio.core.client.js.JsMap;
 import org.rstudio.studio.client.common.debugging.model.Breakpoint;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.server.Void;
@@ -170,6 +171,9 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    void unfold(AceFold fold);
    void unfold(int row);
    void unfold(Range range);
+   
+   JsMap<Position> getMarks();
+   void setMarks(JsMap<Position> marks);
    
    void toggleCommentLines();
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -21,6 +21,7 @@ import com.google.gwt.event.shared.HasHandlers;
 import com.google.gwt.user.client.Command;
 
 import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.js.JsMap;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 
 import java.util.LinkedList;
@@ -109,6 +110,10 @@ public class AceEditorNative extends JavaScriptObject {
 
    public native final void setKeyboardHandler(KeyboardHandler keyboardHandler) /*-{
       this.setKeyboardHandler(keyboardHandler);
+   }-*/;
+   
+   public native final KeyboardHandler getKeyboardHandler() /*-{
+      return this.getKeyboardHandler();
    }-*/;
    
    public native final void addKeyboardHandler(KeyboardHandler keyboardHandler) /*-{
@@ -398,6 +403,52 @@ public class AceEditorNative extends JavaScriptObject {
    public final native void setCommandManager(AceCommandManager commands)
    /*-{
       this.commands = commands;
+   }-*/;
+   
+   public final native JsMap<Position> getMarks() /*-{
+      
+      var marks = {};
+      if (this.state &&
+          this.state.cm &&
+          this.state.cm.state &&
+          this.state.cm.state.vim &&
+          this.state.cm.state.vim.marks)
+       {
+          marks = this.state.cm.state.vim.marks;
+       }
+       
+      var result = {};
+      for (var key in marks) {
+         var mark = marks[key];
+         result[key] = {
+            row: mark.row,
+            column: mark.column
+         };
+      }
+      
+      return result;
+   
+   }-*/;
+   
+   public final native void setMarks(JsMap<Position> marks) /*-{
+      
+      if (this.state &&
+          this.state.cm &&
+          this.state.cm.state &&
+          this.state.cm.state.vim)
+      {
+         var cm = this.state.cm;
+         var vim = this.state.cm.state.vim;
+         
+         if (!vim.marks)
+            vim.marks = {};
+            
+         for (var key in marks) {
+            var mark = marks[key];
+            vim.marks[key] = cm.setBookmark({line: mark.row, ch: mark.column});
+         }
+      }
+   
    }-*/;
    
    public final static void syncUiPrefs(UIPrefs uiPrefs)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -419,11 +419,13 @@ public class AceEditorNative extends JavaScriptObject {
        
       var result = {};
       for (var key in marks) {
-         var mark = marks[key];
-         result[key] = {
-            row: mark.row,
-            column: mark.column
-         };
+         if (marks.hasOwnProperty(key)) {
+            var mark = marks[key];
+            result[key] = {
+               row: mark.row,
+               column: mark.column
+            };
+         }
       }
       
       return result;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/VimMarks.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/VimMarks.java
@@ -1,0 +1,62 @@
+/*
+ * VimMarks.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text.ace;
+
+import org.rstudio.core.client.js.JsMap;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+/**
+ *  Extract Vim marks with 'editor.state.cm.state.vim.marks'
+ *  Add new marks with 'editor.state.cm.
+ */
+public class VimMarks extends JavaScriptObject
+{
+   protected VimMarks() {}
+   
+   // Encoding: "<key>:<row>,<column>", split with newlines '\n'
+   public static native final String encode(JsMap<Position> marks) /*-{
+      var result = [];
+      for (var key in marks) {
+         var mark = marks[key];
+         result.push(key + ":" + mark.row + "," + mark.column);
+      }
+      return result.join("\n"); 
+   }-*/;
+   
+   public static final native JsMap<Position> decode(String encoded) /*-{
+   
+      if (encoded == null || encoded.length === 0)
+         return {};
+         
+      var result = {};
+      var splat = encoded.split("\n");
+      for (var i = 0; i < splat.length; i++) {
+         
+         var spec = splat[i].split(":");
+         var key = spec[0];
+         var pos = spec[1].split(",");
+         
+         result[key] = {
+            row: parseInt(pos[0], 10),
+            column: parseInt(pos[1], 10)
+         };
+         
+      }
+      
+      return result;
+   
+   }-*/;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
@@ -38,6 +38,7 @@ import org.rstudio.studio.client.workbench.events.LastChanceSaveHandler;
 import org.rstudio.studio.client.workbench.model.ChangeTracker;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
 import org.rstudio.studio.client.workbench.views.source.editors.text.Fold;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.VimMarks;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.FoldChangeEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.SourceOnSaveChangedEvent;
 
@@ -292,6 +293,19 @@ public class DocUpdateSentinel
                              ex.getMessage());
          }
       }
+      
+      // Update marks after document save
+      if (docDisplay_.isVimModeOn())
+      {
+         String oldMarksSpec = "";
+         if (hasProperty("marks"))
+            oldMarksSpec = getProperty("marks");
+
+         String newMarksSpec = VimMarks.encode(docDisplay_.getMarks());
+         if (!oldMarksSpec.equals(newMarksSpec))
+            setProperty("marks", newMarksSpec);
+      }
+      
       return didSave;
    }
 
@@ -471,6 +485,11 @@ public class DocUpdateSentinel
                }
             });
    }
+   
+   public boolean hasProperty(String propertyName)
+   {
+      return sourceDoc_.getProperties().hasKey(propertyName);
+   }
 
    public String getProperty(String propertyName)
    {
@@ -541,7 +560,7 @@ public class DocUpdateSentinel
             properties.setString(entry.getKey(), entry.getValue());
       }
    }
-
+   
    public void onValueChange(ValueChangeEvent<Void> voidValueChangeEvent)
    {
       changesPending_ = true;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.studio.client.workbench.views.source.model;
 
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -295,17 +297,23 @@ public class DocUpdateSentinel
       }
       
       // Update marks after document save
-      if (docDisplay_.isVimModeOn())
+      Scheduler.get().scheduleDeferred(new ScheduledCommand()
       {
-         String oldMarksSpec = "";
-         if (hasProperty("marks"))
-            oldMarksSpec = getProperty("marks");
+         @Override
+         public void execute()
+         {
+            if (docDisplay_.isVimModeOn())
+            {
+               String oldMarksSpec = "";
+               if (hasProperty("marks"))
+                  oldMarksSpec = getProperty("marks");
 
-         String newMarksSpec = VimMarks.encode(docDisplay_.getMarks());
-         if (!oldMarksSpec.equals(newMarksSpec))
-            setProperty("marks", newMarksSpec);
-      }
-      
+               String newMarksSpec = VimMarks.encode(docDisplay_.getMarks());
+               if (!oldMarksSpec.equals(newMarksSpec))
+                  setProperty("marks", newMarksSpec);
+            }
+         }
+      });
       return didSave;
    }
 


### PR DESCRIPTION
This PR brings one feature and one bugfix:

1) Because keyboard handlers are reset on save, Vim local state (e.g. marks) would be lost on save.
2) Vim marks are not set as part of the (durable) document properties, and so are saved and restored when loading documents.

@jmcphers, can you sanity check this?