### PR TITLE
Turn off autocomplete in password field

### DIFF
--- a/src/gwt/www/templates/encrypted-sign-in.htm
+++ b/src/gwt/www/templates/encrypted-sign-in.htm
@@ -189,7 +189,8 @@ function submitRealForm() {
                 name='password' 
                 value='' 
                 id='password' 
-                size='45'/><br />
+                size='45'
+                autocomplete='off' /><br />
       </p>
       <p style="display: #staySignedInDisplay#;">
          <input type="checkbox" name="staySignedIn" id="staySignedIn" value="1"/>


### PR DESCRIPTION
This change simply tells the browser not to autocomplete the user's password. Note that this does *not* disable the browser's password manager nor third-party password managers (see the [OWASP vulnerability page](https://www.owasp.org/index.php/Testing_for_Vulnerable_Remember_Password_(OTG-AUTHN-005)) for more detail), but has been historically associated with inappropriate storage of passwords and therefore [reported by vulnerability scanning tools](https://www.acunetix.com/vulnerabilities/web/password-type-input-with-auto-complete-enabled).



