### PR TITLE
explicitly find git executable

### DIFF
--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -66,9 +66,12 @@ endif()
 # record git revision hash (cache it since we don't use this in development
 # mode and we don't want it to force rebuilds there)
 if(NOT RSTUDIO_SESSION_WIN64 AND NOT RSTUDIO_GIT_REVISION_HASH)
-   exec_program(git ARGS rev-parse HEAD
-                OUTPUT_VARIABLE RSTUDIO_GIT_REVISION_HASH)
-   SET(RSTUDIO_GIT_REVISION_HASH "${RSTUDIO_GIT_REVISION_HASH}" CACHE STRING "Git Revision Hash")
+   find_package(git QUIET)
+   if (GIT_FOUND)
+      exec_program(${GIT_EXECUTABLE} ARGS rev-parse HEAD
+                   OUTPUT_VARIABLE RSTUDIO_GIT_REVISION_HASH)
+      SET(RSTUDIO_GIT_REVISION_HASH "${RSTUDIO_GIT_REVISION_HASH}" CACHE STRING "Git Revision Hash")
+   endif()
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,13 +29,20 @@ endif()
 
 # install root docs
 if (NOT RSTUDIO_SESSION_WIN64)
+
    # dynamically configure SOURCE with the git revision hash
-   INSTALL(CODE "
-      exec_program(git ARGS rev-parse HEAD
-                   OUTPUT_VARIABLE RSTUDIO_GIT_REVISION_HASH)
-      configure_file (\"${CMAKE_CURRENT_SOURCE_DIR}/SOURCE.in\"
-                      \"${CMAKE_CURRENT_BINARY_DIR}/SOURCE\")
-    ")
+   if (NOT GIT_FOUND)
+     find_package(git QUIET)
+   endif()
+
+   if(GIT_FOUND)
+      INSTALL(CODE "
+         exec_program(\"${GIT_EXECUTABLE}\" ARGS rev-parse HEAD
+                      OUTPUT_VARIABLE RSTUDIO_GIT_REVISION_HASH)
+         configure_file (\"${CMAKE_CURRENT_SOURCE_DIR}/SOURCE.in\"
+                         \"${CMAKE_CURRENT_BINARY_DIR}/SOURCE\")
+      ")
+   endif()
 
    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/VERSION.in
                   ${CMAKE_CURRENT_BINARY_DIR}/VERSION)


### PR DESCRIPTION
@jjallaire, this PR is intended alleviate `git` headaches when attempting to build on Windows.

CMake complains if you have the `git` directory on the PATH, as it also has e.g. `sh.exe` within the same directory and this is a big no-no for CMake -- for this reason, the `rebuild-package` script strips the Git binary directory off the PATH. However, we now need `git` to get the current revision during calls to `cmake`, so we now have a little chicken-egg problem.

This PR side-steps the issue by using `find_program(git)` to get a path to the git executable, and uses that as appropriate.