### PR TITLE
show function name as used in document for help

### DIFF
--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -100,7 +100,7 @@ options(help_type = "html")
       sort(utils:::matchAvailableTopics(prefix))
 })
 
-.rs.addFunction("getHelpFromObject", function(object, envir)
+.rs.addFunction("getHelpFromObject", function(object, envir, name = NULL)
 {
    # Try to find the associated namespace of the object
    namespace <- NULL
@@ -194,10 +194,17 @@ options(help_type = "html")
       object <- objects[[i]]
       objectName <- objectNames[[i]]
       
+      # use the function name seen in the
+      # source document if provided
+      sigName <- if (is.null(name))
+         objectName
+      else
+         name
+      
       # Get the associated signature for functions
       signature <- NULL
       if (is.function(object))
-         signature <- sub("function ", objectName, .rs.getSignature(object))
+         signature <- sub("function ", sigName, .rs.getSignature(object))
       
       result <- .rs.getHelp(topic = objectName, package = namespace, sig = signature)
       if (length(result))
@@ -292,7 +299,7 @@ options(help_type = "html")
    {
       object <- tryCatch(get(name, pos = pos), error = function(e) NULL)
       if (!is.null(object))
-         return(.rs.getHelpFromObject(object, envir))
+         return(.rs.getHelpFromObject(object, envir, name))
    }
    
    # Otherwise, check to see if there is an object 'src' in the global env
@@ -302,7 +309,7 @@ options(help_type = "html")
    {
       object <- tryCatch(eval(call("$", container, name)), error = function(e) NULL)
       if (!is.null(object))
-         return(.rs.getHelpFromObject(object, envir))
+         return(.rs.getHelpFromObject(object, envir, name))
    }
    
    # Otherwise, try to get help in the vanilla way
@@ -323,7 +330,7 @@ options(help_type = "html")
    {
       object <- .rs.getAnywhere(functionName, envir)
       if (!is.null(object))
-         return(.rs.getHelpFromObject(object, envir))
+         return(.rs.getHelpFromObject(object, envir, functionName))
    }
    else
    {
@@ -333,7 +340,7 @@ options(help_type = "html")
       {
          object <- tryCatch(get(functionName, pos = pos), error = function(e) NULL)
          if (!is.null(object))
-            return(.rs.getHelpFromObject(object, envir))
+            return(.rs.getHelpFromObject(object, envir, functionName))
       }
    }
    
@@ -382,7 +389,7 @@ options(help_type = "html")
          object <- tryCatch(get(topic, pos = pos), error = function(e) NULL)
          if (is.null(object))
             return(NULL)
-         return(.rs.getHelpFromObject(object, envir))
+         return(.rs.getHelpFromObject(object, envir, topic))
       }
    }
    


### PR DESCRIPTION
This PR resolves an issue where the help information for e.g. `as.numeric` might show the function name being `as.double`.

<img width="722" alt="screen shot 2016-09-10 at 12 16 38 pm" src="https://cloud.githubusercontent.com/assets/1976582/18412952/71695980-7750-11e6-9057-9865d9203293.png">
