### PR TITLE
improve discovery for RStudio main window

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteManager.java
@@ -529,6 +529,9 @@ public class SatelliteManager implements CloseHandler<Window>
    // export the global function required for satellites to register
    private native void exportSatelliteRegistrationCallback() /*-{
       var manager = this;     
+      
+      $wnd.$RStudio = {};
+      
       $wnd.registerAsRStudioSatellite = $entry(
          function(name, satelliteWnd) {
             manager.@org.rstudio.studio.client.common.satellite.SatelliteManager::registerAsSatellite(Ljava/lang/String;Lcom/google/gwt/core/client/JavaScriptObject;)(name, satelliteWnd);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/MainWindowObject.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/MainWindowObject.java
@@ -79,7 +79,7 @@ public class MainWindowObject<T>
       for (var wnd = $wnd; wnd != null; wnd = wnd.opener)
          if (!!wnd.$RStudio)
             return wnd;
-      throw "Failed to discover RStudio main window";
+      return $wnd;
    }-*/;
    
    private static final native JavaScriptObject getRStudioObject(Window wnd) /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/MainWindowObject.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/MainWindowObject.java
@@ -15,7 +15,6 @@
 package org.rstudio.studio.client.workbench;
 
 import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
-
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.user.client.Window;
 
@@ -39,14 +38,14 @@ public class MainWindowObject<T>
    
    public final void set(T value)
    {
-      JavaScriptObject rstudioObject = getRStudioObject(getMainWindow());
+      JavaScriptObject rstudioObject = getRStudioObject(getRStudioMainWindow());
       setImpl(key_, value, rstudioObject);
    }
    
    @SuppressWarnings("unchecked")
    public final T get()
    {
-      JavaScriptObject rstudioObject = getRStudioObject(getMainWindow());
+      JavaScriptObject rstudioObject = getRStudioObject(getRStudioMainWindow());
       if (!hasImpl(key_, rstudioObject))
          return provider_.defaultValue();
       
@@ -76,16 +75,14 @@ public class MainWindowObject<T>
       return object.hasOwnProperty(key);
    }-*/;
    
-   private static final native Window getMainWindow() /*-{
-      var wnd = $wnd;
-      while (wnd.opener != null)
-         wnd = wnd.opener;
-      return wnd;
+   private static final native Window getRStudioMainWindow() /*-{
+      for (var wnd = $wnd; wnd != null; wnd = wnd.opener)
+         if (!!wnd.$RStudio)
+            return wnd;
+      throw "Failed to discover RStudio main window";
    }-*/;
    
    private static final native JavaScriptObject getRStudioObject(Window wnd) /*-{
-      if (wnd.$RStudio == null)
-         wnd.$RStudio = {};
       return wnd.$RStudio;
    }-*/;
    


### PR DESCRIPTION
This PR should resolve an issue where attempts to open RStudio from a browser link could fail.

The overarching issue is that we expected the top-level `opener` object to be the RStudio main window; however, this will not be the case if RStudio is opened through a link in a browser window. The fix here ensures that the `$RStudio` main window object is initialized by the SatelliteManager (which only exists on the main window), and satellites now search for a window providing that object.