### PR TITLE
remove profiles cache when document closes instead of window close

### DIFF
--- a/src/cpp/session/include/session/SessionSourceDatabase.hpp
+++ b/src/cpp/session/include/session/SessionSourceDatabase.hpp
@@ -200,7 +200,7 @@ struct Events : boost::noncopyable
    boost::signal<void(const std::string&,
                       boost::shared_ptr<SourceDocument>)>      onDocRenamed;
    boost::signal<void(const std::string&)>                     onDocAdded;
-   boost::signal<void(const std::string&,
+   boost::signal<void(
       boost::shared_ptr<source_database::SourceDocument>)>     onDocPendingRemove;
    boost::signal<void(const std::string&, const std::string&)> onDocRemoved;
    boost::signal<void()>                                       onRemoveAll;

--- a/src/cpp/session/include/session/SessionSourceDatabase.hpp
+++ b/src/cpp/session/include/session/SessionSourceDatabase.hpp
@@ -200,7 +200,8 @@ struct Events : boost::noncopyable
    boost::signal<void(const std::string&,
                       boost::shared_ptr<SourceDocument>)>      onDocRenamed;
    boost::signal<void(const std::string&)>                     onDocAdded;
-   boost::signal<void(const std::string&)>                     onDocPendingRemove;
+   boost::signal<void(const std::string&,
+      boost::shared_ptr<source_database::SourceDocument>)>     onDocPendingRemove;
    boost::signal<void(const std::string&, const std::string&)> onDocRemoved;
    boost::signal<void()>                                       onRemoveAll;
 };

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -189,7 +189,7 @@
       found <- file.exists(paths)
       
       if (any(found == TRUE)) {
-         validPath <- paths[[which(found == TRUE)]]
+         validPath <- paths[[which(found == TRUE)[[1]]]]
       }
 
       return(.rs.scalar(validPath))

--- a/src/cpp/session/modules/SessionProfiler.cpp
+++ b/src/cpp/session/modules/SessionProfiler.cpp
@@ -66,7 +66,6 @@ void handleProfilerResReq(const http::Request& request,
 }
 
 void onDocPendingRemove(
-        const std::string &id,
         boost::shared_ptr<source_database::SourceDocument> pDoc)
 {
    // check to see if there is html cached data

--- a/src/cpp/session/modules/SessionProfiler.cpp
+++ b/src/cpp/session/modules/SessionProfiler.cpp
@@ -65,32 +65,24 @@ void handleProfilerResReq(const http::Request& request,
    pResponse->setCacheableFile(profileResource, request);
 }
 
-void onDocPendingRemove(const std::string &id)
+void onDocPendingRemove(
+        const std::string &id,
+        boost::shared_ptr<source_database::SourceDocument> pDoc)
 {
-   // retrieve document from source database
-   boost::shared_ptr<source_database::SourceDocument> pDoc(
-               new source_database::SourceDocument());
-   Error error = source_database::get(id, pDoc);
-   if (error)
-   {
-      LOG_ERROR(error);
-         return;
-   }
-
    // check to see if there is html cached data
    std::string htmlLocalPath = pDoc->getProperty("htmlLocalPath");
    if (htmlLocalPath.empty())
       return;
 
-   r::sexp::Protect rProtect;
    r::exec::RFunction rFunction(".rs.rpc.clear_profile");
    rFunction.addParam(htmlLocalPath);
 
-   SEXP resultSEXP;
-   error = rFunction.call(&resultSEXP, &rProtect);
-
-   LOG_ERROR(error);
+   Error error = rFunction.call();
+   if (error)
+   {
+      LOG_ERROR(error);
       return;
+   }
 }
 
 Error initialize()

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -715,11 +715,12 @@ Error closeDocument(const json::JsonRpcRequest& request,
    if (error)
    {
       LOG_ERROR(error);
-      return error;
    }
-   
-   // do any cleanup necessary prior to removal
-   source_database::events().onDocPendingRemove(id, pDoc);
+   else
+   {
+      // do any cleanup necessary prior to removal
+      source_database::events().onDocPendingRemove(pDoc);
+   }
 
    // actually remove from the source database
    error = source_database::remove(id);

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -707,9 +707,19 @@ Error closeDocument(const json::JsonRpcRequest& request,
    // get the path (it's okay if this fails, unsaved docs don't have a path)
    std::string path;
    source_database::getPath(id, &path);
+
+   // retrieve document from source database
+   boost::shared_ptr<source_database::SourceDocument> pDoc(
+               new source_database::SourceDocument());
+   error = source_database::get(id, pDoc);
+   if (error)
+   {
+      LOG_ERROR(error);
+      return error;
+   }
    
    // do any cleanup necessary prior to removal
-   source_database::events().onDocPendingRemove(id);
+   source_database::events().onDocPendingRemove(id, pDoc);
 
    // actually remove from the source database
    error = source_database::remove(id);

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -920,13 +920,12 @@ void onClientInit()
 }
 
 void onDocPendingRemove(
-        const std::string &id,
         boost::shared_ptr<source_database::SourceDocument> pDoc)
 {
    // see if the document has a path (if it does, it can't be a data viewer
    // item)
    std::string path;
-   source_database::getPath(id, &path);
+   source_database::getPath(pDoc->id(), &path);
    if (!path.empty())
       return;
 

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -919,7 +919,9 @@ void onClientInit()
 #endif
 }
 
-void onDocPendingRemove(const std::string &id)
+void onDocPendingRemove(
+        const std::string &id,
+        boost::shared_ptr<source_database::SourceDocument> pDoc)
 {
    // see if the document has a path (if it does, it can't be a data viewer
    // item)
@@ -928,23 +930,13 @@ void onDocPendingRemove(const std::string &id)
    if (!path.empty())
       return;
 
-   // retrieve document from source database
-   boost::shared_ptr<source_database::SourceDocument> pDoc(
-         new source_database::SourceDocument());
-   Error error = source_database::get(id, pDoc);
-   if (error)
-   {
-      LOG_ERROR(error);
-      return;
-   }
-
    // see if it has a cache key we need to remove (if not, no work to do)
    std::string cacheKey = pDoc->getProperty("cacheKey");
    if (cacheKey.empty())
       return;
 
    // remove cache env object and backing file
-   error = removeCacheKey(cacheKey);
+   Error error = removeCacheKey(cacheKey);
    if (error)
       LOG_ERROR(error);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -482,7 +482,6 @@ public class ProfilerEditingTarget implements EditingTarget,
 
    public void onDismiss(int dismissType)
    {
-      clearProfileCache();
       presenter_.detach();
    }
 
@@ -571,25 +570,6 @@ public class ProfilerEditingTarget implements EditingTarget,
    public String getDefaultNamePrefix()
    {
       return "Profile";
-   }
-   
-   private void clearProfileCache()
-   {
-      try
-      {
-         server_.clearProfile(htmlLocalPath_, new ServerRequestCallback<JavaScriptObject>()
-         {
-            @Override
-            public void onError(ServerError error)
-            {
-               Debug.logError(error);
-            }
-         });
-      }
-      catch(Exception e)
-      {
-         Debug.logException(e);
-      }
    }
    
    private void savePropertiesWithPath(String path)


### PR DESCRIPTION
This PR fixes an issue while detaching the profiler window since detaching causes a close/reopen that would clean the not-yet-saved profile files. Instead, we clean the profile when the document entry is removed.