### PR TITLE
Implement display list-based plot resizing for notebooks

### DIFF
--- a/src/cpp/r/include/r/session/RGraphics.hpp
+++ b/src/cpp/r/include/r/session/RGraphics.hpp
@@ -71,6 +71,12 @@ namespace rstudio {
 namespace r {
 namespace session {
 namespace graphics {
+
+namespace device {
+
+double devicePixelRatio();
+
+}
    
 struct DisplayState
 {

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -159,6 +159,7 @@ set (SESSION_SOURCE_FILES
    modules/rmarkdown/NotebookHtmlWidgets.cpp
    modules/rmarkdown/NotebookOutput.cpp
    modules/rmarkdown/NotebookPaths.cpp
+   modules/rmarkdown/NotebookPlotReplay.cpp
    modules/rmarkdown/NotebookPlots.cpp
    modules/rmarkdown/RMarkdownPresentation.cpp
    modules/shiny/SessionShiny.cpp

--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -176,6 +176,9 @@ void AsyncRProcess::start(const char* rCommand,
                               AsyncRProcess::shared_from_this(),
                               _1);
 
+   // forward input if requested
+   input_ = input;
+
    error = module_context::processSupervisor().runProgram(
             rProgramPath.absolutePath(),
             args,

--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionAsyncRProcess.cpp
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-16 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -40,7 +40,8 @@ void AsyncRProcess::start(const char* rCommand,
                           core::system::Options environment,
                           const core::FilePath& workingDir,
                           AsyncRProcessOptions rOptions,
-                          std::vector<core::FilePath> rSourceFiles)
+                          std::vector<core::FilePath> rSourceFiles,
+                          const std::string& input)
 {
    // R binary
    core::FilePath rProgramPath;
@@ -171,6 +172,10 @@ void AsyncRProcess::start(const char* rCommand,
    cb.onExit =  boost::bind(&AsyncRProcess::onProcessCompleted,
                              AsyncRProcess::shared_from_this(),
                              _1);
+   cb.onStarted = boost::bind(&AsyncRProcess::onStarted,
+                              AsyncRProcess::shared_from_this(),
+                              _1);
+
    error = module_context::processSupervisor().runProgram(
             rProgramPath.absolutePath(),
             args,
@@ -180,11 +185,26 @@ void AsyncRProcess::start(const char* rCommand,
    {
       LOG_ERROR(error);
       onCompleted(EXIT_FAILURE);
+   }
+   else
+   {
+      isRunning_ = true;
+   }
 }
-else
+
+void AsyncRProcess::onStarted(core::system::ProcessOperations& operations)
 {
-   isRunning_ = true;
-}
+   if (!input_.empty())
+   {
+      core::Error error = operations.writeToStdin(input_, true);
+      if (error)
+      {
+         LOG_ERROR(error);
+         error = operations.terminate();
+         if (error)
+            LOG_ERROR(error);
+      }
+   }
 }
 
 void AsyncRProcess::onStdout(const std::string& output)

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -151,6 +151,8 @@ const int kRprofCreated = 129;
 const int kEditorCommand = 131;
 const int kPreviewRmd = 132;
 const int kWebsiteFileSaved = 133;
+const int kChunkPlotRefreshed = 134;
+const int kChunkPlotRefreshFinished = 135;
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -412,6 +414,10 @@ std::string ClientEvent::typeName() const
          return "preview_rmd";
       case client_events::kWebsiteFileSaved:
          return "website_file_saved";
+      case client_events::kChunkPlotRefreshed:
+         return "chunk_plot_refreshed";
+      case client_events::kChunkPlotRefreshFinished:
+         return "chunk_plot_refresh_finished";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/include/session/SessionAsyncRProcess.hpp
+++ b/src/cpp/session/include/session/SessionAsyncRProcess.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionAsyncRProcesss.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-16 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -20,6 +20,7 @@
 #include <boost/enable_shared_from_this.hpp>
 
 #include <core/system/Types.hpp>
+#include <core/system/Process.hpp>
 
 namespace core
 {
@@ -57,16 +58,21 @@ public:
    void start(const char* rCommand,
               const core::FilePath& workingDir,
               AsyncRProcessOptions rOptions,
-              std::vector<core::FilePath> rSourceFiles = std::vector<core::FilePath>())
+              std::vector<core::FilePath> rSourceFiles = 
+                 std::vector<core::FilePath>(),
+              const std::string &input = std::string())
    {
-      start(rCommand, core::system::Options(), workingDir, rOptions, rSourceFiles);
+      start(rCommand, core::system::Options(), workingDir, rOptions, 
+            rSourceFiles, input);
    }
 
    void start(const char* rCommand,
               core::system::Options environment,
               const core::FilePath& workingDir,
               AsyncRProcessOptions rOptions,
-              std::vector<core::FilePath> rSourceFiles = std::vector<core::FilePath>());
+              std::vector<core::FilePath> rSourceFiles = 
+                 std::vector<core::FilePath>(),
+              const std::string& input = std::string());
 
    bool isRunning();
    void terminate();
@@ -74,6 +80,7 @@ public:
    bool terminationRequested();
 
 protected:
+   virtual void onStarted(core::system::ProcessOperations& operations);
    virtual bool onContinue();
    virtual void onStdout(const std::string& output);
    virtual void onStderr(const std::string& output);
@@ -84,6 +91,7 @@ private:
    void onProcessCompleted(int exitStatus);
    bool isRunning_;
    bool terminationRequested_;
+   std::string input_;
 };
 
 } // namespace async_r

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -152,6 +152,8 @@ extern const int kRprofCreated;
 extern const int kEditorCommand;
 extern const int kPreviewRmd;
 extern const int kWebsiteFileSaved;
+extern const int kChunkPlotRefreshed;
+extern const int kChunkPlotRefreshFinished;
 }
    
 class ClientEvent

--- a/src/cpp/session/modules/NotebookPlots.R
+++ b/src/cpp/session/modules/NotebookPlots.R
@@ -15,15 +15,15 @@
 
 # creates the notebook graphics device 
 .rs.addFunction("createNotebookGraphicsDevice", function(filename,
-  width, extraArgs)
+  width, pixelRatio, extraArgs)
 {
   require(grDevices, quietly = TRUE)
   args <- list(
     file   = filename,
-    width  = width,
-    height = width / 1.618, 
+    width  = width * pixelRatio,
+    height = (width * pixelRatio) / 1.618, 
     units  = "px",
-    res    = 96)
+    res    = 96 * pixelRatio)
   
   if (nchar(extraArgs) > 0)
   {
@@ -52,7 +52,7 @@
   par(mar = c(5.1, 4.1, 2.1, 2.1))
 })
 
-.rs.addFunction("replayNotebookPlots", function(width, extraArgs) {
+.rs.addFunction("replayNotebookPlots", function(width, pixelRatio, extraArgs) {
   # open stdin (for consuming snapshots from parent process)
   stdin <- file("stdin")
   cat(width, "\n", extraArgs, "\n")
@@ -74,7 +74,7 @@
     # output from the device
     output <- paste(tools::file_path_sans_ext(snapshot), "resized.png",
                     sep = ".")
-    .rs.createNotebookGraphicsDevice(output, width, extraArgs);
+    .rs.createNotebookGraphicsDevice(output, width, pixelRatio, extraArgs);
     cat("created graphics device for ", output, "\n")
 
     # actually replay the plot onto the device

--- a/src/cpp/session/modules/NotebookPlots.R
+++ b/src/cpp/session/modules/NotebookPlots.R
@@ -27,7 +27,7 @@
     # output from the device
     output <- paste(tools::file_path_sans_ext(snapshot), "resized.png",
                     sep = ".")
-    png(file = output, width = width, height = width / 1.618, units="px", 
+    png(file = output, width = width, height = width / 1.618, units = "px", 
         res = 96)
 
     # actually replay the plot onto the device

--- a/src/cpp/session/modules/NotebookPlots.R
+++ b/src/cpp/session/modules/NotebookPlots.R
@@ -14,13 +14,12 @@
 #
 
 .rs.addFunction("replayNotebookPlots", function(width) {
-  # read the names of the snapshot files from standard input -- these are 
-  # passed one per line from the parent process
-  snapshots <- scan(what = character())
+  # open stdin (for consuming snapshots from parent process)
+  stdin <- file("stdin")
 
-  require(grDevices, quietly=TRUE)
+  require(grDevices, quietly = TRUE)
 
-  lapply(snapshots, function(snapshot) {
+  while (length(snapshot <- readLines(stdin, n = 1)) > 0) {
     # create the PNG device on which we'll regenerate the plot -- it's somewhat
     # wasteful to use a separate device per plot, but the alternative is
     # doing a lot of state management and post-processing of the files
@@ -53,7 +52,7 @@
         cat(final, "\n")
       }
     }
-  })
+  }
 
   invisible(NULL)
 })

--- a/src/cpp/session/modules/NotebookPlots.R
+++ b/src/cpp/session/modules/NotebookPlots.R
@@ -55,7 +55,6 @@
 .rs.addFunction("replayNotebookPlots", function(width, pixelRatio, extraArgs) {
   # open stdin (for consuming snapshots from parent process)
   stdin <- file("stdin")
-  cat(width, "\n", extraArgs, "\n")
 
   require(grDevices, quietly = TRUE)
 
@@ -65,8 +64,6 @@
     # ignore empty lines
     if (nchar(tools::file_ext(snapshot)) < 1)
       return(invisible(NULL))
-
-    cat("processing snapshot '", snapshot, "' (", nchar(tools::file_ext(snapshot)), ")\n")
 
     # create the PNG device on which we'll regenerate the plot -- it's somewhat
     # wasteful to use a separate device per plot, but the alternative is

--- a/src/cpp/session/modules/NotebookPlots.R
+++ b/src/cpp/session/modules/NotebookPlots.R
@@ -13,5 +13,47 @@
 #
 #
 
-.rs.addFunction("replayNotebookPlots", function(cacheDir) {
+.rs.addFunction("replayNotebookPlots", function(width) {
+  # read the names of the snapshot files from standard input -- these are 
+  # passed one per line from the parent process
+  snapshots <- scan(what = character())
+
+  require(grDevices, quietly=TRUE)
+
+  lapply(snapshots, function(snapshot) {
+    # create the PNG device on which we'll regenerate the plot -- it's somewhat
+    # wasteful to use a separate device per plot, but the alternative is
+    # doing a lot of state management and post-processing of the files
+    # output from the device
+    output <- paste(tools::file_path_sans_ext(snapshot), "resized.png",
+                    sep = ".")
+    png(file = output, width = width, height = width / 1.618, units="px", 
+        res = 96)
+
+    # actually replay the plot onto the device
+    tryCatch({
+      .rs.restoreGraphics(snapshot)
+    }, error = function(e) {
+      # nothing reasonable we can do here; we'll just omit this file from the
+      # output
+    })
+
+    # close the device; has the side effect of committing the plot to disk
+    dev.off()
+
+    # if the plot file was written out, emit to standard out for the caller to 
+    # consume
+    if (file.exists(output)) {
+      # remove the old copy of the plot if it existed
+      final <- paste(tools::file_path_sans_ext(snapshot), "png", sep = ".")
+      if (file.exists(final))
+        unlink(final)
+      file.rename(output, final)
+      if (file.exists(final)) {
+        cat(final, "\n")
+      }
+    }
+  })
+
+  invisible(NULL)
 })

--- a/src/cpp/session/modules/NotebookPlots.R
+++ b/src/cpp/session/modules/NotebookPlots.R
@@ -75,7 +75,6 @@
     output <- paste(tools::file_path_sans_ext(snapshot), "resized.png",
                     sep = ".")
     .rs.createNotebookGraphicsDevice(output, width, pixelRatio, extraArgs);
-    cat("created graphics device for ", output, "\n")
 
     # actually replay the plot onto the device
     tryCatch({

--- a/src/cpp/session/modules/NotebookPlots.R
+++ b/src/cpp/session/modules/NotebookPlots.R
@@ -19,7 +19,8 @@
 
   require(grDevices, quietly = TRUE)
 
-  while (length(snapshot <- readLines(stdin, n = 1)) > 0) {
+  snapshots <- readLines(stdin, warn = FALSE)
+  lapply(snapshots, function(snapshot) {
     # create the PNG device on which we'll regenerate the plot -- it's somewhat
     # wasteful to use a separate device per plot, but the alternative is
     # doing a lot of state management and post-processing of the files
@@ -52,7 +53,7 @@
         cat(final, "\n")
       }
     }
-  }
+  })
 
   invisible(NULL)
 })

--- a/src/cpp/session/modules/NotebookPlots.R
+++ b/src/cpp/session/modules/NotebookPlots.R
@@ -1,0 +1,17 @@
+#
+# NotebookPlots.R
+#
+# Copyright (C) 2009-16 by RStudio, Inc.
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+.rs.addFunction("replayNotebookPlots", function(cacheDir) {
+})

--- a/src/cpp/session/modules/SessionPlots.R
+++ b/src/cpp/session/modules/SessionPlots.R
@@ -24,7 +24,7 @@ setHook(
 setHook(
   hookName = "before.grid.newpage", 
   value = function() { 
-    .Call("rs_emitBeforeNewPlot")
+    .Call("rs_emitBeforeNewGridPage")
   },
   action = "append")
 

--- a/src/cpp/session/modules/SessionPlots.R
+++ b/src/cpp/session/modules/SessionPlots.R
@@ -21,6 +21,13 @@ setHook(
   },
   action = "append")
 
+setHook(
+  hookName = "before.grid.newpage", 
+  value = function() { 
+    .Call("rs_emitBeforeNewPlot")
+  },
+  action = "append")
+
 # register hook to be invoked when a new plot has been created
 setHook(
   hookName = "plot.new", 

--- a/src/cpp/session/modules/SessionPlots.cpp
+++ b/src/cpp/session/modules/SessionPlots.cpp
@@ -822,6 +822,12 @@ SEXP rs_emitNewPlot()
    return R_NilValue;
 }
 
+SEXP rs_emitBeforeNewGridPage()
+{
+   events().onBeforeNewGridPage();
+   return R_NilValue;
+}
+
 
 } // anonymous namespace  
    
@@ -863,6 +869,7 @@ Error initialize()
    module_context::events().onBackgroundProcessing.connect(onBackgroundProcessing);
 
    RS_REGISTER_CALL_METHOD(rs_emitBeforeNewPlot, 0);
+   RS_REGISTER_CALL_METHOD(rs_emitBeforeNewGridPage, 0);
    RS_REGISTER_CALL_METHOD(rs_emitNewPlot, 0);
 
    // connect to onShowManipulator

--- a/src/cpp/session/modules/SessionPlots.hpp
+++ b/src/cpp/session/modules/SessionPlots.hpp
@@ -36,6 +36,7 @@ core::Error initialize();
 struct Events : boost::noncopyable
 {
    boost::signal<void()> onBeforeNewPlot;
+   boost::signal<void()> onBeforeNewGridPage;
    boost::signal<void()> onNewPlot;
 };
 

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
@@ -108,7 +108,7 @@ void ChunkExecContext::connect()
          boost::bind(&ChunkExecContext::onFileOutput, this, _1, _2, 
                      kChunkOutputPlot)));
 
-   error = beginPlotCapture(outputPath);
+   error = beginPlotCapture(pixelWidth_, outputPath);
    if (error)
       LOG_ERROR(error);
 

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
@@ -105,7 +105,7 @@ void ChunkExecContext::connect()
 
    // begin capturing plots 
    connections_.push_back(events().onPlotOutput.connect(
-         boost::bind(&ChunkExecContext::onFileOutput, this, _1, FilePath(), 
+         boost::bind(&ChunkExecContext::onFileOutput, this, _1, _2, 
                      kChunkOutputPlot)));
 
    error = beginPlotCapture(outputPath);
@@ -205,7 +205,7 @@ void ChunkExecContext::onFileOutput(const FilePath& file,
          LOG_ERROR(error);
    }
 
-   // if JSON metadata was provided, write it out
+   // if output metadata was provided, write it out
    if (!metadata.empty())
    {
       metadata.move(target.parent().complete(

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
@@ -93,7 +93,7 @@ bool ChunkExecContext::connected()
 
 void ChunkExecContext::connect()
 {
-   FilePath outputPath = chunkOutputPath(docId_, chunkId_);
+   FilePath outputPath = chunkOutputPath(docId_, chunkId_, ContextExact);
    Error error = outputPath.ensureDirectory();
    if (error)
    {

--- a/src/cpp/session/modules/rmarkdown/NotebookOutput.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookOutput.cpp
@@ -37,7 +37,6 @@
 
 #include <map>
 
-#define kChunkOutputPath   "chunk_output"
 #define kChunkOutputType   "output_type"
 #define kChunkOutputValue  "output_val"
 #define kChunkOutputs      "chunk_outputs"

--- a/src/cpp/session/modules/rmarkdown/NotebookOutput.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookOutput.cpp
@@ -171,12 +171,6 @@ Error handleChunkOutputRequest(const http::Request& request,
    if (idx != std::string::npos)
       uri = uri.substr(0, idx);
    
-   // strip the querystring from the uri
-   std::string uri = request.uri();
-   size_t idx = uri.find_last_of("?");
-   if (idx != std::string::npos)
-      uri = uri.substr(0, idx);
-   
    // split URI into pieces, extract the document ID, and remove that part of
    // the URI
    std::vector<std::string> parts = algorithm::split(uri, "/");

--- a/src/cpp/session/modules/rmarkdown/NotebookOutput.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookOutput.cpp
@@ -273,14 +273,13 @@ FilePath chunkOutputPath(
       const std::string& docPath, const std::string& docId,
       const std::string& chunkId, const std::string& nbCtxId, 
       ChunkOutputContext ctxType)
-
 {
    // compute path to exact context
    FilePath path = chunkCacheFolder(docPath, docId, nbCtxId).childPath(chunkId);
 
    // fall back to saved context if permitted
    if (!path.exists() && ctxType == ContextSaved)
-      path = chunkCacheFolder(docPath, docId, nbCtxId).childPath(kSavedCtx);
+      path = chunkCacheFolder(docPath, docId, kSavedCtx).childPath(chunkId);
 
    return path;
 }

--- a/src/cpp/session/modules/rmarkdown/NotebookOutput.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookOutput.cpp
@@ -234,10 +234,7 @@ OutputPair lastChunkOutput(const std::string& docId,
       return it->second;
    }
    
-   std::string docPath;
-   source_database::getPath(docId, &docPath);
-   FilePath outputPath = chunkOutputPath(docPath, docId, chunkId, 
-         notebookCtxId());
+   FilePath outputPath = chunkOutputPath(docId, chunkId, ContextExact);
 
    // scan the directory for output
    std::vector<FilePath> outputPaths;
@@ -269,25 +266,34 @@ OutputPair lastChunkOutput(const std::string& docId,
 
 FilePath chunkOutputPath(
       const std::string& docPath, const std::string& docId,
-      const std::string& chunkId, const std::string& nbCtxId)
+      const std::string& chunkId, const std::string& nbCtxId, 
+      ChunkOutputContext ctxType)
 
 {
-   return chunkCacheFolder(docPath, docId, nbCtxId).childPath(chunkId);
+   // compute path to exact context
+   FilePath path = chunkCacheFolder(docPath, docId, nbCtxId).childPath(chunkId);
+
+   // fall back to saved context if permitted
+   if (!path.exists() && ctxType == ContextSaved)
+      path = chunkCacheFolder(docPath, docId, nbCtxId).childPath(kSavedCtx);
+
+   return path;
 }
 
-FilePath chunkOutputPath(const std::string& docId, const std::string& chunkId)
+FilePath chunkOutputPath(const std::string& docId, const std::string& chunkId,
+      ChunkOutputContext ctxType)
 {
    std::string docPath;
    source_database::getPath(docId, &docPath);
 
-   return chunkOutputPath(docPath, docId, chunkId, notebookCtxId());
+   return chunkOutputPath(docPath, docId, chunkId, notebookCtxId(), ctxType);
 }
 
 FilePath chunkOutputFile(const std::string& docId, 
                          const std::string& chunkId, 
                          const OutputPair& output)
 {
-   return chunkOutputPath(docId, chunkId).complete(
+   return chunkOutputPath(docId, chunkId, ContextExact).complete(
          (boost::format("%|1$06x|%2%") 
                      % (output.ordinal % MAX_ORDINAL)
                      % chunkOutputExt(output.outputType)).str());
@@ -333,17 +339,11 @@ Error enqueueChunkOutput(
       const std::string& chunkId, const std::string& nbCtxId,
       const std::string& requestId)
 {
-   std::string ctxId(nbCtxId);
-   FilePath outputPath = chunkOutputPath(docPath, docId, chunkId, nbCtxId);
-
-   // if the contextual output path doesn't exist, try the saved context
-   if (!outputPath.exists())
-   {
-      ctxId = kSavedCtx;
-      outputPath = chunkOutputPath(docPath, docId, chunkId, kSavedCtx);
-   }
+   FilePath outputPath = chunkOutputPath(docPath, docId, chunkId, nbCtxId,
+         ContextSaved);
 
    // scan the directory for output
+   std::string ctxId(outputPath.parent().filename());
    std::vector<FilePath> outputPaths;
    Error error = outputPath.children(&outputPaths);
 
@@ -392,7 +392,7 @@ Error enqueueChunkOutput(
 core::Error cleanChunkOutput(const std::string& docId,
       const std::string& chunkId, bool preserveFolder)
 {
-   FilePath outputPath = chunkOutputPath(docId, chunkId);
+   FilePath outputPath = chunkOutputPath(docId, chunkId, ContextExact);
    if (!outputPath.exists())
       return Success();
 

--- a/src/cpp/session/modules/rmarkdown/NotebookOutput.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookOutput.cpp
@@ -165,9 +165,15 @@ Error handleChunkOutputRequest(const http::Request& request,
 {
    // uri format is: /chunk_output/<ctx-id>/<doc-id>/...
    
+   // strip the querystring from the uri
+   std::string uri = request.uri();
+   size_t idx = uri.find_last_of("?");
+   if (idx != std::string::npos)
+      uri = uri.substr(0, idx);
+   
    // split URI into pieces, extract the document ID, and remove that part of
    // the URI
-   std::vector<std::string> parts = algorithm::split(request.uri(), "/");
+   std::vector<std::string> parts = algorithm::split(uri, "/");
    if (parts.size() < 5) 
       return Success();
 

--- a/src/cpp/session/modules/rmarkdown/NotebookOutput.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookOutput.hpp
@@ -44,6 +44,13 @@ namespace modules {
 namespace rmarkdown {
 namespace notebook {
 
+// forms for requesting the chunk output folder
+enum ChunkOutputContext
+{
+   ContextExact = 0,   // always use the requested context
+   ContextSaved        // fall back to saved context if exact doesn't exist
+};
+
 struct OutputPair
 {
    OutputPair() :
@@ -63,12 +70,14 @@ OutputPair lastChunkOutput(const std::string& docId,
 void updateLastChunkOutput(const std::string& docId, 
                            const std::string& chunkId,
                            const OutputPair& pair);
-// compute chunk output folder paths
+
+// compute chunk output folder paths for specific contexts
 core::FilePath chunkOutputPath(
       const std::string& docPath, const std::string& docId,
-      const std::string& chunkId, const std::string& nbCtxId);
+      const std::string& chunkId, const std::string& nbCtxId,
+      ChunkOutputContext ctxType);
 core::FilePath chunkOutputPath(const std::string& docId, 
-      const std::string& chunkId);
+      const std::string& chunkId, ChunkOutputContext ctxType);
 
 // compute individual chunk output unit paths
 core::FilePath chunkOutputFile(const std::string& docId, 

--- a/src/cpp/session/modules/rmarkdown/NotebookOutput.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookOutput.hpp
@@ -19,6 +19,8 @@
 
 #include <string>
 
+#define kChunkOutputPath   "chunk_output"
+
 #define kChunkOutputNone  0
 #define kChunkOutputText  1
 #define kChunkOutputPlot  2

--- a/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
@@ -1,0 +1,110 @@
+/*
+ * NotebookPlotReplay.cpp
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "SessionRmdNotebook.hpp"
+#include "NotebookPlotReplay.hpp"
+
+#include <core/StringUtils.hpp>
+
+#include <session/SessionAsyncRProcess.hpp>
+#include <session/SessionOptions.hpp>
+
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace rmarkdown {
+namespace notebook {
+
+namespace {
+
+// this class supervises an asynchronous replay of all of a notebook's 
+// plot display lists
+class ReplayPlots : public async_r::AsyncRProcess
+{
+public:
+   static boost::shared_ptr<ReplayPlots> create(const FilePath& cacheFolder)
+   {
+      // load the files which contain the R scripts needed to replay plots 
+      std::vector<core::FilePath> sources;
+
+      FilePath modulesPath = session::options().modulesRSourcePath();
+      FilePath sourcesPath = session::options().coreRSourcePath();
+
+      sources.push_back(sourcesPath.complete("Tools.R"));
+      sources.push_back(modulesPath.complete("ModuleTools.R"));
+      sources.push_back(modulesPath.complete("NotebookPlots.R"));
+
+      // create path to cache folder
+      std::string path = string_utils::utf8ToSystem(cacheFolder.absolutePath());
+      
+      // invoke the asynchronous process
+      boost::shared_ptr<ReplayPlots> pReplayer(new ReplayPlots());
+      pReplayer->start(".rs.replayNotebokPlots(\"" + path + "\")", FilePath(),
+                       async_r::R_PROCESS_VANILLA,
+                       sources);
+      return pReplayer;
+   }
+
+private:
+   void onStdout(const std::string& output)
+   {
+      r::sexp::Protect protect;
+      Error error;
+
+      std::vector<std::string> paths;
+      boost::algorithm::split(paths, output,
+                              boost::algorithm::is_any_of("\n\r"));
+      BOOST_FOREACH(std::string& path, paths)
+      {
+         // TODO: parse & emit client event  
+      }
+   }
+};
+
+
+Error replayPlotOutput(const json::JsonRpcRequest& request,
+                       json::JsonRpcResponse* pResponse)
+{
+   std::string docId;
+   int pixelWidth = 0;
+   bool replace = false;
+   Error error = json::readParams(request.params, &docId, &pixelWidth);
+   if (error)
+      return error;
+
+   // TODO: create replayer
+}
+
+
+} // anonymous namespace
+
+core::Error initializePlotReplay()
+{
+   ExecBlock initBlock;
+   initBlock.addFunctions()
+      (bind(registerRpcMethod, "replay_notebook_plots", replayPlotOutput))
+
+   return initBlock.execute();
+}
+
+
+} // namespace notebook
+} // namespace rmarkdown
+} // namespace modules
+} // namespace session
+} // namespace rstudio
+

--- a/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
@@ -26,7 +26,7 @@
 #include <core/Exec.hpp>
 
 #include <r/RExec.hpp>
-#include <r/RJSon.hpp>
+#include <r/RJson.hpp>
 #include <r/session/RGraphics.hpp>
 
 #include <session/SessionModuleContext.hpp>

--- a/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
@@ -152,8 +152,10 @@ Error replayPlotOutput(const json::JsonRpcRequest& request,
                        json::JsonRpcResponse* pResponse)
 {
    std::string docId;
+   std::string initialChunkId;
    int pixelWidth = 0;
-   Error error = json::readParams(request.params, &docId, &pixelWidth);
+   Error error = json::readParams(request.params, &docId, 
+         &initialChunkId, &pixelWidth);
    if (error)
       return error;
 
@@ -181,6 +183,17 @@ Error replayPlotOutput(const json::JsonRpcRequest& request,
    // convert to chunk IDs
    std::vector<std::string> chunkIds;
    extractChunkIds(chunkIdVals.get_array(), &chunkIds);
+
+   // shuffle the chunk IDs so we re-render the visible ones first
+   std::vector<std::string>::iterator it = std::find(
+         chunkIds.begin(), chunkIds.end(), initialChunkId);
+   if (it != chunkIds.end())
+   {
+      std::vector<std::string> shuffledChunkIds;
+      std::copy(it, chunkIds.end(), std::back_inserter(shuffledChunkIds));
+      std::copy(chunkIds.begin(), it, std::back_inserter(shuffledChunkIds));
+      chunkIds = shuffledChunkIds;
+   }
 
    // look for snapshot files
    std::vector<FilePath> snapshotFiles;

--- a/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
@@ -81,8 +81,11 @@ public:
 
       // form command to pass to R 
       std::string cmd(".rs.replayNotebookPlots(" + 
-                      safe_convert::numberToString(width) + ", '" + 
-                      extraParams + "')");
+                      safe_convert::numberToString(width) + ", " + 
+                      safe_convert::numberToString(
+                         r::session::graphics::device::devicePixelRatio()) +
+                         ", "
+                      "'" + extraParams + "')");
 
       // invoke the asynchronous process
       boost::shared_ptr<ReplayPlots> pReplayer(new ReplayPlots());

--- a/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
@@ -98,16 +98,10 @@ public:
    }
 
 private:
-   void onStderr(const std::string& output)
-   {
-      std::cerr << "cerr: " << output << std::endl;
-   }
-
    void onStdout(const std::string& output)
    {
       r::sexp::Protect protect;
       Error error;
-      std::cerr << "cout: " << output << std::endl;
 
       // output is queued/buffered so multiple paths may be emitted
       std::vector<std::string> paths;

--- a/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
@@ -54,7 +54,7 @@ public:
          int width,
          const std::vector<FilePath>& snapshotFiles)
    {
-      // create the text to send to the process (it'll be read by scan()
+      // create the text to send to the process (it'll be read on stdin
       // inside R)
       std::string input;
       BOOST_FOREACH(const FilePath snapshot, snapshotFiles)

--- a/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
@@ -73,9 +73,9 @@ public:
       sources.push_back(modulesPath.complete("NotebookPlots.R"));
 
       // create path to cache folder
-      std::string cmd(".rs.replayNotebokPlots(" + 
+      std::string cmd(".rs.replayNotebookPlots(" + 
                       safe_convert::numberToString(width) + ")");
-      
+
       // invoke the asynchronous process
       boost::shared_ptr<ReplayPlots> pReplayer(new ReplayPlots());
       pReplayer->docId_ = docId;
@@ -99,7 +99,7 @@ private:
       BOOST_FOREACH(std::string& path, paths)
       {
          // ensure path exists
-         FilePath png(path);
+         FilePath png(string_utils::trimWhitespace(path));
          if (!png.exists())
             continue;
 

--- a/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
@@ -90,6 +90,7 @@ public:
       // invoke the asynchronous process
       boost::shared_ptr<ReplayPlots> pReplayer(new ReplayPlots());
       pReplayer->docId_ = docId;
+      pReplayer->width_ = width;
       pReplayer->start(cmd.c_str(), FilePath(),
                        async_r::R_PROCESS_VANILLA,
                        sources,
@@ -134,11 +135,15 @@ private:
    void onCompleted(int exitStatus)
    {
       // let client know the process is completed (even if it failed)
+      json::Object result;
+      result["doc_id"] = docId_;
+      result["width"] = width_;
       module_context::enqueClientEvent(ClientEvent(
-               client_events::kChunkPlotRefreshFinished, docId_));
+               client_events::kChunkPlotRefreshFinished, result));
    }
 
    std::string docId_;
+   int width_;
 };
 
 boost::shared_ptr<ReplayPlots> s_pPlotReplayer;

--- a/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.hpp
@@ -1,0 +1,39 @@
+/*
+ * NotebookPlotReplay.hpp
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef SESSION_NOTEBOOK_PLOT_REPLAY_HPP
+#define SESSION_NOTEBOOK_PLOT_REPLAY_HPP
+
+namespace rstudio {
+namespace core {
+   class Error;
+}
+}
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace rmarkdown {
+namespace notebook {
+
+core::Error initializePlotReplay();
+
+} // namespace notebook
+} // namespace rmarkdown
+} // namespace modules
+} // namespace session
+} // namespace rstudio
+
+#endif

--- a/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.hpp
@@ -28,7 +28,7 @@ namespace modules {
 namespace rmarkdown {
 namespace notebook {
 
-core::Error initializePlotReplay();
+core::Error initPlotReplay();
 
 } // namespace notebook
 } // namespace rmarkdown

--- a/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
@@ -229,7 +229,9 @@ core::Error beginPlotCapture(int pixelWidth, const FilePath& plotFolder)
    // create the notebook graphics device
    error = r::exec::RFunction(".rs.createNotebookGraphicsDevice",
          plotFolder.absolutePath() + "/" kPlotPrefix "%03d.png",
-         pixelWidth, r::session::graphics::extraBitmapParams()).call();
+         pixelWidth, 
+         r::session::graphics::device::devicePixelRatio(),
+         r::session::graphics::extraBitmapParams()).call();
    if (error)
    {
       // this is fatal; without a graphics device we can't capture plots

--- a/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
@@ -112,7 +112,7 @@ void saveSnapshot(boost::shared_ptr<PlotState> pPlotState)
    // if there's a plot on the device, write its display list before it's
    // cleared for the next page
    FilePath outputFile = pPlotState->plotFolder.complete(
-         core::system::generateUuid(false) + ".snapshot");
+         core::system::generateUuid(false) + kDisplayListExt);
    Error error = r::exec::RFunction(".rs.saveGraphics", 
          outputFile.absolutePath()).call();
    if (error)

--- a/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
@@ -120,7 +120,7 @@ void saveSnapshot(boost::shared_ptr<PlotState> pPlotState)
 
    // if there's already an unconsumed display list, remove it, since this
    // display list replaces it
-   if (pPlotState->snapshotFile.empty())
+   if (!pPlotState->snapshotFile.empty())
    {
       error = pPlotState->snapshotFile.removeIfExists();
       if (error) 

--- a/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
@@ -57,6 +57,7 @@ public:
    r::sexp::PreservedSEXP sexpMargins;
    boost::signals::connection onConsolePrompt;
    boost::signals::connection onBeforeNewPlot;
+   boost::signals::connection onBeforeNewGridPage;
    boost::signals::connection onNewPlot;
 };
 
@@ -181,6 +182,7 @@ void onConsolePrompt(boost::shared_ptr<PlotState> pPlotState,
    pPlotState->onConsolePrompt.disconnect();
    pPlotState->onNewPlot.disconnect();
    pPlotState->onBeforeNewPlot.disconnect();
+   pPlotState->onBeforeNewGridPage.disconnect();
 }
 
 } // anonymous namespace
@@ -259,6 +261,9 @@ core::Error beginPlotCapture(int pixelWidth, const FilePath& plotFolder)
          boost::bind(onConsolePrompt, pPlotState, _1));
 
    pPlotState->onBeforeNewPlot = plots::events().onBeforeNewPlot.connect(
+         boost::bind(onBeforeNewPlot, pPlotState));
+   
+   pPlotState->onBeforeNewGridPage = plots::events().onBeforeNewGridPage.connect(
          boost::bind(onBeforeNewPlot, pPlotState));
 
    pPlotState->onNewPlot = plots::events().onNewPlot.connect(

--- a/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
@@ -200,7 +200,8 @@ core::Error beginPlotCapture(const FilePath& plotFolder)
    boost::format fmt("{ require(grDevices, quietly=TRUE); "
                      "  png(file = \"%1%/" kPlotPrefix "%%03d.png\", "
                      "  width = 6.5, height = 4, "
-                     "  units=\"in\", res = 96 %2%)"
+                     "  units=\"in\", res = 96 %2%); "
+                     "  dev.control(displaylist = \"enable\") "
                      "}");
 
    // marker for content; this is necessary because on Windows, turning off

--- a/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
@@ -115,9 +115,20 @@ void saveSnapshot(boost::shared_ptr<PlotState> pPlotState)
          core::system::generateUuid(false) + kDisplayListExt);
    Error error = r::exec::RFunction(".rs.saveGraphics", 
          outputFile.absolutePath()).call();
+
+   // if there's already an unconsumed display list, remove it, since this
+   // display list replaces it
+   if (pPlotState->snapshotFile.empty())
+   {
+      error = pPlotState->snapshotFile.removeIfExists();
+      if (error) 
+         LOG_ERROR(error);
+      else
+         pPlotState->snapshotFile = FilePath();
+   }
+
    if (error)
    {
-      pPlotState->snapshotFile = FilePath();
       LOG_ERROR(error);
    }
    else

--- a/src/cpp/session/modules/rmarkdown/NotebookPlots.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlots.hpp
@@ -34,7 +34,9 @@ namespace modules {
 namespace rmarkdown {
 namespace notebook {
 
-core::Error beginPlotCapture(const core::FilePath& plotFolder);
+core::Error beginPlotCapture(int pixelWidth, const core::FilePath& plotFolder);
+
+core::Error initPlots();
 
 } // namespace notebook
 } // namespace rmarkdown

--- a/src/cpp/session/modules/rmarkdown/NotebookPlots.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlots.hpp
@@ -19,6 +19,8 @@
 
 #include <boost/function.hpp>
 
+#define kDisplayListExt ".snapshot"
+
 namespace rstudio {
 namespace core {
    class Error;

--- a/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.cpp
@@ -16,6 +16,7 @@
 #include "SessionRmdNotebook.hpp"
 #include "SessionRnbParser.hpp"
 #include "NotebookPlots.hpp"
+#include "NotebookPlotReplay.hpp"
 #include "NotebookCache.hpp"
 #include "NotebookChunkDefs.hpp"
 #include "NotebookOutput.hpp"
@@ -280,7 +281,8 @@ Error initialize()
       (bind(initOutput))
       (bind(initCache))
       (bind(initHtmlWidgets))
-      (bind(initErrors));
+      (bind(initErrors))
+      (bind(initPlotReplay));
 
    return initBlock.execute();
 }

--- a/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.cpp
@@ -282,6 +282,7 @@ Error initialize()
       (bind(initCache))
       (bind(initHtmlWidgets))
       (bind(initErrors))
+      (bind(initPlots))
       (bind(initPlotReplay));
 
    return initBlock.execute();

--- a/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.hpp
@@ -52,7 +52,7 @@ struct Events : boost::noncopyable
                 const std::string&)>
                 onChunkConsoleOutput;
 
-   boost::signal<void(const core::FilePath&)> onPlotOutput;
+   boost::signal<void(const core::FilePath&, const core::FilePath&)> onPlotOutput;
    boost::signal<void(const core::FilePath&, const core::FilePath&)> onHtmlOutput;
    boost::signal<void(const core::json::Object&)> onErrorOutput;
 };

--- a/src/gwt/src/org/rstudio/core/client/widget/FixedRatioWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FixedRatioWidget.java
@@ -21,9 +21,9 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.Widget;
 
-public class FixedRatioWidget <T extends Widget> extends Composite
+public class FixedRatioWidget extends Composite
 {
-   public FixedRatioWidget(T widget, double aspect, int maxWidth)
+   public FixedRatioWidget(Widget widget, double aspect, int maxWidth)
    {
       widget_ = widget;
 
@@ -52,10 +52,10 @@ public class FixedRatioWidget <T extends Widget> extends Composite
       initWidget(outer);
    }
    
-   public T getWidget()
+   public Widget getWidget()
    {
       return widget_;
    }
    
-   private final T widget_;
+   private final Widget widget_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/events/ChunkPlotRefreshFinishedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/events/ChunkPlotRefreshFinishedEvent.java
@@ -1,0 +1,54 @@
+/*
+ * ChunkPlotRefreshFinishedEvent.java
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.rmarkdown.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class ChunkPlotRefreshFinishedEvent 
+             extends GwtEvent<ChunkPlotRefreshFinishedEvent.Handler>
+{  
+   public interface Handler extends EventHandler
+   {
+      void onChunkPlotRefreshFinished(ChunkPlotRefreshFinishedEvent event);
+   }
+
+   public ChunkPlotRefreshFinishedEvent(String docId)
+   {
+      docId_ = docId;
+   }
+
+   public String getDocId()
+   {
+      return docId_;
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onChunkPlotRefreshFinished(this);
+   }
+   
+   private String docId_;
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/events/ChunkPlotRefreshFinishedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/events/ChunkPlotRefreshFinishedEvent.java
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client.rmarkdown.events;
 
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 
@@ -26,14 +27,30 @@ public class ChunkPlotRefreshFinishedEvent
       void onChunkPlotRefreshFinished(ChunkPlotRefreshFinishedEvent event);
    }
 
-   public ChunkPlotRefreshFinishedEvent(String docId)
+   public static class Data extends JavaScriptObject
    {
-      docId_ = docId;
+      protected Data()
+      {  
+      }
+      
+      public final native String getDocId() /*-{
+         return this.doc_id;
+      }-*/;
+      
+      public final native int getWidth() /*-{
+         return this.width;
+      }-*/;
+   }
+   
+
+   public ChunkPlotRefreshFinishedEvent(Data data)
+   {
+      data_ = data;
    }
 
-   public String getDocId()
+   public Data getData()
    {
-      return docId_;
+      return data_;
    }
 
    @Override
@@ -48,7 +65,7 @@ public class ChunkPlotRefreshFinishedEvent
       handler.onChunkPlotRefreshFinished(this);
    }
    
-   private String docId_;
+   private Data data_;
 
    public static final Type<Handler> TYPE = new Type<Handler>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/events/ChunkPlotRefreshedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/events/ChunkPlotRefreshedEvent.java
@@ -1,0 +1,74 @@
+/*
+ * ChunkPlotRefreshedEvent.java
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.rmarkdown.events;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class ChunkPlotRefreshedEvent 
+             extends GwtEvent<ChunkPlotRefreshedEvent.Handler>
+{  
+   public interface Handler extends EventHandler
+   {
+      void onChunkPlotRefreshed(ChunkPlotRefreshedEvent event);
+   }
+
+   public static class Data extends JavaScriptObject
+   {
+      protected Data()
+      {  
+      }
+      
+      public final native String getDocId() /*-{
+         return this.doc_id;
+      }-*/;
+      
+      public final native String getChunkId() /*-{
+         return this.chunk_id;
+      }-*/;
+      
+      public final native String getPlotUrl() /*-{
+         return this.plot_url;
+      }-*/;
+   }
+   
+   public ChunkPlotRefreshedEvent(Data data)
+   {
+      data_ = data;
+   }
+
+   public Data getData()
+   {
+      return data_;
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onChunkPlotRefreshed(this);
+   }
+   
+   private Data data_;
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RMarkdownServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RMarkdownServerOperations.java
@@ -81,6 +81,6 @@ public interface RMarkdownServerOperations extends CryptoServerOperations
    
    void createNotebookFromCache(String rmdPath, String outputPath, ServerRequestCallback<Void> requestCallback);
    
-   void replayNotebookPlots(String docId, int pixelWidth, 
+   void replayNotebookPlots(String docId, String initialChunkId, int pixelWidth, 
          ServerRequestCallback<Boolean> requestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RMarkdownServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RMarkdownServerOperations.java
@@ -80,4 +80,7 @@ public interface RMarkdownServerOperations extends CryptoServerOperations
                         ServerRequestCallback<RmdChunkOptions> requestCallback);
    
    void createNotebookFromCache(String rmdPath, String outputPath, ServerRequestCallback<Void> requestCallback);
+   
+   void replayNotebookPlots(String docId, int pixelWidth, 
+         ServerRequestCallback<Boolean> requestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -142,6 +142,8 @@ class ClientEvent extends JavaScriptObject
    public static final String EditorCommand = "editor_command";
    public static final String PreviewRmd = "preview_rmd";
    public static final String WebsiteFileSaved = "website_file_saved";
+   public static final String ChunkPlotRefreshed = "chunk_plot_refreshed";
+   public static final String ChunkPlotRefreshFinished = "chunk_plot_refresh_finished";
 
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -796,8 +796,8 @@ public class ClientEventDispatcher
          }
          else if (type.equals(ClientEvent.ChunkPlotRefreshFinished))
          {
-            String docId = event.getData();
-            eventBus_.fireEvent(new ChunkPlotRefreshFinishedEvent(docId));
+            ChunkPlotRefreshFinishedEvent.Data data = event.getData();
+            eventBus_.fireEvent(new ChunkPlotRefreshFinishedEvent(data));
          }
          else
          {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -61,6 +61,8 @@ import org.rstudio.studio.client.projects.events.ProjectAccessRevokedEvent;
 import org.rstudio.studio.client.projects.events.ProjectUserChangedEvent;
 import org.rstudio.studio.client.projects.model.OpenProjectError;
 import org.rstudio.studio.client.projects.model.ProjectUser;
+import org.rstudio.studio.client.rmarkdown.events.ChunkPlotRefreshFinishedEvent;
+import org.rstudio.studio.client.rmarkdown.events.ChunkPlotRefreshedEvent;
 import org.rstudio.studio.client.rmarkdown.events.PreviewRmdEvent;
 import org.rstudio.studio.client.rmarkdown.events.ShinyGadgetDialogEvent;
 import org.rstudio.studio.client.rmarkdown.events.RmdChunkOutputEvent;
@@ -786,6 +788,16 @@ public class ClientEventDispatcher
          {
             FileSystemItem fsi = event.getData();
             eventBus_.fireEvent(new WebsiteFileSavedEvent(fsi));
+         }
+         else if (type.equals(ClientEvent.ChunkPlotRefreshed))
+         {
+            ChunkPlotRefreshedEvent.Data data = event.getData();
+            eventBus_.fireEvent(new ChunkPlotRefreshedEvent(data));
+         }
+         else if (type.equals(ClientEvent.ChunkPlotRefreshFinished))
+         {
+            String docId = event.getData();
+            eventBus_.fireEvent(new ChunkPlotRefreshFinishedEvent(docId));
          }
          else
          {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4246,12 +4246,13 @@ public class RemoteServer implements Server
    }
 
    @Override
-   public void replayNotebookPlots(String docId, int pixelWidth,
-         ServerRequestCallback<Boolean> requestCallback)
+   public void replayNotebookPlots(String docId, String initialChunkId,
+         int pixelWidth, ServerRequestCallback<Boolean> requestCallback)
    {
       JSONArray params = new JSONArray();
       params.set(0, new JSONString(docId));
-      params.set(1, new JSONNumber(pixelWidth));
+      params.set(1, new JSONString(initialChunkId));
+      params.set(2, new JSONNumber(pixelWidth));
       sendRequest(RPC_SCOPE, "replay_notebook_plots", params, requestCallback);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4246,6 +4246,16 @@ public class RemoteServer implements Server
    }
 
    @Override
+   public void replayNotebookPlots(String docId, int pixelWidth,
+         ServerRequestCallback<Boolean> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(docId));
+      params.set(1, new JSONNumber(pixelWidth));
+      sendRequest(RPC_SCOPE, "replay_notebook_plots", params, requestCallback);
+   }
+
+   @Override
    public void getRmdOutputInfo(String input,
          ServerRequestCallback<RmdOutputInfo> requestCallback)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -104,6 +104,7 @@ public class ChunkOutputWidget extends Composite
       String overflowY();
       String collapsed();
       String spinner();
+      String pendingResize();
    }
 
    public ChunkOutputWidget(String chunkId, RmdChunkOptions options, 
@@ -405,6 +406,20 @@ public class ChunkOutputWidget extends Composite
       return hasErrors_;
    }
    
+   public void setPlotPending(boolean pending)
+   {
+      for (Widget w: root_)
+      {
+         if (w instanceof Image)
+         {
+            if (pending)
+               w.addStyleName(style.pendingResize());
+            else
+               w.removeStyleName(style.pendingResize());
+         }
+      }
+   }
+   
    public void updatePlot(String plotUrl)
    {
       String plotFile = FilePathUtils.friendlyFileName(plotUrl);
@@ -429,6 +444,7 @@ public class ChunkOutputWidget extends Composite
             // the only purpose of this resize counter is to ensure that the
             // plot URL changes when its geometry does (it's not consumed by
             // the server)
+            w.removeStyleName(style.pendingResize());
             plot.setUrl(plotUrl + "?resize=" + resizeCounter_++);
          }
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -442,9 +442,6 @@ public class ChunkOutputWidget extends Composite
             if (FilePathUtils.friendlyFileName(url) != plotFile)
                continue;
             
-            // the only purpose of this resize counter is to ensure that the
-            // plot URL changes when its geometry does (it's not consumed by
-            // the server)
             w.removeStyleName(style.pendingResize());
             
             // sync height (etc) when render is complete, but don't scroll to 
@@ -452,6 +449,9 @@ public class ChunkOutputWidget extends Composite
             DOM.setEventListener(plot.getElement(), createPlotListener(plot, 
                   false));
 
+            // the only purpose of this resize counter is to ensure that the
+            // plot URL changes when its geometry does (it's not consumed by
+            // the server)
             plot.setUrl(plotUrl + "?resize=" + resizeCounter_++);
          }
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -644,7 +644,8 @@ public class ChunkOutputWidget extends Composite
             // grow the image to fill the container, but not beyond its
             // natural width. also clamp image width to avoid overly-large
             // images in a wide editor buffer
-            int maxWidth = Math.min(624, img.naturalWidth());
+            int maxWidth = Math.min(ChunkOutputUi.MAX_PLOT_WIDTH, 
+                  img.naturalWidth());
             img.getStyle().setWidth(100, Unit.PCT);
             img.getStyle().setProperty("maxWidth", maxWidth + "px");
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.ui.xml
@@ -114,6 +114,12 @@
       margin: -10px 0 0 -10px;
       transition: opacity 400ms ease;
    }
+   
+   .pendingResize
+   {
+      opacity: 0.5;
+      transition: opacity 400ms ease;
+   }
    </ui:style>
    <g:HTMLPanel styleName="{style.outer}">
       <g:HTMLPanel styleName="{style.expander}"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -185,6 +185,9 @@ public class TextEditingTarget implements
    private static final String NOTEBOOK_TITLE = "notebook_title";
    private static final String NOTEBOOK_AUTHOR = "notebook_author";
    private static final String NOTEBOOK_TYPE = "notebook_type";
+   
+   public final static String DOC_OUTLINE_SIZE    = "docOutlineSize";
+   public final static String DOC_OUTLINE_VISIBLE = "docOutlineVisible";
 
    private static final MyCommandBinder commandBinder =
          GWT.create(MyCommandBinder.class);
@@ -5953,12 +5956,12 @@ public class TextEditingTarget implements
    {
       prefs_.preferredDocumentOutlineWidth().setGlobalValue((int) size);
       prefs_.writeUIPrefs();
-      docUpdateSentinel_.setProperty("docOutlineSize", size + "");
+      docUpdateSentinel_.setProperty(DOC_OUTLINE_SIZE, size + "");
    }
    
    public double getPreferredOutlineWidgetSize()
    {
-      String property = docUpdateSentinel_.getProperty("docOutlineSize");
+      String property = docUpdateSentinel_.getProperty(DOC_OUTLINE_SIZE);
       if (StringUtil.isNullOrEmpty(property))
          return prefs_.preferredDocumentOutlineWidth().getGlobalValue();
       
@@ -5983,12 +5986,12 @@ public class TextEditingTarget implements
    
    public void setPreferredOutlineWidgetVisibility(boolean visible)
    {
-      docUpdateSentinel_.setProperty("docOutlineVisible", visible ? "1" : "0");
+      docUpdateSentinel_.setProperty(DOC_OUTLINE_VISIBLE, visible ? "1" : "0");
    }
    
    public boolean getPreferredOutlineWidgetVisibility()
    {
-      String property = docUpdateSentinel_.getProperty("docOutlineVisible");
+      String property = docUpdateSentinel_.getProperty(DOC_OUTLINE_VISIBLE);
       return StringUtil.isNullOrEmpty(property)
             ? (getTextFileType().isRmd() && prefs_.showDocumentOutlineRmd().getGlobalValue())
             : Integer.parseInt(property) > 0;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkOutputUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkOutputUi.java
@@ -224,4 +224,5 @@ public class ChunkOutputUi
    public final static int MAX_CHUNK_HEIGHT = 650;
    
    public final static int MAX_PLOT_WIDTH = 650;
+   public final static double OUTPUT_ASPECT = 1.618;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkOutputUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkOutputUi.java
@@ -222,4 +222,6 @@ public class ChunkOutputUi
    public final static int MIN_CHUNK_HEIGHT = 25;
    public final static int CHUNK_COLLAPSED_HEIGHT = 15;
    public final static int MAX_CHUNK_HEIGHT = 650;
+   
+   public final static int MAX_PLOT_WIDTH = 650;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -203,6 +203,26 @@ public class TextEditingTargetNotebook
          }
       }));
       
+      // when the width of the outline changes, treat it as a resize
+      ValueChangeHandler<String> outlineWidthHandler = 
+         new ValueChangeHandler<String>()
+      {
+         @Override
+         public void onValueChange(ValueChangeEvent<String> event)
+         {
+            onResize(null);
+         }
+      };
+      
+      releaseOnDismiss.add(
+         docUpdateSentinel_.addPropertyValueChangeHandler(
+               TextEditingTarget.DOC_OUTLINE_SIZE, 
+               outlineWidthHandler));
+      releaseOnDismiss.add(
+         docUpdateSentinel_.addPropertyValueChangeHandler(
+               TextEditingTarget.DOC_OUTLINE_VISIBLE, 
+               outlineWidthHandler));
+      
       releaseOnDismiss.add(docDisplay_.addValueChangeHandler(
             new ValueChangeHandler<Void>()
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -1609,8 +1609,24 @@ public class TextEditingTargetNotebook
          if (plotWidth == lastPlotWidth_)
             return;
          
+         // we want to resize the visible plots first, so provide the server
+         // with the id of the first visible chunk as a cue
+         int row = docDisplay_.getFirstVisibleRow();
+         Integer min = null;
+         String chunkId = "";
+         for (ChunkOutputUi output: outputs_.values())
+         {
+            int delta = Math.abs(output.getCurrentRow() - row);
+            if (min == null || delta < min)
+            {
+               min = delta;
+               chunkId = output.getChunkId();
+            }
+         }
+         
          // make the request
          server_.replayNotebookPlots(docUpdateSentinel_.getId(), 
+               chunkId,
                plotWidth,
                new ServerRequestCallback<Boolean>()
                {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -1574,9 +1574,12 @@ public class TextEditingTargetNotebook
    
    private int getPlotWidth()
    {
-      // subtract some space to account for padding (10px on either side) and
-      // ensure the plot doesn't grow arbitrarily large
-      return Math.min(docDisplay_.getPixelWidth() - 30,
+      // subtract some space to account for padding; ensure the plot doesn't
+      // grow arbitrarily large. note that this value must total the amount of
+      // space outside the element (here, 2 * (10px margin + 1px border)); since
+      // we stretch the plot to fit the space it will scale in unpredictable
+      // ways if it doesn't fit exactly
+      return Math.min(docDisplay_.getPixelWidth() - 22,
                       ChunkOutputUi.MAX_PLOT_WIDTH);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -35,6 +35,8 @@ import org.rstudio.studio.client.application.events.RestartStatusEvent;
 import org.rstudio.studio.client.common.FilePathUtils;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.rmarkdown.RmdOutput;
+import org.rstudio.studio.client.rmarkdown.events.ChunkPlotRefreshFinishedEvent;
+import org.rstudio.studio.client.rmarkdown.events.ChunkPlotRefreshedEvent;
 import org.rstudio.studio.client.rmarkdown.events.RmdChunkOutputEvent;
 import org.rstudio.studio.client.rmarkdown.events.RmdChunkOutputFinishedEvent;
 import org.rstudio.studio.client.rmarkdown.events.SendToChunkConsoleEvent;
@@ -100,6 +102,8 @@ public class TextEditingTargetNotebook
                implements EditorThemeStyleChangedEvent.Handler,
                           RmdChunkOutputEvent.Handler,
                           RmdChunkOutputFinishedEvent.Handler,
+                          ChunkPlotRefreshedEvent.Handler,
+                          ChunkPlotRefreshFinishedEvent.Handler,
                           SendToChunkConsoleEvent.Handler, 
                           ChunkChangeEvent.Handler,
                           ChunkContextChangeEvent.Handler,
@@ -313,6 +317,10 @@ public class TextEditingTargetNotebook
             events_.addHandler(RmdChunkOutputEvent.TYPE, this));
       releaseOnDismiss_.add(
             events_.addHandler(RmdChunkOutputFinishedEvent.TYPE, this));
+      releaseOnDismiss_.add(
+            events_.addHandler(ChunkPlotRefreshedEvent.TYPE, this));
+      releaseOnDismiss_.add(
+            events_.addHandler(ChunkPlotRefreshFinishedEvent.TYPE, this));
       releaseOnDismiss_.add(
             events_.addHandler(SendToChunkConsoleEvent.TYPE, this));
       releaseOnDismiss_.add(
@@ -729,6 +737,28 @@ public class TextEditingTargetNotebook
          // process next chunk in execution queue
          processChunkExecQueue();
       }
+   }
+
+
+   @Override
+   public void onChunkPlotRefreshFinished(ChunkPlotRefreshFinishedEvent event)
+   {
+     // TODO: unmark any still-pending plots 
+      
+   }
+
+   @Override
+   public void onChunkPlotRefreshed(ChunkPlotRefreshedEvent event)
+   {
+      // ignore if targeted at another document
+      if (event.getData().getDocId() != docUpdateSentinel_.getId())
+         return;
+      
+      // find chunk containing plot and push the new plot in
+      String chunkId = event.getData().getChunkId();
+      if (outputs_.containsKey(chunkId))
+         outputs_.get(chunkId).getOutputWidget().updatePlot(
+               event.getData().getPlotUrl());
    }
 
    @Override


### PR DESCRIPTION
This change improves the appearance of plots in notebooks in three ways:

1. Plots are now drawn for the notebook's exact width. Plots were formerly drawn at a fixed width and height and scaled to the editor surface using traditional image scaling.

2. The device pixel ratio is now respected, so plots appear sharper on Retina displays. 

3. When the editor is resized, plots are redrawn to fit the new width from a persisted display list.

Display lists are persisted as `.snapshot` files inside the notebook cache; the display lists are written along with the plot's image. A resize causes the image to be recomputed from the display list.

To avoid tying up the main thread during resize, the resizing is performed by a separate R process, which receives the list of `.snapshot` files on standard input and outputs the resized `.png` filenames to standard output, where they're picked up and sent to the client as they become available. 