### PR TITLE
Allow the profile satellite window to reuse document contents

### DIFF
--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -96,8 +96,6 @@
          if (identical(tools::file_ext(profilerOptions$fileName), "Rprof")) {
             profvis <- profvis::profvis(prof_input = profilerOptions$fileName, split="h")
             htmlwidgets::saveWidget(profvis, htmlFile, selfcontained = TRUE)
-
-            file.remove(profilerOptions$fileName)
          }
          else {
             .rs.rpc.copy_profile(profilerOptions$fileName, htmlFile)
@@ -106,11 +104,6 @@
       else {
          profvis <- profilerOptions$profvis
          htmlwidgets::saveWidget(profvis, htmlFile, selfcontained = TRUE)
-
-         if (resources$tempPath == substr(profilerOptions$profvis$x$message$prof_output, 1, nchar(resources$tempPath)))
-         {
-            file.remove(profilerOptions$profvis$x$message$prof_output)
-         }
       }
 
       return(list(

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -150,14 +150,15 @@
    .rs.enqueClientEvent("rprof_created", result);
 })
 
-.rs.addJsonRpcHandler("clear_profile", function(filePath)
+.rs.addJsonRpcHandler("clear_profile", function(filePath, htmlPath)
 {
    tryCatch({
       resources <- .rs.profileResources()
 
-      filePrefix <- tools::file_path_sans_ext(basename(filePath))
+      pathPrefix <- tools::file_path_sans_ext(basename(filePath))
+      filePrefix <- tools::file_path_sans_ext(basename(htmlPath))
       
-      rprofFile <- file.path(resources$tempPath, paste(filePrefix, ".Rprof", sep = ""))
+      rprofFile <- file.path(resources$tempPath, paste(pathPrefix, ".Rprof", sep = ""))
       if (file.exists(rprofFile)) {
          file.remove(rprofFile)
       }

--- a/src/cpp/session/modules/SessionProfiler.cpp
+++ b/src/cpp/session/modules/SessionProfiler.cpp
@@ -68,12 +68,14 @@ void handleProfilerResReq(const http::Request& request,
 void onDocPendingRemove(
         boost::shared_ptr<source_database::SourceDocument> pDoc)
 {
-   // check to see if there is html cached data
+   // check to see if there is cached data
+   std::string path = pDoc->getProperty("path");
    std::string htmlLocalPath = pDoc->getProperty("htmlLocalPath");
-   if (htmlLocalPath.empty())
+   if (htmlLocalPath.empty() && path.empty())
       return;
 
    r::exec::RFunction rFunction(".rs.rpc.clear_profile");
+   rFunction.addParam(path);
    rFunction.addParam(htmlLocalPath);
 
    Error error = rFunction.call();


### PR DESCRIPTION
Popping-out the profiler window not working in some scenarios. The problem is that we reload from the document path which, when the profile is created, points to the `Rprof` file but this file is deleted once the html files are generated. Also, the document properties are not reloaded when the satellite window is open which makes since worse since we don't have the `Rprof` file and the document properties pointing to the html files are also missing.

The first fix is to not delete the `Rprof` until the document closes. That way, if the html file is removed, we can reload from this. This "fixes"

The second fix is to reload the document (and it's missing properties) during activation if the document is de-attached. This change is more scoped than what the git diff looks like, all the "changed" code got refactored into an activateOperation, the new code looks as follows:

```
      if (getId() != null && !SourceWindowManager.isMainSourceWindow()) {
         sourceServer_.getSourceDocument(getId(), new ServerRequestCallback<SourceDocument>()
         {
            @Override
            public void onResponseReceived(SourceDocument document)
            {
               doc_ = document;
               activateOperation.execute();
            }
            
            @Override
            public void onError(ServerError error)
            {
               Debug.logError(error);
            }
         });
      }
      else {
         activateOperation.execute();
      }
```