### PR TITLE
add support for html chunk sizing with knitr.figure=FALSE

### DIFF
--- a/src/cpp/session/modules/NotebookHtmlWidgets.R
+++ b/src/cpp/session/modules/NotebookHtmlWidgets.R
@@ -15,7 +15,10 @@
 
 .rs.addFunction("recordHtmlWidget", function(x, htmlfile, depfile)
 {
-   .Call("rs_recordHtmlWidget", htmlfile, depfile, list(classes = class(x)))
+   .Call("rs_recordHtmlWidget", htmlfile, depfile, list(
+      classes = class(x),
+      sizingPolicy = x$sizingPolicy
+   ))
 })
 
 .rs.addFunction("rnb.setHtmlCaptureContext", function(...)

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/NotebookHtmlMetadata.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/NotebookHtmlMetadata.java
@@ -26,4 +26,16 @@ public class NotebookHtmlMetadata extends JavaScriptObject
    public final native JsArrayString getClasses() /*-{
       return this.classes || [];
    }-*/;
+
+   public final native boolean getSizingPolicyKnitrFigure() /*-{
+      var defaultFigurePolicy = true;
+
+   	if (!this.sizingPolicy) return defaultFigurePolicy;
+   	if (!this.sizingPolicy.knitr) return defaultFigurePolicy;
+   	if (typeof(this.sizingPolicy.knitr.figure) === "undefined") return defaultFigurePolicy;
+   	if (this.sizingPolicy.knitr.figure === null) return defaultFigurePolicy
+
+   	var figure = this.sizingPolicy.knitr.figure;
+      return figure.length ? figure[0] : figure;
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -190,20 +190,23 @@ public class ChunkOutputStream extends FlowPanel
       // persist metadata
       metadata_.put(ordinal, metadata);
       
+      final boolean knitrFigure = metadata.getSizingPolicyKnitrFigure();
+      
       // amend the URL to cause any contained widget to use the RStudio viewer
       // sizing policy
       if (url.indexOf('?') > 0)
          url += "&";
       else
          url += "?";
-      url += "viewer_pane=1";
+
+      if (knitrFigure) {
+         url += "viewer_pane=1";
+      }
 
       final ChunkOutputFrame frame = new ChunkOutputFrame();
 
-      boolean canExpand = metadata.getSizingPolicyKnitrFigure();
-
       if (chunkOutputSize_ == ChunkOutputSize.Default) {
-         if (canExpand) {
+         if (knitrFigure) {
             final FixedRatioWidget fixedFrame = new FixedRatioWidget(frame, 
                         ChunkOutputUi.OUTPUT_ASPECT, 
                         ChunkOutputUi.MAX_HTMLWIDGET_WIDTH);
@@ -212,7 +215,7 @@ public class ChunkOutputStream extends FlowPanel
          }
          else {
             // reduce size of html widget as much as possible and add scroll,
-            // once it loads, we will adjust the height appropiately.
+            // once it loads, we will adjust the height appropriately.
             frame.getElement().getStyle().setHeight(25, Unit.PX);
             frame.getElement().getStyle().setOverflow(Overflow.SCROLL);
 
@@ -245,6 +248,14 @@ public class ChunkOutputStream extends FlowPanel
          public void execute()
          {
             onRenderComplete.execute();
+            
+            if (!knitrFigure) {
+               frame.getWindow().getDocument().getBody().getStyle().setOverflow(Overflow.SCROLL);
+               
+               int contentHeight = frame.getWindow().getDocument().getBody().getOffsetHeight();
+               frame.getElement().getStyle().setHeight(contentHeight, Unit.PX);
+            }
+            
             onHeightChanged();
          };
       });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -211,6 +211,11 @@ public class ChunkOutputStream extends FlowPanel
             addWithOrdinal(fixedFrame, ordinal);
          }
          else {
+            // reduce size of html widget as much as possible and add scroll,
+            // once it loads, we will adjust the height appropiately.
+            frame.getElement().getStyle().setHeight(25, Unit.PX);
+            frame.getElement().getStyle().setOverflow(Overflow.SCROLL);
+
             frame.getElement().getStyle().setWidth(100, Unit.PCT);
             addWithOrdinal(frame, ordinal);
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -200,12 +200,20 @@ public class ChunkOutputStream extends FlowPanel
 
       final ChunkOutputFrame frame = new ChunkOutputFrame();
 
-      if (chunkOutputSize_ == ChunkOutputSize.Default) {
-         final FixedRatioWidget fixedFrame = new FixedRatioWidget(frame, 
-                     ChunkOutputUi.OUTPUT_ASPECT, 
-                     ChunkOutputUi.MAX_HTMLWIDGET_WIDTH);
+      boolean canExpand = metadata.getSizingPolicyKnitrFigure();
 
-         addWithOrdinal(fixedFrame, ordinal);
+      if (chunkOutputSize_ == ChunkOutputSize.Default) {
+         if (canExpand) {
+            final FixedRatioWidget fixedFrame = new FixedRatioWidget(frame, 
+                        ChunkOutputUi.OUTPUT_ASPECT, 
+                        ChunkOutputUi.MAX_HTMLWIDGET_WIDTH);
+
+            addWithOrdinal(fixedFrame, ordinal);
+         }
+         else {
+            frame.getElement().getStyle().setWidth(100, Unit.PCT);
+            addWithOrdinal(frame, ordinal);
+         }
       }
       else if (chunkOutputSize_ == ChunkOutputSize.Full) {
          frame.getElement().getStyle().setPosition(Position.ABSOLUTE);


### PR DESCRIPTION
Adds support for html chunk sizing with `knitr.figure=FALSE` by persisting the sizing policy in the notebook metadata, loading as a 25px height chunk, loading for the html iframe to render and then adjust the size to it's content while disabling `?viewer_pane=1` in the URL to avoid `viewer.fill` (http://www.htmlwidgets.org/develop_sizing.html#examples) to trigger which would cause the iframe and wrapping elements to set `height=100%`.

<img width="1432" alt="screen shot 2016-10-20 at 3 57 45 pm" src="https://cloud.githubusercontent.com/assets/3478847/19580894/0ac24e46-96de-11e6-9331-7caf19b55ddf.png">
