### PR TITLE
tweak pandoc highlighting rules

### DIFF
--- a/src/gwt/acesupport/acemode/markdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/markdown_highlight_rules.js
@@ -219,16 +219,12 @@ var MarkdownHighlightRules = function() {
             token : ["paren.keyword.operator", "text", "paren.keyword.operator"],
             regex : "(\\{)([^\\}]*)(\\})"
         }, {
-            // pandoc citation with brackets
-            token : "markup.list",
-            regex : "\\[-?\\@[\\w\\d-]+\\]"
-        }, {
             // pandoc citation
             token : "markup.list",
             regex : "-?\\@[\\w\\d-]+"
         }, {
             token : "text",
-            regex : "[^\\*_%$`\\[#<>\\\\]+"
+            regex : "[^\\*_%$`\\[#<>\\\\@]+"
         }, {
             token : "text",
             regex : "\\\\"


### PR DESCRIPTION
This PR tweaks Pandoc citation highlight rules for Markdown:

- `[@citation]` is no longer accepted as a special rule, since we already highlight for bare `@citation` and the inconsistency in highlighting is a bit strange;

- The text rule is tweaked to not consume `@` symbols (so that multiple citations on the same line can be highlighted correctly).

Example:

![screen shot 2016-03-04 at 11 45 11 am](https://cloud.githubusercontent.com/assets/1976582/13538299/94c656cc-e1fe-11e5-99de-039e1e47fcba.png)
