### PR TITLE
attempt to resolve notebook encoding issues on Windows

### DIFF
--- a/src/cpp/session/modules/SessionFiles.R
+++ b/src/cpp/session/modules/SessionFiles.R
@@ -61,5 +61,5 @@
 
 .rs.addFunction("readLines", function(filePath)
 {
-   .Call("rs_readLines", .rs.normalizePath(filePath, mustWork = TRUE))
+   .Call("rs_readLines", path.expand(filePath))
 })

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -15,9 +15,6 @@
 assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
 
 .rs.addFunction("extractRmdFromNotebook", function(notebook) {
-   # ensure path encoding is marked correctly
-   if (Encoding(notebook) == "unknown")  Encoding(notebook) <- "UTF-8"
-
    # parse the notebook to get the text of the contained R markdown doc
    parsed <- try(rmarkdown::parse_html_notebook(notebook), silent = TRUE)
    if (inherits(parsed, "try-error") || is.null(parsed$rmd)) {
@@ -63,9 +60,6 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
 
 .rs.addFunction("readRnbCache", function(rmdPath, cachePath)
 {
-   if (Encoding(rmdPath) == "unknown")   Encoding(rmdPath) <- "UTF-8"
-   if (Encoding(cachePath) == "unknown") Encoding(cachePath) <- "UTF-8"
-   
    if (!file.exists(rmdPath))
       stop("No file at path '", rmdPath, "'")
    
@@ -470,10 +464,6 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
       cachePath <- .rs.rnb.cachePathFromRmdPath(rmdPath)
    }
 
-   # mark encoding if unspecified
-   if (Encoding(nbPath) == "unknown")     Encoding(nbPath) <- "UTF-8"
-   if (Encoding(cachePath) == "unknown")  Encoding(cachePath) <- "UTF-8"
-   
    # ensure cache directory
    if (!.rs.dirExists(cachePath))
       dir.create(cachePath, recursive = TRUE)

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -64,7 +64,7 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
       stop("No file at path '", rmdPath, "'")
    
    # tolerate missing cache (implies there's no chunk outputs)
-   rmdPath <- .rs.normalizePath(rmdPath, winslash = "/", mustWork = TRUE)
+   rmdPath <- path.expand(rmdPath)
    rmdContents <- .rs.readLines(rmdPath)
    
    # Begin collecting the units that form the Rnb data structure

--- a/src/cpp/session/modules/rmarkdown/NotebookCache.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookCache.cpp
@@ -151,8 +151,10 @@ Error notebookContentMatches(const FilePath& nbPath, const FilePath& rmdPath,
 {
    // extract content from notebook
    std::string nbRmdContents;
-   Error error = r::exec::RFunction(".rs.extractRmdFromNotebook", 
-         nbPath.absolutePath()).call(&nbRmdContents);
+   r::exec::RFunction extractRmdFromNotebook(
+            ".rs.extractRmdFromNotebook",
+            string_utils::utf8ToSystem(nbPath.absolutePath()));
+   Error error = extractRmdFromNotebook.call(&nbRmdContents);
    if (error) 
       return error;
    if (pContents)
@@ -303,8 +305,9 @@ void onDocAdded(const std::string& id)
    // file
    if (!cachePath.exists() && notebookPath.exists())
    {
-      error = r::exec::RFunction(".rs.hydrateCacheFromNotebook", 
-            notebookPath.absolutePath()).call();
+      error = r::exec::RFunction(
+               ".rs.hydrateCacheFromNotebook",
+               string_utils::utf8ToSystem(notebookPath.absolutePath())).call();
       if (error)
          LOG_ERROR(error);
       return;
@@ -357,8 +360,10 @@ void onDocAdded(const std::string& id)
          return;
       }
 
-      error = r::exec::RFunction(".rs.hydrateCacheFromNotebook", 
-            notebookPath.absolutePath()).call();
+      error = r::exec::RFunction(
+               ".rs.hydrateCacheFromNotebook", 
+               string_utils::utf8ToSystem(notebookPath.absolutePath())).call();
+      
       if (error)
          LOG_ERROR(error);
    }
@@ -565,8 +570,10 @@ Error extractRmdFromNotebook(const json::JsonRpcRequest& request,
    }
 
    // perform the cache hydration
-   error = r::exec::RFunction(".rs.hydrateCacheFromNotebook", 
-         nbPath.absolutePath(), cacheFolder.absolutePath()).call();
+   error = r::exec::RFunction(
+            ".rs.hydrateCacheFromNotebook",
+            string_utils::utf8ToSystem(nbPath.absolutePath()),
+            string_utils::utf8ToSystem(cacheFolder.absolutePath())).call();
    if (error)
       return error;
 


### PR DESCRIPTION
This PR attempts to resolve issues when trying to render notebooks on Windows that have non- ASCII characters in their file path. The main changes:

1. Use `path.expand()` instead of `normalizePath()`,
2. Attempt to convert UTF-8 paths to the system encoding,
3. Don't mark the encoding of those paths as UTF-8.

I haven't yet been able to verify if this fixes the underlying issues -- for what it's worth, I'm seeing this surprising behavior (albeit on an English Windows machine, although I would expect that setting the locale to Russian would in turn ensure that R prints / recognizes Cyrillic characters correctly)

```R
Sys.setlocale(locale = "Russian")
path <- "~/scratch/Д.R"
path
Encoding(path)
file.create(path)
file.exists(path)
normalizePath(path)
```

gives

```R
> Sys.setlocale(locale = "Russian")
[1] "LC_COLLATE=Russian_Russia.1251;LC_CTYPE=Russian_Russia.1251;LC_MONETARY=Russian_Russia.1251;LC_NUMERIC=C;LC_TIME=Russian_Russia.1251"
> path <- "~/scratch/Д.R"
> path
[1] "~/scratch/Ä.R"
> Encoding(path)
[1] "unknown"
> file.create(path)
[1] TRUE
> file.exists(path)
[1] TRUE
> normalizePath(path)
[1] "C:\\Users\\Kevin\\scratch\\Ä.R"
Warning message:
In normalizePath(path.expand(path), winslash, mustWork) :
  path[1]="C:/Users/Kevin/scratch/Ä.R": The system cannot find the file specified
```

For what it's worth, the binary representation of the character is indeed correct; I assume the character is printed assuming a latin-1 locale by default when the encoding is unknown (?).

```
> as.integer(charToRaw("Д"))
[1] 196
```

Regardless, the whole situation seems like kind of a mess unfortunately...