### PR TITLE
provide script for building RStudio with ASAN / UBSAN

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -69,12 +69,23 @@ if(UNIX)
 
       # Figure out what version of Mac OS X this is. Unfortunately 
       # CMAKE_SYSTEM_VERSION does not match uname -r, so get the Mac OS
-      # version number another way. 
+      # version number another way.
       EXECUTE_PROCESS(COMMAND /usr/bin/sw_vers -productVersion OUTPUT_VARIABLE MACOSX_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
       message(STATUS "Mac OS X version: ${MACOSX_VERSION}")
-      if(NOT(${MACOSX_VERSION} VERSION_LESS "10.9"))
+      if(RSTUDIO_USE_LIBCXX)
+         message(STATUS "C++ Standard Library: libc++")
+         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+         set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -stdlib=libc++")
+      elseif(RSTUDIO_USE_LIBSTDCXX)
+         message(STATUS "C++ Standard Library: libstdc++")
          set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
          set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -stdlib=libstdc++")
+      else()
+         if(NOT(${MACOSX_VERSION} VERSION_LESS "10.9"))
+            message(STATUS "C++ Standard Library: libstdc++")
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
+            set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -stdlib=libstdc++")
+         endif()
       endif()
    endif()
 
@@ -122,8 +133,13 @@ if(APPLE OR WIN32 OR RSTUDIO_PACKAGE_BUILD)
    set(Boost_USE_STATIC_LIBS ON)
 endif()
 
-# require boost 1.50
+# default to boost 1.50.0
 set(BOOST_VERSION 1.50.0)
+
+# override if necessary
+if (RSTUDIO_BOOST_VERSION)
+   set(BOOST_VERSION "${RSTUDIO_BOOST_VERSION}")
+endif()
 
 list(APPEND BOOST_LIBS
    date_time
@@ -141,7 +157,7 @@ list(APPEND BOOST_LIBS
 if(UNIX)
    # prefer static link to our custom built version
    set(RSTUDIO_TOOLS_BOOST /opt/rstudio-tools/boost/boost_1_50_0)
-   if(EXISTS ${RSTUDIO_TOOLS_BOOST})
+   if(RSTUDIO_USE_PRECOMPILED_BOOST AND EXISTS ${RSTUDIO_TOOLS_BOOST})
       # find headers
       set(Boost_USE_STATIC_LIBS ON)
       set(BOOST_INCLUDEDIR  ${RSTUDIO_TOOLS_BOOST}/include)

--- a/src/tools/asan-build
+++ b/src/tools/asan-build
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
-: ${ASANFLAGS="-fsanitize=address -fno-omit-frame-pointer -fno-sanitize=float-divide-by-zero"}
+: ${ASANFLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize=float-divide-by-zero"}
 : ${CC="clang-4.0"}
 : ${CXX="clang++-4.0"}
 : ${MAKEFLAGS="-j8"}
@@ -13,7 +13,9 @@ cmake ../cpp                                   \
     -DCMAKE_C_FLAGS="${ASANFLAGS}"             \
     -DCMAKE_CXX_COMPILER="${CXX}"              \
     -DCMAKE_CXX_FLAGS="${ASANFLAGS}"           \
-    -DCMAKE_LINKER="${CXX}"
+    -DRSTUDIO_USE_LIBCXX=Yes                   \
+    -DRSTUDIO_USE_PRECOMPILED_BOOST=No         \
+    -DRSTUDIO_BOOST_VERSION=1.56.0
 cd ..
 
 cmake --build asan-build -- ${MAKEFLAGS}

--- a/src/tools/ubsan-build
+++ b/src/tools/ubsan-build
@@ -3,19 +3,20 @@
 : ${ASANFLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize=float-divide-by-zero"}
 : ${CC="clang-4.0"}
 : ${CXX="clang++-4.0"}
+: ${BUILD_DIR="ubsan-build"}
 : ${MAKEFLAGS="-j8"}
 
-mkdir -p asan-build
-cd asan-build
-rm CMakeCache.txt
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
 cmake ../cpp                                   \
     -DCMAKE_C_COMPILER="${CC}"                 \
     -DCMAKE_C_FLAGS="${ASANFLAGS}"             \
     -DCMAKE_CXX_COMPILER="${CXX}"              \
     -DCMAKE_CXX_FLAGS="${ASANFLAGS}"           \
-    -DRSTUDIO_USE_LIBCXX=Yes                   \
-    -DRSTUDIO_USE_PRECOMPILED_BOOST=No         \
-    -DRSTUDIO_BOOST_VERSION=1.56.0
+    -DRSTUDIO_USE_LIBCXX="Yes"                 \
+    -DRSTUDIO_USE_PRECOMPILED_BOOST="No"       \
+    -DRSTUDIO_BOOST_VERSION="1.56.0"           \
+    "$@"
 cd ..
 
-cmake --build asan-build -- ${MAKEFLAGS}
+cmake --build "${BUILD_DIR}" -- "${MAKEFLAGS}"


### PR DESCRIPTION
This PR adds a script that makes it easier to build RStudio with the address + undefined behavior sanitizers. Testing with versions of RStudio built with sanitizers should help in uncovering hard-to-find memory access / write errors, as well as C++ code that trips undefined behavior.

From the `src` directory, one can run `./tools/ubsan-build` to build RStudio server using these sanitizers.

We also tweak the CMake build scripts, adding `RSTUDIO_USE_LIBCXX` and `RSTUDIO_USE_LIBSTDCXX` to force the use of a particular standard library, as well as `RSTUDIO_BOOST_VERSION` to select a particular version of Boost (in preference to the pre-built version).