### PR TITLE
fix warnings caught by clang static analyzer

### DIFF
--- a/src/cpp/core/include/core/system/ProcessArgs.hpp
+++ b/src/cpp/core/include/core/system/ProcessArgs.hpp
@@ -81,8 +81,8 @@ private:
       {
          for (std::size_t i = 0; i<argCount_; ++i)
             delete [] args_[i] ;
-         delete [] args_ ;
       }
+      delete [] args_ ;
    }
    
 private:

--- a/src/cpp/desktop-mac/AppDelegate.mm
+++ b/src/cpp/desktop-mac/AppDelegate.mm
@@ -446,7 +446,7 @@ bool prepareEnvironment(Options& options)
 - (void) launchNewRStudioWindow
 {
    [NSTask launchedTaskWithLaunchPath: executablePath()
-                            arguments: [NSArray new]];
+                            arguments: [NSArray array]];
 }
 
 @end

--- a/src/cpp/desktop-mac/DockTileView.mm
+++ b/src/cpp/desktop-mac/DockTileView.mm
@@ -83,7 +83,7 @@
       [self drawFrameWithContext: context inRect: badgeRect];
       
       
-      NSMutableParagraphStyle *paraStyle=[[NSMutableParagraphStyle alloc] init];
+      NSMutableParagraphStyle *paraStyle = [[[NSMutableParagraphStyle alloc] init] autorelease];
       [paraStyle setAlignment:NSCenterTextAlignment];
       
       NSDictionary *attributes = [NSDictionary dictionaryWithObjectsAndKeys:
@@ -92,9 +92,9 @@
                      paraStyle, NSParagraphStyleAttributeName,
                      nil];
       
-      NSMutableAttributedString *as = [[NSMutableAttributedString alloc]
+      NSMutableAttributedString *as = [[[NSMutableAttributedString alloc]
                                  initWithString: label_
-                                 attributes:attributes];
+                                 attributes:attributes] autorelease];
       
       NSRect textRect = NSMakeRect(badgeRect.origin.x + inset,
                                    badgeRect.origin.y - (.25 * fontSize),

--- a/src/cpp/desktop-mac/GwtCallbacks.mm
+++ b/src/cpp/desktop-mac/GwtCallbacks.mm
@@ -653,7 +653,7 @@ private:
    }
 
    // return the image
-   return image;
+   return [image autorelease];
 }
 
 
@@ -670,9 +670,6 @@ private:
    [pboard clearContents];
    NSArray *copiedObjects = [NSArray arrayWithObject:image];
    [pboard writeObjects: copiedObjects];
-   
-   // release the image
-   [image release];
 }
 
 
@@ -723,9 +720,6 @@ private:
       error.addProperty("target-file", [targetPath UTF8String]);
       LOG_ERROR(error);
    }
-   
-   // release the image
-   [image release];
 }
 
 
@@ -777,6 +771,8 @@ private:
       
    [alert setMessageText:caption];
    [alert setInformativeText:message];
+   [alert setAlertStyle: style];
+   
    for (NSString* buttonText in dialogButtons)
    {
       [alert addButtonWithTitle: buttonText];

--- a/src/cpp/desktop-mac/MainFrameMenu.mm
+++ b/src/cpp/desktop-mac/MainFrameMenu.mm
@@ -24,10 +24,6 @@
 
 @implementation MainFrameMenu
 
-NSString* charToStr(unichar c) {
-   return [[NSString stringWithCharacters: &c length: 1] autorelease];
-}
-
 - (id)init
 {
    if (self = [super init])

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -1707,7 +1707,7 @@ bool isPackratModeOn()
 
 bool isDevtoolsDevModeOn()
 {
-   bool isDevtoolsDevModeOn;
+   bool isDevtoolsDevModeOn = false;
    Error error = r::exec::RFunction(".rs.devModeOn").call(&isDevtoolsDevModeOn);
    if (error)
       LOG_ERROR(error);

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1003,7 +1003,7 @@ bool isPackageInstalled(const std::string& packageName)
 {
    r::session::utils::SuppressOutputInScope suppressOutput;
 
-   bool installed;
+   bool installed = false;
    r::exec::RFunction func(".rs.isPackageInstalled", packageName);
    Error error = func.call(&installed);
    return !error ? installed : false;
@@ -1014,7 +1014,7 @@ bool isPackageVersionInstalled(const std::string& packageName,
 {
    r::session::utils::SuppressOutputInScope suppressOutput;
 
-   bool installed;
+   bool installed = false;
    r::exec::RFunction func(".rs.isPackageVersionInstalled",
                            packageName, version);
    Error error = func.call(&installed);

--- a/src/cpp/session/modules/SessionHTMLPreview.cpp
+++ b/src/cpp/session/modules/SessionHTMLPreview.cpp
@@ -488,11 +488,12 @@ Error previewHTML(const json::JsonRpcRequest& request,
                                        "requires_knit", &knit,
                                        "is_notebook", &isNotebook);
 
-   if (isNotebook)
-      file = deriveNotebookPath(file);
-
    if (error)
       return error;
+
+   if (isNotebook)
+      file = deriveNotebookPath(file);
+   
    FilePath filePath = module_context::resolveAliasedPath(file);
 
    // if we have a preview already running then just return false


### PR DESCRIPTION
Note: I've added `autorelease` for some objects, but I'm not entirely sure if that's what we want (ie if the caller is supposed to manually release these as desired).

We don't need this for the current release (we can be conservative and AFAICS the potential leaks, if any, would be minor)