### PR TITLE
reset toolbar visibity proactevely to avoid empty toolbar

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
@@ -144,11 +144,6 @@ public class ConsolePane extends WorkbenchPane
    @Override
    public void setDebugMode(boolean debugMode)
    {
-      if (debugMode == debugMode_)
-      {
-         return;
-      }
-
       debugMode_ = debugMode;
       loadDebugToolsIntoSecondaryToolbar();
    }
@@ -156,11 +151,6 @@ public class ConsolePane extends WorkbenchPane
    @Override
    public void setProfilerMode(boolean profilerMode)
    {
-      if (profilerMode == profilerMode_)
-      {
-         return;
-      }
-
       profilerMode_ = profilerMode;
       loadDebugToolsIntoSecondaryToolbar();
    }


### PR DESCRIPTION
Minor fix to proactively set the visibility of the console toolbar. This was the behavior before the profiler change and is required since there are corner-cases where the toolbar will star open by default and we need to proactively close this if we are not debugging nor profiling; otherwise, the toolbar renders with no elements in it.