### PR TITLE
fix publishing profiles to rsconnect from windows

### DIFF
--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -90,7 +90,7 @@
 {
    tryCatch({
       resources <- .rs.profileResources()
-      htmlFile <- tempfile(fileext = ".html", tmpdir = resources$tempPath)
+      htmlFile <- normalizePath(tempfile(fileext = ".html", tmpdir = resources$tempPath), winslash = "/")
 
       if (identical(profilerOptions$profvis, NULL)) {
          if (identical(tools::file_ext(profilerOptions$fileName), "Rprof")) {


### PR DESCRIPTION
Normalize local path to html profile file to avoid rsconnect to not publishing the content while `\` and `/` are mixed in the path.