### PR TITLE
Enable/disable R Markdown behaviors on file type switch

### DIFF
--- a/NEWS.1.0.patch.md
+++ b/NEWS.1.0.patch.md
@@ -1,5 +1,10 @@
 ## v1.0b - Release Notes
 
+### R Notebooks
+
+* Improved sizing of htmlwidgets in R Notebooks
+* Allow changing to R Notebook mode without closing and reopening the file
+
 ### Data Import
 
 * Prompt for a comma-separated list of factors instead of a collection
@@ -7,7 +12,6 @@
 ### Miscellaneous
 
 * Add Ctrl+Tab / Ctrl+Shift+Tab shortcuts to navigate tabs (Desktop only)
-* Improved sizing of htmlwidgets in R Notebooks
 
 ### Bug Fixes
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ImagePreviewer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ImagePreviewer.java
@@ -33,7 +33,6 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Rendere
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Token;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.DocumentChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.RenderFinishedEvent;
-import org.rstudio.studio.client.workbench.views.source.editors.text.events.ScopeTreeReadyEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkOutputHost;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.TextEditingTargetNotebook;
 import org.rstudio.studio.client.workbench.views.source.model.DocUpdateSentinel;
@@ -45,8 +44,6 @@ import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.DOM;
@@ -58,59 +55,16 @@ import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.SimplePanel;
 
 public class ImagePreviewer
-             implements ScopeTreeReadyEvent.Handler,
-                        ValueChangeHandler<String>
 {
    public ImagePreviewer(DocDisplay display, DocUpdateSentinel sentinel, 
          UIPrefs prefs)
    {
       display_ = display;
-      sentinel_ = sentinel;
       prefs_ = prefs;
-      String pref = prefs.showLatexPreviewOnCursorIdle().getValue();
-      
-      sentinel.addPropertyValueChangeHandler(
-            TextEditingTargetNotebook.CONTENT_PREVIEW_ENABLED, this);
-      sentinel.addPropertyValueChangeHandler(
-            TextEditingTargetNotebook.CONTENT_PREVIEW_INLINE, this);
-      
-      if (sentinel.getBoolProperty(
-                TextEditingTargetNotebook.CONTENT_PREVIEW_ENABLED,
-                pref == UIPrefsAccessor.LATEX_PREVIEW_SHOW_ALWAYS) &&
-          sentinel.getBoolProperty(
-                TextEditingTargetNotebook.CONTENT_PREVIEW_INLINE,
-                pref == UIPrefsAccessor.LATEX_PREVIEW_SHOW_ALWAYS))
-      { 
-         reg_ = display.addScopeTreeReadyHandler(this);
-      }
-   }
-
-   @Override
-   public void onScopeTreeReady(ScopeTreeReadyEvent event)
-   {
-      // remove single-shot handler
-      reg_.removeHandler();
-      
-      previewAllLinks();
+      sentinel_ = sentinel;
    }
    
-   @Override
-   public void onValueChange(ValueChangeEvent<String> val)
-   {
-      if (sentinel_.getBoolProperty(
-            TextEditingTargetNotebook.CONTENT_PREVIEW_ENABLED, true) &&
-          sentinel_.getBoolProperty(
-            TextEditingTargetNotebook.CONTENT_PREVIEW_INLINE, true))
-      {
-         previewAllLinks();
-      }
-      else
-      {
-         removeAllPreviews();
-      }
-   }
-   
-   private void previewAllLinks()
+   public void previewAllLinks()
    {
       for (int i = 0, n = display_.getRowCount(); i < n; i++)
       {
@@ -125,7 +79,7 @@ public class ImagePreviewer
       }
    }
    
-   private void removeAllPreviews()
+   public void removeAllPreviews()
    {
       JsArray<LineWidget> widgets = display_.getLineWidgets();
       for (int i = 0; i < widgets.length(); i++)
@@ -526,7 +480,6 @@ public class ImagePreviewer
    private final DocDisplay display_;
    private final DocUpdateSentinel sentinel_;
    private final UIPrefs prefs_;
-   private HandlerRegistration reg_;
 
    private static final String LINE_WIDGET_TYPE = "image-preview" ;
    private static int IMAGE_ID = 0;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/InlinePreviewer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/InlinePreviewer.java
@@ -1,0 +1,102 @@
+/*
+ * InlinePreviewer.java
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text;
+
+import org.rstudio.core.client.HandlerRegistrations;
+import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
+import org.rstudio.studio.client.workbench.prefs.model.UIPrefsAccessor;
+import org.rstudio.studio.client.workbench.views.source.editors.text.events.ScopeTreeReadyEvent;
+import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.TextEditingTargetNotebook;
+import org.rstudio.studio.client.workbench.views.source.model.DocUpdateSentinel;
+
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+public class InlinePreviewer
+             implements ScopeTreeReadyEvent.Handler,
+                        ValueChangeHandler<String>
+{
+   public InlinePreviewer(TextEditingTarget target, DocUpdateSentinel sentinel, 
+         UIPrefs prefs)
+   {
+      display_ = target.getDocDisplay();
+      sentinel_ = sentinel;
+      prefs_ = prefs;
+      regs_ = new HandlerRegistrations();
+      images_ = new ImagePreviewer(display_, sentinel, prefs);
+      mathjax_ = new MathJaxPreviewer(target);
+   }
+   
+   public void preview()
+   {
+      String pref = prefs_.showLatexPreviewOnCursorIdle().getValue();
+      regs_.add(sentinel_.addPropertyValueChangeHandler(
+            TextEditingTargetNotebook.CONTENT_PREVIEW_ENABLED, this));
+      regs_.add(sentinel_.addPropertyValueChangeHandler(
+            TextEditingTargetNotebook.CONTENT_PREVIEW_INLINE, this));
+      
+      if (sentinel_.getBoolProperty(
+                TextEditingTargetNotebook.CONTENT_PREVIEW_ENABLED,
+                pref == UIPrefsAccessor.LATEX_PREVIEW_SHOW_ALWAYS) &&
+          sentinel_.getBoolProperty(
+                TextEditingTargetNotebook.CONTENT_PREVIEW_INLINE,
+                pref == UIPrefsAccessor.LATEX_PREVIEW_SHOW_ALWAYS))
+      { 
+         scopeReg_ = display_.addScopeTreeReadyHandler(this);
+      }
+   }
+   
+   public void onDismiss()
+   {
+      regs_.removeHandler();
+   }
+
+   @Override
+   public void onScopeTreeReady(ScopeTreeReadyEvent event)
+   {
+      // remove single-shot handler
+      scopeReg_.removeHandler();
+      
+      images_.previewAllLinks();
+      mathjax_.renderAllLatex();
+   }
+   
+   @Override
+   public void onValueChange(ValueChangeEvent<String> val)
+   {
+      if (sentinel_.getBoolProperty(
+            TextEditingTargetNotebook.CONTENT_PREVIEW_ENABLED, true) &&
+          sentinel_.getBoolProperty(
+            TextEditingTargetNotebook.CONTENT_PREVIEW_INLINE, true))
+      {
+         images_.previewAllLinks();
+         mathjax_.renderAllLatex();
+      }
+      else
+      {
+         images_.removeAllPreviews();
+         mathjax_.removeAllLatex();
+      }
+   }
+
+   private final DocDisplay display_;
+   private final DocUpdateSentinel sentinel_;
+   private final UIPrefs prefs_;
+   private final ImagePreviewer images_;
+   private final MathJaxPreviewer mathjax_;
+   private HandlerRegistration scopeReg_;
+   private HandlerRegistrations regs_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/MathJaxPreviewer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/MathJaxPreviewer.java
@@ -15,76 +15,24 @@
 package org.rstudio.studio.client.workbench.views.source.editors.text;
 
 import org.rstudio.studio.client.common.mathjax.MathJax;
-import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
-import org.rstudio.studio.client.workbench.prefs.model.UIPrefsAccessor;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.LineWidget;
-import org.rstudio.studio.client.workbench.views.source.editors.text.events.ScopeTreeReadyEvent;
-import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.TextEditingTargetNotebook;
-import org.rstudio.studio.client.workbench.views.source.model.DocUpdateSentinel;
 
 import com.google.gwt.core.client.JsArray;
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
-import com.google.gwt.event.shared.HandlerRegistration;
 
 public class MathJaxPreviewer
-             implements ScopeTreeReadyEvent.Handler,
-                        ValueChangeHandler<String>
 {
-   public MathJaxPreviewer(TextEditingTarget target, DocUpdateSentinel sentinel, 
-         UIPrefs prefs)
+   public MathJaxPreviewer(TextEditingTarget target)
    {
       target_ = target;
       display_= target.getDocDisplay();
-      sentinel_ = sentinel;
-      String pref = prefs.showLatexPreviewOnCursorIdle().getValue();
-      
-      sentinel.addPropertyValueChangeHandler(
-            TextEditingTargetNotebook.CONTENT_PREVIEW_ENABLED, this);
-      sentinel.addPropertyValueChangeHandler(
-            TextEditingTargetNotebook.CONTENT_PREVIEW_INLINE, this);
-      
-      if (sentinel.getBoolProperty(
-                TextEditingTargetNotebook.CONTENT_PREVIEW_ENABLED,
-                pref == UIPrefsAccessor.LATEX_PREVIEW_SHOW_ALWAYS) &&
-          sentinel.getBoolProperty(
-                TextEditingTargetNotebook.CONTENT_PREVIEW_INLINE,
-                pref == UIPrefsAccessor.LATEX_PREVIEW_SHOW_ALWAYS))
-      {
-         reg_ = display_.addScopeTreeReadyHandler(this);
-      }
    }
    
-   @Override
-   public void onScopeTreeReady(ScopeTreeReadyEvent event)
-   {
-      reg_.removeHandler();
-
-      renderAllLatex();
-   }
-
-   @Override
-   public void onValueChange(ValueChangeEvent<String> arg0)
-   {
-      if (sentinel_.getBoolProperty(
-            TextEditingTargetNotebook.CONTENT_PREVIEW_ENABLED, true) &&
-          sentinel_.getBoolProperty(
-            TextEditingTargetNotebook.CONTENT_PREVIEW_INLINE, true))
-      {
-         renderAllLatex();
-      }
-      else
-      {
-         removeAllLatex();
-      }
-   }
-  
-   private void renderAllLatex()
+   public void renderAllLatex()
    {
       target_.renderLatex();
    }
    
-   private void removeAllLatex()
+   public void removeAllLatex()
    {
       JsArray<LineWidget> widgets = display_.getLineWidgets();
       for (int i = 0; i < widgets.length(); i++)
@@ -97,6 +45,4 @@ public class MathJaxPreviewer
    
    private final DocDisplay display_;
    private final TextEditingTarget target_;
-   private final DocUpdateSentinel sentinel_;
-   private HandlerRegistration reg_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -6320,15 +6320,21 @@ public class TextEditingTarget implements
       if (enabled)
       {
          // auto preview images and equations
-         new ImagePreviewer(docDisplay_, docUpdateSentinel_, prefs_);
-         new MathJaxPreviewer(this, docUpdateSentinel_, prefs_);
-      
+         if (inlinePreviewer_ == null)
+            inlinePreviewer_ = new InlinePreviewer(
+                  this, docUpdateSentinel_, prefs_);
+         inlinePreviewer_.preview();
+
          // sync the notebook's output mode (enable/disable inline output)
          if (notebook_ != null)
             notebook_.syncOutputMode();
       }
       else
       {
+         // clean up previewers
+         if (inlinePreviewer_ != null)
+            inlinePreviewer_.onDismiss();
+
          // clean up line widgets
          if (notebook_ != null)
             notebook_.onNotebookClearAllOutput();
@@ -6383,6 +6389,7 @@ public class TextEditingTarget implements
    private final TextEditingTargetRenameHelper renameHelper_;
    private CollabEditStartParams queuedCollabParams_;
    private MathJax mathjax_;
+   private InlinePreviewer inlinePreviewer_;
    
    // Allows external edit checks to supercede one another
    private final Invalidation externalEditCheckInvalidation_ =

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2533,6 +2533,9 @@ public class TextEditingTarget implements
 
       if (notebook_ != null)
          notebook_.onDismiss();
+      
+      if (inlinePreviewer_ != null)
+         inlinePreviewer_.onDismiss();
    }
 
    public ReadOnlyValue<Boolean> dirtyState()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetIdleMonitor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetIdleMonitor.java
@@ -113,7 +113,7 @@ public class TextEditingTargetIdleMonitor
       }
    }
    
-   private void beginMonitoring()
+   public void beginMonitoring()
    {
       endMonitoring();
       monitors_.add(display_.addEditorModeChangedHandler(
@@ -154,7 +154,7 @@ public class TextEditingTargetIdleMonitor
       }));
    }
    
-   private void endMonitoring()
+   public void endMonitoring()
    {
       for (HandlerRegistration monitor : monitors_)
          monitor.removeHandler();


### PR DESCRIPTION
Prior to this change, a file had to be opened in R Markdown mode in order to receive some R Markdown features (for instance, inline output and equation previews). After it, an already-open file can have these features enabled on the fly when it switches to R Markdown mode. For completeness, these feature are also disabled on the fly when switching out of R Markdown mode.