### PR TITLE
avoid looking for sizingpolicy if element is not a list

### DIFF
--- a/src/cpp/session/modules/NotebookHtmlWidgets.R
+++ b/src/cpp/session/modules/NotebookHtmlWidgets.R
@@ -17,7 +17,7 @@
 {
    .Call("rs_recordHtmlWidget", htmlfile, depfile, list(
       classes = class(x),
-      sizingPolicy = x$sizingPolicy
+      sizingPolicy = if (is.list(x)) x$sizingPolicy else list()
    ))
 })
 


### PR DESCRIPTION
Apparently, for `knit_asis` we call `recordHtmlWidget` but the `kable` is not a `list`/`widget` itself and the output breaks. Fix is to only use `sizingPolicy` element when available.

<img width="834" alt="screen shot 2016-10-28 at 1 36 13 pm" src="https://cloud.githubusercontent.com/assets/3478847/19821580/06e17c84-9d14-11e6-95d1-d816ee088a45.png">
