### PR TITLE
open external links to same domain in same web view

### DIFF
--- a/src/cpp/desktop-mac/WebViewController.mm
+++ b/src/cpp/desktop-mac/WebViewController.mm
@@ -473,6 +473,13 @@ runJavaScriptAlertPanelWithMessage: (NSString *) message
    }
    else
    {
+      // get the host name
+      NSString* hostName =
+         [webView stringByEvaluatingJavaScriptFromString: @"window.location.host"];
+      BOOL isSameDomain = false;
+      if (hostName)
+         isSameDomain = [[url host] hasPrefix: hostName];
+      
       // perform a base64 download if necessary
       WebNavigationType navType = (WebNavigationType)[[actionInformation
                         objectForKey:WebActionNavigationTypeKey] intValue];
@@ -485,8 +492,8 @@ runJavaScriptAlertPanelWithMessage: (NSString *) message
                                       objectForKey:WebActionElementKey]];
          [listener ignore];
       }
-      // show external links in a new window
-      else if (navType == WebNavigationTypeLinkClicked)
+      // show external links to a new domain in a new window
+      else if (navType == WebNavigationTypeLinkClicked && !isSameDomain)
       {
          desktop::utils::browseURL(url);
          [listener ignore];


### PR DESCRIPTION
This PR ensures that links that resolve within the same domain are opened within the same web view (rather than an external browser). This ultimately fixes an issue where attempting to sign out of connect while within an RStudio-spawned web view would attempt to open the sign out link in a separate window.

I also tested this on Ubuntu (hence using Qt) and it seems like we already do open such links in the same window (so no change is required on the Qt side).

@jmcphers can you confirm whether this looks like the right change?