### PR TITLE
fix backslash escaping in 'Test Package'

### DIFF
--- a/src/cpp/core/system/PosixShellUtils.cpp
+++ b/src/cpp/core/system/PosixShellUtils.cpp
@@ -23,8 +23,8 @@ namespace shell_utils {
 
 std::string escape(const std::string& arg)
 {
-   boost::regex pattern("(\\\\|\\$|`|!|\n|\")");
-   return "\"" + boost::regex_replace(arg, pattern, "\\\\$1") + "\"";
+   boost::regex pattern("[\\\\$`!\n\"]");
+   return "\"" + boost::regex_replace(arg, pattern, "\\\\$0") + "\"";
 }
 
 std::string escape(const core::FilePath &path)

--- a/src/cpp/core/system/PosixShellUtilsTests.cpp
+++ b/src/cpp/core/system/PosixShellUtilsTests.cpp
@@ -37,6 +37,14 @@ context("Shell Escaping")
       std::string expected = "\"\\$\\$\\$\"";
       expect_true(escaped == expected);
    }
+   
+   test_that("Commands with backslashes are escaped")
+   {
+      std::string backslashes = "\\\\\\";
+      std::string escaped = escape(backslashes);
+      std::string expected = "\"\\\\\\\\\\\\\"";
+      expect_true(escaped == expected);
+   }
 }
 
 } // end namespace tests

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -956,7 +956,7 @@ private:
 
       boost::format fmt(
          "setwd('%1%'); "
-         "invisible(lapply(list.files(pattern = '\\\\.[rR]$'), function(x) { "
+         "invisible(lapply(list.files(pattern = '\\\\\\\\.[rR]$'), function(x) { "
          "    system(paste(shQuote('%2%'), '--vanilla --slave -f', shQuote(x))) "
          "}))"
       );

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -953,11 +953,18 @@ private:
       cmd << "--vanilla";
       cmd << "-e";
       std::vector<std::string> rSourceCommands;
-
+      
+#ifdef _WIN32
+# define kBuildCommandBackslashes "\\\\"
+#else
+# define kBuildCommandBackslashes "\\\\\\\\"
+#endif
+      
       boost::format fmt(
-         "setwd('%1%'); "
-         "invisible(lapply(list.files(pattern = '\\\\\\\\.[rR]$'), function(x) { "
-         "    system(paste(shQuote('%2%'), '--vanilla --slave -f', shQuote(x))) "
+         "setwd('%1%');"
+         "files <- list.files(pattern = '" kBuildCommandBackslashes ".[rR]$');"
+         "invisible(lapply(files, function(x) {"
+         "    system(paste(shQuote('%2%'), '--vanilla --slave -f', shQuote(x)))"
          "}))"
       );
 


### PR DESCRIPTION
This PR fixes an issue when attempting to run `Test Package` in R packages which are not using `devtools` / `testthat` for unit tests. Note that the problem only came to light with the fix in https://github.com/rstudio/rstudio/commit/1b3228a89cfbe565a5444b16a0493f5229bc756.

Ironically, with the previous 'broken' escape functionality, we were sending code to the shell like:

```
list.files(pattern = '$1$1.R$1')
```

which was parsed by the shell fine and handled by R, although did not actually filter the set of files correctly. After this fix, we were constructing the pattern as e.g.

```
"list.files(pattern = '\\\\.R\$')"
```

However, we need to double-escape the backslashes here, as otherwise R will only see

```
> list.files(pattern = '\.R$')
```

and that will produce an error like:

```
==> Sourcing R files in 'tests' directory

Error: '\.' is an unrecognized escape in character string starting "'\."
Execution halted

Exited with status 1.
```