### PR TITLE
Allow package versions in Debian Strech

### DIFF
--- a/package/linux/CMakeLists.txt
+++ b/package/linux/CMakeLists.txt
@@ -67,7 +67,7 @@ elseif(RSTUDIO_DESKTOP)
   set(RPM_POSTRM postrm-desktop.sh.in)
 
   # deb dependencies
-  set(RSTUDIO_DEBIAN_DEPENDS "libjpeg62, libedit2, libgstreamer0.10-0, libgstreamer-plugins-base0.10-0, libssl1.0.0, ")
+  set(RSTUDIO_DEBIAN_DEPENDS "libjpeg62, libedit2, libgstreamer0.10-0 | libgstreamer1.0-0, libgstreamer-plugins-base0.10-0 | libgstreamer-plugins-base1.0-0, libssl1.0.0 | libssl1.0.2, ")
   
   # rpm dependencies
   set(RSTUDIO_RPM_DEPENDS "gstreamer, gstreamer-plugins-base, ")


### PR DESCRIPTION
Debian Stretch (and, soon, distributions which are based on it) does not include some older packages on which RStudio has a declared dependency. The `libgstreamer` dependency is the primary offender: although [Qt 5.x is compatible with the newer 1.0 version of this library](https://doc.qt.io/qt-5/linux-requirements.html), our .deb requires the older 0.1 version. 

This change relaxes the dependencies on `libgstreamer`, `libgstreamer-plugins-base`, and `libssl` so that the .deb can be installed on both newer and older Debian releases. 