### PR TITLE
fix qt satellite chunk window crash during paint by delaying frame load

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkHtmlPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkHtmlPage.java
@@ -23,6 +23,7 @@ import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Widget;
 
 public class ChunkHtmlPage extends ChunkOutputPage
@@ -63,21 +64,41 @@ public class ChunkHtmlPage extends ChunkOutputPage
          content_ = frame_;
       }
 
-      frame_.loadUrl(url, new Command()
+      final String fullUrl = url;
+      Timer frameLoadTimer = new Timer()
       {
          @Override
-         public void execute()
+         public void run()
          {
-            Element body = frame_.getDocument().getBody();
-            Style bodyStyle = body.getStyle();
+            frame_.loadUrl(fullUrl , new Command() 
+            {
+               @Override
+               public void execute()
+               {
+                  Element body = frame_.getDocument().getBody();
+                  Style bodyStyle = body.getStyle();
             
-            bodyStyle.setPadding(0, Unit.PX);
-            bodyStyle.setMargin(0, Unit.PX);
-            onEditorThemeChanged(ChunkOutputWidget.getEditorColors());
-            
-            onRenderComplete.execute();
-         };
-      });
+                  bodyStyle.setPadding(0, Unit.PX);
+                  bodyStyle.setMargin(0, Unit.PX);
+
+                  onEditorThemeChanged(ChunkOutputWidget.getEditorColors());
+
+                  Timer frameFinishLoadTimer = new Timer()
+                  {
+                     @Override
+                     public void run()
+                     {
+                        onRenderComplete.execute();
+                     }
+                  };
+
+                  frameFinishLoadTimer.schedule(100);
+               };
+            });
+         }
+      };
+
+      frameLoadTimer.schedule(400);
    }
       
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -44,6 +44,7 @@ import com.google.gwt.dom.client.Style.Overflow;
 import com.google.gwt.dom.client.Style.Position;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.Image;
@@ -229,22 +230,32 @@ public class ChunkOutputStream extends FlowPanel
          addWithOrdinal(frame, ordinal);
       }
 
-      frame.loadUrl(url, new Command() 
+      Element body = frame.getDocument().getBody();
+      Style bodyStyle = body.getStyle();
+            
+      bodyStyle.setPadding(0, Unit.PX);
+      bodyStyle.setMargin(0, Unit.PX);
+      bodyStyle.setColor(ChunkOutputWidget.getEditorColors().foreground);
+
+      final String fullUrl = url;
+      Timer frameLoadTimer = new Timer()
       {
          @Override
-         public void execute()
+         public void run()
          {
-            Element body = frame.getDocument().getBody();
-            Style bodyStyle = body.getStyle();
-            
-            bodyStyle.setPadding(0, Unit.PX);
-            bodyStyle.setMargin(0, Unit.PX);
-            bodyStyle.setColor(ChunkOutputWidget.getEditorColors().foreground);
-            
-            onRenderComplete.execute();
-            onHeightChanged();
-         };
-      });
+            frame.loadUrl(fullUrl , new Command() 
+            {
+               @Override
+               public void execute()
+               {
+                  onRenderComplete.execute();
+                  onHeightChanged();
+               };
+            });
+         }
+      };
+
+      frameLoadTimer.schedule(250);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkWindowManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkWindowManager.java
@@ -34,13 +34,12 @@ public class ChunkWindowManager
 
    public void openChunkWindow(String docId, String chunkId, Size sourceSize)
    {
-      Size size = ZoomUtils.getZoomWindowSize(sourceSize, new Size(850,1100));
-      Point position = new Point(0, 0);
+      Size size = ZoomUtils.getZoomWindowSize(sourceSize, null);
       
       pSatelliteManager_.get().openSatellite(
          getName(docId, chunkId), 
          ChunkWindowParams.create(docId, chunkId), 
-         size, false, position);
+         size);
    }
    
    public String getName(String docId, String chunkId)


### PR DESCRIPTION
Delaying the html rendering for html chunks in windows under satellite windows fixes hitting this crash:

```
0    WTFCrash    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x133bfcf3    
1    WebCore::FrameView::paintContents(WebCore::GraphicsContext*, WebCore::IntRect const&)    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x12d85e59    
2    WebCore::ScrollView::paint(WebCore::GraphicsContext*, WebCore::IntRect const&)    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x12c84676    
3    WebCore::RenderWidget::paintContents(WebCore::PaintInfo&, WebCore::LayoutPoint const&)    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x11b78870    
4    WebCore::RenderWidget::paint(WebCore::PaintInfo&, WebCore::LayoutPoint const&)    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x11b009be    
5    WebCore::RenderLayer::paintForegroundForFragmentsWithPhase(WebCore::PaintPhase, WTF::Vector<WebCore::LayerFragment, 1u, WTF::CrashOnOverflow> const&, WebCore::GraphicsContext*, WebCore::RenderLayer::LayerPaintingInfo const&, unsigned int, WebCore::RenderObject*)    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x11a9d674    
6    WebCore::RenderLayer::paintForegroundForFragments(WTF::Vector<WebCore::LayerFragment, 1u, WTF::CrashOnOverflow> const&, WebCore::GraphicsContext*, WebCore::GraphicsContext*, WebCore::LayoutRect const&, bool, WebCore::RenderLayer::LayerPaintingInfo const&, unsigned int, WebCore::RenderObject*, bool, bool)    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x11ad077a    
7    WebCore::RenderLayer::paintLayerContents(WebCore::GraphicsContext*, WebCore::RenderLayer::LayerPaintingInfo const&, unsigned int)    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x11b75f15    
8    WebCore::RenderLayer::paintLayer(WebCore::GraphicsContext*, WebCore::RenderLayer::LayerPaintingInfo const&, unsigned int)    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x11b770d7    
9    WebCore::RenderLayer::paintList(WTF::Vector<WebCore::RenderLayer*, 0u, WTF::CrashOnOverflow>*, WebCore::GraphicsContext*, WebCore::RenderLayer::LayerPaintingInfo const&, unsigned int)    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x11b78433    
10    WebCore::RenderLayer::paintLayerContents(WebCore::GraphicsContext*, WebCore::RenderLayer::LayerPaintingInfo const&, unsigned int)    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x11b76397    
11    WebCore::RenderLayerBacking::paintIntoLayer(WebCore::GraphicsLayer const*, WebCore::GraphicsContext*, WebCore::IntRect const&, unsigned int, unsigned int)    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x12c2b0f4    
12    WebCore::RenderLayerBacking::paintContents(WebCore::GraphicsLayer const*, WebCore::GraphicsContext&, unsigned int, WebCore::IntRect const&)    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x12c2b31c    
13    WebCore::GraphicsLayer::paintGraphicsLayerContents(WebCore::GraphicsContext&, WebCore::IntRect const&)    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x12d0445a    
14    WebCore::BitmapTextureImageBuffer::updateContents(WebCore::TextureMapper*, WebCore::GraphicsLayer*, WebCore::IntRect const&, WebCore::IntPoint const&, WebCore::BitmapTexture::UpdateContentsFlag)    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x12b901ed    
15    WebCore::TextureMapperTile::updateContents(WebCore::TextureMapper*, WebCore::GraphicsLayer*, WebCore::IntRect const&, WebCore::BitmapTexture::UpdateContentsFlag)    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x12b8a0e9    
16    WebCore::TextureMapperTiledBackingStore::updateContents(WebCore::TextureMapper*, WebCore::GraphicsLayer*, WebCore::FloatSize const&, WebCore::IntRect const&, WebCore::BitmapTexture::UpdateContentsFlag)    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x12b899e8    
17    WebCore::GraphicsLayerTextureMapper::updateBackingStoreIfNeeded()    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x12b939cf    
18    WebCore::GraphicsLayerTextureMapper::flushCompositingState(WebCore::FloatRect const&)    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x12b931bd    
19    WebCore::GraphicsLayerTextureMapper::flushCompositingState(WebCore::FloatRect const&)    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x12b93217    
20    WebCore::GraphicsLayerTextureMapper::flushCompositingState(WebCore::FloatRect const&)    C:\Qt\Qt5.4.1\5.4\mingw491_32\bin\Qt5WebKitd.dll        0x12b93217    
```