### PR TITLE
Avoid auto adding spark protocol to allow yarn-client

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/NewSparkConnectionContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/NewSparkConnectionContext.java
@@ -139,8 +139,6 @@ public class NewSparkConnectionContext extends JavaScriptObject
          String option = connectionsOption.get(i);
          if (!MASTER_LOCAL.equals(option) && !MASTER_CLUSTER.equals(option))
          {
-            if (!option.startsWith("spark://"))
-               option = "spark://" + option;
             connections.add(option);
          }
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/SparkMasterChooser.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/SparkMasterChooser.java
@@ -112,10 +112,8 @@ public class SparkMasterChooser extends Composite
                      {
                         indicator.onCompleted();
                         
-                        // get master (prepend spark:// if necessary)
+                        // get master
                         String master = input.input;
-                        if (!master.startsWith("spark://"))
-                           master = "spark://" + master;
                         
                         // add the item to the list if necessary
                         int targetItem = -1;


### PR DESCRIPTION
Most Spark cluster URLS start with the prefix `spark://` so we added support in the UI to auto add this in cluster mode. However, some modes like `yarn-client` and `yarn-cluster` are valid and don't require this protocol prefix. Removing this since users can always type their own protocol prefix as needed.

Related to https://github.com/rstudio/sparklyr/issues/218

<img width="479" alt="screen shot 2016-09-20 at 3 41 37 pm" src="https://cloud.githubusercontent.com/assets/3478847/18691481/c570455c-7f48-11e6-820f-3b28018f7534.png">

<img width="481" alt="screen shot 2016-09-20 at 3 41 45 pm" src="https://cloud.githubusercontent.com/assets/3478847/18691482/c5726490-7f48-11e6-8efd-ca4b895f6ea3.png">