### PR TITLE
Fix in timeout while waiting for rsession port

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -3260,7 +3260,7 @@ int main (int argc, char * const argv[])
          return sessionExitFailure(error, ERROR_LOCATION);
          
       // start http connection listener
-      error = waitWithTimeout(startHttpConnectionListenerWithTimeout, 0, 100, 1000);
+      error = waitWithTimeout(startHttpConnectionListenerWithTimeout, 0, 100, 1);
       if (error)
          return sessionExitFailure(error, ERROR_LOCATION);
 


### PR DESCRIPTION
The max waitTime provided by `waitWithTimeout` is specified in seconds, not milliseconds. 