### PR TITLE
fix build error in osx caused by different r-version in build machine

### DIFF
--- a/dependencies/common/install-packages
+++ b/dependencies/common/install-packages
@@ -67,7 +67,11 @@ mv $PACKAGE_ARCHIVE $PACKAGE_ARCHIVE_SHA1
 install rsconnect master
 
 # temporary pointer to profvis until cran transition
-install profvis master --no-build-vignettes
+if R CMD build --help | grep --quiet no-build-vignettes; then
+	install profvis master --no-build-vignettes
+else
+	install profvis master --no-vignettes
+fi 
 
 # back to install-dir
 cd $INSTALL_DIR


### PR DESCRIPTION
Fix build error in osx caused by different r-version in build machine, use `--no-vignettes` or `--no-build-vignettes` accordingly.