### PR TITLE
avoid over-eager rendering from tokenizer

### DIFF
--- a/src/gwt/acesupport/acemixins/token_iterator.js
+++ b/src/gwt/acesupport/acemixins/token_iterator.js
@@ -171,19 +171,27 @@ var Range = require("ace/range").Range;
       }
    };
 
+   var updateTimerId;
+   var lastTokenizedRow = 0;
+
    /**
     * Eagerly tokenize up to the specified row, using the tokenizer
-    * attached to the associated session.
+    * attached to the associated session, but defer rendering the
+    * associated tokens.
     */
    this.tokenizeUpToRow = function(maxRow)
    {
       var tokenizer = this.$session.bgTokenizer;
-      var lastTokenizedRow = tokenizer.currentLine;
+      lastTokenizedRow = Math.min(lastTokenizedRow, tokenizer.currentLine);
       maxRow = Math.max(maxRow, this.$session.getLength() - 1);
       for (var i = lastTokenizedRow; i <= maxRow; i++)
          tokenizer.$tokenizeRow(i);
 
-      tokenizer.fireUpdateEvent(lastTokenizedRow, maxRow);
+      clearTimeout(updateTimerId);
+      updateTimerId = setTimeout(function() {
+         tokenizer.fireUpdateEvent(lastTokenizedRow, maxRow);
+         lastTokenizedRow = maxRow;
+      }, 700);
    };
 
    /**

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -758,10 +758,7 @@ var RCodeModel = function(session, tokenizer,
       // Nudge the maxRow ahead a bit -- some functions may request
       // the tree to be built up to a particular row, but we want to
       // build a bit further ahead in case some lookahead is required.
-      maxRow = Math.min(
-         maxRow + 30,
-         this.$doc.getLength() - 1
-      );
+      maxRow = Math.min(maxRow + 30, this.$doc.getLength() - 1);
 
       // Check if the scope tree has already been built up to this row.
       var scopeRow = this.$scopes.parsePos.row;
@@ -778,9 +775,18 @@ var RCodeModel = function(session, tokenizer,
       // of the tree that have been already built.
       var iterator = new TokenIterator(this.$session);
 
+      // Tokenize eagerly up to the desired row. Note that we have to tokenize
+      // in two places -- the internal Ace tokenizer (whose tokens are used by
+      // the token iterator here), and also the R code model's tokenizer (which
+      // maintains its own set of R tokens used for indentation). In a perfect
+      // world, we wouldn't maintain a separate set of tokens for our R code
+      // model, but ...
+      iterator.tokenizeUpToRow(maxRow);
+      this.$tokenizeUpToRow(maxRow);
+      
+
       var row = this.$scopes.parsePos.row;
       var column = this.$scopes.parsePos.column;
-
       iterator.moveToPosition({row: row, column: column}, true);
 
       var token = iterator.getCurrentToken();
@@ -793,7 +799,7 @@ var RCodeModel = function(session, tokenizer,
       var value = token.value;
       var type = token.type;
       var position = iterator.getCurrentTokenPosition();
-      
+
       do
       {
          // Bail if we've stepped past the max row.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -35,7 +35,6 @@ import com.google.gwt.event.shared.GwtEvent;
 import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.ScrollPanel;
 import com.google.gwt.user.client.ui.Widget;
@@ -264,21 +263,7 @@ public class AceEditor implements DocDisplay,
       completionManager_ = new NullCompletionManager();
       diagnosticsBgPopup_ = new DiagnosticsBackgroundPopup(this);
       
-      bgTokenizer_ = new BackgroundTokenizer();
-      
       RStudioGinjector.INSTANCE.injectMembers(this);
-      
-      widget_.addValueChangeHandler(new ValueChangeHandler<Void>()
-      {
-         public void onValueChange(ValueChangeEvent<Void> evt)
-         {
-            bgTokenizer_.scheduleTokenization(widget_.getEditor().getSession().getSelection().getRange().getStart().getRow());
-            if (!valueChangeSuppressed_)
-            {
-               ValueChangeEvent.fire(AceEditor.this, null);
-            }
-         }
-      });
 
       widget_.addFoldChangeHandler(new FoldChangeEvent.Handler()
       {
@@ -2827,31 +2812,6 @@ public class AceEditor implements DocDisplay,
    private Integer executionLine_ = null;
    private boolean valueChangeSuppressed_ = false;
    private AceInfoBar infoBar_;
-   private final BackgroundTokenizer bgTokenizer_;
-   
-   private class BackgroundTokenizer
-   {
-      public BackgroundTokenizer()
-      {
-         timer_ = new Timer()
-         {
-            @Override
-            public void run()
-            {
-              widget_.getEditor().tokenizeUpToRow(row_);
-            }
-         };
-      }
-      
-      public void scheduleTokenization(int row)
-      {
-         row_ = row;
-         timer_.schedule(300);
-      }
-      
-      private int row_ = 0;
-      private final Timer timer_;
-   }
    
    private static final ExternalJavaScriptLoader getLoader(StaticDataResource release)
    {


### PR DESCRIPTION
This PR fixes an over-eager rendering issue in the tokenizer. We modify the tokenizer to eagerly build a tokenized representation of the document (as required for e.g. the scope tree), but ensure that render events / updates are delayed (to avoid e.g. unclosed strings causing an eager string rendering of the whole document following!)

The BackgroundTokenizer thing in AceEditor was a bit of a hack due to me missing the fact that Ace and our code model maintain a separate set of tokens; it should be obviated now since we now ensure that `$buildScopeTreeUpToRow` updates both the Ace and code model tokens.

We might want to take this for v0.99-700 patch but I think we should let it brew in master first, just to get some exposure + extra testing, since this change is a bit risky.