### PR TITLE
trigger profvis installation from profile code without focus

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -4370,7 +4370,14 @@ public class TextEditingTarget implements
    @Handler
    void onProfileCode()
    {
-      codeExecution_.executeSelection(true, true, "profvis::profvis", true);
+      dependencyManager_.withProfvis("Preparing profiler", new Command()
+      {
+         @Override
+         public void execute()
+         {
+            codeExecution_.executeSelection(true, true, "profvis::profvis", true);
+         }
+      });
    }
   
    private void sourceActiveDocument(final boolean echo)


### PR DESCRIPTION
Fixed one missed case for triggering install of profvis from the "profile this code" menu entry. Original fix was scoped to cases where we have focus, this one triggers cases where focus is not set.