### PR TITLE
preview markdown links as line widgets

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorIdleCommands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorIdleCommands.java
@@ -143,10 +143,6 @@ public class AceEditorIdleCommands
                                Position position,
                                Range tokenRange)
    {
-      // for local images, construct a path that the server URI redirects
-      // will handle properly
-      String srcPath = imgSrcPathFromHref(href);
-      
       // check to see if we already have a popup showing for this image;
       // if we do then bail early
       String encoded = StringUtil.encodeURIComponent(href);
@@ -342,6 +338,7 @@ public class AceEditorIdleCommands
                   return;
                
                // set new src location (load handler will replace label as needed)
+               noImageLabel.setText("(No image at path " + href_ + ")");
                image.getElement().setAttribute("src", imgSrcPathFromHref(href_));
             }
          };

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorIdleCommands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorIdleCommands.java
@@ -328,8 +328,8 @@ public class AceEditorIdleCommands
       // initialize doc changed handler
       docChangedHandler.set(editor.addDocumentChangedHandler(new DocumentChangedEvent.Handler()
       {
-         String href_;
-         final Timer refreshImageTimer = new Timer()
+         private String href_ = href;
+         private final Timer refreshImageTimer = new Timer()
          {
             @Override
             public void run()
@@ -370,6 +370,12 @@ public class AceEditorIdleCommands
                   if (hrefToken == null)
                      return;
                   
+                  // if we have the same href as before, don't update
+                  // (avoid flickering + re-requests of same URL)
+                  if (hrefToken.getValue().equals(href_))
+                     return;
+                  
+                  // cache href and schedule refresh of image
                   href_ = hrefToken.getValue();
                   refreshImageTimer.schedule(700);
                }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorIdleCommands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorIdleCommands.java
@@ -191,35 +191,46 @@ public class AceEditorIdleCommands
       // command that ensures state is cleaned up when widget hidden
       final Command onDetach = new Command()
       {
+         private void detach()
+         {
+            // detach chunk output widget
+            cow.set(null);
+
+            // detach pinned line widget
+            if (plw.get() != null)
+               plw.get().detach();
+            plw.set(null);
+
+            // detach render handler
+            if (renderHandler.get() != null)
+               renderHandler.get().removeHandler();
+            renderHandler.set(null);
+
+            // detach doc changed handler
+            if (docChangedHandler.get() != null)
+               docChangedHandler.get().removeHandler();
+            docChangedHandler.set(null);
+         }
+         
          @Override
          public void execute()
          {
+            // if the associated chunk output widget has been cleaned up,
+            // make a last-ditch detach effort anyhow
             ChunkOutputWidget widget = cow.get();
             if (widget == null)
+            {
+               detach();
                return;
+            }
             
+            // fade out and then detach
             FadeOutAnimation anim = new FadeOutAnimation(widget, new Command()
             {
                @Override
                public void execute()
                {
-                  // detach chunk output widget
-                  cow.set(null);
-
-                  // detach pinned line widget
-                  if (plw.get() != null)
-                     plw.get().detach();
-                  plw.set(null);
-
-                  // detach render handler
-                  if (renderHandler.get() != null)
-                     renderHandler.get().removeHandler();
-                  renderHandler.set(null);
-
-                  // detach doc changed handler
-                  if (docChangedHandler.get() != null)
-                     docChangedHandler.get().removeHandler();
-                  docChangedHandler.set(null);
+                  detach();
                }
             });
             

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorIdleCommands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorIdleCommands.java
@@ -405,8 +405,8 @@ public class AceEditorIdleCommands
       };
       
       cow.set(new ChunkOutputWidget(
-            StringUtil.makeRandomId(8),
-            StringUtil.makeRandomId(8),
+            "",
+            "md-image-preview-" + StringUtil.makeRandomId(8),
             RmdChunkOptions.create(),
             ChunkOutputWidget.EXPANDED,
             host));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorIdleCommands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorIdleCommands.java
@@ -292,6 +292,7 @@ public class AceEditorIdleCommands
             else if (DOM.eventGetType(event) == Event.ONERROR)
             {
                container.setWidget(noImageLabel);
+               onResize.execute(50);
             }
          }
       });
@@ -338,6 +339,7 @@ public class AceEditorIdleCommands
                   return;
                
                // set new src location (load handler will replace label as needed)
+               container.setWidget(new SimplePanel());
                noImageLabel.setText("(No image at path " + href_ + ")");
                image.getElement().setAttribute("src", imgSrcPathFromHref(href_));
             }


### PR DESCRIPTION
This PR previews image links with R Markdown documents as line widgets, for lines in the editor that contain only a single Markdown link. Example:

![screen shot 2016-09-06 at 4 37 06 pm](https://cloud.githubusercontent.com/assets/1976582/18294733/4f8973a2-7450-11e6-8bdd-c5bf347b7b1e.png)

The presentation is simple for invalid links:

![screen shot 2016-09-06 at 4 53 05 pm](https://cloud.githubusercontent.com/assets/1976582/18294987/6feaddc8-7452-11e6-8dfc-6ad17070e00e.png)

The resize behaviors are set to be concordant with regular R plot chunk outputs.