### PR TITLE
check notebook dependencies on save

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2746,37 +2746,66 @@ public class TextEditingTarget implements
                }
             });
    }
+   
+   void withSavePrerequisites(final Command command)
+   {
+      if (isRmdNotebook())
+         dependencyManager_.withRMarkdown("Using R Notebooks", command);
+      else
+         command.execute();
+   }
 
    @Handler
    void onSaveSourceDoc()
    {
-      saveThenExecute(null, postSaveCommand());
+      withSavePrerequisites(new Command()
+      {
+         @Override
+         public void execute()
+         {
+            saveThenExecute(null, postSaveCommand());
+         }
+      });
    }
 
    @Handler
    void onSaveSourceDocAs()
    {
-      saveNewFile(docUpdateSentinel_.getPath(),
+      withSavePrerequisites(new Command()
+      {
+         @Override
+         public void execute()
+         {
+            saveNewFile(docUpdateSentinel_.getPath(),
                   null,
                   postSaveCommand());
+         }
+      });
    }
 
    @Handler
    void onSaveSourceDocWithEncoding()
    {
-      withChooseEncoding(
-            StringUtil.firstNotNullOrEmpty(new String[] {
-                  docUpdateSentinel_.getEncoding(),
-                  prefs_.defaultEncoding().getValue(),
-                  session_.getSessionInfo().getSystemEncoding()
-            }),
-            new CommandWithArg<String>()
-            {
-               public void execute(String encoding)
-               {
-                  saveThenExecute(encoding, postSaveCommand());
-               }
-            });
+      withSavePrerequisites(new Command()
+      {
+         @Override
+         public void execute()
+         {
+            withChooseEncoding(
+                  StringUtil.firstNotNullOrEmpty(new String[] {
+                        docUpdateSentinel_.getEncoding(),
+                        prefs_.defaultEncoding().getValue(),
+                        session_.getSessionInfo().getSystemEncoding()
+                  }),
+                  new CommandWithArg<String>()
+                  {
+                     public void execute(String encoding)
+                     {
+                        saveThenExecute(encoding, postSaveCommand());
+                     }
+                  });
+         }
+      });
    }
 
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -4809,25 +4809,31 @@ public class TextEditingTarget implements
                                       isRmdNotebook() ? RmdOutput.TYPE_NOTEBOOK:
                                                         RmdOutput.TYPE_STATIC;
       
-      saveThenExecute(null, new Command() {
+      withSavePrerequisites(new Command()
+      {
          @Override
          public void execute()
          {
-            boolean asTempfile = isPackageDocumentationFile();
-            
-            rmarkdownHelper_.renderRMarkdown(
-               docUpdateSentinel_.getPath(),
-               docDisplay_.getCursorPosition().getRow() + 1,
-               null,
-               docUpdateSentinel_.getEncoding(),
-               paramsFile,
-               asTempfile,
-               type,
-               false);
+            saveThenExecute(null, new Command() {
+               @Override
+               public void execute()
+               {
+                  boolean asTempfile = isPackageDocumentationFile();
+
+                  rmarkdownHelper_.renderRMarkdown(
+                        docUpdateSentinel_.getPath(),
+                        docDisplay_.getCursorPosition().getRow() + 1,
+                        null,
+                        docUpdateSentinel_.getEncoding(),
+                        paramsFile,
+                        asTempfile,
+                        type,
+                        false);
+               }
+            });   
          }
-      });  
+      });
    }
-   
    
    public boolean isRmdNotebook()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -275,34 +275,25 @@ public class TextEditingTargetNotebook
    
    public void createNotebookFromCache(final String rmdPath, final String outputPath)
    {
-      Command createNotebookCmd = new Command()
-      {
-         @Override
-         public void execute()
-         {
-            server_.createNotebookFromCache(
-                  rmdPath,
-                  outputPath,
-                  new ServerRequestCallback<Void>()
-                  {
-                     @Override
-                     public void onResponseReceived(Void v)
-                     {
-                        events_.fireEvent(new NotebookRenderFinishedEvent(
-                              docUpdateSentinel_.getId(), 
-                              docUpdateSentinel_.getPath()));
-                     }
+      server_.createNotebookFromCache(
+            rmdPath,
+            outputPath,
+            new ServerRequestCallback<Void>()
+            {
+               @Override
+               public void onResponseReceived(Void v)
+               {
+                  events_.fireEvent(new NotebookRenderFinishedEvent(
+                        docUpdateSentinel_.getId(), 
+                        docUpdateSentinel_.getPath()));
+               }
 
-                     @Override
-                     public void onError(ServerError error)
-                     {
-                        Debug.logError(error);
-                     }
-                  });
-         }
-      };
-      
-      dependencyManager_.withRMarkdown("R Notebook", "Creating R Notebooks", createNotebookCmd);
+               @Override
+               public void onError(ServerError error)
+               {
+                  Debug.logError(error);
+               }
+            });
    }
    
    @Inject


### PR DESCRIPTION
This PR adds some top-level handling for Save that ensures the `rmarkdown` package is available when attempting to save (and subsequently preview) notebook files.