### PR TITLE
Add padding to html files to prevent qt bug

### DIFF
--- a/src/cpp/core/BrowserUtils.cpp
+++ b/src/cpp/core/BrowserUtils.cpp
@@ -92,6 +92,12 @@ bool isSafari(const std::string& userAgent)
           !contains(userAgent, "Chrome");
 }
 
+bool isQt(const std::string& userAgent)
+{
+   return (contains(userAgent, "AppleWebKit")) &&
+           contains(userAgent, "Qt");
+}
+
 bool isSafariOlderThan(const std::string& userAgent, double version)
 {
    if (isSafari(userAgent))

--- a/src/cpp/core/include/core/BrowserUtils.hpp
+++ b/src/cpp/core/include/core/BrowserUtils.hpp
@@ -31,6 +31,7 @@ bool isChrome(const std::string& userAgent);
 bool isFirefox(const std::string& userAgent);
 bool isSafari(const std::string& userAgent);
 bool isTrident(const std::string& userAgent);
+bool isQt(const std::string& userAgent);
 
 bool isChromeOlderThan(const std::string& userAgent, double version);
 bool isFirefoxOlderThan(const std::string& userAgent, double version);


### PR DESCRIPTION
Launching RStudio in Windows, creating small HTML file and preview it will render blank. The fix is to add padding to prevent QT from ignoring this file.

I was tempted to scope this fix to only the preview HTML feature; however, I think is worth keeping this a bit more generic to prevent this from happening in other instances. I also considered scoping the fix to only QT platforms but looks like the `Response` might be too low in the stack for checking for `session::options().programMode() == kSessionProgramModeServer` and `#ifdef RSTUDIO_SERVER` seems like too much overhead. Let me know your thoughts to iterate on this if needed.