### PR TITLE
quote insertion surrounds selection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 * Enabled comment/uncomment (Cmd+Shift+C) for Markdown documents
 * Yank before/after (Ctrl+K, Ctrl+U) now use system clipboard on RStudio Desktop
 * Yank after cursor (Ctrl+K) no longer eats end of line character
+* Added option controlling 'surround on text insertion' behaviour
 
 ### R Markdown
 

--- a/src/gwt/acesupport/loader.js
+++ b/src/gwt/acesupport/loader.js
@@ -41,6 +41,23 @@ var RStudioEditor = function(renderer, session) {
 oop.inherits(RStudioEditor, Editor);
 
 (function() {
+
+   // Custom insert to handle enclosing of selection
+   this.insert = function(text, pasted)
+   {
+      var hasSelection = !this.session.selection.isEmpty();
+      if (hasSelection && (text === "'" || text === "\""))
+      {
+         return this.session.replace(
+            this.session.selection.getRange(),
+            text + this.session.getTextRange() + text
+         );
+      }
+
+      // Delegate to default insert implementation otherwise
+      return Editor.prototype.insert.call(this, text, pasted);
+   };
+
    this.remove = function(dir) {
       if (this.session.getMode().wrapRemove) {
          return this.session.getMode().wrapRemove(this, Editor.prototype.remove, dir);

--- a/src/gwt/acesupport/loader.js
+++ b/src/gwt/acesupport/loader.js
@@ -45,13 +45,24 @@ oop.inherits(RStudioEditor, Editor);
    // Custom insert to handle enclosing of selection
    this.insert = function(text, pasted)
    {
-      var hasSelection = !this.session.selection.isEmpty();
-      if (hasSelection && (text === "'" || text === "\""))
+      if (!this.session.selection.isEmpty())
       {
-         return this.session.replace(
-            this.session.selection.getRange(),
-            text + this.session.getTextRange() + text
-         );
+         // Read UI pref to determine what are eligible for surrounding
+         var candidates = [];
+         if (this.$surroundSelection === "quotes")
+            candidates = ["'", "\""];
+         else if (this.$surroundSelection === "quotes_and_brackets")
+            candidates = ["'", "\"", "(", "{", "["];
+
+         if (Utils.contains(candidates, text))
+         {
+            var lhs = text;
+            var rhs = Utils.getComplement(text);
+            return this.session.replace(
+               this.session.selection.getRange(),
+               lhs + this.session.getTextRange() + rhs
+            );
+         }
       }
 
       // Delegate to default insert implementation otherwise

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
@@ -189,6 +189,9 @@ public class UIPrefs extends UIPrefsAccessor implements UiPrefsChangedHandler
          allowTabMultilineCompletion().setGlobalValue(
                                  newUiPrefs.allowTabMultilineCompletion().getGlobalValue());
          
+         surroundSelection().setGlobalValue(
+                                 newUiPrefs.surroundSelection().getGlobalValue());
+         
          enableSnippets().setGlobalValue(
                                  newUiPrefs.enableSnippets().getGlobalValue());
          

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -126,6 +126,15 @@ public class UIPrefsAccessor extends Prefs
       return bool("tab_multiline_completion", false);
    }
    
+   public static final String EDITOR_SURROUND_SELECTION_NEVER               = "never";
+   public static final String EDITOR_SURROUND_SELECTION_QUOTES              = "quotes";
+   public static final String EDITOR_SURROUND_SELECTION_QUOTES_AND_BRACKETS = "quotes_and_brackets";
+   
+   public PrefValue<String> surroundSelection()
+   {
+      return string("surround_selection", EDITOR_SURROUND_SELECTION_QUOTES);
+   }
+   
    public PrefValue<Boolean> enableSnippets()
    {
       return bool("enable_snippets", true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -132,7 +132,7 @@ public class UIPrefsAccessor extends Prefs
    
    public PrefValue<String> surroundSelection()
    {
-      return string("surround_selection", EDITOR_SURROUND_SELECTION_QUOTES);
+      return string("surround_selection", EDITOR_SURROUND_SELECTION_QUOTES_AND_BRACKETS);
    }
    
    public PrefValue<Boolean> enableSnippets()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -80,7 +80,7 @@ public class EditingPreferencesPane extends PreferencesPane
             new String[] {
                   "Never",
                   "Quotes",
-                  "Quotes + Brackets"
+                  "Quotes & Brackets"
             },
             new String[] {
                   UIPrefsAccessor.EDITOR_SURROUND_SELECTION_NEVER,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -75,6 +75,23 @@ public class EditingPreferencesPane extends PreferencesPane
             prefs_.continueCommentsOnNewline(),
             "When enabled, pressing enter will continue comments on new lines. Press Shift + Enter to exit a comment."));
       
+      delimiterSurroundWidget_ = new SelectWidget(
+            "Surround selection on text insertion?",
+            new String[] {
+                  "Never",
+                  "Quotes",
+                  "Quotes + Brackets"
+            },
+            new String[] {
+                  UIPrefsAccessor.EDITOR_SURROUND_SELECTION_NEVER,
+                  UIPrefsAccessor.EDITOR_SURROUND_SELECTION_QUOTES,
+                  UIPrefsAccessor.EDITOR_SURROUND_SELECTION_QUOTES_AND_BRACKETS
+            },
+            false,
+            true,
+            false);
+      editingPanel.add(delimiterSurroundWidget_);
+      
       HorizontalPanel keyboardPanel = new HorizontalPanel();
       editorMode_ = new SelectWidget(
             "Keybindings:",
@@ -434,6 +451,7 @@ public class EditingPreferencesPane extends PreferencesPane
          editorMode_.setValue(UIPrefsAccessor.EDITOR_KEYBINDINGS_EMACS);
       else
          editorMode_.setValue(UIPrefsAccessor.EDITOR_KEYBINDINGS_DEFAULT);
+      delimiterSurroundWidget_.setValue(prefs_.surroundSelection().getValue());
       rmdViewerMode_.setValue(prefs_.rmdViewerType().getValue().toString());
    }
    
@@ -458,6 +476,8 @@ public class EditingPreferencesPane extends PreferencesPane
       prefs_.enableEmacsKeybindings().setGlobalValue(isEmacs);
       prefs_.rmdViewerType().setGlobalValue(Integer.decode(
             rmdViewerMode_.getValue()));
+      
+      prefs_.surroundSelection().setGlobalValue(delimiterSurroundWidget_.getValue());
       
       return reload;
    }
@@ -507,6 +527,7 @@ public class EditingPreferencesPane extends PreferencesPane
    private final SelectWidget showCompletionsOther_;
    private final SelectWidget editorMode_;
    private final SelectWidget rmdViewerMode_;
+   private final SelectWidget delimiterSurroundWidget_;
    private final TextBoxWithButton encoding_;
    private String encodingValue_;
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -76,7 +76,7 @@ public class EditingPreferencesPane extends PreferencesPane
             "When enabled, pressing enter will continue comments on new lines. Press Shift + Enter to exit a comment."));
       
       delimiterSurroundWidget_ = new SelectWidget(
-            "Surround selection on text insertion?",
+            "Surround selection on text insertion:",
             new String[] {
                   "Never",
                   "Quotes",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -758,9 +758,9 @@ public class RCompletionManager implements CompletionManager
          if (docDisplay_.isCursorInSingleLineString())
             return false;
          
-         // if there's a selection, let the encloser handle it
+         // if there's a selection, bail
          if (input_.hasSelection()) 
-            return CompletionUtils.handleEncloseSelection(input_, c);
+            return false;
          
          // Bail if there is an alpha-numeric character
          // following the cursor

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -936,6 +936,12 @@ public class AceEditor implements DocDisplay,
       int lastRow = getRowCount() - 1;
       return Position.create(lastRow, getLength(lastRow));
    }
+   
+   @Override
+   public void setSurroundSelectionPref(String value)
+   {
+      widget_.getEditor().setSurroundSelectionPref(value);
+   }
 
    @Override
    public InputEditorSelection createSelection(Position pos1, Position pos2)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -339,4 +339,5 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    boolean onInsertSnippet();
    
    Position getDocumentEnd();
+   void setSurroundSelectionPref(String value);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -5469,6 +5469,13 @@ public class TextEditingTarget implements
                public void execute(Boolean arg) {
                   docDisplay.forceImmediateRender();
                }}));
+      releaseOnDismiss.add(prefs.surroundSelection().bind(
+            new CommandWithArg<String>() {
+               @Override
+               public void execute(String string)
+               {
+                  docDisplay.setSurroundSelectionPref(string);
+               }}));
       
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -507,5 +507,9 @@ public class AceEditorNative extends JavaScriptObject {
       uiPrefsSynced_ = true;
    }
    
+   public final native void setSurroundSelectionPref(String value) /*-{
+      this.$surroundSelection = value;
+   }-*/;
+   
    private static boolean uiPrefsSynced_ = false;
 }


### PR DESCRIPTION
This PR changes the quote (`'`, `"`) insertion behaviour such that, if the user types a quotation character while a word is selected in the editor, the selection is then surrounded with those quotes. The primary motivation is to ensure that quote insertion for Markdown documents surrounds, instead of replaces, the selection.

Previously, this behaviour was enabled only in R modes (through the completion manager); now, it's instead enabled globally.

(Looking ahead, I think eventually the 'surround selection' stuff that's in the R completion manager will get moved to acesupport, and then enabled / toggled with a UI pref for the desired characters)