### PR TITLE
truncate long lines in console history

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.core.client;
 
+import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.i18n.client.NumberFormat;
 import com.google.gwt.user.client.Window;
@@ -1051,6 +1052,10 @@ public class StringUtil
    
    public static final native String normalizeNewLines(String string) /*-{
       return string.replace(/\r\n|\n\r|\r/g, "\n");
+   }-*/;
+   
+   public static final native JsArrayString split(String string, String delimiter) /*-{
+      return string.split(delimiter);
    }-*/;
    
    public static final HashMap<String, String> COMPLEMENTS =

--- a/src/gwt/src/org/rstudio/core/client/widget/NumericValueWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/NumericValueWidget.java
@@ -54,6 +54,11 @@ public class NumericValueWidget extends Composite
    {
       textBox_.setValue(value, fireEvents);
    }
+   
+   public void setWidth(String width)
+   {
+      textBox_.setWidth(width);
+   }
 
    public HandlerRegistration addValueChangeHandler(ValueChangeHandler<String> handler)
    {

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -18,6 +18,7 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.inject.client.GinModules;
 import com.google.gwt.inject.client.Ginjector;
 
+import org.rstudio.core.client.VirtualConsole;
 import org.rstudio.core.client.command.AddinCommandBinding;
 import org.rstudio.core.client.command.ApplicationCommandManager;
 import org.rstudio.core.client.command.EditorCommandManager;
@@ -174,6 +175,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(DataImportOptionsUiCsv dataImport);
    void injectMembers(CppCompletion completion);
    void injectMembers(ConsoleTabPanel consoleTabPanel);
+   void injectMembers(VirtualConsole console);
    
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
@@ -282,6 +282,10 @@ public class UIPrefs extends UIPrefsAccessor implements UiPrefsChangedHandler
          highlightRFunctionCalls().setGlobalValue(
                              newUiPrefs.highlightRFunctionCalls().getGlobalValue());
          
+         // truncate long lines in console history
+         truncateLongLinesInConsoleHistory().setGlobalValue(
+                             newUiPrefs.truncateLongLinesInConsoleHistory().getGlobalValue());
+         
          // chunk toolbar
          showInlineToolbarForRCodeChunks().setGlobalValue(
                newUiPrefs.showInlineToolbarForRCodeChunks().getGlobalValue());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -296,6 +296,11 @@ public class UIPrefsAccessor extends Prefs
       return bool("highlight_r_function_calls", false);
    }
    
+   public PrefValue<Integer> truncateLongLinesInConsoleHistory()
+   {
+      return integer("truncate_long_lines_in_console", 1000);
+   }
+   
    public PrefValue<Boolean> showInlineToolbarForRCodeChunks()
    {
       return bool("show_inline_toolbar_for_r_code_chunks", true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -194,7 +194,10 @@ public class EditingPreferencesPane extends PreferencesPane
       displayPanel.add(foldMode_);
       
       displayPanel.add(headerLabel("Console"));
-      displayPanel.add(numericPref("Truncate long lines in console history", prefs_.truncateLongLinesInConsoleHistory()));
+      NumericValueWidget limitLengthPref =
+            numericPref("Limit length of lines displayed in console to:", prefs_.truncateLongLinesInConsoleHistory());
+      limitLengthPref.setWidth("36px");
+      displayPanel.add(limitLengthPref);
       
       VerticalPanel savePanel = new VerticalPanel();
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -193,6 +193,9 @@ public class EditingPreferencesPane extends PreferencesPane
       
       displayPanel.add(foldMode_);
       
+      displayPanel.add(headerLabel("Console"));
+      displayPanel.add(numericPref("Truncate long lines in console history", prefs_.truncateLongLinesInConsoleHistory()));
+      
       VerticalPanel savePanel = new VerticalPanel();
       
       savePanel.add(headerLabel("General"));


### PR DESCRIPTION
This PR truncates long lines when emitted to the console history (to avoid IDE hangs / freezes when attempting to render overly-long lines). This is a stop-gap fix until we get a fully virtualized console history.

We may want to tweak the display / labeling of the preference (and double-check with @jmcphers  that the `toString()` method is the most appropriate place to perform the truncation).

<img width="583" alt="screen shot 2016-03-26 at 1 30 18 pm" src="https://cloud.githubusercontent.com/assets/1976582/14062284/edc84c80-f356-11e5-9224-60e56d266485.png">

<img width="707" alt="screen shot 2016-03-26 at 1 31 17 pm" src="https://cloud.githubusercontent.com/assets/1976582/14062293/18cec5e4-f357-11e5-87c6-04146b424694.png">
