### PR TITLE
avoid printing data table in notebooks when assigning new column (6181)

### DIFF
--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -20,12 +20,13 @@
     "print.tbl_df" = function(x, options)     list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x))),
     "print.grouped_df" = function(x, options) list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x))),
     "print.data.table" = function(x, options) {
-      shouldPrintTable <- TRUE
-      if (exists(x = "shouldPrint", envir = as.environment("package:data.table"))) {
-        shouldPrintTable <- data.table::shouldPrint(x)
-      } else {
-        shouldPrintTable <- data.table:::.global$print == "" || data.table::address(x) != data.table:::.global$print
-      }
+      shouldPrintTable <- tryCatch({
+        if (packageVersion("data.table") >= package_version("1.9.7")) {
+          data.table::shouldPrint(x)
+        } else {
+          data.table:::.global$print == "" || data.table::address(x) != data.table:::.global$print
+        }
+      }, error = function(e) TRUE)
 
       if (!shouldPrintTable) {
         return(NULL)

--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -20,13 +20,17 @@
     "print.tbl_df" = function(x, options)     list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x))),
     "print.grouped_df" = function(x, options) list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x))),
     "print.data.table" = function(x, options) {
-      shouldPrintTable <- tryCatch({
-        if (packageVersion("data.table") >= package_version("1.9.7")) {
-          data.table::shouldPrint(x)
-        } else {
-          data.table:::.global$print == "" || data.table::address(x) != data.table:::.global$print
-        }
-      }, error = function(e) TRUE)
+      shouldPrintTable <- TRUE
+
+      if ("data.table" %in% loadedNamespaces() &&
+          exists("shouldPrint", envir = asNamespace("data.table")))
+      {
+        shouldPrint <- get("shouldPrint", envir = asNamespace("data.table"))
+        shouldPrintTable <- tryCatch(
+          shouldPrint(x) || !inherits(x, "data.table"),
+          error = function(e) TRUE
+        )
+      }
 
       if (!shouldPrintTable) {
         return(NULL)

--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -19,7 +19,20 @@
     "print.data.frame" = function(x, options) list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x))),
     "print.tbl_df" = function(x, options)     list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x))),
     "print.grouped_df" = function(x, options) list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x))),
-    "print.data.table" = function(x, options) list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x))),
+    "print.data.table" = function(x, options) {
+      shouldPrintTable <- TRUE
+      if (exists(x = "shouldPrint", envir = as.environment("package:data.table"))) {
+        shouldPrintTable <- data.table::shouldPrint(x)
+      } else {
+        shouldPrintTable <- data.table:::.global$print == "" || data.table::address(x) != data.table:::.global$print
+      }
+
+      if (!shouldPrintTable) {
+        return(NULL)
+      }
+
+      list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x)))
+    },
     "print.tbl_lazy" = function(x, options) {
       tblLazyData <- lapply(dplyr::tbl_vars(x), function(e) character(0))
       names(tblLazyData) <- dplyr::tbl_vars(x)
@@ -72,7 +85,9 @@
       overrideName,
       function(x, ...) {
         o <- overrideMap(x, options)
-        overridePrint(o$x, o$options, o$className, o$nRow, o$nCol)
+        if (!is.null(o)) {
+          overridePrint(o$x, o$options, o$className, o$nRow, o$nCol)
+        }
       },
       envir = as.environment("tools:rstudio")
     )
@@ -171,15 +186,15 @@
 
   is_list <- vapply(data, is.list, logical(1))
   data[is_list] <- lapply(data[is_list], function(x) {
-    summary <- tibble::obj_sum(x)
-    paste0("<", summary, ">")
-  })
+        summary <- tibble::obj_sum(x)
+        paste0("<", summary, ">")
+      })
 
   if (length(columns) > 0) {
     first_column = data[[1]]
     if (is.numeric(first_column) && isTRUE(all(diff(first_column) == 1)))
       columns[[1]]$align <- "left"
-  }
+    }
 
   data <- as.data.frame(
     lapply(


### PR DESCRIPTION
Similar issue suggested for v1.0-patch: https://github.com/rstudio/rmarkdown/pull/830

```{r}
library(rmarkdown)
library(data.table)  
DT = data.table(x=c(1,2,3), y=4:6)    # should not print  
DT                                    # should print
DT[, z := 7:9]                        # should not print but prints in notebooks
print(DT[, z := 10:12])               # should print according to user post...
```

Now, that said, in console we see this behavior:

```{r}
library(rmarkdown)
library(data.table)  
DT = data.table(x=c(1,2,3), y=4:6)    # not print  
DT                                    # print
DT[, z := 7:9]                        # not print
print(DT[, z := 10:12])               # not print
```

I believe a fix should match the console behavior.