### PR TITLE
install pagedtable.css for windows

### DIFF
--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -463,6 +463,10 @@ if (NOT RSTUDIO_SESSION_WIN64)
    install(DIRECTORY "resources/notebook"
            DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/resources)
 
+   # install pagedtable
+   install(DIRECTORY "resources/pagedtable"
+           DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/resources)
+
    # install libclang
    if(WIN32)
       file(GLOB LIBCLANG_32_FILES "${LIBCLANG_DIR}/x86/libclang.*")


### PR DESCRIPTION
I believe we need this for windows since the css is not being found while installed from the daily build. Is there a way I can validate this since the css is actually found while building locally but not while installing the daily build?