### PR TITLE
resolve Safari / WebKit sizing issue for toolbars

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -42,6 +42,7 @@ import org.rstudio.core.client.dom.impl.DomUtilsImpl;
 import org.rstudio.core.client.dom.impl.NodeRelativePosition;
 import org.rstudio.core.client.regex.Match;
 import org.rstudio.core.client.regex.Pattern;
+import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.FontSizer;
 import org.rstudio.studio.client.application.Desktop;
 
@@ -1007,6 +1008,18 @@ public class DomUtils
    {
       return getCharacterWidth(ele.getClientWidth(), ele.getOffsetWidth(), 
             style);
+   }
+   
+   public static void toggleParentVisibility(Element el, boolean visible, ElementPredicate predicate)
+   {
+      Element parentEl = el.getParentElement();
+      if (parentEl == null)
+         return;
+      
+      if (predicate != null && !predicate.test(parentEl))
+         return;
+      
+      toggleClass(parentEl, ThemeStyles.INSTANCE.displayNone(), !visible);
    }
 
    public static final int ESTIMATED_SCROLLBAR_WIDTH = 19;

--- a/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
@@ -173,4 +173,6 @@ public interface ThemeStyles extends CssResource
    String borderedIFrame();
    
    String toolbarInfoLabel();
+   
+   String displayNone();
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1483,3 +1483,7 @@ body.ubuntu_mono .searchBox {
    margin-right: 6px;
 }
 
+.displayNone {
+	display: none !important;
+}
+

--- a/src/gwt/src/org/rstudio/core/client/widget/Toolbar.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/Toolbar.java
@@ -16,6 +16,7 @@ package org.rstudio.core.client.widget;
 
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Overflow;
 import com.google.gwt.dom.client.Style.Unit;
@@ -23,7 +24,11 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.HasVerticalAlignment.VerticalAlignmentConstant;
+
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.SeparatorManager;
+import org.rstudio.core.client.dom.DomUtils;
+import org.rstudio.core.client.dom.DomUtils.ElementPredicate;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 
@@ -132,6 +137,9 @@ public class Toolbar extends Composite
             new ChildWidgetList(leftToolbarPanel_));
       new ToolbarSeparatorManager().manageSeparators(
             new ChildWidgetList(rightToolbarPanel_));
+      
+      updateStyles(leftToolbarPanel_);
+      updateStyles(rightToolbarPanel_);
    }
 
    public void invalidateSeparators()
@@ -144,6 +152,34 @@ public class Toolbar extends Composite
             public void execute()
             {
                manageSeparators();
+            }
+         });
+      }
+   }
+   
+   private void updateStyles(HorizontalPanel panel)
+   {
+      if (BrowseCap.isSafari())
+         updateStylesSafari(panel);
+   }
+   
+   // This is used to work around a button sizing issue on Safari where
+   // TD elements with a child element having 'display: none' might
+   // still take up some space, thereby messing with the layout
+   // when the DOM has a number of TD elements with undisplayed
+   // contents.
+   private void updateStylesSafari(HorizontalPanel panel)
+   {
+      for (int i = 0; i < panel.getWidgetCount(); i++)
+      {
+         Widget widget = panel.getWidget(i);
+         boolean visible = widget.isVisible();
+         DomUtils.toggleParentVisibility(widget.getElement(), visible, new ElementPredicate()
+         {
+            @Override
+            public boolean test(Element el)
+            {
+               return el.getTagName().toLowerCase().equals("td");
             }
          });
       }


### PR DESCRIPTION
This PR resolves a Safari / WebKit issue where `<td>` elements containing a single child element styled with `display: none` would still be 'sized' (seemingly a single pixel in size). This causes the toolbar used in the source pane to appear to be inconsistently sized across different document types, as for disabled commands we still add these to the DOM but toggle their visibility with e.g. `display: none`.

Here's a small screencast showcasing the issue -- the effect is most prominent on the 'document outline' toolbar button, but notice how the icons seem to 'jump' a bit as the document is changed:

![toolbar-sizing](https://cloud.githubusercontent.com/assets/1976582/18531017/047f7c96-7a89-11e6-9c45-7a36088df571.gif)

Probably too late in the game / inconsequential for the v1.0 release, but let me know what you think.