### PR TITLE
work around RStudio crash (toolchain issue?)

### DIFF
--- a/src/cpp/core/http/Message.cpp
+++ b/src/cpp/core/http/Message.cpp
@@ -49,7 +49,11 @@ std::string Message::contentType() const
 
 std::size_t Message::contentLength() const
 {
-   return safe_convert::stringTo<std::size_t>(headerValue("Content-Length"), 0);
+   std::string value = headerValue("Content-Length");
+   if (value.empty())
+      return 0;
+
+   return safe_convert::stringTo<std::size_t>(value, 0);
 }
 
 void Message::setContentLength(int contentLength)


### PR DESCRIPTION
This PR works around a crash that occurs on Windows when 404 (or other error) responses are returned. See the following stack trace for some more information.

![ouch](https://cloud.githubusercontent.com/assets/1976582/19406121/3463500e-9235-11e6-933e-1f8f9943ee16.PNG)

Here's my hypothesis. Two things worth noting:

1. The Qt bits we link against are built against a _non-static_ version of the MinGW toolchain,
2. The RStudio + rsession executables are built against Rtools 3.3, which is a _static_ version of the MinGW toolchain.

(by static, I mean the supporting libraries are linked statically into the compiler toolchain, e.g. `libgcc` and friends)

Now, we register some functions as callbacks to Qt functions, and my guess is that any RStudio functions we register in this form that can throw C++ exceptions can crash (even if those exceptions are supposed to be immediately caught), just because of the toolchain mixing. Note that we see effectively the same issue with older versions of RStudio running with R packages built with Rtools 3.3 -- the rsession will crash as soon as C++ code within an R package attempts to throw a C++ exception, even if that exception is caught immediately after.

The workaround here is to simply avoid relying on exception handling to convert the failed attempt to lexically cast an empty string (`""`) to zero, and instead detect that up-front and return zero (without allowing exceptions into play).

Note that if this hypothesis is correct, we may indeed need to force the RStudio executable to be built with the Qt MinGW toolchain, rather than the Rtools toolchain.