### PR TITLE
remove profvis from build if requirements not met

### DIFF
--- a/dependencies/common/install-packages
+++ b/dependencies/common/install-packages
@@ -69,8 +69,6 @@ install rsconnect master
 # temporary pointer to profvis until cran transition
 if R CMD build --help | grep --quiet no-build-vignettes; then
 	install profvis master --no-build-vignettes
-else
-	install profvis master --no-vignettes
 fi 
 
 # back to install-dir

--- a/dependencies/common/install-packages
+++ b/dependencies/common/install-packages
@@ -67,9 +67,7 @@ mv $PACKAGE_ARCHIVE $PACKAGE_ARCHIVE_SHA1
 install rsconnect master
 
 # temporary pointer to profvis until cran transition
-if R CMD build --help | grep --quiet no-build-vignettes; then
-	install profvis master --no-build-vignettes
-fi 
+# install profvis master --no-build-vignettes
 
 # back to install-dir
 cd $INSTALL_DIR

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -31,9 +31,9 @@ endif()
 if(NOT EXISTS "${RSTUDIO_DEPENDENCIES_DIR}/common/rsconnect")
   message(FATAL_ERROR "rsconnect package not found (re-run install-dependencies script to install)")
 endif()
-if(NOT EXISTS "${RSTUDIO_DEPENDENCIES_DIR}/common/profvis")
-  message(FATAL_ERROR "profvis package not found (re-run install-dependencies script to install)")
-endif()
+# if(NOT EXISTS "${RSTUDIO_DEPENDENCIES_DIR}/common/profvis")
+#   message(FATAL_ERROR "profvis package not found (re-run install-dependencies script to install)")
+# endif()
 
 # verify libclang is installed
 if(WIN32)
@@ -421,9 +421,9 @@ if (NOT RSTUDIO_SESSION_WIN64)
            DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/R/packages)
 
    # install profvis package
-   file(GLOB PROFVIS_PACKAGE "${RSTUDIO_DEPENDENCIES_DIR}/common/profvis*.tar.gz")
-   install(FILES ${PROFVIS_PACKAGE}
-           DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/R/packages)
+   # file(GLOB PROFVIS_PACKAGE "${RSTUDIO_DEPENDENCIES_DIR}/common/profvis*.tar.gz")
+   # install(FILES ${PROFVIS_PACKAGE}
+   #        DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/R/packages)
 
    # install PDF.js
    install(DIRECTORY "resources/pdfjs"


### PR DESCRIPTION
still hitting the compilation issue in build machine since profvis requires R 3.0+. Will have to rethink this approach, in the meantime, disabling to unblock build.