### PR TITLE
handle profiler status when console has more than one tab

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.console;
 
+import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
@@ -26,6 +27,7 @@ import org.rstudio.core.client.widget.SecondaryToolbar;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.common.filetypes.FileIconResources;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.ui.WorkbenchPane;
@@ -98,7 +100,9 @@ public class ConsolePane extends WorkbenchPane
       consoleInterruptButton_ = commands_.interruptR().createToolbarButton();
       toolbar.addRightWidget(consoleInterruptButton_);
       
-      profilerInterruptButton_ = commands_.interruptR().createToolbarButton();
+      ImageResource profilerIcon = FileIconResources.INSTANCE.iconProfiler();
+      profilerInterruptButton_= new ToolbarButton(profilerIcon, commands_.stopProfiler());
+
       toolbar.addRightWidget(profilerInterruptButton_);
       
       return toolbar;


### PR DESCRIPTION
There are two code paths to show contextual buttons in console: one when there is no primary toolbar, and one when there is. This change fixes the latter, where a primary toolbar does exists (e.g. when more than two console tabs are open); the former code path already works as expected.