### PR TITLE
ensure RCntxtInterface has virtual dtor

### DIFF
--- a/src/cpp/r/include/r/RCntxtInterface.hpp
+++ b/src/cpp/r/include/r/RCntxtInterface.hpp
@@ -40,6 +40,8 @@ public:
    // computed properties
    virtual bool isNull() const        = 0;
    virtual RCntxt nextcontext() const = 0;
+   
+   virtual ~RCntxtInterface() {}
 };
 
 } // namespace context


### PR DESCRIPTION
Minor fix, but since `RCntxtInterface` has virtual functions, it should also have a virtual destructor. (Spotted by the static analyzer bundled with Xcode 8.0)