### PR TITLE
apply zoom level when copying plot from Viewer

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/export/DesktopExport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/export/DesktopExport.java
@@ -13,10 +13,12 @@
 
 package org.rstudio.studio.client.workbench.views.viewer.export;
 
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Rectangle;
 import org.rstudio.core.client.dom.ElementEx;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.workbench.exportplot.ExportPlotSizeEditor;
 
 import com.google.gwt.core.client.Scheduler;
@@ -25,6 +27,10 @@ import com.google.gwt.user.client.Command;
 
 public class DesktopExport
 {
+   private static final native double getSafariZoomFactor() /*-{
+      return $doc.width / $doc.body.clientWidth;
+   }-*/;
+   
    public static void export(final ExportPlotSizeEditor sizeEditor,
                              final OperationWithInput<Rectangle> exporter,
                              final Operation onCompleted)
@@ -37,13 +43,18 @@ public class DesktopExport
             // hide gripper
             sizeEditor.setGripperVisible(false);
             
+            // get zoom level
+            double zoomLevel = BrowseCap.isMacintoshDesktop()
+                  ? getSafariZoomFactor()
+                  : Desktop.getFrame().getZoomLevel();
+            
             // get the preview iframe rect
             ElementEx iframe = sizeEditor.getPreviewIFrame().<ElementEx>cast();
             final Rectangle viewerRect = new Rectangle(
-                   iframe.getClientLeft(),
-                   iframe.getClientTop(),
-                   iframe.getClientWidth(),
-                   iframe.getClientHeight()).inflate(-1);
+                   (int) Math.ceil(zoomLevel * iframe.getClientLeft()),
+                   (int) Math.ceil(zoomLevel * iframe.getClientTop()),
+                   (int) Math.ceil(zoomLevel * iframe.getClientWidth()),
+                   (int) Math.ceil(zoomLevel * iframe.getClientHeight())).inflate(-1);
             
             // perform the export
             Scheduler.get().scheduleDeferred(new ScheduledCommand() {


### PR DESCRIPTION
This PR fixes an issue where attempts to copy the state of the Viewer to the clipboard would not be sized correctly when the browser was zoomed in. It looks like this error occurs both on OS X desktop as well as Windows desktop (ie, Qt), so I've made the zoom change for all cases.

Still pending tests on Windows + Linux, so let's wait for that before merge.