### PR TITLE
resolve issue with latex tokenization within '{}'

### DIFF
--- a/src/gwt/acesupport/acemode/markdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/markdown_highlight_rules.js
@@ -214,22 +214,22 @@ var MarkdownHighlightRules = function() {
             token : "constant",
             regex : "^[ ]{0,2}(?:[ ]?\\_[ ]?){3,}\\s*$"
         }, { // MathJax native display \[ ... \]
-            token : "latex.markup.list.begin",
+            token : "latex.markup.list.string.begin",
             regex : "\\\\\\[",
             next  : "mathjaxnativedisplay"
         }, { // MathJax native inline \( ... \)
-            token : "latex.markup.list.begin",
+            token : "latex.markup.list.string.begin",
             regex : "\\\\\\(",
             next  : "mathjaxnativeinline"
         }, { // $ escape
             token : "text",
             regex : "\\\\\\$"
         }, { // MathJax $$
-            token : "latex.markup.list.begin",
+            token : "latex.markup.list.string.begin",
             regex : "\\${2}",
             next  : "mathjaxdisplay"
         }, { // MathJax $...$ (org-mode style)
-            token : ["latex.markup.list.begin","latex.support.function","latex.markup.list.end"],
+            token : ["latex.markup.list.string.begin","latex.support.function","latex.markup.list.string.end"],
             regex : "(\\$)((?:(?:\\\\.)|(?:[^\\$\\\\]))*?)(\\$)"
         },
             strongStars,
@@ -372,7 +372,7 @@ var MarkdownHighlightRules = function() {
         }],
 
         "mathjaxdisplay" : [{
-            token : "latex.markup.list.end",
+            token : "latex.markup.list.string.end",
             regex : "\\${2}",
             next  : "start"
         }, {
@@ -381,7 +381,7 @@ var MarkdownHighlightRules = function() {
         }],
         
         "mathjaxnativedisplay" : [{
-            token : "latex.markup.list.end",
+            token : "latex.markup.list.string.end",
             regex : "\\\\\\]",
             next  : "start"
         }, {
@@ -390,7 +390,7 @@ var MarkdownHighlightRules = function() {
         }],
         
         "mathjaxnativeinline" : [{
-            token : "latex.markup.list.end",
+            token : "latex.markup.list.string.end",
             regex : "\\\\\\)",
             next  : "start"
         }, {

--- a/src/gwt/acesupport/acemode/markdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/markdown_highlight_rules.js
@@ -246,18 +246,18 @@ var MarkdownHighlightRules = function() {
         }, {
             // embedded latex command
             token : "keyword",
-            regex : "\\\\(?:[a-zA-z0-9]+|[^a-zA-z0-9])"
+            regex : "\\\\(?:[a-zA-Z0-9]+|[^a-zA-Z0-9])"
         }, {
-            // embedded latex arg
-            token : ["paren.keyword.operator", "text", "paren.keyword.operator"],
-            regex : "(\\{)([^\\}]*)(\\})"
+            // brackets
+            token : "paren.keyword.operator",
+            regex : "[{}]"
         }, {
             // pandoc citation
             token : "markup.list",
             regex : "-?\\@[\\w\\d-]+"
         }, {
             token : "text",
-            regex : "[^\\*_%$`\\[#<>\\\\@\\s]+"
+            regex : "[^\\*_%$`\\[#<>{}\\\\@\\s]+"
         }, {
             token : "text",
             regex : "\\\\"
@@ -368,7 +368,7 @@ var MarkdownHighlightRules = function() {
             next  : "fieldblock"
         }, {
             token : "text",
-            regex : ".+"
+            regex : "[^{}]+"
         }],
 
         "mathjaxdisplay" : [{


### PR DESCRIPTION
This PR resolves a tokenization issue where math markup within a latex command, e.g. `\foo{$bar$}`, would not be tokenized correctly.

![screen shot 2016-09-27 at 10 12 47 am](https://cloud.githubusercontent.com/assets/1976582/18885115/1b7ab27e-849f-11e6-85aa-e11992611188.png)

The overarching issue -- our highlighter previously attempted to consume an entire 'line' containing a matching pair of `{` and `}`, tokenizing the inner contents as plain text. However, this is suboptimal for a couple reasons:

1. It's possible for a latex command to span multiple lines,
2. It's possible for non-textual content to be included within `{}`.

The solution here is to simply tokenize `{` and `}` separately as brackets, and to avoid including `{}` when tokenizing a region of text.