### PR TITLE
Enable auto-preview for images and equations above current line

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJax.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJax.java
@@ -195,8 +195,7 @@ public class MathJax
    
    public void renderLatex()
    {
-      final List<Range> ranges = MathJaxUtil.findLatexChunks(
-            docDisplay_.getFirstVisibleRow(), docDisplay_);
+      final List<Range> ranges = MathJaxUtil.findLatexChunks(docDisplay_);
       renderQueue_.enqueueAndRender(ranges);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJaxUtil.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJaxUtil.java
@@ -104,14 +104,13 @@ public class MathJaxUtil
       return true;
    }
    
-   public static List<Range> findLatexChunks(int startRow, 
-         DocDisplay docDisplay)
+   public static List<Range> findLatexChunks(DocDisplay docDisplay)
    {
       docDisplay.tokenizeDocument();
       List<Range> ranges = new ArrayList<Range>();
       
       Position startPos = null;
-      for (int i = startRow, n = docDisplay.getRowCount(); i < n; i++)
+      for (int i = 0, n = docDisplay.getRowCount(); i < n; i++)
       {
          Position pos = Position.create(i, 0);
          Token token = docDisplay.getTokenAt(Position.create(i, 0));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -3468,6 +3468,12 @@ public class AceEditor implements DocDisplay,
    @Override
    public void addLineWidget(LineWidget widget)
    {
+      // position the element far offscreen if it's above the currently
+      // visible row; Ace does not position line widgets above the viewport
+      // until the document is scrolled there
+      if (widget.getRow() < getFirstVisibleRow())
+         widget.getElement().getStyle().setTop(-10000, Unit.PX);
+      
       widget_.getLineWidgetManager().addLineWidget(widget);
       fireLineWidgetsChanged();
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -18,7 +18,6 @@ import java.util.List;
 
 import org.rstudio.core.client.ColorUtil;
 import org.rstudio.core.client.Size;
-import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.widget.ProgressSpinner;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -213,11 +212,6 @@ public class ChunkOutputWidget extends Composite
       return expansionState_.getValue();
    }
    
-   public boolean needsHeightSync()
-   {
-      return needsHeightSync_;
-   }
-   
    public void setExpansionState(int state)
    {
       if (state == expansionState_.getValue())
@@ -306,26 +300,9 @@ public class ChunkOutputWidget extends Composite
       // don't sync if not visible and no output yet
       if (!isVisible() && (state_ == CHUNK_EMPTY || state_ == CHUNK_PRE_OUTPUT))
          return;
-      
-      // don't sync if Ace hasn't positioned us yet
-      if (StringUtil.isNullOrEmpty(getElement().getStyle().getTop()))
-      {
-         needsHeightSync_ = true;
-         return;
-      }
 
       setVisible(true);
       
-      if (root_.getElement().getScrollHeight() == 0 && presenter_.hasOutput())
-      {
-         // if we have no height but we do have content, mark ourselves as 
-         // requiring a sync
-         needsHeightSync_ = true;
-      }
-      else
-      {
-         needsHeightSync_ = false;
-      }
       // clamp chunk height to min/max (the +19 is the sum of the vertical
       // padding on the element)
       int height = ChunkOutputUi.CHUNK_COLLAPSED_HEIGHT;
@@ -908,7 +885,6 @@ public class ChunkOutputWidget extends Composite
    private int pendingRenders_ = 0;
    private int lastOutputType_ = RmdChunkOutputUnit.TYPE_NONE;
    private boolean hasErrors_ = false;
-   private boolean needsHeightSync_ = false;
    private boolean hideSatellitePopup_ = false;
    
    private Timer collapseTimer_ = null;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ImagePreviewer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ImagePreviewer.java
@@ -112,8 +112,7 @@ public class ImagePreviewer
    
    private void previewAllLinks()
    {
-      for (int i = display_.getFirstVisibleRow(), n = display_.getRowCount(); 
-           i < n; i++)
+      for (int i = 0, n = display_.getRowCount(); i < n; i++)
       {
          String line = display_.getLine(i);
          if (isStandaloneMarkdownLink(line))


### PR DESCRIPTION
There's a bug in Ace which causes line widgets to "float" if they are added above the viewport. This happens because Ace does not position widgets above the viewport until the line to which they are attached is visible. Until the widget is positioned, it sits there attached to the DOM but not tracking the scroll position, appearing to float in place. The subset of line widgets to position is computed here:

https://github.com/ajaxorg/ace/blob/4c7e5eb3f5d5ca9434847be51834a4e41661b852/lib/ace/line_widgets.js#L334-L341

We have a couple of existing workarounds for this. One sidesteps the problem by making chunk outputs invisible (i.e. have no height) until they are scrolled into view (a timer detects when this happens). Another avoids creating them entirely if they are above the viewport.

This change eliminates both of these workarounds with a simpler one: instead of attempting to guess whether the chunk is floating and showing/hiding it based on this state, we just manually position it far offscreen. When Ace gets around to correctly positioning the line widget, it's attached to the correct location, which -- as far as the user can tell -- is where it's been all along.

In addition to being dramatically more straightforward, this approach frees us from having to do any synchronization or rendering after the widget is attached, since it can be fully rendered while offscreen (whereas hiding it or leaving it detached from the DOM keeps us from being able to render its content accurately). 

I'm opening this as PR since we've had a number of lingering issues and regressions in this area and a second set of eyes would be helpful, but will merge it tonight if there aren't any concerns.