### PR TITLE
enable multiple bindings to same command

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/ApplicationCommandManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ApplicationCommandManager.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.core.client.command;
 
+import java.util.List;
+
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.command.EditorCommandManager.EditorKeyBindings;
 import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
@@ -102,8 +104,9 @@ public class ApplicationCommandManager
                   continue;
                }
                
-               KeySequence keys = bindings.get(commandId).getKeyBinding();
-               shortcuts_.addCustomBinding(keys, command);
+               List<KeySequence> keyList = bindings.get(commandId).getKeyBindings();
+               for (KeySequence keys : keyList)
+                  shortcuts_.addCustomBinding(keys, command);
             }
             
             if (afterLoad != null)

--- a/src/gwt/src/org/rstudio/core/client/command/EditorCommandManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/EditorCommandManager.java
@@ -14,10 +14,16 @@
  */
 package org.rstudio.core.client.command;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
 import org.rstudio.core.client.files.FileBacked;
 import org.rstudio.core.client.js.JsObject;
+import org.rstudio.core.client.js.JsUtil;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.AddEditorCommandEvent;
 import org.rstudio.studio.client.application.events.EventBus;
@@ -30,6 +36,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.events.Edit
 
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.user.client.Command;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -61,14 +68,30 @@ public class EditorCommandManager
    {
       protected EditorKeyBinding() {}
       
-      public final KeySequence getKeyBinding()
+      public final List<KeySequence> getKeyBindings()
       {
-         return KeySequence.fromShortcutString(getBindingString());
+         JsArrayString bindings = getBindingsInternal();
+         Set<KeySequence> keys = new HashSet<KeySequence>();
+         for (String binding : JsUtil.asIterable(bindings))
+         {
+            String[] splat = binding.split("\\|");
+            for (String item : splat)
+            {
+               keys.add(KeySequence.fromShortcutString(item));
+            }
+         }
+         
+         List<KeySequence> keyList = new ArrayList<KeySequence>();
+         keyList.addAll(keys);
+         return keyList;
       }
       
-      private final native String getBindingString()
+      private final native JsArrayString getBindingsInternal()
       /*-{
-         return this;
+         var result = this;
+         if (typeof result === "string")
+            result = [result];
+         return result;
       }-*/;
    }
    
@@ -117,10 +140,10 @@ public class EditorCommandManager
       return manager_.hasPrefix(keys);
    }
    
-   public void rebindCommand(String id, KeySequence keySequence)
+   public void rebindCommand(String id, List<KeySequence> keys)
    {
-      manager_.rebindCommand(id, keySequence);
-      events_.fireEvent(new AddEditorCommandEvent(id, keySequence, true));
+      manager_.rebindCommand(id, keys);
+      events_.fireEvent(new AddEditorCommandEvent(id, keys, true));
    }
    
    public void addBindingsAndSave(final EditorKeyBindings newBindings)
@@ -158,9 +181,10 @@ public class EditorCommandManager
             for (String commandName : bindings.iterableKeys())
             {
                EditorKeyBinding binding = bindings.get(commandName);
+               
                rebindCommand(
                      commandName,
-                     binding.getKeyBinding());
+                     binding.getKeyBindings());
                
                if (afterLoad != null)
                   afterLoad.execute();

--- a/src/gwt/src/org/rstudio/core/client/command/EditorCommandManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/EditorCommandManager.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
 import org.rstudio.core.client.files.FileBacked;
 import org.rstudio.core.client.js.JsObject;
@@ -56,9 +57,13 @@ public class EditorCommandManager
          return getObject(key).cast();
       }
       
-      public final void setBinding(String key, KeySequence binding)
+      public final void setBindings(String key, List<KeySequence> ksList)
       {
-         setString(key,  binding.toString());
+         List<String> bindings = new ArrayList<String>();
+         for (KeySequence ks : ksList)
+            bindings.add(ks.toString());
+         
+         setString(key, StringUtil.join(bindings, "|"));
       }
       
       protected EditorKeyBindings() {}

--- a/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
@@ -403,20 +403,25 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
       for (Map.Entry<CommandBinding, CommandBinding> entry : changes_.entrySet())
       {
          CommandBinding newBinding = entry.getValue();
+         String id = newBinding.getId();
          
+         // Get all commands with this ID.
+         List<CommandBinding> bindingsWithId = new ArrayList<CommandBinding>();
+         for (CommandBinding binding : originalBindings_)
+            if (binding.getId().equals(id))
+               bindingsWithId.add(binding);
+         
+         // Collect all shortcuts.
+         List<KeySequence> keys = new ArrayList<KeySequence>();
+         for (CommandBinding binding : bindingsWithId)
+            keys.add(binding.getKeySequence());
+            
          int commandType = newBinding.getCommandType();
+         
          if (commandType == CommandBinding.TYPE_RSTUDIO_COMMAND)
-         {
-            appBindings.setBinding(
-                  newBinding.getId(),
-                  newBinding.getKeySequence());
-         }
+            appBindings.setBindings(id, keys);
          else if (commandType == CommandBinding.TYPE_EDITOR_COMMAND)
-         {
-            editorBindings.setBinding(
-                  newBinding.getId(),
-                  newBinding.getKeySequence());
-         }
+            editorBindings.setBindings(id, keys);
       }
       
       appCommands_.addBindingsAndSave(appBindings);

--- a/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
@@ -971,15 +971,21 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
 
                String id = command.getId();
                String name = getAppCommandName(command);
-               
-               KeySequence keySequence = customBindings.hasKey(id) ?
-                     customBindings.get(id).getKeyBinding() :
-                     command.getKeySequence();
-                     
                int type = CommandBinding.TYPE_RSTUDIO_COMMAND;
                boolean isCustom = customBindings.hasKey(id);
-               bindings.add(new CommandBinding(id, name, keySequence, type, isCustom,
-                     command.getContext()));
+               
+               List<KeySequence> keySequences = new ArrayList<KeySequence>();
+               if (isCustom)
+                  keySequences = customBindings.get(id).getKeyBindings();
+               else
+                  keySequences.add(command.getKeySequence());
+                     
+               for (KeySequence keys : keySequences)
+               {
+                  CommandBinding binding = new CommandBinding(
+                        id, name, keys, type, isCustom, command.getContext());
+                  bindings.add(binding);
+               }
             }
             
             Collections.sort(bindings, new Comparator<CommandBinding>()

--- a/src/gwt/src/org/rstudio/studio/client/application/events/AddEditorCommandEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/AddEditorCommandEvent.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.studio.client.application.events;
 
+import java.util.List;
+
 import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
 
 import com.google.gwt.event.shared.EventHandler;
@@ -26,7 +28,7 @@ public class AddEditorCommandEvent extends GwtEvent<AddEditorCommandEvent.Handle
       void onAddEditorCommand(AddEditorCommandEvent event);
    }
 
-   public AddEditorCommandEvent(String id, KeySequence keys, boolean replace)
+   public AddEditorCommandEvent(String id, List<KeySequence> keys, boolean replace)
    {
       id_ = id;
       keys_ = keys;
@@ -34,11 +36,11 @@ public class AddEditorCommandEvent extends GwtEvent<AddEditorCommandEvent.Handle
    }
    
    public String getId() { return id_; }
-   public KeySequence getKeySequence() { return keys_; }
+   public List<KeySequence> getKeySequences() { return keys_; }
    public boolean replaceOldBindings() { return replace_; }
    
    private final String id_;
-   private final KeySequence keys_;
+   private final List<KeySequence> keys_;
    private final boolean replace_;
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.text;
 
+import java.util.List;
+
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.JsArrayString;
@@ -419,7 +421,7 @@ public class AceEditor implements DocDisplay,
       return getWidget().getEditor().getCommandManager();
    }
    
-   public void addEditorCommandBinding(String id, KeySequence keys, boolean replace)
+   public void addEditorCommandBinding(String id, List<KeySequence> keys, boolean replace)
    {
       getWidget().getEditor().getCommandManager().rebindCommand(id, keys);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.text;
 
+import java.util.List;
+
 import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
 import org.rstudio.core.client.js.JsMap;
 import org.rstudio.studio.client.common.debugging.model.Breakpoint;
@@ -178,7 +180,7 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    void toggleCommentLines();
    
    AceCommandManager getCommandManager();
-   void addEditorCommandBinding(String id, KeySequence keys, boolean replace);
+   void addEditorCommandBinding(String id, List<KeySequence> keys, boolean replace);
    void resetCommands();
 
    HandlerRegistration addEditorFocusHandler(FocusHandler handler);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -716,7 +716,7 @@ public class TextEditingTarget implements
                {
                   getDocDisplay().addEditorCommandBinding(
                         event.getId(),
-                        event.getKeySequence(),
+                        event.getKeySequences(),
                         event.replaceOldBindings());
                }
             });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceCommandManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceCommandManager.java
@@ -1,5 +1,7 @@
 package org.rstudio.studio.client.workbench.views.source.editors.text.ace;
 
+import java.util.List;
+
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.JsArrayString;
@@ -133,12 +135,15 @@ public class AceCommandManager extends JavaScriptObject
       return binding != null && binding === "chainKeys";
    }-*/;
    
-   public final void rebindCommand(String id, KeySequence keys)
+   public final void rebindCommand(String id, List<KeySequence> keys)
    {
-      rebindCommand(id, toAceStyleShortcutString(keys));
+      JsArrayString shortcuts = JavaScriptObject.createArray().cast();
+      for (KeySequence ks : keys)
+         shortcuts.push(toAceStyleShortcutString(ks));
+      rebindCommand(id, shortcuts);
    }
    
-   private final native void rebindCommand(String id, String keys)
+   private final native void rebindCommand(String id, JsArrayString keys)
    /*-{
       var command = this.byName[id];
       
@@ -157,9 +162,28 @@ public class AceCommandManager extends JavaScriptObject
          }
       }
       
-      newCommand.bindKey = keys;
+      newCommand.bindKey = keys.join("|");
       newCommand.isCustom = true;
+      
       this.addCommand(newCommand);
+      
+      // Refresh the 'chainKeys' fields. This is necessary
+      // to ensure that Ace can dispatch to commands requiring
+      // multiple key combinations.
+      for (var i = 0; i < keys.length; i++) {
+         var keySequence = keys[i];
+         var splat = keySequence.split(" ");
+         if (splat.length <= 1)
+            continue;
+         
+         var field = splat[0];
+         this.commandKeyBinding[field] = "chainKeys";
+         for (var j = 1; j < splat.length - 1; j++) {
+            field += " " + splat[i];
+            this.commandKeyBinding[field] = "chainKeys";
+         }
+      }
+      
    }-*/;
    
    public final native void addCommand(AceCommand command) /*-{


### PR DESCRIPTION
This PR allows us to bind multiple key sequences to the same command. This is enabled the following way:

1. We have the notion that a particular command id is bound to an array (list) of key sequences, rather than a single key sequence,

2. The array of key sequences is serialized as a single string, with each key sequence being delimited by a single `|`,

3. When a particular keybinding is modified in the keyboard shortcut widget, all keybindings currently available for that command are serialized (rather than just the single, modified binding)

One final piece that we might want to include for the keyboard shortcut widget is the notion of 'duplicating' a command binding, so that we might map a particular RStudio AppCommand to multiple key sequences (rather than just enabling this for Ace bindings).