### PR TITLE
add support for paged.print=FALSE in notebook data chunks

### DIFF
--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -57,6 +57,11 @@
 
 .rs.addFunction("initDataCapture", function(outputFolder, options)
 {
+  pagedOption <- if (!is.null(options[["paged.print"]])) options[["paged.print"]] else getOption("paged.print")
+  if (identical(pagedOption, FALSE)) {
+    return()
+  }
+
   overridePrint <- function(x, options, className, nRow, nCol) {
     original <- x
     options <- if (is.null(options)) list() else options
@@ -127,18 +132,25 @@
 
 .rs.addFunction("releaseDataCapture", function()
 {
-  options(
-    "dplyr.tibble.print" = get(
-      "dplyr_tibble_print_original",
-      envir = as.environment("tools:rstudio")
+  if (!is.null(getOption("dplyr_tibble_print_original"))) {
+    options(
+      "dplyr.tibble.print" = get(
+        "dplyr_tibble_print_original",
+        envir = as.environment("tools:rstudio")
+      )
     )
-  )
+  }
 
-  overrides <- names(.rs.dataCaptureOverrides())
-  rm(
-    list = overrides,
-    envir = as.environment("tools:rstudio")
-  )
+  overrides <- .rs.dataCaptureOverrides()
+  lapply(names(overrides), function(override) {
+    if (exists(override, envir = as.environment("tools:rstudio"), inherits = FALSE)) {
+      rm(
+        list = override,
+        envir = as.environment("tools:rstudio"),
+        inherits = FALSE
+      )
+    }
+  })
 })
 
 .rs.addFunction("readDataCapture", function(path)

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
@@ -229,7 +229,7 @@ void ChunkExecContext::connect()
 
    error = pDataCapture->connectDataCapture(
             outputPath_,
-            options_.chunkOptions());
+            options_.mergedOptions());
    if (error)
       LOG_ERROR(error);
 


### PR DESCRIPTION
The `paged.print=FALSE` option forces notebooks and notebook preview to not use paged tables:

<img width="833" alt="screen shot 2016-11-04 at 2 19 22 pm" src="https://cloud.githubusercontent.com/assets/3478847/20022853/b9b0d7da-a299-11e6-8c4f-ff5da90d48a8.png">
