### PR TITLE
allow notebook chunks to grow

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -288,10 +288,8 @@ public class ChunkOutputWidget extends Composite
       int height = ChunkOutputUi.CHUNK_COLLAPSED_HEIGHT;
       if (expansionState_.getValue() == EXPANDED)
       {
-         int contentHeight = root_.getElement().getScrollHeight() + 19;
-         height = Math.min(
-               Math.max(ChunkOutputUi.MIN_CHUNK_HEIGHT, contentHeight), 
-               ChunkOutputUi.MAX_CHUNK_HEIGHT);
+         int contentHeight = root_.getElement().getOffsetHeight() + 19;
+         height = Math.max(ChunkOutputUi.MIN_CHUNK_HEIGHT, contentHeight);
 
          // if we have renders pending, don't shrink until they're loaded 
          if (pendingRenders_ > 0 && height < renderedHeight_)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.ui.xml
@@ -59,8 +59,6 @@
    .root
    {
       position: relative;
-      overflow: auto;
-      max-height: 630px;
       transition: opacity 400ms ease;
       margin: 10px;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkOutputUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkOutputUi.java
@@ -207,8 +207,8 @@ public class ChunkOutputUi
       int height = 
             outputWidget_.getExpansionState() == ChunkOutputWidget.COLLAPSED ?
                CHUNK_COLLAPSED_HEIGHT :
-               Math.max(MIN_CHUNK_HEIGHT, 
-                 Math.min(outputHeight, MAX_CHUNK_HEIGHT));
+               Math.max(MIN_CHUNK_HEIGHT, outputHeight);
+
       outputWidget_.getElement().getStyle().setHeight(height, Unit.PX);
       display_.onLineWidgetChanged(lineWidget_.getLineWidget());
       


### PR DESCRIPTION
@jmcphers: We want to allow data chunks to grow in size if the user specifies a chunk option (`rows.print`) to display more data. However, chunks are currently capped in height. Would it be possible to remove this restriction with this PR? Or what else should we consider?