### PR TITLE
Fixes for 'Rename in File'

### DIFF
--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -998,14 +998,12 @@ var RCodeModel = function(session, tokenizer,
             var tokenCursor = this.getTokenCursor();
             tokenCursor.moveToPosition(position, true);
             var localCursor = tokenCursor.cloneCursor();
-            var bracePos = localCursor.currentPosition();
             
             var startPos;
             if (findAssocFuncToken(localCursor))
             {
                var argsCursor = localCursor.cloneCursor();
                argsCursor.moveToNextToken();
-               var argsStartPos = argsCursor.currentPosition();
 
                var functionName = null;
                if (moveFromFunctionTokenToEndOfFunctionName(localCursor))
@@ -1035,7 +1033,7 @@ var RCodeModel = function(session, tokenizer,
                         localCursor.$row = functionStartPos.row;
                         localCursor.$offset = 0;
                      } else {
-                        localCursor.moveToPosition(functionStartPos);
+                        localCursor.moveToPosition(functionStartPos, true);
                      }
 
                      functionName = this.$doc.getTextRange(new Range(

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -321,7 +321,7 @@ public class TextFileType extends EditableFileType
          results.add(commands.commentUncomment());
          results.add(commands.reflowComment());
          results.add(commands.reformatCode());
-         results.add(commands.renameInFile());
+         results.add(commands.renameInScope());
          results.add(commands.profileCode());
          results.add(commands.profileCodeWithoutFocus());
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -180,7 +180,7 @@ well as menu structures (for main menu and popup menus).
          <separator/>
          <cmd refid="extractFunction"/>
          <cmd refid="extractLocalVariable"/>
-         <cmd refid="renameInFile"/>
+         <cmd refid="renameInScope"/>
          <separator/>
          <cmd refid="reflowComment"/>
          <cmd refid="commentUncomment"/>
@@ -535,7 +535,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut value="Ctrl+T" title="Transpose Letters" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut value="Alt+-" title="Insert Assignment Operator"/>
          <shortcut value="Cmd+Shift+M" title="Insert Pipe Operator" />
-         <shortcut refid="renameInFile" value="Cmd+Alt+Shift+M" />
+         <shortcut refid="renameInScope" value="Cmd+Alt+Shift+M" />
          <shortcut refid="insertRoxygenSkeleton" value="Cmd+Shift+Alt+R" title="Insert Roxygen Skeleton" />
          <shortcut refid="insertSnippet" value="Shift+Tab" title="Insert Snippet"/>
       </shortcutgroup>
@@ -1507,10 +1507,10 @@ well as menu structures (for main menu and popup menus).
         desc="Reflow selected comment lines so they wrap evenly"
         context="editor"/>
         
-   <cmd id="renameInFile"
-        label="Rename Symbol in File"
-        menuLabel="Rename in File"
-        desc="Rename symbol in current file"
+   <cmd id="renameInScope"
+        label="Rename Symbol in Scope"
+        menuLabel="Rename in Scope"
+        desc="Rename symbol in current scope"
         context="editor"/>
         
    <cmd id="insertSnippet"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -126,7 +126,7 @@ public abstract class
    public abstract AppCommand findUsages();
    public abstract AppCommand editRmdFormatOptions();
    public abstract AppCommand knitWithParameters();
-   public abstract AppCommand renameInFile();
+   public abstract AppCommand renameInScope();
    public abstract AppCommand insertRoxygenSkeleton();
    public abstract AppCommand insertSnippet();
  

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -336,7 +336,7 @@ public class Source implements InsertSourceHandler,
       dynamicCommands_.add(commands.editRmdFormatOptions());
       dynamicCommands_.add(commands.reformatCode());
       dynamicCommands_.add(commands.showDiagnosticsActiveDocument());
-      dynamicCommands_.add(commands.renameInFile());
+      dynamicCommands_.add(commands.renameInScope());
       dynamicCommands_.add(commands.insertRoxygenSkeleton());
       dynamicCommands_.add(commands.expandSelection());
       dynamicCommands_.add(commands.shrinkSelection());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -1720,6 +1720,16 @@ public class AceEditor implements DocDisplay,
       var Mode = $wnd.require("mode/r_highlight_rules");
       Mode.setHighlightRFunctionCalls(highlight);
    }-*/;
+   
+   public void enableSearchHighlight()
+   {
+      widget_.getEditor().enableSearchHighlight();
+   }
+   
+   public void disableSearchHighlight()
+   {
+      widget_.getEditor().disableSearchHighlight();
+   }
 
    /**
     * Warning: This will be overridden whenever the file type is set

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -168,6 +168,9 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    void setBlinkingCursor(boolean blinking);
    void setHighlightRFunctionCalls(boolean highlight);
    
+   void enableSearchHighlight();
+   void disableSearchHighlight();
+   
    void setUseEmacsKeybindings(boolean use);
    boolean isEmacsModeOn();
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2573,50 +2573,70 @@ public class TextEditingTarget implements
    }
    
    @Handler
-   void onRenameInFile()
+   void onRenameInScope()
    {
-      int matches = renameHelper_.renameInFile();
-      if (matches > 0)
+      docDisplay_.focus();
+      
+      int matches = renameHelper_.renameInScope();
+      if (matches <= 0)
       {
-         String message = "Found " + matches;
-         if (matches == 1)
-            message += " match";
-         else
-            message += " matches";
-         
-         String selectedItem = docDisplay_.getSelectionValue();
-         message += " for '" + selectedItem + "'";
-         
-         view_.getStatusBar().showMessage(message, new HideMessageHandler()
+         if (!docDisplay_.getSelectionValue().isEmpty())
          {
-            @Override
-            public boolean onNativePreviewEvent(NativePreviewEvent preview)
+            String message = "No matches for '" + docDisplay_.getSelectionValue() + "'";
+            view_.getStatusBar().showMessage(message, 1000);
+         }
+         
+         return;
+      }
+      
+      String message = "Found " + matches;
+      if (matches == 1)
+         message += " match";
+      else
+         message += " matches";
+
+      String selectedItem = docDisplay_.getSelectionValue();
+      message += " for " + selectedItem + ".";
+
+      docDisplay_.disableSearchHighlight();
+      view_.getStatusBar().showMessage(message, new HideMessageHandler()
+      {
+         @Override
+         public boolean onNativePreviewEvent(NativePreviewEvent preview)
+         {
+            int type = preview.getTypeInt();
+            if (docDisplay_.isPopupVisible())
+               return false;
+            
+            // End if the user clicks somewhere
+            if (type == Event.ONCLICK)
             {
-               if (!docDisplay_.isFocused() || !docDisplay_.inMultiSelectMode())
+               docDisplay_.exitMultiSelectMode();
+               docDisplay_.clearSelection();
+               docDisplay_.enableSearchHighlight();
+               return true;
+            }
+
+            // Otherwise, handle key events
+            else if (type == Event.ONKEYDOWN)
+            {
+               switch (preview.getNativeEvent().getKeyCode())
                {
+               case KeyCodes.KEY_ENTER:
+                  preview.cancel();
+               case KeyCodes.KEY_UP:
+               case KeyCodes.KEY_DOWN:
+               case KeyCodes.KEY_ESCAPE:
                   docDisplay_.exitMultiSelectMode();
                   docDisplay_.clearSelection();
+                  docDisplay_.enableSearchHighlight();
                   return true;
                }
-               
-               if (preview.getTypeInt() == Event.ONKEYDOWN)
-               {
-                  switch (preview.getNativeEvent().getKeyCode())
-                  {
-                  case KeyCodes.KEY_ENTER:
-                     preview.cancel();
-                  case KeyCodes.KEY_UP:
-                  case KeyCodes.KEY_DOWN:
-                  case KeyCodes.KEY_ESCAPE:
-                     docDisplay_.exitMultiSelectMode();
-                     docDisplay_.clearSelection();
-                     return true;
-                  }
-               }
-               return false;
             }
-         });
-      }
+            
+            return false;
+         }
+      });
    }
    
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -453,7 +453,7 @@ public class TextEditingTargetWidget
          menu.addSeparator();
          menu.addItem(commands_.extractFunction().createMenuItem(false));
          menu.addItem(commands_.extractLocalVariable().createMenuItem(false));
-         menu.addItem(commands_.renameInFile().createMenuItem(false));
+         menu.addItem(commands_.renameInScope().createMenuItem(false));
          menu.addSeparator();
          menu.addItem(commands_.reflowComment().createMenuItem(false));
          menu.addItem(commands_.commentUncomment().createMenuItem(false));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -554,5 +554,20 @@ public class AceEditorNative extends JavaScriptObject {
       return null;
    }-*/;
    
+   public final native void disableSearchHighlight() /*-{
+      var highlight = this.session.$searchHighlight;
+      if (highlight) {
+         highlight.$update = highlight.update;
+         highlight.update = function() {}
+      }
+   }-*/;
+   
+   public final native void enableSearchHighlight() /*-{
+      var highlight = this.session.$searchHighlight;
+      if (highlight && highlight.$update) {
+         highlight.update = highlight.$update;
+      }
+   }-*/;
+   
    private static boolean uiPrefsSynced_ = false;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Token.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Token.java
@@ -120,6 +120,11 @@ public class Token extends JavaScriptObject
       );
    }-*/;
    
+   public final String asString()
+   {
+      return "'" + getType() + "' -> '" + getValue() + "'";
+   }
+   
    // NOTE: Tokens attached to a document should be considered immutable;
    // use setters only when applying to a tokenized line separate from an
    // active editor!

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/TokenCursor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/TokenCursor.java
@@ -250,5 +250,16 @@ public class TokenCursor extends JavaScriptObject
       return false;
    }
    
+   public final boolean isWithinFunctionDefinitionArgumentList()
+   {
+      TokenCursor clone = cloneCursor();
+      do
+      {
+         if (clone.peekBwd(1).valueEquals("function"))
+            return true;
+      } while (clone.findOpeningBracket("(", false));
+      return false;
+   }
+   
 }
 


### PR DESCRIPTION
This PR fixes a couple of issues with the `Rename in File` action:

- occasionally failed when executed from a menu, as the underlying editor lost focus;
- failed when only one instance of the desired token was found (the 'refactoring mode' was exited over-aggressively),
- enabled refactoring of strings

Will double-check with @dfalty to confirm that this fixes the issues he discovered.
