### PR TITLE
improvements from profiler testpass

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.studio.client.workbench.views.console;
 
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Label;
@@ -156,6 +158,14 @@ public class ConsolePane extends WorkbenchPane
    {
       profilerMode_ = profilerMode;
       loadDebugToolsIntoSecondaryToolbar();
+      
+      Scheduler.get().scheduleFinally(new ScheduledCommand()
+      {
+         public void execute()
+         {
+            ensureCursorVisible();
+         }
+      });
    }
    
    private void loadDebugToolsIntoSecondaryToolbar()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceShim.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceShim.java
@@ -226,8 +226,11 @@ public class SourceShim extends Composite
    @Override
    public void onEnsureVisibleSourceWindow(EnsureVisibleSourceWindowEvent e)
    {
-      fireEvent(new EnsureVisibleEvent());
-      fireEvent(new EnsureHeightEvent(EnsureHeightEvent.NORMAL));
+      if (source_.getView().getTabCount() > 0)
+      {
+         fireEvent(new EnsureVisibleEvent());
+         fireEvent(new EnsureHeightEvent(EnsureHeightEvent.NORMAL));
+      }
    }
 
    public void forceLoad()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -255,6 +255,14 @@ public class ProfilerEditingTarget implements EditingTarget,
          else
          {
             view_.showProfilePage(htmlPath_);
+
+            Scheduler.get().scheduleDeferred(new ScheduledCommand()
+            {
+               public void execute()
+               {
+                  pSourceWindowManager_.get().maximizeSourcePaneIfNecessary();
+               }
+            });
          }
       }
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -16,6 +16,8 @@ package org.rstudio.studio.client.workbench.views.source.editors.profiler;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.event.shared.GwtEvent;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -178,6 +180,7 @@ public class ProfilerEditingTarget implements EditingTarget,
          commands.add(commands_.popoutDoc());
       else
          commands.add(commands_.returnDocToMain());
+      commands.add(commands_.printSourceDoc());
       return commands;
    }
    
@@ -387,6 +390,18 @@ public class ProfilerEditingTarget implements EditingTarget,
    public void revertChanges(Command onCompleted)
    {
       onCompleted.execute();
+   }
+   
+   @Handler
+   void onPrintSourceDoc()
+   {
+      Scheduler.get().scheduleDeferred(new ScheduledCommand()
+      {
+         public void execute()
+         {
+            view_.print();
+         }
+      });
    }
    
    private String getAndSetInitialName()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
@@ -19,6 +19,8 @@ import com.google.gwt.user.client.ui.Frame;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 
+import org.rstudio.core.client.dom.WindowEx;
+import org.rstudio.core.client.widget.RStudioFrame;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.studio.client.rsconnect.RSConnect;
 import org.rstudio.studio.client.rsconnect.model.PublishHtmlSource;
@@ -31,7 +33,7 @@ public class ProfilerEditingTargetWidget extends Composite
                                          implements ProfilerPresenter.Display
               
 {
-   private Frame profilePage_;
+   private RStudioFrame profilePage_;
    
    public ProfilerEditingTargetWidget(Commands commands, PublishHtmlSource publishHtmlSource)
    {
@@ -42,7 +44,7 @@ public class ProfilerEditingTargetWidget extends Composite
                                           createToolbar(commands, publishHtmlSource), 
                                           panel);
 
-      profilePage_ = new Frame();
+      profilePage_ = new RStudioFrame();
       profilePage_.setWidth("100%");
       profilePage_.setHeight("100%");
       
@@ -51,6 +53,13 @@ public class ProfilerEditingTargetWidget extends Composite
       panel.setHeight("100%");
       
       initWidget(mainPanel);
+   }
+
+   public void print()
+   {
+      WindowEx window = profilePage_.getWindow();
+      window.focus();
+      window.print();
    }
 
    private Toolbar createToolbar(Commands commands, PublishHtmlSource publishHtmlSource)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
@@ -15,7 +15,6 @@
 package org.rstudio.studio.client.workbench.views.source.editors.profiler;
 
 import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.Frame;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 


### PR DESCRIPTION
- Fix profiler pushing console down one line when user starts profiling  
- Prevent profiler form creating a new R script when starting the profiler with no files open  
- Implement printing profiles  
- Minimize console when profiler is invoked from console or profile selected line(s) command.  

<img width="1440" alt="screen shot 2016-03-14 at 3 11 56 pm" src="https://cloud.githubusercontent.com/assets/3478847/13761639/3725567a-e9f7-11e5-8a5d-6dcc78591193.png">

