### PR TITLE
use 'Ctrl+Shift+Z' for undo rather than 'Ctrl+Y'

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -194,6 +194,7 @@ private:
    void activateAndFocusOwner();
 
 private:
+   void doAction(const QKeySequence& keys);
    void doAction(QKeySequence::StandardKey key);
    MainWindow* pMainWindow_;
    GwtCallbackOwner* pOwner_;


### PR DESCRIPTION
This PR fixes an issue where attempting to execute `Redo` from the main menu would instead perform a yank (ie, the key sequence `Ctrl+Y` was sent to the browser rather than `Ctrl+Shift+Z`).

The solution here is to (always) send `Ctrl+Shift+Z` for a redo, which is handled correctly across all platforms where we use Qt.

(For reference, this behaviour is documented here: http://doc.qt.io/qt-4.8/qkeysequence.html)