### PR TITLE
respect active codepage for console output

### DIFF
--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -272,14 +272,14 @@ std::string utf8ToSystem(const std::string& str,
 #endif
 }
 
-std::string systemToUtf8(const std::string& str)
+std::string systemToUtf8(const std::string& str, int codepage)
 {
    if (str.empty())
       return std::string();
 
 #ifdef _WIN32
    wchar_t wide[str.length() + 1];
-   int chars = ::MultiByteToWideChar(CP_ACP, 0, str.c_str(), str.length(), wide, sizeof(wide));
+   int chars = ::MultiByteToWideChar(codepage, 0, str.c_str(), str.length(), wide, sizeof(wide));
    if (chars < 0)
    {
       LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));

--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -35,6 +35,10 @@
 #include <winnls.h>
 #endif
 
+#ifndef CP_ACP
+# define CP_ACP 0
+#endif
+
 namespace rstudio {
 namespace core {
 namespace string_utils {
@@ -302,6 +306,11 @@ std::string systemToUtf8(const std::string& str, int codepage)
 #else
    return str;
 #endif
+}
+
+std::string systemToUtf8(const std::string& str)
+{
+   return systemToUtf8(str, CP_ACP);
 }
 
 std::string toLower(const std::string& str)

--- a/src/cpp/core/include/core/StringUtils.hpp
+++ b/src/cpp/core/include/core/StringUtils.hpp
@@ -75,7 +75,7 @@ std::string getExtension(std::string const& str);
 
 std::string utf8ToSystem(const std::string& str,
                          bool escapeInvalidChars=false);
-std::string systemToUtf8(const std::string& str);
+std::string systemToUtf8(const std::string& str, int codepage = 0);
 
 std::string toLower(const std::string& str);
 std::string textToHtml(const std::string& str);

--- a/src/cpp/core/include/core/StringUtils.hpp
+++ b/src/cpp/core/include/core/StringUtils.hpp
@@ -75,7 +75,9 @@ std::string getExtension(std::string const& str);
 
 std::string utf8ToSystem(const std::string& str,
                          bool escapeInvalidChars=false);
-std::string systemToUtf8(const std::string& str, int codepage = 0);
+
+std::string systemToUtf8(const std::string& str);
+std::string systemToUtf8(const std::string& str, int codepage);
 
 std::string toLower(const std::string& str);
 std::string textToHtml(const std::string& str);

--- a/src/cpp/r/RUtil.cpp
+++ b/src/cpp/r/RUtil.cpp
@@ -29,6 +29,10 @@
 
 #include <R_ext/Riconv.h>
 
+#ifndef CP_ACP
+# define CP_ACP 0
+#endif
+
 using namespace rstudio::core;
 
 namespace rstudio {
@@ -75,7 +79,7 @@ bool hasCapability(const std::string& capability)
 
 std::string rconsole2utf8(const std::string& encoded)
 {
-   int codepage = 0;
+   int codepage = CP_ACP;
 #ifdef _WIN32
    Error error = r::exec::evaluateString("base::l10n_info()$codepage", &codepage);
    if (error)

--- a/src/cpp/r/RUtil.cpp
+++ b/src/cpp/r/RUtil.cpp
@@ -75,6 +75,12 @@ bool hasCapability(const std::string& capability)
 
 std::string rconsole2utf8(const std::string& encoded)
 {
+   int codepage = 0;
+#ifdef _WIN32
+   Error error = r::exec::evaluateString("base::l10n_info()$codepage", &codepage);
+   if (error)
+      LOG_ERROR(error);
+#endif
    boost::regex utf8("\x02\xFF\xFE(.*?)(\x03\xFF\xFE|\\')");
 
    std::string output;
@@ -83,12 +89,12 @@ std::string rconsole2utf8(const std::string& encoded)
    while (pos != encoded.end() && boost::regex_search(pos, encoded.end(), m, utf8))
    {
       if (pos < m[0].first)
-         output.append(string_utils::systemToUtf8(std::string(pos, m[0].first)));
+         output.append(string_utils::systemToUtf8(std::string(pos, m[0].first), codepage));
       output.append(m[1].first, m[1].second);
       pos = m[0].second;
    }
    if (pos != encoded.end())
-      output.append(string_utils::systemToUtf8(std::string(pos, encoded.end())));
+      output.append(string_utils::systemToUtf8(std::string(pos, encoded.end()), codepage));
 
    return output;
 }


### PR DESCRIPTION
NOTE: should probably chat realtime just to ascertain if we want to take this + if so what other work might be necessary (also we might prefer to take this for v1.1 instead).

---

This PR resolves a Windows console text rendering issue wherein attempts to convert console output to UTF-8 could fail if the current locale had been changed from the default system locale.

To reproduce, on an English Windows system, try running the following code:

```R
Sys.setlocale(locale = "Russian")
text <- "Привет мир"
text
```

You should see something like:

```
> locale <- Sys.setlocale(locale = "Russian")
> text <- "Привет мир"
> text
[1] "Ïðèâåò ìèð"
```

Note that this issue is unique to RStudio (RGui produces the correct text here).

The issue here is that RStudio has assumed the default system codepage (CP1252 on my system), and converted from that to UTF-8 when returning console output. This PR ensures that we use the active codepage specified by the locale when converting console output.

We might want to tweak the logic here to avoid calling `l10n_info()` so eagerly, but I'm not sure if there's a direct way to detect locale changes on Windows in an application.