### PR TITLE
add applescript support

### DIFF
--- a/src/cpp/desktop-mac/CMakeLists.txt
+++ b/src/cpp/desktop-mac/CMakeLists.txt
@@ -40,9 +40,10 @@ set(DESKTOP_MAC_SOURCE_FILES
    SatelliteController.mm
    SecondaryWindowController.mm
    SessionLauncher.mm
+   ScriptCommand.mm
    Utils.mm
    WebViewController.mm
-   
+
 )
 
 # include directories
@@ -95,12 +96,11 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/mac-terminal.in
                ${CMAKE_CURRENT_BINARY_DIR}/mac-terminal)
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/mac-terminal
                  DESTINATION ${RSTUDIO_INSTALL_BIN})
-                 
-# enable developer extras 
-exec_program(defaults 
+
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/RStudio.sdef
+                 DESTINATION ${RSTUDIO_INSTALL_SUPPORTING})
+
+# enable developer extras
+exec_program(defaults
              ARGS write org.rstudio.RStudio WebKitDeveloperExtras -bool true
              OUTPUT_VARIABLE DEV_EXTRAS)
-
-
-
-

--- a/src/cpp/desktop-mac/Info.plist.in
+++ b/src/cpp/desktop-mac/Info.plist.in
@@ -247,6 +247,10 @@
   <true/>
   <key>NSPrincipalClass</key>
   <string>NSApplication</string>
+  <key>NSAppleScriptEnabled</key>
+  <true/>
+  <key>OSAScriptingDefinition</key>
+  <string>RStudio.sdef</string>
    <key>LSEnvironment</key>
    <dict>
       <key>DYLD_VERSIONED_FRAMEWORK_PATH</key>

--- a/src/cpp/desktop-mac/RStudio.sdef
+++ b/src/cpp/desktop-mac/RStudio.sdef
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE dictionary SYSTEM "file://localhost/System/Library/DTDs/sdef.dtd">
+
+<dictionary title="RStudio">
+    <suite name="RStudio Suite" code="MApN" description="RStudio Scripts">
+        <command name="do javascript" code="djsstrng" description="do javascript">
+            <cocoa class="doJavaScriptCommand"/>
+            <direct-parameter description="JS code to evaluate.">
+                <type type="text"/>
+            </direct-parameter>
+        </command>
+        <command name="do rscript" code="dorstrng" description="do rscript">
+            <cocoa class="doRscriptCommand"/>
+            <direct-parameter description="R code to evaluate.">
+                <type type="text"/>
+            </direct-parameter>
+        </command>
+    </suite>
+</dictionary>

--- a/src/cpp/desktop-mac/RStudio.sdef
+++ b/src/cpp/desktop-mac/RStudio.sdef
@@ -3,8 +3,8 @@
 
 <dictionary title="RStudio">
     <suite name="RStudio Suite" code="MApN" description="RStudio Scripts">
-        <command name="do rscript" code="dorstrng" description="do rscript">
-            <cocoa class="doRscriptCommand"/>
+        <command name="cmd" code="dorstrng" description="Evaluate R code.">
+            <cocoa class="evaluateRScriptCommand"/>
             <direct-parameter description="R code to evaluate.">
                 <type type="text"/>
             </direct-parameter>

--- a/src/cpp/desktop-mac/RStudio.sdef
+++ b/src/cpp/desktop-mac/RStudio.sdef
@@ -3,12 +3,6 @@
 
 <dictionary title="RStudio">
     <suite name="RStudio Suite" code="MApN" description="RStudio Scripts">
-        <command name="do javascript" code="djsstrng" description="do javascript">
-            <cocoa class="doJavaScriptCommand"/>
-            <direct-parameter description="JS code to evaluate.">
-                <type type="text"/>
-            </direct-parameter>
-        </command>
         <command name="do rscript" code="dorstrng" description="do rscript">
             <cocoa class="doRscriptCommand"/>
             <direct-parameter description="R code to evaluate.">

--- a/src/cpp/desktop-mac/ScriptCommand.h
+++ b/src/cpp/desktop-mac/ScriptCommand.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-@interface doRscriptCommand : NSScriptCommand
+@interface evaluateRScriptCommand : NSScriptCommand
 
 -(id) performDefaultImplementation;
 

--- a/src/cpp/desktop-mac/ScriptCommand.h
+++ b/src/cpp/desktop-mac/ScriptCommand.h
@@ -1,11 +1,5 @@
 #import <Foundation/Foundation.h>
 
-@interface doJavaScriptCommand : NSScriptCommand
-
--(id) performDefaultImplementation;
-
-@end
-
 @interface doRscriptCommand : NSScriptCommand
 
 -(id) performDefaultImplementation;

--- a/src/cpp/desktop-mac/ScriptCommand.h
+++ b/src/cpp/desktop-mac/ScriptCommand.h
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+
+@interface doJavaScriptCommand : NSScriptCommand
+
+-(id) performDefaultImplementation;
+
+@end
+
+@interface doRscriptCommand : NSScriptCommand
+
+-(id) performDefaultImplementation;
+
+@end

--- a/src/cpp/desktop-mac/ScriptCommand.mm
+++ b/src/cpp/desktop-mac/ScriptCommand.mm
@@ -14,16 +14,40 @@
     script = [script stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
     script = [script stringByReplacingOccurrencesOfString:@"\n" withString:@"\\n"];
     NSString *jscript = [NSString stringWithFormat:
-      @"var input = document.getElementById('rstudio_console_input'); \
-      var textarea = input.getElementsByTagName('textarea')[0]; \
-      textarea.value += \"%@\"; \
-      var e = document.createEvent('KeyboardEvent'); \
-      e.initKeyboardEvent('input'); \
-      textarea.dispatchEvent(e); \
-      var e = document.createEvent('KeyboardEvent'); \
-      e.initKeyboardEvent('keydown'); \
-      Object.defineProperty(e, 'keyCode', {'value' : 13}); \
-      input.dispatchEvent(e);", script];
+      @"if (typeof evaluateRscript == 'undefined') { \
+         var evaluateRscript = function(){ \
+              var queue = []; \
+              var running = 0; \
+              var run_queue = function(){ \
+                   if (queue.length > 0 && running == 0){ \
+                        running = 1; \
+                        evaluate(queue[0]); \
+                        queue.splice(0, 1); \
+                        setTimeout(function(){ \
+                             running = 0; \
+                             run_queue(); \
+                        }, 100); \
+                   } \
+              }; \
+              var evaluate = function(str){ \
+                   var input = document.getElementById('rstudio_console_input'); \
+                   var textarea = input.getElementsByTagName('textarea')[0]; \
+                   textarea.value += str; \
+                   var e = document.createEvent('KeyboardEvent'); \
+                   e.initKeyboardEvent('input'); \
+                   textarea.dispatchEvent(e); \
+                   var e = document.createEvent('KeyboardEvent'); \
+                   e.initKeyboardEvent('keydown'); \
+                   Object.defineProperty(e, 'keyCode', {'value' : 13}); \
+                   input.dispatchEvent(e); \
+              }; \
+              return function(str) { \
+                   queue.push(str); \
+                   run_queue(); \
+              } \
+         }(); \
+      }; \
+      evaluateRscript(\"%@\");", script];
    [[MainFrameController instance] evaluateJavaScript: jscript];
 
    return [NSNumber numberWithBool:YES];

--- a/src/cpp/desktop-mac/ScriptCommand.mm
+++ b/src/cpp/desktop-mac/ScriptCommand.mm
@@ -3,7 +3,7 @@
 #import "MainFrameController.h"
 
 
-@implementation doRscriptCommand
+@implementation evaluateRScriptCommand
 
 -(id) performDefaultImplementation
 {

--- a/src/cpp/desktop-mac/ScriptCommand.mm
+++ b/src/cpp/desktop-mac/ScriptCommand.mm
@@ -3,21 +3,6 @@
 #import "MainFrameController.h"
 
 
-@implementation doJavaScriptCommand
-
--(id) performDefaultImplementation
-{
-    NSString *script = [self directParameter];
-    if (!script || [script isEqualToString:@""])
-        return [NSNumber numberWithBool:NO];
-   [[MainFrameController instance] evaluateJavaScript: script];
-
-   return [NSNumber numberWithBool:YES];
-}
-
-@end
-
-
 @implementation doRscriptCommand
 
 -(id) performDefaultImplementation

--- a/src/cpp/desktop-mac/ScriptCommand.mm
+++ b/src/cpp/desktop-mac/ScriptCommand.mm
@@ -1,0 +1,47 @@
+#import <Foundation/Foundation.h>
+#import "ScriptCommand.h"
+#import "MainFrameController.h"
+
+
+@implementation doJavaScriptCommand
+
+-(id) performDefaultImplementation
+{
+    NSString *script = [self directParameter];
+    if (!script || [script isEqualToString:@""])
+        return [NSNumber numberWithBool:NO];
+   [[MainFrameController instance] evaluateJavaScript: script];
+
+   return [NSNumber numberWithBool:YES];
+}
+
+@end
+
+
+@implementation doRscriptCommand
+
+-(id) performDefaultImplementation
+{
+    NSString *script = [self directParameter];
+    if (!script || [script isEqualToString:@""])
+        return [NSNumber numberWithBool:NO];
+    script = [script stringByReplacingOccurrencesOfString:@"\\" withString:@"\\\\"];
+    script = [script stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
+    script = [script stringByReplacingOccurrencesOfString:@"\n" withString:@"\\n"];
+    NSString *jscript = [NSString stringWithFormat:
+      @"var input = document.getElementById('rstudio_console_input'); \
+      var textarea = input.getElementsByTagName('textarea')[0]; \
+      textarea.value += \"%@\"; \
+      var e = document.createEvent('KeyboardEvent'); \
+      e.initKeyboardEvent('input'); \
+      textarea.dispatchEvent(e); \
+      var e = document.createEvent('KeyboardEvent'); \
+      e.initKeyboardEvent('keydown'); \
+      Object.defineProperty(e, 'keyCode', {'value' : 13}); \
+      input.dispatchEvent(e);", script];
+   [[MainFrameController instance] evaluateJavaScript: jscript];
+
+   return [NSNumber numberWithBool:YES];
+}
+
+@end


### PR DESCRIPTION
It is a hack to implement applescript support. Basically it uses `MainFrameController evaluateJavaScript` to run a piece of javascript which pastes and runs the R code at the console.

The implementation may be hacky, but it works.
 
![untitled](https://cloud.githubusercontent.com/assets/1690993/11157636/8e6e1714-8a20-11e5-98bc-d82e0597e384.gif)

```applescript
tell application "/Applications/RStudio.app"
	do rscript "a=1"
	do javascript "alert('hi')"
end tell
```