### PR TITLE
Fix .DollarNames method lookup

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -777,8 +777,9 @@
       if (excludeBaseClasses && class %in% c("list", "environment"))
          next
       
-      methodName <- paste(".DollarNames", class, sep = ".")
-      method <- .rs.getAnywhere(methodName, envir = envir)
+      method <- utils::getS3method(".DollarNames", class, optional = TRUE, 
+        envir = getNamespace("utils"))
+      
       if (!is.null(method))
          return(method)
    }


### PR DESCRIPTION
cc @kevinushey 

The current implemenation fails to find `.DollarNames` methods which are defined in packages. The dev version of openssl has a reproducible example:

```r
install.packages("https://github.com/jeroenooms/openssl/archive/master.tar.gz", repos = NULL)
```

And then:

```r
key <- openssl::rsa_keygen()
.DollarNames(key, "") #works
key$ #hit tab
```

You will see that in the terminal you get tab completion, but in RStudio it does not work. This PR should fix that.