### PR TITLE
improve editing experience in large documents

### DIFF
--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1073,6 +1073,7 @@ var RCodeModel = function(session, tokenizer,
          row: rowTokenizedUpTo, column: -1
       };
 
+      return rowTokenizedUpTo;
    };
 
    this.$getFoldToken = function(session, foldStyle, row) {

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -763,7 +763,7 @@ var RCodeModel = function(session, tokenizer,
       // Check if the scope tree has already been built up to this row.
       var scopeRow = this.$scopes.parsePos.row;
       if (scopeRow >= maxRow)
-          return;
+          return scopeRow;
 
       // We explicitly use a TokenIterator rather than a TokenCursor here.
       // We want to iterate over all token types here (including non-R code)
@@ -793,7 +793,7 @@ var RCodeModel = function(session, tokenizer,
       
       // If this failed, give up.
       if (token == null)
-         return;
+         return row;
 
       // Grab local state that we'll use when building the scope tree.
       var value = token.value;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
@@ -291,7 +291,6 @@ public class DocumentOutlineWidget extends Composite
       
       docUpdateTimer_ = new Timer()
       {
-         
          @Override
          public void run()
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
@@ -23,7 +23,8 @@ import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.source.editors.text.Scope;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ScopeFunction;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTarget;
-import org.rstudio.studio.client.workbench.views.source.editors.text.events.DocumentChangedEvent;
+import org.rstudio.studio.client.workbench.views.source.editors.text.events.CursorChangedEvent;
+import org.rstudio.studio.client.workbench.views.source.editors.text.events.CursorChangedHandler;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.RenderFinishedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorThemeStyleChangedEvent;
 
@@ -265,23 +266,14 @@ public class DocumentOutlineWidget extends Composite
          }
       });
       
-      target_.getDocDisplay().addDocumentChangedHandler(
-            new DocumentChangedEvent.Handler()
-            {
-               @Override
-               public void onDocumentChanged(final DocumentChangedEvent event)
-               {
-                  Scheduler.get().scheduleDeferred(new ScheduledCommand()
-                  {
-                     @Override
-                     public void execute()
-                     {
-                        DocumentOutlineWidget.this.onDocumentChanged(event);
-                     }
-                  });
-               }
-            });
-      
+      target_.getDocDisplay().addCursorChangedHandler(new CursorChangedHandler()
+      {
+         @Override
+         public void onCursorChanged(CursorChangedEvent event)
+         {
+            DocumentOutlineWidget.this.onCursorChanged(event);
+         }
+      });
    }
    
    private void onRenderFinished()
@@ -290,7 +282,7 @@ public class DocumentOutlineWidget extends Composite
       resetTreeStyles();
    }
    
-   private void onDocumentChanged(final DocumentChangedEvent event)
+   private void onCursorChanged(final CursorChangedEvent event)
    {
       // Debounce value changed events to avoid over-aggressively rebuilding
       // the scope tree.
@@ -308,7 +300,8 @@ public class DocumentOutlineWidget extends Composite
          }
       };
       
-      docUpdateTimer_.schedule(1000);
+      int delayMs = target_.getDocDisplay().getSuggestedScopeUpdateDelay() + 200;
+      docUpdateTimer_.schedule(delayMs);
    }
    
    private void updateStyles(Widget widget, Style computed)
@@ -334,7 +327,7 @@ public class DocumentOutlineWidget extends Composite
       }
    }
    
-   private void updateScopeTree(DocumentChangedEvent event)
+   private void updateScopeTree(CursorChangedEvent event)
    {
       rebuildScopeTree();
    }
@@ -348,6 +341,7 @@ public class DocumentOutlineWidget extends Composite
    private void rebuildScopeTree()
    {
       scopeTree_ = target_.getDocDisplay().getScopeTree();
+      currentScope_ = target_.getDocDisplay().getCurrentScope();
       
       if (scopeTree_.length() == 0)
       {
@@ -469,7 +463,7 @@ public class DocumentOutlineWidget extends Composite
    
    private boolean isActiveNode(Scope node)
    {
-      return node.equals(target_.getDocDisplay().getCurrentScope());
+      return node.equals(currentScope_);
    }
    
    private final DockLayoutPanel container_;
@@ -482,6 +476,7 @@ public class DocumentOutlineWidget extends Composite
    private final Timer renderTimer_;
    private Timer docUpdateTimer_;
    private JsArray<Scope> scopeTree_;
+   private Scope currentScope_;
    
    private UIPrefs uiPrefs_;
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -43,6 +43,7 @@ import com.google.inject.Inject;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.ExternalJavaScriptLoader;
+import org.rstudio.core.client.MathUtil;
 import org.rstudio.core.client.ExternalJavaScriptLoader.Callback;
 import org.rstudio.core.client.Rectangle;
 import org.rstudio.core.client.StringUtil;
@@ -1841,6 +1842,12 @@ public class AceEditor implements DocDisplay,
    public HandlerRegistration addEditorFocusHandler(FocusHandler handler)
    {
       return widget_.addFocusHandler(handler);
+   }
+   
+   public int getSuggestedScopeUpdateDelay()
+   {
+      int nrow = getRowCount();
+      return MathUtil.clamp(nrow / 20, 0, 700);
    }
 
    public Scope getCurrentScope()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -273,7 +273,8 @@ public class AceEditor implements DocDisplay,
 
       completionManager_ = new NullCompletionManager();
       diagnosticsBgPopup_ = new DiagnosticsBackgroundPopup(this);
-      scopeTimer_ = new ScopeTimer(this);
+      if (hasScopeTree())
+         scopeTimer_ = new ScopeTimer(this);
       
       RStudioGinjector.INSTANCE.injectMembers(this);
 
@@ -2049,12 +2050,12 @@ public class AceEditor implements DocDisplay,
          getScopeTree();
    }
    
-   public void buildScopeTreeUpToRow(int row)
+   public int buildScopeTreeUpToRow(int row)
    {
       if (!hasScopeTree())
-         return;
+         return 0;
       
-      getSession().getMode().getRCodeModel().buildScopeTreeUpToRow(row);
+      return getSession().getMode().getRCodeModel().buildScopeTreeUpToRow(row);
    }
 
    public JsArray<Scope> getScopeTree()
@@ -2934,7 +2935,7 @@ public class AceEditor implements DocDisplay,
                   return;
                
                row_ += 200;
-               editor.buildScopeTreeUpToRow(row_);
+               row_ = editor.buildScopeTreeUpToRow(row_);
                timer_.schedule(DELAY_MS);
             }
          };
@@ -2982,7 +2983,7 @@ public class AceEditor implements DocDisplay,
    private boolean valueChangeSuppressed_ = false;
    private AceInfoBar infoBar_;
    private boolean showChunkOutputInline_ = false;
-   private final ScopeTimer scopeTimer_;
+   private ScopeTimer scopeTimer_;
    
    private static final ExternalJavaScriptLoader getLoader(StaticDataResource release)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -42,7 +42,6 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
 import org.rstudio.core.client.CommandWithArg;
-import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.ExternalJavaScriptLoader;
 import org.rstudio.core.client.MathUtil;
@@ -2930,7 +2929,6 @@ public class AceEditor implements DocDisplay,
             @Override
             public void run()
             {
-               Debug.logToConsole("Tokenizing up to row: " + row_);
                if (row_ >= editor.getRowCount())
                   return;
                

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -2932,13 +2932,11 @@ public class AceEditor implements DocDisplay,
                if (row_ >= editor.getRowCount())
                   return;
                
-               row_ += 200;
+               row_ += ROWS_TOKENIZED_PER_ITERATION;
                row_ = editor.buildScopeTreeUpToRow(row_);
                timer_.schedule(DELAY_MS);
             }
          };
-         
-         row_ = 0;
          
          editor.addCursorChangedHandler(new CursorChangedHandler()
          {
@@ -2953,9 +2951,10 @@ public class AceEditor implements DocDisplay,
       }
       
       private final Timer timer_;
-      private int row_;
+      private int row_ = 0;
       
-      private static final int DELAY_MS = 10;
+      private static final int DELAY_MS = 5;
+      private static final int ROWS_TOKENIZED_PER_ITERATION = 50;
    }
    
    private static final int DEBUG_CONTEXT_LINES = 2;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -237,6 +237,7 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    void alignCursor(Position position, double ratio);
    void centerSelection();
    
+   int getSuggestedScopeUpdateDelay();
    Scope getCurrentScope();
    Scope getCurrentChunk();
    Scope getCurrentChunk(Position position);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/CodeModel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/CodeModel.java
@@ -122,8 +122,8 @@ public class CodeModel extends JavaScriptObject
       this.insertRoxygenSkeleton && this.insertRoxygenSkeleton();
    }-*/;
    
-   public native final void buildScopeTreeUpToRow(int row) /*-{
-      this.$buildScopeTreeUpToRow && this.$buildScopeTreeUpToRow(row);
+   public native final int buildScopeTreeUpToRow(int row) /*-{
+      return this.$buildScopeTreeUpToRow && this.$buildScopeTreeUpToRow(row);
    }-*/;
    
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/CodeModel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/CodeModel.java
@@ -122,4 +122,8 @@ public class CodeModel extends JavaScriptObject
       this.insertRoxygenSkeleton && this.insertRoxygenSkeleton();
    }-*/;
    
+   public native final void buildScopeTreeUpToRow(int row) /*-{
+      this.$buildScopeTreeUpToRow && this.$buildScopeTreeUpToRow(row);
+   }-*/;
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/CodeModel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/CodeModel.java
@@ -123,7 +123,9 @@ public class CodeModel extends JavaScriptObject
    }-*/;
    
    public native final int buildScopeTreeUpToRow(int row) /*-{
-      return this.$buildScopeTreeUpToRow && this.$buildScopeTreeUpToRow(row);
+      if (typeof this.$buildScopeTreeUpToRow !== "function")
+         return 0;
+      return this.$buildScopeTreeUpToRow(row);
    }-*/;
    
 }


### PR DESCRIPTION
This PR seeks to improve the editing experience in large documents (and avoids over-eager tokenization once more).

There were two spots in the code base that requested eager (per-keystroke) tokenization through building of the scope tree:

1. The status bar, and
2. The document outline widget.

This PR delays the re-rendering (and hence scope-tree tokenization) by placing the updates behind a timer, whose delay adapts to the size of the document. This should avoid 'laggy typing' issues, but will still cause brief pauses when attempting to rebuild the scope tree after the timer eventually fires.

I think a more full-fledged solution would involve the following:

1. Eagerly, but incrementally, rebuild the scope tree behind the scenes following every key press (e.g. 200 rows every 5ms or something to that effect),

2. Have the scope tree fire an event when it's finished rebuilding, which listeners can use (e.g. the status bar + document outline widget) to signal that they can update their UI.