### PR TITLE
avoid duplicating keydown handler in WidgetListBox

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/Debug.java
+++ b/src/gwt/src/org/rstudio/core/client/Debug.java
@@ -150,4 +150,9 @@ public class Debug
       consoleEl.appendChild(Document.get().createBRElement());
       consoleEl.setScrollTop(Integer.MAX_VALUE);
    }
+   
+   public static native void breakpoint() /*-{
+      debugger;
+   }-*/;
+      
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/WidgetListBox.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/WidgetListBox.java
@@ -87,6 +87,7 @@ public class WidgetListBox<T extends Widget>
    public WidgetListBox()
    {
       super();
+      
       resources_ = GWT.create(Resources.class);
       style_ = resources_.listStyle();
       style_.ensureInjected();
@@ -107,12 +108,7 @@ public class WidgetListBox<T extends Widget>
       emptyTextLabel_ = new Label();
       emptyTextLabel_.addStyleName(style_.scrollPanel());
       emptyTextLabel_.addStyleName(style_.emptyMessage());
-   }
-
-   @Override 
-   protected void onLoad()
-   {
-      super.onLoad();
+      
       addKeyDownHandler(new KeyDownHandler()
       {
          @Override


### PR DESCRIPTION
This PR fixes an issue where keydown handlers could get duplicated for a `WidgetListBox`. This is seen in e.g. the R Markdown template selection dialog.

The problem is that the event handlers are attached in 'onLoad()', but not detached in 'onUnload()'. It seems that it's possible for a widget to be constructed, and then loaded / unloaded multiple times, thereby causing duplication of handlers attached in this way.

The resolution is to just generate the handlers in the constructor, rather than the onLoad handler.