### PR TITLE
fix parameter arguments for async profile calls in Windows

### DIFF
--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -102,6 +102,11 @@ void AsyncRProcess::start(const char* rCommand,
    if (needsQuote)
       command << "\"";
 
+   std::string escapedCommand = rCommand;
+
+   if (needsQuote)
+      boost::algorithm::replace_all(escapedCommand, "\"", "\\\"");
+    
    if (rSourceFiles.size())
    {
       // add in the r source files requested
@@ -112,11 +117,11 @@ void AsyncRProcess::start(const char* rCommand,
          command << "source('" << it->absolutePath() << "');";
       }
       
-      command << rCommand;
+      command << escapedCommand.c_str();
    }
    else
    {
-      command << rCommand;
+      command << escapedCommand.c_str();
    }
 
    if (needsQuote)

--- a/src/cpp/session/modules/data/SessionData.cpp
+++ b/src/cpp/session/modules/data/SessionData.cpp
@@ -98,11 +98,11 @@ private:
       }
 
       std::string cmd = std::string(".rs.callWithRDS(") +
-        "\".rs.rpc.preview_data_import\", \"" +
-      	inputLocation_ +
-      	"\", \"" + 
-      	outputLocation_ +
-      	"\")";
+        "'.rs.rpc.preview_data_import', '" +
+        inputLocation_ +
+        "', '" +
+        outputLocation_ +
+        "')";
 
       std::vector<core::FilePath> sources;
       sources.push_back(pathFromSource("Tools.R"));
@@ -149,6 +149,12 @@ private:
       {
          json::JsonRpcResponse response;
          continuation_(Success(), &response);
+         return;
+      }
+
+      if (exitStatus != EXIT_SUCCESS)
+      {
+         continuationWithError("Operation finished with error code.");
          return;
       }
 

--- a/src/cpp/session/modules/data/SessionData.cpp
+++ b/src/cpp/session/modules/data/SessionData.cpp
@@ -98,11 +98,11 @@ private:
       }
 
       std::string cmd = std::string(".rs.callWithRDS(") +
-        "'.rs.rpc.preview_data_import', '" +
+        "\".rs.rpc.preview_data_import\", \"" +
         inputLocation_ +
-        "', '" +
+        "\", \"" +
         outputLocation_ +
-        "')";
+        "\")";
 
       std::vector<core::FilePath> sources;
       sources.push_back(pathFromSource("Tools.R"));


### PR DESCRIPTION
Passing parameters through `async_r::AsyncRProcess::start` with `"` removes `"` in Windows, escaping using `'` instead.

Additionally, this change also check for `exitStatus != EXIT_SUCCESS` to avoid throwing exceptions in cases where the r-process fails.

Verified this fix in OS X and Windows, building Ubuntu now.