### PR TITLE
fix up some indentation rules within '(', '['

### DIFF
--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1424,12 +1424,24 @@ var RCodeModel = function(session, tokenizer,
 
             if (tokenCursor.isAtStartOfNewExpression(false))
             {
-               if (currentValue === "{")
+               if (currentValue === "{" ||
+                   currentValue === "[" ||
+                   currentValue === "(")
+               {
                   continuationIndent = tab;
+               }
 
                return this.$getIndent(
                   this.$doc.getLine(tokenCursor.$row)
                ) + continuationIndent;
+            }
+
+            if (currentValue === "(" &&
+                tokenCursor.isAtStartOfNewExpression(true))
+            {
+               return this.$getIndent(
+                  this.$doc.getLine(tokenCursor.$row)
+               ) + tab;
             }
              
             // Walk over matching braces ('()', '{}', '[]')

--- a/src/gwt/test/autoindent_test_r.html
+++ b/src/gwt/test/autoindent_test_r.html
@@ -386,6 +386,18 @@ foo()
 <li><pre data-expected="2">
 ()
 {
+
+<li><pre data-expected="2">
+(
+</pre></li>
+
+<li><pre data-expected="2">
+(apple
+</pre></li>
+
+<li><pre data-expected="2">
+x <- 1
+(apple
 </pre></li>
 
 </ol>


### PR DESCRIPTION
NOTE: Leave for next release.

This PR fixes up some indentation rules when indenting within plain `()` or `[]` (ie, those not associated with function calls).