### PR TITLE
don't check git on PATH if user-supplied git executable defined

### DIFF
--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -2635,7 +2635,8 @@ bool isGitInstalled()
 
    // special handling for mavericks for case where there is /usr/bin/git
    // but it's the fake on installed by osx
-   if (module_context::isOSXMavericks() &&
+   if ((s_gitExePath.empty() || s_gitExePath == "/usr/bin/git") &&
+       module_context::isOSXMavericks() &&
        !module_context::hasOSXMavericksDeveloperTools() &&
        whichGitExe().empty())
    {


### PR DESCRIPTION
This PR should resolve an issue where git detection fails on RStudio Desktop with OS X where a user-defined git executable is set, but command line tools are not installed.