### PR TITLE
more permissive httpdport-as-function detection

### DIFF
--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -17,7 +17,7 @@
 options(help_type = "html")
 
 .rs.addFunction( "httpdPortIsFunction", function() {
-   getRversion() >= "3.2" && .rs.haveRequiredRSvnRev(67550)
+   is.function(tools:::httpdPort)
 })
 
 .rs.addFunction( "httpdPort", function()


### PR DESCRIPTION
This PR checks directly whether `tools:::httpdPort` is a function, rather than introspecting on the R / SVN revision.

This seems necessary in some cases as some users might build R from sources without setting / propagating the SVN revision (it looks like it defaults to `-99` in that case).