### PR TITLE
next version of haven renames path to file param

### DIFF
--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -396,7 +396,9 @@
       "statistics" = function() {
          # load parameters
          options <- list()
-         options[["path"]] <- cacheOrFileFromOptions(dataImportOptions)
+
+         # current version of haven uses "path", next version uses "file"
+         options[["path"]] <- options[["file"]] <- cacheOrFileFromOptions(dataImportOptions)
          options[["b7dat"]] <- cacheOrFileFromOptions(dataImportOptions)
          options[["b7cat"]] <- cacheOrFileFromOptions(dataImportOptions, "modelLocation")
 
@@ -410,7 +412,7 @@
 
          # set special parameter types
          optionTypes <- list()
-         optionTypes[["path"]] <- cacheTypeOrFileTypeFromOptions(dataImportOptions)
+         optionTypes[["path"]] <- optionTypes[["file"]] <- cacheTypeOrFileTypeFromOptions(dataImportOptions)
          optionTypes[["b7dat"]] <- cacheTypeOrFileTypeFromOptions(dataImportOptions)
          optionTypes[["b7cat"]] <- cacheTypeOrFileTypeFromOptions(dataImportOptions, "modelLocation")
 


### PR DESCRIPTION
next version of haven renames `path` to `file` parameter. This fix adds support to handle both cases since the use of `formals()` in data import handles cases where the parameter is not used.