### PR TITLE
pass along all repos in CRANDownloadOptions

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1936,22 +1936,10 @@ std::string downloadFileMethod(const std::string& defaultMethod)
 
 std::string CRANDownloadOptions()
 {
-   std::string options("options(repos = c(CRAN='" +
-                    module_context::CRANReposURL() + "')");
-   std::string method = module_context::downloadFileMethod();
-   if (!method.empty())
-      options += ", download.file.method = '" + method + "'";
-   if (method == "curl")
-   {
-      std::string extraArgs;
-      Error error = r::exec::RFunction(".rs.downloadFileExtraWithCurlArgs")
-                                                            .call(&extraArgs);
-      if (error)
-         LOG_ERROR(error);
-      options += ", download.file.extra = '" + extraArgs + "'";
-   }
-
-   options += ")";
+   std::string options;
+   Error error = r::exec::RFunction(".rs.CRANDownloadOptionsString").call(&options);
+   if (error)
+      LOG_ERROR(error);
    return options;
 }
 

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1699,3 +1699,46 @@
 {
    .Call("rs_base64decode", data, binary)
 })
+
+.rs.addFunction("CRANDownloadOptionsString", function() {
+   
+   # collect elements of interest
+   repos <- getOption("repos")
+   method <- getOption("download.file.method")
+   extra <- if (identical(method, "curl"))
+      .rs.downloadFileExtraWithCurlArgs()
+   else
+      getOption("download.file.extra")
+   
+   data <- list()
+   if (length(repos)) {
+      data[["repos"]] <- sprintf(
+         "c(%s)",
+         paste(
+            names(repos),
+            .rs.surround(as.character(repos), with = "'"),
+            sep = " = ",
+            collapse = ", "
+         )
+      )
+   }
+   
+   if (length(method) && nzchar(method))
+      data[["download.file.method"]] <- .rs.surround(method, "'")
+   
+   if (length(extra) && nzchar(extra))
+      data[["download.file.extra"]] <- .rs.surround(extra, "'")
+   
+   code <- sprintf(
+      "options(%s)",
+      paste(
+         names(data),
+         data,
+         sep = " = ",
+         collapse = ", "
+      )
+   )
+   
+   code
+   
+})

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -1129,9 +1129,9 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    
 
 .rs.addFunction("downloadFileExtraWithCurlArgs", function() {
-   curlArgs <- "-L -f"
-   existingArgs <- getOption("download.file.extra")
-   if (!is.null(existingArgs) && !grepl(curlArgs, existingArgs, fixed = TRUE))
-      curlArgs <- paste(existingArgs, curlArgs)
-   curlArgs
+   newArgs <- "-L -f"
+   curArgs <- getOption("download.file.extra")
+   if (!is.null(curArgs) && !grepl(newArgs, curArgs, fixed = TRUE))
+      curArgs <- paste(newArgs, curArgs)
+   curArgs
 })


### PR DESCRIPTION
This PR ensures that `CRANDownloadOptions` passes along all active repositories, not just the current CRAN repository.