### PR TITLE
Add frame origin controls

### DIFF
--- a/src/cpp/core/gwt/GwtFileHandler.cpp
+++ b/src/cpp/core/gwt/GwtFileHandler.cpp
@@ -38,6 +38,7 @@ void handleFileRequest(const std::string& wwwLocalPath,
                        const std::string& initJs,
                        const std::string& gwtPrefix,
                        bool useEmulatedStack,
+                       const std::string& frameOptions,
                        const http::Request& request, 
                        http::Response* pResponse)
 {
@@ -125,7 +126,7 @@ void handleFileRequest(const std::string& wwwLocalPath,
 
       // don't allow main page to be framed by other domains (clickjacking
       // defense)
-      pResponse->setFrameOptionHeaders(http::frame_options::SameOrigin);
+      pResponse->setFrameOptionHeaders(frameOptions);
 
       // return the page
       pResponse->setNoCacheHeaders();
@@ -150,7 +151,8 @@ http::UriHandlerFunction fileHandlerFunction(
                                        http::UriFilterFunction mainPageFilter,
                                        const std::string& initJs,
                                        const std::string& gwtPrefix,
-                                       bool useEmulatedStack)
+                                       bool useEmulatedStack,
+                                       const std::string& frameOptions)
 {
    return boost::bind(handleFileRequest,
                       wwwLocalPath,
@@ -159,6 +161,7 @@ http::UriHandlerFunction fileHandlerFunction(
                       initJs,
                       gwtPrefix,
                       useEmulatedStack,
+                      frameOptions,
                       _1,
                       _2);
 }  

--- a/src/cpp/core/gwt/GwtFileHandler.cpp
+++ b/src/cpp/core/gwt/GwtFileHandler.cpp
@@ -123,6 +123,10 @@ void handleFileRequest(const std::string& wwwLocalPath,
       // gwt prefix
       vars["gwt_prefix"] = gwtPrefix;
 
+      // don't allow main page to be framed by other domains (clickjacking
+      // defense)
+      pResponse->setFrameOptionHeaders(http::frame_options::SameOrigin);
+
       // return the page
       pResponse->setNoCacheHeaders();
       pResponse->setFile(filePath, request, text::TemplateFilter(vars));

--- a/src/cpp/core/http/Response.cpp
+++ b/src/cpp/core/http/Response.cpp
@@ -107,6 +107,23 @@ void Response::setNoCacheHeaders()
              "no-cache, no-store, max-age=0, must-revalidate");
 }
 
+void Response::setFrameOptionHeaders(frame_options::XFrameOptions options)
+{
+   std::string option;
+   if (options == frame_options::Deny)
+      option = "DENY";
+   else if (options == frame_options::SameOrigin)
+      option = "SAMEORIGIN";
+   else 
+   {
+      LOG_WARNING_MESSAGE("Unknown X-Frame-Options value " +
+            safe_convert::numberToString(options));
+      return;
+   }
+   
+   setHeader("X-Frame-Options", option);
+}
+
 // mark this request's user agent compatibility
 void Response::setBrowserCompatible(const Request& request)
 {

--- a/src/cpp/core/http/Response.cpp
+++ b/src/cpp/core/http/Response.cpp
@@ -107,20 +107,30 @@ void Response::setNoCacheHeaders()
              "no-cache, no-store, max-age=0, must-revalidate");
 }
 
-void Response::setFrameOptionHeaders(frame_options::XFrameOptions options)
+void Response::setFrameOptionHeaders(const std::string& options)
 {
    std::string option;
-   switch(options)
+
+   if (options.empty() || options == "none")
    {
-      case frame_options::Deny:
-         option = "DENY";
-         break;
-      case frame_options::SameOrigin:
-         option = "SAMEORIGIN";
-         break;
+      // the default is to deny all framing
+      option = "DENY";
    }
-   
-   setHeader("X-Frame-Options", option);
+   else if (options == "same")
+   {
+      // this special string indicates that framing is permissible on the same
+      // domain
+      option = "SAMEORIGIN";
+   }
+   else
+   {
+      // the special string "any" means any origin
+      if (options != "any")
+         option = "ALLOW-FROM " + options;
+   }
+
+   if (!option.empty())
+      setHeader("X-Frame-Options", option);
 }
 
 // mark this request's user agent compatibility

--- a/src/cpp/core/http/Response.cpp
+++ b/src/cpp/core/http/Response.cpp
@@ -110,15 +110,14 @@ void Response::setNoCacheHeaders()
 void Response::setFrameOptionHeaders(frame_options::XFrameOptions options)
 {
    std::string option;
-   if (options == frame_options::Deny)
-      option = "DENY";
-   else if (options == frame_options::SameOrigin)
-      option = "SAMEORIGIN";
-   else 
+   switch(options)
    {
-      LOG_WARNING_MESSAGE("Unknown X-Frame-Options value " +
-            safe_convert::numberToString(options));
-      return;
+      case frame_options::Deny:
+         option = "DENY";
+         break;
+      case frame_options::SameOrigin:
+         option = "SAMEORIGIN";
+         break;
    }
    
    setHeader("X-Frame-Options", option);

--- a/src/cpp/core/include/core/gwt/GwtFileHandler.hpp
+++ b/src/cpp/core/include/core/gwt/GwtFileHandler.hpp
@@ -28,7 +28,8 @@ http::UriHandlerFunction fileHandlerFunction(
       http::UriFilterFunction mainPageFilter = http::UriFilterFunction(),
       const std::string& initJs = std::string(),
       const std::string& gwtPrefix = std::string(),
-      bool useEmulatedStack = false);
+      bool useEmulatedStack = false,
+      const std::string& frameOptions = std::string());
    
 } // namespace gwt
 } // namespace core

--- a/src/cpp/core/include/core/http/Response.hpp
+++ b/src/cpp/core/include/core/http/Response.hpp
@@ -68,13 +68,6 @@ enum Code {
 };
 } 
 
-namespace frame_options {
-enum XFrameOptions {
-   Deny,
-   SameOrigin
-};
-}
-    
 class NullOutputFilter : public boost::iostreams::multichar_output_filter 
 {   
 public:
@@ -120,7 +113,7 @@ public:
    void setPrivateCacheForeverHeaders();
    void setNoCacheHeaders();
 
-   void setFrameOptionHeaders(frame_options::XFrameOptions options);
+   void setFrameOptionHeaders(const std::string& options);
    
    void setBrowserCompatible(const Request& request);
 

--- a/src/cpp/core/include/core/http/Response.hpp
+++ b/src/cpp/core/include/core/http/Response.hpp
@@ -67,6 +67,13 @@ enum Code {
    GatewayTimeout = 504 
 };
 } 
+
+namespace frame_options {
+enum XFrameOptions {
+   Deny,
+   SameOrigin
+};
+}
     
 class NullOutputFilter : public boost::iostreams::multichar_output_filter 
 {   
@@ -112,6 +119,8 @@ public:
    void setCacheForeverHeaders();
    void setPrivateCacheForeverHeaders();
    void setNoCacheHeaders();
+
+   void setFrameOptionHeaders(frame_options::XFrameOptions options);
    
    void setBrowserCompatible(const Request& request);
 

--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -102,7 +102,8 @@ http::UriHandlerFunction blockingFileHandler()
                                    mainPageFilter,
                                    initJs,
                                    options.gwtPrefix(),
-                                   options.wwwUseEmulatedStack());
+                                   options.wwwUseEmulatedStack(),
+                                   options.wwwFrameOrigin());
 }
 
 //

--- a/src/cpp/server/ServerOptions.cpp
+++ b/src/cpp/server/ServerOptions.cpp
@@ -231,7 +231,10 @@ ProgramStatus Options::read(int argc,
          "proxy requests to localhost ports over main server port")
       ("www-verify-user-agent",
          value<bool>(&wwwVerifyUserAgent_)->default_value(true),
-         "verify that the user agent is compatible");
+         "verify that the user agent is compatible")
+      ("www-frame-origin",
+         value<std::string>(&wwwFrameOrigin_)->default_value("none"),
+         "allowed origin for hosting frame");
 
    // rsession
    Deprecated dep;

--- a/src/cpp/server/ServerPAMAuth.cpp
+++ b/src/cpp/server/ServerPAMAuth.cpp
@@ -260,7 +260,7 @@ void signIn(const http::Request& request,
 
    // don't allow sign-in page to be framed by other domains (clickjacking
    // defense)
-   pResponse->setFrameOptionHeaders(http::frame_options::SameOrigin);
+   pResponse->setFrameOptionHeaders(options.wwwFrameOrigin());
 
    pResponse->setFile(signInPath, request, filter);
    pResponse->setContentType("text/html");

--- a/src/cpp/server/ServerPAMAuth.cpp
+++ b/src/cpp/server/ServerPAMAuth.cpp
@@ -258,6 +258,10 @@ void signIn(const http::Request& request,
 
    text::TemplateFilter filter(variables);
 
+   // don't allow sign-in page to be framed by other domains (clickjacking
+   // defense)
+   pResponse->setFrameOptionHeaders(http::frame_options::SameOrigin);
+
    pResponse->setFile(signInPath, request, filter);
    pResponse->setContentType("text/html");
 }

--- a/src/cpp/server/include/server/ServerOptions.hpp
+++ b/src/cpp/server/include/server/ServerOptions.hpp
@@ -1,7 +1,7 @@
 /*
  * ServerOptions.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-16 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -102,6 +102,11 @@ public:
    std::string wwwLocalPath() const
    {
       return std::string(wwwLocalPath_.c_str()); 
+   }
+
+   std::string wwwFrameOrigin() const
+   {
+      return std::string(wwwFrameOrigin_.c_str());
    }
 
    core::FilePath wwwSymbolMapsPath() const
@@ -257,6 +262,7 @@ private:
    std::string wwwPort_ ;
    std::string wwwLocalPath_ ;
    std::string wwwSymbolMapsPath_;
+   std::string wwwFrameOrigin_;
    bool wwwUseEmulatedStack_;
    int wwwThreadPoolSize_;
    bool wwwProxyLocalhost_;


### PR DESCRIPTION
This changes makes it possible for RStudio Server administrators to indicate permissible hosting frame origins, using a new `www-frame-origin` option, which defaults to `none`, a secure default which indicates that RStudio should not load inside a frame.

The option is a thin wrapper over the `X-Frame-Options` HTTP header, and can emit all of the legal values for the header (including omitting it entirely). 

The new option is documented in the RStudio Server admin guide. 