### PR TITLE
allow downloading excel files with different extensions

### DIFF
--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -387,8 +387,7 @@
             package = "readr",
             paramsPackage = "readr",
             options = options,
-            optionTypes = optionTypes,
-            cacheFileExtension = ".txt"
+            optionTypes = optionTypes
          ))
       },
       "statistics" = function() {
@@ -417,8 +416,7 @@
             reference = havenFunction$ref,
             package = "haven",
             options = options,
-            optionTypes = optionTypes,
-            cacheFileExtension = ".dat"
+            optionTypes = optionTypes
          ))
       },
       "xls" = function() {
@@ -444,8 +442,7 @@
             package = "readxl",
             paramsPackage = NULL,
             options = options,
-            optionTypes = optionTypes,
-            cacheFileExtension = ".xls"
+            optionTypes = optionTypes
          ))
       }
    )

--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -390,7 +390,7 @@
             paramsPackage = "readr",
             options = options,
             optionTypes = optionTypes,
-            cacheFileExtension = c(".txt")
+            cacheFileExtension = ".txt"
          ))
       },
       "statistics" = function() {
@@ -420,7 +420,7 @@
             package = "haven",
             options = options,
             optionTypes = optionTypes,
-            cacheFileExtension = c(".dat")
+            cacheFileExtension = ".dat"
          ))
       },
       "xls" = function() {

--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -274,6 +274,7 @@
          cacheVariableName <- options$cacheVariableNames[[resource]]
          cacheUrlName <- options$cacheUrlNames[[resource]]
          downloadResource <- options[[resource]]
+         resourceExtension <- sub(".*([.][^.]*$)", "\\1", basename(downloadResource), perl = TRUE)
 
          cacheDataCode <- append(
             cacheDataCode,
@@ -293,7 +294,7 @@
                   cacheVariableName,
                   " <- \"",
                   options$dataName,
-                  functionInfo$cacheFileExtension,
+                  resourceExtension,
                   "\"",
                   sep = "")
             )
@@ -304,7 +305,7 @@
             {
                localFile <- tempfile(
                   tmpdir = dirname(tempdir()),
-                  fileext = functionInfo$cacheFileExtension
+                  fileext = resourceExtension
                )
             }
 

--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -274,7 +274,9 @@
          cacheVariableName <- options$cacheVariableNames[[resource]]
          cacheUrlName <- options$cacheUrlNames[[resource]]
          downloadResource <- options[[resource]]
-         resourceExtension <- sub(".*([.][^.]*$)", "\\1", basename(downloadResource), perl = TRUE)
+         resourceExtension <- sub("[^\\?]*([.][^.\\?]*)(\\?.*)?$", "\\1", basename(downloadResource), perl = TRUE)
+         if (!(resourceExtension %in% functionInfo$cacheFileExtension))
+            resourceExtension <- functionInfo$cacheFileExtension[[1]]
 
          cacheDataCode <- append(
             cacheDataCode,
@@ -387,7 +389,8 @@
             package = "readr",
             paramsPackage = "readr",
             options = options,
-            optionTypes = optionTypes
+            optionTypes = optionTypes,
+            cacheFileExtension = c(".txt")
          ))
       },
       "statistics" = function() {
@@ -416,7 +419,8 @@
             reference = havenFunction$ref,
             package = "haven",
             options = options,
-            optionTypes = optionTypes
+            optionTypes = optionTypes,
+            cacheFileExtension = c(".dat")
          ))
       },
       "xls" = function() {
@@ -442,7 +446,8 @@
             package = "readxl",
             paramsPackage = NULL,
             options = options,
-            optionTypes = optionTypes
+            optionTypes = optionTypes,
+            cacheFileExtension = c(".xls", ".xlsx")
          ))
       }
    )


### PR DESCRIPTION
In data import, `.xls` and other extensions are picked for the user since urls don't necessarily contain a file extension. However, there are cases where an extension is present in the url and we want to honor it. Therefore, the fix here in this pr is to extract the extension first and validate against the supported extensions, if it's supported, we will use that extension instead.