### PR TITLE
[emacs] C-f no longer opens find with Emacs mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 ### Bug Fixes
 
 * Diagnostics: fix false positive errors with '{' following function calls
+* Emacs mode: C-f now moves the cursor forward instead of opening Find dialog
 * Ensure that modal dialogs capture all input even in the presence of multiple modals
 * Filter out "00LOCK" directories from package name completions
 * Provide completions for 'lazydata' objects within namespaces

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -431,7 +431,7 @@ public class TextEditingTarget implements
             NativeEvent ne = event.getNativeEvent();
             int mod = KeyboardShortcut.getModifierValue(ne);
             
-            if ((mod == KeyboardShortcut.META || (mod == KeyboardShortcut.CTRL && !BrowseCap.hasMetaKey()))
+            if ((mod == KeyboardShortcut.META || (mod == KeyboardShortcut.CTRL && !BrowseCap.hasMetaKey() && !docDisplay_.isEmacsModeOn()))
                 && ne.getKeyCode() == 'F')
             {
                event.preventDefault();


### PR DESCRIPTION
`C-f` is normally used to move the cursor forward; however, it was shadowed by our binding for the find-replace dialog. This PR ensures that `Ctrl+F` is only active when emacs mode is off.