### PR TITLE
Enable recording profiler state while ran as profvis command

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -397,7 +397,7 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
 
 
 # hook an internal R function
-.rs.addFunction( "registerHook", function(name, package, hookFactory)
+.rs.addFunction( "registerHook", function(name, package, hookFactory, namespace = FALSE)
 {
    # get the original function  
    packageName = paste("package:", package, sep="")
@@ -414,6 +414,13 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
       unlockBinding(name, packageEnv)
       assign(name, new, packageName)
       lockBinding(name, packageEnv)
+
+      if (namespace && package %in% loadedNamespaces()) {
+         ns <- asNamespace(package)
+         unlockBinding(name, ns)
+         assign(name, new, envir = ns)
+         lockBinding(name, ns)
+      }
    }
    else
    {
@@ -453,7 +460,7 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
 })
 
 # notification that an internal R function was called
-.rs.addFunction( "registerNotifyHook", function(name, package, hook)
+.rs.addFunction( "registerNotifyHook", function(name, package, hook, namespace = FALSE)
 {
    hookFactory <- function(original) function(...) 
    { 
@@ -463,7 +470,7 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
       # call original
       .rs.callAs(name, original, ...)
    }
-   .rs.registerHook(name, package, hookFactory);
+   .rs.registerHook(name, package, hookFactory, namespace);
 })
 
 # marking functions in R packages as unsupported

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -417,9 +417,11 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
 
       if (namespace && package %in% loadedNamespaces()) {
          ns <- asNamespace(package)
-         unlockBinding(name, ns)
-         assign(name, new, envir = ns)
-         lockBinding(name, ns)
+         if (exists(name, envir = ns, mode="function")) {
+            unlockBinding(name, ns)
+            assign(name, new, envir = ns)
+            lockBinding(name, ns)
+         }
       }
    }
    else

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -138,7 +138,7 @@
    {
       .rs.enqueClientEvent("rprof_stopped");
    }
-})
+}, namespace = TRUE)
 
 .rs.addFunction("profilePrint", function(x)
 {


### PR DESCRIPTION
Currently, when one runs:

```{r}
x <- profvis::profvis({
  profvis::pause(5)
})
```

The state of the ide does not change into "profiling" since the `Rprof` hook was added through `registerNotifyHook` which registers this hook in the environment, not the namespace (thanks @kevinushey for explaining this). So in order to track this state, we need to also get notifications for the times when `rprofvis` calls `Rprof` to start/stop profiling.

The bug that this fixes is a corner case tracked by fogbugz 5689, in which starting the profiler, then starting another profile with `profvis` and then stopping the profiler would cause us to try to read a file that was not created and a not very useful error to trigger as a pop up.