### PR TITLE
remove error message while double-clicking on profiler expressions

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -754,7 +754,7 @@ public class ProfilerEditingTarget implements EditingTarget,
                            FileSystemItem.createFile(navigationTarget.getFile()),
                            filePosition);
                   }
-                  else
+                  else if (selectedPath_.indexOf("<expr>") == -1)
                   {
                      globalDisplay_.showMessage(GlobalDisplay.MSG_ERROR,
                            "Error while opening profiler source",


### PR DESCRIPTION
Feedback from @wch regarding the error message "The <expr> file was not found" not being very useful while attempting to browse to soures in profiler. Removing this error for expressions.