### PR TITLE
support custom attributes in Markdown links for image preview

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/html/HTMLAttributesParser.java
+++ b/src/gwt/src/org/rstudio/core/client/html/HTMLAttributesParser.java
@@ -1,0 +1,166 @@
+/*
+ * HTMLAttributesParser.java
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.html;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.rstudio.core.client.regex.Match;
+import org.rstudio.core.client.regex.Pattern;
+
+import com.google.gwt.user.client.Command;
+
+public class HTMLAttributesParser
+{
+   private static class Parser
+   {
+      public Parser(String attributes)
+      {
+         attributes_ = attributes.trim();
+         map_ = new HashMap<String, String>();
+         
+         index_ = 0;
+         currentKey_ = "";
+         currentValue_ = "";
+      }
+      
+      public boolean consumeKey()
+      {
+         final int index = index_;
+         return consumeUntilRegex("[\\s=]", new Command()
+         {
+            @Override
+            public void execute()
+            {
+               currentKey_ = attributes_.substring(index, index_);
+               map_.put(currentKey_, null);
+            }
+         });
+      }
+      
+      public boolean consumeWhitespace()
+      {
+         return consumeUntilRegex("\\S");
+      }
+      
+      public boolean consumeEquals()
+      {
+         return consumeUntilRegex("[^\\s=]");
+      }
+      
+      public boolean consumeValue()
+      {
+         final int index = index_;
+         char ch = attributes_.charAt(index_);
+         if (ch == '\'' || ch == '"')
+         {
+            return consumeQuotedValue(ch, new Command()
+            {
+               @Override
+               public void execute()
+               {
+                  currentValue_ = attributes_.substring(index + 1, index_ - 1);
+                  map_.put(currentKey_, currentValue_);
+               }
+            });
+         }
+         
+         return consumeUntilRegex("(?:\\s|$)", new Command()
+         {
+            @Override
+            public void execute()
+            {
+               currentValue_ = attributes_.substring(index, index_);
+               map_.put(currentKey_, currentValue_);
+            }
+         });
+      }
+      
+      public Map<String, String> parsedAttributes()
+      {
+         return map_;
+      }
+      
+      private boolean consumeUntilRegex(String regex)
+      {
+         return consumeUntilRegex(regex, null);
+      }
+      
+      private boolean consumeUntilRegex(String regex, Command command)
+      {
+         Pattern pattern = Pattern.create(regex);
+         Match match = pattern.match(attributes_, index_);
+         if (match == null)
+            return false;
+         
+         index_ = match.getIndex();
+         if (command != null)
+            command.execute();
+         
+         return true;
+      }
+      
+      private boolean consumeQuotedValue(char ch, Command command)
+      {
+         int index = attributes_.indexOf(ch, index_ + 1);
+         if (index == -1)
+            return false;
+         
+         while (attributes_.charAt(index - 1) == ch)
+         {
+            index = attributes_.indexOf(ch, index + 1);
+            if (index == -1)
+               return false;
+         }
+         
+         index_ = index + 1;
+         if (command != null)
+            command.execute();
+            
+         return true;
+      }
+      
+      private final String attributes_;
+      private final Map<String, String> map_;
+      
+      private int index_;
+      private String currentKey_;
+      private String currentValue_;
+   }
+   
+   public static Map<String, String> parseAttributes(String attributes)
+   {
+      Parser parser = new Parser(attributes);
+      while (true)
+      {
+         parser.consumeWhitespace();
+         
+         if (!parser.consumeKey())
+            break;
+         
+         parser.consumeWhitespace();
+         
+         if (!parser.consumeEquals())
+            break;
+         
+         parser.consumeWhitespace();
+         
+         if (!parser.consumeValue())
+            break;
+      }
+      
+      return parser.parsedAttributes();
+   }
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ImagePreviewer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ImagePreviewer.java
@@ -15,10 +15,13 @@
 package org.rstudio.studio.client.workbench.views.source.editors.text;
 
 
+import java.util.Map;
+
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Mutable;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.ImageElementEx;
+import org.rstudio.core.client.html.HTMLAttributesParser;
 import org.rstudio.core.client.js.JsUtil;
 import org.rstudio.core.client.layout.FadeOutAnimation;
 import org.rstudio.core.client.regex.Pattern;
@@ -281,8 +284,18 @@ public class ImagePreviewer
       // construct our image
       String srcPath = imgSrcPathFromHref(sentinel, href);
       final Image image = new Image(srcPath);
-      injectAttributes(image.getElement(), attributes);
+      
+      // parse and inject attributes
+      Map<String, String> parsedAttributes = HTMLAttributesParser.parseAttributes(attributes);
       final Element imgEl = image.getElement();
+      for (Map.Entry<String, String> entry : parsedAttributes.entrySet())
+      {
+         String key = entry.getKey();
+         String val = entry.getValue();
+         if (StringUtil.isNullOrEmpty(key) || StringUtil.isNullOrEmpty(val))
+            continue;
+         imgEl.setAttribute(key, val);
+      }
       
       // add load handlers to image
       DOM.sinkEvents(imgEl, Event.ONLOAD | Event.ONERROR);
@@ -554,29 +567,6 @@ public class ImagePreviewer
       panel.show();
    }
    
-   private static final native void injectAttributes(Element el, String attributes)
-   /*-{
-      // create an element, inject inner HTML, and then extract attributes
-      var ctr = $doc.createElement("div");
-      ctr.innerHTML = "<div " + attributes + ">";
-      var div = ctr.firstChild;
-      
-      // loop over attributes and apply to our element
-      for (var i = 0; i < div.attributes.length; i++) {
-         var attr = div.attributes[i];
-         if (attr && attr.specified) {
-            el.setAttribute(attr.name, attr.value);
-         }
-      }
-   }-*/;
-   
-   private static final native Element createImageElement(String srcPath, String attributes)
-   /*-{
-      var div = $doc.createElement("div");
-      div.innerHTML = "<img src=\"" + srcPath + "\" " + (attributes || "") + ">";
-      return div.firstChild;
-   }-*/;
-
    private final DocDisplay display_;
    private final DocUpdateSentinel sentinel_;
    private final UIPrefs prefs_;


### PR DESCRIPTION
This PR will allow users to specify custom HTML attributes in their Markdown image links, e.g.

```
![](plot.png){width=400 height=300}
```