### PR TITLE
changes required to proxy SparkUI Jetty application over localhost

### DIFF
--- a/src/cpp/server/ServerSessionProxy.cpp
+++ b/src/cpp/server/ServerSessionProxy.cpp
@@ -294,7 +294,7 @@ void handleLocalhostResponse(
             // determine url prefix based on how deep we are in the path
             std::string path = ptrConnection->request().path();
             size_t slashes = std::count(path.begin(), path.end(), '/');
-            size_t up = slashes - 3;
+            size_t up = slashes >= 4 ? (slashes - 3) : 0;
             std::vector<std::string> dirs;
             for (size_t i=0; i<up; i++)
                dirs.push_back("..");


### PR DESCRIPTION
There were a number of problems I encountered attempting to get the SparkUI application to proxy correctly over localhost when running under RStudio Server:

1. Jetty didn't send a Content Length header which caused some localhost proxying logic we have for httpuv to kick in and close the connection. I overcame this by not applying that logic when Jetty is the server we are proxying to.

2. The SparkUI application uses paths hard-coded to the root (e.g. "/static/") which all break when we are proxying via e.g. "/p/4040/static/". To overcome this I look for sentinel text indicating we are serving a SparkUI page (the SparkUI logo PNG) and fixup URLs within image, script, and anchor tags. This is super gross but I can't think of another way to fix the problem and the code only runs when it sees the sentinel text.

3. If we sent gzip as an Accept Encoding then Jetty uses gzip, however without a Content Length our gzip HTTP stream code failed.

This change fixes all of these issues in a fairly nasty fashion. Again, I can't see a more elegant way and I think we definitely need to be able to proxy SparkUI on RStudio Server.

@jmcphers @javierluraschi 