### PR TITLE
remove unused dependencies to jsonlite from data import

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -299,7 +299,6 @@ public class DependencyManager implements InstallShinyEvent.Handler
       ArrayList<Dependency> deps = new ArrayList<Dependency>();
       deps.add(Dependency.cranPackage("readr", "0.2.2"));
       deps.add(Dependency.cranPackage("Rcpp", "0.11.5"));
-      deps.add(Dependency.cranPackage("jsonlite", "0.9.16"));
       return deps;
    }
    
@@ -333,7 +332,6 @@ public class DependencyManager implements InstallShinyEvent.Handler
       ArrayList<Dependency> deps = new ArrayList<Dependency>();
       deps.add(Dependency.cranPackage("haven", "0.2.0"));
       deps.add(Dependency.cranPackage("Rcpp", "0.11.4"));
-      deps.add(Dependency.cranPackage("jsonlite", "0.9.16"));
       return deps;
    }
    
@@ -367,7 +365,6 @@ public class DependencyManager implements InstallShinyEvent.Handler
       ArrayList<Dependency> deps = new ArrayList<Dependency>();
       deps.add(Dependency.cranPackage("readxl", "0.1.0"));
       deps.add(Dependency.cranPackage("Rcpp", "0.11.5"));
-      deps.add(Dependency.cranPackage("jsonlite", "0.9.16"));
       return deps;
    }
    
@@ -400,7 +397,6 @@ public class DependencyManager implements InstallShinyEvent.Handler
    {
       ArrayList<Dependency> deps = new ArrayList<Dependency>();
       deps.add(Dependency.cranPackage("xml2", "0.1.2"));
-      deps.add(Dependency.cranPackage("jsonlite", "0.9.16"));
       return deps;
    }
    
@@ -466,7 +462,6 @@ public class DependencyManager implements InstallShinyEvent.Handler
       ArrayList<Dependency> deps = new ArrayList<Dependency>();
       deps.add(Dependency.cranPackage("RJDBC", "0.2-5"));
       deps.add(Dependency.cranPackage("rJava", "0.4-15"));
-      deps.add(Dependency.cranPackage("jsonlite", "0.9.16"));
       return deps;
    }
    
@@ -499,7 +494,6 @@ public class DependencyManager implements InstallShinyEvent.Handler
    {
       ArrayList<Dependency> deps = new ArrayList<Dependency>();
       deps.add(Dependency.cranPackage("RODBC", "1.3-12"));
-      deps.add(Dependency.cranPackage("jsonlite", "0.9.16"));
       return deps;
    }
    
@@ -532,7 +526,6 @@ public class DependencyManager implements InstallShinyEvent.Handler
    {
       ArrayList<Dependency> deps = new ArrayList<Dependency>();
       deps.add(Dependency.cranPackage("mongolite", "0.8"));
-      deps.add(Dependency.cranPackage("jsonlite", "0.9.16"));
       deps.add(Dependency.cranPackage("jsonlite", "0.9.16"));
       return deps;
    }


### PR DESCRIPTION
remove unused dependencies to `jsonlite` from data import, missed to miss dependencies after transitioning to `RDS` based communication between async processes.