### PR TITLE
apply theme colors to html notebook chunks with retries to wait for load

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkHtmlPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkHtmlPage.java
@@ -107,17 +107,43 @@ public class ChunkHtmlPage extends ChunkOutputPage
    public void onSelected()
    {
       // no action necessary for HTML widgets
+      updateHtmlPageTheme();
    }
 
    @Override
    public void onEditorThemeChanged(Colors colors)
    {
-      Element body = frame_.getDocument().getBody();
-      Style bodyStyle = body.getStyle();
-      bodyStyle.setColor(colors.foreground);
+      themeColors_ = colors;
+      updateHtmlPageTheme();
+   }
+
+   private void updateHtmlPageTheme()
+   {
+      if (themeColors_ == null) return;
+
+      Timer updateThemeTimer = new Timer() {
+         private int retryCount_ = 0;
+
+         @Override
+         public void run()
+         {
+            Element body = frame_.getDocument().getBody();
+
+            if (body.getChildCount() > 0) {
+               Style bodyStyle = body.getStyle();
+               bodyStyle.setColor(themeColors_.foreground);
+            } else if (retryCount_ < 50) {
+               retryCount_++;
+               schedule(100);
+            }
+         }
+      };
+      
+      updateThemeTimer.schedule(100);
    }
 
    private ChunkOutputFrame frame_;
    final private Widget thumbnail_;
    final private Widget content_;
+   private Colors themeColors_ = null;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkHtmlPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkHtmlPage.java
@@ -89,6 +89,26 @@ public class ChunkHtmlPage extends ChunkOutputPage
             frameFinishLoadTimer.schedule(100);
          };
       });
+
+      afterRender_ = new Command() {
+         @Override
+         public void execute()
+         {
+            Element body = frame_.getDocument().getBody();
+
+            Style bodyStyle = body.getStyle();
+      
+            bodyStyle.setPadding(0, Unit.PX);
+            bodyStyle.setMargin(0, Unit.PX);
+
+            if (themeColors_ != null)
+            {
+               bodyStyle.setColor(themeColors_.foreground);
+            }
+         }
+      };
+
+      frame_.runAfterRender(afterRender_);
    }
       
    @Override
@@ -106,44 +126,19 @@ public class ChunkHtmlPage extends ChunkOutputPage
    @Override
    public void onSelected()
    {
-      // no action necessary for HTML widgets
-      updateHtmlPageTheme();
+      frame_.runAfterRender(afterRender_);
    }
 
    @Override
    public void onEditorThemeChanged(Colors colors)
    {
       themeColors_ = colors;
-      updateHtmlPageTheme();
-   }
-
-   private void updateHtmlPageTheme()
-   {
-      if (themeColors_ == null) return;
-
-      Timer updateThemeTimer = new Timer() {
-         private int retryCount_ = 0;
-
-         @Override
-         public void run()
-         {
-            Element body = frame_.getDocument().getBody();
-
-            if (body.getChildCount() > 0) {
-               Style bodyStyle = body.getStyle();
-               bodyStyle.setColor(themeColors_.foreground);
-            } else if (retryCount_ < 50) {
-               retryCount_++;
-               schedule(100);
-            }
-         }
-      };
-      
-      updateThemeTimer.schedule(100);
+      afterRender_.execute();
    }
 
    private ChunkOutputFrame frame_;
    final private Widget thumbnail_;
    final private Widget content_;
    private Colors themeColors_ = null;
+   private Command afterRender_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputFrame.java
@@ -16,6 +16,7 @@ package org.rstudio.studio.client.workbench.views.source.editors.text;
 
 import org.rstudio.core.client.widget.DynamicIFrame;
 
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Timer;
 
@@ -81,6 +82,30 @@ public class ChunkOutputFrame extends DynamicIFrame
    {
       if (onCompleted_ != null)
          onCompleted_.execute();
+   }
+
+   public void runAfterRender(final Command command)
+   {
+      if (command == null) return;
+
+      Timer onRenderedTimer = new Timer() {
+         private int retryCount_ = 0;
+
+         @Override
+         public void run()
+         {
+            Element body = getDocument().getBody();
+
+            if (body.getChildCount() > 0) {
+               command.execute();
+            } else if (retryCount_ < 50) {
+               retryCount_++;
+               schedule(100);
+            }
+         }
+      };
+      
+      onRenderedTimer.schedule(100);
    }
    
    private final Timer timer_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -42,6 +42,7 @@ import com.google.gwt.dom.client.Style.Overflow;
 import com.google.gwt.dom.client.Style.Position;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Widget;
@@ -258,6 +259,8 @@ public class ChunkOutputStream extends FlowPanel
             }
             
             onHeightChanged();
+
+            updateHtmlChunkTheme(frame, ChunkOutputWidget.getEditorColors());
          };
       });
    }
@@ -381,6 +384,33 @@ public class ChunkOutputStream extends FlowPanel
          }
       }
    }
+
+   private void updateHtmlChunkTheme(
+      final ChunkOutputFrame frame,
+      final EditorThemeListener.Colors colors)
+   {
+      if (colors == null) return;
+
+      Timer updateThemeTimer = new Timer() {
+         private int retryCount_ = 0;
+
+         @Override
+         public void run()
+         {
+            Element body = frame.getDocument().getBody();
+
+            if (body.getChildCount() > 0) {
+               Style bodyStyle = body.getStyle();
+               bodyStyle.setColor(colors.foreground);
+            } else if (retryCount_ < 50) {
+               retryCount_++;
+               schedule(100);
+            }
+         }
+      };
+      
+      updateThemeTimer.schedule(100);
+   }
    
    @Override
    public void onEditorThemeChanged(EditorThemeListener.Colors colors)
@@ -391,8 +421,7 @@ public class ChunkOutputStream extends FlowPanel
          if (w instanceof ChunkOutputFrame)
          {
             ChunkOutputFrame frame = (ChunkOutputFrame)w;
-            Style bodyStyle = frame.getDocument().getBody().getStyle();
-            bodyStyle.setColor(colors.foreground);
+            updateHtmlChunkTheme(frame, colors);
          }
          else if (w instanceof EditorThemeListener)
          {


### PR DESCRIPTION
Fixing two timing issues where html chunks had no color themes applied since the page loads after the call to apply themes. Fix applied to stream and gallery since it repros in both. With fix:

<img width="829" alt="screen shot 2016-10-28 at 3 47 44 pm" src="https://cloud.githubusercontent.com/assets/3478847/19824620/f10ff31a-9d25-11e6-89b9-e7faa81a1f42.png">
<img width="830" alt="screen shot 2016-10-28 at 3 47 56 pm" src="https://cloud.githubusercontent.com/assets/3478847/19824619/f10f5cfc-9d25-11e6-8045-9d19550ae234.png">
