### PR TITLE
add data import support for havens data_file new parameter

### DIFF
--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -424,9 +424,9 @@
          # load parameters
          options <- list()
 
-         # current version of haven uses "path", next version uses "file"
+         # current version of haven uses "path", next version uses "file" or "data_file"
          options[["path"]] <- options[["file"]] <- cacheOrFileFromOptions(dataImportOptions)
-         options[["b7dat"]] <- cacheOrFileFromOptions(dataImportOptions)
+         options[["b7dat"]] <- options[["data_file"]] <- cacheOrFileFromOptions(dataImportOptions)
          options[["b7cat"]] <- cacheOrFileFromOptions(dataImportOptions, "modelLocation")
 
          havenFunction <- switch(dataImportOptions$format,
@@ -440,7 +440,7 @@
          # set special parameter types
          optionTypes <- list()
          optionTypes[["path"]] <- optionTypes[["file"]] <- cacheTypeOrFileTypeFromOptions(dataImportOptions)
-         optionTypes[["b7dat"]] <- cacheTypeOrFileTypeFromOptions(dataImportOptions)
+         optionTypes[["b7dat"]] <- optionTypes[["data_file"]] <- cacheTypeOrFileTypeFromOptions(dataImportOptions)
          optionTypes[["b7cat"]] <- cacheTypeOrFileTypeFromOptions(dataImportOptions, "modelLocation")
 
          return(list(


### PR DESCRIPTION
Importing a `sas` file with `haven` `1.0.0` fails to add the file name. `haven` renamed the `b7dat` to `data_file` (https://github.com/tidyverse/haven/commit/884980a6ccac6db3c1da5b1b3c67f6247c1abc60) which prevents the us from setting this parameter. Fix is to maintain backwards compatibility with the `b7dat` and add the `data_file`. We caught a similar issue where `path` became `file` but we missed this renamed that came a bit later on the the `1.0` release.