### PR TITLE
activate embedded markdown modes (e.g. js) within knitr chunks

### DIFF
--- a/src/gwt/acesupport/acemode/markdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/markdown_highlight_rules.js
@@ -65,7 +65,7 @@ var escaped = function(ch) {
 function github_embed(tag, prefix) {
     return { // Github style block
         token : "support.function",
-        regex : "^\\s*```" + tag + "\\s*$",
+        regex : "^\\s*```\\{?" + tag + "([^\\}]*\\})?\\s*$",
         push  : prefix + "start"
     };
 }

--- a/src/gwt/acesupport/acemode/markdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/markdown_highlight_rules.js
@@ -65,7 +65,7 @@ var escaped = function(ch) {
 function github_embed(tag, prefix) {
     return { // Github style block
         token : "support.function",
-        regex : "^\\s*```\\{?" + tag + "([^\\}]*\\})?\\s*$",
+        regex : "^\\s*```(?:" + "\\{" + tag + "[^\\}]*\\}" + "|" + tag + ")\\s*$",
         push  : prefix + "start"
     };
 }


### PR DESCRIPTION
Goes along with this knitr PR to add js and css engines: https://github.com/yihui/knitr/pull/1193

@kevinushey Could you take a look to ensure I've done everything correctly and completely here?