### PR TITLE
fix highlighting for escaped '$' in mathjax

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 * Diagnostics: fix false positive errors with '{' following function calls
 * Avoid over-eager re-rendering + tokenization of documents
 * Fix block commenting of Sweave chunks
+* Fix highlighting of escaped '$' in inline Mathjax expressions
 * Emacs mode: C-f now moves the cursor forward instead of opening Find dialog
 * Ensure that modal dialogs capture all input even in the presence of multiple modals
 * Filter out "00LOCK" directories from package name completions

--- a/src/gwt/acesupport/acemode/markdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/markdown_highlight_rules.js
@@ -196,7 +196,7 @@ var MarkdownHighlightRules = function() {
             next  : "mathjaxdisplay"
         }, { // MathJax $...$ (org-mode style)
             token : ["markup.list","support.function","markup.list"],
-            regex : "(\\$)" + "((?!\\s)[^$]*[^$\\s])" + "(\\$)" + "(?![\\w\\d`])"
+            regex : "(\\$)((?:(?:\\\\.)|(?:[^\\$\\\\]))*?)(\\$)"
         }, { // strong ** __
             token : ["constant.numeric", "constant.numeric", "constant.numeric"],
             regex : "([*]{2}|[_]{2}(?=\\S))([^\\r]*?\\S[*_]*)(\\1)"
@@ -366,15 +366,6 @@ var MarkdownHighlightRules = function() {
             regex : "[\\s\\S]+?"
         }],
         
-        "mathjaxinline" : [{
-            token : "markup.list",
-            regex : "\\$",
-            next  : "start"
-        }, {
-            token : "support.function",
-            regex : "[^\\$]+"
-        }],
-
         "mathjaxnativeinline" : [{
             token : "markup.list",
             regex : "\\\\\\)",


### PR DESCRIPTION
This PR fixes an issue where escaped `$` within an inline Math(jax) expressions did not highlight correctly. It also removes an unused mathjax rule from the highlighter.