### PR TITLE
add support to edit casing in data import dataset name

### DIFF
--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -452,13 +452,18 @@
       }
    )
 
-   dataName <- .rs.assemble_data_import_name(dataImportOptions)
-   if (is.null(dataName) || identical(dataName, ""))
+   dataName <- dataImportOptions$dataName
+   if (identical(dataName, NULL) || identical(dataName, ""))
    {
-      dataName <- "dataset"
+      dataName <- tolower(.rs.assemble_data_import_name(dataImportOptions))
+      if (is.null(dataName) || identical(dataName, ""))
+      {
+         dataName <- "dataset"
+      }
    }
 
-   dataName <- tolower(gsub("[\\._]+", "_", c(make.names(dataName)), perl=TRUE))
+   dataName <- gsub("[\\._]+", "_", c(make.names(dataName)), perl=TRUE)
+
    importInfo$dataName <- dataImportOptions$dataName <- dataName
 
    dataImportOptions$cacheUrlNames <- list()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUi.java
@@ -24,7 +24,9 @@ import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.GwtEvent;
 import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.TextBox;
 
 public class DataImportOptionsUi extends Composite implements HasValueChangeHandlers<DataImportOptions>
 {
@@ -57,7 +59,7 @@ public class DataImportOptionsUi extends Composite implements HasValueChangeHand
    
    public void setImportLocation(String importLocation)
    {
-      
+      nameTextBox_.setText("");
    }
    
    void triggerChange()
@@ -72,4 +74,7 @@ public class DataImportOptionsUi extends Composite implements HasValueChangeHand
    {
       handlerManager_.fireEvent(event);
    }
+   
+   @UiField
+   protected TextBox nameTextBox_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.java
@@ -230,9 +230,6 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
    }
    
    @UiField
-   TextBox nameTextBox_;
-   
-   @UiField
    TextBox skipTextBox_;
    
    @UiField

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.java
@@ -100,6 +100,8 @@ public class DataImportOptionsUiSav extends DataImportOptionsUi
    @Override
    public void setImportLocation(String importLocation)
    {
+      nameTextBox_.setText("");
+      
       String[] components = importLocation.split("\\.");
       if (components.length > 0)
       {
@@ -169,9 +171,6 @@ public class DataImportOptionsUiSav extends DataImportOptionsUi
          fileChooser_.setEnabled(false);
       }
    }
-   
-   @UiField
-   TextBox nameTextBox_;
    
    @UiField
    ListBox formatListBox_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
@@ -146,9 +146,6 @@ public class DataImportOptionsUiXls extends DataImportOptionsUi
    }
    
    @UiField
-   TextBox nameTextBox_;
-   
-   @UiField
    ListBox sheetListBox_;
    
    @UiField


### PR DESCRIPTION
Allow users to change the casing in the dataset name for data import. The fix has two components:
1) It clears the dataset name when the import location changes
2) It avoids switching to lowercase only when we are assembling data import options but the location has not changed. This is to still allow the dialog to format casing when the location is new.