### PR TITLE
split source database files into contents + properties

### DIFF
--- a/src/cpp/session/SessionSourceDatabase.cpp
+++ b/src/cpp/session/SessionSourceDatabase.cpp
@@ -87,7 +87,7 @@ struct PropertiesDatabase
 
 Error getPropertiesDatabase(PropertiesDatabase* pDatabase)
 {
-   pDatabase->path = module_context::scopedScratchPath().complete("sdb/prop");
+   pDatabase->path = module_context::scopedScratchPath().complete(kSessionSourceDatabasePrefix "/prop");
    Error error = pDatabase->path.ensureDirectory();
    if (error)
       return error;

--- a/src/cpp/session/SessionSourceDatabase.cpp
+++ b/src/cpp/session/SessionSourceDatabase.cpp
@@ -461,7 +461,7 @@ void SourceDocument::writeToJson(json::Object* pDocJson, bool includeContents) c
    jsonDoc["project_path"] = pathToProjectPath(path_);
    jsonDoc["type"] = !type().empty() ? type_ : json::Value();
    jsonDoc["hash"] = hash();
-   if (includeContents) jsonDoc["contents"] = contents();
+   jsonDoc["contents"] = includeContents ? contents() : std::string();
    jsonDoc["dirty"] = dirty();
    jsonDoc["created"] = created();
    jsonDoc["source_on_save"] = sourceOnSave();
@@ -606,7 +606,7 @@ Error get(const std::string& id, bool includeContents, boost::shared_ptr<SourceD
       
       // embed 'contents' in properties file (we always write this when not
       // available just to ensure unchecked access to 'contents' succeeds)
-      if (!jsonDoc.count("contents"))
+      if (includeContents || !jsonDoc.count("contents"))
          jsonDoc["contents"] = contents;
       
       return pDoc->readFromJson(&jsonDoc);

--- a/src/cpp/session/SessionSourceDatabaseSupervisor.cpp
+++ b/src/cpp/session/SessionSourceDatabaseSupervisor.cpp
@@ -56,17 +56,17 @@ FilePath oldSourceDatabaseRoot()
 
 FilePath sourceDatabaseRoot()
 {
-   return module_context::scopedScratchPath().complete("sdb");
+   return module_context::scopedScratchPath().complete(kSessionSourceDatabasePrefix);
 }
 
 FilePath mostRecentTitledDir()
 {
-   return module_context::scopedScratchPath().complete("sdb/mt");
+   return module_context::scopedScratchPath().complete(kSessionSourceDatabasePrefix "/mt");
 }
 
 FilePath mostRecentUntitledDir()
 {
-   return module_context::scopedScratchPath().complete("sdb/mu");
+   return module_context::scopedScratchPath().complete(kSessionSourceDatabasePrefix "/mu");
 }
 
 

--- a/src/cpp/session/SessionSourceDatabaseSupervisor.hpp
+++ b/src/cpp/session/SessionSourceDatabaseSupervisor.hpp
@@ -16,6 +16,8 @@
 #ifndef SESSION_SOURCE_DATABASE_SUPERVISOR_HPP
 #define SESSION_SOURCE_DATABASE_SUPERVISOR_HPP
 
+#define kSessionSourceDatabasePrefix "sources"
+
 namespace rstudio {
 namespace core {
    class Error;

--- a/src/cpp/session/include/session/SessionSourceDatabase.hpp
+++ b/src/cpp/session/include/session/SessionSourceDatabase.hpp
@@ -144,7 +144,7 @@ public:
    core::Error readFromJson(core::json::Object* pDocJson);
    void writeToJson(core::json::Object* pDocJson, bool includeContents = true) const;
 
-   core::Error writeToFile(const core::FilePath& filePath) const;
+   core::Error writeToFile(const core::FilePath& filePath, bool writeContents = true) const;
 
    SEXP toRObject(r::sexp::Protect* pProtect, bool includeContents = true) const;
 
@@ -187,10 +187,11 @@ bool sortByRelativeOrder(const boost::shared_ptr<SourceDocument>& pDoc1,
 
 core::FilePath path();
 core::Error get(const std::string& id, boost::shared_ptr<SourceDocument> pDoc);
+core::Error get(const std::string& id, bool includeContents, boost::shared_ptr<SourceDocument> pDoc);
 core::Error getDurableProperties(const std::string& path,
                                  core::json::Object* pProperties);
 core::Error list(std::vector<boost::shared_ptr<SourceDocument> >* pDocs);
-core::Error put(boost::shared_ptr<SourceDocument> pDoc);
+core::Error put(boost::shared_ptr<SourceDocument> pDoc, bool writeContents = true);
 core::Error remove(const std::string& id);
 core::Error removeAll();
 core::Error getPath(const std::string& id, std::string* pPath);

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -110,11 +110,11 @@ int numSourceDocuments()
 
 // wrap source_database::put for situations where there are new contents
 // (so we can index the contents)
-Error sourceDatabasePutWithUpdatedContents(
-                              boost::shared_ptr<SourceDocument> pDoc)
+Error sourceDatabasePutWithUpdatedContents(boost::shared_ptr<SourceDocument> pDoc,
+                                           bool writeContents = true)
 {
    // write the file to the database
-   Error error = source_database::put(pDoc);
+   Error error = source_database::put(pDoc, writeContents);
    if (error)
       return error ;
 
@@ -393,15 +393,17 @@ Error saveDocument(const json::JsonRpcRequest& request,
    boost::shared_ptr<SourceDocument> pDoc(new SourceDocument());
    error = source_database::get(id, pDoc);
    if (error)
-      return error ;
+      return error;
    
+   // check if the document contents have changed
+   bool hasChanges = contents != pDoc->contents();
    error = saveDocumentCore(contents, jsonPath, jsonType, jsonEncoding,
                             jsonFoldSpec, jsonChunkOutput, pDoc);
    if (error)
       return error;
    
    // write to the source_database
-   error = sourceDatabasePutWithUpdatedContents(pDoc);
+   error = sourceDatabasePutWithUpdatedContents(pDoc, hasChanges);
    if (error)
       return error;
 
@@ -476,13 +478,16 @@ Error saveDocumentDiff(const json::JsonRpcRequest& request,
       contents.erase(rangeBegin, rangeEnd);
       contents.insert(rangeBegin, replacement.begin(), replacement.end());
       
+      // track if we're updating the document contents
+      bool hasChanges = contents != pDoc->contents();
       error = saveDocumentCore(contents, jsonPath, jsonType, jsonEncoding,
                                jsonFoldSpec, jsonChunkOutput, pDoc);
       if (error)
          return error;
       
-      // write to the source_database
-      error = sourceDatabasePutWithUpdatedContents(pDoc);
+      // write to the source database (don't worry about writing document
+      // contents if those have not changed)
+      error = sourceDatabasePutWithUpdatedContents(pDoc, hasChanges);
       if (error)
          return error;
 
@@ -666,13 +671,13 @@ Error modifyDocumentProperties(const json::JsonRpcRequest& request,
 
    // get the doc
    boost::shared_ptr<SourceDocument> pDoc(new SourceDocument());
-   error = source_database::get(id, pDoc);
+   error = source_database::get(id, false, pDoc);
    if (error)
       return error ;
 
    // edit properties and write the document
    pDoc->editProperties(properties);
-   return source_database::put(pDoc);
+   return source_database::put(pDoc, false);
 }
 
 Error getDocumentProperties(const json::JsonRpcRequest& request,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
@@ -29,7 +29,6 @@ import org.rstudio.core.client.Barrier.Token;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.DebouncedCommand;
 import org.rstudio.core.client.Debug;
-import org.rstudio.core.client.TimeBufferedCommand;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.patch.SubstringDiff;
 import org.rstudio.core.client.widget.Operation;


### PR DESCRIPTION
This PR splits the source database files into two files: one containing the document properties, and one containing the document contents. This PR should allow us to update the document properties without forcing a (potentially large) re-write of the file's contents as well.

The scheme used here attempts to be backwards compatible with the old source database scheme. We achieve this in the following way -- for a document with ID `abc123`, we:

1. Write the document properties to the same file as we would have before (`abc123`),
2. Write the document contents (if requested) to a side-car file (`abc123-contents`).

When reading a document from the source database, we construct the same JSON payload as used before; that is:

1. We read the document properties as JSON (note that for older versions of the source database this will include document contents),
2. If the `-contents` sidecar file exists, then we will inject those document contents into the JSON payload.

With this split, we now try to detect if we really need to write the document contents to file -- we only write the document contents in the source database if those contents have actually changed, and attempts to modify document properties do not update the document contents.

@jjallaire @jmcphers let me know if this all sounds sensible, or if you think an alternate approach is warranted here. Initial testing seems to indicate that this does work as expected, but definitely a close look is warranted!