### PR TITLE
Avoid integer truncation while computing console width

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -709,7 +709,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
       RootPanel.get().remove(widthChecker);
       
       // compute the points per character 
-      int pointsPerCharacter = labelWidth / text.length();
+      float pointsPerCharacter = (float)labelWidth / (float)text.length();
       
       // compute client width
       int clientWidth = getElement().getClientWidth();
@@ -726,8 +726,9 @@ public class ShellWidget extends Composite implements ShellDisplay,
       
       // compute character width (add pad so characters aren't flush to right)
       final int RIGHT_CHARACTER_PAD = 2;
-      int width = (clientWidth / pointsPerCharacter) - RIGHT_CHARACTER_PAD ;
-      
+      int width = Math.round((float)clientWidth / pointsPerCharacter) - 
+            RIGHT_CHARACTER_PAD;
+
       // enforce a minimum width
       final int MINIMUM_WIDTH = 30;
       return Math.max(width, MINIMUM_WIDTH);


### PR DESCRIPTION
This change fixes a problem on high DPI displays in which the console over-reports its width.

The problem is caused by fractional character widths on high DPI displays and GWT integer truncation, with the result that the width is computed as if characters were narrower than they really are (e.g. `7px` rather than `7.5px`). 