### PR TITLE
Add support to import data from sav, dta, por, sas and stata using haven

### DIFF
--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -218,14 +218,26 @@
          # load parameters
          options <- list()
          options[["path"]] <- dataImportOptions$importLocation
+         options[["b7dat"]] <- dataImportOptions$importLocation
+         options[["b7cat"]] <- dataImportOptions$modelLocation
+
+         havenFunction <- switch(dataImportOptions$format,
+            "sav" = list(name = "read_sav", ref = haven::read_sav),
+            "dta" = list(name = "read_dta", ref = haven::read_dta),
+            "por" = list(name = "read_por", ref = haven::read_por),
+            "sas" = list(name = "read_sas", ref = haven::read_sas),
+            "stata" = list(name = "read_stata", ref = haven::read_stata)
+         )
 
          # set special parameter types
          optionTypes <- list()
          optionTypes[["path"]] <- "character"
+         optionTypes[["b7dat"]] <- "character"
+         optionTypes[["b7cat"]] <- "character"
 
          return(list(
-            name = "read_sav",
-            reference = haven::read_sav,
+            name = havenFunction$name,
+            reference = havenFunction$ref,
             package = "haven",
             options = options,
             optionTypes = optionTypes,

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -696,27 +696,50 @@ public class Application implements ApplicationEventHandlers
          commands_.importDatasetFromFile().remove();
          commands_.importDatasetFromURL().remove();
          
-         String rVersion = sessionInfo.getRVersionsInfo().getRVersion();
-         if (ApplicationUtils.compareVersions(rVersion, "3.0.2") < 0)
+         commands_.importDatasetFromCSV().setVisible(false);
+         commands_.importDatasetFromSAV().setVisible(false);
+         commands_.importDatasetFromSAS().setVisible(false);
+         commands_.importDatasetFromStata().setVisible(false);
+         commands_.importDatasetFromXML().setVisible(false);
+         commands_.importDatasetFromODBC().setVisible(false);
+         commands_.importDatasetFromJDBC().setVisible(false);
+         
+         try
          {
-            commands_.importDatasetFromCSV().setVisible(false);
+            String rVersion = sessionInfo.getRVersionsInfo().getRVersion();
+            if (ApplicationUtils.compareVersions(rVersion, "3.0.2") >= 0)
+            {
+               commands_.importDatasetFromCSV().setVisible(true);
+            }
+            if (ApplicationUtils.compareVersions(rVersion, "3.1.0") >= 0)
+            {
+               commands_.importDatasetFromSAV().setVisible(true);
+               commands_.importDatasetFromSAS().setVisible(true);
+               commands_.importDatasetFromStata().setVisible(true);
+               
+               commands_.importDatasetFromXML().setVisible(true);
+            }
+            if (ApplicationUtils.compareVersions(rVersion, "3.0.0") >= 0)
+            {
+               commands_.importDatasetFromODBC().setVisible(true);
+            }
+            if (ApplicationUtils.compareVersions(rVersion, "2.4.0") >= 0)
+            {
+               commands_.importDatasetFromJDBC().setVisible(true);
+            }
          }
-         if (ApplicationUtils.compareVersions(rVersion, "3.1.0") < 0)
+         catch (Exception e)
          {
-            commands_.importDatasetFromSAV().setVisible(false);
-            commands_.importDatasetFromSAS().setVisible(false);
-            commands_.importDatasetFromStata().setVisible(false);
-            
-            commands_.importDatasetFromXML().setVisible(false);
          }
-         if (ApplicationUtils.compareVersions(rVersion, "3.0.0") < 0)
-         {
-            commands_.importDatasetFromODBC().setVisible(false);
-         }
-         if (ApplicationUtils.compareVersions(rVersion, "2.4.0") < 0)
-         {
-            commands_.importDatasetFromJDBC().setVisible(false);
-         }
+         
+         
+         // Removing data import dialogs that are NYI
+         commands_.importDatasetFromXLS().remove();
+         commands_.importDatasetFromXML().remove();
+         commands_.importDatasetFromJSON().remove();
+         commands_.importDatasetFromJDBC().remove();
+         commands_.importDatasetFromODBC().remove();
+         commands_.importDatasetFromMongo().remove();
       }
       else
       {

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -699,23 +699,23 @@ public class Application implements ApplicationEventHandlers
          String rVersion = sessionInfo.getRVersionsInfo().getRVersion();
          if (ApplicationUtils.compareVersions(rVersion, "3.0.2") < 0)
          {
-            commands_.importDatasetFromCSV().setEnabled(false);
+            commands_.importDatasetFromCSV().setVisible(false);
          }
          if (ApplicationUtils.compareVersions(rVersion, "3.1.0") < 0)
          {
-            commands_.importDatasetFromSAV().setEnabled(false);
-            commands_.importDatasetFromSAS().setEnabled(false);
-            commands_.importDatasetFromStata().setEnabled(false);
+            commands_.importDatasetFromSAV().setVisible(false);
+            commands_.importDatasetFromSAS().setVisible(false);
+            commands_.importDatasetFromStata().setVisible(false);
             
-            commands_.importDatasetFromXML().setEnabled(false);
+            commands_.importDatasetFromXML().setVisible(false);
          }
          if (ApplicationUtils.compareVersions(rVersion, "3.0.0") < 0)
          {
-            commands_.importDatasetFromODBC().setEnabled(false);
+            commands_.importDatasetFromODBC().setVisible(false);
          }
          if (ApplicationUtils.compareVersions(rVersion, "2.4.0") < 0)
          {
-            commands_.importDatasetFromJDBC().setEnabled(false);
+            commands_.importDatasetFromJDBC().setVisible(false);
          }
       }
       else

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -699,6 +699,7 @@ public class Application implements ApplicationEventHandlers
       else
       {
          commands_.importDatasetFromCSV().remove();
+         commands_.importDatasetFromSAV().remove();
       }
       
       // show workbench

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -695,11 +695,41 @@ public class Application implements ApplicationEventHandlers
       {
          commands_.importDatasetFromFile().remove();
          commands_.importDatasetFromURL().remove();
+         
+         String rVersion = sessionInfo.getRVersionsInfo().getRVersion();
+         if (ApplicationUtils.compareVersions(rVersion, "3.0.2") < 0)
+         {
+            commands_.importDatasetFromCSV().setEnabled(false);
+         }
+         if (ApplicationUtils.compareVersions(rVersion, "3.1.0") < 0)
+         {
+            commands_.importDatasetFromSAV().setEnabled(false);
+            commands_.importDatasetFromSAS().setEnabled(false);
+            commands_.importDatasetFromStata().setEnabled(false);
+            
+            commands_.importDatasetFromXML().setEnabled(false);
+         }
+         if (ApplicationUtils.compareVersions(rVersion, "3.0.0") < 0)
+         {
+            commands_.importDatasetFromODBC().setEnabled(false);
+         }
+         if (ApplicationUtils.compareVersions(rVersion, "2.4.0") < 0)
+         {
+            commands_.importDatasetFromJDBC().setEnabled(false);
+         }
       }
       else
       {
          commands_.importDatasetFromCSV().remove();
          commands_.importDatasetFromSAV().remove();
+         commands_.importDatasetFromSAS().remove();
+         commands_.importDatasetFromStata().remove();
+         commands_.importDatasetFromXLS().remove();
+         commands_.importDatasetFromXML().remove();
+         commands_.importDatasetFromJSON().remove();
+         commands_.importDatasetFromJDBC().remove();
+         commands_.importDatasetFromODBC().remove();
+         commands_.importDatasetFromMongo().remove();
       }
       
       // show workbench
@@ -827,7 +857,6 @@ public class Application implements ApplicationEventHandlers
    {
       navigateWindowTo("auth-sign-in");
    }
-   
    
    private final ApplicationView view_ ;
    private final GlobalDisplay globalDisplay_ ;

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationUtils.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationUtils.java
@@ -30,4 +30,22 @@ public class ApplicationUtils
       return pattern.replaceAll(url, replaceWith);
    }
    
+   // Returns:
+   // < 0 if version1 is earlier than version 2
+   // 0 if version1 and version2 are the same 
+   // > 0 if version1 is later than version 2
+   public static int compareVersions(String version1, String version2)
+   {
+      String[] v1parts = version1.split(".");
+      String[] v2parts = version2.split(".");
+      int numParts = Math.min(v1parts.length, v2parts.length);
+      for (int i = 0; i < numParts; i++)
+      {
+         int result = Integer.parseInt(v1parts[i]) - 
+                      Integer.parseInt(v2parts[i]);
+         if (result != 0)
+            return result;
+      }
+      return 0;
+   }
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationUtils.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationUtils.java
@@ -36,8 +36,8 @@ public class ApplicationUtils
    // > 0 if version1 is later than version 2
    public static int compareVersions(String version1, String version2)
    {
-      String[] v1parts = version1.split(".");
-      String[] v2parts = version2.split(".");
+      String[] v1parts = version1.split("\\.");
+      String[] v2parts = version2.split("\\.");
       int numParts = Math.min(v1parts.length, v2parts.length);
       for (int i = 0; i < numParts; i++)
       {

--- a/src/gwt/src/org/rstudio/studio/client/application/IgnoredUpdates.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/IgnoredUpdates.java
@@ -46,31 +46,12 @@ public class IgnoredUpdates extends JavaScriptObject
          // 0.98.411, the new set should be { 0.98.411, 0.99.440 }. Do this by
          // only keeping updates in the list that are newer than the update 
          // we're about to add.
-         if (compareVersions(update, existingUpdateList.get(i)) < 0)
+         if (ApplicationUtils.compareVersions(update, existingUpdateList.get(i)) < 0)
          {
             newUpdateList.push(existingUpdateList.get(i));
          }
       }
       newUpdateList.push(update);
       setIgnoredUpdates(newUpdateList);
-   }
-   
-   // Returns:
-   // < 0 if version1 is earlier than version 2
-   // 0 if version1 and version2 are the same 
-   // > 0 if version1 is later than version 2
-   private final int compareVersions(String version1, String version2)
-   {
-      String[] v1parts = version1.split(".");
-      String[] v2parts = version2.split(".");
-      int numParts = Math.min(v1parts.length, v2parts.length);
-      for (int i = 0; i < numParts; i++)
-      {
-         int result = Integer.parseInt(v1parts[i]) - 
-                      Integer.parseInt(v2parts[i]);
-         if (result != 0)
-            return result;
-      }
-      return 0;
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -307,7 +307,7 @@ public class DependencyManager implements InstallShinyEvent.Handler
    public void withDataImportSAV(String userAction, final Command command)
    {
      withDependencies(
-        "Preparing Import from SAV",
+        "Preparing Import from SPSS, SAS and Stata",
         userAction, 
         dataImportSavDependenciesArray(), 
         false,
@@ -334,6 +334,201 @@ public class DependencyManager implements InstallShinyEvent.Handler
    private Dependency[] dataImportSavDependenciesArray()
    {
       ArrayList<Dependency> deps = dataImportSavDependencies();
+      return deps.toArray(new Dependency[deps.size()]);
+   }
+
+   public void withDataImportXLS(String userAction, final Command command)
+   {
+     withDependencies(
+        "Preparing Import from Excel",
+        userAction, 
+        dataImportXlsDependenciesArray(), 
+        false,
+        new CommandWithArg<Boolean>()
+        {
+           @Override
+           public void execute(Boolean succeeded)
+           {
+              if (succeeded)
+                 command.execute();
+           }
+        }
+     );
+   }
+   
+   private ArrayList<Dependency> dataImportXlsDependencies()
+   {
+      ArrayList<Dependency> deps = new ArrayList<Dependency>();
+      deps.add(Dependency.cranPackage("readxl", "0.1.0"));
+      deps.add(Dependency.cranPackage("Rcpp", "0.11.5"));
+      return deps;
+   }
+   
+   private Dependency[] dataImportXlsDependenciesArray()
+   {
+      ArrayList<Dependency> deps = dataImportXlsDependencies();
+      return deps.toArray(new Dependency[deps.size()]);
+   }
+
+   public void withDataImportXML(String userAction, final Command command)
+   {
+     withDependencies(
+        "Preparing Import from XML",
+        userAction, 
+        dataImportXmlDependenciesArray(), 
+        false,
+        new CommandWithArg<Boolean>()
+        {
+           @Override
+           public void execute(Boolean succeeded)
+           {
+              if (succeeded)
+                 command.execute();
+           }
+        }
+     );
+   }
+   
+   private ArrayList<Dependency> dataImportXmlDependencies()
+   {
+      ArrayList<Dependency> deps = new ArrayList<Dependency>();
+      deps.add(Dependency.cranPackage("xml2", "0.1.2"));
+      return deps;
+   }
+   
+   private Dependency[] dataImportXmlDependenciesArray()
+   {
+      ArrayList<Dependency> deps = dataImportXmlDependencies();
+      return deps.toArray(new Dependency[deps.size()]);
+   }
+
+   public void withDataImportJSON(String userAction, final Command command)
+   {
+     withDependencies(
+        "Preparing Import from JSON",
+        userAction, 
+        dataImportJsonDependenciesArray(), 
+        false,
+        new CommandWithArg<Boolean>()
+        {
+           @Override
+           public void execute(Boolean succeeded)
+           {
+              if (succeeded)
+                 command.execute();
+           }
+        }
+     );
+   }
+   
+   private ArrayList<Dependency> dataImportJsonDependencies()
+   {
+      ArrayList<Dependency> deps = new ArrayList<Dependency>();
+      deps.add(Dependency.cranPackage("jsonlite", "0.9.19"));
+      return deps;
+   }
+   
+   private Dependency[] dataImportJsonDependenciesArray()
+   {
+      ArrayList<Dependency> deps = dataImportJsonDependencies();
+      return deps.toArray(new Dependency[deps.size()]);
+   }
+
+   public void withDataImportJDBC(String userAction, final Command command)
+   {
+     withDependencies(
+        "Preparing Import from JDBC",
+        userAction, 
+        dataImportJdbcDependenciesArray(), 
+        false,
+        new CommandWithArg<Boolean>()
+        {
+           @Override
+           public void execute(Boolean succeeded)
+           {
+              if (succeeded)
+                 command.execute();
+           }
+        }
+     );
+   }
+   
+   private ArrayList<Dependency> dataImportJdbcDependencies()
+   {
+      ArrayList<Dependency> deps = new ArrayList<Dependency>();
+      deps.add(Dependency.cranPackage("RJDBC", "0.2-5"));
+      deps.add(Dependency.cranPackage("rJava", "0.4-15"));
+      return deps;
+   }
+   
+   private Dependency[] dataImportJdbcDependenciesArray()
+   {
+      ArrayList<Dependency> deps = dataImportJdbcDependencies();
+      return deps.toArray(new Dependency[deps.size()]);
+   }
+
+   public void withDataImportODBC(String userAction, final Command command)
+   {
+     withDependencies(
+        "Preparing Import from ODBC",
+        userAction, 
+        dataImportOdbcDependenciesArray(), 
+        false,
+        new CommandWithArg<Boolean>()
+        {
+           @Override
+           public void execute(Boolean succeeded)
+           {
+              if (succeeded)
+                 command.execute();
+           }
+        }
+     );
+   }
+   
+   private ArrayList<Dependency> dataImportOdbcDependencies()
+   {
+      ArrayList<Dependency> deps = new ArrayList<Dependency>();
+      deps.add(Dependency.cranPackage("RODBC", "1.3-12"));
+      return deps;
+   }
+   
+   private Dependency[] dataImportOdbcDependenciesArray()
+   {
+      ArrayList<Dependency> deps = dataImportOdbcDependencies();
+      return deps.toArray(new Dependency[deps.size()]);
+   }
+
+   public void withDataImportMongo(String userAction, final Command command)
+   {
+     withDependencies(
+        "Preparing Import from Mongo DB",
+        userAction, 
+        dataImportMongoDependenciesArray(), 
+        false,
+        new CommandWithArg<Boolean>()
+        {
+           @Override
+           public void execute(Boolean succeeded)
+           {
+              if (succeeded)
+                 command.execute();
+           }
+        }
+     );
+   }
+   
+   private ArrayList<Dependency> dataImportMongoDependencies()
+   {
+      ArrayList<Dependency> deps = new ArrayList<Dependency>();
+      deps.add(Dependency.cranPackage("mongolite", "0.8"));
+      deps.add(Dependency.cranPackage("jsonlite", "0.9.16"));
+      return deps;
+   }
+   
+   private Dependency[] dataImportMongoDependenciesArray()
+   {
+      ArrayList<Dependency> deps = dataImportMongoDependencies();
       return deps.toArray(new Dependency[deps.size()]);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -304,6 +304,39 @@ public class DependencyManager implements InstallShinyEvent.Handler
       return deps.toArray(new Dependency[deps.size()]);
    }
    
+   public void withDataImportSAV(String userAction, final Command command)
+   {
+     withDependencies(
+        "Preparing Import from SAV",
+        userAction, 
+        dataImportSavDependenciesArray(), 
+        false,
+        new CommandWithArg<Boolean>()
+        {
+           @Override
+           public void execute(Boolean succeeded)
+           {
+              if (succeeded)
+                 command.execute();
+           }
+        }
+     );
+   }
+   
+   private ArrayList<Dependency> dataImportSavDependencies()
+   {
+      ArrayList<Dependency> deps = new ArrayList<Dependency>();
+      deps.add(Dependency.cranPackage("haven", "0.2.0"));
+      deps.add(Dependency.cranPackage("Rcpp", "0.11.4"));
+      return deps;
+   }
+   
+   private Dependency[] dataImportSavDependenciesArray()
+   {
+      ArrayList<Dependency> deps = dataImportSavDependencies();
+      return deps.toArray(new Dependency[deps.size()]);
+   }
+   
    private void withDependencies(String progressCaption,
                                  final String userAction,
                                  final CommandWith2Args<String,Command> userPrompt,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -2068,12 +2068,12 @@ well as menu structures (for main menu and popup menus).
 
    <cmd id="importDatasetFromSAS"
         label="Import Dataset from SAS..."
-        menuLabel="From _SAS..."
+        menuLabel="From S_AS..."
         windowMode="main"/>
 
    <cmd id="importDatasetFromStata"
         label="Import Dataset from Stata..."
-        menuLabel="From _Stata..."
+        menuLabel="From S_tata..."
         windowMode="main"/>
 
    <cmd id="importDatasetFromXLS"
@@ -2102,8 +2102,8 @@ well as menu structures (for main menu and popup menus).
         windowMode="main"/>
 
    <cmd id="importDatasetFromMongo"
-        label="Import Dataset from Mongo..."
-        menuLabel="From _Mongo..."
+        label="Import Dataset from Mongo DB..."
+        menuLabel="From _Mongo DB..."
         windowMode="main"/>
 
    <cmd id="refreshWorkspace"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -364,6 +364,7 @@ well as menu structures (for main menu and popup menus).
             <cmd refid="importDatasetFromFile"/>
             <cmd refid="importDatasetFromURL"/>
             <cmd refid="importDatasetFromCSV"/>
+            <cmd refid="importDatasetFromSAV"/>
          </menu>
          <separator/>
          <cmd refid="installPackage"/>
@@ -2040,6 +2041,11 @@ well as menu structures (for main menu and popup menus).
    <cmd id="importDatasetFromCSV"
         label="Import Dataset from CSV..."
         menuLabel="From _CSV..."
+        windowMode="main"/>
+
+   <cmd id="importDatasetFromSAV"
+        label="Import Dataset from SAV..."
+        menuLabel="From _SAV..."
         windowMode="main"/>
 
    <cmd id="refreshWorkspace"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -364,7 +364,20 @@ well as menu structures (for main menu and popup menus).
             <cmd refid="importDatasetFromFile"/>
             <cmd refid="importDatasetFromURL"/>
             <cmd refid="importDatasetFromCSV"/>
+            <separator/>
+            <cmd refid="importDatasetFromXLS"/>
+            <separator/>
             <cmd refid="importDatasetFromSAV"/>
+            <cmd refid="importDatasetFromSAS"/>
+            <cmd refid="importDatasetFromStata"/>
+            <separator/>
+            <cmd refid="importDatasetFromXML"/>
+            <cmd refid="importDatasetFromJSON"/>
+            <separator/>
+            <cmd refid="importDatasetFromJDBC"/>
+            <cmd refid="importDatasetFromODBC"/>
+            <separator/>
+            <cmd refid="importDatasetFromMongo"/>
          </menu>
          <separator/>
          <cmd refid="installPackage"/>
@@ -2046,6 +2059,51 @@ well as menu structures (for main menu and popup menus).
    <cmd id="importDatasetFromSAV"
         label="Import Dataset from SAV..."
         menuLabel="From _SAV..."
+        windowMode="main"/>
+
+   <cmd id="importDatasetFromSAV"
+        label="Import Dataset from SPSS..."
+        menuLabel="From _SPSS..."
+        windowMode="main"/>
+
+   <cmd id="importDatasetFromSAS"
+        label="Import Dataset from SAS..."
+        menuLabel="From _SAS..."
+        windowMode="main"/>
+
+   <cmd id="importDatasetFromStata"
+        label="Import Dataset from Stata..."
+        menuLabel="From _Stata..."
+        windowMode="main"/>
+
+   <cmd id="importDatasetFromXLS"
+        label="Import Dataset from Excel..."
+        menuLabel="From _Excel..."
+        windowMode="main"/>
+
+   <cmd id="importDatasetFromXML"
+        label="Import Dataset from XML..."
+        menuLabel="From _XML..."
+        windowMode="main"/>
+
+   <cmd id="importDatasetFromJSON"
+        label="Import Dataset from JSON..."
+        menuLabel="From _JSON..."
+        windowMode="main"/>
+
+   <cmd id="importDatasetFromJDBC"
+        label="Import Dataset from JDBC..."
+        menuLabel="From _JDBC..."
+        windowMode="main"/>
+
+   <cmd id="importDatasetFromODBC"
+        label="Import Dataset from ODBC..."
+        menuLabel="From _ODBC..."
+        windowMode="main"/>
+
+   <cmd id="importDatasetFromMongo"
+        label="Import Dataset from Mongo..."
+        menuLabel="From _Mongo..."
         windowMode="main"/>
 
    <cmd id="refreshWorkspace"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -267,6 +267,7 @@ public abstract class
    public abstract AppCommand importDatasetFromFile();
    public abstract AppCommand importDatasetFromURL();
    public abstract AppCommand importDatasetFromCSV();
+   public abstract AppCommand importDatasetFromSAV();
 
    // Environment
    public abstract AppCommand activateEnvironment();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -268,6 +268,14 @@ public abstract class
    public abstract AppCommand importDatasetFromURL();
    public abstract AppCommand importDatasetFromCSV();
    public abstract AppCommand importDatasetFromSAV();
+   public abstract AppCommand importDatasetFromSAS();
+   public abstract AppCommand importDatasetFromStata();
+   public abstract AppCommand importDatasetFromXLS();
+   public abstract AppCommand importDatasetFromXML();
+   public abstract AppCommand importDatasetFromJSON();
+   public abstract AppCommand importDatasetFromJDBC();
+   public abstract AppCommand importDatasetFromODBC();
+   public abstract AppCommand importDatasetFromMongo();
 
    // Environment
    public abstract AppCommand activateEnvironment();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -419,7 +419,20 @@ public class EnvironmentPane extends WorkbenchPane
       menu.addItem(commands_.importDatasetFromCSV().createMenuItem(false));
       menu.addItem(commands_.importDatasetFromFile().createMenuItem(false));
       menu.addItem(commands_.importDatasetFromURL().createMenuItem(false));
+      menu.addSeparator();
+      menu.addItem(commands_.importDatasetFromXLS().createMenuItem(false));
+      menu.addSeparator();
       menu.addItem(commands_.importDatasetFromSAV().createMenuItem(false));
+      menu.addItem(commands_.importDatasetFromSAS().createMenuItem(false));
+      menu.addItem(commands_.importDatasetFromStata().createMenuItem(false));
+      menu.addSeparator();
+      menu.addItem(commands_.importDatasetFromXML().createMenuItem(false));
+      menu.addItem(commands_.importDatasetFromJSON().createMenuItem(false));
+      menu.addSeparator();
+      menu.addItem(commands_.importDatasetFromJDBC().createMenuItem(false));
+      menu.addItem(commands_.importDatasetFromODBC().createMenuItem(false));
+      menu.addSeparator();
+      menu.addItem(commands_.importDatasetFromMongo().createMenuItem(false));
       
       dataImportButton_ = new ToolbarButton(
               "Import Dataset",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -419,6 +419,7 @@ public class EnvironmentPane extends WorkbenchPane
       menu.addItem(commands_.importDatasetFromCSV().createMenuItem(false));
       menu.addItem(commands_.importDatasetFromFile().createMenuItem(false));
       menu.addItem(commands_.importDatasetFromURL().createMenuItem(false));
+      menu.addItem(commands_.importDatasetFromSAV().createMenuItem(false));
       
       dataImportButton_ = new ToolbarButton(
               "Import Dataset",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -519,8 +519,88 @@ public class EnvironmentPresenter extends BasePresenter
       dependencyManager_.withDataImportSAV(
             dataImportDependecyUserAction_, 
             getImportDatasetCommandFromMode(
-                  DataImportModes.Statistics,
+                  DataImportModes.SAV,
                   "Import Statistical Data")
+      );
+   }
+
+   void onImportDatasetFromSAS()
+   {
+      dependencyManager_.withDataImportSAV(
+            dataImportDependecyUserAction_, 
+            getImportDatasetCommandFromMode(
+                  DataImportModes.SAS,
+                  "Import Statistical Data")
+      );
+   }
+
+   void onImportDatasetFromStata()
+   {
+      dependencyManager_.withDataImportSAV(
+            dataImportDependecyUserAction_, 
+            getImportDatasetCommandFromMode(
+                  DataImportModes.Stata,
+                  "Import Statistical Data")
+      );
+   }
+
+   void onImportDatasetFromXLS()
+   {
+      dependencyManager_.withDataImportXLS(
+            dataImportDependecyUserAction_, 
+            getImportDatasetCommandFromMode(
+                  DataImportModes.XLS,
+                  "Import Excel Data")
+      );
+   }
+
+   void onImportDatasetFromXML()
+   {
+      dependencyManager_.withDataImportXML(
+            dataImportDependecyUserAction_, 
+            getImportDatasetCommandFromMode(
+                  DataImportModes.XML,
+                  "Import XML Data")
+      );
+   }
+
+   void onImportDatasetFromJSON()
+   {
+      dependencyManager_.withDataImportJSON(
+            dataImportDependecyUserAction_, 
+            getImportDatasetCommandFromMode(
+                  DataImportModes.JSON,
+                  "Import JSON Data")
+      );
+   }
+
+   void onImportDatasetFromJDBC()
+   {
+      dependencyManager_.withDataImportJDBC(
+            dataImportDependecyUserAction_, 
+            getImportDatasetCommandFromMode(
+                  DataImportModes.JDBC,
+                  "Import from JDBC")
+      );
+   }
+
+   void onImportDatasetFromODBC()
+   {
+      dependencyManager_.withDataImportODBC(
+            dataImportDependecyUserAction_, 
+            getImportDatasetCommandFromMode(
+                  DataImportModes.ODBC,
+                  "Import from ODBC")
+      );
+   }
+
+   void onImportDatasetFromMongo()
+   {
+      dependencyManager_.withDataImportMongo(
+            dataImportDependecyUserAction_, 
+            getImportDatasetCommandFromMode(
+                  DataImportModes.Mongo,
+                  "Import from Mongo DB")
       );
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -476,20 +476,20 @@ public class EnvironmentPresenter extends BasePresenter
                  }
               });
    }
-
-   void onImportDatasetFromCSV()
+   
+   Command getImportDatasetCommandFromMode(
+      final DataImportModes dataImportMode,
+      final String dialogTitle)
    {
-      final String action = "Preparing data import";
-      dependencyManager_.withDataImportCSV(
-         action, 
+      return 
          new Command() {
             @Override
             public void execute()
             {
                view_.bringToFront();
                DataImportDialog dataImportDialog = new DataImportDialog(
-                     DataImportModes.Text,
-                     "Data Import",
+                     dataImportMode,
+                     dialogTitle,
                      new OperationWithInput<String>()
                {
                   @Override
@@ -501,7 +501,27 @@ public class EnvironmentPresenter extends BasePresenter
                
                dataImportDialog.showModal();
             }
-      });
+         };
+   }
+
+   void onImportDatasetFromCSV()
+   {
+      dependencyManager_.withDataImportCSV(
+            dataImportDependecyUserAction_, 
+            getImportDatasetCommandFromMode(
+                  DataImportModes.Text,
+                  "Import Text Data")
+      );
+   }
+   
+   void onImportDatasetFromSAV()
+   {
+      dependencyManager_.withDataImportSAV(
+            dataImportDependecyUserAction_, 
+            getImportDatasetCommandFromMode(
+                  DataImportModes.Statistics,
+                  "Import Statistical Data")
+      );
    }
 
    public void onOpenDataFile(OpenDataFileEvent event)
@@ -946,4 +966,6 @@ public class EnvironmentPresenter extends BasePresenter
    private String functionEnvName_;
    private Timer requeryContextTimer_;
    private SearchPathFunctionDefinition searchFunction_;
+   
+   final String dataImportDependecyUserAction_ = "Preparing data import";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentTab.java
@@ -48,6 +48,8 @@ public class EnvironmentTab extends DelayLoadWorkbenchTab<EnvironmentPresenter>
       @Handler
       public abstract void onImportDatasetFromCSV();
       @Handler
+      public abstract void onImportDatasetFromSAV();
+      @Handler
       public abstract void onClearWorkspace();
 
       abstract void initialize(EnvironmentContextData environmentState);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentTab.java
@@ -50,6 +50,22 @@ public class EnvironmentTab extends DelayLoadWorkbenchTab<EnvironmentPresenter>
       @Handler
       public abstract void onImportDatasetFromSAV();
       @Handler
+      public abstract void onImportDatasetFromSAS();
+      @Handler
+      public abstract void onImportDatasetFromStata();
+      @Handler
+      public abstract void onImportDatasetFromXLS();
+      @Handler
+      public abstract void onImportDatasetFromXML();
+      @Handler
+      public abstract void onImportDatasetFromJSON();
+      @Handler
+      public abstract void onImportDatasetFromJDBC();
+      @Handler
+      public abstract void onImportDatasetFromODBC();
+      @Handler
+      public abstract void onImportDatasetFromMongo();
+      @Handler
       public abstract void onClearWorkspace();
 
       abstract void initialize(EnvironmentContextData environmentState);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -18,7 +18,6 @@ package org.rstudio.studio.client.workbench.views.environment.dataimport;
 import org.rstudio.core.client.Size;
 import org.rstudio.core.client.dom.DomMetrics;
 import org.rstudio.core.client.dom.DomUtils;
-import org.rstudio.core.client.widget.FileOrUrlChooserTextBox;
 import org.rstudio.core.client.widget.GridViewerFrame;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
@@ -152,31 +151,31 @@ public class DataImport extends Composite
    }
    
    @UiFactory
-   FileOrUrlChooserTextBox makeFileOrUrlChooserTextBox() {
-      FileOrUrlChooserTextBox fileOrUrlChooserTextBox = new FileOrUrlChooserTextBox(
-            "File/URL:",
+   DataImportFileChooser makeFileOrUrlChooserTextBox() {
+      DataImportFileChooser dataImportFileChooser = new DataImportFileChooser(
             new Operation()
             {
                @Override
                public void execute()
                {
-                  if (fileOrUrlChooserTextBox_.getText() != importOptions_.getImportLocation())
+                  if (dataImportFileChooser_.getText() != importOptions_.getImportLocation())
                   {
                      lastSuccessfulResponse_ = null;
                      importOptions_.resetColumnDefinitions();
                   }
                   
                   importOptions_.setImportLocation(
-                     !fileOrUrlChooserTextBox_.getText().isEmpty() ?
-                     fileOrUrlChooserTextBox_.getText() :
+                     !dataImportFileChooser_.getText().isEmpty() ?
+                           dataImportFileChooser_.getText() :
                      null);
                   dataImportOptionsUi_.clearDataName();
+                  dataImportOptionsUi_.setImportLocation(dataImportFileChooser_.getText());
                   previewDataImport();
                }
             },
-            null);
+            true);
       
-      return fileOrUrlChooserTextBox;
+      return dataImportFileChooser;
    }
    
    @UiFactory
@@ -193,7 +192,7 @@ public class DataImport extends Composite
    }
    
    @UiField
-   FileOrUrlChooserTextBox fileOrUrlChooserTextBox_;
+   DataImportFileChooser dataImportFileChooser_;
    
    @UiField
    GridViewerFrame gridViewer_;
@@ -375,7 +374,7 @@ public class DataImport extends Composite
       
       assembleDataImport();
       
-      if (fileOrUrlChooserTextBox_.getText() == "")
+      if (dataImportFileChooser_.getText() == "")
       {
          gridViewer_.setData(null);
          return;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -136,6 +136,8 @@ public class DataImport extends Composite
       {
       case Text:
          return new DataImportOptionsUiCsv();
+      case Statistics:
+         return new DataImportOptionsUiSav();
       }
       
       return null;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -135,8 +135,22 @@ public class DataImport extends Composite
       {
       case Text:
          return new DataImportOptionsUiCsv();
-      case Statistics:
-         return new DataImportOptionsUiSav();
+      case SAV:
+      case SAS:
+      case Stata:
+         return new DataImportOptionsUiSav(mode);
+      case XLS:
+         return new DataImportOptionsUiXls();
+      case XML:
+         return new DataImportOptionsUiXml();
+      case JSON:
+         return new DataImportOptionsUiJson();
+      case ODBC:
+         return new DataImportOptionsUiOdbc();
+      case JDBC:
+         return new DataImportOptionsUiJdbc();
+      case Mongo:
+         return new DataImportOptionsUiMongo();
       }
       
       return null;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -355,6 +355,18 @@ public class DataImport extends Composite
       gridViewer_.setOption("ordering", "false");
       gridViewer_.setOption("rowNumbers", "false");
       gridViewer_.setData(response);
+      
+      if (response.supportsColumnOperations())
+      {
+         gridViewer_.setColumnDefinitionsUIVisible(true, onColumnMenuShow(), new Operation()
+         {
+            @Override
+            public void execute()
+            {
+               columnTypesMenu_.hide();
+            }
+         });
+      }
    }
    
    private void previewDataImport()
@@ -398,14 +410,6 @@ public class DataImport extends Composite
             assignColumnDefinitions(response, importOptions_.getColumnDefinitions());
             
             setGridViewerData(response);
-            gridViewer_.setColumnDefinitionsUIVisible(true, onColumnMenuShow(), new Operation()
-            {
-               @Override
-               public void execute()
-               {
-                  columnTypesMenu_.hide();
-               }
-            });
             
             progressIndicator_.onCompleted();
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.ui.xml
@@ -23,7 +23,7 @@
 			margin-left: 5px;
 		}
 		.topImportLabel {	
-			margin-top: 6px;
+			margin-top: 0px;
 			margin-right: 5px;
 			margin-left: 5px;
 		}
@@ -58,9 +58,9 @@
 			flex-grow: 1;
 		}
 		.codePanel {
-			-ms-flex-grow: 1;
-			-webkit-flex-grow: 1;
-			flex-grow: 1;
+			-ms-flex-grow: 10;
+			-webkit-flex-grow: 10;
+			flex-grow: 10;
 
 			display: -ms-flexbox;
 			display: -webkit-flex;
@@ -111,12 +111,21 @@
 			margin: 3px 3px 3px 3px;
 		}
 		.fileChooser {
+			display: -ms-flexbox;
+			display: -webkit-flex;
+			display: flex;
+
+			-webkit-flex-direction: row;
+			-ms-flex-direction: row;
+			flex-direction: row;
+
 			margin-right: 5px;
 			margin-left: 5px;
 		}
 	</ui:style>
 	<g:HTMLPanel styleName="{style.flexPanel}">
-	    <rs:FileOrUrlChooserTextBox ui:field="fileOrUrlChooserTextBox_"
+	    <g:Label text="File/Url:" styleName="{style.topImportLabel}"/>
+	    <rsdi:DataImportFileChooser ui:field="dataImportFileChooser_"
 	        						styleName="{style.fileChooser}"/>
 		<g:Label text="Data Preview:" styleName="{style.importLabel}"/>
 		<rs:GridViewerFrame ui:field="gridViewer_"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportFileChooser.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportFileChooser.ui.xml
@@ -1,0 +1,40 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
+	xmlns:g="urn:import:com.google.gwt.user.client.ui"
+	xmlns:rs="urn:import:org.rstudio.core.client.widget">
+	<ui:style>
+		.modelChooser {
+			display: -ms-flexbox;
+			display: -webkit-flex;
+			display: flex;
+
+			-webkit-flex-direction: row;
+			-ms-flex-direction: row;
+			flex-direction: row;
+
+			-ms-flex-grow: 1;
+			-webkit-flex-grow: 1;
+			flex-grow: 1;
+
+			height: 24px;
+		}
+		.modelTextBox {
+			margin-top: 3px;
+
+			display: -ms-flexbox;
+			display: -webkit-flex;
+			display: flex;
+
+			-ms-flex-grow: 1;
+			-webkit-flex-grow: 1;
+			flex-grow: 1;
+
+			padding-left: 5px;
+			padding-right: 5px;
+		}
+	</ui:style>
+	<g:HTMLPanel styleName="{style.modelChooser}">
+		<g:TextBox ui:field="locationTextBox_" styleName="{style.modelTextBox}"/>
+        <rs:ThemedButton ui:field="actionButton_" text="Browse..."/>
+	</g:HTMLPanel>
+</ui:UiBinder> 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptions.java
@@ -23,7 +23,7 @@ public class DataImportOptions extends JavaScriptObject
    {
    }
    
-   public final static native DataImportOptionsCsv create() /*-{
+   public static native DataImportOptions create() /*-{
       return {};
    }-*/;
    
@@ -43,6 +43,7 @@ public class DataImportOptions extends JavaScriptObject
    public final native void setOptions(JavaScriptObject options) /*-{
       var this_ = this;
       this_.importLocation = options.importLocation;
+      this_.mode = options.mode;
       
       if (options.columnDefinitions) {
          Object.keys(options.columnDefinitions).forEach(function(key) {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsCsv.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsCsv.java
@@ -33,6 +33,7 @@ public class DataImportOptionsCsv extends DataImportOptions
                                                           String comments,
                                                           int skip) /*-{
       return {
+         "mode": "text",
          "dataName": dataName,
          "delimiter": delimiter,
          "quotes": quotes,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsJdbc.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsJdbc.java
@@ -1,5 +1,5 @@
 /*
- * DataImportModes.java
+ * DataImportOptionsJdbc.java
  *
  * Copyright (C) 2009-16 by RStudio, Inc.
  *
@@ -15,16 +15,17 @@
 
 package org.rstudio.studio.client.workbench.views.environment.dataimport;
 
-public enum DataImportModes
+public class DataImportOptionsJdbc extends DataImportOptions
 {
-   Text,
-   SAV,
-   SAS,
-   Stata,
-   XLS,
-   XML,
-   JSON,
-   JDBC,
-   ODBC,
-   Mongo,
+   protected DataImportOptionsJdbc()
+   {
+   }
+   
+   public final static native DataImportOptionsJdbc create(
+      String dataName) /*-{
+         return {
+            "mode": "jdbc",
+            "dataName": dataName
+       }
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsJson.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsJson.java
@@ -1,5 +1,5 @@
 /*
- * DataImportModes.java
+ * DataImportOptionsJson.java
  *
  * Copyright (C) 2009-16 by RStudio, Inc.
  *
@@ -15,16 +15,17 @@
 
 package org.rstudio.studio.client.workbench.views.environment.dataimport;
 
-public enum DataImportModes
+public class DataImportOptionsJson extends DataImportOptions
 {
-   Text,
-   SAV,
-   SAS,
-   Stata,
-   XLS,
-   XML,
-   JSON,
-   JDBC,
-   ODBC,
-   Mongo,
+   protected DataImportOptionsJson()
+   {
+   }
+   
+   public final static native DataImportOptionsJson create(
+      String dataName) /*-{
+         return {
+            "mode": "json",
+            "dataName": dataName
+       }
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsMongo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsMongo.java
@@ -1,5 +1,5 @@
 /*
- * DataImportModes.java
+ * DataImportOptionsMongo.java
  *
  * Copyright (C) 2009-16 by RStudio, Inc.
  *
@@ -15,16 +15,17 @@
 
 package org.rstudio.studio.client.workbench.views.environment.dataimport;
 
-public enum DataImportModes
+public class DataImportOptionsMongo extends DataImportOptions
 {
-   Text,
-   SAV,
-   SAS,
-   Stata,
-   XLS,
-   XML,
-   JSON,
-   JDBC,
-   ODBC,
-   Mongo,
+   protected DataImportOptionsMongo()
+   {
+   }
+   
+   public final static native DataImportOptionsMongo create(
+      String dataName) /*-{
+         return {
+            "mode": "mongo",
+            "dataName": dataName
+       }
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsOdbc.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsOdbc.java
@@ -1,5 +1,5 @@
 /*
- * DataImportModes.java
+ * DataImportOptionsOdbc.java
  *
  * Copyright (C) 2009-16 by RStudio, Inc.
  *
@@ -15,16 +15,17 @@
 
 package org.rstudio.studio.client.workbench.views.environment.dataimport;
 
-public enum DataImportModes
+public class DataImportOptionsOdbc extends DataImportOptions
 {
-   Text,
-   SAV,
-   SAS,
-   Stata,
-   XLS,
-   XML,
-   JSON,
-   JDBC,
-   ODBC,
-   Mongo,
+   protected DataImportOptionsOdbc()
+   {
+   }
+   
+   public final static native DataImportOptionsOdbc create(
+      String dataName) /*-{
+         return {
+            "mode": "odbc",
+            "dataName": dataName
+       }
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsSav.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsSav.java
@@ -23,6 +23,7 @@ public class DataImportOptionsSav extends DataImportOptions
    
    public final static native DataImportOptionsSav create(String dataName) /*-{
       return {
+         "mode": "statistics",
          "dataName": dataName
       }
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsSav.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsSav.java
@@ -1,5 +1,5 @@
 /*
- * DataImportModes.java
+ * DataImportOptionsSav.java
  *
  * Copyright (C) 2009-16 by RStudio, Inc.
  *
@@ -15,8 +15,15 @@
 
 package org.rstudio.studio.client.workbench.views.environment.dataimport;
 
-public enum DataImportModes
+public class DataImportOptionsSav extends DataImportOptions
 {
-   Text,
-   Statistics,
+   protected DataImportOptionsSav()
+   {
+   }
+   
+   public final static native DataImportOptionsSav create(String dataName) /*-{
+      return {
+         "dataName": dataName
+      }
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsSav.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsSav.java
@@ -21,10 +21,15 @@ public class DataImportOptionsSav extends DataImportOptions
    {
    }
    
-   public final static native DataImportOptionsSav create(String dataName) /*-{
+   public final static native DataImportOptionsSav create(
+      String dataName,
+      String modelLocation,
+      String format) /*-{
       return {
          "mode": "statistics",
-         "dataName": dataName
+         "dataName": dataName,
+         "modelLocation": modelLocation,
+         "format": format
       }
    }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUi.java
@@ -54,6 +54,11 @@ public class DataImportOptionsUi extends Composite implements HasValueChangeHand
       
    }
    
+   void triggerChange()
+   {
+      ValueChangeEvent.fire(this, getOptions());
+   }
+   
    private final HandlerManager handlerManager_ = new HandlerManager(this);
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUi.java
@@ -18,7 +18,10 @@ package org.rstudio.studio.client.workbench.views.environment.dataimport;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportAssembleResponse;
 
 import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Composite;
 
@@ -31,7 +34,9 @@ public class DataImportOptionsUi extends Composite implements HasValueChangeHand
 
    public HandlerRegistration addValueChangeHandler(ValueChangeHandler<DataImportOptions> handler)
    {
-      return null;
+      return handlerManager_.addHandler(
+            ValueChangeEvent.getType(),
+            handler);
    }
    
    public void setAssembleResponse(DataImportAssembleResponse response)
@@ -42,5 +47,18 @@ public class DataImportOptionsUi extends Composite implements HasValueChangeHand
    public void clearDataName()
    {
       
+   }
+   
+   public void setImportLocation(String importLocation)
+   {
+      
+   }
+   
+   private final HandlerManager handlerManager_ = new HandlerManager(this);
+   
+   @Override
+   public void fireEvent(GwtEvent<?> event)
+   {
+      handlerManager_.fireEvent(event);
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.java
@@ -28,9 +28,6 @@ import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
-import com.google.gwt.event.shared.GwtEvent;
-import com.google.gwt.event.shared.HandlerManager;
-import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.CheckBox;
@@ -175,11 +172,6 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
          }
       });
      
-   }
-   
-   void triggerChange()
-   {
-      ValueChangeEvent.fire(this, getOptions());
    }
    
    void initEvents()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.java
@@ -255,20 +255,4 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
    
    @UiField
    CheckBox trimSpacesCheckBox_;
-   
-   private final HandlerManager handlerManager_ = new HandlerManager(this);
-
-   @Override
-   public HandlerRegistration addValueChangeHandler(ValueChangeHandler<DataImportOptions> handler)
-   {
-      return handlerManager_.addHandler(
-            ValueChangeEvent.getType(),
-            handler);
-   }
-   
-   @Override
-   public void fireEvent(GwtEvent<?> event)
-   {
-      handlerManager_.fireEvent(event);
-   }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.ui.xml
@@ -18,9 +18,6 @@
 			flex-grow: 1;
 		}
 		.optionsBlock {
-			margin-top: 3px;
-			padding-left: 7px;
-			
 			display: -ms-flexbox;
 			display: -webkit-flex;
 			display: flex;
@@ -39,6 +36,7 @@
 			padding-left: 10px;
 			padding-bottom: 3px;
 
+			margin-top: 3px;
 			margin-right: 5px;
 			margin-left: 5px;
 		}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiJdbc.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiJdbc.java
@@ -1,0 +1,64 @@
+/*
+ * DataImportOptionsUiJdbc.java
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.environment.dataimport;
+
+import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportAssembleResponse;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.TextBox;
+import com.google.gwt.user.client.ui.Widget;
+
+public class DataImportOptionsUiJdbc extends DataImportOptionsUi
+{
+
+   private static DataImportOptionsUiJdbcUiBinder uiBinder = GWT
+         .create(DataImportOptionsUiJdbcUiBinder.class);
+
+   interface DataImportOptionsUiJdbcUiBinder
+         extends UiBinder<Widget, DataImportOptionsUiJdbc>
+   {
+   }
+
+   public DataImportOptionsUiJdbc()
+   {
+      initWidget(uiBinder.createAndBindUi(this));
+   }
+
+   @Override
+   public DataImportOptionsJdbc getOptions()
+   {
+      return DataImportOptionsJdbc.create(
+         nameTextBox_.getValue()
+      );
+   }
+   
+   @Override
+   public void setAssembleResponse(DataImportAssembleResponse response)
+   {
+      nameTextBox_.setText(response.getDataName());
+   }
+   
+   @Override
+   public void clearDataName()
+   {
+      nameTextBox_.setText("");
+   }
+   
+   @UiField
+   TextBox nameTextBox_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiJdbc.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiJdbc.ui.xml
@@ -1,0 +1,16 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
+	xmlns:g="urn:import:com.google.gwt.user.client.ui">
+	<ui:style src="res/DataImportStyles.css"
+    	type="org.rstudio.studio.client.workbench.views.environment.dataimport.res.DataImportResources.Style">
+    </ui:style>
+	<g:HTMLPanel styleName="{style.mainPanel}">
+	    <g:Label text="Import Options:" styleName="{style.optionsLabel}"/>
+	    <div class="{style.optionsBlock}">
+		    <div class="{style.optionsRow}">
+		        <div class="{style.optionLabel} {style.nameLabel}">Name:</div>
+		        <g:TextBox ui:field="nameTextBox_" styleName="{style.nameTextBox}"/>
+		    </div>
+	    </div>
+	</g:HTMLPanel>
+</ui:UiBinder> 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiJson.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiJson.java
@@ -1,0 +1,64 @@
+/*
+ * DataImportOptionsUiJson.java
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.environment.dataimport;
+
+import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportAssembleResponse;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.TextBox;
+import com.google.gwt.user.client.ui.Widget;
+
+public class DataImportOptionsUiJson extends DataImportOptionsUi
+{
+
+   private static DataImportOptionsUiJsonUiBinder uiBinder = GWT
+         .create(DataImportOptionsUiJsonUiBinder.class);
+
+   interface DataImportOptionsUiJsonUiBinder
+         extends UiBinder<Widget, DataImportOptionsUiJson>
+   {
+   }
+
+   public DataImportOptionsUiJson()
+   {
+      initWidget(uiBinder.createAndBindUi(this));
+   }
+
+   @Override
+   public DataImportOptionsMongo getOptions()
+   {
+      return DataImportOptionsMongo.create(
+         nameTextBox_.getValue()
+      );
+   }
+   
+   @Override
+   public void setAssembleResponse(DataImportAssembleResponse response)
+   {
+      nameTextBox_.setText(response.getDataName());
+   }
+   
+   @Override
+   public void clearDataName()
+   {
+      nameTextBox_.setText("");
+   }
+   
+   @UiField
+   TextBox nameTextBox_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiJson.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiJson.ui.xml
@@ -1,0 +1,16 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
+	xmlns:g="urn:import:com.google.gwt.user.client.ui">
+	<ui:style src="res/DataImportStyles.css"
+    	type="org.rstudio.studio.client.workbench.views.environment.dataimport.res.DataImportResources.Style">
+    </ui:style>
+	<g:HTMLPanel styleName="{style.mainPanel}">
+	    <g:Label text="Import Options:" styleName="{style.optionsLabel}"/>
+	    <div class="{style.optionsBlock}">
+		    <div class="{style.optionsRow}">
+		        <div class="{style.optionLabel} {style.nameLabel}">Name:</div>
+		        <g:TextBox ui:field="nameTextBox_" styleName="{style.nameTextBox}"/>
+		    </div>
+	    </div>
+	</g:HTMLPanel>
+</ui:UiBinder> 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiMongo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiMongo.java
@@ -1,0 +1,64 @@
+/*
+ * DataImportOptionsUiMongo.java
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.environment.dataimport;
+
+import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportAssembleResponse;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.TextBox;
+import com.google.gwt.user.client.ui.Widget;
+
+public class DataImportOptionsUiMongo extends DataImportOptionsUi
+{
+
+   private static DataImportOptionsUiMongoUiBinder uiBinder = GWT
+         .create(DataImportOptionsUiMongoUiBinder.class);
+
+   interface DataImportOptionsUiMongoUiBinder
+         extends UiBinder<Widget, DataImportOptionsUiMongo>
+   {
+   }
+
+   public DataImportOptionsUiMongo()
+   {
+      initWidget(uiBinder.createAndBindUi(this));
+   }
+
+   @Override
+   public DataImportOptionsMongo getOptions()
+   {
+      return DataImportOptionsMongo.create(
+         nameTextBox_.getValue()
+      );
+   }
+   
+   @Override
+   public void setAssembleResponse(DataImportAssembleResponse response)
+   {
+      nameTextBox_.setText(response.getDataName());
+   }
+   
+   @Override
+   public void clearDataName()
+   {
+      nameTextBox_.setText("");
+   }
+   
+   @UiField
+   TextBox nameTextBox_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiMongo.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiMongo.ui.xml
@@ -1,0 +1,16 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
+	xmlns:g="urn:import:com.google.gwt.user.client.ui">
+	<ui:style src="res/DataImportStyles.css"
+    	type="org.rstudio.studio.client.workbench.views.environment.dataimport.res.DataImportResources.Style">
+    </ui:style>
+	<g:HTMLPanel styleName="{style.mainPanel}">
+	    <g:Label text="Import Options:" styleName="{style.optionsLabel}"/>
+	    <div class="{style.optionsBlock}">
+		    <div class="{style.optionsRow}">
+		        <div class="{style.optionLabel} {style.nameLabel}">Name:</div>
+		        <g:TextBox ui:field="nameTextBox_" styleName="{style.nameTextBox}"/>
+		    </div>
+	    </div>
+	</g:HTMLPanel>
+</ui:UiBinder> 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiOdbc.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiOdbc.java
@@ -1,0 +1,64 @@
+/*
+ * DataImportOptionsUiOdbc.java
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.environment.dataimport;
+
+import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportAssembleResponse;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.TextBox;
+import com.google.gwt.user.client.ui.Widget;
+
+public class DataImportOptionsUiOdbc extends DataImportOptionsUi
+{
+
+   private static DataImportOptionsUiOdbcUiBinder uiBinder = GWT
+         .create(DataImportOptionsUiOdbcUiBinder.class);
+
+   interface DataImportOptionsUiOdbcUiBinder
+         extends UiBinder<Widget, DataImportOptionsUiOdbc>
+   {
+   }
+
+   public DataImportOptionsUiOdbc()
+   {
+      initWidget(uiBinder.createAndBindUi(this));
+   }
+
+   @Override
+   public DataImportOptionsOdbc getOptions()
+   {
+      return DataImportOptionsOdbc.create(
+         nameTextBox_.getValue()
+      );
+   }
+   
+   @Override
+   public void setAssembleResponse(DataImportAssembleResponse response)
+   {
+      nameTextBox_.setText(response.getDataName());
+   }
+   
+   @Override
+   public void clearDataName()
+   {
+      nameTextBox_.setText("");
+   }
+   
+   @UiField
+   TextBox nameTextBox_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiOdbc.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiOdbc.ui.xml
@@ -1,0 +1,16 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
+	xmlns:g="urn:import:com.google.gwt.user.client.ui">
+	<ui:style src="res/DataImportStyles.css"
+    	type="org.rstudio.studio.client.workbench.views.environment.dataimport.res.DataImportResources.Style">
+    </ui:style>
+	<g:HTMLPanel styleName="{style.mainPanel}">
+	    <g:Label text="Import Options:" styleName="{style.optionsLabel}"/>
+	    <div class="{style.optionsBlock}">
+		    <div class="{style.optionsRow}">
+		        <div class="{style.optionLabel} {style.nameLabel}">Name:</div>
+		        <g:TextBox ui:field="nameTextBox_" styleName="{style.nameTextBox}"/>
+		    </div>
+	    </div>
+	</g:HTMLPanel>
+</ui:UiBinder> 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.java
@@ -15,8 +15,12 @@
 
 package org.rstudio.studio.client.workbench.views.environment.dataimport;
 
+import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportAssembleResponse;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.Widget;
 
 public class DataImportOptionsUiSav extends DataImportOptionsUi
@@ -38,6 +42,21 @@ public class DataImportOptionsUiSav extends DataImportOptionsUi
    @Override
    public DataImportOptionsSav getOptions()
    {
-      return DataImportOptionsSav.create("test");
+      return DataImportOptionsSav.create(nameTextBox_.getValue());
    }
+   
+   @Override
+   public void setAssembleResponse(DataImportAssembleResponse response)
+   {
+      nameTextBox_.setText(response.getDataName());
+   }
+   
+   @Override
+   public void clearDataName()
+   {
+      nameTextBox_.setText("");
+   }
+   
+   @UiField
+   TextBox nameTextBox_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.java
@@ -1,0 +1,43 @@
+/*
+ * DataImportOptionsUiSav.java
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.environment.dataimport;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.user.client.ui.Widget;
+
+public class DataImportOptionsUiSav extends DataImportOptionsUi
+{
+
+   private static DataImportOptionsUiSavUiBinder uiBinder = GWT
+         .create(DataImportOptionsUiSavUiBinder.class);
+
+   interface DataImportOptionsUiSavUiBinder
+         extends UiBinder<Widget, DataImportOptionsUiSav>
+   {
+   }
+
+   public DataImportOptionsUiSav()
+   {
+      initWidget(uiBinder.createAndBindUi(this));
+   }
+   
+   @Override
+   public DataImportOptionsSav getOptions()
+   {
+      return DataImportOptionsSav.create("test");
+   }
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.java
@@ -41,21 +41,34 @@ public class DataImportOptionsUiSav extends DataImportOptionsUi
    {
    }
 
-   public DataImportOptionsUiSav()
+   public DataImportOptionsUiSav(DataImportModes mode)
    {
       initWidget(uiBinder.createAndBindUi(this));
       
-      initDefaults();
+      initDefaults(mode);
       initEvents();
    }
    
-   void initDefaults()
+   void initDefaults(DataImportModes mode)
    {
       formatListBox_.addItem("SAV", "sav");
       formatListBox_.addItem("DTA", "dta");
       formatListBox_.addItem("POR", "por");
       formatListBox_.addItem("SAS", "sas");
       formatListBox_.addItem("Stata", "stata");
+      
+      switch(mode)
+      {
+      case SAS:
+         formatListBox_.setSelectedIndex(3);
+         break;
+      case Stata:
+         formatListBox_.setSelectedIndex(4);
+         break;
+      default:
+         formatListBox_.setSelectedIndex(0);
+         break;
+      }
    }
    
    @Override
@@ -112,11 +125,6 @@ public class DataImportOptionsUiSav extends DataImportOptionsUi
          false);
       
       return dataImportFileChooser;
-   }
-   
-   void triggerChange()
-   {
-      ValueChangeEvent.fire(this, getOptions());
    }
    
    void initEvents()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.ui.xml
@@ -2,84 +2,8 @@
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
 	xmlns:g="urn:import:com.google.gwt.user.client.ui"
 	xmlns:rsdi="urn:import:org.rstudio.studio.client.workbench.views.environment.dataimport">
-	<ui:style>
-		.mainPanel {
-			display: -ms-flexbox;
-			display: -webkit-flex;
-			display: flex;
-
-			-webkit-flex-direction: column;
-			-ms-flex-direction: column;
-			flex-direction: column;
-
-			-ms-flex-grow: 1;
-			-webkit-flex-grow: 1;
-			flex-grow: 1;
-
-			min-width: 300px;
-		}
-		.optionsBlock {
-			border: 1px solid #999;
-			background-color: #F7F8F9;
-			padding-top: 12px;
-			padding-left: 16px;
-			padding-bottom: 3px;
-			padding-right: 6px;
-
-			display: -ms-flexbox;
-			display: -webkit-flex;
-			display: flex;
-
-			-webkit-flex-direction: column;
-			-ms-flex-direction: column;
-			flex-direction: column;
-
-			-ms-flex-grow: 1;
-			-webkit-flex-grow: 1;
-			flex-grow: 1;
-
-			margin-top: 3px;
-			margin-right: 5px;
-			margin-left: 5px;
-		}
-		.optionsLabel {
-			margin-top: 14px;
-
-			margin-left: 5px;
-			margin-right: 5px;
-		}
-		.optionsRow {
-			display: -ms-flexbox;
-			display: -webkit-flex;
-			display: flex;
-
-			-webkit-flex-direction: row;
-			-ms-flex-direction: row;
-			flex-direction: row;
-
-			-ms-flex-grow: 1;
-			-webkit-flex-grow: 1;
-			flex-grow: 1;
-
-			height: 24px;
-			margin-right: 10px;
-		}
-		.optionLabel {
-			width: 54px;
-		}
-		.nameLabel {
-			margin-top: 3px;
-		}
-		.nameTextBox {
-			height: 22px;
-
-			-ms-flex-grow: 1;
-			-webkit-flex-grow: 1;
-			flex-grow: 1;
-
-			padding-left: 5px;
-			padding-right: 5px;
-		}
+	<ui:style src="res/DataImportStyles.css"
+    	type="org.rstudio.studio.client.workbench.views.environment.dataimport.res.DataImportResources.Style">
 		.modelLabel {
 			margin-top: 6px;
 		}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.ui.xml
@@ -51,7 +51,7 @@
 	            <tr>
 	                <td>Name:</td>
 	                <td>
-	                    <g:TextBox styleName="{style.nameTextBox}"/>
+	                    <g:TextBox ui:field="nameTextBox_" styleName="{style.nameTextBox}"/>
 	                </td>
 	            </tr>
 	        </table>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.ui.xml
@@ -1,60 +1,116 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
-	xmlns:g="urn:import:com.google.gwt.user.client.ui">
+	xmlns:g="urn:import:com.google.gwt.user.client.ui"
+	xmlns:rsdi="urn:import:org.rstudio.studio.client.workbench.views.environment.dataimport">
 	<ui:style>
-	.mainPanel {
-		display: -ms-flexbox;
-		display: -webkit-flex;
-		display: flex;
+		.mainPanel {
+			display: -ms-flexbox;
+			display: -webkit-flex;
+			display: flex;
 
-		-webkit-flex-direction: column;
-		-ms-flex-direction: column;
-		flex-direction: column;
+			-webkit-flex-direction: column;
+			-ms-flex-direction: column;
+			flex-direction: column;
 
-		-ms-flex-grow: 1;
-		-webkit-flex-grow: 1;
-		flex-grow: 1;
-	}
-	.optionsBlock {
-		margin-top: 3px;
-		padding-left: 7px;
+			-ms-flex-grow: 1;
+			-webkit-flex-grow: 1;
+			flex-grow: 1;
 
-		-ms-flex-grow: 1;
-		-webkit-flex-grow: 1;
-		flex-grow: 1;
+			min-width: 300px;
+		}
+		.optionsBlock {
+			border: 1px solid #999;
+			background-color: #F7F8F9;
+			padding-top: 12px;
+			padding-left: 16px;
+			padding-bottom: 3px;
+			padding-right: 6px;
 
-		border: 1px solid #999;
-		background-color: #F7F8F9;
-		padding-top: 10px;
-		padding-left: 10px;
-		padding-bottom: 3px;
+			display: -ms-flexbox;
+			display: -webkit-flex;
+			display: flex;
 
-		margin-right: 5px;
-		margin-left: 5px;
-	}
-	.optionsLabel {
-		margin-top: 14px;
+			-webkit-flex-direction: column;
+			-ms-flex-direction: column;
+			flex-direction: column;
 
-		margin-left: 5px;
-		margin-right: 5px;
-	}
-	.nameTextBox {
-		-ms-flex-grow: 1;
-		-webkit-flex-grow: 1;
-		flex-grow: 1;
-	}
+			-ms-flex-grow: 1;
+			-webkit-flex-grow: 1;
+			flex-grow: 1;
+
+			margin-top: 3px;
+			margin-right: 5px;
+			margin-left: 5px;
+		}
+		.optionsLabel {
+			margin-top: 14px;
+
+			margin-left: 5px;
+			margin-right: 5px;
+		}
+		.optionsRow {
+			display: -ms-flexbox;
+			display: -webkit-flex;
+			display: flex;
+
+			-webkit-flex-direction: row;
+			-ms-flex-direction: row;
+			flex-direction: row;
+
+			-ms-flex-grow: 1;
+			-webkit-flex-grow: 1;
+			flex-grow: 1;
+
+			height: 24px;
+			margin-right: 10px;
+		}
+		.optionLabel {
+			width: 54px;
+		}
+		.nameLabel {
+			margin-top: 3px;
+		}
+		.nameTextBox {
+			height: 22px;
+
+			-ms-flex-grow: 1;
+			-webkit-flex-grow: 1;
+			flex-grow: 1;
+
+			padding-left: 5px;
+			padding-right: 5px;
+		}
+		.modelLabel {
+			margin-top: 6px;
+		}
+		.formatRow {
+			margin-top: 2px;
+		}
+		.formatLabel {
+			margin-top: 4px;
+		}
+		.formatListBox {
+			margin-top: 3px;
+			width: 85px;
+		}
+		.modelButton {
+		}
 	</ui:style>
 	<g:HTMLPanel styleName="{style.mainPanel}">
 	    <g:Label text="Import Options:" styleName="{style.optionsLabel}"/>
-		<div class="{style.optionsBlock}">
-		    <table>
-	            <tr>
-	                <td>Name:</td>
-	                <td>
-	                    <g:TextBox ui:field="nameTextBox_" styleName="{style.nameTextBox}"/>
-	                </td>
-	            </tr>
-	        </table>
-		</div>
+	    <div class="{style.optionsBlock}">
+		    <div class="{style.optionsRow}">
+		        <div class="{style.optionLabel} {style.nameLabel}">Name:</div>
+		        <g:TextBox ui:field="nameTextBox_" styleName="{style.nameTextBox}"/>
+		    </div>
+		    <div class="{style.optionsRow}">
+		        <div class="{style.optionLabel} {style.modelLabel}">Model:</div>
+		        <rsdi:DataImportFileChooser ui:field="fileChooser_"/>
+		    </div>
+		    <div class="{style.optionsRow} {style.formatRow}">
+		        <div class="{style.optionLabel} {style.formatLabel}">Format:</div>
+		        <g:ListBox ui:field="formatListBox_" styleName="{style.formatListBox}"/>
+		    </div>
+	    </div>
 	</g:HTMLPanel>
 </ui:UiBinder> 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.ui.xml
@@ -1,0 +1,60 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
+	xmlns:g="urn:import:com.google.gwt.user.client.ui">
+	<ui:style>
+	.mainPanel {
+		display: -ms-flexbox;
+		display: -webkit-flex;
+		display: flex;
+
+		-webkit-flex-direction: column;
+		-ms-flex-direction: column;
+		flex-direction: column;
+
+		-ms-flex-grow: 1;
+		-webkit-flex-grow: 1;
+		flex-grow: 1;
+	}
+	.optionsBlock {
+		margin-top: 3px;
+		padding-left: 7px;
+
+		-ms-flex-grow: 1;
+		-webkit-flex-grow: 1;
+		flex-grow: 1;
+
+		border: 1px solid #999;
+		background-color: #F7F8F9;
+		padding-top: 10px;
+		padding-left: 10px;
+		padding-bottom: 3px;
+
+		margin-right: 5px;
+		margin-left: 5px;
+	}
+	.optionsLabel {
+		margin-top: 14px;
+
+		margin-left: 5px;
+		margin-right: 5px;
+	}
+	.nameTextBox {
+		-ms-flex-grow: 1;
+		-webkit-flex-grow: 1;
+		flex-grow: 1;
+	}
+	</ui:style>
+	<g:HTMLPanel styleName="{style.mainPanel}">
+	    <g:Label text="Import Options:" styleName="{style.optionsLabel}"/>
+		<div class="{style.optionsBlock}">
+		    <table>
+	            <tr>
+	                <td>Name:</td>
+	                <td>
+	                    <g:TextBox styleName="{style.nameTextBox}"/>
+	                </td>
+	            </tr>
+	        </table>
+		</div>
+	</g:HTMLPanel>
+</ui:UiBinder> 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
@@ -1,0 +1,64 @@
+/*
+ * DataImportOptionsUiXls.java
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.environment.dataimport;
+
+import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportAssembleResponse;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.TextBox;
+import com.google.gwt.user.client.ui.Widget;
+
+public class DataImportOptionsUiXls extends DataImportOptionsUi
+{
+
+   private static DataImportOptionsUiXlsUiBinder uiBinder = GWT
+         .create(DataImportOptionsUiXlsUiBinder.class);
+
+   interface DataImportOptionsUiXlsUiBinder
+         extends UiBinder<Widget, DataImportOptionsUiXls>
+   {
+   }
+
+   public DataImportOptionsUiXls()
+   {
+      initWidget(uiBinder.createAndBindUi(this));
+   }
+   
+   @Override
+   public DataImportOptionsXls getOptions()
+   {
+      return DataImportOptionsXls.create(
+         nameTextBox_.getValue()
+      );
+   }
+   
+   @Override
+   public void setAssembleResponse(DataImportAssembleResponse response)
+   {
+      nameTextBox_.setText(response.getDataName());
+   }
+   
+   @Override
+   public void clearDataName()
+   {
+      nameTextBox_.setText("");
+   }
+   
+   @UiField
+   TextBox nameTextBox_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.ui.xml
@@ -1,0 +1,16 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
+	xmlns:g="urn:import:com.google.gwt.user.client.ui">
+	<ui:style src="res/DataImportStyles.css"
+    	type="org.rstudio.studio.client.workbench.views.environment.dataimport.res.DataImportResources.Style">
+    </ui:style>
+	<g:HTMLPanel styleName="{style.mainPanel}">
+	    <g:Label text="Import Options:" styleName="{style.optionsLabel}"/>
+	    <div class="{style.optionsBlock}">
+		    <div class="{style.optionsRow}">
+		        <div class="{style.optionLabel} {style.nameLabel}">Name:</div>
+		        <g:TextBox ui:field="nameTextBox_" styleName="{style.nameTextBox}"/>
+		    </div>
+	    </div>
+	</g:HTMLPanel>
+</ui:UiBinder> 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXml.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXml.java
@@ -1,0 +1,64 @@
+/*
+ * DataImportOptionsUiXml.java
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.environment.dataimport;
+
+import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportAssembleResponse;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.TextBox;
+import com.google.gwt.user.client.ui.Widget;
+
+public class DataImportOptionsUiXml extends DataImportOptionsUi
+{
+
+   private static DataImportOptionsUiXmlUiBinder uiBinder = GWT
+         .create(DataImportOptionsUiXmlUiBinder.class);
+
+   interface DataImportOptionsUiXmlUiBinder
+         extends UiBinder<Widget, DataImportOptionsUiXml>
+   {
+   }
+
+   public DataImportOptionsUiXml()
+   {
+      initWidget(uiBinder.createAndBindUi(this));
+   }
+
+   @Override
+   public DataImportOptionsXml getOptions()
+   {
+      return DataImportOptionsXml.create(
+         nameTextBox_.getValue()
+      );
+   }
+   
+   @Override
+   public void setAssembleResponse(DataImportAssembleResponse response)
+   {
+      nameTextBox_.setText(response.getDataName());
+   }
+   
+   @Override
+   public void clearDataName()
+   {
+      nameTextBox_.setText("");
+   }
+   
+   @UiField
+   TextBox nameTextBox_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXml.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXml.ui.xml
@@ -1,0 +1,16 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
+	xmlns:g="urn:import:com.google.gwt.user.client.ui">
+	<ui:style src="res/DataImportStyles.css"
+    	type="org.rstudio.studio.client.workbench.views.environment.dataimport.res.DataImportResources.Style">
+    </ui:style>
+	<g:HTMLPanel styleName="{style.mainPanel}">
+	    <g:Label text="Import Options:" styleName="{style.optionsLabel}"/>
+	    <div class="{style.optionsBlock}">
+		    <div class="{style.optionsRow}">
+		        <div class="{style.optionLabel} {style.nameLabel}">Name:</div>
+		        <g:TextBox ui:field="nameTextBox_" styleName="{style.nameTextBox}"/>
+		    </div>
+	    </div>
+	</g:HTMLPanel>
+</ui:UiBinder> 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsXls.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsXls.java
@@ -1,5 +1,5 @@
 /*
- * DataImportModes.java
+ * DataImportOptionsXls.java
  *
  * Copyright (C) 2009-16 by RStudio, Inc.
  *
@@ -15,16 +15,17 @@
 
 package org.rstudio.studio.client.workbench.views.environment.dataimport;
 
-public enum DataImportModes
+public class DataImportOptionsXls extends DataImportOptions
 {
-   Text,
-   SAV,
-   SAS,
-   Stata,
-   XLS,
-   XML,
-   JSON,
-   JDBC,
-   ODBC,
-   Mongo,
+   protected DataImportOptionsXls()
+   {
+   }
+   
+   public final static native DataImportOptionsXls create(
+      String dataName) /*-{
+         return {
+            "mode": "xls",
+            "dataName": dataName
+       }
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsXml.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsXml.java
@@ -1,5 +1,5 @@
 /*
- * DataImportModes.java
+ * DataImportOptionsXml.java
  *
  * Copyright (C) 2009-16 by RStudio, Inc.
  *
@@ -15,16 +15,17 @@
 
 package org.rstudio.studio.client.workbench.views.environment.dataimport;
 
-public enum DataImportModes
+public class DataImportOptionsXml extends DataImportOptions
 {
-   Text,
-   SAV,
-   SAS,
-   Stata,
-   XLS,
-   XML,
-   JSON,
-   JDBC,
-   ODBC,
-   Mongo,
+   protected DataImportOptionsXml()
+   {
+   }
+   
+   public final static native DataImportOptionsXml create(
+      String dataName) /*-{
+         return {
+            "mode": "xml",
+            "dataName": dataName
+       }
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportPreviewResponse.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportPreviewResponse.java
@@ -36,4 +36,8 @@ public class DataImportPreviewResponse extends JavaScriptObject
          return this.columns = response.columns;
       }
    }-*/;
+   
+   public final native boolean supportsColumnOperations() /*-{
+      return this.supportsColumnOperations == true;
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/res/DataImportResources.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/res/DataImportResources.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.views.environment.dataimport.res;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.resources.client.ClientBundle;
+import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.resources.client.ImageResource;
 
 public interface DataImportResources extends ClientBundle
@@ -25,4 +26,7 @@ public interface DataImportResources extends ClientBundle
    
    @Source("copyCodeToClipboard.png")
    ImageResource copyImage();
+   
+   interface Style extends CssResource {
+   }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/res/DataImportStyles.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/res/DataImportStyles.css
@@ -1,0 +1,77 @@
+.mainPanel {
+	display: -ms-flexbox;
+	display: -webkit-flex;
+	display: flex;
+
+	-webkit-flex-direction: column;
+	-ms-flex-direction: column;
+	flex-direction: column;
+
+	-ms-flex-grow: 1;
+	-webkit-flex-grow: 1;
+	flex-grow: 1;
+
+	min-width: 300px;
+}	
+.optionsLabel {
+	margin-top: 14px;
+
+	margin-left: 5px;
+	margin-right: 5px;
+}
+.optionsBlock {
+	border: 1px solid #999;
+	background-color: #F7F8F9;
+	padding-top: 12px;
+	padding-left: 16px;
+	padding-bottom: 3px;
+	padding-right: 6px;
+
+	display: -ms-flexbox;
+	display: -webkit-flex;
+	display: flex;
+
+	-webkit-flex-direction: column;
+	-ms-flex-direction: column;
+	flex-direction: column;
+
+	-ms-flex-grow: 1;
+	-webkit-flex-grow: 1;
+	flex-grow: 1;
+
+	margin-top: 3px;
+	margin-right: 5px;
+	margin-left: 5px;
+}
+.optionsRow {
+	display: -ms-flexbox;
+	display: -webkit-flex;
+	display: flex;
+
+	-webkit-flex-direction: row;
+	-ms-flex-direction: row;
+	flex-direction: row;
+
+	-ms-flex-grow: 1;
+	-webkit-flex-grow: 1;
+	flex-grow: 1;
+
+	height: 24px;
+	margin-right: 10px;
+}
+.optionLabel {
+	width: 54px;
+}
+.nameLabel {
+	margin-top: 3px;
+}
+.nameTextBox {
+	height: 22px;
+
+	-ms-flex-grow: 1;
+	-webkit-flex-grow: 1;
+	flex-grow: 1;
+
+	padding-left: 5px;
+	padding-right: 5px;
+}


### PR DESCRIPTION
This PR adds support to import data from sav, dta, por, sas and stata using haven. Refactored `FileOrUrlChooserTextBox` into `DataImportFileChooser` to reuse in sas options with support for flexbox.

<img width="1440" alt="screen shot 2016-01-28 at 8 30 40 am" src="https://cloud.githubusercontent.com/assets/3478847/12650921/8f26e56e-c599-11e5-831a-fa754e02a46e.png">