### PR TITLE
allow users to programmatically overwrite profiler split default

### DIFF
--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -142,7 +142,6 @@
 
 .rs.addFunction("profilePrint", function(x)
 {
-   x$x$message$split <- "h"
    result <- .rs.rpc.open_profile(list(
       profvis = x
    ))


### PR DESCRIPTION
We are changing the split default in profvis to allow users to overwrite the split between horizontal and vertical programatically. Therefore, we no longer need to overwrite the split parameter. + @wch