### PR TITLE
initial work on handling alternate engines

### DIFF
--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -155,6 +155,7 @@ set (SESSION_SOURCE_FILES
    modules/presentation/TutorialInstaller.cpp
    modules/rmarkdown/SessionRMarkdown.cpp
    modules/rmarkdown/SessionRmdNotebook.cpp
+   modules/rmarkdown/SessionExecuteChunkOperation.cpp
    modules/rmarkdown/NotebookCache.cpp
    modules/rmarkdown/NotebookChunkDefs.cpp
    modules/rmarkdown/NotebookErrors.cpp

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
@@ -34,8 +34,6 @@
 
 #include <iostream>
 
-#define kStagingSuffix "_t"
-
 using namespace rstudio::core;
 
 namespace rstudio {

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.hpp
@@ -24,6 +24,8 @@
 
 #include <r/RSexp.hpp>
 
+#define kStagingSuffix "_t"
+
 namespace rstudio {
 namespace core {
    class Error;

--- a/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
@@ -85,20 +85,6 @@ private:
       using namespace core;
       Error error = Success();
       
-      // ensure staging directory
-      FilePath stagingPath = chunkOutputPath(
-               docId_,
-               chunkId_ + kStagingSuffix,
-               ContextExact);
-      
-      error = stagingPath.removeIfExists();
-      if (error)
-         LOG_ERROR(error);
-      
-      error = stagingPath.ensureDirectory();
-      if (error)
-         LOG_ERROR(error);
-      
       // ensure regular directory
       FilePath outputPath = chunkOutputPath(
                docId_,

--- a/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
@@ -225,7 +225,6 @@ private:
    bool terminationRequested_;
    std::string docId_;
    std::string chunkId_;
-   std::vector<boost::signals::connection> connections_;
    ShellCommand command_;
    
 private:

--- a/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
@@ -21,6 +21,7 @@
 #include <boost/shared_ptr.hpp>
 
 #include <core/FileSerializer.hpp>
+#include <core/StringUtils.hpp>
 #include <core/text/CsvParser.hpp>
 #include <core/system/Process.hpp>
 #include <core/system/ShellUtils.hpp>
@@ -45,7 +46,7 @@ core::shell_utils::ShellCommand shellCommandForEngine(
    if (engine == "Rscript")
       command << "-f";
    
-   command << scriptPath;
+   command << core::string_utils::utf8ToSystem(scriptPath.absolutePathNative());
    
    return command;
 }

--- a/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
@@ -60,13 +60,15 @@ class ExecuteChunkOperation : boost::noncopyable,
 public:
    static boost::shared_ptr<ExecuteChunkOperation> create(const std::string& docId,
                                                           const std::string& chunkId,
-                                                          const ShellCommand& command)
+                                                          const ShellCommand& command,
+                                                          const core::FilePath& scriptPath)
    {
       boost::shared_ptr<ExecuteChunkOperation> pProcess =
             boost::shared_ptr<ExecuteChunkOperation>(new ExecuteChunkOperation(
                                                         docId,
                                                         chunkId,
-                                                        command));
+                                                        command,
+                                                        scriptPath));
       pProcess->registerProcess();
       return pProcess;
    }
@@ -75,11 +77,13 @@ private:
    
    ExecuteChunkOperation(const std::string& docId,
                          const std::string& chunkId,
-                         const ShellCommand& command)
+                         const ShellCommand& command,
+                         const core::FilePath& scriptPath)
       : terminationRequested_(false),
         docId_(docId),
         chunkId_(chunkId),
-        command_(command)
+        command_(command),
+        scriptPath_(scriptPath)
    {
       using namespace core;
       Error error = Success();
@@ -153,6 +157,7 @@ private:
    {
       events().onChunkExecCompleted(docId_, chunkId_, notebookCtxId());
       deregisterProcess();
+      scriptPath_.removeIfExists();
    }
    
    void onStdout(const std::string& output)
@@ -208,6 +213,7 @@ private:
    std::string docId_;
    std::string chunkId_;
    ShellCommand command_;
+   core::FilePath scriptPath_;
    
 private:
    
@@ -263,7 +269,7 @@ core::Error runChunk(const std::string& docId,
 
    // create and run process
    boost::shared_ptr<ExecuteChunkOperation> operation =
-         ExecuteChunkOperation::create(docId, chunkId, command);
+         ExecuteChunkOperation::create(docId, chunkId, command, scriptPath);
 
    // generate process options
    core::system::ProcessOptions options;

--- a/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
@@ -113,24 +113,20 @@ public:
       
       callbacks.onStarted = boost::bind(
                &ExecuteChunkOperation::onStarted,
-               shared_from_this(),
-               _1);
+               shared_from_this());
       
       callbacks.onContinue = boost::bind(
                &ExecuteChunkOperation::onContinue,
-               shared_from_this(),
-               _1);
+               shared_from_this());
       
       callbacks.onStdout = boost::bind(
                &ExecuteChunkOperation::onStdout,
                shared_from_this(),
-               _1,
                _2);
       
       callbacks.onStderr = boost::bind(
                &ExecuteChunkOperation::onStderr,
                shared_from_this(),
-               _1,
                _2);
       
       callbacks.onExit = boost::bind(
@@ -145,12 +141,12 @@ private:
    
    enum OutputType { OUTPUT_STDOUT, OUTPUT_STDERR };
    
-   void onStarted(ProcessOperations& operations)
+   void onStarted()
    {
       isRunning_ = true;
    }
    
-   bool onContinue(ProcessOperations& operations)
+   bool onContinue()
    {
       return !terminationRequested_;
    }
@@ -162,12 +158,12 @@ private:
       isRunning_ = false;
    }
    
-   void onStdout(ProcessOperations& operations, const std::string& output)
+   void onStdout(const std::string& output)
    {
       onText(output, OUTPUT_STDOUT);
    }
    
-   void onStderr(ProcessOperations& operations, const std::string& output)
+   void onStderr(const std::string& output)
    {
       onText(output, OUTPUT_STDERR);
    }

--- a/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
@@ -34,6 +34,21 @@ namespace rstudio {
 namespace session {
 namespace modules {
 namespace rmarkdown {
+namespace notebook {
+
+core::shell_utils::ShellCommand shellCommandForEngine(
+      const std::string& engine,
+      const core::FilePath& scriptPath)
+{
+   core::shell_utils::ShellCommand command(engine);
+   
+   if (engine == "Rscript")
+      command << "-f";
+   
+   command << scriptPath;
+   
+   return command;
+}
 
 class ExecuteChunkOperation : boost::noncopyable,
                               public boost::enable_shared_from_this<ExecuteChunkOperation>
@@ -68,10 +83,10 @@ private:
       Error error = Success();
       
       // ensure staging directory
-      FilePath stagingPath = notebook::chunkOutputPath(
+      FilePath stagingPath = chunkOutputPath(
                docId_,
                chunkId_ + kStagingSuffix,
-               notebook::ContextExact);
+               ContextExact);
       
       error = stagingPath.removeIfExists();
       if (error)
@@ -82,10 +97,10 @@ private:
          LOG_ERROR(error);
       
       // ensure regular directory
-      FilePath outputPath = notebook::chunkOutputPath(
+      FilePath outputPath = chunkOutputPath(
                docId_,
                chunkId_,
-               notebook::ContextExact);
+               ContextExact);
       
       error = outputPath.removeIfExists();
       if (error)
@@ -96,7 +111,7 @@ private:
          LOG_ERROR(error);
       
       // clean old chunk output
-      error = notebook::cleanChunkOutput(docId_, chunkId_, true);
+      error = cleanChunkOutput(docId_, chunkId_, true);
       if (error)
          LOG_ERROR(error);
    }
@@ -153,7 +168,7 @@ private:
    
    void onExit(int exitStatus)
    {
-      notebook::events().onChunkExecCompleted(docId_, chunkId_, notebook::notebookCtxId());
+      events().onChunkExecCompleted(docId_, chunkId_, notebookCtxId());
       isRunning_ = false;
    }
    
@@ -172,7 +187,7 @@ private:
       using namespace core;
       
       // get path to cache file
-      FilePath target = notebook::chunkOutputFile(docId_, chunkId_, kChunkOutputText);
+      FilePath target = chunkOutputFile(docId_, chunkId_, kChunkOutputText);
       
       // generate CSV to write
       std::vector<std::string> values;
@@ -186,10 +201,10 @@ private:
          LOG_ERROR(error);
       
       // emit client event
-      notebook::enqueueChunkOutput(
+      enqueueChunkOutput(
                docId_,
                chunkId_,
-               notebook::notebookCtxId(),
+               notebookCtxId(),
                kChunkOutputText,
                target);
    }
@@ -214,6 +229,7 @@ private:
    ShellCommand command_;
 };
 
+} // end namespace notebook
 } // end namespace rmarkdown
 } // end namespace modules
 } // end namespace session

--- a/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
@@ -1,0 +1,185 @@
+/*
+ * SessionExecuteChunkOperation.hpp
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+#ifndef SESSION_MODULES_RMARKDOWN_SESSION_EXECUTE_CHUNK_OPERATIONR_HPP
+#define SESSION_MODULES_RMARKDOWN_SESSION_EXECUTE_CHUNK_OPERATIONR_HPP
+
+#include <boost/bind.hpp>
+#include <boost/enable_shared_from_this.hpp>
+#include <boost/noncopyable.hpp>
+#include <boost/shared_ptr.hpp>
+
+#include <core/system/Process.hpp>
+#include <core/system/ShellUtils.hpp>
+#include <core/system/System.hpp>
+
+#include "NotebookOutput.hpp"
+#include "NotebookExec.hpp"
+#include "SessionRmdNotebook.hpp"
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace rmarkdown {
+
+class ExecuteChunkOperation : boost::noncopyable,
+                              public boost::enable_shared_from_this<ExecuteChunkOperation>
+{
+   typedef core::shell_utils::ShellCommand ShellCommand;
+   typedef core::system::ProcessCallbacks ProcessCallbacks;
+   typedef core::system::ProcessOperations ProcessOperations;
+   
+public:
+   static boost::shared_ptr<ExecuteChunkOperation> create(const std::string& docId,
+                                                          const std::string& chunkId,
+                                                          const ShellCommand& command)
+   {
+      return boost::shared_ptr<ExecuteChunkOperation>(new ExecuteChunkOperation(
+                                                         docId,
+                                                         chunkId,
+                                                         command));
+   }
+   
+private:
+   
+   ExecuteChunkOperation(const std::string& docId,
+                         const std::string& chunkId,
+                         const ShellCommand& command)
+      : isRunning_(false),
+        terminationRequested_(false),
+        docId_(docId),
+        chunkId_(chunkId),
+        command_(command)
+   {
+   }
+   
+public:
+   
+   ProcessCallbacks processCallbacks()
+   {
+      ProcessCallbacks callbacks;
+      
+      callbacks.onStarted = boost::bind(
+               &ExecuteChunkOperation::onStarted,
+               shared_from_this(),
+               _1);
+      
+      callbacks.onContinue = boost::bind(
+               &ExecuteChunkOperation::onContinue,
+               shared_from_this(),
+               _1);
+      
+      callbacks.onStdout = boost::bind(
+               &ExecuteChunkOperation::onStdout,
+               shared_from_this(),
+               _1,
+               _2);
+      
+      callbacks.onStderr = boost::bind(
+               &ExecuteChunkOperation::onStderr,
+               shared_from_this(),
+               _1,
+               _2);
+      
+      callbacks.onExit = boost::bind(
+               &ExecuteChunkOperation::onExit,
+               shared_from_this(),
+               _1);
+      
+      return callbacks;
+   }
+   
+private:
+   
+   void onStarted(ProcessOperations& operations)
+   {
+      using namespace core;
+      Error error = Success();
+      
+      // ensure staging directory
+      FilePath stagingPath = notebook::chunkOutputPath(
+               docId_,
+               chunkId_ + kStagingSuffix,
+               notebook::ContextExact);
+      
+      error = stagingPath.ensureDirectory();
+      if (error)
+         LOG_ERROR(error);
+      
+      // ensure regular directory
+      FilePath outputPath = notebook::chunkOutputPath(
+               docId_,
+               chunkId_,
+               notebook::ContextExact);
+      
+      error = outputPath.ensureDirectory();
+      if (error)
+         LOG_ERROR(error);
+      
+      // clean old chunk output
+      error = notebook::cleanChunkOutput(docId_, chunkId_, true);
+      if (error)
+         LOG_ERROR(error);
+      
+      isRunning_ = true;
+   }
+   
+   bool onContinue(ProcessOperations& operations)
+   {
+      return !terminationRequested_;
+   }
+   
+   void onExit(int exitStatus)
+   {
+      isRunning_ = false;
+   }
+   
+   void onStdout(ProcessOperations& operations, const std::string& output)
+   {
+      core::FilePath target = notebook::chunkOutputFile(docId_, chunkId_, notebook::ContextExact);
+      notebook::enqueueChunkOutput(docId_, chunkId_, notebook::notebookCtxId(), kChunkOutputText, target);
+   }
+   
+   void onStderr(ProcessOperations& operations, const std::string& output)
+   {
+      core::FilePath target = notebook::chunkOutputFile(docId_, chunkId_, notebook::ContextExact);
+      notebook::enqueueChunkOutput(docId_, chunkId_, notebook::notebookCtxId(), kChunkOutputError, target);
+   }
+   
+   void terminate()
+   {
+      terminationRequested_ = true;
+   }
+   
+public:
+   
+   bool isRunning() const { return isRunning_; }
+   bool terminationRequested() const { return terminationRequested_; }
+   const std::string& chunkId() const { return chunkId_; }
+   
+private:
+   bool isRunning_;
+   bool terminationRequested_;
+   std::string docId_;
+   std::string chunkId_;
+   std::vector<boost::signals::connection> connections_;
+   ShellCommand command_;
+};
+
+} // end namespace rmarkdown
+} // end namespace modules
+} // end namespace session
+} // end namespace rstudio
+
+#endif /* SESSION_MODULES_RMARKDOWN_SESSION_EXECUTE_CHUNK_OPERATIONR_HPP */

--- a/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
@@ -284,11 +284,15 @@ core::Error runChunk(const std::string& docId,
    boost::shared_ptr<ExecuteChunkOperation> operation =
          ExecuteChunkOperation::create(docId, chunkId, command);
 
+   // generate process options
    core::system::ProcessOptions options;
-   core::system::ProcessCallbacks callbacks = operation->processCallbacks();
-   error = module_context::processSupervisor().runCommand(command,
-                                                          options,
-                                                          callbacks);
+   options.terminateChildren = true;
+   
+   error = module_context::processSupervisor().runCommand(
+            command,
+            options,
+            operation->processCallbacks());
+   
    if (error)
       LOG_ERROR(error);
    

--- a/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
@@ -76,8 +76,7 @@ private:
    ExecuteChunkOperation(const std::string& docId,
                          const std::string& chunkId,
                          const ShellCommand& command)
-      : isRunning_(false),
-        terminationRequested_(false),
+      : terminationRequested_(false),
         docId_(docId),
         chunkId_(chunkId),
         command_(command)
@@ -143,7 +142,6 @@ private:
    
    void onStarted()
    {
-      isRunning_ = true;
    }
    
    bool onContinue()
@@ -155,7 +153,6 @@ private:
    {
       events().onChunkExecCompleted(docId_, chunkId_, notebookCtxId());
       deregisterProcess();
-      isRunning_ = false;
    }
    
    void onStdout(const std::string& output)
@@ -177,7 +174,9 @@ private:
       
       // generate CSV to write
       std::vector<std::string> values;
-      values.push_back(outputType == OUTPUT_STDOUT ? "1" : "2");
+      values.push_back(outputType == OUTPUT_STDOUT
+               ? safe_convert::numberToString(kChunkConsoleOutput)
+               : safe_convert::numberToString(kChunkConsoleError));
       values.push_back(output);
       std::string encoded = text::encodeCsvLine(values) + "\n";
       
@@ -197,13 +196,11 @@ private:
    
 public:
    
-   bool isRunning() const { return isRunning_; }
    void terminate() { terminationRequested_ = true; }
    bool terminationRequested() const { return terminationRequested_; }
    const std::string& chunkId() const { return chunkId_; }
    
 private:
-   bool isRunning_;
    bool terminationRequested_;
    std::string docId_;
    std::string chunkId_;

--- a/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
@@ -183,7 +183,10 @@ private:
       // write to cache
       Error error = writeStringToFile(target, encoded);
       if (error)
+      {
          LOG_ERROR(error);
+         return;
+      }
       
       // emit client event
       enqueueChunkOutput(

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -1334,38 +1334,7 @@ Error executeAlternateEngineChunk(const json::JsonRpcRequest& request,
    if (engine == "Rcpp")
       return executeRcppEngineChunk(docId, chunkId, code, pResponse);
    
-   using namespace notebook;
-   typedef core::shell_utils::ShellCommand ShellCommand;
-   
-   // write code to temporary file
-   FilePath scriptPath = module_context::tempFile("chunk-code", "");
-   error = core::writeStringToFile(scriptPath, code);
-   if (error)
-   {
-      LOG_ERROR(error);
-      return error;
-   }
-   
-   // get command
-   ShellCommand command = notebook::shellCommandForEngine(engine, scriptPath);
-
-   // create and run process
-   boost::shared_ptr<ExecuteChunkOperation> operation =
-         ExecuteChunkOperation::create(docId, chunkId, command);
-
-   // create process options
-   core::system::ProcessOptions options;
-
-   // create process callbacks
-   core::system::ProcessCallbacks callbacks = operation->processCallbacks();
-
-   error = module_context::processSupervisor().runCommand(command,
-                                                          options,
-                                                          callbacks);
-   if (error)
-      LOG_ERROR(error);
-
-   pResponse->setResult(true);
+   notebook::runChunk(docId, chunkId, engine, code);
    return Success();
 }
 

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -1315,6 +1315,15 @@ Error executeRcppEngineChunk(const std::string& docId,
    return Success();
 }
 
+Error executeStanEngineChunk(const std::string& docId,
+                             const std::string& chunkId,
+                             const std::string& code,
+                             json::JsonRpcResponse* pResponse)
+{
+   // TODO:
+   return Success();
+}
+
 Error executeAlternateEngineChunk(const json::JsonRpcRequest& request,
                                   json::JsonRpcResponse* pResponse)
 {
@@ -1333,6 +1342,8 @@ Error executeAlternateEngineChunk(const json::JsonRpcRequest& request,
    // handle Rcpp specially
    if (engine == "Rcpp")
       return executeRcppEngineChunk(docId, chunkId, code, pResponse);
+   else if (engine == "stan")
+      return executeStanEngineChunk(docId, chunkId, code, pResponse);
    
    notebook::runChunk(docId, chunkId, engine, code);
    return Success();

--- a/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
@@ -22,6 +22,9 @@ define("mode/rmarkdown_highlight_rules", ["require", "exports", "module"], funct
 var oop = require("ace/lib/oop");
 var RHighlightRules = require("mode/r_highlight_rules").RHighlightRules;
 var c_cppHighlightRules = require("mode/c_cpp_highlight_rules").c_cppHighlightRules;
+var PerlHighlightRules = require("ace/mode/perl_highlight_rules").PerlHighlightRules;
+var PythonHighlightRules = require("ace/mode/python_highlight_rules").PythonHighlightRules;
+var RubyHighlightRules = require("ace/mode/ruby_highlight_rules").RubyHighlightRules;
 var MarkdownHighlightRules = require("mode/markdown_highlight_rules").MarkdownHighlightRules;
 var TextHighlightRules = require("ace/mode/text_highlight_rules").TextHighlightRules;
 var YamlHighlightRules = require("ace/mode/yaml_highlight_rules").YamlHighlightRules;
@@ -59,6 +62,36 @@ var RMarkdownHighlightRules = function() {
       c_cppHighlightRules,
       "r-cpp",
       this.$reCppChunkStartString,
+      this.$reChunkEndString,
+      ["start", "listblock", "allowBlock"]
+   );
+
+   // Embed perl highlight rules
+   Utils.embedRules(
+      this,
+      PerlHighlightRules,
+      "perl",
+      this.$rePerlChunkStartString,
+      this.$reChunkEndString,
+      ["start", "listblock", "allowBlock"]
+   );
+
+   // Embed python highlight rules
+   Utils.embedRules(
+      this,
+      PythonHighlightRules,
+      "python",
+      this.$rePythonChunkStartString,
+      this.$reChunkEndString,
+      ["start", "listblock", "allowBlock"]
+   );
+
+   // Embed ruby highlight rules
+   Utils.embedRules(
+      this,
+      RubyHighlightRules,
+      "ruby",
+      this.$reRubyChunkStartString,
       this.$reChunkEndString,
       ["start", "listblock", "allowBlock"]
    );
@@ -115,6 +148,15 @@ oop.inherits(RMarkdownHighlightRules, TextHighlightRules);
 
    this.$reMarkdownChunkStartString =
       "^(?:[ ]{4})?`{3,}\\s*\\{\\s*block(?:.*)\\}\\s*$";
+
+   this.$rePerlChunkStartString =
+      "^(?:[ ]{4})?`{3,}\\s*\\{perl\\b(?:.*)\\}\\s*$";
+
+   this.$rePythonChunkStartString =
+      "^(?:[ ]{4})?`{3,}\\s*\\{python\\b(?:.*)\\}\\s*$";
+
+   this.$reRubyChunkStartString =
+      "^(?:[ ]{4})?`{3,}\\s*\\{ruby\\b(?:.*)\\}\\s*$";
 
    this.$reChunkEndString =
       "^(?:[ ]{4})?`{3,}\\s*$";

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RMarkdownServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RMarkdownServerOperations.java
@@ -83,4 +83,10 @@ public interface RMarkdownServerOperations extends CryptoServerOperations
    
    void replayNotebookPlots(String docId, String initialChunkId, int pixelWidth, 
          ServerRequestCallback<Boolean> requestCallback);
+   
+   void executeAlternateEngineChunk(String docId,
+                                    String chunkId,
+                                    String engine,
+                                    String code,
+                                    ServerRequestCallback<String> requestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4255,6 +4255,21 @@ public class RemoteServer implements Server
       params.set(2, new JSONNumber(pixelWidth));
       sendRequest(RPC_SCOPE, "replay_notebook_plots", params, requestCallback);
    }
+   
+   @Override
+   public void executeAlternateEngineChunk(String docId,
+                                           String chunkId,
+                                           String engine,
+                                           String code,
+                                           ServerRequestCallback<String> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(docId));
+      params.set(1, new JSONString(chunkId));
+      params.set(2, new JSONString(engine));
+      params.set(3, new JSONString(code));
+      sendRequest(RPC_SCOPE, "execute_alternate_engine_chunk", params, requestCallback);
+   }
 
    @Override
    public void getRmdOutputInfo(String input,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetChunks.java
@@ -205,22 +205,14 @@ public class TextEditingTargetChunks
       }
    }
    
-   private String extractChunkHeaderContents(String line)
-   {
-      int startIdx = line.indexOf('{') + 1;
-      int endIdx = line.lastIndexOf('}');
-      return line.substring(startIdx, endIdx);
-   }
-   
    private boolean isRunnableChunk(int row)
    {
       // extract chunk header
       String header = target_.getDocDisplay().getLine(row);
-      String inner = extractChunkHeaderContents(header);
       
       // parse contents
       Map<String, String> options = new HashMap<String, String>();
-      TextEditingTargetNotebook.parseChunkOptions(inner, options);
+      TextEditingTargetNotebook.parseChunkOptions(header, options);
       
       // check runnable engine
       String engine = options.containsKey("engine")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetChunks.java
@@ -15,15 +15,16 @@
 package org.rstudio.studio.client.workbench.views.source.editors.text;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
-import org.rstudio.core.client.regex.Match;
-import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.LineWidget;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorModeChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.ScopeTreeReadyEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkContextUi;
+import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.TextEditingTargetNotebook;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
 
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
@@ -204,41 +205,34 @@ public class TextEditingTargetChunks
       }
    }
    
+   private String extractChunkHeaderContents(String line)
+   {
+      int startIdx = line.indexOf('{') + 1;
+      int endIdx = line.lastIndexOf('}');
+      return line.substring(startIdx, endIdx);
+   }
+   
    private boolean isRunnableChunk(int row)
    {
-      String text = target_.getDocDisplay().getLine(row);
+      // extract chunk header
+      String header = target_.getDocDisplay().getLine(row);
+      String inner = extractChunkHeaderContents(header);
       
-      // Check for R Markdown chunks, and verify that the engine is 'r' or 'rscript'.
-      // First, check for chunk headers of the form:
-      //
-      //     ```{r ...}
-      //
-      // as opposed to
-      //
-      //     ```{sh ...}
-      String lower = text.toLowerCase().trim();
-      if (lower.startsWith("```{"))
-      {
-         Pattern reREngine = Pattern.create("```{r(?:script)?[ ,}]", "");
-         if (!reREngine.test(lower))
-            return false;
-      }
+      // parse contents
+      Map<String, String> options = new HashMap<String, String>();
+      TextEditingTargetNotebook.parseChunkOptions(inner, options);
       
-      // If this is an 'R' chunk, it's possible that an alternate engine
-      // has been specified, e.g.
-      //
-      //     ```{r, engine = 'awk'}
-      //
-      // which is the 'old-fashioned' way of specifying non-R chunks.
-      Pattern pattern = Pattern.create("engine\\s*=\\s*['\"]([^'\"]*)['\"]", "");
-      Match match = pattern.match(text, 0);
-      
-      if (match == null)
-         return true;
-      
-      String engine = match.getGroup(1).toLowerCase();
-      
-      return engine.equals("r") || engine.equals("rscript");
+      // check runnable engine
+      String engine = options.containsKey("engine")
+            ? options.get("engine")
+            : "r";
+            
+      return isExecutableKnitrEngine(engine);
+   }
+   
+   private boolean isExecutableKnitrEngine(String engine)
+   {
+      return RE_RUNNABLE_ENGINES.indexOf(engine + "|") != -1;
    }
    
    private final TextEditingTarget target_;
@@ -249,6 +243,9 @@ public class TextEditingTargetChunks
    private AceThemes themes_;
 
    private int lastRow_;
+   
+   // runnable engines within the R Notebook mode
+   private static final String RE_RUNNABLE_ENGINES = "r|Rscript|Rcpp|python|ruby|perl|";
    
    // renderPass_ need only be unique from one pass through the scope tree to
    // the next; we wrap it at 255 to avoid the possibility of overflow

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetChunks.java
@@ -224,6 +224,10 @@ public class TextEditingTargetChunks
    
    private boolean isExecutableKnitrEngine(String engine)
    {
+      // TODO: only enable non-R engine work for notebooks for now
+      if (!target_.getDocDisplay().showChunkOutputInline())
+         return engine.equals("r");
+      
       return RE_RUNNABLE_ENGINES.indexOf(engine + "|") != -1;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -1350,7 +1350,6 @@ public class TextEditingTargetNotebook
                @Override
                public void onResponseReceived(String response)
                {
-                  cleanCurrentExecChunk();
                   processChunkExecQueue();
                }
 
@@ -1358,7 +1357,6 @@ public class TextEditingTargetNotebook
                public void onError(ServerError error)
                {
                   Debug.logError(error);
-                  cleanCurrentExecChunk();
                   processChunkExecQueue();
                }
             });
@@ -1368,8 +1366,8 @@ public class TextEditingTargetNotebook
    //
    //    r label, foo=1, bar=2
    //
-   private static void parseChunkOptions(String line,
-                                         Map<String, String> chunkOptions)
+   public static void parseChunkOptions(String line,
+                                        Map<String, String> chunkOptions)
    {
       TextCursor cursor = new TextCursor(line);
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -1362,13 +1362,14 @@ public class TextEditingTargetNotebook
             });
    }
    
-   // Parse a chunk header (without the delimiting braces), e.g.
-   //
-   //    r label, foo=1, bar=2
-   //
    public static void parseChunkOptions(String line,
                                         Map<String, String> chunkOptions)
    {
+      // strip '```{' and '}' if necessary
+      line = line.trim();
+      if (line.startsWith("```{") && line.endsWith("}"))
+         line = line.substring(4, line.length() - 1);
+      
       TextCursor cursor = new TextCursor(line);
       
       // parse preamble


### PR DESCRIPTION
NOTE: not yet ready for merge.

This PR represents the initial work re: handling execution of chunks with alternate engines; typically this will involve farming the work off to a separate process (e.g. executing `python` on a script asynchronously).

@jmcphers, I think I'll need your help on this as I'm not exactly sure what handlers (if any) are needed to ensure chunk output goes to the right place.

---

### TODO
- [ ] Properly connect output, error to chunk + cache folders.
- [ ] Implement for most common engines. (`python`, `ruby`, ...)
- [ ] Separate (synchronous) pathway for `cpp` (`Rcpp::sourceCpp('...')`)
- [ ] Wire up 'stop' button behavior.