### PR TITLE
set initial profiler status to hidden and correct order in toolbar

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
@@ -98,12 +98,13 @@ public class ConsolePane extends WorkbenchPane
       toolbar.addLeftWidget(workingDir_);
       toolbar.addLeftWidget(commands_.goToWorkingDir().createToolbarButton());
       consoleInterruptButton_ = commands_.interruptR().createToolbarButton();
-      toolbar.addRightWidget(consoleInterruptButton_);
       
       ImageResource profilerIcon = FileIconResources.INSTANCE.iconProfiler();
-      profilerInterruptButton_= new ToolbarButton(profilerIcon, commands_.stopProfiler());
+      profilerInterruptButton_ = new ToolbarButton(profilerIcon, commands_.stopProfiler());
+      profilerInterruptButton_.setVisible(false);
 
       toolbar.addRightWidget(profilerInterruptButton_);
+      toolbar.addRightWidget(consoleInterruptButton_);
       
       return toolbar;
    }


### PR DESCRIPTION
The profiler is being shown by default in the primary toolbar. Previous fix should have set the state as hidden by default. Also, swapping profiler/interrupt buttons to maintain consistency. Merging since the fix is very safe.