### PR TITLE
fix merge conflict in docpropmenuitem.java

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/DocPropMenuItem.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/DocPropMenuItem.java
@@ -97,6 +97,12 @@ public class DocPropMenuItem extends CheckableMenuItem
          public void onProgress(String message)
          {
          }
+
+         @Override
+         public void onProgress(String message, Operation onCancel)
+         {
+
+         }
       });
    }
    


### PR DESCRIPTION
Found a merge conflict in updated `ProgressIndicator` after a full build that I wasn't able to detect with incremental `ant devmode`, merging.