### PR TITLE
avoid having multiple shortcuts for 'S' in menu

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -995,14 +995,14 @@ well as menu structures (for main menu and popup menus).
    
    <cmd id="openProjectInNewWindow"
         label="Open Project with New R Session"
-        menuLabel="Open Project in New _Session..."
+        menuLabel="Open Project in New Session..."
         buttonLabel=""
         desc="Open project in a new R session"
         windowMode="main"/>
    
    <cmd id="shareProject"
         label="Share Project..."
-        menuLabel="_Share Project..."
+        menuLabel="Share Project..."
         buttonLabel=""
         desc="Share this project with others"
         windowMode="main"/>


### PR DESCRIPTION
We received a bug report on the support forums re: our use of multiple menu entries for 's' in the File menu:

https://support.rstudio.com/hc/en-us/community/posts/214194388--Open-Project-in-New-Session-breaks-Alt-F-S-key-binding
https://support.rstudio.com/hc/en-us/community/posts/214190628-Shortcut-Key-Error

Note that it's possible to toggle through the set of available menu items by typing `s` multiple times, but it might be best to avoid duplication.

If we wanted to ensure a keyboard shortcut was available, we could switch from Session to Window and use `d` as the shortcut key.

(Opening this PR mainly just for discussion; we may not want to do anything here)