### PR TITLE
fix HOME, R_USER, R_LIBS_USER encoding issue on Windows

### DIFF
--- a/src/cpp/r/session/REmbeddedWin32.cpp
+++ b/src/cpp/r/session/REmbeddedWin32.cpp
@@ -31,6 +31,7 @@
 
 #include <core/FilePath.hpp>
 #include <core/Exec.hpp>
+#include <core/StringUtils.hpp>
 
 #include <r/RInterface.hpp>
 #include <r/RFunctionHook.hpp>
@@ -149,8 +150,10 @@ void runEmbeddedR(const core::FilePath& rHome,
    ::R_DefParams(pRP);
 
    // set paths (copy to new string so we can provide char*)
-   std::string* pRHome = new std::string(rHome.absolutePath());
-   std::string* pUserHome = new std::string(userHome.absolutePath());
+   std::string* pRHome = new std::string(
+            core::string_utils::utf8ToSystem(rHome.absolutePath()));
+   std::string* pUserHome = new std::string(
+            core::string_utils::utf8ToSystem(userHome.absolutePath()));
    pRP->rhome = const_cast<char*>(pRHome->c_str());
    pRP->home = const_cast<char*>(pUserHome->c_str());
 

--- a/src/cpp/session/modules/SessionProfiler.cpp
+++ b/src/cpp/session/modules/SessionProfiler.cpp
@@ -48,8 +48,9 @@ std::string profilesCacheDir()
 
 SEXP rs_profilesPath()
 {
-	r::sexp::Protect rProtect;
-	return r::sexp::create(profilesCacheDir(), &rProtect);
+   r::sexp::Protect rProtect;
+   std::string cacheDir = core::string_utils::utf8ToSystem(profilesCacheDir());
+   return r::sexp::create(cacheDir, &rProtect);
 }
 
 } // anonymous namespace


### PR DESCRIPTION
This PR fixes an issue where the values of the environment variables `HOME`, `R_USER`, and `R_LIBS_USER` would be mis-encoded on Windows for users with non-ASCII characters in their names. This should ultimately fix a large number of issues for such users on Windows (e.g. inability to install packages).

We may want to take this for v1.0, although we should confirm that `utf8ToSystem` won't cause something terrible to happen on failure.