### PR TITLE
[diagnostics] '{' can't form argument lists

### DIFF
--- a/src/cpp/session/modules/SessionDiagnosticsTests.cpp
+++ b/src/cpp/session/modules/SessionDiagnosticsTests.cpp
@@ -263,6 +263,8 @@ context("Diagnostics")
       EXPECT_NO_ERRORS("y ~ s(x, bs = 'cs')");
       
       EXPECT_NO_ERRORS("y ~ (1)");
+      
+      EXPECT_NO_ERRORS("{x()\n{}}");
    }
    
    lintRStudioRFiles();

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -2419,9 +2419,28 @@ ARGUMENT_LIST_END:
       
       MOVE_TO_NEXT_SIGNIFICANT_TOKEN(cursor, status);
       
-      if (isLeftBracket(cursor))
-         goto ARGUMENT_LIST;
-      else if (isBinaryOp(cursor))
+      // Check for a 'chain' of function calls, e.g.
+      //
+      //     x <- foo()(bar)[baz]
+      //
+      // We need to double-check a couple of things to
+      // get this parse correct -- either one of these
+      // conditions needs to hold.
+      //
+      //    1. The '(' token is on the same line, or
+      //    2. We're within a 'parenthetical' context.
+      if (cursor.isType(RToken::LPAREN) ||
+          cursor.isType(RToken::LBRACKET) ||
+          cursor.isType(RToken::LDBRACKET))
+      {
+         if (cursor.row() == cursor.previousSignificantToken().row() ||
+             status.isInParentheticalScope())
+         {
+            goto ARGUMENT_LIST;
+         }
+      }
+      
+      if (isBinaryOp(cursor))
          goto BINARY_OPERATOR;
       else
          goto START;


### PR DESCRIPTION
This PR fixes a couple of issues when parsing after a function call.