### PR TITLE
ensure addin shortcuts work on satellite windows

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/dom/DocumentEx.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DocumentEx.java
@@ -21,6 +21,10 @@ public class DocumentEx extends Document
    protected DocumentEx()
    {
    }
+   
+   public final native boolean hasFocus() /*-{
+      return this.hasFocus && this.hasFocus();
+   }-*/;
 
    public final native String getReadyState() /*-{
       return this.readyState || null;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/addins/Addins.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/addins/Addins.java
@@ -88,6 +88,7 @@ public class Addins
    public static class RAddins extends JsMap<RAddin>
    {
       protected RAddins() {}
+      public static final native RAddins createDefault() /*-{ return {}; }-*/;
    }
    
    public static class AddinExecutor

--- a/src/gwt/src/org/rstudio/studio/client/workbench/addins/AddinsCommandManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/addins/AddinsCommandManager.java
@@ -15,6 +15,7 @@ import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
 import org.rstudio.core.client.command.ShortcutManager;
 import org.rstudio.core.client.files.FileBacked;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.workbench.MainWindowObject;
 import org.rstudio.studio.client.workbench.addins.Addins.RAddin;
 import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
 import org.rstudio.studio.client.workbench.addins.events.AddinRegistryUpdatedEvent;
@@ -47,7 +48,7 @@ public class AddinsCommandManager
                @Override
                public void onSessionInit(SessionInitEvent sie)
                {
-                  rAddins_ = session.getSessionInfo().getAddins();
+                  MainWindowObject.rAddins().set(session.getSessionInfo().getAddins());
                   loadBindings();
                }
             });
@@ -72,7 +73,7 @@ public class AddinsCommandManager
                @Override
                public void onAddinRegistryUpdated(AddinRegistryUpdatedEvent event)
                {
-                  rAddins_ = event.getData();
+                  MainWindowObject.rAddins().set(event.getData());
                   loadBindings();
                }
             });
@@ -122,10 +123,11 @@ public class AddinsCommandManager
       List<Pair<List<KeySequence>, CommandBinding>> commands =
             new ArrayList<Pair<List<KeySequence>, CommandBinding>>();
    
+      RAddins rAddins = MainWindowObject.rAddins().get();
       for (String id : bindings.iterableKeys())
       {
          List<KeySequence> keyList = bindings.get(id).getKeyBindings();
-         RAddin addin = rAddins_.get(id);
+         RAddin addin = rAddins.get(id);
          if (addin == null)
             continue;
          CommandBinding binding = new AddinCommandBinding(addin);
@@ -164,10 +166,8 @@ public class AddinsCommandManager
    
    public RAddins getRAddins()
    {
-      return rAddins_;
+      return MainWindowObject.rAddins().get();
    }
-   
-   private RAddins rAddins_ = RAddins.create().cast(); 
    
    private final FileBacked<EditorKeyBindings> bindings_;
    private static final String KEYBINDINGS_PATH = "~/.R/rstudio/keybindings/addins.json";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/addins/AddinsCommandManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/addins/AddinsCommandManager.java
@@ -22,6 +22,7 @@ import org.rstudio.studio.client.workbench.addins.events.AddinRegistryUpdatedEve
 import org.rstudio.studio.client.workbench.events.SessionInitEvent;
 import org.rstudio.studio.client.workbench.events.SessionInitHandler;
 import org.rstudio.studio.client.workbench.model.Session;
+import org.rstudio.studio.client.workbench.views.source.SourceWindowManager;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -73,7 +74,10 @@ public class AddinsCommandManager
                @Override
                public void onAddinRegistryUpdated(AddinRegistryUpdatedEvent event)
                {
-                  MainWindowObject.rAddins().set(event.getData());
+                  // all windows will receive this event, so just let the main window
+                  // cache the addins in its own window
+                  if (SourceWindowManager.isMainSourceWindow())
+                     MainWindowObject.rAddins().set(event.getData());
                   loadBindings();
                }
             });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -656,7 +656,7 @@ public class Source implements InsertSourceHandler,
    
    private boolean consoleEditorHadFocusLast()
    {
-      String id = MainWindowObject.get(MainWindowObject.LAST_FOCUSED_EDITOR);
+      String id = MainWindowObject.lastFocusedEditor().get();
       return "rstudio_console_input".equals(id);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
@@ -210,7 +210,9 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
       }
       
       // signal that this window has focus
-      MainWindowObject.lastFocusedWindow().set(getSourceWindowId());
+      if (WindowEx.get().getDocument().hasFocus())
+         MainWindowObject.lastFocusedWindow().set(getSourceWindowId());
+      
       WindowEx.addFocusHandler(new FocusHandler()
       {
          @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
@@ -209,6 +209,8 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
          }
       }
       
+      // signal that this window has focus
+      MainWindowObject.lastFocusedWindow().set(getSourceWindowId());
       WindowEx.addFocusHandler(new FocusHandler()
       {
          @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
@@ -214,9 +214,7 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
          @Override
          public void onFocus(FocusEvent event)
          {
-            MainWindowObject.set(
-                  MainWindowObject.LAST_FOCUSED_WINDOW,
-                  getSourceWindowId());
+            MainWindowObject.lastFocusedWindow().set(getSourceWindowId());
          }
       });
    }
@@ -269,12 +267,12 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
    
    public String getLastFocusedSourceWindowId()
    {
-      return MainWindowObject.get(MainWindowObject.LAST_FOCUSED_SOURCE_WINDOW);
+      return MainWindowObject.lastFocusedSourceWindow().get();
    }
    
    public String getLastFocusedWindowId()
    {
-      return MainWindowObject.get(MainWindowObject.LAST_FOCUSED_WINDOW);
+      return MainWindowObject.lastFocusedWindow().get();
    }
    
    public int getSourceWindowOrdinal()
@@ -772,7 +770,7 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
                   ? ""
                   : sourceWindowId(event.originWindowName());
 
-            MainWindowObject.set(MainWindowObject.LAST_FOCUSED_SOURCE_WINDOW, id);
+            MainWindowObject.lastFocusedSourceWindow().set(id);
          }
       });
    }
@@ -1252,7 +1250,7 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
    private WindowEx getLastFocusedSourceWindow()
    {
       String lastFocusedSourceWindow =
-            MainWindowObject.get(MainWindowObject.LAST_FOCUSED_SOURCE_WINDOW);
+            MainWindowObject.lastFocusedSourceWindow().get();
             
       // if the last window focused was the main one, or there's no longer an
       // addressable window, there's nothing to do

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -432,9 +432,8 @@ public class AceEditor implements DocDisplay,
          @Override
          public void onFocus(FocusEvent event)
          {
-            MainWindowObject.set(
-                  MainWindowObject.LAST_FOCUSED_EDITOR,
-                  AceEditor.this.getWidget().getElement().getId());
+            String id = AceEditor.this.getWidget().getElement().getId();
+            MainWindowObject.lastFocusedEditor().set(id);
          }
       });
    }


### PR DESCRIPTION
This PR does two things:

1. It cleans up the `MainWindowObject` interface -- the class itself has a bunch of static 'generators', which can be used for type-safe getting / setting of JavaScript objects on the main window. This should be cleaner than the previous 'static-methods-only' implementation, as we now have static methods returning typed objects that know how to get / set in the correct way.

2. It fixes an issue where non-interactive addins could not be executed within satellite windows. This is fixed by placing the addins JavaScript object on the main window, and having all methods access it from there -- this should ensure that both the main window and satellites see the same objects.