### PR TITLE
minor tweaks to rserver so we can run multiple rservers (eg for different versions of R)

### DIFF
--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -1363,6 +1363,7 @@ Error launchChildProcess(std::string path,
       copyEnvironmentVar("PATH", &env);
       copyEnvironmentVar("MANPATH", &env);
       copyEnvironmentVar("LANG", &env);
+      copyEnvironmentVar("TMPDIR", &env);
       core::system::setenv(&env, "USER", user.username);
       core::system::setenv(&env, "LOGNAME", user.username);
       core::system::setenv(&env, "HOME", user.homeDirectory);

--- a/src/cpp/server/ServerPAMAuth.cpp
+++ b/src/cpp/server/ServerPAMAuth.cpp
@@ -84,6 +84,12 @@ const char * const kFormAction = "formAction";
 
 const char * const kStaySignedInDisplay = "staySignedInDisplay";
 
+std::string cookieName()
+{
+    std::string name = std::string(kUserId) + "-" + server::options().wwwPort();
+    return name;
+}
+
 
 std::string applicationURL(const http::Request& request,
                            const std::string& path = std::string())
@@ -121,7 +127,7 @@ std::string getUserIdentifier(const core::http::Request& request)
    if (server::options().authNone())
       return core::system::username();
    else
-      return auth::secure_cookie::readSecureCookie(request, kUserId);
+      return auth::secure_cookie::readSecureCookie(request, cookieName());
 }
 
 std::string userIdentifierToLocalUsername(const std::string& userIdentifier)
@@ -167,7 +173,7 @@ void signIn(const http::Request& request,
             http::Response* pResponse)
 {
    auth::secure_cookie::remove(request,
-                               kUserId,
+                               cookieName(),
                                "/",
                                pResponse);
 
@@ -221,7 +227,7 @@ void setSignInCookies(const core::http::Request& request,
    else
       expiry = boost::none;
 
-   auth::secure_cookie::set(kUserId,
+   auth::secure_cookie::set(cookieName(),
                             username,
                             request,
                             boost::posix_time::time_duration(24*staySignedInDays,
@@ -338,7 +344,7 @@ void signOut(const http::Request& request,
    }
 
    auth::secure_cookie::remove(request,
-                               kUserId,
+                               cookieName(),
                                "/",
                                pResponse);
 

--- a/src/cpp/session/include/session/SessionLocalStreams.hpp
+++ b/src/cpp/session/include/session/SessionLocalStreams.hpp
@@ -17,6 +17,7 @@
 #define SESSION_SESSION_LOCAL_STREAMS_HPP
 
 #include <string>
+#include <stdlib.h>
 
 #include <core/Error.hpp>
 #include <core/FilePath.hpp>
@@ -24,21 +25,30 @@
 
 #include <core/http/LocalStreamSocketUtils.hpp>
 
-#define kSessionLocalStreamsDir "/tmp/rstudio-rsession"
-
 namespace rstudio {
 namespace session {
 namespace local_streams {
 
+inline const std::string getTmpDir()
+{
+    std::string dir;
+    if (getenv("TMPDIR")) {
+        dir = std::string(getenv("TMPDIR")) + "/rstudio-rsession";
+    } else {
+        dir = std::string("/tmp/rstudio-rsession");
+    }
+    return dir;
+}
+
 inline core::Error ensureStreamsDir()
 {
-   core::FilePath sessionStreamsPath(kSessionLocalStreamsDir);
+   core::FilePath sessionStreamsPath(getTmpDir());
    return core::http::initializeStreamDir(sessionStreamsPath);
 }
    
 inline core::FilePath streamPath(const std::string& file)
 {
-   core::FilePath path = core::FilePath(kSessionLocalStreamsDir).complete(file);
+   core::FilePath path = core::FilePath(getTmpDir()).complete(file);
    core::Error error = core::http::initializeStreamDir(path.parent());
    if (error)
       LOG_ERROR(error);


### PR DESCRIPTION
we have multiple desktop users who connect to our more powerful workstations/servers to run R; when we tried having multiple R-Studio servers it didn't work since they all tried talking over /tmp/rstudio-rsession/$username socket and connect to the first rsession that the user had created.

1. use $TMPDIR in unix socket path & preserve when forking for rsession, so we can have multiple rservers running on the same host.

2. use port number in cookie name, so we can connect to multiple rservers on the same host

So now we can successfully run multiple rservers with different --rsession-which-r and -www-port settings, as long as we give each one a different TMPDIR when starting.

[I also encountered another problem where the rserver was linked with -Wl,--rpath=/usr/lib/R/lib so trying to run multiple servers with different versions of R initially didn't work until we figured that out and removed it - I couldn't easily figure out where in the configure/CMake setup this argument came from]