### PR TITLE
stop-gap fix to prevent data viewer crash

### DIFF
--- a/src/cpp/r/include/r/RMemoryInternals.hpp
+++ b/src/cpp/r/include/r/RMemoryInternals.hpp
@@ -1,0 +1,50 @@
+/*
+ * RMemoryInternals.hpp
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#define R_INTERNAL_FUNCTIONS
+#include <r/RInternal.hpp>
+
+#ifndef R_R_MEMORY_INTERNALS_HPP
+#define R_R_MEMORY_INTERNALS_HPP
+
+/* Access unexported information about R's memory internals */
+extern "C" {
+extern SEXP* R_PPStack;
+extern int R_PPStackTop;
+extern int R_PPStackSize;
+}
+
+namespace rstudio {
+namespace r {
+namespace internals {
+
+int protectStackTop()
+{
+   return R_PPStackTop;
+}
+
+void logProtectedSEXPs()
+{
+   ::Rprintf("Begin protected R items\n");
+   for (int i = 0; i < R_PPStackTop; ++i)
+      Rf_PrintValue(R_PPStack[i]);
+   ::Rprintf("End protected R items\n");
+}
+
+} // end namespace internals
+} // end namespace r
+} // end namespace rstudio
+
+#endif /* R_R_MEMORY_INTERNALS_HPP */

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -593,6 +593,11 @@ json::Value getData(SEXP dataSEXP, const http::Fields& fields)
    // extract the portion of the column vector requested by the client
    SEXP formattedDataSEXP = Rf_allocVector(VECSXP, ncol);
    protect.add(formattedDataSEXP);
+   
+   // reprotect dataSEXP
+   // TODO: figure out why upstream it's not protected
+   protect.add(dataSEXP);
+   
    for (unsigned i = 0; i < static_cast<unsigned>(ncol); i++)
    {
       SEXP columnSEXP = VECTOR_ELT(dataSEXP, i);


### PR DESCRIPTION
This PR fixes a crash that occasionally occurs when attempting to view non-data.frame objects (e.g. `View(volcano)`).

The issue appears to be due to the (missing) protection on the `dataSEXP` object; however, I cannot see why exactly this is occurring (it's also possible that an earlier routine is decrementing the protect stack more than it should, leaving that object unprotected).

We should investigate more, but in absence of discovering the root cause we might take this as-is.