### PR TITLE
limit amount of time spent calling 'str()'

### DIFF
--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -15,7 +15,10 @@
 
 .rs.addFunction("valueFromStr", function(val)
 {
-   capture.output(try({ str(val) }, silent = TRUE));
+   .rs.withTimeLimit(1, fail = "<truncated>", {
+      capture.output(try(str(val), silent = TRUE))
+   })
+   
 })
 
 .rs.addFunction("valueAsString", function(val)


### PR DESCRIPTION
This PR fixes an issue where the rsession could hang when attempting to call `str()` on heavily recursive objects.

Test case from a user:

```R
A <- setRefClass(Class = "A", fields = list(prev="list", func="character"),
  methods = list(
  show=function() {
    print(func)
  }
))

setMethod("+", signature = c(e1="A", e2="A"), definition = function(e1, e2) {
  result <- A$new(prev=list(e1, e2), func="+")
})

a <- A$new(prev=list(), func="")
b <- A$new(prev=list(), func="")

for (i in 1:10) {
  c <- a + b
  b <- c + a
  a <- c + b
}
print(c)
```

If you try calling `str(c)` in an R terminal, you'll see that a lot of output is emitted.