### PR TITLE
Allow plot to grow with plot warnings in satellite chunks

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkPlotWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkPlotWidget.java
@@ -136,6 +136,10 @@ public class ChunkPlotWidget extends Composite
             outer.getElement().getStyle().setProperty("msFlexDirection", "column");
             outer.getElement().getStyle().setProperty("webkitFlexDirection", "column");
             outer.getElement().getStyle().setProperty("flexDirection", "column");
+
+            outer.getElement().getStyle().setProperty("msFlexGrow", "1");
+            outer.getElement().getStyle().setProperty("webkitFlexGrow", "1");
+            outer.getElement().getStyle().setProperty("flexGrow", "1");
          }
          else
          {


### PR DESCRIPTION
Plots don't display when there is a plot warning on the satellite chunk since the element is not marked as `flex-grow`. Fix scoped to plots with warnings. 