### PR TITLE
avoid window reload in ace preview

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AceEditorPreview.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AceEditorPreview.java
@@ -156,7 +156,7 @@ public class AceEditorPreview extends DynamicIFrame
       if (!isFrameLoaded_)
          return;
 
-      FontSizer.setNormalFontSize(getDocument(), fontSize);
+      FontSizer.setNormalFontSize(getDocument(), fontSize_ * zoomLevel_);
    }
 
    public void setFont(String font)
@@ -185,33 +185,9 @@ public class AceEditorPreview extends DynamicIFrame
       zoomLevel_ = zoomLevel;
       if (!isFrameLoaded_)
          return;
-   
-      final String STYLE_EL_ID = "__rstudio_zoom_level";
-      Document document = getDocument();
-
-      Element oldStyle = document.getElementById(STYLE_EL_ID);
-
-      StyleElement style = document.createStyleElement();
-      style.setAttribute("type", "text/css");
-      String zoom = Double.toString(zoomLevel);
-      style.setInnerText(".ace_line {\n" +
-                         "  -webkit-transform: scale(" + zoom + ");\n" +
-                         "}");
-
-      document.getBody().appendChild(style);
-
-      if (oldStyle != null)
-         oldStyle.removeFromParent();
-
-      style.setId(STYLE_EL_ID);
+      
+      setFontSize(fontSize_);
    }
-   
-   public void reload()
-   {
-      getWindow().reload();
-   }
-   
- 
  
    private LinkElement currentStyleLink_;
    private boolean isFrameLoaded_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -85,7 +85,6 @@ public class AppearancePreferencesPane extends PreferencesPane
                public void onChange(ChangeEvent event)
                {
                   updatePreviewZoomLevel();
-                  preview_.reload();
                }
             });
          }


### PR DESCRIPTION
This PR fixes an issue where the Ace editor preview would vanish after changing the zoom level in the appearance preferences pane. My fix is to just use the font sizer (which works fine) and scale the font size by the selected zoom level.