### PR TITLE
Enable display of diagnostics when publishing

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/js/JsObject.java
+++ b/src/gwt/src/org/rstudio/core/client/js/JsObject.java
@@ -144,6 +144,10 @@ public class JsObject extends JavaScriptObject
    public final native void _setBoolean(String key, boolean value) /*-{
       this[key] = value;
    }-*/;
+   
+   public final native void setJsArrayString(String key, JsArrayString value) /*-{
+      this[key] = value;
+   }-*/;
 
    public final native JsArrayString keys() /*-{
       return Object.keys(this);

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSettings.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSettings.java
@@ -16,6 +16,12 @@ package org.rstudio.studio.client.rsconnect.model;
 
 import java.util.ArrayList;
 
+import org.rstudio.core.client.JsArrayUtil;
+import org.rstudio.core.client.js.JsObject;
+import org.rstudio.studio.client.RStudioGinjector;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
 public class RSConnectPublishSettings
 {
    public RSConnectPublishSettings(ArrayList<String> deployFiles, 
@@ -54,6 +60,23 @@ public class RSConnectPublishSettings
    public boolean getAsStatic()
    {
       return asStatic_;
+   }
+   
+   public JavaScriptObject toJso()
+   {
+      JsObject obj = JsObject.createJsObject();
+      obj.setJsArrayString("deploy_files", 
+            JsArrayUtil.toJsArrayString(getDeployFiles()));
+      obj.setJsArrayString("additional_files", 
+            JsArrayUtil.toJsArrayString(getAdditionalFiles()));
+      obj.setJsArrayString("ignored_files", 
+            JsArrayUtil.toJsArrayString(getIgnoredFiles()));
+      obj.setBoolean("as_multiple", getAsMultiple());
+      obj.setBoolean("as_static", getAsStatic());
+      obj.setBoolean("show_diagnostics", 
+            RStudioGinjector.INSTANCE.getUIPrefs()
+                            .showPublishDiagnostics().getValue());
+      return obj.cast();
    }
 
    private final ArrayList<String> deployFiles_;

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSource.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSource.java
@@ -16,7 +16,10 @@ package org.rstudio.studio.client.rsconnect.model;
 
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.files.FileSystemItem;
+import org.rstudio.core.client.js.JsObject;
 import org.rstudio.studio.client.rsconnect.RSConnect;
+
+import com.google.gwt.core.client.JavaScriptObject;
 
 public class RSConnectPublishSource
 {
@@ -188,6 +191,23 @@ public class RSConnectPublishSource
    public boolean isStatic()
    {
       return isStatic_;
+   }
+   
+   public JavaScriptObject toJso()
+   {
+      // create summary of publish source for server
+      JsObject obj = JsObject.createJsObject();
+      obj.setString("deploy_dir", getDeployDir());
+      obj.setString("deploy_file", isDocument() ||
+            isSingleFileShiny() ? getDeployFileName() : "");
+      obj.setString("source_file", 
+            isDocument() && 
+            getSourceFile() != null && 
+            getContentCategory() != RSConnect.CONTENT_CATEGORY_SITE ?
+               getSourceFile() : "");
+      obj.setString("content_category", StringUtil.notNull(
+            getContentCategory()));
+      return obj.cast();
    }
    
    private final String deployFile_;

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -3964,25 +3964,12 @@ public class RemoteServer implements Server
          ServerRequestCallback<Boolean> requestCallback)
    {
       JSONArray params = new JSONArray();
-      params.set(0, new JSONString(source.getDeployDir()));
-      params.set(1, JSONUtils.toJSONStringArray(settings.getDeployFiles()));
-      params.set(2, new JSONString(source.isDocument() ||
-            source.isSingleFileShiny() ? source.getDeployFileName() : ""));
-      params.set(3, new JSONString(
-            source.isDocument() && 
-            source.getSourceFile() != null && 
-            source.getContentCategory() != RSConnect.CONTENT_CATEGORY_SITE ?
-               source.getSourceFile() : ""));
-      params.set(4, new JSONString(account));
-      params.set(5, new JSONString(server));
-      params.set(6, new JSONString(appName));
-      params.set(7, new JSONString(appTitle == null ? "": appTitle));
-      params.set(8, new JSONString(source.getContentCategory() == null ? "" :
-            source.getContentCategory()));
-      params.set(9, JSONUtils.toJSONStringArray(settings.getAdditionalFiles()));
-      params.set(10, JSONUtils.toJSONStringArray(settings.getIgnoredFiles()));
-      params.set(11, JSONBoolean.getInstance(settings.getAsMultiple()));
-      params.set(12, JSONBoolean.getInstance(settings.getAsStatic()));
+      params.set(0, new JSONObject(source.toJso()));
+      params.set(1, new JSONObject(settings.toJso()));
+      params.set(2, new JSONString(account));
+      params.set(3, new JSONString(server));
+      params.set(4, new JSONString(appName));
+      params.set(5, new JSONString(StringUtil.notNull(appTitle)));
       sendRequest(RPC_SCOPE,
             RSCONNECT_PUBLISH,
             params,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -545,6 +545,11 @@ public class UIPrefsAccessor extends Prefs
       return object("preferred_publish_account");
    }
    
+   public PrefValue<Boolean> showPublishDiagnostics()
+   {
+      return bool("show_publish_diagnostics", false);
+   }
+   
    public PrefValue<String> connectionsDbInterface()
    {
       return string("connections_db_interface", 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PublishingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PublishingPreferencesPane.java
@@ -204,6 +204,9 @@ public class PublishingPreferencesPane extends PreferencesPane
       if (RSConnect.showRSConnectUI())
          add(rsconnectPanel);
       
+      add(checkboxPref("Show diagnostic information when publishing",
+            uiPrefs_.showPublishDiagnostics()));
+      
       server_.hasOrphanedAccounts(new ServerRequestCallback<Int>()
       {
          @Override


### PR DESCRIPTION
This change adds a new UI pref that turns on a diagnostic mode for publishing.

![image](https://cloud.githubusercontent.com/assets/470418/19951660/d2ed347e-a11c-11e6-8f19-b157bda94764.png)

When enabled, lots of additional information is emitted to the Deploy tab, including:

- the full text of the `deployApp` command submitted on the user's behalf
- the user's `sessionInfo()`
- all the JSON messages sent and received from the server
- a full stack trace for any locally occurring errors

As part of this change, I've done some shallow refactoring on the publish RPC. It has so many parameters that we have to modify our function templates every time we add one. I've split the major groupings of parameters into objects.