### PR TITLE
alternate implementation for syncing addin MRU list

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -151,6 +151,7 @@ extern "C" const char *locale2charset(const char *);
 #include "modules/SessionMarkers.hpp"
 #include "modules/SessionSnippets.hpp"
 #include "modules/SessionUserCommands.hpp"
+#include "modules/SessionRAddins.hpp"
 
 #include "modules/SessionGit.hpp"
 #include "modules/SessionSVN.hpp"
@@ -643,6 +644,8 @@ void handleClientInit(const boost::function<void()>& initFunction,
 
    sessionInfo["show_user_home_page"] = options.showUserHomePage();
    sessionInfo["user_home_page_url"] = json::Value();
+   
+   sessionInfo["r_addins"] = modules::r_addins::addinRegistryAsJson();
 
    module_context::events().onSessionInfo(&sessionInfo);
 

--- a/src/cpp/session/modules/SessionLists.cpp
+++ b/src/cpp/session/modules/SessionLists.cpp
@@ -331,7 +331,7 @@ Error initialize()
    s_lists[kHelpHistory] = 15;
    s_lists[kPlotPublishMru] = 15;
    s_lists[kUserDictioanry] = 10000;
-   s_lists[kAddinsMru] = 10;
+   s_lists[kAddinsMru] = 15;
 
    // monitor the lists directory
    s_listsPath = module_context::registerMonitoredUserScratchDir(

--- a/src/cpp/session/modules/SessionRAddins.cpp
+++ b/src/cpp/session/modules/SessionRAddins.cpp
@@ -579,6 +579,11 @@ Error executeRAddin(const json::JsonRpcRequest& request,
 }
 
 } // end anonymous namespace
+
+core::json::Value addinRegistryAsJson()
+{
+   return addinRegistry().toJson();
+}
   
 Error initialize()
 {

--- a/src/cpp/session/modules/SessionRAddins.hpp
+++ b/src/cpp/session/modules/SessionRAddins.hpp
@@ -16,6 +16,8 @@
 #ifndef SESSION_R_ADDINS_HPP
 #define SESSION_R_ADDINS_HPP
 
+#include <core/json/Json.hpp>
+
 namespace rstudio {
 namespace core {
    class Error;
@@ -26,7 +28,9 @@ namespace rstudio {
 namespace session {
 namespace modules {
 namespace r_addins {
-   
+
+core::json::Value addinRegistryAsJson();
+
 core::Error initialize();
 
 } // namespace r_addins

--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
@@ -340,7 +340,8 @@ public class ShortcutManager implements NativePreviewHandler,
          return false;
       }
       
-      keyBuffer_.add(event);
+      KeyCombination keyCombination = new KeyCombination(event);
+      keyBuffer_.add(keyCombination);
       
       // Loop through all active key maps, and attempt to find an active
       // binding. 'pending' is used to indicate whether there are any bindings
@@ -362,7 +363,7 @@ public class ShortcutManager implements NativePreviewHandler,
             pending = true;
       }
       
-      if (!pending)
+      if (!(pending || isPrefixForEditor(keyCombination)))
          keyBuffer_.clear();
       
       // Assume that a keypress without a modifier key clears the keybuffer.
@@ -377,6 +378,26 @@ public class ShortcutManager implements NativePreviewHandler,
          KeyCombination keys = keyBuffer_.get(keyBuffer_.size() - 1);
          if (keys.getModifier() == KeyboardShortcut.NONE)
             keyBuffer_.clear();
+      }
+      
+      return false;
+   }
+   
+   // TODO: In a perfect world, this function does not exist and
+   // instead we populate an editor key map based on the current state
+   // of the Ace editor, which we could check for prefix matches.
+   // For now, we'll just hard code the prefix
+   // keys used in the default keymaps for Emacs.
+   private boolean isPrefixForEditor(KeyCombination keys)
+   {
+      if (editorMode_ == KeyboardShortcut.MODE_EMACS)
+      {
+         if (keys.isCtrlPressed())
+         {
+            int keyCode = keys.getKeyCode();
+            return keyCode == KeyCodes.KEY_C ||
+                   keyCode == KeyCodes.KEY_X;
+         }
       }
       
       return false;

--- a/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
@@ -486,28 +486,6 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
          }
       });
       
-      // Addins: ensure any recently bound addins become part of the MRU
-      addinsServer_.getRAddins(false, new ServerRequestCallback<RAddins>()
-      {
-         @Override
-         public void onError(ServerError error)
-         {
-            Debug.logError(error);
-         }
-         
-         @Override
-         public void onResponseReceived(RAddins addins)
-         {
-            for (String id : JsUtil.asIterable(addinBindings.keys()))
-            {
-               RAddin addin = addins.get(id);
-               String encoded = RAddin.encode(addin);
-               if (!mruAddins_.contains(encoded))
-                  mruAddins_.add(encoded);
-               mruAddins_.updateShortcuts();
-            }
-         }
-      });
       closeDialog();
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
@@ -240,8 +240,6 @@ public class GlobalToolbar extends Toolbar
       addinsMenu.addItem(commands_.addinsMru13().createMenuItem(false));
       addinsMenu.addItem(commands_.addinsMru14().createMenuItem(false));
       addinsMenu.addSeparator();
-      addinsMenu.addItem(commands_.clearAddinsMruList().createMenuItem(false));
-      addinsMenu.addSeparator();
       addinsMenu.addItem(commands_.browseAddins().createMenuItem(false));
       addLeftSeparator();
       ToolbarButton addinsButton = new ToolbarButton(

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -81,6 +81,7 @@ import org.rstudio.studio.client.rsconnect.events.RSConnectDeploymentOutputEvent
 import org.rstudio.studio.client.server.Bool;
 import org.rstudio.studio.client.shiny.events.ShinyApplicationStatusEvent;
 import org.rstudio.studio.client.shiny.model.ShinyApplicationParams;
+import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
 import org.rstudio.studio.client.workbench.addins.events.AddinRegistryUpdatedEvent;
 import org.rstudio.studio.client.workbench.codesearch.model.SearchPathFunctionDefinition;
 import org.rstudio.studio.client.workbench.events.*;
@@ -750,7 +751,8 @@ public class ClientEventDispatcher
          }
          else if (type.equals(ClientEvent.AddinRegistryUpdated))
          {
-            eventBus_.fireEvent(new AddinRegistryUpdatedEvent());
+            RAddins data = event.getData();
+            eventBus_.fireEvent(new AddinRegistryUpdatedEvent(data));
          }
          else
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/AddinsMRUList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/AddinsMRUList.java
@@ -79,8 +79,8 @@ public class AddinsMRUList implements SessionInitHandler,
             commands_.addinsMru14()
       };
       
-      events.addHandler(SessionInitEvent.TYPE, this);
-      events.addHandler(AddinRegistryUpdatedEvent.TYPE, this);
+      events_.addHandler(SessionInitEvent.TYPE, this);
+      events_.addHandler(AddinRegistryUpdatedEvent.TYPE, this);
       
       initCommandHandlers();
    }
@@ -110,7 +110,15 @@ public class AddinsMRUList implements SessionInitHandler,
       update(event.getData());
    }
    
-   private void update(final RAddins addins)
+   private void update(RAddins addins)
+   {
+      List<RAddin> addinsList = new ArrayList<RAddin>();
+      for (String key : JsUtil.asIterable(addins.keys()))
+         addinsList.add(addins.get(key));
+      update(addinsList);
+   }
+   
+   private void update(final List<RAddin> addins)
    {
       pAddinManager_.get().loadBindings(new CommandWithArg<EditorKeyBindings>()
       {
@@ -122,14 +130,10 @@ public class AddinsMRUList implements SessionInitHandler,
       });
    }
    
-   private void finishUpdate(RAddins addins)
+   private void finishUpdate(List<RAddin> addinsList)
    {
-      // Collect the addins as key-value pairs (so we can sort)
-      List<RAddin> addinsList = new ArrayList<RAddin>();
-      
-      for (String key : JsUtil.asIterable(addins.keys()))
-         addinsList.add(addins.get(key));
-      
+      // Sort the addins list, favoring addins that have
+      // been recently updated.
       Collections.sort(addinsList, new Comparator<RAddin>()
       {
          @Override
@@ -206,6 +210,7 @@ public class AddinsMRUList implements SessionInitHandler,
    public void add(RAddin addin)
    {
       mruList_.prepend(addin.getId());
+      update(addinsList_);
    }
    
    public AppCommand[] getAddinMruCommands()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/AddinsMRUList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/AddinsMRUList.java
@@ -61,6 +61,24 @@ public class AddinsMRUList implements SessionInitHandler,
       events_ = events;
       commands_ = commands;
       
+      mruCommands_ = new AppCommand[] {
+            commands_.addinsMru0(),
+            commands_.addinsMru1(),
+            commands_.addinsMru2(),
+            commands_.addinsMru3(),
+            commands_.addinsMru4(),
+            commands_.addinsMru5(),
+            commands_.addinsMru6(),
+            commands_.addinsMru7(),
+            commands_.addinsMru8(),
+            commands_.addinsMru9(),
+            commands_.addinsMru10(),
+            commands_.addinsMru11(),
+            commands_.addinsMru12(),
+            commands_.addinsMru13(),
+            commands_.addinsMru14()
+      };
+      
       events.addHandler(SessionInitEvent.TYPE, this);
       events.addHandler(AddinRegistryUpdatedEvent.TYPE, this);
       
@@ -69,21 +87,8 @@ public class AddinsMRUList implements SessionInitHandler,
    
    private void initCommandHandlers()
    {
-      addIndexedHandler(commands_.addinsMru0(),   0);
-      addIndexedHandler(commands_.addinsMru1(),   1);
-      addIndexedHandler(commands_.addinsMru2(),   2);
-      addIndexedHandler(commands_.addinsMru3(),   3);
-      addIndexedHandler(commands_.addinsMru4(),   4);
-      addIndexedHandler(commands_.addinsMru5(),   5);
-      addIndexedHandler(commands_.addinsMru6(),   6);
-      addIndexedHandler(commands_.addinsMru7(),   7);
-      addIndexedHandler(commands_.addinsMru8(),   8);
-      addIndexedHandler(commands_.addinsMru9(),   9);
-      addIndexedHandler(commands_.addinsMru10(), 10);
-      addIndexedHandler(commands_.addinsMru11(), 11);
-      addIndexedHandler(commands_.addinsMru12(), 12);
-      addIndexedHandler(commands_.addinsMru13(), 13);
-      addIndexedHandler(commands_.addinsMru14(), 14);
+      for (int i = 0; i < mruCommands_.length; i++)
+         addIndexedHandler(mruCommands_[i], i);
    }
    
    private void addIndexedHandler(AppCommand command, int index)
@@ -149,21 +154,8 @@ public class AddinsMRUList implements SessionInitHandler,
             ShortcutManager.INSTANCE.getKeyMap(KeyMapType.ADDIN);
       
       // Populate up to 15 commands.
-      manageCommand(commands_.addinsMru0(),  addinsList, addinsKeyMap,  0);
-      manageCommand(commands_.addinsMru1(),  addinsList, addinsKeyMap,  1);
-      manageCommand(commands_.addinsMru2(),  addinsList, addinsKeyMap,  2);
-      manageCommand(commands_.addinsMru3(),  addinsList, addinsKeyMap,  3);
-      manageCommand(commands_.addinsMru4(),  addinsList, addinsKeyMap,  4);
-      manageCommand(commands_.addinsMru5(),  addinsList, addinsKeyMap,  5);
-      manageCommand(commands_.addinsMru6(),  addinsList, addinsKeyMap,  6);
-      manageCommand(commands_.addinsMru7(),  addinsList, addinsKeyMap,  7);
-      manageCommand(commands_.addinsMru8(),  addinsList, addinsKeyMap,  8);
-      manageCommand(commands_.addinsMru9(),  addinsList, addinsKeyMap,  9);
-      manageCommand(commands_.addinsMru10(), addinsList, addinsKeyMap, 10);
-      manageCommand(commands_.addinsMru11(), addinsList, addinsKeyMap, 11);
-      manageCommand(commands_.addinsMru12(), addinsList, addinsKeyMap, 12);
-      manageCommand(commands_.addinsMru13(), addinsList, addinsKeyMap, 13);
-      manageCommand(commands_.addinsMru14(), addinsList, addinsKeyMap, 14);
+      for (int i = 0; i < mruCommands_.length; i++)
+         manageCommand(mruCommands_[i], addinsList, addinsKeyMap, i);
    }
    
    private class AddinCommandHandler implements CommandHandler
@@ -216,9 +208,16 @@ public class AddinsMRUList implements SessionInitHandler,
       mruList_.prepend(addin.getId());
    }
    
+   public AppCommand[] getAddinMruCommands()
+   {
+      return mruCommands_;
+   }
+   
    // Private Members ----
    private WorkbenchList mruList_;
    private List<RAddin> addinsList_;
+   
+   private final AppCommand[] mruCommands_;
    
    // Injected ----
    private final Provider<WorkbenchListManager> pListManager_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/AddinsMRUList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/AddinsMRUList.java
@@ -148,7 +148,7 @@ public class AddinsMRUList implements SessionInitHandler,
       // of addins that the dummy MRU commands will dispatch to
       List<RAddin> addinList = new ArrayList<RAddin>();
       
-      // Set used for quick lookup (map MRU ids to Addins)
+      // Map used for quick lookup of MRU addin ids
       Map<String, RAddin> addinMap = new HashMap<String, RAddin>();
       for (RAddin addin : addinRegistry)
          addinMap.put(addin.getId(), addin);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/AddinsMRUList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/AddinsMRUList.java
@@ -140,7 +140,7 @@ public class AddinsMRUList implements SessionInitHandler,
             
             // Recently used commands come first.
             if (r1 != r2)
-               return r1 ? 1 : -1;
+               return r1 ? -1 : 1;
             
             // Otherwise, compare on IDs.
             return o1.getId().compareTo(o2.getId());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
@@ -331,35 +331,25 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
       }
       
       return new ExecuteAddinCommand(
-            mruList_,
             addins_.get(selection_.getId()),
-            RAddin.encode(selection_),
             new AddinExecutor());
    }
    
    private static class ExecuteAddinCommand implements Command
    {
-      public ExecuteAddinCommand(AddinsMRUList mruList,
-                                 RAddin addin,
-                                 String encoded,
-                                 AddinExecutor executor)
+      public ExecuteAddinCommand(RAddin addin, AddinExecutor executor)
       {
-         mruList_ = mruList;
          addin_ = addin;
-         encoded_ = encoded;
          executor_ = executor;
       }
       
       @Override
       public void execute()
       {
-         mruList_.add(encoded_);
          executor_.execute(addin_);
       }
       
-      private final AddinsMRUList mruList_;
       private final RAddin addin_;
-      private final String encoded_;
       private final AddinExecutor executor_;
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
@@ -191,11 +191,9 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
    }
    
    @Inject
-   private void initialize(AddinsServerOperations server,
-                           AddinsMRUList mruList)
+   private void initialize(AddinsServerOperations server)
    {
       server_ = server;
-      mruList_ = mruList;
    }
    
    private void addColumns()
@@ -387,7 +385,6 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
    
    // Injected ----
    private AddinsServerOperations server_;
-   private AddinsMRUList mruList_;
    
    // Resources, etc ----
    public interface Resources extends RStudioDataGridResources

--- a/src/gwt/src/org/rstudio/studio/client/workbench/MRUList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/MRUList.java
@@ -76,11 +76,6 @@ public class MRUList
          }
       });
    }
-   
-   public boolean contains(String entry)
-   {
-      return mruList_.contains(entry);
-   }
 
    public void add(String entry)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/WorkbenchList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/WorkbenchList.java
@@ -34,9 +34,6 @@ public interface WorkbenchList
    void remove(String item);
    void clear();
    
-   // status
-   boolean contains(String item);
-   
    // change handler
    HandlerRegistration addListChangedHandler(ListChangedHandler handler);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/WorkbenchListManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/WorkbenchListManager.java
@@ -151,12 +151,6 @@ public class WorkbenchListManager
       }
       
       @Override
-      public boolean contains(String item)
-      {
-         return list_.contains(item);
-      }
-
-      @Override
       public void clear()
       {
          server_.listClear(name_, new ListRequestCallback());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/addins/Addins.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/addins/Addins.java
@@ -10,6 +10,7 @@ import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.server.Void;
+import org.rstudio.studio.client.workbench.AddinsMRUList;
 import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
 
 public class Addins
@@ -91,10 +92,13 @@ public class Addins
       }
       
       @Inject
-      private void initialize(AddinsServerOperations server, EventBus events)
+      private void initialize(AddinsServerOperations server,
+                              EventBus events,
+                              AddinsMRUList mruList)
       {
          server_ = server;
          events_ = events;
+         mruList_ = mruList;
       }
       
       public void execute(RAddin addin)
@@ -116,6 +120,8 @@ public class Addins
                   addin.getId(),
                   new SimpleRequestCallback<Void>("Error Executing Addin", true));
          }
+         
+         mruList_.add(addin);
       }
       
       private boolean injected_ = false;
@@ -123,6 +129,7 @@ public class Addins
       // Injected ----
       private AddinsServerOperations server_;
       private EventBus events_;
+      private AddinsMRUList mruList_;
    }
    
    private static final String DELIMITER = "|||";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/addins/events/AddinRegistryUpdatedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/addins/events/AddinRegistryUpdatedEvent.java
@@ -14,11 +14,25 @@
  */
 package org.rstudio.studio.client.workbench.addins.events;
 
+import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
+
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 
 public class AddinRegistryUpdatedEvent extends GwtEvent<AddinRegistryUpdatedEvent.Handler>
 {
+   public AddinRegistryUpdatedEvent(RAddins data)
+   {
+      data_ = data;
+   }
+   
+   public RAddins getData()
+   {
+      return data_;
+   }
+   
+   private final RAddins data_;
+   
    // Boilerplate ----
    
    public interface Handler extends EventHandler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -405,8 +405,6 @@ well as menu structures (for main menu and popup menus).
             <cmd refid="addinsMru13"/>
             <cmd refid="addinsMru14"/>
             <separator/>
-            <cmd refid="clearAddinsMruList"/>
-            <separator/>
             <cmd refid="browseAddins"/>
          </menu>
          <separator/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -23,6 +23,7 @@ import org.rstudio.studio.client.common.compilepdf.model.CompilePdfState;
 import org.rstudio.studio.client.common.console.ConsoleProcessInfo;
 import org.rstudio.studio.client.common.debugging.model.ErrorManagerState;
 import org.rstudio.studio.client.common.rnw.RnwWeave;
+import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
 import org.rstudio.studio.client.workbench.views.buildtools.model.BuildState;
 import org.rstudio.studio.client.workbench.views.environment.model.EnvironmentContextData;
 import org.rstudio.studio.client.workbench.views.output.find.model.FindInFilesState;
@@ -423,6 +424,10 @@ public class SessionInfo extends JavaScriptObject
    
    public final native String getUserHomePageUrl() /*-{
       return this.user_home_page_url;
+   }-*/;
+   
+   public final native RAddins getAddins() /*-{
+      return this.r_addins;
    }-*/;
    
 }


### PR DESCRIPTION
Not yet ready for merge, but parts are ready for review.

The goal of this PR is to remove away from extending `MRUList`, and instead manually managing commands + an internal `WorkbenchList` when commands are executed. By ensuring that commands are updated in response to events, we can ensure that we aren't at risk of server races as in the previous implementation.