### PR TITLE
expand initial .Rbuildignore to factor in new CRAN checks.

### DIFF
--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -229,14 +229,16 @@ void ProjectContext::augmentRbuildignore()
       // constants
       const char * const kIgnoreRproj = "^.*\\.Rproj$";
       const char * const kIgnoreRprojUser = "^\\.Rproj\\.user$";
-
+      const char * const kIgnoreSrcFile = "^.*\.o$";
+      const std::string newLine = "\n";
+      
       // create the file if it doesn't exists
       FilePath rbuildIgnorePath = directory().childPath(".Rbuildignore");
       if (!rbuildIgnorePath.exists())
       {
          Error error = writeStringToFile(rbuildIgnorePath,
-                                         kIgnoreRproj + std::string("\n") +
-                                         kIgnoreRprojUser + std::string("\n"),
+                                         kIgnoreRproj + newLine +
+                                         kIgnoreRprojUser + newLine,
                                          string_utils::LineEndingNative);
          if (error)
             LOG_ERROR(error);
@@ -261,19 +263,22 @@ void ProjectContext::augmentRbuildignore()
          // for previous less precisely specified .Rproj entries
          bool hasRProj = strIgnore.find("\\.Rproj$") != std::string::npos;
          bool hasRProjUser = strIgnore.find(kIgnoreRprojUser) != std::string::npos;
+         bool ignoresSrcFiles = strIgnore.find(kIgnoreSrcFile) != std::string::npos;
 
-         if (hasRProj && hasRProjUser)
+         if (hasRProj && hasRProjUser && ignoresSrcFiles)
             return;
 
          bool addExtraNewline = strIgnore.size() > 0
                                 && strIgnore[strIgnore.size() - 1] != '\n';
 
          if (addExtraNewline)
-            strIgnore += "\n";
+            strIgnore += newLine;
          if (!hasRProj)
-            strIgnore += kIgnoreRproj + std::string("\n");
+            strIgnore += kIgnoreRproj + newLine;
          if (!hasRProjUser)
-            strIgnore += kIgnoreRprojUser + std::string("\n");
+            strIgnore += kIgnoreRprojUser + newLine;
+         if(!ignoresSrcFiles)
+            strIgnore += kIgnoreSrcFile + newLine;
          error = core::writeStringToFile(rbuildIgnorePath,
                                          strIgnore,
                                          string_utils::LineEndingNative);

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -229,7 +229,7 @@ void ProjectContext::augmentRbuildignore()
       // constants
       const char * const kIgnoreRproj = "^.*\\.Rproj$";
       const char * const kIgnoreRprojUser = "^\\.Rproj\\.user$";
-      const char * const kIgnoreSrcFile = "^.*\.o$";
+      const char * const kIgnoreSrcFile = "^.*\\.o$";
       const std::string newLine = "\n";
       
       // create the file if it doesn't exists


### PR DESCRIPTION
New CRAN checks warn loudly if there are .o files included in the checked code, which is fairly standard with any R package involving Rcpp. This patch automatically adds .o files to the .Rbuildignore created with a new project (since making sure those are ignored everywhere is just generally good practice).

(In addition it creates a const string called newLine which contains, well, a newLine, because you are converting that from an inline char to a string a good five or six times in that function)