### PR TITLE
fix intermittent satellite chunk rendering blank for html widgets

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -235,7 +235,11 @@ public class ChunkOutputStream extends FlowPanel
             
       bodyStyle.setPadding(0, Unit.PX);
       bodyStyle.setMargin(0, Unit.PX);
-      bodyStyle.setColor(ChunkOutputWidget.getEditorColors().foreground);
+
+      if (ChunkOutputWidget.getEditorColors() != null)
+      {
+         bodyStyle.setColor(ChunkOutputWidget.getEditorColors().foreground);
+      }
 
       final String fullUrl = url;
       Timer frameLoadTimer = new Timer()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -673,7 +673,7 @@ public class ChunkOutputWidget extends Composite
 
    private void showReadyState()
    {
-      if (getElement() != null && getElement().getStyle() != null)
+      if (getElement() != null && getElement().getStyle() != null && s_colors != null)
       {
          getElement().getStyle().setBackgroundColor(s_colors.background);
       }


### PR DESCRIPTION
At times, in some machines, the editor colors events might not arrive at the same time and would trigger the following exceptions. Fix is to avoid assigning theme colors when this information is not available. Safe fix, worth taking for `v1.0`.

```
rstudio-0.js:14079 com.google.gwt.event.shared.UmbrellaException: Exception caught: (TypeError) : Cannot read property 'foreground_1_g$' of undefined
  at fillInStackTrace_0_g$
  at Throwable_3_g$
  at Exception_3_g$
  at RuntimeException_3_g$
  at UmbrellaException_3_g$
  at UmbrellaException_5_g$
  at fireEvent_2_g$
  at fireEvent_15_g$
  at fireEvent_14_g$
  at dispatchEvent_9_g$
  at execute_402_g$
  at $executeRepeating_0_g$
  at runScheduledTasks_0_g$
  at flushPostEventPumpCommands_0_g$
  at execute_6_g$
  at execute_5_g$
  at apply_0_g$
  at entry0_0_g$
  at anonymous
  at callback_0_g$
Caused by: com.google.gwt.core.client.JavaScriptException: (TypeError) : Cannot read property 'foreground_1_g$' of undefined
  at showHtmlOutput_1_g$
  at showChunkOutputUnit_0_g$
  at showChunkOutput_0_g$
  at onRmdChunkOutput_0_g$
  at dispatch_333_g$
  at dispatch_332_g$
  at dispatch_0_g$
  at dispatchEvent_3_g$
  at doFire_0_g$
  at fireEvent_3_g$
```

also:

```
rstudio-0.js:14079 com.google.gwt.event.shared.UmbrellaException: Exception caught: (TypeError) : Cannot read property 'background_1_g$' of undefined
  at fillInStackTrace_0_g$
  at Throwable_3_g$
  at Exception_3_g$
  at RuntimeException_3_g$
  at UmbrellaException_3_g$
  at UmbrellaException_5_g$
  at fireEvent_2_g$
  at fireEvent_15_g$
  at fireEvent_14_g$
  at dispatchEvent_9_g$
  at execute_402_g$
  at $executeRepeating_0_g$
  at runScheduledTasks_0_g$
  at flushPostEventPumpCommands_0_g$
  at execute_6_g$
  at execute_5_g$
  at apply_0_g$
  at entry0_0_g$
  at anonymous
  at callback_0_g$
Caused by: com.google.gwt.core.client.JavaScriptException: (TypeError) : Cannot read property 'background_1_g$' of undefined
  at showReadyState_0_g$
  at onOutputFinished_0_g$
  at onRmdChunkOutputFinished_0_g$
  at dispatch_335_g$
  at dispatch_334_g$
  at dispatch_0_g$
  at dispatchEvent_3_g$
  at doFire_0_g$
  at fireEvent_3_g$
  at fireEvent_2_g$
```