### PR TITLE
fix 'pending' check for bindings; update editor mode on prefs change

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/DirectedGraph.java
+++ b/src/gwt/src/org/rstudio/core/client/DirectedGraph.java
@@ -29,6 +29,11 @@ public class DirectedGraph<K, V>
       public R create();
    }
    
+   public interface ForEachNodeCommand<K, V>
+   {
+      public boolean continueExecution(DirectedGraph<K, V> node);
+   }
+   
    public DirectedGraph()
    {
       this(null, null, null, null);
@@ -168,16 +173,18 @@ public class DirectedGraph<K, V>
       return chain;
    }
    
-   public void forEachNode(CommandWithArg<DirectedGraph<K, V>> command)
+   public void forEachNode(ForEachNodeCommand<K, V> command)
    {
       forEachNodeImpl(this, command);
    }
    
    private static <K, V> void forEachNodeImpl(
          DirectedGraph<K, V> node,
-         CommandWithArg<DirectedGraph<K, V>> command)
+         ForEachNodeCommand<K, V> command)
    {
-      command.execute(node);
+      if (!command.continueExecution(node))
+         return;
+      
       for (Map.Entry<K, DirectedGraph<K, V>> entry : node.getChildren().entrySet())
          forEachNodeImpl(entry.getValue(), command);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -29,6 +29,8 @@ import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.inject.Inject;
 
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.command.KeyboardShortcut;
+import org.rstudio.core.client.command.ShortcutManager;
 import org.rstudio.core.client.prefs.PreferencesDialogBaseResources;
 import org.rstudio.core.client.theme.DialogTabLayoutPanel;
 import org.rstudio.core.client.widget.HelpButton;
@@ -474,6 +476,14 @@ public class EditingPreferencesPane extends PreferencesPane
       
       prefs_.useVimMode().setGlobalValue(isVim);
       prefs_.enableEmacsKeybindings().setGlobalValue(isEmacs);
+      
+      if (isVim)
+         ShortcutManager.INSTANCE.setEditorMode(KeyboardShortcut.MODE_VIM);
+      else if (isEmacs)
+         ShortcutManager.INSTANCE.setEditorMode(KeyboardShortcut.MODE_EMACS);
+      else
+         ShortcutManager.INSTANCE.setEditorMode(KeyboardShortcut.MODE_DEFAULT);
+      
       prefs_.rmdViewerType().setGlobalValue(Integer.decode(
             rmdViewerMode_.getValue()));
       


### PR DESCRIPTION
This PR fixes two issues:

1. It looks like the editor mode was not always synchronized (in the ShortcutManager) after the editor mode was changed in the EditingPreferencesPane, even though it was changed in the underlying Ace instance. This meant that certain RStudio commands would not be properly toggled on/off when the mode was changed.

2. The 'pending' check in the ShortcutManager did not work properly -- it merely checked to see if there were _any_ commands available in the following key sequence, but it did not confirm whether any of those commands were actually enabled. This meant that e.g. `Ctrl+C` would be logged as a 'pending' key sequence, even though the underlying commands would only be accessible in Emacs mode.

I discovered this while in Vim mode: attempting to return to normal mode (with `Ctrl+C`) and then save (with `Cmd + S`) failed, as the shortcut manager expected there to be more commands available after `Ctrl+C`. So, instead of looking for commands bound to `Cmd+S`, it looks for commands bound to `Ctrl+C Cmd+S`, which then fails.