### PR TITLE
add support for 'gvis' outputs in R Notebook

### DIFF
--- a/src/cpp/session/modules/NotebookHtmlWidgets.R
+++ b/src/cpp/session/modules/NotebookHtmlWidgets.R
@@ -50,6 +50,8 @@
       jsDrawChart[[injectionLoc]] <- paste(
          paste(
             "google.visualization.events.addListener(chart, 'ready', function() {",
+            "    if (typeof parent === 'undefined') return;",
+            "    if (typeof parent.$onGvisChartReady === 'undefined') return;",
             "    parent.$onGvisChartReady(data);",
             "})",
             sep = "\n"

--- a/src/cpp/session/modules/NotebookHtmlWidgets.R
+++ b/src/cpp/session/modules/NotebookHtmlWidgets.R
@@ -64,7 +64,9 @@
    # write HTML out to file
    html <- capture.output(googleVis:::print.gvis(x))
    cat(html, file = htmlfile, sep = "\n")
-   .rs.recordHtmlWidget(x, htmlfile, depfile)
+   
+   # record the generated artefacts
+   invisible(.rs.recordHtmlWidget(x, htmlfile, depfile))
 })
 
 .rs.addFunction("rnb.saveHtmlToCache", function(x, ...)
@@ -90,7 +92,7 @@
    }
    
    # record the generated artefacts
-   .rs.recordHtmlWidget(x, htmlfile, depfile)
+   invisible(.rs.recordHtmlWidget(x, htmlfile, depfile))
 })
 
 .rs.addFunction("rnbHooks.print.html",           .rs.rnb.saveHtmlToCache)
@@ -98,6 +100,7 @@
 .rs.addFunction("rnbHooks.print.shiny.tag.list", .rs.rnb.saveHtmlToCache)
 
 .rs.addFunction("rnbHooks.print.gvis",           .rs.rnb.saveGoogleVisToCache)
+.rs.addFunction("rnbHooks.plot.gvis",            .rs.rnb.saveGoogleVisToCache)
 
 .rs.addFunction("rnbHooks.print.knit_asis", function(x, ...) 
 {
@@ -304,7 +307,8 @@
       "print.shiny.tag.list"   = .rs.rnbHooks.print.shiny.tag.list,
       "print.gvis"             = .rs.rnbHooks.print.gvis,
       "print.knit_asis"        = .rs.rnbHooks.print.knit_asis,
-      "print.knit_image_paths" = .rs.rnbHooks.print.knit_image_paths
+      "print.knit_image_paths" = .rs.rnbHooks.print.knit_image_paths,
+      "plot.gvis"              = .rs.rnbHooks.plot.gvis
    )
 })
 

--- a/src/cpp/session/modules/NotebookHtmlWidgets.R
+++ b/src/cpp/session/modules/NotebookHtmlWidgets.R
@@ -33,6 +33,19 @@
 
 # Hooks ----
 
+.rs.addFunction("rnb.saveGoogleVisToCache", function(x, ...)
+{
+   ctx <- .rs.rnb.getHtmlCaptureContext()
+   
+   # tempfile paths for html resources
+   htmlfile <- tempfile("_rs_gvis_", tmpdir = ctx$outputFolder, fileext = ".html")
+   depfile  <- tempfile("_rs_gvis_deps_", tmpdir = ctx$outputFolder, fileext = ".json")
+   
+   html <- capture.output(googleVis:::print.gvis(x))
+   cat(html, file = htmlfile, sep = "\n")
+   .rs.recordHtmlWidget(x, htmlfile, depfile)
+})
+
 .rs.addFunction("rnb.saveHtmlToCache", function(x, ...)
 {
    ctx <- .rs.rnb.getHtmlCaptureContext()
@@ -62,6 +75,8 @@
 .rs.addFunction("rnbHooks.print.html",           .rs.rnb.saveHtmlToCache)
 .rs.addFunction("rnbHooks.print.shiny.tag",      .rs.rnb.saveHtmlToCache)
 .rs.addFunction("rnbHooks.print.shiny.tag.list", .rs.rnb.saveHtmlToCache)
+
+.rs.addFunction("rnbHooks.print.gvis",           .rs.rnb.saveGoogleVisToCache)
 
 .rs.addFunction("rnbHooks.print.knit_asis", function(x, ...) 
 {
@@ -266,6 +281,7 @@
       "print.html"             = .rs.rnbHooks.print.html,
       "print.shiny.tag"        = .rs.rnbHooks.print.shiny.tag,
       "print.shiny.tag.list"   = .rs.rnbHooks.print.shiny.tag.list,
+      "print.gvis"             = .rs.rnbHooks.print.gvis,
       "print.knit_asis"        = .rs.rnbHooks.print.knit_asis,
       "print.knit_image_paths" = .rs.rnbHooks.print.knit_image_paths
    )

--- a/src/cpp/session/modules/NotebookHtmlWidgets.R
+++ b/src/cpp/session/modules/NotebookHtmlWidgets.R
@@ -41,6 +41,27 @@
    htmlfile <- tempfile("_rs_gvis_", tmpdir = ctx$outputFolder, fileext = ".html")
    depfile  <- tempfile("_rs_gvis_deps_", tmpdir = ctx$outputFolder, fileext = ".json")
    
+   # inject some of our own JavaScript event handlers in the gvis object
+   # mutates 'x' on success
+   try(silent = TRUE, {
+      jsDrawChart <- strsplit(x$html$chart[["jsDrawChart"]], "\n", fixed = TRUE)[[1]]
+      injectionLoc <- grep("chart.draw", jsDrawChart)[[1]]
+      
+      jsDrawChart[[injectionLoc]] <- paste(
+         paste(
+            "google.visualization.events.addListener(chart, 'ready', function() {",
+            "    parent.$onGvisChartReady(data);",
+            "})",
+            sep = "\n"
+         ),
+         jsDrawChart[[injectionLoc]],
+         sep = "\n"
+      )
+      
+      x$html$chart[["jsDrawChart"]] <- paste(jsDrawChart, collapse = "\n")
+   })
+   
+   # write HTML out to file
    html <- capture.output(googleVis:::print.gvis(x))
    cat(html, file = htmlfile, sep = "\n")
    .rs.recordHtmlWidget(x, htmlfile, depfile)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkHtmlPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkHtmlPage.java
@@ -40,8 +40,13 @@ public class ChunkHtmlPage extends ChunkOutputPage
          classes = metadata.getClasses();
 
       String clazz = classes.length() > 0 ? classes.get(0) : "html";
-      thumbnail_ = new ChunkOutputThumbnail(clazz, 
-            classes.length() > 1 ? classes.get(1) : "",
+      String secondClazz = classes.length() > 1 ? classes.get(1) : "";
+      
+      // don't report 'list' class for 'gvis' objects
+      if (clazz.equals("gvis"))
+         secondClazz = "";
+      
+      thumbnail_ = new ChunkOutputThumbnail(clazz, secondClazz,
             new ChunkHtmlPreview(), ChunkOutputWidget.getEditorColors());
 
       // amend the URL to cause any contained widget to use the RStudio viewer

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -16,7 +16,9 @@ package org.rstudio.studio.client.workbench.views.source.editors.text;
 
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.rstudio.core.client.ColorUtil;
 import org.rstudio.core.client.Size;
@@ -46,6 +48,8 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.IFrameElement;
+import com.google.gwt.dom.client.NodeList;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Overflow;
 import com.google.gwt.dom.client.Style.Unit;
@@ -114,6 +118,8 @@ public class ChunkOutputWidget extends Composite
          RmdChunkOptions options, int expansionState, boolean canClose, 
          ChunkOutputHost host, ChunkOutputSize chunkOutputSize)
    {
+      initializeGvisHandlers();
+      
       documentId_ = documentId;
       chunkId_ = chunkId;
       host_ = host;
@@ -158,6 +164,7 @@ public class ChunkOutputWidget extends Composite
             {
             case Event.ONCLICK:
                host_.onOutputRemoved(ChunkOutputWidget.this);
+               REGISTRY.remove(ChunkOutputWidget.this);
                break;
             };
          }
@@ -205,6 +212,8 @@ public class ChunkOutputWidget extends Composite
       events.addHandler(InterruptStatusEvent.TYPE, this);
 
       chunkWindowManager_ = RStudioGinjector.INSTANCE.getChunkWindowManager();
+      
+      REGISTRY.add(this);
    }
    
    // Public methods ----------------------------------------------------------
@@ -302,21 +311,15 @@ public class ChunkOutputWidget extends Composite
       // don't sync if not visible and no output yet
       if (!isVisible() && (state_ == CHUNK_EMPTY || state_ == CHUNK_PRE_OUTPUT))
          return;
-
-      setVisible(true);
       
-      // clamp chunk height to min/max (the +19 is the sum of the vertical
-      // padding on the element)
-      int height = ChunkOutputUi.CHUNK_COLLAPSED_HEIGHT;
-      if (expansionState_.getValue() == EXPANDED)
-      {
-         int contentHeight = root_.getElement().getOffsetHeight() + 19;
-         height = Math.max(ChunkOutputUi.MIN_CHUNK_HEIGHT, contentHeight);
+      setVisible(true);
 
-         // if we have renders pending, don't shrink until they're loaded 
-         if (pendingRenders_ > 0 && height < renderedHeight_)
-            return;
-      }
+      // infer an appropriate widget height
+      int height = inferWidgetHeight(40);
+      
+      // if we have renders pending, don't shrink until they're loaded 
+      if (pendingRenders_ > 0 && height < renderedHeight_)
+         return;
 
       // don't report height if it hasn't changed (unless we also need to ensure
       // visibility)
@@ -879,6 +882,49 @@ public class ChunkOutputWidget extends Composite
       return true;
    }
    
+   private static final native void initializeGvisHandlers() /*-{
+      $wnd.$onGvisChartReady = $entry(function(data) {
+         @org.rstudio.studio.client.workbench.views.source.editors.text.ChunkOutputWidget::onGvisChartReady()();
+      });
+   }-*/;
+   
+   private int inferWidgetHeight(int verticalPadding)
+   {
+      // determine height
+      Element rootEl = root_.getElement();
+      NodeList<Element> iFrameEls = rootEl.getElementsByTagName("iframe");
+      
+      // if we failed to find an iFrame, use pre-existing logic
+      if (iFrameEls == null || iFrameEls.getLength() != 1)
+         return defaultWidgetHeight(verticalPadding);
+
+      // form height from iFrame inner body
+      IFrameElement iFrameEl = iFrameEls.getItem(0).cast();
+      Element bodyEl = iFrameEl.getContentDocument().getBody();
+
+      // some padding for the border
+      return bodyEl.getOffsetHeight() + verticalPadding;
+   }
+   
+   private int defaultWidgetHeight(int verticalPadding)
+   {
+      int height = ChunkOutputUi.CHUNK_COLLAPSED_HEIGHT;
+      if (expansionState_.getValue() == EXPANDED)
+      {
+         int contentHeight = root_.getElement().getOffsetHeight() + 19;
+         height = Math.max(ChunkOutputUi.MIN_CHUNK_HEIGHT, contentHeight);
+      }
+
+      return height;
+   }
+   
+   private static void onGvisChartReady()
+   {
+      // TODO: modify this method so we can figure out what gVis chart was just resized?
+      for (ChunkOutputWidget cow : REGISTRY)
+         cow.syncHeight(true, false);
+   }
+   
    @UiField Image clear_;
    @UiField Image expand_;
    @UiField Image popout_;
@@ -918,4 +964,7 @@ public class ChunkOutputWidget extends Composite
    public final static int CHUNK_READY       = 2;
    public final static int CHUNK_PRE_OUTPUT  = 3;
    public final static int CHUNK_POST_OUTPUT = 4;
+   
+   private static final Set<ChunkOutputWidget> REGISTRY = new HashSet<ChunkOutputWidget>();
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -920,9 +920,15 @@ public class ChunkOutputWidget extends Composite
    
    private static void onGvisChartReady()
    {
-      // TODO: modify this method so we can figure out what gVis chart was just resized?
-      for (ChunkOutputWidget cow : REGISTRY)
-         cow.syncHeight(true, false);
+      new Timer()
+      {
+         @Override
+         public void run()
+         {
+            for (ChunkOutputWidget cow : REGISTRY)
+               cow.syncHeight(true, false);
+         }
+      }.schedule(100);
    }
    
    @UiField Image clear_;


### PR DESCRIPTION
NOTE: if we take this, we'll likely want to do the associated work in R Markdown to support this as `gvis` outputs are not properly rendered (by default) in their current form.

See https://github.com/rstudio/rstudio/pull/809 for some details on prior work.

TODO:
- [ ] Fix up vertical sizing behaviors (sometimes the widget opens too small, too large, etc.)
- [ ] Support `gvis` outputs in `rmarkdown` package (consider adding a `knit_print` method)
