### PR TITLE
avoid longjmps when restoring workspace

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -76,6 +76,18 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
    eval(parse(text=code), envir=globalenv())
 })
 
+# attempts to restore the global environment from a file
+# on success, returns an empty string; on failure, returns
+# the error message
+.rs.addFunction("restoreGlobalEnvFromFile", function(path)
+{
+   status <- try(load(path, envir = .GlobalEnv), silent = TRUE)
+   if (inherits(status, "try-error"))
+      paste(attr(status, "condition")$message, collapse = "\n")
+   else
+      ""
+})
+
 # save current state of options() to file
 .rs.addFunction( "saveOptions", function(filename)
 {

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -82,10 +82,24 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
 .rs.addFunction("restoreGlobalEnvFromFile", function(path)
 {
    status <- try(load(path, envir = .GlobalEnv), silent = TRUE)
-   if (inherits(status, "try-error"))
-      paste(attr(status, "condition")$message, collapse = "\n")
-   else
-      ""
+   if (!inherits(status, "try-error"))
+      return("")
+   
+   # older versions of R don't provide a 'condition' attribute
+   # for 'try()' errors
+   condition <- attr(status, "condition")
+   if (is.null(condition)) {
+      if (is.character(status))
+         return(paste(c(status), collapse = "\n"))
+      else
+         return("Unknown Error")
+   }
+   
+   # has condition, but no message? should not happen
+   if (!"message" %in% names(condition))
+      return("Unknown Error")
+   
+   paste(condition$message, collapse = "\n")
 })
 
 # save current state of options() to file

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -292,27 +292,30 @@ void deferredRestoreNewSession()
       r::exec::IgnoreInterruptsScope ignoreInterrupts;
 
       std::string path = string_utils::utf8ToSystem(globalEnvPath.absolutePath());
+      std::string aliasedPath = createAliasedPath(globalEnvPath);
       
       std::string errMessage;
       Error error = restoreGlobalEnvFromFile(path, &errMessage);
       if (error)
       {
+         ::REprintf(
+                  "WARNING: Failed to restore workspace from '%s' "
+                  "(an internal error occurred)\n",
+                  aliasedPath.c_str());
          LOG_ERROR(error);
       }
       else if (!errMessage.empty())
       {
          std::stringstream ss;
-         std::string aliasedPath = createAliasedPath(globalEnvPath);
-         ss << "WARNING: Failed to restore workspace from '" << aliasedPath << "'.\n"
+         ss << "WARNING: Failed to restore workspace from "
+            << "'" << aliasedPath << "'" << std::endl
             << "Reason: " << errMessage << std::endl;
-         
-         ::REprintf(ss.str().c_str());
-         LOG_ERROR_MESSAGE(ss.str());
+         std::string message = ss.str();
+         ::REprintf(message.c_str());
+         LOG_ERROR_MESSAGE(message);
       }
       else
       {
-         // print path to console
-         std::string aliasedPath = createAliasedPath(globalEnvPath);
          Rprintf(("[Workspace loaded from " + aliasedPath + "]\n\n").c_str());
       }
    }


### PR DESCRIPTION
Note: obviously risky but also fixes a pretty bad IDE hang on Windows with 64bit R when attempting to load a corrupt `.RData` file (due to `longjmp` madness).

This PR attempts to safely restore the user's workspace on startup. Note that:

1. `R_RestoreGlobalEnvironmentFromFile` is a C entrypoint that just calls the R code `sys.load.image()`,
2. That itself is just an R function that calls `load(file, envir = .GlobalEnv)` (and does some optional printing),
3. Calls to `load` can produce a (catchable) R error.

This PR avoids that R `longjmp` leaking out by catching the R error, and returning the error message as a string (or an empty string if everything succeeded).

cross-ref: https://github.com/wch/r-source/blob/trunk/src/main/saveload.c#L2174-L2195