### PR TITLE
resolve save/load issues in profiler commands

### DIFF
--- a/src/cpp/core/FilePath.cpp
+++ b/src/cpp/core/FilePath.cpp
@@ -469,7 +469,7 @@ MimeType s_mimeTypes[] =
    { "gitignore", "text/plain"},
    { "Rbuildignore", "text/plain"},
    { "Rprofile", "text/x-r-source"},
-   { "rprof",   "text/x-r-profile" },
+   { "rprofvis",   "text/x-r-profile" },
 
    { "tif",   "image/tiff" },
    { "tiff",  "image/tiff" },

--- a/src/cpp/desktop-mac/Info.plist.in
+++ b/src/cpp/desktop-mac/Info.plist.in
@@ -215,8 +215,8 @@
       <dict>
          <key>CFBundleTypeExtensions</key>
          <array>
-             <string>Rprof</string>
-             <string>rprof</string>
+             <string>Rprofvis</string>
+             <string>rprofvis</string>
          </array>
          <key>CFBundleTypeIconFile</key>
          <string>RSource.icns</string>

--- a/src/cpp/desktop/Info.plist.in
+++ b/src/cpp/desktop/Info.plist.in
@@ -202,8 +202,8 @@
       <dict>
          <key>CFBundleTypeExtensions</key>
          <array>
-             <string>Rprof</string>
-             <string>rprof</string>
+             <string>Rprofvis</string>
+             <string>rprofvis</string>
          </array>
          <key>CFBundleTypeIconFile</key>
          <string>RSource.icns</string>

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -93,7 +93,7 @@
       htmlFile <- tempfile(fileext = ".html", tmpdir = resources$tempPath)
 
       if (identical(profilerOptions$profvis, NULL)) {
-         if (identical(tools::file_ext(profilerOptions$fileName), ".Rprof")) {
+         if (identical(tools::file_ext(profilerOptions$fileName), "Rprof")) {
             profvis <- profvis::profvis(prof_input = profilerOptions$fileName, split="h")
             htmlwidgets::saveWidget(profvis, htmlFile, selfcontained = TRUE)
          }

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -160,8 +160,16 @@
       resources <- .rs.profileResources()
 
       filePrefix <- tools::file_path_sans_ext(basename(filePath))
-      file.remove(file.path(resources$tempPath, paste(filePrefix, ".html", sep = "")))
-      unlink(file.path(resources$tempPath, paste(filePrefix, "_files", sep = "")), recursive = TRUE)
+      
+      profileHtml <- file.path(resources$tempPath, paste(filePrefix, ".html", sep = ""))
+      if (file.exists(profileHtml)) {
+         file.remove(profileHtml)
+      }
+
+      profileDir <- paste(filePrefix, "_files", sep = "")
+      if (file.exists(profileDir)) {
+         unlink(file.path(resources$tempPath, profileDir), recursive = TRUE)
+      }
 
       return(list(
       ))

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -166,9 +166,9 @@
          file.remove(profileHtml)
       }
 
-      profileDir <- paste(filePrefix, "_files", sep = "")
+      profileDir <- file.path(resources$tempPath, paste(filePrefix, "_files", sep = ""))
       if (file.exists(profileDir)) {
-         unlink(file.path(resources$tempPath, profileDir), recursive = TRUE)
+         unlink(profileDir), recursive = TRUE)
       }
 
       return(list(

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -168,7 +168,7 @@
 
       profileDir <- file.path(resources$tempPath, paste(filePrefix, "_files", sep = ""))
       if (file.exists(profileDir)) {
-         unlink(profileDir), recursive = TRUE)
+         unlink(profileDir, recursive = TRUE)
       }
 
       return(list(

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -96,6 +96,8 @@
          if (identical(tools::file_ext(profilerOptions$fileName), "Rprof")) {
             profvis <- profvis::profvis(prof_input = profilerOptions$fileName, split="h")
             htmlwidgets::saveWidget(profvis, htmlFile, selfcontained = TRUE)
+
+            file.remove(profilerOptions$fileName)
          }
          else {
             .rs.rpc.copy_profile(profilerOptions$fileName, htmlFile)
@@ -104,6 +106,8 @@
       else {
          profvis <- profilerOptions$profvis
          htmlwidgets::saveWidget(profvis, htmlFile, selfcontained = TRUE)
+
+         file.remove(profilerOptions$profvis$x$message$prof_output)
       }
 
       return(list(
@@ -148,4 +152,20 @@
    ))
 
    .rs.enqueClientEvent("rprof_created", result);
+})
+
+.rs.addJsonRpcHandler("clear_profile", function(filePath)
+{
+   tryCatch({
+      resources <- .rs.profileResources()
+
+      filePrefix <- tools::file_path_sans_ext(basename(filePath))
+      file.remove(file.path(resources$tempPath, paste(filePrefix, ".html", sep = "")))
+      unlink(file.path(resources$tempPath, paste(filePrefix, "_files", sep = "")), recursive = TRUE)
+
+      return(list(
+      ))
+   }, error = function(e) {
+      return(list(error = .rs.scalar(e$message)))
+   })
 })

--- a/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
+++ b/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
@@ -388,7 +388,7 @@ public class FileSystemItem extends JavaScriptObject
       MIME_TYPES.put( "gitignore",   "text/plain");
       MIME_TYPES.put( "rbuildignore","text/plain");
       MIME_TYPES.put( "rprofile", "text/x-r-source");
-      MIME_TYPES.put( "rprof", "text/x-r-profile");
+      MIME_TYPES.put( "rprofvis", "text/x-r-profile");
 
       MIME_TYPES.put( "tif",   "image/tiff" );
       MIME_TYPES.put( "tiff",  "image/tiff" );

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
@@ -396,7 +396,7 @@ public class FileTypeRegistry
       register("*.rs", RUST, icons.iconRust());
       register("*.scala", SCALA, icons.iconScala());
       register("*.snippets", SNIPPETS, icons.iconSnippets());
-      register("*.Rprof", PROFILER, icons.iconRprofile());
+      register("*.Rprofvis", PROFILER, icons.iconRprofile());
 
       registerIcon(".jpg", icons.iconPng());
       registerIcon(".jpeg", icons.iconPng());

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/ProfilerType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/ProfilerType.java
@@ -60,6 +60,6 @@ public class ProfilerType extends EditableFileType
    
    public String getDefaultExtension()
    {
-      return ".Rprof";
+      return ".Rprofvis";
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/ProfilerType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/ProfilerType.java
@@ -38,7 +38,8 @@ public class ProfilerType extends EditableFileType
                         int navMethod,
                         EventBus eventBus)
    {
-      eventBus.fireEvent(new OpenProfileEvent(file.getPath(), false));
+      eventBus.fireEvent(new OpenProfileEvent(
+            file.getPath(), null, null, false));
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4560,6 +4560,14 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, COPY_PROFILE, params, requestCallback);
    }
 
+   public void clearProfile(String path,
+                           ServerRequestCallback<JavaScriptObject> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(path));
+      sendRequest(RPC_SCOPE, CLEAR_PROFILE, params, requestCallback);
+   }
+
    private String clientId_;
    private String clientVersion_ = "";
    private boolean listeningForEvents_;
@@ -4920,4 +4928,5 @@ public class RemoteServer implements Server
    private static final String STOP_PROFILING = "stop_profiling";
    private static final String OPEN_PROFILE = "open_profile";
    private static final String COPY_PROFILE = "copy_profile";
+   private static final String CLEAR_PROFILE = "clear_profile";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client.workbench.views.environment.dataimport;
 
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.Size;
 import org.rstudio.core.client.dom.DomMetrics;
 import org.rstudio.core.client.dom.DomUtils;
@@ -457,6 +458,7 @@ public class DataImport extends Composite
             @Override
             public void onError(ServerError error)
             {
+               Debug.logError(error);
             }
          });
       }
@@ -519,6 +521,7 @@ public class DataImport extends Composite
                      @Override
                      public void onError(ServerError error)
                      {
+                        Debug.logError(error);
                         progressIndicator_.onError(error.getMessage());
                      }
                   });
@@ -574,6 +577,7 @@ public class DataImport extends Composite
                @Override
                public void onError(ServerError error)
                {
+                  Debug.logError(error);
                   cleanPreviewResources();
                   gridViewer_.setData(null);
                   progressIndicator_.onError(error.getMessage());
@@ -627,6 +631,7 @@ public class DataImport extends Composite
          @Override
          public void onError(ServerError error)
          {
+            Debug.logError(error);
             globalDisplay_.showErrorMessage(codePreviewErrorMessage_, error.getMessage());
          }
       });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -1072,6 +1072,8 @@ public class Source implements InsertSourceHandler,
    public void onShowProfiler(OpenProfileEvent event)
    {
       String profilePath = event.getFilePath();
+      String htmlPath = event.getHtmlPath();
+      String htmlLocalPath = event.getHtmlLocalPath();
       
       // first try to activate existing
       for (int idx = 0; idx < editors_.size(); idx++)
@@ -1092,6 +1094,8 @@ public class Source implements InsertSourceHandler,
             null,
             (JsObject) ProfilerContents.create(
                   profilePath,
+                  htmlPath, 
+                  htmlLocalPath,
                   event.getCreateProfile()).cast(),
             new SimpleRequestCallback<SourceDocument>("Show Profiler")
             {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/OpenProfileEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/OpenProfileEvent.java
@@ -47,7 +47,7 @@ public class OpenProfileEvent extends GwtEvent<OpenProfileEvent.Handler>
    {
       handler.onOpenProfileEvent(this);
    }
-
+   
    public String getFilePath()
    {
       return filePath_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/OpenProfileEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/OpenProfileEvent.java
@@ -25,9 +25,14 @@ public class OpenProfileEvent extends GwtEvent<OpenProfileEvent.Handler>
       void onOpenProfileEvent(OpenProfileEvent event);
    }
    
-   public OpenProfileEvent(String filePath, boolean createProfile)
+   public OpenProfileEvent(String filePath,
+                           String htmlPath,
+                           String htmlLocalPath,
+                           boolean createProfile)
    {
       filePath_ = filePath;
+      htmlPath_ = htmlPath;
+      htmlLocalPath_ = htmlLocalPath;
       createProfile_ = createProfile;
    }
    
@@ -42,10 +47,20 @@ public class OpenProfileEvent extends GwtEvent<OpenProfileEvent.Handler>
    {
       handler.onOpenProfileEvent(this);
    }
-   
+
    public String getFilePath()
    {
       return filePath_;
+   }
+
+   public String getHtmlPath()
+   {
+      return htmlPath_;
+   }
+   
+   public String getHtmlLocalPath()
+   {
+      return htmlLocalPath_;
    }
    
    public boolean getCreateProfile()
@@ -55,5 +70,7 @@ public class OpenProfileEvent extends GwtEvent<OpenProfileEvent.Handler>
    
    public static final Type<Handler> TYPE = new Type<Handler>();
    private String filePath_;
+   private String htmlPath_;
+   private String htmlLocalPath_;
    private boolean createProfile_ = false;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -61,7 +61,6 @@ import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.WorkbenchContext;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.RemoteFileSystemContext;
-import org.rstudio.studio.client.workbench.views.files.model.FilesServerOperations;
 import org.rstudio.studio.client.workbench.views.source.SourceWindowManager;
 import org.rstudio.studio.client.workbench.views.source.editors.EditingTarget;
 import org.rstudio.studio.client.workbench.views.source.editors.profiler.model.ProfileOperationResponse;
@@ -103,8 +102,7 @@ public class ProfilerEditingTarget implements EditingTarget,
                                 RemoteFileSystemContext fileContext,
                                 WorkbenchContext workbenchContext,
                                 EventBus eventBus,
-                                SourceServerOperations sourceServer,
-                                FilesServerOperations fileServer)
+                                SourceServerOperations sourceServer)
    {
       presenter_ = presenter;
       commands_ = commands;
@@ -117,7 +115,6 @@ public class ProfilerEditingTarget implements EditingTarget,
       workbenchContext_ = workbenchContext;
       eventBus_ = eventBus;
       sourceServer_ = sourceServer;
-      fileServer_ = fileServer;
       
       if (!initializedEvents_)
       {
@@ -180,7 +177,6 @@ public class ProfilerEditingTarget implements EditingTarget,
          commands.add(commands_.popoutDoc());
       else
          commands.add(commands_.returnDocToMain());
-      
       return commands;
    }
    
@@ -700,7 +696,6 @@ public class ProfilerEditingTarget implements EditingTarget,
    private final WorkbenchContext workbenchContext_;
    private final EventBus eventBus_;
    private Provider<String> defaultNameProvider_;
-   private FilesServerOperations fileServer_;
    
    private ProfilerType fileType_ = new ProfilerType();
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -78,7 +78,6 @@ import org.rstudio.studio.client.workbench.views.source.model.SourceNavigation;
 import org.rstudio.studio.client.workbench.views.source.model.SourcePosition;
 import org.rstudio.studio.client.workbench.views.source.model.SourceServerOperations;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 
@@ -529,36 +528,15 @@ public class ProfilerEditingTarget implements EditingTarget,
       return "Profile";
    }
    
-   private void deleteFile(String targetFile)
+   private void clearProfileCache()
    {
-      fileServer_.stat(targetFile, new ServerRequestCallback<FileSystemItem>()
+      server_.clearProfile(htmlLocalPath_, new ServerRequestCallback<JavaScriptObject>()
       {
-         @Override
-         public void onResponseReceived(final FileSystemItem fsi)
-         {
-            ArrayList<FileSystemItem> cachedFiles = new ArrayList<FileSystemItem>();
-            cachedFiles.add(fsi);
-            
-            fileServer_.deleteFiles(
-                  cachedFiles,
-                  new ServerRequestCallback<Void>() {
-                     @Override
-                     public void onError(ServerError error)
-                     {
-                     }
-            });
-         }
-
          @Override
          public void onError(ServerError error)
          {
          }
       });
-   }
-   
-   private void clearProfileCache()
-   {
-      deleteFile(htmlLocalPath_);
    }
    
    private void savePropertiesWithPath(String path)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -234,8 +234,8 @@ public class ProfilerEditingTarget implements EditingTarget,
                @Override
                public void execute(ProfileOperationResponse response)
                {
-                  htmlPath_ = response.getHtmlFile();
-                  htmlLocalPath_ = response.getHtmlLocalFile();
+                  htmlPath_ = response.getHtmlPath();
+                  htmlLocalPath_ = response.getHtmlLocalPath();
                   
                   persistDocumentProperty("htmlPath", htmlPath_);
                   persistDocumentProperty("htmlLocalPath", htmlLocalPath_);
@@ -561,7 +561,6 @@ public class ProfilerEditingTarget implements EditingTarget,
    
    private void clearProfileCache()
    {
-      deleteFile(getPath());
       deleteFile(htmlLocalPath_);
    }
    
@@ -631,7 +630,7 @@ public class ProfilerEditingTarget implements EditingTarget,
                   
                   final String toPath = saveItem.getPath();
                   server_.copyProfile(
-                     getPath(),
+                     htmlLocalPath_,
                      toPath,
                      new ServerRequestCallback<JavaScriptObject>() {
                         @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -102,8 +102,7 @@ public class ProfilerEditingTarget implements EditingTarget,
                                 RemoteFileSystemContext fileContext,
                                 WorkbenchContext workbenchContext,
                                 EventBus eventBus,
-                                SourceServerOperations sourceServer,
-                                ProfilerPresenter profilerPresenter)
+                                SourceServerOperations sourceServer)
    {
       presenter_ = presenter;
       commands_ = commands;
@@ -116,7 +115,6 @@ public class ProfilerEditingTarget implements EditingTarget,
       workbenchContext_ = workbenchContext;
       eventBus_ = eventBus;
       sourceServer_ = sourceServer;
-      profilerPresenter_ = profilerPresenter;
       
       if (!initializedEvents_)
       {
@@ -227,7 +225,7 @@ public class ProfilerEditingTarget implements EditingTarget,
          
          if (htmlPath_ == null)
          {
-            profilerPresenter_.buildHtmlPath(new OperationWithInput<ProfileOperationResponse>()
+            presenter_.buildHtmlPath(new OperationWithInput<ProfileOperationResponse>()
             {
                @Override
                public void execute(ProfileOperationResponse response)
@@ -690,7 +688,6 @@ public class ProfilerEditingTarget implements EditingTarget,
    private final WorkbenchContext workbenchContext_;
    private final EventBus eventBus_;
    private Provider<String> defaultNameProvider_;
-   private ProfilerPresenter profilerPresenter_;
    
    private ProfilerType fileType_ = new ProfilerType();
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -181,6 +181,7 @@ public class ProfilerEditingTarget implements EditingTarget,
          commands.add(commands_.popoutDoc());
       else
          commands.add(commands_.returnDocToMain());
+      
       return commands;
    }
    
@@ -218,8 +219,6 @@ public class ProfilerEditingTarget implements EditingTarget,
 
    public void onActivate()
    {
-      commands_.saveProfileAs().setEnabled(true);
-      
       if (!htmlPathInitialized_) {
          htmlPathInitialized_ = true;
          
@@ -273,8 +272,6 @@ public class ProfilerEditingTarget implements EditingTarget,
 
    public void onDeactivate()
    {
-      commands_.saveProfileAs().setEnabled(false);
-      
       recordCurrentNavigationPosition();
       
       commandHandlerReg_.removeHandler();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -40,6 +40,7 @@ import org.rstudio.core.client.events.HasSelectionCommitHandlers;
 import org.rstudio.core.client.events.SelectionCommitHandler;
 import org.rstudio.core.client.files.FileSystemContext;
 import org.rstudio.core.client.files.FileSystemItem;
+import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.ProgressOperationWithInput;
@@ -239,10 +240,10 @@ public class ProfilerEditingTarget implements EditingTarget,
                   pSourceWindowManager_.get().maximizeSourcePaneIfNecessary();
                }
                
-            }, new OperationWithInput<Void>()
+            }, new Operation()
             {
                @Override
-               public void execute(Void input)
+               public void execute()
                {
                   commands_.closeSourceDoc().execute();
                }
@@ -526,13 +527,21 @@ public class ProfilerEditingTarget implements EditingTarget,
    
    private void clearProfileCache()
    {
-      server_.clearProfile(htmlLocalPath_, new ServerRequestCallback<JavaScriptObject>()
+      try
       {
-         @Override
-         public void onError(ServerError error)
+         server_.clearProfile(htmlLocalPath_, new ServerRequestCallback<JavaScriptObject>()
          {
-         }
-      });
+            @Override
+            public void onError(ServerError error)
+            {
+               Debug.logError(error);
+            }
+         });
+      }
+      catch(Exception e)
+      {
+         Debug.logException(e);
+      }
    }
    
    private void savePropertiesWithPath(String path)
@@ -568,6 +577,7 @@ public class ProfilerEditingTarget implements EditingTarget,
             @Override
             public void onError(ServerError error)
             {
+               Debug.logError(error);
                globalDisplay_.showErrorMessage("Failed to Save Profile Properties",
                      error.getMessage());
             }
@@ -618,6 +628,7 @@ public class ProfilerEditingTarget implements EditingTarget,
                         @Override
                         public void onError(ServerError error)
                         {
+                           Debug.logError(error);
                            indicator.onCompleted();
                            globalDisplay_.showErrorMessage("Failed to Save Profile",
                                  error.getMessage());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerPresenter.java
@@ -114,8 +114,14 @@ public class ProfilerPresenter implements RprofEvent.Handler
          case STOP:
             enableStoppedCommands();
             break;
+         case CREATE:
+            events_.fireEvent(new OpenProfileEvent(
+               event.getData().getPath(),
+               event.getData().getHtmlPath(),
+               event.getData().getHtmlLocalPath(),
+               true));
+            break;
          default:
-            events_.fireEvent(new OpenProfileEvent(event.getData().getPath(), true));
             break;
       }
    }
@@ -240,38 +246,31 @@ public class ProfilerPresenter implements RprofEvent.Handler
                              final OperationWithInput<Void> onError,
                              final String path)
    {
-      dependencyManager_.withProfvis(profilerDependecyUserAction_, new Command()
+      ProfileOperationRequest request = ProfileOperationRequest.create(path);
+       
+      server_.openProfile(request, 
+            new ServerRequestCallback<ProfileOperationResponse>()
       {
          @Override
-         public void execute()
+         public void onResponseReceived(ProfileOperationResponse response)
          {
-            ProfileOperationRequest request = ProfileOperationRequest.create(path);
-             
-            server_.openProfile(request, 
-                  new ServerRequestCallback<ProfileOperationResponse>()
+            if (response.getErrorMessage() != null)
             {
-               @Override
-               public void onResponseReceived(ProfileOperationResponse response)
-               {
-                  if (response.getErrorMessage() != null)
-                  {
-                     globalDisplay_.showErrorMessage("Profiler Error",
-                           response.getErrorMessage());
-                     onError.execute(null);
-                     return;
-                  }
-                   
-                  continuation.execute(response);
-               }
-         
-               @Override
-               public void onError(ServerError error)
-               {
-                  globalDisplay_.showErrorMessage("Failed to Open Profile",
-                        error.getMessage());
-                  onError.execute(null);
-               }
-            });
+               globalDisplay_.showErrorMessage("Profiler Error",
+                     response.getErrorMessage());
+               onError.execute(null);
+               return;
+            }
+             
+            continuation.execute(response);
+         }
+   
+         @Override
+         public void onError(ServerError error)
+         {
+            globalDisplay_.showErrorMessage("Failed to Open Profile",
+                  error.getMessage());
+            onError.execute(null);
          }
       });
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerPresenter.java
@@ -246,31 +246,38 @@ public class ProfilerPresenter implements RprofEvent.Handler
                              final OperationWithInput<Void> onError,
                              final String path)
    {
-      ProfileOperationRequest request = ProfileOperationRequest.create(path);
-       
-      server_.openProfile(request, 
-            new ServerRequestCallback<ProfileOperationResponse>()
+      dependencyManager_.withProfvis(profilerDependecyUserAction_, new Command()
       {
          @Override
-         public void onResponseReceived(ProfileOperationResponse response)
+         public void execute()
          {
-            if (response.getErrorMessage() != null)
-            {
-               globalDisplay_.showErrorMessage("Profiler Error",
-                     response.getErrorMessage());
-               onError.execute(null);
-               return;
-            }
+            ProfileOperationRequest request = ProfileOperationRequest.create(path);
              
-            continuation.execute(response);
-         }
-   
-         @Override
-         public void onError(ServerError error)
-         {
-            globalDisplay_.showErrorMessage("Failed to Open Profile",
-                  error.getMessage());
-            onError.execute(null);
+            server_.openProfile(request, 
+                  new ServerRequestCallback<ProfileOperationResponse>()
+            {
+               @Override
+               public void onResponseReceived(ProfileOperationResponse response)
+               {
+                  if (response.getErrorMessage() != null)
+                  {
+                     globalDisplay_.showErrorMessage("Profiler Error",
+                           response.getErrorMessage());
+                     onError.execute(null);
+                     return;
+                  }
+                   
+                  continuation.execute(response);
+               }
+         
+               @Override
+               public void onError(ServerError error)
+               {
+                  globalDisplay_.showErrorMessage("Failed to Open Profile",
+                        error.getMessage());
+                  onError.execute(null);
+               }
+            });
          }
       });
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerPresenter.java
@@ -212,7 +212,7 @@ public class ProfilerPresenter implements RprofEvent.Handler
          "Open File",
          fileContext_,
          workbenchContext_.getDefaultFileDialogDir(),
-         ".Rprof",
+         ".Rprofvis",
          new ProgressOperationWithInput<FileSystemItem>()
          {
             public void execute(final FileSystemItem input,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerPresenter.java
@@ -14,10 +14,12 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.profiler;
 
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
 import org.rstudio.core.client.files.FileSystemItem;
+import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.ProgressOperationWithInput;
@@ -28,7 +30,6 @@ import org.rstudio.studio.client.common.dependencies.DependencyManager;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
-import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.WorkbenchContext;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.RemoteFileSystemContext;
@@ -167,6 +168,7 @@ public class ProfilerPresenter implements RprofEvent.Handler
                @Override
                public void onError(ServerError error)
                {
+                  Debug.logError(error);
                   globalDisplay_.showErrorMessage("Failed to Stop Profiler",
                         error.getMessage());
                }
@@ -199,6 +201,7 @@ public class ProfilerPresenter implements RprofEvent.Handler
                @Override
                public void onError(ServerError error)
                {
+                  Debug.logError(error);
                   globalDisplay_.showErrorMessage("Failed to Stop Profiler",
                         error.getMessage());
                }
@@ -243,7 +246,7 @@ public class ProfilerPresenter implements RprofEvent.Handler
    }
    
    public void buildHtmlPath(final OperationWithInput<ProfileOperationResponse> continuation,
-                             final OperationWithInput<Void> onError,
+                             final Operation onError,
                              final String path)
    {
       ProfileOperationRequest request = ProfileOperationRequest.create(path);
@@ -258,7 +261,7 @@ public class ProfilerPresenter implements RprofEvent.Handler
             {
                globalDisplay_.showErrorMessage("Profiler Error",
                      response.getErrorMessage());
-               onError.execute(null);
+               onError.execute();
                return;
             }
              
@@ -268,9 +271,10 @@ public class ProfilerPresenter implements RprofEvent.Handler
          @Override
          public void onError(ServerError error)
          {
+            Debug.logError(error);
             globalDisplay_.showErrorMessage("Failed to Open Profile",
                   error.getMessage());
-            onError.execute(null);
+            onError.execute();
          }
       });
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerPresenter.java
@@ -246,38 +246,31 @@ public class ProfilerPresenter implements RprofEvent.Handler
                              final OperationWithInput<Void> onError,
                              final String path)
    {
-      dependencyManager_.withProfvis(profilerDependecyUserAction_, new Command()
+      ProfileOperationRequest request = ProfileOperationRequest.create(path);
+       
+      server_.openProfile(request, 
+            new ServerRequestCallback<ProfileOperationResponse>()
       {
          @Override
-         public void execute()
+         public void onResponseReceived(ProfileOperationResponse response)
          {
-            ProfileOperationRequest request = ProfileOperationRequest.create(path);
-             
-            server_.openProfile(request, 
-                  new ServerRequestCallback<ProfileOperationResponse>()
+            if (response.getErrorMessage() != null)
             {
-               @Override
-               public void onResponseReceived(ProfileOperationResponse response)
-               {
-                  if (response.getErrorMessage() != null)
-                  {
-                     globalDisplay_.showErrorMessage("Profiler Error",
-                           response.getErrorMessage());
-                     onError.execute(null);
-                     return;
-                  }
-                   
-                  continuation.execute(response);
-               }
-         
-               @Override
-               public void onError(ServerError error)
-               {
-                  globalDisplay_.showErrorMessage("Failed to Open Profile",
-                        error.getMessage());
-                  onError.execute(null);
-               }
-            });
+               globalDisplay_.showErrorMessage("Profiler Error",
+                     response.getErrorMessage());
+               onError.execute(null);
+               return;
+            }
+             
+            continuation.execute(response);
+         }
+   
+         @Override
+         public void onError(ServerError error)
+         {
+            globalDisplay_.showErrorMessage("Failed to Open Profile",
+                  error.getMessage());
+            onError.execute(null);
          }
       });
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/RprofEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/RprofEvent.java
@@ -37,6 +37,14 @@ public class RprofEvent extends GwtEvent<RprofEvent.Handler>
       public final native String getPath() /*-{
          return this.path;
       }-*/;
+
+      public final native String getHtmlPath() /*-{
+         return this.htmlPath;
+      }-*/;
+
+      public final native String getHtmlLocalPath() /*-{
+         return this.htmlLocalPath;
+      }-*/;
    }
    
    public interface Handler extends EventHandler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/model/ProfileOperationResponse.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/model/ProfileOperationResponse.java
@@ -31,11 +31,11 @@ public class ProfileOperationResponse extends JavaScriptObject
       return this.fileName;
    }-*/;
    
-   public final native String getHtmlFile() /*-{
-      return this.htmlFile;
+   public final native String getHtmlPath() /*-{
+      return this.htmlPath;
    }-*/;
    
-   public final native String getHtmlLocalFile() /*-{
-      return this.htmlLocalFile;
+   public final native String getHtmlLocalPath() /*-{
+      return this.htmlLocalPath;
    }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/model/ProfilerContents.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/model/ProfilerContents.java
@@ -23,9 +23,16 @@ public class ProfilerContents extends JavaScriptObject
    }
    
    public static final native ProfilerContents create(
-      String path, boolean createProfile) /*-{
+      String path, 
+      String htmlPath, 
+      String htmlLocalPath, 
+      boolean createProfile) /*-{
       var contents = new Object();
+
       contents.path = path;
+      contents.htmlPath = htmlPath;
+      contents.htmlLocalPath = htmlLocalPath;
+
       contents.createProfile = createProfile;
       return contents;
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/model/ProfilerServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/model/ProfilerServerOperations.java
@@ -33,4 +33,7 @@ public interface ProfilerServerOperations
    void copyProfile(String fromPath,
                     String toPath,
                     ServerRequestCallback<JavaScriptObject> requestCallback);
+
+   void clearProfile(String path,
+                     ServerRequestCallback<JavaScriptObject> requestCallback);
 }


### PR DESCRIPTION
The major change in this pr is to transition from the `rprof` profile extension into `rprofvis`. The reason behind this is that `rprof` contains insufficient information to reliable map back to the sources while building a `profvis` visualization from the `rprof` file. For instance, one could take a profile and change code related to the profile, in this case, reopening the profile would not reference the right sources.

The fix implemented in this pr is to store the `profvis` html output as the contents of the new `.Rprofvis` file type.

Additionally, addresing the following issues:
- Support package dependencies to install when opening a profiler file. This fix is actually no longer needed since the new self-contained file format enables opening profiles even when profvis is not installed.
- Support profiler to clean up `profiler-cache` folder. This is implemented with a new rpc with the specific purpose of cleaning cache files.