### PR TITLE
fix off by 2px input box in csv import dialog for desktop clients

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.ui.xml
@@ -71,7 +71,7 @@
             padding-right: 5px;
         }
         .skipTextBox {
-            width: 50px;
+            max-width: 50px;
             text-align: right;
             padding-left: 5px;
             padding-right: 5px;


### PR DESCRIPTION
Fix off by 2px in csv data import dialog. This seems to be a safari issue where `width` in combination with `flex-grow: 1` is causing a bad alignment. Using `max-width` fixed this and verified the fix in OS X desktop, Chrome and Windows.

<img width="205" alt="screen shot 2016-11-09 at 10 40 25 am" src="https://cloud.githubusercontent.com/assets/3478847/20150271/d0727c84-a669-11e6-85d6-6429e17d9741.png">
