### PR TITLE
don't display chunk toolbars for chunks that lie within folds

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/EditSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/EditSession.java
@@ -154,7 +154,15 @@ public class EditSession extends JavaScriptObject
    public native final JsArray<AceFold> getAllFolds() /*-{
       return this.getAllFolds();
    }-*/;
+   
+   public native final AceFold getFoldAt(Position position) /*-{
+      return this.getFoldAt(position.row, position.column);
+   }-*/;
 
+   public native final AceFold getFoldAt(int row, int column) /*-{
+      return this.getFoldAt(row, column);
+   }-*/;
+   
    public native final void addFold(String placeholder, Range range) /*-{
       this.addFold(placeholder, range);
    }-*/;


### PR DESCRIPTION
This PR fixes an issue where chunk toolbars would still get drawn for R chunks within a folded Markdown section.