### PR TITLE
Avoid nested restarts to prevent crashes during restart

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
@@ -464,6 +464,10 @@ public class ApplicationQuit implements SaveActionChangedHandler,
    @Override
    public void onSuspendAndRestart(final SuspendAndRestartEvent event)
    {
+      // Ignore nested restarts once restart starts
+      if (suspendingAndRestarting_) return;
+      suspendingAndRestarting_ = true;
+
       // set restart pending for desktop
       setPendinqQuit(DesktopFrame.PENDING_QUIT_AND_RESTART);
       
@@ -485,6 +489,8 @@ public class ApplicationQuit implements SaveActionChangedHandler,
                @Override
                public void execute()
                {
+                  suspendingAndRestarting_ = false;
+
                   eventBus_.fireEvent(new RestartStatusEvent(
                                     RestartStatusEvent.RESTART_COMPLETED));
                   
@@ -495,6 +501,8 @@ public class ApplicationQuit implements SaveActionChangedHandler,
          @Override
          protected void onFailure()
          {
+            suspendingAndRestarting_ = false;
+
             eventBus_.fireEvent(
                new RestartStatusEvent(RestartStatusEvent.RESTART_COMPLETED));
             
@@ -773,4 +781,6 @@ public class ApplicationQuit implements SaveActionChangedHandler,
    private final SourceShim sourceShim_;
    
    private SaveAction saveAction_ = SaveAction.saveAsk();
+
+   private boolean suspendingAndRestarting_ = false;
 }


### PR DESCRIPTION
Multiple subsequent restarts crash the IDE. While I spent some time trying to narrow this down, the code in https://github.com/rstudio/rstudio/blob/master/src/cpp/r/session/RSession.cpp#L1598-L1654 does not seem safe to reentrancy to me. The fact that we are saving the session state and allowing another overlapping restart seems dangerous enough to be blocked. Thoughts? Can anyone think of a case where a user would actually be interested in restarting during a restart that currently works as expected?