### PR TITLE
prevent concurrent attempts to create line widget

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJax.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJax.java
@@ -392,7 +392,10 @@ public class MathJax
    {
       ChunkOutputWidget cow = lwToPlwMap_.get(widget);
       if (cow == null)
+      {
+         onExpansionCompleted.execute(false);
          return;
+      }
       
       cow.setExpansionState(ChunkOutputWidget.EXPANDED, onExpansionCompleted);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
@@ -90,7 +90,7 @@ public class EditingTargetCodeExecution
          boolean onlyUseConsole)
    {
       // when executing LaTeX in R Markdown, show a popup preview
-      if (executeLatex())
+      if (executeLatex(false))
          return;
       
       // when executing inline R code, show a popup preview
@@ -343,7 +343,7 @@ public class EditingTargetCodeExecution
       return (trimmedLine.length() == 0) || trimmedLine.startsWith("#'");
    }
    
-   private boolean executeLatex()
+   private boolean executeLatex(boolean background)
    {
       // need a suitable editing target to render LaTeX chunks
       if (target_ == null)
@@ -352,7 +352,7 @@ public class EditingTargetCodeExecution
       Range range = MathJaxUtil.getLatexRange(docDisplay_);
       if (range == null)
          return false;
-      target_.renderLatex(range);
+      target_.renderLatex(range, background);
       return true;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorIdleCommands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorIdleCommands.java
@@ -73,7 +73,7 @@ public class AceEditorIdleCommands
             TextEditingTargetNotebook.CONTENT_PREVIEW_ENABLED,
             pref != UIPrefsAccessor.LATEX_PREVIEW_SHOW_NEVER))
       {
-         target.renderLatex(range);
+         target.renderLatex(range, true);
       }
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -4453,10 +4453,10 @@ public class TextEditingTarget implements
          mathjax_.renderLatex();
    }
    
-   public void renderLatex(Range range)
+   public void renderLatex(Range range, boolean background)
    {
       if (mathjax_ != null)
-         mathjax_.renderLatex(range);
+         mathjax_.renderLatex(range, background);
    }
 
    public String getDefaultNamePrefix()


### PR DESCRIPTION
This PR resolves an issue where 'floating' MathJax line widgets can be generated if concurrent attempts to render a latex chunk are made (e.g. by holding down `Cmd + Enter` within a latex chunk)