### PR TITLE
more options re: display of items in doc outline

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -540,9 +540,13 @@ public class UIPrefsAccessor extends Prefs
       return bool("show_doc_outline_rmd", false);
    }
    
-   public PrefValue<Boolean> showUnnamedEntriesInDocumentOutline()
+   public static final String DOC_OUTLINE_SHOW_SECTIONS_ONLY = "show_sections_only";
+   public static final String DOC_OUTLINE_SHOW_SECTIONS_AND_NAMED_CHUNKS = "show_sections_and_chunks";
+   public static final String DOC_OUTLINE_SHOW_ALL = "show_all";
+   
+   public PrefValue<String> shownSectionsInDocumentOutline()
    {
-      return bool("show_unnamed_chunks_in_document_outline", true);
+      return string("shown_sections_in_document_outline", DOC_OUTLINE_SHOW_ALL);
    }
 
    public PrefValue<Boolean> showProfiler()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -205,7 +205,7 @@ public class EditingPreferencesPane extends PreferencesPane
             new String[] {
                   "Sections Only",
                   "Sections and Named Chunks",
-                  "All"
+                  "Sections and Chunks"
             },
             new String[] {
                   UIPrefsAccessor.DOC_OUTLINE_SHOW_SECTIONS_ONLY,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -199,7 +199,24 @@ public class EditingPreferencesPane extends PreferencesPane
       displayPanel.add(rMarkdownLabel);
       displayPanel.add(checkboxPref("Show inline toolbar for R code chunks", prefs_.showInlineToolbarForRCodeChunks()));
       displayPanel.add(checkboxPref("Show document outline by default", prefs_.showDocumentOutlineRmd()));
-      displayPanel.add(checkboxPref("Show unnamed entries in document outline", prefs_.showUnnamedEntriesInDocumentOutline()));
+      
+      docOutlineDisplay_ = new SelectWidget(
+            "Show in Document Outline: ",
+            new String[] {
+                  "Sections Only",
+                  "Sections and Named Chunks",
+                  "All"
+            },
+            new String[] {
+                  UIPrefsAccessor.DOC_OUTLINE_SHOW_SECTIONS_ONLY,
+                  UIPrefsAccessor.DOC_OUTLINE_SHOW_SECTIONS_AND_NAMED_CHUNKS,
+                  UIPrefsAccessor.DOC_OUTLINE_SHOW_ALL
+            },
+            false,
+            true,
+            false);
+      displayPanel.add(docOutlineDisplay_);
+      
       rmdViewerMode_ = new SelectWidget(
             "Show output preview in: ",
             new String[] {
@@ -474,6 +491,7 @@ public class EditingPreferencesPane extends PreferencesPane
       
       foldMode_.setValue(prefs_.foldStyle().getValue());
       delimiterSurroundWidget_.setValue(prefs_.surroundSelection().getValue());
+      docOutlineDisplay_.setValue(prefs_.shownSectionsInDocumentOutline().getValue().toString());
       rmdViewerMode_.setValue(prefs_.rmdViewerType().getValue().toString());
    }
    
@@ -503,6 +521,9 @@ public class EditingPreferencesPane extends PreferencesPane
          ShortcutManager.INSTANCE.setEditorMode(KeyboardShortcut.MODE_EMACS);
       else
          ShortcutManager.INSTANCE.setEditorMode(KeyboardShortcut.MODE_DEFAULT);
+      
+      prefs_.shownSectionsInDocumentOutline().setGlobalValue(
+            docOutlineDisplay_.getValue());
       
       prefs_.rmdViewerType().setGlobalValue(Integer.decode(
             rmdViewerMode_.getValue()));
@@ -560,6 +581,7 @@ public class EditingPreferencesPane extends PreferencesPane
    private final SelectWidget rmdViewerMode_;
    private final SelectWidget foldMode_;
    private final SelectWidget delimiterSurroundWidget_;
+   private final SelectWidget docOutlineDisplay_;
    private final TextBoxWithButton encoding_;
    private String encodingValue_;
    


### PR DESCRIPTION
This PR augments the choices in the document outline display to allow showing:

1. Sections only,
2. Sections and named chunks,
3. All (sections, named, unnamed chunks).

![screen shot 2016-03-08 at 11 48 28 am](https://cloud.githubusercontent.com/assets/1976582/13614103/b4872068-e523-11e5-9ac4-ea37e4c3f94f.png)

It kind of bugs me that the 'Add' field is so much smaller than the others -- I wonder if the language / display can be tweaked here?