### PR TITLE
simpler implementation for getting active frame

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.cpp
+++ b/src/cpp/session/modules/SessionRCompletions.cpp
@@ -316,19 +316,6 @@ SEXP rs_isSubsequence(SEXP stringsSEXP, SEXP querySEXP)
 
 }
 
-SEXP rs_getActiveFrame(SEXP depthSEXP)
-{
-   int depth = r::sexp::asInteger(depthSEXP);
-   RCNTXT* context = r::getGlobalContext();
-   for (int i = 0; i < depth; ++i)
-   {
-      context = context->nextcontext;
-      if (context == NULL)
-         return R_NilValue;
-   }
-   return context->cloenv;
-}
-
 SEXP rs_getNAMESPACEImportedSymbols(SEXP documentIdSEXP)
 {
    std::string documentId = r::sexp::asString(documentIdSEXP);
@@ -496,7 +483,6 @@ Error initialize() {
    RS_REGISTER_CALL_METHOD(rs_getSourceIndexCompletions, 1);
    RS_REGISTER_CALL_METHOD(rs_scanFiles, 4);
    RS_REGISTER_CALL_METHOD(rs_isSubsequence, 2);
-   RS_REGISTER_CALL_METHOD(rs_getActiveFrame, 1);
    RS_REGISTER_CALL_METHOD(rs_listInferredPackages, 1);
    RS_REGISTER_CALL_METHOD(rs_getInferredCompletions, 1);
    RS_REGISTER_CALL_METHOD(rs_getNAMESPACEImportedSymbols, 1);


### PR DESCRIPTION
This PR fixes an issue where attempting to obtain the 'active' frame failed, when the package `lfe` was loaded. This caused autocompletion to fail for e.g.

```R
library("lfe")
mydata <- mtcars
mydata$<TAB>
```