### PR TITLE
bugfix for chunks rendered with 'results = "hold"'

### DIFF
--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -350,9 +350,11 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
                  includeSource = includeSource)
       })
       
-      # remove nulls and return
-      Filter(Negate(is.null), outputList)
-      
+      # remove nulls
+      filtered <- Filter(Negate(is.null), outputList)
+      lapply(filtered, function(x) {
+         if (!is.list(x)) list(x) else x
+      })
    }
 })
 


### PR DESCRIPTION
This PR fixes an R Notebook issue where attempts to render plots in a chunk with `results = "hold"` would produce verbatim HTML (ie, wrapped in `<pre><code>`), rather than the expected HTML output.

This occurs because `knitr` attempts to reorder all character results, pasting them at the end:

https://github.com/yihui/knitr/blob/9fc0c6143605612ad32e04da0d34708d02747817/R/block.R#L205-L208

When an R Notebook generates plot outputs, it generates raw HTML as a length-one character vector with the `knit_asis` class -- because the underlying object is still `character`, `knitr` grabs those and 'paste'd them at the end (thereby losing the class and the special rendering we desire).

I'll try to distill this into a reproducible example in case we can demonstrate that some changes are needed in `knitr`.

Note that we still do not respect the `results = "hold"` attribute; this just ensures that the Notebook is generated as expected.