### PR TITLE
fix number highlighting with trailing decimal (e.g. '1.')

### DIFF
--- a/src/cpp/core/r_util/RTokenizerTests.cpp
+++ b/src/cpp/core/r_util/RTokenizerTests.cpp
@@ -129,6 +129,7 @@ void testNumbers()
    v.verify(L"1");
    v.verify(L"10");
    v.verify(L"0.1");
+   v.verify(L"1.");
    v.verify(L".2");
    v.verify(L"1e-7");
    v.verify(L"1.2e+7");
@@ -170,9 +171,12 @@ void testOperators()
    v.verify(L"~");
    v.verify(L"->");
    v.verify(L"<-");
+   v.verify(L"->>");
+   v.verify(L"<<-");
    v.verify(L"$");
    v.verify(L":");
    v.verify(L"=");
+   v.verify(L":=");
 }
 
 void testUOperators()

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -108,19 +108,19 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
       rules["#number"] = [
          {
             token : "constant.numeric", // hex
-            regex : "0[xX][0-9a-fA-F]+[Li]?\\b",
+            regex : "0[xX][0-9a-fA-F]+[Li]?",
             merge : false,
             next  : "start"
          },
          {
             token : "constant.numeric", // number + integer
-            regex : "\\d+(?:\\.\\d*)?(?:[eE][+\\-]?\\d*)?[iL]?\\b",
+            regex : "\\d+(?:\\.\\d*)?(?:[eE][+\\-]?\\d*)?[iL]?",
             merge : false,
             next  : "start"
          },
          {
             token : "constant.numeric", // number + integer with leading decimal
-            regex : "\\.\\d+(?:[eE][+\\-]?\\d*)?[iL]?\\b",
+            regex : "\\.\\d+(?:[eE][+\\-]?\\d*)?[iL]?",
             merge : false,
             next  : "start"
          }

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -114,13 +114,7 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
          },
          {
             token : "constant.numeric", // number + integer
-            regex : "\\d+(?:\\.\\d*)?(?:[eE][+\\-]?\\d*)?[iL]?",
-            merge : false,
-            next  : "start"
-         },
-         {
-            token : "constant.numeric", // number + integer with leading decimal
-            regex : "\\.\\d+(?:[eE][+\\-]?\\d*)?[iL]?",
+            regex : "(?:(?:\\d+(?:\\.\\d*)?)|(?:\\.\\d+))(?:[eE][+\\-]?\\d*)?[iL]?",
             merge : false,
             next  : "start"
          }


### PR DESCRIPTION
(Note: not necessary for this release; hold until after)

For R, numbers of the form `1.` (with no leading decimal, but with a trailing decimal) are valid; however, our tokenizer doesn't recognize this and highlights the `.` as a separate symbol. This PR fixes that.