### PR TITLE
Include runtime information on synthesized Shiny doc renders

### DIFF
--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -513,6 +513,8 @@ private:
 
                startedJson["url"] = url + targetFile_.filename();
 
+               startedJson["runtime"] = getRuntime(targetFile_);
+
                module_context::enqueClientEvent(ClientEvent(
                            client_events::kRmdShinyDocStarted,
                            startedJson));

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdRenderResult.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdRenderResult.java
@@ -40,6 +40,7 @@ public class RmdRenderResult extends RmdSlideNavigationInfo
         is_shiny_document: true,
         preview_slide: doc.preview_slide,
         slide_navigation: doc.slide_navigation,
+        runtime: doc.runtime,
         viewed: false
      };
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdShinyDocInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdShinyDocInfo.java
@@ -31,4 +31,8 @@ public class RmdShinyDocInfo extends RmdSlideNavigationInfo
    public native final RmdOutputFormat getFormat() /*-{
       return this.output_format;
    }-*/;
+   
+   public native final String getRuntime() /*-{
+      return this.runtime;
+   }-*/;
 }


### PR DESCRIPTION
This change fixes an issue introduced by https://github.com/rstudio/rstudio/commit/533c967f59c39bb97d801eda0edaf1ee944964e9 in which Shiny documents no longer maintain their scroll positions when being refreshed.

The problem is that the object that gives information about the rendered Shiny document is not constructed on the server in this codepath, but on the client, in https://github.com/rstudio/rstudio/blob/546868c6b6ffd56a4961a513af64f0ff9cbef906/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdRenderResult.java#L28-L45. Consequently the `runtime` field isn't available, and a full re-render is performed instead of a refresh.

The fix is to deduce the `runtime` field in this codepath and inject it into the synthesized render result. 