### PR TITLE
Fix the bug that encoding="" will be passed to knitr if the .Rpres file does not belong to any project,

### DIFF
--- a/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
+++ b/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
@@ -327,6 +327,7 @@ bool performKnit(const FilePath& rmdPath,
                      "render_markdown(); "
                      "knit('%2%', output = '%3%', encoding='%4%');");
    std::string encoding = projects::projectContext().defaultEncoding();
+   if(encoding.empty()) encoding = "UTF-8";
    std::string cmd = boost::str(
       fmt % string_utils::utf8ToSystem(rmdPath.stem())
           % string_utils::utf8ToSystem(rmdPath.filename())


### PR DESCRIPTION
This small patch fixes the bug that, encoding="" will be passed to knitr
if the .Rpres file does not belong to any project,

knitr will try to interpret .Rpres file with plathome's native file
encoding. But especially in Windows environment, there is no version of
Windows that has "UTF-8" as the native encoding.
So, in many cases, the resulted presentation file will be corrupted,
even if the user created .Rpres file with UTF-8 encoding.

If the user make the project first, then create .Rpres file within the
project, this problem does not occur. Because in that case, knitr will
receive "encoding='UTF-8'" parameter, and work perfectly.

This small patch will rescue many non-ASCII character users, who will
try to create .Rpres presentation WITHOUT creating Rstudio's project.