### PR TITLE
Prevent framing of sign-in & main page 

### DIFF
--- a/src/cpp/core/gwt/GwtFileHandler.cpp
+++ b/src/cpp/core/gwt/GwtFileHandler.cpp
@@ -123,6 +123,10 @@ void handleFileRequest(const std::string& wwwLocalPath,
       // gwt prefix
       vars["gwt_prefix"] = gwtPrefix;
 
+      // don't allow main page to be framed by other domains (clickjacking
+      // defense)
+      pResponse->setFrameOptionHeaders(http::frame_options::SameOrigin);
+
       // return the page
       pResponse->setNoCacheHeaders();
       pResponse->setFile(filePath, request, text::TemplateFilter(vars));

--- a/src/cpp/core/http/Response.cpp
+++ b/src/cpp/core/http/Response.cpp
@@ -107,6 +107,23 @@ void Response::setNoCacheHeaders()
              "no-cache, no-store, max-age=0, must-revalidate");
 }
 
+void Response::setFrameOptionHeaders(frame_options::XFrameOptions options)
+{
+   std::string option;
+   if (options == frame_options::Deny)
+      option = "DENY";
+   else if (options == frame_options::SameOrigin)
+      option = "SAMEORIGIN";
+   else 
+   {
+      LOG_WARNING_MESSAGE("Unknown X-Frame-Options value " +
+            safe_convert::numberToString(options));
+      return;
+   }
+   
+   setHeader("X-Frame-Options", option);
+}
+
 // mark this request's user agent compatibility
 void Response::setBrowserCompatible(const Request& request)
 {

--- a/src/cpp/core/http/Response.cpp
+++ b/src/cpp/core/http/Response.cpp
@@ -110,15 +110,14 @@ void Response::setNoCacheHeaders()
 void Response::setFrameOptionHeaders(frame_options::XFrameOptions options)
 {
    std::string option;
-   if (options == frame_options::Deny)
-      option = "DENY";
-   else if (options == frame_options::SameOrigin)
-      option = "SAMEORIGIN";
-   else 
+   switch(options)
    {
-      LOG_WARNING_MESSAGE("Unknown X-Frame-Options value " +
-            safe_convert::numberToString(options));
-      return;
+      case frame_options::Deny:
+         option = "DENY";
+         break;
+      case frame_options::SameOrigin:
+         option = "SAMEORIGIN";
+         break;
    }
    
    setHeader("X-Frame-Options", option);

--- a/src/cpp/core/include/core/http/Response.hpp
+++ b/src/cpp/core/include/core/http/Response.hpp
@@ -67,6 +67,13 @@ enum Code {
    GatewayTimeout = 504 
 };
 } 
+
+namespace frame_options {
+enum XFrameOptions {
+   Deny,
+   SameOrigin
+};
+}
     
 class NullOutputFilter : public boost::iostreams::multichar_output_filter 
 {   
@@ -112,6 +119,8 @@ public:
    void setCacheForeverHeaders();
    void setPrivateCacheForeverHeaders();
    void setNoCacheHeaders();
+
+   void setFrameOptionHeaders(frame_options::XFrameOptions options);
    
    void setBrowserCompatible(const Request& request);
 

--- a/src/cpp/server/ServerPAMAuth.cpp
+++ b/src/cpp/server/ServerPAMAuth.cpp
@@ -258,6 +258,10 @@ void signIn(const http::Request& request,
 
    text::TemplateFilter filter(variables);
 
+   // don't allow sign-in page to be framed by other domains (clickjacking
+   // defense)
+   pResponse->setFrameOptionHeaders(http::frame_options::SameOrigin);
+
    pResponse->setFile(signInPath, request, filter);
    pResponse->setContentType("text/html");
 }


### PR DESCRIPTION
This change prevents the RStudio sign-in page and its main application window from being being hosted in a frame of a different origin, following the [OWASP guidance](https://www.owasp.org/index.php/Clickjacking).