### PR TITLE
Register the function editor on all OS'

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1821,12 +1821,9 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
                                  userSettings().removeHistoryDuplicates());
 
 
-   // register function editor on windows
-#ifdef _WIN32
    error = rstudio::r::exec::RFunction(".rs.registerFunctionEditor").call();
    if (error)
       LOG_ERROR(error);
-#endif
 
    // set flag indicating we had an abnormal end (if this doesn't get
    // unset by the time we launch again then we didn't terminate normally


### PR DESCRIPTION
I did not try building RStudio with this enabled.

However the current behavior on Linux (Ubuntu 14.04) for RStudio Desktop (preview v0.99.669) is broken.

With `options(editor)` unset in `.Rprofile` I get the following error when running `edit()` in RStudio

```
Error in .External2(C_edit, name, file, title, editor) : 
  problem with running editor vim"
```
Trying to use any other common editor, `emacs`, `nano` ect yields the same results (with editor substituted).

Preferably I would like my set editor to be opened, but barring that opening an RStudio window (as is done on Windows) would work better than the error, which is what this pull request is attempting to do.

I have not tested the behavior on OSX, as I don't have a vm handy but I would guess it is similar to Linux.