### PR TITLE
add missing profiler dependencies and options fix

### DIFF
--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -25,6 +25,10 @@
       dir.create(tempPath, recursive = TRUE)
    }
 
+   if (identical(getOption("profvis.prof_output"), NULL)) {
+      options("profvis.prof_output" = tempPath)
+   }
+
    return (list(
       tempPath = tempPath
    ))

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -542,7 +542,9 @@ public class DependencyManager implements InstallShinyEvent.Handler
         "Preparing Profiler",
         userAction, 
         new Dependency[] {
-           Dependency.embeddedPackage("profvis")
+           Dependency.embeddedPackage("profvis"),
+           Dependency.cranPackage("htmlwidgets", "0.6"),
+           Dependency.cranPackage("stringr", "0.6")
         }, 
         false,
         new CommandWithArg<Boolean>()


### PR DESCRIPTION
Two fixes for profivs integration:

1. Add missing dependencies required by `profvis`, one is `stringr` and the other one `htmlwidget`

2. Fix regression preventing profiler pane from opening when `profvis::` triggers. This got introduced while refactoring the `options` that the profiler code assigns to `profvis`