### PR TITLE
ensure POSIX line endings for Rmd template files

### DIFF
--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -1053,7 +1053,7 @@ Error getRmdTemplate(const json::JsonRpcRequest& request,
    std::string templateContent;
    if (skeletonPath.exists())
    {
-      error = readStringFromFile(skeletonPath, &templateContent);
+      error = readStringFromFile(skeletonPath, &templateContent, string_utils::LineEndingPosix);
       if (error)
          return error;
    }


### PR DESCRIPTION
This PR fixes an issue that occurs when custom R Markdown templates are created using Windows CR+LF line endings (e.g. by a client package developed on Windows). When those are read by the client, the line endings are not sanitized, and the document is populated with `CR + LF` line-endings version of the document. This causes code execution errors when attempting to execute a multi-line selection.

Although the previous client-side sanitization PR also helps resolve this issue, this fix is slightly more scoped, and I think is safer for including as part of v0.99-700 patch.