### PR TITLE
user authentication filter improvements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -84,6 +84,7 @@
 * Use more resilient file locking mechanism for compatibility with NFS volumes
 * Attempt to close application window when quitting
 * Track installed client version using git commit hash rather than timestamp
+* Detect minimum user id from /etc/login.defs (can also be specified via option)
 * Server Pro: Shared Projects (including concurrent multi-user editing)
 * Server Pro: Support for multiple concurrent R sessions per-user
 * Server Pro: Support for running against multiple versions of R

--- a/src/cpp/core/include/core/system/System.hpp
+++ b/src/cpp/core/include/core/system/System.hpp
@@ -228,6 +228,7 @@ std::string username();
 FilePath userHomePath(std::string envOverride = std::string());
 FilePath userSettingsPath(const FilePath& userHomeDirectory,
                           const std::string& appName);
+unsigned int effectiveUserId();
 bool currentUserIsPrivilleged(unsigned int minimumUserId);
 
 // log

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -437,6 +437,11 @@ std::string username()
    return system::getenv("USER");
 }
 
+unsigned int effectiveUserId()
+{
+   return ::geteuid();
+}
+
 FilePath userHomePath(std::string envOverride)
 {
    using namespace boost::algorithm;

--- a/src/cpp/core/system/Win32System.cpp
+++ b/src/cpp/core/system/Win32System.cpp
@@ -247,6 +247,11 @@ std::string username()
    return system::getenv("USERNAME");
 }
 
+unsigned int effectiveUserId()
+{
+   return 0; // no concept of this on Win32
+}
+
 // home path strategies
 namespace {
 

--- a/src/cpp/server/ServerOptions.cpp
+++ b/src/cpp/server/ServerOptions.cpp
@@ -15,6 +15,10 @@
 
 #include <server/ServerOptions.hpp>
 
+#include <fstream>
+
+#include <boost/algorithm/string/trim.hpp>
+
 #include <core/ProgramStatus.hpp>
 #include <core/ProgramOptions.hpp>
 #include <core/FilePath.hpp>
@@ -73,6 +77,60 @@ void reportDeprecationWarnings(const Deprecated& userOptions,
 
    if (userOptions.authPamRequiresPriv != defaultOptions.authPamRequiresPriv)
       reportDeprecationWarning("auth-pam-requires-priv", os);
+}
+
+unsigned int stringToUserId(std::string minimumUserId,
+                            unsigned int defaultMinimumId,
+                            std::ostream& osWarnings)
+{
+   try
+   {
+      return boost::lexical_cast<unsigned int>(minimumUserId);
+   }
+   catch(boost::bad_lexical_cast&)
+   {
+      osWarnings << "Invalid value for auth-minimum-user-id '"
+                 << minimumUserId << "'. Using default of "
+                 << defaultMinimumId << "." << std::endl;
+
+      return defaultMinimumId;
+   }
+}
+
+unsigned int resolveMinimumUserId(std::string minimumUserId,
+                                  std::ostream& osWarnings)
+{
+   // default for invalid input
+   const unsigned int kDefaultMinimumId = 100;
+
+   // auto-detect if requested
+   if (minimumUserId == "auto")
+   {
+      // if /etc/login.defs exists, scan it and look for a UID_MIN setting
+      FilePath loginDefs("/etc/login.defs");
+      if (loginDefs.exists())
+      {
+         const char uidMin[] = "UID_MIN";
+         std::ifstream defStream(loginDefs.absolutePath().c_str());
+         std::string line;
+         while (std::getline(defStream, line))
+         {
+            if (line.substr(0, sizeof(uidMin) - 1) == uidMin)
+            {
+               std::string value = boost::algorithm::trim_copy(
+                                       line.substr(sizeof(uidMin) + 1));
+               return stringToUserId(value, kDefaultMinimumId, osWarnings);
+            }
+         }
+      }
+
+      // none found, return default
+      return kDefaultMinimumId;
+   }
+   else
+   {
+      return stringToUserId(minimumUserId, kDefaultMinimumId, osWarnings);
+   }
 }
 
 } // anonymous namespace
@@ -204,6 +262,7 @@ ProgramStatus Options::read(int argc,
          "rsession user process limit - DEPRECATED");
    
    // still read depracated options (so we don't break config files)
+   std::string authMinimumUserId;
    options_description auth("auth");
    auth.add_options()
       ("auth-none",
@@ -223,6 +282,9 @@ ProgramStatus Options::read(int argc,
       ("auth-required-user-group",
         value<std::string>(&authRequiredUserGroup_)->default_value(""),
         "limit to users belonging to the specified group")
+      ("auth-minimum-user-id",
+        value<std::string>(&authMinimumUserId)->default_value("auto"),
+        "limit to users with a required minimum user id")
       ("auth-pam-helper-path",
         value<std::string>(&authPamHelperPath_)->default_value("rserver-pam"),
        "path to PAM helper binary")
@@ -326,6 +388,9 @@ ProgramStatus Options::read(int argc,
    resolvePath(binaryPath, &rsessionPath_);
    resolvePath(binaryPath, &rldpathPath_);
    resolvePath(resourcePath, &rsessionConfigFile_);
+
+   // resolve minimum user id
+   authMinimumUserId_ = resolveMinimumUserId(authMinimumUserId, osWarnings);
 
    // return status
    return status;

--- a/src/cpp/server/ServerSessionManager.cpp
+++ b/src/cpp/server/ServerSessionManager.cpp
@@ -127,9 +127,14 @@ core::system::ProcessConfig sessionProcessConfig(
                         kRStudioDefaultRVersionHome,
                         rVersion.homeDir().absolutePath());
 
-   // forward the required groups option
-   core::system::setenv(kRStudioRequiredUserGroup,
+   // forward the auth options
+   core::system::setenv(&environment,
+                        kRStudioRequiredUserGroup,
                         options.authRequiredUserGroup());
+   core::system::setenv(&environment,
+                        kRStudioMinimumUserId,
+                        safe_convert::numberToString(
+                                 options.authMinimumUserId()));
    
    // add monitor shared secret
    environment.push_back(std::make_pair(kMonitorSharedSecretEnvVar,

--- a/src/cpp/server/auth/ServerValidateUser.cpp
+++ b/src/cpp/server/auth/ServerValidateUser.cpp
@@ -63,7 +63,9 @@ bool validateUser(const std::string& username,
       {
          boost::format fmt(
             "User %1% could not be authenticated because they "
-            "did not meet the minimum required user id (%2%)");
+            "did not meet the minimum required user id (%2%). "
+            "The minimum user id is controlled by the "
+            "auth-minimum-user-id rserver.conf option.");
          std::string msg = boost::str(fmt % username % minimumUserId);
          LOG_WARNING_MESSAGE(msg);
       }

--- a/src/cpp/server/auth/ServerValidateUser.cpp
+++ b/src/cpp/server/auth/ServerValidateUser.cpp
@@ -57,7 +57,7 @@ bool validateUser(const std::string& username,
    }
 
    // validate minimum user id
-   if (core::system::effectiveUserId() < minimumUserId)
+   if (user.userId < minimumUserId)
    {
       if (failureWarning)
       {

--- a/src/cpp/server/include/server/ServerOptions.hpp
+++ b/src/cpp/server/include/server/ServerOptions.hpp
@@ -155,6 +155,11 @@ public:
       return std::string(authRequiredUserGroup_.c_str());
    }
 
+   unsigned int authMinimumUserId()
+   {
+      return authMinimumUserId_;
+   }
+
    std::string authPamHelperPath() const
    {
       return std::string(authPamHelperPath_.c_str());
@@ -256,6 +261,7 @@ private:
    int authStaySignedInDays_;
    bool authEncryptPassword_;
    std::string authRequiredUserGroup_;
+   unsigned int authMinimumUserId_;
    std::string authPamHelperPath_;
    std::string rsessionWhichR_;
    std::string rsessionPath_;

--- a/src/cpp/server/include/server/auth/ServerValidateUser.hpp
+++ b/src/cpp/server/include/server/auth/ServerValidateUser.hpp
@@ -27,12 +27,14 @@ namespace auth {
 bool validateUser(
   const std::string& username,
   const std::string& requiredGroup,
-  bool groupFailureWarning);
+  unsigned int minimumUserId,
+  bool failureWarning);
 
 inline bool validateUser(const std::string& username)
 {
    return validateUser(username,
                        server::options().authRequiredUserGroup(),
+                       server::options().authMinimumUserId(),
                        true);
 }
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -3094,10 +3094,17 @@ int main (int argc, char * const argv[])
            
       // ensure we aren't being started as a low (priviliged) account
       if (serverMode &&
-          core::system::currentUserIsPrivilleged(options.minimumUserId()))
+          core::system::currentUserIsPrivilleged(options.authMinimumUserId()))
       {
          Error error = systemError(boost::system::errc::permission_denied,
                                    ERROR_LOCATION);
+         boost::format fmt("User '%1%' has id %2%, which is lower than the "
+                           "minimum user id of %3% (this is controlled by "
+                           "the the auth-minimum-user-id rserver option)");
+         std::string msg = boost::str(fmt % core::system::username()
+                                          % core::system::effectiveUserId()
+                                          % options.authMinimumUserId());
+         error.addProperty("message", msg);
          return sessionExitFailure(error, ERROR_LOCATION);
       }
 

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -554,9 +554,17 @@ core::ProgramStatus Options::read(int argc, char * const argv[])
    defaultRVersionHome_ = core::system::getenv(kRStudioDefaultRVersionHome);
    core::system::unsetenv(kRStudioDefaultRVersionHome);
    
-   // capture auth required user group environment variable
-   authRequiredUserGroup_ = core::system::getenv(kRStudioRequiredUserGroup);
-   core::system::unsetenv(kRStudioRequiredUserGroup);
+   // capture auth environment variables
+   authMinimumUserId_ = 0;
+   if (programMode_ == kSessionProgramModeServer)
+   {
+      authRequiredUserGroup_ = core::system::getenv(kRStudioRequiredUserGroup);
+      core::system::unsetenv(kRStudioRequiredUserGroup);
+
+      authMinimumUserId_ = safe_convert::stringTo<unsigned int>(
+                              core::system::getenv(kRStudioMinimumUserId), 100);
+      core::system::unsetenv(kRStudioMinimumUserId);
+   }
 
    // return status
    return status;

--- a/src/cpp/session/include/session/SessionConstants.hpp
+++ b/src/cpp/session/include/session/SessionConstants.hpp
@@ -29,6 +29,7 @@
 #define kRStudioSessionScopeId            "RSTUDIO_SESSION_SCOPE_ID"
 #define kRStudioSessionRoute              "RSTUDIO_SESSION_ROUTE"
 #define kRStudioRequiredUserGroup         "RSTUDIO_REQUIRED_USER_GROUP"
+#define kRStudioMinimumUserId             "RSTUDIO_MINIMUM_USER_ID"
 
 #define kRStudioDefaultRVersion           "RSTUDIO_DEFAULT_R_VERSION"
 #define kRStudioDefaultRVersionHome       "RSTUDIO_DEFAULT_R_VERSION_HOME"

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -152,7 +152,7 @@ public:
 
    int saveActionDefault() const { return saveActionDefault_; }
 
-   unsigned int minimumUserId() const { return 100; }
+   unsigned int authMinimumUserId() const { return authMinimumUserId_; }
 
    std::string authRequiredUserGroup() const { return authRequiredUserGroup_; }
 
@@ -515,6 +515,7 @@ private:
    int saveActionDefault_;
    bool standalone_;
    std::string authRequiredUserGroup_;
+   unsigned int authMinimumUserId_;
    bool showHelpHome_;
    bool showUserHomePage_;
 


### PR DESCRIPTION
- detect minimum user id from /etc/login.defs when possible
- enable rserver.conf option for manual override of minimum user id
- check minimum user id along with required group (improved experience/diagnostics for minimum user id failures)
- forward minimum user id and required user group to rsession (will use for project sharing)

@jmcphers Here is phase one of the changes required to get the right user list populated for project sharing. Could you please review?
