### PR TITLE
allow 'Ctrl+[Shift]+Tab' to navigate tabs on Desktop

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -620,19 +620,20 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="switchToTab" value="Ctrl+X B" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="switchToTab" value="Ctrl+X B" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim"/>
          <shortcut refid="switchToTab" value="Ctrl+Shift+."/>
-         <shortcut refid="previousTab" value="Ctrl+Alt+Left" if="!org.rstudio.core.client.BrowseCap.isLinux()"/>
          <shortcut refid="nextTab" value="Ctrl+Alt+Right" if="!org.rstudio.core.client.BrowseCap.isLinux()"/>
-         <shortcut refid="previousTab" value="Ctrl+PageUp" if="org.rstudio.core.client.BrowseCap.isLinux()"/>
          <shortcut refid="nextTab" value="Ctrl+PageDown" if="org.rstudio.core.client.BrowseCap.isLinux()"/>
-         <shortcut refid="firstTab" value="Ctrl+Alt+Shift+Left"/>
-         <shortcut refid="lastTab" value="Ctrl+Alt+Shift+Right"/>
-         <shortcut refid="previousTab" value="Ctrl+X Left" disableModes="default,vim"/>
-         <shortcut refid="previousTab" value="Ctrl+F11"/>
          <shortcut refid="nextTab" value="Ctrl+X Right" disableModes="default,vim"/>
          <shortcut refid="nextTab" value="Ctrl+F12"/>
+         <shortcut refid="nextTab" value="Ctrl+Tab" if="org.rstudio.studio.client.application.Desktop.isDesktop()"/>
+         <shortcut refid="previousTab" value="Ctrl+Alt+Left" if="!org.rstudio.core.client.BrowseCap.isLinux()"/>
+         <shortcut refid="previousTab" value="Ctrl+F11"/>
+         <shortcut refid="previousTab" value="Ctrl+PageUp" if="org.rstudio.core.client.BrowseCap.isLinux()"/>
+         <shortcut refid="previousTab" value="Ctrl+X Left" disableModes="default,vim"/>
+         <shortcut refid="previousTab" value="Ctrl+Shift+Tab" if="org.rstudio.studio.client.application.Desktop.isDesktop()"/>
+         <shortcut refid="firstTab" value="Ctrl+Alt+Shift+Left"/>
          <shortcut refid="firstTab" value="Ctrl+Shift+F11"/>
+         <shortcut refid="lastTab" value="Ctrl+Alt+Shift+Right"/>
          <shortcut refid="lastTab" value="Ctrl+Shift+F12"/>
-
       </shortcutgroup>
       <shortcutgroup name="Files">
       


### PR DESCRIPTION
This PR does what it says on the tin; it allows `Ctrl+Tab` to navigate tabs forward, and `Ctrl+Shift+Tab` to navigate tabs backward, when using the desktop IDE. (We don't enable this in the browser since we can't / shouldn't -- this is reserved for navigating browser tabs)

(sorry for deltas -- I moved commands around to be more logically sorted together; the only changes are the addition of two new bindings)