### PR TITLE
fix various warnings when compiling in Xcode

### DIFF
--- a/src/cpp/desktop-mac/GwtCallbacks.mm
+++ b/src/cpp/desktop-mac/GwtCallbacks.mm
@@ -314,19 +314,37 @@ private:
    }
 }
 
+- (void) performClipboardAction: (SEL) selector
+{
+   WKWebView* view = [[[NSApp mainWindow] windowController] webView];
+   if (view == nil) {
+      NSString* errorMsg = [NSString stringWithFormat: @"nil webView on clipboard action %@", NSStringFromSelector(selector)];
+      LOG_ERROR_MESSAGE([errorMsg UTF8String]);
+      return;
+   }
+
+   if ([view respondsToSelector: selector]) {
+      [view performSelector: selector withObject: view];
+   } else {
+      NSString* errorMsg = [NSString stringWithFormat: @"@webView does not respond to selector %@", NSStringFromSelector(selector)];
+      LOG_ERROR_MESSAGE([errorMsg UTF8String]);
+      return;
+   }
+}
+
 - (void) clipboardCut
 {
-   [[[[NSApp mainWindow] windowController] webView] cut: self];
+   [self performClipboardAction: @selector(cut:)];
 }
 
 - (void) clipboardCopy
 {
-   [[[[NSApp mainWindow] windowController] webView] copy: self];
+   [self performClipboardAction: @selector(copy:)];
 }
 
 - (void) clipboardPaste
 {
-   [[[[NSApp mainWindow] windowController] webView] paste: self];
+   [self performClipboardAction: @selector(paste:)];
 }
 
 - (NSString*) getUriForPath: (NSString*) path

--- a/src/cpp/desktop-mac/GwtCallbacks.mm
+++ b/src/cpp/desktop-mac/GwtCallbacks.mm
@@ -116,7 +116,7 @@ private:
 {
    NSString* path = @"";
    [panel beginSheetModalForWindow: [uiDelegate_ uiWindow]
-                completionHandler: nil];
+                 completionHandler: ^(NSInteger result) {}];
    long int result = [panel runModal];
    @try
    {
@@ -704,7 +704,7 @@ private:
    }
    
    // write to file
-   NSBitmapImageRep *imageRep = [[image representations] objectAtIndex: 0];
+   NSBitmapImageRep *imageRep = (NSBitmapImageRep*) [[image representations] objectAtIndex: 0];
    NSData *data = [imageRep representationUsingType: imageFileType properties: properties];
    if (![data writeToFile: targetPath atomically: NO])
    {

--- a/src/cpp/desktop-mac/WebViewController.mm
+++ b/src/cpp/desktop-mac/WebViewController.mm
@@ -796,7 +796,7 @@ decidePolicyForMIMEType: (NSDictionary *) actionInformation
                         filename: (NSString*) filename
 {
    [panel setNameFieldStringValue: filename];
-   [panel beginSheetModalForWindow: [self window] completionHandler: nil];
+   [panel beginSheetModalForWindow: [self window] completionHandler: ^(NSInteger result) {}];
    long int result = [panel runModal];
    [NSApp endSheet: panel];
    
@@ -831,7 +831,7 @@ decidePolicyForMIMEType: (NSDictionary *) actionInformation
    [panel setCanChooseFiles: true];
    [panel setCanChooseDirectories: false];
    [panel beginSheetModalForWindow: [self uiWindow]
-                 completionHandler: nil];
+                 completionHandler: ^(NSInteger result) {}];
    long int result = [panel runModal];
    @try
    {


### PR DESCRIPTION
This PR handles various warnings given by Xcode when compiling on El Capitan.

Not needed for this release, but I am marginally hopeful that we might get logged warnings on users who cut / copy / paste actions do not work. (On the other hand, those also may be manifestations of the bizarre focus issue we've heard some rumblings about...)