### PR TITLE
Retry opening rsession port for up to 1s

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -3243,11 +3243,25 @@ int main (int argc, char * const argv[])
       error = workingDir.makeCurrentPath();
       if (error)
          return sessionExitFailure(error, ERROR_LOCATION);
-         
-      // start http connection listener
-      error = startHttpConnectionListener();
-      if (error)
-         return sessionExitFailure(error, ERROR_LOCATION);
+
+      int retries = 10;
+      while (retries > 0)
+      {
+          // start http connection listener
+          error = startHttpConnectionListener();
+          if (error)
+          {
+             boost::this_thread::sleep(boost::posix_time::milliseconds(100));
+             retries--;
+          }
+          else
+          {
+              break;
+          }
+      }
+
+      if (retries == 0)
+          return sessionExitFailure(error, ERROR_LOCATION);
 
       // run optional preflight script -- needs to be after the http listeners
       // so the proxy server sees that we have startup up

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -3080,6 +3080,8 @@ bool ensureUtf8Charset()
 #endif
 #endif
 }
+
+
 } // anonymous namespace
 
 // run session
@@ -3256,7 +3258,7 @@ int main (int argc, char * const argv[])
       error = workingDir.makeCurrentPath();
       if (error)
          return sessionExitFailure(error, ERROR_LOCATION);
-      
+         
       // start http connection listener
       error = waitWithTimeout(startHttpConnectionListenerWithTimeout, 0, 100, 1000);
       if (error)

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -3243,7 +3243,9 @@ int main (int argc, char * const argv[])
       error = workingDir.makeCurrentPath();
       if (error)
          return sessionExitFailure(error, ERROR_LOCATION);
-
+      
+      // Wait for port to be ready, if needed. This triggers when the
+      // rsession restarts but takes the port a few ms to become available
       int retries = 10;
       while (retries > 0)
       {

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1617,7 +1617,8 @@ WaitResult startHttpConnectionListenerWithTimeout()
 {
    Error error = startHttpConnectionListener();
 
-   // Retry connection, but only for address_in_use error
+   // When the rsession restarts, it may take a few ms for the port to become
+   // available; therefore, retry connection, but only for address_in_use error
    if (!error)
        return WaitResult(WaitSuccess, Success());
    else if (error.code() != boost::system::errc::address_in_use)
@@ -3256,9 +3257,7 @@ int main (int argc, char * const argv[])
       if (error)
          return sessionExitFailure(error, ERROR_LOCATION);
       
-      // start http connection listener and wait for the port to be ready,
-      // if needed. For instance, when the rsession restarts but takes the
-      // port a few ms to become available
+      // start http connection listener
       error = waitWithTimeout(startHttpConnectionListenerWithTimeout, 0, 100, 1000);
       if (error)
          return sessionExitFailure(error, ERROR_LOCATION);


### PR DESCRIPTION
Found a "crash" on session restart while debugging an Spark package. However, this issue manifest in other packages as well, for instance, see `finalizer` workaround in this package: https://github.com/apache/spark/blob/branch-1.4/R/pkg/R/sparkR.R#L212

Technically speaking this is not a crash, what happens is that the rsession gets restarted using the same port, the port happens to be already in use by the old rsession which is releasing resources, and RStudio quits when the rsession can't be initialized.

We know this is caused by the rsession port being in used from rsession.log entries that look like this:

```
14 Apr 2016 20:13:06 [rsession-javierluraschi] ERROR system error 48 (Address already in use); OCCURRED AT: rstudio::core::Error rstudio::core::http::initTcpIpAcceptor(SocketAcceptorService<boost::asio::ip::tcp> &, const std::string &, const std::string &) /Users/javierluraschi/RStudio/rstudio/src/cpp/core/include/core/http/TcpIpSocketUtils.hpp:103; LOGGED FROM: int main(int, char *const *) /Users/javierluraschi/RStudio/rstudio/src/cpp/session/SessionMain.cpp:3250
```

The proposed fix is to wait for up to 1s for the port to become available during boot. If the time expires, the same error triggers.

An alternate fix that was explored was to wait for the port to be release; however, exploring that fix proved to be more complicated than I would expected. The exploration of this fix is available here: https://github.com/rstudio/rstudio/commit/dd67b9f71357ee8864dd32d53558d9d85865dd62

Finally, we could also explore changing the port number when the rsession restarts; however, I'm less aware of the implications of that change.

From all, the less-risky fix would be to take this change making RStudio more resilient to port issues while booting.