### PR TITLE
provide facilities for getting + printing backtrace

### DIFF
--- a/src/cpp/core/Backtrace.cpp
+++ b/src/cpp/core/Backtrace.cpp
@@ -1,0 +1,111 @@
+/*
+ * Backtrace.cpp
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <core/Backtrace.hpp>
+
+#ifndef _WIN32
+# include <core/Algorithm.hpp>
+# include <iostream>
+# include <boost/regex.hpp>
+# include <execinfo.h>
+#endif
+
+namespace rstudio {
+namespace core {
+namespace backtrace {
+
+std::string demangle(const std::string& name)
+{
+   std::string result = name;
+   
+#ifndef _WIN32
+   int status = -1;
+   char* demangled = ::abi::__cxa_demangle(name.c_str(), 0, 0, &status);
+   if (status == 0) {
+      result = demangled;
+      free(demangled);
+   }
+#endif
+  
+   return result;
+}
+
+void printBacktrace(std::ostream& os)
+{
+#ifndef _WIN32
+   
+   std::size_t maxDepth = 100;
+   std::size_t stackDepth;
+   
+   void* stackAddrs[maxDepth];
+   stackDepth = ::backtrace(stackAddrs, maxDepth);
+   
+   char** stackStrings;
+   stackStrings = ::backtrace_symbols(stackAddrs, stackDepth);
+   
+   std::vector<std::string> demangled;
+   demangled.reserve(stackDepth);
+   
+   // Each printed string will have output of the form:
+   //
+   //     (row) (program) (address) (function) + (offset)
+   //
+   // with variable numbers of spaces separating each field.
+   std::string reBacktraceString = std::string() +
+         "(\\d+)" +           // stack number
+         "(\\s+)" +           // spaces
+         "([^\\s]+)" +        // program name
+         "(\\s+)" +           // spaces
+         "([^\\s]+)" +        // address
+         "(\\s+)" +           // spaces
+         "([^\\s]+)" +        // (mangled) function name
+         "(.*)";              // offset (the rest)
+   
+   boost::regex reBacktrace(reBacktraceString);
+   boost::cmatch match;
+   
+   for (std::size_t i = 0; i < stackDepth; ++i)
+   {
+      std::string readyForPrinting = stackStrings[i];
+      if (boost::regex_match(stackStrings[i], match, reBacktrace))
+      {
+         std::size_t n = match.length();
+         if (n >= 8)
+         {
+            std::string demangled = demangle(match[7]);
+            
+            std::string joined;
+            for (std::size_t i = 1; i < 7; ++i)
+               joined += match[i];
+            
+            joined += demangled;
+            if (n > 8)
+               joined += match[8];
+            
+            readyForPrinting = joined;
+         }
+      }
+      os << readyForPrinting << std::endl;
+   }
+   
+   if (stackStrings != NULL)
+      ::free(stackStrings);
+   
+#endif
+}
+
+} // namespace debug
+} // namespace core
+} // namespace rstudio

--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -24,6 +24,7 @@ file(GLOB_RECURSE CORE_HEADER_FILES "*.h*")
 # source files
 set (CORE_SOURCE_FILES
    Assert.cpp
+   Backtrace.cpp
    Base64.cpp
    BoostErrors.cpp
    BrowserUtils.cpp

--- a/src/cpp/core/include/core/Algorithm.hpp
+++ b/src/cpp/core/include/core/Algorithm.hpp
@@ -204,6 +204,11 @@ inline std::vector<std::string> split(const std::string& string, const std::stri
    return result;
 }
 
+inline std::string join(const std::vector<std::string>& container, const std::string& delim)
+{
+   return boost::algorithm::join(container, delim);
+}
+
 } // namespace algorithm
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/include/core/Backtrace.hpp
+++ b/src/cpp/core/include/core/Backtrace.hpp
@@ -1,0 +1,34 @@
+/*
+ * Backtrace.hpp
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef CORE_BACKTRACE_HPP
+#define CORE_BACKTRACE_HPP
+
+#include <string>
+#include <iostream>
+
+namespace rstudio {
+namespace core {
+namespace backtrace {
+
+std::string demangle(const std::string& name);
+void printBacktrace(std::ostream& os = std::cerr);
+
+} // namespace debug
+} // namespace core
+} // namespace rstudio
+
+#endif /* CORE_BACKTRACE_HPP */
+

--- a/src/cpp/core/include/core/Debug.hpp
+++ b/src/cpp/core/include/core/Debug.hpp
@@ -21,6 +21,8 @@
 #include <vector>
 #include <map>
 
+#include <boost/regex.hpp>
+
 namespace rstudio {
 namespace core {
 namespace debug {

--- a/src/cpp/core/include/core/json/spirit/json_spirit_value.h
+++ b/src/cpp/core/include/core/json/spirit/json_spirit_value.h
@@ -10,6 +10,8 @@
 # pragma once
 #endif
 
+#include <core/Backtrace.hpp>
+
 #include <vector>
 #include <map>
 #include <string>
@@ -342,6 +344,10 @@ namespace json_spirit
             std::ostringstream os;
 
             os << "value type is " << type() << " not " << vtype;
+            os << std::endl << std::endl << "Backtrace (most recent calls first):" <<
+                  std::endl << std::endl;
+            
+            rstudio::core::backtrace::printBacktrace(os);
 
             throw std::runtime_error( os.str() );
         }

--- a/src/cpp/core/include/core/type_traits/TypeTraits.hpp
+++ b/src/cpp/core/include/core/type_traits/TypeTraits.hpp
@@ -17,8 +17,6 @@
 #ifndef CORE_TYPETRAITS_HPP
 #define CORE_TYPETRAITS_HPP
 
-#include <core/json/Json.hpp>
-
 #include <boost/type_traits.hpp>
 
 namespace rstudio {

--- a/src/cpp/session/modules/SessionBreakpoints.cpp
+++ b/src/cpp/session/modules/SessionBreakpoints.cpp
@@ -516,13 +516,20 @@ Error initBreakpoints()
        json::isType<core::json::Object>(breakpointStateValue))
    {
       json::Object breakpointState = breakpointStateValue.get_obj();
-      json::Array breakpointArray = breakpointState["breakpoints"].get_array();
-      s_breakpoints.clear();
-      BOOST_FOREACH(json::Value bp, breakpointArray)
+      
+      // Protect against the breakpoint array being serialized as an
+      // empty object
+      json::Value jsonBreakpointArray = breakpointState["breakpoints"];
+      if (json::isType<core::json::Array>(jsonBreakpointArray))
       {
-         if (json::isType<core::json::Object>(bp))
+         json::Array breakpointArray = jsonBreakpointArray.get_array();
+         s_breakpoints.clear();
+         BOOST_FOREACH(json::Value bp, breakpointArray)
          {
-            s_breakpoints.push_back(breakpointFromJson(bp.get_obj()));
+            if (json::isType<core::json::Object>(bp))
+            {
+               s_breakpoints.push_back(breakpointFromJson(bp.get_obj()));
+            }
          }
       }
    }

--- a/src/cpp/session/modules/SessionBreakpoints.cpp
+++ b/src/cpp/session/modules/SessionBreakpoints.cpp
@@ -520,7 +520,15 @@ Error initBreakpoints()
       // Protect against the breakpoint array being serialized as an
       // empty object
       json::Value jsonBreakpointArray = breakpointState["breakpoints"];
-      if (json::isType<core::json::Array>(jsonBreakpointArray))
+      if (!json::isType<core::json::Array>(jsonBreakpointArray))
+      {
+         Error error = json::errors::typeMismatch(
+                  jsonBreakpointArray,
+                  json::ArrayType,
+                  ERROR_LOCATION);
+         LOG_ERROR(error);
+      }
+      else
       {
          json::Array breakpointArray = jsonBreakpointArray.get_array();
          s_breakpoints.clear();


### PR DESCRIPTION
This PR provides a way for us to print backtraces when desired -- this can be useful when attempting to pin down things like uncaught exceptions.

(most recently used to track down a JSON deserialization issue...)