### PR TITLE
Dynamic command management for notebook-only commands

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/MessageDisplay.java
+++ b/src/gwt/src/org/rstudio/core/client/MessageDisplay.java
@@ -331,4 +331,11 @@ public abstract class MessageDisplay
             "Cancel",
             true);
    }
+   
+   public void showNotYetImplemented()
+   {
+      showMessage(MSG_INFO, 
+                 "Not Yet Implemetned", 
+                 "This feature has not yet been implemented.");
+   }
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -351,6 +351,7 @@ public class TextFileType extends EditableFileType
          results.add(commands.restartRRunAllChunks());
          results.add(commands.notebookCollapseAllOutput());
          results.add(commands.notebookExpandAllOutput());
+         results.add(commands.executeSetupChunk());
       }
       if (canKnitToHTML() || canCompileNotebook())
       {
@@ -372,7 +373,6 @@ public class TextFileType extends EditableFileType
       if (canExecuteChunks())
       {
          results.add(commands.insertChunk());
-         results.add(commands.executeSetupChunk());
          results.add(commands.executePreviousChunks());
          results.add(commands.executeSubsequentChunks());
          results.add(commands.executeCurrentChunk());

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -347,6 +347,8 @@ public class TextFileType extends EditableFileType
       {
          results.add(commands.editRmdFormatOptions());
          results.add(commands.knitWithParameters());
+         results.add(commands.restartRClearOutput());
+         results.add(commands.restartRRunAllChunks());
       }
       if (canKnitToHTML() || canCompileNotebook())
       {

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -349,6 +349,8 @@ public class TextFileType extends EditableFileType
          results.add(commands.knitWithParameters());
          results.add(commands.restartRClearOutput());
          results.add(commands.restartRRunAllChunks());
+         results.add(commands.notebookCollapseAllOutput());
+         results.add(commands.notebookExpandAllOutput());
       }
       if (canKnitToHTML() || canCompileNotebook())
       {
@@ -372,6 +374,7 @@ public class TextFileType extends EditableFileType
          results.add(commands.insertChunk());
          results.add(commands.executeSetupChunk());
          results.add(commands.executePreviousChunks());
+         results.add(commands.executeSubsequentChunks());
          results.add(commands.executeCurrentChunk());
          results.add(commands.executeNextChunk());
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -297,10 +297,12 @@ well as menu structures (for main menu and popup menus).
          <cmd refid="newSession"/>
          <separator/>
          <cmd refid="interruptR"/>
-         <cmd refid="restartR"/>
+         <cmd refid="terminateR"/>
          <cmd refid="suspendSession"/>
          <separator/>
-         <cmd refid="terminateR"/>
+         <cmd refid="restartR"/>
+         <cmd refid="restartRClearOutput"/>
+         <cmd refid="restartRRunAllChunks"/>
          <separator/>
          <menu label="Set _Working Directory">
             <cmd refid="setWorkingDirToProjectDir"/>
@@ -1841,6 +1843,18 @@ well as menu structures (for main menu and popup menus).
         label="Restart R Session"
         menuLabel="_Restart R"
         desc="Restart R"
+        windowMode="main"/>
+        
+  <cmd id="restartRClearOutput"
+        label="Restart R Session and Clear Chunk Output"
+        menuLabel="Restart R and Clear Output"
+        desc="Restart R session and clear chunk output"
+        windowMode="main"/>
+        
+   <cmd id="restartRRunAllChunks"
+        label="Restart R Session and Run All Chunks"
+        menuLabel="Restart R and Run All Chunks"
+        desc="Restart R session and run all chunks"
         windowMode="main"/>
         
    <cmd id="terminateR"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -143,6 +143,9 @@ well as menu structures (for main menu and popup menus).
             <cmd refid="unfoldAll"/>
          </menu>
          <separator/>
+         <cmd refid="notebookCollapseAllOutput"/>
+         <cmd refid="notebookExpandAllOutput"/>        
+         <separator/>
          <cmd refid="goToLine"/>
          <separator/>
          <cmd refid="findReplace"/>
@@ -194,6 +197,7 @@ well as menu structures (for main menu and popup menus).
          <menu label="Run Regi_on">
             <cmd refid="executeSetupChunk"/>
             <cmd refid="executePreviousChunks"/>
+            <cmd refid="executeSubsequentChunks"/>
             <cmd refid="executeCurrentChunk"/>
             <cmd refid="executeNextChunk"/>
             <cmd refid="executeToCurrentLine"/>
@@ -1402,8 +1406,13 @@ well as menu structures (for main menu and popup menus).
         context="editor"/>
         
    <cmd id="executePreviousChunks"
-        menuLabel="Run _Previous Chunks"
-        desc="Run all previous chunks in the source file"
+        menuLabel="Run All Chunks Above"
+        desc="Run all above the current one"
+        context="r"/>
+        
+   <cmd id="executeSubsequentChunks"
+        menuLabel="Run All Chunks Below"
+        desc="Run all chunks after the current one"
         context="r"/>
         
    <cmd id="executeCurrentChunk"
@@ -1658,6 +1667,16 @@ well as menu structures (for main menu and popup menus).
         label="Knit with Parameters..."
         menuLabel="Knit _with Parameters..."
         desc="Knit the document with a set of custom parameters"/>
+        
+   <cmd id="notebookExpandAllOutput"
+        buttonLabel=""
+        menuLabel="Expand All Output"
+        desc="Expand all code chunk output in the current file"/>
+        
+   <cmd id="notebookCollapseAllOutput"
+        buttonLabel=""
+        menuLabel="Collapse All Output"
+        desc="Collapse all code chunk output in the current file"/>
 
    <cmd id="synctexSearch"
         menuLabel="S_ync PDF View to Editor"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -161,6 +161,8 @@ public abstract class
    public abstract AppCommand consoleClear();
    public abstract AppCommand interruptR();
    public abstract AppCommand restartR();
+   public abstract AppCommand restartRClearOutput();
+   public abstract AppCommand restartRRunAllChunks();
    public abstract AppCommand terminateR();
    public abstract AppCommand activateConsole();
    public abstract AppCommand layoutZoomConsole();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -62,6 +62,7 @@ public abstract class
    public abstract AppCommand insertChunk();
    public abstract AppCommand insertSection();
    public abstract AppCommand executePreviousChunks();
+   public abstract AppCommand executeSubsequentChunks();
    public abstract AppCommand executeCurrentChunk();
    public abstract AppCommand executeNextChunk();
    public abstract AppCommand executeSetupChunk();
@@ -126,6 +127,8 @@ public abstract class
    public abstract AppCommand findUsages();
    public abstract AppCommand editRmdFormatOptions();
    public abstract AppCommand knitWithParameters();
+   public abstract AppCommand notebookExpandAllOutput();
+   public abstract AppCommand notebookCollapseAllOutput();
    public abstract AppCommand renameInScope();
    public abstract AppCommand insertRoxygenSkeleton();
    public abstract AppCommand insertSnippet();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -347,6 +347,8 @@ public class Source implements InsertSourceHandler,
       dynamicCommands_.add(commands.profileCode());
       dynamicCommands_.add(commands.profileCodeWithoutFocus());
       dynamicCommands_.add(commands.saveProfileAs());
+      dynamicCommands_.add(commands.restartRClearOutput());
+      dynamicCommands_.add(commands.restartRRunAllChunks());
       for (AppCommand command : dynamicCommands_)
       {
          command.setVisible(false);
@@ -3332,6 +3334,10 @@ public class Source implements InsertSourceHandler,
       manageMultiTabCommands();
       
       activeCommands_ = newCommands;
+      
+      // give the active editor a chance to manage commands
+      if (activeEditor_ != null)
+         activeEditor_.manageCommands();
 
       assert verifyNoUnsupportedCommands(newCommands)
             : "Unsupported commands detected (please add to Source.dynamicCommands_)";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -298,6 +298,7 @@ public class Source implements InsertSourceHandler,
       dynamicCommands_.add(commands.insertSection());
       dynamicCommands_.add(commands.executeSetupChunk());
       dynamicCommands_.add(commands.executePreviousChunks());
+      dynamicCommands_.add(commands.executeSubsequentChunks());
       dynamicCommands_.add(commands.executeCurrentChunk());
       dynamicCommands_.add(commands.executeNextChunk());
       dynamicCommands_.add(commands.sourceActiveDocument());
@@ -349,6 +350,8 @@ public class Source implements InsertSourceHandler,
       dynamicCommands_.add(commands.saveProfileAs());
       dynamicCommands_.add(commands.restartRClearOutput());
       dynamicCommands_.add(commands.restartRRunAllChunks());
+      dynamicCommands_.add(commands.notebookCollapseAllOutput());
+      dynamicCommands_.add(commands.notebookExpandAllOutput());
       for (AppCommand command : dynamicCommands_)
       {
          command.setVisible(false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
@@ -60,6 +60,7 @@ public interface EditingTarget extends IsWidget,
    String getExtendedFileType();
    
    HashSet<AppCommand> getSupportedCommands();
+   void manageCommands();
    boolean canCompilePdf();
    
    void verifyCppPrerequisites();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
@@ -435,6 +435,11 @@ public class CodeBrowserEditingTarget implements EditingTarget
          commands.add(commands_.returnDocToMain());
       return commands;
    }
+   
+   @Override
+   public void manageCommands()
+   {
+   }
 
    @Override
    public boolean canCompilePdf()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -187,6 +187,11 @@ public class ProfilerEditingTarget implements EditingTarget,
    }
    
    @Override
+   public void manageCommands()
+   {
+   }
+   
+   @Override
    public boolean canCompilePdf()
    {
       return false;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1213,7 +1213,7 @@ public class TextEditingTarget implements
       
       // create notebook and forward resize events
       notebook_ = new TextEditingTargetNotebook(this, docDisplay_, 
-            docUpdateSentinel_, document);
+            docUpdateSentinel_, document, releaseOnDismiss_);
       view_.addResizeHandler(notebook_);
       
       // ensure that Makefile and Makevars always use tabs

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -4038,6 +4038,12 @@ public class TextEditingTarget implements
       executePreviousChunks(null);
    }
    
+   @Handler
+   void onExecuteSubsequentChunks()
+   {
+      globalDisplay_.showNotYetImplemented();
+   }
+   
    public void executePreviousChunks(final Position position)
    {
       if (docDisplay_.showChunkOutputInline())
@@ -4924,6 +4930,18 @@ public class TextEditingTarget implements
    
    @Handler
    void onRestartRRunAllChunks()
+   {
+      globalDisplay_.showNotYetImplemented();
+   }
+   
+   @Handler
+   void onNotebookCollapseAllOutput()
+   {
+      globalDisplay_.showNotYetImplemented();
+   }
+   
+   @Handler
+   void onNotebookExpandAllOutput()
    {
       globalDisplay_.showNotYetImplemented();
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1931,6 +1931,13 @@ public class TextEditingTarget implements
    }
    
    @Override
+   public void manageCommands()
+   {
+      if (fileType_.isRmd())
+         notebook_.manageCommands();
+   }
+   
+   @Override
    public boolean canCompilePdf()
    {
       return fileType_.canCompilePDF();
@@ -4908,6 +4915,19 @@ public class TextEditingTarget implements
          }
       });  
    }
+   
+   @Handler
+   void onRestartRClearOutput()
+   {
+      globalDisplay_.showNotYetImplemented();
+   }
+   
+   @Handler
+   void onRestartRRunAllChunks()
+   {
+      globalDisplay_.showNotYetImplemented();
+   }
+   
 
    @Handler
    void onSynctexSearch()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -335,12 +335,9 @@ public class TextEditingTargetWidget
       chunksMenu.addItem(commands_.executeNextChunk().createMenuItem(false));
       chunksMenu.addSeparator();
       chunksMenu.addItem(commands_.executeSetupChunk().createMenuItem(false));
-      if (uiPrefs_.showRmdChunkOutputInline().getValue())
-      {
-         chunksMenu.addItem(new UIPrefMenuItem<Boolean>(
-               uiPrefs_.autoRunSetupChunk(), true, "Run Setup Chunk Automatically", 
-               uiPrefs_));
-      }
+      chunksMenu.addItem(runSetupChunkOptionMenu_= new UIPrefMenuItem<Boolean>(
+            uiPrefs_.autoRunSetupChunk(), true, "Run Setup Chunk Automatically", 
+            uiPrefs_));
       chunksMenu.addSeparator();
       chunksMenu.addItem(commands_.executePreviousChunks().createMenuItem(false));
       chunksMenu.addItem(commands_.executeSubsequentChunks().createMenuItem(false));
@@ -539,6 +536,10 @@ public class TextEditingTargetWidget
       compilePdfButton_.setVisible(canCompilePdf);
       chunksButton_.setVisible(canExecuteChunks);
       
+      runSetupChunkOptionMenu_.setVisible(
+            canKnitToHTML &&
+            uiPrefs_.showRmdChunkOutputInline().getValue());
+                    
       notebookSeparatorWidget_.setVisible(canCompileNotebook);
       notebookToolbarButton_.setVisible(canCompileNotebook);
       
@@ -1090,6 +1091,7 @@ public class TextEditingTargetWidget
    private ToolbarButton runLastButton_;
    private ToolbarButton sourceButton_;
    private ToolbarButton sourceMenuButton_;
+   private UIPrefMenuItem<Boolean> runSetupChunkOptionMenu_;
    private ToolbarButton chunksButton_;
    private ToolbarButton shinyLaunchButton_;
    private ToolbarButton rmdOptionsButton_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -331,19 +331,20 @@ public class TextEditingTargetWidget
       toolbar.addRightWidget(chunksRunButton_ = commands_.executeCode().createToolbarButton(false));
       ToolbarPopupMenu chunksMenu = new ToolbarPopupMenu();
       chunksMenu.addItem(commands_.executeCode().createMenuItem(false));
+      chunksMenu.addSeparator();
+      chunksMenu.addItem(commands_.executeCurrentChunk().createMenuItem(false));
+      chunksMenu.addItem(commands_.executeNextChunk().createMenuItem(false));
+      chunksMenu.addSeparator();
+      chunksMenu.addItem(commands_.executeSetupChunk().createMenuItem(false));
       if (uiPrefs_.showRmdChunkOutputInline().getValue())
       {
-         chunksMenu.addSeparator();
          chunksMenu.addItem(new UIPrefMenuItem<Boolean>(
                uiPrefs_.autoRunSetupChunk(), true, "Run Setup Chunk Automatically", 
                uiPrefs_));
       }
       chunksMenu.addSeparator();
-      chunksMenu.addItem(commands_.executeSetupChunk().createMenuItem(false));
       chunksMenu.addItem(commands_.executePreviousChunks().createMenuItem(false));
       chunksMenu.addItem(commands_.executeSubsequentChunks().createMenuItem(false));
-      chunksMenu.addItem(commands_.executeCurrentChunk().createMenuItem(false));
-      chunksMenu.addItem(commands_.executeNextChunk().createMenuItem(false));
       chunksMenu.addSeparator();
       chunksMenu.addItem(commands_.executeAllCode().createMenuItem(false));
       chunksButton_ = new ToolbarButton(

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -341,6 +341,7 @@ public class TextEditingTargetWidget
       chunksMenu.addSeparator();
       chunksMenu.addItem(commands_.executeSetupChunk().createMenuItem(false));
       chunksMenu.addItem(commands_.executePreviousChunks().createMenuItem(false));
+      chunksMenu.addItem(commands_.executeSubsequentChunks().createMenuItem(false));
       chunksMenu.addItem(commands_.executeCurrentChunk().createMenuItem(false));
       chunksMenu.addItem(commands_.executeNextChunk().createMenuItem(false));
       chunksMenu.addSeparator();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -328,7 +328,6 @@ public class TextEditingTargetWidget
 
       //toolbar.addRightSeparator();
      
-      toolbar.addRightWidget(chunksRunButton_ = commands_.executeCode().createToolbarButton(false));
       ToolbarPopupMenu chunksMenu = new ToolbarPopupMenu();
       chunksMenu.addItem(commands_.executeCode().createMenuItem(false));
       chunksMenu.addSeparator();
@@ -348,7 +347,9 @@ public class TextEditingTargetWidget
       chunksMenu.addSeparator();
       chunksMenu.addItem(commands_.executeAllCode().createMenuItem(false));
       chunksButton_ = new ToolbarButton(
-                       chunksMenu, 
+                       "Run",
+                       commands_.executeCode().getImageResource(),
+                       chunksMenu,
                        true);
       toolbar.addRightWidget(chunksButton_);
       
@@ -537,7 +538,6 @@ public class TextEditingTargetWidget
       texToolbarButton_.setVisible(canCompilePdf);
       compilePdfButton_.setVisible(canCompilePdf);
       chunksButton_.setVisible(canExecuteChunks);
-      chunksRunButton_.setVisible(canExecuteChunks);
       
       notebookSeparatorWidget_.setVisible(canCompileNotebook);
       notebookToolbarButton_.setVisible(canCompileNotebook);
@@ -626,7 +626,6 @@ public class TextEditingTargetWidget
       else
          srcOnSaveLabel_.setText(width < 450 ? "Source" : "Source on Save");
       sourceButton_.setText(width < 400 ? "" : sourceCommandText_);
-      chunksRunButton_.setText(width < 400 ? "" : "Run");
    }
    
    
@@ -1088,7 +1087,6 @@ public class TextEditingTargetWidget
    private ToolbarButton goToPrevButton_;
    private ToolbarButton goToNextButton_;
    private ToolbarButton runButton_;
-   private ToolbarButton chunksRunButton_;
    private ToolbarButton runLastButton_;
    private ToolbarButton sourceButton_;
    private ToolbarButton sourceMenuButton_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -109,10 +109,12 @@ public class TextEditingTargetNotebook
    public TextEditingTargetNotebook(final TextEditingTarget editingTarget,
                                     DocDisplay docDisplay,
                                     DocUpdateSentinel docUpdateSentinel,
-                                    SourceDocument document)
+                                    SourceDocument document,
+                                    ArrayList<HandlerRegistration> releaseOnDismiss)
    {
       docDisplay_ = docDisplay;
       docUpdateSentinel_ = docUpdateSentinel;  
+      releaseOnDismiss_ = releaseOnDismiss;
       initialChunkDefs_ = document.getChunkDefs();
       outputWidgets_ = new HashMap<String, ChunkOutputWidget>();
       lineWidgets_ = new HashMap<String, LineWidget>();
@@ -200,7 +202,6 @@ public class TextEditingTargetNotebook
          ConsoleServerOperations console,
          Session session,
          UIPrefs prefs,
-         ArrayList<HandlerRegistration> releaseOnDismiss,
          Commands commands,
          Provider<SourceWindowManager> pSourceWindowManager)
    {
@@ -223,7 +224,7 @@ public class TextEditingTargetNotebook
       
       // subscribe to global rmd output inline preference and sync
       // again when it changes
-      releaseOnDismiss.add(
+      releaseOnDismiss_.add(
          prefs_.showRmdChunkOutputInline().addValueChangeHandler(
             new ValueChangeHandler<Boolean>() {
                @Override
@@ -293,8 +294,7 @@ public class TextEditingTargetNotebook
       commands_.notebookCollapseAllOutput().setEnabled(inlineOutput);
       commands_.notebookCollapseAllOutput().setVisible(inlineOutput);
       commands_.notebookExpandAllOutput().setEnabled(inlineOutput);
-      commands_.notebookExpandAllOutput().setVisible(inlineOutput);
-      
+      commands_.notebookExpandAllOutput().setVisible(inlineOutput); 
    }
    
    private void processChunkExecQueue()
@@ -868,6 +868,7 @@ public class TextEditingTargetNotebook
    
    private final DocDisplay docDisplay_;
    private final DocUpdateSentinel docUpdateSentinel_;
+   ArrayList<HandlerRegistration> releaseOnDismiss_;
    private final TextEditingTarget editingTarget_;
    private Session session_;
    private Provider<SourceWindowManager> pSourceWindowManager_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -40,6 +40,7 @@ import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
+import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.console.events.ConsolePromptEvent;
@@ -71,6 +72,7 @@ import com.google.gwt.event.logical.shared.ResizeEvent;
 import com.google.gwt.event.logical.shared.ResizeHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
@@ -119,22 +121,9 @@ public class TextEditingTargetNotebook
       editingTarget_ = editingTarget;
       RStudioGinjector.INSTANCE.injectMembers(this);
       
-      // initialize the display's default output mode 
-      String outputType = 
-            document.getProperties().getAsString(CHUNK_OUTPUT_TYPE);
-      if (!outputType.isEmpty() && outputType != "undefined")
-      {
-         // if the document property is set, apply it directly
-         docDisplay_.setShowChunkOutputInline(
-               outputType == CHUNK_OUTPUT_INLINE);
-      }
-      else
-      {
-         // otherwise, use the global preference to set the value
-         docDisplay_.setShowChunkOutputInline(
-            RStudioGinjector.INSTANCE.getUIPrefs()
-                                     .showRmdChunkOutputInline().getValue());
-      }
+      // initialize the display's default output mode based on 
+      // global and per-document preferences
+      syncOutputMode();    
       
       docDisplay_.addEditorFocusHandler(new FocusHandler()
       {
@@ -211,6 +200,8 @@ public class TextEditingTargetNotebook
          ConsoleServerOperations console,
          Session session,
          UIPrefs prefs,
+         ArrayList<HandlerRegistration> releaseOnDismiss,
+         Commands commands,
          Provider<SourceWindowManager> pSourceWindowManager)
    {
       events_ = events;
@@ -218,6 +209,7 @@ public class TextEditingTargetNotebook
       console_ = console;
       session_ = session;
       prefs_ = prefs;
+      commands_ = commands;
       pSourceWindowManager_ = pSourceWindowManager;
       
       events_.addHandler(RmdChunkOutputEvent.TYPE, this);
@@ -228,6 +220,18 @@ public class TextEditingTargetNotebook
       events_.addHandler(ConsolePromptEvent.TYPE, this);
       events_.addHandler(InterruptStatusEvent.TYPE, this);
       events_.addHandler(RestartStatusEvent.TYPE, this);
+      
+      // subscribe to global rmd output inline preference and sync
+      // again when it changes
+      releaseOnDismiss.add(
+         prefs_.showRmdChunkOutputInline().addValueChangeHandler(
+            new ValueChangeHandler<Boolean>() {
+               @Override
+               public void onValueChange(ValueChangeEvent<Boolean> event)
+               {
+                  syncOutputMode();
+               }
+            }));
    }
    
    public void executeChunk(Scope chunk, String code, String options)
@@ -277,6 +281,15 @@ public class TextEditingTargetNotebook
       
       // initiate queue processing
       processChunkExecQueue();
+   }
+   
+   public void manageCommands()
+   {
+      boolean inlineOutput = docDisplay_.showChunkOutputInline();   
+      commands_.restartRClearOutput().setEnabled(inlineOutput);
+      commands_.restartRClearOutput().setVisible(inlineOutput);
+      commands_.restartRRunAllChunks().setEnabled(inlineOutput);
+      commands_.restartRRunAllChunks().setVisible(inlineOutput);
    }
    
    private void processChunkExecQueue()
@@ -684,6 +697,9 @@ public class TextEditingTargetNotebook
    {
       docDisplay_.setShowChunkOutputInline(mode == CHUNK_OUTPUT_INLINE);
 
+      // manage commands
+      manageCommands();
+         
       // if we don't have any inline output, we're done
       if (lineWidgets_.size() == 0 || mode != CHUNK_OUTPUT_CONSOLE)
          return;
@@ -714,6 +730,26 @@ public class TextEditingTargetNotebook
             "Remove Output", 
             "Keep Output", 
             false);
+   }
+   
+   // set the output mode based on the global pref (or our local 
+   // override of it, if any)
+   private void syncOutputMode()
+   {
+      String outputType = docUpdateSentinel_.getProperty(CHUNK_OUTPUT_TYPE);
+      if (!StringUtil.isNullOrEmpty(outputType) && outputType != "undefined")
+      {
+         // if the document property is set, apply it directly
+         docDisplay_.setShowChunkOutputInline(
+               outputType == CHUNK_OUTPUT_INLINE);
+      }
+      else
+      {
+         // otherwise, use the global preference to set the value
+         docDisplay_.setShowChunkOutputInline(
+            RStudioGinjector.INSTANCE.getUIPrefs()
+                                     .showRmdChunkOutputInline().getValue());
+      }
    }
    
    private void populateChunkDefs(JsArray<ChunkDefinition> defs)
@@ -831,6 +867,7 @@ public class TextEditingTargetNotebook
    private Session session_;
    private Provider<SourceWindowManager> pSourceWindowManager_;
    private UIPrefs prefs_;
+   private Commands commands_;
 
    private RMarkdownServerOperations server_;
    private ConsoleServerOperations console_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -290,6 +290,11 @@ public class TextEditingTargetNotebook
       commands_.restartRClearOutput().setVisible(inlineOutput);
       commands_.restartRRunAllChunks().setEnabled(inlineOutput);
       commands_.restartRRunAllChunks().setVisible(inlineOutput);
+      commands_.notebookCollapseAllOutput().setEnabled(inlineOutput);
+      commands_.notebookCollapseAllOutput().setVisible(inlineOutput);
+      commands_.notebookExpandAllOutput().setEnabled(inlineOutput);
+      commands_.notebookExpandAllOutput().setVisible(inlineOutput);
+      
    }
    
    private void processChunkExecQueue()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
@@ -146,6 +146,11 @@ public class UrlContentEditingTarget implements EditingTarget
    }
    
    @Override
+   public void manageCommands()
+   {
+   }
+   
+   @Override
    public boolean canCompilePdf()
    {
       return false;


### PR DESCRIPTION
Some commands will be notebook-only (e.g. Restart R and Clear Output) and these commands will therefore need be dynamically managed based on whether inline output is enabled for the active document.

This commit introduces a scheme for this, in summary:

1. The active editor now gets a chance to manage commands after all default command management has taken place.

2. The notebook helper uses this hook to manage notebook-only commands based on the per-document and global preference.

3. The notebook helper now listens for changes in the global inline output preference and syncs it's own behavior accordingly (this change is orthagonal to the PR but was an ommission which needed correcting)

4. If the user interactively changes the inline output preference then commands are managed at that point as well.

@jmcphers 