### PR TITLE
avoid errors when getting help for S4 class in global env

### DIFF
--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -126,7 +126,9 @@ options(help_type = "html")
       return()
    
    # Get objects from that namespace
-   ns <- asNamespace(namespace)
+   ns <- try(asNamespace(namespace), silent = TRUE)
+   if (inherits(ns, "try-error"))
+      return()
    
    # Datasets don't live in the namespace -- ennumerate them separately
    # We have to avoid the 'base' package, though.


### PR DESCRIPTION
This PR fixes an issue where attempts to get help for an S4 class defined in the global environment would cause an R execution error.

This is a candidate for the patch release.