### PR TITLE
allow 'Ctrl+N', 'Ctrl+P' to navigate items in completion list

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
@@ -36,6 +36,7 @@ import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.Rectangle;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.KeyboardShortcut;
+import org.rstudio.core.client.command.ShortcutManager;
 import org.rstudio.core.client.events.SelectionCommitEvent;
 import org.rstudio.core.client.events.SelectionCommitHandler;
 import org.rstudio.core.client.widget.ThemedPopupPanel;
@@ -128,6 +129,13 @@ public class CompletionPopupPanel extends ThemedPopupPanel
                                     PositionCallback callback,
                                     boolean truncated)
    {
+      if (handle_ != null)
+      {
+         handle_.close();
+         handle_ = null;
+      }
+      handle_ = ShortcutManager.INSTANCE.disable();
+      
       CompletionList<QualifiedName> list = new CompletionList<QualifiedName>(
                                        values,
                                        6,
@@ -210,6 +218,11 @@ public class CompletionPopupPanel extends ThemedPopupPanel
    public void hide()
    {
       unregisterNativeHandler();
+      if (handle_ != null)
+      {
+         handle_.close();
+         handle_ = null;
+      }
       super.hide();
    }
    
@@ -424,4 +437,5 @@ public class CompletionPopupPanel extends ThemedPopupPanel
    private final Label truncated_;
    private final NativePreviewHandler handler_;
    private HandlerRegistration handlerRegistration_;
+   private ShortcutManager.Handle handle_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
@@ -14,7 +14,9 @@
  */
 package org.rstudio.studio.client.workbench.views.console.shell.assist;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.dom.client.*;
@@ -36,6 +38,7 @@ import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.Rectangle;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.KeyboardShortcut;
+import org.rstudio.core.client.command.KeyboardShortcut.KeyCombination;
 import org.rstudio.core.client.command.ShortcutManager;
 import org.rstudio.core.client.events.SelectionCommitEvent;
 import org.rstudio.core.client.events.SelectionCommitHandler;
@@ -129,13 +132,7 @@ public class CompletionPopupPanel extends ThemedPopupPanel
                                     PositionCallback callback,
                                     boolean truncated)
    {
-      if (handle_ != null)
-      {
-         handle_.close();
-         handle_ = null;
-      }
-      handle_ = ShortcutManager.INSTANCE.disable();
-      
+      registerIgnoredKeys();
       CompletionList<QualifiedName> list = new CompletionList<QualifiedName>(
                                        values,
                                        6,
@@ -217,12 +214,8 @@ public class CompletionPopupPanel extends ThemedPopupPanel
    @Override
    public void hide()
    {
+      unregisterIgnoredKeys();
       unregisterNativeHandler();
-      if (handle_ != null)
-      {
-         handle_.close();
-         handle_ = null;
-      }
       super.hide();
    }
    
@@ -427,6 +420,29 @@ public class CompletionPopupPanel extends ThemedPopupPanel
    {
       if (handlerRegistration_ != null)
          handlerRegistration_.removeHandler();
+   }
+   
+   private void resetIgnoredKeysHandle()
+   {
+      if (handle_ != null)
+      {
+         handle_.close();
+         handle_ = null;
+      }
+   }
+   
+   private void registerIgnoredKeys()
+   {
+      resetIgnoredKeysHandle();
+      Set<KeyCombination> keySet = new HashSet<KeyCombination>();
+      keySet.add(new KeyCombination(KeyCodes.KEY_N, KeyboardShortcut.CTRL));
+      keySet.add(new KeyCombination(KeyCodes.KEY_P, KeyboardShortcut.CTRL));
+      handle_ = ShortcutManager.INSTANCE.addIgnoredKeys(keySet);
+   }
+   
+   private void unregisterIgnoredKeys()
+   {
+      resetIgnoredKeysHandle();
    }
    
    private CompletionList<QualifiedName> list_ ;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -508,7 +508,16 @@ public class RCompletionManager implements CompletionManager
             return false ; // bare modifiers should do nothing
          }
          
-         if (modifier == KeyboardShortcut.NONE)
+         if (modifier == KeyboardShortcut.CTRL)
+         {
+            switch (keycode)
+            {
+            case KeyCodes.KEY_P: return popup_.selectPrev();
+            case KeyCodes.KEY_N: return popup_.selectNext();
+            }
+         }
+         
+         else if (modifier == KeyboardShortcut.NONE)
          {
             if (keycode == KeyCodes.KEY_ESCAPE)
             {


### PR DESCRIPTION
This PR allows `Ctrl+N` and `Ctrl+P` to navigate the R completion list when autocompletion results are requested.

To facilitate this, I've added a mechanism for ignoring certain keys in the shortcut manager -- popups can register ignored keys while they're showing, and then clear those when they hide. This is useful for the case where we don't want to disable the shortcut manager outright, but do want to make sure it ignores specific keys.