### PR TITLE
warning bar rather than prompt on save for missing rmarkdown

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -16,6 +16,7 @@
 package org.rstudio.studio.client.common.dependencies;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.rstudio.core.client.CommandWith2Args;
 import org.rstudio.core.client.CommandWithArg;
@@ -156,7 +157,7 @@ public class DependencyManager implements InstallShinyEvent.Handler
      );
    }
    
-   private ArrayList<Dependency> rmarkdownDependencies()
+   public static List<Dependency> rmarkdownDependencies()
    {
       ArrayList<Dependency> deps = new ArrayList<Dependency>();
       deps.add(Dependency.cranPackage("evaluate", "0.8"));
@@ -176,9 +177,9 @@ public class DependencyManager implements InstallShinyEvent.Handler
       return deps;
    }
    
-   private Dependency[] rmarkdownDependenciesArray()
+   public static Dependency[] rmarkdownDependenciesArray()
    {
-      ArrayList<Dependency> deps = rmarkdownDependencies();
+      List<Dependency> deps = rmarkdownDependencies();
       return deps.toArray(new Dependency[deps.size()]);
    }
  
@@ -828,6 +829,27 @@ public class DependencyManager implements InstallShinyEvent.Handler
       for (int i = 0; i < dependencies.length(); i++)
          deps.add(dependencies.get(i).getName());
       return StringUtil.join(deps, ", ");
+   }
+   
+   public void withUnsatisfiedDependencies(final Dependency dependency,
+                                           final ServerRequestCallback<JsArray<Dependency>> requestCallback)
+   {
+      List<Dependency> dependencies = new ArrayList<Dependency>();
+      dependencies.add(dependency);
+      withUnsatisfiedDependencies(dependencies, requestCallback);
+   }
+   
+   public void withUnsatisfiedDependencies(final List<Dependency> dependencies,
+                                           final ServerRequestCallback<JsArray<Dependency>> requestCallback)
+   {
+      JsArray<Dependency> jsDependencies = JsArray.createArray(dependencies.size()).cast();
+      for (int i = 0; i < dependencies.size(); i++)
+         jsDependencies.set(i, dependencies.get(i));
+      
+      server_.unsatisfiedDependencies(
+            jsDependencies,
+            false,
+            requestCallback);
    }
    
    private final GlobalDisplay globalDisplay_;


### PR DESCRIPTION
This PR displays a warning bar, rather than a prompt, when saving a Notebook file if the `rmarkdown` package is not present. (This change is made because if a user is editing a Notebook `.Rmd` file without internet access, the repeated on save prompts will be disruptive / annoying; the warning bar is less intrusive)

![screen shot 2016-05-16 at 3 21 22 pm](https://cloud.githubusercontent.com/assets/1976582/15305745/e227e98a-1b79-11e6-9406-26f1adbb1b4c.png)

This state will be quite ephemeral in the general case -- most users will be prompted to install `rmarkdown` through e.g. the new R Markdown dialogs, or by clicking the Preview button, and so on.