### PR TITLE
ensure prefix keys don't cause beeps

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
@@ -334,7 +334,7 @@ public class ShortcutManager implements NativePreviewHandler,
       
       return filtered;
    }
-
+   
    private boolean handleKeyDown(NativeEvent event)
    {
       // Bail if the shortcut manager is not enabled (e.g.
@@ -420,6 +420,22 @@ public class ShortcutManager implements NativePreviewHandler,
    private void swallowEvents(Object object)
    {
       NativeEvent event = (NativeEvent) object;
+      
+      // If the keybuffer is a prefix key sequence, swallow
+      // the event. This ensures that the system doesn't 'beep'
+      // when seeing unhandled keys.
+      if (!keyBuffer_.isEmpty())
+      {
+         for (Map.Entry<KeyMapType, KeyMap> entry : keyMaps_.entrySet())
+         {
+            if (entry.getValue().isPrefix(keyBuffer_))
+            {
+               event.stopPropagation();
+               event.preventDefault();
+               return;
+            }
+         }
+      }
       
       // Suppress save / quit events from reaching the browser
       KeyCombination keys = new KeyCombination(event);


### PR DESCRIPTION
This PR should ensure that prefix keys don't cause beeps.

This does affect code that runs on every keystroke, so we should double-check that this is doing what's expected. Just to outline how the keyboard shortcut manager works here and how a keydown event is handled:

1. An event previewer looks at keydown events, and appends the keys pressed to the keybuffer,
2. We search through the active keymaps to find an active command bound to the current keybuffer state,
3. If a command is found, the keybuffer is cleared and that command is executed,
4. Otherwise, the keybuffer is kept alive.

This PR effectively ensures that if the keybuffer is 'alive', and is actually the prefix of some mapping in our keymaps, then the browser doesn't see the event. Note that the `swallowEvents` function basically looks at keys at the 'final' point before the browser would handle it (hence it being a sort of 'post-view' handler)

Note that if Ace handles a keydown event, it also emits a signal that we use to ensure the global keybuffer is cleared as well.