### PR TITLE
prevent wrapping in files pane

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesList.java
@@ -34,6 +34,7 @@ import com.google.gwt.cell.client.CheckboxCell;
 import com.google.gwt.cell.client.ImageResourceCell;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.dom.client.Style.WhiteSpace;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
@@ -73,6 +74,8 @@ public class FilesList extends Composite
          selectionModel_, 
          DefaultSelectionEventManager.<FileSystemItem> createCheckboxManager());
       filesCellTable_.setWidth("100%", false);
+      
+      filesCellTable_.getElement().getStyle().setWhiteSpace(WhiteSpace.NOWRAP);
       
       // hook-up data provider 
       dataProvider_.addDataDisplay(filesCellTable_);


### PR DESCRIPTION
This PR ensures we don't wrap text within the files list. I think it's overall better to let the modified text overflow, compared to wrapping and making the height of each row potentially inconsistent. I investigated making the text within the modification column overflow with an ellipsis (ie, with a simple `text-overflow: ellipsis;`) but ran into road blocks.

Before:

![screen shot 2016-02-09 at 1 17 52 pm](https://cloud.githubusercontent.com/assets/1976582/12930888/ae3cd856-cf2f-11e5-82a0-d2b5f5eb9f80.png)

After:

![screen shot 2016-02-09 at 1 18 12 pm](https://cloud.githubusercontent.com/assets/1976582/12930889/afe07690-cf2f-11e5-8ef4-bf86854ff9f5.png)

---

I think it's overall preferable to have horizontal overflow rather than wrapping in the files pane, but let's only merge the PR if we all agree.