### PR TITLE
add pretty json print to request debugging

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RequestLogDetail.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RequestLogDetail.java
@@ -22,6 +22,18 @@ import org.rstudio.core.client.jsonrpc.RequestLogEntry;
 
 public class RequestLogDetail extends Composite
 {
+   private native String tryPrettyJson(String raw) /*-{
+      var pretty = raw;
+
+      try {
+        pretty = JSON.stringify(JSON.parse(raw), null, 2);
+      }
+      catch(e) {
+      }
+
+      return pretty;
+   }-*/;
+
    public RequestLogDetail(RequestLogEntry entry)
    {
       String req = entry.getRequestData();
@@ -33,10 +45,10 @@ public class RequestLogDetail extends Composite
       HTML html = new HTML();
       html.setText("Request ID: " + entry.getRequestId() + "\n\n"
                    + "== REQUEST ======\n"
-                   + req
+                   + tryPrettyJson(req)
                    + "\n\n"
                    + "== RESPONSE ======\n"
-                   + resp
+                   + tryPrettyJson(resp)
                    + "\n");
       html.getElement().getStyle().setProperty("whiteSpace", "pre-wrap");
 


### PR DESCRIPTION
Found is was helpful to pretty-print JSON while debugging, any objections? It does use more space, but I find the non-pretty version is most of the times, unreadable.

<img width="1038" alt="screen shot 2016-09-06 at 4 50 16 pm" src="https://cloud.githubusercontent.com/assets/3478847/18294945/1d0d309c-7452-11e6-9d48-cbbbe774a603.png">
