### PR TITLE
add support to format data chunks using tibble

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -174,6 +174,7 @@ public class DependencyManager implements InstallShinyEvent.Handler
       deps.add(Dependency.cranPackage("knitr", "1.13", true));
       deps.add(Dependency.cranPackage("jsonlite", "0.9.19"));
       deps.add(Dependency.cranPackage("base64enc", "0.1-3"));
+      deps.add(Dependency.cranPackage("tibble", "1.1"));
       deps.add(Dependency.embeddedPackage("rmarkdown"));
       return deps;
    }


### PR DESCRIPTION
This PR adds support to format data chunks using tibble formatting methods.

Couple related PR follow; however, this PR is not dependent on them. If the dplyr PR is not available, printing dplyr results will use the usual tibble output.

- https://github.com/rstudio/rmarkdown/pull/770
- https://github.com/hadley/dplyr/pull/2060

<img width="921" alt="screen shot 2016-08-09 at 4 35 39 pm" src="https://cloud.githubusercontent.com/assets/3478847/17537195/64c9562c-5e4f-11e6-8079-74c0f07e7e88.png">

<img width="920" alt="screen shot 2016-08-09 at 4 35 48 pm" src="https://cloud.githubusercontent.com/assets/3478847/17537196/64ca52e8-5e4f-11e6-9a1b-b3940f3b62d4.png">


<img width="918" alt="screen shot 2016-08-09 at 4 03 43 pm" src="https://cloud.githubusercontent.com/assets/3478847/17537143/000a09fc-5e4f-11e6-9584-1888509baf24.png">
