### PR TITLE
tweaks around sizing of inline chunk popups

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/MiniPopupPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/MiniPopupPanel.java
@@ -75,6 +75,10 @@ public class MiniPopupPanel extends DecoratedPopupPanel
          pageY = bounds.getTop() - 10 - getOffsetHeight();
       }
       
+      // avoid leaking off left side of page
+      pageX = Math.max(20, pageX);
+      pageY = Math.max(20, pageY);
+      
       setPopupPosition(pageX, pageY);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkInlineOutput.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkInlineOutput.css
@@ -10,6 +10,9 @@
 
 .panel {
   background-color: #ffffff;
+  max-width: 600px;
+  max-height: 400px;
+  overflow: auto !important;
 }
 
 .panel pre {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkInlineOutput.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkInlineOutput.java
@@ -52,6 +52,7 @@ public class ChunkInlineOutput extends MiniPopupPanel
       chunkId_ = chunkId;
       selection_ = selection;
       state_ = State.Queued;
+      
       addStyleName(RES.styles().panel());
       
       // detach anchored selection when closing so we don't accumulate 


### PR DESCRIPTION
This PR ensures that we don't generate overly large inline chunk previews when executing inline R chunks (and also attempts to make sure we don't overflow the window, at least on the left + top).

