### PR TITLE
improve PopupPositioner horizontal overflow computation

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/PopupPositioner.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/PopupPositioner.java
@@ -75,17 +75,27 @@ public class PopupPositioner implements PositionCallback
       int windowRight = windowLeft + Window.getClientWidth();
       int windowBottom = windowTop + Window.getClientHeight();
       
-      boolean positionRight =
-            pageX + width + fudgeFactor < windowRight;
+      // Compute the horizontal position.
+      int left = pageX + fudgeFactor;
       
-      boolean positionBottom =
+      // Check to see if the popup would overflow to the right.
+      // If so, nudge the coordinates left to prevent this.
+      int horizontalOverflow = pageX + width + fudgeFactor - windowRight;
+      if (horizontalOverflow > 0)
+      {
+         left = Math.max(
+               fudgeFactor + 10,
+               left - horizontalOverflow);
+      }
+      
+      // Compute the vertical position. Normally we want the
+      // completion popup to appear below the rectangle, but
+      // we may need to position it above (e.g. R completions
+      // in the console).
+      boolean showOnBottom =
             pageY + height + fudgeFactor < windowBottom;
       
-      int left = positionRight ?
-            pageX + fudgeFactor :
-            pageX - width - fudgeFactor;
-      
-      int top = positionBottom ?
+      int top = showOnBottom ?
             pageY + fudgeFactor :
             pageY - height - fudgeFactor - 10;
       


### PR DESCRIPTION
This PR improves the `PopupPositioner` horizontal overflow logic.

Previously, if we detected that the popup was going to overflow horizontally (to the right), we instead attempted to position the popup at the left corner of the rectangle (without checking the overflow in that case). This behaviour is bogus however and leads to left-overflow in cases with e.g. a data.frame having very long names, or overly long file paths.

This PR fixes that by instead just nudging the popup left to avoid overflow as much as possible, without overflowing left.