### PR TITLE
suppress httpd warnings on invalid queries

### DIFF
--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -409,13 +409,8 @@ options(help_type = "html")
    dirpath <- dirname(path)
    pkgname <- basename(dirpath)
    
-   html = tools:::httpd(paste("/library/", 
-                              pkgname, 
-                              "/html/", 
-                              basename(file),
-                              ".html", sep=""),
-                        NULL,
-                        NULL)$payload
+   query <- paste("/library/", pkgname, "/html/", basename(file), ".html", sep = "")
+   html <- suppressWarnings(tools:::httpd(query, NULL, NULL))$payload
    
    match = suppressWarnings(regexpr('<body>.*</body>', html))
    if (match < 0)

--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -577,12 +577,19 @@ SEXP callHandler(const std::string& path,
    pProtect->add(argsSEXP);
 
    // form the call expression
-   SEXP callSEXP;
-   pProtect->add(callSEXP = Rf_lang3(
+   SEXP innerCallSEXP;
+   pProtect->add(innerCallSEXP = Rf_lang3(
          Rf_install("try"),
          Rf_lcons( (handlerSource(path)), argsSEXP),
          trueSEXP));
-   SET_TAG(CDR(CDR(callSEXP)), Rf_install("silent"));
+   SET_TAG(CDR(CDR(innerCallSEXP)), Rf_install("silent"));
+   
+   // suppress warnings
+   SEXP suppressWarningsSEXP;
+   pProtect->add(suppressWarningsSEXP = r::sexp::findFunction("suppressWarnings", "base"));
+   
+   SEXP callSEXP;
+   pProtect->add(callSEXP = Rf_lang2(suppressWarningsSEXP, innerCallSEXP));
 
    // execute and return
    SEXP resultSEXP;


### PR DESCRIPTION
This PR fixes an issue where attempting to search with an invalid query in the Help pane (e.g. type `cbinddddd<ENTER>`) would cause a `httpd` warning to be emitted to the console.

<img width="638" alt="screen shot 2015-10-22 at 11 17 05 am" src="https://cloud.githubusercontent.com/assets/1976582/10674168/76a667fe-78ae-11e5-8a21-c338d10d1c11.png">
