### PR TITLE
Add UI pref to allow multi-line execution in R scripts

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -572,6 +572,11 @@ public class UIPrefsAccessor extends Prefs
       return bool("hide_console_on_chunk_execute", true);
    }
    
+   public PrefValue<Boolean> executeMultiLineStatements()
+   {
+      return bool("execute_multi_line_statements", false);
+   }
+   
    public static final String DOC_OUTLINE_SHOW_SECTIONS_ONLY = "show_sections_only";
    public static final String DOC_OUTLINE_SHOW_SECTIONS_AND_NAMED_CHUNKS = "show_sections_and_chunks";
    public static final String DOC_OUTLINE_SHOW_ALL = "show_all";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -574,7 +574,7 @@ public class UIPrefsAccessor extends Prefs
    
    public PrefValue<Boolean> executeMultiLineStatements()
    {
-      return bool("execute_multi_line_statements", false);
+      return bool("execute_multi_line_statements", true);
    }
    
    public static final String DOC_OUTLINE_SHOW_SECTIONS_ONLY = "show_sections_only";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -132,8 +132,7 @@ public class EditingPreferencesPane extends PreferencesPane
       executionLabel.getElement().getStyle().setMarginTop(8, Unit.PX);
       editingPanel.add(checkboxPref("Always save R scripts before sourcing", prefs.saveBeforeSourcing()));
       editingPanel.add(checkboxPref("Focus console after executing from source", prefs_.focusConsoleAfterExec()));
-      
-    
+      editingPanel.add(checkboxPref("Execute all lines in a statement", prefs_.executeMultiLineStatements()));
       
       Label snippetsLabel = headerLabel("Snippets");
       snippetsLabel.getElement().getStyle().setMarginTop(8, Unit.PX);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
@@ -89,13 +89,27 @@ public class EditingTargetCodeExecution
          Scope scope = docDisplay_.getCurrentChunk();
          if (scope == null)
          {
-            int row = docDisplay_.getSelectionStart().getRow();
-            selectionRange = Range.fromPoints(
-                  Position.create(row, 0),
-                  Position.create(row, docDisplay_.getLength(row)));
+            if (prefs_.executeMultiLineStatements().getValue())
+            {
+               // no scope to guard region, check the document itself to find
+               // the region to execute
+               selectionRange = docDisplay_.getMultiLineExpr(
+                     docDisplay_.getCursorPosition(), 1, 
+                     docDisplay_.getRowCount());
+            }
+            else
+            {
+               // single-line execution
+               int row = docDisplay_.getSelectionStart().getRow();
+               selectionRange = Range.fromPoints(
+                     Position.create(row, 0),
+                     Position.create(row, docDisplay_.getLength(row)));
+            }
          }
          else
          {
+            // inside a chunk, always execute multiple lines (bounded by the
+            // chunk)
             selectionRange = docDisplay_.getMultiLineExpr(
                   docDisplay_.getCursorPosition(), 
                   scope.getBodyStart().getRow(), 


### PR DESCRIPTION
While listening to @hadley demo at the UseR 2016 keynote, I noticed that he manually selected multi-line expressions in R scripts to execute them with Cmd+Enter and had the thought that some people might prefer the multi-line execution behavior everywhere. 

This change allows users to opt in, via a UI pref, to the same behavior in R scripts that already exists in R Markdown documents: automatic execution of multi-line statements. 