### PR TITLE
evaluate notebook condition handler code in base namespace

### DIFF
--- a/src/cpp/r/RExec.cpp
+++ b/src/cpp/r/RExec.cpp
@@ -237,16 +237,24 @@ core::Error executeSafely(boost::function<SEXP()> function, SEXP* pSEXP)
    }
 }
 
-Error executeStringUnsafe(const std::string& str, SEXP* pSEXP, 
-      sexp::Protect* pProtect)
+Error executeStringUnsafe(const std::string& str,
+                          SEXP envirSEXP,
+                          SEXP* pSEXP, 
+                          sexp::Protect* pProtect)
 {
    SEXP parsedSEXP = R_NilValue;
    Error error = r::exec::parseString(str, &parsedSEXP, pProtect);
    if (error)
       return error;
    
-   return evaluateExpressionsUnsafe(parsedSEXP, R_GlobalEnv, 
-         pSEXP, pProtect, EvalDirect);
+   return evaluateExpressionsUnsafe(parsedSEXP, envirSEXP, pSEXP, pProtect, EvalDirect);
+}
+
+Error executeStringUnsafe(const std::string& str,
+                          SEXP* pSEXP, 
+                          sexp::Protect* pProtect)
+{
+   return executeStringUnsafe(str, R_GlobalEnv, pSEXP, pProtect);
 }
   
 Error executeString(const std::string& str)

--- a/src/cpp/r/include/r/RExec.hpp
+++ b/src/cpp/r/include/r/RExec.hpp
@@ -75,8 +75,13 @@ core::Error executeSafely(boost::function<T()> function, T* pReturn)
    
 // parse and evaluate expressions  
 core::Error executeStringUnsafe(const std::string& str, 
-                        SEXP* pSEXP, 
-                        sexp::Protect* pProtect);
+                                SEXP* pSEXP, 
+                                sexp::Protect* pProtect);
+core::Error executeStringUnsafe(const std::string& str,
+                                SEXP envirSEXP,
+                                SEXP* pSEXP,
+                                sexp::Protect* pProtect);
+
 core::Error executeString(const std::string& str);
 core::Error evaluateString(const std::string& str, 
                            SEXP* pSEXP, 

--- a/src/cpp/session/modules/rmarkdown/NotebookConditions.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookConditions.cpp
@@ -67,7 +67,7 @@ void ConditionCapture::connect()
          "          m$message); "
          "   invokeRestart(\"muffleMessage\") "
          " } "
-         "), .GlobalEnv, NULL, TRUE))", &retSEXP, &protect);
+         "), .GlobalEnv, NULL, TRUE))", R_BaseNamespace, &retSEXP, &protect);
    if (error)
    {
       LOG_ERROR(error);
@@ -101,7 +101,7 @@ void ConditionCapture::disconnect()
       Error error = r::exec::executeStringUnsafe(
             ".Internal(.resetCondHands(get(\"_rs_handlerStack\", "
             "   envir = as.environment(\"tools:rstudio\")))) ",
-            &retSEXP, &protect);
+            R_BaseNamespace, &retSEXP, &protect);
       if (error)
          LOG_ERROR(error);
 
@@ -109,7 +109,7 @@ void ConditionCapture::disconnect()
       error = r::exec::executeStringUnsafe(
             "rm(\"_rs_handlerStack\", "
             "   envir = as.environment(\"tools:rstudio\"))",
-            &retSEXP, &protect);
+            R_BaseNamespace, &retSEXP, &protect);
       if (error)
          LOG_ERROR(error);
    }


### PR DESCRIPTION
This PR resolves an infinite loop error that occurs when executing a notebook chunk if the user has defined a custom function called `c` in the global environment.

The overarching issue -- `evaluateStringUnsafe` evaluates its code in the global environment by default; hence, symbols will be resolved from there as well. This implies that any user-defined functions or symbols in the global environment that mask those in `base` will be picked up instead (note that in some occasions this behavior might actually be desired, but that isn't the case here).

The change here ensures that we evaluate the handler-attaching code directly in the base namespace.