### PR TITLE
Update for newer Qt (5.5.1)

### DIFF
--- a/src/cpp/desktop/3rdparty/qtsingleapplication/qtlocalpeer.cpp
+++ b/src/cpp/desktop/3rdparty/qtsingleapplication/qtlocalpeer.cpp
@@ -41,6 +41,7 @@
 
 #include "qtlocalpeer.h"
 #include <QCoreApplication>
+#include <QDataStream>    // Patch for building against Qt 5.5.1
 #include <QTime>
 
 #if defined(Q_OS_WIN)


### PR DESCRIPTION
When compiled against Qt 5.5.1 an error occurs while compiling during make.
error: variable ‘QDataStream ds’ has initializer but incomplete type
     QDataStream ds(&socket);
error: variable ‘QDataStream ds’ has initializer but incomplete type
     QDataStream ds(socket);

Including QDataStream fixes this so that compilation is successful.