### PR TITLE
ignore '.', '_' when filtering completion results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ CMakeLists.txt.user
 *swp
 .orig
 .vagrant
+.*.Rnb.cached

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,3 @@ CMakeLists.txt.user
 *swp
 .orig
 .vagrant
-.*.Rnb.cached

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * Added option for display of 'end' fold markers
 * Display function tooltip on mouse over of function name
 * Added option to display function signature tooltip on cursor idle
+* Autocompletion allows mismatch between '.', '\_' in token
 
 ### Data Import
 

--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -105,16 +105,21 @@ bool isSubsequence(std::string const& self,
 std::vector<int> subsequenceIndices(std::string const& sequence,
                                     std::string const& query)
 {
-   int query_n = query.length();
+   std::string::size_type querySize = query.length();
    std::vector<int> result;
-   result.reserve(query.length());
+   result.reserve(querySize);
 
-   int prevMatchIndex = -1;
-   for (int i = 0; i < query_n; i++)
+   std::string::size_type prevMatchIndex = -1;
+   for (std::string::size_type i = 0; i < querySize; i++)
    {
-      result[i] = sequence.find(query[i], prevMatchIndex + 1);
-      prevMatchIndex = result[i];
+      std::string::size_type index = sequence.find(query[i], prevMatchIndex + 1);
+      if (index == std::string::npos)
+         continue;
+      
+      result.push_back(index);
+      prevMatchIndex = index;
    }
+   
    return result;
 }
 

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -1274,7 +1274,7 @@ int scoreMatch(std::string const& suggestion,
          char prevChar = suggestion[matchPos - 1];
          if (prevChar == '_' || prevChar == '-' || (!isFile && prevChar == '.'))
          {
-            penalty = j;
+            penalty = j + 1;
          }
       }
 

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -1247,23 +1247,13 @@ int scoreMatch(std::string const& suggestion,
    if (suggestion == query)
       return 0;
    
-   int query_n = query.length();
-
-   // Call a version of subsequence indices that returns false if the query is not
-   // actually a subsequence
-   std::vector<int> matches;
-   bool success = string_utils::subsequenceIndices(
-            boost::algorithm::to_lower_copy(suggestion),
-            boost::algorithm::to_lower_copy(query),
-            &matches);
+   std::vector<int> matches =
+         string_utils::subsequenceIndices(suggestion, query);
    
-   if (!success)
-      return -1;
-
    int totalPenalty = 0;
 
    // Loop over the matches and assign a score
-   for (int j = 0; j < query_n; j++)
+   for (int j = 0, n = matches.size(); j < n; j++)
    {
       int matchPos = matches[j];
       int penalty = matchPos;
@@ -1297,6 +1287,9 @@ int scoreMatch(std::string const& suggestion,
    // Penalize files
    if (isFile)
       ++totalPenalty;
+   
+   // Penalize unmatched characters
+   totalPenalty += (query.size() - matches.size()) * query.size();
 
    return totalPenalty;
 }

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1415,7 +1415,7 @@ assign(x = ".rs.acCompletionTypes",
    else
       .rs.objectsOnSearchPath()
    
-   objects[["keywords"]] <-  c(
+   objects[["keywords"]] <- c(
       "NULL", "NA", "TRUE", "FALSE", "T", "F", "Inf", "NaN",
       "NA_integer_", "NA_real_", "NA_character_", "NA_complex_"
    )

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -821,6 +821,7 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("fuzzyMatches", function(completions, token)
 {
+   token <- gsub("(?!^)[._]", "", token, perl = TRUE)
    .rs.startsWith(tolower(completions), tolower(token))
 })
 
@@ -1409,9 +1410,12 @@ assign(x = ".rs.acCompletionTypes",
 .rs.addFunction("getCompletionsSearchPath", function(token,
                                                      overrideInsertParens = FALSE)
 {
-   objects <- .rs.objectsOnSearchPath(token, TRUE)
+   objects <- if (.rs.startsWith(token, "."))
+      .rs.objectsOnSearchPath(".")
+   else
+      .rs.objectsOnSearchPath()
    
-   objects[["keywords"]] <- c(
+   objects[["keywords"]] <-  c(
       "NULL", "NA", "TRUE", "FALSE", "T", "F", "Inf", "NaN",
       "NA_integer_", "NA_real_", "NA_character_", "NA_complex_"
    )

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -829,20 +829,23 @@ public class StringUtil
       return false;
    }
    
-   public static int[] subsequenceIndices(
-         String sequence, String query)
+   public static List<Integer> subsequenceIndices(String sequence, String query)
    {
-      int query_n = query.length();
-      int[] result = new int[query.length()];
+      List<Integer> result = new ArrayList<Integer>();
+      int querySize = query.length();
       
       int prevMatchIndex = -1;
-      for (int i = 0; i < query_n; i++)
+      for (int i = 0; i < querySize; i++)
       {
-         result[i] = sequence.indexOf(query.charAt(i), prevMatchIndex + 1);
-         prevMatchIndex = result[i];
+         int index = sequence.indexOf(query.charAt(i), prevMatchIndex + 1);
+         if (index == -1)
+            continue;
+         
+         result.add(index);
+         prevMatchIndex = index;
       }
-      return result;
       
+      return result;
    }
    
    public static String getExtension(String string, int dots)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
@@ -16,6 +16,7 @@ package org.rstudio.studio.client.workbench.codesearch;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 
 import org.rstudio.core.client.CodeNavigationTarget;
 import org.rstudio.core.client.DuplicateHelper;
@@ -65,19 +66,15 @@ public class CodeSearchOracle extends SuggestOracle
       if (suggestion == query)
          return 0;
       
-      int query_n = query.length();
-      
       int totalPenalty = 0;
       
       // Get query matches in string (ordered)
-      // Note: we have already guaranteed this to be a subsequence so
-      // this will succeed
-      int[] matches = StringUtil.subsequenceIndices(suggestionLower, queryLower);
+      List<Integer> matches = StringUtil.subsequenceIndices(suggestionLower, queryLower);
       
       // Loop over the matches and assign a score
-      for (int j = 0; j < query_n; j++)
+      for (int j = 0, n = matches.size(); j < n; j++)
       {
-         int matchPos = matches[j];
+         int matchPos = matches.get(j);
          
          // The initial penalty is equal to the match position
          int penalty = matchPos;
@@ -113,6 +110,9 @@ public class CodeSearchOracle extends SuggestOracle
       // Penalize file targets
       if (isFile)
          totalPenalty++;
+      
+      // Penalize unmatched characters
+      totalPenalty += (query.length() - matches.size()) * query.length();
       
       return totalPenalty;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
@@ -89,7 +89,7 @@ public class CodeSearchOracle extends SuggestOracle
             if (prevChar == '_' || prevChar == '-' ||
                   (!isFile && prevChar == '.'))
             {
-               penalty = j;
+               penalty = j + 1;
             }
          }
          

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -150,7 +150,7 @@ public class CompletionRequester
       return string.replace(/(?!^)[._]/g, "");
    }-*/;
    
-   private CompletionResult narrow(String token,
+   private CompletionResult narrow(final String token,
                                    final String diff,
                                    CompletionResult cachedResult)
    {
@@ -164,19 +164,20 @@ public class CompletionRequester
       // trailing slashes)
       
       // Transform the token once beforehand for completions.
-      final String fuzzyToken = fuzzy(token.substring(token.lastIndexOf('/') + 1));
+      final String tokenSub   = token.substring(token.lastIndexOf('/') + 1);
+      final String tokenFuzzy = fuzzy(tokenSub);
       
       for (QualifiedName qname : cachedResult.completions)
       {
          // File types are narrowed only by the file name
          if (RCompletionType.isFileType(qname.type))
          {
-            if (StringUtil.isSubsequence(basename(qname.name), fuzzyToken, true))
+            if (StringUtil.isSubsequence(basename(qname.name), tokenFuzzy, true))
                newCompletions.add(qname);
          }
          else
          {
-            if (StringUtil.isSubsequence(qname.name, fuzzyToken, true) &&
+            if (StringUtil.isSubsequence(qname.name, tokenFuzzy, true) &&
                 filterStartsWithDot(qname.name, token))
                newCompletions.add(qname) ;
          }
@@ -191,16 +192,16 @@ public class CompletionRequester
             int lhsScore;
             if (RCompletionType.isFileType(lhs.type))
                lhsScore = CodeSearchOracle.scoreMatch(
-                     basename(lhs.name), fuzzyToken, true);
+                     basename(lhs.name), tokenSub, true);
             else
-               lhsScore = CodeSearchOracle.scoreMatch(lhs.name, fuzzyToken, false);
+               lhsScore = CodeSearchOracle.scoreMatch(lhs.name, token, false);
             
             int rhsScore;
             if (RCompletionType.isFileType(rhs.type))
                rhsScore = CodeSearchOracle.scoreMatch(
-                     basename(rhs.name), fuzzyToken, true);
+                     basename(rhs.name), tokenSub, true);
             else
-               rhsScore = CodeSearchOracle.scoreMatch(rhs.name, fuzzyToken, false);
+               rhsScore = CodeSearchOracle.scoreMatch(rhs.name, token, false);
             
             // Place arguments higher (give less penalty)
             if (lhs.type == RCompletionType.ARGUMENT) lhsScore -= 3;


### PR DESCRIPTION
This is a much simpler version of the previous PR. I realized we can accomplish our goal simply by munging the query token; ie, we don't need all of the special logic attached to `isSubsequence` and friends.