### PR TITLE
make scope tree listeners more event driven

### DIFF
--- a/src/gwt/acesupport/acemixins/token_iterator.js
+++ b/src/gwt/acesupport/acemixins/token_iterator.js
@@ -172,7 +172,8 @@ var Range = require("ace/range").Range;
    };
 
    var updateTimerId;
-   var lastTokenizedRow = 0;
+   var renderStart = 0;
+   var renderEnd   = 0;
 
    /**
     * Eagerly tokenize up to the specified row, using the tokenizer
@@ -182,15 +183,18 @@ var Range = require("ace/range").Range;
    this.tokenizeUpToRow = function(maxRow)
    {
       var tokenizer = this.$session.bgTokenizer;
-      lastTokenizedRow = Math.min(lastTokenizedRow, tokenizer.currentLine);
-      maxRow = Math.max(maxRow, this.$session.getLength() - 1);
-      for (var i = lastTokenizedRow; i <= maxRow; i++)
+
+      renderStart = Math.min(renderStart, tokenizer.currentLine);
+      renderEnd   = Math.max(renderEnd, maxRow);
+
+      for (var i = tokenizer.currentLine; i <= maxRow; i++)
          tokenizer.$tokenizeRow(i);
 
       clearTimeout(updateTimerId);
       updateTimerId = setTimeout(function() {
-         tokenizer.fireUpdateEvent(lastTokenizedRow, maxRow);
-         lastTokenizedRow = maxRow;
+         tokenizer.fireUpdateEvent(renderStart, renderEnd);
+         renderStart = renderEnd;
+         renderEnd = 0;
       }, 700);
    };
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
@@ -25,8 +25,8 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ScopeFuncti
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTarget;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.CursorChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.CursorChangedHandler;
-import org.rstudio.studio.client.workbench.views.source.editors.text.events.RenderFinishedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorThemeStyleChangedEvent;
+import org.rstudio.studio.client.workbench.views.source.editors.text.events.ScopeTreeReadyEvent;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JsArray;
@@ -39,7 +39,6 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
-import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.DockLayoutPanel;
 import com.google.gwt.user.client.ui.FlowPanel;
@@ -227,17 +226,6 @@ public class DocumentOutlineWidget extends Composite
       container_.add(panel_);
       initHandlers();
       
-      // Since render events can be run in quick succession, we use a timer
-      // to ensure multiple render events are 'bundled' into a single run (debounced)
-      renderTimer_ = new Timer()
-      {
-         @Override
-         public void run()
-         {
-            onRenderFinished();
-         }
-      };
-      
       target.addEditorThemeStyleChangedHandler(this);
           
       initWidget(container_);
@@ -257,12 +245,13 @@ public class DocumentOutlineWidget extends Composite
    
    private void initHandlers()
    {
-      target_.getDocDisplay().addRenderFinishedHandler(new RenderFinishedEvent.Handler()
+      target_.getDocDisplay().addScopeTreeReadyHandler(new ScopeTreeReadyEvent.Handler()
       {
          @Override
-         public void onRenderFinished(RenderFinishedEvent event)
+         public void onScopeTreeReady(ScopeTreeReadyEvent event)
          {
-            renderTimer_.schedule(10);
+            rebuildScopeTree(event.getScopeTree(), event.getCurrentScope());
+            resetTreeStyles();
          }
       });
       
@@ -271,36 +260,13 @@ public class DocumentOutlineWidget extends Composite
          @Override
          public void onCursorChanged(CursorChangedEvent event)
          {
-            DocumentOutlineWidget.this.onCursorChanged(event);
+            if (target_.getDocDisplay().isScopeTreeReady())
+            {
+               currentScope_ = target_.getDocDisplay().getCurrentScope();
+               resetTreeStyles();
+            }
          }
       });
-   }
-   
-   private void onRenderFinished()
-   {
-      ensureScopeTreePopulated();
-      resetTreeStyles();
-   }
-   
-   private void onCursorChanged(final CursorChangedEvent event)
-   {
-      // Debounce value changed events to avoid over-aggressively rebuilding
-      // the scope tree.
-      if (docUpdateTimer_ != null)
-         docUpdateTimer_.cancel();
-      
-      docUpdateTimer_ = new Timer()
-      {
-         @Override
-         public void run()
-         {
-            updateScopeTree(event);
-            resetTreeStyles();
-         }
-      };
-      
-      int delayMs = target_.getDocDisplay().getSuggestedScopeUpdateDelay() + 200;
-      docUpdateTimer_.schedule(delayMs);
    }
    
    private void updateStyles(Widget widget, Style computed)
@@ -326,21 +292,16 @@ public class DocumentOutlineWidget extends Composite
       }
    }
    
-   private void updateScopeTree(CursorChangedEvent event)
-   {
-      rebuildScopeTree();
-   }
-   
    private void setActiveWidget(Widget widget)
    {
       panel_.clear();
       panel_.add(widget);
    }
    
-   private void rebuildScopeTree()
+   private void rebuildScopeTree(JsArray<Scope> scopeTree, Scope currentScope)
    {
-      scopeTree_ = target_.getDocDisplay().getScopeTree();
-      currentScope_ = target_.getDocDisplay().getCurrentScope();
+      scopeTree_ = scopeTree;
+      currentScope_ = currentScope;
       
       if (scopeTree_.length() == 0)
       {
@@ -437,12 +398,6 @@ public class DocumentOutlineWidget extends Composite
          setTreeItemStyles((DocumentOutlineTreeItem) tree_.getItem(i));
    }
    
-   private void ensureScopeTreePopulated()
-   {
-      if (scopeTree_ == null)
-         rebuildScopeTree();
-   }
-   
    private DocumentOutlineTreeItem createEntry(Scope node, int depth)
    {
       DocumentOutlineTreeEntry entry = new DocumentOutlineTreeEntry(node, depth);
@@ -472,8 +427,6 @@ public class DocumentOutlineWidget extends Composite
    private final FlowPanel emptyPlaceholder_;
    private final TextEditingTarget target_;
    
-   private final Timer renderTimer_;
-   private Timer docUpdateTimer_;
    private JsArray<Scope> scopeTree_;
    private Scope currentScope_;
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
@@ -260,7 +260,7 @@ public class DocumentOutlineWidget extends Composite
          @Override
          public void onCursorChanged(CursorChangedEvent event)
          {
-            if (target_.getDocDisplay().isScopeTreeReady())
+            if (target_.getDocDisplay().isScopeTreeReady(event.getPosition().getRow()))
             {
                currentScope_ = target_.getDocDisplay().getCurrentScope();
                resetTreeStyles();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -2366,9 +2366,9 @@ public class AceEditor implements DocDisplay,
       return handlers_.addHandler(LineWidgetsChangedEvent.TYPE, handler);
    }
    
-   public boolean isScopeTreeReady()
+   public boolean isScopeTreeReady(int row)
    {
-      return !backgroundTokenizer_.isRunning();
+      return backgroundTokenizer_.isReady(row);
    }
    
    public HandlerRegistration addScopeTreeReadyHandler(ScopeTreeReadyEvent.Handler handler)
@@ -2970,7 +2970,7 @@ public class AceEditor implements DocDisplay,
             {
                mutated_ = true;
                row_ = event.getEvent().getRange().getStart().getRow();
-               timer_.schedule(editor_.getSuggestedScopeUpdateDelay() / 2);
+               timer_.schedule(editor_.getSuggestedScopeUpdateDelay());
             }
          });
          
@@ -2981,13 +2981,15 @@ public class AceEditor implements DocDisplay,
             @Override
             public void onCursorChanged(CursorChangedEvent event)
             {
-               row_ = event.getPosition().getRow();
-               timer_.schedule(editor_.getSuggestedScopeUpdateDelay() / 2);
+               timer_.schedule(editor_.getSuggestedScopeUpdateDelay());
             }
          });
       }
       
-      public boolean isRunning() { return mutated_; }
+      public boolean isReady(int row)
+      {
+         return row < row_;
+      }
       
       private final AceEditor editor_;
       private final Timer timer_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -2944,16 +2944,9 @@ public class AceEditor implements DocDisplay,
                // Stop our timer if we've tokenized up to the end of the document.
                if (row_ >= editor_.getRowCount())
                {
-                  // If the timer was triggered by a document change event,
-                  // then fire an event signaling that we have a new scope
-                  // tree ready.
-                  if (mutated_)
-                  {
-                     editor_.fireEvent(new ScopeTreeReadyEvent(
-                           editor_.getScopeTree(),
-                           editor_.getCurrentScope()));
-                     mutated_ = false;
-                  }
+                  editor_.fireEvent(new ScopeTreeReadyEvent(
+                        editor_.getScopeTree(),
+                        editor_.getCurrentScope()));
                   return;
                }
                
@@ -2968,20 +2961,8 @@ public class AceEditor implements DocDisplay,
             @Override
             public void onDocumentChanged(DocumentChangedEvent event)
             {
-               mutated_ = true;
                row_ = event.getEvent().getRange().getStart().getRow();
-               timer_.schedule(editor_.getSuggestedScopeUpdateDelay());
-            }
-         });
-         
-         // We signal on cursor change as well so that the background
-         // tokenization pauses while the user is scrolling or typing.
-         editor_.addCursorChangedHandler(new CursorChangedHandler()
-         {
-            @Override
-            public void onCursorChanged(CursorChangedEvent event)
-            {
-               timer_.schedule(editor_.getSuggestedScopeUpdateDelay());
+               timer_.schedule(DELAY_MS);
             }
          });
       }
@@ -2995,10 +2976,9 @@ public class AceEditor implements DocDisplay,
       private final Timer timer_;
       
       private int row_ = 0;
-      private boolean mutated_ = true;
       
-      private static final int DELAY_MS = 0;
-      private static final int ROWS_TOKENIZED_PER_ITERATION = 1000;
+      private static final int DELAY_MS = 5;
+      private static final int ROWS_TOKENIZED_PER_ITERATION = 200;
    }
    
    private static final int DEBUG_CONTEXT_LINES = 2;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -199,7 +199,7 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    
    HandlerRegistration addCursorChangedHandler(CursorChangedHandler handler);
    
-   boolean isScopeTreeReady();
+   boolean isScopeTreeReady(int row);
    HandlerRegistration addScopeTreeReadyHandler(ScopeTreeReadyEvent.Handler handler);
    
    Position getCursorPosition();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -48,6 +48,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.events.HasD
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.HasFoldChangeHandlers;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.HasLineWidgetsChangedHandlers;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.HasRenderFinishedHandlers;
+import org.rstudio.studio.client.workbench.views.source.editors.text.events.ScopeTreeReadyEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.UndoRedoHandler;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkDefinition;
 import org.rstudio.studio.client.workbench.views.source.events.CollabEditStartParams;
@@ -197,6 +198,9 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    HandlerRegistration addFindRequestedHandler(FindRequestedEvent.Handler handler);
    
    HandlerRegistration addCursorChangedHandler(CursorChangedHandler handler);
+   
+   boolean isScopeTreeReady();
+   HandlerRegistration addScopeTreeReadyHandler(ScopeTreeReadyEvent.Handler handler);
    
    Position getCursorPosition();
    void setCursorPosition(Position position);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1628,7 +1628,7 @@ public class TextEditingTarget implements
          public void onCursorChanged(CursorChangedEvent event)
          {
             updateStatusBarPosition();
-            if (docDisplay_.isScopeTreeReady())
+            if (docDisplay_.isScopeTreeReady(event.getPosition().getRow()))
                updateCurrentScope();
                
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/events/ScopeTreeReadyEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/events/ScopeTreeReadyEvent.java
@@ -1,0 +1,58 @@
+/*
+ * ScopeTreeReadyEvent.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text.events;
+
+import org.rstudio.studio.client.workbench.views.source.editors.text.Scope;
+
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class ScopeTreeReadyEvent extends GwtEvent<ScopeTreeReadyEvent.Handler>
+{
+   public ScopeTreeReadyEvent(JsArray<Scope> scopeTree,
+                              Scope currentScope)
+   {
+      scopeTree_ = scopeTree;
+      currentScope_ = currentScope;
+   }
+   
+   public JsArray<Scope> getScopeTree() { return scopeTree_; }
+   public Scope getCurrentScope() { return currentScope_; }
+   
+   private final JsArray<Scope> scopeTree_;
+   private final Scope currentScope_;
+   
+   // Boilerplate ----
+   
+   public interface Handler extends EventHandler
+   {
+      void onScopeTreeReady(ScopeTreeReadyEvent event);
+   }
+   
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onScopeTreeReady(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}


### PR DESCRIPTION
This further refines the tokenization improvements by making the background tokenization fire an update event on completion, which clients can listen to as a signal for updating (ie, the status bar and the document outline widget).

@jmcphers, if you have time later can we review together?