### PR TITLE
fix Windows hang when errors emitted from graphics device

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -244,6 +244,22 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
    save(plot, file=filename)
 })
 
+.rs.addFunction("GEplayDisplayList", function()
+{
+   tryCatch(
+      .Call("rs_GEplayDisplayList"),
+      error = function(e) warning(e)
+   )
+})
+
+.rs.addFunction("GEcopyDisplayList", function(fromDevice)
+{
+   tryCatch(
+      .Call("rs_GEcopyDisplayList", fromDevice),
+      error = function(e) warning(e)
+   )
+})
+
 # record an object to a file
 .rs.addFunction( "saveGraphics", function(filename)
 {

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -52,6 +52,7 @@
 #include "RRestartContext.hpp"
 #include "REmbedded.hpp"
 
+#include "graphics/RGraphicsDevDesc.hpp"
 #include "graphics/RGraphicsUtils.hpp"
 #include "graphics/RGraphicsDevice.hpp"
 #include "graphics/RGraphicsPlotManager.hpp"
@@ -1354,6 +1355,22 @@ bool win32Quit(const std::string& saveAction,
 }
 #endif
 
+namespace {
+
+SEXP rs_GEcopyDisplayList(SEXP fromDeviceSEXP)
+{
+   int fromDevice = r::sexp::asInteger(fromDeviceSEXP);
+   GEcopyDisplayList(fromDevice);
+   return Rf_ScalarLogical(1);
+}
+
+SEXP rs_GEplayDisplayList()
+{
+   graphics::device::playDisplayList();
+   return Rf_ScalarLogical(1);
+}
+
+} // end anonymous namespace
    
 Error run(const ROptions& options, const RCallbacks& callbacks) 
 {   
@@ -1466,6 +1483,9 @@ Error run(const ROptions& options, const RCallbacks& callbacks)
    saveHistoryMethodDef.numArgs = 1;
    r::routines::addCallMethod(saveHistoryMethodDef);
 
+   // register graphics methods
+   RS_REGISTER_CALL_METHOD(rs_GEcopyDisplayList, 1);
+   RS_REGISTER_CALL_METHOD(rs_GEplayDisplayList, 0);
 
    // run R
 

--- a/src/cpp/r/session/graphics/RGraphicsDevice.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsDevice.cpp
@@ -404,8 +404,7 @@ void resyncDisplayList()
    // replay the display list onto the resized surface
    {
       SuppressDeviceEventsScope scope(plotManager());
-      Error error = r::exec::executeSafely(
-                              boost::bind(GEplayDisplayList,s_pGEDevDesc));
+      Error error = r::exec::RFunction(".rs.GEplayDisplayList").call();
       if (error)
       {
          std::string errMsg;
@@ -651,7 +650,7 @@ Error restoreSnapshot(const core::FilePath& snapshotFile)
 void copyToActiveDevice()
 {
    int rsDeviceNumber = GEdeviceNumber(s_pGEDevDesc);
-   GEcopyDisplayList(rsDeviceNumber);
+   r::exec::RFunction(".rs.GEcopyDisplayList", rsDeviceNumber).call();
 }
    
 std::string imageFileExtension()
@@ -671,6 +670,11 @@ void onBeforeExecute()
 
 } // anonymous namespace
     
+void playDisplayList()
+{
+   GEplayDisplayList(s_pGEDevDesc);
+}
+
 const int kDefaultWidth = 500;   
 const int kDefaultHeight = 500; 
 const double kDefaultDevicePixelRatio = 1.0;

--- a/src/cpp/r/session/graphics/RGraphicsDevice.hpp
+++ b/src/cpp/r/session/graphics/RGraphicsDevice.hpp
@@ -46,6 +46,12 @@ int getWidth();
 int getHeight();
 double devicePixelRatio();
 
+// NOTE: should not be called directly!
+// use RFunction(".rs.GEplayDisplayList") instead to ensure
+// appropriate R calling handlers are active (that function will
+// then call through to this)
+void playDisplayList();
+
 // reset
 void close();
 

--- a/src/cpp/r/session/graphics/RGraphicsPlot.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsPlot.cpp
@@ -128,7 +128,7 @@ Error Plot::renderFromDisplay()
    {
       return Success();
    }
-    
+   
    // generate a new storage uuid
    std::string storageUuid = core::system::generateUuid();
    

--- a/src/cpp/r/session/graphics/RShadowPngGraphicsHandler.cpp
+++ b/src/cpp/r/session/graphics/RShadowPngGraphicsHandler.cpp
@@ -195,8 +195,7 @@ void shadowDevSync(DeviceContext* pDC)
    // the invalid name warning in checkValidSymbolId in dotcode.c
    {
       r::session::utils::SuppressOutputInScope scope;
-      error = r::exec::executeSafely(boost::bind(GEcopyDisplayList,
-                                                    rsDeviceNumber));
+      error = r::exec::RFunction(".rs.GEcopyDisplayList", rsDeviceNumber).call();
       if (error && !r::isCodeExecutionError(error))
          LOG_ERROR(error);
    }


### PR DESCRIPTION
This PR fixes a hang on Windows when errors are emitted when generating plots (e.g. through `GEplayDisplayList()` or `GEcopyDisplayList()`).

The fix effectively uses R-level `tryCatch()` rather than C-level `R_ToplevelExec()` to trap errors. For reasons unknown to me, `R_ToplevelExec()` (as used in `r::exec::executeSafely`) is not sufficient in trapping these errors -- likely, this is a bug in the SJLJ error handling in the new MinGW toolchain distributed with Qt, as this code has lived and run fine for a long time with older versions of RStudio (e.g. 0.98 and older).

For whatever reason, ensuring that the error handlers are attached in R code (through `tryCatch()`) side-steps this problem.