### PR TITLE
fix some El Capitan compilation issues

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -42,7 +42,7 @@ if(UNIX)
    add_definitions(-Wall -pthread)
 
    if(APPLE)
-      add_definitions(-Wsign-compare)
+      add_definitions(-Wsign-compare -Wno-unused-local-typedefs)
    endif()
 
    # workaround boost bug (https://svn.boost.org/trac/boost/ticket/4568)

--- a/src/cpp/desktop-mac/WebViewController.mm
+++ b/src/cpp/desktop-mac/WebViewController.mm
@@ -192,12 +192,13 @@ static PendingWindow pendingWindow_;
          [self setWindowFrameAutosaveName: name];
       
       // create web view, save it as a member, and register as it's delegate,
+      
       webView_ = [[WebViewWithKeyEquiv alloc] initWithFrame: frameRect];
-      [webView_ setUIDelegate: self];
-      [webView_ setFrameLoadDelegate: self];
-      [webView_ setResourceLoadDelegate: self];
-      [webView_ setPolicyDelegate: self];
-      [webView_ setKeyEquivDelegate: self];
+      [webView_ setUIDelegate: (id) self];
+      [webView_ setFrameLoadDelegate: (id) self];
+      [webView_ setResourceLoadDelegate: (id) self];
+      [webView_ setPolicyDelegate: (id) self];
+      [webView_ setKeyEquivDelegate: (id) self];
       
       // respect the current zoom level
       [self syncZoomLevel];


### PR DESCRIPTION
This fixes a couple compiler errors / warnings:

- Noisy `no unused local typedef` warnings get spat out from our Boost headers (due to heavy use of static assertions, I think),
- Xcode now refuses to cast `T*` to `id<T>` implicitly; cast explicitly instead.