### PR TITLE
implement client-side parser for Rmd chunk headers

### DIFF
--- a/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
@@ -161,33 +161,25 @@ oop.inherits(RMarkdownHighlightRules, TextHighlightRules);
 
 (function() {
 
+   function engineRegex(engine) {
+      return "^(?:[ ]{4})?`{3,}\\s*\\{[Rr]\\b(?:.*)engine\\s*\\=\\s*['\"]" + engine + "['\"](?:.*)\\}\\s*$|" +
+         "^(?:[ ]{4})?`{3,}\\s*\\{" + engine + "\\b(?:.*)\\}\\s*$";
+   }
+
    this.$reRChunkStartString =
       "^(?:[ ]{4})?`{3,}\\s*\\{[Rr]\\b(.*)\\}\\s*$";
 
-   this.$reCppChunkStartString =
-      "^(?:[ ]{4})?`{3,}\\s*\\{[Rr]\\b(?:.*)engine\\s*\\=\\s*['\"]Rcpp['\"](?:.*)\\}\\s*$|" +
-      "^(?:[ ]{4})?`{3,}\\s*\\{[Rr]cpp\\b(?:.*)\\}\\s*$";
-
-   this.$reMarkdownChunkStartString =
-      "^(?:[ ]{4})?`{3,}\\s*\\{\\s*block\\b(?:.*)\\}\\s*$";
-
-   this.$rePerlChunkStartString =
-      "^(?:[ ]{4})?`{3,}\\s*\\{perl\\b(?:.*)\\}\\s*$";
-
-   this.$rePythonChunkStartString =
-      "^(?:[ ]{4})?`{3,}\\s*\\{python\\b(?:.*)\\}\\s*$";
-
-   this.$reRubyChunkStartString =
-      "^(?:[ ]{4})?`{3,}\\s*\\{ruby\\b(?:.*)\\}\\s*$";
-
-   this.$reShChunkStartString =
-      "^(?:[ ]{4})?`{3,}\\s*\\{(?:bash|sh)\\b(?:.*)\\}\\s*$";
-
-   this.$reStanChunkStartString =
-      "^(?:[ ]{4})?`{3,}\\s*\\{stan\\b(?:.*)\\}\\s*$";
-
    this.$reChunkEndString =
       "^(?:[ ]{4})?`{3,}\\s*$";
+
+   this.$reCppChunkStartString      = engineRegex("[Rr]cpp");
+   this.$reMarkdownChunkStartString = engineRegex("block");
+   this.$rePerlChunkStartString     = engineRegex("perl");
+   this.$rePythonChunkStartString   = engineRegex("python");
+   this.$reRubyChunkStartString     = engineRegex("ruby");
+   this.$reShChunkStartString       = engineRegex("(?:bash|sh)");
+   this.$reStanChunkStartString     = engineRegex("stan");
+
    
 }).call(RMarkdownHighlightRules.prototype);
 

--- a/src/gwt/src/org/rstudio/core/client/Mutable.java
+++ b/src/gwt/src/org/rstudio/core/client/Mutable.java
@@ -17,6 +17,11 @@ package org.rstudio.core.client;
 // A utility class primarily used for creating mutable integers etc.
 public class Mutable<T>
 {
+   public Mutable()
+   {
+      data_ = null;
+   }
+   
    public Mutable(T data)
    {
       data_ = data;

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -1046,6 +1046,31 @@ public class StringUtil
       return id;
    }
    
+   public static String ensureQuoted(String string)
+   {
+      String[] quotes = new String[] { "\"", "'", "`" };
+      for (String quote : quotes)
+         if (string.startsWith(quote) && string.endsWith(quote))
+            return string;
+      
+      return "\"" + string.replaceAll("\"", "\\\\\"") + "\"";
+   }
+   
+   public static String stringValue(String string)
+   {
+      String[] quotes = new String[] { "\"", "'", "`" };
+      for (String quote : quotes)
+      {
+         if (string.startsWith(quote) && string.endsWith(quote))
+         {
+            String substring = string.substring(1, string.length() - 1);
+            return substring.replaceAll("\\\\" + quote, quote);
+         }
+      }
+      
+      return string;
+   }
+   
    public static final native String encodeURI(String string) /*-{
       return $wnd.encodeURI(string);
    }-*/;

--- a/src/gwt/src/org/rstudio/core/client/TextCursor.java
+++ b/src/gwt/src/org/rstudio/core/client/TextCursor.java
@@ -14,6 +14,9 @@
  */
 package org.rstudio.core.client;
 
+import org.rstudio.core.client.regex.Match;
+import org.rstudio.core.client.regex.Pattern;
+
 public class TextCursor
 {
    public TextCursor(String data, int index)
@@ -149,7 +152,7 @@ public class TextCursor
    
    private boolean fwdToCharacter__noskip(char ch)
    {
-      int idx = data_.indexOf(ch, index_ + 1);
+      int idx = data_.indexOf(ch, index_);
       if (idx == -1) return false;
       index_ = idx;
       return true;
@@ -160,7 +163,65 @@ public class TextCursor
       return data_.indexOf(ch, index_ + 1);
    }
    
-   public String getData() { return data_; }
+   public char peek()
+   {
+      return peek(0);
+   }
+   
+   public char peek(int offset)
+   {
+      int index = index_ + offset;
+      if (index < 0 || index >= n_)
+         return '\0';
+      return data_.charAt(index);
+   }
+   
+   public boolean consume(char expected)
+   {
+      boolean matches = data_.charAt(index_) == expected;
+      index_ += matches ? 1 : 0;
+      return matches;
+   }
+   
+   public boolean consumeUntil(char expected)
+   {
+      int index = data_.indexOf(expected, index_);
+      if (index != -1)
+      {
+         index_ = index;
+         return true;
+      }
+      return false;
+   }
+   
+   public boolean consumeUntil(String expected)
+   {
+      int index = data_.indexOf(expected, index_);
+      if (index != -1)
+      {
+         index_ = index;
+         return true;
+      }
+      return false;
+   }
+   
+   public boolean consumeUntilRegex(String regex)
+   {
+      Pattern pattern = Pattern.create(regex);
+      Match match = pattern.match(data_, index_);
+      if (match == null)
+         return false;
+      
+      index_ = match.getIndex();
+      return true;
+   }
+   
+   public String getData()
+   {
+      return data_;
+   }
+   
+   public void setIndex(int index) { index_ = index; }
    public int getIndex() { return index_; }
    
    public boolean isLeftBracket()
@@ -173,6 +234,16 @@ public class TextCursor
    {
       char ch = data_.charAt(index_);
       return ch == '}' || ch == ']' || ch == ')';
+   }
+   
+   public boolean isSingleQuote()
+   {
+      return data_.charAt(index_) == '\'';
+   }
+   
+   public boolean isDoubleQuote()
+   {
+      return data_.charAt(index_) == '"';
    }
    
    private char complement(char ch)

--- a/src/gwt/src/org/rstudio/studio/client/common/r/knitr/RMarkdownChunkHeaderParser.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/r/knitr/RMarkdownChunkHeaderParser.java
@@ -1,0 +1,276 @@
+/*
+ * RMarkdownChunkHeaderParser.java
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.common.r.knitr;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.rstudio.core.client.Mutable;
+import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.TextCursor;
+import org.rstudio.core.client.regex.Match;
+import org.rstudio.core.client.regex.Pattern;
+
+public class RMarkdownChunkHeaderParser
+{
+   public static Map<String, String> parse(String line)
+   {
+      Map<String, String> options = new HashMap<String, String>();
+      parse(line, options);
+      return options;
+   }
+   
+   public static final void parse(String line, Map<String, String> options)
+   {
+      // set up state
+      Mutable<String> key = new Mutable<String>();
+      Consumer keyConsumer = new MutableConsumer(key);
+      
+      Mutable<String> val = new Mutable<String>();
+      Consumer valConsumer = new MutableConsumer(val);
+      
+      line = trimBoundary(line);
+      TextCursor cursor = new TextCursor(line);
+      
+      // force default R engine
+      options.put("engine", ensureQuoted("r"));
+      
+      // consume engine
+      if (!consumeEngine(cursor, options))
+         return;
+      
+      // consume whitespace and commas
+      if (!cursor.consumeUntilRegex("[^\\s,]"))
+         return;
+      
+      // consume next token -- need to determine
+      // whether this is a chunk option name or
+      // a label soon after
+      if (!consumeKey(cursor, keyConsumer))
+         return;
+      
+      // consume until ',' or '='. if nothing is
+      // found, this must have been a label
+      if (!cursor.consumeUntilRegex("[,=]"))
+      {
+         options.put("label", ensureQuoted(key.get().trim()));
+         return;
+      }
+      
+      char ch = cursor.peek();
+      if (ch == ',')
+      {
+         // found a comma -- this must have been a label
+         options.put("label", ensureQuoted(key.get().trim()));
+      }
+      else
+      {
+         // found an '=' -- this was a key for a chunk option
+         if (!cursor.consume('='))
+            return;
+         
+         // eat whitespace
+         if (!cursor.consumeUntilRegex("\\S"))
+            return;
+         
+         // consume value
+         if (!consumeValue(cursor, valConsumer))
+            return;
+         
+         // set option
+         options.put(key.get(), val.get());
+         
+         // move to next comma
+         if (!cursor.fwdToCharacter(',', false))
+            return;
+      }
+      
+      while (cursor.peek() == ',')
+      {
+         // eat whitespace and commas
+         if (!cursor.consumeUntilRegex("[^\\s,]"))
+            return;
+         
+         // consume key
+         if (!consumeKey(cursor, keyConsumer))
+            return;
+         
+         // eat whitespace
+         if (!cursor.consumeUntilRegex("\\S"))
+            return;
+         
+         // check '='
+         if (!cursor.consume('='))
+            return;
+         
+         // eat whitespace
+         if (!cursor.consumeUntilRegex("\\S"))
+            return;
+         
+         // consume value
+         if (!consumeValue(cursor, valConsumer))
+            return;
+         
+         // update options
+         options.put(
+               StringUtil.stringValue(key.get().trim()),
+               val.get().trim());
+         
+         // find next comma
+         if (!cursor.consumeUntil(','))
+            return;
+      }
+      
+      return;
+   }
+   
+   private static final String trimBoundary(String line)
+   {
+      return line
+            .replaceAll("^\\s*```{\\s*", "")
+            .replaceAll("\\s*}\\s*$", "")
+            .trim();
+   }
+   
+   private static final boolean consumeEngine(final TextCursor cursor,
+                                              final Map<String, String> options)
+   {
+      Consumer consumer = new Consumer()
+      {
+         @Override
+         public void consume(String value)
+         {
+            options.put("engine", ensureQuoted(value));
+         }
+      };
+      
+      if (consumeUntilRegex(cursor, "(?:$|[\\s,])", consumer))
+         return true;
+      
+      return false;
+   }
+   
+   private static final boolean consumeUntilRegex(TextCursor cursor,
+                                                  String regex,
+                                                  Consumer consumer)
+   {
+      Pattern pattern = Pattern.create(regex);
+      Match match = pattern.match(cursor.getData(), cursor.getIndex());
+      if (match == null)
+         return false;
+      
+      int startIdx = cursor.getIndex();
+      int endIdx = match.getIndex();
+      if (consumer != null)
+      {
+         String value = cursor.getData().substring(startIdx, endIdx);
+         consumer.consume(value);
+      }
+
+      cursor.setIndex(endIdx);
+      return true;
+   }
+   
+   private static final boolean consumeQuotedItem(TextCursor cursor, Consumer consumer)
+   {
+      if (!isQuote(cursor.peek()))
+         return false;
+      
+      int startIndex = cursor.getIndex();
+      if (cursor.fwdToMatchingCharacter())
+      {
+         int endIndex = cursor.getIndex() + 1;
+         if (consumer != null)
+         {
+            String value = cursor.getData().substring(startIndex, endIndex);
+            consumer.consume(value);
+         }
+         cursor.setIndex(endIndex);
+         return true;
+      }
+      return false;
+   }
+   
+   private static final boolean consumeKey(TextCursor cursor, Consumer consumer)
+   {
+      if (isQuote(cursor.peek()) && consumeQuotedItem(cursor, consumer))
+         return true;
+      
+      return consumeUntilRegex(cursor, "(?:$|[^a-zA-Z0-9_])", consumer);
+   }
+   
+   private static final boolean consumeValue(TextCursor cursor,
+                                             Consumer consumer)
+   {
+      if (consumeQuotedItem(cursor, consumer))
+         return true;
+      
+      int startIdx = cursor.getIndex();
+      do
+      {
+         if (cursor.isLeftBracket() && cursor.fwdToMatchingCharacter())
+            continue;
+         
+         if (cursor.peek() == ',')
+            break;
+      }
+      while (cursor.moveToNextCharacter());
+      
+      int endIdx = cursor.getIndex();
+      if (consumer != null)
+      {
+         String value = cursor.getData().substring(startIdx, endIdx);
+         consumer.consume(value);
+      }
+      cursor.setIndex(endIdx);
+      return true;
+   }
+   
+   private static final boolean isQuote(char ch)
+   {
+      return ch == '\'' || ch == '"' || ch == '`';
+   }
+   
+   private static final String ensureQuoted(String string)
+   {
+      String[] quotes = new String[] { "\"", "'", "`" };
+      for (String quote : quotes)
+         if (string.startsWith(quote) && string.endsWith(quote))
+            return string;
+      
+      return "\"" + string.replaceAll("\"", "\\\\\"") + "\"";
+   }
+   
+   private static interface Consumer
+   {
+      public void consume(String value);
+   }
+   
+   private static class MutableConsumer implements Consumer
+   {
+      public MutableConsumer(Mutable<String> value)
+      {
+         value_ = value;
+      }
+      
+      @Override
+      public void consume(String value)
+      {
+         value_.set(value);
+      }
+      
+      private final Mutable<String> value_;
+   }
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetChunks.java
@@ -223,9 +223,9 @@ public class TextEditingTargetChunks
    {
       // TODO: only enable non-R engine work for notebooks for now
       if (!target_.getDocDisplay().showChunkOutputInline())
-         return engine.equals("r");
+         return engine.equalsIgnoreCase("r");
       
-      return RE_RUNNABLE_ENGINES.indexOf(engine + "|") != -1;
+      return RE_RUNNABLE_ENGINES.indexOf(engine.toLowerCase() + "|") != -1;
    }
    
    private final TextEditingTarget target_;
@@ -239,7 +239,7 @@ public class TextEditingTargetChunks
    
    // runnable engines within the R Notebook mode
    private static final String RE_RUNNABLE_ENGINES =
-         "r|Rscript|Rcpp|python|ruby|perl|bash|sh|stan|";
+         "r|rscript|rcpp|python|ruby|perl|bash|sh|stan|";
    
    // renderPass_ need only be unique from one pass through the scope tree to
    // the next; we wrap it at 255 to avoid the possibility of overflow

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetChunks.java
@@ -15,16 +15,16 @@
 package org.rstudio.studio.client.workbench.views.source.editors.text;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Map;
 
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.common.r.knitr.RMarkdownChunkHeaderParser;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.LineWidget;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorModeChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.ScopeTreeReadyEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkContextUi;
-import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.TextEditingTargetNotebook;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
 
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
@@ -211,14 +211,11 @@ public class TextEditingTargetChunks
       String header = target_.getDocDisplay().getLine(row);
       
       // parse contents
-      Map<String, String> options = new HashMap<String, String>();
-      TextEditingTargetNotebook.parseChunkOptions(header, options);
+      Map<String, String> options = 
+            RMarkdownChunkHeaderParser.parse(header);
       
       // check runnable engine
-      String engine = options.containsKey("engine")
-            ? options.get("engine")
-            : "r";
-            
+      String engine = StringUtil.stringValue(options.get("engine"));
       return isExecutableKnitrEngine(engine);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -24,7 +24,6 @@ import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.StringUtil;
-import org.rstudio.core.client.TextCursor;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.js.JsObject;
@@ -39,6 +38,7 @@ import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.Value;
 import org.rstudio.studio.client.common.dependencies.DependencyManager;
 import org.rstudio.studio.client.common.dependencies.model.Dependency;
+import org.rstudio.studio.client.common.r.knitr.RMarkdownChunkHeaderParser;
 import org.rstudio.studio.client.rmarkdown.RmdOutput;
 import org.rstudio.studio.client.rmarkdown.events.ChunkPlotRefreshFinishedEvent;
 import org.rstudio.studio.client.rmarkdown.events.ChunkPlotRefreshedEvent;
@@ -1352,14 +1352,11 @@ public class TextEditingTargetNotebook
       }
       
       // if we're using a non-R engine, farm that out to separate routine
-      Map<String, String> chunkOptions = new HashMap<String, String>();
-      parseChunkOptions(unit.options, chunkOptions);
+      String line = docDisplay_.getLine(chunk.getPreamble().getRow());
+      Map<String, String> chunkOptions = RMarkdownChunkHeaderParser.parse(line);
        
-      String engine = chunkOptions.containsKey("engine")
-            ? chunkOptions.get("engine")
-            : "r";
-            
-      if (engine != "r")
+      String engine = StringUtil.stringValue(chunkOptions.get("engine"));
+      if (!engine.toLowerCase().equals("r"))
       {
          execAlternateEngineChunk(
                docUpdateSentinel_.getId(),
@@ -1466,68 +1463,6 @@ public class TextEditingTargetNotebook
                   processChunkExecQueue();
                }
             });
-   }
-   
-   public static void parseChunkOptions(String line,
-                                        Map<String, String> chunkOptions)
-   {
-      // strip '```{' and '}' if necessary
-      // some callers only pass in the leading '```{'
-      line = line.trim();
-      if (line.startsWith("```{"))
-      {
-         int endIndex = line.length();
-         if (line.endsWith("}"))
-            endIndex--;
-         
-         line = line.substring(4, endIndex);
-      }
-      
-      TextCursor cursor = new TextCursor(line);
-      
-      // parse preamble
-      int preambleStartIdx = cursor.getIndex();
-      int preambleEndIdx   = line.length();
-      
-      if (cursor.fwdToCharacter(',', false))
-         preambleEndIdx = cursor.getIndex();
-      
-      parseChunkPreamble(
-            line.substring(preambleStartIdx, preambleEndIdx),
-            chunkOptions);
-      
-      // parse chunk options
-      while (cursor.contentEquals(','))
-      {
-         int startIdx = cursor.getIndex() + 1;
-         if (!cursor.fwdToCharacter('=', false))
-            break;
-         int equalsIdx = cursor.getIndex();
-         int endIdx = cursor.fwdToCharacter(',', true)
-               ? cursor.getIndex() 
-               : line.length();
-         
-         String argName  = line.substring(startIdx, equalsIdx).trim();
-         String argValue = line.substring(equalsIdx + 1, endIdx).trim();
-         if (argValue.startsWith("\"") && argValue.endsWith("\""))
-            argValue = argValue.substring(1, argValue.length() - 1);
-         else if (argValue.startsWith("'") && argValue.endsWith("'"))
-            argValue = argValue.substring(1, argValue.length() - 1);
-         chunkOptions.put(argName, argValue);
-      }
-   }
-   
-   private static void parseChunkPreamble(String preamble,
-                                          Map<String, String> chunkOptions)
-   {
-      // split into pieces
-      String[] splat = preamble.split("\\s+");
-      
-      if (splat.length >= 1)
-         chunkOptions.put("engine", splat[0].trim());
-      
-      if (splat.length >= 2)
-         chunkOptions.put("label", splat[1].trim());
    }
    
    private void loadInitialChunkOutput()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -1356,7 +1356,7 @@ public class TextEditingTargetNotebook
       Map<String, String> chunkOptions = RMarkdownChunkHeaderParser.parse(line);
        
       String engine = StringUtil.stringValue(chunkOptions.get("engine"));
-      if (!engine.toLowerCase().equals("r"))
+      if (!engine.equalsIgnoreCase("r"))
       {
          execAlternateEngineChunk(
                docUpdateSentinel_.getId(),


### PR DESCRIPTION
This PR implements a more comprehensive chunk header parser, effectively splitting options into key-value pairs. For example, we can parse e.g.

    ```{r hello, echo = TRUE, fig.width=4, opts=list(a = 1)}

would be parsed as

    engine: "r"
    label: "hello"
    echo: TRUE
    fig.width: 4
    opts: list(a = 1)

Note that we don't attempt to parse the chunk 'values' as they can be arbitrary R code; we just split them into key-value components.

---

We should hold this for after the weekend + a bit of extra review since this is code that will be running quite often (basically, any time the document mutates and we need to re-detect whether a chunk is executable, etc.)