### PR TITLE
handle unnamed sections, sub-sections in R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 ### Editor
 
 * Enabled auto-pairing of backticks (\`\`) in R documents
+* Fixed regression re: folding of unnamed sections, e.g. '#####'
+* Implemented folding for sub-sections in R documents
 * Added option for display of 'end' fold markers
 * Display function tooltip on mouse over of function name
 * Added option to display function signature tooltip on cursor idle

--- a/src/gwt/acesupport/acemode/cpp_code_model.js
+++ b/src/gwt/acesupport/acemode/cpp_code_model.js
@@ -336,6 +336,9 @@ var CppCodeModel = function(session, tokenizer,
             var sectionHeadMatch = /^\/\/'?[-=#\s]*(.*?)\s*[-=#]+\s*$/.exec(
                   tokenCursor.currentValue());
 
+            if (!sectionHeadMatch)
+               continue;
+
             var label = "" + sectionHeadMatch[1];
             if (label.length == 0)
                label = "(Untitled)";

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -64,7 +64,7 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
       rules["#comment"] = [
          {
             token : "comment.sectionhead",
-            regex : "#+(?!')(?:[^-=#]).*(?:----|====|####)\\s*$",
+            regex : "#+(?!').*(?:----|====|####)\\s*$",
             next  : "start"
          },
          {


### PR DESCRIPTION
This PR implements a couple things:

1. It allows empty section headers, e.g. `#####` -- this was a regression from v0.98 and it looks like it's bugged quite a few users,

2. It enables folding for sub-sections (ie, sections within a function body).

I've confirmed that this works in R, Rmd, Rhtml and C++ modes, but let's leave this for a bit before merging.