### PR TITLE
add (devmode-only) session suspend command

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
@@ -43,6 +43,7 @@ import org.rstudio.studio.client.application.model.SaveAction;
 import org.rstudio.studio.client.application.model.SuspendOptions;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.GlobalProgressDelayer;
+import org.rstudio.studio.client.common.SuperDevMode;
 import org.rstudio.studio.client.common.filetypes.FileIconResources;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
@@ -95,6 +96,9 @@ public class ApplicationQuit implements SaveActionChangedHandler,
       
       // bind to commands
       binder.bind(commands, this);
+      
+      // only enable suspendSession() in devmode
+      commands.suspendSession().setVisible(SuperDevMode.isActive());
       
       // subscribe to events
       eventBus.addHandler(SaveActionChangedEvent.TYPE, this);   
@@ -438,6 +442,12 @@ public class ApplicationQuit implements SaveActionChangedHandler,
                                  SuspendOptions.createSaveMinimal(saveChanges),
                                  null));  
 
+   }
+   
+   @Handler
+   public void onSuspendSession()
+   {
+      server_.suspendSession(true, new VoidServerRequestCallback());
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -298,6 +298,7 @@ well as menu structures (for main menu and popup menus).
          <separator/>
          <cmd refid="interruptR"/>
          <cmd refid="restartR"/>
+         <cmd refid="suspendSession"/>
          <separator/>
          <cmd refid="terminateR"/>
          <separator/>
@@ -2400,6 +2401,12 @@ well as menu structures (for main menu and popup menus).
         desc="Open a new R session"
         windowMode="main"/>
 
+   <cmd id="suspendSession"
+        label="Suspend R Session"
+        menuLabel="_Suspend R Session"
+        rebindable="false"
+        windowMode="main"/>
+        
    <cmd id="quitSession"
         label="Quit the Current R Session"
         menuLabel="_Quit Session..."

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -373,6 +373,7 @@ public abstract class
 
    // Application
    public abstract AppCommand newSession();
+   public abstract AppCommand suspendSession();
    public abstract AppCommand quitSession();
    public abstract AppCommand updateCredentials();
    public abstract AppCommand diagnosticsReport();


### PR DESCRIPTION
This PR adds the `suspendSession()` command and places it within the `Session` menu, but enables it only for SuperDevMode. This should make it a bit easier to debug suspend-resume related bugs.