### PR TITLE
fix markdown image preview for Qt platforms

### DIFF
--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -944,7 +944,7 @@ void viewPdfPostback(const std::string& pdfPath,
 void handleFileShow(const http::Request& request, http::Response* pResponse)
 {
    // get the file path
-   FilePath filePath(request.queryParamValue("path"));
+   FilePath filePath = module_context::resolveAliasedPath(request.queryParamValue("path"));
    if (!filePath.exists())
    {
       pResponse->setNotFoundError(request.uri());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorIdleCommands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorIdleCommands.java
@@ -139,7 +139,7 @@ public class AceEditorIdleCommands
       
       // check to see if we already have a popup showing for this image;
       // if we do then bail early
-      String encoded = StringUtil.encodeURIComponent(srcPath);
+      String encoded = StringUtil.encodeURIComponent(href);
       Element el = Document.get().getElementById(encoded);
       if (el != null)
          return;
@@ -170,10 +170,7 @@ public class AceEditorIdleCommands
          absPath = FilePathUtils.dirFromFile(docPath) + "/" + absPath;
       }
       
-      if (absPath.startsWith("~/"))
-         return "files/" + StringUtil.encodeURIComponent(absPath.substring(2));
-      else
-         return "file_show?path=" + StringUtil.encodeURIComponent(absPath);
+      return "file_show?path=" + StringUtil.encodeURIComponent(absPath) + "&id=" + ID++;
    }
    
    private static Position resolvePosition(AceEditor editor, IdleState state)
@@ -305,6 +302,8 @@ public class AceEditorIdleCommands
    
    public final IdleCommand PREVIEW_LINK;
    public final IdleCommand PREVIEW_LATEX;
+   
+   private static int ID;
    
    // Injected ----
    private SourceWindowManager swm_;


### PR DESCRIPTION
This PR resolves an issue where image preview on Qt platforms failed due to an apparent lost response re: cached images. We resolve this by adding a unique id to the query, thereby defeating caching.

Note that this PR also adds a 'resolveAliasedPath' call into the `file_show` RPC handler, so that it can handle paths from the client prefixed with `~`.