### PR TITLE
smarter opts_chunk replacement

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOptionsPopupPanel.java
@@ -277,9 +277,9 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
       buttonPanel.addStyleName(RES.styles().buttonPanel());
       buttonPanel.setHorizontalAlignment(HorizontalPanel.ALIGN_RIGHT);
       
-      SmallButton revertButton = new SmallButton("Revert");
-      revertButton.getElement().getStyle().setMarginRight(8, Unit.PX);
-      revertButton.addClickHandler(new ClickHandler()
+      revertButton_ = new SmallButton("Revert");
+      revertButton_.getElement().getStyle().setMarginRight(8, Unit.PX);
+      revertButton_.addClickHandler(new ClickHandler()
       {
          
          @Override
@@ -289,10 +289,10 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
             hideAndFocusEditor();
          }
       });
-      buttonPanel.add(revertButton);
+      buttonPanel.add(revertButton_);
       
-      SmallButton applyButton = new SmallButton("Apply");
-      applyButton.addClickHandler(new ClickHandler()
+      applyButton_ = new SmallButton("Apply");
+      applyButton_.addClickHandler(new ClickHandler()
       {
          
          @Override
@@ -302,7 +302,7 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
             hideAndFocusEditor();
          }
       });
-      buttonPanel.add(applyButton);
+      buttonPanel.add(applyButton_);
       
       footerPanel.setVerticalAlignment(VerticalPanel.ALIGN_BOTTOM);
       footerPanel.add(linkPanel);
@@ -564,6 +564,8 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
    protected final Grid figureDimensionsPanel_;
    protected final TextBox figWidthBox_;
    protected final TextBox figHeightBox_;
+   protected final SmallButton revertButton_;
+   protected final SmallButton applyButton_;
    protected final ThemedCheckBox useCustomFigureCheckbox_;
    protected final TriStateCheckBox showWarningsInOutputCb_;
    protected final TriStateCheckBox showMessagesInOutputCb_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/SetupChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/SetupChunkOptionsPopupPanel.java
@@ -108,6 +108,16 @@ public class SetupChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
          options.put(name, value);
    }
    
+   private Position findKnitrPrefix(TokenIterator iterator)
+   {
+      Token token = iterator.stepBackward();
+      if (!(token.valueEquals("::") || token.valueEquals(":::")))
+         return null;
+      
+      token = iterator.stepBackward();
+      return token.valueEquals("knitr") ? iterator.getCurrentTokenPosition() : null;
+   }
+   
    private Range findOptsChunk()
    {
       TokenIterator iterator = TokenIterator.create(
@@ -125,17 +135,12 @@ public class SetupChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
             break;
          
          Position startPos = iterator.getCurrentTokenPosition();
-         
-         if (!token.getValue().equals("knitr"))
-            continue;
-         
-         token = iterator.stepForward();
-         if (!token.getValue().equals("::"))
-            continue;
-         
-         token = iterator.stepForward();
          if (!token.getValue().equals("opts_chunk"))
             continue;
+         
+         Position knitrPrefixPos = findKnitrPrefix(iterator.clone());
+         if (knitrPrefixPos != null)
+            startPos = knitrPrefixPos;
          
          token = iterator.stepForward();
          if (!token.getValue().equals("$"))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/SetupChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/SetupChunkOptionsPopupPanel.java
@@ -52,6 +52,7 @@ public class SetupChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
       
       figureDimensionsPanel_.setVisible(false);
       useCustomFigureCheckbox_.setVisible(false);
+      revertButton_.setVisible(false);
       
       setHeader("Default Chunk Options", true);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/SetupChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/SetupChunkOptionsPopupPanel.java
@@ -152,10 +152,9 @@ public class SetupChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
          if (!iterator.fwdToMatchingToken())
             continue;
          
+         
+         token = iterator.stepForward();
          Position endPos = iterator.getCurrentTokenPosition();
-         endPos = Position.create(
-               endPos.getRow(),
-               endPos.getColumn() + 1);
          
          return Range.fromPoints(startPos, endPos);
       }
@@ -218,25 +217,10 @@ public class SetupChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
             });
    }
    
-   private boolean shouldAppendNewline(Range range)
-   {
-      Position startPos = range.getStart();
-      Position endPos = range.getEnd();
-      
-      if (!startPos.isEqualTo(endPos))
-         return false;
-      
-      TokenIterator iterator = TokenIterator.create(widget_.getEditor().getSession());
-      Token token = iterator.moveToPosition(endPos);
-      return token != null && token.hasType("codeend");
-   }
-   
    @Override
    protected void synchronize()
    {
       Range range = syncSelection();
-      String maybeNewLine = shouldAppendNewline(range) ? "\n" : "";
-      
       Map<String, String> options = new LinkedHashMap<String, String>();
       
       Set<String> keys = chunkOptions_.keySet();
@@ -263,16 +247,17 @@ public class SetupChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
       if (options.size() <= 2)
       {
          String joined = StringUtil.collapse(options, " = ", ", ");
-         String code = "knitr::opts_chunk$set(" + joined + ")" + maybeNewLine;
+         String code = "knitr::opts_chunk$set(" + joined + ")\n";
          widget_.getEditor().insert(code);
          return;
       }
       
       Map<String, String> sorted = sortedOptions(options);
       
-      String code = "knitr::opts_chunk$set(\n\t";
-      code += joinOptions(sorted);
-      code += "\n)" + maybeNewLine;
+      String code =
+            "knitr::opts_chunk$set(\n\t" +
+            joinOptions(sorted) +
+            "\n)\n";
       
       widget_.getEditor().insert(code);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/TokenIterator.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/TokenIterator.java
@@ -31,6 +31,10 @@ public class TokenIterator extends JavaScriptObject
    }-*/;
    
    protected TokenIterator() {}
+   
+   public native final TokenIterator clone() /*-{
+      return this.clone();
+   }-*/;
 
    public native final Token stepForward() /*-{
       return this.stepForward();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/TokenIterator.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/TokenIterator.java
@@ -25,6 +25,11 @@ public class TokenIterator extends JavaScriptObject
       return new TokenIterator(session, initialRow, initialColumn);
    }-*/;
 
+   public static native TokenIterator create(EditSession session) /*-{
+      var TokenIterator = $wnd.require('ace/token_iterator').TokenIterator;
+      return new TokenIterator(session);
+   }-*/;
+   
    protected TokenIterator() {}
 
    public native final Token stepForward() /*-{
@@ -38,6 +43,10 @@ public class TokenIterator extends JavaScriptObject
    public native final Token getCurrentToken() /*-{
       return this.getCurrentToken();
    }-*/;
+   
+   public native final Position getCurrentTokenPosition() /*-{
+      return this.getCurrentTokenPosition();
+   }-*/;
 
    public native final int getCurrentTokenRow() /*-{
       return this.getCurrentTokenRow();
@@ -45,5 +54,21 @@ public class TokenIterator extends JavaScriptObject
 
    public native final int getCurrentTokenColumn() /*-{
       return this.getCurrentTokenColumn();
+   }-*/;
+   
+   public native final boolean fwdToMatchingToken() /*-{
+      return this.fwdToMatchingToken();
+   }-*/;
+   
+   public native final boolean bwdToMatchingToken() /*-{
+      return this.bwdToMatchingToken();
+   }-*/;
+   
+   public native final void tokenizeUpToRow(int row) /*-{
+      this.tokenizeUpToRow(row);
+   }-*/;
+   
+   public native final Token moveToPosition(Position pos) /*-{
+      return this.moveToPosition(pos);
    }-*/;
 }


### PR DESCRIPTION
This PR does a better job of locating and replacing the `knitr::opts_chunk$set()` statement within a chunk when using the setup chunk options popup. This should ensure that text following the `opts_chunk` statement is not eaten when interacting with the popup.