### PR TITLE
Default to advisory-based locks on Windows

### DIFF
--- a/src/cpp/core/file_lock/FileLock.cpp
+++ b/src/cpp/core/file_lock/FileLock.cpp
@@ -124,8 +124,16 @@ void FileLock::initialize(FilePath locksConfPath)
 void FileLock::initialize(const Settings& settings)
 {
    // default lock type
-   FileLock::s_defaultType = stringToLockType(settings.get("lock-type", kLockTypeLinkBased));
-   
+   FileLock::s_defaultType = stringToLockType(settings.get("lock-type",
+#ifdef _WIN32
+      // default lock type to advisory on Windows (link-based locks are not
+      // supported on Windows)
+      kLockTypeAdvisory
+#else
+      kLockTypeLinkBased
+#endif
+   ));
+
    // timeout interval
    double timeoutInterval = getFieldPositive(settings, "timeout-interval", kDefaultTimeoutInterval);
    FileLock::s_timeoutInterval = boost::posix_time::seconds(timeoutInterval);


### PR DESCRIPTION
`FileLock::createDefault()` currently returns an unusable lock on Windows since link-based locks are the default, but don't work on Windows filesystems. This change makes advisory locks the default on Windows.