### PR TITLE
improve resilience against malformed YAML header

### DIFF
--- a/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
@@ -139,10 +139,7 @@ var RMarkdownHighlightRules = function() {
        ["start", "listblock", "allowBlock"]
    );
 
-   // Embed YAML highlight rules, but ensure that they can only be
-   // found at the start of a document. We do this by moving all of the
-   // start rules to a second '$start' state, and ensuring that YAML headers
-   // can only be encountered in the initial 'start' state.
+   // ensure that YAML highlight rules only start of document
    this.$rules["$start"] = this.$rules["start"].slice();
    for (var key in this.$rules)
    {
@@ -153,7 +150,16 @@ var RMarkdownHighlightRules = function() {
             stateRules[i].next = "$start";
       }
    }
-   
+
+   // escape eagerly from 'start' to '$start' state
+   var startRules = this.$rules["start"];
+   for (var i = 0; i < startRules.length; i++)
+   {
+      if (startRules[i].next == null)
+         startRules[i].next = "$start";
+   }
+
+   // Embed YAML highlighting rules
    Utils.embedRules(
       this,
       YamlHighlightRules,
@@ -166,7 +172,6 @@ var RMarkdownHighlightRules = function() {
       token: ["string"],
       regex: makeDateRegex()
    });
-
 };
 oop.inherits(RMarkdownHighlightRules, TextHighlightRules);
 


### PR DESCRIPTION
Currently, malformed YAML headers can cause the rest of the document to be mis-tokenized:

![screen shot 2016-09-27 at 1 10 43 pm](https://cloud.githubusercontent.com/assets/1976582/18889878/d452485c-84b3-11e6-98e8-b1bd8e7ec8aa.png)

Note that the R chunk below is not properly highlighted as R code, and it also does not have a chunk toolbar + the other 'goodies' normally afforded to R chunks. This is occurring because the second instance of `---` is being interpreted as the start of a YAML block, and hence the rest of the following code also as YAML.

We had code that intended to ensure that YAML headers would only be detected at the very start of the document, but this did not always function in practice. This PR remedies that, so that a `---` is only ever interpreted as the start of a YAML block at the very start of the document.

With this PR:

![screen shot 2016-09-27 at 1 15 28 pm](https://cloud.githubusercontent.com/assets/1976582/18890032/7dcf6de2-84b4-11e6-9b25-150893b89e90.png)
