### PR TITLE
re-encode notebooks as UTF-8 before preview

### DIFF
--- a/src/cpp/session/include/session/SessionSourceDatabase.hpp
+++ b/src/cpp/session/include/session/SessionSourceDatabase.hpp
@@ -26,6 +26,8 @@
 #include <core/FilePath.hpp>
 #include <core/json/Json.hpp>
 
+#include <r/RSexp.hpp>
+
 namespace rstudio {
 namespace core {
    class Error;
@@ -143,6 +145,8 @@ public:
    void writeToJson(core::json::Object* pDocJson) const;
 
    core::Error writeToFile(const core::FilePath& filePath) const;
+
+   SEXP toRObject(r::sexp::Protect* pProtect) const;
 
 private:
    void editProperty(const core::json::Object::value_type& property);

--- a/src/cpp/session/include/session/SessionSourceDatabase.hpp
+++ b/src/cpp/session/include/session/SessionSourceDatabase.hpp
@@ -142,11 +142,11 @@ public:
    }
 
    core::Error readFromJson(core::json::Object* pDocJson);
-   void writeToJson(core::json::Object* pDocJson) const;
+   void writeToJson(core::json::Object* pDocJson, bool includeContents = true) const;
 
    core::Error writeToFile(const core::FilePath& filePath) const;
 
-   SEXP toRObject(r::sexp::Protect* pProtect) const;
+   SEXP toRObject(r::sexp::Protect* pProtect, bool includeContents = true) const;
 
 private:
    void editProperty(const core::json::Object::value_type& property);

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -377,7 +377,10 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    # in the system encoding
    if (!identical(properties$encoding, "UTF-8")) {
       contents <- readLines(inputFile)
-      utf8 <- iconv(contents, from = properties$encoding, to = "UTF-8")
+      utf8 <- tryCatch(
+         iconv(contents, from = properties$encoding, to = "UTF-8"),
+         error = function(e) contents
+      )
       inputFile <- tempfile(fileext = ".Rmd")
       writeLines(utf8, con = inputFile, sep = "\n", useBytes = TRUE)
    }

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -350,13 +350,13 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
 })
 
 # SessionSourceDatabase.cpp
-.rs.addFunction("getSourceDocumentProperties", function(path)
+.rs.addFunction("getSourceDocumentProperties", function(path, includeContents = FALSE)
 {
    if (!file.exists(path))
       return(NULL)
    
    path <- normalizePath(path, winslash = "/", mustWork = TRUE)
-   .Call("rs_getDocumentProperties", path)
+   .Call("rs_getDocumentProperties", path, includeContents)
 })
    
 .rs.addFunction("createNotebookFromCacheData", function(rnbData,
@@ -367,22 +367,35 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    if (is.null(outputFile))
       outputFile <- .rs.withChangedExtension(inputFile, ext = ".nb.html")
 
+   # specify default encoding (we'll try to infer + convert to UTF-8
+   # if necessary)
+   encoding <- getOption("encoding")
+   
    # attempt to get encoding from source database (note: this will only
    # succeed for files already open in the IDE, but since this operation
    # is normally called when attempting to preview / create a notebook on
    # save we generally expect the document to be available)
-   properties <- .rs.getSourceDocumentProperties(inputFile)
+   properties <- .rs.getSourceDocumentProperties(inputFile, FALSE)
    
    # attempt to read and re-encode the file to UTF-8 if it's specified
    # in the system encoding
    if (!identical(properties$encoding, "UTF-8")) {
-      contents <- readLines(inputFile)
-      utf8 <- tryCatch(
-         iconv(contents, from = properties$encoding, to = "UTF-8"),
-         error = function(e) contents
+      
+      # updates 'inputFile' on success to a UTF-8 encoded document
+      tryCatch(
+         expr = {
+            contents <- readLines(inputFile)
+            iconv(contents, from = properties$encoding, to = "UTF-8")
+            newInputFile <- tempfile(fileext = ".Rmd")
+            on.exit(unlink(newInputFile), add = TRUE)
+            writeLines(utf8, con = newInputFile, sep = "\n", useBytes = TRUE)
+            
+            # if we got here, then we'll use the newly written file
+            inputFile <- inputFile
+            encoding <- "UTF-8"
+         },
+         error = identity
       )
-      inputFile <- tempfile(fileext = ".Rmd")
-      writeLines(utf8, con = inputFile, sep = "\n", useBytes = TRUE)
    }
    
    # reset the knitr chunk counter (it can be modified as a side effect of
@@ -399,7 +412,7 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
                      output_file = outputFile,
                      quiet = TRUE,
                      envir = envir,
-                     encoding = "UTF-8")
+                     encoding = encoding)
 })
 
 .rs.addFunction("createNotebookFromCache", function(rmdPath, outputPath = NULL)

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -376,27 +376,8 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    # is normally called when attempting to preview / create a notebook on
    # save we generally expect the document to be available)
    properties <- .rs.getSourceDocumentProperties(inputFile, FALSE)
-   
-   # attempt to read and re-encode the file to UTF-8 if it's specified
-   # in the system encoding
-   if (!identical(properties$encoding, "UTF-8")) {
-      
-      # updates 'inputFile' on success to a UTF-8 encoded document
-      tryCatch(
-         expr = {
-            contents <- readLines(inputFile)
-            iconv(contents, from = properties$encoding, to = "UTF-8")
-            newInputFile <- tempfile(fileext = ".Rmd")
-            on.exit(unlink(newInputFile), add = TRUE)
-            writeLines(utf8, con = newInputFile, sep = "\n", useBytes = TRUE)
-            
-            # if we got here, then we'll use the newly written file
-            inputFile <- inputFile
-            encoding <- "UTF-8"
-         },
-         error = identity
-      )
-   }
+   if (!is.null(properties$encoding))
+      encoding <- properties$encoding
    
    # reset the knitr chunk counter (it can be modified as a side effect of
    # parse_params, which is called during notebook execution)


### PR DESCRIPTION
This PR resolves an issue wherein documents saved with the system encoding on Windows would not preview correctly when such documents contained multibyte characters.

We work around this by explicitly re-encoding the document as UTF-8, writing the UTF-8-encoded contents to file, and then rendering the newly-encoded UTF-8 file.