### PR TITLE
don't emit copy / cut when selection is empty

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,7 @@
 ### Miscellaneous
 
 * Improved performance of 'Find in Files' tool
+* Attempting to cut or copy with an empty selection no longer clears the clipboard
 * Files pane now has a fixed header row
 * Published plots are larger and responsive to changes in browser size
 * Implement gt/gT bindings in Vim mode to switch to next/previous tab

--- a/package/linux/.gitignore
+++ b/package/linux/.gitignore
@@ -1,2 +1,3 @@
 iterate*
+cmake*
 

--- a/src/cpp/desktop-mac/WebViewController.mm
+++ b/src/cpp/desktop-mac/WebViewController.mm
@@ -705,16 +705,22 @@ decidePolicyForMIMEType: (NSDictionary *) actionInformation
       }
       return YES;
    }
+   
+   // check for empty selection (we don't want to blast the clipboard when
+   // cutting or copying and there's no text)
+   BOOL emptySelection = [[webView_ stringByEvaluatingJavaScriptFromString: @"window.desktopHooks.isSelectionEmpty()"] boolValue];
 
    // Without these, secondary/satellite windows don't respond to clipboard shortcuts
    if ([chr isEqualToString: @"x"] && mod == NSCommandKeyMask)
    {
-      [webView_ cut: self];
+      if (!emptySelection)
+         [webView_ cut: self];
       return YES;
    }
    if ([chr isEqualToString: @"c"] && mod == NSCommandKeyMask)
    {
-      [webView_ copy: self];
+      if (!emptySelection)
+         [webView_ copy: self];
       return YES;
    }
    if ([chr isEqualToString: @"v"] && mod == NSCommandKeyMask)

--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -21,6 +21,7 @@
 #include <QtWebKit>
 #include <QToolBar>
 #include <QWebFrame>
+#include <QClipboard>
 
 #include <boost/bind.hpp>
 #include <boost/format.hpp>
@@ -91,6 +92,9 @@ MainWindow::MainWindow(QUrl url) :
    connect(qApp, SIGNAL(commitDataRequest(QSessionManager&)),
            this, SLOT(commitDataRequest(QSessionManager&)),
            Qt::DirectConnection);
+
+   connect(QApplication::clipboard(), SIGNAL(dataChanged()),
+           this, SLOT(onClipboardDataChanged()));
 
    setWindowIcon(QIcon(QString::fromUtf8(":/icons/RStudio.ico")));
 
@@ -345,6 +349,22 @@ void MainWindow::onActivated()
 {
    if (desktopHooksAvailable())
       invokeCommand(QString::fromUtf8("vcsRefreshNoError"));
+}
+
+void MainWindow::onClipboardDataChanged()
+{
+   static QString s_data;
+
+   // if the user attempts to copy empty data to the clipboard,
+   // undo that action and replace it with the last copied data
+   QClipboard* clipboard = QApplication::clipboard();
+   QString data = clipboard->text();
+   if (data.isEmpty() && !s_data.isEmpty())
+      clipboard->setText(s_data);
+
+   // save the copied text to static var
+   if (!data.isEmpty())
+      s_data = data;
 }
 
 } // namespace desktop

--- a/src/cpp/desktop/DesktopMainWindow.hpp
+++ b/src/cpp/desktop/DesktopMainWindow.hpp
@@ -63,6 +63,7 @@ protected slots:
    void onWorkbenchInitialized();
    void resetMargins();
    void commitDataRequest(QSessionManager &manager);
+   void onClipboardDataChanged();
 
 protected:
    virtual void closeEvent(QCloseEvent*);

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopHooks.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopHooks.java
@@ -31,6 +31,7 @@ import org.rstudio.studio.client.application.events.SaveActionChangedEvent;
 import org.rstudio.studio.client.application.events.SaveActionChangedHandler;
 import org.rstudio.studio.client.application.events.SuicideEvent;
 import org.rstudio.studio.client.application.model.SaveAction;
+import org.rstudio.studio.client.application.ui.impl.DesktopApplicationHeader;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.server.Server;
@@ -207,6 +208,11 @@ public class DesktopHooks
    String getSumatraPdfExePath()
    {
       return session_.getSessionInfo().getSumatraPdfExePath();
+   }
+   
+   boolean isSelectionEmpty()
+   {
+      return DesktopApplicationHeader.isSelectionEmpty();
    }
 
    private final Commands commands_;

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -52,11 +52,14 @@ import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
 import org.rstudio.studio.client.workbench.views.files.events.ShowFolderEvent;
 import org.rstudio.studio.client.workbench.views.files.events.ShowFolderHandler;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEditorNative;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Selection;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Widget;
@@ -214,6 +217,7 @@ public class DesktopApplicationHeader implements ApplicationHeader
    @Handler
    void onCutDummy()
    {
+      if (isSelectionEmpty()) return;
       fireEditEvent(EditEvent.TYPE_CUT);
       Desktop.getFrame().clipboardCut();
    }
@@ -221,6 +225,7 @@ public class DesktopApplicationHeader implements ApplicationHeader
    @Handler
    void onCopyDummy()
    {
+      if (isSelectionEmpty()) return;
       fireEditEvent(EditEvent.TYPE_COPY);
       Desktop.getFrame().clipboardCopy();
    }
@@ -368,6 +373,18 @@ public class DesktopApplicationHeader implements ApplicationHeader
                               "No Update Available", 
                               "You're using the newest version of RStudio.");
       }
+   }
+   
+   public static boolean isSelectionEmpty()
+   {
+      Element activeElement = DomUtils.getActiveElement();
+      AceEditorNative editor = AceEditorNative.getEditor(activeElement);
+      if (editor != null)
+      {
+         Selection selection = editor.getSession().getSelection();
+         return selection.isEmpty();
+      }
+      return DomUtils.getSelectionText(Document.get()).isEmpty();
    }
    
    private static boolean isFocusInAceInstance()


### PR DESCRIPTION
This PR attempts to avoid blasting away the clipboard when pressing e.g. `Ctrl+C` or `Ctrl+X` with no selection active. Note that this PR is not yet complete (need to figure out how to perform the same check on Qt Desktop; @jjallaire if you have any pointers it would be appreciated)