### PR TITLE
avoid using temp files in code preview for data import

### DIFF
--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -196,7 +196,14 @@
    for (optionName in parameterNames) {
       if (!identical(NULL, options[[optionName]]) &&
             !identical(options[[optionName]], parameterDefinitions[[optionName]])) {
-         optionsNoDefaults[[optionName]] <- options[[optionName]]
+         if (is.numeric(options[[optionName]]) && is.numeric(parameterDefinitions[[optionName]])) {
+            if (!isTRUE(all.equal(options[[optionName]], parameterDefinitions[[optionName]]))) {
+               optionsNoDefaults[[optionName]] <- options[[optionName]]
+            }
+         }
+         else {
+            optionsNoDefaults[[optionName]] <- options[[optionName]]
+         }
       }
    }
 
@@ -272,7 +279,8 @@
                cacheDataCode,
                paste(
                   cacheVariableName,
-                  " <- tempfile(tmpdir = getwd(), fileext = \"",
+                  " <- file.path(getwd(), \"",
+                  options$dataName,
                   functionInfo$cacheFileExtension,
                   "\")",
                   sep = "")
@@ -298,7 +306,7 @@
          downloadCondition <- ''
          if (canCacheData && !cacheDataWorkingDir)
          {
-            downloadCondition <- paste("if(!file.exists(", cacheVariableName, ")) ", sep = "")
+            downloadCondition <- paste("if (!file.exists(", cacheVariableName, ")) ", sep = "")
          }
 
          cacheDataCode <- append(cacheDataCode, list(
@@ -429,13 +437,14 @@
       }
    )
 
-   dataName <- importInfo$dataName <- .rs.assemble_data_import_name(dataImportOptions)
+   dataName <- .rs.assemble_data_import_name(dataImportOptions)
    if (is.null(dataName) || identical(dataName, ""))
    {
       dataName <- "dataset"
    }
 
    dataName <- tolower(gsub("[\\._]+", "_", c(make.names(dataName)), perl=TRUE))
+   importInfo$dataName <- dataImportOptions$dataName <- dataName
 
    dataImportOptions$cacheVariableNames <- list()
    dataImportOptions$cacheVariableNames$importLocation <- paste(dataName, "_file", sep = "")

--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -272,6 +272,18 @@
       if (importFromUrl && canCacheData)
       {
          cacheVariableName <- options$cacheVariableNames[[resource]]
+         cacheUrlName <- options$cacheUrlNames[[resource]]
+         downloadResource <- options[[resource]]
+
+         cacheDataCode <- append(
+            cacheDataCode,
+            paste(
+               cacheUrlName,
+               " <- \"",
+               downloadResource,
+               "\"",
+               sep = "")
+         )
 
          if (cacheDataWorkingDir)
          {
@@ -312,9 +324,9 @@
          cacheDataCode <- append(cacheDataCode, list(
             paste(
                downloadCondition,
-               "download.file(\"",
-               options[[resource]],
-               "\", ",
+               "download.file(",
+               cacheUrlName,
+               ", ",
                cacheVariableName,
                ")",
                sep = ""
@@ -446,9 +458,14 @@
    dataName <- tolower(gsub("[\\._]+", "_", c(make.names(dataName)), perl=TRUE))
    importInfo$dataName <- dataImportOptions$dataName <- dataName
 
+   dataImportOptions$cacheUrlNames <- list()
+   dataImportOptions$cacheUrlNames$importLocation <- paste("url", sep = "")
+   dataImportOptions$cacheUrlNames$modelLocation <- paste("modelurl", sep = "")
+
    dataImportOptions$cacheVariableNames <- list()
-   dataImportOptions$cacheVariableNames$importLocation <- paste(dataName, "_file", sep = "")
-   dataImportOptions$cacheVariableNames$modelLocation <- paste(dataName, "_model_file", sep = "")
+   dataImportOptions$cacheVariableNames$importLocation <- paste("destfile", sep = "")
+   dataImportOptions$cacheVariableNames$modelLocation <- paste("modelfile", sep = "")
+
    if (identical(dataImportOptions$localFiles, NULL)) {
       dataImportOptions$localFiles <- list()
    }

--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -662,3 +662,17 @@
    })
 })
 
+.rs.addJsonRpcHandler("preview_data_import_clean", function(dataImportOptions)
+{
+   tryCatch({
+      if (!identical(dataImportOptions$localFiles, NULL))
+      {
+         lapply(dataImportOptions$localFiles, function (e) {
+            file.remove(paste(e));
+         })
+         dataImportOptions
+      }
+   }, error = function(e) {
+      return(list(error = e))
+   })
+})

--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -291,10 +291,10 @@
                cacheDataCode,
                paste(
                   cacheVariableName,
-                  " <- file.path(getwd(), \"",
+                  " <- \"",
                   options$dataName,
                   functionInfo$cacheFileExtension,
-                  "\")",
+                  "\"",
                   sep = "")
             )
          }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4920,6 +4920,7 @@ public class RemoteServer implements Server
    private static final String ASSEMBLE_DATA_IMPORT = "assemble_data_import";
    private static final String PREVIEW_DATA_IMPORT_ASYNC = "preview_data_import_async";
    private static final String PREVIEW_DATA_IMPORT_ASYNC_ABORT = "preview_data_import_async_abort";
+   private static final String PREVIEW_DATA_IMPORT_CLEAN = "preview_data_import_clean";
 
    private static final String START_PROFILING = "start_profiling";
    private static final String STOP_PROFILING = "stop_profiling";

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4554,6 +4554,15 @@ public class RemoteServer implements Server
    }
 
    @Override
+   public void previewDataImportClean(DataImportOptions dataImportOptions, 
+                                      ServerRequestCallback<Void> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONObject(dataImportOptions));
+      sendRequest(RPC_SCOPE, PREVIEW_DATA_IMPORT_CLEAN, params, requestCallback);
+   }
+
+   @Override
    public void previewDataImportAsyncAbort(ServerRequestCallback<Void> requestCallback)
    {
       JSONArray params = new JSONArray();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -220,7 +220,7 @@ public class DataImport extends Composite
                public void execute()
                {
                   // Invalidate cached files, click update to refresh stale files
-                  localFiles_ = null;
+                  cleanPreviewResources();
                   
                   if (dataImportFileChooser_.getText() != importOptions_.getImportLocation())
                   {
@@ -441,6 +441,29 @@ public class DataImport extends Composite
       return options;
    }
    
+   @Override
+   public void onDetach()
+   {
+      cleanPreviewResources();
+      super.onDetach();
+   }
+   
+   private void cleanPreviewResources()
+   {
+      if (localFiles_ != null)
+      {
+         server_.previewDataImportClean(getOptions(), new ServerRequestCallback<Void>()
+         {
+            @Override
+            public void onError(ServerError error)
+            {
+            }
+         });
+      }
+      
+      localFiles_ = null;
+   }
+   
    private void setGridViewerData(DataImportPreviewResponse response)
    {
       gridViewer_.setOption("nullsAsNAs", "true");
@@ -484,7 +507,7 @@ public class DataImport extends Composite
                public void execute()
                {
                   progressIndicator_.clearProgress();
-                  localFiles_ = null;
+                  cleanPreviewResources();
                   
                   server_.previewDataImportAsyncAbort(new ServerRequestCallback<Void>()
                   {
@@ -551,7 +574,7 @@ public class DataImport extends Composite
                @Override
                public void onError(ServerError error)
                {
-                  localFiles_ = null;
+                  cleanPreviewResources();
                   gridViewer_.setData(null);
                   progressIndicator_.onError(error.getMessage());
                }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -528,6 +528,11 @@ public class DataImport extends Composite
                   lastSuccessfulResponse_ = response;
                   
                   dataImportOptionsUi_.setPreviewResponse(response);
+
+                  if (response.getLocalFiles() != null)
+                  {
+                     localFiles_ = response.getLocalFiles();
+                  }
                   
                   gridViewer_.setOption("status",
                         "Previewing first " + toLocaleString(maxRows_) + 
@@ -582,7 +587,10 @@ public class DataImport extends Composite
             
             codePreview_ = response.getImportCode();
             dataImportOptionsUi_.setAssembleResponse(response);
-            localFiles_ = response.getLocalFiles();
+            if (response.getLocalFiles() != null)
+            {
+               localFiles_ = response.getLocalFiles();
+            }
             
             setCodeAreaDefaults();
             codeArea_.setCode(codePreview_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportPreviewResponse.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportPreviewResponse.java
@@ -44,4 +44,8 @@ public class DataImportPreviewResponse extends JavaScriptObject
    public final native String[] getSupportedColumnTypes() /*-{
       return this.options && this.options.columnTypes ? this.options.columnTypes : [];
    }-*/;
+   
+   public final native JavaScriptObject getLocalFiles() /*-{
+      return this.localFiles;
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportServerOperations.java
@@ -37,4 +37,6 @@ public interface DataImportServerOperations
    void interrupt(ServerRequestCallback<Void> requestCallback);
    
    void previewDataImportAsyncAbort(ServerRequestCallback<Void> requestCallback);
+   
+   void previewDataImportClean(DataImportOptions dataImportOptions, ServerRequestCallback<Void> requestCallback);
 }


### PR DESCRIPTION
This PR adds two options to the data import options request:
- `canCacheData`: If `TRUE`, allows data import code generation to cache data for URLs
- `cacheDataWorkingDir`: If `TRUE`, makes data import use the `getwd()` instead of the temp directory

It also adds a `preview_data_import_clean` RPC to clean up temp files when the dialog closes (notice that OS also have policies to clean the temp directory, but it's a good practice for data import to clean up this proactively as well).

Couple changes in the data import process:
- Preview code always sets `canCacheData` to `FALSE` to allow users to import fresh data with clean code that does not rely on temp files.
- Preview code for XLS does set `canCacheData` to `TRUE`; however, it also sets `cacheDataWorkingDir` to `TRUE` to allow users to download datasets directly into their working directory.