### PR TITLE
defend against unloadable cache data file

### DIFF
--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -450,8 +450,11 @@
   # cached environment
   cacheFile <- file.path(cacheDir, paste(cacheKey, "Rdata", sep = "."))
   if (file.exists(cacheFile))
-  { 
-    load(cacheFile, envir = .rs.CachedDataEnv)
+  {
+    status <- try(load(cacheFile, envir = .rs.CachedDataEnv), silent = TRUE)
+    if (inherits(status, "try-error"))
+       return(NULL)
+     
     if (exists(cacheKey, where = .rs.CachedDataEnv, inherits = FALSE))
       return(get(cacheKey, envir = .rs.CachedDataEnv, inherits = FALSE))
   }


### PR DESCRIPTION
A user reported on the support forums the following error on startup after a forceful kill of RStudio:

    Error in load(cacheFile, envir = .rs.CachedDataEnv) : 
      empty (zero-byte) input file

This PR handles + suppresses that error. @jmcphers, if this looks okay can you merge?