### PR TITLE
implement base64 encoder/decoder

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -41,6 +41,10 @@ if(UNIX)
    # compiler flags
    add_definitions(-Wall -pthread)
 
+   if(CMAKE_BUILD_TYPE MATCHES Debug)
+      add_definitions(-g -O2)
+   endif()
+
    if(APPLE)
       add_definitions(-Wno-unknown-warning-option -Wsign-compare -Wno-unused-local-typedefs)
    endif()

--- a/src/cpp/core/Base64.cpp
+++ b/src/cpp/core/Base64.cpp
@@ -52,6 +52,8 @@ public:
       init(table);
    }
    
+   // COPYING: copyable members
+   
 private:
    
    void init(const std::string& table)
@@ -160,6 +162,8 @@ public:
    {
       init(table);
    }
+   
+   // COPYING: copyable members
 
 private:
 

--- a/src/cpp/core/Base64.cpp
+++ b/src/cpp/core/Base64.cpp
@@ -13,51 +13,121 @@
  *
  */
 
-#include <sstream>
-
-#include <algorithm>
-
-#include <boost/archive/iterators/base64_from_binary.hpp>
-#include <boost/archive/iterators/binary_from_base64.hpp>
-#include <boost/archive/iterators/transform_width.hpp>
-#include <boost/archive/iterators/ostream_iterator.hpp>
-
+#include <core/Macros.hpp>
 #include <core/Error.hpp>
 #include <core/Log.hpp>
 #include <core/FileSerializer.hpp>
+
+#include <boost/scoped_array.hpp>
 
 namespace rstudio {
 namespace core {
 namespace base64 {
 
-Error encode(const std::string& input, std::string* pOutput)
+typedef unsigned char Byte;
+
+namespace {
+
+std::string table()
 {
-   using namespace boost::archive::iterators;
+   return "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+}
 
-   try
+std::size_t encoded_size(std::size_t n)
+{
+   return (n + 2) / 3 * 4;
+}
+
+class Encoder
+{
+public:
+
+   Encoder()
    {
-      typedef base64_from_binary<transform_width<const char *,6,8> > b64_text;
-      std::stringstream os;
-      std::copy(b64_text(input.c_str()),
-                b64_text(input.c_str() + input.size()),
-                ostream_iterator<char>(os));
+      init(table());
+   }
 
-      pOutput->clear();
-      pOutput->reserve(((input.size() * 4) / 3) + 3);
-      pOutput->append(os.str());
+   explicit Encoder(const std::string& table)
+   {
+      init(table);
+   }
+   
+private:
+   
+   void init(const std::string& table)
+   {
+      const Byte* pData = (const Byte*) table.c_str();
+      table_.assign(pData, pData + table.size());
+   }
 
-      std::size_t mod = input.size() % 3;
-      if (mod == 1)
-         pOutput->append("==");
-      else if(mod == 2)
-         pOutput->append("=");
+public:
+   
+   Error operator()(const std::string& string, std::string* pOutput)
+   {
+      return (*this)(string.c_str(), string.size(), pOutput);
+   }
 
+   Error operator()(const char* pData, std::size_t n, std::string* pOutput)
+   {
+      return (*this)((const Byte*) pData, n, pOutput);
+   }
+   
+   Error operator()(const Byte* pData, std::size_t n, std::string* pOutput)
+   {
+      std::size_t size = encoded_size(n);
+      boost::scoped_array<Byte> pBuffer(new Byte[size + 1]);
+      pBuffer[size] = '\0';
+      
+      Byte* pTable = &table_[0];
+      Byte* it = pBuffer.get();
+      while (n >= 3)
+      {
+         *it++ = pTable[pData[0] >> 2];
+         *it++ = pTable[((pData[0] & 0x03) << 4) | ((pData[1] & 0xF0) >> 4)];
+         *it++ = pTable[((pData[1] & 0x0F) << 2) | ((pData[2] & 0xC0) >> 6)];
+         *it++ = pTable[pData[2] & 0x3F];
+
+         n -= 3;
+         pData += 3;
+      }
+
+      if (n == 0)
+         goto FINISH;
+
+      *it++ = pTable[pData[0] >> 2];
+      if (n == 1)
+      {
+         *it++ = pTable[(pData[0] & 0x03) << 4];
+         *it++ = '=';
+         *it++ = '=';
+         goto FINISH;
+      }
+
+      *it++ = pTable[((pData[0] & 0x03) << 4) | ((pData[1] & 0xF0) >> 4)];
+      *it++ = pTable[(pData[1] & 0x0F) << 2];
+      *it++ = '=';
+
+FINISH:
+      pOutput->assign((const char*) pBuffer.get(), size);
       return Success();
    }
-   CATCH_UNEXPECTED_EXCEPTION
 
-   // keep compiler happy
-   return Success();
+private:
+   std::vector<Byte> table_;
+};
+
+} // end anonymous namesapce
+
+Error encode(const char* pData, std::size_t n, std::string* pOutput)
+{
+   Encoder encode;
+   return encode(pData, n, pOutput);
+}
+
+Error encode(const std::string& input, std::string* pOutput)
+{
+   Encoder encode;
+   return encode(input, pOutput);
 }
 
 Error encode(const FilePath& inputFile, std::string* pOutput)
@@ -70,45 +140,187 @@ Error encode(const FilePath& inputFile, std::string* pOutput)
    return encode(contents, pOutput);
 }
 
+namespace {
+
+std::size_t decoded_size(std::size_t n)
+{
+   return n * 3 / 4;
+}
+
+class Decoder
+{
+public:
+
+   Decoder()
+   {
+      init(table());
+   }
+
+   explicit Decoder(const std::string& table)
+   {
+      init(table);
+   }
+
+private:
+
+   void init(const std::string& table)
+   {
+      table_.resize(1 << CHAR_BIT, (Byte) -1);
+      const Byte* pData = reinterpret_cast<const Byte*>(table.c_str());
+      for (Byte i = 0, n = table.size(); i < n; ++i)
+         table_[pData[i]] = i;
+   }
+   
+   bool invalid(Byte byte)
+   {
+      return byte == (Byte) -1;
+   }
+   
+   Error decodeError(const ErrorLocation& location, const std::string& reason)
+   {
+      Error error = systemError(
+               boost::system::errc::illegal_byte_sequence,
+               location);
+      error.addProperty("reason", reason);
+      return error;
+   }
+   
+   Error decodeLengthError(std::size_t size, const ErrorLocation& location)
+   {
+      std::stringstream ss;
+      ss << "string length " << size << " is not a multiple of 4";
+      return decodeError(location, ss.str());
+   }
+   
+   Error decodeByteError(Byte byte, const ErrorLocation& location)
+   {
+      std::stringstream ss;
+      ss << "invalid byte '" << byte << "'";
+      return decodeError(location, ss.str());
+   }
+
+public:
+
+   Error operator()(const std::string& input, std::string* pOutput)
+   {
+      return (*this)(
+               reinterpret_cast<const Byte*>(input.c_str()),
+               input.size(),
+               pOutput);
+   }
+
+   Error operator()(const char* pEncoded,
+                    std::size_t n,
+                    std::string* pOutput)
+   {
+      return (*this)(
+               reinterpret_cast<const Byte*>(pEncoded),
+               n,
+               pOutput);
+   }
+   
+   Error operator()(const Byte* pEncoded,
+                    std::size_t n,
+                    std::string* pOutput)
+   {
+      if (n % 4 != 0)
+         return decodeLengthError(n, ERROR_LOCATION);
+
+      std::size_t size = decoded_size(n);
+      boost::scoped_array<Byte> pBuffer(new Byte[size + 1]);
+      pBuffer.get()[size] = '\0';
+      Byte* it = pBuffer.get();
+
+      Byte* pTable = &table_[0];
+      
+      Byte lhsByte, rhsByte;
+      while (n != 4)
+      {
+         lhsByte = pTable[pEncoded[0]];
+         if (UNLIKELY(invalid(lhsByte)))
+            return decodeByteError(pEncoded[0], ERROR_LOCATION);
+         
+         rhsByte = pTable[pEncoded[1]];
+         if (UNLIKELY(invalid(rhsByte)))
+            return decodeByteError(pEncoded[1], ERROR_LOCATION);
+         
+         *it++ = (lhsByte << 2) | (rhsByte >> 4);
+
+         lhsByte = pTable[pEncoded[2]];
+         if (UNLIKELY(invalid(lhsByte)))
+            return decodeByteError(pEncoded[2], ERROR_LOCATION);
+         
+         *it++ = (rhsByte << 4) | (lhsByte >> 2);
+
+         rhsByte = pTable[pEncoded[3]];
+         if (UNLIKELY(invalid(rhsByte)))
+            return decodeByteError(pEncoded[3], ERROR_LOCATION);
+         
+         *it++ = (lhsByte << 6) | rhsByte;
+
+         n -= 4;
+         pEncoded += 4;
+      }
+      
+      lhsByte = pTable[pEncoded[0]];
+      if (UNLIKELY(invalid(lhsByte)))
+         return decodeByteError(pEncoded[0], ERROR_LOCATION);
+      
+      rhsByte = pTable[pEncoded[1]];
+      if (UNLIKELY(invalid(rhsByte)))
+         return decodeByteError(pEncoded[1], ERROR_LOCATION);
+      
+      *it++ = (lhsByte << 2) | (rhsByte >> 4);
+
+      if (pEncoded[2] == '=')
+      {
+         size -= 2;
+         goto FINISH;
+      }
+
+      lhsByte = pTable[pEncoded[2]];
+      if (UNLIKELY(invalid(lhsByte)))
+         return decodeByteError(pEncoded[2], ERROR_LOCATION);
+      
+      *it++ = (rhsByte << 4) | (lhsByte >> 2);
+
+      if (pEncoded[3] == '=')
+      {
+         size -= 1;
+         goto FINISH;
+      }
+
+      rhsByte = pTable[pEncoded[3]];
+      if (UNLIKELY(invalid(rhsByte)))
+         return decodeByteError(pEncoded[3], ERROR_LOCATION);
+
+      *it++ = (lhsByte << 6) | rhsByte;
+
+FINISH:
+      pOutput->assign(
+               reinterpret_cast<const char*>(pBuffer.get()),
+               size);
+      return Success();
+   }
+
+private:
+   std::vector<Byte> table_;
+};
+
+} // end anonymous namespace
 
 Error decode(const std::string& input, std::string* pOutput)
 {
-   using namespace boost::archive::iterators;
+   Decoder decode;
+   return decode(input, pOutput);
+}
 
-   typedef transform_width<binary_from_base64<
-                           std::string::const_iterator>, 8, 6 > text_b64;
-
-   // cast away const so we can temporarily manipulate the input string without
-   // making a copy 
-   std::string& base64 = const_cast<std::string&>(input);
-   unsigned pad = 0;
-
-   try
-   {
-      // remove = padding from end and replace with base64 encoding for 0
-      // (count instances removed)
-      while (base64.at(base64.size() - (pad + 1)) == '=')
-        base64[base64.size() - (pad++ + 1)] = 'A';
-
-      // perform the decoding
-      *pOutput = std::string(text_b64(base64.begin()), text_b64(base64.end()));
-
-      // erase padding from output
-      pOutput->erase(pOutput->end() - pad, pOutput->end());
-   }
-   CATCH_UNEXPECTED_EXCEPTION
-
-   // restore the input string contents
-   for (size_t i = 0; i < pad; i++)
-      base64[base64.size() - (i + 1)] = '=';
-
-   return Success();
+Error decode(const char* pData, std::size_t n, std::string* pOutput)
+{
+   Decoder decode;
+   return decode(pData, n, pOutput);
 }
 
 } // namespace base64
 } // namespace core
 } // namespace rstudio
-
-
-
-

--- a/src/cpp/core/Base64Tests.cpp
+++ b/src/cpp/core/Base64Tests.cpp
@@ -1,0 +1,95 @@
+/*
+ * StringUtils.cpp
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <tests/TestThat.hpp>
+
+#include <core/Error.hpp>
+#include <core/Base64.hpp>
+#include <core/StringUtils.hpp>
+
+namespace rstudio {
+namespace core {
+namespace base64 {
+
+context("Base64 Encoding")
+{
+   std::string encoded;
+   test_that("Various small strings encode correctly")
+   {
+      encode("a", &encoded);
+      expect_true(encoded == "YQ==");
+      
+      encode("ab", &encoded);
+      expect_true(encoded == "YWI=");
+      
+      encode("abc", &encoded);
+      expect_true(encoded == "YWJj");
+      
+      encode("abcd", &encoded);
+      expect_true(encoded == "YWJjZA==");
+      
+      encode("abcde", &encoded);
+      expect_true(encoded == "YWJjZGU=");
+      
+      encode("abcdef", &encoded);
+      expect_true(encoded == "YWJjZGVm");
+   }
+   
+   std::string decoded;
+   test_that("Various small strings decode correctly")
+   {
+      decode("YQ==", &decoded);
+      expect_true(decoded == "a");
+      
+      decode("YWI=", &decoded);
+      expect_true(decoded ==  "ab");
+      
+      decode("YWJj", &decoded);
+      expect_true(decoded == "abc");
+      
+      decode("YWJjZA==", &decoded);
+      expect_true(decoded == "abcd");
+      
+      decode("YWJjZGU=", &decoded);
+      expect_true(decoded == "abcde");
+      
+      decode("YWJjZGVm", &decoded);
+      expect_true(decoded == "abcdef");
+   }
+   
+   test_that("Contents are preserved in encode / decode process")
+   {
+      Error error;
+      for (std::size_t i = 0; i < 100; ++i)
+      {
+         std::string random =
+               string_utils::makeRandomByteString(::rand() % 1024);
+         
+         std::string encoded;
+         error = encode(random, &encoded);
+         expect_true(error == Success());
+         
+         std::string decoded;
+         error = decode(encoded, &decoded);
+         expect_true(error == Success());
+         
+         expect_true(random == decoded);
+      }
+   }
+}
+
+} // end namespace base64
+} // end namespace core
+} // end namespace rstudio

--- a/src/cpp/core/Base64Tests.cpp
+++ b/src/cpp/core/Base64Tests.cpp
@@ -72,6 +72,7 @@ context("Base64 Encoding")
    test_that("Contents are preserved in encode / decode process")
    {
       Error error;
+      ::srand(1);
       for (std::size_t i = 0; i < 100; ++i)
       {
          std::string random =

--- a/src/cpp/core/Base64Tests.cpp
+++ b/src/cpp/core/Base64Tests.cpp
@@ -1,7 +1,7 @@
 /*
- * StringUtils.cpp
+ * Base64Tests.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-16 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -653,6 +653,15 @@ bool isPrefixOf(const std::string& self, const std::string& prefix)
    return boost::algorithm::starts_with(self, prefix);
 }
 
+std::string makeRandomByteString(std::size_t n)
+{
+   std::string result;
+   result.resize(n);
+   for (std::size_t i = 0; i < n; ++i)
+      result[i] = (unsigned char) (::rand() % UCHAR_MAX);
+   return result;
+}
+
 } // namespace string_utils
 } // namespace core 
 } // namespace rstudio

--- a/src/cpp/core/include/core/Base64.hpp
+++ b/src/cpp/core/include/core/Base64.hpp
@@ -27,8 +27,11 @@ class FilePath;
 namespace base64 {
       
 
+Error encode(const char* pData, std::size_t n, std::string* pOutput);
 Error encode(const std::string& input, std::string* pOutput);
 Error encode(const FilePath& inputFile, std::string* pOutput);
+
+Error decode(const char* pData, std::size_t n, std::string* pOutput);
 Error decode(const std::string& input, std::string* pOutput);
 
          

--- a/src/cpp/core/include/core/StringUtils.hpp
+++ b/src/cpp/core/include/core/StringUtils.hpp
@@ -279,6 +279,8 @@ inline std::wstring trimWhitespace(const std::wstring& string)
    return detail::trimWhitespace(string, std::wstring(L" \t\n\r\f\v"));
 }
 
+std::string makeRandomByteString(std::size_t n);
+
 } // namespace string_utils
 } // namespace core 
 } // namespace rstudio

--- a/src/cpp/session/modules/SessionCrypto.cpp
+++ b/src/cpp/session/modules/SessionCrypto.cpp
@@ -22,10 +22,14 @@
 #include <core/Log.hpp>
 #include <core/Error.hpp>
 #include <core/Exec.hpp>
+#include <core/Base64.hpp>
 
 #include <core/json/JsonRpc.hpp>
 
 #include <core/system/Crypto.hpp>
+
+#include <r/RSexp.hpp>
+#include <r/RRoutines.hpp>
 
 #include <session/SessionModuleContext.hpp>
 
@@ -46,6 +50,68 @@ Error getPublicKey(const json::JsonRpcRequest& request,
    return Success();
 }
 
+SEXP rs_base64encode(SEXP dataSEXP)
+{
+   const char* pData;
+   std::size_t n;
+   
+   if (TYPEOF(dataSEXP) == STRSXP)
+   {
+      SEXP charSEXP = STRING_ELT(dataSEXP, 0);
+      pData = CHAR(charSEXP);
+      n = r::sexp::length(charSEXP);
+   }
+   else if (TYPEOF(dataSEXP) == RAWSXP)
+   {
+      pData = reinterpret_cast<const char*>(RAW(dataSEXP));
+      n = r::sexp::length(dataSEXP);
+   }
+   else
+   {
+      LOG_ERROR_MESSAGE("Unexpected data type");
+      return R_NilValue;
+   }
+   
+   std::string output;
+   Error error = base64::encode(pData, n, &output);
+   if (error)
+      LOG_ERROR(error);
+   
+   r::sexp::Protect protect;
+   return r::sexp::create(output, &protect);
+}
+
+SEXP rs_base64decode(SEXP dataSEXP)
+{
+   const char* pData;
+   std::size_t n;
+   
+   if (TYPEOF(dataSEXP) == STRSXP)
+   {
+      SEXP charSEXP = STRING_ELT(dataSEXP, 0);
+      pData = CHAR(charSEXP);
+      n = r::sexp::length(charSEXP);
+   }
+   else if (TYPEOF(dataSEXP) == RAWSXP)
+   {
+      pData = reinterpret_cast<const char*>(RAW(dataSEXP));
+      n = r::sexp::length(dataSEXP);
+   }
+   else
+   {
+      LOG_ERROR_MESSAGE("Unexpected data type");
+      return R_NilValue;
+   }
+   
+   std::string output;
+   Error error = base64::decode(pData, n, &output);
+   if (error)
+      LOG_ERROR(error);
+   
+   r::sexp::Protect protect;
+   return r::sexp::create(output, &protect);
+}
+
 } // anonymous namespace
 
 
@@ -64,6 +130,9 @@ json::Object publicKeyInfoJson()
 Error initialize()
 {
    // install rpc methods
+   RS_REGISTER_CALL_METHOD(rs_base64encode, 1);
+   RS_REGISTER_CALL_METHOD(rs_base64decode, 1);
+   
    using boost::bind;
    using namespace module_context;
    ExecBlock initBlock ;


### PR DESCRIPTION
I noticed that the Boost base64 encoder / decoder was actually surprisingly slow on larger strings (something that might come up more often with the notebook work) -- this PR implements a less featureful but much faster base64 encoder / decoder.

This is definitely something we shouldn't do / accept lightly, so feel free to close this if we'd rather not take the risk, but this implementation is ~10x faster on strings of ~1,000,000 bytes (and we could certainly expect some base64 encoded images of that size).