### PR TITLE
remove duplicate fix for notebook data digits

### DIFF
--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -205,7 +205,7 @@
           y[y == "NA"] <- "__NA__"
         }
 
-        y <- encodeString(format(y, digits = getOption("digits")))
+        y <- encodeString(format(y))
 
         # trim spaces
         gsub("^\\s+|\\s+$", "", y)


### PR DESCRIPTION
Code cleanup to fix bug case: Fix was added to support `options("digits")` in pagedtables, but the fix is not actually needed since this is the default behavior of `format`.