### PR TITLE
enable copy from javascript options

### DIFF
--- a/src/cpp/desktop-mac/Utils.mm
+++ b/src/cpp/desktop-mac/Utils.mm
@@ -97,6 +97,7 @@ void initializeSystemPrefs()
    NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
    [defaults setBool:YES forKey: @"WebKitWebGLEnabled"];
    [defaults setBool:YES forKey: @"WebKitDeveloperExtras"];
+   [defaults setBool:YES forKey: @"WebKitJavaScriptCanAccessClipboard"];
 }
  
 // PORT: from DesktopUtils.cpp

--- a/src/cpp/desktop/DesktopWebPage.cpp
+++ b/src/cpp/desktop/DesktopWebPage.cpp
@@ -52,6 +52,7 @@ WebPage::WebPage(QUrl baseUrl, QWidget *parent, bool allowExternalNavigate) :
    settings()->setAttribute(QWebSettings::DeveloperExtrasEnabled, true);
    settings()->setAttribute(QWebSettings::JavascriptCanOpenWindows, true);
    settings()->setAttribute(QWebSettings::LocalStorageEnabled, true);
+   settings()->setAttribute(QWebSettings::JavascriptCanAccessClipboard, true);
    QString storagePath = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
    settings()->setOfflineStoragePath(storagePath);
    settings()->enablePersistentStorage(storagePath);


### PR DESCRIPTION
Enable javascript to be able to access the clipboard for qt and mac, verified fix in Windows and OS X. This is to enable the copy-code command in the data import dialog for desktop clients.