### PR TITLE
further refine pane zoom behaviour

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/events/ManageLayoutCommandsEvent.java
+++ b/src/gwt/src/org/rstudio/core/client/events/ManageLayoutCommandsEvent.java
@@ -1,5 +1,5 @@
 /*
- * RequestCurrentZoomEvent.java
+ * ManageLayoutCommands.java
  *
  * Copyright (C) 2009-12 by RStudio, Inc.
  *
@@ -14,30 +14,16 @@
  */
 package org.rstudio.core.client.events;
 
-import org.rstudio.studio.client.workbench.ui.PaneManager.Tab;
-
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 
-public class RequestCurrentlyZoomedTabEvent extends GwtEvent<RequestCurrentlyZoomedTabEvent.Handler>
+public class ManageLayoutCommandsEvent extends GwtEvent<ManageLayoutCommandsEvent.Handler>
 {
-   public void setZoomedTab(Tab tab)
-   {
-      tab_ = tab;
-   }
-   
-   public Tab getZoomedTab()
-   {
-      return tab_;
-   }
-   
-   private Tab tab_;
-   
    // Boilerplate ----
    
    public interface Handler extends EventHandler
    {
-      void onRequestCurrentlyZoomedTab(RequestCurrentlyZoomedTabEvent event);
+      void onManageLayoutCommands(ManageLayoutCommandsEvent event);
    }
    
    @Override
@@ -49,7 +35,7 @@ public class RequestCurrentlyZoomedTabEvent extends GwtEvent<RequestCurrentlyZoo
    @Override
    protected void dispatch(Handler handler)
    {
-      handler.onRequestCurrentlyZoomedTab(this);
+      handler.onManageLayoutCommands(this);
    }
 
    public static final Type<Handler> TYPE = new Type<Handler>();

--- a/src/gwt/src/org/rstudio/core/client/events/RequestCurrentlyZoomedTabEvent.java
+++ b/src/gwt/src/org/rstudio/core/client/events/RequestCurrentlyZoomedTabEvent.java
@@ -1,0 +1,56 @@
+/*
+ * RequestCurrentZoomEvent.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.events;
+
+import org.rstudio.studio.client.workbench.ui.PaneManager.Tab;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class RequestCurrentlyZoomedTabEvent extends GwtEvent<RequestCurrentlyZoomedTabEvent.Handler>
+{
+   public void setZoomedTab(Tab tab)
+   {
+      tab_ = tab;
+   }
+   
+   public Tab getZoomedTab()
+   {
+      return tab_;
+   }
+   
+   private Tab tab_;
+   
+   // Boilerplate ----
+   
+   public interface Handler extends EventHandler
+   {
+      void onRequestCurrentlyZoomedTab(RequestCurrentlyZoomedTabEvent event);
+   }
+   
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onRequestCurrentlyZoomedTab(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -31,6 +31,7 @@ import org.rstudio.core.client.widget.LocalRepositoriesWidget;
 import org.rstudio.core.client.widget.ModifyKeyboardShortcutsWidget;
 import org.rstudio.studio.client.application.Application;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.application.ui.GlobalToolbar;
 import org.rstudio.studio.client.application.ui.ProjectPopupMenu;
 import org.rstudio.studio.client.application.ui.impl.DesktopApplicationHeader;
 import org.rstudio.studio.client.application.ui.impl.WebApplicationHeader;
@@ -151,6 +152,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(ApplicationCommandManager manager);
    void injectMembers(FileBacked<?> object);
    void injectMembers(WindowFrame frame);
+   void injectMembers(GlobalToolbar toolbar);
    
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);
 

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
@@ -14,11 +14,8 @@
  */
 package org.rstudio.studio.client.application.ui;
 
-import org.rstudio.core.client.command.AppCommand;
-import org.rstudio.core.client.events.RequestCurrentlyZoomedTabEvent;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.widget.CanFocus;
-import org.rstudio.core.client.widget.CheckableMenuItem;
 import org.rstudio.core.client.widget.FocusContext;
 import org.rstudio.core.client.widget.FocusHelper;
 import org.rstudio.core.client.widget.Toolbar;
@@ -31,9 +28,7 @@ import org.rstudio.studio.client.common.vcs.VCSConstants;
 import org.rstudio.studio.client.workbench.codesearch.CodeSearch;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.SessionInfo;
-import org.rstudio.studio.client.workbench.ui.PaneManager;
 
-import com.google.gwt.event.logical.shared.AttachEvent;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
@@ -144,51 +139,6 @@ public class GlobalToolbar extends Toolbar
       events_ = events;
    }
    
-   public CheckableMenuItem createCheckableMenuItem(final AppCommand command,
-                                                    final String name,
-                                                    final ToolbarPopupMenu menu)
-   {
-      final CheckableMenuItem item = new CheckableMenuItem()
-      {
-         @Override
-         public void onInvoked()
-         {
-            command.execute();
-         }
-         
-         @Override
-         public boolean isChecked()
-         {
-            RequestCurrentlyZoomedTabEvent event = new RequestCurrentlyZoomedTabEvent();
-            events_.fireEvent(event);
-            
-            PaneManager.Tab tab = event.getZoomedTab();
-            if (tab == null)
-               return name.equalsIgnoreCase("None");
-            
-            return tab.toString().equalsIgnoreCase(name);
-         }
-         
-         @Override
-         public String getLabel()
-         {
-            return command.getLabel();
-         }
-      };
-      
-      menu.addAttachHandler(new AttachEvent.Handler()
-      {
-         @Override
-         public void onAttachOrDetach(AttachEvent event)
-         {
-            if (event.isAttached())
-               item.onStateChanged();
-         }
-      });
-      
-      return item;
-   }
-   
    public void completeInitialization(SessionInfo sessionInfo)
    { 
       StandardIcons icons = StandardIcons.INSTANCE;
@@ -233,19 +183,20 @@ public class GlobalToolbar extends Toolbar
       addLeftSeparator();
       
       ToolbarPopupMenu paneLayoutMenu = new ToolbarPopupMenu();
-      paneLayoutMenu.addItem(createCheckableMenuItem(commands_.layoutEndZoom(), "None", paneLayoutMenu));
+      
+      paneLayoutMenu.addItem(commands_.layoutEndZoom().createMenuItem(false));
       paneLayoutMenu.addSeparator();
-      paneLayoutMenu.addItem(createCheckableMenuItem(commands_.layoutZoomSource(), "Source", paneLayoutMenu));
-      paneLayoutMenu.addItem(createCheckableMenuItem(commands_.layoutZoomConsole(), "Console", paneLayoutMenu));
-      paneLayoutMenu.addItem(createCheckableMenuItem(commands_.layoutZoomHelp(), "Help", paneLayoutMenu));
+      paneLayoutMenu.addItem(commands_.layoutZoomSource().createMenuItem(false));
+      paneLayoutMenu.addItem(commands_.layoutZoomConsole().createMenuItem(false));
+      paneLayoutMenu.addItem(commands_.layoutZoomHelp().createMenuItem(false));
       paneLayoutMenu.addSeparator();
-      paneLayoutMenu.addItem(createCheckableMenuItem(commands_.layoutZoomHistory(), "History", paneLayoutMenu));
-      paneLayoutMenu.addItem(createCheckableMenuItem(commands_.layoutZoomFiles(), "Files", paneLayoutMenu));
-      paneLayoutMenu.addItem(createCheckableMenuItem(commands_.layoutZoomPlots(), "Plots", paneLayoutMenu));
-      paneLayoutMenu.addItem(createCheckableMenuItem(commands_.layoutZoomPackages(), "Packages", paneLayoutMenu));
-      paneLayoutMenu.addItem(createCheckableMenuItem(commands_.layoutZoomEnvironment(), "Environment", paneLayoutMenu));
-      paneLayoutMenu.addItem(createCheckableMenuItem(commands_.layoutZoomVcs(), "Vcs", paneLayoutMenu));
-      paneLayoutMenu.addItem(createCheckableMenuItem(commands_.layoutZoomBuild(), "Build", paneLayoutMenu));
+      paneLayoutMenu.addItem(commands_.layoutZoomHistory().createMenuItem(false));
+      paneLayoutMenu.addItem(commands_.layoutZoomFiles().createMenuItem(false));
+      paneLayoutMenu.addItem(commands_.layoutZoomPlots().createMenuItem(false));
+      paneLayoutMenu.addItem(commands_.layoutZoomPackages().createMenuItem(false));
+      paneLayoutMenu.addItem(commands_.layoutZoomEnvironment().createMenuItem(false));
+      paneLayoutMenu.addItem(commands_.layoutZoomVcs().createMenuItem(false));
+      paneLayoutMenu.addItem(commands_.layoutZoomBuild().createMenuItem(false));
       
       ImageResource paneLayoutIcon = ThemeResources.INSTANCE.paneLayoutIcon();
       ToolbarButton paneLayoutButton = new ToolbarButton(

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
@@ -196,6 +196,7 @@ public class GlobalToolbar extends Toolbar
       paneLayoutMenu.addItem(commands_.layoutZoomPackages().createMenuItem(false));
       paneLayoutMenu.addItem(commands_.layoutZoomEnvironment().createMenuItem(false));
       paneLayoutMenu.addItem(commands_.layoutZoomVcs().createMenuItem(false));
+      paneLayoutMenu.addItem(commands_.layoutZoomViewer().createMenuItem(false));
       paneLayoutMenu.addItem(commands_.layoutZoomBuild().createMenuItem(false));
       
       ImageResource paneLayoutIcon = ThemeResources.INSTANCE.paneLayoutIcon();

--- a/src/gwt/src/org/rstudio/studio/client/common/NotifyingSplitLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/NotifyingSplitLayoutPanel.java
@@ -14,8 +14,13 @@
  */
 package org.rstudio.studio.client.common;
 
+import com.google.gwt.core.shared.GWT;
+import com.google.gwt.resources.client.ClientBundle;
+import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.user.client.ui.*;
 import com.google.inject.Inject;
+
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.widget.events.GlassVisibilityEvent;
 import org.rstudio.studio.client.application.events.EventBus;
 
@@ -44,6 +49,29 @@ public class NotifyingSplitLayoutPanel extends SplitLayoutPanel
          }
       });
    }
+   
+   public void setSplitterEnabled(boolean enabled)
+   {
+      DomUtils.toggleClass(getElement(), RES.styles().disableSplitter(), !enabled);
+   }
 
    private final EventBus events_;
+   
+   // Styles, Resources etc. ----
+   public interface Styles extends CssResource
+   {
+      String disableSplitter();
+   }
+   
+   public interface Resources extends ClientBundle
+   {
+      @Source("NotifyingSplitPanel.css")
+      Styles styles();
+   }
+   
+   private static Resources RES = GWT.create(Resources.class);
+   static {
+      RES.styles().ensureInjected();
+   }
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/NotifyingSplitPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/common/NotifyingSplitPanel.css
@@ -1,0 +1,5 @@
+@external gwt-SplitLayoutPanel-HDragger;
+
+.disableSplitter .gwt-SplitLayoutPanel-HDragger {
+	width: 0px !important;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -218,6 +218,8 @@ well as menu structures (for main menu and popup menus).
          <separator/>
          
          <menu label="Pane Layout">
+            <cmd refid="layoutEndZoom"/>
+            <separator/>
             <cmd refid="layoutZoomSource"/>
             <cmd refid="layoutZoomConsole"/>
             <cmd refid="layoutZoomHelp"/>
@@ -1004,56 +1006,70 @@ well as menu structures (for main menu and popup menus).
         
         
    <cmd id="layoutZoomSource"
+        checkable="true"
         label="Zoom Source"/>
         
    <cmd id="layoutZoomConsole"
+        checkable="true"
         label="Zoom Console"
         windowMode="main"/>
         
    <cmd id="layoutZoomEnvironment"
+        checkable="true"
         label="Zoom Environment Pane"
         windowMode="main"/>
         
    <cmd id="layoutZoomData"
+        checkable="true"
         label="Zoom Data Pane"
         windowMode="main"/>
         
    <cmd id="layoutZoomHistory"
+        checkable="true"
         label="Zoom History Pane"
         windowMode="main"/>
         
    <cmd id="layoutZoomFiles"
+        checkable="true"
         label="Zoom Files Pane"
         windowMode="main"/>
         
    <cmd id="layoutZoomPlots"
+        checkable="true"
         label="Zoom Plots Pane"
         windowMode="main"/>
         
    <cmd id="layoutZoomPackages"
+        checkable="true"
         label="Zoom Packages Pane"
         windowMode="main"/>
         
    <cmd id="layoutZoomHelp"
+        checkable="true"
         label="Zoom Help Pane"
         windowMode="main"/>
         
    <cmd id="layoutZoomVcs"
+        checkable="true"
         label="Zoom VCS Pane"
         windowMode="main"/>
         
    <cmd id="layoutZoomBuild"
+        checkable="true"
         label="Zoom Build Pane"
         windowMode="main"/>
         
    <cmd id="layoutZoomPresentation"
+        checkable="true"
         label="Zoom Presentation Pane"
         windowMode="main"/>
         
    <cmd id="layoutZoomCurrentPane"
+        checkable="true"
         label="Toggle Zoom for Current Pane"/>
 
    <cmd id="layoutEndZoom"
+        checkable="true"
         label="Show All Panes"/>
         
    <cmd id="jumpTo"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -230,6 +230,7 @@ well as menu structures (for main menu and popup menus).
             <cmd refid="layoutZoomPackages"/>
             <cmd refid="layoutZoomEnvironment"/>
             <cmd refid="layoutZoomVcs"/>
+            <cmd refid="layoutZoomViewer"/>
             <cmd refid="layoutZoomBuild"/>
          </menu>
          
@@ -258,6 +259,7 @@ well as menu structures (for main menu and popup menus).
          <cmd refid="activatePackages"/>
          <cmd refid="activateEnvironment"/>
          <cmd refid="activateVcs"/>
+         <cmd refid="activateViewer"/>
          <cmd refid="activateBuild"/>
          
          <separator/>
@@ -527,7 +529,8 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="activatePackages" value="Ctrl+7"/>
          <shortcut refid="activateEnvironment" value="Ctrl+8"/>
          <shortcut refid="activateVcs" value="Ctrl+9"/>
-         <shortcut refid="activateBuild" value="Ctrl+0"/>
+         <shortcut refid="activateViewer" value="Ctrl+0"/>
+         <shortcut refid="activateBuild" value="Ctrl+F1"/>
          
          <shortcut refid="layoutZoomSource" value="Ctrl+Shift+1"/>
          <shortcut refid="layoutZoomConsole" value="Ctrl+Shift+2"/>
@@ -538,7 +541,9 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="layoutZoomPackages" value="Ctrl+Shift+7"/>
          <shortcut refid="layoutZoomEnvironment" value="Ctrl+Shift+8"/>
          <shortcut refid="layoutZoomVcs" value="Ctrl+Shift+9"/>
-         <shortcut refid="layoutZoomBuild" value="Ctrl+Shift+0"/>
+         <shortcut refid="layoutZoomViewer" value="Ctrl+Shift+0"/>
+         <shortcut refid="layoutZoomBuild" value="Ctrl+Shift+F1"/>
+         <shortcut refid="layoutEndZoom" value="Ctrl+Shift+F10"/>
          
          <shortcut refid="switchToTab" value="Ctrl+Shift+."/>
          <shortcut refid="previousTab" value="Ctrl+Alt+Left" if="!org.rstudio.core.client.BrowseCap.isLinux()"/>
@@ -999,6 +1004,9 @@ well as menu structures (for main menu and popup menus).
         menuLabel="Show _Build"
         windowMode="main"/>
         
+   <cmd id="activateViewer"
+        label="Show Viewer"/>
+        
    <cmd id="activatePresentation"
         label="Show Presentation Pane"
         menuLabel="Show Presentation"
@@ -1016,53 +1024,57 @@ well as menu structures (for main menu and popup menus).
         
    <cmd id="layoutZoomEnvironment"
         checkable="true"
-        label="Zoom Environment Pane"
+        label="Zoom Environment"
         windowMode="main"/>
         
    <cmd id="layoutZoomData"
         checkable="true"
-        label="Zoom Data Pane"
+        label="Zoom Data"
         windowMode="main"/>
         
    <cmd id="layoutZoomHistory"
         checkable="true"
-        label="Zoom History Pane"
+        label="Zoom History"
         windowMode="main"/>
         
    <cmd id="layoutZoomFiles"
         checkable="true"
-        label="Zoom Files Pane"
+        label="Zoom Files"
         windowMode="main"/>
         
    <cmd id="layoutZoomPlots"
         checkable="true"
-        label="Zoom Plots Pane"
+        label="Zoom Plots"
         windowMode="main"/>
         
    <cmd id="layoutZoomPackages"
         checkable="true"
-        label="Zoom Packages Pane"
+        label="Zoom Packages"
         windowMode="main"/>
         
    <cmd id="layoutZoomHelp"
         checkable="true"
-        label="Zoom Help Pane"
+        label="Zoom Help"
         windowMode="main"/>
         
    <cmd id="layoutZoomVcs"
         checkable="true"
-        label="Zoom VCS Pane"
+        label="Zoom VCS"
         windowMode="main"/>
         
    <cmd id="layoutZoomBuild"
         checkable="true"
-        label="Zoom Build Pane"
+        label="Zoom Build"
         windowMode="main"/>
         
    <cmd id="layoutZoomPresentation"
         checkable="true"
-        label="Zoom Presentation Pane"
+        label="Zoom Presentation"
         windowMode="main"/>
+        
+   <cmd id="layoutZoomViewer"
+        checkable="true"
+        label="Zoom Viewer"/>
         
    <cmd id="layoutZoomCurrentPane"
         checkable="true"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -335,6 +335,8 @@ public abstract class
    public abstract AppCommand viewShortcuts();
    
    // Viewer
+   public abstract AppCommand activateViewer();
+   public abstract AppCommand layoutZoomViewer();
    public abstract AppCommand viewerPopout();
    public abstract AppCommand viewerBack(); 
    public abstract AppCommand viewerForward();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/events/ZoomPaneEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/events/ZoomPaneEvent.java
@@ -23,16 +23,30 @@ public class ZoomPaneEvent extends GwtEvent<ZoomPaneEvent.Handler>
    {
       void onZoomPane(ZoomPaneEvent event);
    }
+   
+   public ZoomPaneEvent(String pane, String tab)
+   {
+      pane_ = pane;
+      tab_ = tab;
+   }
 
    public ZoomPaneEvent(String pane)
    {
-      pane_ = pane;
+      this(pane, pane);
    }
    
    public String getPane()
    {
       return pane_;
    }
+   
+   public String getTab()
+   {
+      return tab_;
+   }
+   
+   private final String pane_;
+   private final String tab_;
    
    @Override
    public Type<Handler> getAssociatedType()
@@ -46,7 +60,5 @@ public class ZoomPaneEvent extends GwtEvent<ZoomPaneEvent.Handler>
       handler.onZoomPane(this);
    }
 
-   private final String pane_;
-   
    public static final Type<Handler> TYPE = new Type<Handler>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
@@ -253,7 +253,7 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
          }
       }
    }
-
+   
    private Double splitPercent_ = null;
    private Integer previousOffsetWidth_ = null;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -259,7 +259,7 @@ public class PaneManager
             };
             
             int newWidth = computeAppropriateWidth();
-            horizontalResizeAnimation(0, newWidth, afterAnimation).run(300);
+            resizeHorizontally(0, newWidth, afterAnimation);
          }
       });
       
@@ -377,13 +377,20 @@ public class PaneManager
       if (targetSize < 0)
          targetSize = 0;
       
-      horizontalResizeAnimation(initialSize, targetSize).run(300);
+      resizeHorizontally(initialSize, targetSize);
    }
    
-   private Animation horizontalResizeAnimation(final double start,
-                                               final double end)
+   private void resizeHorizontally(final double start,
+                                   final double end)
    {
-      return horizontalResizeAnimation(start, end, null);
+      resizeHorizontally(start, end, null);
+   }
+   
+   private void resizeHorizontally(final double start,
+                                   final double end,
+                                   final Command afterComplete)
+   {
+      horizontalResizeAnimation(start, end, afterComplete).run(300);
    }
    
    private Animation horizontalResizeAnimation(final double start,
@@ -445,7 +452,7 @@ public class PaneManager
       if (rightWidth >= 10)
          return;
       
-      horizontalResizeAnimation(rightWidth, computeAppropriateWidth()).run(300);
+      resizeHorizontally(rightWidth, computeAppropriateWidth());
    }
    
    private void restoreSavedLayout()
@@ -456,7 +463,7 @@ public class PaneManager
          window.onWindowStateChange(new WindowStateChangeEvent(WindowState.NORMAL, true));
       
       maximizedWindow_.onWindowStateChange(new WindowStateChangeEvent(WindowState.NORMAL, true));
-      horizontalResizeAnimation(panel_.getWidgetSize(right_), widgetSizePriorToZoom_).run(300);
+      resizeHorizontally(panel_.getWidgetSize(right_), widgetSizePriorToZoom_);
       
       // Invalidate the saved state.
       maximizedWindow_ = null;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -484,12 +484,15 @@ public class PaneManager
          window.onWindowStateChange(new WindowStateChangeEvent(WindowState.NORMAL, true));
       
       double rightWidth = panel_.getWidgetSize(right_);
+      double panelWidth = panel_.getOffsetWidth();
       
-      // If the right pane is already visible horizontally, bail.
-      if (rightWidth >= 10)
-         return;
+      double leftThreshold = (2.0 / 5.0) * panelWidth;
+      double rightThreshold = (3.0 / 5.0) * panelWidth;
       
-      resizeHorizontally(rightWidth, computeAppropriateWidth());
+      if (rightWidth <= leftThreshold)
+         resizeHorizontally(rightWidth, leftThreshold);
+      else if (panelWidth - rightWidth <= rightThreshold)
+         resizeHorizontally(rightWidth, rightThreshold);
    }
    
    private void restoreSavedLayout()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -486,13 +486,13 @@ public class PaneManager
       double rightWidth = panel_.getWidgetSize(right_);
       double panelWidth = panel_.getOffsetWidth();
       
-      double leftThreshold = (2.0 / 5.0) * panelWidth;
-      double rightThreshold = (3.0 / 5.0) * panelWidth;
+      double minThreshold = (2.0 / 5.0) * panelWidth;
+      double maxThreshold = (3.0 / 5.0) * panelWidth;
       
-      if (rightWidth <= leftThreshold)
-         resizeHorizontally(rightWidth, leftThreshold);
-      else if (panelWidth - rightWidth <= rightThreshold)
-         resizeHorizontally(rightWidth, rightThreshold);
+      if (rightWidth <= minThreshold)
+         resizeHorizontally(rightWidth, minThreshold);
+      else if (rightWidth >= maxThreshold)
+         resizeHorizontally(rightWidth, maxThreshold);
    }
    
    private void restoreSavedLayout()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -220,7 +220,7 @@ public class PaneManager
             assert window != null :
                "No pane with name '" + pane + "'";
             
-            toggleWindowZoom(window, null);
+            toggleWindowZoom(window, tabForName(event.getTab()));
          }
       });
       
@@ -331,15 +331,52 @@ public class PaneManager
       restoreLayout();
    }
    
+   private <T> boolean equals(T lhs, T rhs)
+   {
+      if (lhs == null)
+         return rhs == null;
+      
+      return lhs.equals(rhs);
+   }
+   
    public void toggleWindowZoom(LogicalWindow window, Tab tab)
    {
       if (isAnimating_)
          return;
       
-      if (window.equals(maximizedWindow_))
-         restoreLayout();
+      boolean hasZoom = maximizedWindow_ != null;
+      
+      if (hasZoom)
+      {
+         if (equals(window, maximizedWindow_))
+         {
+            // If we're zooming a different tab in the same window,
+            // just activate that tab.
+            if (!equals(tab, maximizedTab_))
+            {
+               maximizedTab_ = tab;
+               activateTab(tab);
+            }
+            
+            // Otherwise, we're trying to maximize the same tab
+            // and the same window. Interpret this as a toggle off.
+            else
+            {
+               restoreLayout();
+            }
+         }
+         else
+         {
+            // We're transferring zoom from one window to another --
+            // maximize the new window.
+            fullyMaximizeWindow(window, tab);
+         }
+      }
       else
+      {
+         // No zoom currently on -- just zoom the selected window + tab.
          fullyMaximizeWindow(window, tab);
+      }
    }
    
    private void fullyMaximizeWindow(final LogicalWindow window, final Tab tab)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -394,6 +394,7 @@ public class PaneManager
          maximizedTab_ = tab;
       
       manageLayoutCommands();
+      panel_.setSplitterEnabled(false);
          
       maximizedWindow_ = window;
       if (widgetSizePriorToZoom_ < 0)
@@ -412,11 +413,7 @@ public class PaneManager
       
       final double initialSize = panel_.getWidgetSize(right_);
       
-      // Ensure that a couple pixels are left after zoom so that the pane
-      // can be manually pulled out (with the mouse).
-      double targetSize = isLeftWidget ?
-            0 :
-            panel_.getOffsetWidth() - 3;
+      double targetSize = isLeftWidget ? 0 : panel_.getOffsetWidth();
       
       if (targetSize < 0)
          targetSize = 0;
@@ -482,6 +479,15 @@ public class PaneManager
          restoreFourPaneLayout();
    }
    
+   private void invalidateSavedLayoutState(boolean enableSplitter)
+   {
+      maximizedWindow_ = null;
+      maximizedTab_ = null;
+      widgetSizePriorToZoom_ = -1;
+      panel_.setSplitterEnabled(enableSplitter);
+      manageLayoutCommands();
+   }
+   
    private void restoreFourPaneLayout()
    {
       // Ensure that all windows are in the 'normal' state. This allows
@@ -500,6 +506,8 @@ public class PaneManager
          resizeHorizontally(rightWidth, minThreshold);
       else if (rightWidth >= maxThreshold)
          resizeHorizontally(rightWidth, maxThreshold);
+      
+      invalidateSavedLayoutState(true);
    }
    
    private void restoreSavedLayout()
@@ -511,12 +519,7 @@ public class PaneManager
       
       maximizedWindow_.onWindowStateChange(new WindowStateChangeEvent(WindowState.NORMAL, true));
       resizeHorizontally(panel_.getWidgetSize(right_), widgetSizePriorToZoom_);
-      
-      // Invalidate the saved state.
-      maximizedWindow_ = null;
-      maximizedTab_ = null;
-      widgetSizePriorToZoom_ = -1;
-      manageLayoutCommands();
+      invalidateSavedLayoutState(true);
    }
    
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchScreen.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchScreen.java
@@ -23,7 +23,9 @@ import com.google.gwt.event.logical.shared.ResizeEvent;
 import com.google.gwt.event.logical.shared.ResizeHandler;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
+import com.google.gwt.event.shared.GwtEvent;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.*;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -294,6 +296,18 @@ public class WorkbenchScreen extends Composite
    {
       paneManager_.activateTab(event.getPane());
    }
+   
+   private void fireEventDelayed(final GwtEvent<?> event, int delayMs)
+   {
+      new Timer()
+      {
+         @Override
+         public void run()
+         {
+            eventBus_.fireEvent(event);
+         }
+      }.schedule(delayMs);
+   }
 
    @Handler
    void onActivateEnvironment() { paneManager_.activateTab(Tab.Environment); }
@@ -309,7 +323,7 @@ public class WorkbenchScreen extends Composite
    void onActivateHelp() 
    { 
       paneManager_.activateTab(Tab.Help); 
-      eventBus_.fireEvent(new ActivateHelpEvent());
+      fireEventDelayed(new ActivateHelpEvent(), 200);
    }
    @Handler
    void onActivateVcs() { paneManager_.activateTab(Tab.VCS); }
@@ -332,14 +346,7 @@ public class WorkbenchScreen extends Composite
    void onLayoutZoomHelp() 
    { 
       paneManager_.zoomTab(Tab.Help);
-      Scheduler.get().scheduleDeferred(new ScheduledCommand()
-      {
-         @Override
-         public void execute()
-         {
-            eventBus_.fireEvent(new ActivateHelpEvent());
-         }
-      });
+      fireEventDelayed(new ActivateHelpEvent(), 200);
    }
    @Handler
    void onLayoutZoomVcs() { paneManager_.zoomTab(Tab.VCS); }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchScreen.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchScreen.java
@@ -330,7 +330,10 @@ public class WorkbenchScreen extends Composite
    @Handler
    void onActivateBuild() { paneManager_.activateTab(Tab.Build); }
    @Handler
-   void onActivatePresentation() { paneManager_.activateTab(Tab.Presentation);}
+   void onActivatePresentation() { paneManager_.activateTab(Tab.Presentation); }
+   @Handler
+   void onActivateViewer() { paneManager_.activateTab(Tab.Viewer); }
+   
    
    @Handler
    void onLayoutZoomEnvironment() { paneManager_.zoomTab(Tab.Environment); }
@@ -353,7 +356,9 @@ public class WorkbenchScreen extends Composite
    @Handler
    void onLayoutZoomBuild() { paneManager_.zoomTab(Tab.Build); }
    @Handler
-   void onLayoutZoomPresentation() { paneManager_.zoomTab(Tab.Presentation);}
+   void onLayoutZoomPresentation() { paneManager_.zoomTab(Tab.Presentation); }
+   @Handler
+   void onLayoutZoomViewer() { paneManager_.zoomTab(Tab.Viewer); }
 
    @Handler
    void onMacPreferences()


### PR DESCRIPTION
@jjallaire, the implementation here feels fairly clunky but I can't think of a much better way of sharing this much state across the different elements in the IDE. Let me know if you can think of a cleaner way...

This PR ensures that the currently selected layout state is zoomed when opening the layout dropdown, e.g.

<img width="387" alt="screen shot 2015-09-04 at 11 32 58 am" src="https://cloud.githubusercontent.com/assets/1976582/9691667/b976d93c-52f8-11e5-8fce-569726f31e56.png">

This is done in the following way:

1) The `PaneManager` maintains the currently zoomed 'tab' (or none, if no tab is zoomed),
2) An event is used to communicate the currently zoomed tab (requesters can fire that event, the pane manager will supply the currently zoomed tab),
3) When opening the popup menu, each item then asks the pane manager if it's the currently zoomed tab, and uses that to select its 'checked' status.

Also -- let's not merge right away (I'll try to bring in other timing related fixes for zoom; you might have noticed that 'sometimes' zooming the 'help' Pane does not actually fully zoom it, for example)