### PR TITLE
simple tool for focus management in widgets

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/FocusMap.java
+++ b/src/gwt/src/org/rstudio/core/client/FocusMap.java
@@ -1,0 +1,106 @@
+/*
+ * FocusMap.java
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.rstudio.core.client.widget.CanFocus;
+
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.dom.client.KeyDownEvent;
+import com.google.gwt.event.dom.client.KeyDownHandler;
+import com.google.gwt.user.client.ui.Focusable;
+import com.google.gwt.user.client.ui.Widget;
+
+public class FocusMap
+{
+   public FocusMap()
+   {
+      fwd_ = new HashMap<Widget, Widget>();
+      bwd_ = new HashMap<Widget, Widget>();
+      registration_ = new HashSet<Widget>();
+   }
+
+   public final void add(Widget source, Widget target)
+   {
+      fwd_.put(source, target);
+      bwd_.put(target, source);
+      listen(source, target);
+   }
+
+   public final Widget get(Widget widget, boolean forward)
+   {
+      Widget target = forward ? fwd_.get(widget) : bwd_.get(widget);
+      return target;
+   }
+
+   private final void listen(Widget... widgets)
+   {
+      for (Widget widget : widgets)
+         register(widget);
+   }
+
+   private void register(final Widget widget)
+   {
+      if (registration_.contains(widget))
+         return;
+
+      registration_.add(widget);
+      widget.addDomHandler(new KeyDownHandler()
+      {
+         @Override
+         public void onKeyDown(KeyDownEvent event)
+         {
+            if (event.getNativeKeyCode() == KeyCodes.KEY_TAB)
+            {
+               boolean forward = !event.isShiftKeyDown();
+               Widget target = get(widget, forward);
+               if (target == null)
+                  return;
+
+               if (target instanceof CanFocus)
+               {
+                  event.stopPropagation();
+                  event.preventDefault();
+                  focus((CanFocus) target);
+               }
+               else if (target instanceof Focusable)
+               {
+                  event.stopPropagation();
+                  event.preventDefault();
+                  focus((Focusable) target);
+               }
+            }
+         }
+      }, KeyDownEvent.getType());
+   }
+
+   private void focus(CanFocus focusable)
+   {
+      focusable.focus();
+   }
+
+   private void focus(Focusable focusable)
+   {
+      focusable.setFocus(true);
+   }
+
+   private final Map<Widget, Widget> fwd_;
+   private final Map<Widget, Widget> bwd_;
+   private final Set<Widget> registration_;
+}

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/DirectoryContentsWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/DirectoryContentsWidget.java
@@ -157,15 +157,18 @@ public class DirectoryContentsWidget
       {
          public void onKeyDown(KeyDownEvent event)
          {
-            bufferTimer_.schedule(1000);
+            bufferTimer_.schedule(700);
             int keyCode = event.getNativeKeyCode();
             
-            if (keyCode >= 'a' && keyCode <= 'z' ||
-                keyCode >= 'A' && keyCode <= 'Z' ||
+            if (keyCode >= 'A' && keyCode <= 'Z' ||
                 keyCode >= '0' && keyCode <= '9' ||
                 keyCode == '.' || keyCode == '_' || keyCode == '-')
             {
-               buffer_.append((char) keyCode);
+               char ch = (char) keyCode;
+               if (keyCode >= 'A' && keyCode <= 'Z' && !event.isShiftKeyDown())
+                  ch = Character.toLowerCase(ch);
+               
+               buffer_.append(ch);
                selectBufferMatch();
                return;
             }
@@ -255,9 +258,24 @@ public class DirectoryContentsWidget
       if (buffer_.length() == 0)
          return;
       
-      String string = buffer_.toString().toLowerCase();
+      // Check for case-sensitive match
+      String string = buffer_.toString();
       int i = 0;
+      for (Map.Entry<String, FileSystemItem> entry : items_.entrySet())
+      {
+         String fileName = entry.getKey();
+         if (fileName.startsWith(string))
+         {
+            setSelectedRow(i);
+            return;
+         }
+         
+         i++;
+      }
       
+      // Check for case-insensitive match
+      string = string.toLowerCase();
+      i = 0;
       for (Map.Entry<String, FileSystemItem> entry : items_.entrySet())
       {
          String fileName = entry.getKey().toLowerCase();
@@ -269,6 +287,7 @@ public class DirectoryContentsWidget
          
          i++;
       }
+      
    }
 
    private void moveSelection(int offset)

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/DirectoryContentsWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/DirectoryContentsWidget.java
@@ -37,6 +37,7 @@ import org.rstudio.core.client.events.SelectionCommitEvent;
 import org.rstudio.core.client.events.SelectionCommitHandler;
 import org.rstudio.core.client.files.FileSystemContext;
 import org.rstudio.core.client.files.FileSystemItem;
+import org.rstudio.core.client.widget.CanFocus;
 import org.rstudio.core.client.widget.DoubleClickState;
 import org.rstudio.core.client.widget.ScrollPanelWithClick;
 import org.rstudio.core.client.widget.SimplePanelWithProgress;
@@ -49,7 +50,10 @@ public class DirectoryContentsWidget
       extends Composite
    implements HasSelectionHandlers<FileSystemItem>,
               HasSelectionCommitHandlers<FileSystemItem>,
-              HasFocusHandlers, HasBlurHandlers
+              HasFocusHandlers,
+              HasBlurHandlers,
+              CanFocus
+              
 {
 
    private static class FlexTableEx extends FlexTable
@@ -458,6 +462,11 @@ public class DirectoryContentsWidget
          focusImpl_.focus(table_.getElement());
       else
          focusImpl_.blur(table_.getElement());
+   }
+   
+   public void focus()
+   {
+      setFocus(true);
    }
 
    private Map<String, FileSystemItem> items_ =

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/FileBrowserWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/FileBrowserWidget.java
@@ -14,26 +14,16 @@
  */
 package org.rstudio.core.client.files.filedialog;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
+import org.rstudio.core.client.FocusMap;
 import org.rstudio.core.client.events.SelectionCommitHandler;
 import org.rstudio.core.client.files.FileSystemContext;
 import org.rstudio.core.client.files.FileSystemItem;
-import org.rstudio.core.client.widget.CanFocus;
-
 import com.google.gwt.dom.client.Style;
-import com.google.gwt.event.dom.client.KeyCodes;
-import com.google.gwt.event.dom.client.KeyDownEvent;
-import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.event.dom.client.KeyPressHandler;
 import com.google.gwt.event.dom.client.KeyUpHandler;
 import com.google.gwt.event.logical.shared.SelectionHandler;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.DockPanel;
-import com.google.gwt.user.client.ui.Focusable;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.TextBox;
@@ -214,85 +204,5 @@ public class FileBrowserWidget extends Composite
    private String initialFilename_;
    private Host host_;
    private FocusMap focusMap_;
-   
-   private static class FocusMap
-   {
-      public FocusMap()
-      {
-         fwd_ = new HashMap<Widget, Widget>();
-         bwd_ = new HashMap<Widget, Widget>();
-         registration_ = new HashSet<Widget>();
-      }
-      
-      public final void add(Widget source, Widget target)
-      {
-         fwd_.put(source, target);
-         bwd_.put(target, source);
-         listen(source, target);
-      }
-      
-      public final Widget get(Widget widget, boolean forward)
-      {
-         Widget target = forward
-               ? fwd_.get(widget)
-               : bwd_.get(widget);
-         return target;
-      }
-      
-      private final void listen(Widget... widgets)
-      {
-         for (Widget widget : widgets)
-            register(widget);
-      }
-      
-      private void register(final Widget widget)
-      {
-         if (registration_.contains(widget))
-            return;
-         
-         registration_.add(widget);
-         widget.addDomHandler(new KeyDownHandler()
-         {
-            @Override
-            public void onKeyDown(KeyDownEvent event)
-            {
-               if (event.getNativeKeyCode() == KeyCodes.KEY_TAB)
-               {
-                  boolean forward = !event.isShiftKeyDown();
-                  Widget target = get(widget, forward);
-                  if (target == null)
-                     return;
-                  
-                  if (target instanceof CanFocus)
-                  {
-                     event.stopPropagation();
-                     event.preventDefault();
-                     focus((CanFocus) target);
-                  }
-                  else if (target instanceof Focusable)
-                  {
-                     event.stopPropagation();
-                     event.preventDefault();
-                     focus((Focusable) target);
-                  }
-               }
-            }
-         }, KeyDownEvent.getType());
-      }
-      
-      private void focus(CanFocus focusable)
-      {
-         focusable.focus();
-      }
-      
-      private void focus(Focusable focusable)
-      {
-         focusable.setFocus(true);
-      }
-      
-      private final Map<Widget, Widget> fwd_;
-      private final Map<Widget, Widget> bwd_;
-      private final Set<Widget> registration_;
-   }
    
 }


### PR DESCRIPTION
This PR adds a tool that makes it easy to control focus transfer on Tab / Shift + Tab within widgets, and uses it when transferring focus within the directory chooser widget.

The net result is that Tab now transfers between the text box and the directory widget, skipping over the (somewhat bogus) focusing of the 'path breadcrumb' widget in the header, and making it easy to switch to and from directory widget focus vs. text box focus.