### PR TITLE
Relocate settings on Windows for proper functionality of networked systems

### DIFF
--- a/src/cpp/core/system/Win32System.cpp
+++ b/src/cpp/core/system/Win32System.cpp
@@ -298,7 +298,7 @@ FilePath currentCSIDLPersonalHomePath()
    }
    else
    {
-      LOG_WARNING_MESSAGE("Unable to retreive user home path. HRESULT:  " +
+      LOG_WARNING_MESSAGE("Unable to retrieve user home path. HRESULT:  " +
                           safe_convert::numberToString(hr));
       return FilePath();
    }
@@ -321,7 +321,7 @@ FilePath defaultCSIDLPersonalHomePath()
    }
    else
    {
-      LOG_WARNING_MESSAGE("Unable to retreive user home path. HRESULT:  " +
+      LOG_WARNING_MESSAGE("Unable to retrieve user home path. HRESULT:  " +
                           safe_convert::numberToString(hr));
       return FilePath();
    }
@@ -413,7 +413,7 @@ FilePath userSettingsPath(const FilePath& userHomeDirectory,
 
    if (hr != S_OK)
    {
-      LOG_ERROR_MESSAGE("Unable to retreive user home path. HRESULT:  " +
+      LOG_ERROR_MESSAGE("Unable to retrieve user home path. HRESULT:  " +
                         safe_convert::numberToString(hr));
       return FilePath();
    }

--- a/src/cpp/core/system/Win32System.cpp
+++ b/src/cpp/core/system/Win32System.cpp
@@ -405,7 +405,7 @@ FilePath userSettingsPath(const FilePath& userHomeDirectory,
    std::wstring appNameWide(appName.begin(), appName.end());
    HRESULT hr = ::SHGetFolderPathAndSubDirW(
          NULL,
-         CSIDL_LOCAL_APPDATA | CSIDL_FLAG_CREATE,
+         CSIDL_APPDATA | CSIDL_FLAG_CREATE,
          NULL,
          SHGFP_TYPE_CURRENT,
          appNameWide.c_str(),

--- a/src/cpp/session/modules/SessionVCS.cpp
+++ b/src/cpp/session/modules/SessionVCS.cpp
@@ -184,7 +184,16 @@ FilePath getTrueHomeDir()
 #if _WIN32
    // On Windows, R's idea of "$HOME" is not, by default, the same as
    // $USERPROFILE, which is what we want for ssh purposes
-   return FilePath(string_utils::systemToUtf8(core::system::getenv("USERPROFILE")));
+   // However, it may not be the suitable path when home is on a share,
+   // in which case we use $HOMEDRIVE + $HOMEPATH
+   std::string homeShare = core::system::getenv("HOMESHARE");
+   std::string homeDrive = core::system::getenv("HOMEDRIVE");
+   std::string homePath = core::system::getenv("HOMEPATH");
+   if (!homeShare.empty() && !homeDrive.empty() && !homePath.empty()) {
+      return FilePath(string_utils::systemToUtf8(homeDrive + homePath));
+   } else {
+      return FilePath(string_utils::systemToUtf8(core::system::getenv("USERPROFILE")));
+   }
 #else
    return FilePath(string_utils::systemToUtf8(core::system::getenv("HOME")));
 #endif


### PR DESCRIPTION
When run in Windows, RStudio currently stores its settings in the `Local Settings/Application Data` folder within a user's local home (i.e., on a local disk). This folder is intended for settings that stay on a machine - for a networked system, this means that RStudio's settings will not reappear when a user logs in to a different machine. Additionally, on networks such as the one on the university where I teach, these settings will eventually get deleted even from a single machine. As a consequence, RStudio will take a long time to start up after login (subsequent launches are faster) and will forget any previously set preferences.

Therefore, the settings should not be stored in the folder mentioned above, but in the `Application Data` folder, which, on a networked system, will reside on the share containing the user's files (and will typically also allow more storage). This pull request thus changes the location of RStudio's settings to the folder determined by `CSIDL_APPDATA`, which resolves to the desired folder.

Another related issue is the home folder to be used for `git` and `ssh` when called from RStudio (the value of `getTrueHomeDir()`). When running Git Bash on a networked system, it will start in the home folder on the share (where `git` and `ssh` then also store their settings); however, RStudio will currently use the `USERPROFILE` environment variable, which points to the local profile. This pull request thus changes the behaviour of `getTrueHomeDir` to return a path obtained from `HOMEDRIVE` and `HOMEPATH` when they point to a share (i.e., when `HOMESHARE` is set). Here, I am being cautious - it might be the case that such a path will always be OK, but someone with more experience with Windows should tell if this is the case.

Another thing which should probably be done if this is accepted, is to migrate the user's settings from the current to the new location (if they already exist), so that Windows users will not lose their settings when upgrading RStudio. This migration should not be needed for `getTrueHomeDir()`, as its value is not expected to change on most systems. As I said above, I'm not too familiar with Windows or RStudio's codebase, so if anyone wants to do this, I'll be happy to grant access to my fork so that this PR remains self-contained. Of course, I'll also be happy to have any pointers (where to add this etc.), so I can do it myself.

Last but not the least, let me warn that I haven't tried recompiling RStudio with my changes - I hope I haven't introduced any obvious errors. Again, I'll be happy if someone can confirm that everything is OK.
