### PR TITLE
fix El Capitan crash by using 'placeholder' attribute for cue text

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithCue.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithCue.java
@@ -15,33 +15,29 @@
 package org.rstudio.core.client.widget;
 
 import com.google.gwt.dom.client.Element;
-import com.google.gwt.event.dom.client.BlurEvent;
-import com.google.gwt.event.dom.client.BlurHandler;
-import com.google.gwt.event.dom.client.FocusEvent;
-import com.google.gwt.event.dom.client.FocusHandler;
-import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.TextBox;
-import org.rstudio.core.client.StringUtil;
-import org.rstudio.core.client.dom.DomUtils;
-import org.rstudio.core.client.dom.WindowEx;
 
 public class TextBoxWithCue extends TextBox
 {
    public TextBoxWithCue() 
    {
-      this("");
+      init("", getElement());
    }
 
    public TextBoxWithCue(String cueText)
    {
-      cueText_ = cueText;
-      getElement().setAttribute("spellcheck", "false");
+      init(cueText, getElement());
    }
 
    public TextBoxWithCue(String cueText, Element element)
    {
       super(element);
-      cueText_ = cueText;
+      init(cueText, element);
+   }
+   
+   private void init(String cueText, Element element)
+   {
+      setCueText(cueText);
       element.setAttribute("spellcheck", "false");
    }
 
@@ -53,99 +49,8 @@ public class TextBoxWithCue extends TextBox
    public void setCueText(String cueText)
    {
       cueText_ = cueText;
-   }
-
-   @Override
-   public String getText()
-   {
-      return isCueMode() ? "" : super.getText();
-   }
-
-   @Override
-   protected void onAttach()
-   {
-      super.onAttach();
-      if (!StringUtil.isNullOrEmpty(cueText_))
-         hookEvents();
-   }
-
-   @Override
-   protected void onDetach()
-   {
-      super.onDetach();
-      unhookEvents();
-   }
-
-   private void hookEvents()
-   {
-      unhookEvents();
-
-      FocusHandler focusHandler = new FocusHandler()
-      {
-         public void onFocus(FocusEvent event)
-         {
-            if (DomUtils.hasFocus(getElement()))
-            {
-               if (isCueMode())
-               {
-                  setText("");
-                  removeStyleName(CUE_STYLE);
-               }
-            }
-         }
-      };
-
-      BlurHandler blurHandler = new BlurHandler()
-      {
-         public void onBlur(BlurEvent event)
-         {
-            if (getText().length() == 0)
-            {
-               addStyleName(CUE_STYLE);
-               setText(cueText_);
-            }
-         }
-      };
-
-      registrations_ = new HandlerRegistration[] {
-            addFocusHandler(focusHandler),
-            addBlurHandler(blurHandler),
-            WindowEx.addFocusHandler(focusHandler),
-            WindowEx.addBlurHandler(blurHandler)
-      };
-
-      blurHandler.onBlur(null);
-   }
-
-   private boolean isCueMode()
-   {
-      return (getStyleName() + " ").indexOf(CUE_STYLE + " ") >= 0;
-   }
-   
-   public void setCueMode(boolean cueMode)
-   {
-      if (cueMode)
-      {
-         addStyleName(CUE_STYLE);
-         setText(cueText_);
-      }
-      else
-      {
-         removeStyleName(CUE_STYLE);
-      }
-   }
-
-   private void unhookEvents()
-   {
-      if (registrations_ != null)
-      {
-         for (HandlerRegistration reg : registrations_)
-            reg.removeHandler();
-         registrations_ = null;
-      }
+      getElement().setAttribute("placeholder", cueText);
    }
 
    private String cueText_;
-   private final String CUE_STYLE = "cueText";
-   private HandlerRegistration[] registrations_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DefaultChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DefaultChunkOptionsPopupPanel.java
@@ -159,15 +159,8 @@ public class DefaultChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
       chunkPreamble_ = extractChunkPreamble(extracted, modeId);
       
       String chunkLabel = extractChunkLabel(extracted);
-      if (StringUtil.isNullOrEmpty(chunkLabel))
-      {
-         tbChunkLabel_.setCueMode(true);
-      }
-      else
-      {
-         tbChunkLabel_.setCueMode(false);
+      if (!StringUtil.isNullOrEmpty(chunkLabel))
          tbChunkLabel_.setText(extractChunkLabel(extracted));
-      }
       
       int firstCommaIndex = extracted.indexOf(',');
       String arguments = extracted.substring(firstCommaIndex + 1);


### PR DESCRIPTION
This PR fixes a crash that occurs when attempting to focus a `TextBoxWithCue` element on OS X El Capitan.

The crash is reproducible on Apple laptops running El Capitan using the Trackpad, when attempting to click such textboxes with three fingers, and with the `Look up & data detectors` gesture enabled:

<img width="668" alt="screen shot 2015-11-23 at 4 07 58 pm" src="https://cloud.githubusercontent.com/assets/1976582/11353960/ca83e326-91fc-11e5-8290-6ad5afadd216.png">

To reproduce, simply try to three-click on e.g. the `Go to file/function...` widget in the globar toolbar; or more generally, any field with custom cue text.

<img width="385" alt="screen shot 2015-11-23 at 4 13 27 pm" src="https://cloud.githubusercontent.com/assets/1976582/11354021/35e8b7a4-91fd-11e5-9c9f-5c568088f07f.png">

Here's my guess as to what was causing the issue:

1. The user three-clicks on the field. Apple notices the gesture, and initiates a dictionary lookup for the cue text.

2. The focus handler clears the cue text (preparing for input from the user), and focuses the text box.

3. Apple ends up running the dictionary lookup gesture with some bogus state, leading to a crash.

The `placeholder` attribute has been supported in all real browsers since forever, and in Internet Explorer since IE 10 (which we require for RStudio users). I think we can safely remove the focus / blur handlers and just rely on the `placeholder` attribute + the browser to render cue text here.