### PR TITLE
respect 'show inline toolbar' UI pref

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetChunks.java
@@ -107,9 +107,12 @@ public class TextEditingTargetChunks
    private void initialize(UIPrefs prefs, AceThemes themes)
    {
       themes_ = themes;
+      prefs_ = prefs;
+      
       dark_ = themes_.isDark(themes_.getEffectiveThemeName(
             prefs.theme().getValue()));
-      prefs.theme().addValueChangeHandler(new ValueChangeHandler<String>()
+      
+      prefs_.theme().addValueChangeHandler(new ValueChangeHandler<String>()
       {
          @Override
          public void onValueChange(ValueChangeEvent<String> theme)
@@ -131,6 +134,21 @@ public class TextEditingTargetChunks
             }
          }
       });
+      
+      prefs_.showInlineToolbarForRCodeChunks().addValueChangeHandler(new ValueChangeHandler<Boolean>()
+      {
+         @Override
+         public void onValueChange(ValueChangeEvent<Boolean> event)
+         {
+            lastRow_ = 0;
+            boolean showToolbars = event.getValue();
+            
+            if (showToolbars)
+               syncWidgets();
+            else
+               removeAllToolbars();
+         }
+      });
    }
    
    private void removeAllToolbars()
@@ -142,6 +160,11 @@ public class TextEditingTargetChunks
    
    private void syncWidgets()
    {
+      // bail early if we don't want to render inline toolbars
+      boolean showInlineToolbars = prefs_.showInlineToolbarForRCodeChunks().getValue();
+      if (!showInlineToolbars)
+         return;
+      
       Scope currentScope = target_.getDocDisplay().getCurrentScope();
       if (initialized_ && currentScope != null && 
           lastRow_ == currentScope.getPreamble().getRow())
@@ -240,7 +263,9 @@ public class TextEditingTargetChunks
    
    private boolean dark_;
    private boolean initialized_;
+   
    private AceThemes themes_;
+   private UIPrefs prefs_;
 
    private int lastRow_;
    


### PR DESCRIPTION
It looks like we were failing to respect the 'Show inline toolbar for R code chunks' preference -- this PR adds it back in.

@jmcphers, since you're most familiar with the new inline toolbar drawing code, can you review?