### PR TITLE
Make Rmd format switching additive; don't show notebook unless present

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdFrontMatter.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdFrontMatter.java
@@ -106,14 +106,28 @@ public class RmdFrontMatter extends JavaScriptObject
      if (typeof this.output === "undefined")
         this.output = {};
         
+     // default format options
      if (Object.getOwnPropertyNames(options).length === 0)
      {
-        if (typeof this.output === "undefined" ||
-            typeof this.output === "string" ||
-            Object.getOwnPropertyNames(this.output).length === 0)
-           this.output = format;
-        else
-           this.output[format] = "default"
+        if (typeof this.output === "string")
+        {
+           // already have a default output format -- convert to list
+           var prevFormat = this.output;
+           this.output = {};
+           this.output[prevFormat] = "default";
+        }
+        if (typeof this.output === "object") 
+        {
+           if (Object.getOwnPropertyNames(this.output).length === 0)
+           {
+              // no existing output format, use this one with defaults
+              this.output = format;
+           }
+           else
+           {
+              this.output[format] = "default";
+           }
+        }
      }
      else
      {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3593,10 +3593,9 @@ public class TextEditingTarget implements
             JsArray<RmdTemplateFormat> formats = selTemplate.template.getFormats();
             for (int i = 0; i < formats.length(); i++)
             {
-               // hide notebook if not enabled
+               // skip notebook format (will enable it later if discovered)
                if (formats.get(i).getName() == 
-                     RmdOutputFormat.OUTPUT_HTML_NOTEBOOK &&
-                   !prefs_.enableRNotebooks().getValue())
+                     RmdOutputFormat.OUTPUT_HTML_NOTEBOOK)
                {
                   continue;
                }
@@ -3618,8 +3617,15 @@ public class TextEditingTarget implements
          for (int i = 0; i < outputFormats.size(); i++)
          {
             String format = outputFormats.get(i);
-            if (format == RmdOutputFormat.OUTPUT_HTML_NOTEBOOK && i == 0)
-               isNotebook = true;
+            if (format == RmdOutputFormat.OUTPUT_HTML_NOTEBOOK)
+            {
+               if (i == 0)
+                  isNotebook = true;
+               formatList.add(0, "Notebook");
+               valueList.add(0, format);
+               extensionList.add(0, ".nb.html");
+               continue;
+            }
             if (!valueList.contains(format))
             {
                String uiName = format;


### PR DESCRIPTION
Two changes here:

1. Don't show "Preview Notebook" in the format switcher unless it's present in the output list.
2. When using the format switcher, always add the new format to the list.