### PR TITLE
Show custom R Markdown formats in the Knit menu

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,13 @@
 * Enable data import preview to be cancelled
 * Enable data import to cache web files
 
+### R Markdown
+
+* Show custom formats in Knit menu
+* Show options menu and Knit w/ Params for custom formats
+* Use "Run Document" for custom formats with runtime: shiny
+* Add option to suppress Knit preview entirely
+
 ### C / C++
 
 * Provide autocompletion of header paths

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/YamlTree.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/YamlTree.java
@@ -118,7 +118,7 @@ public class YamlTree
       
       private String getKey(String line)
       {
-         RegExp keyReg = RegExp.compile("^\\s*([^:]+):");
+         RegExp keyReg = RegExp.compile("^\\s*(.+):(?!:)");
          MatchResult result = keyReg.exec(line);
          if (result == null)
             return "";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
@@ -942,6 +942,20 @@ public class TextEditingTargetRMarkdownHelper
       return result;
    }
       
+   public List<String> getOutputFormats(String yaml)
+   {
+      try
+      {  
+         YamlTree tree = new YamlTree(yaml);
+         return getOutputFormats(tree);   
+      }
+      catch (Exception e)
+      {
+         Debug.log("Warning: Exception thrown while parsing YAML:\n" + yaml);
+      }
+      return null;
+   }
+   
    private List<String> getOutputFormats(YamlTree tree)
    {
       List<String> outputs = tree.getChildKeys(RmdFrontMatter.OUTPUT_KEY);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -759,21 +759,22 @@ public class TextEditingTargetWidget
    
    @Override
    public void setFormatOptions(TextFileType fileType,
+                                boolean canEditFormatOptions,
                                 List<String> options, 
                                 List<String> values, 
                                 List<String> extensions, 
                                 String selectedOption)
-   {
-      boolean haveFormatOptions = options.size() > 0;
-      
-      if (!haveFormatOptions)
+   { 
+      if (!canEditFormatOptions)
       {
          setFormatText("");
       }
-      setRmdFormatButtonVisible(haveFormatOptions);
-      rmdFormatButton_.setEnabled(haveFormatOptions);
       
-      if (haveFormatOptions)
+      boolean haveMultipleFormats = options.size() > 0;
+      setRmdFormatButtonVisible(haveMultipleFormats);
+      rmdFormatButton_.setEnabled(haveMultipleFormats);
+      
+      if (haveMultipleFormats)
       {
          rmdFormatButton_.clearMenu();
          int parenPos = selectedOption.indexOf('(');
@@ -784,8 +785,10 @@ public class TextEditingTargetWidget
          String prefix = fileType.isPlainMarkdown() ? "Preview " : "Knit to ";
          for (int i = 0; i < Math.min(options.size(), values.size()); i++)
          {
-            ImageResource img = fileTypeRegistry_.getIconForFilename("output." + 
-                        extensions.get(i));
+            String ext = extensions.get(i);
+            ImageResource img = ext != null ? 
+                  fileTypeRegistry_.getIconForFilename("output." + ext) :
+                  fileTypeRegistry_.getIconForFilename("Makefile");
             final String valueName = values.get(i);
             ScheduledCommand cmd = new ScheduledCommand()
             {
@@ -803,7 +806,7 @@ public class TextEditingTargetWidget
          }
       }
       
-      showRmdViewerMenuItems(true, haveFormatOptions, fileType.isRmd(), false);
+      showRmdViewerMenuItems(true, canEditFormatOptions, fileType.isRmd(), false);
      
       if (publishButton_ != null)
          publishButton_.setIsStatic(true);


### PR DESCRIPTION
This PR extends the existing logic for building the Knit w/ Format menu to include custom formats. The original logic depends on the notion of discovering an active "template" (i.e. conventional document or presentation) then building the menu off of that. This PR doesn't interfere with that mechanism (as it's used to provide format option editing) but instead amends the list for formats with any other ones discovered in the YAML.

Note there is one important change in the way YAML is parsed (we updated our regex that discovers keys to allow for a key containing a double-colon (::), which is necessary for custom formats. We should look that change over carefully to make sure it doesn't have unexpected side effects.

@jmcphers Could you review?

@yihui This should make the default Tufte template much nicer to work with in RStudio!