### PR TITLE
respect setup chunk's fig.width, fig.height

### DIFF
--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -897,13 +897,28 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    grepl("^\\s*```{[Rr]\\s+setup[\\s,}]", lines[[1]], perl = TRUE)
 })
 
-.rs.addFunction("defaultChunkOptions", function()
-{
-   .rs.scalarListFromList(knitr::opts_chunk$get())
-})
-
 .rs.addFunction("setDefaultChunkOptions", function()
 {
-   knitr::opts_chunk$set(error = FALSE)
+   # cache the current set of chunk options
+   chunkOptions <- knitr::opts_chunk$get()
+   assign(".rs.knitr.chunkOptions", chunkOptions, envir = .rs.toolsEnv())
+   
+   # unset the chunk options (so we know what options
+   # were actually specified in setup chunk later)
+   defaults <- list(error = FALSE)
+   knitr::opts_chunk$restore(defaults)
+})
+
+.rs.addFunction("defaultChunkOptions", function()
+{
+   # get current set of options
+   defaultOptions <- knitr::opts_chunk$get()
+   
+   # restore the previously cached knitr options
+   chunkOptions <- get(".rs.knitr.chunkOptions", envir = .rs.toolsEnv())
+   knitr::opts_chunk$restore(chunkOptions)
+   
+   # return current set
+   .rs.scalarListFromList(defaultOptions)
 })
 

--- a/src/cpp/session/modules/rmarkdown/NotebookChunkOptions.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookChunkOptions.cpp
@@ -35,6 +35,12 @@ const core::json::Object& ChunkOptions::chunkOptions() const
    return chunkOptions_;
 }
 
+const core::json::Object& ChunkOptions::defaultOptions() const
+{
+   return defaultOptions_;
+}
+
+
 core::json::Object ChunkOptions::mergedOptions() const
 {
    json::Object merged(defaultOptions_);

--- a/src/cpp/session/modules/rmarkdown/NotebookChunkOptions.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookChunkOptions.hpp
@@ -48,6 +48,9 @@ public:
 
    // return overlay only
    const core::json::Object& chunkOptions() const;
+   
+   // return defaults (from setup chunk)
+   const core::json::Object& defaultOptions() const;
 
    // returned merged object with all options
    core::json::Object mergedOptions() const;

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
@@ -120,12 +120,9 @@ void ChunkExecContext::connect()
    connections_.push_back(events().onCondition.connect(
          boost::bind(&ChunkExecContext::onCondition, this, _1, _2)));
 
-   // extract knitr figure options if present (currently supported at the 
-   // chunk level only)
-   double figWidth = 0;
-   double figHeight = 0;
-   json::readObject(options_.chunkOptions(), "fig.width",  &figWidth);
-   json::readObject(options_.chunkOptions(), "fig.height", &figHeight);
+   // extract knitr figure options if present
+   double figWidth = options_.getOverlayOption("fig.width", 0.0);
+   double figHeight = options_.getOverlayOption("fig.height", 0.0);
 
    // begin capturing plots 
    connections_.push_back(events().onPlotOutput.connect(


### PR DESCRIPTION
This PR ensures that R Notebooks will respect a custom-set `fig.width`, `fig.height` within the setup chunk.

We accomplish this by ensuring that the 'default' chunks inferred from the setup chunk are only the user-set chunks, and not the knitr default options. We now:

1. Cache and clear the current chunk options,
2. Execute the setup chunk,
3. Record the change in the chunk options state,
4. Restore the chunk options set in (1).

One TODO item here -- it looks like empty chunks are ignored right now when sent to the execution queue, so attempting to clear the setup chunk doesn't actually reset the default chunk options for that notebook.