### PR TITLE
Improved Rmd toolbar/menu behavior for custom formats

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
@@ -488,6 +488,27 @@ public class TextEditingTargetRMarkdownHelper
       return null;
    }
    
+   public boolean isRuntimeShiny(String yaml)
+   {
+      // This is in the editor load path, so guard against exceptions and log
+      // any we find without bringing down the editor. 
+      try
+      {  
+         YamlTree tree = new YamlTree(yaml);
+         
+         if (tree.getKeyValue(RmdFrontMatter.KNIT_KEY).length() > 0)
+            return false;
+         
+         return tree.getKeyValue(
+             RmdFrontMatter.RUNTIME_KEY).equals(RmdFrontMatter.SHINY_RUNTIME);
+      }
+      catch (Exception e)
+      {
+         Debug.log("Warning: Exception thrown while parsing YAML:\n" + yaml);
+      }
+      return false;
+   }
+   
    // Parses YAML, adds the given format option with any transferable
    // defaults, and returns the resulting YAML
    public void setOutputFormat(String yaml, final String format, 


### PR DESCRIPTION
@jmcphers Could you please review this? (it's a pretty intrusive refactor of some of your code and I believe it's in the editor load path so exceptions would be fatal!)

To date whenever a custom format is active in an Rmd we pretty much bail on any attempt to provide the options menu, knit with parameters, etc. This PR attempts to arrange things so we are better behaved:

1. We move the "Knit with Parameters" menu to the Options menu;

2. We always show the Options menu, but make the "Output Options..." menu conditional on having and RmdTemplate available and the "Knit with Parameters" menu conditional on NOT being in runtime: shiny;

3. We detect runtime: shiny for custom formats and in that case provide the "Run Document" treatment rather than the "Knit" treatment.

4. Unrelated change: Added "(No Preview)" as an option alongside "Preview in Viewer Pane" and "Preview in Window"

