### PR TITLE
allow users to invalidate data import cached web files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 * Preview data while importing datasets
 * Explicitly set column types while importing datasets
 * Preview and copy code while importing datasets
+* Enable data import preview to be cancelled
+* Enable data import to cache web files
 
 ### Miscellaneous
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -219,10 +219,12 @@ public class DataImport extends Composite
                @Override
                public void execute()
                {
+                  // Invalidate cached files, click update to refresh stale files
+                  localFiles_ = null;
+                  
                   if (dataImportFileChooser_.getText() != importOptions_.getImportLocation())
                   {
                      lastSuccessfulResponse_ = null;
-                     localFiles_ = null;
                      resetColumnDefinitions();
                   }
                   


### PR DESCRIPTION
Allow users to invalidate web files being cached locally when they click "update" in data import