### PR TITLE
trim whitespace when parsing key in YAML header

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/YamlTree.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/YamlTree.java
@@ -123,7 +123,7 @@ public class YamlTree
          if (result == null)
             return "";
           else
-            return result.getGroup(1);
+            return result.getGroup(1).trim();
       }
 
       private int getIndentLevel()


### PR DESCRIPTION
This PR fixes an issue where an R Markdown document with a YAML header as e.g.

```
---
output : html_notebook
---
```

would not be discovered to be an HTML notebook. (note the space separating the `output` and `:` tokens)