### PR TITLE
Avoid hardcoding the path to bash.

### DIFF
--- a/dependencies/common/install-boost
+++ b/dependencies/common/install-boost
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # install-boost

--- a/dependencies/common/install-cef
+++ b/dependencies/common/install-cef
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # install-cef

--- a/dependencies/common/install-common
+++ b/dependencies/common/install-common
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # install-common

--- a/dependencies/common/install-dictionaries
+++ b/dependencies/common/install-dictionaries
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # install-dictionaries

--- a/dependencies/common/install-gwt
+++ b/dependencies/common/install-gwt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # install-gwt

--- a/dependencies/common/install-libclang
+++ b/dependencies/common/install-libclang
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # install-libclang

--- a/dependencies/common/install-mathjax
+++ b/dependencies/common/install-mathjax
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # install-mathjax

--- a/dependencies/common/install-packages
+++ b/dependencies/common/install-packages
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # install-packages

--- a/dependencies/common/install-pandoc
+++ b/dependencies/common/install-pandoc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # install-pandoc

--- a/dependencies/common/update-mathjax.sh
+++ b/dependencies/common/update-mathjax.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # update-pandoc

--- a/dependencies/common/update-pandoc
+++ b/dependencies/common/update-pandoc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # update-pandoc

--- a/dependencies/linux/install-boost
+++ b/dependencies/linux/install-boost
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # install-boost

--- a/dependencies/linux/install-dependencies-debian
+++ b/dependencies/linux/install-dependencies-debian
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # install-dependencies-debian

--- a/dependencies/linux/install-dependencies-yum
+++ b/dependencies/linux/install-dependencies-yum
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # install-dependencies-yum

--- a/dependencies/linux/install-dependencies-zypper
+++ b/dependencies/linux/install-dependencies-zypper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # install-dependencies-zypper

--- a/dependencies/linux/install-qt-sdk
+++ b/dependencies/linux/install-qt-sdk
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # install-qt-sdk

--- a/dependencies/osx/install-dependencies-osx
+++ b/dependencies/osx/install-dependencies-osx
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # install-dependencies-osx

--- a/dependencies/tools/prune-mathjax
+++ b/dependencies/tools/prune-mathjax
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # prune-mathjax

--- a/dependencies/tools/sync-hunspell-dictionaries
+++ b/dependencies/tools/sync-hunspell-dictionaries
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # sync-hunspell-dictionaries

--- a/package/linux/fix-debian-permissions
+++ b/package/linux/fix-debian-permissions
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # create directory to host uncompressed dpkg
 mkdir tmp_deb

--- a/package/linux/install-dependencies
+++ b/package/linux/install-dependencies
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/package/linux/make-desktop-package
+++ b/package/linux/make-desktop-package
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/package/linux/make-server-package
+++ b/package/linux/make-server-package
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/src/cpp/core/dev/coredev-profile.in
+++ b/src/cpp/core/dev/coredev-profile.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # coredev-profile

--- a/src/cpp/desktop/rstudio-backtrace.sh.in
+++ b/src/cpp/desktop/rstudio-backtrace.sh.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # check if rstudio is already running
 PIDOF_RSTUDIO=`pidof rstudio`

--- a/src/cpp/rdesktop-dev.in
+++ b/src/cpp/rdesktop-dev.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # rdesktop-dev

--- a/src/cpp/rserver-dev.in
+++ b/src/cpp/rserver-dev.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # rserver-dev

--- a/src/cpp/rserver-test.in
+++ b/src/cpp/rserver-test.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # rserver-test

--- a/src/cpp/rstudio-dev.in
+++ b/src/cpp/rstudio-dev.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # rstudio-dev

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -760,7 +760,8 @@ Error startShellDialog(const json::JsonRpcRequest& request,
    options.environment = shellEnv;
 
    // configure bash command
-   core::shell_utils::ShellCommand bashCommand("/bin/bash");
+   core::shell_utils::ShellCommand bashCommand("/usr/bin/env");
+   bashCommand << "bash";
    bashCommand << "--norc";
 
    // run process

--- a/src/cpp/session/postback/askpass-passthrough
+++ b/src/cpp/session/postback/askpass-passthrough
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # askpass-passthrough

--- a/src/cpp/session/postback/rpostback-askpass
+++ b/src/cpp/session/postback/rpostback-askpass
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # rpostback-askpass

--- a/src/cpp/session/postback/rpostback-editfile
+++ b/src/cpp/session/postback/rpostback-editfile
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # rpostback-editfile

--- a/src/cpp/session/postback/rpostback-gitssh
+++ b/src/cpp/session/postback/rpostback-gitssh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # rpostback-gitssh

--- a/src/cpp/session/postback/rpostback-pdfviewer
+++ b/src/cpp/session/postback/rpostback-pdfviewer
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # rpostback-pdfviewer

--- a/src/cpp/session/r-ldpath.in
+++ b/src/cpp/session/r-ldpath.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # r-ldpath

--- a/src/cpp/tools/extract-rstudio_boost
+++ b/src/cpp/tools/extract-rstudio_boost
@@ -1,5 +1,5 @@
 
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/src/gwt/tools/sync-pdfjs
+++ b/src/gwt/tools/sync-pdfjs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/src/gwt/tools/update-rsa-js
+++ b/src/gwt/tools/update-rsa-js
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # update-rsa-js


### PR DESCRIPTION
This improves portability to systems without /bin/bash installed by default (e.g., FreeBSD). Ideally we would just use /bin/sh, since most of the scripts don't seem to use anything bash-specific.
