### PR TITLE
Add support for paged_table function

### DIFF
--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -18,6 +18,7 @@
   c(
     "print.data.frame" = function(x, options) list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x))),
     "print.tbl_df" = function(x, options)     list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x))),
+    "print.paged_df" = function(x, options)   list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x))),
     "print.grouped_df" = function(x, options) list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x))),
     "print.data.table" = function(x, options) {
       shouldPrintTable <- TRUE


### PR DESCRIPTION
Add support for `paged_table()` to print `data.frame`s in `rmarkdown`.

This PR depends on: https://github.com/rstudio/rmarkdown/pull/857