### PR TITLE
Changes required for RTools 3.3 w/ GCC 4.9

### DIFF
--- a/src/cpp/core/include/core/r_util/RToolsInfo.hpp
+++ b/src/cpp/core/include/core/r_util/RToolsInfo.hpp
@@ -47,6 +47,7 @@ public:
    std::string url(const std::string& repos) const;
    const std::string& versionPredicate() const { return versionPredicate_; }
    const FilePath& installPath() const { return installPath_; }
+   const std::vector<std::string> clangArgs() const { return clangArgs_; }
    const std::vector<FilePath>& pathEntries() const { return pathEntries_; }
    const std::vector<core::system::Option> environmentVars() const
    {
@@ -56,6 +57,7 @@ public:
 private:
    std::string name_;
    FilePath installPath_;
+   std::vector<std::string> clangArgs_;
    std::string versionPredicate_;
    std::vector<FilePath> pathEntries_;
    std::vector<core::system::Option> environmentVars_;

--- a/src/cpp/core/include/core/r_util/RToolsInfo.hpp
+++ b/src/cpp/core/include/core/r_util/RToolsInfo.hpp
@@ -34,7 +34,8 @@ class RToolsInfo
 public:
    RToolsInfo() {}
    RToolsInfo(const std::string& name,
-              const FilePath& installPath);
+              const FilePath& installPath,
+              bool usingMingwGcc49);
 
    bool empty() const { return name_.empty(); }
 
@@ -62,7 +63,7 @@ private:
 
 std::ostream& operator<<(std::ostream& os, const RToolsInfo& info);
 
-Error scanRegistryForRTools(std::vector<RToolsInfo>* pRTools);
+Error scanRegistryForRTools(bool usingMingwGcc49, std::vector<RToolsInfo>* pRTools);
 
 template <typename T>
 void prependToSystemPath(const RToolsInfo& toolsInfo, T* pTarget)

--- a/src/cpp/core/r_util/RToolsInfo.cpp
+++ b/src/cpp/core/r_util/RToolsInfo.cpp
@@ -136,14 +136,9 @@ RToolsInfo::RToolsInfo(const std::string& name,
          // set environment variables
          // TODO: work out which ones to actually set
          // TODO: figure out how these propagate into libclang compliation db
-         FilePath gcc32Path = installPath_.childPath("mingw_32/bin");
+         FilePath gccPath = installPath_.childPath("mingw_$(WIN)/bin");
          environmentVars.push_back(
-               std::make_pair("BINPREF", asRBuildPath(gcc32Path)));
-         FilePath gcc64Path = installPath_.childPath("mingw_64/bin");
-         environmentVars.push_back(
-               std::make_pair("BINPREF64", asRBuildPath(gcc64Path)));
-         environmentVars.push_back(
-               std::make_pair("RTOOLS", asRBuildPath(installPath_)));
+               std::make_pair("BINPREF", asRBuildPath(gccPath)));
       }
       else
       {

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -236,6 +236,13 @@ SEXP rs_rstudioCitation()
    }
 }
 
+SEXP rs_setUsingMingwGcc49(SEXP usingSEXP)
+{
+   bool usingMingwGcc49 = r::sexp::asLogical(usingSEXP);
+   userSettings().setUsingMingwGcc49(usingMingwGcc49);
+   return R_NilValue;
+}
+
 // ensure file hidden
 SEXP rs_ensureFileHidden(SEXP fileSEXP)
 {
@@ -2015,6 +2022,19 @@ bool isLoadBalanced()
    return !core::system::getenv(kRStudioSessionRoute).empty();
 }
 
+#ifdef _WIN32
+bool usingMingwGcc49()
+{
+   // temporarily determine this using a setting (eventually we'll want to check the
+   // R version and SVN revision number)
+   return userSettings().usingMingwGcc49();
+}
+#else
+bool usingMingwGcc49()
+{
+   return false;
+}
+#endif
 
 Error initialize()
 {
@@ -2146,6 +2166,12 @@ Error initialize()
             "rs_rstudioCitation",
             (DL_FUNC) rs_rstudioCitation,
             0);
+
+   // register rs_setUsingMingwGcc49
+   r::routines::registerCallMethod(
+            "rs_setUsingMingwGcc49",
+            (DL_FUNC)rs_setUsingMingwGcc49,
+            1);
    
    // initialize monitored scratch dir
    initializeMonitoredUserScratchDir();

--- a/src/cpp/session/SessionUserSettings.cpp
+++ b/src/cpp/session/SessionUserSettings.cpp
@@ -849,5 +849,16 @@ void UserSettings::setLintRFunctionCalls(bool enable)
    settings_.set("lintRFunctionCalls", enable);
 }
 
+bool  UserSettings::usingMingwGcc49() const
+{
+   return settings_.getBool("usingMingwGcc49", false);
+}
+
+void  UserSettings::setUsingMingwGcc49(bool usingMingwGcc49)
+{
+   settings_.set("usingMingwGcc49", usingMingwGcc49);
+}
+
+
 } // namespace session
 } // namespace rstudio

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -806,6 +806,8 @@ void showSourceMarkers(const SourceMarkerSet& markerSet,
 
 bool isLoadBalanced();
 
+bool usingMingwGcc49();
+
 } // namespace module_context
 } // namespace session
 } // namespace rstudio

--- a/src/cpp/session/include/session/SessionUserSettings.hpp
+++ b/src/cpp/session/include/session/SessionUserSettings.hpp
@@ -199,6 +199,9 @@ public:
    bool enableStyleDiagnostics() const;
    void setEnableStyleDiagnostics(bool enable);
 
+   bool usingMingwGcc49() const;
+   void setUsingMingwGcc49(bool usingMingwGcc49);
+
 private:
 
    void onSettingsFileChanged(

--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -274,3 +274,6 @@
   invisible(.Call(.rs.routines$rs_writeUiPref, prefName, .rs.scalar(value)))
 })
 
+.rs.addFunction("setUsingMingwGcc49", function(usingMingwGcc49) {
+  invisible(.Call("rs_setUsingMingwGcc49", usingMingwGcc49))
+})

--- a/src/cpp/session/modules/build/SessionBuildEnvironment.cpp
+++ b/src/cpp/session/modules/build/SessionBuildEnvironment.cpp
@@ -82,7 +82,9 @@ r_util::RToolsInfo scanPathForRTools()
    boost::regex pattern("Rtools version (\\d\\.\\d\\d)[\\d\\.]+$");
    boost::smatch match;
    if (boost::regex_search(contents, match, pattern))
-      return r_util::RToolsInfo(match[1], installPath);
+      return r_util::RToolsInfo(match[1],
+                                installPath,
+                                module_context::usingMingwGcc49());
    else
       return noToolsFound;
 }
@@ -134,8 +136,9 @@ bool doAddRtoolsToPathIfNecessary(T* pTarget,
     }
 
     // ok so scan for R tools
+    bool usingGcc49 = module_context::usingMingwGcc49();
     std::vector<r_util::RToolsInfo> rTools;
-    error = core::r_util::scanRegistryForRTools(&rTools);
+    error = core::r_util::scanRegistryForRTools(usingGcc49, &rTools);
     if (error)
     {
        LOG_ERROR(error);

--- a/src/cpp/session/modules/build/SessionInstallRtools.cpp
+++ b/src/cpp/session/modules/build/SessionInstallRtools.cpp
@@ -61,18 +61,19 @@ void onDownloadCompleted(const core::system::ProcessResult& result,
 Error installRtools()
 {
    // determine the correct version of rtools
+   bool gcc49 = module_context::usingMingwGcc49();
    std::string version, url;
    FilePath installPath("C:\\Rtools");
    std::vector<r_util::RToolsInfo> availableRtools;
-   availableRtools.push_back(r_util::RToolsInfo("3.3", installPath));
-   availableRtools.push_back(r_util::RToolsInfo("3.2", installPath));
-   availableRtools.push_back(r_util::RToolsInfo("3.1", installPath));
-   availableRtools.push_back(r_util::RToolsInfo("3.0", installPath));
-   availableRtools.push_back(r_util::RToolsInfo("2.15", installPath));
-   availableRtools.push_back(r_util::RToolsInfo("2.14", installPath));
-   availableRtools.push_back(r_util::RToolsInfo("2.13", installPath));
-   availableRtools.push_back(r_util::RToolsInfo("2.12", installPath));
-   availableRtools.push_back(r_util::RToolsInfo("2.11", installPath));
+   availableRtools.push_back(r_util::RToolsInfo("3.3", installPath, gcc49));
+   availableRtools.push_back(r_util::RToolsInfo("3.2", installPath, gcc49));
+   availableRtools.push_back(r_util::RToolsInfo("3.1", installPath, gcc49));
+   availableRtools.push_back(r_util::RToolsInfo("3.0", installPath, gcc49));
+   availableRtools.push_back(r_util::RToolsInfo("2.15", installPath, gcc49));
+   availableRtools.push_back(r_util::RToolsInfo("2.14", installPath, gcc49));
+   availableRtools.push_back(r_util::RToolsInfo("2.13", installPath, gcc49));
+   availableRtools.push_back(r_util::RToolsInfo("2.12", installPath, gcc49));
+   availableRtools.push_back(r_util::RToolsInfo("2.11", installPath, gcc49));
    BOOST_FOREACH(const r_util::RToolsInfo& rTools, availableRtools)
    {
       if (module_context::isRtoolsCompatible(rTools))

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -845,8 +845,9 @@ std::vector<std::string> RCompilationDatabase::rToolsArgs() const
    if (rToolsArgs_.empty())
    {
       // scan for Rtools
+      bool usingMingwGcc49 = module_context::usingMingwGcc49();
       std::vector<core::r_util::RToolsInfo> rTools;
-      Error error = core::r_util::scanRegistryForRTools(&rTools);
+      Error error = core::r_util::scanRegistryForRTools(usingMingwGcc49, &rTools);
       if (error)
          LOG_ERROR(error);
 

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -858,21 +858,10 @@ std::vector<std::string> RCompilationDatabase::rToolsArgs() const
       {
          if (module_context::isRtoolsCompatible(*it))
          {
-            FilePath rtoolsPath = it->installPath();
-
-            rToolsArgs_.push_back("-I" + rtoolsPath.childPath(
-               "gcc-4.6.3/i686-w64-mingw32/include").absolutePath());
-
-            rToolsArgs_.push_back("-I" + rtoolsPath.childPath(
-               "gcc-4.6.3/include/c++/4.6.3").absolutePath());
-
-            std::string bits = "-I" + rtoolsPath.childPath(
-               "gcc-4.6.3/include/c++/4.6.3/i686-w64-mingw32").absolutePath();
-#ifdef _WIN64
-            bits += "/64";
-#endif
-            rToolsArgs_.push_back(bits);
-
+            std::vector<std::string> clangArgs = it->clangArgs();
+            std::copy(clangArgs.begin(),
+                      clangArgs.end(),
+                      std::back_inserter(rToolsArgs_));
             break;
          }
       }


### PR DESCRIPTION
Not yet ready for merge (waiting on the final mechanism for specifying architecture-specific compiler locations and for R-devel to switch over to the new toolchain).
