### PR TITLE
use DebouncedCommand for autosave (prevent autosave while typing)

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/DebouncedCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/DebouncedCommand.java
@@ -1,0 +1,58 @@
+/*
+ * DebouncedCommand.java
+ *
+ * Copyright (C) 2016 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client;
+
+import com.google.gwt.user.client.Timer;
+
+public abstract class DebouncedCommand
+{
+   public DebouncedCommand(int delayMs)
+   {
+      timer_ = new Timer()
+      {
+         @Override
+         public void run()
+         {
+            execute();
+         }
+      };
+      
+      delayMs_ = delayMs;
+      suspended_ = false;
+   }
+   
+   public void nudge()
+   {
+      if (!suspended_)
+         timer_.schedule(delayMs_);
+   }
+   
+   public void suspend()
+   {
+      timer_.cancel();
+      suspended_ = true;
+   }
+   
+   public void resume()
+   {
+      suspended_ = false;
+   }
+   
+   protected abstract void execute();
+   
+   private final Timer timer_;
+   private final int delayMs_;
+   private boolean suspended_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
@@ -27,6 +27,7 @@ import com.google.gwt.user.client.Window.ClosingHandler;
 
 import org.rstudio.core.client.Barrier.Token;
 import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.DebouncedCommand;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.TimeBufferedCommand;
 import org.rstudio.core.client.js.JsObject;
@@ -117,12 +118,11 @@ public class DocUpdateSentinel
       propertyChangeHandlers_ = 
             new HashMap<String, ValueChangeHandlerManager<String>>();
 
-      bufferedCommand_ = new TimeBufferedCommand(2000)
+      autosaver_ = new DebouncedCommand(2000)
       {
          @Override
-         protected void performAction(boolean shouldSchedulePassive)
+         protected void execute()
          {
-            assert !shouldSchedulePassive;
             maybeAutoSave();
          }
       };
@@ -265,7 +265,7 @@ public class DocUpdateSentinel
                                           String encoding,
                                           final ProgressIndicator progress)
    {
-      bufferedCommand_.suspend();
+      autosaver_.suspend();
       doSave(path, fileType, encoding, new ProgressIndicator()
       {
          public void onProgress(String message)
@@ -281,21 +281,21 @@ public class DocUpdateSentinel
          
          public void clearProgress()
          {
-            bufferedCommand_.resume();
+            autosaver_.resume();
             if (progress != null)
                progress.clearProgress();
          }
 
          public void onCompleted()
          {
-            bufferedCommand_.resume();
+            autosaver_.resume();
             if (progress != null)
                progress.onCompleted();
          }
 
          public void onError(String message)
          {
-            bufferedCommand_.resume();
+            autosaver_.resume();
             if (progress != null)
                progress.onError(message);
          }
@@ -675,14 +675,14 @@ public class DocUpdateSentinel
    public void onValueChange(ValueChangeEvent<Void> voidValueChangeEvent)
    {
       changesPending_ = true;
-      bufferedCommand_.nudge();
+      autosaver_.nudge();
    }
 
    @Override
    public void onFoldChange(FoldChangeEvent event)
    {
       changesPending_ = true;
-      bufferedCommand_.nudge();
+      autosaver_.nudge();
    }
    
    public String getPath()
@@ -702,7 +702,7 @@ public class DocUpdateSentinel
 
    public void stop()
    {
-      bufferedCommand_.suspend();
+      autosaver_.suspend();
       closeHandlerReg_.removeHandler();
       lastChanceSaveHandlerReg_.removeHandler();
    }
@@ -763,7 +763,7 @@ public class DocUpdateSentinel
    private final ProgressIndicator progress_;
    private final DirtyState dirtyState_;
    private final EventBus eventBus_;
-   private final TimeBufferedCommand bufferedCommand_;
+   private final DebouncedCommand autosaver_;
    private final HandlerRegistration closeHandlerReg_;
    private HandlerRegistration lastChanceSaveHandlerReg_;
    private final HashMap<String, ValueChangeHandlerManager<String>> 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
@@ -118,7 +118,7 @@ public class DocUpdateSentinel
       propertyChangeHandlers_ = 
             new HashMap<String, ValueChangeHandlerManager<String>>();
 
-      autosaver_ = new DebouncedCommand(2000)
+      autosaver_ = new DebouncedCommand(1000)
       {
          @Override
          protected void execute()


### PR DESCRIPTION
This PR switches away from using a `TimeBufferedCommand` to a `DebouncedCommand` for autosave. The intention here is to:
1. Avoid creating + running timers so eagerly, and
2. Resolve an issue where autosaves could run while the user was actively typing.

The `TimeBufferedCommand` class actually generates new timers very eagerly -- every time it is `nudge()`d, it generates a new timer -- and we often call this `nudge()` method within event handlers that occur often, e.g. value changed handlers, as in this case.

It also does not debounce as one might expect (although perhaps that was not the intention of the class?) In other words, after nudging a TimeBufferedCommand that is set to run every 2000 milliseconds, it will _definitely_ run after 2000 seconds, even if re-nudged in that time interval. This implies that if a user begins typing, they will get interleaving autosaves every 2 seconds while they type.

This change should also fix a performance issue that can occur when editing near the start of large R Markdown documents. Because these autosaves are running eagerly, and those autosaves can force a rebuild of the scope tree (since they need knowledge of chunks in the document), they can effectively 'freeze' the editor for a short period of time (enough to be perceptible as a 'lagginess' in typing).

We might also want to audit other uses of `TimeBufferedCommand` to see if we really do want the semantics of that class, or if debouncing fits better.

Note that the `DebouncedCommand` class intentionally tries to mimic the interface of the `TimeBufferedCommand` class (for 'passively-triggered' commands), so that it can act as a drop-in replacement when appropriate.
