### PR TITLE
Add secure flag to cookies when SSL is enabled

### DIFF
--- a/src/cpp/core/http/Cookie.cpp
+++ b/src/cpp/core/http/Cookie.cpp
@@ -29,12 +29,14 @@ Cookie::Cookie(const Request& request,
                const std::string& name,
                const std::string& value, 
                const std::string& path,
-               bool httpOnly) 
+               bool httpOnly, 
+               bool secure) 
    :  name_(name), 
       value_(value), 
       path_(path), 
       expires_(not_a_date_time),
-      httpOnly_(httpOnly)
+      httpOnly_(httpOnly),
+      secure_(secure)
 {
    if (path.empty() && URL::complete(request.uri(), "") != "/")
    {
@@ -67,6 +69,11 @@ void Cookie::setHttpOnly()
 {
    httpOnly_ = true;
 }
+
+void Cookie::setSecure()
+{
+   secure_ = true;
+}
    
 std::string Cookie::cookieHeaderValue() const
 {
@@ -97,6 +104,10 @@ std::string Cookie::cookieHeaderValue() const
    // http only if specified
    if (httpOnly_)
       headerValue << "; HttpOnly";
+
+   // secure if specified
+   if (secure_)
+      headerValue << "; secure";
 
    // return the header value 
    return headerValue.str() ;

--- a/src/cpp/core/include/core/http/Cookie.hpp
+++ b/src/cpp/core/include/core/http/Cookie.hpp
@@ -1,7 +1,7 @@
 /*
  * Cookie.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-16 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -32,7 +32,8 @@ public:
           const std::string& name,
           const std::string& value, 
           const std::string& path,
-          bool httpOnly = false) ;
+          bool httpOnly = false,
+          bool secure = false);
    virtual ~Cookie();
 
    // COPYING: via compiler (copyable members)
@@ -55,6 +56,7 @@ public:
    const boost::gregorian::date& expires() const { return expires_; }
    
    void setHttpOnly();
+   void setSecure();
 
    std::string cookieHeaderValue() const ;
 
@@ -65,6 +67,7 @@ private:
    std::string path_ ;
    boost::gregorian::date expires_ ;
    bool httpOnly_;
+   bool secure_;
 };
 
 

--- a/src/cpp/server/auth/ServerCSRFToken.cpp
+++ b/src/cpp/server/auth/ServerCSRFToken.cpp
@@ -14,6 +14,7 @@
  */
 
 #include <server/auth/ServerCSRFToken.hpp>
+#include <server/ServerOptions.hpp>
 
 #include <core/http/Cookie.hpp>
 #include <core/http/Request.hpp>
@@ -44,8 +45,9 @@ void setCSRFTokenCookie(const http::Request& request,
             kCSRFTokenName, 
             csrfToken, 
             "/",  // cookie for root path
-            false // can't be HTTP only since it's read by client script
-            ));
+            false, // can't be HTTP only since it's read by client script
+            // secure if delivered via SSL
+            options().getOverlayOption("ssl-enabled") == "1"));
 }
 
 bool validateCSRFForm(const http::Request& request, 

--- a/src/cpp/server/auth/ServerSecureCookie.cpp
+++ b/src/cpp/server/auth/ServerSecureCookie.cpp
@@ -1,7 +1,7 @@
 /*
  * ServerSecureCookie.cpp
  *
- * Copyright (C) 2009-15 by RStudio, Inc.
+ * Copyright (C) 2009-16 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -40,6 +40,7 @@
 
 #include <server/ServerOptions.hpp>
 #include <server/ServerSecureKeyFile.hpp>
+#include <server/ServerOptionsOverlay.hpp>
 
 namespace rstudio {
 namespace server {
@@ -100,7 +101,9 @@ http::Cookie createSecureCookie(
                        name,
                        signedCookieValue,
                        path,
-                       true);
+                       true, // HTTP only
+                       // secure if delivered via SSL
+                       options().getOverlayOption("ssl-enabled") == "1");
 }
 
 } // anonymous namespace

--- a/src/cpp/server/auth/ServerSecureCookie.cpp
+++ b/src/cpp/server/auth/ServerSecureCookie.cpp
@@ -40,7 +40,6 @@
 
 #include <server/ServerOptions.hpp>
 #include <server/ServerSecureKeyFile.hpp>
-#include <server/ServerOptionsOverlay.hpp>
 
 namespace rstudio {
 namespace server {


### PR DESCRIPTION
This change adds the Secure flag to cookies when SSL is enabled. This flag simply tells the browser to never transmit the cookie over vanilla HTTP, following the [OWASP guidance](https://www.owasp.org/index.php/SecureFlag). 