### PR TITLE
various tweaks to pane menus

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
@@ -176,6 +176,8 @@ public class GlobalToolbar extends Toolbar
       
       paneLayoutMenu.addItem(commands_.layoutEndZoom().createMenuItem(false));
       paneLayoutMenu.addSeparator();
+      paneLayoutMenu.addItem(commands_.paneLayout().createMenuItem(false));
+      paneLayoutMenu.addSeparator();
       paneLayoutMenu.addItem(commands_.layoutZoomSource().createMenuItem(false));
       paneLayoutMenu.addItem(commands_.layoutZoomConsole().createMenuItem(false));
       paneLayoutMenu.addItem(commands_.layoutZoomHelp().createMenuItem(false));
@@ -194,7 +196,7 @@ public class GlobalToolbar extends Toolbar
             null,
             paneLayoutIcon,
             paneLayoutMenu);
-      paneLayoutButton.setTitle("Pane Layout");
+      paneLayoutButton.setTitle("Workspace Panes");
       
       addLeftWidget(paneLayoutButton);
       // project popup menu

--- a/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
@@ -159,6 +159,8 @@ public class Projects implements OpenProjectFileHandler,
             {
                commands.activateVcs().setMenuLabel(
                                     "Show _" + sessionInfo.getVcsName());
+               commands.layoutZoomVcs().setMenuLabel(
+                                    "Zoom _" + sessionInfo.getVcsName());
                
                // customize for svn if necessary
                if (sessionInfo.getVcsName().equals(VCSConstants.SVN_ID))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -217,8 +217,10 @@ well as menu structures (for main menu and popup menus).
          
          <separator/>
          
-         <menu label="Pane Layout">
+         <menu label="P_anes">
             <cmd refid="layoutEndZoom"/>
+            <separator/>
+            <cmd refid="paneLayout"/>
             <separator/>
             <cmd refid="layoutZoomSource"/>
             <cmd refid="layoutZoomConsole"/>
@@ -258,8 +260,8 @@ well as menu structures (for main menu and popup menus).
          <cmd refid="activatePlots"/>
          <cmd refid="activatePackages"/>
          <cmd refid="activateEnvironment"/>
-         <cmd refid="activateVcs"/>
          <cmd refid="activateViewer"/>
+         <cmd refid="activateVcs"/>
          <cmd refid="activateBuild"/>
          
          <separator/>
@@ -986,7 +988,7 @@ well as menu structures (for main menu and popup menus).
         
    <cmd id="activatePackages"
         label="Show Packages Pane"
-        menuLabel="Show P_ackages"
+        menuLabel="Show Pac_kages"
         windowMode="main"/>
         
    <cmd id="activateHelp"
@@ -1005,7 +1007,9 @@ well as menu structures (for main menu and popup menus).
         windowMode="main"/>
         
    <cmd id="activateViewer"
-        label="Show Viewer"/>
+        label="Show Viewer Pane"
+        menuLabel="Show Vie_wer"
+        windowMode="main"/>
         
    <cmd id="activatePresentation"
         label="Show Presentation Pane"
@@ -1015,66 +1019,68 @@ well as menu structures (for main menu and popup menus).
         
    <cmd id="layoutZoomSource"
         checkable="true"
-        label="Zoom Source"/>
+        label="Zoom Source"
+        menuLabel="Zoom Sou_rce"/>
         
    <cmd id="layoutZoomConsole"
         checkable="true"
         label="Zoom Console"
+        menuLabel="Zoom _Console"
         windowMode="main"/>
         
    <cmd id="layoutZoomEnvironment"
         checkable="true"
         label="Zoom Environment"
-        windowMode="main"/>
-        
-   <cmd id="layoutZoomData"
-        checkable="true"
-        label="Zoom Data"
+        menuLabel="Zoom _Environment"
         windowMode="main"/>
         
    <cmd id="layoutZoomHistory"
         checkable="true"
         label="Zoom History"
+        menuLabel="Zoom Histor_y"
         windowMode="main"/>
         
    <cmd id="layoutZoomFiles"
         checkable="true"
         label="Zoom Files"
+        menuLabel="Zoom F_iles"
         windowMode="main"/>
         
    <cmd id="layoutZoomPlots"
         checkable="true"
         label="Zoom Plots"
+        menuLabel="Zoom Pl_ots"
         windowMode="main"/>
         
    <cmd id="layoutZoomPackages"
         checkable="true"
         label="Zoom Packages"
+        menuLabel="Zoom P_ackages"
         windowMode="main"/>
         
    <cmd id="layoutZoomHelp"
         checkable="true"
         label="Zoom Help"
+        menuLabel="Zoom _Help"
         windowMode="main"/>
         
    <cmd id="layoutZoomVcs"
         checkable="true"
         label="Zoom VCS"
+        menuLabel="Zoom VCS"
         windowMode="main"/>
         
    <cmd id="layoutZoomBuild"
         checkable="true"
         label="Zoom Build"
+        menuLabel="Zoom _Build"
         windowMode="main"/>
-        
-   <cmd id="layoutZoomPresentation"
-        checkable="true"
-        label="Zoom Presentation"
-        windowMode="main"/>
-        
+               
    <cmd id="layoutZoomViewer"
         checkable="true"
-        label="Zoom Viewer"/>
+        label="Zoom Viewer"
+        menuLabel="Zoom Vie_wer"
+        windowMode="main"/>
         
    <cmd id="layoutZoomCurrentPane"
         checkable="true"
@@ -1082,7 +1088,13 @@ well as menu structures (for main menu and popup menus).
 
    <cmd id="layoutEndZoom"
         checkable="true"
-        label="Show All Panes"/>
+        label="Show All Panes"
+        menuLabel="_Show All Panes"
+        windowMode="main"/>
+        
+   <cmd id="paneLayout"
+        menuLabel="Pane Layo_ut..."
+        windowMode="main"/>     
         
    <cmd id="jumpTo"
         label="Jump To..."

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -215,7 +215,6 @@ public abstract class
    public abstract AppCommand presentationViewInBrowser();
    public abstract AppCommand presentationSaveAsStandalone();
    public abstract AppCommand activatePresentation();
-   public abstract AppCommand layoutZoomPresentation();
    public abstract AppCommand tutorialFeedback();
    public abstract AppCommand clearPresentationCache();
    
@@ -430,6 +429,7 @@ public abstract class
    public abstract AppCommand checkSpelling();   
    public abstract AppCommand layoutZoomCurrentPane();
    public abstract AppCommand layoutEndZoom();
+   public abstract AppCommand paneLayout();
    public abstract AppCommand maximizeConsole();
    
    public static final String KEYBINDINGS_PATH =

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -59,6 +59,7 @@ import org.rstudio.studio.client.workbench.model.WorkbenchServerOperations;
 import org.rstudio.studio.client.workbench.model.helper.IntStateValue;
 import org.rstudio.studio.client.workbench.model.helper.JSObjectStateValue;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
+import org.rstudio.studio.client.workbench.prefs.views.PaneLayoutPreferencesPane;
 import org.rstudio.studio.client.workbench.views.console.ConsoleInterruptButton;
 import org.rstudio.studio.client.workbench.views.console.ConsolePane;
 import org.rstudio.studio.client.workbench.views.output.find.FindOutputTab;
@@ -219,7 +220,8 @@ public class PaneManager
                       @Named("R Markdown") final WorkbenchTab renderRmdTab,
                       @Named("Deploy") final WorkbenchTab deployContentTab,
                       final MarkersOutputTab markersTab,
-                      final FindOutputTab findOutputTab)
+                      final FindOutputTab findOutputTab,
+                      OptionsLoader.Shim optionsLoader)
    {
       eventBus_ = eventBus;
       session_ = session;
@@ -243,6 +245,7 @@ public class PaneManager
       renderRmdTab_ = renderRmdTab;
       deployContentTab_ = deployContentTab;
       markersTab_ = markersTab;
+      optionsLoader_ = optionsLoader;
       
       binder.bind(commands, this);
       
@@ -422,6 +425,12 @@ public class PaneManager
    public void onLayoutEndZoom()
    {
       restoreLayout();
+   }
+   
+   @Handler
+   public void onPaneLayout()
+   {
+      optionsLoader_.showOptions(PaneLayoutPreferencesPane.class);
    }
    
    private <T> boolean equals(T lhs, T rhs)
@@ -960,7 +969,6 @@ public class PaneManager
       case History:      return commands_.layoutZoomHistory();
       case Packages:     return commands_.layoutZoomPackages();
       case Plots:        return commands_.layoutZoomPlots();
-      case Presentation: return commands_.layoutZoomPresentation();
       case Source:       return commands_.layoutZoomSource();
       case VCS:          return commands_.layoutZoomVcs();
       case Viewer:       return commands_.layoutZoomViewer();
@@ -991,7 +999,6 @@ public class PaneManager
       commands.add(commands_.layoutZoomHistory());
       commands.add(commands_.layoutZoomPackages());
       commands.add(commands_.layoutZoomPlots());
-      commands.add(commands_.layoutZoomPresentation());
       commands.add(commands_.layoutZoomSource());
       commands.add(commands_.layoutZoomVcs());
       commands.add(commands_.layoutZoomViewer());
@@ -1021,6 +1028,7 @@ public class PaneManager
    private final WorkbenchTab renderRmdTab_;
    private final WorkbenchTab deployContentTab_;
    private final MarkersOutputTab markersTab_;
+   private final OptionsLoader.Shim optionsLoader_;
    private MainSplitPanel panel_;
    private LogicalWindow sourceLogicalWindow_;
    private final HashMap<Tab, WorkbenchTabPanel> tabToPanel_ =

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchScreen.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchScreen.java
@@ -356,8 +356,6 @@ public class WorkbenchScreen extends Composite
    @Handler
    void onLayoutZoomBuild() { paneManager_.zoomTab(Tab.Build); }
    @Handler
-   void onLayoutZoomPresentation() { paneManager_.zoomTab(Tab.Presentation); }
-   @Handler
    void onLayoutZoomViewer() { paneManager_.zoomTab(Tab.Viewer); }
 
    @Handler


### PR DESCRIPTION
A few tweaks:

- Add a "Pane Layout" menu item that opens the Prefs dialog with Pane Layout selected
- Moved the Viewer above Build and Vcs in the menus (so numeric-based shortcuts were contiguous e.g. Ctrl+8, Ctrl+9 then Ctrl+F1)
- Dynamically set the title of the Zoom VCS menu to Zoom Git or Zoom SVN as appropriate
- Remove the Zoom Presentation command (it has it's own internal zooming meant to be invoked from the pane directly)
- Added mnemonic for all Zoom menus

There's one question I have remaining based on editing the Commands.xml file, have we used windowWode="main" on all of the zoom / pane layout commands that we shoudl?
