### PR TITLE
SVN: perform non-recursive revert

### DIFF
--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -719,6 +719,9 @@ Error svnDelete(const json::JsonRpcRequest& request,
    return Success();
 }
 
+Error status(const FilePath& filePath,
+             std::vector<source_control::FileWithStatus>* pFiles);
+
 Error svnRevert(const json::JsonRpcRequest& request,
                 json::JsonRpcResponse* pResponse)
 {
@@ -733,13 +736,73 @@ Error svnRevert(const json::JsonRpcRequest& request,
    std::transform(files.begin(), files.end(), std::back_inserter(paths),
                   &resolveAliasedJsonPath);
 
-   core::system::ProcessResult result;
-   error = runSvn(ShellArgs() << "revert" << globalArgs() << "-q" <<
-                  "--depth" << "infinity" <<
-                  "--" << paths,
-                  true, &result);
+   // split into two groups -- those for which we desire
+   // a recursive revert, and those for which we desire
+   // a non-recursive revert
+   std::vector<source_control::FileWithStatus> fileStatusVector;
+   error = status(FilePath(), &fileStatusVector);
    if (error)
+   {
+      LOG_ERROR(error);
       return error;
+   }
+   
+   // build map (indexed on file path) for easy lookup
+   std::map<std::string, source_control::FileWithStatus> fileStatusMap;
+   BOOST_FOREACH(const source_control::FileWithStatus& file, fileStatusVector)
+   {
+      fileStatusMap[file.path.absolutePath()] = file;
+   }
+   
+   std::vector<FilePath> recursiveReverts;
+   std::vector<FilePath> nonRecursiveReverts;
+   BOOST_FOREACH(const FilePath& filePath, paths)
+   {
+      if (!filePath.isDirectory())
+      {
+         recursiveReverts.push_back(filePath);
+         continue;
+      }
+      
+      bool shouldRevertRecursively = false;
+      std::string key = filePath.absolutePath();
+      if (fileStatusMap.count(key))
+      {
+         const source_control::FileWithStatus& fileStatus =
+               fileStatusMap[key];
+         
+         shouldRevertRecursively = fileStatus.status.status() == "A";
+      }
+      
+      if (shouldRevertRecursively)
+         recursiveReverts.push_back(filePath);
+      else
+         nonRecursiveReverts.push_back(filePath);
+   }
+   
+   // perform non-recursive reverts
+   core::system::ProcessResult result;
+   if (!nonRecursiveReverts.empty())
+   {
+      error = runSvn(ShellArgs() << "revert" << globalArgs() << "-q" <<
+                     "--" << nonRecursiveReverts,
+                     true,
+                     &result);
+      if (error)
+         return error;
+   }
+   
+   // perform recursive reverts
+   if (!recursiveReverts.empty())
+   {
+      error = runSvn(ShellArgs() << "revert" << globalArgs() << "-q" <<
+                     "--depth" << "infinity" <<
+                     "--" << recursiveReverts,
+                     true,
+                     &result);
+      if (error)
+         return error;
+   }
 
    pResponse->setResult(processResultToJson(result));
 


### PR DESCRIPTION
This PR fixes an issue where attempts to 'revert' changes to a directory (ie, changes to its properties; for example, ignore properties) would cause a recursive revert, thereby reverting all changes files within that directory.