### PR TITLE
fix escaping of shell characters

### DIFF
--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -104,7 +104,6 @@ set (CORE_SOURCE_FILES
    r_util/RSessionContext.cpp
    r_util/RTokenizer.cpp
    r_util/RSourceIndex.cpp
-   r_util/RTokenizerTests.cpp
    r_util/RUserData.cpp
    spelling/HunspellCustomDictionaries.cpp
    spelling/HunspellDictionaryManager.cpp

--- a/src/cpp/core/system/PosixShellUtils.cpp
+++ b/src/cpp/core/system/PosixShellUtils.cpp
@@ -23,9 +23,8 @@ namespace shell_utils {
 
 std::string escape(const std::string& arg)
 {
-   using namespace boost;
-   regex pattern("[\\\\$`!\\n\"]", regex_constants::normal);
-   return "\"" + regex_replace(arg, pattern, "\\$1") + "\"";
+   boost::regex pattern("(\\\\|\\$|`|!|\n|\")");
+   return "\"" + boost::regex_replace(arg, pattern, "\\\\$1") + "\"";
 }
 
 std::string escape(const core::FilePath &path)

--- a/src/cpp/core/system/PosixShellUtilsTests.cpp
+++ b/src/cpp/core/system/PosixShellUtilsTests.cpp
@@ -1,0 +1,43 @@
+/*
+ * PosixShellUtilsTests.cpp
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <tests/TestThat.hpp>
+
+#include <iostream>
+
+#include <core/Error.hpp>
+
+#include <core/system/ShellUtils.hpp>
+
+namespace rstudio {
+namespace core {
+namespace shell_utils {
+namespace tests {
+
+context("Shell Escaping")
+{
+   test_that("Commands with special characters are escaped")
+   {
+      std::string dollars = "$$$";
+      std::string escaped  = escape(dollars);
+      std::string expected = "\"\\$\\$\\$\"";
+      expect_true(escaped == expected);
+   }
+}
+
+} // end namespace tests
+} // end namespace shell_utils
+} // end namespace core
+} // end namespace rstudio


### PR DESCRIPTION
This PR resolves an issue where elements were incorrectly escaped when passed to shell commands on POSIX systems.

One way to reproduce this -- in a Git project, attempt to stage a file with the name `$$$.R`. This fails because the filename is 'escaped' as `$1$1$1.R`, and an attempt to commit that file fails. The issue here is that we attempted to perform regex substitution without actually specifying a capture group in the regular expression used.

I think this is a candidate for v1.0-patch but let me know what you think.