### PR TITLE
fix erroneous popup positioning when cursor near right of screen

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/RCompletionToolTip.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/RCompletionToolTip.java
@@ -152,10 +152,7 @@ public class RCompletionToolTip extends CppCompletionToolTip
             // if we are showing left then adjust
             int adjustedLeft = left;
             if (showLeft)
-            {
-               adjustedLeft = getAbsoluteLeft() -
-                     offsetWidth - H_PAD;
-            }
+               adjustedLeft = left - offsetWidth - H_PAD;
 
             setPopupPosition(adjustedLeft, top - getOffsetHeight() - V_PAD);
          }


### PR DESCRIPTION
This PR fixes an issue where signature tooltips were displayed incorrectly when near the right of the screen.

The problem here was that we attempted to calculate the position relative to the popup window's 'left', before the popup had even been positioned -- we should be using the initial 'left' specified.

The new positioning:

<img width="234" alt="screen shot 2016-02-11 at 9 54 31 am" src="https://cloud.githubusercontent.com/assets/1976582/12985041/7db43fe0-d0a5-11e5-9416-812f67f68971.png">
