### PR TITLE
scope readr parsing errors for anything but text

### DIFF
--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -662,6 +662,16 @@
          }
       )
 
+      parsingErrorsFromMode <- function(mode, data) {
+         modeFunc <- list(
+            "text" = function(data) {
+               length(readr::problems(data)$row)
+            }
+         )
+
+         if (identical(modeFunc[[mode]], NULL)) 0 else modeFunc[[mode]](data)
+      }
+
       if (dataImportOptions$mode %in% names(beforeImportFromOptions))
       {
          beforeImportFromOptions[[dataImportOptions$mode]]()
@@ -679,7 +689,7 @@
          columns <- .rs.describeCols(data, maxCols, maxFactors)
       }
       
-      parsingErrors <-length(readr::problems(data)$row)
+      parsingErrors <- parsingErrorsFromMode(dataImportOptions$mode, data)
 
       cnames <- names(data)
       size <- nrow(data)


### PR DESCRIPTION
Fix to "readr not installed" data import error while loading a sav file when `readr::` is not installed. This probably also affects reading `xls` file when `readr::` is not installed. Regression from adding parsing errors feature https://github.com/rstudio/rstudio/commit/6ff32399b53c2a9e86f361aae586a491cea560a2.