### PR TITLE
check rmarkdown dependency while opening notebook file

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -2453,31 +2453,12 @@ public class Source implements InsertSourceHandler,
     
    public void onOpenSourceFile(final OpenSourceFileEvent event)
    {
-      if (event.getFileType().isRmd())
-      {
-         dependencyManager_.withRMarkdown("R Notebook",
-            "Opening R Notebook", new Command() {
-            @Override
-            public void execute()
-            {
-               doOpenSourceFile(event.getFile(),
-                          event.getFileType(),
-                          event.getPosition(),
-                          null, 
-                          event.getNavigationMethod(),
-                          false);
-            }
-         });
-      }
-      else
-      {
-        doOpenSourceFile(event.getFile(),
-                       event.getFileType(),
-                       event.getPosition(),
-                       null, 
-                       event.getNavigationMethod(),
-                       false);
-      }
+      doOpenSourceFile(event.getFile(),
+                     event.getFileType(),
+                     event.getPosition(),
+                     null, 
+                     event.getNavigationMethod(),
+                     false);
    }
    
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -2451,14 +2451,33 @@ public class Source implements InsertSourceHandler,
    }
    
     
-   public void onOpenSourceFile(OpenSourceFileEvent event)
+   public void onOpenSourceFile(final OpenSourceFileEvent event)
    {
-      doOpenSourceFile(event.getFile(),
+      if (event.getFileType().isRmd())
+      {
+         dependencyManager_.withRMarkdown("R Notebook",
+            "Opening R Notebook", new Command() {
+            @Override
+            public void execute()
+            {
+               doOpenSourceFile(event.getFile(),
+                          event.getFileType(),
+                          event.getPosition(),
+                          null, 
+                          event.getNavigationMethod(),
+                          false);
+            }
+         });
+      }
+      else
+      {
+        doOpenSourceFile(event.getFile(),
                        event.getFileType(),
                        event.getPosition(),
                        null, 
                        event.getNavigationMethod(),
                        false);
+      }
    }
    
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1235,7 +1235,7 @@ public class TextEditingTarget implements
       chunks_ = new TextEditingTargetChunks(this);
       notebook_ = new TextEditingTargetNotebook(this, chunks_, view_, 
             docDisplay_, dirtyState_, docUpdateSentinel_, document, 
-            releaseOnDismiss_);
+            releaseOnDismiss_, dependencyManager_);
       view_.addResizeHandler(notebook_);
       
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -126,7 +126,8 @@ public class TextEditingTargetNotebook
                                     DirtyState dirtyState,
                                     DocUpdateSentinel docUpdateSentinel,
                                     SourceDocument document,
-                                    ArrayList<HandlerRegistration> releaseOnDismiss)
+                                    ArrayList<HandlerRegistration> releaseOnDismiss,
+                                    DependencyManager dependencyManager)
    {
       docDisplay_ = docDisplay;
       docUpdateSentinel_ = docUpdateSentinel;  
@@ -141,6 +142,7 @@ public class TextEditingTargetNotebook
       chunks_ = chunks;
       editingDisplay_ = editingDisplay;
       scopeHelper_ = new TextEditingTargetScopeHelper(docDisplay_);
+      dependencyManager_ = dependencyManager;
       RStudioGinjector.INSTANCE.injectMembers(this);
       
       // initialize the display's default output mode based on 
@@ -855,37 +857,44 @@ public class TextEditingTargetNotebook
    @Override
    public void onRenderFinished(RenderFinishedEvent event)
    {
-      // single shot rendering of output line widgets (we wait until after the
-      // first render to ensure that ace places the line widgets correctly)
-      if (initialChunkDefs_ != null)
-      {
-         for (int i = 0; i < initialChunkDefs_.length(); i++)
+      dependencyManager_.withRMarkdown("R Notebook",
+         "Opening R Notebook", new Command() {
+         @Override
+         public void execute()
          {
-            createChunkOutput(initialChunkDefs_.get(i));
-         }
-         // if we got chunk content, load initial chunk output from server
-         if (initialChunkDefs_.length() > 0)
-            loadInitialChunkOutput();
+            // single shot rendering of output line widgets (we wait until after the
+            // first render to ensure that ace places the line widgets correctly)
+            if (initialChunkDefs_ != null)
+            {
+               for (int i = 0; i < initialChunkDefs_.length(); i++)
+               {
+                  createChunkOutput(initialChunkDefs_.get(i));
+               }
+               // if we got chunk content, load initial chunk output from server
+               if (initialChunkDefs_.length() > 0)
+                  loadInitialChunkOutput();
 
-         initialChunkDefs_ = null;
-         
-         // sync to editor style changes
-         editingTarget_.addEditorThemeStyleChangedHandler(
-                                       TextEditingTargetNotebook.this);
-         
-         // read and/or set initial render width
-         lastPlotWidth_ = notebookDoc_.getChunkRenderedWidth();
-         if (lastPlotWidth_ == 0)
-         {
-            lastPlotWidth_ = getPlotWidth();
+               initialChunkDefs_ = null;
+               
+               // sync to editor style changes
+               editingTarget_.addEditorThemeStyleChangedHandler(
+                                             TextEditingTargetNotebook.this);
+               
+               // read and/or set initial render width
+               lastPlotWidth_ = notebookDoc_.getChunkRenderedWidth();
+               if (lastPlotWidth_ == 0)
+               {
+                  lastPlotWidth_ = getPlotWidth();
+               }
+            }
+            else
+            {
+               // on ordinary render, we need to sync any chunk line widgets that have
+               // just been laid out; debounce this
+               syncHeightTimer_.schedule(250);
+            }
          }
-      }
-      else
-      {
-         // on ordinary render, we need to sync any chunk line widgets that have
-         // just been laid out; debounce this
-         syncHeightTimer_.schedule(250);
-      }
+      });
    }
 
    @Override
@@ -1779,6 +1788,7 @@ public class TextEditingTargetNotebook
    private final DirtyState dirtyState_;
    private final NotebookDoc notebookDoc_;
    private final TextEditingTargetScopeHelper scopeHelper_;
+   private final DependencyManager dependencyManager_;
    
    ArrayList<HandlerRegistration> releaseOnDismiss_;
    private Session session_;


### PR DESCRIPTION
Users from previous versions of rmarkdown can be found missing functionality (for instance, missing paged tables to render data.frames) if they never create a new notebook file. This fix adds a dependency check to upgrade rmarkdown when an existing notebook file is opened.

Repro steps:

1) Create a notebook with a data frame.
2) Run the following code to install a previous version of rmarkdown
```{r}
remove.packages("rmarkdown")
packageurl <- "https://cran.r-project.org/src/contrib/Archive/rmarkdown/rmarkdown_0.9.6.tar.gz"
install.packages(packageurl, repos=NULL, type="source")
```
3) Restart the r-session.
4) Reopen the notebook file. Notice that data.frames won't render without this fix since the rmarkdown package is not upgraded.