### PR TITLE
consolidate '.rs.scalar()' methods

### DIFF
--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -46,13 +46,7 @@
 # marshalled as scalar types instead of arrays
 .rs.addFunction("scalar", function(obj)
 {
-   class(obj) <- 'rs.scalar'
-   return(obj)
-})
-
-.rs.addFunction("nullOrScalar", function(obj)
-{
-   if (!identical(obj, NULL))
+   if (!is.null(obj))
       class(obj) <- 'rs.scalar'
    return(obj)
 })

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -79,7 +79,7 @@
       }
 
       return(list(
-         fileName = .rs.nullOrScalar(profilerOptions$fileName)
+         fileName = .rs.scalar(profilerOptions$fileName)
       ))
    }, error = function(e) {
       return(list(error = .rs.scalar(e$message)))


### PR DESCRIPTION
This PR consolidates the `.rs.scalar()` and `.rs.nullOrScalar()` methods into a single method. Some motivation:

1) R throws an error if you attempt to set a class on `NULL`;

2) A user reported an error occurring from this method (unfortunately without a stack trace) due to a call to `.rs.scalar(NULL)` -- unfortunately, we do not know where that `NULL` came from. Odds are this would either work fine, or pass along the error further upstream, but in that case it's likely that we would get better logging of the error (after receiving an unexpected result on the client side).

Adding this as a PR first just to sanity check that there's not a reason why we might want to preserve the existing behavior (since `.rs.scalar()` is quite commonly used)