### PR TITLE
prevent col_numeric deprecated in data import

### DIFF
--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -102,7 +102,7 @@
                         time = paste(ns, "col_time(", parseString, ")", sep = ""),
                         double = paste(ns, "col_double()", sep = ""),
                         factor = paste(ns, "col_factor(", parseString, ")", sep = ""),
-                        numeric = paste(ns, "col_numeric()", sep = ""),
+                        numeric = paste(ns, "col_number()", sep = ""),
                         integer = paste(ns, "col_integer()", sep = ""),
                         logical = paste(ns, "col_logical()", sep = ""),
                         dateTime = paste(ns, "col_datetime(", parseString, ")", sep = ""),


### PR DESCRIPTION
`col_numeric` is deprecated, need to use `col_number`. Warning triggers in `readr` `0.2.2` which we have a dependency on already.