### PR TITLE
don't save + restore workspace for 'install.packages'

### DIFF
--- a/src/cpp/r/session/RSearchPath.cpp
+++ b/src/cpp/r/session/RSearchPath.cpp
@@ -226,17 +226,20 @@ void attachEnvironmentData(const FilePath& dataFilePath,
 } // anonymous namespace
    
 
-Error save(const FilePath& statePath)
+Error save(const FilePath& statePath, bool saveWorkspace)
 {
-   // save the global environment
-   FilePath environmentFile = statePath.complete(kEnvironmentFile);
-   Error error = saveGlobalEnvironmentToFile(environmentFile);
-   if (error)
-      return error;
+   // save the global environment if requested
+   if (saveWorkspace)
+   {
+      FilePath environmentFile = statePath.complete(kEnvironmentFile);
+      Error error = saveGlobalEnvironmentToFile(environmentFile);
+      if (error)
+         return error;
+   }
    
    // reset the contents of the search path dir
    FilePath searchPathDir = statePath.complete(kSearchPathDir);
-   error = searchPathDir.resetDirectory();
+   Error error = searchPathDir.resetDirectory();
    if (error)
       return error ;
    

--- a/src/cpp/r/session/RSearchPath.hpp
+++ b/src/cpp/r/session/RSearchPath.hpp
@@ -28,7 +28,7 @@ namespace r {
 namespace session {
 namespace search_path {
 
-core::Error save(const core::FilePath& statePath);
+core::Error save(const core::FilePath& statePath, bool saveWorkspace);
 core::Error saveGlobalEnvironment(const core::FilePath& statePath);
 core::Error restore(const core::FilePath& statePath);
    

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -213,6 +213,7 @@ bool saveSessionState(const RSuspendOptions& options,
       return r::session::state::save(suspendedSessionPath,
                                      s_options.serverMode,
                                      options.excludePackages,
+                                     options.saveWorkspace,
                                      disableSaveCompression);
    }
 }

--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -289,6 +289,7 @@ void saveWorkingContext(const FilePath& statePath,
 bool save(const FilePath& statePath,
           bool serverMode,
           bool excludePackages,
+          bool saveWorkspace,
           bool disableSaveCompression)
 {
    // initialize context
@@ -366,14 +367,14 @@ bool save(const FilePath& statePath,
 
    if (!excludePackages)
    {
-      error = search_path::save(statePath);
+      error = search_path::save(statePath, saveWorkspace);
       if (error)
       {
          reportError(kSaving, kSearchPath, error, ERROR_LOCATION);
          saved = false;
       }
    }
-   else
+   else if (saveWorkspace)
    {
       error = search_path::saveGlobalEnvironment(statePath);
       if (error)

--- a/src/cpp/r/session/RSessionState.hpp
+++ b/src/cpp/r/session/RSessionState.hpp
@@ -36,6 +36,7 @@ namespace state {
 bool save(const core::FilePath& statePath,
           bool serverMode,
           bool excludePackages,
+          bool saveWorkspace,
           bool disableSaveCompression);
 
 bool saveMinimal(const core::FilePath& statePath,

--- a/src/gwt/src/org/rstudio/studio/client/application/events/SuspendAndRestartEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/SuspendAndRestartEvent.java
@@ -48,7 +48,7 @@ public class SuspendAndRestartEvent extends GwtEvent<SuspendAndRestartHandler>
                                  String afterRestartCommand)
    {
       if (suspendOptions == null)
-         suspendOptions = SuspendOptions.createSaveAll(false);
+         suspendOptions = SuspendOptions.createSaveAll(true, false);
       suspendOptions_ = suspendOptions;
       afterRestartCommand_ = afterRestartCommand;
    }

--- a/src/gwt/src/org/rstudio/studio/client/application/model/SuspendOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/model/SuspendOptions.java
@@ -22,9 +22,10 @@ public class SuspendOptions extends JavaScriptObject
    {  
    }
    
-   public static final SuspendOptions createSaveAll(boolean excludePackages) 
+   public static final SuspendOptions createSaveAll(boolean saveWorkspace,
+                                                    boolean excludePackages)
    {
-      return create(false, false, excludePackages);
+      return create(false, saveWorkspace, excludePackages);
    }
    
    public static final SuspendOptions createSaveMinimal(boolean saveWorkspace) 
@@ -43,7 +44,7 @@ public class SuspendOptions extends JavaScriptObject
    }-*/;
    
    /*
-    * Indidates that only a minimal amount of session state should be 
+    * Indicates that only a minimal amount of session state should be 
     * saved (e.g. working directory and up-arrow history). 
     * 
     * If this option is true then the save_workspace option will be 
@@ -56,9 +57,6 @@ public class SuspendOptions extends JavaScriptObject
       return this.save_minimal;
    }-*/;
 
-   /*
-    * This option is only consulted if save_minimal is true
-    */
    public native final boolean getSaveWorkspace() /*-{
       return this.save_workspace;
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -921,7 +921,7 @@ public class Packages
             new Operation() { public void execute()
             {
                events_.fireEvent(new SuspendAndRestartEvent(
-                      SuspendOptions.createSaveAll(true), installCmd));  
+                      SuspendOptions.createSaveAll(false, true), installCmd));  
                   
             }},
             new Operation() { public void execute()


### PR DESCRIPTION
This PR seeks to resolve a loop that can occur when attempting to install a package that is currently loaded.

The overarching issue -- when RStudio restarts the session when installing a package, it also saves and restores the global environment. However, certain objects can force the load of a package namespace -- if the namespace of the package which we want to install is inadvertently loaded while restoring the global environment, then RStudio will present us with the same prompt again.

![install-loop](https://cloud.githubusercontent.com/assets/1976582/19951602/5cf5efa4-a11c-11e6-81bb-2a1e6abdff12.gif)

This PR seeks to resolve the issue by passing along the `saveWorkspace` argument through the regular `save` call. Previously, this argument was ignored (from the comments before it appears this was intentional, although I don't know why exactly); so the change here just makes sure that we respect this option in the regular `save` code path.

One major change with this PR is that we now actually discard the global environment when restarting for a package installation -- we could also defer restoration of the global environment instead until after the `install.packages()` command has run to completion.