### PR TITLE
Only use libcurl when R SVN >= 69197

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1816,6 +1816,16 @@ std::string CRANDownloadOptions()
    std::string method = module_context::downloadFileMethod();
    if (!method.empty())
       options += ", download.file.method = '" + method + "'";
+   if (method == "curl")
+   {
+      std::string extraArgs;
+      Error error = r::exec::RFunction(".rs.downloadFileExtraWithCurlArgs")
+                                                            .call(&extraArgs);
+      if (error)
+         LOG_ERROR(error);
+      options += ", download.file.extra = '" + extraArgs + "'";
+   }
+
    options += ")";
    return options;
 }


### PR DESCRIPTION
This PR prevents the use of the libcurl method when we aren't running against recent (as of now only in dev versions) SVN revisions of R. This is to workaround the fact that in the original implementation of libcurl in R 3.2 HTTP 404 status results actually downloaded the 404 HTML page and treated the request as if it was successful.

This PR also adds two command line flags for the curl method:

- The "-L" flag (to tell it to follow redirects)
- The "-f" flag (to tell it to fail silently, R will take care of reporting failures)

@kevinushey Could you review and merge if this looks okay?
