### PR TITLE
only provide directories for package completions

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -639,3 +639,34 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
 .rs.addFunction("rVersionString", function() {
    as.character(getRversion())
 })
+
+.rs.addFunction("listDirs", function(dir = ".", full.names = TRUE, recursive = FALSE)
+{
+   # Normalize directory path
+   if (!file.exists(dir))
+      return(character())
+   dir <- normalizePath(dir, winslash = "/", mustWork = TRUE)
+   
+   # Shortcut if we have 'list.dirs'.
+   if (exists("list.dirs", envir = .BaseNamespaceEnv))
+      return(list.dirs(dir, full.names = full.names, recursive = recursive))
+   
+   
+   # Otherwise, use 'list.files' and filter results.
+   hasIncludeDirs <- "include.dirs" %in% names(formals(base::list.files))
+   args <- if (hasIncludeDirs)
+   {
+      list(path = dir,
+           full.names = full.names,
+           recursive = recursive,
+           include.dirs = TRUE)
+   }
+   else
+   {
+      list(path = dir,
+           full.names = full.names,
+           recursive = recursive)
+   }
+   
+   do.call(base::list.files, args)
+})

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1229,11 +1229,21 @@ assign(x = ".rs.acCompletionTypes",
                                                    excludeOtherCompletions = FALSE,
                                                    quote = !appendColons)
 {
+   # List all directories within the .libPaths()
    allPackages <- Reduce(union, lapply(.libPaths(), .rs.listDirs))
    
    # Not sure why 'DESCRIPTION' might show up here, but let's take it out
    allPackages <- setdiff(allPackages, "DESCRIPTION")
    
+   # Also remove any '00LOCK' directories -- these might be leftovers
+   # from earlier failed package installations
+   if (length(allPackages))
+   {
+      isLockDir <- substring(allPackages, 1, 6) == "00LOCK"
+      allPackages <- allPackages[!isLockDir]
+   }
+   
+   # Construct our completions, and we're done
    completions <- .rs.selectFuzzyMatches(allPackages, token)
    .rs.makeCompletions(token = token,
                        results = if (appendColons && length(completions))

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1229,7 +1229,7 @@ assign(x = ".rs.acCompletionTypes",
                                                    excludeOtherCompletions = FALSE,
                                                    quote = !appendColons)
 {
-   allPackages <- Reduce(union, lapply(.libPaths(), list.files))
+   allPackages <- Reduce(union, lapply(.libPaths(), .rs.listDirs))
    
    # Not sure why 'DESCRIPTION' might show up here, but let's take it out
    allPackages <- setdiff(allPackages, "DESCRIPTION")


### PR DESCRIPTION
Currently, the autocompletion system for packages (e.g. in `library()` calls) works by listing all _files_ within the library paths; this PR tidied up the logic a bit to exclude any files, or lock directories, that may have snuck in.