### PR TITLE
re-write formula skipper

### DIFF
--- a/src/cpp/session/modules/SessionDiagnosticsTests.cpp
+++ b/src/cpp/session/modules/SessionDiagnosticsTests.cpp
@@ -265,6 +265,7 @@ context("Diagnostics")
       EXPECT_NO_ERRORS("y ~ (1)");
       
       EXPECT_NO_ERRORS("{x()\n{}}");
+      EXPECT_NO_ERRORS("{a <- 1\n~ x + 1}\n");
    }
    
    lintRStudioRFiles();

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -1712,11 +1712,8 @@ bool skipFormulas(RTokenCursor& origin, ParseStatus& status)
    RTokenCursor cursor = origin.clone();
    bool foundTilde = false;
 
-   while (true)
+   while (!cursor.isAtEndOfDocument())
    {
-      if (cursor.isAtEndOfDocument())
-         break;
-
       // Initial unary operators
       while (isValidAsUnaryOperator(cursor))
       {

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -1724,7 +1724,7 @@ bool skipFormulas(RTokenCursor& origin, ParseStatus& status)
             foundTilde = true;
 
          if (!cursor.moveToNextSignificantToken())
-            return false;
+            break;
       }
 
       // Stand-alone bracketed scopes
@@ -1747,7 +1747,7 @@ bool skipFormulas(RTokenCursor& origin, ParseStatus& status)
             return false;
 
          if (!cursor.moveToNextSignificantToken())
-            return false;
+            break;
 
          if (cursor.isAtEndOfStatement(status.isInParentheticalScope()))
             break;
@@ -1762,7 +1762,7 @@ bool skipFormulas(RTokenCursor& origin, ParseStatus& status)
 
       // Step over the operator and start again
       if (!cursor.moveToNextSignificantToken())
-         return false;
+         break;
    }
 
    if (foundTilde)

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -1705,41 +1705,72 @@ void validateFunctionCall(RTokenCursor cursor,
 //
 //    foo$bar$log(1 + y) + log(2 + y) ~ ({1 ~ 2}) ^ 5
 //
+// and so, effectively, this needs to be a mini-parser of R
+// code.
 bool skipFormulas(RTokenCursor& origin, ParseStatus& status)
 {
    RTokenCursor cursor = origin.clone();
-
    bool foundTilde = false;
-   
-   while (cursor.moveToEndOfEvaluation())
+
+   while (true)
    {
+      if (cursor.isAtEndOfDocument())
+         break;
+
+      // Initial unary operators
+      while (isValidAsUnaryOperator(cursor))
+      {
+         if (cursor.contentEquals(L"~"))
+            foundTilde = true;
+
+         if (!cursor.moveToNextSignificantToken())
+            return false;
+      }
+
+      // Stand-alone bracketed scopes
+      if (isLeftBracket(cursor))
+         if (!cursor.fwdToMatchingToken())
+            return false;
+
+      // Check for end of statement
+      if (cursor.isAtEndOfStatement(status.isInParentheticalScope()))
+         break;
+
+      // Expecting a symbol or right bracket
       if (!cursor.moveToNextSignificantToken())
+         break;
+
+      // Function calls
+      while (isLeftBracket(cursor))
+      {
+         if (!cursor.fwdToMatchingToken())
+            return false;
+
+         if (!cursor.moveToNextSignificantToken())
+            return false;
+
+         if (cursor.isAtEndOfStatement(status.isInParentheticalScope()))
+            break;
+      }
+
+      // Binary operator or bust
+      if (!isBinaryOp(cursor))
          break;
 
       if (cursor.contentEquals(L"~"))
          foundTilde = true;
-      
-      while (cursor.fwdToMatchingToken())
-         if (!cursor.moveToNextSignificantToken())
-            break;
-      
-      if (!cursor.moveToNextSignificantToken())
-         break;
-      
-      while (cursor.fwdToMatchingToken())
-         if (!cursor.moveToNextSignificantToken())
-            break;
 
-      if (!isBinaryOp(cursor))
-         break;
-
+      // Step over the operator and start again
       if (!cursor.moveToNextSignificantToken())
-         break;
+         return false;
    }
-   
+
    if (foundTilde)
+   {
+      DEBUG("Skipped formula: " << origin.currentToken() << " --> " << cursor.currentToken());
       origin.setOffset(cursor.offset());
-   
+   }
+
    return foundTilde;
 }
 


### PR DESCRIPTION
This PR re-writes the formula skipper, fixing many issues that occurred when attempting to skip formulas when parsing an R expression.

The formula skipper is effectively a mini R parser, that parses to the end of a statement, and keeps track of whether a `~` operator was encountered within that statement.