### PR TITLE
ignore '.', '_' when filtering completion results

### DIFF
--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -42,18 +42,18 @@ namespace string_utils {
 
 bool isSubsequence(std::string const& sequence,
                    std::string const& query,
-                   std::string::size_type queryN,
+                   std::string::size_type querySize,
                    const std::vector<char>& skip)
 {
    std::string::size_type sequenceN = sequence.length();
 
-   if (queryN == 0)
+   if (querySize == 0)
       return true;
 
-   if (queryN > query.length())
-      queryN = query.length();
+   if (querySize > query.length())
+      querySize = query.length();
 
-   if (!skip.empty() && queryN > sequenceN)
+   if (!skip.empty() && querySize > sequenceN)
       return false;
 
    std::string::size_type sequenceIdx = 0;
@@ -67,7 +67,7 @@ bool isSubsequence(std::string const& sequence,
       while (core::algorithm::contains(skip, queryChar))
       {
          ++queryIdx;
-         if (queryIdx == queryN)
+         if (queryIdx == querySize)
             return true;
          queryChar = query[queryIdx];
       }
@@ -75,7 +75,7 @@ bool isSubsequence(std::string const& sequence,
       if (queryChar == sequenceChar)
       {
          ++queryIdx;
-         if (queryIdx == queryN)
+         if (queryIdx == querySize)
             return true;
       }
       
@@ -124,12 +124,12 @@ std::vector<int> subsequenceIndices(std::string const& sequence,
                                     std::string const& query,
                                     const std::vector<char>& skip)
 {
-   std::string::size_type queryN = query.length();
+   std::string::size_type querySize = query.length();
    std::vector<int> result;
-   result.reserve(queryN);
+   result.reserve(querySize);
 
    std::size_t prevMatchIndex = -1;
-   for (std::string::size_type i = 0; i < queryN; i++)
+   for (std::string::size_type i = 0; i < querySize; i++)
    {
       char ch = query[i];
       if (core::algorithm::contains(skip, ch))
@@ -148,10 +148,10 @@ bool subsequenceIndices(std::string const& sequence,
                         std::vector<int> *pIndices,
                         const std::vector<char>& skip)
 {
-   std::string::size_type queryN = query.length();
+   std::string::size_type querySize = query.length();
    std::string::size_type prevMatchIndex = -1;
    
-   for (std::string::size_type i = 0; i < queryN; i++)
+   for (std::string::size_type i = 0; i < querySize; i++)
    {
       char ch = query[i];
       if (core::algorithm::contains(skip, ch))

--- a/src/cpp/core/include/core/StringUtils.hpp
+++ b/src/cpp/core/include/core/StringUtils.hpp
@@ -62,23 +62,23 @@ inline const std::vector<char>& rAutocompletionSkippableCharacters()
    return instance;
 }
 
-bool isSubsequence(const std::string& self,
-                   const std::string& other,
+bool isSubsequence(const std::string& sequence,
+                   const std::string& query,
                    const std::vector<char>& skip = std::vector<char>());
 
-bool isSubsequence(const std::string& self,
-                   const std::string& other,
+bool isSubsequence(const std::string& sequence,
+                   const std::string& query,
                    bool caseInsensitive,
                    const std::vector<char>& skip = std::vector<char>());
 
-bool isSubsequence(const std::string& self,
-                   const std::string& other,
-                   std::string::size_type other_n,
+bool isSubsequence(const std::string& sequence,
+                   const std::string& query,
+                   std::string::size_type querySize,
                    const std::vector<char>& skip = std::vector<char>());
 
-bool isSubsequence(const std::string& self,
-                   const std::string& other,
-                   std::string::size_type other_n,
+bool isSubsequence(const std::string& sequence,
+                   const std::string& query,
+                   std::string::size_type querySize,
                    bool caseInsensitive,
                    const std::vector<char>& skip = std::vector<char>());
 

--- a/src/cpp/core/include/core/StringUtils.hpp
+++ b/src/cpp/core/include/core/StringUtils.hpp
@@ -48,28 +48,48 @@ private:
    std::string needle_;
 };
 
-bool isSubsequence(std::string const& self,
-                   std::string const& other);
+inline std::vector<char> makeRAutocompletionSkippableCharacters()
+{
+   std::vector<char> instance;
+   instance.push_back('.');
+   instance.push_back('_');
+   return instance;
+}
 
-bool isSubsequence(std::string const& self,
-                   std::string const& other,
-                   bool caseInsensitive);
+inline const std::vector<char>& rAutocompletionSkippableCharacters()
+{
+   static std::vector<char> instance = makeRAutocompletionSkippableCharacters();
+   return instance;
+}
 
-bool isSubsequence(std::string const& self,
-                   std::string const& other,
+bool isSubsequence(const std::string& self,
+                   const std::string& other,
+                   const std::vector<char>& skip = std::vector<char>());
+
+bool isSubsequence(const std::string& self,
+                   const std::string& other,
+                   bool caseInsensitive,
+                   const std::vector<char>& skip = std::vector<char>());
+
+bool isSubsequence(const std::string& self,
+                   const std::string& other,
                    std::string::size_type other_n,
-                   bool caseInsensitive);
+                   const std::vector<char>& skip = std::vector<char>());
 
-bool isSubsequence(std::string const& self,
-                   std::string const& other,
-                   std::string::size_type other_n);
+bool isSubsequence(const std::string& self,
+                   const std::string& other,
+                   std::string::size_type other_n,
+                   bool caseInsensitive,
+                   const std::vector<char>& skip = std::vector<char>());
 
-std::vector<int> subsequenceIndices(std::string const& sequence,
-                                    std::string const& query);
+std::vector<int> subsequenceIndices(const std::string& sequence,
+                                    const std::string& query,
+                                    const std::vector<char>& skip = std::vector<char>());
 
-bool subsequenceIndices(std::string const& sequence,
-                        std::string const& query,
-                        std::vector<int> *pIndices);
+bool subsequenceIndices(const std::string& sequence,
+                        const std::string& query,
+                        std::vector<int> *pIndices,
+                        const std::vector<char>& skip = std::vector<char>());
 
 std::string getExtension(std::string const& str);
 

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -821,6 +821,9 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("fuzzyMatches", function(completions, token)
 {
+   token       <- gsub("[._]", "", token, perl = TRUE)
+   completions <- gsub("[._]", "", completions, perl = TRUE)
+   
    .rs.startsWith(tolower(completions), tolower(token))
 })
 
@@ -1409,7 +1412,7 @@ assign(x = ".rs.acCompletionTypes",
 .rs.addFunction("getCompletionsSearchPath", function(token,
                                                      overrideInsertParens = FALSE)
 {
-   objects <- .rs.objectsOnSearchPath(token, TRUE)
+   objects <- .rs.objectsOnSearchPath()
    
    objects[["keywords"]] <- c(
       "NULL", "NA", "TRUE", "FALSE", "T", "F", "Inf", "NaN",

--- a/src/cpp/session/modules/SessionRCompletions.cpp
+++ b/src/cpp/session/modules/SessionRCompletions.cpp
@@ -28,6 +28,7 @@
 #include <r/session/RClientState.hpp>
 #include <r/session/RSessionUtils.hpp>
 
+#include <core/StringUtils.hpp>
 #include <core/system/FileScanner.hpp>
 
 #include <core/r_util/RProjectFile.hpp>
@@ -309,7 +310,8 @@ SEXP rs_isSubsequence(SEXP stringsSEXP, SEXP querySEXP)
                   boost::bind(
                      string_utils::isSubsequence,
                      _1,
-                     query));
+                     query,
+                     string_utils::rAutocompletionSkippableCharacters()));
 
    r::sexp::Protect protect;
    return r::sexp::create(result, &protect);

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -788,61 +788,113 @@ public class StringUtil
       return inSingleQuotes || inDoubleQuotes;
    }
    
-   public static boolean isSubsequence(String self,
-         String other,
-         boolean caseInsensitive)
+   public static char[] R_AUTOCOMPLETION_SKIPS = new char[] {
+      '.', '_'
+   };
+   
+   public static boolean isSubsequence(String sequence,
+                                       String query,
+                                       boolean caseInsensitive,
+                                       char[] skips)
    {
       return caseInsensitive ?
-            isSubsequence(self.toLowerCase(), other.toLowerCase()) :
-            isSubsequence(self, other)
+            isSubsequence(sequence.toLowerCase(), query.toLowerCase(), skips) :
+            isSubsequence(sequence, query, skips)
       ;
    }
    
-   public static boolean isSubsequence(String self,
-         String other)
+   public static boolean contains(String[] array, String string)
    {
-
-      final int self_n = self.length();
-      final int other_n = other.length();
-
-      if (other_n > self_n)
+      if (string == null)
          return false;
-
-      int self_idx = 0;
-      int other_idx = 0;
-         
-      while (self_idx < self_n)
-      {
-         char selfChar = self.charAt(self_idx);
-         char otherChar = other.charAt(other_idx);
-         
-         if (otherChar == selfChar)
-         {
-            ++other_idx;
-            if (other_idx == other_n)
-            {
-               return true;
-            }
-         }
-         ++self_idx;
-      }
+      
+      if (array.length == 0)
+         return false;
+      
+      for (int i = 0; i < array.length; i++)
+         if (string.equals(array[i]))
+            return true;
+      
       return false;
    }
    
-   public static int[] subsequenceIndices(
-         String sequence, String query)
+   public static boolean contains(char[] array, char ch)
    {
-      int query_n = query.length();
-      int[] result = new int[query.length()];
+      if (array.length == 0)
+         return false;
       
-      int prevMatchIndex = -1;
-      for (int i = 0; i < query_n; i++)
+      for (int i = 0; i < array.length; i++)
+         if (array[i] == ch)
+            return true;
+      
+      return false;
+   }
+   
+   public static boolean isSubsequence(String sequence, String query, char[] skips)
+   {
+      final int sequenceN = sequence.length();
+      final int queryN = query.length();
+
+      if (skips.length == 0 && queryN > sequenceN)
+         return false;
+
+      int sequenceIdx = 0;
+      int queryIdx = 0;
+         
+      while (sequenceIdx < sequenceN)
       {
-         result[i] = sequence.indexOf(query.charAt(i), prevMatchIndex + 1);
-         prevMatchIndex = result[i];
+         char sequenceChar = sequence.charAt(sequenceIdx);
+         char queryChar = query.charAt(queryIdx);
+         
+         // Update the query character if it's equal to one of the skips.
+         // Check success (as we might have a skippable character as the
+         // last character in the query)
+         while (contains(skips, queryChar))
+         {
+            queryIdx++;
+            if (queryIdx == queryN)
+               return true;
+            queryChar = query.charAt(queryIdx);
+         }
+         
+         // Check whether the query character matches the current character in
+         // the sequence. If so, advance the query index, and check success.
+         if (queryChar == sequenceChar)
+         {
+            ++queryIdx;
+            if (queryIdx == queryN)
+               return true;
+         }
+         
+         ++sequenceIdx;
       }
-      return result;
       
+      return false;
+   }
+   
+   public static int[] subsequenceIndices(String sequence, String query, char[] skips)
+   {
+      List<Integer> list = new ArrayList<Integer>();
+      
+      int queryN = query.length();
+      int prevMatchIndex = -1;
+      
+      for (int queryIdx = 0; queryIdx < queryN; queryIdx++)
+      {
+         char ch = query.charAt(queryIdx);
+         
+         if (contains(skips, ch))
+            continue;
+         
+         int idx = sequence.indexOf(ch, prevMatchIndex + 1);
+         list.add(idx);
+         prevMatchIndex = idx;
+      }
+      
+      int[] result = new int[list.size()];
+      for (int i = 0; i < list.size(); i++)
+         result[i] = list.get(i);
+      return result;
    }
    
    public static String getExtension(String string, int dots)

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -872,7 +872,9 @@ public class StringUtil
       return false;
    }
    
-   public static int[] subsequenceIndices(String sequence, String query, char[] skips)
+   public static List<Integer> subsequenceIndices(String sequence,
+                                                  String query,
+                                                  char[] skips)
    {
       List<Integer> list = new ArrayList<Integer>();
       
@@ -891,10 +893,7 @@ public class StringUtil
          prevMatchIndex = idx;
       }
       
-      int[] result = new int[list.size()];
-      for (int i = 0; i < list.size(); i++)
-         result[i] = list.get(i);
-      return result;
+      return list;
    }
    
    public static String getExtension(String string, int dots)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
@@ -65,17 +65,18 @@ public class CodeSearchOracle extends SuggestOracle
       if (suggestion == query)
          return 0;
       
-      int query_n = query.length();
-      
       int totalPenalty = 0;
       
       // Get query matches in string (ordered)
       // Note: we have already guaranteed this to be a subsequence so
       // this will succeed
-      int[] matches = StringUtil.subsequenceIndices(suggestionLower, queryLower);
+      int[] matches = StringUtil.subsequenceIndices(
+            suggestionLower,
+            queryLower,
+            StringUtil.R_AUTOCOMPLETION_SKIPS);
       
       // Loop over the matches and assign a score
-      for (int j = 0; j < query_n; j++)
+      for (int j = 0; j < matches.length; j++)
       {
          int matchPos = matches[j];
          
@@ -169,7 +170,7 @@ public class CodeSearchOracle extends SuggestOracle
                   if (colonIndex == -1)
                      colonIndex = query.length();
                   
-                  if (StringUtil.isSubsequence(name, query.substring(0, colonIndex), true))
+                  if (StringUtil.isSubsequence(name, query.substring(0, colonIndex), true, StringUtil.R_AUTOCOMPLETION_SKIPS))
                      suggestions.add(sugg);
                }
             }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
@@ -16,6 +16,7 @@ package org.rstudio.studio.client.workbench.codesearch;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 
 import org.rstudio.core.client.CodeNavigationTarget;
 import org.rstudio.core.client.DuplicateHelper;
@@ -70,15 +71,15 @@ public class CodeSearchOracle extends SuggestOracle
       // Get query matches in string (ordered)
       // Note: we have already guaranteed this to be a subsequence so
       // this will succeed
-      int[] matches = StringUtil.subsequenceIndices(
+      List<Integer> matches = StringUtil.subsequenceIndices(
             suggestionLower,
             queryLower,
             StringUtil.R_AUTOCOMPLETION_SKIPS);
       
       // Loop over the matches and assign a score
-      for (int j = 0; j < matches.length; j++)
+      for (int j = 0; j < matches.size(); j++)
       {
-         int matchPos = matches[j];
+         int matchPos = matches.get(j);
          
          // The initial penalty is equal to the match position
          int penalty = matchPos;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -168,12 +168,12 @@ public class CompletionRequester
          // File types are narrowed only by the file name
          if (RCompletionType.isFileType(qname.type))
          {
-            if (StringUtil.isSubsequence(basename(qname.name), tokenSub, true))
+            if (StringUtil.isSubsequence(basename(qname.name), tokenSub, true, StringUtil.R_AUTOCOMPLETION_SKIPS))
                newCompletions.add(qname);
          }
          else
          {
-            if (StringUtil.isSubsequence(qname.name, token, true) &&
+            if (StringUtil.isSubsequence(qname.name, token, true, StringUtil.R_AUTOCOMPLETION_SKIPS) &&
                 filterStartsWithDot(qname.name, token))
                newCompletions.add(qname) ;
          }


### PR DESCRIPTION
This PR augments the autocompletion system (client side) to ignore `_` and `.` when filtering matches.

This should enable something like the following:

1. The user wants to write `large.variable.name`,
2. The user writes `lar`, and requests completions (either manually or automatically),
3. They continue writing `large_va` (to filter out other candidate completions),
4. They select `large.variable.name` from the completion list (as it is not excluded based on the mismatch of `_` vs `.`.
