### PR TITLE
Enable implementors of .DollarNames to return types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,7 @@
 * The various 'yank' commands are now rebindable (Ctrl + Y, Ctrl + K, Ctrl + U)
 * Insert assignment operator (Alt+-, '<-') is now rebindable
 * Insert pipe operator (Cmd+Shift+M, '%>%') is now rebindable
+* Enable implementors of .DollarNames to provide custom types
 
 ### R Markdown
 

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -829,7 +829,12 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("selectFuzzyMatches", function(completions, token)
 {
-   completions[.rs.fuzzyMatches(completions, token)]
+   types <- attr(completions, "types")
+   matches <- .rs.fuzzyMatches(completions, token)
+   completions <- completions[matches]
+   if (!is.null(types))
+      attr(completions, "types") <- types[matches]
+   completions
 })
 
 .rs.addFunction("formCompletionVector", function(object, default, n)
@@ -1127,10 +1132,15 @@ assign(x = ".rs.acCompletionTypes",
          }
          
          names <- .rs.selectFuzzyMatches(allNames, token)
+
+         # See if types were provided
+         types <- attr(names, "types")
+         if (!is.null(types) && length(types) == length(names))
+            type <- types
          
          # NOTE: Getting the types forces evaluation; we avoid that if
          # there are too many names to evaluate.
-         if (length(names) > 2E2)
+         else if (length(names) > 2E2)
             type <- .rs.acCompletionTypes$UNKNOWN
          else
          {

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1135,7 +1135,7 @@ assign(x = ".rs.acCompletionTypes",
 
          # See if types were provided
          types <- attr(names, "types")
-         if (!is.null(types) && length(types) == length(names))
+         if (is.integer(types) && length(types) == length(names))
             type <- types
          
          # NOTE: Getting the types forces evaluation; we avoid that if


### PR DESCRIPTION
This PR enables implementors of `.DollarNames` to provide an optional "types" attribute on the character vector containing the names. The types attribute should be of identical length as the names vector, and should include integer values indicating the type of each named object according to this schema: https://github.com/rstudio/rstudio/blob/master/src/cpp/session/modules/SessionRCompletions.R#L38-L69

The motivation for this PR is that by default RStudio eagerly evaluates the names returned to determine their type. However, for inter-language interfaces this isn't always ideal (i.e. evaluation could produce an expensive copy operation or evaluation might not be enough to determine the type if it's hidden behind an opaque handle of some kind).

@kevinushey  @jeroenooms 
