### PR TITLE
fix to data import column selection and parameter escaping

### DIFF
--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -123,7 +123,7 @@
                !identical(x$assignedType, NULL)
             }
 
-            if (!any(hasAssignedType(optionValue)))
+            if (!any(unlist(lapply(optionValue, hasAssignedType), use.names = FALSE)))
                return (NULL)
 
             colsByIndex <- list()
@@ -390,7 +390,7 @@
       beforeImportFromOptions <- list(
          "text" = function() {
             # while previewing data, always return a column even if it will be skipped
-            dataImportOptions$columnsOnly = FALSE;
+            dataImportOptions$columnsOnly <<- FALSE;
             if (!identical(dataImportOptions$columnDefinitions, NULL))
             {
                dataImportOptions$columnDefinitions <<- Filter(function (e) {

--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -53,6 +53,8 @@
 
       switch(optionType,
          "character" = {
+            optionValue <- gsub("\\", "\\\\", optionValue, fixed = TRUE)
+            optionValue <- gsub("\"", "\\\"", optionValue, fixed = TRUE)
             return (paste("\"", optionValue, "\"", sep = ""))
          },
          "locale" = {


### PR DESCRIPTION
Fixing 3 data import issues that we are hitting in the daily build:
- Missing to escape a couple characters (quotes and backslashes) for the comments parameter.
- Including "only" a column not working: The problem is that while refactoring code we stopped assigning a value to `dataImportOptions$columnsOnly`.
- Switching columns in XLS not working: Another refactoring issue caused by trying to clean code to use `any` + `hasAssignedType` without mapping into a vector first.