### PR TITLE
provide top-level file completions in unmonitored dir

### DIFF
--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -654,12 +654,7 @@ public:
       Entry parentEntry(core::toFileInfo(parentPath));
       EntryTree::iterator parentItr = pEntries_->find(parentEntry);
       if (parentItr == pEntries_->end())
-      {
-         std::stringstream ss;
-         ss << "Expected node '" << parentPath.absolutePath() << "' in index tree but none found";
-         LOG_ERROR_MESSAGE(ss.str());
          return;
-      }
       
       EntryTree::iterator it = parentItr.begin();
       EntryTree::iterator end = parentItr.end();
@@ -701,12 +696,7 @@ public:
       Entry parentEntry(core::toFileInfo(parentPath));
       EntryTree::iterator parentItr = pEntries_->find(parentEntry);
       if (parentItr == pEntries_->end())
-      {
-         std::stringstream ss;
-         ss << "Expected node '" << parentPath.absolutePath() << "' in index tree but none found";
-         LOG_ERROR_MESSAGE(ss.str());
          return;
-      }
 
       EntryTree::iterator it = parentItr.begin();
       EntryTree::iterator end = parentItr.end();

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -264,6 +264,7 @@ assign(x = ".rs.acCompletionTypes",
    usingFileMonitor <- .rs.hasFileMonitor() &&
       .rs.startsWith(directory, projDirEndsWithSlash)
    
+   absolutePaths <- character()
    if (usingFileMonitor)
    {
       if (directoriesOnly)
@@ -275,51 +276,7 @@ assign(x = ".rs.acCompletionTypes",
       absolutePaths <- index$paths
    }
    
-   # Otherwise, result to a listing of just the current directory.
-   else
-   {
-      pattern <- if (nzchar(tokenName))
-         paste("^", .rs.asCaseInsensitiveRegex(.rs.escapeForRegex(tokenName)), sep = "")
-      
-      # Manually construct a call to `list.files` which should work across
-      # versions of R >= 2.11.
-      formals <- as.list(formals(base::list.files))
-      
-      formals$path <- directory
-      formals$pattern <- pattern
-      formals$all.files <- TRUE
-      formals$full.names <- TRUE
-      
-      # NOTE: not available in older versions of R, but defaults to FALSE
-      # with newer versions.
-      if ("include.dirs" %in% names(formals))
-         formals[["include.dirs"]] <- TRUE
-      
-      # NOTE: not available with older versions of R, but defaults to FALSE
-      if ("no.." %in% names(formals))
-         formals[["no.."]] <- TRUE
-      
-      # Generate the call, and evaluate it.
-      result <- do.call(base::list.files, formals)
-      
-      # Clean up duplicated '/'.
-      absolutePaths <- gsub("/+", "/", result)
-      
-      # Remove un-needed `.` paths. These paths will look like
-      #
-      #     <path>/.
-      #     <path>/..
-      #
-      # This is only unnecessary if we couldn't use 'no..'.
-      if (!("no.." %in% names(formals)))
-      {
-         absolutePaths <- grep("/\\.+$",
-                               absolutePaths,
-                               invert = TRUE,
-                               value = TRUE)
-      }
-      
-   }
+   absolutePaths <- sort(union(absolutePaths, .rs.listFilesFuzzy(directory, tokenName)))
    
    ## Bail out early if we didn't get any completions.
    if (!length(absolutePaths))


### PR DESCRIPTION
Previously, we relied on the file monitor always for providing file
completions when within a monitored project. However, certain files /
folders will be excluded from the file monitor; we still want to produce
(top-level, non-recursive) completions within that directory, so we make
sure that we take the union of what the file monitor gives us, alongside
a simple 'list.files()' listing.

Ultimately, this fixes a bug where file completions within the `packrat` directory of a packrat-managed project failed.