### PR TITLE
Enable data import from csv, spss and excel

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -395,7 +395,7 @@ public class UIPrefsAccessor extends Prefs
    
    public PrefValue<Boolean> useDataImport()
    {
-      return bool("use_dataimport", false);
+      return bool("use_dataimport", true);
    }
    
    public static final String PDF_PREVIEW_NONE = "none";


### PR DESCRIPTION
Setting `use_dataimport` to enable by default. Flag still works to reverted to old functionality using `.rs.writeUiPref("use_dataimport", FALSE)`.