### PR TITLE
sql chunk improvements

### DIFF
--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -224,7 +224,7 @@
       query <- gsub(".*\\*\\/", "", query)
     }
 
-    grepl("^\\s*(INSERT|UPDATE|DELETE|CREATE).*", query)
+    grepl("^\\s*(INSERT|UPDATE|DELETE|CREATE).*", query, ignore.case = TRUE)
   }
 
   # precreate directories if needed

--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -297,3 +297,17 @@
     )
   }
 })
+
+.rs.addJsonRpcHandler("default_sql_connection_name", function()
+{
+  dbiClassNames <- lapply(methods::.S4methods("dbGetQuery"), function(methodInfo) {
+    methodInfoSplit <- strsplit(methodInfo, split = ",")[[1]]
+    methodInfoSplit[[2]]
+  })
+
+  dbiObjectNames <- Filter(function(objName) {
+    any(class(get(objName, envir = globalenv())) %in% dbiClassNames)
+  }, ls(envir = globalenv()))
+
+  if (length(dbiObjectNames) > 0) .rs.scalar(dbiObjectNames[[1]]) else null
+})

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4776,6 +4776,13 @@ public class RemoteServer implements Server
                   new ConsoleProcessCallbackAdapter(callback));
    }
 
+   @Override
+   public void defaultSqlConnectionName(ServerRequestCallback<String> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      sendRequest(RPC_SCOPE, SQL_CHUNK_DEFAULT_CONNECTION, params, requestCallback);
+   }
+
    private String clientId_;
    private String clientVersion_ = "";
    private boolean listeningForEvents_;
@@ -5148,4 +5155,6 @@ public class RemoteServer implements Server
    private static final String CONNECTION_PREVIEW_TABLE = "connection_preview_table";
    private static final String GET_NEW_SPARK_CONNECTION_CONTEXT = "get_new_spark_connection_context";
    private static final String INSTALL_SPARK = "install_spark";
+
+   private static final String SQL_CHUNK_DEFAULT_CONNECTION = "default_sql_connection_name";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -4023,7 +4023,7 @@ public class TextEditingTarget implements
       return Position.create(endRow, endColumn);
    }
    
-   private void onInsertChunk(String chunkPlaceholder)
+   private void onInsertChunk(String chunkPlaceholder, int rowOffset, int colOffset)
    {
       String sel = null;
       Range selRange = null;
@@ -4071,8 +4071,8 @@ public class TextEditingTarget implements
                
          Position cursorPosition = insertChunkInfo.getCursorPosition();
          docDisplay_.setCursorPosition(Position.create(
-               pos.getRow() + cursorPosition.getRow(),
-               cursorPosition.getColumn()));
+               pos.getRow() + cursorPosition.getRow() + rowOffset,
+               colOffset));
          docDisplay_.focus();
       }
       else
@@ -4090,37 +4090,58 @@ public class TextEditingTarget implements
    @Handler
    void onInsertChunkR()
    {
-      onInsertChunk("```{r}\n\n```\n");
+      onInsertChunk("```{r}\n\n```\n", 1, 0);
    }
 
    @Handler
    void onInsertChunkBash()
    {
-      onInsertChunk("```{bash}\n\n```\n");
+      onInsertChunk("```{bash}\n\n```\n", 1, 0);
    }
 
    @Handler
    void onInsertChunkPython()
    {
-      onInsertChunk("```{python}\n\n```\n");
+      onInsertChunk("```{python}\n\n```\n", 1, 0);
    }
 
    @Handler
    void onInsertChunkRCPP()
    {
-      onInsertChunk("```{rcpp}\n\n```\n");
+      onInsertChunk("```{rcpp}\n\n```\n", 1, 0);
    }
 
    @Handler
    void onInsertChunkStan()
    {
-      onInsertChunk("```{stan}\n\n```\n");
+      onInsertChunk("```{stan output.var=}\n\n```\n", 0, 20);
    }
 
    @Handler
    void onInsertChunkSQL()
    {
-      onInsertChunk("```{sql}\n\n```\n");
+      server_.defaultSqlConnectionName(new ServerRequestCallback<String>()
+      {
+         @Override
+         public void onResponseReceived(String name)
+         {
+            if (name != null)
+            {
+               onInsertChunk("```{sql connection=" + name + "}\n\n```\n", 1, 0);
+            }
+            else
+            {
+               onInsertChunk("```{sql connection=}\n\n```\n", 0, 19);
+            }
+         }
+         
+         @Override
+         public void onError(ServerError error)
+         {
+            Debug.logError(error);
+            onInsertChunk("```{sql connection=}\n\n```\n", 0, 19);
+         }
+      });
    }
 
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextToolbar.java
@@ -73,7 +73,6 @@ public class ChunkContextToolbar extends Composite
 
       initRunPrevious(dark);
       setRunPrevious(runPrevious);
-      initChangeChunkEngine(engine);
       
       initRun();
       setRun(run);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextToolbar.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextToolbar.ui.xml
@@ -49,6 +49,7 @@
       vertical-align: top;
       text-align: center;
       margin-right: 6px;
+      display: none
    }
 
    .chunkTypeLabel

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceServerOperations.java
@@ -236,4 +236,6 @@ public interface SourceServerOperations extends FilesServerOperations,
    
    public void extractRmdFromNotebook(String inputPath,
          ServerRequestCallback<SourceDocumentResult> requestCallback);
+
+   public void defaultSqlConnectionName(ServerRequestCallback<String> requestCallback);
 }


### PR DESCRIPTION
Couple improvements for chunk insertion and sql chunks:

1. Remove change type contextual menu
2. After inserting chunk, set cursor inside code block
3. Unless inserting STAN chunk which needs an `output.var` param where the cursor is set
4. For SQL chunks, try to find an `S4` object that implements `dbGetQuery`
5. Add support for `RJDBC` in SQL chunks by not using `dbGetRowCount` which is not implemented in `RJDBC`. This one is a port from `knitr` fix: https://github.com/yihui/knitr/issues/1271