### PR TITLE
data.table development version emits errors when > 1 column in notebook

### DIFF
--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -52,7 +52,7 @@
 
     max.print <- if (is.null(options$max.print)) getOption("max.print", 1000) else options$max.print
 
-    x <- head(x, max.print)
+    x <- as.data.frame(head(x, max.print))
 
     save(
       x,

--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -52,7 +52,7 @@
 
     max.print <- if (is.null(options$max.print)) getOption("max.print", 1000) else options$max.print
 
-    x <- as.data.frame(head(x, max.print))
+    x <- .rs.toDataFrame(head(x, max.print), "x", flatten = FALSE, force = TRUE)
 
     save(
       x,

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -217,9 +217,9 @@
     cols
 })
 
-.rs.addFunction("toDataFrame", function(x, name, flatten) {
+.rs.addFunction("toDataFrame", function(x, name, flatten, force = FALSE) {
   # if it's not already a frame, coerce it to a frame
-  if (!is.data.frame(x)) {
+  if (!is.data.frame(x) || force) {
     frame <- NULL
     # attempt to coerce to a data frame--this can throw errors in the case
     # where we're watching a named object in an environment and the user


### PR DESCRIPTION
The code from:

https://github.com/rstudio/rstudio/blob/917f4003b2072dbef900b12d4a7601e14c3a969e/src/cpp/session/modules/NotebookData.R#L123-L221

was written with the assumption that `data` is a `data.frame`; however, when serializing a notebook, we preserve the original type, a `data.table` in this case. However, operations between a `data.table` and `data.frame` behave differently and break in development builds for `data.table` for the following code:

```{r}
  is_list <- vapply(data, is.list, logical(1))
  data[is_list] <- lapply(data[is_list], function(x) {
    summary <- tibble::obj_sum(x)
    paste0("<", summary, ">")
  })
```

Therefore, the fix here is to persist data always as a `data.frame`.