### PR TITLE
[WIP] disable in-RStudio auth on CentOS

### DIFF
--- a/dependencies/common/.gitignore
+++ b/dependencies/common/.gitignore
@@ -14,3 +14,4 @@ shinyapps*.tar.gz
 rsconnect/
 rsconnect*.tar.gz
 *.tar.bz
+*.tar.bz2

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -76,6 +76,7 @@ if(UNIX)
 
    # gcc hardending options (see: http://wiki.debian.org/Hardening)
    if(NOT APPLE)
+      add_definitions(-O2)
       add_definitions(-Wformat -Wformat-security)
       add_definitions(-D_FORTIFY_SOURCE=2)
       add_definitions(-fstack-protector --param ssp-buffer-size=4)

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -76,7 +76,6 @@ if(UNIX)
 
    # gcc hardending options (see: http://wiki.debian.org/Hardening)
    if(NOT APPLE)
-      add_definitions(-O2)
       add_definitions(-Wformat -Wformat-security)
       add_definitions(-D_FORTIFY_SOURCE=2)
       add_definitions(-fstack-protector --param ssp-buffer-size=4)

--- a/src/cpp/desktop-mac/GwtCallbacks.mm
+++ b/src/cpp/desktop-mac/GwtCallbacks.mm
@@ -1005,6 +1005,11 @@ private:
           boost::algorithm::starts_with(version, "10.10");
 }
 
+- (Boolean) isCentOS
+{
+   return NO;
+}
+
 // On Mavericks we need to tell the OS that we are busy so that
 // AppNap doesn't kick in. Declare a local version of NSActivityOptions
 // so we can build this on non-Mavericks systems

--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -1075,6 +1075,11 @@ bool GwtCallback::isOSXMavericks()
    return desktop::isOSXMavericks();
 }
 
+bool GwtCallback::isCentOS()
+{
+   return desktop::isCentOS();
+}
+
 QString GwtCallback::getScrollingCompensationType()
 {
 #if defined(Q_OS_MAC)

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -178,6 +178,7 @@ public slots:
    QString getScrollingCompensationType();
 
    bool isOSXMavericks();
+   bool isCentOS();
 
    void setBusy(bool busy);
 

--- a/src/cpp/desktop/DesktopUtils.cpp
+++ b/src/cpp/desktop/DesktopUtils.cpp
@@ -23,6 +23,7 @@
 
 #include <core/Error.hpp>
 #include <core/FilePath.hpp>
+#include <core/FileSerializer.hpp>
 #include <core/system/Process.hpp>
 #include <core/system/System.hpp>
 #include <core/system/Environment.hpp>
@@ -80,6 +81,22 @@ double devicePixelRatio(QMainWindow* pMainWindow)
 bool isOSXMavericks()
 {
    return false;
+}
+
+// NOTE: also RHEL
+bool isCentOS()
+{
+   FilePath redhatRelease("/etc/redhat-release");
+   if (!redhatRelease.exists())
+      return false;
+
+   std::string contents;
+   Error error = readStringFromFile(redhatRelease, &contents);
+   if (error)
+      return false;
+
+   return contents.find("CentOS") != std::string::npos ||
+          contents.find("Red Hat Enterprise Linux") != std::string::npos;
 }
 
 void enableFullscreenMode(QMainWindow* pMainWindow, bool primary)

--- a/src/cpp/desktop/DesktopUtils.hpp
+++ b/src/cpp/desktop/DesktopUtils.hpp
@@ -39,6 +39,7 @@ core::FilePath userLogPath();
 double devicePixelRatio(QMainWindow* pMainWindow);
 
 bool isOSXMavericks();
+bool isCentOS();
 
 void raiseAndActivateWindow(QWidget* pWindow);
 

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -151,6 +151,7 @@ public interface DesktopFrame extends JavaScriptPassthrough
    void setShinyDialogUrl(String url);
    
    boolean isOSXMavericks();
+   boolean isCentOS();
 
    String getScrollingCompensationType();
    

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/NewRSConnectAuthPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/NewRSConnectAuthPage.java
@@ -305,14 +305,17 @@ public class NewRSConnectAuthPage
                   contents_.showWaiting();
                   
                   // prepare a new window with the auth URL loaded
-                  NewWindowOptions options = new NewWindowOptions();
-                  options.setName(AUTH_WINDOW_NAME);
-                  options.setAllowExternalNavigation(true);
-                  options.setShowDesktopToolbar(false);
-                  display_.openWebMinimalWindow(
-                        result_.getPreAuthToken().getClaimUrl(),
-                        false, 
-                        700, 800, options);
+                  if (canSpawnAuthenticationWindow())
+                  {
+                     NewWindowOptions options = new NewWindowOptions();
+                     options.setName(AUTH_WINDOW_NAME);
+                     options.setAllowExternalNavigation(true);
+                     options.setShowDesktopToolbar(false);
+                     display_.openWebMinimalWindow(
+                           result_.getPreAuthToken().getClaimUrl(),
+                           false, 
+                           700, 800, options);
+                  }
                   
                   // close the window automatically when authentication finishes
                   pollForAuthCompleted();
@@ -352,6 +355,17 @@ public class NewRSConnectAuthPage
             onResult.execute(null);
          }
       });
+   }
+   
+   private boolean canSpawnAuthenticationWindow()
+   {
+      if (!Desktop.isDesktop())
+         return true;
+      
+      if (Desktop.getFrame().isCentOS())
+         return false;
+      
+      return true;
    }
    
    private OperationWithInput<Boolean> setOkButtonVisible_;

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/NewRSConnectAuthPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/NewRSConnectAuthPage.java
@@ -316,6 +316,10 @@ public class NewRSConnectAuthPage
                            false, 
                            700, 800, options);
                   }
+                  else
+                  {
+                     Desktop.getFrame().browseUrl(result_.getPreAuthToken().getClaimUrl());
+                  }
                   
                   // close the window automatically when authentication finishes
                   pollForAuthCompleted();


### PR DESCRIPTION
NOTE: not ready for merge (pending testing) but an initial look at the implementation would be helpful, since I haven't played with the desktop JavaScript pass-through objects much before.

This PR adds a function, `isCentOS()`, that attempts to detect whether the current system is a CentOS system. It does so by looking for files at `/etc/os-release` and `/etc/redhat-release`, and asking those files what kind of Linux flavor the current system is. I think that `/etc/os-release` might be a new-ish construct so we likely need a couple more fallbacks (`lsb_release`, other heuristics?)

We might want to expand the scope to all members of the RedHat family just to be safe (or at least test on Fedora / RHEL to see if we can replicate there)