### PR TITLE
open data import file chooser with same open file menu path

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -121,6 +121,7 @@ import org.rstudio.studio.client.workbench.views.vcs.svn.SVNCommandHandler;
 import org.rstudio.studio.client.workbench.views.environment.ClearAllDialog;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.DataImport;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.DataImportDialog;
+import org.rstudio.studio.client.workbench.views.environment.dataimport.DataImportFileChooser;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.DataImportOptionsUiCsv;
 
 @GinModules(RStudioGinModuleOverlay.class)
@@ -201,6 +202,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(TextEditingTargetIdleMonitor monitor);
    void injectMembers(AceEditorIdleCommands commands);
    void injectMembers(EditingTargetInlineChunkExecution executor);
+   void injectMembers(DataImportFileChooser dataImportFileChooser);
    
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportFileChooser.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportFileChooser.java
@@ -21,6 +21,7 @@ import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.ProgressOperationWithInput;
 import org.rstudio.core.client.widget.ThemedButton;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.workbench.WorkbenchContext;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Style.Unit;
@@ -34,6 +35,7 @@ import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.Widget;
+import com.google.inject.Inject;
 
 public class DataImportFileChooser extends Composite
 {
@@ -55,6 +57,8 @@ public class DataImportFileChooser extends Composite
    public DataImportFileChooser(Operation updateOperation,
                                 boolean growTextbox)
    {  
+      RStudioGinjector.INSTANCE.injectMembers(this);
+
       initWidget(uiBinder.createAndBindUi(this));
       
       updateOperation_ = updateOperation;
@@ -83,10 +87,15 @@ public class DataImportFileChooser extends Composite
             }
             else
             {
+               FileSystemItem fileSystemItemPath = FileSystemItem.createFile(getText());
+               if (getText() == "") {
+                  fileSystemItemPath = workbenchContext_.getDefaultFileDialogDir();
+               }
+               
                RStudioGinjector.INSTANCE.getFileDialogs().openFile(
                      "Choose File",
                      RStudioGinjector.INSTANCE.getRemoteFileSystemContext(),
-                     FileSystemItem.createFile(getText()),
+                     fileSystemItemPath,
                      new ProgressOperationWithInput<FileSystemItem>()
                      {
                         public void execute(FileSystemItem input,
@@ -108,6 +117,12 @@ public class DataImportFileChooser extends Composite
       });
       
       checkForTextBoxChange();
+   }
+
+   @Inject
+   private void initialize(WorkbenchContext workbenchContext)
+   {
+      workbenchContext_ = workbenchContext;
    }
    
    public void setEnabled(boolean enabled)
@@ -180,4 +195,6 @@ public class DataImportFileChooser extends Composite
          }
       }
    }
+
+   private WorkbenchContext workbenchContext_;
 }


### PR DESCRIPTION
Users expect similar behavior to "File Open..." while browsing a file in all the data import dialogs. Fix is to math behavior with "File Open..." path.