### PR TITLE
implement 'Ctrl+Click' URL navigation

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/regex/Pattern.java
+++ b/src/gwt/src/org/rstudio/core/client/regex/Pattern.java
@@ -36,7 +36,7 @@ public class Pattern extends JavaScriptObject
    public final native int search(String string) /*-{
       return string.search(this);
    }-*/;
-
+   
    public final native Match match(String input, int index) /*-{
       this.lastIndex = index ;
       var result = this.exec(input) ;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -340,11 +340,8 @@ public class AceEditor implements DocDisplay,
                event.preventDefault();
                event.stopPropagation();
 
-               // set the cursor position
-               setCursorPosition(event.getDocumentPosition());
-
                // go to function definition
-               fireEvent(new CommandClickEvent());
+               fireEvent(new CommandClickEvent(event.getDocumentPosition()));
             }
             else
             {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -854,7 +854,24 @@ public class TextEditingTarget implements
          int endIdx   = match.getIndex() + match.getValue().length();
          if (startIdx <= column && column <= endIdx)
          {
-            navigateToUrl(match.getValue());
+            // attempt to trim off enclosing quotes, etc
+            String url = match.getValue();
+            for (int index = startIdx - 1; index >= 0; index--)
+            {
+               char beforeStart = line.charAt(index);
+               boolean needsTrim =
+                     beforeStart == '(' && url.endsWith(")")  ||
+                     beforeStart == '[' && url.endsWith("]")  ||
+                     beforeStart == '{' && url.endsWith("}")  ||
+                     beforeStart == '[' && url.endsWith("]")  ||
+                     beforeStart == '"' && url.endsWith("\"") ||
+                     beforeStart == '\'' && url.endsWith("'");
+
+               if (needsTrim)
+                  url = url.substring(0, url.length() - 1);
+            }
+            
+            navigateToUrl(url);
             return true;
          }
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -871,6 +871,10 @@ public class TextEditingTarget implements
                   url = url.substring(0, url.length() - 1);
             }
             
+            // trim off trailing punctuation (characters unlikely
+            // to be found at the end of a URL)
+            url = url.replaceAll("[,.?!@#$%^&*;:-]+$", "");
+            
             navigateToUrl(url);
             return true;
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -789,8 +789,7 @@ public class TextEditingTarget implements
    
    private void navigateToUrl(String url)
    {
-      // if the url starts with a plain 'www.', then append http
-      // prefix
+      // allow web links starting with 'www'
       if (url.startsWith("www."))
          url = "http://" + url;
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -71,11 +71,14 @@ import org.rstudio.studio.client.common.debugging.events.BreakpointsSavedEvent;
 import org.rstudio.studio.client.common.debugging.model.Breakpoint;
 import org.rstudio.studio.client.common.dependencies.DependencyManager;
 import org.rstudio.studio.client.common.filetypes.DocumentMode;
+import org.rstudio.studio.client.common.filetypes.EditableFileType;
 import org.rstudio.studio.client.common.filetypes.FileType;
 import org.rstudio.studio.client.common.filetypes.FileTypeCommands;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.filetypes.SweaveFileType;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
+import org.rstudio.studio.client.common.filetypes.events.OpenFileInBrowserEvent;
+import org.rstudio.studio.client.common.filetypes.model.NavigationMethods;
 import org.rstudio.studio.client.common.r.roxygen.RoxygenHelper;
 import org.rstudio.studio.client.common.rnw.RnwWeave;
 import org.rstudio.studio.client.common.synctex.Synctex;
@@ -139,6 +142,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceFold
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Mode.InsertChunkInfo;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Token;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.VimMarks;
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionContext;
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionOperation;
@@ -554,13 +558,20 @@ public class TextEditingTarget implements
          @Override
          public void onCommandClick(CommandClickEvent event)
          {
+            Position position = event.getDocumentPosition();
+            if (attemptNavigationToUrl(position))
+               return;
+            
+            // force cursor position
+            docDisplay_.setCursorPosition(position);
+            
             if (fileType_.canCompilePDF() && 
                 commands_.synctexSearch().isEnabled())
             {
                // warn firefox users that this doesn't really work in Firefox
                if (BrowseCap.isFirefox() && !BrowseCap.isMacintosh())
                   SynctexUtils.maybeShowFirefoxWarning("PDF preview");
-               
+
                doSynctexSearch(true);
             }
             else
@@ -774,6 +785,82 @@ public class TextEditingTarget implements
                   }
                }
             });
+   }
+   
+   private void navigateToUrl(final String url)
+   {
+      // attempt to open web links in a new window
+      Pattern reWebLink = Pattern.create("^https?://");
+      if (reWebLink.test(url))
+      {
+         globalDisplay_.openWindow(url);
+         return;
+      }
+      
+      // treat other URLs as paths to files on the server
+      server_.stat(url, new ServerRequestCallback<FileSystemItem>()
+      {
+         @Override
+         public void onResponseReceived(FileSystemItem file)
+         {
+            // inform user non-obtrusively if no file found
+            if (file == null || !file.exists())
+            {
+               String message = "No file at path '" + url + "'";
+               globalDisplay_.showWarningBar(false, message);
+               return;
+            }
+            
+            // if we have a registered filetype for this file, try
+            // to open it in the IDE; otherwise open in browser
+            FileType fileType = fileTypeRegistry_.getTypeForFile(file);
+            if (fileType != null && fileType instanceof EditableFileType)
+            {
+               fileType.openFile(file, null, NavigationMethods.DEFAULT, events_);
+            }
+            else
+            {
+               events_.fireEvent(new OpenFileInBrowserEvent(file));
+            }
+         }
+         
+         @Override
+         public void onError(ServerError error)
+         {
+            Debug.logError(error);
+         }
+      });
+   }
+   
+   private boolean attemptNavigationToUrl(final Position position)
+   {
+      // check to see if we're on a token with the 'href' type
+      Token token = docDisplay_.getTokenAt(position);
+      if (token != null && token.hasType("href"))
+      {
+         navigateToUrl(token.getValue());
+         return true;
+      }
+      
+      // check to see if this position lies within a web link
+      String line = docDisplay_.getLine(position.getRow());
+      int column = position.getColumn();
+      Pattern reWebLink = Pattern.create("https?://\\S+");
+      for (Match match = reWebLink.match(line, 0);
+           match != null;
+           match = match.nextMatch())
+      {
+         int startIdx = match.getIndex();
+         int endIdx   = match.getIndex() + match.getValue().length();
+         if (startIdx <= column && column <= endIdx)
+         {
+            navigateToUrl(match.getValue());
+            return true;
+         }
+      }
+      
+      // not applicable for url navigation; return false
+      return false;
    }
    
    static {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -787,8 +787,13 @@ public class TextEditingTarget implements
             });
    }
    
-   private void navigateToUrl(final String url)
+   private void navigateToUrl(String url)
    {
+      // if the url starts with a plain 'www.', then append http
+      // prefix
+      if (url.startsWith("www."))
+         url = "http://" + url;
+      
       // attempt to open web links in a new window
       Pattern reWebLink = Pattern.create("^https?://");
       if (reWebLink.test(url))
@@ -798,7 +803,8 @@ public class TextEditingTarget implements
       }
       
       // treat other URLs as paths to files on the server
-      server_.stat(url, new ServerRequestCallback<FileSystemItem>()
+      final String finalUrl = url;
+      server_.stat(finalUrl, new ServerRequestCallback<FileSystemItem>()
       {
          @Override
          public void onResponseReceived(FileSystemItem file)
@@ -806,8 +812,7 @@ public class TextEditingTarget implements
             // inform user non-obtrusively if no file found
             if (file == null || !file.exists())
             {
-               String message = "No file at path '" + url + "'";
-               globalDisplay_.showWarningBar(false, message);
+               view_.showWarningBar("No file at path '" + finalUrl + "'.");
                return;
             }
             
@@ -845,7 +850,7 @@ public class TextEditingTarget implements
       // check to see if this position lies within a web link
       String line = docDisplay_.getLine(position.getRow());
       int column = position.getColumn();
-      Pattern reWebLink = Pattern.create("https?://\\S+");
+      Pattern reWebLink = Pattern.create("(?:https?://|www)\\S+");
       for (Match match = reWebLink.match(line, 0);
            match != null;
            match = match.nextMatch())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/events/CommandClickEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/events/CommandClickEvent.java
@@ -14,16 +14,31 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.text.events;
 
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
+
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 
 public class CommandClickEvent extends GwtEvent<CommandClickEvent.Handler>
 {
+   public CommandClickEvent(Position position)
+   {
+      position_ = position;
+   }
+   
+   public Position getDocumentPosition()
+   {
+      return position_;
+   }
+   
+   private final Position position_;
+   
+   // Boilerplate ----
+   
    public interface Handler extends EventHandler
    {
       void onCommandClick(CommandClickEvent event);
    }
-
    
    public static final Type<Handler> TYPE = new Type<Handler>();
 


### PR DESCRIPTION
This PR implements Ctrl+Click navigation in two contexts:

1. For Markdown-style links, e.g. `[URL](http://www.google.com)`, Ctrl+Clicking on the URL itself will attempt navigation to that path. Both web links and server-located files are allowed.

2. In other contexts, command-clicking on a URL (a string beginning with `http`) will attempt navigation to that URL. Note that this is tricky because of what characters are considered valid for a URL, but we try to catch some common cases where the URL is enclosed in e.g. parentheses or quotes. This means that e.g. Ctrl + Clicking in text in R code like:

```
# Please see (http://www.rstudio.com) for more information.
# Learn about the Joker playing card at [https://en.wikipedia.org/wiki/Joker_(playing_card)].
```

should successfully navigate you to the expected location.