### PR TITLE
clear incremental search position when activating Find/Replace

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplace.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplace.java
@@ -163,6 +163,7 @@ public class FindReplace
                         boolean inSelection)
    {
       defaultForward_ = defaultForward;
+      incrementalSearchPosition_ = null;
       display_.activate(searchText, defaultForward, inSelection);
    }
    


### PR DESCRIPTION
This PR resolves an issue where opening the Find / Replace bar could re-initiate a previous search session. For example, in this document:

```
abc
def
abc
def
abc
```
1. Press `Cmd+F`, and search for the term `abc`,
2. Press `Cmd+G` twice to select the final instance of `abc`,
3. Press `Cmd+1` to send focus to the source editor,
4. Navigate the cursor back to the start of the document,
5. Press `Cmd+F` again.

The 'saved' search position from the previous search session is used / restored, even though this is likely not what was intended (the search session was implicitly ended when the Find/Replace bar lost focus).

We should double-check that this isn't an intentional behavior for other uses of the Find/Replace bar before merging this.
