### PR TITLE
Re-enable use of system proxy on Windows

### DIFF
--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -41,6 +41,7 @@
 #include "DesktopUtils.hpp"
 #include "DesktopSessionLauncher.hpp"
 #include "DesktopProgressActivator.hpp"
+#include "DesktopNetworkProxyFactory.hpp"
 
 QProcess* pRSessionProcess;
 QString sharedSecret;
@@ -339,6 +340,9 @@ int main(int argc, char* argv[])
 #endif
       }
       core::system::fixupExecutablePath(&sessionPath);
+
+      NetworkProxyFactory* pProxyFactory = new NetworkProxyFactory();
+      QNetworkProxyFactory::setApplicationProxyFactory(pProxyFactory);
 
       // set the scripts path in options
       desktop::options().setScriptsPath(scriptsPath);

--- a/src/cpp/desktop/DesktopNetworkAccessManager.cpp
+++ b/src/cpp/desktop/DesktopNetworkAccessManager.cpp
@@ -29,8 +29,6 @@ using namespace rstudio::desktop;
 NetworkAccessManager::NetworkAccessManager(QString secret, QObject *parent) :
     QNetworkAccessManager(parent), secret_(secret)
 {
-   setProxy(QNetworkProxy::NoProxy);
-
    QTimer* pTimer = new QTimer(this);
    connect(pTimer, SIGNAL(timeout()), SLOT(pollForIO()));
    pTimer->start(25);

--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -111,14 +111,6 @@ Error SessionLauncher::launchFirstSession(const QString& filename,
                            + port.toStdString() +
                            "...");
 
-   // jcheng 03/16/2011: Due to crashing caused by authenticating
-   // proxies, bypass all proxies from Qt until we can get the problem
-   // completely solved. This is only expected to affect CRAN mirror
-   // selection (which falls back to local mirror list) and update
-   // checking.
-   //NetworkProxyFactory* pProxyFactory = new NetworkProxyFactory();
-   //QNetworkProxyFactory::setApplicationProxyFactory(pProxyFactory);
-
    pMainWindow_ = new MainWindow(url);
    pMainWindow_->setSessionLauncher(this);
    pMainWindow_->setSessionProcess(pRSessionProcess_);


### PR DESCRIPTION
This change fixes a long-standing bug on Windows in which HTML widgets that use external resources (e.g. googleVis and leaflet) do not work if the network connection is proxied.

The fix is basically just to reinstate code that was previously disabled. @jcheng5 's comments indicate that it was disabled due to crashes with authenticating proxies, which no longer appear to be a problem; simulating an authenticating proxy does prevent the requests from succeeding (as we do not supply any UI for injecting a username or password), but the failures are handled cleanly in QtWebKit and do not result in a crash. It seems very possible that the crash was a bug in Qt that has since been fixed in 5.4.

cc @jcheng5 @jjallaire 