### PR TITLE
remove unused parameter causing some df to not render in notebooks data

### DIFF
--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -80,7 +80,7 @@
 
     max.print <- if (is.null(options$max.print)) getOption("max.print", 1000) else options$max.print
 
-    x <- as.data.frame(head(x, max.print), "x", flatten = FALSE, force = TRUE)
+    x <- as.data.frame(head(x, max.print))
 
     save(
       x,


### PR DESCRIPTION
Spotted by @jmcphers in https://support.rstudio.com/hc/en-us/community/posts/244972287-Chunk-Output-Inline-and-Notebook-frustration 

Missed to remove parameters while moving away from `.rs.toDataFrame` to `as.data.frame` from commit: https://github.com/rstudio/rstudio/commit/c22a42286f5e4bdcad04bfd8aa92fb6af9fb5476

We could consider an earlier build for this one since, unfortunately, it blocks people from using data frames in notebooks in several cases.