### PR TITLE
replace data import collection prompt for a comma separated list prompt

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -308,6 +308,40 @@ public class DataImport extends Composite
             }
          });
    }
+
+   private void promptForFactorString(
+      String title,
+      final Operation complete,
+      final String columnName,
+      final String columnType)
+   {
+      globalDisplay_.promptForText(
+         title,
+         "Please a comma separated list of factors",
+         "",
+         new OperationWithInput<String>()
+         {
+            @Override
+            public void execute(final String formatString)
+            {
+               String[] parts = formatString.split(",");
+
+               String factorsString = "";
+               boolean first = true;
+               for (String part : parts)
+               {
+                  part = part.replaceAll("^\\s+|\\s+$", "");
+
+                  if (!first) factorsString = factorsString + ", ";
+                  factorsString = factorsString + "\"" + part + "\"";
+                  first = false;
+               }
+
+               importOptions_.setColumnDefinition(columnName, columnType, "c(" + factorsString + ")");
+               complete.execute();
+            }
+         });
+   }
    
    private Operation onColumnMenuShow(final DataImportPreviewResponse response)
    {
@@ -364,8 +398,8 @@ public class DataImport extends Composite
                   }
                   else if (input == "factor")
                   {
-                     promptForParseString(
-                        "Factors", "c()", completeAndPreview, column.getName(), input);
+                     promptForFactorString(
+                        "Factors", completeAndPreview, column.getName(), input);
                   }
                   else
                   {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -317,7 +317,7 @@ public class DataImport extends Composite
    {
       globalDisplay_.promptForText(
          title,
-         "Please a comma separated list of factors",
+         "Please insert a comma separated list of factors",
          "",
          new OperationWithInput<String>()
          {


### PR DESCRIPTION
Users are reporting that switching columns in data import into factors is confusing since:
 1. We prompt for a collection, say: `c("factor1", "factor2")`
 2. Sometimes `"` autocorrects for opening-quote (not quote character) which causes the import to fail.

See: https://support.rstudio.com/hc/en-us/articles/218611977

Instead, prompt for a comma separated list of factors:

<img width="1257" alt="screen shot 2016-09-12 at 10 51 12 pm" src="https://cloud.githubusercontent.com/assets/3478847/18463035/f39cf8fc-793b-11e6-93ea-b998bdb3a9a0.png">
