### PR TITLE
use html_notebook from dev version of rmarkdown

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -2693,8 +2693,8 @@ public class Source implements InsertSourceHandler,
                              final ResultCallback<EditingTarget, ServerError> resultCallback)
    {
       // construct path to .Rmd
-      String rnbPath = rnbFile.getPath();
-      String rmdPath = FilePathUtils.filePathSansExtension(rnbPath) + ".Rmd";
+      final String rnbPath = rnbFile.getPath();
+      final String rmdPath = FilePathUtils.filePathSansExtension(rnbPath) + ".Rmd";
       final FileSystemItem rmdFile = FileSystemItem.createFile(rmdPath);
       
       // if we already have associated .Rmd file open, then just edit it
@@ -2703,23 +2703,32 @@ public class Source implements InsertSourceHandler,
          return;
       
       // ask the server to extract the .Rmd, then open that
-      server_.extractRmdFromNotebook(
-            rnbPath,
-            rmdPath,
-            new ServerRequestCallback<Boolean>()
-            {
-               @Override
-               public void onResponseReceived(Boolean success)
-               {
-                  openFileFromServer(rmdFile, FileTypeRegistry.RMARKDOWN, resultCallback);
-               }
-               
-               @Override
-               public void onError(ServerError error)
-               {
-                  Debug.logError(error);
-               }
-            });
+      Command extractRmdCommand = new Command()
+      {
+         @Override
+         public void execute()
+         {
+            server_.extractRmdFromNotebook(
+                  rnbPath,
+                  rmdPath,
+                  new ServerRequestCallback<Boolean>()
+                  {
+                     @Override
+                     public void onResponseReceived(Boolean success)
+                     {
+                        openFileFromServer(rmdFile, FileTypeRegistry.RMARKDOWN, resultCallback);
+                     }
+
+                     @Override
+                     public void onError(ServerError error)
+                     {
+                        Debug.logError(error);
+                     }
+                  });
+         }
+      };
+      
+      dependencyManager_.withRMarkdown("R Notebook", "Using R Notebooks", extractRmdCommand);
    }
    
    private boolean openFileAlreadyOpen(final FileSystemItem file,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -34,6 +34,8 @@ import org.rstudio.studio.client.application.events.InterruptStatusEvent;
 import org.rstudio.studio.client.application.events.RestartStatusEvent;
 import org.rstudio.studio.client.common.FilePathUtils;
 import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.common.dependencies.DependencyManager;
+import org.rstudio.studio.client.common.dependencies.model.Dependency;
 import org.rstudio.studio.client.rmarkdown.RmdOutput;
 import org.rstudio.studio.client.rmarkdown.events.RmdChunkOutputEvent;
 import org.rstudio.studio.client.rmarkdown.events.RmdChunkOutputFinishedEvent;
@@ -265,6 +267,18 @@ public class TextEditingTargetNotebook
             String outputPath = FilePathUtils.filePathSansExtension(rmdPath) + 
                                 RmdOutput.NOTEBOOK_EXT;
             
+            createNotebookFromCache(rmdPath, outputPath);
+         }
+      }));
+   }
+   
+   public void createNotebookFromCache(final String rmdPath, final String outputPath)
+   {
+      Command createNotebookCmd = new Command()
+      {
+         @Override
+         public void execute()
+         {
             server_.createNotebookFromCache(
                   rmdPath,
                   outputPath,
@@ -285,7 +299,9 @@ public class TextEditingTargetNotebook
                      }
                   });
          }
-      }));
+      };
+      
+      dependencyManager_.withRMarkdown("R Notebook", "Creating R Notebooks", createNotebookCmd);
    }
    
    @Inject
@@ -297,7 +313,8 @@ public class TextEditingTargetNotebook
          UIPrefs prefs,
          Commands commands,
          Binder binder,
-         Provider<SourceWindowManager> pSourceWindowManager)
+         Provider<SourceWindowManager> pSourceWindowManager,
+         DependencyManager dependencyManager)
    {
       events_ = events;
       server_ = server;
@@ -308,6 +325,7 @@ public class TextEditingTargetNotebook
       commands_ = commands;
       binder.bind(commands, this);
       pSourceWindowManager_ = pSourceWindowManager;
+      dependencyManager_ = dependencyManager;
       
       releaseOnDismiss_.add(
             events_.addHandler(RmdChunkOutputEvent.TYPE, this));
@@ -1507,6 +1525,7 @@ public class TextEditingTargetNotebook
    ArrayList<HandlerRegistration> releaseOnDismiss_;
    private Session session_;
    private Provider<SourceWindowManager> pSourceWindowManager_;
+   private DependencyManager dependencyManager_;
    private UIPrefs prefs_;
    private Commands commands_;
 


### PR DESCRIPTION
This PR accompanies https://github.com/rstudio/rmarkdown/pull/691. The goal here is to:

1. Move the 'guts' of notebook generation to the `rmarkdown` package, and
2. Keep the 'notebook from cache' stuff within RStudio, but allow it to work through the `evaluate` hook.

Together with the `rmarkdown` PR, this will imply that:

1. An `rmarkdown::render()` on a `.Rmd` will use the `html_notebook` format, and will work regardless of RStudio;

2. The (already existing) augmented `evaluate` hook will be used as necessary when generating `.nb.html` files form the cache.

There is likely still some dust that needs to settle but I think these two PRs should be good to go (there may be a bit more churn on the master branches for each as needed).

Note that a lot of code is deleted here as effectively that code has been moved to the `rmarkdown` package.