### PR TITLE
use '.nb.html' filetype

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -790,10 +790,31 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
 
 .rs.addFunction("withChangedExtension", function(path, ext)
 {
-   paste(tools::file_path_sans_ext(path), ext, sep = ".")
+   ext <- sub("^\\.+", "", ext)
+   if (.rs.endsWith(path, ".nb.html"))
+      paste(substring(path, 1, nchar(path) - 8), ext, sep = ".")
+   else if (.rs.endsWith(path, ".tar.gz"))
+      paste(substring(path, 1, nchar(path) - 7), ext, sep = ".")
+   else
+      paste(tools::file_path_sans_ext(path), ext, sep = ".")
 })
 
 .rs.addFunction("dirExists", function(path)
 {
    utils::file_test('-d', path)
+})
+
+.rs.addFunction("ensureDirectory", function(path)
+{
+   if (file.exists(path)) {
+      if (!utils::file_test("-d", path))
+         stop("file at path '", path, "' exists but is not a directory")
+      return(TRUE)
+   }
+   
+   success <- dir.create(path, recursive = TRUE)
+   if (!success)
+      stop("failed to create directory at path '", path, "'")
+   
+   TRUE
 })

--- a/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
+++ b/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
@@ -89,6 +89,9 @@ public class FileSystemItem extends JavaScriptObject
    public static String getExtensionFromPath(String path)
    {
       String filename = getNameFromPath(path);
+      if (filename.endsWith(".nb.html"))
+         return ".nb.html";
+      
       int lastDotIndex = filename.lastIndexOf('.');
       if (lastDotIndex != -1)
          return filename.substring(lastDotIndex);

--- a/src/gwt/src/org/rstudio/studio/client/common/FilePathUtils.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/FilePathUtils.java
@@ -106,6 +106,8 @@ public class FilePathUtils
    {
       if (path.endsWith(".tar.gz"))
          return path.length() - 7;
+      else if (path.endsWith(".nb.html"))
+         return path.length() - 8;
       
       int lastDotIndex = path.lastIndexOf('.');
       if (lastDotIndex == -1 || lastDotIndex < fromIndex)

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
@@ -99,7 +99,7 @@ public class FileTypeRegistry
    
    public static final RWebContentFileType RNOTEBOOK =
          new RWebContentFileType("r_notebook", "R Notebook", EditorLanguage.LANG_RMARKDOWN,
-                                 ".Rnb", ICONS.iconRnotebook(), true);
+                                 ".nb.html", ICONS.iconRnotebook(), true);
 
    public static final RWebContentFileType RPRESENTATION = new RPresentationFileType();
 
@@ -346,7 +346,7 @@ public class FileTypeRegistry
       register("*.json", JSON, icons.iconJavascript());
       register("*.rmd", RMARKDOWN, icons.iconRmarkdown());
       register("*.rmarkdown", RMARKDOWN, icons.iconRmarkdown());
-      register("*.rnb", RNOTEBOOK, icons.iconRnotebook());
+      register("*.nb.html", RNOTEBOOK, icons.iconRnotebook());
       register("*.rpres", RPRESENTATION, icons.iconRpresentation());
       register("*.md", MARKDOWN, icons.iconMarkdown());
       register("*.mdtxt", MARKDOWN, icons.iconMarkdown());


### PR DESCRIPTION
This PR switches from using `.Rnb` to `.nb.html` for the generated notebook filetype.

@jjallaire, making this a PR just to double check that this looks okay (is there any server side work that should be done as well?)

I guess we'll need to register filetypes for the desktop products but just want to double-check that this looks okay.