### PR TITLE
Add function to navigate to source file to rstudioapi

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -118,3 +118,34 @@
    
    invisible(.Call("rs_sourceMarkers", name, markers, basePath, autoSelect))
 })
+
+.rs.addApiFunction("navigateToFile", function(filePath, line = 1L, col = 1L) {
+   # validate file argument
+   if (!is.character(filePath)) {
+      stop("filePath must be a character")  
+   }
+   if (!file.exists(filePath)) {
+      stop(filePath, " does not exist.")
+   }
+
+   # validate line/col arguments
+   if (!is.integer(line) || length(line) != 1 ||
+       !is.integer(col)  || length(col) != 1) {
+      stop("line and column must be integer values.")
+   }
+
+   # expand and alias for client
+   filePath <- .rs.normalizePath(filePath, winslash="/", mustWork = TRUE) 
+   homeDir <- path.expand("~")
+   if (identical(substr(filePath, 1, nchar(homeDir)), homeDir)) {
+      filePath <- file.path("~", substring(filePath, nchar(homeDir) + 2))
+   }
+   
+   # send event to client
+   .rs.enqueClientEvent("jump_to_function", list(
+      file_name     = .rs.scalar(filePath),
+      line_number   = .rs.scalar(line), 
+      column_number = .rs.scalar(col)))
+
+   invisible(NULL)
+})

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -133,6 +133,8 @@ SEXP rs_enqueClientEvent(SEXP nameSEXP, SEXP dataSEXP)
          type = session::client_events::kRmdParamsEdit;
       else if (name == "rmd_params_ready")
          type = session::client_events::kRmdParamsReady;
+      else if (name == "jump_to_function")
+         type = session::client_events::kJumpToFunction;
 
       if (type != -1)
       {


### PR DESCRIPTION
This change adds a new rstudioapi function for code navigation in RStudio (motivated by @wch's profvis work). There's no need to take it prior to the preview release (although it doesn't create much risk). 