### PR TITLE
Split master and app name in spark ui

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewSparkConnectionDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewSparkConnectionDialog.java
@@ -273,9 +273,17 @@ public class NewSparkConnectionDialog extends ModalDialog<ConnectionOptions>
                builder.append("library(dplyr)\n");
             }
             
+            String[] masterComponents = master_.getSelection().split(" - ");
+
             builder.append("sc <- spark_connect(master = \"");
-            builder.append(master_.getSelection());
+            builder.append(masterComponents[0]);
             builder.append("\"");
+            if (masterComponents.length > 0)
+            {
+               builder.append(", app_name = \"");
+               builder.append(masterComponents[1]);
+               builder.append("\"");
+            }
            
             // spark version
             if (master_.isLocalMasterSelected())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewSparkConnectionDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewSparkConnectionDialog.java
@@ -278,7 +278,7 @@ public class NewSparkConnectionDialog extends ModalDialog<ConnectionOptions>
             builder.append("sc <- spark_connect(master = \"");
             builder.append(masterComponents[0]);
             builder.append("\"");
-            if (masterComponents.length > 0)
+            if (masterComponents.length > 1)
             {
                builder.append(", app_name = \"");
                builder.append(masterComponents[1]);


### PR DESCRIPTION
To address https://github.com/rstudio/sparklyr/issues/218 - Safe fix with broken functionality worth merging into 1.0 branch.

The issue is that the parameter `master` and  `app_name` are getting merged:

<img width="480" alt="screen shot 2016-09-16 at 12 23 00 pm" src="https://cloud.githubusercontent.com/assets/3478847/18599649/46d755ba-7c0e-11e6-8faf-8a86a40d2740.png">

With fix:

<img width="481" alt="screen shot 2016-09-16 at 1 06 16 pm" src="https://cloud.githubusercontent.com/assets/3478847/18599675/63de73e6-7c0e-11e6-9e31-298632252b8c.png">
