### PR TITLE
Minor improvements and fixes to data import

### DIFF
--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -280,6 +280,7 @@
       importInfo <- .rs.assemble_data_import(dataImportOptions)
       data <- eval(parse(text=importInfo$previewCode))
       columns <- .rs.describeCols(data, maxCols, maxFactors)
+      parsingErrors <-length(readr::problems(data)$row)
 
       cnames <- names(data)
       size <- nrow(data)
@@ -289,7 +290,8 @@
       }
 
       return(list(data = unname(data),
-                  columns = columns))
+                  columns = columns,
+                  parsingErrors = parsingErrors))
    }, error = function(e) {
       return(list(error = e))
    })

--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -50,7 +50,7 @@
             return (paste("\"", optionValue, "\"", sep = ""))
          },
          "locale" = {
-            return (paste(ns, "locale(date_names=\"", optionValue, "\")", sep = ""))
+            return (paste(ns, "locale(encoding=\"", optionValue, "\")", sep = ""))
          },
          "columnDefinitions" = {
             colParams <- c()

--- a/src/cpp/session/resources/grid/gridviewer.js
+++ b/src/cpp/session/resources/grid/gridviewer.js
@@ -866,7 +866,7 @@ var initDataTable = function(resCols, data) {
         "sClass": className,
         "visible": (!rowNumbers && idx === 0) ? false : true,
         "data": function (row, type, set, meta) {
-          return (meta.col == 0 ? meta.row : data[meta.col-1][meta.row]);
+          return (meta.col == 0 ? meta.row : (data ? data[meta.col-1][meta.row] : null));
         },
         "width": "4em",
         "render": e.col_type === "numeric" ? renderNumberCell : renderTextCell
@@ -1000,11 +1000,19 @@ var bootstrap = function(data) {
       runAfterSizing(function() {
 
         // Assign line numbers:
-        data.data = data.data.map(function (e, idx) {
-          var eWithNumber = e;
-          eWithNumber[""] = idx + 1;
-          return eWithNumber;
-        })
+        if (data.data) {
+          data.data = data.data.map(function (e, idx) {
+            var eWithNumber = e;
+            eWithNumber[""] = idx + 1;
+            return eWithNumber;
+          })
+        }
+        else {
+          data.data = {}
+          data.data = [
+            []
+          ];
+        }
 
         initDataTable(data.columns, data.data);
       });

--- a/src/cpp/session/resources/grid/gridviewer.js
+++ b/src/cpp/session/resources/grid/gridviewer.js
@@ -1014,7 +1014,9 @@ var bootstrap = function(data) {
           ];
         }
 
-        initDataTable(data.columns, data.data);
+        if (data.columns) {
+          initDataTable(data.columns, data.data);
+        }
       });
     });
   }

--- a/src/cpp/session/resources/grid/gridviewer.js
+++ b/src/cpp/session/resources/grid/gridviewer.js
@@ -1008,7 +1008,6 @@ var bootstrap = function(data) {
           })
         }
         else {
-          data.data = {}
           data.data = [
             []
           ];

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/FileSystemDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/FileSystemDialog.java
@@ -190,6 +190,14 @@ public abstract class FileSystemDialog extends ModalDialogBase
    public void showModal()
    {
       super.showModal();
+      
+      // Modal dialogs always open with zindex of 1001 for the dialog and 1000
+      // for the glass. Therefore, when opening this file dialog inside a modal,
+      // the glass element fails to cover the existing modal. Setting the zIndex
+      // higher than the average modal fixes this issues.
+      getGlassElement().getStyle().setZIndex(2000);
+      getElement().getStyle().setZIndex(2001);
+      
       Scheduler.get().scheduleDeferred(new ScheduledCommand()
       {
          public void execute()

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/FileSystemDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/FileSystemDialog.java
@@ -191,13 +191,6 @@ public abstract class FileSystemDialog extends ModalDialogBase
    {
       super.showModal();
       
-      // Modal dialogs always open with zindex of 1001 for the dialog and 1000
-      // for the glass. Therefore, when opening this file dialog inside a modal,
-      // the glass element fails to cover the existing modal. Setting the zIndex
-      // higher than the average modal fixes this issues.
-      getGlassElement().getStyle().setZIndex(2000);
-      getElement().getStyle().setZIndex(2001);
-      
       Scheduler.get().scheduleDeferred(new ScheduledCommand()
       {
          public void execute()

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -384,11 +384,11 @@ pre {
 }
 
 .gwt-DialogBox-ModalDialog, .gwt-DecoratedPopupPanel {
-   z-index: 1001;
+   z-index: 1000;
 }
 
 .gwt-SuggestBoxPopup {
-   z-index: 1002;	
+   z-index: 1000;	
    cursor: default;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/widget/FileOrUrlChooserTextBox.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FileOrUrlChooserTextBox.java
@@ -18,6 +18,7 @@ package org.rstudio.core.client.widget;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.studio.client.RStudioGinjector;
 
+import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
@@ -39,6 +40,8 @@ public class FileOrUrlChooserTextBox extends TextBoxWithButton
       super(label, "", browseModeCaption_, null);
       
       updateOperation_ = updateOperation;
+      
+      getTextBox().getElement().getStyle().setHeight(22, Unit.PX);
       
       super.addValueChangeHandler(new ValueChangeHandler<String>()
       {

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -104,6 +104,7 @@ import org.rstudio.studio.client.workbench.views.vcs.svn.SVNCommandHandler;
 import org.rstudio.studio.client.workbench.views.environment.ClearAllDialog;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.DataImport;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.DataImportDialog;
+import org.rstudio.studio.client.workbench.views.environment.dataimport.DataImportOptionsUiCsv;
 
 @GinModules(RStudioGinModuleOverlay.class)
 public interface RStudioGinjector extends Ginjector
@@ -166,6 +167,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(AddinExecutor addinExecutor);
    void injectMembers(DataImportDialog dataImportDialog);
    void injectMembers(DataImport dataImport);
+   void injectMembers(DataImportOptionsUiCsv dataImport);
    
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -373,7 +373,9 @@ public class DataImport extends Composite
             
             gridViewer_.setOption("nullsAsNAs", "true");
             gridViewer_.setOption("status",
-                  "Previewing first " + toLocaleString(maxRows_) + " entries");
+                  "Previewing first " + toLocaleString(maxRows_) + 
+                  " entries. " + Integer.toString(response.getParsingErrors()) +
+                  " parsing errors.");
             gridViewer_.setOption("ordering", "false");
             gridViewer_.setOption("rowNumbers", "false");
             

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -156,6 +156,11 @@ public class DataImport extends Composite
                @Override
                public void execute()
                {
+                  if (fileOrUrlChooserTextBox_.getText() != importOptions_.getImportLocation())
+                  {
+                     importOptions_.resetColumnDefinitions();
+                  }
+                  
                   importOptions_.setImportLocation(
                      !fileOrUrlChooserTextBox_.getText().isEmpty() ?
                      fileOrUrlChooserTextBox_.getText() :
@@ -342,10 +347,6 @@ public class DataImport extends Composite
    private void previewDataImport()
    {
       DataImportOptions previewImportOptions = getOptions();
-      if (previewImportOptions.getImportLocation() != importOptions_.getImportLocation())
-      {
-         importOptions_.resetColumnDefinitions();
-      }
       
       assembleDataImport();
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -97,6 +97,8 @@ public class DataImport extends Composite
       Size size = DomMetrics.adjustedElementSizeToDefaultMax();
       setSize(Math.max(minWidth, size.width) + "px", Math.max(minHeight, size.height) + "px");
       
+      setCodeAreaDefaults();
+      
       columnTypesMenu_ = new DataImportColumnTypesMenu();
       
       dataImportOptionsUi_ = getOptionsUiForMode(dataImportMode);
@@ -397,6 +399,15 @@ public class DataImport extends Composite
       });
    }
    
+   private void setCodeAreaDefaults()
+   {
+      codeArea_.getEditor().getSession().setEditorMode(
+            EditorLanguage.LANG_R.getParserName(), false);
+      codeArea_.getEditor().getSession().setUseWrapMode(true);
+      codeArea_.getEditor().getSession().setWrapLimitRange(20, 120);
+      codeArea_.getEditor().getRenderer().setShowGutter(false);
+   }
+   
    private void assembleDataImport()
    {
       server_.assembleDataImport(getOptions(),
@@ -413,11 +424,7 @@ public class DataImport extends Composite
             
             codePreview_ = response.getImportCode();
             dataImportOptionsUi_.setAssembleResponse(response);
-            codeArea_.getEditor().getSession().setEditorMode(
-                  EditorLanguage.LANG_R.getParserName(), false);
-            codeArea_.getEditor().getSession().setUseWrapMode(true);
-            codeArea_.getEditor().getSession().setWrapLimitRange(20, 120);
-            codeArea_.getEditor().getRenderer().setShowGutter(false);
+            setCodeAreaDefaults();
             codeArea_.setCode(codePreview_);
          }
          

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -307,8 +307,10 @@ public class DataImport extends Composite
             
             columnTypesMenu_.setSize(column.getWidth() + "px", "");
             
-            columnTypesMenu_.getElement().getStyle().setZIndex(
-                  zIndex_ != null ? zIndex_ + 1000 : 2000);
+            if (zIndex_ != null)
+            {
+               columnTypesMenu_.getElement().getStyle().setZIndex(zIndex_);
+            }
             
             boolean columnOnly = importOptions_.getColumnOnly(column.getName());
             String columnType = importOptions_.getColumnType(column.getName());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -388,9 +388,10 @@ public class DataImport extends Composite
             
             gridViewer_.setOption("status",
                   "Previewing first " + toLocaleString(maxRows_) + 
-                  " entries. " + Integer.toString(response.getParsingErrors()) +
-                  " parsing errors.");
-            
+                  " entries. " + (
+                        response.getParsingErrors() > 0 ?
+                        Integer.toString(response.getParsingErrors()) + " parsing errors." : "")
+                  );
             
             assignColumnDefinitions(response, importOptions_.getColumnDefinitions());
             

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -80,6 +80,8 @@ public class DataImport extends Composite
    
    private DataImportColumnTypesMenu columnTypesMenu_;
    
+   private DataImportPreviewResponse lastSuccessfulResponse_;
+   
    interface DataImportUiBinder extends UiBinder<Widget, DataImport>
    {
    }
@@ -344,6 +346,14 @@ public class DataImport extends Composite
       return options;
    }
    
+   private void setGridViewerData(DataImportPreviewResponse response)
+   {
+      gridViewer_.setOption("nullsAsNAs", "true");
+      gridViewer_.setOption("ordering", "false");
+      gridViewer_.setOption("rowNumbers", "false");
+      gridViewer_.setData(response);
+   }
+   
    private void previewDataImport()
    {
       DataImportOptions previewImportOptions = getOptions();
@@ -367,22 +377,23 @@ public class DataImport extends Composite
          {
             if (response.getErrorMessage() != null)
             {
-               gridViewer_.setData(null);
+               response.setColumnDefinitions(lastSuccessfulResponse_);
+               setGridViewerData(response);
                progressIndicator_.onError(response.getErrorMessage());
                return;
             }
             
-            gridViewer_.setOption("nullsAsNAs", "true");
+            lastSuccessfulResponse_ = response;
+            
             gridViewer_.setOption("status",
                   "Previewing first " + toLocaleString(maxRows_) + 
                   " entries. " + Integer.toString(response.getParsingErrors()) +
                   " parsing errors.");
-            gridViewer_.setOption("ordering", "false");
-            gridViewer_.setOption("rowNumbers", "false");
+            
             
             assignColumnDefinitions(response, importOptions_.getColumnDefinitions());
             
-            gridViewer_.setData(response);
+            setGridViewerData(response);
             gridViewer_.setColumnDefinitionsUIVisible(true, onColumnMenuShow(), new Operation()
             {
                @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -160,6 +160,7 @@ public class DataImport extends Composite
                {
                   if (fileOrUrlChooserTextBox_.getText() != importOptions_.getImportLocation())
                   {
+                     lastSuccessfulResponse_ = null;
                      importOptions_.resetColumnDefinitions();
                   }
                   

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.ui.xml
@@ -18,17 +18,26 @@
 			margin-bottom: 7px;
 		}
 		.importLabel {	
-			margin-top: 14px;
+			margin-top: 12px;
+			margin-right: 5px;
+			margin-left: 5px;
+		}
+		.topImportLabel {	
+			margin-top: 6px;
+			margin-right: 5px;
+			margin-left: 5px;
 		}
 		.gridViewerFrame {
 			margin-top: 3px;
 			border: 1px solid #999;
-			width: 100%;
+			width: literal("calc(100% - 10px)");
 			height: 10px;
 			
 			-ms-flex-grow: 4;
 			-webkit-flex-grow: 4;
 			flex-grow: 4;
+			margin-right: 5px;
+			margin-left: 5px;
 		}
 		.optionsPanel {
 			display: -ms-flexbox;
@@ -38,8 +47,6 @@
 			-ms-flex-grow: 1;
 			-webkit-flex-grow: 1;
 			flex-grow: 1;
-
-			padding-right: 10px
 		}
 		.optionsElement {
 			display: -ms-flexbox;
@@ -66,11 +73,14 @@
 			min-width: 300px;
 		}
 		.codeTextArea {
-			width: 100%;
+			width: literal("calc(100% - 10px)");
 			height: 110px;
 			border: 1px solid #999;
 			background-color: #FFF;
 			margin-top: 3px;
+
+			margin-right: 5px;
+			margin-left: 5px;
 		}
 		.bottomPanel {
 			display: -ms-flexbox;
@@ -84,6 +94,7 @@
 		.copyButton {
 			margin-left: auto;
 			margin-top: 9px;
+			margin-right: 5px;
 			height: 20px;
 		}
 		.copyButton:active {
@@ -99,9 +110,14 @@
 			height: literal("calc(100% - 6px)");
 			margin: 3px 3px 3px 3px;
 		}
+		.fileChooser {
+			margin-right: 5px;
+			margin-left: 5px;
+		}
 	</ui:style>
 	<g:HTMLPanel styleName="{style.flexPanel}">
-	    <rs:FileOrUrlChooserTextBox ui:field="fileOrUrlChooserTextBox_"/>
+	    <rs:FileOrUrlChooserTextBox ui:field="fileOrUrlChooserTextBox_"
+	        						styleName="{style.fileChooser}"/>
 		<g:Label text="Data Preview:" styleName="{style.importLabel}"/>
 		<rs:GridViewerFrame ui:field="gridViewer_"
 		    				styleName="{style.gridViewerFrame}"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.java
@@ -15,9 +15,15 @@
 
 package org.rstudio.studio.client.workbench.views.environment.dataimport;
 
+import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.server.ServerError;
+import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportAssembleResponse;
+import org.rstudio.studio.client.workbench.views.source.editors.text.IconvListResult;
+import org.rstudio.studio.client.workbench.views.source.model.SourceServerOperations;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
@@ -31,6 +37,7 @@ import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.TextBox;
+import com.google.inject.Inject;
 
 public class DataImportOptionsUiCsv extends DataImportOptionsUi
 {
@@ -46,6 +53,9 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
 
    HTMLPanel mainPanel_;
    
+   SourceServerOperations sourceServer_;
+   
+   @Inject
    public DataImportOptionsUiCsv()
    {
       super();
@@ -53,8 +63,17 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
       
       initWidget(mainPanel_);
       
-      initDefaults();
       initEvents();
+      
+      RStudioGinjector.INSTANCE.injectMembers(this);
+   }
+   
+   @Inject
+   private void initialize(SourceServerOperations sourceServer)
+   {
+      sourceServer_ = sourceServer;
+      
+      initDefaults();
    }
    
    private boolean isBackslashValue(String value)
@@ -137,28 +156,25 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
       commentListBox_.addItem("\\", "\\");
       commentListBox_.addItem("*>", "*>");
       
-      String langs[] = {
-         "af","agq","ak","am","ar","as","asa","az","bas","be","bem","bez",
-         "bg","bm","bn","bo","br","brx","bs","ca","cgg","chr","cs","cy","da",
-         "dav","de","dje","dsb","dua","dyo","dz","ebu","ee","el","en","eo",
-         "es","et","eu","ewo","fa","ff","fi","fil","fo","fr","fur","fy","ga",
-         "gd","gl","gsw","gu","guz","gv","ha","haw","he","hi","hr","hsb","hu",
-         "hy","id","ig","ii","is","it","ja","jgo","jmc","ka","kab","kam","kde",
-         "kea","khq","ki","kk","kkj","kl","kln","km","kn","ko","kok","ks","ksb",
-         "ksf","ksh","kw","ky","lag","lb","lg","lkt","ln","lo","lt","lu","luo",
-         "luy","lv","mas","mer","mfe","mg","mgh","mgo","mk","ml","mn","mr","ms",
-         "mt","mua","my","naq","nb","nd","ne","nl","nmg","nn","nnh","nus","nyn",
-         "om","or","os","pa","pl","ps","pt","qu","rm","rn","ro","rof","ru","rw",
-         "rwk","sah","saq","sbp","se","seh","ses","sg","shi","si","sk","sl",
-         "smn","sn","so","sq","sr","sv","sw","ta","te","teo","th","ti","to","tr",
-         "twq","tzm","ug","uk","ur","uz","vai","vi","vun","wae","xog","yav","yi",
-         "yo","zgh","zh","zu"
-      };
-      
       localeListBox_.addItem("Default", "");
-      for(String lang : langs) {
-         localeListBox_.addItem(lang, lang);
-      }
+      sourceServer_.iconvlist(new ServerRequestCallback<IconvListResult>()
+      {
+         @Override
+         public void onResponseReceived(IconvListResult result)
+         {
+            JsArrayString encodings = result.getAll();
+            for (int i = 0; i < encodings.length(); i++)
+            {
+               localeListBox_.addItem(encodings.get(i), encodings.get(i));
+            }
+         }
+
+         @Override
+         public void onError(ServerError error)
+         {
+         }
+      });
+     
    }
    
    void triggerChange()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.ui.xml
@@ -38,6 +38,9 @@
 			padding-top: 10px;
 			padding-left: 10px;
 			padding-bottom: 3px;
+
+			margin-right: 5px;
+			margin-left: 5px;
 		}
 		.optionsColumn {
 			display: -ms-flexbox;
@@ -56,6 +59,9 @@
 		}
 		.optionsLabel {
 			margin-top: 14px;
+
+			margin-left: 5px;
+			margin-right: 5px;
 		}
 		.nameTextBox {
 			-ms-flex-grow: 1;
@@ -64,12 +70,13 @@
 		}
 		.skipTextBox {
 			width: 50px;
+			text-align: right;
 		}
 		.optionsRow {
 			height: 23px;
 		}
 		.optionsListBox {
-			min-width: 95px;
+			width: 95px;
 		}
 	</ui:style>
 	<g:HTMLPanel styleName="{style.mainPanel}">
@@ -115,7 +122,7 @@
 			        </td>
 			    </tr>
 			    <tr class="{style.optionsRow}">
-			        <td>Locale:</td>
+			        <td>Encoding:</td>
 			        <td>
 			            <g:ListBox ui:field="localeListBox_" styleName="{style.optionsListBox}" />
 			        </td>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportPreviewResponse.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportPreviewResponse.java
@@ -26,4 +26,8 @@ public class DataImportPreviewResponse extends JavaScriptObject
    public final native String getErrorMessage() /*-{
       return this.error ? this.error.message.join(' ') : null;
    }-*/;
+   
+   public final native int getParsingErrors() /*-{
+      return this.parsingErrors;
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportPreviewResponse.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportPreviewResponse.java
@@ -30,4 +30,8 @@ public class DataImportPreviewResponse extends JavaScriptObject
    public final native int getParsingErrors() /*-{
       return this.parsingErrors;
    }-*/;
+   
+   public final native void setColumnDefinitions(DataImportPreviewResponse response) /*-{
+      return this.columns = response.columns;
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportPreviewResponse.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportPreviewResponse.java
@@ -32,6 +32,8 @@ public class DataImportPreviewResponse extends JavaScriptObject
    }-*/;
    
    public final native void setColumnDefinitions(DataImportPreviewResponse response) /*-{
-      return this.columns = response.columns;
+      if (response) {
+         return this.columns = response.columns;
+      }
    }-*/;
 }


### PR DESCRIPTION
- Fix issue where the code preview line numbers would flash for a fraction of a sec while the dialog loads.
- Fix to file picker to enable modal dialogs to display the file picker as modal. Otherwise the glass panel is shown behind the 1st level modal and the 2nd modal window does not render as modal at all.
- Add suggestion from @hadley to display parsing errors in the footer.
- Fix to clear column definitions while switching files, otherwise stagnant columns became visible in code preview.
- Show columns in data preview even if data preview fails. For instance, if one enters a bad factors expression, one can recover by clearing up the column.