### PR TITLE
save html widgets as 'knitr' figures; display as 'viewer' in IDE

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -727,7 +727,7 @@ public class ChunkOutputWidget extends Composite
       final ChunkOutputFrame frame = new ChunkOutputFrame();
       final FixedRatioWidget fixedFrame = new FixedRatioWidget(frame, 
                   ChunkOutputUi.OUTPUT_ASPECT, 
-                  ChunkOutputUi.MAX_PLOT_WIDTH);
+                  ChunkOutputUi.MAX_HTMLWIDGET_WIDTH);
 
       root_.add(fixedFrame);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkOutputUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkOutputUi.java
@@ -225,5 +225,7 @@ public class ChunkOutputUi
    public final static int MAX_CHUNK_HEIGHT = 650;
    
    public final static int MAX_PLOT_WIDTH = 650;
+   public final static int MAX_HTMLWIDGET_WIDTH = 800;
+   
    public final static double OUTPUT_ASPECT = 1.618;
 }


### PR DESCRIPTION
This PR implements a simple `regex_filter` that allows us to save HTML widgets in their 'embedded' representation, while later showing them with their 'standalone' representation when loaded in the IDE.

Just to set the stage, when an HTML widget is saved, it goes through `htmlwidgets:::toHTML(x, standalone)`, where the `standalone` parameter is used to state whether the widget should be shown standalone or not. When called through `knitr::knit_print` (as in `render`), standalone is set to `FALSE`.

The main difference between these two representations is whether their sizing policy is also included in the HTML output: the 'embedded' representation might look like

```html
<div id="htmlwidget-123" class="htmlwidget"></div>
<script type="application/json" data-for="htmlwidget-123">{...}</script>
```

while the 'standalone' representation might look like

```html
<div id="htmlwidget_container">
    <div id="htmlwidget-123" class="htmlwidget"></div>
</div>
<script type="application/json" data-for="htmlwidget-123">{...}</script>
<script type="application/htmlwidget-sizing" data-for="htmlwidget-4214">{<sizing policy data>}</script>
```

Since we can recover the 'embedded' representation from the 'standalone' representation (but not the other way around), we save a modified version of the standalone representation, and use a server-side filter to recover the original standalone representation when displaying in the IDE.

Note that this is not quite finished -- we need to ensure we aren't duplicating the `htmlwidget_container` IDs when generating a preview; likely this needs a separate filter.

As an aside, in a perfect world, it seems like we would _always_ write the same representation for embedded vs. standalone widgets, e.g.

```html
<div id="htmlwidget-123-container">
    <div id="htmlwidget-123" class="htmlwidget"></div>
</div>
<script type="application/json" data-for="htmlwidget-123">{...}</script>
<script type="application/htmlwidget-sizing" data-for="htmlwidget-4214">{<sizing policy data>}</script>
```

and use some global JS flag to denote which sizing policy should be applied (if any).