### PR TITLE
fix for first file open after desktop launch

### DIFF
--- a/src/cpp/desktop-mac/AppDelegate.h
+++ b/src/cpp/desktop-mac/AppDelegate.h
@@ -6,6 +6,7 @@
 @interface AppDelegate : NSObject <NSApplicationDelegate> {
    NSString* openFile_;
    NSMenu* dockMenu_;
+   BOOL initialized_;
 }
 @end
 

--- a/src/cpp/desktop-mac/AppDelegate.mm
+++ b/src/cpp/desktop-mac/AppDelegate.mm
@@ -248,7 +248,7 @@ bool prepareEnvironment(Options& options)
             openFile:(NSString *) filename
 {
    // open file and application together
-   if (!openFile_)
+   if (!initialized_ && !openFile_)
    {
       openFile_ = [filename copy];
    }
@@ -366,6 +366,8 @@ bool prepareEnvironment(Options& options)
                             [NSString stringWithUTF8String: msg.c_str()]);
       [NSApp terminate: self];
    }
+
+   initialized_ = YES;
 }
 
 - (void) pollProcessSupervisor


### PR DESCRIPTION
This PR fixes an issue on OS X where the first attempt to open a file (by e.g. double-clicking it in the Finder, or on the Desktop) would not open that file in an already open RStudio instance.

If I understand correctly, the bug manifests in this way:

1. RStudio is launched (e.g. from Spotlight). The `openFile_` field in the `AppDelegate` is left `nil` and unset.
2. A user attempts to open e.g. an `.R` file, by double-clicking.
3. The `application` instance method is called, with that file -- however, because the `openFile_` field has not yet been set, we instead just set that field and do nothing (expecting that soon-to-come initialization logic would take care of it).

This PR fixes the issue by ensuring that the `openFile_` assignment can only happen on initialization (by using an `initialized_` member variable to track whether RStudio initialization finished successfully).