### PR TITLE
implement dymamic resize for data chunks

### DIFF
--- a/src/cpp/session/resources/pagedtable/pagedtable.css
+++ b/src/cpp/session/resources/pagedtable/pagedtable.css
@@ -98,7 +98,6 @@ a.pagedtable-index-current {
 }
 
 .pagedtable-footer {
-  min-width: 380px;
   padding-top: 9px;
   padding-bottom: 5px;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.text;
 
+import java.util.ArrayList;
+
 import org.rstudio.core.client.ColorUtil;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
@@ -529,6 +531,14 @@ public class ChunkOutputWidget extends Composite
    {
       host_ = host;
    }
+
+   public void onResize()
+   {
+      for(JavaScriptObject pagedTable : pagedTables_)
+      {
+         resizeDataOutputStyleNative(pagedTable);
+      }
+   }
    
    // Event handlers ----------------------------------------------------------
 
@@ -870,7 +880,7 @@ public class ChunkOutputWidget extends Composite
       });
    }
 
-   private final native void showDataOutputNative(Element parent, JavaScriptObject data) /*-{
+   private final native JavaScriptObject showDataOutputNative(Element parent, JavaScriptObject data) /*-{
       var pagedTable = $doc.createElement("div");
       pagedTable.setAttribute("data-pagedtable", "");
       parent.appendChild(pagedTable);
@@ -889,6 +899,8 @@ public class ChunkOutputWidget extends Composite
       });
 
       pagedTableInstance.render();
+
+      return pagedTableInstance;
    }-*/;
 
    private final native void applyDataOutputStyleNative(
@@ -919,6 +931,10 @@ public class ChunkOutputWidget extends Composite
       }
    }-*/;
 
+   private final native void resizeDataOutputStyleNative(JavaScriptObject pagedTable) /*-{
+      pagedTable.fitColumns(false);
+   }-*/;
+
    public void onDataOutputChange()
    {
       applyDataOutputStyle();
@@ -926,7 +942,7 @@ public class ChunkOutputWidget extends Composite
 
    private void showDataOutput(JavaScriptObject data)
    {
-      showDataOutputNative(root_.getElement(), data);
+      pagedTables_.add(showDataOutputNative(root_.getElement(), data));
 
       applyDataOutputStyle();
    }
@@ -1225,6 +1241,7 @@ public class ChunkOutputWidget extends Composite
    private boolean hasErrors_ = false;
    private int resizeCounter_ = 0;
    private boolean needsHeightSync_ = false;
+   private ArrayList<JavaScriptObject> pagedTables_ = new ArrayList<JavaScriptObject>();
    
    private Timer collapseTimer_ = null;
    private final String chunkId_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -841,6 +841,11 @@ public class TextEditingTargetNotebook
       // (this actually spins up a separate R process to re-render all the
       // plots at the new resolution)
       resizePlotsRemote_.schedule(500);
+
+      for (ChunkOutputUi output: outputs_.values())
+      {
+         output.getOutputWidget().onResize();
+      }
    }
 
    @Override


### PR DESCRIPTION
Couple minor changes but will also need to be ported to the gallery branch @jmcphers.

This changes adds dymaic resizeing of numbner of columns based on available space, most changes implemented in rmarkdown: https://github.com/rstudio/rmarkdown/commit/899c05eaab45bb552242e921080cd0eb2dd1d376

<img width="322" alt="screen shot 2016-08-11 at 1 14 16 pm" src="https://cloud.githubusercontent.com/assets/3478847/17603422/d9f65b94-5fc5-11e6-8b40-812a1829fbd6.png">
<img width="1371" alt="screen shot 2016-08-11 at 1 14 37 pm" src="https://cloud.githubusercontent.com/assets/3478847/17603423/da0c7a82-5fc5-11e6-898c-17986f2239b5.png">
