### PR TITLE
re-implement yank and interact with system clipboard on desktop

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -484,6 +484,9 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="renameInFile" value="Cmd+Alt+Shift+M" />
          <shortcut refid="insertRoxygenSkeleton" value="Cmd+Shift+Alt+R" title="Insert Roxygen Skeleton" />
          <shortcut refid="insertSnippet" value="Shift+Tab" title="Insert Snippet"/>
+         <shortcut refid="yankBeforeCursor" value="Ctrl+U" disableModes="vim"/>
+         <shortcut refid="yankAfterCursor" value="Ctrl+K" disableModes="vim"/>
+         <shortcut refid="pasteLastYank" value="Ctrl+Y" disableModes="vim"/>
       </shortcutgroup>
       <shortcutgroup name="Source Navigation">
          <shortcut refid="sourceNavigateBack" value="Cmd+F9"/>
@@ -2327,6 +2330,18 @@ well as menu structures (for main menu and popup menus).
    <cmd id="pasteDummy"
         menuLabel="_Paste"
         rebindable="false"/>
+        
+   <cmd id="yankBeforeCursor"
+        label="Yank Before Cursor"
+        context="editor"/>
+   
+   <cmd id="yankAfterCursor"
+        label="Yank After Cursor"
+        context="editor"/>
+        
+   <cmd id="pasteLastYank"
+        label="Paste Last Yank"
+        context="editor"/>
         
    <cmd id="maximizeConsole"
         menuLabel="Maximize Console"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -125,6 +125,9 @@ public abstract class
    public abstract AppCommand renameInFile();
    public abstract AppCommand insertRoxygenSkeleton();
    public abstract AppCommand insertSnippet();
+   public abstract AppCommand yankBeforeCursor();
+   public abstract AppCommand yankAfterCursor();
+   public abstract AppCommand pasteLastYank();
  
    // Projects
    public abstract AppCommand newProject();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -45,7 +45,6 @@ import org.rstudio.core.client.ExternalJavaScriptLoader;
 import org.rstudio.core.client.ExternalJavaScriptLoader.Callback;
 import org.rstudio.core.client.Rectangle;
 import org.rstudio.core.client.StringUtil;
-import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.WindowEx;
@@ -75,7 +74,6 @@ import org.rstudio.studio.client.workbench.views.console.shell.assist.RCompletio
 import org.rstudio.studio.client.workbench.views.console.shell.editor.InputEditorDisplay;
 import org.rstudio.studio.client.workbench.views.console.shell.editor.InputEditorPosition;
 import org.rstudio.studio.client.workbench.views.console.shell.editor.InputEditorSelection;
-import org.rstudio.studio.client.workbench.views.console.shell.editor.InputEditorUtil;
 import org.rstudio.studio.client.workbench.views.output.lint.DiagnosticsBackgroundPopup;
 import org.rstudio.studio.client.workbench.views.output.lint.model.AceAnnotation;
 import org.rstudio.studio.client.workbench.views.output.lint.model.LintItem;
@@ -280,40 +278,6 @@ public class AceEditor implements DocDisplay,
          public void onFoldChange(FoldChangeEvent event)
          {
             AceEditor.this.fireEvent(new FoldChangeEvent());
-         }
-      });
-
-      addCapturingKeyDownHandler(new KeyDownHandler()
-      {
-         @Override
-         public void onKeyDown(KeyDownEvent event)
-         {
-            if (isVimModeOn() || isEmacsModeOn())
-               return;
-
-            int mod = KeyboardShortcut.getModifierValue(event.getNativeEvent());
-            if (mod == KeyboardShortcut.CTRL)
-            {
-               switch (event.getNativeKeyCode())
-               {
-                  case 'U':
-                     event.preventDefault();
-                     InputEditorUtil.yankBeforeCursor(AceEditor.this, true);
-                     break;
-                  case 'K':
-                     event.preventDefault();
-                     InputEditorUtil.yankAfterCursor(AceEditor.this, true);
-                     break;
-                  case 'Y':
-                     event.preventDefault();
-                     Position start = getSelectionStart();
-                     InputEditorUtil.pasteYanked(AceEditor.this);
-                     indentPastedRange(Range.fromPoints(start,
-                                                        getSelectionEnd()));
-                     break;
-               }
-            }
-
          }
       });
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -4904,6 +4904,56 @@ public class TextEditingTarget implements
       }
    }
    
+   @Handler
+   void onYankBeforeCursor()
+   {
+      Position cursorPos = docDisplay_.getCursorPosition();
+      docDisplay_.setSelectionRange(Range.fromPoints(
+            Position.create(cursorPos.getRow(), 0),
+            cursorPos));
+      
+      if (Desktop.isDesktop())
+         commands_.cutDummy().execute();
+      else
+      {
+         yankedText_ = docDisplay_.getSelectionValue();
+         docDisplay_.replaceSelection("");
+      }
+   }
+   
+   @Handler
+   void onYankAfterCursor()
+   {
+      Position cursorPos = docDisplay_.getCursorPosition();
+      int lineLength = docDisplay_.getLine(cursorPos.getRow()).length();
+      docDisplay_.setSelectionRange(Range.fromPoints(
+            cursorPos,
+            Position.create(cursorPos.getRow(), lineLength)));
+      
+      if (Desktop.isDesktop())
+         commands_.cutDummy().execute();
+      else
+      {
+         yankedText_ = docDisplay_.getSelectionValue();
+         docDisplay_.replaceSelection("");
+      }
+   }
+   
+   @Handler
+   void onPasteLastYank()
+   {
+      if (Desktop.isDesktop())
+         commands_.pasteDummy().execute();
+      else
+      {
+         if (yankedText_ == null)
+            return;
+         
+         docDisplay_.replaceSelection(yankedText_);
+         docDisplay_.setCursorPosition(docDisplay_.getSelectionEnd());
+      }
+   }
+   
    boolean useScopeTreeFolding()
    {
       return docDisplay_.hasScopeTree();
@@ -5622,6 +5672,7 @@ public class TextEditingTarget implements
    private boolean isDebugWarningVisible_ = false;
    private boolean isBreakpointWarningVisible_ = false;
    private String extendedType_;
+   private String yankedText_ = null;
 
    private abstract class RefactorServerRequestCallback
            extends ServerRequestCallback<JsArrayString>


### PR DESCRIPTION
This PR:

- implements various 'yank' commands as RStudio AppCommands (thereby making them rebindable),
- uses the system clipboard in desktop mode (browser security restrictions mean we cannot access the clipboard from arbitrary keypresses, unfortunately),
- ensures that 'yank to end' does not eat the linefeed as well.

@jjallaire, do you think it's okay for behaviour to differ between browser and desktop with respect to clipboard interaction? Or should we just have a preset 'yank' buffer for these actions always?