### PR TITLE
use correct completion result for 'filter' when dplyr loaded

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1460,10 +1460,17 @@ assign(x = ".rs.acCompletionTypes",
    # Keywords are really from the base package
    packages[packages == "keywords"] <- "base"
    
+   # discover completion matches for this token
    keep <- .rs.fuzzyMatches(results, token)
    results <- results[keep]
    packages <- packages[keep]
    
+   # remove duplicates (assume first element masks next)
+   dupes    <- duplicated(results)
+   results  <- results[!dupes]
+   packages <- packages[!dupes]
+   
+   # re-order the completion results (lexically)
    order <- order(results)
    
    # If the token is 'T' or 'F', prefer 'TRUE' and 'FALSE' completions


### PR DESCRIPTION
This PR resolves an issue where, even if `dplyr` is loaded, the help topic for `stats::filter` was shown in preference to that for `dplyr::filter`.

<img width="213" alt="screen shot 2016-09-22 at 3 33 00 pm" src="https://cloud.githubusercontent.com/assets/1976582/18768422/e496b212-80d9-11e6-89cc-999720886b5f.png">
