### PR TITLE
remove quotes when parsing file names from `git status --porcelain`

### DIFF
--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -414,8 +414,18 @@ public:
          file.status = line.substr(0, 2);
 
          std::string filePath = line.substr(3);
+
+         // git status --porcelain will quote paths that contain special
+         // characters (e.g. spaces on Windows). strip those characters
+         // when encountered
+         std::string::size_type n = filePath.size();
+         if (n >= 2 && filePath[0] == '"' && filePath[n - 1] == '"')
+            filePath = filePath.substr(1, n - 2);
+
+         // remove trailing slashes
          if (filePath.length() > 1 && filePath[filePath.length() - 1] == '/')
             filePath = filePath.substr(0, filePath.size() - 1);
+
          file.path = root_.childPath(string_utils::systemToUtf8(filePath));
 
          files.push_back(file);

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -420,7 +420,10 @@ public:
          // when encountered
          std::string::size_type n = filePath.size();
          if (n >= 2 && filePath[0] == '"' && filePath[n - 1] == '"')
+         {
             filePath = filePath.substr(1, n - 2);
+            boost::algorithm::replace_all(filePath, "\\\"", "\"");
+         }
 
          // remove trailing slashes
          if (filePath.length() > 1 && filePath[filePath.length() - 1] == '/')


### PR DESCRIPTION
This PR fixes an issue on Windows where the Git integration failed to work with files in this specific scenario:

1. The project directory contains spaces, e.g. `C:\Users\Foo McBar\Projects\Baz`, and
2. The file to be staged / committed also contains spaces, e.g. `"A Report.Rmd"`.

It looks like `git` will quote paths containing special characters; the space character being such a character on Windows. This means that the file path parsed from Git output by RStudio would be quoted.

![screen shot 2016-10-20 at 3 36 04 pm](https://cloud.githubusercontent.com/assets/1976582/19580419/f3134bae-96da-11e6-9da5-970eaa61959b.png)

RStudio also attempts to quote arguments to programs when run on Windows, but the quote logic is a bit complicated. Effectively, if RStudio detects a quote in the argument somewhere, it does not add its own quotes; if no quotes are detected, then RStudio will quote the argument.

This means that, prior to this PR, RStudio was invoking Git with a path like:

    C:\Users\Foo McBar\Projects\Baz\"A Report.Rmd"

And because quotes were detected in that file path, RStudio didn't apply any quoting of its own -- implying the space in the initial part of the path would cause issues. With this change, paths will be passed down simply as:

    C:\Users\Foo McBar\Projects\Baz\A Report.Rmd

and RStudio will automatically quote it in the expected way (quoting the entirety of the path).