### PR TITLE
Allow highlighting of .Rtex files.

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
@@ -328,6 +328,7 @@ public class FileTypeRegistry
       register("*.rhistory", RHISTORY, icons.iconRhistory());
       register("*.rproj", RPROJECT, icons.iconRproject());
       register("*.rnw", SWEAVE, icons.iconRsweave());
+      register("*.rtex", SWEAVE, icons.iconRsweave());
       register("*.snw", SWEAVE, icons.iconRsweave());
       register("*.nw", SWEAVE, icons.iconRsweave());
       register("*.tex", TEX, icons.iconTex());


### PR DESCRIPTION
`.Rtex` files are also standard knitr files (see https://cran.r-project.org/web/packages/knitr/knitr.pdf) . These files will be used here: https://de.sharelatex.com/learn/Knitr#Introduction , however RStudio does not use syntax highlighting for those `.Rtex` files.

This pull-request should solve the issue discussed here http://stackoverflow.com/questions/21102806/treating-files-with-rtex-extension-like-knitr-sweave-files-in-rstudio and also solves an old feature request from 2014: https://support.rstudio.com/hc/en-us/community/posts/200769406-Recognize-Rtex-extension-and-chunk-style

please check and merge if it works properly