### PR TITLE
enable 'execute current function' in more R docs

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -294,12 +294,20 @@ public class TextFileType extends EditableFileType
       results.add(commands.goToLine());
       results.add(commands.expandSelection());
       results.add(commands.shrinkSelection());
+      
       if (canExecuteCode() || isC())
       {
          results.add(commands.reindent());
          results.add(commands.showDiagnosticsActiveDocument());
       }
-      if (canExecuteCode()) {
+      
+      if (canExecuteCode() && !isC())
+      {
+         results.add(commands.executeCurrentFunction());
+      }
+      
+      if (canExecuteCode())
+      {
          results.add(commands.executeCode());
          results.add(commands.executeCodeWithoutFocus());
          results.add(commands.executeLastCode());
@@ -310,6 +318,7 @@ public class TextFileType extends EditableFileType
          results.add(commands.reformatCode());
          results.add(commands.renameInFile());
       }
+      
       if (canExecuteAllCode())
       {
          results.add(commands.executeAllCode());
@@ -319,11 +328,11 @@ public class TextFileType extends EditableFileType
          if (!canExecuteChunks())
             results.add(commands.sourceActiveDocumentWithEcho());
       }
+      
       if (canExecuteToCurrentLine())
       {
          results.add(commands.executeToCurrentLine());
          results.add(commands.executeFromCurrentLine());
-         results.add(commands.executeCurrentFunction());
          results.add(commands.executeCurrentSection());
       }
       if (canKnitToHTML())


### PR DESCRIPTION
This PR enables 'execute current function' (`Cmd+Alt+F`) in more documents; in particular, it enables it for all documents that can execute code (other than C/C++).