### PR TITLE
make yank commands rebindable

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -536,9 +536,9 @@ well as menu structures (for main menu and popup menus).
          <shortcut value="Alt+Down" title="Move Lines Down" />
          <shortcut value="Ctrl+D" title="Delete Line" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" />
          <shortcut value="Cmd+D" title="Delete Line" if="org.rstudio.core.client.BrowseCap.isMacintosh()" />
-         <shortcut value="Ctrl+U" title="Yank Line Up to Cursor" />
-         <shortcut value="Ctrl+K" title="Yank Line After Cursor" />
-         <shortcut value="Ctrl+Y" title="Insert Yanked Text" />
+         <shortcut refid="yankBeforeCursor" value="Ctrl+U" title="Yank Line Up to Cursor" />
+         <shortcut refid="yankAfterCursor" value="Ctrl+K" title="Yank Line After Cursor" />
+         <shortcut refid="pasteLastYank" value="Ctrl+Y" title="Insert Yanked Text" />
          <shortcut value="Ctrl+T" title="Transpose Letters" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut value="Alt+-" title="Insert Assignment Operator"/>
          <shortcut value="Cmd+Shift+M" title="Insert Pipe Operator" />

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -132,6 +132,9 @@ public abstract class
    public abstract AppCommand renameInScope();
    public abstract AppCommand insertRoxygenSkeleton();
    public abstract AppCommand insertSnippet();
+   public abstract AppCommand yankBeforeCursor();
+   public abstract AppCommand yankAfterCursor();
+   public abstract AppCommand pasteLastYank();
  
    // Projects
    public abstract AppCommand newProject();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -47,7 +47,6 @@ import org.rstudio.core.client.ExternalJavaScriptLoader;
 import org.rstudio.core.client.ExternalJavaScriptLoader.Callback;
 import org.rstudio.core.client.Rectangle;
 import org.rstudio.core.client.StringUtil;
-import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.WindowEx;
@@ -368,43 +367,6 @@ public class AceEditor implements DocDisplay,
          {
             lastModifiedTime_ = System.currentTimeMillis();
             clearDebugLineHighlight();
-         }
-      });
-      
-      addCapturingKeyDownHandler(new KeyDownHandler()
-      {
-         @Override
-         public void onKeyDown(KeyDownEvent event)
-         {
-            if (isVimModeOn() && !isVimInInsertMode())
-               return;
-            
-            if (isEmacsModeOn())
-               return;
-            
-            int modifier = KeyboardShortcut.getModifierValue(event.getNativeEvent());
-            boolean isCtrl = modifier == KeyboardShortcut.CTRL;
-            if (isCtrl)
-            {
-               switch (event.getNativeKeyCode())
-               {
-               case KeyCodes.KEY_K:
-                  event.stopPropagation();
-                  event.preventDefault();
-                  yankAfterCursor();
-                  break;
-               case KeyCodes.KEY_U:
-                  event.stopPropagation();
-                  event.preventDefault();
-                  yankBeforeCursor();
-                  break;
-               case KeyCodes.KEY_Y:
-                  event.stopPropagation();
-                  event.preventDefault();
-                  pasteLastYank();
-                  break;
-               }
-            }
          }
       });
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -119,6 +119,10 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    boolean inMultiSelectMode();
    void exitMultiSelectMode();
    
+   void yankBeforeCursor();
+   void yankAfterCursor();
+   void pasteLastYank();
+   
    void clearSelection();
    void replaceSelection(String code);
    void replaceRange(Range range, String text);


### PR DESCRIPTION
This PR makes the various yank commands rebindable, rather than implementing them directly within the Ace Editor instance.

The biggest gain from this PR is that `Ctrl + Y` can now be properly used as `redo` on e.g. Windows and Linux, by unbinding the yank commands.