### PR TITLE
first round of fixes from profiler test pass

### DIFF
--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -21,8 +21,12 @@
    resetOptions <- rStudioVersion > "0.99.1053" && rStudioVersion < "0.99.1099"
 
    if (identical(getOption("profvis.print"), NULL) || resetOptions) {
-      options("profvis.print" = function(x, ...) {
-         .rs.profilePrint(x, ...)
+      options(profvis.print = function(x) {
+         envir <- as.environment(which(search() == "tools:rstudio"))
+         eval(
+            substitute(.rs.profilePrint(x), list(x = x)),
+            envir = envir
+         )
       })
    }
 

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -15,8 +15,20 @@
 
 .rs.addFunction("profileResources", function()
 {
+   rStudioVersion <- package_version(
+      .Call(getNativeSymbolInfo("rs_rstudioVersion", PACKAGE=""))
+   )
+   resetOptions <- rStudioVersion > "0.99.1053" && rStudioVersion < "0.99.1099"
+
+   if (identical(getOption("profvis.print"), NULL) || resetOptions) {
+      options("profvis.print" = function(x, ...) {
+         .rs.profilePrint(x, ...)
+      })
+   }
+
    if (identical(getOption("profvis.prof_extension"), NULL) ||
-       identical(getOption("profvis.prof_extension"), ".rprof")) {
+       identical(getOption("profvis.prof_extension"), ".rprof") ||
+       resetOptions) {
       options("profvis.prof_extension" = ".Rprof")
    }
 
@@ -25,7 +37,7 @@
       dir.create(tempPath, recursive = TRUE)
    }
 
-   if (identical(getOption("profvis.prof_output"), NULL)) {
+   if (identical(getOption("profvis.prof_output"), NULL) || resetOptions) {
       options("profvis.prof_output" = tempPath)
    }
 
@@ -119,9 +131,3 @@
       path = .rs.scalar(x$x$message$prof_output)
    ));
 })
-
-if (identical(getOption("profvis.print"), NULL)) {
-   options("profvis.print" = function(x, ...) {
-      .rs.profilePrint(x, ...)
-   })
-}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleInterruptProfilerButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleInterruptProfilerButton.java
@@ -38,6 +38,7 @@ public class ConsoleInterruptProfilerButton extends Composite
       Image button = new Image(icon);
       button.addStyleName(ThemeResources.INSTANCE.themeStyles().toolbarButtonLeftImage());
       button.getElement().getStyle().setMarginRight(4,Unit.PX);
+      button.setTitle("Profiling Code");
       
       return button;
    }
@@ -55,7 +56,7 @@ public class ConsoleInterruptProfilerButton extends Composite
       
       ImageResource icon = FileIconResources.INSTANCE.iconProfiler();
       Image button = CreateProfilerButton();
-      
+
       width_ = icon.getWidth() + 6;
       height_ = icon.getHeight();
       panel.setWidget(button);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -242,6 +242,13 @@ public class ProfilerEditingTarget implements EditingTarget,
                   pSourceWindowManager_.get().maximizeSourcePaneIfNecessary();
                }
                
+            }, new OperationWithInput<Void>()
+            {
+               @Override
+               public void execute(Void input)
+               {
+                  commands_.closeSourceDoc().execute();
+               }
             });
          }
          else
@@ -536,7 +543,9 @@ public class ProfilerEditingTarget implements EditingTarget,
       return doc_.getProperties().cast();
    }
 
-   private void buildHtmlPath(final OperationWithInput<ProfileOperationResponse> continuation)
+   private void buildHtmlPath(
+                              final OperationWithInput<ProfileOperationResponse> continuation,
+                              final OperationWithInput<Void> onError)
    {
       ProfileOperationRequest request = ProfileOperationRequest
             .create(getPath());
@@ -551,6 +560,7 @@ public class ProfilerEditingTarget implements EditingTarget,
                {
                   globalDisplay_.showErrorMessage("Profiler Error",
                         response.getErrorMessage());
+                  onError.execute(null);
                   return;
                }
                
@@ -562,6 +572,7 @@ public class ProfilerEditingTarget implements EditingTarget,
             {
                globalDisplay_.showErrorMessage("Failed to Open Profile",
                      error.getMessage());
+               onError.execute(null);
             }
          });
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -514,13 +514,13 @@ public class ProfilerEditingTarget implements EditingTarget,
    @Handler
    void onSaveSourceDoc()
    {
-      saveNewFile(getPath());
+      saveNewFile(null);
    }
 
    @Handler
    void onSaveSourceDocAs()
    {
-      saveNewFile(getPath());
+      saveNewFile(isUserSaved_ ? getPath() : null);
    }
 
    public String getDefaultNamePrefix()


### PR DESCRIPTION
First round of fixes from profiler test pass:
- 5433 Profiler - Naming convention issue when selecting “Profile Selected Line(s)” 
- 5434 Profiler - New .Rprof files when saved puts the user in the profiles-cache folder 
- 5435 Profiler - Empty .Rprof file is opened if there is no data to profile
- 5436 Profiler - Request to have the profiler icon to have hover text.