### PR TITLE
Add support for paged tables for dplyr data frames

### DIFF
--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -18,6 +18,7 @@
   c(
     "print.data.frame" = function(x, options) list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x))),
     "print.tbl_df" = function(x, options)     list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x))),
+    "print.paged_df" = function(x, options)   list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x))),
     "print.grouped_df" = function(x, options) list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x))),
     "print.data.table" = function(x, options) {
       shouldPrintTable <- TRUE

--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -15,11 +15,14 @@
 
 .rs.addFunction("dataCaptureOverrides", function(outputFolder, libraryFolder)
 {
+  defaultOverride <- function(x, options) list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x)))
   c(
-    "print.data.frame" = function(x, options) list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x))),
-    "print.tbl_df" = function(x, options)     list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x))),
-    "print.paged_df" = function(x, options)   list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x))),
-    "print.grouped_df" = function(x, options) list(x = x, options = options, className = class(x), nRow = .rs.scalar(nrow(x)), nCol = .rs.scalar(ncol(x))),
+    "print.data.frame" = defaultOverride,
+    "print.tbl_df"     = defaultOverride,
+    "print.paged_df"   = defaultOverride,
+    "print.grouped_df" = defaultOverride,
+    "print.rowwise_df" = defaultOverride,
+    "print.tbl_sql"    = defaultOverride,
     "print.data.table" = function(x, options) {
       shouldPrintTable <- TRUE
 

--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -80,7 +80,7 @@
 
     max.print <- if (is.null(options$max.print)) getOption("max.print", 1000) else options$max.print
 
-    x <- .rs.toDataFrame(head(x, max.print), "x", flatten = FALSE, force = TRUE)
+    x <- as.data.frame(head(x, max.print), "x", flatten = FALSE, force = TRUE)
 
     save(
       x,

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -217,9 +217,9 @@
     cols
 })
 
-.rs.addFunction("toDataFrame", function(x, name, flatten, force = FALSE) {
+.rs.addFunction("toDataFrame", function(x, name, flatten) {
   # if it's not already a frame, coerce it to a frame
-  if (!is.data.frame(x) || force) {
+  if (!is.data.frame(x)) {
     frame <- NULL
     # attempt to coerce to a data frame--this can throw errors in the case
     # where we're watching a named object in an environment and the user


### PR DESCRIPTION
Related to: https://github.com/rstudio/rmarkdown/pull/859

Currently, `grouped_df`. `rowwise_df` and `tbl_sql` do not print as paged tables when `df_print: paged`. This makes things like the `sparklyr` `README` to render as console output.

A while ago it was explored to, rather than override, provide an option in `dplyr` to print those through an override since those 3 methods print a bit of text and then a data frame. See https://github.com/hadley/dplyr/pull/2060.

However, not that the ide supports a gallery, this new option in dplyr does not help that much since the output would appear in a separate console gallery and a data gallery entry making a simple `collect()` more complex that what we would want.

Instead, the fix is to override these 3 directly in the ide to allow `dplyr` clients like `sparklyr` to render as follows in a notebook:

<img width="824" alt="screen shot 2016-11-07 at 5 14 53 pm" src="https://cloud.githubusercontent.com/assets/3478847/20082863/ddc84376-a50d-11e6-98fb-d50940b37b39.png">
