### PR TITLE
implement 'stan' chunk execution

### DIFF
--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -673,6 +673,12 @@ Error extract(SEXP valueSEXP, std::map< std::string, std::set<std::string> >* pM
    
    return Success();
 }
+
+SEXP create(SEXP valueSEXP, Protect* pProtect)
+{
+   pProtect->add(valueSEXP);
+   return valueSEXP;
+}
    
 SEXP create(const json::Value& value, Protect* pProtect)
 {

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -123,6 +123,7 @@ core::Error extract(SEXP valueSEXP, std::set<std::string>* pSet);
 core::Error extract(SEXP valueSEXP, std::map< std::string, std::set<std::string> >* pMap);
       
 // create SEXP from c++ type
+SEXP create(SEXP valueSEXP, Protect* pProtect);
 SEXP create(const core::json::Value& value, Protect* pProtect);
 SEXP create(const char* value, Protect* pProtect);
 SEXP create(const std::string& value, Protect* pProtect);

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -1343,9 +1343,9 @@ private:
    std::string chunkId_;
 };
 
-void sourceCppConsoleOutputHandler(module_context::ConsoleOutputType type,
-                                   const std::string& output,
-                                   FilePath targetPath)
+void chunkConsoleOutputHandler(module_context::ConsoleOutputType type,
+                               const std::string& output,
+                               const FilePath& targetPath)
 {
    using namespace module_context;
    
@@ -1357,43 +1357,61 @@ void sourceCppConsoleOutputHandler(module_context::ConsoleOutputType type,
       LOG_ERROR(error);
 }
 
+Error prepareCacheConsoleOutputFile(const std::string& docId,
+                                    const std::string& chunkId,
+                                    const std::string& nbCtxId,
+                                    FilePath* pChunkOutputFile)
+{
+   // forward declare error
+   Error error;
+   
+   // prepare chunk directory
+   FilePath cachePath = notebook::chunkOutputPath(
+            docId,
+            chunkId,
+            notebook::ContextExact);
+   
+   error = cachePath.removeIfExists();
+   if (error)
+      return error;
+   
+   error = cachePath.ensureDirectory();
+   if (error)
+      return error;
+   
+   // prepare cache console output file
+   *pChunkOutputFile =
+         notebook::chunkOutputFile(docId, chunkId, nbCtxId, kChunkOutputText);
+   
+   return Success();
+}
+
 Error executeRcppEngineChunk(const std::string& docId,
                              const std::string& chunkId,
                              const std::string& nbCtxId,
                              const std::string& code,
+                             const std::map<std::string, std::string>& options,
                              json::JsonRpcResponse* pResponse)
 {
    // forward declare error
-   Error error = Success();
+   Error error;
    
    // always ensure we emit a 'execution complete' event on exit
    ChunkExecCompletedScope execScope(docId, chunkId);
    
-   // prepare chunk directory
-   FilePath outputPath = notebook::chunkOutputPath(
-            docId,
-            chunkId,
-            notebook::ContextExact);
-
-   error = outputPath.removeIfExists();
+   // prepare cache output file (use tempfile on failure)
+   FilePath targetPath = module_context::tempFile("rcpp-cache", "");
+   error = prepareCacheConsoleOutputFile(docId, chunkId, nbCtxId, &targetPath);
    if (error)
       LOG_ERROR(error);
-
-   error = outputPath.ensureDirectory();
-   if (error)
-      LOG_ERROR(error);
-   
-   // prepare to write chunk cache output
-   FilePath target = notebook::chunkOutputFile(docId, chunkId, nbCtxId, 
-         kChunkOutputText);
    
    // capture console output, error
    boost::signals::scoped_connection consoleHandler =
          module_context::events().onConsoleOutput.connect(
-            boost::bind(sourceCppConsoleOutputHandler,
+            boost::bind(chunkConsoleOutputHandler,
                         _1,
                         _2,
-                        target));
+                        targetPath));
 
    // call Rcpp::sourceCpp on code
    std::string escaped = boost::regex_replace(
@@ -1408,7 +1426,7 @@ Error executeRcppEngineChunk(const std::string& docId,
    error = notebook::appendConsoleOutput(
             kChunkConsoleInput,
             code,
-            target);
+            targetPath);
    if (error)
       LOG_ERROR(error);
    
@@ -1417,9 +1435,9 @@ Error executeRcppEngineChunk(const std::string& docId,
    error = r::exec::executeString(execCode);
    if (error)
    {
-      sourceCppConsoleOutputHandler(module_context::ConsoleOutputError,
-                                    r::endUserErrorMessage(error),
-                                    target);
+      chunkConsoleOutputHandler(module_context::ConsoleOutputError,
+                                r::endUserErrorMessage(error),
+                                targetPath);
    }
 
    // forward success / failure to chunk
@@ -1428,18 +1446,180 @@ Error executeRcppEngineChunk(const std::string& docId,
             chunkId,
             nbCtxId,
             kChunkOutputText,
-            target);
+            targetPath);
    
    return error;
 }
+
+void reportChunkExecutionError(const std::string& docId,
+                               const std::string& chunkId,
+                               const std::string& nbCtxId,
+                               const std::string& message,
+                               const FilePath& targetPath)
+{
+   // emit chunk error
+   chunkConsoleOutputHandler(
+            module_context::ConsoleOutputError,
+            message,
+            targetPath);
+   
+   // forward failure to chunk
+   notebook::enqueueChunkOutput(
+            docId,
+            chunkId,
+            nbCtxId,
+            kChunkOutputText,
+            targetPath);
+}
+
+void reportStanExecutionError(const std::string& docId,
+                              const std::string& chunkId,
+                              const std::string& nbCtxId,
+                              const FilePath& targetPath)
+{
+   std::string message =
+         "engine.opts$x must be a character string providing a "
+         "name for the returned `stanmodel` object";
+   reportChunkExecutionError(docId, chunkId, nbCtxId, message, targetPath);
+}
+
 
 Error executeStanEngineChunk(const std::string& docId,
                              const std::string& chunkId,
                              const std::string& nbCtxId,
                              const std::string& code,
+                             const std::map<std::string, std::string>& options,
                              json::JsonRpcResponse* pResponse)
 {
-   // TODO:
+   // forward-declare error
+   Error error;
+   
+   // ensure we always emit an execution complete event on exit
+   ChunkExecCompletedScope execScope(docId, chunkId);
+   
+   // prepare console output file -- use tempfile on failure
+   FilePath targetPath = module_context::tempFile("stan-cache-", "");
+   error = prepareCacheConsoleOutputFile(docId, chunkId, nbCtxId, &targetPath);
+   if (error)
+      LOG_ERROR(error);
+   
+   // capture console output, error
+   boost::signals::scoped_connection consoleHandler =
+         module_context::events().onConsoleOutput.connect(
+            boost::bind(chunkConsoleOutputHandler,
+                        _1,
+                        _2,
+                        targetPath)); 
+   
+   // write code to file
+   FilePath tempFile = module_context::tempFile("stan-", ".stan");
+   error = writeStringToFile(tempFile, code);
+   if (error)
+   {
+      reportChunkExecutionError(
+               docId,
+               chunkId,
+               nbCtxId,
+               r::endUserErrorMessage(error),
+               targetPath);
+      LOG_ERROR(error);
+      return Success();
+   }
+   RemoveOnExitScope removeOnExitScope(tempFile, ERROR_LOCATION);
+   
+   // ensure existence of 'engine.opts' with 'x' parameter
+   if (!options.count("engine.opts"))
+   {
+      reportStanExecutionError(docId, chunkId, nbCtxId, targetPath);
+      return Success();
+   }
+   
+   // evaluate engine options (so we can pass them through to stan call)
+   r::sexp::Protect protect;
+   SEXP engineOptsSEXP = R_NilValue;
+   error = r::exec::evaluateString(
+            options.at("engine.opts"),
+            &engineOptsSEXP,
+            &protect);
+   
+   if (error)
+   {
+      reportStanExecutionError(docId, chunkId, nbCtxId, targetPath);
+      return Success();
+   }
+   
+   // construct call to 'stan_model'
+   r::exec::RFunction fStanEngine("rstan:::stan_model");
+   std::vector<std::string> engineOptsNames;
+   error = r::sexp::getNames(engineOptsSEXP, &engineOptsNames);
+   if (error)
+   {
+      reportStanExecutionError(docId, chunkId, nbCtxId, targetPath);
+      return Success();
+   }
+   
+   // build parameters
+   std::string modelName;
+   for (std::size_t i = 0, n = r::sexp::length(engineOptsSEXP); i < n; ++i)
+   {
+      // skip 'x' engine option (this is the variable we wish to assign to
+      // after evaluating the stan model)
+      if (engineOptsNames[i] == "x")
+      {
+         modelName = r::sexp::asString(VECTOR_ELT(engineOptsSEXP, i));
+         continue;
+      }
+      
+      fStanEngine.addParam(
+               engineOptsNames[i],
+               VECTOR_ELT(engineOptsSEXP, i));
+   }
+   
+   // if no model name was set, return error message
+   if (modelName.empty())
+   {
+      reportStanExecutionError(docId, chunkId, nbCtxId, targetPath);
+      return Success();
+   }
+   
+   // if the 'file' option was not set, set it explicitly
+   if (!core::algorithm::contains(engineOptsNames, "file"))
+      fStanEngine.addParam("file", tempFile.absolutePath());
+   
+   // evaluate stan_model call
+   SEXP stanModelSEXP = R_NilValue;
+   error = fStanEngine.call(&stanModelSEXP, &protect);
+   if (error)
+   {
+      std::string msg = r::endUserErrorMessage(error);
+      reportChunkExecutionError(docId, chunkId, nbCtxId, msg, targetPath);
+      return Success();
+   }
+   
+   // assign in global env on success
+   if (stanModelSEXP != R_NilValue)
+   {
+      r::exec::RFunction assign("base:::assign");
+      assign.addParam("x", modelName);
+      assign.addParam("value", stanModelSEXP);
+      error = assign.call();
+      if (error)
+      {
+         std::string msg = r::endUserErrorMessage(error);
+         reportChunkExecutionError(docId, chunkId, nbCtxId, msg, targetPath);
+         LOG_ERROR(error);
+         return Success();
+      }
+   }
+   
+   // forward success / failure to chunk
+   notebook::enqueueChunkOutput(
+            docId,
+            chunkId,
+            notebook::notebookCtxId(),
+            kChunkOutputText,
+            targetPath);
+   
    return Success();
 }
 
@@ -1448,16 +1628,27 @@ Error executeAlternateEngineChunk(const json::JsonRpcRequest& request,
 {
    std::string docId, chunkId, engine, code;
    int commitMode;
+   json::Object jsonChunkOptions;
    Error error = json::readParams(request.params,
                                   &docId,
                                   &chunkId,
                                   &commitMode,
                                   &engine,
-                                  &code);
+                                  &code,
+                                  &jsonChunkOptions);
    if (error)
    {
       LOG_ERROR(error);
       return error;
+   }
+   
+   // read json chunk options
+   std::map<std::string, std::string> options;
+   for (json::Object::const_iterator it = jsonChunkOptions.begin();
+        it != jsonChunkOptions.end();
+        ++it)
+   {
+      options[it->first] = it->second.get_str();
    }
    
    // choose appropriate notebook context to write to -- if this is a saved
@@ -1468,9 +1659,9 @@ Error executeAlternateEngineChunk(const json::JsonRpcRequest& request,
 
    // handle Rcpp specially
    if (engine == "Rcpp")
-      return executeRcppEngineChunk(docId, chunkId, nbCtxId, code, pResponse);
+      return executeRcppEngineChunk(docId, chunkId, nbCtxId, code, options, pResponse);
    else if (engine == "stan")
-      return executeStanEngineChunk(docId, chunkId, nbCtxId, code, pResponse);
+      return executeStanEngineChunk(docId, chunkId, nbCtxId, code, options, pResponse);
    
    notebook::runChunk(docId, chunkId, nbCtxId, engine, code);
    return Success();

--- a/src/gwt/acesupport/acemode/markdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/markdown_highlight_rules.js
@@ -62,6 +62,7 @@ var PythonHighlightRules = require("ace/mode/python_highlight_rules").PythonHigh
 var RubyHighlightRules = require("ace/mode/ruby_highlight_rules").RubyHighlightRules;
 var ScalaHighlightRules = require("ace/mode/scala_highlight_rules").ScalaHighlightRules;
 var ShHighlightRules = require("ace/mode/sh_highlight_rules").ShHighlightRules;
+var StanHighlightRules = require("mode/stan_highlight_rules").StanHighlightRules;
 
 var escaped = function(ch) {
     return "(?:[^" + lang.escapeRegExp(ch) + "\\\\]|\\\\.)*";
@@ -157,6 +158,7 @@ var MarkdownHighlightRules = function() {
         github_embed("scala", "scalacode-"),
         github_embed("sh", "shcode-"),
         github_embed("bash", "bashcode-"),
+        github_embed("stan", "stancode-"),
         
         { // Github style block
             token : "support.function",

--- a/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
@@ -29,6 +29,7 @@ var MarkdownHighlightRules = require("mode/markdown_highlight_rules").MarkdownHi
 var TextHighlightRules = require("ace/mode/text_highlight_rules").TextHighlightRules;
 var YamlHighlightRules = require("ace/mode/yaml_highlight_rules").YamlHighlightRules;
 var ShHighlightRules = require("ace/mode/sh_highlight_rules").ShHighlightRules;
+var StanHighlightRules = require("mode/stan_highlight_rules").StanHighlightRules;
 var Utils = require("mode/utils");
 
 function makeDateRegex()
@@ -117,6 +118,16 @@ var RMarkdownHighlightRules = function() {
        ["start", "listblock", "allowBlock"]
    );
 
+   // Embed stan highlighting rules
+   Utils.embedRules(
+       this,
+       StanHighlightRules,
+       "stan",
+       this.$reStanChunkStartString,
+       this.$reChunkEndString,
+       ["start", "listblock", "allowBlock"]
+   );
+
    // Embed YAML highlight rules, but ensure that they can only be
    // found at the start of a document. We do this by moving all of the
    // start rules to a second '$start' state, and ensuring that YAML headers
@@ -171,6 +182,9 @@ oop.inherits(RMarkdownHighlightRules, TextHighlightRules);
 
    this.$reShChunkStartString =
       "^(?:[ ]{4})?`{3,}\\s*\\{(?:bash|sh)\\b(?:.*)\\}\\s*$";
+
+   this.$reStanChunkStartString =
+      "^(?:[ ]{4})?`{3,}\\s*\\{stan\\b(?:.*)\\}\\s*$";
 
    this.$reChunkEndString =
       "^(?:[ ]{4})?`{3,}\\s*$";

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RMarkdownServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RMarkdownServerOperations.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.rmarkdown.model;
 
 import org.rstudio.core.client.files.FileSystemItem;
+import org.rstudio.core.client.js.JsObject;
 import org.rstudio.studio.client.common.crypto.CryptoServerOperations;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
@@ -89,6 +90,7 @@ public interface RMarkdownServerOperations extends CryptoServerOperations
                                     int commitMode,
                                     String engine,
                                     String code,
+                                    JsObject options,
                                     ServerRequestCallback<String> requestCallback);
    
    void interruptChunk(String docId,

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4268,6 +4268,7 @@ public class RemoteServer implements Server
                                            int commitMode,
                                            String engine,
                                            String code,
+                                           JsObject options,
                                            ServerRequestCallback<String> requestCallback)
    {
       JSONArray params = new JSONArray();
@@ -4276,6 +4277,7 @@ public class RemoteServer implements Server
       params.set(2, new JSONNumber(commitMode));
       params.set(3, new JSONString(engine));
       params.set(4, new JSONString(code));
+      params.set(5, new JSONObject(options));
       sendRequest(RPC_SCOPE, "execute_alternate_engine_chunk", params, requestCallback);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetChunks.java
@@ -242,7 +242,7 @@ public class TextEditingTargetChunks
    
    // runnable engines within the R Notebook mode
    private static final String RE_RUNNABLE_ENGINES =
-         "r|Rscript|Rcpp|python|ruby|perl|bash|sh|";
+         "r|Rscript|Rcpp|python|ruby|perl|bash|sh|stan|";
    
    // renderPass_ need only be unique from one pass through the scope tree to
    // the next; we wrap it at 255 to avoid the possibility of overflow

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -27,6 +27,7 @@ import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.TextCursor;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.dom.DomUtils;
+import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.layout.FadeOutAnimation;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -1364,7 +1365,8 @@ public class TextEditingTargetNotebook
                docUpdateSentinel_.getId(),
                unit.chunkId,
                engine,
-               unit.code);
+               unit.code,
+               chunkOptions);
          return;
       }
       
@@ -1435,14 +1437,20 @@ public class TextEditingTargetNotebook
    private void execAlternateEngineChunk(String docId,
                                          String chunkId,
                                          String engine,
-                                         String code)
+                                         String code,
+                                         Map<String, String> options)
    {
+      JsObject jsOptions = JsObject.createJsObject();
+      for (Map.Entry<String, String> entry : options.entrySet())
+         jsOptions.setString(entry.getKey(), entry.getValue());
+      
       server_.executeAlternateEngineChunk(
             docId,
             chunkId,
             getCommitMode(),
             engine,
             code,
+            jsOptions,
             new ServerRequestCallback<String>()
             {
                @Override


### PR DESCRIPTION
This PR is a slightly trimmed down version of https://github.com/rstudio/rstudio/pull/708; in particular the client-side chunk parsing work is left out (to be more fully packaged in a separate PR). This PR should just have the guts of `stan` execution as-is from the previous PR.