### PR TITLE
clean up handlers generated by completion manager on save

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/DocumentIdleBackgroundTask.java
+++ b/src/gwt/src/org/rstudio/core/client/DocumentIdleBackgroundTask.java
@@ -63,8 +63,15 @@ public class DocumentIdleBackgroundTask
    
    public void start()
    {
+      // If we try to 'stop()' then 'start()' the background task in quick
+      // succession, we should unset the 'stopRequested_' field to ensure that
+      // the 'stop()' request is cancelled, and let the originally scheduled
+      // task continue running.
       if (isRunning_)
+      {
+         stopRequested_ = false;
          return;
+      }
       
       if (!task_.onStart())
          return;
@@ -156,7 +163,7 @@ public class DocumentIdleBackgroundTask
    
    public void detach()
    {
-      stopExecution();
+      stop();
       handlers_.removeHandler();
    }
    

--- a/src/gwt/src/org/rstudio/core/client/DocumentIdleBackgroundTask.java
+++ b/src/gwt/src/org/rstudio/core/client/DocumentIdleBackgroundTask.java
@@ -56,24 +56,9 @@ public class DocumentIdleBackgroundTask
       pollDelayMs_ = pollDelayMs;
       idleThresholdMs_ = idleThresholdMs;
       task_ = task;
+      handlers_ = new HandlerRegistrations();
       
-      docDisplay_.addFocusHandler(new FocusHandler()
-      {
-         @Override
-         public void onFocus(FocusEvent event)
-         {
-            start();
-         }
-      });
-      
-      docDisplay_.addBlurHandler(new BlurHandler()
-      {
-         @Override
-         public void onBlur(BlurEvent event)
-         {
-            stop();
-         }
-      });
+      attach();
    }
    
    public void start()
@@ -148,6 +133,33 @@ public class DocumentIdleBackgroundTask
       stopRequested_ = true;
    }
    
+   private void attach()
+   {
+      handlers_.add(docDisplay_.addFocusHandler(new FocusHandler()
+      {
+         @Override
+         public void onFocus(FocusEvent event)
+         {
+            start();
+         }
+      }));
+      
+      handlers_.add(docDisplay_.addBlurHandler(new BlurHandler()
+      {
+         @Override
+         public void onBlur(BlurEvent event)
+         {
+            stop();
+         }
+      }));
+   }
+   
+   public void detach()
+   {
+      stopExecution();
+      handlers_.removeHandler();
+   }
+   
    private boolean stopExecution()
    {
       task_.onStop();
@@ -168,6 +180,7 @@ public class DocumentIdleBackgroundTask
    private final long pollDelayMs_;
    private final long idleThresholdMs_;
    private final BackgroundTask task_;
+   private final HandlerRegistrations handlers_;
    
    private long lastMouseMoveTime_;
    private ScreenCoordinates lastMouseCoords_;

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -97,7 +97,6 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditing
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetRMarkdownHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionManager;
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionRequest;
-import org.rstudio.studio.client.workbench.views.source.editors.text.r.RCompletionToolTip;
 import org.rstudio.studio.client.workbench.views.source.model.CppCompletion;
 import org.rstudio.studio.client.workbench.views.source.editors.text.r.SignatureToolTipManager;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkIconsManager;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/snippets/SnippetHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/snippets/SnippetHelper.java
@@ -22,6 +22,7 @@ import com.google.gwt.core.client.JsArrayString;
 import com.google.inject.Inject;
 
 import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.regex.Pattern;
@@ -58,10 +59,11 @@ public class SnippetHelper
       native_ = editor.getWidget().getEditor();
       manager_ = getSnippetManager();
       path_ = path;
+      handlers_ = new HandlerRegistrations();
       
       RStudioGinjector.INSTANCE.injectMembers(this);
       
-      editor_.getWidget().addEditorLoadedHandler(new EditorLoadedHandler()
+      handlers_.add(editor_.getWidget().addEditorLoadedHandler(new EditorLoadedHandler()
       {
          @Override
          public void onEditorLoaded(EditorLoadedEvent event)
@@ -69,7 +71,12 @@ public class SnippetHelper
             if (editor_.getFileType() != null)
                ensureSnippetsLoaded();
          }
-      });
+      }));
+   }
+   
+   public void detach()
+   {
+      handlers_.removeHandler();
    }
    
    @Inject
@@ -432,6 +439,7 @@ public class SnippetHelper
    private final AceEditorNative native_;
    private final SnippetManager manager_;
    private final String path_;
+   private final HandlerRegistrations handlers_;
    
    private static boolean customCppSnippetsLoaded_;
    private static boolean customRSnippetsLoaded_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManager.java
@@ -35,5 +35,7 @@ public interface CompletionManager extends KeyDownPreviewHandler,
    void close();
    
    void onPaste(PasteEvent event);
+   
+   void detach();
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/NullCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/NullCompletionManager.java
@@ -49,5 +49,9 @@ public class NullCompletionManager implements CompletionManager
    {
       return false;
    }
+   
+   public void detach()
+   {
+   }
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -263,6 +263,7 @@ public class RCompletionManager implements CompletionManager
       handlers_.removeHandler();
       sigTipManager_.detach();
       snippets_.detach();
+      popup_.hide();
    }
 
    public void close()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.java
@@ -177,6 +177,11 @@ public class CodeBrowserEditingTargetWidget extends ResizeComposite
          {
          }
          
+         @Override
+         public void detach()
+         {
+         }
+         
       }); 
       
       initWidget(panel_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -416,6 +416,11 @@ public class AceEditor implements DocDisplay,
                for (HandlerRegistration handler : editorEventListeners_)
                   handler.removeHandler();
                editorEventListeners_.clear();
+               if (completionManager_ != null)
+               {
+                  completionManager_.detach();
+                  completionManager_ = null;
+               }
             }
          }
       });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -44,7 +44,6 @@ import com.google.inject.Inject;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.ExternalJavaScriptLoader;
-import org.rstudio.core.client.MathUtil;
 import org.rstudio.core.client.ExternalJavaScriptLoader.Callback;
 import org.rstudio.core.client.Rectangle;
 import org.rstudio.core.client.StringUtil;
@@ -617,6 +616,12 @@ public class AceEditor implements DocDisplay,
       if (fileType_ == null)
          return;
 
+      if (completionManager_ != null)
+      {
+         completionManager_.detach();
+         completionManager_ = null;
+      }
+      
       completionManager_ = completionManager;
 
       updateKeyboardHandlers();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.views.source.editors.text.cpp;
 
 
 import org.rstudio.core.client.CommandWith2Args;
+import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.Invalidation;
 import org.rstudio.core.client.command.KeyboardHelper;
 import org.rstudio.core.client.command.KeyboardShortcut;
@@ -63,14 +64,15 @@ public class CppCompletionManager implements CompletionManager
       completionContext_ = completionContext;
       rCompletionManager_ = rCompletionManager;
       snippets_ = new SnippetHelper((AceEditor) docDisplay_, completionContext.getDocPath());
+      handlers_ = new HandlerRegistrations();
       
-      docDisplay_.addClickHandler(new ClickHandler()
+      handlers_.add(docDisplay_.addClickHandler(new ClickHandler()
       {
          public void onClick(ClickEvent event)
          {
             terminateCompletionRequest();
          }
-      });
+      }));
    }
  
    @Inject
@@ -100,6 +102,12 @@ public class CppCompletionManager implements CompletionManager
       }
    }
    
+   @Override
+   public void detach()
+   {
+      handlers_.removeHandler();
+      snippets_.detach();
+   }
    
    // perform completion at the current cursor location
    @Override
@@ -503,6 +511,7 @@ public class CppCompletionManager implements CompletionManager
    private final Invalidation completionRequestInvalidation_ = new Invalidation();
    private final SnippetHelper snippets_;
    
+   private final HandlerRegistrations handlers_;
   
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/SignatureToolTipManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/SignatureToolTipManager.java
@@ -65,6 +65,11 @@ public class SignatureToolTipManager
       server_ = server;
    }
    
+   public void detach()
+   {
+      idleTask_.detach();
+   }
+   
    public RCompletionToolTip getToolTip()
    {
       return toolTip_;


### PR DESCRIPTION
This PR fixes an issue where handlers generated by a completion manager would get leaked (and so remain active) after document save, or a language change. This fixes an issue where duplicated tooltip popups could be displayed in a document, but should also improve performance in long-running sessions.

The general scope of this PR is just ensuring that we collect any generated handlers in a `HandlerRegistrations` object, and we ensure that we detach those handlers whenever we change the completion manager.