### PR TITLE
Remap Show All Panes on Windows

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -567,7 +567,9 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="activateVcs" value="Ctrl+F1"/>
          <shortcut refid="activateBuild" value="Ctrl+F2"/>
 
-         <shortcut refid="layoutEndZoom" value="Ctrl+Shift+0"/>
+         <!-- Windows masks Ctrl+Shift+0 for IME input -->
+         <shortcut refid="layoutEndZoom" value="Ctrl+Shift+0" if="!org.rstudio.core.client.BrowseCap.isWindowsDesktop()" />
+         <shortcut refid="layoutEndZoom" value="Ctrl+Alt+Shift+0" if="org.rstudio.core.client.BrowseCap.isWindowsDesktop()" />
       </shortcutgroup>
       <shortcutgroup name="Tabs">
          <shortcut refid="switchToTab" value="Ctrl+X B" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>


### PR DESCRIPTION
@kevinushey discovered that [Windows takes *Ctrl+Shift+0* for itself](http://www.eightforums.com/general-support/22552-cant-use-ctrl-shift-0-windows-has.html) on Windows 8 and newer. It is possible to disable this behavior so the binding is open for application use, but I don't think we can realistically expect users to figure this out.

This change remaps the command to *Ctrl+Alt+Shift+0* on Windows (and leaves other platforms alone). This isn't terribly ergonomic but the other key combos we tried were somewhat nonsensical or already taken (eg. *Ctrl+Shift+-* is unbound in RStudio but Chrome takes it for zooming). 