### PR TITLE
Add support for custom help handlers

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -859,7 +859,8 @@
       signature <- help$signature
       if (!is.null(signature)) {
          paren <- regexpr("\\(", signature)[[1]]
-         signature <- substring(signature, paren)
+         if (paren != -1)
+            signature <- substring(signature, paren)
       }
       return (.rs.scalar(signature))
    }

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -550,8 +550,7 @@
    }
 })
 
-# check to see whether there is a custom help handler for this token
-.rs.addFunction("getCustomHelpUrl", function(token) {
+.rs.addFunction("findCustomHelpContext", function(token, handler) {
    
    # if the token has a '$' in it then it might have a custom
    # help handler that can field this request
@@ -569,10 +568,13 @@
       # look for a help url handler
       if (!is.null(source)) {
          for (cls in class(source)) {
-            res <- utils::getAnywhere(paste0("help_url_handler.", cls))
+            res <- utils::getAnywhere(paste0(handler, ".", cls))
             if (length(res$objs) > 0) {
-               handler <- res$objs[[1]]
-               return (handler(topic, source))
+               return(list(
+                  topic = topic,
+                  source = source,
+                  handler = res$objs[[1]]
+               ))
             }
          }
       }
@@ -580,6 +582,16 @@
    
    # default to none found
    NULL
+   
+})
+
+# check to see whether there is a custom help handler for this token
+.rs.addFunction("getCustomHelpUrl", function(token) {
+   custom <- .rs.findCustomHelpContext(token, "help_url_handler")
+   if (!is.null(custom))
+      custom$handler(custom$topic, custom$source)
+   else
+      NULL
 })
 
 .rs.addJsonRpcHandler("execute_r_code", function(code)

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -832,8 +832,20 @@
    NULL
 })
 
-.rs.addJsonRpcHandler("get_args", function(name, src)
+.rs.addJsonRpcHandler("get_args", function(name, src, helpHandler)
 {
+   # call custom help handler if provided
+   if (nzchar(helpHandler)) {
+      helpHandlerFunc <- tryCatch(eval(parse(text = helpHandler)),
+                                  error = function(e) NULL)
+      if (!is.function(helpHandlerFunc))
+         return(NULL)
+      help <- helpHandlerFunc("completion", name, src)
+      if (is.null(help))
+         return(NULL)
+      return (help$signature)
+   }
+
    if (identical(src, ""))
       src <- .GlobalEnv
    

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -559,7 +559,7 @@
       # split on $ (it has at least one so components will be > 1)
       components <- strsplit(token, "\\$")[[1]]
       topic <- components[[length(components)]]
-      source <- paste(components[1:length(components)-1], collapse = "$")
+      source <- paste(components[1:(length(components)-1)], collapse = "$")
       
       # evaluate the source
       source <- tryCatch(eval(parse(text = source), envir = globalenv()), 

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -568,7 +568,7 @@
       # look for a help url handler
       if (!is.null(source)) {
          for (cls in class(source)) {
-            res <- utils::getAnywhere(paste0(handler, ".", cls))
+            res <- utils::getAnywhere(paste(handler, ".", cls, sep=""))
             if (length(res$objs) > 0) {
                return(list(
                   topic = topic,

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -857,8 +857,10 @@
       if (is.null(help))
          return(NULL)
       signature <- help$signature
-      paren <- regexpr("\\(", signature)[[1]]
-      signature <- substring(signature, paren)
+      if (!is.null(signature)) {
+         paren <- regexpr("\\(", signature)[[1]]
+         signature <- substring(signature, paren)
+      }
       return (.rs.scalar(signature))
    }
 

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -541,11 +541,12 @@
    else {
       # try custom help handler, otherwise fall through to default handler
       helpUrl <- .rs.getCustomHelpUrl(token)
-      if (!is.null(helpUrl))
+      if (!is.null(helpUrl)) {
          if (nzchar(helpUrl)) # handlers return "" to indicate no help available
             utils::browseURL(helpUrl)
-      else
+      } else {
          print(help(pieces[1], help_type='html', try.all.packages=TRUE))
+      }
    }
 })
 

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -844,7 +844,10 @@
       help <- helpHandlerFunc("completion", name, src)
       if (is.null(help))
          return(NULL)
-      return (help$signature)
+      signature <- help$signature
+      paren <- regexpr("\\(", signature)[[1]]
+      signature <- substring(signature, paren)
+      return (.rs.scalar(signature))
    }
 
    if (identical(src, ""))

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -293,6 +293,16 @@ options(help_type = "html")
    helpHandlerFunc("completion", topic, source)
 })
 
+.rs.addJsonRpcHandler("get_custom_parameter_help", function(helpHandler, source) {
+   
+   helpHandlerFunc <- tryCatch(eval(parse(text = helpHandler)), 
+                               error = function(e) NULL)
+   if (!is.function(helpHandlerFunc))
+      return()
+   
+   helpHandlerFunc("parameter", NULL, source)
+})
+
 .rs.addJsonRpcHandler("show_custom_help_topic", function(helpHandler, topic, source) {
    
    helpHandlerFunc <- tryCatch(eval(parse(text = helpHandler)), 

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -301,7 +301,7 @@ options(help_type = "html")
       return()
    
    url <- helpHandlerFunc("url", topic, source)
-   if (!is.null(url))
+   if (!is.null(url) && nzchar(url)) # handlers return "" for no help topic
       utils::browseURL(url)
 })
 

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -283,6 +283,29 @@ options(help_type = "html")
       return()
 })
 
+.rs.addJsonRpcHandler("get_custom_help", function(helpHandler, topic, source) {
+   
+   helpHandlerFunc <- tryCatch(eval(parse(text = helpHandler)), 
+                               error = function(e) NULL)
+   if (!is.function(helpHandlerFunc))
+      return()
+   
+   helpHandlerFunc("completion", topic, source)
+})
+
+.rs.addJsonRpcHandler("show_custom_help_topic", function(helpHandler, topic, source) {
+   
+   helpHandlerFunc <- tryCatch(eval(parse(text = helpHandler)), 
+                               error = function(e) NULL)
+   if (!is.function(helpHandlerFunc))
+      return()
+   
+   url <- helpHandlerFunc("url", topic, source)
+   if (!is.null(url))
+      utils::browseURL(url)
+})
+
+
 .rs.addFunction("getHelpFunction", function(name, src, envir = parent.frame())
 {
    # If 'src' is the name of something on the searchpath, get that object

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1783,16 +1783,20 @@ assign(x = ".rs.acCompletionTypes",
       custom <- .rs.findCustomHelpContext(scope, "help_formals_handler")
       if (!is.null(custom)) {
          formals <- custom$handler(custom$topic, custom$source)
-         results <- paste(formals$formals, "= ")
-         results <- .rs.selectFuzzyMatches(results, token)
-         return(.rs.makeCompletions(
-            token = token,
-            results = results,
-            packages = scope,
-            type = .rs.acCompletionTypes$ARGUMENT,
-            excludeOtherCompletions = TRUE,
-            helpHandler = formals$helpHandler)
-         )
+         if (!is.null(formals)) {
+            results <- paste(formals$formals, "= ")
+            results <- .rs.selectFuzzyMatches(results, token)
+            return(.rs.makeCompletions(
+               token = token,
+               results = results,
+               packages = scope,
+               type = .rs.acCompletionTypes$ARGUMENT,
+               excludeOtherCompletions = TRUE,
+               helpHandler = formals$helpHandler)
+            )
+         } else {
+            return (.rs.emptyCompletions(excludeOtherCompletions = TRUE))
+         }
       }
    }
    

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1072,7 +1072,7 @@ assign(x = ".rs.acCompletionTypes",
             allNames <- dollarNamesMethod(object)
             
             # check for custom helpHandler
-            helpHandler <- attr(allNames, "helpHandler")
+            helpHandler <- attr(allNames, "helpHandler", exact = TRUE)
          }
          
          # Reference class generators / objects

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -854,7 +854,8 @@ assign(x = ".rs.acCompletionTypes",
                                             excludeOtherCompletions = FALSE,
                                             overrideInsertParens = FALSE,
                                             orderStartsWithAlnumFirst = TRUE,
-                                            cacheable = TRUE)
+                                            cacheable = TRUE,
+                                            helpHandler = NULL)
 {
    if (is.null(results))
       results <- character()
@@ -901,7 +902,8 @@ assign(x = ".rs.acCompletionTypes",
         fguess = fguess,
         excludeOtherCompletions = .rs.scalar(excludeOtherCompletions),
         overrideInsertParens = .rs.scalar(overrideInsertParens),
-        cacheable = .rs.scalar(cacheable))
+        cacheable = .rs.scalar(cacheable),
+        helpHandler = .rs.scalar(helpHandler))
 })
 
 .rs.addFunction("subsetCompletions", function(completions, indices)
@@ -1028,6 +1030,7 @@ assign(x = ".rs.acCompletionTypes",
       allNames <- character()
       names <- character()
       type <- numeric()
+      helpHandler <- NULL
       
       if (isAt)
       {
@@ -1064,6 +1067,9 @@ assign(x = ".rs.acCompletionTypes",
          if (is.function(dollarNamesMethod))
          {
             allNames <- dollarNamesMethod(object)
+            
+            # check for custom helpHandler
+            helpHandler <- attr(allNames, "helpHandler")
          }
          
          # Reference class generators / objects
@@ -1164,7 +1170,8 @@ assign(x = ".rs.acCompletionTypes",
          packages = string,
          quote = FALSE,
          type = type,
-         excludeOtherCompletions = TRUE
+         excludeOtherCompletions = TRUE,
+         helpHandler = helpHandler
       )
    }
    

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -945,6 +945,9 @@ assign(x = ".rs.acCompletionTypes",
    if (length(new$cacheable) && !new$cacheable)
       old$cacheable <- new$cacheable
    
+   if (length(new$helpHandler))
+      old$helpHandler <- new$helpHandler
+   
    old
 })
 
@@ -1773,6 +1776,25 @@ assign(x = ".rs.acCompletionTypes",
    )
    
    ## Handle some special cases early
+   
+   # custom help handler for arguments
+   if (.rs.acContextTypes$FUNCTION %in% type) {
+      scope <- string[[length(string)]]
+      custom <- .rs.findCustomHelpContext(scope, "help_formals_handler")
+      if (!is.null(custom)) {
+         formals <- custom$handler(custom$topic, custom$source)
+         results <- paste(formals$formals, "= ")
+         results <- .rs.selectFuzzyMatches(results, token)
+         return(.rs.makeCompletions(
+            token = token,
+            results = results,
+            packages = scope,
+            type = .rs.acCompletionTypes$ARGUMENT,
+            excludeOtherCompletions = TRUE,
+            helpHandler = formals$helpHandler)
+         )
+      }
+   }
    
    # help
    if (.rs.acContextTypes$HELP %in% type)

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/CodeToolsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/CodeToolsServerOperations.java
@@ -68,6 +68,7 @@ public interface CodeToolsServerOperations extends HelpServerOperations,
    
    void getArgs(String name,
                 String source,
+                String helpHandler,
                 ServerRequestCallback<String> callback);
    
    void extractChunkOptions(

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/Completions.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/Completions.java
@@ -29,7 +29,8 @@ public class Completions extends JavaScriptObject
                                                       String fguess,
                                                       boolean excludeOtherCompletions,
                                                       boolean overrideInsertParens,
-                                                      boolean cacheable)
+                                                      boolean cacheable,
+                                                      String helpHandler)
    /*-{
       return {
          token: [token],
@@ -40,7 +41,8 @@ public class Completions extends JavaScriptObject
          fguess: fguess ? [fguess] : null,
          excludeOtherCompletions: excludeOtherCompletions,
          overrideInsertParens: overrideInsertParens,
-         cacheable: cacheable
+         cacheable: cacheable,
+         helpHandler: helpHandler
       };
    }-*/;
 
@@ -109,6 +111,10 @@ public class Completions extends JavaScriptObject
    
    public final native boolean getOverrideInsertParens() /*-{
       return this.overrideInsertParens;
+   }-*/;
+   
+   public final native String getHelpHandler() /*-{
+      return this.helpHandler;
    }-*/;
    
    

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -742,11 +742,13 @@ public class RemoteServer implements Server
    
    public void getArgs(String name,
                        String source,
+                       String helpHandler,
                        ServerRequestCallback<String> requestCallback)
    {
       JSONArray params = new JSONArray();
       params.set(0, new JSONString(name));
       params.set(1, new JSONString(source));
+      params.set(2,  new JSONString(StringUtil.notNull(helpHandler)));
       sendRequest(
             RPC_SCOPE,
             GET_ARGS,

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1004,6 +1004,19 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, GET_HELP, params, requestCallback);
    }
    
+   public void getCustomHelp(String helpHandler,
+                             String topic, 
+                             String source,
+                             ServerRequestCallback<HelpInfo.Custom> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(helpHandler));
+      params.set(1, new JSONString(topic));
+      params.set(2, new JSONString(source));
+      sendRequest(RPC_SCOPE, GET_CUSTOM_HELP, params, requestCallback);
+   }
+
+   
    public void showHelpTopic(String what, String from, int type)
    {
       JSONArray params = new JSONArray() ;
@@ -1017,6 +1030,20 @@ public class RemoteServer implements Server
                   SHOW_HELP_TOPIC,
                   params,
                   null) ;
+   }
+   
+   public void showCustomHelpTopic(String helpHandler, 
+                                   String topic, 
+                                   String source)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(helpHandler));
+      params.set(1, new JSONString(topic));
+      params.set(2, new JSONString(source));
+      sendRequest(RPC_SCOPE, 
+                  SHOW_CUSTOM_HELP_TOPIC, 
+                  params, 
+                  null);
    }
    
    public void search(String query, 
@@ -4902,6 +4929,8 @@ public class RemoteServer implements Server
    private static final String GET_HELP = "get_help";
    private static final String SHOW_HELP_TOPIC = "show_help_topic" ;
    private static final String SEARCH = "search" ;
+   private static final String GET_CUSTOM_HELP = "get_custom_help";
+   private static final String SHOW_CUSTOM_HELP_TOPIC = "show_custom_help_topic" ;
 
    private static final String STAT = "stat";
    private static final String IS_TEXT_FILE = "is_text_file";

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1017,6 +1017,16 @@ public class RemoteServer implements Server
       params.set(2, new JSONString(source));
       sendRequest(RPC_SCOPE, GET_CUSTOM_HELP, params, requestCallback);
    }
+   
+   public void getCustomParameterHelp(String helpHandler,
+                                      String source,
+                                      ServerRequestCallback<HelpInfo.Custom> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(helpHandler));
+      params.set(1, new JSONString(source));
+      sendRequest(RPC_SCOPE, GET_CUSTOM_PARAMETER_HELP, params, requestCallback);
+   }
 
    
    public void showHelpTopic(String what, String from, int type)
@@ -4932,6 +4942,7 @@ public class RemoteServer implements Server
    private static final String SHOW_HELP_TOPIC = "show_help_topic" ;
    private static final String SEARCH = "search" ;
    private static final String GET_CUSTOM_HELP = "get_custom_help";
+   private static final String GET_CUSTOM_PARAMETER_HELP = "get_custom_parameter_help";
    private static final String SHOW_CUSTOM_HELP_TOPIC = "show_custom_help_topic" ;
 
    private static final String STAT = "stat";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -298,7 +298,7 @@ public class CompletionRequester
       ArrayList<QualifiedName> newComp = new ArrayList<QualifiedName>();
       for (int i = 0; i < comp.length(); i++)
       {
-         newComp.add(new QualifiedName(comp.get(i), pkgs.get(i), quote.get(i), type.get(i)));
+         newComp.add(new QualifiedName(comp.get(i), pkgs.get(i), quote.get(i), type.get(i), response.getHelpHandler()));
       }
 
       CompletionResult result = new CompletionResult(
@@ -385,7 +385,7 @@ public class CompletionRequester
             // Get function completions from the server
             for (int i = 0; i < comp.length(); i++)
                if (comp.get(i).endsWith(" = "))
-                  newComp.add(new QualifiedName(comp.get(i), pkgs.get(i), quote.get(i), type.get(i)));
+                  newComp.add(new QualifiedName(comp.get(i), pkgs.get(i), quote.get(i), type.get(i), response.getHelpHandler()));
             
             // Try getting our own function argument completions
             if (!response.getExcludeOtherCompletions())
@@ -404,7 +404,7 @@ public class CompletionRequester
             // Get other server completions
             for (int i = 0; i < comp.length(); i++)
                if (!comp.get(i).endsWith(" = "))
-                  newComp.add(new QualifiedName(comp.get(i), pkgs.get(i), quote.get(i), type.get(i)));
+                  newComp.add(new QualifiedName(comp.get(i), pkgs.get(i), quote.get(i), type.get(i), response.getHelpHandler()));
             
             // Get snippet completions. Bail if this isn't a top-level
             // completion -- TODO is to add some more context that allows us
@@ -680,7 +680,8 @@ public class CompletionRequester
                   "",
                   false,
                   false,
-                  true);
+                  true,
+                  null);
             
             // Unlike other completion types, Sweave completions are not
             // guaranteed to narrow the candidate list (in particular
@@ -733,14 +734,21 @@ public class CompletionRequester
    
    public static class QualifiedName implements Comparable<QualifiedName>
    {
-      
       public QualifiedName(
             String name, String source, boolean shouldQuote, int type)
+      {
+         this(name, source, shouldQuote, type, null);
+      }
+      
+      public QualifiedName(
+            String name, String source, boolean shouldQuote, int type, String helpHandler)
       {
          this.name = name;
          this.source = source;
          this.shouldQuote = shouldQuote;
          this.type = type;
+         this.helpHandler = helpHandler;
+         
       }
       
       public QualifiedName(String name, String source)
@@ -749,6 +757,7 @@ public class CompletionRequester
          this.source = source;
          this.shouldQuote = false;
          this.type = RCompletionType.UNKNOWN;
+         this.helpHandler = null;
       }
       
       public static QualifiedName createSnippet(String name)
@@ -757,7 +766,8 @@ public class CompletionRequester
                name,
                "snippet",
                false,
-               RCompletionType.SNIPPET);
+               RCompletionType.SNIPPET,
+               null);
       }
       
       @Override
@@ -842,9 +852,12 @@ public class CompletionRequester
                RES.styles().completion(),
                name);
 
-         // Display the source for functions and snippets
-         if (RCompletionType.isFunctionType(type) ||
-             type == RCompletionType.SNIPPET)
+         // Display the source for functions and snippets (unless there
+         // is a custom helpHandler provided, indicating that the "source"
+         // isn't a package but rather some custom DollarNames scope)
+         if ((RCompletionType.isFunctionType(type) ||
+             type == RCompletionType.SNIPPET) &&
+             helpHandler == null)
          {
             SafeHtmlUtil.appendSpan(
                   sb,
@@ -962,6 +975,7 @@ public class CompletionRequester
       public final String source ;
       public final boolean shouldQuote ;
       public final int type ;
+      public final String helpHandler;
       private static final FileTypeRegistry FILE_TYPE_REGISTRY =
             RStudioGinjector.INSTANCE.getFileTypeRegistry();
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpStrategy.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpStrategy.java
@@ -187,6 +187,36 @@ public class HelpStrategy
          return;
       }
 
+      if (selectedItem.helpHandler != null)
+      {
+         server_.getCustomHelp(selectedItem.helpHandler,
+                               selectedItem.name,
+                               selectedItem.source,
+               new ServerRequestCallback<HelpInfo.Custom>() {
+            @Override
+            public void onError(ServerError error)
+            {
+               display.clearHelp(false) ;
+            }
+
+            public void onResponseReceived(HelpInfo.Custom response)
+            {
+               if (response != null)
+               {
+                  HelpInfo.ParsedInfo info = response.toParsedInfo();
+                  cache_.put(selectedItem, info);
+                  doShowParameterHelp(info, name, display);
+               }
+               else
+               {
+                  display.setHelpVisible(false);
+                  display.clearHelp(false) ;
+               }
+            }
+         }) ;
+      }
+      else
+      {
          server_.getHelp(selectedItem.source,
                          null,
                          selectedItem.type,
@@ -213,6 +243,7 @@ public class HelpStrategy
                }
             }
          }) ;
+      }
    }
    
    private void doShowParameterHelp(final ParsedInfo info,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -2118,7 +2118,9 @@ public class RCompletionManager implements CompletionManager
             editor.moveCursorLeft();
          
          if (RCompletionType.isFunctionType(qualifiedName.type))
-            sigTipManager_.displayToolTip(qualifiedName.name, qualifiedName.source);
+            sigTipManager_.displayToolTip(qualifiedName.name, 
+                                          qualifiedName.source,
+                                          qualifiedName.helpHandler);
       }
       
       private final Invalidation.Token invalidationToken_ ;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/HelpInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/HelpInfo.java
@@ -206,6 +206,47 @@ public class HelpInfo extends JavaScriptObject
    private final native String getPackageName() /*-{
       return this.pkgname ? this.pkgname[0] : null ;
    }-*/;
+   
+   public static class Custom extends JavaScriptObject
+   {
+      protected Custom()
+      {  
+      }
+      
+      public final native String getPackageName() /*-{
+         return this.package_name[0];
+      }-*/;
+
+   
+      public final native String getTitle() /*-{
+         return this.title ? this.title[0] : null;
+      }-*/;
+
+      public final native String getSignature() /*-{
+         return this.signature ? this.signature[0]: null;
+      }-*/;
+   
+      public final native String getDescription() /*-{
+         return this.description[0];
+      }-*/;
+      
+      public final ParsedInfo toParsedInfo() 
+      {
+         HashMap<String,String> values = new HashMap<String,String>();
+         values.put("Title", getTitle());
+         values.put("Description", getDescription());
+         HashMap<String, String> args = new HashMap<String,String>();
+         HashMap<String, String> slots = new HashMap<String,String>();
+         
+         return new ParsedInfo(getPackageName(),
+                               getSignature(),
+                               values,
+                               args,
+                               slots);
+      }
+      
+   }
+   
 
    public static class ParsedInfo
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/HelpInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/HelpInfo.java
@@ -215,20 +215,20 @@ public class HelpInfo extends JavaScriptObject
       }
       
       public final native String getPackageName() /*-{
-         return this.package_name[0];
+         return this.package_name ? this.package_name[0] : "";
       }-*/;
 
    
       public final native String getTitle() /*-{
-         return this.title ? this.title[0] : null;
+         return this.title ? this.title[0] : "";
       }-*/;
 
       public final native String getSignature() /*-{
-         return this.signature ? this.signature[0]: null;
+         return this.signature ? this.signature[0]: "";
       }-*/;
    
       public final native String getDescription() /*-{
-         return this.description[0];
+         return this.description ? this.description[0] : "";
       }-*/;
       
       public final native JsArrayString getArgs() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/HelpInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/HelpInfo.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.workbench.views.help.model ;
 
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.dom.client.*;
 
 import org.rstudio.core.client.dom.DomUtils;
@@ -230,19 +231,38 @@ public class HelpInfo extends JavaScriptObject
          return this.description[0];
       }-*/;
       
+      public final native JsArrayString getArgs() /*-{
+         return this.args;
+      }-*/;
+      
+      public final native JsArrayString getArgDescriptions() /*-{
+         return this.arg_descriptions;
+      }-*/;
+      
       public final ParsedInfo toParsedInfo() 
       {
+         // values
          HashMap<String,String> values = new HashMap<String,String>();
          values.put("Title", getTitle());
          values.put("Description", getDescription());
-         HashMap<String, String> args = new HashMap<String,String>();
-         HashMap<String, String> slots = new HashMap<String,String>();
          
+         // args
+         HashMap<String, String> args = null;
+         JsArrayString jsArgs = getArgs();
+         JsArrayString jsArgDescriptions = getArgDescriptions();
+         if (jsArgs != null && jsArgDescriptions != null)
+         {
+            args = new HashMap<String,String>();
+            for (int i =0; i<jsArgs.length(); i++)
+               args.put(jsArgs.get(i), jsArgDescriptions.get(i));
+         }
+          
+         // return parsed info
          return new ParsedInfo(getPackageName(),
                                getSignature(),
                                values,
                                args,
-                               slots);
+                               null);
       }
       
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/HelpServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/HelpServerOperations.java
@@ -39,5 +39,9 @@ public interface HelpServerOperations
          String source,
          ServerRequestCallback<HelpInfo.Custom> requestCallback);
    
+   void getCustomParameterHelp(String helpHandler,
+                               String source,
+                               ServerRequestCallback<HelpInfo.Custom> requestCallback);
+   
    void showCustomHelpTopic(String helpHandler, String topic, String source);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/HelpServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/HelpServerOperations.java
@@ -33,4 +33,11 @@ public interface HelpServerOperations
 
    void search(String query, 
                ServerRequestCallback<JsArrayString> requestCallback) ;
+   
+   void getCustomHelp(String helpHandler,
+         String topic, 
+         String source,
+         ServerRequestCallback<HelpInfo.Custom> requestCallback);
+   
+   void showCustomHelpTopic(String helpHandler, String topic, String source);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/SignatureToolTipManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/SignatureToolTipManager.java
@@ -485,11 +485,11 @@ public class SignatureToolTipManager
          @Override
          public void onResponseReceived(String arguments)
          {
-            final String signature = fnString + arguments;
-            
             if (StringUtil.isNullOrEmpty(arguments))
                return;
             
+            final String signature = fnString + arguments;
+              
             resolvePositionAndShow(signature, position);
          }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/SignatureToolTipManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/SignatureToolTipManager.java
@@ -273,12 +273,14 @@ public class SignatureToolTipManager
       return boring.some(function(x) { return x === name; });
    }-*/;
    
-   public void displayToolTip(final String name, final String source)
+   public void displayToolTip(final String name, 
+                              final String source,
+                              String helpHandler)
    {
       if (isBoringFunction(name))
          return;
       
-      server_.getArgs(name, source, new ServerRequestCallback<String>()
+      server_.getArgs(name, source, helpHandler, new ServerRequestCallback<String>()
       {
          @Override
          public void onResponseReceived(String response)
@@ -478,7 +480,7 @@ public class SignatureToolTipManager
       setAnchor(cursor.cloneCursor());
       
       final String fnString = callString;
-      server_.getArgs(fnString, "", new ServerRequestCallback<String>() {
+      server_.getArgs(fnString, "", "", new ServerRequestCallback<String>() {
          
          @Override
          public void onResponseReceived(String arguments)


### PR DESCRIPTION
This PR defines a mechanism by which implementors of the .DollarNames method can provide custom help content for completions and custom urls for F1-based help requests.

To provide custom help content for completion a "helpHandler" attribute is added to the results returned from .DollarNames. The helpHandler is a function which can produce custom help info and URLs for a given symbol.

To provide a custom URL for an F1-based help request an S3-style method ("help_url_handler") is provided for a given class and F1 help requests for symbols of that class accessed via $ are routed to the handler.