### PR TITLE
add Interactive flag for addins

### DIFF
--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -144,6 +144,7 @@ const int kUserFollowStarted = 120;
 const int kUserFollowEnded = 121;
 const int kProjectAccessRevoked = 122;
 const int kCollabEditSaved = 123;
+const int kAddinRegistryUpdated = 124;
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -391,6 +392,8 @@ std::string ClientEvent::typeName() const
          return "project_access_revoked";
       case client_events::kCollabEditSaved:
          return "collab_edit_saved";
+      case client_events::kAddinRegistryUpdated:
+         return "addin_registry_updated";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -145,6 +145,7 @@ extern const int kUserFollowStarted;
 extern const int kUserFollowEnded;
 extern const int kProjectAccessRevoked;
 extern const int kCollabEditSaved;
+extern const int kAddinRegistryUpdated;
 }
    
 class ClientEvent

--- a/src/cpp/session/modules/SessionRAddins.cpp
+++ b/src/cpp/session/modules/SessionRAddins.cpp
@@ -257,12 +257,7 @@ private:
       std::string lower = string_utils::trimWhitespace(
                boost::algorithm::to_lower_copy(string));
       
-      return
-            lower == "true" ||
-            lower == "t" ||
-            lower == "yes" ||
-            lower == "y" ||
-            lower == "please";
+      return lower == "true";
    }
 
    std::map<std::string, AddinSpecification> addins_;

--- a/src/cpp/session/modules/SessionRAddins.cpp
+++ b/src/cpp/session/modules/SessionRAddins.cpp
@@ -276,8 +276,14 @@ FilePath addinRegistryPath()
 
 void updateAddinRegistry(boost::shared_ptr<AddinRegistry> pRegistry)
 {
+   // update registry in memory + on disk
    s_pCurrentRegistry = pRegistry;
    s_pCurrentRegistry->saveToFile(addinRegistryPath());
+   
+   // notify client
+   json::Value data = s_pCurrentRegistry->toJson();
+   ClientEvent event(client_events::kAddinRegistryUpdated, data);
+   module_context::enqueClientEvent(event);
 }
 
 void loadAddinRegistry()

--- a/src/gwt/src/org/rstudio/core/client/command/AddinCommandBinding.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AddinCommandBinding.java
@@ -14,37 +14,28 @@
  */
 package org.rstudio.core.client.command;
 
-import com.google.inject.Inject;
-
 import org.rstudio.core.client.command.KeyMap.CommandBinding;
-import org.rstudio.studio.client.RStudioGinjector;
-import org.rstudio.studio.client.server.VoidServerRequestCallback;
-import org.rstudio.studio.client.workbench.addins.AddinsServerOperations;
+import org.rstudio.studio.client.workbench.addins.Addins.RAddin;
+import org.rstudio.studio.client.workbench.addins.Addins.AddinExecutor;
 
 public class AddinCommandBinding implements CommandBinding
 {
-   public AddinCommandBinding(String id)
+   public AddinCommandBinding(RAddin addin)
    {
-      RStudioGinjector.INSTANCE.injectMembers(this);
-      id_ = id;
-   }
-   
-   @Inject
-   private void initialize(AddinsServerOperations server)
-   {
-      server_ = server;
+      addin_ = addin;
+      executor_ = new AddinExecutor();
    }
    
    @Override
    public String getId()
    {
-      return id_;
+      return addin_.getId();
    }
 
    @Override
    public void execute()
    {
-      server_.executeRAddin(id_, new VoidServerRequestCallback());
+      executor_.execute(addin_);
    }
 
    @Override
@@ -59,6 +50,6 @@ public class AddinCommandBinding implements CommandBinding
       return true;
    }
    
-   private final String id_;
-   private AddinsServerOperations server_;
+   private final RAddin addin_;
+   private final AddinExecutor executor_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -71,6 +71,7 @@ import org.rstudio.studio.client.shiny.ui.ShinyGadgetDialog;
 import org.rstudio.studio.client.shiny.ui.ShinyViewerTypePopupMenu;
 import org.rstudio.studio.client.vcs.VCSApplication;
 import org.rstudio.studio.client.workbench.BrowseAddinsDialog;
+import org.rstudio.studio.client.workbench.addins.Addins.AddinExecutor;
 import org.rstudio.studio.client.workbench.addins.AddinsCommandManager;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.RemoteFileSystemContext;
@@ -162,6 +163,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(NewShinyWebApplication dialog);
    void injectMembers(AddinCommandBinding binding);
    void injectMembers(BrowseAddinsDialog dialog);
+   void injectMembers(AddinExecutor addinExecutor);
    
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);
 

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -135,6 +135,7 @@ class ClientEvent extends JavaScriptObject
    public static final String UserFollowEnded = "user_follow_ended";
    public static final String ProjectAccessRevoked = "project_access_revoked";
    public static final String CollabEditSaved = "collab_edit_saved";
+   public static final String AddinRegistryUpdated = "addin_registry_updated";
    
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -81,6 +81,7 @@ import org.rstudio.studio.client.rsconnect.events.RSConnectDeploymentOutputEvent
 import org.rstudio.studio.client.server.Bool;
 import org.rstudio.studio.client.shiny.events.ShinyApplicationStatusEvent;
 import org.rstudio.studio.client.shiny.model.ShinyApplicationParams;
+import org.rstudio.studio.client.workbench.addins.events.AddinRegistryUpdatedEvent;
 import org.rstudio.studio.client.workbench.codesearch.model.SearchPathFunctionDefinition;
 import org.rstudio.studio.client.workbench.events.*;
 import org.rstudio.studio.client.workbench.model.*;
@@ -746,6 +747,10 @@ public class ClientEventDispatcher
          {
             CollabEditSavedEvent.Data data = event.getData();
             eventBus_.fireEvent(new CollabEditSavedEvent(data));
+         }
+         else if (type.equals(ClientEvent.AddinRegistryUpdated))
+         {
+            eventBus_.fireEvent(new AddinRegistryUpdatedEvent());
          }
          else
          {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -3758,7 +3758,7 @@ public class RemoteServer implements Server
    }
    
    @Override
-   public void executeRAddin(String commandId, ServerRequestCallback<Void> requestCallback)
+   public void executeRAddinNonInteractively(String commandId, ServerRequestCallback<Void> requestCallback)
    {
       JSONArray params = new JSONArray();
       params.set(0, new JSONString(commandId));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/AddinsMRUList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/AddinsMRUList.java
@@ -30,8 +30,7 @@ import org.rstudio.core.client.command.KeyMap.KeyMapType;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
-import org.rstudio.studio.client.common.SimpleRequestCallback;
-import org.rstudio.studio.client.server.Void;
+import org.rstudio.studio.client.workbench.addins.Addins.AddinExecutor;
 import org.rstudio.studio.client.workbench.addins.Addins.RAddin;
 import org.rstudio.studio.client.workbench.addins.AddinsServerOperations;
 import org.rstudio.studio.client.workbench.commands.Commands;
@@ -51,7 +50,8 @@ public class AddinsMRUList extends MRUList
                         final EventBus events,
                         final Session session,
                         final GlobalDisplay display,
-                        final AddinsServerOperations server)
+                        final AddinsServerOperations server,
+                        final AddinExecutor executor)
    {
       super(
             listManager.getAddinsMruList(),
@@ -76,9 +76,7 @@ public class AddinsMRUList extends MRUList
                public void execute(final String encoded)
                {
                   final RAddin addin = RAddin.decode(encoded);
-                  server.executeRAddin(
-                        addin.getId(),
-                        new SimpleRequestCallback<Void>("Error Executing Addin", true));
+                  executor.execute(addin);
                }
             });
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
@@ -35,7 +35,6 @@ import com.google.gwt.view.client.SelectionChangeEvent;
 import com.google.gwt.view.client.SingleSelectionModel;
 import com.google.inject.Inject;
 
-import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ListUtil;
 import org.rstudio.core.client.ListUtil.FilterPredicate;
@@ -119,13 +118,12 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
       // get R addins handler
       class AddinsServerRequestCallback extends ServerRequestCallback<RAddins>
       {
-         @SuppressWarnings("unused")
          AddinsServerRequestCallback()
          {
             this(null);
          }
          
-         AddinsServerRequestCallback(CommandWithArg<RAddins> onSuccess)
+         AddinsServerRequestCallback(Command onSuccess)
          {
             onSuccess_ = onSuccess;
          }
@@ -133,6 +131,7 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
          @Override
          public void onResponseReceived(RAddins addins)
          {
+            addins_ = addins;
             List<RAddin> data = new ArrayList<RAddin>();
             for (String key : JsUtil.asIterable(addins.keys()))
                data.add(addins.get(key));
@@ -142,7 +141,7 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
             table_.setEmptyTableWidget(emptyTableLabel("No addins available"));
             
             if (onSuccess_ != null)
-               onSuccess_.execute(addins);
+               onSuccess_.execute();
          }
          
          @Override
@@ -151,24 +150,16 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
             Debug.logError(error);
          }
          
-         private CommandWithArg<RAddins> onSuccess_;
+         private Command onSuccess_;
          
       };
      
       // first call for cached addins then call for full reindex
-      server_.getRAddins(false, new AddinsServerRequestCallback(new CommandWithArg<RAddins>() {
+      server_.getRAddins(false, new AddinsServerRequestCallback(new Command() {
          @Override
-         public void execute(RAddins addins)
+         public void execute()
          {
-            addins_ = addins;
-            server_.getRAddins(true, new AddinsServerRequestCallback(new CommandWithArg<RAddins>()
-            {
-               @Override
-               public void execute(RAddins addins)
-               {
-                  addins_ = addins;
-               }
-            }));
+            server_.getRAddins(true, new AddinsServerRequestCallback());
          }
       }));
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/addins/AddinsCommandManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/addins/AddinsCommandManager.java
@@ -22,6 +22,8 @@ import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.workbench.addins.Addins.RAddin;
 import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
 import org.rstudio.studio.client.workbench.addins.events.AddinRegistryUpdatedEvent;
+import org.rstudio.studio.client.workbench.events.SessionInitEvent;
+import org.rstudio.studio.client.workbench.events.SessionInitHandler;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,6 +40,19 @@ public class AddinsCommandManager
             false,
             EditorKeyBindings.create());
       
+      // load addin bindings on session init
+      events_.addHandler(
+            SessionInitEvent.TYPE,
+            new SessionInitHandler()
+            {
+               @Override
+               public void onSessionInit(SessionInitEvent sie)
+               {
+                  loadBindings();
+               }
+            });
+      
+      // set bindings when updated (e.g. through ModifyKeyboardShortcuts widget)
       events_.addHandler(
             AddinsKeyBindingsChangedEvent.TYPE,
             new AddinsKeyBindingsChangedEvent.Handler()
@@ -49,6 +64,7 @@ public class AddinsCommandManager
                }
             });
       
+      // update addin bindings when registry populated
       events_.addHandler(
             AddinRegistryUpdatedEvent.TYPE,
             new AddinRegistryUpdatedEvent.Handler()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/addins/AddinsCommandManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/addins/AddinsCommandManager.java
@@ -5,6 +5,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.Pair;
 import org.rstudio.core.client.command.AddinCommandBinding;
 import org.rstudio.core.client.command.EditorCommandManager.EditorKeyBindings;
@@ -16,6 +17,10 @@ import org.rstudio.core.client.command.ShortcutManager;
 import org.rstudio.core.client.files.FileBacked;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.server.ServerError;
+import org.rstudio.studio.client.server.ServerRequestCallback;
+import org.rstudio.studio.client.workbench.addins.Addins.RAddin;
+import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorLoadedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorLoadedHandler;
 
@@ -58,9 +63,11 @@ public class AddinsCommandManager
    }
    
    @Inject
-   private void initialize(EventBus events)
+   private void initialize(EventBus events,
+                           AddinsServerOperations server)
    {
       events_ = events;
+      server_ = server;
    }
    
    public void addBindingsAndSave(final EditorKeyBindings newBindings,
@@ -104,26 +111,46 @@ public class AddinsCommandManager
    private void registerBindings(final EditorKeyBindings bindings,
                                  final CommandWithArg<EditorKeyBindings> afterLoad)
    {
-      List<Pair<List<KeySequence>, CommandBinding>> commands =
-            new ArrayList<Pair<List<KeySequence>, CommandBinding>>();
-      
-      for (String id : bindings.iterableKeys())
+      server_.getRAddins(false, new ServerRequestCallback<RAddins>()
       {
-         List<KeySequence> keyList = bindings.get(id).getKeyBindings();
-         CommandBinding binding = new AddinCommandBinding(id);
-         commands.add(new Pair<List<KeySequence>, CommandBinding>(keyList, binding));
-      }
-      
-      KeyMap map = ShortcutManager.INSTANCE.getKeyMap(KeyMapType.ADDIN);
-      for (int i = 0; i < commands.size(); i++)
-      {
-         map.setBindings(
-               commands.get(i).first,
-               commands.get(i).second);
-      }
-      
-      if (afterLoad != null)
-         afterLoad.execute(bindings);
+         @Override
+         public void onResponseReceived(RAddins addins)
+         {
+            List<Pair<List<KeySequence>, CommandBinding>> commands =
+                  new ArrayList<Pair<List<KeySequence>, CommandBinding>>();
+
+            for (String id : bindings.iterableKeys())
+            {
+               List<KeySequence> keyList = bindings.get(id).getKeyBindings();
+               RAddin addin = addins.get(id);
+               if (addin == null)
+               {
+                  Debug.log("Failed to register addin with id '" + id + "'");
+                  continue;
+               }
+               CommandBinding binding = new AddinCommandBinding(addin);
+               commands.add(new Pair<List<KeySequence>, CommandBinding>(keyList, binding));
+            }
+
+            KeyMap map = ShortcutManager.INSTANCE.getKeyMap(KeyMapType.ADDIN);
+            for (int i = 0; i < commands.size(); i++)
+            {
+               map.setBindings(
+                     commands.get(i).first,
+                     commands.get(i).second);
+            }
+
+            if (afterLoad != null)
+               afterLoad.execute(bindings);
+            
+         }
+         
+         @Override
+         public void onError(ServerError error)
+         {
+            Debug.logError(error);
+         }
+      });
    }
    
    public void resetBindings()
@@ -150,5 +177,6 @@ public class AddinsCommandManager
    
    // Injected ----
    private EventBus events_;
+   private AddinsServerOperations server_;
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/addins/AddinsCommandManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/addins/AddinsCommandManager.java
@@ -21,8 +21,7 @@ import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.workbench.addins.Addins.RAddin;
 import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
-import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorLoadedEvent;
-import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorLoadedHandler;
+import org.rstudio.studio.client.workbench.addins.events.AddinRegistryUpdatedEvent;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,17 +39,6 @@ public class AddinsCommandManager
             EditorKeyBindings.create());
       
       events_.addHandler(
-            EditorLoadedEvent.TYPE,
-            new EditorLoadedHandler()
-            {
-               @Override
-               public void onEditorLoaded(EditorLoadedEvent event)
-               {
-                  loadBindings();
-               }
-            });
-      
-      events_.addHandler(
             AddinsKeyBindingsChangedEvent.TYPE,
             new AddinsKeyBindingsChangedEvent.Handler()
             {
@@ -58,6 +46,17 @@ public class AddinsCommandManager
                public void onAddinsKeyBindingsChanged(AddinsKeyBindingsChangedEvent event)
                {
                   registerBindings(event.getBindings(), null);
+               }
+            });
+      
+      events_.addHandler(
+            AddinRegistryUpdatedEvent.TYPE,
+            new AddinRegistryUpdatedEvent.Handler()
+            {
+               @Override
+               public void onAddinRegistryUpdated(AddinRegistryUpdatedEvent event)
+               {
+                  loadBindings();
                }
             });
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/addins/AddinsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/addins/AddinsServerOperations.java
@@ -8,5 +8,5 @@ public interface AddinsServerOperations
 {
    void getRAddins(boolean reindex,
                    ServerRequestCallback<RAddins> requestCallback);
-   void executeRAddin(String commandId, ServerRequestCallback<Void> requestCallback);
+   void executeRAddinNonInteractively(String commandId, ServerRequestCallback<Void> requestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/addins/events/AddinRegistryUpdatedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/addins/events/AddinRegistryUpdatedEvent.java
@@ -1,0 +1,42 @@
+/*
+ * AddinRegistryUpdatedEvent.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.addins.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class AddinRegistryUpdatedEvent extends GwtEvent<AddinRegistryUpdatedEvent.Handler>
+{
+   // Boilerplate ----
+   
+   public interface Handler extends EventHandler
+   {
+      void onAddinRegistryUpdated(AddinRegistryUpdatedEvent event);
+   }
+   
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onAddinRegistryUpdated(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}


### PR DESCRIPTION
This PR adds the `interactive` field for an addin, and uses that to control whether an addin is executed through a `SendToConsoleEvent` or through an `executeRAddinNonInteractively` server call.

@jjallaire can you double-check that I'm properly using the amended `getRAddins` server call correctly?