### PR TITLE
run 'testthat::test_file()' on source

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -659,7 +659,9 @@ void handleClientInit(const boost::function<void()>& initFunction,
 
    sessionInfo["packrat_available"] =
                      module_context::isRequiredPackratInstalled();
-
+   
+   sessionInfo["testthat_available"] =
+         module_context::isPackageVersionInstalled("testthat", "0.11.0");
 
    sessionInfo["knit_params_available"] =
          modules::rmarkdown::knitParamsAvailable();

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -278,17 +278,22 @@ SEXP rs_sourceDiagnostics()
    return R_NilValue;
 }
 
-SEXP rs_packageLoaded(SEXP pkgnameSEXP)
+SEXP rs_packageLoaded(SEXP pkgnameSEXP, SEXP pkgversionSEXP)
 {
-   std::string pkgname = r::sexp::safeAsString(pkgnameSEXP);
-
+   std::string pkgname    = r::sexp::safeAsString(pkgnameSEXP);
+   std::string pkgversion = r::sexp::safeAsString(pkgversionSEXP);
+   
    // fire server event
    events().onPackageLoaded(pkgname);
 
    // fire client event
+   json::Object jsonData;
+   jsonData["package_name"] = pkgname;
+   jsonData["package_version"] = pkgversion;
+
    ClientEvent packageLoadedEvent(
             client_events::kPackageLoaded,
-            json::Value(pkgname));
+            jsonData);
    enqueClientEvent(packageLoadedEvent);
 
    return R_NilValue;
@@ -2151,7 +2156,7 @@ Error initialize()
    R_CallMethodDef methodDef11;
    methodDef11.name = "rs_packageLoaded" ;
    methodDef11.fun = (DL_FUNC) rs_packageLoaded;
-   methodDef11.numArgs = 1;
+   methodDef11.numArgs = 2;
    r::routines::addCallMethod(methodDef11);
 
    // register rs_packageUnloaded

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -54,7 +54,8 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    
    notifyPackageLoaded <- function(pkgname, ...)
    {
-      .Call(.rs.routines$rs_packageLoaded, pkgname)
+      version <- as.character(utils::packageVersion(pkgname))
+      .Call(.rs.routines$rs_packageLoaded, pkgname, version)
    }
 
    notifyPackageUnloaded <- function(pkgname, ...)

--- a/src/gwt/src/org/rstudio/studio/client/common/debugging/events/PackageLoadedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/debugging/events/PackageLoadedEvent.java
@@ -14,25 +14,40 @@
  */
 package org.rstudio.studio.client.common.debugging.events;
 
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 
 public class PackageLoadedEvent
         extends GwtEvent<PackageLoadedEvent.Handler>
 {
+   public static class Data extends JavaScriptObject
+   {
+      protected Data() {}
+      
+      public final native String getPackageName()    /*-{ return this["package_name"]; }-*/;
+      public final native String getPackageVersion() /*-{ return this["package_version"]; }-*/;
+   }
+   
    public interface Handler extends EventHandler
    {
       void onPackageLoaded(PackageLoadedEvent event);
    }
 
-   public PackageLoadedEvent(String packageName)
+   public PackageLoadedEvent(Data data)
    {
-      packageName_ = packageName;
+      packageName_ = data.getPackageName();
+      packageVersion_ = data.getPackageVersion();
    }
    
    public String getPackageName()
    {
       return packageName_;
+   }
+   
+   public String getPackageVersion()
+   {
+      return packageVersion_;
    }
    
    @Override
@@ -49,5 +64,6 @@ public class PackageLoadedEvent
 
    public static final Type<Handler> TYPE = new Type<Handler>();
    
-   private String packageName_;   
+   private final String packageName_;
+   private final String packageVersion_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/r/RPackageMonitor.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/r/RPackageMonitor.java
@@ -1,0 +1,59 @@
+/*
+ * RPackageMonitor.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.common.r;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.common.debugging.events.PackageLoadedEvent;
+import org.rstudio.studio.client.common.debugging.events.PackageUnloadedEvent;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+@Singleton
+public class RPackageMonitor implements PackageLoadedEvent.Handler, PackageUnloadedEvent.Handler
+{
+   @Inject
+   public RPackageMonitor(EventBus events)
+   {
+      events_ = events;
+      loadedPackages_ = new HashSet<String>();
+      
+      events_.addHandler(PackageLoadedEvent.TYPE, this);
+      events_.addHandler(PackageUnloadedEvent.TYPE, this);
+   }
+   
+   public boolean isPackageLoaded(String pkg)
+   {
+      return loadedPackages_.contains(pkg);
+   }
+   
+   @Override
+   public void onPackageUnloaded(PackageUnloadedEvent event)
+   {
+      loadedPackages_.remove(event.getPackageName());
+   }
+
+   @Override
+   public void onPackageLoaded(PackageLoadedEvent event)
+   {
+      loadedPackages_.add(event.getPackageName());
+   }
+   
+   private final EventBus events_;
+   private final Set<String> loadedPackages_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/common/r/RPackageMonitor.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/r/RPackageMonitor.java
@@ -20,26 +20,38 @@ import java.util.Set;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.debugging.events.PackageLoadedEvent;
 import org.rstudio.studio.client.common.debugging.events.PackageUnloadedEvent;
+import org.rstudio.studio.client.workbench.views.packages.events.PackageStatusChangedEvent;
+import org.rstudio.studio.client.workbench.views.packages.events.PackageStatusChangedHandler;
+import org.rstudio.studio.client.workbench.views.packages.model.PackageStatus;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 @Singleton
-public class RPackageMonitor implements PackageLoadedEvent.Handler, PackageUnloadedEvent.Handler
+public class RPackageMonitor implements PackageLoadedEvent.Handler,
+                                        PackageUnloadedEvent.Handler,
+                                        PackageStatusChangedHandler
 {
    @Inject
    public RPackageMonitor(EventBus events)
    {
       events_ = events;
       loadedPackages_ = new HashSet<String>();
+      attachedPackages_ = new HashSet<String>();
       
       events_.addHandler(PackageLoadedEvent.TYPE, this);
       events_.addHandler(PackageUnloadedEvent.TYPE, this);
+      events_.addHandler(PackageStatusChangedEvent.TYPE, this);
    }
    
    public boolean isPackageLoaded(String pkg)
    {
       return loadedPackages_.contains(pkg);
+   }
+   
+   public boolean isPackageAttached(String pkg)
+   {
+      return attachedPackages_.contains(pkg);
    }
    
    @Override
@@ -54,6 +66,17 @@ public class RPackageMonitor implements PackageLoadedEvent.Handler, PackageUnloa
       loadedPackages_.add(event.getPackageName());
    }
    
+   @Override
+   public void onPackageStatusChanged(PackageStatusChangedEvent event)
+   {
+      PackageStatus status = event.getPackageStatus();
+      if (status.isLoaded())
+         attachedPackages_.add(status.getName());
+      else
+         attachedPackages_.remove(status.getName());
+   }
+   
    private final EventBus events_;
    private final Set<String> loadedPackages_;
+   private final Set<String> attachedPackages_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -537,8 +537,8 @@ public class ClientEventDispatcher
          }
          else if (type.equals(ClientEvent.PackageLoaded))
          {
-            eventBus_.fireEvent(new PackageLoadedEvent(
-                  (String)event.getData()));
+            PackageLoadedEvent.Data data = event.getData();
+            eventBus_.fireEvent(new PackageLoadedEvent(data));
          }
          else if (type.equals(ClientEvent.PackageUnloaded))
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -424,7 +424,7 @@ public class SessionInfo extends JavaScriptObject
    }-*/;
    
    public final native boolean isTestthatAvailable() /*-{
-      return this.testthat_available;
+      return !!this.testthat_available;
    }-*/;
    
    public final native boolean getShowUserHomePage() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -423,6 +423,10 @@ public class SessionInfo extends JavaScriptObject
       return this.packrat_available;
    }-*/;
    
+   public final native boolean isTestthatAvailable() /*-{
+      return this.testthat_available;
+   }-*/;
+   
    public final native boolean getShowUserHomePage() /*-{
       return this.show_user_home_page;
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -4274,7 +4274,8 @@ public class TextEditingTarget implements
       
       // If the document being sourced is a testthat test file
       // and we have testthat available then use that
-      if (isTestthatTestFile())
+      if (isTestthatTestFile() &&
+          session_.getSessionInfo().isTestthatAvailable())
       {
          runTestthatTestFile();
          return;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1574,6 +1574,17 @@ public class TextEditingTarget implements
       }
    }
    
+   private boolean isTestthatTestFile()
+   {
+      String path = getPath();
+      if (path == null || fileType_ == null)
+         return false;
+      
+      return
+            fileType_.isR() &&
+            path.contains("/tests/testthat/test-");
+   }
+   
    private boolean isPackageFile()
    {
       // not a package file if we're not in package development mode
@@ -4261,6 +4272,14 @@ public class TextEditingTarget implements
          return;
       }
       
+      // If the document being sourced is a testthat test file
+      // and we have testthat available then use that
+      if (isTestthatTestFile())
+      {
+         runTestthatTestFile();
+         return;
+      }
+      
       // If the document being sourced is a script then use that codepath
       if (fileType_.isScript())
       {
@@ -4363,6 +4382,23 @@ public class TextEditingTarget implements
                   getExtendedFileType()));
          }
       }, "Run Shiny Application");
+   }
+   
+   private void runTestthatTestFile()
+   {
+      final String command =
+            "testthat::test_file(\"" +
+            getPath() +
+            "\")";
+            
+      saveThenExecute(null, new Command()
+      {
+         @Override
+         public void execute()
+         {
+            events_.fireEvent(new SendToConsoleEvent(command, true));
+         }
+      });
    }
    
    private void runScript()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -4400,6 +4400,12 @@ public class TextEditingTarget implements
          @Override
          public void execute()
          {
+            if (rPackageMonitor_.isPackageAttached("testthat"))
+            {
+               events_.fireEvent(new SendToConsoleEvent(command, true));
+               return;
+            }
+            
             server_.executeRCode("library(testthat)", new ServerRequestCallback<String>()
             {
                @Override


### PR DESCRIPTION
NOTE: not quite ready for merge.

This PR augments the source command to use `testthat::test_file()` when appropriate.

## TODO

- [x] Avoid eager system callback to check `testthat` version (ie, update some client state on startup / package install)
- [ ] Only enable for testthat files in current project?