### PR TITLE
treat makefile.in as make file as well

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
@@ -318,8 +318,10 @@ public class FileTypeRegistry
       register("cleanup", SH, icons.iconSh());
       register("cleanup.win", SH, icons.iconSh());
       register("Makefile", MAKEFILE, icons.iconMakefile());
+      register("Makefile.in", MAKEFILE, icons.iconMakefile());
       register("Makefile.win", MAKEFILE, icons.iconMakefile());
       register("Makevars", MAKEFILE, icons.iconMakefile());
+      register("Makevars.in", MAKEFILE, icons.iconMakefile());
       register("Makevars.win", MAKEFILE, icons.iconMakefile());
       register("TUTORIAL", DCF, icons.iconDCF());
       register("NAMESPACE", NAMESPACE, icons.iconText());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1218,8 +1218,10 @@ public class TextEditingTarget implements
          public void onValueChange(ValueChangeEvent<String> event)
          {
             if ("Makefile".equals(event.getValue()) ||
+                "Makefile.in".equals(event.getValue()) ||
                 "Makefile.win".equals(event.getValue()) ||
                 "Makevars".equals(event.getValue()) ||
+                "Makevars.in".equals(event.getValue()) ||
                 "Makevars.win".equals(event.getValue()))
             {
                docDisplay_.setUseSoftTabs(false);


### PR DESCRIPTION
This frequently bothers me. Rstudio replaces tabs with spaces in make files with `.in` extension.