### PR TITLE
fix autocompletion issue for project files on Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 * Improve resilience against malformed YAML header in R Markdown documents
 * Avoid triggering active bindings in environments from the Environment pane
 * Fix encoding of R_HOME, R_USER, and R_LIBS_USER on Windows
+* Fix project-based file completion on Windows
 * Respect loaded packages in R help topic completion
 * Fix positioning of editor toolbar buttons in Safari and Mac OS client
 * Fix incorrect height of R Notebook outputs when run above viewport

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -916,7 +916,7 @@
 
 .rs.addFunction("doListIndex", function(routine, term, inDirectory, maxCount)
 {
-   if (!.rs.hasFileMonitor())
+   if (!.rs.hasFileMonitor() || is.null(inDirectory))
       return(NULL)
    
    inDirectory <- suppressWarnings(.rs.normalizePath(inDirectory))

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -914,37 +914,36 @@
    .Call("rs_hasFileMonitor")
 })
 
+.rs.addFunction("doListIndex", function(routine, term, inDirectory, maxCount)
+{
+   if (!.rs.hasFileMonitor())
+      return(NULL)
+   
+   inDirectory <- suppressWarnings(.rs.normalizePath(inDirectory))
+   inDirectory <- gsub("[/\\\\]+$", "", inDirectory)
+   
+   .Call(routine, term, inDirectory, as.integer(maxCount))
+})
+
 .rs.addFunction("listIndexedFiles", function(term = "",
                                              inDirectory = .rs.getProjectDirectory(),
                                              maxCount = 200L)
 {
-   if (is.null(.rs.getProjectDirectory()))
-      return(NULL)
-   
-   .Call("rs_listIndexedFiles",
-         term,
-         suppressWarnings(.rs.normalizePath(inDirectory)),
-         as.integer(maxCount))
+   .rs.doListIndex("rs_listIndexedFiles", term, inDirectory, as.integer(maxCount))
 })
 
 .rs.addFunction("listIndexedFolders", function(term = "",
                                                inDirectory = .rs.getProjectDirectory(),
                                                maxCount = 200L)
 {
-   if (is.null(inDirectory))
-      return(character())
-   
-   .Call("rs_listIndexedFolders", term, inDirectory, maxCount)
+   .rs.doListIndex("rs_listIndexedFolders", term, inDirectory, maxCount)
 })
 
 .rs.addFunction("listIndexedFilesAndFolders", function(term = "",
                                                        inDirectory = .rs.getProjectDirectory(),
                                                        maxCount = 200L)
 {
-   if (is.null(inDirectory))
-      return(character())
-   
-   .Call("rs_listIndexedFilesAndFolders", term, inDirectory, maxCount)
+   .rs.doListIndex("rs_listIndexedFilesAndFolders", term, inDirectory, maxCount)
 })
 
 .rs.addFunction("doGetIndex", function(term = "",
@@ -969,7 +968,7 @@
       ))
    }
    
-   paths <- suppressWarnings(.rs.normalizePath(index$paths))
+   paths <- suppressWarnings(.rs.normalizePath(index$paths, winslash = "/"))
    scores <- .rs.scoreMatches(basename(paths), term)
    index$paths <- paths[order(scores)]
    index

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -234,9 +234,8 @@ assign(x = ".rs.acCompletionTypes",
       if (!identical(tokenSlashIndices, -1L))
       {
          maxIndex <- max(tokenSlashIndices)
-         directory <- suppressWarnings(
-            .rs.normalizePath(file.path(path, substring(token, 1, maxIndex - 1)))
-         )
+         fullPath <- file.path(path, substring(token, 1, maxIndex - 1))
+         directory <- suppressWarnings(.rs.normalizePath(fullPath, winslash = "/"))
       }
       else
       {


### PR DESCRIPTION
This PR resolves an issue where filesystem autocompletion failed on Windows; ie, queries for terms as e.g. `"perf<TAB>` would fail to discover filesystem autocompletions of the form `docs/perf_foo.Rmd`.