### PR TITLE
add right padding after argnames

### DIFF
--- a/src/cpp/session/resources/R.css
+++ b/src/cpp/session/resources/R.css
@@ -100,3 +100,7 @@ table p {
    margin-bottom: 6px;
 }
 
+table[summary="R argblock"] tr td:first-child {
+   min-width: 24px;
+   padding-right: 12px;
+}


### PR DESCRIPTION
This PR adds a bit of padding following the argument names in the displayed help. Examples from `?readLines` documentation.

Before:

![screen shot 2016-04-05 at 10 41 10 am](https://cloud.githubusercontent.com/assets/1976582/14292002/f6b90c82-fb1a-11e5-89a2-9713814b5221.png)


After:

![screen shot 2016-04-05 at 10 39 23 am](https://cloud.githubusercontent.com/assets/1976582/14292005/f985e2dc-fb1a-11e5-9e24-f461c80ee409.png)

Note the extra breathing room after the `encoding` argument.
