### PR TITLE
allow http loads from localhost on El Capitan

### DIFF
--- a/src/cpp/desktop-mac/Info.plist.in
+++ b/src/cpp/desktop-mac/Info.plist.in
@@ -254,5 +254,10 @@
    </dict>
   <key>LSMinimumSystemVersion</key>
   <string>10.6.0</string>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+  </dict>
 </dict>
 </plist>


### PR DESCRIPTION
This PR works around the following warning from App Transport Security when launching RStudio Desktop built on El Capitan:

```
$ 2015-10-20 14:11:24.157 RStudio[90625:243250]
App Transport Security has blocked a cleartext HTTP (http://) resource load
    since it is insecure.
Temporary exceptions can be configured via your app's Info.plist file.
```

We work around this by amending the `.plist` file to explicitly allow HTTP resource loads.

One thing I'm not sure of -- what will happen on the build server when it encounters this `plist` entry? Will it be ignored, or will it cause an error if it's unrecognized?