### PR TITLE
resolve some ASAN errors related to use of boost::regex

### DIFF
--- a/src/cpp/session/modules/SessionDependencies.cpp
+++ b/src/cpp/session/modules/SessionDependencies.cpp
@@ -79,8 +79,8 @@ EmbeddedPackage embeddedPackageInfo(const std::string& name)
    BOOST_FOREACH(const FilePath& child, children)
    {
       boost::smatch match;
-      std::string name = child.filename();
-      if (boost::regex_match(name, match, re))
+      std::string filename = child.filename();
+      if (boost::regex_match(filename, match, re))
       {
          EmbeddedPackage pkg;
          pkg.name = name;

--- a/src/cpp/session/modules/SessionDependencies.cpp
+++ b/src/cpp/session/modules/SessionDependencies.cpp
@@ -79,7 +79,8 @@ EmbeddedPackage embeddedPackageInfo(const std::string& name)
    BOOST_FOREACH(const FilePath& child, children)
    {
       boost::smatch match;
-      if (boost::regex_match(child.filename(), match, re))
+      std::string name = child.filename();
+      if (boost::regex_match(name, match, re))
       {
          EmbeddedPackage pkg;
          pkg.name = name;

--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -197,9 +197,10 @@ bool handleLocalHttpUrl(const std::string& url)
 // displaying the manual. Redirect these to the appropriate help event
 bool handleRShowDocFile(const core::FilePath& filePath)
 {
+   std::string absPath = filePath.absolutePath();
    boost::regex manualRegx(".*/lib/R/(doc/manual/[A-Za-z0-9_\\-]*\\.html)");
    boost::smatch match;
-   if (regex_match(filePath.absolutePath(), match, manualRegx))
+   if (regex_match(absPath, match, manualRegx))
    {
       ClientEvent helpEvent(client_events::kShowHelp, match[1]);
       module_context::enqueClientEvent(helpEvent);

--- a/src/cpp/session/modules/presentation/SlideRenderer.cpp
+++ b/src/cpp/session/modules/presentation/SlideRenderer.cpp
@@ -219,9 +219,11 @@ void computeColumnWidths(const Slide& slide,
    boost::regex re("([0-9]+)\\s*%?");
    boost::smatch match;
 
-   if (boost::regex_match(slide.left(), match, re))
+   std::string slideLeft = slide.left();
+   std::string slideRight = slide.right();
+   if (boost::regex_match(slideLeft, match, re))
       computeColumnWidths(match[1], pLeftWidth, pRightWidth);
-   else if (boost::regex_match(slide.right(), match, re))
+   else if (boost::regex_match(slideRight, match, re))
       computeColumnWidths(match[1], pRightWidth, pLeftWidth);
 }
 

--- a/src/tools/asan-build
+++ b/src/tools/asan-build
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+: ${ASANFLAGS="-fsanitize=address -fno-omit-frame-pointer -fno-sanitize=float-divide-by-zero"}
+: ${CC="clang-4.0"}
+: ${CXX="clang++-4.0"}
+: ${MAKEFLAGS="-j8"}
+
+mkdir -p asan-build
+cd asan-build
+rm CMakeCache.txt
+cmake ../cpp                                   \
+    -DCMAKE_C_COMPILER="${CC}"                 \
+    -DCMAKE_C_FLAGS="${ASANFLAGS}"             \
+    -DCMAKE_CXX_COMPILER="${CXX}"              \
+    -DCMAKE_CXX_FLAGS="${ASANFLAGS}"           \
+    -DCMAKE_LINKER="${CXX}"
+cd ..
+
+cmake --build asan-build -- ${MAKEFLAGS}


### PR DESCRIPTION
A version of RStudio compiled with sanitizers spat out some errors when attempting to access submatches from a `boost::regex_search()` result.

The overarching issue -- when `boost::regex_search()` is called, the generated match object contains references to the input string. However, there are a few instances where we call `boost::regex_search()` with a temporary string -- which implies that the generated match object contains pointers to potentially invalid memory.

The solution in most cases is to simply ensure we construct the desired string as a separate object before invoking `boost::regex_search()`, rather than calling it on a (temporary) string.