### PR TITLE
Implement all readr::locale options to csv import dialog

### DIFF
--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -64,7 +64,34 @@
             return (paste("\"", optionValue, "\"", sep = ""))
          },
          "locale" = {
-            return (paste(ns, "locale(encoding=\"", optionValue, "\")", sep = ""))
+            localeDefaults <- formals(readr::locale)
+
+            localeOrNull <- function(paramName, jsonName) {
+               if (!identical(localeDefaults[[paramName]], optionValue[[jsonName]])) {
+                  if (typeof(localeDefaults[[paramName]]) == "logical") {
+                     paste(paramName, " = ", optionValue[[jsonName]])
+                  }
+                  else {
+                     paste(paramName, " = \"", optionValue[[jsonName]], "\"", sep = "")
+                  }
+               }
+               else NULL
+            }
+
+            return (paste(
+               ns, 
+               "locale(",
+               paste(c(
+                  localeOrNull("date_names", "dateName"),
+                  localeOrNull("date_format", "dateFormat"),
+                  localeOrNull("time_format", "timeFormat"),
+                  localeOrNull("decimal_mark", "decimalMark"),
+                  localeOrNull("grouping_mark", "groupingMark"),
+                  localeOrNull("tz", "tz"),
+                  localeOrNull("encoding", "encoding"),
+                  localeOrNull("asciify", "asciify")
+               ), collapse = ", "),
+               ")", sep = ""))
          },
          "columnDefinitionsReadR" = {
             colParams <- c()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsCsv.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsCsv.java
@@ -28,7 +28,7 @@ public class DataImportOptionsCsv extends DataImportOptions
                                                           boolean escapeDouble,
                                                           boolean columnNames,
                                                           boolean trimSpaces,
-                                                          String locale,
+                                                          DataImportOptionsCsvLocale locale,
                                                           String na,
                                                           String comments,
                                                           int skip,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsCsvLocale.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsCsvLocale.java
@@ -22,25 +22,46 @@ public class DataImportOptionsCsvLocale extends JavaScriptObject
    protected DataImportOptionsCsvLocale()
    {
    }
+   
+   public static native DataImportOptionsCsvLocale createLocaleNative(
+      String dateName,
+      String dateFormat,
+      String timeFormat,
+      String decimalMark,
+      String groupingMark,
+      String tz,
+      String encoding,
+      boolean asciify) /*-{
+      return {
+         dateName: dateName,
+         dateFormat: dateFormat,
+         timeFormat: timeFormat,
+         decimalMark: decimalMark,
+         groupingMark: groupingMark,
+         tz: tz,
+         encoding: encoding,
+         asciify: asciify
+      }
+   }-*/;
   
-   public final native String getDateNames() /*-{
-      return this.dateNames;
+   public final native String getDateName() /*-{
+      return this.dateName;
    }-*/;
    
    public final native String getDateFormat() /*-{
-      return this.dateFormat_;
+      return this.dateFormat;
    }-*/;
 
    public final native String getTimeFormat() /*-{
-      return this.timeFormat_;
+      return this.timeFormat;
    }-*/;
 
    public final native String getDecimalMark() /*-{
-      return this.decimalMark_;
+      return this.decimalMark;
    }-*/;
 
    public final native String getGroupingMark() /*-{
-      return this.groupingMark_;
+      return this.groupingMark;
    }-*/;
    
    public final native String getTZ() /*-{
@@ -51,7 +72,28 @@ public class DataImportOptionsCsvLocale extends JavaScriptObject
       return this.encoding;
    }-*/;
 
-   public final native String getAsciify() /*-{
+   public final native boolean getAsciify() /*-{
       return this.asciify;
    }-*/;
+
+   public static DataImportOptionsCsvLocale createLocale(
+      String dateName,
+      String dateFormat,
+      String timeFormat,
+      String decimalMark,
+      String groupingMark,
+      String tz,
+      String encoding,
+      boolean asciify)
+   {
+      return createLocaleNative(
+         dateName,
+         dateFormat,
+         timeFormat,
+         decimalMark,
+         groupingMark,
+         tz,
+         encoding,
+         asciify);
+   }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsCsvLocale.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsCsvLocale.java
@@ -1,0 +1,57 @@
+/*
+ * DataImportOptionsCsvLocale.java
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.environment.dataimport;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+public class DataImportOptionsCsvLocale extends JavaScriptObject
+{
+   protected DataImportOptionsCsvLocale()
+   {
+   }
+  
+   public final native String getDateNames() /*-{
+      return this.dateNames;
+   }-*/;
+   
+   public final native String getDateFormat() /*-{
+      return this.dateFormat_;
+   }-*/;
+
+   public final native String getTimeFormat() /*-{
+      return this.timeFormat_;
+   }-*/;
+
+   public final native String getDecimalMark() /*-{
+      return this.decimalMark_;
+   }-*/;
+
+   public final native String getGroupingMark() /*-{
+      return this.groupingMark_;
+   }-*/;
+   
+   public final native String getTZ() /*-{
+      return this.tz;
+   }-*/;
+
+   public final native String getEncoding() /*-{
+      return this.encoding;
+   }-*/;
+
+   public final native String getAsciify() /*-{
+      return this.asciify;
+   }-*/;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.java
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client.workbench.views.environment.dataimport;
 
+import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportAssembleResponse;
 import org.rstudio.studio.client.workbench.views.source.model.SourceServerOperations;
@@ -22,10 +23,13 @@ import org.rstudio.studio.client.workbench.views.source.model.SourceServerOperat
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.ListBox;
@@ -41,6 +45,8 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
    private final String escapeBoth_ = "both";
    private final String escapeBackslash_ = "backslash";
    private final String escapeDouble_ = "double";
+
+   private DataImportOptionsCsvLocale localeInfo_ = null;
    
    interface DataImportOptionsCsvUiBinder extends UiBinder<HTMLPanel, DataImportOptionsUiCsv> {}
 
@@ -52,6 +58,7 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
    public DataImportOptionsUiCsv()
    {
       super();
+
       mainPanel_ = uiBinder.createAndBindUi(this);
       
       initWidget(mainPanel_);
@@ -89,7 +96,7 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
             isDoubleValue(escapeListBox_.getSelectedValue()),
             columnNamesCheckBox_.getValue().booleanValue(),
             trimSpacesCheckBox_.getValue().booleanValue(),
-            !localeListBox_.getSelectedValue().isEmpty() ? localeListBox_.getSelectedValue() : null,
+            localeInfo_,
             !naListBox_.getSelectedValue().isEmpty() ? naListBox_.getSelectedValue() : null,
             !commentListBox_.getSelectedValue().isEmpty() ? commentListBox_.getSelectedValue() : null,
             Integer.parseInt(skipTextBox_.getText()),
@@ -150,20 +157,6 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
       commentListBox_.addItem("\"", "\"");
       commentListBox_.addItem("\\", "\\");
       commentListBox_.addItem("*>", "*>");
-      
-      localeListBox_.addItem("Default", "");
-      localeListBox_.addItem("ASCII", "ASCII");
-      localeListBox_.addItem("UTF-16", "UTF-16");
-      localeListBox_.addItem("UTF-16BE", "UTF-16BE");
-      localeListBox_.addItem("UTF-16LE", "UTF-16LE");
-      localeListBox_.addItem("UTF-32", "UTF-32");
-      localeListBox_.addItem("UTF-32BE", "UTF-32BE");
-      localeListBox_.addItem("UTF-32LE", "UTF-32LE");
-      localeListBox_.addItem("UTF-7", "UTF-7");
-      localeListBox_.addItem("UTF-8", "UTF-8");
-      localeListBox_.addItem("UTF-8-MAC", "UTF-8-MAC");
-      localeListBox_.addItem("UTF8", "UTF8");
-      localeListBox_.addItem("UTF8-MAC", "UTF8-MAC");
      
       updateEnabled();
    }
@@ -172,7 +165,6 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
    {
       ValueChangeHandler<String> valueChangeHandler = new ValueChangeHandler<String>()
       {
-         
          @Override
          public void onValueChange(ValueChangeEvent<String> arg0)
          {
@@ -210,10 +202,23 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
       columnNamesCheckBox_.addValueChangeHandler(booleanValueChangeHandler);
       trimSpacesCheckBox_.addValueChangeHandler(booleanValueChangeHandler);
       openDataViewerCheckBox_.addValueChangeHandler(booleanValueChangeHandler);
-      localeListBox_.addChangeHandler(changeHandler);
       naListBox_.addChangeHandler(changeHandler);
       commentListBox_.addChangeHandler(changeHandler);
       skipTextBox_.addValueChangeHandler(valueChangeHandler);
+      
+      localeButton_.addClickHandler(new ClickHandler() {
+         public void onClick(ClickEvent event) {
+            new DataImportOptionsUiCsvLocale(
+               new OperationWithInput<DataImportOptionsCsvLocale>() {
+                  @Override
+                  public void execute(final DataImportOptionsCsvLocale result)
+                  {
+                     //localeInfo_ = result;
+                  }
+               }
+            ).showModal();
+         }
+      });
    }
    
    void updateEnabled()
@@ -242,7 +247,7 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
    ListBox quotesListBox_;
    
    @UiField
-   ListBox localeListBox_;
+   Button localeButton_;
    
    @UiField
    ListBox naListBox_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.java
@@ -213,9 +213,13 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
                   @Override
                   public void execute(final DataImportOptionsCsvLocale result)
                   {
-                     //localeInfo_ = result;
+                     localeInfo_ = result;
+                     
+                     updateEnabled();
+                     triggerChange();
                   }
-               }
+               },
+               localeInfo_
             ).showModal();
          }
       });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.ui.xml
@@ -85,6 +85,12 @@
         input:disabled+label {
             color: #999;
         }
+        .localeListBox {
+            width: 50px;
+            text-align: right;
+            padding-left: 5px;
+            padding-right: 5px;
+        }
     </ui:style>
     <g:HTMLPanel styleName="{style.mainPanel}">
         <g:Label text="Import Options:" styleName="{style.optionsLabel}"/>
@@ -134,9 +140,11 @@
                     </td>
                 </tr>
                 <tr class="{style.optionsRow}">
-                    <td>Encoding:</td>
+                    <td>Locale:</td>
                     <td>
-                        <g:ListBox ui:field="localeListBox_" styleName="{style.optionsListBox}" />
+                        <g:Button ui:field="localeButton_" styleName="{style.optionsListBox}">
+                            Select
+                        </g:Button>
                     </td>
                 </tr>
             </table>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.ui.xml
@@ -143,7 +143,7 @@
                     <td>Locale:</td>
                     <td>
                         <g:Button ui:field="localeButton_" styleName="{style.optionsListBox}">
-                            Select
+                            Configure
                         </g:Button>
                     </td>
                 </tr>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsvLocale.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsvLocale.java
@@ -43,10 +43,32 @@ public class DataImportOptionsUiCsvLocale extends ModalDialog<DataImportOptionsC
    {
    }
    
-   public DataImportOptionsUiCsvLocale(OperationWithInput<DataImportOptionsCsvLocale> operation)
+   public DataImportOptionsUiCsvLocale(
+      OperationWithInput<DataImportOptionsCsvLocale> operation,
+      DataImportOptionsCsvLocale locale)
    {
-      super("Select Data Import Locale", operation);
+      super("Select Locale", operation);
       widget_ = GWT.<Binder> create(Binder.class).createAndBindUi(this);
+      initialLocale_ = locale;
+   }
+   
+   private void assignLocale(DataImportOptionsCsvLocale locale)
+   {
+      if (locale == null) return;
+      
+      for (int idxEncoding = 0; idxEncoding < encoding_.getItemCount(); idxEncoding ++) {
+         if (encoding_.getValue(idxEncoding) == locale.getEncoding()) {
+            encoding_.setSelectedIndex(idxEncoding);
+         }
+      }
+      
+      dateName_.setText(locale.getDateName());
+      dateFormat_.setText(locale.getDateFormat());
+      timeFormat_.setText(locale.getTimeFormat());
+      decimalMark_.setText(locale.getDecimalMark());
+      groupingMark_.setText(locale.getGroupingMark());
+      timeZone_.setText(locale.getTZ());
+      asciify_.setValue(locale.getAsciify());
    }
    
    @Override
@@ -55,8 +77,9 @@ public class DataImportOptionsUiCsvLocale extends ModalDialog<DataImportOptionsC
       super.onDialogShown();
 
       initializeDefaults();
+      assignLocale(initialLocale_);
 
-      setOkButtonCaption("Select");
+      setOkButtonCaption("Configure");
    }
    
    @Override
@@ -68,7 +91,16 @@ public class DataImportOptionsUiCsvLocale extends ModalDialog<DataImportOptionsC
    @Override
    protected DataImportOptionsCsvLocale collectInput()
    {
-      return null;
+      return DataImportOptionsCsvLocale.createLocale(
+        dateName_.getText(),
+        dateFormat_.getText(),
+        timeFormat_.getText(),
+        decimalMark_.getText(),
+        groupingMark_.getText(),
+        timeZone_.getText(),
+        encoding_.getSelectedValue(),
+        asciify_.getValue()
+      );
    }
    
    @Inject
@@ -79,7 +111,6 @@ public class DataImportOptionsUiCsvLocale extends ModalDialog<DataImportOptionsC
 
    private void initializeDefaults()
    {
-      encoding_.addItem("Default", "");
       encoding_.addItem("ASCII", "ASCII");
       encoding_.addItem("UTF-16", "UTF-16");
       encoding_.addItem("UTF-16BE", "UTF-16BE");
@@ -92,6 +123,8 @@ public class DataImportOptionsUiCsvLocale extends ModalDialog<DataImportOptionsC
       encoding_.addItem("UTF-8-MAC", "UTF-8-MAC");
       encoding_.addItem("UTF8", "UTF8");
       encoding_.addItem("UTF8-MAC", "UTF8-MAC");
+      
+      encoding_.setSelectedIndex(8);
    }
 
    
@@ -117,7 +150,8 @@ public class DataImportOptionsUiCsvLocale extends ModalDialog<DataImportOptionsC
    TextBox timeZone_;
    
    @UiField
-   CheckBox columnNamesCheckBox_;
+   CheckBox asciify_;
    
    private Widget widget_;
+   private DataImportOptionsCsvLocale initialLocale_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsvLocale.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsvLocale.java
@@ -1,0 +1,97 @@
+/*
+ * DataImportOptionsUiCsvLocale.java
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.environment.dataimport;
+
+import org.rstudio.core.client.widget.ModalDialog;
+import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.studio.client.common.filetypes.FileTypeCommands;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.resources.client.CssResource;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.user.client.ui.ListBox;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.inject.Inject;
+
+public class DataImportOptionsUiCsvLocale extends ModalDialog<DataImportOptionsCsvLocale>
+{
+   interface Binder extends UiBinder<Widget, DataImportOptionsUiCsvLocale> {}
+   
+   public interface DataImportOptionsUiCsvLocaleStyle extends CssResource
+   {
+      String dialog();
+   }
+
+   @Inject
+   private void initialize()
+   {
+   }
+   
+   public DataImportOptionsUiCsvLocale(OperationWithInput<DataImportOptionsCsvLocale> operation)
+   {
+      super("Select Data Import Locale", operation);
+      widget_ = GWT.<Binder> create(Binder.class).createAndBindUi(this);
+   }
+   
+   @Override
+   protected void onDialogShown()
+   {
+      super.onDialogShown();
+
+      initializeDefaults();
+
+      setOkButtonCaption("Select");
+   }
+   
+   @Override
+   protected Widget createMainWidget()
+   {
+      return widget_;
+   }
+   
+   @Override
+   protected DataImportOptionsCsvLocale collectInput()
+   {
+      return null;
+   }
+   
+   @Inject
+   void initialize(FileTypeCommands fileTypeCommands)
+   {
+      initializeDefaults();
+   }
+
+   private void initializeDefaults()
+   {
+      encoding_.addItem("Default", "");
+      encoding_.addItem("ASCII", "ASCII");
+      encoding_.addItem("UTF-16", "UTF-16");
+      encoding_.addItem("UTF-16BE", "UTF-16BE");
+      encoding_.addItem("UTF-16LE", "UTF-16LE");
+      encoding_.addItem("UTF-32", "UTF-32");
+      encoding_.addItem("UTF-32BE", "UTF-32BE");
+      encoding_.addItem("UTF-32LE", "UTF-32LE");
+      encoding_.addItem("UTF-7", "UTF-7");
+      encoding_.addItem("UTF-8", "UTF-8");
+      encoding_.addItem("UTF-8-MAC", "UTF-8-MAC");
+      encoding_.addItem("UTF8", "UTF8");
+      encoding_.addItem("UTF8-MAC", "UTF8-MAC");
+   }
+
+   private ListBox encoding_;
+   
+   private Widget widget_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsvLocale.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsvLocale.java
@@ -22,6 +22,7 @@ import org.rstudio.studio.client.common.filetypes.FileTypeCommands;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
@@ -91,7 +92,8 @@ public class DataImportOptionsUiCsvLocale extends ModalDialog<DataImportOptionsC
       encoding_.addItem("UTF8-MAC", "UTF8-MAC");
    }
 
-   private ListBox encoding_;
+   @UiField
+   ListBox encoding_;
    
    private Widget widget_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsvLocale.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsvLocale.java
@@ -23,7 +23,9 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.ListBox;
+import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
@@ -92,8 +94,30 @@ public class DataImportOptionsUiCsvLocale extends ModalDialog<DataImportOptionsC
       encoding_.addItem("UTF8-MAC", "UTF8-MAC");
    }
 
+   
+   @UiField
+   TextBox dateName_;
+
    @UiField
    ListBox encoding_;
+   
+   @UiField
+   TextBox dateFormat_;
+   
+   @UiField
+   TextBox timeFormat_;
+   
+   @UiField
+   TextBox decimalMark_;
+   
+   @UiField
+   TextBox groupingMark_;
+   
+   @UiField
+   TextBox timeZone_;
+   
+   @UiField
+   CheckBox columnNamesCheckBox_;
    
    private Widget widget_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsvLocale.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsvLocale.java
@@ -47,7 +47,7 @@ public class DataImportOptionsUiCsvLocale extends ModalDialog<DataImportOptionsC
       OperationWithInput<DataImportOptionsCsvLocale> operation,
       DataImportOptionsCsvLocale locale)
    {
-      super("Select Locale", operation);
+      super("Configure Locale", operation);
       widget_ = GWT.<Binder> create(Binder.class).createAndBindUi(this);
       initialLocale_ = locale;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsvLocale.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsvLocale.ui.xml
@@ -3,35 +3,82 @@
 
    <ui:style type="org.rstudio.studio.client.workbench.views.environment.dataimport.DataImportOptionsUiCsvLocale.DataImportOptionsUiCsvLocaleStyle">
       .dialog {
-         width: 350px;
+         width: 420px;
+      }
+      .textBox {
+         width: 90px;
+      }
+      table.localeTable {
+        width: 100%;
+
+        padding-left: 5px;
+        padding-right: 5px;
+      }
+      td.checkbocCell {
+        text-align: right;
+        padding-right: 8px;
+      }
+      td.spacedCell {
+        padding-left: 10px;
       }
    </ui:style>
 
    <g:HTMLPanel styleName="{style.dialog}">
-      <table>
+      <table class="{style.localeTable}">
          <tr>
-            <td><g:Label text="Date Name:" /></td>
-            <td></td>
-            <td><g:Label text="Encoding:" /></td>
-            <td><g:ListBox ui:field="encoding_" /></td>
+            <td>
+                <g:Label text="Date Name:" />
+            </td>
+            <td>
+                <g:TextBox ui:field="dateName_" styleName="{style.textBox}" text="en" />
+            </td>
+            <td class="{style.spacedCell}">
+                <g:Label text="Encoding:" />
+            </td>
+            <td>
+                <g:ListBox ui:field="encoding_" />
+            </td>
          </tr>
          <tr>
-            <td><g:Label text="Date Format:" /></td>
-            <td></td>
-            <td><g:Label text="Time Format:" /></td>
-            <td></td>
+            <td>
+                <g:Label text="Date Format:" />
+            </td>
+            <td>
+                <g:TextBox ui:field="dateFormat_" styleName="{style.textBox}" text="%AD" />
+            </td>
+            <td class="{style.spacedCell}">
+                <g:Label text="Time Format:" />
+            </td>
+            <td>
+                <g:TextBox ui:field="timeFormat_" styleName="{style.textBox}" text="%AT" />
+            </td>
          </tr>
          <tr>
-            <td><g:Label text="Decimal Mark:" /></td>
-            <td></td>
-            <td><g:Label text="Grouping Mark:" /></td>
-            <td></td>
+            <td>
+                <g:Label text="Decimal Mark:" />
+            </td>
+            <td>
+                <g:TextBox ui:field="decimalMark_" styleName="{style.textBox}" text="." />
+            </td>
+            <td class="{style.spacedCell}">
+                <g:Label text="Grouping Mark:" />
+            </td>
+            <td>
+                <g:TextBox ui:field="groupingMark_" styleName="{style.textBox}" text="," />
+            </td>
          </tr>
          <tr>
-            <td><g:Label text="Time Zone:" /></td>
-            <td></td>
-            <td><g:Label text="Asciify:" /></td>
-            <td></td>
+            <td>
+                <g:Label text="Time Zone:" />
+            </td>
+            <td>
+                <g:TextBox ui:field="timeZone_" styleName="{style.textBox}" text="UTF-8" />
+            </td>
+            <td class="{style.spacedCell}">
+            </td>
+            <td class="{style.checkbocCell}">
+                <g:CheckBox ui:field="columnNamesCheckBox_" text="Asciify"/>
+            </td>
          </tr>
       </table>
    </g:HTMLPanel>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsvLocale.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsvLocale.ui.xml
@@ -72,12 +72,12 @@
                 <g:Label text="Time Zone:" />
             </td>
             <td>
-                <g:TextBox ui:field="timeZone_" styleName="{style.textBox}" text="UTF-8" />
+                <g:TextBox ui:field="timeZone_" styleName="{style.textBox}" text="UTC" />
             </td>
             <td class="{style.spacedCell}">
             </td>
             <td class="{style.checkbocCell}">
-                <g:CheckBox ui:field="columnNamesCheckBox_" text="Asciify"/>
+                <g:CheckBox ui:field="asciify_" text="Asciify"/>
             </td>
          </tr>
       </table>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsvLocale.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsvLocale.ui.xml
@@ -1,0 +1,13 @@
+<ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
+             xmlns:g='urn:import:com.google.gwt.user.client.ui'>
+
+   <ui:style type="org.rstudio.studio.client.workbench.views.environment.dataimport.DataImportOptionsUiCsvLocale.DataImportOptionsUiCsvLocaleStyle">
+      .dialog {
+         width: 350px;
+      }
+   </ui:style>
+
+   <g:HTMLPanel styleName="{style.dialog}">
+   </g:HTMLPanel>
+
+</ui:UiBinder>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsvLocale.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsvLocale.ui.xml
@@ -8,6 +8,32 @@
    </ui:style>
 
    <g:HTMLPanel styleName="{style.dialog}">
+      <table>
+         <tr>
+            <td><g:Label text="Date Name:" /></td>
+            <td></td>
+            <td><g:Label text="Encoding:" /></td>
+            <td><g:ListBox ui:field="encoding_" /></td>
+         </tr>
+         <tr>
+            <td><g:Label text="Date Format:" /></td>
+            <td></td>
+            <td><g:Label text="Time Format:" /></td>
+            <td></td>
+         </tr>
+         <tr>
+            <td><g:Label text="Decimal Mark:" /></td>
+            <td></td>
+            <td><g:Label text="Grouping Mark:" /></td>
+            <td></td>
+         </tr>
+         <tr>
+            <td><g:Label text="Time Zone:" /></td>
+            <td></td>
+            <td><g:Label text="Asciify:" /></td>
+            <td></td>
+         </tr>
+      </table>
    </g:HTMLPanel>
 
 </ui:UiBinder>


### PR DESCRIPTION
Previously, data importing from csv only supported the `encoding` parameters, while helpful, users have requested the additional parameters, especially the `decimal_mark` parameters. This PR adds a modal dialog to configure the locale parameters of a given import.

<img width="1260" alt="screen shot 2016-10-24 at 2 13 49 pm" src="https://cloud.githubusercontent.com/assets/3478847/19664184/1feea206-99f4-11e6-8cd1-6690b2ec4d89.png">

