### PR TITLE
Profiler fixes for cleanup, memory profiles, warning and windows command

### DIFF
--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -164,6 +164,11 @@
 
       filePrefix <- tools::file_path_sans_ext(basename(filePath))
       
+      rprofFile <- file.path(resources$tempPath, paste(filePrefix, ".Rprof", sep = ""))
+      if (file.exists(rprofFile)) {
+         file.remove(rprofFile)
+      }
+
       profileHtml <- file.path(resources$tempPath, paste(filePrefix, ".html", sep = ""))
       if (file.exists(profileHtml)) {
          file.remove(profileHtml)

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -56,7 +56,7 @@
       resources <- .rs.profileResources()
       fileName <- tempfile(fileext = ".Rprof", tmpdir = resources$tempPath)
 
-      Rprof(filename = fileName, line.profiling = TRUE)
+      Rprof(filename = fileName, line.profiling = TRUE, memory.profiling = TRUE)
 
       return(list(
          fileName = .rs.scalar(fileName)

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -90,7 +90,7 @@
 {
    tryCatch({
       resources <- .rs.profileResources()
-      suppressWarnings(htmlFile <- normalizePath(tempfile(fileext = ".html", tmpdir = resources$tempPath), winslash = "/"))
+      htmlFile <- normalizePath(tempfile(fileext = ".html", tmpdir = resources$tempPath), winslash = "/", mustWork = FALSE)
 
       if (identical(profilerOptions$profvis, NULL)) {
          if (identical(tools::file_ext(profilerOptions$fileName), "Rprof")) {
@@ -180,7 +180,7 @@
       }
 
       rsconnectDir <- file.path(resources$tempPath, "rsconnect", "documents", paste(filePrefix, ".html", sep = ""))
-      if (dir.exists(rsconnectDir)) {
+      if (.rs.dirExists(rsconnectDir)) {
          unlink(rsconnectDir, recursive = TRUE)
       }
 

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -179,6 +179,11 @@
          unlink(profileDir, recursive = TRUE)
       }
 
+      rsconnectDir <- file.path(resources$tempPath, "rsconnect", "documents", paste(filePrefix, ".html", sep = ""))
+      if (dir.exists(rsconnectDir)) {
+         unlink(rsconnectDir, recursive = TRUE)
+      }
+
       return(list(
       ))
    }, error = function(e) {

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -90,7 +90,7 @@
 {
    tryCatch({
       resources <- .rs.profileResources()
-      htmlFile <- normalizePath(tempfile(fileext = ".html", tmpdir = resources$tempPath), winslash = "/")
+      suppressWarnings(htmlFile <- normalizePath(tempfile(fileext = ".html", tmpdir = resources$tempPath), winslash = "/"))
 
       if (identical(profilerOptions$profvis, NULL)) {
          if (identical(tools::file_ext(profilerOptions$fileName), "Rprof")) {

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/ProfilerType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/ProfilerType.java
@@ -39,7 +39,17 @@ public class ProfilerType extends EditableFileType
                         EventBus eventBus)
    {
       eventBus.fireEvent(new OpenProfileEvent(
-            file.getPath(), null, null, false));
+            file.getPath(), null, null, false, null));
+   }
+   
+   public void openFile(FileSystemItem file,
+                        FilePosition position,
+                        int navMethod,
+                        EventBus eventBus,
+                        String docId)
+   {
+      eventBus.fireEvent(new OpenProfileEvent(
+            file.getPath(), null, null, false, docId));
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -1044,6 +1044,7 @@ public class Source implements InsertSourceHandler,
             public void onError(ServerError error)
             {
                Debug.logError(error);
+               globalDisplay_.showErrorMessage("Source Document Error", error.getUserMessage());
             }
          });
       }
@@ -1069,6 +1070,7 @@ public class Source implements InsertSourceHandler,
                public void onError(ServerError error)
                {
                   Debug.logError(error);
+                  globalDisplay_.showErrorMessage("Source Document Error", error.getUserMessage());
                }
             });
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -1029,7 +1029,27 @@ public class Source implements InsertSourceHandler,
       
       // create new profiler 
       ensureVisible(true);
-      server_.newDocument(
+
+      if (event.getDocId() != null)
+      {
+         server_.getSourceDocument(event.getDocId(), new ServerRequestCallback<SourceDocument>()
+         {
+            @Override
+            public void onResponseReceived(SourceDocument response)
+            {
+               addTab(response);
+            }
+            
+            @Override
+            public void onError(ServerError error)
+            {
+               Debug.logError(error);
+            }
+         });
+      }
+      else
+      {
+         server_.newDocument(
             FileTypeRegistry.PROFILER.getTypeId(),
             null,
             (JsObject) ProfilerContents.create(
@@ -1044,7 +1064,14 @@ public class Source implements InsertSourceHandler,
                {
                   addTab(response);
                }
+               
+               @Override
+               public void onError(ServerError error)
+               {
+                  Debug.logError(error);
+               }
             });
+      }
    }
    
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/OpenProfileEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/OpenProfileEvent.java
@@ -28,12 +28,14 @@ public class OpenProfileEvent extends GwtEvent<OpenProfileEvent.Handler>
    public OpenProfileEvent(String filePath,
                            String htmlPath,
                            String htmlLocalPath,
-                           boolean createProfile)
+                           boolean createProfile,
+                           String docId)
    {
       filePath_ = filePath;
       htmlPath_ = htmlPath;
       htmlLocalPath_ = htmlLocalPath;
       createProfile_ = createProfile;
+      docId_ = docId;
    }
    
    @Override
@@ -68,9 +70,15 @@ public class OpenProfileEvent extends GwtEvent<OpenProfileEvent.Handler>
       return createProfile_;
    }
    
+   public String getDocId()
+   {
+      return docId_;
+   }
+   
    public static final Type<Handler> TYPE = new Type<Handler>();
    private String filePath_;
    private String htmlPath_;
    private String htmlLocalPath_;
    private boolean createProfile_ = false;
+   private String docId_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -265,7 +265,20 @@ public class ProfilerEditingTarget implements EditingTarget,
                @Override
                public void execute()
                {
-                  commands_.closeSourceDoc().execute();
+                  server_.clearProfile(getPath(), new ServerRequestCallback<JavaScriptObject>()
+                  {
+                     @Override
+                     public void onResponseReceived(JavaScriptObject response)
+                     {
+                        commands_.closeSourceDoc().execute();
+                     }
+                     
+                     @Override
+                     public void onError(ServerError error)
+                     {
+                        Debug.logError(error);
+                     }
+                  });
                }
             }, getPath());
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -761,7 +761,7 @@ public class ProfilerEditingTarget implements EditingTarget,
       var handler = $entry(function(e) {
          if (typeof e.data != 'object')
             return;
-         if (!e.origin.startsWith($wnd.location.origin))
+         if (e.origin.substr(0, e.origin.length) != $wnd.location.origin)
             return;
          if (e.data.source != "profvis")
             return;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -277,6 +277,7 @@ public class ProfilerEditingTarget implements EditingTarget,
                      public void onError(ServerError error)
                      {
                         Debug.logError(error);
+                        commands_.closeSourceDoc().execute();
                      }
                   });
                }


### PR DESCRIPTION
Couple fixes for the profiler:
 1. In windows, go-to-source profiler command is disabled. The problem was that `startsWith` is not supported in Safari 5.x
 2. `normalizePath` throws a warning when the path is not yet available
 3. Add support to collect memory profiles since they are now supported in `profvis`
 4. Clean up `rprof` files when the ide is closed and profiling is leaved turned on. This was the most convoluted fix since we had no considered this scenario previously. The fix is to create the profile document when we start profiling, such that, if the ide is closed, we retain a pointer to the created `Rprof` file. With this fix, once the ide reopens the profile will be loaded and also, when it's closed, the `Rprof` file gets deleted appropiately.
 5. Minor fix to clean up the rsconnect cache once the document closes