### PR TITLE
[WIP] initial work porting to QWebEngine

### DIFF
--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -19,14 +19,9 @@ cmake_policy(SET CMP0020 OLD)
 
 project(DESKTOP)
 
-# require Qt 5.4
-if(WIN32)
-  set(QT_VERSION "5.4.1")
-else()
-  set(QT_VERSION "5.4.0")
-endif()
-
-set(QT_VERSION_SUBDIR "5.4")
+# require Qt 5.6
+set(QT_VERSION "5.6.1")
+set(QT_VERSION_SUBDIR "5.6")
 
 # on unix prefer qtsdk installs over system-level libraries. note this
 # can be overriden by defining QT_QMAKE_EXECUTABLE when invoking cmake
@@ -65,6 +60,8 @@ else()
    endif()
 endif()
 
+message(STATUS "Found Qt ${QT_VERSION} (qmake: ${QT_QMAKE_EXECUTABLE})")
+
 # set the cmake prefix path based on the location of the qmake executable
 get_filename_component(QT_BIN_DIR ${QT_QMAKE_EXECUTABLE} PATH)
 set(CMAKE_PREFIX_PATH "${QT_BIN_DIR}//..//lib//cmake")
@@ -77,8 +74,8 @@ find_package(Qt5Core REQUIRED)
 find_package(Qt5Widgets REQUIRED)
 find_package(Qt5Gui REQUIRED)
 find_package(Qt5Network REQUIRED)
-find_package(Qt5WebKit REQUIRED)
-find_package(Qt5WebKitWidgets REQUIRED)
+find_package(Qt5WebEngine REQUIRED)
+find_package(Qt5WebEngineWidgets REQUIRED)
 find_package(Qt5PrintSupport REQUIRED)
 find_package(Qt5Quick REQUIRED)
 find_package(Qt5Positioning REQUIRED)
@@ -304,8 +301,8 @@ if(NOT APPLE)
       Widgets
       Gui
       Network
-      WebKit
-      WebKitWidgets
+      WebEngine
+      WebEngineWidgets
       PrintSupport
       Quick
       Positioning
@@ -362,7 +359,7 @@ else()
       ${DESKTOP_UI_SOURCES}
       ${ICNS_FILES})
 
-   qt5_use_modules(RStudio Core Widgets Gui Network WebKit WebKitWidgets)
+   qt5_use_modules(RStudio Core Widgets Gui Network WebEngine WebEngineWidgets)
 
    target_link_libraries(RStudio
       ${QT_LIBRARIES}
@@ -467,10 +464,10 @@ if(RSTUDIO_BUNDLE_QT)
                        ${QT_LIBRARY_DIR}/libQt5Network.so.${QT_FULL_VERSION}
                        ${QT_LIBRARY_DIR}/libQt5Widgets.so.5
                        ${QT_LIBRARY_DIR}/libQt5Widgets.so.${QT_FULL_VERSION}
-                       ${QT_LIBRARY_DIR}/libQt5WebKit.so.5
-                       ${QT_LIBRARY_DIR}/libQt5WebKit.so.${QT_FULL_VERSION}
-                       ${QT_LIBRARY_DIR}/libQt5WebKitWidgets.so.5
-                       ${QT_LIBRARY_DIR}/libQt5WebKitWidgets.so.${QT_FULL_VERSION}
+                       ${QT_LIBRARY_DIR}/libQt5WebEngine.so.5
+                       ${QT_LIBRARY_DIR}/libQt5WebEngine.so.${QT_FULL_VERSION}
+                       ${QT_LIBRARY_DIR}/libQt5WebEngineWidgets.so.5
+                       ${QT_LIBRARY_DIR}/libQt5WebEngineWidgets.so.${QT_FULL_VERSION}
                        ${QT_LIBRARY_DIR}/libQt5WebChannel.so.5
                        ${QT_LIBRARY_DIR}/libQt5WebChannel.so.${QT_FULL_VERSION}
                        ${QT_LIBRARY_DIR}/libQt5Positioning.so.5

--- a/src/cpp/desktop/DesktopBrowserWindow.hpp
+++ b/src/cpp/desktop/DesktopBrowserWindow.hpp
@@ -18,7 +18,7 @@
 
 #include <QAction>
 #include <QMainWindow>
-#include <QtWebKitWidgets/QWebView>
+#include <QtWebEngineWidgets/QWebEngineView>
 #include <QLineEdit>
 
 #include "DesktopWebView.hpp"
@@ -38,7 +38,8 @@ public:
                            QWidget *parent = NULL,
                            WebPage *pOpener = NULL,
                            bool allowExternalNavigate = false);
-    WebView* webView();
+     WebView* webView();
+     void avoidMoveCursorIfNecessary();
 
 protected slots:
 
@@ -46,16 +47,15 @@ protected slots:
      void setProgress(int p);
      virtual void finishLoading(bool);
      virtual void onJavaScriptWindowObjectCleared();
-     void printRequested(QWebFrame* frame);
+     void printRequested(QWebEnginePage* frame);
 
 protected:
-     void avoidMoveCursorIfNecessary();
 
      // implement GwtCallbackOwner
      virtual QWidget* asWidget();
      virtual WebPage* webPage();
      virtual void postWebViewEvent(QEvent *event);
-     virtual void triggerPageAction(QWebPage::WebAction action);
+     virtual void triggerPageAction(QWebEnginePage::WebAction action);
      virtual void closeEvent(QCloseEvent *event);
 
      // hooks for subclasses

--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -27,7 +27,7 @@
 #include <QMessageBox>
 #include <QApplication>
 #include <QAbstractButton>
-#include <QWebFrame>
+#include <QWebEnginePage>
 
 #include <core/FilePath.hpp>
 #include <core/DateTime.hpp>
@@ -495,9 +495,10 @@ void GwtCallback::activateSatelliteWindow(QString name)
 
 void GwtCallback::copyImageToClipboard(int left, int top, int width, int height)
 {
-   pOwner_->webPage()->updatePositionDependentActions(
-         QPoint(left + (width/2), top + (height/2)));
-   pOwner_->triggerPageAction(QWebPage::CopyImageToClipboard);
+   // TODO: no longer availble?
+   // pOwner_->webPage()->updatePositionDependentActions(
+   //       QPoint(left + (width/2), top + (height/2)));
+   pOwner_->triggerPageAction(QWebEnginePage::CopyImageToClipboard);
 }
 
 void GwtCallback::copyPageRegionToClipboard(int left, int top, int width, int height)
@@ -1051,7 +1052,7 @@ void GwtCallback::launchSession(bool reload)
 void GwtCallback::activateAndFocusOwner()
 {
    desktop::raiseAndActivateWindow(pOwner_->asWidget());
-   pOwner_->webPage()->mainFrame()->setFocus();
+   pOwner_->webView()->setFocus();
 }
 
 void GwtCallback::reloadZoomWindow()

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -17,7 +17,7 @@
 #define DESKTOP_GWT_CALLBACK_HPP
 
 #include <QObject>
-#include <QtWebKit>
+#include <QtWebEngine>
 
 #include "DesktopGwtCallbackOwner.hpp"
 

--- a/src/cpp/desktop/DesktopGwtCallbackOwner.hpp
+++ b/src/cpp/desktop/DesktopGwtCallbackOwner.hpp
@@ -18,12 +18,13 @@
 
 #include <QWidget>
 #include <QString>
-#include <QWebPage>
+#include <QWebEnginePage>
 
 namespace rstudio {
 namespace desktop {
 
 class WebPage;
+class WebView;
 
 class GwtCallbackOwner
 {
@@ -31,9 +32,10 @@ public:
    virtual ~GwtCallbackOwner() {}
 
    virtual QWidget* asWidget() = 0;
+   virtual WebView* webView() = 0;
    virtual WebPage* webPage() = 0;
    virtual void postWebViewEvent(QEvent *event) = 0;
-   virtual void triggerPageAction(QWebPage::WebAction action) = 0;
+   virtual void triggerPageAction(QWebEnginePage::WebAction action) = 0;
 };
 
 } // namespace desktop

--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -14,7 +14,7 @@
  */
 
 #include <QtGui>
-#include <QtWebKit>
+#include <QtWebEngine>
 #include <QPushButton>
 
 #include <boost/bind.hpp>

--- a/src/cpp/desktop/DesktopOptions.cpp
+++ b/src/cpp/desktop/DesktopOptions.cpp
@@ -205,7 +205,7 @@ QString Options::fixedWidthFont() const
 #endif
            ;
 
-   // The fallback font is Courier, not monospace, because QtWebKit doesn't
+   // The fallback font is Courier, not monospace, because QtWebEngine doesn't
    // actually provide a monospace font (appears to use Helvetica)
 
    return detectedFont = QString::fromUtf8("\"") +

--- a/src/cpp/desktop/DesktopSatelliteWindow.hpp
+++ b/src/cpp/desktop/DesktopSatelliteWindow.hpp
@@ -17,7 +17,7 @@
 #define DESKTOP_SATELLITE_WINDOW_HPP
 
 #include <QMainWindow>
-#include <QtWebKit>
+#include <QtWebEngine>
 #include "DesktopGwtWindow.hpp"
 
 #include "DesktopGwtCallback.hpp"

--- a/src/cpp/desktop/DesktopSecondaryWindow.cpp
+++ b/src/cpp/desktop/DesktopSecondaryWindow.cpp
@@ -18,6 +18,7 @@
 #include <QApplication>
 #include <QToolBar>
 #include <QDesktopWidget>
+#include <QWebEngineHistory>
 
 #include "DesktopWebView.hpp"
 
@@ -94,7 +95,7 @@ SecondaryWindow::SecondaryWindow(bool showToolbar, QString name, QUrl baseUrl,
 
 void SecondaryWindow::print()
 {
-   printRequested(webView()->page()->mainFrame());
+   printRequested(webView()->page());
 }
 
 void SecondaryWindow::manageCommandState()

--- a/src/cpp/desktop/DesktopSecondaryWindow.hpp
+++ b/src/cpp/desktop/DesktopSecondaryWindow.hpp
@@ -17,7 +17,7 @@
 #define DESKTOP_SECONDARY_WINDOW_HPP
 
 #include <QMainWindow>
-#include <QtWebKit>
+#include <QtWebEngine>
 #include "DesktopBrowserWindow.hpp"
 
 namespace rstudio {
@@ -45,7 +45,7 @@ private:
     QAction* reload_;
     QAction* print_;
 
-    QWebHistory* history_;
+    QWebEngineHistory* history_;
 };
 
 } // namespace desktop

--- a/src/cpp/desktop/DesktopWebPage.hpp
+++ b/src/cpp/desktop/DesktopWebPage.hpp
@@ -17,8 +17,8 @@
 #define DESKTOP_WEB_PAGE_HPP
 
 #include <QtGui>
-#include <QtWebKit>
-#include <QWebPage>
+#include <QtWebEngine>
+#include <QWebEnginePage>
 
 namespace rstudio {
 namespace desktop {
@@ -69,7 +69,7 @@ struct PendingWindow
 };
 
 
-class WebPage : public QWebPage
+class WebPage : public QWebEnginePage
 {
    Q_OBJECT
 
@@ -85,22 +85,22 @@ public:
    void activateWindow(QString name);
    void prepareForWindow(const PendingWindow& pendingWnd);
    void closeWindow(QString name);
-   virtual void triggerAction(QWebPage::WebAction action, bool checked = false);
+   virtual void triggerAction(QWebEnginePage::WebAction action, bool checked = false);
 
 public slots:
    bool shouldInterruptJavaScript();
    void closeRequested();
 
 protected:
-   QWebPage* createWindow(QWebPage::WebWindowType type);
+   QWebEnginePage* createWindow(QWebEnginePage::WebWindowType type);
    void javaScriptConsoleMessage(const QString& message, int lineNumber, const QString& sourceID);
    QString userAgentForUrl(const QUrl &url) const;
-   bool acceptNavigationRequest(QWebFrame* frame,
+   bool acceptNavigationRequest(QWebEnginePage* frame,
                                 const QNetworkRequest& request,
                                 NavigationType type);
 
 private:
-   void handleBase64Download(QWebFrame* pWebFrame, QUrl url);
+   void handleBase64Download(QWebEnginePage* pWebFrame, QUrl url);
 
 private:
    QUrl baseUrl_;

--- a/src/cpp/desktop/DesktopWebView.hpp
+++ b/src/cpp/desktop/DesktopWebView.hpp
@@ -17,8 +17,7 @@
 #define DESKTOP_WEB_VIEW_HPP
 
 #include <QtGui>
-#include <QWebView>
-#include <QWebInspector>
+#include <QWebEngineView>
 
 #include "DesktopWebPage.hpp"
 
@@ -27,7 +26,7 @@ namespace desktop {
 
 class MainWindow;
 
-class WebView : public ::QWebView
+class WebView : public ::QWebEngineView
 {
    Q_OBJECT
 
@@ -63,7 +62,6 @@ protected slots:
 
 private:
    QUrl baseUrl_;
-   QWebInspector* pWebInspector_;
    WebPage* pWebPage_;
    double dpiZoomScaling_;
 };

--- a/src/cpp/rstudio-dev.in
+++ b/src/cpp/rstudio-dev.in
@@ -17,14 +17,14 @@
 
 PLUGIN_PREFIX=""
 
-if [[ -e ~/Qt5.4.0/5.4/gcc_64/plugins ]] 
+if [[ -e ~/Qt5.6.1/5.6/gcc_64/plugins ]] 
 then
   # 64 bit systems
-  PLUGIN_PREFIX=~/Qt5.4.0/5.4/gcc_64/plugins
-elif [[ -e ~/Qt5.40/5.4/gcc/plugins ]]
+  PLUGIN_PREFIX=~/Qt5.6.1/5.6/gcc_64/plugins
+elif [[ -e ~/Qt5.6.1/5.6/gcc/plugins ]]
 then
   # 32 bit systems
-  PLUGIN_PREFIX=~/Qt5.4.0/5.4/gcc/plugins
+  PLUGIN_PREFIX=~/Qt5.6.1/5.6/gcc/plugins
 fi
 
 if [[ $PLUGIN_PREFIX ==  "" ]]


### PR DESCRIPTION
NOTE: not ready to merge! I don't think we'll take this work to completion right away but hopefully this will give us a starting point once we get v1.0 + patches out the door.

This represents some of the early work + investigation into porting to QtWebEngine (and hence Chromium as the rendering engine). This version currently compiles, but lots of code that needs to change has been stubbed out. The main changes that need to be made (some already outlined by @jjallaire, and discussed on https://wiki.qt.io/Porting_from_QtWebKit_to_QtWebEngine):
1. Re-write our calls to the synchronous API `evaluateJavascript` to the asynchronous `runJavascript`, and see if we can adjust any of the APIs where we attempt to make synchronous calls to JavaScript to run asynchronously (or through some other mechanism).
2. Rewrite our uses of `QNetworkAccessManager` -- most of the APIs we might've used there before should now live in the `QWebEnginePage`.
3. Remove our usages of `QWebElement` and friends, and find an alternative -- these synchronous APIs are no longer available.
4. The `addToJavaScriptWindowObject()` method is no longer available -- it looks like we'll need to look at the [`QWebChannel`](http://doc.qt.io/qt-5/qwebchannel.html) class for bridging the C++ / JavaScript worlds now.

Note that I also looked at using Qt 5.7, but since that version seems to require C++11 support we would likely want to stay on Qt 5.6.1 for now (especially since Qt has deemed it a LTS release).
