### PR TITLE
Use pending HTML widget frame URL on transition to gallery

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkHtmlPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkHtmlPage.java
@@ -64,41 +64,31 @@ public class ChunkHtmlPage extends ChunkOutputPage
          content_ = frame_;
       }
 
-      final String fullUrl = url;
-      Timer frameLoadTimer = new Timer()
+      frame_.loadUrlDelayed(url, 400, new Command() 
       {
          @Override
-         public void run()
+         public void execute()
          {
-            frame_.loadUrl(fullUrl , new Command() 
+            Element body = frame_.getDocument().getBody();
+            Style bodyStyle = body.getStyle();
+      
+            bodyStyle.setPadding(0, Unit.PX);
+            bodyStyle.setMargin(0, Unit.PX);
+
+            onEditorThemeChanged(ChunkOutputWidget.getEditorColors());
+
+            Timer frameFinishLoadTimer = new Timer()
             {
                @Override
-               public void execute()
+               public void run()
                {
-                  Element body = frame_.getDocument().getBody();
-                  Style bodyStyle = body.getStyle();
-            
-                  bodyStyle.setPadding(0, Unit.PX);
-                  bodyStyle.setMargin(0, Unit.PX);
+                  onRenderComplete.execute();
+               }
+            };
 
-                  onEditorThemeChanged(ChunkOutputWidget.getEditorColors());
-
-                  Timer frameFinishLoadTimer = new Timer()
-                  {
-                     @Override
-                     public void run()
-                     {
-                        onRenderComplete.execute();
-                     }
-                  };
-
-                  frameFinishLoadTimer.schedule(100);
-               };
-            });
-         }
-      };
-
-      frameLoadTimer.schedule(400);
+            frameFinishLoadTimer.schedule(100);
+         };
+      });
    }
       
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputFrame.java
@@ -21,6 +21,18 @@ import com.google.gwt.user.client.Timer;
 
 public class ChunkOutputFrame extends DynamicIFrame
 {
+   public ChunkOutputFrame()
+   {
+      timer_ = new Timer() 
+      {
+         @Override
+         public void run()
+         {
+            loadUrl(url_, onCompleted_);
+         }
+      };
+   }
+
    void loadUrl(String url, Command onCompleted)
    {
       onCompleted_ = onCompleted;
@@ -39,19 +51,18 @@ public class ChunkOutputFrame extends DynamicIFrame
          Command onCompleted)
    {
       // prevent stacking timers
-      if (timer_ != null && timer_.isRunning())
+      if (timer_.isRunning())
          timer_.cancel();
       
       onCompleted_ = onCompleted;
       url_ = url;
 
-      timer_ = new FrameLoadTimer();
       timer_.schedule(delayMs);
    }
    
    public void cancelPendingLoad()
    {
-      if (timer_ != null && timer_.isRunning())
+      if (timer_.isRunning())
          timer_.cancel();
    }
 
@@ -59,7 +70,7 @@ public class ChunkOutputFrame extends DynamicIFrame
    public String getUrl()
    {
       // return the pending URL if we haven't loaded one yet
-      if (timer_ != null && timer_.isRunning())
+      if (timer_.isRunning())
          return url_;
       else
          return super.getUrl();
@@ -72,16 +83,7 @@ public class ChunkOutputFrame extends DynamicIFrame
          onCompleted_.execute();
    }
    
-   private class FrameLoadTimer extends Timer
-   {
-      @Override
-      public void run()
-      {
-         loadUrl(url_, onCompleted_);
-      }
-   }
-   
-   private FrameLoadTimer timer_;
+   private final Timer timer_;
    private String url_;
    private Command onCompleted_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -44,7 +44,6 @@ import com.google.gwt.dom.client.Style.Overflow;
 import com.google.gwt.dom.client.Style.Position;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.Image;
@@ -241,25 +240,15 @@ public class ChunkOutputStream extends FlowPanel
          bodyStyle.setColor(ChunkOutputWidget.getEditorColors().foreground);
       }
 
-      final String fullUrl = url;
-      Timer frameLoadTimer = new Timer()
+      frame.loadUrlDelayed(url, 250, new Command() 
       {
          @Override
-         public void run()
+         public void execute()
          {
-            frame.loadUrl(fullUrl , new Command() 
-            {
-               @Override
-               public void execute()
-               {
-                  onRenderComplete.execute();
-                  onHeightChanged();
-               };
-            });
-         }
-      };
-
-      frameLoadTimer.schedule(250);
+            onRenderComplete.execute();
+            onHeightChanged();
+         };
+      });
    }
 
    @Override
@@ -488,6 +477,10 @@ public class ChunkOutputStream extends FlowPanel
             ChunkOutputFrame frame = (ChunkOutputFrame)inner;
             ChunkHtmlPage html = new ChunkHtmlPage(frame.getUrl(), 
                   (NotebookHtmlMetadata)metadata.cast(), ordinal, null, chunkOutputSize_);
+
+            // cancel any pending page load
+            frame.cancelPendingLoad();
+
             pages.add(html);
             remove(w);
          }


### PR DESCRIPTION
This change fixes a timing issue introduced by https://github.com/rstudio/rstudio/commit/649a617b71f0c1906a0fc37dea6516defd731d2f. 

When the notebook's chunk output widget receives enough output to transition from stream mode to gallery mode, it collects its existing content and creates pages for it. However, if this happens prior to the content being assigned a URL, a page with no URL is created, which results in an amusing but unhelpful nested instance of RStudio.

The fix is twofold:

1. Add a method to the frame widget, `loadUrlDelayed`, which centralizes the logic that loads a URL after some delay. 

1. When retrieving the URL associated with the frame widget, return the pending URL if one exists.

@javierluraschi you're probably the most familiar with this code; would you be willing to review it?