### PR TITLE
implement 'quick add next'

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -535,13 +535,13 @@ well as menu structures (for main menu and popup menus).
          <shortcut value="Alt+Up" title="Move Lines Up" />
          <shortcut value="Alt+Down" title="Move Lines Down" />
          <shortcut value="Ctrl+D" title="Delete Line" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" />
+         <shortcut value="Cmd+D" title="Delete Line" if="org.rstudio.core.client.BrowseCap.isMacintosh()" />
          <shortcut value="Ctrl+U" title="Yank Line Up to Cursor" />
          <shortcut value="Ctrl+K" title="Yank Line After Cursor" />
          <shortcut value="Ctrl+Y" title="Insert Yanked Text" />
          <shortcut value="Ctrl+T" title="Transpose Letters" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut value="Alt+-" title="Insert Assignment Operator"/>
          <shortcut value="Cmd+Shift+M" title="Insert Pipe Operator" />
-         <shortcut refid="quickAddNext" value="Meta+D" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="renameInScope" value="Cmd+Alt+Shift+M" />
          <shortcut refid="insertRoxygenSkeleton" value="Cmd+Shift+Alt+R" title="Insert Roxygen Skeleton" />
          <shortcut refid="insertSnippet" value="Shift+Tab" title="Insert Snippet"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -1277,8 +1277,7 @@ well as menu structures (for main menu and popup menus).
    <cmd id="quickAddNext"
         buttonLabel="Add"
         menuLabel="Find and Add Next"
-        desc="Find and add next occurence"
-        rebindable="false"/>
+        desc="Find and add next occurence"/>
         
    <cmd id="findAll"
         label="Find All"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -535,13 +535,13 @@ well as menu structures (for main menu and popup menus).
          <shortcut value="Alt+Up" title="Move Lines Up" />
          <shortcut value="Alt+Down" title="Move Lines Down" />
          <shortcut value="Ctrl+D" title="Delete Line" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" />
-         <shortcut value="Cmd+D" title="Delete Line" if="org.rstudio.core.client.BrowseCap.isMacintosh()" />
          <shortcut value="Ctrl+U" title="Yank Line Up to Cursor" />
          <shortcut value="Ctrl+K" title="Yank Line After Cursor" />
          <shortcut value="Ctrl+Y" title="Insert Yanked Text" />
          <shortcut value="Ctrl+T" title="Transpose Letters" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut value="Alt+-" title="Insert Assignment Operator"/>
          <shortcut value="Cmd+Shift+M" title="Insert Pipe Operator" />
+         <shortcut refid="quickAddNext" value="Meta+D" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="renameInScope" value="Cmd+Alt+Shift+M" />
          <shortcut refid="insertRoxygenSkeleton" value="Cmd+Shift+Alt+R" title="Insert Roxygen Skeleton" />
          <shortcut refid="insertSnippet" value="Shift+Tab" title="Insert Snippet"/>
@@ -1273,6 +1273,12 @@ well as menu structures (for main menu and popup menus).
 
    <cmd id="findFromSelection"
         menuLabel="_Use Selection for Find"/>
+        
+   <cmd id="quickAddNext"
+        buttonLabel="Add"
+        menuLabel="Find and Add Next"
+        desc="Find and add next occurence"
+        rebindable="false"/>
         
    <cmd id="findAll"
         label="Find All"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -93,6 +93,7 @@ public abstract class
    public abstract AppCommand vcsFileRevert();
    public abstract AppCommand popoutDoc();
    public abstract AppCommand returnDocToMain();
+   public abstract AppCommand quickAddNext();
    public abstract AppCommand findReplace();
    public abstract AppCommand findNext();
    public abstract AppCommand findPrevious();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -2709,7 +2709,7 @@ public class AceEditor implements DocDisplay,
    {
       return popupVisible_;
    }
-
+   
    public void selectAll(String needle)
    {
       widget_.getEditor().findAll(needle);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -922,6 +922,34 @@ public class AceEditor implements DocDisplay,
          return null;
       }
    }
+   
+   @Override
+   public void quickAddNext()
+   {
+      if (getNativeSelection().isEmpty())
+      {
+         getNativeSelection().selectWord();
+         return;
+      }
+      
+      String needle = getSelectionValue();
+      Search search = Search.create(
+            needle,
+            false,
+            true,
+            true,
+            true,
+            getCursorPosition(),
+            null,
+            false);
+      
+      Range range = search.find(getSession());
+      if (range == null)
+         return;
+      
+      getNativeSelection().addRange(range, false);
+      centerSelection();
+   }
 
    @Override
    public void insertCode(InputEditorPosition position, String content)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -119,6 +119,8 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    boolean inMultiSelectMode();
    void exitMultiSelectMode();
    
+   void quickAddNext();
+   
    void clearSelection();
    void replaceSelection(String code);
    void replaceRange(Range range, String text);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -136,7 +136,6 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceFold
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Mode.InsertChunkInfo;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
-import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Search;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.VimMarks;
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionContext;
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionOperation;
@@ -4989,35 +4988,8 @@ public class TextEditingTarget implements
    @Handler
    void onQuickAddNext()
    {
-      if (!(docDisplay_ instanceof AceEditor))
-         return;
-      
-      AceEditor editor = (AceEditor) docDisplay_;
-      if (editor.getNativeSelection().isEmpty())
-      {
-         editor.getNativeSelection().selectWord();
-         return;
-      }
-      
-      String needle = editor.getSelectionValue();
-      Search search = Search.create(
-            needle,
-            false,
-            true,
-            true,
-            true,
-            editor.getCursorPosition(),
-            null,
-            false);
-      
-      Range range = search.find(editor.getSession());
-      if (range == null)
-         return;
-      
-      editor.getNativeSelection().addRange(range, false);
-      editor.centerSelection();
+      docDisplay_.quickAddNext();
    }
-
    @Handler
    void onFindReplace()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -136,6 +136,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceFold
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Mode.InsertChunkInfo;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Search;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.VimMarks;
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionContext;
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionOperation;
@@ -4983,6 +4984,38 @@ public class TextEditingTarget implements
       int line = selPos.getRow() + 1;
       int column = selPos.getColumn() + 1;
       return SourceLocation.create(file, line, column, fromClick);
+   }
+   
+   @Handler
+   void onQuickAddNext()
+   {
+      if (!(docDisplay_ instanceof AceEditor))
+         return;
+      
+      AceEditor editor = (AceEditor) docDisplay_;
+      if (editor.getNativeSelection().isEmpty())
+      {
+         editor.getNativeSelection().selectWord();
+         return;
+      }
+      
+      String needle = editor.getSelectionValue();
+      Search search = Search.create(
+            needle,
+            false,
+            true,
+            true,
+            true,
+            editor.getCursorPosition(),
+            null,
+            false);
+      
+      Range range = search.find(editor.getSession());
+      if (range == null)
+         return;
+      
+      editor.getNativeSelection().addRange(range, false);
+      editor.centerSelection();
    }
 
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRenameHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRenameHelper.java
@@ -2,7 +2,6 @@ package org.rstudio.studio.client.workbench.views.source.editors.text;
 
 import com.google.gwt.core.client.JsArrayString;
 
-import org.rstudio.core.client.Debug;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Selection.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Selection.java
@@ -22,6 +22,10 @@ import org.rstudio.core.client.CommandWithArg;
 public class Selection extends JavaScriptObject
 {
    protected Selection() {}
+   
+   public native final void selectWord() /*-{
+      this.selectWord();
+   }-*/;
 
    public native final Range getRange() /*-{
       return this.getRange();


### PR DESCRIPTION
This PR implements 'quick find next' functionality (similar to that of Sublime Text). It allows you to add multiple find targets to the selection, using multiple cursors. I take over the `Meta + D` keybinding for this action (note that this was previously bound to 'delete line', so we may want to reconsider the binding)

Note that I didn't add this to our Find + Replace toolbar yet -- since real estate there is a bit limited, I wasn't sure if we really wanted to stuff it in there; or, if we did we might want to fiddle around to generate some more space.

![quick-find](https://cloud.githubusercontent.com/assets/1976582/14090616/43bf8d16-f4f0-11e5-957d-5e2570ae140f.gif)
