### PR TITLE
tweak display + checkout behavior for remote branches

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -88,6 +88,7 @@
 * Improved performance of 'Find in Files' tool
 * Attempting to cut or copy with an empty selection no longer clears the clipboard
 * Files pane now has a fixed header row
+* Attempting to check out remote git branch now checks out local copy tracking remote
 * Published plots are larger and responsive to changes in browser size
 * Implement gt/gT bindings in Vim mode to switch to next/previous tab
 * Always provide file completions for top-level current directory

--- a/src/cpp/core/include/core/Algorithm.hpp
+++ b/src/cpp/core/include/core/Algorithm.hpp
@@ -229,6 +229,22 @@ inline std::string join(const std::vector<std::string>& container, const std::st
    return boost::algorithm::join(container, delim);
 }
 
+template <typename Iterator>
+inline std::string join(Iterator begin, Iterator end, const std::string& delim)
+{
+   if (begin >= end)
+      return std::string();
+   
+   std::string result;
+   result += *begin;
+   for (Iterator it = begin + 1; it != end; ++it)
+   {
+      result += delim;
+      result += *it;
+   }
+   return result;
+}
+
 } // namespace algorithm
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -580,8 +580,9 @@ public:
          std::vector<std::string> splat = core::algorithm::split(id, "/");
          if (splat.size() > 2)
          {
-            std::string branch = core::algorithm::join(splat.begin() + 2, splat.end(), "/");
-            args << "checkout" << branch << "--";
+            std::string localBranch = core::algorithm::join(splat.begin() + 2, splat.end(), "/");
+            std::string remoteBranch = core::algorithm::join(splat.begin() + 1, splat.end(), "/");
+            args << "checkout" << "-b" << localBranch << remoteBranch << "--";
          }
          else
          {

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -573,7 +573,28 @@ public:
    core::Error checkout(const std::string& id,
                         boost::shared_ptr<ConsoleProcess>* ppCP)
    {
-      return createConsoleProc(ShellArgs() << "checkout" << id << "--",
+      ShellArgs args;
+      if (id.find("remotes/") == 0)
+      {
+         // check out a local copy of branch, tracking remote
+         std::vector<std::string> splat = core::algorithm::split(id, "/");
+         if (splat.size() > 2)
+         {
+            std::string branch = core::algorithm::join(splat.begin() + 2, splat.end(), "/");
+            args << "checkout" << branch << "--";
+         }
+         else
+         {
+            // shouldn't happen, but provide valid shell command regardless
+            args << "checkout" << id << "--";
+         }
+      }
+      else
+      {
+         args << "checkout" << id << "--";
+      }
+      
+      return createConsoleProc(args,
                                "Git Checkout " + id,
                                true,
                                ppCP);

--- a/src/gwt/src/org/rstudio/core/client/widget/CustomMenuItemSeparator.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/CustomMenuItemSeparator.java
@@ -1,7 +1,7 @@
 /*
- * LabelledMenuSeparator.java
+ * CustomMenuItemSeparator.java
  *
- * Copyright (C) 2009-15 by RStudio, Inc.
+ * Copyright (C) 2009-16 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,17 +14,25 @@
  */
 package org.rstudio.core.client.widget;
 
-import org.rstudio.core.client.theme.res.ThemeStyles;
-
-import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.MenuItemSeparator;
+import com.google.gwt.user.client.ui.Widget;
 
-public class LabelledMenuSeparator extends MenuItemSeparator
+public abstract class CustomMenuItemSeparator extends MenuItemSeparator
 {
-   public LabelledMenuSeparator(String text)
+   // the actual widget to be used as a separator
+   public abstract Widget createMainWidget();
+   
+   public Widget getMainWidget()
    {
-      Label label = new Label(text);
-      label.addStyleName(ThemeStyles.INSTANCE.menuSubheader());
-      getElement().appendChild(label.getElement());
+      return widget_;
    }
+   
+   public CustomMenuItemSeparator()
+   {
+      widget_ = createMainWidget();
+      getElement().removeAllChildren();
+      getElement().appendChild(widget_.getElement());
+   }
+   
+   private final Widget widget_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/LabelledMenuSeparator.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/LabelledMenuSeparator.java
@@ -23,8 +23,15 @@ public class LabelledMenuSeparator extends MenuItemSeparator
 {
    public LabelledMenuSeparator(String text)
    {
+      this(text, true);
+   }
+   
+   public LabelledMenuSeparator(String text, boolean includeLineSeparator)
+   {
       Label label = new Label(text);
       label.addStyleName(ThemeStyles.INSTANCE.menuSubheader());
+      if (!includeLineSeparator)
+         getElement().removeAllChildren();
       getElement().appendChild(label.getElement());
    }
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
@@ -26,6 +26,7 @@ import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.Event.NativePreviewHandler;
 import com.google.gwt.user.client.ui.MenuItem;
+import com.google.gwt.user.client.ui.MenuItemSeparator;
 import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.command.AppMenuItem;
 import org.rstudio.core.client.command.BaseMenuBar;
@@ -108,14 +109,14 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
       menuBar_.addSeparator();
    }
    
+   public void addSeparator(MenuItemSeparator separator)
+   {
+      menuBar_.addSeparator(separator);
+   }
+   
    public void addSeparator(String label)
    {
       menuBar_.addSeparator(new LabelledMenuSeparator(label));
-   }
-   
-   public void addSeparator(String label, boolean includeLineSeparator)
-   {
-      menuBar_.addSeparator(new LabelledMenuSeparator(label, includeLineSeparator));
    }
    
    public void addSeparator(int minPx)

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
@@ -113,6 +113,11 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
       menuBar_.addSeparator(new LabelledMenuSeparator(label));
    }
    
+   public void addSeparator(String label, boolean includeLineSeparator)
+   {
+      menuBar_.addSeparator(new LabelledMenuSeparator(label, includeLineSeparator));
+   }
+   
    public void addSeparator(int minPx)
    {
       menuBar_.addSeparator(new MinWidthMenuSeparator(minPx));
@@ -126,6 +131,11 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
    public void focus()
    {
       menuBar_.focus();
+   }
+   
+   public void setAutoHideRedundantSeparators(boolean value)
+   {
+      menuBar_.setAutoHideRedundantSeparators(value);
    }
 
    public void getDynamicPopupMenu(DynamicPopupMenuCallback callback)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
@@ -15,12 +15,15 @@
 package org.rstudio.studio.client.workbench.views.vcs;
 
 import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.MenuItem;
+import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
@@ -33,6 +36,8 @@ import org.rstudio.core.client.MapUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.WidgetHandlerRegistration;
 import org.rstudio.core.client.js.JsUtil;
+import org.rstudio.core.client.theme.res.ThemeStyles;
+import org.rstudio.core.client.widget.CustomMenuItemSeparator;
 import org.rstudio.core.client.widget.ScrollableToolbarPopupMenu;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
@@ -110,7 +115,7 @@ public class BranchToolbarButton extends ToolbarButton
       // separate branches based on remote name
       Map<String, List<String>> branchMap = new LinkedHashMap<String, List<String>>();
       List<String> localBranches = new ArrayList<String>();
-      branchMap.put("(local branches)", localBranches);
+      branchMap.put(LOCAL_BRANCHES, localBranches);
       for (String branch : JsUtil.asIterable(branches))
       {
          if (branch.startsWith("remotes/"))
@@ -132,8 +137,6 @@ public class BranchToolbarButton extends ToolbarButton
       }
       
       onBeforePopulateMenu(rootMenu);
-      
-      // populate local branches
       populateMenu(rootMenu, branchMap);
    }
    
@@ -142,9 +145,23 @@ public class BranchToolbarButton extends ToolbarButton
       MapUtil.forEach(branchMap, new MapUtil.ForEachCommand<String, List<String>>()
       {
          @Override
-         public void execute(String caption, List<String> branches)
+         public void execute(final String caption, final List<String> branches)
          {
-            menu.addSeparator(caption, false);
+            menu.addSeparator(new CustomMenuItemSeparator()
+            {
+               @Override
+               public Widget createMainWidget()
+               {
+                  String branchLabel = caption.equals(LOCAL_BRANCHES)
+                        ? LOCAL_BRANCHES
+                        : "(Remote: " + caption + ")";
+                  Label label = new Label(branchLabel);
+                  label.addStyleName(ThemeStyles.INSTANCE.menuSubheader());
+                  label.getElement().getStyle().setPaddingLeft(2, Unit.PX);
+                  return label;
+               }
+            });
+            
             for (String branch : branches)
             {
                // skip detached branches
@@ -174,4 +191,5 @@ public class BranchToolbarButton extends ToolbarButton
    protected final Provider<GitState> pVcsState_;
 
    private static final String NO_BRANCH = "(No branch)";
+   private static final String LOCAL_BRANCHES = "(local branches)";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
@@ -187,6 +187,7 @@ public class BranchToolbarButton extends ToolbarButton
                   return label;
                }
             });
+            menu.addSeparator();
             
             for (String branch : branches)
             {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
@@ -139,6 +139,10 @@ public class BranchToolbarButton extends ToolbarButton
             if (branch.contains("HEAD detached at"))
                continue;
             
+            // skip HEAD branches
+            if (branch.contains("HEAD ->"))
+               continue;
+            
             final String branchLabel = branch.replaceAll("^remotes/", "");
             final String branchValue = branch.replaceAll("\\s+\\-\\>.*", "");
             menu.addItem(new MenuItem(

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
@@ -28,6 +28,8 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -147,6 +149,30 @@ public class BranchToolbarButton extends ToolbarButton
          @Override
          public void execute(final String caption, final List<String> branches)
          {
+            // place commonly-used branches at the top
+            Collections.sort(branches, new Comparator<String>()
+            {
+               private final String[] specialBranches_ = new String[] {
+                     "master",
+                     "develop",
+                     "trunk"
+               };
+               
+               @Override
+               public int compare(String o1, String o2)
+               {
+                  for (String specialBranch : specialBranches_)
+                  {
+                     if (o1.endsWith(specialBranch))
+                        return -1;
+                     else if (o2.endsWith(specialBranch))
+                        return 1;
+                  }
+                  
+                  return o1.compareToIgnoreCase(o2);
+               }
+            });
+            
             menu.addSeparator(new CustomMenuItemSeparator()
             {
                @Override


### PR DESCRIPTION
This PR tweaks the behavior when displaying git branches, and how remote branches are checked out.

We now separate remote and local branches into separate blocks, e.g.

![screen shot 2016-08-30 at 4 33 48 pm](https://cloud.githubusercontent.com/assets/1976582/18110838/901dacc0-6ecf-11e6-9882-69d4c25bb8e6.png)

And attempting to check out a remote branch now checks out a local copy of the branch tracking that remote.

Let me know what you think -- one other thing we might want to consider is, rather than grouping all remote branches into a single group, separating them into groups based on the remote name.