### PR TITLE
implement improved roxygen highlighting

### DIFF
--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -337,11 +337,6 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
          },
          {
             token : "keyword",
-            regex : "@examples",
-            next  : "rd-examples"
-         },
-         {
-            token : "keyword",
             regex : "@(?!@)[^ ]*"
          },
          {
@@ -378,54 +373,7 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
          }
       ];
 
-      // entrypoint for R code highlight in roxygen examples
-      this.$rules["rd-examples"] = [
-         {
-            token : "comment",
-            regex : "#+'\\s*(?=@)",
-            next  : "rd-start"
-         },
-         {
-            token : "comment",
-            regex : "#+'\\s*",
-            next  : "rd-examples-start"
-         },
-         {
-            token : "comment",
-            regex : "^",
-            next  : "start"
-         }
-      ];
-
-      // highlight R code in roxygen examples
-      this.$rules["rd-examples-start"] = [
-         {
-            token : "identifier.support.function",
-            regex : "\\\\dont(?:run|test)"
-         },
-         {
-            token : "comment",
-            regex : "^",
-            next  : "rd-examples"
-         },
-         {
-            include : "start"
-         }
-      ];
-
       this.normalizeRules();
-
-      for (var i = 0; i < this.$rules["rd-examples-start"].length; i++) {
-         var rule = this.$rules["rd-examples-start"][i];
-         if (rule.next === "start") {
-            this.$rules["rd-examples-start"][i] = {
-               token : rule.token,
-               regex : rule.regex,
-               merge : rule.merge,
-               next  : "rd-examples-start"
-            };
-         }
-      }
 
    };
 

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -323,25 +323,110 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
       }
 
       this.addRules(rdRules, "rd-");
-      this.$rules["rd-start"].unshift({
-          token: "text",
-          regex: "^",
-          next: "start"
-      });
-      this.$rules["rd-start"].unshift({
-         token : "keyword",
-         regex : "@(?!@)[^ ]*"
-      });
-      this.$rules["rd-start"].unshift({
-         token : "comment",
-         regex : "@@"
-      });
-      this.$rules["rd-start"].push({
-         token : "comment",
-         regex : "[^%\\\\[({\\])}]+"
-      });
+
+      // embed our own roxygen highlight rules
+      var rdStartRulesBefore = [
+         {
+            token : "comment",
+            regex : "@@"
+         },
+         {
+            token : ["keyword", "comment"],
+            regex : "(@(?:export|inheritParams|name|param|rdname|slot|template|useDynLib))(\\s+)(?=[a-zA-Z0-9._-])",
+            next  : "rd-highlight"
+         },
+         {
+            token : "keyword",
+            regex : "@examples",
+            next  : "rd-examples"
+         },
+         {
+            token : "keyword",
+            regex : "@(?!@)[^ ]*"
+         },
+         {
+            token : "comment",
+            regex : "^",
+            next  : "start"
+         }
+      ];
+
+      var rdStartRulesAfter = [
+         {
+            token : "comment",
+            regex : "[^%\\\\[({\\])}]+"
+         }
+      ];
+
+      this.$rules["rd-start"] =
+         rdStartRulesBefore.concat(this.$rules["rd-start"]).concat(rdStartRulesAfter);
+
+      // highlight terms after certain roxygen tags
+      this.$rules["rd-highlight"] = [
+         {
+            token : "identifier.support.function",
+            regex : "[a-zA-Z0-9._-]+"
+         },
+         {
+            token : "comment",
+            regex : ","
+         },
+         {
+            token : "comment",
+            regex : "\\s*",
+            next  : "rd-start"
+         }
+      ];
+
+      // entrypoint for R code highlight in roxygen examples
+      this.$rules["rd-examples"] = [
+         {
+            token : "comment",
+            regex : "#+'\\s*(?=@)",
+            next  : "rd-start"
+         },
+         {
+            token : "comment",
+            regex : "#+'\\s*",
+            next  : "rd-examples-start"
+         },
+         {
+            token : "comment",
+            regex : "^",
+            next  : "start"
+         }
+      ];
+
+      // highlight R code in roxygen examples
+      this.$rules["rd-examples-start"] = [
+         {
+            token : "identifier.support.function",
+            regex : "\\\\dont(?:run|test)"
+         },
+         {
+            token : "comment",
+            regex : "^",
+            next  : "rd-examples"
+         },
+         {
+            include : "start"
+         }
+      ];
 
       this.normalizeRules();
+
+      for (var i = 0; i < this.$rules["rd-examples-start"].length; i++) {
+         var rule = this.$rules["rd-examples-start"][i];
+         if (rule.next === "start") {
+            this.$rules["rd-examples-start"][i] = {
+               token : rule.token,
+               regex : rule.regex,
+               merge : rule.merge,
+               next  : "rd-examples-start"
+            };
+         }
+      }
+
    };
 
    oop.inherits(RHighlightRules, TextHighlightRules);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -77,6 +77,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ace.RInfixD
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Token;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.TokenCursor;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.TokenIterator;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.PasteEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.r.RCompletionToolTip;
 import org.rstudio.studio.client.workbench.views.source.editors.text.r.SignatureToolTipManager;
@@ -1100,7 +1101,8 @@ public class RCompletionManager implements CompletionManager
    
    private boolean isLineInRoxygenComment(String line)
    {
-      return line.matches("^\\s*#+'\\s*[^\\s].*");
+      Pattern pattern = Pattern.create("^\\s*#+'");
+      return pattern.test(line);
    }
    
    private boolean isLineInComment(String line)
@@ -1431,10 +1433,30 @@ public class RCompletionManager implements CompletionManager
       if (firstLine.matches("^\\s*[?].*"))
          return new AutocompletionContext(token, AutocompletionContext.TYPE_HELP);
       
-      // escape early for roxygen
+      // escape early for (non-examples) roxygen
       if (firstLine.matches("\\s*#+'.*"))
-         return new AutocompletionContext(
-               token, AutocompletionContext.TYPE_ROXYGEN);
+      {
+         TokenIterator it = docDisplay_.getTokenIterator(input_.getCursorPosition());
+         for (Token currentToken = it.getCurrentToken();
+              currentToken != null;
+              currentToken = it.stepBackward())
+         {
+            if (it.bwdToMatchingToken())
+               continue;
+            
+            String tokenContents = currentToken.getValue();
+            if (tokenContents.startsWith("@"))
+            {
+               // if we discovered an '@examples' tag, then we want to use R code style completion
+               if (tokenContents.equals("@examples"))
+                  break;
+
+               return new AutocompletionContext(
+                     token,
+                     AutocompletionContext.TYPE_ROXYGEN);
+            }
+         }
+      }
       
       // If the token has '$' or '@', add in the autocompletion context --
       // note that we still need parent contexts to give more information

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1155,6 +1155,11 @@ public class RCompletionManager implements CompletionManager
       if (context.getToken().startsWith("-"))
          context.setToken(context.getToken().substring(1));
       
+      // fix up roxygen autocompletion for case where '@' is snug against
+      // the comment marker
+      if (context.getToken().equals("'@"))
+         context.setToken(context.getToken().substring(1));
+      
       context_ = new CompletionRequestContext(invalidation_.getInvalidationToken(),
                                               selection,
                                               canAutoInsert);


### PR DESCRIPTION
Note: not quite ready for merge; would like to get some feedback from @hadley et al. on other things that might be worth tweaking (or not tweaking) for Roxygen highlighting.

This PR currently does two things:

1. Highlights the first term after certain roxygen tags (e.g. `@param`, `@slot`)

2. Highlights R code within an `@examples` block as R code.

Example from `dplyr` sources:

![screen shot 2016-08-12 at 3 08 01 pm](https://cloud.githubusercontent.com/assets/1976582/17638393/9a63197a-609e-11e6-950d-7d03ef437a06.png)
