### PR TITLE
Update CMAKE for OpenSSL in El Capitan OSX

### DIFF
--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -187,6 +187,11 @@ if (UNIX)
          set(CORE_INCLUDE_DIRS
             ${CORE_INCLUDE_DIRS}
             /usr/local/opt/openssl/include)
+
+         if(NOT DEFINED OPENSSL_ROOT_DIR)
+            set(OPENSSL_ROOT_DIR
+               /usr/local/opt/openssl)
+         endif()
       endif()
    endif()
 


### PR DESCRIPTION
While setting up my dev environment @jmcphers and I found that OpenSSL is not configured for CMAKE on El Capitan (OSX). This adds the missing reference to the cmake file and would also require a change in the dependencies wiki to instruct devs to install OpenSSL (I used "brew install OpenSSL")