### PR TITLE
Apply max.print notebook cols

### DIFF
--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -73,6 +73,10 @@
 
     x <- .rs.toDataFrame(head(x, max.print), "x", flatten = FALSE, force = TRUE)
 
+    if (NCOL(x) > max.print) {
+      x <- x[,c(1:max.print)]
+    }
+
     save(
       x,
       options,

--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -70,11 +70,11 @@
                        fileext = ".rdf")
 
     max.print <- if (is.null(options$max.print)) getOption("max.print", 1000) else options$max.print
-
     x <- .rs.toDataFrame(head(x, max.print), "x", flatten = FALSE, force = TRUE)
 
-    if (NCOL(x) > max.print) {
-      x <- x[,c(1:max.print)]
+    cols.max.print <- if (is.null(options$cols.max.print)) getOption("cols.max.print", 1000) else options$cols.max.print
+    if (NCOL(x) > cols.max.print) {
+      x <- x[,c(1:cols.max.print)]
     }
 
     save(


### PR DESCRIPTION
Applies max.print to notebook data columns to prevent huge data sets from taking too long to render.
