### PR TITLE
avoid scrollbars for html notebooks output for nonfigures

### DIFF
--- a/src/cpp/session/modules/NotebookHtmlWidgets.R
+++ b/src/cpp/session/modules/NotebookHtmlWidgets.R
@@ -133,6 +133,11 @@
    # force a responsive viewer sizing policy
    x$sizingPolicy$viewer.padding <- 0
    x$sizingPolicy$viewer.fill <- TRUE
+
+   # make width dinamic to size correctly non-figured
+   if (!is.null(x$sizingPolicy$knitr) && identical(x$sizingPolicy$knitr$figure, FALSE)) {
+      x$sizingPolicy$defaultWidth <- "auto"
+   }
    
    # collect knitr options
    knitrOptions <- knitr::opts_current$get()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -250,10 +250,11 @@ public class ChunkOutputStream extends FlowPanel
             onRenderComplete.execute();
             
             if (!knitrFigure) {
-               frame.getWindow().getDocument().getBody().getStyle().setOverflow(Overflow.SCROLL);
-               
                int contentHeight = frame.getWindow().getDocument().getBody().getOffsetHeight();
                frame.getElement().getStyle().setHeight(contentHeight, Unit.PX);
+
+               frame.getElement().getStyle().setOverflow(Overflow.HIDDEN);
+               frame.getWindow().getDocument().getBody().getStyle().setOverflow(Overflow.HIDDEN);
             }
             
             onHeightChanged();


### PR DESCRIPTION
Feature was enabled to size height correctly for notebook html non-figure output; however, this can still happen:

![2016-10-25_1649](https://cloud.githubusercontent.com/assets/3478847/19709070/6da5b6da-9ad8-11e6-8053-c844e60bcb74.png)

This is not an issue in OS X since by default scrollbars are hidden, but other OS or settings in OS X would add the additional scrollbars.

Fix is two part: 1) Remove scrollbars once the widget loads and 2) Set the width as `auto` since the default width is `960px` which is set in `htmlwidgets` for non-figures causing the scrollbar to appear even if there is not enough content to require one.

With this fix:

<img width="826" alt="screen shot 2016-10-25 at 5 24 33 pm" src="https://cloud.githubusercontent.com/assets/3478847/19709097/b1d0e460-9ad8-11e6-9e57-362861472eec.png">
