### PR TITLE
add support to print total rows and cols in paged tables when available

### DIFF
--- a/src/cpp/desktop-mac/GwtCallbacks.mm
+++ b/src/cpp/desktop-mac/GwtCallbacks.mm
@@ -323,7 +323,7 @@ private:
 # elif defined(__MAC_10_11) && __MAC_OS_X_VERSION_MAX_ALLOWED == __MAC_10_11
    typedef WkWebView RSWebView;
 # else
-   typedef WebView RSWebView;
+   typedef WKWebView RSWebView;
 # endif
 #else
    typedef WebView RSWebView;

--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -44,6 +44,8 @@
     
     optionRowNames <- options[["rownames.print"]]
     options[["rownames.print"]] <- if (is.null(optionRowNames)) (.row_names_info(x, type = 1) > 0) else optionRowNames
+    options[["rows.total"]] <- nrow(x)
+    options[["cols.total"]] <- ncol(x)
 
     output <- tempfile(pattern = "_rs_rdf_", tmpdir = outputFolder, 
                        fileext = ".rdf")
@@ -200,11 +202,13 @@
   pagedTableOptions <- list(
     columns = list(
       min = options[["cols.min.print"]],
-      max = if (is.null(options[["cols.print"]])) 10 else options[["cols.print"]]
+      max = if (is.null(options[["cols.print"]])) 10 else options[["cols.print"]],
+      total = options[["cols.total"]]
     ),
     rows = list(
       min = if (is.null(options[["rows.print"]])) 10 else options[["rows.print"]],
-      max = if (is.null(options[["rows.print"]])) 10 else options[["rows.print"]]
+      max = if (is.null(options[["rows.print"]])) 10 else options[["rows.print"]],
+      total = options[["rows.total"]]
     ),
     pages = options[["pages.print"]]
   )


### PR DESCRIPTION
Changes data chunks to display total number of rows/cols in a data set rather than the total number of printed rows/cols.

For instance, from this:

<img width="929" alt="screen shot 2016-09-28 at 10 26 23 am" src="https://cloud.githubusercontent.com/assets/3478847/18924990/fbbf721c-8566-11e6-9a02-3327df730920.png">

to this:

<img width="917" alt="screen shot 2016-09-28 at 12 01 12 pm" src="https://cloud.githubusercontent.com/assets/3478847/18928042/50145916-8573-11e6-8eb6-4d79a4412e7a.png">

