### PR TITLE
fix protection errors in RFunction class

### DIFF
--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -1075,6 +1075,22 @@ void PreservedSEXP::releaseNow()
    }
 }
 
+SEXP SEXPPreserver::add(SEXP dataSEXP)
+{
+   if (dataSEXP != R_NilValue)
+   {
+      ::R_PreserveObject(dataSEXP);
+      preservedSEXPs_.push_back(dataSEXP);
+   }
+   return dataSEXP;
+}
+
+SEXPPreserver::~SEXPPreserver()
+{
+   for (std::size_t i = 0, n = preservedSEXPs_.size(); i < n; ++i)
+      ::R_ReleaseObject(preservedSEXPs_[n - i - 1]);
+}
+
 void printValue(SEXP object)
 {
    Error error = r::exec::executeSafely(

--- a/src/cpp/r/include/r/RExec.hpp
+++ b/src/cpp/r/include/r/RExec.hpp
@@ -192,7 +192,9 @@ public:
    template <typename T>
    void addParam(const std::string& name, const T& param)
    {
-      SEXP paramSEXP = sexp::create(param, &rProtect_);
+      r::sexp::Protect protect;
+      SEXP paramSEXP = sexp::create(param, &protect);
+      preserver_.add(paramSEXP);
       params_.push_back(Param(name, paramSEXP));
    }
                         
@@ -228,8 +230,8 @@ private:
    void commonInit(const std::string& functionName);
    
 private:
-   // protect included SEXPs
-   sexp::Protect rProtect_ ;
+   // preserve SEXPs
+   r::sexp::SEXPPreserver preserver_;
    
    // function 
    SEXP functionSEXP_;

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -302,6 +302,17 @@ private:
    SEXP sexp_;
 };
 
+class SEXPPreserver : boost::noncopyable
+{
+public:
+   SEXPPreserver() {}
+   ~SEXPPreserver();
+   SEXP add(SEXP dataSEXP);
+   
+private:
+   std::vector<SEXP> preservedSEXPs_;
+};
+
 class ListBuilder : boost::noncopyable
 {
 public:

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -729,7 +729,7 @@ Error getGridData(const http::Request& request,
       {
          LOG_ERROR(error);
       }
-
+      
       // couldn't find the original object
       if (dataSEXP == NULL || dataSEXP == R_UnboundValue || 
           Rf_isNull(dataSEXP) || TYPEOF(dataSEXP) == NILSXP)


### PR DESCRIPTION
The RFunction class used its own protection stack, which unfortunately did not play well when attempting to return new, protected objects (as the destruction of the RFunction class would then unprotect the resulting object!)

The RFunction class is modified to use `R_PreserveObject()` and `R_ReleaseObject()`, which should help ensure we don't run into such protection stack issues.