### PR TITLE
use new rmarkdown's 'output_source'

### DIFF
--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -129,219 +129,63 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    .rs.trimWhitespace(contents)
 })
 
-.rs.addFunction("rnb.getActiveChunkId", function(rnbData, row)
+.rs.addFunction("rnb.resolveActiveChunkId", function(rnbData, label)
 {
    chunkDefns <- rnbData$chunk_info$chunk_definitions
-   chunkRows <- vapply(chunkDefns, `[[`, "row", FUN.VALUE = numeric(1))
-   idx <- match(row, chunkRows)
-   if (is.na(idx)) NULL else names(chunkRows)[[idx]]
-})
-
-.rs.addFunction("rnb.renderHtmlWidget", function(output)
-{
-   unpreserved <- substring(
-      output,
-      .rs.nBytes("<!--html_preserve-->") + 1,
-      .rs.nBytes(output) - .rs.nBytes("<!--/html_preserve-->")
-   )
-   
-   meta <- .rs.rnb.encode(attr(output, "knit_meta"))
-   
-   before <- sprintf("\n<!-- rnb-htmlwidget-begin %s-->", meta)
-   after  <- "<!-- rnb-htmlwidget-end -->\n"
-   annotated <- htmltools::htmlPreserve(paste(before, unpreserved, after, sep = "\n"))
-   attributes(annotated) <- attributes(output)
-   return(annotated)
-})
-
-.rs.addFunction("rnb.getKnitrHookList", function()
-{
-   hookNames <- c("knit_hooks", "opts_chunk", "opts_hooks", "opts_knit")
-   knitrNamespace <- asNamespace("knitr")
-   hookList <- lapply(hookNames, function(hookName) {
-      hooks <- get(hookName, envir = knitrNamespace, inherits = FALSE)
-      hooks$get()
-   })
-   names(hookList) <- hookNames
-   hookList
-})
-
-.rs.addFunction("rnb.setKnitrHookList", function(hookList)
-{
-   knitrNamespace <- asNamespace("knitr")
-   .rs.enumerate(hookList, function(hookName, hookValue)
-   {
-      hook <- get(hookName, envir = knitrNamespace, inherits = FALSE)
-      hook$set(hookValue)
-   })
-})
-
-.rs.addFunction("rnb.htmlAnnotatedOutput", function(output, label, meta = NULL)
-{
-   before <- if (is.null(meta)) {
-      sprintf("\n<!-- rnb-%s-begin -->\n", label)
-   } else {
-      meta <- .rs.rnb.encode(meta)
-      sprintf("\n<!-- rnb-%s-begin %s -->\n", label, meta)
+   for (defn in chunkDefns) {
+      if (defn$chunk_label == label)
+         return(defn$chunk_id)
    }
-   after  <- sprintf("\n<!-- rnb-%s-end -->\n", label)
-   paste(before, output, after, sep = "\n")
+   return(NULL)
 })
 
-.rs.addFunction("rnb.annotatedKnitrHook", function(label, hook, meta = NULL) {
-   force(list(label, hook, meta))
-   function(x, ...) {
-      output <- hook(x, ...)
-      meta <- if (is.function(meta)) meta(x, output, ...)
-      .rs.rnb.htmlAnnotatedOutput(output, label, meta)
-   }
-})
-
-# The hooks here are used to pull output from a cache directory, rather
-# than based on evaluating the R code within each chunk. To this end, we
-# override the 'evaluate' hook and, instead of evaluating the R code within,
-# we instead recover output(s) from the cache and return those instead.
-.rs.addFunction("rnb.cacheAugmentKnitrHooks", function(rnbData, format)
-{
-   # save original hooks (to be restored after knit)
-   savedHookList <- .rs.rnb.getKnitrHookList()
-   on.exit(.rs.rnb.setKnitrHookList(savedHookList), add = TRUE)
-   
-   # use 'render_markdown()' to get default hooks
-   knitr::render_markdown()
-   
-   # store original hooks and annotate in format
-   knitHooks <- knitr::knit_hooks$get()
-   
-   # track number of lines processed (so we can correctly map
-   # chunks in document back to chunks in cache)
-   linesProcessed <- 1
-   
-   # capture + override include hooks -- we always want our
-   # chunk hook to fire + include output, but we can make sure
-   # that only the annotations are included in such a case
-   #
-   # we hook the 'include' option but this is just an excuse
-   # + nice location to capture chunk options (before they're
-   # handled anywhere else)
-   chunkOptions <- list()
-   format$knitr$opts_hooks$include <- function(options) {
-      chunkOptions <<- options
-      options
-   }
-   
-   # generate our custom hooks
-   newKnitHooks <- list(
+.rs.addFunction("rnb.outputSource", function(rnbData) {
+   force(rnbData)
+   function(code, context, ...) {
       
-      text = function(x, ...) {
-         newLineMatches <- gregexpr('\n', x, fixed = TRUE)[[1]]
-         n <- if (identical(c(newLineMatches), -1L)) 0 else length(newLineMatches)
-         linesProcessed <<- linesProcessed + n + 1
-         output <- knitHooks$text(x, ...)
-         annotated <- .rs.rnb.htmlAnnotatedOutput(output, "text")
-         annotated
-      },
+      # resolve chunk id (attempt to match labels)
+      chunkId <- .rs.rnb.resolveActiveChunkId(rnbData, context$label)
+      if (is.null(chunkId)) {
+         return(knitr::asis_output("<!-- empty-output-placeholder -->"))
+      }
       
-      chunk = function(...) {
-         output <- if (chunkOptions$include) knitHooks$chunk(...) else ""
-         annotated <- .rs.rnb.htmlAnnotatedOutput(output, "chunk")
-         annotated
-      },
-      
-      evaluate = function(code, ...) {
+      chunkData <- rnbData$chunk_data[[chunkId]]
+      outputList <- .rs.enumerate(chunkData, function(key, val) {
          
-         # restore original hook temporarily (so that any sub-calls
-         # to 'evaluate' go to the correct function)
-         evaluate <- get(".rs.evaluate", envir = .rs.toolsEnv())
-         hook <- .rs.replaceBinding("evaluate", "evaluate", evaluate)
-         on.exit(.rs.replaceBinding("evaluate", "evaluate", hook), add = TRUE)
-         
-         linesProcessed <<- linesProcessed + length(code)
-         activeChunkId <- .rs.rnb.getActiveChunkId(rnbData, linesProcessed)
-         linesProcessed <<- linesProcessed + 2
-         
-         # return placeholder when include is FALSE (don't include
-         # plain empty output as we want to still insert something
-         # into document)
-         if (!chunkOptions$include)
-            return(knitr::asis_output("<!-- placeholder -->"))
-         
-         # no output associated with this chunk -- only display
-         # source code
-         if (is.null(activeChunkId)) {
-            output <- if (chunkOptions$echo) .rs.rnb.renderCode(code, list(class = "r"))
-            return(output)
+         # png output: create base64 encoded image
+         if (.rs.endsWith(key, ".png")) {
+            return(rmarkdown::html_notebook_output_png(bytes = val))
          }
          
-         # attempt to pull output from cache
-         # TODO: respect output options?
-         activeChunkData <- rnbData$chunk_data[[activeChunkId]]
-         htmlOutput <- .rs.enumerate(activeChunkData, function(key, val) {
-            
-            # png output: create base64 encoded image
-            if (.rs.endsWith(key, ".png")) {
-               rendered <- .rs.rnb.renderBase64Png(bytes = val)
-               annotated <- .rs.rnb.htmlAnnotatedOutput(rendered, "plot")
-               return(knitr::asis_output(annotated))
-            }
-            
-            # console output
-            if (.rs.endsWith(key, ".csv")) {
-               
-               # convert console data to HTML
-               htmlList <- .rs.rnb.consoleDataToHtmlList(val)
-               
-               # drop input if echo is false
-               if (!chunkOptions$echo) {
-                  htmlList <- Filter(function(el) {
-                     el$type != "input"
-                  }, htmlList)
-               }
-               
-               # transform into html string
-               transformed <- lapply(htmlList, function(el) {
-                  output <- el$output
-                  label <- if (el$type == "input") "source" else "output"
-                  meta <- list(data = el$input)
-                  .rs.rnb.htmlAnnotatedOutput(output, label, meta)
-               })
-               
-               # return output
-               output <- paste(transformed, collapse = "\n")
-               return(knitr::asis_output(output))
-            }
-            
-            # html widgets
-            if (.rs.endsWith(key, ".html")) {
-               jsonName <- .rs.withChangedExtension(key, ".json")
-               jsonPath <- file.path(rnbData$cache_path, activeChunkId, jsonName)
-               jsonContents <- .rs.fromJSON(.rs.readFile(jsonPath))
-               for (i in seq_along(jsonContents))
-                  class(jsonContents[[i]]) <- "html_dependency"
-               
-               bodyEl <- .rs.extractHTMLBodyElement(val)
-               
-               rendered <- htmltools::htmlPreserve(bodyEl)
-               annotated <- .rs.rnb.htmlAnnotatedOutput(rendered, "htmlwidget", meta = jsonContents)
-               output <- knitr::asis_output(annotated, meta = jsonContents)
-               return(output)
-            }
-            
-            # TODO: shouldn't get here?
-            NULL
-         })
+         # console output
+         if (.rs.endsWith(key, ".csv")) {
+            # TODO
+            browser()
+         }
          
-         list(
-            structure(list(src = NULL), class = "source"),
-            htmlOutput
-         )
-      }
-   )
-   
-   # save to format
-   format$knitr$knit_hooks <- newKnitHooks
-   
-   format
+         # html widgets
+         if (.rs.endsWith(key, ".html")) {
+            
+            # re-construct htmlwidget object using attached json data
+            jsonName <- .rs.withChangedExtension(key, ".json")
+            jsonPath <- file.path(rnbData$cache_path, chunkId, jsonName)
+            jsonContents <- .rs.fromJSON(.rs.readFile(jsonPath))
+            for (i in seq_along(jsonContents))
+               class(jsonContents[[i]]) <- "html_dependency"
+            
+            bodyEl <- .rs.extractHTMLBodyElement(val)
+            
+            widget <- knitr::asis_output(bodyEl)
+            attr(widget, "knit_meta") <- jsonContents
+            return(widget)
+         }
+         
+         return(knitr::asis_output("<!-- unknown-chunk-output -->"))
+      })
+      
+      # return output list
+      outputList
+   }
 })
    
 .rs.addFunction("createNotebookFromCacheData", function(rnbData,
@@ -351,29 +195,17 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
 {
    if (is.null(outputFile))
       outputFile <- .rs.withChangedExtension(inputFile, ext = ".nb.html")
-   
-   # TODO: pass encoding through from front end
-   encoding = getOption("encoding")
 
-   # generate format
-   outputFormat <- rmarkdown::resolve_output_format(inputFile,
-                                                    "html_notebook",
-                                                    encoding = encoding)
+   # TODO: pass encoding from frontend
+   encoding <- "UTF-8"
    
-   # augment hooks
-   outputFormat <- .rs.rnb.cacheAugmentKnitrHooks(rnbData, outputFormat)
-   
-   # override evaluate (so that we can use 'evaluate' knitr hook)
-   # TODO: this code can be removed once knitr hits CRAN
-   evaluate <- .rs.replaceBinding("evaluate", "evaluate", function(...) {
-      knitr::knit_hooks$get("evaluate")(...)
-   })
-   assign(".rs.evaluate", evaluate, envir = .rs.toolsEnv())
-   on.exit(.rs.replaceBinding("evaluate", "evaluate", evaluate), add = TRUE)
+   # implement output_source
+   outputOptions <- list(output_source = .rs.rnb.outputSource(rnbData))
    
    # call render with special format hooks
    rmarkdown::render(input = inputFile,
-                     output_format = outputFormat,
+                     output_format = "html_notebook",
+                     output_options = outputOptions,
                      output_file = outputFile,
                      quiet = TRUE,
                      envir = envir,
@@ -403,96 +235,6 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    csvData
 })
 
-.rs.addFunction("rnb.renderBase64Html", function(path = NULL, bytes = NULL, format)
-{
-   if (is.null(bytes))
-      bytes <- .rs.readFile(path, binary = TRUE)
-   
-   encoded <- .rs.base64encode(bytes)
-   sprintf(format, encoded)
-})
-
-.rs.addFunction("rnb.renderBase64Png", function(path = NULL, bytes = NULL)
-{
-   format <- '<img src="data:image/png;base64,%s" />'
-   .rs.rnb.renderBase64Html(path, bytes, format)
-})
-
-.rs.addFunction("rnb.renderBase64JavaScript", function(path = NULL, bytes = NULL)
-{
-   format <- '<script src="data:application/x-javascript;base64,%s"></script>'
-   .rs.rnb.renderBase64Html(path, bytes, format)
-})
-
-.rs.addFunction("rnb.renderBase64StyleSheet", function(path = NULL, bytes = NULL)
-{
-   format <- '<link href="data:text/css;charset=utf8;base64,%s" />'
-   .rs.rnb.renderBase64Html(path, bytes, format)
-})
-
-.rs.addFunction("rnb.renderCode", function(code, attributes = NULL)
-{
-   # convert attributes list to string
-   attributes <- if (length(attributes))
-      paste(" ", .rs.listToHtmlAttributes(attributes), sep = "")
-   else
-      ""
-   
-   # escape output
-   pasted <- htmltools::htmlEscape(paste(code, collapse = "\n"))
-   
-   # produce html
-   knitr::asis_output(sprintf('<pre%s><code>%s</code></pre>', attributes, pasted))
-})
-
-.rs.addFunction("rnb.consoleDataToHtmlList", function(data)
-{
-   csvData <- .rs.rnb.parseConsoleData(data)
-   cutpoints <- .rs.cutpoints(csvData$type)
-   
-   ranges <- Map(
-      function(start, end) list(start = start, end = end),
-      c(1, cutpoints),
-      c(cutpoints - 1, nrow(csvData))
-   )
-   
-   splat <- lapply(ranges, function(range) {
-      
-      type <- csvData$type[[range$start]]
-      collapse <- if (type == 0) "\n" else ""
-      
-      pasted <- paste(csvData$text[range$start:range$end], collapse = collapse)
-      result <- .rs.trimWhitespace(pasted)
-      if (!nzchar(result))
-         return(NULL)
-      attr(result, ".class") <- if (type == 0) "r"
-      result
-   })
-   
-   filtered <- Filter(Negate(is.null), splat)
-   htmlList <- lapply(filtered, function(el) {
-      class <- attr(el, ".class")
-      result <- if (is.null(class)) {
-         sprintf(
-            "<pre><code>%s</code></pre>",
-            el
-         )
-      } else {
-         sprintf(
-            "<pre class=\"%s\"><code>%s</code></pre>",
-            class,
-            el
-         )
-      }
-      
-      list(input = el,
-           output = result,
-           type = if (is.null(class)) "output" else "input")
-   })
-   
-   htmlList
-})
-
 .rs.addFunction("scrapeHtmlAttributes", function(line)
 {
    reData <- '([[:alnum:]_-]+)[[:space:]]*=[[:space:]]*"(\\\\.|[^"])+"'
@@ -505,20 +247,6 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    rhs <- substring(stripped, equalsIndex + 2, nchar(stripped) - 1)
    names(rhs) <- lhs
    as.list(rhs)
-})
-
-.rs.addFunction("listToHtmlAttributes", function(data)
-{
-   if (!length(data)) return("")
-   
-   # escape if necessary
-   escaped <- unlist(lapply(data, function(el) {
-      htmltools::htmlEscape(as.character(el), attribute = TRUE)
-   }))
-   
-   # produce output
-   quoted <- .rs.surround(escaped, with = "\"")
-   paste(names(data), quoted, sep = "=")
 })
 
 .rs.addFunction("rnb.encode", function(data)
@@ -553,72 +281,6 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
   error = function(e) {})
 
   .rs.scalarListFromList(opts)
-})
-
-# TODO: Consider re-implementing in C++ if processing
-# in R is too slow.
-.rs.addFunction("parseNotebook", function(nbPath)
-{
-   contents <- .rs.readLines(nbPath)
-   
-   reComment  <- "^\\s*<!--\\s*rnb-([^-]+)-(begin|end)\\s*([^\\s-]+)?\\s*-->\\s*$"
-   reDocument <- "^<div id=\"rmd-source-code\">([^<]+)<\\/div>$"
-   
-   rmdContents <- NULL
-   builder <- .rs.listBuilder()
-   
-   for (row in seq_along(contents)) {
-      line <- contents[[row]]
-      
-      # extract document contents
-      matches <- gregexpr(reDocument, line, perl = TRUE)[[1]]
-      if (!identical(c(matches), -1L)) {
-         start <- c(attr(matches, "capture.start"))
-         end   <- start + c(attr(matches, "capture.length")) - 1
-         decoded <- .rs.base64decode(substring(line, start, end))
-         rmdContents <- strsplit(decoded, "\\r?\\n", perl = TRUE)[[1]]
-         next
-      }
-      
-      # extract information from comment
-      matches <- gregexpr(reComment, line, perl = TRUE)[[1]]
-      if (identical(c(matches), -1L))
-         next
-      
-      starts <- c(attr(matches, "capture.start"))
-      ends   <- starts + c(attr(matches, "capture.length")) - 1
-      strings <- substring(line, starts, ends)
-      
-      n <- length(strings)
-      if (n < 2)
-         stop("invalid rnb comment")
-      
-      # decode comment information and update stack
-      data <- list(row = row,
-                   label = strings[[1]],
-                   state = strings[[2]])
-      
-      # add metadata if available
-      if (n >= 3 && nzchar(strings[[3]]))
-         data[["meta"]] <- .rs.rnb.decode(strings[[3]])
-      else
-         data["meta"] <- list(NULL)
-      
-      # append
-      builder$append(data)
-   }
-   
-   annotations <- builder$data()
-   
-   # extract header content
-   headStart <- grep("^\\s*<head>\\s*$", contents, perl = TRUE)[[1]]
-   headEnd   <- grep("^\\s*</head>\\s*$", contents, perl = TRUE)[[1]]
-   
-   list(source = contents,
-        rmd = rmdContents,
-        header = contents[headStart:headEnd],
-        annotations = annotations)
-   
 })
 
 .rs.addFunction("extractRmdChunkInformation", function(rmd)
@@ -662,7 +324,7 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
       dir.create(cachePath, recursive = TRUE)
    
    # parse the notebook file
-   nbData <- .rs.parseNotebook(nbPath)
+   nbData <- rmarkdown::parse_html_notebook(nbPath)
    
    # clear out old cache
    unlink(list.files(cachePath, full.names = TRUE), recursive = TRUE)


### PR DESCRIPTION
NOTE: hold this PR pending some more testing.

This PR implements cache item injection using the `output_source` hook provided by `rmarkdown`. Essentially, a cleaned-up version of the code we were injecting into the `evaluate` hook has now been moved to `output_source`, and we remove a bunch of unneeded code (as that code has been moved to `rmarkdown`.

We should make sure we sync an `rmarkdown` version bump and pin to that before merging this PR.