### PR TITLE
improve keyboard navigation in directory widget

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
@@ -442,6 +442,9 @@ public class ShortcutManager implements NativePreviewHandler,
       int keyCode = keys.getKeyCode();
       int modifiers = keys.getModifier();
       
+      if (keyCode == KeyCodes.KEY_BACKSPACE)
+         event.preventDefault();
+      
       boolean isSaveQuitKey =
             keyCode == KeyCodes.KEY_S ||
             keyCode == KeyCodes.KEY_W;

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/FileBrowserWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/FileBrowserWidget.java
@@ -109,6 +109,7 @@ public class FileBrowserWidget extends Composite
       directory_.setContents(
             host_.ls(),
             parsedDir.length > 1 ? parsedDir[parsedDir.length-2] : null);
+      setDirectoryFocus(true);
    }
 
    public void cd(String path)


### PR DESCRIPTION
This PR improves keyboard navigation in the file selection widgets (e.g. on `Open File...`):

1) You can type the name of the directory you wish to navigate to (prefix matching); the first prefix match is selected, and a timer clears the current prefix 'buffer' after 1 second;

2) Backspace now navigates to the parent directory (if available),

3) The widget is focused on open (so that keyboard navigation will immediately work)

We also now ensure backspace can't perform a browser back action when the IDE has focus.