### PR TITLE
Delay restoring document outline until activated

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1266,16 +1266,6 @@ public class TextEditingTarget implements
       String contents = document.getContents();
       docDisplay_.setCode(contents, false);
       
-      // show outline view (deferred so that widget itself can be sized first)
-      Scheduler.get().scheduleDeferred(new ScheduledCommand()
-      {
-         @Override
-         public void execute()
-         {
-            view_.initWidgetSize();
-         }
-      });
-      
       // Load and apply folds.
       final ArrayList<Fold> folds = Fold.decode(document.getFoldSpec());
       Scheduler.get().scheduleDeferred(new ScheduledCommand()
@@ -2061,6 +2051,20 @@ public class TextEditingTarget implements
          commandHandlerReg_ = null;
       }
       commandHandlerReg_ = commandBinder.bind(commands_, this);
+
+      // show outline if not yet rendered (deferred so that widget itself can 
+      // be sized first)
+      if (!docDisplay_.isRendered())
+      {
+         Scheduler.get().scheduleDeferred(new ScheduledCommand()
+         {
+            @Override
+            public void execute()
+            {
+               view_.initWidgetSize();
+            }
+         });
+      }
 
       Scheduler.get().scheduleFinally(new ScheduledCommand()
       {


### PR DESCRIPTION
This fixes an issue in which document outline state is not restored for any document except the one open when you start RStudio. 

The problem appears to have been introduced with https://github.com/rstudio/rstudio/commit/26103fabe8ce0c1f59ab83d962cb7cd6e291dc7a; prior to the editor's tab being activated, its with is 0, so the outline's width is set to 0 too. This change just moves the sizing logic to the activate phase so that it doesn't run until the editor's tab is actually selected. 