### PR TITLE
ensure UTF-8 for pandoc-rendered notebook items

### DIFF
--- a/src/cpp/session/modules/NotebookHtmlWidgets.R
+++ b/src/cpp/session/modules/NotebookHtmlWidgets.R
@@ -73,7 +73,7 @@
                         fileext = ".html")
 
    # save contents to temporary file
-   cat(as.character(x), file = mdfile, sep = "\n")
+   writeLines(enc2utf8(x), con = mdfile, useBytes = TRUE)
    
    # render to HTML with pandoc
    rmarkdown::pandoc_convert(input = rmarkdown::pandoc_path_arg(mdfile), 


### PR DESCRIPTION
This should resolve https://github.com/rstudio/rmarkdown/issues/860.