### PR TITLE
Fix crash when closing projects on OS X El Capitan

### DIFF
--- a/src/cpp/desktop-mac/AppDelegate.mm
+++ b/src/cpp/desktop-mac/AppDelegate.mm
@@ -8,6 +8,7 @@
 #include <core/r_util/RProjectFile.hpp>
 #include <core/r_util/RUserData.hpp>
 #include <core/r_util/REnvironment.hpp>
+#include <core/r_util/RSessionContext.hpp>
 
 #import <AppKit/AppKit.h>
 
@@ -138,13 +139,22 @@ void initializeWorkingDirectory(const std::string& filename)
 // PORT: from DesktopMain.cpp
 void setInitialProject(const FilePath& projectFile, std::string* pFilename)
 {
-   core::system::setenv(kRStudioInitialProject, projectFile.absolutePath());
+   core::system::setenv(kRStudioInitialProject,
+                        projectFile.absolutePath().empty() ?
+                        *pFilename : projectFile.absolutePath());
    pFilename->clear();
 }
 
 // PORT: from DesktopMain.cpp
 void initializeStartupEnvironment(std::string* pFilename)
 {
+   // handle manual override for switching to project: none
+   if (*pFilename == kProjectNone)
+   {
+      setInitialProject(FilePath(), pFilename);
+      return;
+   }
+   
    // if the filename ends with .RData or .rda then this is an
    // environment file. if it ends with .Rproj then it is
    // a project file. we handle both cases by setting an environment
@@ -264,7 +274,11 @@ bool prepareEnvironment(Options& options)
    // check for open file request (either apple event or command line)
    NSString* openFile = verifyAndNormalizeFilename(openFile_);
    if (!openFile)
-      openFile = verifyAndNormalizeFilename(openFileCommandLineArgument());
+   {
+      openFile = openFileCommandLineArgument();
+      if (![openFile isEqualToString: @"none"])
+         openFile = verifyAndNormalizeFilename(openFile);
+   }
    std::string filename;
    if (openFile)
       filename = [openFile UTF8String];

--- a/src/cpp/desktop-mac/GwtCallbacks.mm
+++ b/src/cpp/desktop-mac/GwtCallbacks.mm
@@ -837,7 +837,8 @@ private:
 
 - (void) openProjectInOverlaidNewWindow: (NSString*) projectFilePath
 {
-   projectFilePath = resolveAliasedPath(projectFilePath);
+   if (![projectFilePath isEqualToString: @"none"])
+      projectFilePath = resolveAliasedPath(projectFilePath);
    NSArray* args = [NSArray arrayWithObjects: projectFilePath, nil];
    [self openInNewWindow: args];
 }

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -526,7 +526,8 @@ void startup()
    FilePath lastProjectPath = projSettings.lastProjectPath();
 
    // check for explicit project none scope
-   if (session::options().sessionScope().isProjectNone())
+   if (session::options().sessionScope().isProjectNone() || 
+       session::options().initialProjectPath().absolutePath() == kProjectNone)
    {
       projectFilePath = resolveProjectSwitch(kProjectNone);
    }

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
@@ -636,8 +636,7 @@ public class ApplicationQuit implements SaveActionChangedHandler,
                if (Desktop.isDesktop())
                {
                   if (Desktop.getFrame().isCocoa() && 
-                      switchToProject_ != null &&
-                      switchToProject_ != "none")
+                      switchToProject_ != null)
                   {
                      // on Cocoa there's an ugly intermittent crash that occurs 
                      // when we reload, so exit this instance and start a new


### PR DESCRIPTION
This change fixes a reported crash on El Capitan when closing projects (i.e. switching to the 'none' project), by making closing projects symmetric with switching: the executable now accepts `none` as a special command-line parameter indicating that no project should be opened at startup.

N.B. This change is not intended for backporting to 0.99-400. That change is here: https://github.com/rstudio/rstudio/commit/962e4760923d1bdf7103a47412bbf6ff523e4bea