### PR TITLE
add support for profile go-to-sources to find files in normalized path

### DIFF
--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -181,13 +181,18 @@
    })
 })
 
-.rs.addJsonRpcHandler("profile_sources", function(filePath)
+.rs.addJsonRpcHandler("profile_sources", function(filePath, normPath)
 {
    tryCatch({
-      fixedPath <- filePath
-      exists <- file.exists(fixedPath)
+      validPath <- ""
+      paths <- c(filePath, normPath)
+      found <- file.exists(paths)
+      
+      if (any(found == TRUE)) {
+         validPath <- paths[[which(found == TRUE)]]
+      }
 
-      return(.rs.scalar(if (exists) fixedPath else ""))
+      return(.rs.scalar(validPath))
    }, error = function(e) {
       return(list(error = .rs.scalar(e$message)))
    })

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4569,11 +4569,12 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, CLEAR_PROFILE, params, requestCallback);
    }
 
-   public void profileSources(String path,
+   public void profileSources(String path, String normPath,
                               ServerRequestCallback<String> requestCallback)
    {
       JSONArray params = new JSONArray();
       params.set(0, new JSONString(path));
+      params.set(1, new JSONString(normPath));
       sendRequest(RPC_SCOPE, PROFILE_SOURCES, params, requestCallback);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -698,12 +698,13 @@ public class ProfilerEditingTarget implements EditingTarget,
    
    private void onMessage(final String message,
                           final String file,
+                          final String normPath,
                           final String details,
                           final int line)
    {
       if (message == "sourcefile")
       {
-         server_.profileSources(file, new ServerRequestCallback<String>()
+         server_.profileSources(file, normPath, new ServerRequestCallback<String>()
          {
             @Override
             public void onResponseReceived(String response)
@@ -719,7 +720,7 @@ public class ProfilerEditingTarget implements EditingTarget,
                   if (hasValidPath_)
                   {
                      FilePosition filePosition = FilePosition.create(line, 0);
-                     CodeNavigationTarget navigationTarget = new CodeNavigationTarget(file, filePosition);
+                     CodeNavigationTarget navigationTarget = new CodeNavigationTarget(response, filePosition);
                      
                      fileTypeRegistry_.editFile(
                            FileSystemItem.createFile(navigationTarget.getFile()),
@@ -745,12 +746,14 @@ public class ProfilerEditingTarget implements EditingTarget,
    
    public static void onGlobalMessage(final String message,
                                 final String file,
+                                final String normPath,
                                 final String details,
                                 final int line)
    {
       if (activeProfilerEditingTarger_ != null)
       {
-         activeProfilerEditingTarger_.onMessage(message, file, details, line);
+         
+         activeProfilerEditingTarger_.onMessage(message, file, normPath, details, line);
       }
    }
 
@@ -778,7 +781,13 @@ public class ProfilerEditingTarget implements EditingTarget,
          if (e.data.source != "profvis")
             return;
             
-         @org.rstudio.studio.client.workbench.views.source.editors.profiler.ProfilerEditingTarget::onGlobalMessage(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)(e.data.message, e.data.file, e.data.details, e.data.line);
+         @org.rstudio.studio.client.workbench.views.source.editors.profiler.ProfilerEditingTarget::onGlobalMessage(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)(
+            e.data.message,
+            e.data.file,
+            e.data.normpath,
+            e.data.details,
+            e.data.line
+         );
       });
       $wnd.addEventListener("message", handler, true);
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/model/ProfilerServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/model/ProfilerServerOperations.java
@@ -37,6 +37,6 @@ public interface ProfilerServerOperations
    void clearProfile(String path,
                      ServerRequestCallback<JavaScriptObject> requestCallback);
 
-   void profileSources(String path,
+   void profileSources(String path, String normPath,
                        ServerRequestCallback<String> requestCallback);
 }


### PR DESCRIPTION
This change fixes scenarios where different users open the same profile in the same machine and are unable to navigate to sources. The fix is to use the relative path and absolute path to find a valid path and use that to open the sources. This fix depends on https://github.com/rstudio/profvis/pull/37.