### PR TITLE
only check file size for regular files

### DIFF
--- a/src/cpp/core/FilePath.cpp
+++ b/src/cpp/core/FilePath.cpp
@@ -328,7 +328,7 @@ uintmax_t FilePath::size() const
 {
    try
    {
-      if (!exists())
+      if (!exists() || !boost::filesystem::is_regular_file(pImpl_->path))
          return 0;
       else
          return boost::filesystem::file_size(pImpl_->path) ;


### PR DESCRIPTION
Under Linux, Rstudio tries to check size of non regular files, such as socket files in `/tmp`. This very simple check avoid unnecessary warnings in log files.