### PR TITLE
remove usage of '.rs.routines' object

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -264,19 +264,19 @@
 # of the 'rstudioapi' package -- it is superceded by
 # '.rs.getLastActiveEditorContext()'.
 .rs.addApiFunction("getActiveDocumentContext", function() {
-   .Call(.rs.routines$rs_getEditorContext, 0L)
+   .rs.Call("rs_getEditorContext", 0L)
 })
 
 .rs.addApiFunction("getLastActiveEditorContext", function() {
-   .Call(.rs.routines$rs_getEditorContext, 0L)
+   .rs.Call("rs_getEditorContext", 0L)
 })
 
 .rs.addApiFunction("getConsoleEditorContext", function() {
-   .Call(.rs.routines$rs_getEditorContext, 1L)
+   .rs.Call("rs_getEditorContext", 1L)
 })
 
 .rs.addApiFunction("getSourceEditorContext", function() {
-   .Call(.rs.routines$rs_getEditorContext, 2L)
+   .rs.Call("rs_getEditorContext", 2L)
 })
 
 .rs.addApiFunction("getActiveProject", function() {

--- a/src/cpp/r/R/Options.R
+++ b/src/cpp/r/R/Options.R
@@ -21,7 +21,7 @@
 # custom browseURL implementation
 options(browser = function(url)
 {
-   .Call(.rs.routines$rs_browseURL, url) ;
+   .rs.Call("rs_browseURL", url) ;
 })
 
 # default viewer option if not already set

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -104,6 +104,10 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
   .libPaths(libPaths)
 })
 
+.rs.addFunction("Call", function(routine, ...)
+{
+   .Call(routine, ..., PACKAGE = "(embedding)")
+})
 
 # try to determine if devtools::dev_mode is on
 .rs.addFunction( "devModeOn", function(){
@@ -174,7 +178,7 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
 
 .rs.addGlobalFunction( "RStudioGD", function()
 {
-   .Call(.rs.routines$rs_createGD)
+   .rs.Call("rs_createGD")
 })
 
 # set our graphics device as the default and cause it to be created/set
@@ -288,7 +292,7 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
 # generate a uuid
 .rs.addFunction( "createUUID", function()
 {
-  .Call(.rs.routines$rs_createUUID)
+  .rs.Call("rs_createUUID")
 })
 
 # check the current R architecture
@@ -306,7 +310,7 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
       else
          fileTitle <- header[[i]]
 
-      .Call(.rs.routines$rs_showFile, fileTitle, files[[i]], delete.file)
+      .rs.Call("rs_showFile", fileTitle, files[[i]], delete.file)
    }
 })
 
@@ -736,7 +740,7 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
 
 .rs.addFunction("fromJSON", function(string)
 {
-   .Call(.rs.routines$rs_fromJSON, string)
+   .rs.Call("rs_fromJSON", string)
 })
 
 .rs.addFunction("stringBuilder", function()

--- a/src/cpp/r/RRoutines.cpp
+++ b/src/cpp/r/RRoutines.cpp
@@ -78,11 +78,6 @@ void registerAll()
    
    DllInfo *info = R_getEmbeddingDllInfo() ;
    R_registerRoutines(info, pCMethods, pCallMethods, NULL, NULL);
-   
-   exec::RFunction registerNativeRoutines(".rs.registerNativeRoutines");
-   core::Error error = registerNativeRoutines.call();
-   if (error)
-      LOG_ERROR(error);
 }
    
    

--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -15,22 +15,22 @@
 
 .rs.addFunction("enqueClientEvent", function(type, data = NULL)
 {
-   .Call(.rs.routines$rs_enqueClientEvent, type, data)
+   .rs.Call("rs_enqueClientEvent", type, data)
 })
 
 .rs.addFunction("showErrorMessage", function(title, message)
 {
-   .Call(.rs.routines$rs_showErrorMessage, title, message)
+   .rs.Call("rs_showErrorMessage", title, message)
 })
 
 .rs.addFunction("logErrorMessage", function(message)
 {
-   .Call(.rs.routines$rs_logErrorMessage, message)
+   .rs.Call("rs_logErrorMessage", message)
 })
 
 .rs.addFunction("logWarningMessage", function(message)
 {
-   .Call(.rs.routines$rs_logWarningMessage, message)
+   .rs.Call("rs_logWarningMessage", message)
 })
 
 .rs.addFunction("getSignature", function(obj)
@@ -212,7 +212,7 @@
 {
   pkgDir <- find.package(name)
   .rs.forceUnloadPackage(name)
-  .Call(.rs.routines$rs_installPackage,  archive, dirname(pkgDir))
+  .rs.Call("rs_installPackage",  archive, dirname(pkgDir))
 })
 
 
@@ -257,13 +257,13 @@
 .rs.addFunction("restartR", function(afterRestartCommand = "") {
    afterRestartCommand <- paste(as.character(afterRestartCommand),
                                 collapse = "\n")
-   .Call(.rs.routines$rs_restartR, afterRestartCommand)
+   .rs.Call("rs_restartR", afterRestartCommand)
 })
 
 .rs.addFunction("readUiPref", function(prefName) {
   if (missing(prefName) || is.null(prefName))
     stop("No preference name supplied")
-  .Call(.rs.routines$rs_readUiPref, prefName)
+  .rs.Call("rs_readUiPref", prefName)
 })
 
 
@@ -272,7 +272,7 @@
     stop("No preference name supplied")
   if (missing(value))
     stop("No value supplied")
-  invisible(.Call(.rs.routines$rs_writeUiPref, prefName, .rs.scalar(value)))
+  invisible(.rs.Call("rs_writeUiPref", prefName, .rs.scalar(value)))
 })
 
 .rs.addFunction("setUsingMingwGcc49", function(usingMingwGcc49) {

--- a/src/cpp/session/modules/NotebookHtmlWidgets.R
+++ b/src/cpp/session/modules/NotebookHtmlWidgets.R
@@ -44,7 +44,7 @@
          selfcontained = FALSE, 
          libdir = libraryFolder
       )
-      .Call(.rs.routines$rs_recordHtmlWidget, htmlfile, depfile)
+      .rs.Call("rs_recordHtmlWidget", htmlfile, depfile)
       
    }, envir = as.environment("tools:rstudio"))
 })

--- a/src/cpp/session/modules/SessionAskPass.R
+++ b/src/cpp/session/modules/SessionAskPass.R
@@ -15,6 +15,6 @@
 
 .rs.addFunction( "askForPassword", function(prompt)
 {
-    .Call(.rs.routines$rs_askForPassword, prompt)
+    .rs.Call("rs_askForPassword", prompt)
 })
 

--- a/src/cpp/session/modules/SessionBreakpoints.R
+++ b/src/cpp/session/modules/SessionBreakpoints.R
@@ -507,7 +507,7 @@
    params$fun <- fun
 
    # Register the function with RStudio (may set breakpoints)
-   .Call(.rs.routines$rs_registerShinyFunction, params)
+   .rs.Call("rs_registerShinyFunction", params)
 })
 
 .rs.addJsonRpcHandler("get_function_steps", function(

--- a/src/cpp/session/modules/SessionBuild.R
+++ b/src/cpp/session/modules/SessionBuild.R
@@ -14,11 +14,11 @@
 #
 
 setHook("sourceCpp.onBuild", function(file, fromCode, showOutput) {
-   .Call(.rs.routines$rs_sourceCppOnBuild, file, fromCode, showOutput)
+   .rs.Call("rs_sourceCppOnBuild", file, fromCode, showOutput)
 })
 
 setHook("sourceCpp.onBuildComplete", function(succeeded, output) {
-   .Call(.rs.routines$rs_sourceCppOnBuildComplete, succeeded, output)
+   .rs.Call("rs_sourceCppOnBuildComplete", succeeded, output)
 })
 
 .rs.addFunction("installBuildTools", function(action) {
@@ -28,7 +28,7 @@ setHook("sourceCpp.onBuildComplete", function(succeeded, output) {
       paste(action, " requires installation of additional build tools.\n\n",
       "Do you want to install the additional tools now?", sep = ""))
    if (identical(response, "yes")) {
-      .Call(.rs.routines$rs_installBuildTools)
+      .rs.Call("rs_installBuildTools")
       return(TRUE)
    } else {
       return(FALSE)
@@ -39,7 +39,7 @@ setHook("sourceCpp.onBuildComplete", function(succeeded, output) {
 
    if (identical(.Platform$pkgType, "mac.binary.mavericks")) {
       # this will auto-prompt to install on mavericks
-      .Call(.rs.routines$rs_canBuildCpp)
+      .rs.Call("rs_canBuildCpp")
    } else {
       if (!.Call("rs_canBuildCpp")) {
         .rs.installBuildTools(action)

--- a/src/cpp/session/modules/SessionClang.R
+++ b/src/cpp/session/modules/SessionClang.R
@@ -25,7 +25,7 @@
 
 .rs.addFunction( "isClangAvailable", function() {
    cat("Attemping to load libclang for", R.version$platform, "\n")
-   .Call(.rs.routines$rs_isLibClangAvailable)
+   .rs.Call("rs_isLibClangAvailable")
 })
 
 .rs.addFunction( "setClangDiagnostics", function(level) {
@@ -33,7 +33,7 @@
       stop("level must be 0, 1, or 2")
    if (level > 0)
       .rs.isClangAvailable()
-   .Call(.rs.routines$rs_setClangDiagnostics, level)
+   .rs.Call("rs_setClangDiagnostics", level)
    .rs.restartR()
    invisible(NULL)
 })

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -316,7 +316,7 @@
 
 .rs.addFunction("getPendingInput", function()
 {
-   .Call(.rs.routines$rs_getPendingInput)
+   .rs.Call("rs_getPendingInput")
 })
 
 .rs.addFunction("doStripSurrounding", function(string, complements)
@@ -653,7 +653,7 @@
 
 .rs.addFunction("isSubsequence", function(strings, string)
 {
-   .Call(.rs.routines$rs_isSubsequence, strings, string)
+   .rs.Call("rs_isSubsequence", strings, string)
 })
 
 .rs.addFunction("whichIsSubsequence", function(strings, string)
@@ -744,12 +744,12 @@
 
 .rs.addFunction("packageNameForSourceFile", function(filePath)
 {
-   .Call(.rs.routines$rs_packageNameForSourceFile, filePath)
+   .rs.Call("rs_packageNameForSourceFile", filePath)
 })
 
 .rs.addFunction("isRScriptInPackageBuildTarget", function(filePath)
 {
-   .Call(.rs.routines$rs_isRScriptInPackageBuildTarget, filePath)
+   .rs.Call("rs_isRScriptInPackageBuildTarget", filePath)
 })
 
 .rs.addFunction("namedVectorAsList", function(vector)
@@ -828,17 +828,17 @@
 
 .rs.addFunction("scoreMatches", function(strings, string)
 {
-   .Call(.rs.routines$rs_scoreMatches, strings, string)
+   .rs.Call("rs_scoreMatches", strings, string)
 })
 
 .rs.addFunction("getProjectDirectory", function()
 {
-   .Call(.rs.routines$rs_getProjectDirectory)
+   .rs.Call("rs_getProjectDirectory")
 })
 
 .rs.addFunction("hasFileMonitor", function()
 {
-   .Call(.rs.routines$rs_hasFileMonitor)
+   .rs.Call("rs_hasFileMonitor")
 })
 
 .rs.addFunction("listIndexedFiles", function(term = "",
@@ -848,7 +848,7 @@
    if (is.null(.rs.getProjectDirectory()))
       return(NULL)
    
-   .Call(.rs.routines$rs_listIndexedFiles,
+   .rs.Call("rs_listIndexedFiles",
          term,
          suppressWarnings(.rs.normalizePath(inDirectory)),
          as.integer(maxCount))
@@ -861,7 +861,7 @@
    if (is.null(inDirectory))
       return(character())
    
-   .Call(.rs.routines$rs_listIndexedFolders, term, inDirectory, maxCount)
+   .rs.Call("rs_listIndexedFolders", term, inDirectory, maxCount)
 })
 
 .rs.addFunction("listIndexedFilesAndFolders", function(term = "",
@@ -871,7 +871,7 @@
    if (is.null(inDirectory))
       return(character())
    
-   .Call(.rs.routines$rs_listIndexedFilesAndFolders, term, inDirectory, maxCount)
+   .rs.Call("rs_listIndexedFilesAndFolders", term, inDirectory, maxCount)
 })
 
 .rs.addFunction("doGetIndex", function(term = "",
@@ -1523,32 +1523,6 @@
       symbols <- c(symbols, names(public)[-1])
    
    symbols
-})
-
-.rs.addFunction("registerNativeRoutines", function()
-{
-   pos <- match("tools:rstudio", search())
-   if (is.na(pos))
-      return()
-   
-   if (exists(".rs.routines", pos))
-      return()
-   
-   routineEnv <- new.env(parent = emptyenv())
-   routines <- tryCatch(
-      getDLLRegisteredRoutines("(embedding)"),
-      error = function(e) NULL
-   )
-   
-   if (is.null(routines))
-      return(NULL)
-   
-   .CallRoutines <- routines[[".Call"]]
-   lapply(.CallRoutines, function(routine) {
-      routineEnv[[routine$name]] <- routine
-   })
-   assign(".rs.routines", routineEnv, pos = which(search() == "tools:rstudio"))
-   routineEnv
 })
 
 .rs.addFunction("setEncodingUnknownToUTF8", function(object)

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -601,7 +601,7 @@
 
 .rs.addFunction("addCachedData", function(obj, objName) 
 {
-   cacheKey <- .Call(.rs.routines$rs_generateShortUuid)
+   cacheKey <- .rs.Call("rs_generateShortUuid")
    .rs.assignCachedData(cacheKey, obj, objName)
    cacheKey
 })

--- a/src/cpp/session/modules/SessionDiagnostics.R
+++ b/src/cpp/session/modules/SessionDiagnostics.R
@@ -75,7 +75,7 @@
 
 .rs.addFunction("lintRFile", function(filePath)
 {
-   .Call(.rs.routines$rs_lintRFile, filePath)
+   .rs.Call("rs_lintRFile", filePath)
 })
 
 .rs.addFunction("showLintMarkers", function(lint, filePath)
@@ -154,7 +154,7 @@
 
 .rs.addFunction("lintDirectory", function(directory = .rs.getProjectDirectory())
 {
-   .Call(.rs.routines$rs_lintDirectory, directory)
+   .rs.Call("rs_lintDirectory", directory)
 })
 
 .rs.addJsonRpcHandler("analyze_project", function(directory = .rs.getProjectDirectory())

--- a/src/cpp/session/modules/SessionFiles.R
+++ b/src/cpp/session/modules/SessionFiles.R
@@ -52,7 +52,7 @@
                                       asRelativePath = TRUE,
                                       maxCount = 200L)
 {
-   .Call(.rs.routines$rs_scanFiles,
+   .rs.Call("rs_scanFiles",
          as.character(path),
          as.character(pattern),
          as.logical(asRelativePath),

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -54,12 +54,12 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    
    notifyPackageLoaded <- function(pkgname, ...)
    {
-      .Call(.rs.routines$rs_packageLoaded, pkgname)
+      .rs.Call("rs_packageLoaded", pkgname)
    }
 
    notifyPackageUnloaded <- function(pkgname, ...)
    {
-      .Call(.rs.routines$rs_packageUnloaded, pkgname)
+      .rs.Call("rs_packageUnloaded", pkgname)
    }
    
    # NOTE: `list.dirs()` was introduced with R 2.13 but was buggy until 3.0
@@ -140,7 +140,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
       # do housekeeping after we execute the original
       on.exit({
          .rs.updatePackageEvents()
-         .Call(.rs.routines$rs_packageLibraryMutated)
+         .rs.Call("rs_packageLibraryMutated")
          .rs.restorePreviousPath()
       })
 
@@ -166,12 +166,12 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
 
 .rs.addFunction( "addRToolsToPath", function()
 {
-    .Call(.rs.routines$rs_addRToolsToPath)
+    .rs.Call("rs_addRToolsToPath")
 })
 
 .rs.addFunction( "restorePreviousPath", function()
 {
-    .Call(.rs.routines$rs_restorePreviousPath)
+    .rs.Call("rs_restorePreviousPath")
 })
 
 .rs.addFunction( "uniqueLibraryPaths", function()
@@ -531,7 +531,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
 
 .rs.addFunction("enqueLoadedPackageUpdates", function(installCmd)
 {
-   .Call(.rs.routines$rs_enqueLoadedPackageUpdates, installCmd)
+   .rs.Call("rs_enqueLoadedPackageUpdates", installCmd)
 })
 
 .rs.addJsonRpcHandler("loaded_package_updates_required", function(pkgs)
@@ -546,12 +546,12 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
 
 .rs.addFunction("getCachedAvailablePackages", function(contribUrl)
 {
-   .Call(.rs.routines$rs_getCachedAvailablePackages, contribUrl)
+   .rs.Call("rs_getCachedAvailablePackages", contribUrl)
 })
 
 .rs.addFunction("downloadAvailablePackages", function(contribUrl)
 {
-   .Call(.rs.routines$rs_downloadAvailablePackages, contribUrl)
+   .rs.Call("rs_downloadAvailablePackages", contribUrl)
 })
 
 .rs.addJsonRpcHandler("package_skeleton", function(packageName,
@@ -963,7 +963,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    # NOTE: this file is not always generated (e.g. people who have implicitly opted
    # into using devtools won't need the template file)
    if (file.exists(file.path(packageDirectory, "R", "hello.R")))
-      .Call(.rs.routines$rs_addFirstRunDoc, RprojPath, "R/hello.R")
+      .rs.Call("rs_addFirstRunDoc", RprojPath, "R/hello.R")
 
    ## NOTE: This must come last to ensure the other package
    ## infrastructure bits have been generated; otherwise
@@ -974,7 +974,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    {
       Rcpp::compileAttributes(packageDirectory)
       if (file.exists(file.path(packageDirectory, "src/rcpp_hello.cpp")))
-         .Call(.rs.routines$rs_addFirstRunDoc, RprojPath, "src/rcpp_hello.cpp")
+         .rs.Call("rs_addFirstRunDoc", RprojPath, "src/rcpp_hello.cpp")
    }
    
    .rs.success()

--- a/src/cpp/session/modules/SessionPackrat.R
+++ b/src/cpp/session/modules/SessionPackrat.R
@@ -26,7 +26,7 @@
 
 .rs.addFunction ("installPackratActionHook", function() {
   setHook("packrat.onAction", function(project, action, running) {
-    .Call(.rs.routines$rs_onPackratAction, project, action, running)
+    .rs.Call("rs_onPackratAction", project, action, running)
   })
 })
 

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -36,7 +36,7 @@
       options("profvis.prof_extension" = ".Rprof")
    }
 
-   tempPath <- .Call(.rs.routines$rs_profilesPath)
+   tempPath <- .rs.Call("rs_profilesPath")
    if (!.rs.dirExists(tempPath)) {
       dir.create(tempPath, recursive = TRUE)
    }

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -704,7 +704,7 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("getSourceIndexCompletions", function(token)
 {
-   .Call(.rs.routines$rs_getSourceIndexCompletions, token)
+   .rs.Call("rs_getSourceIndexCompletions", token)
 })
 
 .rs.addFunction("getCompletionsNamespace", function(token, string, exportsOnly, envir)
@@ -1381,7 +1381,7 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("getNAMESPACEImportedSymbols", function(documentId)
 {
-   .Call(.rs.routines$rs_getNAMESPACEImportedSymbols, documentId)
+   .rs.Call("rs_getNAMESPACEImportedSymbols", documentId)
 })
 
 .rs.addFunction("getCompletionsNAMESPACE", function(token, documentId)
@@ -1477,7 +1477,7 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("finishExpression", function(string)
 {
-   .Call(.rs.routines$rs_finishExpression, as.character(string))
+   .rs.Call("rs_finishExpression", as.character(string))
 })
 
 .rs.addFunction("getCompletionsAttr", function(token,
@@ -1512,7 +1512,7 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("isBrowserActive", function()
 {
-   .Call(.rs.routines$rs_isBrowserActive)
+   .rs.Call("rs_isBrowserActive")
 })
 
 # NOTE: This function attempts to find an active frame (if
@@ -1585,7 +1585,7 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("getKnitParamsForDocument", function(documentId)
 {
-   .Call(.rs.routines$rs_getKnitParamsForDocument, documentId)
+   .rs.Call("rs_getKnitParamsForDocument", documentId)
 })
 
 .rs.addFunction("knitParams", function(content)
@@ -2881,13 +2881,13 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("listInferredPackages", function(documentId)
 {
-   .Call(.rs.routines$rs_listInferredPackages, documentId)
+   .rs.Call("rs_listInferredPackages", documentId)
 })
 
 .rs.addFunction("getInferredCompletions", function(packages = character(),
                                                    simplify = TRUE)
 {
-   result <- .Call(.rs.routines$rs_getInferredCompletions, as.character(packages))
+   result <- .rs.Call("rs_getInferredCompletions", as.character(packages))
    if (simplify && length(result) == 1)
       return(result[[1]])
    result

--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -38,7 +38,7 @@
 {
   pkgDir <- find.package("rmarkdown")
   .rs.forceUnloadPackage("rmarkdown")
-  .Call(.rs.routines$rs_installPackage,  archive, dirname(pkgDir))
+  .rs.Call("rs_installPackage",  archive, dirname(pkgDir))
 })
 
 .rs.addFunction("getCustomRenderFunction", function(file) {

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -532,7 +532,7 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
 
 .rs.addFunction("rnb.cachePathFromRmdPath", function(rmdPath)
 {
-  .Call(.rs.routines$rs_chunkCacheFolder, rmdPath)
+  .rs.Call("rs_chunkCacheFolder", rmdPath)
 })
 
 .rs.addFunction("rnb.parseConsoleData", function(data)

--- a/src/cpp/session/modules/SessionSource.R
+++ b/src/cpp/session/modules/SessionSource.R
@@ -37,14 +37,14 @@
    if (sweave)
    {
       op <- function() {
-         .Call(.rs.routines$rs_rnwTangle, activeRStudioDoc, "UTF-8", rnwWeave)
+         .rs.Call("rs_rnwTangle", activeRStudioDoc, "UTF-8", rnwWeave)
          file.remove(activeRStudioDoc)
          file.rename(paste(activeRStudioDoc, ".R", sep=""), activeRStudioDoc)
       }
       capture.output(op())
    }
 
-   .Call(.rs.routines$rs_ensureFileHidden, activeRStudioDoc)
+   .rs.Call("rs_ensureFileHidden", activeRStudioDoc)
 
    return()
 })

--- a/src/cpp/session/modules/SessionUserCommands.R
+++ b/src/cpp/session/modules/SessionUserCommands.R
@@ -77,7 +77,7 @@ assign(".rs.userCommands", new.env(parent = emptyenv()), envir = .rs.toolsEnv())
    
    shortcuts <- unlist(lapply(shortcuts, .rs.normalizeKeyboardShortcut))
    .rs.userCommands[[name]] <- fn
-   .Call(.rs.routines$rs_registerUserCommand, .rs.scalar(name), shortcuts)
+   .rs.Call("rs_registerUserCommand", .rs.scalar(name), shortcuts)
    
    TRUE
 })


### PR DESCRIPTION
This PR removes the `.rs.routines` stuff I added a while ago, and instead just uses a `.rs.Call` method which delegates to `.Call` with the `PACKAGE =` argument set appropriately.

Was prompted to do this as I was bumping into more of the weird `.rs.routines` call errors when attempting to run `profvis` that seemed to be caused by a stale `.rs.routines` object.