### PR TITLE
avoid calling `str()` on objects containing active bindings

### DIFF
--- a/src/cpp/r/include/r/RExec.hpp
+++ b/src/cpp/r/include/r/RExec.hpp
@@ -176,29 +176,33 @@ public:
    
    // COPYING: boost::noncopyable
    
-   void addParam(SEXP param)
+   RFunction& addParam(SEXP param)
    {
       addParam(std::string(), param);
+      return *this;
    }
    
    template <typename T>
-   void addParam(const T& param)
+   RFunction& addParam(const T& param)
    {
       addParam(std::string(), param);
+      return *this;
    }
    
-   void addParam(const std::string& name, SEXP param)
+   RFunction& addParam(const std::string& name, SEXP param)
    {
       params_.push_back(Param(name, param));
+      return *this;
    }
                         
    template <typename T>
-   void addParam(const std::string& name, const T& param)
+   RFunction& addParam(const std::string& name, const T& param)
    {
       r::sexp::Protect protect;
       SEXP paramSEXP = sexp::create(param, &protect);
       preserver_.add(paramSEXP);
       params_.push_back(Param(name, paramSEXP));
+      return *this;
    }
                         
    core::Error call(SEXP evalNS = R_GlobalEnv, bool safely = true);

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -77,6 +77,7 @@ SEXP getNames(SEXP sexp);
 bool setNames(SEXP sexp, const std::vector<std::string>& names);
 
 core::Error getNames(SEXP sexp, std::vector<std::string>* pNames);  
+bool hasActiveBinding(const std::string&, const SEXP);
 bool isActiveBinding(const std::string&, const SEXP);
 
 // function introspection
@@ -89,6 +90,7 @@ bool isList(SEXP object);
 bool isMatrix(SEXP object);
 bool isDataFrame(SEXP object);   
 bool isNull(SEXP object);
+bool isEnvironment(SEXP object);
 
 // type coercions
 std::string asString(SEXP object);

--- a/src/cpp/session/modules/environment/EnvironmentUtils.cpp
+++ b/src/cpp/session/modules/environment/EnvironmentUtils.cpp
@@ -91,10 +91,15 @@ json::Value varToJson(SEXP env, const r::sexp::Variable& var)
    // a few cases in which attempting to inspect the object will lead to
    // undesirable behavior. For these special value types, construct the
    // object definition manually.
+   bool isActiveBinding = r::sexp::isActiveBinding(var.first, env);
+   bool hasActiveBinding = isActiveBinding
+         ? true
+         : r::sexp::hasActiveBinding(var.first, env);
+   
    if ((varSEXP == R_UnboundValue) ||
        (varSEXP == R_MissingArg) ||
        isUnevaluatedPromise(varSEXP) ||
-       r::sexp::isActiveBinding(var.first, env))
+       hasActiveBinding)
    {
       varJson["name"] = var.first;
       if (isUnevaluatedPromise(varSEXP))
@@ -102,10 +107,15 @@ json::Value varToJson(SEXP env, const r::sexp::Variable& var)
          varJson["type"] = std::string("promise");
          varJson["value"] = descriptionOfVar(varSEXP);
       }
-      else if (r::sexp::isActiveBinding(var.first, env))
+      else if (isActiveBinding)
       {
          varJson["type"] = std::string("active binding");
          varJson["value"] = std::string("<Active binding>");
+      }
+      else if (hasActiveBinding)
+      {
+         varJson["type"] = std::string("object containing active binding");
+         varJson["value"] = std::string("<Object containing active binding>");
       }
       else
       {


### PR DESCRIPTION
This PR resolves an issue where environments containing active bindings would be fired by the Environment pane (in response to a call to `str()` on that object).

We resolve this by recursively checking environments for active bindings, with some safeguards against cycles.