### PR TITLE
update pagedtable.js from rmarkdown to enable notebook preview

### DIFF
--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -253,7 +253,7 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    data <- .rs.readDataCapture(rdfPath)
    
    paste(
-      "<div data-pagedtable>",
+      "<div data-pagedtable=\"false\">",
       "  <script data-pagedtable-source type=\"application/json\">",
       jsonlite::toJSON(data),
       "  </script>",

--- a/src/cpp/session/resources/pagedtable/pagedtable.js
+++ b/src/cpp/session/resources/pagedtable/pagedtable.js
@@ -539,6 +539,7 @@ var PagedTable = function (pagedTable) {
       }
 
       var columnName = document.createElement("div");
+      columnName.setAttribute("class", "pagedtable-header-name");
       if (columnData.label === "") {
         columnName.innerHTML = "&nbsp;";
       }
@@ -1121,8 +1122,9 @@ var PagedTableDoc;
   PagedTableDoc.initAll = function() {
     allPagedTables = [];
 
-    var pagedTables = [].slice.call(document.querySelectorAll('[data-pagedtable]'));
+    var pagedTables = [].slice.call(document.querySelectorAll('[data-pagedtable="false"]'));
     pagedTables.forEach(function(pagedTable, idx) {
+      pagedTable.setAttribute("data-pagedtable", "true");
       pagedTable.setAttribute("pagedtable-page", 0);
       pagedTable.setAttribute("class", "pagedtable-wrapper");
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkDataWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkDataWidget.java
@@ -125,7 +125,7 @@ public class ChunkDataWidget extends SimplePanel
    private final native JavaScriptObject showDataOutputNative(JavaScriptObject data, 
          Element parent, boolean fullSize) /*-{
       var pagedTable = $doc.createElement("div");
-      pagedTable.setAttribute("data-pagedtable", "");
+      pagedTable.setAttribute("data-pagedtable", "false");
 
       if (fullSize) {
          pagedTable.setAttribute("class", "pagedtable-expand");


### PR DESCRIPTION
Need follow up from https://github.com/rstudio/rmarkdown/commit/ee5d8d4db58d02f249ef7627189cd87c87455de5 to allow `pagedtables` to render in notebook preview mode.

Preview does not render since the notebook preview injects (indirectly) the `js` resources from `rmarkdown` but generate the chunks in the `ide`. When `rmarkdown` introduced the `[data-pagedtable="false"]` attribute, the  `ide` code was not generating it as `data-pagedtable="false"` which made preview not find the `datatables`.

Some cases worth walking through (all fine with this change now):
 1. **old-ide old-markdown**: Works fine, both `js` scripts are the same.
 2. **new-ide new-markdown**: Works fine, both `js` scripts are the same.
 3. **old-ide new-markdown**: In this case, the old-ide does not assign `false` and new-markdown looks for `false` and the preview breaks. This is fixed with this PR.
 4. **new-ide old-rmarkdown**: In this case, the old-rmarkdown is going to look for the attribute `[data-pagedtable]` without caring about its default, so even when set to `false` in the ide, this would work fine.