### PR TITLE
improvements to profiler integratior

### DIFF
--- a/src/cpp/desktop-mac/Info.plist.in
+++ b/src/cpp/desktop-mac/Info.plist.in
@@ -219,7 +219,7 @@
              <string>rprof</string>
          </array>
          <key>CFBundleTypeIconFile</key>
-         <string>RMarkdown.icns</string>
+         <string>RSource.icns</string>
          <key>CFBundleTypeName</key>
          <string>R Profile File</string>
          <key>CFBundleTypeRole</key>

--- a/src/cpp/desktop-mac/Info.plist.in
+++ b/src/cpp/desktop-mac/Info.plist.in
@@ -212,6 +212,21 @@
          <key>CFBundleTypeRole</key>
          <string>Editor</string>
       </dict>
+      <dict>
+         <key>CFBundleTypeExtensions</key>
+         <array>
+             <string>Rprof</string>
+             <string>rprof</string>
+         </array>
+         <key>CFBundleTypeIconFile</key>
+         <string>RMarkdown.icns</string>
+         <key>CFBundleTypeName</key>
+         <string>R Profile File</string>
+         <key>CFBundleTypeRole</key>
+         <string>Editor</string>
+         <key>LSIsAppleDefaultForType</key>
+         <true/>
+      </dict>
    </array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>

--- a/src/cpp/desktop/Info.plist.in
+++ b/src/cpp/desktop/Info.plist.in
@@ -206,7 +206,7 @@
              <string>rprof</string>
          </array>
          <key>CFBundleTypeIconFile</key>
-         <string>RMarkdown.icns</string>
+         <string>RSource.icns</string>
          <key>CFBundleTypeName</key>
          <string>R Profile File</string>
          <key>CFBundleTypeRole</key>

--- a/src/cpp/desktop/Info.plist.in
+++ b/src/cpp/desktop/Info.plist.in
@@ -199,6 +199,21 @@
          <key>CFBundleTypeRole</key>
          <string>Editor</string>
       </dict>
+      <dict>
+         <key>CFBundleTypeExtensions</key>
+         <array>
+             <string>Rprof</string>
+             <string>rprof</string>
+         </array>
+         <key>CFBundleTypeIconFile</key>
+         <string>RMarkdown.icns</string>
+         <key>CFBundleTypeName</key>
+         <string>R Profile File</string>
+         <key>CFBundleTypeRole</key>
+         <string>Editor</string>
+         <key>LSIsAppleDefaultForType</key>
+         <true/>
+      </dict>
    </array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -506,7 +506,7 @@ Error initialize()
    }
 
    // initialize profile resources
-   error = r::exec::RFunction(".rs.profile_resources").call();
+   error = r::exec::RFunction(".rs.profileResources").call();
    if (error)
       return error;
 

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -505,6 +505,11 @@ Error initialize()
          return error;
    }
 
+   // initialize profile resources
+   error = r::exec::RFunction(".rs.profile_resources").call();
+   if (error)
+      return error;
+
    // complete embedded r initialization
    error = r::session::completeEmbeddedRInitialization(s_options.useInternet2);
    if (error)

--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -50,6 +50,13 @@
    return(obj)
 })
 
+.rs.addFunction("nullOrScalar", function(obj)
+{
+   if (!identical(obj, NULL))
+      class(obj) <- 'rs.scalar'
+   return(obj)
+})
+
 .rs.addFunction("validateAndNormalizeEncoding", function(encoding)
 {
    iconvList <- toupper(iconvlist())

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -101,3 +101,11 @@
       .rs.enqueClientEvent("rprof_stopped");
    }
 })
+
+options("profvis.print" = function(x)
+{
+   options("profvis.prof_output" = .rs.profile_resources()$tempPath)
+   options("profvis.prof_extension" = ".rprof")
+
+   invisible(.Call(.rs.routines$rs_fileEdit, c(x$x$message$prof_output)))
+})

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -118,7 +118,9 @@
    }
 })
 
-options("profvis.print" = function(x)
-{
-   invisible(.Call(.rs.routines$rs_fileEdit, c(x$x$message$prof_output)))
-})
+if (identical(getOption("profvis.print"), NULL)) {
+   options("profvis.print" = function(x)
+   {
+      invisible(.Call(.rs.routines$rs_fileEdit, c(x$x$message$prof_output)))
+   })
+}

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -29,7 +29,7 @@
          fileName = .rs.scalar(fileName)
       ))
    }, error = function(e) {
-      return(list(error = .rs.scalar(e)))
+      return(list(error = .rs.scalar(e$message)))
    })
 })
 
@@ -47,7 +47,7 @@
          fileName = .rs.scalar(profilerOptions$fileName)
       ))
    }, error = function(e) {
-      return(list(error = .rs.scalar(e)))
+      return(list(error = .rs.scalar(e$message)))
    })
 })
 
@@ -64,7 +64,7 @@
          htmlFile = .rs.scalar(paste("profiles/", basename(htmlFile), sep = ""))
       ))
    }, error = function(e) {
-      return(list(error = .rs.scalar(e)))
+      return(list(error = .rs.scalar(e$message)))
    })
 })
 

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -64,7 +64,7 @@
 {
    tryCatch({
       resources <- .rs.profile_resources()
-      profvis <- profvis::profvis(prof_input = profilerOptions$fileName)
+      profvis <- profvis::profvis(prof_input = profilerOptions$fileName, split="h")
 
       htmlFile <- tempfile(fileext = ".html", tmpdir = resources$tempPath)
       htmlwidgets::saveWidget(profvis, htmlFile, selfcontained = FALSE)

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -20,9 +20,9 @@
       dir.create(tempPath, recursive = TRUE)
    }
 
-   return list(
+   return (list(
       tempPath = tempPath
-   )
+   ))
 })
 
 .rs.addJsonRpcHandler("start_profiling", function(profilerOptions)
@@ -67,7 +67,7 @@
       profvis <- profvis::profvis(prof_input = profilerOptions$fileName)
 
       htmlFile <- tempfile(fileext = ".html", tmpdir = resources$tempPath)
-      htmlwidgets::saveWidget(profvis, htmlFile)
+      htmlwidgets::saveWidget(profvis, htmlFile, selfcontained = FALSE)
 
       return(list(
          htmlFile = .rs.scalar(paste("profiles/", basename(htmlFile), sep = ""))

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -15,6 +15,10 @@
 
 .rs.addFunction("profile_resources", function()
 {
+   if (identical(getOption("profvis.prof_extension"), NULL)) {
+      options("profvis.prof_extension" = ".rprof")
+   }
+
    tempPath <- .Call(.rs.routines$rs_profilesPath)
    if (!.rs.dirExists(tempPath)) {
       dir.create(tempPath, recursive = TRUE)
@@ -53,7 +57,7 @@
       }
 
       return(list(
-         fileName = .rs.scalar(profilerOptions$fileName)
+         fileName = .rs.nullOrScalar(profilerOptions$fileName)
       ))
    }, error = function(e) {
       return(list(error = .rs.scalar(e$message)))
@@ -104,8 +108,5 @@
 
 options("profvis.print" = function(x)
 {
-   options("profvis.prof_output" = .rs.profile_resources()$tempPath)
-   options("profvis.prof_extension" = ".rprof")
-
    invisible(.Call(.rs.routines$rs_fileEdit, c(x$x$message$prof_output)))
 })

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -68,6 +68,18 @@
    })
 })
 
+.rs.addJsonRpcHandler("copy_profile", function(fromPath, toPath)
+{
+   tryCatch({
+      file.copy(fromPath, toPath, overwrite = TRUE)
+
+      return(list(
+      ))
+   }, error = function(e) {
+      return(list(error = .rs.scalar(e$message)))
+   })
+})
+
 .rs.registerNotifyHook("Rprof", "utils", function(...) 
 {
    args <- c(...)

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -13,15 +13,24 @@
 #
 #
 
+.rs.addFunction("profile_resources", function()
+{
+   tempPath <- .Call(.rs.routines$rs_profilesPath)
+   if (!.rs.dirExists(tempPath)) {
+      dir.create(tempPath, recursive = TRUE)
+   }
+
+   return list(
+      tempPath = tempPath
+   )
+})
+
 .rs.addJsonRpcHandler("start_profiling", function(profilerOptions)
 {
    tryCatch({
-      tempPath <- .Call(.rs.routines$rs_profilesPath)
-      if (!.rs.dirExists(tempPath)) {
-         dir.create(tempPath, recursive = TRUE)
-      }
+      resources <- .rs.profile_resources()
       
-   	fileName <- tempfile(fileext = ".rprof", tmpdir = tempPath)
+   	fileName <- tempfile(fileext = ".rprof", tmpdir = resources$tempPath)
 
       Rprof(filename = fileName, line.profiling = TRUE)
 
@@ -54,10 +63,10 @@
 .rs.addJsonRpcHandler("open_profile", function(profilerOptions)
 {
    tryCatch({
+      resources <- .rs.profile_resources()
       profvis <- profvis::profvis(prof_input = profilerOptions$fileName)
 
-      tempPath <- .Call(.rs.routines$rs_profilesPath)
-      htmlFile <- tempfile(fileext = ".html", tmpdir = tempPath)
+      htmlFile <- tempfile(fileext = ".html", tmpdir = resources$tempPath)
       htmlwidgets::saveWidget(profvis, htmlFile)
 
       return(list(

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -13,7 +13,7 @@
 #
 #
 
-.rs.addFunction("profile_resources", function()
+.rs.addFunction("profileResources", function()
 {
    if (identical(getOption("profvis.prof_extension"), NULL)) {
       options("profvis.prof_extension" = ".rprof")
@@ -29,12 +29,24 @@
    ))
 })
 
+.rs.addFunction("newProfileFileName" , function(path) {
+   profileFileName <- function (path, i) {
+      file.path(path, paste("profile", i, ".rprof", sep=""))
+   }
+
+   i <- 1
+   while (file.exists(profileFileName(path, i))) {
+      i <- i + 1
+   }
+
+   profileFileName(path, i)
+})
+
 .rs.addJsonRpcHandler("start_profiling", function(profilerOptions)
 {
    tryCatch({
-      resources <- .rs.profile_resources()
-      
-   	fileName <- tempfile(fileext = ".rprof", tmpdir = resources$tempPath)
+      resources <- .rs.profileResources()
+      fileName <- .rs.newProfileFileName(resources$tempPath)
 
       Rprof(filename = fileName, line.profiling = TRUE)
 
@@ -67,7 +79,7 @@
 .rs.addJsonRpcHandler("open_profile", function(profilerOptions)
 {
    tryCatch({
-      resources <- .rs.profile_resources()
+      resources <- .rs.profileResources()
       profvis <- profvis::profvis(prof_input = profilerOptions$fileName, split="h")
 
       htmlFile <- tempfile(fileext = ".html", tmpdir = resources$tempPath)

--- a/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
@@ -15,12 +15,15 @@
 package org.rstudio.core.client.theme;
 
 import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.Style.Float;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.*;
 import com.google.inject.Inject;
+
+import java.util.HashMap;
 
 import org.rstudio.core.client.events.*;
 import org.rstudio.core.client.layout.RequiresVisibilityChanged;
@@ -103,7 +106,16 @@ public class WindowFrame extends Composite
       frame_.setWidgetRightWidth(minimize,
                                  ShadowBorder.RIGHT_SHADOW_WIDTH + 25, Style.Unit.PX,
                                  14, Style.Unit.PX);
-
+      
+      buttonsArea_ = new FlowPanel();
+      
+      // Without z-index, the header widget will obscure the context button
+      // if the former is set after the latter.
+      buttonsArea_.getElement().getStyle().setZIndex(10);
+      
+      frame_.add(buttonsArea_);
+      frame_.setWidgetRightWidth(buttonsArea_, 48, Unit.PX, 100, Unit.PX);
+      
       initWidget(frame_);
    }
    
@@ -290,23 +302,24 @@ public class WindowFrame extends Composite
       }
    }
 
-   public void setContextButton(Widget button, int width, int height)
+   public void setContextButton(Widget button, int width, int height, int position)
    {
-      if (contextButton_ != null)
+      if (contextButtons_.containsKey(position) && contextButtons_.get(position) != null)
       {
-         contextButton_.removeFromParent();
-         contextButton_ = null;
+         contextButtons_.get(position).removeFromParent();
+         contextButtons_.put(position, null);
       }
 
       if (button != null)
       {
-         contextButton_ = button;
-         frame_.add(button);
-         frame_.setWidgetRightWidth(button, 48, Unit.PX, width, Unit.PX);
-         frame_.setWidgetTopHeight(button, 3, Unit.PX, height, Unit.PX);
-         // Without z-index, the header widget will obscure the context button
-         // if the former is set after the latter.
-         frame_.getWidgetContainerElement(button).getStyle().setZIndex(10);
+         contextButtons_.put(position, button);
+         button.getElement().getStyle().setFloat(Float.RIGHT);
+         
+         buttonsArea_.add(button);
+         frame_.setWidgetTopHeight(buttonsArea_, 3, Unit.PX, height, Unit.PX);
+         
+         button.getElement().setAttribute("display", "inline-block");
+         button.getElement().setAttribute("float", "right");
       }
    }
 
@@ -363,10 +376,11 @@ public class WindowFrame extends Composite
    private Widget main_;
    private Widget header_;
    private Widget fill_;
-   private Widget contextButton_;
+   private HashMap<Integer, Widget> contextButtons_ = new HashMap<Integer, Widget>();
    private HandlerRegistration ensureVisibleRegistration_;
    private HandlerRegistration ensureHeightRegistration_;
    private Widget previousHeader_;
+   private FlowPanel buttonsArea_;
    
    // Injected ----
    private EventBus events_;

--- a/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
@@ -108,13 +108,7 @@ public class WindowFrame extends Composite
                                  14, Style.Unit.PX);
       
       buttonsArea_ = new FlowPanel();
-      
-      // Without z-index, the header widget will obscure the context button
-      // if the former is set after the latter.
-      buttonsArea_.getElement().getStyle().setZIndex(10);
-      
       frame_.add(buttonsArea_);
-      frame_.setWidgetRightWidth(buttonsArea_, 48, Unit.PX, 100, Unit.PX);
       
       initWidget(frame_);
    }
@@ -316,7 +310,11 @@ public class WindowFrame extends Composite
          button.getElement().getStyle().setFloat(Float.RIGHT);
          
          buttonsArea_.add(button);
+         frame_.setWidgetRightWidth(buttonsArea_, 48, Unit.PX, width * contextButtons_.size(), Unit.PX);
          frame_.setWidgetTopHeight(buttonsArea_, 3, Unit.PX, height, Unit.PX);
+         // Without z-index, the header widget will obscure the context button
+         // if the former is set after the latter.
+         frame_.getWidgetContainerElement(buttonsArea_).getStyle().setZIndex(10);
          
          button.getElement().setAttribute("display", "inline-block");
          button.getElement().setAttribute("float", "right");

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -78,6 +78,7 @@ import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.snippets.SnippetHelper;
 import org.rstudio.studio.client.workbench.snippets.ui.EditSnippetsDialog;
+import org.rstudio.studio.client.workbench.ui.ConsoleTabPanel;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.CompletionRequester;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.HelpStrategy;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.RCompletionManager;
@@ -173,6 +174,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(DataImport dataImport);
    void injectMembers(DataImportOptionsUiCsv dataImport);
    void injectMembers(CppCompletion completion);
+   void injectMembers(ConsoleTabPanel consoleTabPanel);
    
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);
 

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/ProfilerType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/ProfilerType.java
@@ -14,10 +14,14 @@
  */
 package org.rstudio.studio.client.common.filetypes;
 
+import java.util.HashSet;
+
 import org.rstudio.core.client.FilePosition;
+import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.filetypes.model.NavigationMethods;
+import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.source.editors.profiler.OpenProfileEvent;
 
 public class ProfilerType extends EditableFileType
@@ -41,5 +45,18 @@ public class ProfilerType extends EditableFileType
    public void openFile(FileSystemItem file, EventBus eventBus)
    {
       openFile(file, null, NavigationMethods.DEFAULT, eventBus);
+   }
+
+   public HashSet<AppCommand> getSupportedCommands(Commands commands)
+   {
+      HashSet<AppCommand> results = new HashSet<AppCommand>();
+      results.add(commands.saveSourceDocAs());
+
+      return results;
+   }
+   
+   public String getDefaultExtension()
+   {
+      return "Rprof";
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -322,6 +322,8 @@ public class TextFileType extends EditableFileType
          results.add(commands.reflowComment());
          results.add(commands.reformatCode());
          results.add(commands.renameInFile());
+         results.add(commands.profileCode());
+         results.add(commands.profileCodeWithoutFocus());
       }
       
       if (canExecuteAllCode())
@@ -339,6 +341,7 @@ public class TextFileType extends EditableFileType
          results.add(commands.executeToCurrentLine());
          results.add(commands.executeFromCurrentLine());
          results.add(commands.executeCurrentSection());
+         results.add(commands.profileCode());
       }
       if (canKnitToHTML())
       {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4567,6 +4567,15 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, OPEN_PROFILE, params, requestCallback);
    }
 
+   public void copyProfile(String fromPath, String toPath,
+                           ServerRequestCallback<JavaScriptObject> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(fromPath));
+      params.set(1, new JSONString(toPath));
+      sendRequest(RPC_SCOPE, COPY_PROFILE, params, requestCallback);
+   }
+
    private String clientId_;
    private String clientVersion_ = "";
    private boolean listeningForEvents_;
@@ -4926,4 +4935,5 @@ public class RemoteServer implements Server
    private static final String START_PROFILING = "start_profiling";
    private static final String STOP_PROFILING = "stop_profiling";
    private static final String OPEN_PROFILE = "open_profile";
+   private static final String COPY_PROFILE = "copy_profile";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -203,7 +203,8 @@ well as menu structures (for main menu and popup menus).
             <separator/>
             <cmd refid="executeAllCode"/>
          </menu>
-
+         <separator/>
+         <cmd refid="profileCode"/>
          <separator/>
          <cmd refid="sourceActiveDocument"/>
          <cmd refid="sourceActiveDocumentWithEcho"/>
@@ -660,6 +661,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="executeCurrentChunk" value="Cmd+Alt+C"/>
          <shortcut refid="executeCurrentChunk" value="Cmd+Shift+Enter"/>
          <shortcut refid="executeNextChunk" value="Cmd+Alt+N"/>
+         <shortcut refid="profileCode" value="Cmd+Alt+Shift+P"/>
       </shortcutgroup>
       <shortcutgroup name="Debug">
          <shortcut refid="debugBreakpoint" value="Shift+F9"/>
@@ -1374,6 +1376,16 @@ well as menu structures (for main menu and popup menus).
         menuLabel="Re-Run _Previous"
         desc="Re-run the previous code region"
         context="r"/>
+
+   <cmd id="profileCode"
+        label="Profile Current Line or Selection"
+        buttonLabel="Profile"
+        menuLabel="_Profile Selected Line(s)"
+        desc="Profile the current line or selection"
+        context="r"/>
+
+   <cmd id="profileCodeWithoutFocus"
+        rebindable="false"/>
         
    <cmd id="insertChunk"
         menuLabel="_Insert Chunk"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -2608,6 +2608,7 @@ well as menu structures (for main menu and popup menus).
         
    <cmd id="stopProfiler"
         menuLabel="Stop Profiling"
+        buttonLabel="Stop Profiling"
         desc="Stop profiling R code"
         rebindable="false"/>
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -319,6 +319,8 @@ public abstract class
    public abstract AppCommand showProfiler();
    public abstract AppCommand startProfiler();
    public abstract AppCommand stopProfiler();
+   public abstract AppCommand profileCode();
+   public abstract AppCommand profileCodeWithoutFocus();
    
    // Tools
    public abstract AppCommand showShellDialog();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
@@ -18,18 +18,30 @@ import org.rstudio.core.client.events.*;
 import org.rstudio.core.client.layout.LogicalWindow;
 import org.rstudio.core.client.theme.PrimaryWindowFrame;
 import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.workbench.views.console.ConsoleInterruptButton;
+import org.rstudio.studio.client.workbench.views.console.ConsoleInterruptProfilerButton;
 import org.rstudio.studio.client.workbench.views.console.ConsolePane;
 import org.rstudio.studio.client.workbench.views.console.events.WorkingDirChangedEvent;
 import org.rstudio.studio.client.workbench.views.console.events.WorkingDirChangedHandler;
 import org.rstudio.studio.client.workbench.views.output.find.FindOutputTab;
 import org.rstudio.studio.client.workbench.views.output.markers.MarkersOutputTab;
 
+import com.google.inject.Inject;
+
 import java.util.ArrayList;
 
 public class ConsoleTabPanel extends WorkbenchTabPanel
 {
+   @Inject
+   public void initialize(ConsoleInterruptButton consoleInterrupt,
+                          ConsoleInterruptProfilerButton consoleInterruptProfiler)
+   {
+      consoleInterrupt_ = consoleInterrupt;
+      consoleInterruptProfiler_ = consoleInterruptProfiler;
+   }
+   
    public ConsoleTabPanel(final PrimaryWindowFrame owner,
                           final LogicalWindow parentWindow,
                           ConsolePane consolePane,
@@ -40,7 +52,6 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
                           WorkbenchTab deployContentTab,
                           MarkersOutputTab markersTab,
                           EventBus events,
-                          ConsoleInterruptButton consoleInterrupt,
                           ToolbarButton goToWorkingDirButton)
    {
       super(owner, parentWindow);
@@ -49,11 +60,12 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
       compilePdfTab_ = compilePdfTab;
       findResultsTab_ = findResultsTab;
       sourceCppTab_ = sourceCppTab;
-      consoleInterrupt_ = consoleInterrupt;
       goToWorkingDirButton_ = goToWorkingDirButton;
       renderRmdTab_ = renderRmdTab;
       deployContentTab_ = deployContentTab;
       markersTab_ = markersTab;
+      
+      RStudioGinjector.INSTANCE.injectMembers(this);
 
       compilePdfTab.addEnsureVisibleHandler(new EnsureVisibleHandler()
       {
@@ -252,7 +264,12 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
             owner_.addLeftWidget(goToWorkingDirButton_);
             owner_.setContextButton(consoleInterrupt_,
                                     consoleInterrupt_.getWidth(),
-                                    consoleInterrupt_.getHeight());
+                                    consoleInterrupt_.getHeight(),
+                                    0);
+            owner_.setContextButton(consoleInterruptProfiler_,
+                  consoleInterruptProfiler_.getWidth(),
+                  consoleInterruptProfiler_.getHeight(),
+                  1);
             consolePane_.onBeforeSelected();
             consolePane_.onSelected();
             consolePane_.setVisible(true);
@@ -261,7 +278,8 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
          {
             consolePane_.onBeforeUnselected();
             owner_.setFillWidget(this);
-            owner_.setContextButton(null, 0, 0);
+            owner_.setContextButton(null, 0, 0, 0);
+            owner_.setContextButton(null, 0, 0, 1);
          }
       }
    }
@@ -279,7 +297,8 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
    private boolean deployContentTabVisible_;
    private final MarkersOutputTab markersTab_;
    private boolean markersTabVisible_;
-   private final ConsoleInterruptButton consoleInterrupt_;
+   private ConsoleInterruptButton consoleInterrupt_;
+   private ConsoleInterruptProfilerButton consoleInterruptProfiler_;
    private final ToolbarButton goToWorkingDirButton_;
    private boolean findResultsTabVisible_;
    private boolean consoleOnly_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -61,7 +61,6 @@ import org.rstudio.studio.client.workbench.model.helper.IntStateValue;
 import org.rstudio.studio.client.workbench.model.helper.JSObjectStateValue;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.prefs.views.PaneLayoutPreferencesPane;
-import org.rstudio.studio.client.workbench.views.console.ConsoleInterruptButton;
 import org.rstudio.studio.client.workbench.views.console.ConsolePane;
 import org.rstudio.studio.client.workbench.views.output.find.FindOutputTab;
 import org.rstudio.studio.client.workbench.views.output.markers.MarkersOutputTab;
@@ -204,7 +203,6 @@ public class PaneManager
                       Commands commands,
                       UIPrefs uiPrefs,
                       @Named("Console") final Widget consolePane,
-                      ConsoleInterruptButton consoleInterrupt,
                       SourceShim source,
                       @Named("History") final WorkbenchTab historyTab,
                       @Named("Files") final WorkbenchTab filesTab,
@@ -229,7 +227,6 @@ public class PaneManager
       commands_ = commands;
       uiPrefs_ = uiPrefs;
       consolePane_ = (ConsolePane)consolePane;
-      consoleInterrupt_ = consoleInterrupt;
       source_ = source;
       historyTab_ = historyTab;
       filesTab_ = filesTab;
@@ -881,7 +878,6 @@ public class PaneManager
                                                             deployContentTab_,
                                                             markersTab_,
                                                             eventBus_,
-                                                            consoleInterrupt_,
                                                             goToWorkingDirButton);
       
       return logicalWindow;
@@ -1101,7 +1097,6 @@ public class PaneManager
    private final WorkbenchTab compilePdfTab_;
    private final WorkbenchTab sourceCppTab_;
    private final ConsolePane consolePane_;
-   private final ConsoleInterruptButton consoleInterrupt_;
    private final SourceShim source_;
    private final WorkbenchTab historyTab_;
    private final WorkbenchTab filesTab_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/Console.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/Console.java
@@ -47,6 +47,7 @@ public class Console
       IsWidget getConsoleInterruptButton();
       IsWidget getProfilerInterruptButton();
       void setDebugMode(boolean debugMode);
+      void setProfilerMode(boolean profilerMode);
    }
    
    @Inject
@@ -85,6 +86,7 @@ public class Console
          @Override
          public void onRprofEvent(RprofEvent event)
          {
+            view.setProfilerMode(event.getStarted());
             if (event.getStarted())
             {
                profilerFadeInHelper_.beginShow();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/Console.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/Console.java
@@ -33,6 +33,7 @@ import org.rstudio.studio.client.workbench.views.console.events.ConsolePromptHan
 import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
 import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleHandler;
 import org.rstudio.studio.client.workbench.views.environment.events.DebugModeChangedEvent;
+import org.rstudio.studio.client.workbench.views.source.editors.profiler.RprofEvent;
 
 public class Console
 {
@@ -44,6 +45,7 @@ public class Console
       void focus();
       void ensureCursorVisible();
       IsWidget getConsoleInterruptButton();
+      IsWidget getProfilerInterruptButton();
       void setDebugMode(boolean debugMode);
    }
    
@@ -64,7 +66,7 @@ public class Console
 
       ((Binder) GWT.create(Binder.class)).bind(commands, this);
 
-      fadeInHelper_ = new DelayFadeInHelper(
+      interruptFadeInHelper_ = new DelayFadeInHelper(
             view_.getConsoleInterruptButton().asWidget());
       events.addHandler(BusyEvent.TYPE, new BusyHandler()
       {
@@ -72,7 +74,25 @@ public class Console
          public void onBusy(BusyEvent event)
          {
             if (event.isBusy())
-               fadeInHelper_.beginShow();
+               interruptFadeInHelper_.beginShow();
+         }
+      });
+      
+      profilerFadeInHelper_ = new DelayFadeInHelper(
+            view_.getProfilerInterruptButton().asWidget());
+      events.addHandler(RprofEvent.TYPE, new RprofEvent.Handler()
+      {
+         @Override
+         public void onRprofEvent(RprofEvent event)
+         {
+            if (event.getStarted())
+            {
+               profilerFadeInHelper_.beginShow();
+            }
+            else
+            {
+               profilerFadeInHelper_.hide();
+            }
          }
       });
 
@@ -81,7 +101,7 @@ public class Console
          @Override
          public void onConsolePrompt(ConsolePromptEvent event)
          {
-            fadeInHelper_.hide();
+            interruptFadeInHelper_.hide();
          }
       });
       
@@ -134,7 +154,8 @@ public class Console
       return view_ ;
    }
 
-   private final DelayFadeInHelper fadeInHelper_;
+   private final DelayFadeInHelper interruptFadeInHelper_;
+   private final DelayFadeInHelper profilerFadeInHelper_;
    private final EventBus events_;
    private final Display view_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleInterruptProfilerButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleInterruptProfilerButton.java
@@ -18,6 +18,7 @@ package org.rstudio.studio.client.workbench.views.console;
 import org.rstudio.core.client.layout.DelayFadeInHelper;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.common.filetypes.FileIconResources;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.source.editors.profiler.RprofEvent;
 
@@ -31,7 +32,7 @@ public class ConsoleInterruptProfilerButton extends Composite
 {
    @Inject
    public ConsoleInterruptProfilerButton(final EventBus events,
-                                  Commands commands)
+                                         Commands commands)
    {
       fadeInHelper_ = new DelayFadeInHelper(this);
 
@@ -40,8 +41,7 @@ public class ConsoleInterruptProfilerButton extends Composite
       SimplePanel panel = new SimplePanel();
       panel.getElement().getStyle().setPosition(Position.RELATIVE);
 
-      commands_ = commands;
-      ImageResource icon = commands_.stopProfiler().getImageResource();
+      ImageResource icon = FileIconResources.INSTANCE.iconProfiler();;
       ToolbarButton button = new ToolbarButton(icon,
                                                commands.stopProfiler());
       width_ = icon.getWidth() + 6;
@@ -81,5 +81,4 @@ public class ConsoleInterruptProfilerButton extends Composite
    private final DelayFadeInHelper fadeInHelper_;
    private final int width_;
    private final int height_;
-   private final Commands commands_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleInterruptProfilerButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleInterruptProfilerButton.java
@@ -1,0 +1,85 @@
+/*
+ * ConsoleInterruptProfilerButton.java
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.console;
+
+import org.rstudio.core.client.layout.DelayFadeInHelper;
+import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.workbench.views.source.editors.profiler.RprofEvent;
+
+import com.google.gwt.dom.client.Style.Position;
+import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.SimplePanel;
+import com.google.inject.Inject;
+
+public class ConsoleInterruptProfilerButton extends Composite
+{
+   @Inject
+   public ConsoleInterruptProfilerButton(final EventBus events,
+                                  Commands commands)
+   {
+      fadeInHelper_ = new DelayFadeInHelper(this);
+
+      // The SimplePanel wrapper is necessary for the toolbar button's "pushed"
+      // effect to work.
+      SimplePanel panel = new SimplePanel();
+      panel.getElement().getStyle().setPosition(Position.RELATIVE);
+
+      commands_ = commands;
+      ImageResource icon = commands_.stopProfiler().getImageResource();
+      ToolbarButton button = new ToolbarButton(icon,
+                                               commands.stopProfiler());
+      width_ = icon.getWidth() + 6;
+      height_ = icon.getHeight();
+      panel.setWidget(button);
+
+      initWidget(panel);
+      setVisible(false);
+      
+      events.addHandler(RprofEvent.TYPE, new RprofEvent.Handler()
+      {
+         @Override
+         public void onRprofEvent(RprofEvent event)
+         {
+            if (event.getStarted())
+            {
+               fadeInHelper_.beginShow();
+            }
+            else
+            {
+               fadeInHelper_.hide();
+            }
+         }
+      });
+   }
+
+   public int getWidth()
+   {
+      return width_;
+   }
+
+   public int getHeight()
+   {
+      return height_;
+   }
+
+   private final DelayFadeInHelper fadeInHelper_;
+   private final int width_;
+   private final int height_;
+   private final Commands commands_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
@@ -14,8 +14,6 @@
  */
 package org.rstudio.studio.client.workbench.views.console;
 
-import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
@@ -152,30 +150,7 @@ public class ConsolePane extends WorkbenchPane
       }
 
       debugMode_ = debugMode;
-      setSecondaryToolbarVisible(debugMode_ || profilerMode_);
-      
-      secondaryToolbar_.removeAllWidgets();
-      if (debugMode)
-      {
-         loadDebugToolsIntoSecondaryToolbar();
-         if (profilerMode_)
-         {
-            loadProfilerToolsIntoSecondaryToolbar();
-         }
-
-         Scheduler.get().scheduleDeferred(new ScheduledCommand() {
-            @Override
-            public void execute()
-            {
-               if (shell_ != null)
-                  shell_.getDisplay().ensureInputVisible();
-            }
-         });
-      }
-      else if (profilerMode_)
-      {
-         loadProfilerToolsIntoSecondaryToolbar();
-      }
+      loadDebugToolsIntoSecondaryToolbar();
    }
 
    @Override
@@ -187,42 +162,34 @@ public class ConsolePane extends WorkbenchPane
       }
 
       profilerMode_ = profilerMode;
-      setSecondaryToolbarVisible(debugMode_ || profilerMode_);
-
-      secondaryToolbar_.removeAllWidgets();
-      if (profilerMode_)
-      {
-         if (debugMode_)
-         {
-            loadDebugToolsIntoSecondaryToolbar();
-         }
-         loadProfilerToolsIntoSecondaryToolbar();
-      }
-      else if (debugMode_)
-      {
-         loadDebugToolsIntoSecondaryToolbar();
-      }
+      loadDebugToolsIntoSecondaryToolbar();
    }
    
    private void loadDebugToolsIntoSecondaryToolbar()
-   {
-      secondaryToolbar_.addLeftWidget(commands_.debugStep().createToolbarButton()); 
-      if (session_.getSessionInfo().getHaveAdvancedStepCommands())
+   {      
+      setSecondaryToolbarVisible(debugMode_ || profilerMode_);
+      secondaryToolbar_.removeAllWidgets();
+      
+      if (debugMode_)
       {
+         secondaryToolbar_.addLeftWidget(commands_.debugStep().createToolbarButton()); 
+         if (session_.getSessionInfo().getHaveAdvancedStepCommands())
+         {
+            secondaryToolbar_.addLeftSeparator();
+            secondaryToolbar_.addLeftWidget(commands_.debugStepInto().createToolbarButton());
+            secondaryToolbar_.addLeftSeparator();
+            secondaryToolbar_.addLeftWidget(commands_.debugFinish().createToolbarButton());
+         }
          secondaryToolbar_.addLeftSeparator();
-         secondaryToolbar_.addLeftWidget(commands_.debugStepInto().createToolbarButton());
+         secondaryToolbar_.addLeftWidget(commands_.debugContinue().createToolbarButton());
          secondaryToolbar_.addLeftSeparator();
-         secondaryToolbar_.addLeftWidget(commands_.debugFinish().createToolbarButton());
+         secondaryToolbar_.addLeftWidget(commands_.debugStop().createToolbarButton());
       }
-      secondaryToolbar_.addLeftSeparator();
-      secondaryToolbar_.addLeftWidget(commands_.debugContinue().createToolbarButton());
-      secondaryToolbar_.addLeftSeparator();
-      secondaryToolbar_.addLeftWidget(commands_.debugStop().createToolbarButton());
-   }
-   
-   private void loadProfilerToolsIntoSecondaryToolbar()
-   {
-      secondaryToolbar_.addLeftWidget(commands_.stopProfiler().createToolbarButton()); 
+      
+      if (profilerMode_)
+      {
+         secondaryToolbar_.addLeftWidget(commands_.stopProfiler().createToolbarButton()); 
+      }
    }
    
    private Provider<Shell> consoleProvider_ ;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
@@ -77,6 +77,12 @@ public class ConsolePane extends WorkbenchPane
    {
       return consoleInterruptButton_;
    }
+   
+   @Override
+   public IsWidget getProfilerInterruptButton()
+   {
+      return profilerInterruptButton_;
+   }
 
    public int getCharacterWidth()
    {
@@ -93,6 +99,10 @@ public class ConsolePane extends WorkbenchPane
       toolbar.addLeftWidget(commands_.goToWorkingDir().createToolbarButton());
       consoleInterruptButton_ = commands_.interruptR().createToolbarButton();
       toolbar.addRightWidget(consoleInterruptButton_);
+      
+      profilerInterruptButton_ = commands_.interruptR().createToolbarButton();
+      toolbar.addRightWidget(profilerInterruptButton_);
+      
       return toolbar;
    }
    
@@ -169,5 +179,6 @@ public class ConsolePane extends WorkbenchPane
    private Session session_;
    private Label workingDir_;
    private ToolbarButton consoleInterruptButton_;
+   private ToolbarButton profilerInterruptButton_;
    private boolean debugMode_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
@@ -109,20 +109,9 @@ public class ConsolePane extends WorkbenchPane
    @Override
    protected SecondaryToolbar createSecondaryToolbar()
    {
-      SecondaryToolbar toolbar = new SecondaryToolbar(true);
-      toolbar.addLeftWidget(commands_.debugStep().createToolbarButton()); 
-      if (session_.getSessionInfo().getHaveAdvancedStepCommands())
-      {
-         toolbar.addLeftSeparator();
-         toolbar.addLeftWidget(commands_.debugStepInto().createToolbarButton());
-         toolbar.addLeftSeparator();
-         toolbar.addLeftWidget(commands_.debugFinish().createToolbarButton());
-      }
-      toolbar.addLeftSeparator();
-      toolbar.addLeftWidget(commands_.debugContinue().createToolbarButton());
-      toolbar.addLeftSeparator();
-      toolbar.addLeftWidget(commands_.debugStop().createToolbarButton());    
-      return toolbar;
+      secondaryToolbar_ = new SecondaryToolbar(true);
+       
+      return secondaryToolbar_;
    }
 
    @Override
@@ -157,11 +146,23 @@ public class ConsolePane extends WorkbenchPane
    @Override
    public void setDebugMode(boolean debugMode)
    {
-      debugMode_ = debugMode;
-      setSecondaryToolbarVisible(debugMode_);
-      
-      if (debugMode_)
+      if (debugMode == debugMode_)
       {
+         return;
+      }
+
+      debugMode_ = debugMode;
+      setSecondaryToolbarVisible(debugMode_ || profilerMode_);
+      
+      secondaryToolbar_.removeAllWidgets();
+      if (debugMode)
+      {
+         loadDebugToolsIntoSecondaryToolbar();
+         if (profilerMode_)
+         {
+            loadProfilerToolsIntoSecondaryToolbar();
+         }
+
          Scheduler.get().scheduleDeferred(new ScheduledCommand() {
             @Override
             public void execute()
@@ -171,6 +172,57 @@ public class ConsolePane extends WorkbenchPane
             }
          });
       }
+      else if (profilerMode_)
+      {
+         loadProfilerToolsIntoSecondaryToolbar();
+      }
+   }
+
+   @Override
+   public void setProfilerMode(boolean profilerMode)
+   {
+      if (profilerMode == profilerMode_)
+      {
+         return;
+      }
+
+      profilerMode_ = profilerMode;
+      setSecondaryToolbarVisible(debugMode_ || profilerMode_);
+
+      secondaryToolbar_.removeAllWidgets();
+      if (profilerMode_)
+      {
+         if (debugMode_)
+         {
+            loadDebugToolsIntoSecondaryToolbar();
+         }
+         loadProfilerToolsIntoSecondaryToolbar();
+      }
+      else if (debugMode_)
+      {
+         loadDebugToolsIntoSecondaryToolbar();
+      }
+   }
+   
+   private void loadDebugToolsIntoSecondaryToolbar()
+   {
+      secondaryToolbar_.addLeftWidget(commands_.debugStep().createToolbarButton()); 
+      if (session_.getSessionInfo().getHaveAdvancedStepCommands())
+      {
+         secondaryToolbar_.addLeftSeparator();
+         secondaryToolbar_.addLeftWidget(commands_.debugStepInto().createToolbarButton());
+         secondaryToolbar_.addLeftSeparator();
+         secondaryToolbar_.addLeftWidget(commands_.debugFinish().createToolbarButton());
+      }
+      secondaryToolbar_.addLeftSeparator();
+      secondaryToolbar_.addLeftWidget(commands_.debugContinue().createToolbarButton());
+      secondaryToolbar_.addLeftSeparator();
+      secondaryToolbar_.addLeftWidget(commands_.debugStop().createToolbarButton());
+   }
+   
+   private void loadProfilerToolsIntoSecondaryToolbar()
+   {
+      secondaryToolbar_.addLeftWidget(commands_.stopProfiler().createToolbarButton()); 
    }
    
    private Provider<Shell> consoleProvider_ ;
@@ -181,4 +233,6 @@ public class ConsolePane extends WorkbenchPane
    private ToolbarButton consoleInterruptButton_;
    private ToolbarButton profilerInterruptButton_;
    private boolean debugMode_;
+   private boolean profilerMode_;
+   private SecondaryToolbar secondaryToolbar_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/events/ConsoleExecutePendingInputEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/events/ConsoleExecutePendingInputEvent.java
@@ -18,20 +18,26 @@ import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 
 public class ConsoleExecutePendingInputEvent extends GwtEvent<ConsoleExecutePendingInputEvent.Handler>
-{
+{  
    public interface Handler extends EventHandler
    {
       void onExecutePendingInput(ConsoleExecutePendingInputEvent event);
    }
-
-   public ConsoleExecutePendingInputEvent()
+   
+   public ConsoleExecutePendingInputEvent(String commandId)
    {
+      commandId_ = commandId;
    }
 
    @Override
    public Type<Handler> getAssociatedType()
    {
       return TYPE;
+   }
+   
+   public String getCommandId()
+   {
+      return commandId_;
    }
 
    @Override
@@ -41,4 +47,5 @@ public class ConsoleExecutePendingInputEvent extends GwtEvent<ConsoleExecutePend
    }
 
    public static final Type<Handler> TYPE = new Type<Handler>();
+   private String commandId_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -399,7 +399,7 @@ public class Shell implements ConsoleInputHandler,
       // call a method on the SourceShim
       else
       {
-         commands_.executeCodeWithoutFocus().execute();
+         commands_.getCommandById(event.getCommandId()).execute();
       }
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -344,6 +344,8 @@ public class Source implements InsertSourceHandler,
       dynamicCommands_.add(commands.knitWithParameters());
       dynamicCommands_.add(commands.goToNextSection());
       dynamicCommands_.add(commands.goToPrevSection());
+      dynamicCommands_.add(commands.profileCode());
+      dynamicCommands_.add(commands.profileCodeWithoutFocus());
       for (AppCommand command : dynamicCommands_)
       {
          command.setVisible(false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -68,8 +68,10 @@ import org.rstudio.studio.client.workbench.views.source.model.SourceNavigation;
 import org.rstudio.studio.client.workbench.views.source.model.SourcePosition;
 import org.rstudio.studio.client.workbench.views.source.model.SourceServerOperations;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 
 public class ProfilerEditingTarget implements EditingTarget
 {
@@ -430,6 +432,14 @@ public class ProfilerEditingTarget implements EditingTarget
    {
       return getContents().getPath();
    }
+   
+   public void onMessage(String data, String origin)
+   {
+      if (view_.getUrl().startsWith(origin))
+      {
+         
+      }
+   }
 
    @Handler
    void onSaveSourceDocAs()
@@ -559,6 +569,26 @@ public class ProfilerEditingTarget implements EditingTarget
       };
    }
    
+   private static void onGLobalMessage(String data, String origin)
+   {  
+      if ("gotosource".equals(data))
+      {
+         for (ProfilerEditingTarget profilerEditingTarget : allProfilerEditingTargets_)
+         {
+            profilerEditingTarget.onMessage(data, origin);
+         }
+      }
+   }
+
+   private native static void initializeEvents() /*-{  
+      var handler = $entry(function(e) {
+         if (typeof e.data != 'string')
+            return;
+         @org.rstudio.studio.client.workbench.views.source.editors.profiler.ProfileEditingTarget::onGLobalMessage(Ljava/lang/String;Ljava/lang/String;)(e.data, e.origin);
+      });
+      $wnd.addEventListener("message", handler, true);
+   }-*/;
+   
    private SourceDocument doc_;
    private ProfilerEditingTargetWidget view_;
    private final ProfilerPresenter presenter_;
@@ -581,4 +611,7 @@ public class ProfilerEditingTarget implements EditingTarget
    private HandlerRegistration commandHandlerReg_;
    
    private boolean htmlPathInitialized_;
+   
+   private static List<ProfilerEditingTarget> allProfilerEditingTargets_ = 
+         new ArrayList<ProfilerEditingTarget>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -452,7 +452,7 @@ public class ProfilerEditingTarget implements EditingTarget,
    @Handler
    void onSaveSourceDocAs()
    {
-      saveNewFile(getPath(), postSaveProfileCommand());
+      saveNewFile(getPath());
    }
 
    private ProfilerContents getContents()
@@ -486,8 +486,6 @@ public class ProfilerEditingTarget implements EditingTarget,
             {
                globalDisplay_.showErrorMessage("Failed to Open Profile",
                      error.getMessage());
-               
-               continuation.execute(null);
             }
          });
    }
@@ -516,8 +514,7 @@ public class ProfilerEditingTarget implements EditingTarget,
       });
    }
 
-   private void saveNewFile(final String suggestedPath,
-                            final Command executeOnSuccess)
+   private void saveNewFile(final String suggestedPath)
    {
       FileSystemItem fsi;
       if (suggestedPath != null)
@@ -595,7 +592,7 @@ public class ProfilerEditingTarget implements EditingTarget,
       var handler = $entry(function(e) {
          if (typeof e.data != 'object')
             return;
-         if (!e.origin.startsWith(window.location.origin))
+         if (!e.origin.startsWith($wnd.location.origin))
             return;
          if (e.data.source != "profvis")
             return;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -50,7 +50,6 @@ import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.Value;
 import org.rstudio.studio.client.common.filetypes.FileIconResources;
 import org.rstudio.studio.client.common.filetypes.FileType;
-import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.filetypes.ProfilerType;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.server.ServerError;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -588,7 +588,6 @@ public class ProfilerEditingTarget implements EditingTarget,
    }
 
    private static native void initializeEvents() /*-{
-      var this_ = this;  
       var handler = $entry(function(e) {
          if (typeof e.data != 'object')
             return;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
@@ -68,4 +68,9 @@ public class ProfilerEditingTargetWidget extends Composite
    {
       profilePage_.setUrl(path);
    }
+   
+   public String getUrl()
+   {
+      return profilePage_.getUrl();
+   }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/model/ProfilerContents.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/model/ProfilerContents.java
@@ -32,4 +32,8 @@ public class ProfilerContents extends JavaScriptObject
    public final native String getPath() /*-{
       return this.path;
    }-*/;
+   
+   public final native String getHtmlPath() /*-{
+      return this.htmlPath;
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/model/ProfilerServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/model/ProfilerServerOperations.java
@@ -16,6 +16,8 @@ package org.rstudio.studio.client.workbench.views.source.editors.profiler.model;
 
 import org.rstudio.studio.client.server.ServerRequestCallback;
 
+import com.google.gwt.core.client.JavaScriptObject;
+
 
 public interface ProfilerServerOperations
 {
@@ -27,4 +29,8 @@ public interface ProfilerServerOperations
 
    void openProfile(ProfileOperationRequest profilerRequest,
                     ServerRequestCallback<ProfileOperationResponse> requestCallback);
+   
+   void copyProfile(String fromPath,
+                    String toPath,
+                    ServerRequestCallback<JavaScriptObject> requestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3703,6 +3703,12 @@ public class TextEditingTarget implements
    {
       codeExecution_.executeSelection(false);
    }
+
+   @Handler
+   void onProfileCodeWithoutFocus()
+   {
+      codeExecution_.executeSelection(false, false, "profvis::profvis");
+   }
    
    @Handler
    void onExecuteCodeWithoutMovingCursor()
@@ -4237,6 +4243,11 @@ public class TextEditingTarget implements
       sourceActiveDocument(true);
    }
    
+   @Handler
+   void onProfileCode()
+   {
+      codeExecution_.executeSelection(true, true, "profvis::profvis");
+   }
   
    private void sourceActiveDocument(final boolean echo)
    {


### PR DESCRIPTION
This pr completes most of the profiler features, the only remaining work item is to integrate with shiny apps.

- [x] **Jump to source from profile results**: Open code entry at an specific line number from the profvis results, require change in profvis.
- [x] **Load/save support**: Adds ability to open rprof file from menu and to save a profile, once the file is saved, the tab name will reflect the new name, otherwise, profile# will be assigned.
- [x] **Console profiling toolbar and indicator**: In order to make users aware that a profile is running, the profile icon will be shown in the console by the interrupt icon. Additionally, a toolbar (similar to the debug toolbar) will be presented with the option to “stop profiling” and a stop icon.
- [x] **Profile this code command**: A new menu entry will be added to the “code” menu to “Profile Selected Line(s)”. This will trigger the selected code under profvis() in the console.
- [x] **Rprof file association with RStudio**: We will associate rprof files with RStudio and open a profiler tab on launch with the results.
- [x] **Profvis integration**: Triggering profvis from console shows results in the profiler pane.

- [x] **Shiny integration**: Enable starting/stopping a profile while shiny is running.

Some screenshots follow for visual changes:

<img width="1440" alt="screen shot 2016-02-26 at 7 37 24 am" src="https://cloud.githubusercontent.com/assets/3478847/13356753/d60a37d2-dc5b-11e5-9330-8c4ce7fbb5b7.png">

<img width="1440" alt="screen shot 2016-02-26 at 7 31 37 am" src="https://cloud.githubusercontent.com/assets/3478847/13356611/10688ff6-dc5b-11e5-8c9e-fa60e427fc4e.png">

<img width="1440" alt="screen shot 2016-02-26 at 9 10 15 am" src="https://cloud.githubusercontent.com/assets/3478847/13359372/c569818c-dc68-11e5-834f-8e4daf461866.png">

