### PR TITLE
debounce 'onContentSizeChanged()' calls

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -169,12 +169,13 @@ public class ShellWidget extends Composite implements ShellDisplay,
 
       secondaryInputHandler.setInput(editor);
 
-      scrollToBottomCommand_ = new TimeBufferedCommand(5)
+      resizeCommand_ = new TimeBufferedCommand(5)
       {
          @Override
          protected void performAction(boolean shouldSchedulePassive)
          {
-            if (!DomUtils.selectionExists())
+            scrollPanel_.onContentSizeChanged();
+            if (!DomUtils.selectionExists() && scrollPanel_.isScrolledToBottom())
                scrollPanel_.scrollToBottom();
          }
       };
@@ -423,9 +424,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
       }
       boolean result = !trimExcess();
 
-      scrollPanel_.onContentSizeChanged();
-      if (scrollPanel_.isScrolledToBottom())
-         scrollToBottomCommand_.nudge();
+      resizeCommand_.nudge();
 
       return result;
    }
@@ -733,7 +732,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
    private final VerticalPanel verticalPanel_ ;
    protected final ClickableScrollPanel scrollPanel_ ;
    private ConsoleResources.ConsoleStyles styles_;
-   private final TimeBufferedCommand scrollToBottomCommand_;
+   private final TimeBufferedCommand resizeCommand_;
    private boolean suppressPendingInput_;
    private final EventBus events_;
    


### PR DESCRIPTION
This PR improves the performance of the console in response to large amounts of console input by debouncing both `onContentSizeChanged()` and `scrollToBottom()` requests (using the `TimeBufferedCommand`).

Previously, `scrollPanel_.onContentSizeChanged()` was called eagerly in response to _all_ console IO, which placed heavy strain on the browser when re-sizing the console history + other dependent UI elements; by placing this in the `TimeBufferedCommand` as well we ensure that these resize requests only happen at most once every 5ms during the execution of large amounts of R code.