### PR TITLE
remove key-column special-case alignment in pagedtables

### DIFF
--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -196,12 +196,6 @@
         paste0("<", summary, ">")
       })
 
-  if (length(columns) > 0) {
-    first_column = data[[1]]
-    if (is.numeric(first_column) && isTRUE(all(diff(first_column) == 1)))
-      columns[[1]]$align <- "left"
-    }
-
   data <- as.data.frame(
     lapply(
       data,


### PR DESCRIPTION
On notebook data chunks, functionality was added to left align a numeric column if it looked like a key column. This was performed by checking if numeric and incrementing. However, this introduced to problems:

1) Users (Hadley for instance), suggest that this is confusing since simple tables with similar first columns, say, `[1, 2, 3]` and `[1, 1, 2]` will have different alignments.

2) In `tibble`, which we've tried to have partify with in notebook data tables, does not perform this alignment.

Sent also PR to `rmarkdown`: https://github.com/rstudio/rmarkdown/pull/843