### PR TITLE
avoid firing active bindings in completion system

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1146,7 +1146,10 @@ assign(x = ".rs.acCompletionTypes",
             for (i in seq_along(names))
             {
                type[[i]] <- suppressWarnings(tryCatch(
-                  .rs.getCompletionType(eval(call("$", quote(object), names[[i]]))),
+                  if (is.environment(object) && bindingIsActive(names[[i]], object))
+                     .rs.acCompletionTypes$UNKNOWN
+                  else
+                     .rs.getCompletionType(eval(call("$", quote(object), names[[i]]))),
                   error = function(e) .rs.acCompletionTypes$UNKNOWN
                ))
             }


### PR DESCRIPTION
This PR ensures that we don't execute `foo$bar` in determining the type of an object, if the object is an active binding.