### PR TITLE
ensure double-clicking on a toolbar button removes 'pushed' state

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarButton.java
@@ -173,7 +173,10 @@ public class ToolbarButton extends FocusWidget
                public void onPopupMenu(final ToolbarPopupMenu menu)
                {
                   if (menuShowing[0])
+                  {
+                     removeStyleName(styles_.toolbarButtonPushed());
                      menu.hide();
+                  }
                   else
                   {
                      if (rightAlign)


### PR DESCRIPTION
This PR fixes an issue where clicking on a toolbar button twice (e.g. to show and then dismiss the underlying menu) would leave the button in the 'pushed' state, thereby leaving to nudged down a pixel.

I think this is safe enough to take for the next release, but submitting as PR just in case we prefer not to.