### PR TITLE
remove dependency to tibble

### DIFF
--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -143,6 +143,86 @@
 
 .rs.addFunction("readDataCapture", function(path)
 {
+  type_sum <- function(x) {
+    format_sum <- switch (class(x)[[1]],
+                          ordered = "ord",
+                          factor = "fctr",
+                          POSIXt = "dttm",
+                          difftime = "time",
+                          Date = date,
+                          data.frame = class(x)[[1]],
+                          tbl_df = "tibble",
+                          NULL
+    )
+    if (!is.null(format_sum)) {
+      format_sum
+    } else if (!is.object(x)) {
+      switch(typeof(x),
+             logical = "lgl",
+             integer = "int",
+             double = "dbl",
+             character = "chr",
+             complex = "cplx",
+             closure = "fun",
+             environment = "env",
+             typeof(x)
+      )
+    } else if (!isS4(x)) {
+      paste0("S3: ", class(x)[[1]])
+    } else {
+      paste0("S4: ", methods::is(x)[[1]])
+    }
+  }
+
+  "%||%" <- function(x, y) {
+    if(is.null(x)) y else x
+  }
+
+  big_mark <- function(x, ...) {
+    mark <- if (identical(getOption("OutDec"), ",")) "." else ","
+    formatC(x, big.mark = mark, ...)
+  }
+
+  dim_desc <- function(x) {
+    dim <- dim(x) %||% length(x)
+    format_dim <- vapply(dim, big_mark, character(1))
+    format_dim[is.na(dim)] <- "??"
+    paste0(format_dim, collapse = " \u00d7 ")
+  }
+
+  is_atomic <- function(x) {
+    is.atomic(x) && !is.null(x)
+  }
+
+  is_vector <- function(x) {
+    is_atomic(x) || is.list(x)
+  }
+
+  paged_table_is_vector_s3 <- function(x) {
+    switch(class(x)[[1]],
+      ordered = TRUE,
+      factor = TRUE,
+      Date = TRUE,
+      POSIXct = TRUE,
+      difftime = TRUE,
+      data.frame = TRUE,
+      !is.object(x) && is_vector(x))
+  }
+
+  size_sum <- function(x) {
+    if (!paged_table_is_vector_s3(x)) return("")
+
+    paste0(" [", dim_desc(x), "]" )
+  }
+
+  obj_sum <- function(x) {
+    switch(class(x)[[1]],
+      POSIXlt = rep("POSIXlt", length(x)),
+      list = vapply(x, obj_sum, character(1L)),
+      paste0(type_sum(x), size_sum(x))
+    )
+  }
+
   e <- new.env(parent = emptyenv())
   load(file = path, envir = e)
 
@@ -158,7 +238,7 @@
     function(columnIdx) {
       column <- data[[columnIdx]]
       baseType <- class(column)[[1]]
-      tibbleType <- tibble::type_sum(column)
+      tibbleType <- type_sum(column)
 
       list(
         label = if (!is.null(columnNames)) columnNames[[columnIdx]] else "",
@@ -192,7 +272,7 @@
 
   is_list <- vapply(data, is.list, logical(1))
   data[is_list] <- lapply(data[is_list], function(x) {
-        summary <- tibble::obj_sum(x)
+        summary <- obj_sum(x)
         paste0("<", summary, ">")
       })
 


### PR DESCRIPTION
Consider removing dependency to `tibble` since `tibble` currently requires `3.1.2`.

**Dependent**: Dependent on https://github.com/rstudio/rmarkdown/pull/853