### PR TITLE
show chunk output UI unconditionally for Rmd

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -1159,20 +1159,16 @@ public class TextEditingTargetWidget
       if (uiPrefs_.showRmdChunkOutputInline().getValue() &&
           type != RmdOutput.TYPE_SHINY)
       {
-         if (type != RmdOutput.TYPE_NOTEBOOK)
-         {
-            menu.addItem(new DocPropMenuItem(
-                  "Chunk Output Inline", docUpdateSentinel_, 
-                  true, 
-                  TextEditingTargetNotebook.CHUNK_OUTPUT_TYPE, 
-                  TextEditingTargetNotebook.CHUNK_OUTPUT_INLINE));
-            menu.addItem(new DocPropMenuItem(
-                  "Chunk Output in Console", docUpdateSentinel_, 
-                  false, 
-                  TextEditingTargetNotebook.CHUNK_OUTPUT_TYPE, 
-                  TextEditingTargetNotebook.CHUNK_OUTPUT_CONSOLE));
-            menu.addSeparator();
-         }
+        menu.addItem(new DocPropMenuItem(
+              "Chunk Output Inline", docUpdateSentinel_,
+              true,
+              TextEditingTargetNotebook.CHUNK_OUTPUT_TYPE,
+              TextEditingTargetNotebook.CHUNK_OUTPUT_INLINE));
+        menu.addItem(new DocPropMenuItem(
+              "Chunk Output in Console", docUpdateSentinel_,
+              false,
+              TextEditingTargetNotebook.CHUNK_OUTPUT_TYPE,
+              TextEditingTargetNotebook.CHUNK_OUTPUT_CONSOLE));
          
          menu.addSeparator();
 


### PR DESCRIPTION
This PR ensures that the `Chunk Output Inline` / `Chunk Output in Console` is shown unconditionally for R Markdown files, as a number of users had been confused by their absence in `html_notebook` documents.

