### PR TITLE
prevent backspace when 'body' target of event

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
@@ -30,6 +30,7 @@ import org.rstudio.core.client.command.KeyMap.CommandBinding;
 import org.rstudio.core.client.command.KeyMap.KeyMapType;
 import org.rstudio.core.client.command.KeyboardShortcut.KeyCombination;
 import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.events.NativeKeyDownEvent;
 import org.rstudio.core.client.events.NativeKeyDownHandler;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -436,6 +437,10 @@ public class ShortcutManager implements NativePreviewHandler,
             }
          }
       }
+      
+      // Prevent backspace from performing a browser 'back'
+      if (DomUtils.preventBackspaceCausingBrowserBack(event))
+         return;
       
       // Suppress save / quit events from reaching the browser
       KeyCombination keys = new KeyCombination(event);

--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -21,6 +21,7 @@ import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.dom.client.*;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.dom.client.HasAllKeyHandlers;
+import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.event.dom.client.KeyPressEvent;
@@ -39,6 +40,7 @@ import org.rstudio.core.client.dom.impl.DomUtilsImpl;
 import org.rstudio.core.client.dom.impl.NodeRelativePosition;
 import org.rstudio.core.client.regex.Match;
 import org.rstudio.core.client.regex.Pattern;
+import org.rstudio.studio.client.application.Desktop;
 
 /**
  * Helper methods that are mostly useful for interacting with 
@@ -914,6 +916,26 @@ public class DomUtils
       JsArrayString classes = JsArrayString.createArray().cast();
       classes.push(className);
       return extractCssValue(classes, propertyName);
+   }
+   
+   public static final boolean preventBackspaceCausingBrowserBack(NativeEvent event)
+   {
+      if (Desktop.isDesktop())
+         return false;
+      
+      if (event.getKeyCode() != KeyCodes.KEY_BACKSPACE)
+         return false;
+      
+      EventTarget target = event.getEventTarget();
+      if (target == null)
+         return false;
+      
+      Element elementTarget = Element.as(target);
+      if (!elementTarget.getNodeName().equals("BODY"))
+         return false;
+      
+      event.preventDefault();
+      return true;
    }
    
    public static final native String extractCssValue(JsArrayString className, 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -42,6 +42,7 @@ import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.command.ShortcutManager;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.ElementEx;
 import org.rstudio.core.client.dom.IFrameElementEx;
 import org.rstudio.core.client.dom.WindowEx;
@@ -95,14 +96,14 @@ public class HelpPane extends WorkbenchPane
    @Override 
    protected Widget createMainWidget()
    {
-      frame_ = new RStudioFrame() ;
+      frame_ = new RStudioFrame();
       frame_.setSize("100%", "100%");
-      frame_.setStylePrimaryName("rstudio-HelpFrame") ;
+      frame_.setStylePrimaryName("rstudio-HelpFrame");
       ElementIds.assignElementId(frame_.getElement(), ElementIds.HELP_FRAME);
 
       return new AutoGlassPanel(frame_);
    }
-
+   
    @Override
    public void onResize()
    {
@@ -200,23 +201,23 @@ public class HelpPane extends WorkbenchPane
          WindowEx.get().focus();
          findTextBox_.focus();
          findTextBox_.selectAll();
+         return;
       }
       
+      // don't let backspace perform browser back
+      DomUtils.preventBackspaceCausingBrowserBack(e);
+      
       // delegate to the shortcut manager
-      else
+      NativeKeyDownEvent evt = new NativeKeyDownEvent(e);
+      ShortcutManager.INSTANCE.onKeyDown(evt);
+      if (evt.isCanceled())
       {
-         NativeKeyDownEvent evt = new NativeKeyDownEvent(e);
-         ShortcutManager.INSTANCE.onKeyDown(evt);
-         if (evt.isCanceled())
-         {
-            e.preventDefault();
-            e.stopPropagation();
-            
-            // since this is a shortcut handled by the main window
-            // we set focus to it
-            WindowEx.get().focus();
-         }
-         
+         e.preventDefault();
+         e.stopPropagation();
+
+         // since this is a shortcut handled by the main window
+         // we set focus to it
+         WindowEx.get().focus();
       }
    }
    
@@ -573,6 +574,7 @@ public class HelpPane extends WorkbenchPane
                   frame_.setUrl(targetUrl_);
                   replaceFrameUrl(frame_.getIFrame().cast(), targetUrl_);
                }
+               
                return false;
             }
             else


### PR DESCRIPTION
This PR seeks to (safely) prevent Backspace keypresses from causing a browser 'Back' event.

In a previous commit, we attempted to suppress all backspace handling by the browser -- however, this breaks editing with editable fields (e.g. text areas, inputs, and otherwise). This PR implements a more targeted suppression of backspace: if the `body` element is the target of a backspace keydown event, only then do we suppress it.

Tested with Chrome + FireFox on OS X, and this seems to handle the main cases.