### PR TITLE
Start development of data import improvements

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -363,6 +363,7 @@ well as menu structures (for main menu and popup menus).
          <menu label="_Import Dataset">
             <cmd refid="importDatasetFromFile"/>
             <cmd refid="importDatasetFromURL"/>
+            <cmd refid="importDatasetFromCSV"/>
          </menu>
          <separator/>
          <cmd refid="installPackage"/>
@@ -2034,6 +2035,11 @@ well as menu structures (for main menu and popup menus).
    <cmd id="importDatasetFromURL"
         label="Import Dataset from URL..."
         menuLabel="From _Web URL..."
+        windowMode="main"/>
+
+   <cmd id="importDatasetFromCSV"
+        label="Import Dataset from CSV..."
+        menuLabel="From _CSV..."
         windowMode="main"/>
 
    <cmd id="refreshWorkspace"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -266,6 +266,7 @@ public abstract class
    public abstract AppCommand loadWorkspace();
    public abstract AppCommand importDatasetFromFile();
    public abstract AppCommand importDatasetFromURL();
+   public abstract AppCommand importDatasetFromCSV();
 
    // Environment
    public abstract AppCommand activateEnvironment();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
@@ -433,6 +433,10 @@ public class UIPrefs extends UIPrefsAccessor implements UiPrefsChangedHandler
          // how to view R Markdown documents
          rmdViewerType().setGlobalValue(
                newUiPrefs.rmdViewerType().getGlobalValue());
+         
+         // show improved data import dialog
+         useDataImport().setGlobalValue(
+               newUiPrefs.useDataImport().getGlobalValue());
       }
       else if (e.getType().equals(UiPrefsChangedEvent.PROJECT_TYPE))
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -393,6 +393,11 @@ public class UIPrefsAccessor extends Prefs
       return bool("use_roxygen", false);
    }
    
+   public PrefValue<Boolean> useDataImport()
+   {
+      return bool("use_dataimport", false);
+   }
+   
    public static final String PDF_PREVIEW_NONE = "none";
    public static final String PDF_PREVIEW_RSTUDIO = "rstudio";
    public static final String PDF_PREVIEW_DESKTOP_SYNCTEX = "desktop-synctex";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -415,9 +415,17 @@ public class EnvironmentPane extends WorkbenchPane
    private Widget createImportMenu()
    {
       ToolbarPopupMenu menu = new ToolbarPopupMenu();
-      menu.addItem(commands_.importDatasetFromFile().createMenuItem(false));
-      menu.addItem(commands_.importDatasetFromURL().createMenuItem(false));
-      menu.addItem(commands_.importDatasetFromCSV().createMenuItem(false));
+      
+      if (prefs_.useDataImport().getValue())
+      {
+         menu.addItem(commands_.importDatasetFromCSV().createMenuItem(false));
+      }
+      else
+      {
+         menu.addItem(commands_.importDatasetFromFile().createMenuItem(false));
+         menu.addItem(commands_.importDatasetFromURL().createMenuItem(false));
+      }
+      
       dataImportButton_ = new ToolbarButton(
               "Import Dataset",
               StandardIcons.INSTANCE.import_dataset(),

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -417,6 +417,7 @@ public class EnvironmentPane extends WorkbenchPane
       ToolbarPopupMenu menu = new ToolbarPopupMenu();
       menu.addItem(commands_.importDatasetFromFile().createMenuItem(false));
       menu.addItem(commands_.importDatasetFromURL().createMenuItem(false));
+      menu.addItem(commands_.importDatasetFromCSV().createMenuItem(false));
       dataImportButton_ = new ToolbarButton(
               "Import Dataset",
               StandardIcons.INSTANCE.import_dataset(),

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -475,7 +475,7 @@ public class EnvironmentPresenter extends BasePresenter
    void onImportDatasetFromCSV()
    {
       view_.bringToFront();
-      DataImportDialog dataImportDialog = new DataImportDialog("CSV Import", new OperationWithInput<String>()
+      DataImportDialog dataImportDialog = new DataImportDialog("Import CSV", new OperationWithInput<String>()
       {
          @Override
          public void execute(String input)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -63,6 +63,7 @@ import com.google.gwt.core.client.JsArray;
 import com.google.gwt.user.client.Timer;
 import com.google.inject.Inject;
 
+import org.rstudio.studio.client.workbench.views.environment.dataimport.DataImportDialog;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.ImportFileSettings;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.ImportFileSettingsDialog;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.ImportFileSettingsDialogResult;
@@ -474,6 +475,16 @@ public class EnvironmentPresenter extends BasePresenter
    void onImportDatasetFromCSV()
    {
       view_.bringToFront();
+      DataImportDialog dataImportDialog = new DataImportDialog("CSV Import", new OperationWithInput<String>()
+      {
+         @Override
+         public void execute(String input)
+         {
+            
+         }
+      });
+      
+      dataImportDialog.showModal();
    }
 
    public void onOpenDataFile(OpenDataFileEvent event)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -471,6 +471,11 @@ public class EnvironmentPresenter extends BasePresenter
               });
    }
 
+   void onImportDatasetFromCSV()
+   {
+      view_.bringToFront();
+   }
+
    public void onOpenDataFile(OpenDataFileEvent event)
    {
       final String dataFilePath = event.getFile().getPath();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentTab.java
@@ -46,6 +46,8 @@ public class EnvironmentTab extends DelayLoadWorkbenchTab<EnvironmentPresenter>
       @Handler
       public abstract void onImportDatasetFromURL();
       @Handler
+      public abstract void onImportDatasetFromCSV();
+      @Handler
       public abstract void onClearWorkspace();
 
       abstract void initialize(EnvironmentContextData environmentState);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -1,0 +1,19 @@
+package org.rstudio.studio.client.workbench.views.environment.dataimport;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.Widget;
+
+public class DataImport extends Composite {
+
+	private static DataImportUiBinder uiBinder = GWT.create(DataImportUiBinder.class);
+
+	interface DataImportUiBinder extends UiBinder<Widget, DataImport> {
+	}
+
+	public DataImport() {
+		initWidget(uiBinder.createAndBindUi(this));
+	}
+
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.ui.xml
@@ -1,0 +1,10 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
+	xmlns:g="urn:import:com.google.gwt.user.client.ui">
+	<ui:style>
+	
+	</ui:style>
+	<g:HTMLPanel>
+	    <g:Label text="Import form CSV"></g:Label>
+	</g:HTMLPanel>
+</ui:UiBinder> 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportDialog.java
@@ -11,6 +11,7 @@ public class DataImportDialog extends ModalDialog<String>
    public DataImportDialog(String caption, OperationWithInput<String> operation)
    {
       super(caption, operation);
+      super.setOkButtonCaption("Import");
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportDialog.java
@@ -1,0 +1,27 @@
+package org.rstudio.studio.client.workbench.views.environment.dataimport;
+
+import org.rstudio.core.client.widget.ModalDialog;
+import org.rstudio.core.client.widget.OperationWithInput;
+
+import com.google.gwt.user.client.ui.Widget;
+
+public class DataImportDialog extends ModalDialog<String>
+{
+
+   public DataImportDialog(String caption, OperationWithInput<String> operation)
+   {
+      super(caption, operation);
+   }
+
+   @Override
+   protected String collectInput()
+   {
+      return null;
+   }
+
+   @Override
+   protected Widget createMainWidget()
+   {
+      return new DataImport();
+   }
+}


### PR DESCRIPTION
This pull requests adds a new user preference "use_dataimport" that enables the new data import menu. So far, it only adds a menu entry to "Load from CSV" but using this branch we will also add "Load from SPSS" and "Load from Excel". Additionally, this pull requests adds a new data import dialog which is currently empty. With subsequent pull requests the plan is to implement a new dialog to support CSV and the new file formats. For reference, here is an initial sketch for this dialog:

![dataimport-sketch-01](https://cloud.githubusercontent.com/assets/3478847/12154378/f7f2cf90-b473-11e5-9100-4664bd526872.png)
