### PR TITLE
refine multiline execution logic

### DIFF
--- a/src/gwt/acesupport/acemode/token_cursor.js
+++ b/src/gwt/acesupport/acemode/token_cursor.js
@@ -60,6 +60,16 @@ var TokenCursor = function(tokens, row, offset) {
       this.$offset = 0;
    };
 
+   this.moveToEndOfRow = function(row)
+   {
+      this.$row = row;
+      var tokens = this.$tokens[row];
+      if (tokens && tokens.length)
+         this.$offset = tokens.length - 1;
+      else
+         this.$offset = 0;
+   }
+
    // Move the cursor to the previous token. Returns true (and moves the
    // the cursor) on success; returns false (and does not move the cursor)
    // on failure.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/TokenCursor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/TokenCursor.java
@@ -109,6 +109,10 @@ public class TokenCursor extends JavaScriptObject
       this.moveToStartOfRow(row);
    }-*/;
    
+   public native final void moveToEndOfRow(int row) /*-{
+      this.moveToEndOfRow(row);
+   }-*/;
+   
    public native final boolean seekToNearestToken(Position position, int maxRow) /*-{
       return !! this.seekToNearestToken(position, maxRow);
    }-*/;

--- a/src/gwt/test/test-multiline-expr.R
+++ b/src/gwt/test/test-multiline-expr.R
@@ -1,0 +1,36 @@
+# To test here, try typing 'Cmd + Enter' and ensure that the cursor
+# executes and jumps from the consecutively numbered blocks.
+
+# 1
+{
+  1234 %>%
+    # a comment
+    rnorm() %>%
+
+    sum()
+}
+
+# 2
+{
+  1 + 2
+}
+
+# 3
+apple <- function(banana) {
+  print(1 +
+          2 +
+          3)
+}
+
+# 4
+1 + 2
+
+# 5
+1234 %>% {
+  1
+  2
+  3
+} %>% sum()
+
+# 6
+1 + 2


### PR DESCRIPTION
This PR refines the multi-line execution logic in a couple of ways:

1. We now step over empty / commented lines when expanding the selection,
2. We expand an initial selection within `(` and `[`,
3. We grow the selection from `2.` by walking binary operators.

I've also added a little test file that we can use (manually) to test that execution works as expected.