### PR TITLE
prevent warnings from leaking when accessing refClass elements

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1016,10 +1016,10 @@ assign(x = ".rs.acCompletionTypes",
                   type <- numeric(length(names))
                   for (i in seq_along(names))
                   {
-                     type[[i]] <- tryCatch(
+                     type[[i]] <- suppressWarnings(tryCatch(
                         .rs.getCompletionType(eval(call("@", quote(object), names[[i]]))),
                         error = function(e) .rs.acCompletionTypes$UNKNOWN
-                     )
+                     ))
                   }
                }
             }, error = function(e) NULL
@@ -1105,10 +1105,10 @@ assign(x = ".rs.acCompletionTypes",
             type <- numeric(length(names))
             for (i in seq_along(names))
             {
-               type[[i]] <- tryCatch(
+               type[[i]] <- suppressWarnings(tryCatch(
                   .rs.getCompletionType(eval(call("$", quote(object), names[[i]]))),
                   error = function(e) .rs.acCompletionTypes$UNKNOWN
-               )
+               ))
             }
          }
       }


### PR DESCRIPTION
This fixes an issue where warnings are emitted when getting `$` completions on reference classes, e.g.

```R
RC <- setRefClass("RC")
rc <- RC$new()
rc$<TAB>
```

Note that the issue is caused by attempting to evaluate e.g. `rc$.objectPackage` to get the object type; I believe this is a relatively recent change in R (hence why we hadn't seen it until now)