### PR TITLE
avoid prompting for spark install or show versions when spark home set

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ConnectionsPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ConnectionsPresenter.java
@@ -257,7 +257,7 @@ public class ConnectionsPresenter extends BasePresenter
                                                    "New Connection...") {
    
             @Override
-            protected void onSuccess(NewSparkConnectionContext context)
+            protected void onSuccess(final NewSparkConnectionContext context)
             {
                // prompt for no java installed
                if (!context.isJavaInstalled())
@@ -285,6 +285,7 @@ public class ConnectionsPresenter extends BasePresenter
                         withRequiredSparkInstallation(
                               result.getSparkVersion(),
                               result.getRemote(),
+                              context.getSparkHome() != null,
                               new Command() {
                                  @Override
                                  public void execute()
@@ -305,6 +306,7 @@ public class ConnectionsPresenter extends BasePresenter
    
    private void withRequiredSparkInstallation(final SparkVersion sparkVersion,
                                               boolean remote,
+                                              boolean hasSparkHome,
                                               final Command command)
    {
       // if there is no spark version then just execute immediately
@@ -314,7 +316,7 @@ public class ConnectionsPresenter extends BasePresenter
          return;
       }
       
-      if (!sparkVersion.isInstalled())
+      if (!sparkVersion.isInstalled() && !hasSparkHome)
       {
          globalDisplay_.showYesNoMessage(
             MessageDialog.QUESTION, 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewSparkConnectionDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewSparkConnectionDialog.java
@@ -122,7 +122,7 @@ public class NewSparkConnectionDialog extends ModalDialog<ConnectionOptions>
          @Override
          public void execute()
          {
-            versionGrid.setVisible(master_.isLocalMasterSelected());
+            versionGrid.setVisible(master_.isLocalMasterSelected() && context_.getSparkHome() == null);
          }
       };
       onMasterChanged.execute();
@@ -215,7 +215,7 @@ public class NewSparkConnectionDialog extends ModalDialog<ConnectionOptions>
          {   
             SparkVersion sparkVersion = getSelectedSparkVersion();
             
-            if (sparkVersion != null)
+            if (sparkVersion != null && context_.getSparkHome() == null)
             {
                boolean remote = !master_.isLocalMaster(master_.getSelection());
             


### PR DESCRIPTION
Another one to address issues form https://github.com/rstudio/sparklyr/issues/218 - Safe fix with broken functionality worth merging into 1.0 branch.

The issue is that one can configure `SPARK_HOME` and still get this dialog:

<img width="483" alt="screen shot 2016-09-16 at 1 30 05 pm" src="https://cloud.githubusercontent.com/assets/3478847/18600449/890cb976-7c12-11e6-896a-d7dd03c3b4c9.png">

When the versions will be effectively ignored; therefore, this dialog makes more sense for this fix:

<img width="479" alt="screen shot 2016-09-16 at 1 29 10 pm" src="https://cloud.githubusercontent.com/assets/3478847/18602352/56c042a2-7c1d-11e6-816c-01a8fe5005d3.png">

Validated that we still have the original dialog when `SPARK_HOME` is not present.