### PR TITLE
set sizing policy to not-fill to allow height of html chunk for nonfigures to grow

### DIFF
--- a/src/cpp/session/modules/NotebookHtmlWidgets.R
+++ b/src/cpp/session/modules/NotebookHtmlWidgets.R
@@ -137,6 +137,7 @@
    # make width dinamic to size correctly non-figured
    if (!is.null(x$sizingPolicy$knitr) && identical(x$sizingPolicy$knitr$figure, FALSE)) {
       x$sizingPolicy$defaultWidth <- "auto"
+      x$sizingPolicy$browser$fill <- FALSE
    }
    
    # collect knitr options


### PR DESCRIPTION
The problem is that the sizing policy is causing the iframes html to be set to `height: 100%` which when rendered for nonfigures, takes 80px and never grows past that. The fix is to remove the `fill = false` property to allow the html inside the iframe to grow as needed and then the html widget chunk will grow in size.

With fix:

<img width="850" alt="screen shot 2016-11-03 at 5 43 30 pm" src="https://cloud.githubusercontent.com/assets/3478847/19990725/190a50a6-a1ed-11e6-9a66-dbeda8855c56.png">
