### PR TITLE
normalize line endings when inserting text for Ace

### DIFF
--- a/src/gwt/acesupport/loader.js
+++ b/src/gwt/acesupport/loader.js
@@ -87,6 +87,10 @@ oop.inherits(RStudioEditor, Editor);
       Editor.prototype.redo.call(this);
       this._dispatchEvent("redo");
    };
+
+   this.onPaste = function(text, event) {
+      Editor.prototype.onPaste.call(this, text.replace(/\r\n|\n\r|\r/g, "\n"), event);
+   };
 }).call(RStudioEditor.prototype);
 
 

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -1030,6 +1030,10 @@ public class StringUtil
       return $wnd.encodeURI(string);
    }-*/;
    
+   public static final native String normalizeNewLines(String string) /*-{
+      return string.replace(/\r\n|\n\r|\r/g, "\n");
+   }-*/;
+   
    public static final HashMap<String, String> COMPLEMENTS =
          makeComplementsMap();
    

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -1026,6 +1026,10 @@ public class StringUtil
       return id;
    }
    
+   public static final native String encodeURI(String string) /*-{
+      return $wnd.encodeURI(string);
+   }-*/;
+   
    public static final HashMap<String, String> COMPLEMENTS =
          makeComplementsMap();
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -1247,7 +1247,6 @@ public class AceEditor implements DocDisplay,
    {
       Selection selection = getSession().getSelection();
       String oldValue = getSession().getTextRange(selection.getRange());
-      value = StringUtil.normalizeNewLines(value);
 
       replaceSelection(value);
 
@@ -1387,6 +1386,7 @@ public class AceEditor implements DocDisplay,
 
    public void replaceSelection(String code)
    {
+      code = StringUtil.normalizeNewLines(code);
       Range selRange = getSession().getSelection().getRange();
       Position position = getSession().replace(selRange, code);
       Range range = Range.fromPoints(selRange.getStart(), position);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -302,7 +302,7 @@ public class AceEditor implements DocDisplay,
                completionManager_.onPaste(event);
 
             final Position start = getSelectionStart();
-
+            
             Scheduler.get().scheduleDeferred(new ScheduledCommand()
             {
                @Override
@@ -790,6 +790,9 @@ public class AceEditor implements DocDisplay,
       // bug in 0.95. We can choose to remove this when 0.95 ships, hopefully
       // any documents that would be affected by this will be gone by then.
       code = code.replaceAll("\u001B", "");
+      
+      // Normalize newlines -- convert all of '\r', '\r\n', '\n\r' to '\n'.
+      code = StringUtil.normalizeNewLines(code);
 
       final AceEditorNative ed = widget_.getEditor();
 
@@ -855,14 +858,13 @@ public class AceEditor implements DocDisplay,
 
    public void insertCode(String code, boolean blockMode)
    {
-      widget_.getEditor().insert(code);
+      widget_.getEditor().insert(StringUtil.normalizeNewLines(code));
    }
 
    public String getCode(Position start, Position end)
    {
       return getSession().getTextRange(Range.fromPoints(start, end));
    }
-
 
    @Override
    public InputEditorSelection search(String needle,
@@ -1245,6 +1247,7 @@ public class AceEditor implements DocDisplay,
    {
       Selection selection = getSession().getSelection();
       String oldValue = getSession().getTextRange(selection.getRange());
+      value = StringUtil.normalizeNewLines(value);
 
       replaceSelection(value);
 


### PR DESCRIPTION
This PR fixes an issue where a mix of CR+LF and LF line endings entering a document could confuse Ace, and cause issues when executing code in the console. This should resolve errors when copy + pasting text from certain PDFs, as well as https://github.com/rstudio/rmarkdown/issues/622.

One thing to double check -- I believe that when we write the files out to disk, we choose an appropriate line ending based on the platform / user preference, so it should be okay to just enforce LF on the client side -- is that correct?

(note that this PR is obviously risky so we might want to discuss / think about whether this is the most appropriate solution as well)