### PR TITLE
mark encoding of console output in notebooks

### DIFF
--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -185,6 +185,7 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
                                                     includeSource,
                                                     ...)
 {
+   Encoding(fileContents) <- "UTF-8"
    parsed <- .rs.rnb.readConsoleData(fileContents)
    
    # exclude source code if requested


### PR DESCRIPTION
This PR fixes an issue where non-ASCII console output in Windows notebooks could become mangled. 