### PR TITLE
remove profiler buttons from toolbar

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
@@ -53,9 +53,6 @@ public class ProfilerEditingTargetWidget extends Composite
    private Toolbar createToolbar(Commands commands)
    {
       Toolbar toolbar = new EditingTargetToolbar(commands);
-      toolbar.addLeftSeparator();
-      toolbar.addLeftWidget(commands.startProfiler().createToolbarButton());
-      toolbar.addLeftWidget(commands.stopProfiler().createToolbarButton());
       return toolbar;
    }
    


### PR DESCRIPTION
Feedback from @jmcphers on usability of profile buttons point out to me that having start/stop commands it's confusing since starting a new profile doesn't change the state of the current profile pane, and stopping the profile opens a separate window. The buttons in this toolbar would make sense if we could resume the current profile, but since this is currently not supported, it makes more sense to me to have them removed:

<img width="1440" alt="screen shot 2016-02-26 at 2 52 06 pm" src="https://cloud.githubusercontent.com/assets/3478847/13367659/ff9b93a6-dc98-11e5-90d6-c54682d7ca90.png">
