### PR TITLE
Fix first satellite chunk launch timing issues

### DIFF
--- a/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.cpp
@@ -70,13 +70,20 @@ void replayChunkOutputs(const std::string& docPath, const std::string& docId,
    std::vector<std::string> chunkIds;
    extractChunkIds(chunkOutputs, &chunkIds);
 
-   // find all the chunks and play them back to the client
-   BOOST_FOREACH(const std::string& chunkId, chunkIds)
+   if (singleChunkId.empty())
    {
-      if (singleChunkId.empty() || singleChunkId == chunkId)
+      // find all the chunks and play them back to the client
+      BOOST_FOREACH(const std::string& chunkId, chunkIds)
       {
-         enqueueChunkOutput(docPath, docId, chunkId, notebookCtxId(), requestId);
+         if (singleChunkId.empty() || singleChunkId == chunkId)
+         {
+            enqueueChunkOutput(docPath, docId, chunkId, notebookCtxId(), requestId);
+         }
       }
+   }
+   else
+   {
+      enqueueChunkOutput(docPath, docId, singleChunkId, notebookCtxId(), requestId);
    }
 
    json::Object result;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkSatelliteWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkSatelliteWindow.java
@@ -253,14 +253,14 @@ public class ChunkSatelliteWindow extends SatelliteWindow
 
       if (event.getData().getChunkId() != chunkWindowParams_.getChunkId())
          return;
+
+      resizePlotsRemote_.schedule(10);
       
       RmdChunkOutputFinishedEvent.Data data = event.getData();
 
       chunkOutputWidget_.onOutputFinished(
          false,
          data.getScope());
-
-      resizePlotsRemote_.schedule(1);
    }
 
    @Override
@@ -293,7 +293,7 @@ public class ChunkSatelliteWindow extends SatelliteWindow
          // avoid reentrancy
          if (currentPlotsReplayId_ != null)
             return;
-         
+
          server_.replayNotebookChunkPlots(
             chunkWindowParams_.getDocId(), 
             chunkWindowParams_.getChunkId(),


### PR DESCRIPTION
This satellite chunk bug got opened being ubuntu specific but I was able to reproduce this also on OS X. To repro the issue one needs to:
 1. Clear a chunk with plot, say `plot(iris)`
 2. Execute the chunk
 3. Immediately (less than one second) open the chunk as a satellite window

The satellite chunks register itself to the main window and triggers `refresh_chunk_output` which will call the server and play asynchronously the chunk output through `refreshChunkOutput` in `SessionRmdNotebook.cpp`. However, during initialization, `getChunkValue` is empty (see [SessionRmdNotebook.cpp#L106-L109](https://github.com/rstudio/rstudio/blob/9c25b3adf4d58f314792bae255e606815bf9f1d6/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.cpp#L106-L109)) and the output loop in `replayChunkOutputs` (see [SessionRmdNotebook.cpp#L74-L80](https://github.com/rstudio/rstudio/blob/9c25b3adf4d58f314792bae255e606815bf9f1d6/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.cpp#L74-L80)) does not return chunk outputs at all.

See details on trace:

<img width="1063" alt="screen shot 2016-09-14 at 7 23 58 am" src="https://cloud.githubusercontent.com/assets/3478847/18521010/39116c46-7a5f-11e6-88dd-3adf544508df.png">

I haven't pinpointed why exactly this happens, I've noticed that while the chunk is created there is a `chunkid_t` directory created and the `json` file also changes, which my guess is that, there are cases where this data is not yet available and the chunk renders blank. Notice that delaying opening the chunk window fixes this problem so definitely timing related.

The fix that I'm proposing is to rely on the chunkId (through a code path currently only used by satellite chunks) instead of scanning the JSON file to get the chunkIds. This seems reasonable to me, but @jmcphers, you might have other insights into this issue.

The other part of the fix is also timing related on first launch, but this time related to triggering resize after other events have been initialized.
