### PR TITLE
Enable editor split (multiple views of same file)

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -2131,6 +2131,8 @@ well as menu structures (for main menu and popup menus).
    <cmd id="debugImportDump"
         menuLabel="_Import Editor Contents..."
         rebindable="false"/>
+   
+   <cmd id="splitEditor"/>
         
    <cmd id="refreshSuperDevMode"
         rebindable="false"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -124,6 +124,7 @@ public abstract class
    public abstract AppCommand renameInFile();
    public abstract AppCommand insertRoxygenSkeleton();
    public abstract AppCommand insertSnippet();
+   public abstract AppCommand splitEditor();
  
    // Projects
    public abstract AppCommand newProject();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -2662,6 +2662,18 @@ public class AceEditor implements DocDisplay,
       return snippets_.onInsertSnippet();
    }
    
+   public AceEditor clone()
+   {
+      AceEditor cloned = new AceEditor();
+      cloned.getWidget().getEditor().attachTo(this.getWidget().getEditor());
+      return cloned;
+   }
+   
+   public void destroy()
+   {
+      widget_.getEditor().destroy();
+   }
+   
    private static final int DEBUG_CONTEXT_LINES = 2;
    private final HandlerManager handlers_ = new HandlerManager(this);
    private final AceEditorWidget widget_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -335,4 +335,7 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    void setDragEnabled(boolean enabled);
    
    boolean onInsertSnippet();
+   
+   void destroy();
+   DocDisplay clone();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -803,6 +803,12 @@ public class TextEditingTarget implements
    }
    
    @Handler
+   public void onSplitEditor()
+   {
+      events_.fireEvent(new EditorSplitEvent());
+   }
+   
+   @Handler
    void onGoToNextSection()
    {
       if (docDisplay_.getFileType().isRmd() || docDisplay_.getFileType().isRpres())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -492,5 +492,25 @@ public class AceEditorNative extends JavaScriptObject {
       uiPrefsSynced_ = true;
    }
    
+   public final native void attachTo(AceEditorNative editor) /*-{
+      
+      var EditSession = $wnd.require("ace/edit_session").EditSession;
+      
+      var session = new EditSession(editor.session.getDocument(), editor.session.getMode());
+      session.setTabSize(this.session.getTabSize());
+      session.setUseSoftTabs(this.session.getUseSoftTabs());
+      session.setOverwrite(this.session.getOverwrite());
+      session.setBreakpoints(this.session.getBreakpoints());
+      session.setUseWrapMode(this.session.getUseWrapMode());
+      session.setUseWorker(this.session.getUseWorker());
+      session.setWrapLimitRange(this.session.$wrapLimitRange.min,
+                                this.session.$wrapLimitRange.max);
+      
+      this.setSession(session);
+      
+   }-*/;
+   
+   public final native void destroy() /*-{ this.destroy(); }-*/;
+   
    private static boolean uiPrefsSynced_ = false;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/events/EditorSplitEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/events/EditorSplitEvent.java
@@ -1,0 +1,63 @@
+/*
+ * EditorSplitEvent.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class EditorSplitEvent extends GwtEvent<EditorSplitEvent.Handler>
+{
+   public enum EditorSplitType {
+      None, Horizontal, Vertical
+   }
+   
+   public EditorSplitEvent()
+   {
+      split_ = EditorSplitType.Horizontal;
+   }
+   
+   public EditorSplitEvent(EditorSplitType split)
+   {
+      split_ = split;
+   }
+   
+   public EditorSplitType getSplitType()
+   {
+      return split_;
+   }
+   
+   private final EditorSplitType split_;
+   
+   // Boilerplate ----
+   
+   public interface Handler extends EventHandler
+   {
+      void onEditorSplit(EditorSplitEvent event);
+   }
+   
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onEditorSplit(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}


### PR DESCRIPTION
This is of course not ready for merge, but I was pleasantly surprised at how smoothly the mockup came together... This is a quick example of editor splitting (for multiple views on the same file):

![editor-split](https://cloud.githubusercontent.com/assets/1976582/9697128/ce51d61c-5335-11e5-8bf5-efeaa534ecf5.gif)

There's a lot of work needed to take this over the finish line, though:

- [ ] Attach completion previewer to split editors,
- [ ] Ensure that various navigation commands work properly when a split editor is open,
- [ ] Double-check that this works cross-browser and nothing 'funky' happens in 'split editor' mode regarding the view,
- [ ] Add a 'splitter' to enable resizing of the editors,
- [ ] And more to be discovered...