### PR TITLE
enable <!-- --> comments for Markdown

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/Debug.java
+++ b/src/gwt/src/org/rstudio/core/client/Debug.java
@@ -19,8 +19,8 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.AttachDetachException;
-
 import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.studio.client.server.ServerError;
 
@@ -144,7 +144,8 @@ public class Debug
          return;
       
       Element textEl = Document.get().createSpanElement();
-      textEl.setInnerHTML("* " + message);
+      String safe = SafeHtmlUtils.fromString(message).asString();
+      textEl.setInnerHTML("* " + safe);
       consoleEl.appendChild(textEl);
       consoleEl.appendChild(Document.get().createBRElement());
       consoleEl.setScrollTop(Integer.MAX_VALUE);

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -973,6 +973,11 @@ public class StringUtil
              result.substring(1);
    }
    
+   public static native final String escapeRegex(String regexString) /*-{
+      var utils = $wnd.require("mode/utils");
+      return utils.escapeRegExp(regexString);
+   }-*/;
+   
    public static final HashMap<String, String> COMPLEMENTS =
          makeComplementsMap();
    

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -354,7 +354,8 @@ public class StringUtil
     * @return
     */
    public static String getCommonPrefix(String[] lines,
-                                        boolean allowPhantomWhitespace)
+                                        boolean allowPhantomWhitespace,
+                                        boolean skipWhitespaceOnlyLines)
    {
       if (lines.length == 0)
          return "";
@@ -390,6 +391,9 @@ public class StringUtil
       for (int i = 1; i < lines.length && prefix.length() > 0; i++)
       {
          String line = notNull(lines[i]);
+         if (line.trim().isEmpty() && skipWhitespaceOnlyLines)
+            continue;
+         
          int len = whitespaceExpansionAllowed ? Math.max(prefix.length(), line.length()) :
                    allowPhantomWhitespace ? prefix.length() :
                    Math.min(prefix.length(), line.length());
@@ -978,6 +982,11 @@ public class StringUtil
       return utils.escapeRegExp(regexString);
    }-*/;
    
+   public static final String getIndent(String line)
+   {
+      return RE_INDENT.match(line, 0).getGroup(0);
+   }
+   
    public static final HashMap<String, String> COMPLEMENTS =
          makeComplementsMap();
    
@@ -985,5 +994,6 @@ public class StringUtil
    private static final NumberFormat PRETTY_NUMBER_FORMAT = NumberFormat.getFormat("#,##0.#####");
    private static final DateTimeFormat DATE_FORMAT
                           = DateTimeFormat.getFormat("MMM d, yyyy, h:mm a");
+   private static final Pattern RE_INDENT = Pattern.create("^\\s*", "");
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2963,14 +2963,22 @@ public class TextEditingTarget implements
       // Also figure out if we're commenting an Roxygen block.
       boolean looksLikeRoxygen = false;
       
+      // Skip commenting the last line if the selection is
+      // multiline and ends on the first column of the end row.
+      boolean dontCommentLastLine = false;
+      if (rowStart != rowEnd && initialRange.getEnd().getColumn() == 0)
+         dontCommentLastLine = true;
+      
       Range expanded = Range.create(
             rowStart,
             0,
             rowEnd,
-            docDisplay_.getLine(rowEnd).length());
+            dontCommentLastLine ? 0 : docDisplay_.getLine(rowEnd).length());
       docDisplay_.setSelectionRange(expanded);
       
-      String[] lines = JsUtil.toStringArray(docDisplay_.getLines(rowStart, rowEnd));
+      String[] lines = JsUtil.toStringArray(
+            docDisplay_.getLines(rowStart, rowEnd - (dontCommentLastLine ? 1 : 0)));
+      
       String commonPrefix = StringUtil.getCommonPrefix(
             lines,
             true,
@@ -3080,7 +3088,8 @@ public class TextEditingTarget implements
          }
       }
       
-      String newSelection =
+      String newSelection = dontCommentLastLine ?
+            builder.toString() :
             builder.substring(0, builder.length() - 1);
             
       docDisplay_.replaceSelection(newSelection);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2970,13 +2970,6 @@ public class TextEditingTarget implements
             docDisplay_.getLine(rowEnd).length());
       docDisplay_.setSelectionRange(expanded);
       
-      boolean keepFinalNewline = false;
-      if (rowStart != rowEnd && initialRange.getEnd().getColumn() == 0)
-      {
-         rowEnd--;
-         keepFinalNewline = true;
-      }
-      
       String[] lines = JsUtil.toStringArray(docDisplay_.getLines(rowStart, rowEnd));
       String commonPrefix = StringUtil.getCommonPrefix(
             lines,
@@ -3087,8 +3080,7 @@ public class TextEditingTarget implements
          }
       }
       
-      String newSelection = keepFinalNewline ?
-            builder.toString() :
+      String newSelection =
             builder.substring(0, builder.length() - 1);
             
       docDisplay_.replaceSelection(newSelection);
@@ -3097,6 +3089,11 @@ public class TextEditingTarget implements
       if (isSingleLineAction)
       {
          int diff = newSelection.length() - lines[0].length();
+         if (commentEnd != null)
+            diff = diff < 0 ?
+                  diff + commentEnd.length() + 1 :
+                  diff - commentEnd.length() - 1;
+         
          int colStart = initialRange.getStart().getColumn();
          int colEnd = initialRange.getEnd().getColumn();
          Range newRange = Range.create(


### PR DESCRIPTION
(NOTE: not quite ready for merge)

This PR:

1) Rewrites the `doCommentUncomment()` method to be line-by-line, rather than targeted on a whole selection (using regexes). This makes it easier to control how commenting works for 'double-sided' comments and also makes it a bit easier to handle what happens when considering commenting a line containing only whitespace.

2) Using the above, enables `<!-- -->` comments for Markdown modes.

As is tradition, a GIF showing this in action in an R Markdown document. Note that lines containing only whitespace within a selection are commented when within R mode, but not when within Markdown mode. (This seems like the most natural behaviour to me)

![comment](https://cloud.githubusercontent.com/assets/1976582/9506573/c0660f8a-4bfd-11e5-897c-b5bdacd43664.gif)

