### PR TITLE
incorrect formatting of dataimport sav dialog in windows

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportFileChooser.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportFileChooser.ui.xml
@@ -15,8 +15,6 @@
             -ms-flex-grow: 1;
             -webkit-flex-grow: 1;
             flex-grow: 1;
-
-            height: 24px;
         }
         .modelTextBox {
             margin-top: 3px;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.ui.xml
@@ -20,7 +20,12 @@
         .modelButton {
         }
         .optionsLeftBlock {
+            display: -ms-flexbox;
+            display: -webkit-flex;
             display: flex;
+
+            -webkit-flex-direction: row;
+            -ms-flex-direction: row;
             flex-direction: row;
         }
         .optionsRightBlock {


### PR DESCRIPTION
Need to fallback while using flex-box and remove height restriction which cuts off by a couple pixels button in windows.