### PR TITLE
implement 'engine.path', 'engine.opts' UI

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -110,6 +110,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppComp
 import org.rstudio.studio.client.workbench.views.source.model.CppCompletion;
 import org.rstudio.studio.client.workbench.views.source.editors.text.r.SignatureToolTipManager;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.TextEditingTargetNotebook;
+import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.display.ChunkOptionsPopupPanel;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.display.SetupChunkOptionsPopupPanel;
 import org.rstudio.studio.client.workbench.views.vcs.svn.SVNCommandHandler;
 import org.rstudio.studio.client.workbench.views.environment.ClearAllDialog;
@@ -190,6 +191,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(TableBrowser tableBrowser);
    void injectMembers(TableBrowserModel tableBrowserModel);
    void injectMembers(MathJax mathjax);
+   void injectMembers(ChunkOptionsPopupPanel panel);
    
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);
 

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -109,8 +109,8 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppComp
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionRequest;
 import org.rstudio.studio.client.workbench.views.source.model.CppCompletion;
 import org.rstudio.studio.client.workbench.views.source.editors.text.r.SignatureToolTipManager;
-import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.SetupChunkOptionsPopupPanel;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.TextEditingTargetNotebook;
+import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.display.SetupChunkOptionsPopupPanel;
 import org.rstudio.studio.client.workbench.views.vcs.svn.SVNCommandHandler;
 import org.rstudio.studio.client.workbench.views.environment.ClearAllDialog;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.DataImport;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUi.java
@@ -30,6 +30,10 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditing
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.LineWidget;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
+import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.display.ChunkOptionsPopupPanel;
+import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.display.CustomEngineChunkOptionsPopupPanel;
+import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.display.DefaultChunkOptionsPopupPanel;
+import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.display.SetupChunkOptionsPopupPanel;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.events.InterruptChunkEvent;
 
 import com.google.gwt.core.client.JsArrayString;
@@ -128,9 +132,7 @@ public class ChunkContextUi implements ChunkContextToolbar.Host
    @Override
    public void showOptions(int x, int y)
    {
-      ChunkOptionsPopupPanel panel = isSetupChunk(lineWidget_.getRow()) ?
-         new SetupChunkOptionsPopupPanel() :
-         new DefaultChunkOptionsPopupPanel();
+      ChunkOptionsPopupPanel panel = createPopupPanel();
       
       panel.init(target_.getDocDisplay(), chunkPosition());
       panel.show();
@@ -233,6 +235,19 @@ public class ChunkContextUi implements ChunkContextToolbar.Host
       String engine = StringUtil.stringValue(options.get("engine"));
 
       return engine;
+   }
+   
+   private ChunkOptionsPopupPanel createPopupPanel()
+   {
+      int row = lineWidget_.getRow();
+      if (isSetupChunk(row))
+         return new SetupChunkOptionsPopupPanel();
+      
+      String engine = getEngine(row);
+      if (!engine.toLowerCase().equals("r"))
+         return new CustomEngineChunkOptionsPopupPanel();
+      
+      return new DefaultChunkOptionsPopupPanel();
    }
 
    private final TextEditingTarget target_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUi.java
@@ -233,7 +233,6 @@ public class ChunkContextUi implements ChunkContextToolbar.Host
          RMarkdownChunkHeaderParser.parse(line);
       
       String engine = StringUtil.stringValue(options.get("engine"));
-
       return engine;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.css
@@ -31,4 +31,5 @@
 }
 
 .checkBox {
+	margin: 2px;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
@@ -357,7 +357,10 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
                   boolean isEmpty = StringUtil.isNullOrEmpty(text);
                   
                   if (enquote && !isEmpty)
+                  {
                      text = StringUtil.ensureQuoted(text);
+                     text = text.replaceAll("\\\\", "\\\\\\\\");
+                  }
                   
                   if (isEmpty)
                      unset(option);
@@ -505,12 +508,14 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
             if (has("engine.path"))
             {
                String enginePath = StringUtil.stringValue(get("engine.path"));
+               enginePath = enginePath.replaceAll("\\\\\\\\", "\\\\");
                enginePathBox_.setValue(enginePath);
             }
             
             if (has("engine.opts"))
             {
                String engineOpts = StringUtil.stringValue(get("engine.opts"));
+               engineOpts = engineOpts.replaceAll("\\\\\\\\", "\\\\");
                engineOptsBox_.setValue(engineOpts);
             }
             

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
@@ -12,7 +12,7 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
-package org.rstudio.studio.client.workbench.views.source.editors.text.rmd;
+package org.rstudio.studio.client.workbench.views.source.editors.text.rmd.display;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,6 +30,7 @@ import org.rstudio.core.client.widget.SmallButton;
 import org.rstudio.core.client.widget.TextBoxWithCue;
 import org.rstudio.core.client.widget.ThemedCheckBox;
 import org.rstudio.core.client.widget.TriStateCheckBox;
+import org.rstudio.core.client.widget.VerticalSpacer;
 import org.rstudio.core.client.widget.TriStateCheckBox.State;
 import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
@@ -210,21 +211,16 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
       
       panel_.add(nameAndOutputGrid);
       
-      panel_.add(verticalSpacer(4));
-      
       showWarningsInOutputCb_ = makeTriStateCheckBox(
             "Show warnings",
             "warning");
       panel_.add(showWarningsInOutputCb_);
       
-      panel_.add(verticalSpacer(6));
-      
       showMessagesInOutputCb_ = makeTriStateCheckBox(
             "Show messages",
             "message");
-      panel_.add(showMessagesInOutputCb_);
       
-      panel_.add(verticalSpacer(6));
+      panel_.add(showMessagesInOutputCb_);
       
       useCustomFigureCheckbox_ = new ThemedCheckBox("Use custom figure size");
       useCustomFigureCheckbox_.addStyleName(RES.styles().checkBox());
@@ -251,13 +247,13 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
       figureDimensionsPanel_ = new Grid(2, 2);
       figureDimensionsPanel_.getElement().getStyle().setMarginTop(5, Unit.PX);
       
-      figWidthBox_ = makeInputBox("fig.width");
+      figWidthBox_ = makeInputBox("fig.width", false);
       Label widthLabel = new Label("Width (inches):");
       widthLabel.getElement().getStyle().setMarginLeft(20, Unit.PX);
       figureDimensionsPanel_.setWidget(0, 0, widthLabel);
       figureDimensionsPanel_.setWidget(0, 1, figWidthBox_);
       
-      figHeightBox_ = makeInputBox("fig.height");
+      figHeightBox_ = makeInputBox("fig.height", false);
       Label heightLabel = new Label("Height (inches):");
       heightLabel.getElement().getStyle().setMarginLeft(20, Unit.PX);
       figureDimensionsPanel_.setWidget(1, 0, heightLabel);
@@ -265,12 +261,28 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
       
       panel_.add(figureDimensionsPanel_);
       
-      panel_.add(verticalSpacer(8));
+      enginePanel_ = new Grid(2, 2);
+      enginePanel_.getElement().getStyle().setMarginTop(5, Unit.PX);
+      
+      enginePathBox_ = makeInputBox("engine.path", true);
+      enginePathBox_.getElement().getStyle().setWidth(120, Unit.PX);
+      Label enginePathLabel = new Label("Engine path:");
+      enginePanel_.setWidget(0, 0, enginePathLabel);
+      enginePanel_.setWidget(0, 1, enginePathBox_);
+      
+      engineOptsBox_ = makeInputBox("engine.opts", true);
+      engineOptsBox_.getElement().getStyle().setWidth(120, Unit.PX);
+      Label engineOptsLabel = new Label("Engine options:");
+      enginePanel_.setWidget(1, 0, engineOptsLabel);
+      enginePanel_.setWidget(1, 1, engineOptsBox_);
+      
+      panel_.add(enginePanel_);
       
       HorizontalPanel footerPanel = new HorizontalPanel();
       footerPanel.getElement().getStyle().setWidth(100, Unit.PCT);
       
       FlowPanel linkPanel = new FlowPanel();
+      linkPanel.add(new VerticalSpacer("8px"));
       HelpLink helpLink = new HelpLink("Chunk options", "chunk-options", false);
       linkPanel.add(helpLink);
       
@@ -325,7 +337,7 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
       tbChunkLabel_.setFocus(true);
    }
    
-   private TextBox makeInputBox(final String option)
+   private TextBox makeInputBox(final String option, final boolean enquote)
    {
       final TextBox box = new TextBox();
       box.getElement().setAttribute("placeholder", "Default");
@@ -342,10 +354,16 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
                public void execute()
                {
                   String text = box.getText().trim();
-                  if (StringUtil.isNullOrEmpty(text))
+                  boolean isEmpty = StringUtil.isNullOrEmpty(text);
+                  
+                  if (enquote && !isEmpty)
+                     text = StringUtil.ensureQuoted(text);
+                  
+                  if (isEmpty)
                      unset(option);
                   else
                      set(option, text);
+                  
                   synchronize();
                }
             });
@@ -374,6 +392,7 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
                   synchronize();
                }
             });
+      checkBox.getElement().getStyle().setMargin(2, Unit.PX);
       return checkBox;
    }
    
@@ -483,6 +502,18 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
             if (has("message"))
                showMessagesInOutputCb_.setValue(getBoolean("message"));
             
+            if (has("engine.path"))
+            {
+               String enginePath = StringUtil.stringValue(get("engine.path"));
+               enginePathBox_.setValue(enginePath);
+            }
+            
+            if (has("engine.opts"))
+            {
+               String engineOpts = StringUtil.stringValue(get("engine.opts"));
+               engineOptsBox_.setValue(engineOpts);
+            }
+            
             setVisible(true);
          }
       };
@@ -508,14 +539,6 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
    {
       hide();
       display_.focus();
-   }
-   
-   private FlowPanel verticalSpacer(int sizeInPixels)
-   {
-      FlowPanel panel = new FlowPanel();
-      panel.setWidth("100%");
-      panel.setHeight("" + sizeInPixels + "px");
-      return panel;
    }
    
    private int getPriority(String key)
@@ -565,6 +588,9 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
    protected final Grid figureDimensionsPanel_;
    protected final TextBox figWidthBox_;
    protected final TextBox figHeightBox_;
+   protected final Grid enginePanel_;
+   protected final TextBox enginePathBox_;
+   protected final TextBox engineOptsBox_;
    protected final SmallButton revertButton_;
    protected final SmallButton applyButton_;
    protected final ThemedCheckBox useCustomFigureCheckbox_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
@@ -36,8 +36,11 @@ import org.rstudio.core.client.widget.TriStateCheckBox;
 import org.rstudio.core.client.widget.VerticalSpacer;
 import org.rstudio.core.client.widget.TriStateCheckBox.State;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.common.FileDialogs;
 import org.rstudio.studio.client.common.FilePathUtils;
 import org.rstudio.studio.client.common.HelpLink;
+import org.rstudio.studio.client.workbench.WorkbenchContext;
+import org.rstudio.studio.client.workbench.model.RemoteFileSystemContext;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 
@@ -65,6 +68,7 @@ import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.inject.Inject;
 
 public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
 {
@@ -82,10 +86,21 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
    protected abstract void synchronize();
    protected abstract void revert();
    
+   @Inject
+   private void initialize(WorkbenchContext workbench,
+                           FileDialogs fileDialogs,
+                           RemoteFileSystemContext rfsContext)
+   {
+      fileDialogs_ = fileDialogs;
+      rfsContext_ = rfsContext;
+   }
+   
    public ChunkOptionsPopupPanel(boolean includeChunkNameUI)
    {
       super(true);
       setVisible(false);
+      
+      RStudioGinjector.INSTANCE.injectMembers(this);
       
       chunkOptions_ = new HashMap<String, String>();
       originalChunkOptions_ = new HashMap<String, String>();
@@ -284,9 +299,9 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
                   ? FileSystemItem.createDir("~/")
                   : FileSystemItem.createDir(FilePathUtils.dirFromFile(path));
             
-            RStudioGinjector.INSTANCE.getFileDialogs().openFile(
+            fileDialogs_.openFile(
                   "Select Engine",
-                  RStudioGinjector.INSTANCE.getRemoteFileSystemContext(),
+                  rfsContext_,
                   initialPath,
                   new ProgressOperationWithInput<FileSystemItem>()
                   {
@@ -694,4 +709,9 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
    static {
       RES.styles().ensureInjected();
    }
+   
+   // Injected ----
+   protected FileDialogs fileDialogs_;
+   protected RemoteFileSystemContext rfsContext_;
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
@@ -287,7 +287,7 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
       enginePathBox_ = makeInputBox("engine.path", true);
       enginePathBox_.getElement().getStyle().setWidth(120, Unit.PX);
       Label enginePathLabel = new Label("Engine path:");
-      SmallButton enginePathBrowseButton = new SmallButton("Browse...");
+      SmallButton enginePathBrowseButton = new SmallButton("...");
       enginePathBrowseButton.addClickHandler(new ClickHandler()
       {
          @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/CustomEngineChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/CustomEngineChunkOptionsPopupPanel.java
@@ -1,0 +1,28 @@
+/*
+ * CustomEngineChunkOptionsPopupPanel.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text.rmd.display;
+
+public class CustomEngineChunkOptionsPopupPanel extends DefaultChunkOptionsPopupPanel
+{
+   public CustomEngineChunkOptionsPopupPanel()
+   {
+      super();
+      
+      showWarningsInOutputCb_.setVisible(false);
+      showMessagesInOutputCb_.setVisible(false);
+      useCustomFigureCheckbox_.setVisible(false);
+      enginePanel_.setVisible(true);
+   }
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/DefaultChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/DefaultChunkOptionsPopupPanel.java
@@ -1,4 +1,4 @@
-package org.rstudio.studio.client.workbench.views.source.editors.text.rmd;
+package org.rstudio.studio.client.workbench.views.source.editors.text.rmd.display;
 
 import com.google.gwt.user.client.Command;
 
@@ -19,6 +19,8 @@ public class DefaultChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
    public DefaultChunkOptionsPopupPanel()
    {
       super(true);
+      
+      enginePanel_.setVisible(false);
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/SetupChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/SetupChunkOptionsPopupPanel.java
@@ -12,7 +12,7 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
-package org.rstudio.studio.client.workbench.views.source.editors.text.rmd;
+package org.rstudio.studio.client.workbench.views.source.editors.text.rmd.display;
 
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.user.client.Command;
@@ -53,6 +53,7 @@ public class SetupChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
       figureDimensionsPanel_.setVisible(false);
       useCustomFigureCheckbox_.setVisible(false);
       revertButton_.setVisible(false);
+      enginePanel_.setVisible(false);
       
       setHeader("Default Chunk Options", true);
    }


### PR DESCRIPTION
This PR implements UI in the chunk options popup for setting the engine path + engine options. These fields are shown for any non-R chunks.

![screen shot 2016-08-22 at 11 57 27 am](https://cloud.githubusercontent.com/assets/1976582/17867567/d8d5991c-685f-11e6-96ab-6512de2139e9.png)
