### PR TITLE
report R launch errors

### DIFF
--- a/src/cpp/core/include/core/system/Process.hpp
+++ b/src/cpp/core/include/core/system/Process.hpp
@@ -140,6 +140,9 @@ struct ProcessResult
    int exitStatus;
 };
 
+// Return a user-friendly error message for process results.
+std::string processExitStatusMessage(const ProcessResult& result,
+                                     const std::string& command);
 
 // Run a program synchronously. Note that if executable is not an absolute
 // path then runProgram will duplicate the actions of the shell in searching

--- a/src/cpp/core/system/Process.cpp
+++ b/src/cpp/core/system/Process.cpp
@@ -20,6 +20,7 @@
 #include <boost/bind.hpp>
 #include <boost/foreach.hpp>
 
+#include <core/SafeConvert.hpp>
 #include <core/Scope.hpp>
 #include <core/Error.hpp>
 #include <core/Log.hpp>
@@ -33,6 +34,33 @@ namespace rstudio {
 namespace core {
 namespace system {
 
+std::string processExitStatusMessage(const ProcessResult& result,
+                                     const std::string& command)
+{
+   // build prefix for message
+   std::string message = (result.exitStatus == 0)
+         ? "'" + command + "':"
+         : "Error executing '" + command + "': ";
+   
+   switch (result.exitStatus)
+   {
+   case -1:
+      message += "process had unknown exit status";
+      break;
+   case 0:
+      message += "process executed successfully";
+      break;
+   case 15:
+      message += "process was terminated";
+      break;
+   default:
+      message += "process had exit status " +
+            core::safe_convert::numberToString(result.exitStatus);
+      break;
+   }
+   
+   return message;
+}
 
 Error runProgram(const std::string& executable,
                  const std::vector<std::string>& args,


### PR DESCRIPTION
This PR modifies some of the R startup error reporting such that non-zero exit statuses are now reported to the user. (Note that processes that run to completion, but return a non-zero exit status, return a `Success()` error object -- hence they are often not reported as one might expect).

The overall goal is to ensure that initialization errors are better reported to users.