### PR TITLE
allow customization of home, scratch directories

### DIFF
--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -200,7 +200,13 @@ core::ProgramStatus Options::read(int argc, char * const argv[])
        "default directory for new projects")
       ("show-help-home",
        value<bool>(&showHelpHome_)->default_value(false),
-         "show help home page at startup");
+         "show help home page at startup")
+      ("session-user-home-path",
+       value<std::string>(&userHomePath_)->default_value(""),
+       "default user home path")
+      ("session-user-scratch-path",
+       value<std::string>(&userScratchPath_)->default_value(""),
+       "default user scratch path");
 
    // allow options
    options_description allow("allow");
@@ -448,8 +454,13 @@ core::ProgramStatus Options::read(int argc, char * const argv[])
                                     r_util::SessionTypeServer;
 
    r_util::UserDirectories userDirs = r_util::userDirectories(sessionType);
-   userHomePath_ = userDirs.homePath;
-   userScratchPath_ = userDirs.scratchPath;
+   
+   // use user paths (unless specified by option)
+   if (userHomePath_.empty())
+      userHomePath_ = userDirs.homePath;
+   
+   if (userScratchPath_.empty())
+      userScratchPath_ = userDirs.scratchPath;
 
    // set HOME if we are in standalone mode (this enables us to reflect
    // R_USER back into HOME on Linux)


### PR DESCRIPTION
This PR allows users to customize the default home directory, alongside the RStudio 'scratch' directory, using options passed to `rsession.conf`. This should be useful for RStudio Server users with limited space in their home directories, who instead want to tell RStudio to use + write configuration / state to a separate directory.

We likely want to tweak this PR a bit if we end up taking it, e.g.

1. We might want to allow 'templates' for the path; e.g. allow users to provide something like `/usr/local/rstudio/rstudio-$USER-$PID/`, and expand those shell variables (so one global config file can serve + separate for multiple users),

2. We might also want to allow users to set this with an environment variable.

Thoughts, @jjallaire @jmcphers?