### PR TITLE
enable 'scroll past end' in Ace renderer

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -91,6 +91,7 @@ public class AceEditorWidget extends Composite
       editor_ = AceEditorNative.createEditor(getElement());
       editor_.manageDefaultKeybindings();
       editor_.getRenderer().setHScrollBarAlwaysVisible(false);
+      editor_.getRenderer().setScrollPastEnd(true);
       editor_.setShowPrintMargin(false);
       editor_.setPrintMarginColumn(0);
       editor_.setHighlightActiveLine(false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Renderer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Renderer.java
@@ -166,4 +166,12 @@ public class Renderer extends JavaScriptObject
       this.alignCursor(position, ratio);
    }-*/;
    
+   public final native void setScrollPastEnd(boolean value) /*-{
+      this.$scrollPastEnd = value;
+   }-*/;
+   
+   public final native boolean getScrollPastEnd() /*-{
+      return !!this.$scrollPastEnd;
+   }-*/;
+   
 }


### PR DESCRIPTION
This allows users to scroll (e.g. with the mouse wheel, or a trackpad) such that the final line in the document is visible at the top of the screen. This is useful when you're making edits near the end of the document, but want to have some empty space following just for comfort.