### PR TITLE
refactor addins indexer to provide extensible package resource indexer

### DIFF
--- a/src/cpp/session/include/session/SessionPackageProvidedExtension.hpp
+++ b/src/cpp/session/include/session/SessionPackageProvidedExtension.hpp
@@ -39,6 +39,7 @@ class Indexer : public boost::noncopyable
    virtual void onIndexingStarted() = 0;
    virtual void onWork(const std::string& pkgName, const core::FilePath& resourcePath) = 0;
    virtual void onIndexingCompleted() = 0;
+   virtual void ~Indexer() {}
    
 public:
    explicit Indexer(const std::string& resourcePath)

--- a/src/cpp/session/include/session/SessionPackageProvidedExtension.hpp
+++ b/src/cpp/session/include/session/SessionPackageProvidedExtension.hpp
@@ -1,0 +1,156 @@
+/*
+ * SessionPackageProvidedExtension.hpp
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef SESSION_MODULES_PACKAGE_PROVIDED_EXTENSION_HPP
+#define SESSION_MODULES_PACKAGE_PROVIDED_EXTENSION_HPP
+
+#include <cstddef>
+
+#include <string>
+#include <map>
+
+#include <boost/bind.hpp>
+#include <boost/foreach.hpp>
+#include <boost/noncopyable.hpp>
+
+#include <core/FilePath.hpp>
+
+#include <session/SessionModuleContext.hpp>
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace ppe {
+
+class Indexer : public boost::noncopyable
+{
+   virtual void onIndexingStarted() = 0;
+   virtual void onWork(const std::string& pkgName, const core::FilePath& resourcePath) = 0;
+   virtual void onIndexingCompleted() = 0;
+   
+public:
+   explicit Indexer(const std::string& resourcePath)
+      : resourcePath_(resourcePath),
+        index_(0),
+        n_(0),
+        running_(false)
+   {
+   }
+   
+   void start()
+   {
+      start(300, 20);
+   }
+   
+   void start(int initialDurationMs, int incrementalDurationMs)
+   {
+      if (running_)
+         return;
+      
+      running_ = true;
+      beginIndexing();
+      module_context::scheduleIncrementalWork(
+               boost::posix_time::milliseconds(initialDurationMs),
+               boost::posix_time::milliseconds(incrementalDurationMs),
+               boost::bind(&Indexer::work, this),
+               false);
+   }
+   
+   bool running()
+   {
+      return running_;
+   }
+   
+private:
+   
+   bool work()
+   {
+      // check whether we've run out of work items
+      if (index_ == n_)
+      {
+         endIndexing();
+         return false;
+      }
+      
+      std::size_t index = index_++;
+      
+      // discover path to package resource
+      const core::FilePath& pkgPath = pkgDirs_[index];
+      core::FilePath resourcePath = pkgPath.childPath(resourcePath_);
+      std::string pkgName = pkgPath.filename();
+      
+      // bail if the resource doesn't exist
+      if (!resourcePath.exists())
+         return true;
+      
+      // handle work item
+      onWork(pkgName, resourcePath);
+      return true;
+   }
+   
+   void beginIndexing()
+   {
+      // reset indexer state
+      pkgDirs_.clear();
+      index_ = 0;
+      
+      // discover packages available on the current library paths
+      std::vector<core::FilePath> libPaths = module_context::getLibPaths();
+      BOOST_FOREACH(const core::FilePath& libPath, libPaths)
+      {
+         if (!libPath.exists())
+            continue;
+         
+         std::vector<core::FilePath> pkgPaths;
+         core::Error error = libPath.children(&pkgPaths);
+         if (error)
+            LOG_ERROR(error);
+         
+         pkgDirs_.insert(
+                  pkgDirs_.end(),
+                  pkgPaths.begin(),
+                  pkgPaths.end());
+      }
+      
+      // store number of work items
+      n_ = pkgDirs_.size();
+      
+      // call subclass method
+      onIndexingStarted();
+   }
+   
+   void endIndexing()
+   {
+      running_ = false;
+      onIndexingCompleted();
+   }
+   
+   std::string resourcePath_;
+   
+   // Indexer state
+   std::vector<core::FilePath> pkgDirs_;
+   std::size_t index_;
+   std::size_t n_;
+   bool running_;
+};
+
+core::Error initialize();
+
+} // end namespace ppe
+} // end namespace modules
+} // end namespace session
+} // end namespace rstudio
+
+#endif /* SESSION_MODULES_PACKAGE_PROVIDED_EXTENSION_HPP */

--- a/src/cpp/session/modules/SessionRAddins.cpp
+++ b/src/cpp/session/modules/SessionRAddins.cpp
@@ -1,7 +1,7 @@
 /*
- * SessionRAddins.cpp.in
+ * SessionRAddins.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-16 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -33,6 +33,7 @@
 
 #include <session/projects/SessionProjects.hpp>
 #include <session/SessionModuleContext.hpp>
+#include <session/SessionPackageProvidedExtension.hpp>
 
 using namespace rstudio::core;
 
@@ -307,167 +308,76 @@ AddinRegistry& addinRegistry()
    return *s_pCurrentRegistry;
 }
 
-class AddinIndexer : public boost::noncopyable
+class AddinIndexer : public ppe::Indexer
 {
+   void onIndexingStarted()
+   {
+      pRegistry_ = boost::make_shared<AddinRegistry>();
+   }
+   
+   void onWork(const std::string& pkgName, const FilePath& addinPath)
+   {
+      pRegistry_->add(pkgName, addinPath);
+   }
+   
+   void onIndexingCompleted()
+   {
+      // finalize by indexing current package
+      if (isDevtoolsLoadAllActive())
+      {
+         FilePath pkgPath = projects::projectContext().buildTargetPath();
+         FilePath addinPath = pkgPath.childPath("inst/rstudio/addins.dcf");
+         if (addinPath.exists())
+         {
+            std::string pkgName = projects::projectContext().packageInfo().name();
+            pRegistry_->add(pkgName, addinPath);
+         }
+      }
+
+      // update the addin registry
+      updateAddinRegistry(pRegistry_);
+
+      // handle pending continuations
+      json::Object registryJson = addinRegistry().toJson();
+      BOOST_FOREACH(json::JsonRpcFunctionContinuation continuation, continuations_)
+      {
+         json::JsonRpcResponse response;
+         response.setResult(registryJson);
+         continuation(Success(), &response);
+      }
+   }
+
 public:
    
-   AddinIndexer()
+   AddinIndexer(const std::string& resourcePath)
+      : ppe::Indexer(resourcePath)
    {
-      clear();
    }
-
-   void start(const std::vector<FilePath>& libPaths)
-   {
-      // reset instance data
-      clear();
-
-      // prime work list
-      std::vector<FilePath> pkgPaths;
-      BOOST_FOREACH(const FilePath& libPath, libPaths)
-      {
-         if (!libPath.exists())
-            continue;
-         
-         pkgPaths.clear();
-         Error error = libPath.children(&pkgPaths);
-         if (error)
-            LOG_ERROR(error);
-         children_.insert(
-                  children_.end(),
-                  pkgPaths.begin(),
-                  pkgPaths.end());
-      }
-      
-      n_ = children_.size();
-   }
-
+   
    void addContinuation(json::JsonRpcFunctionContinuation continuation)
    {
       continuations_.push_back(continuation);
    }
 
-   bool running()
-   {
-      return index_ != n_;
-   }
-   
-   bool work()
-   {
-      const FilePath& pkgPath = children_[index_];
-      
-      // std::cout << "Job " << index_ + 1 << " of " << n_ << "\n";
-      // std::cout << "Package: '" << pkgPath.absolutePath() << "'\n";
-      // ::usleep(10000);
-      
-      FilePath addinPath = pkgPath.childPath("rstudio/addins.dcf");
-      if (!addinPath.exists())
-      {
-         ++index_;
-         return maybeFinishRunning();
-      }
-      
-      std::string pkgName = pkgPath.filename();
-      pRegistry_->add(pkgName, addinPath);
-      
-      ++index_;
-      return maybeFinishRunning();
-   }
-
 private:
-
-   // reset all instance data
-   void clear()
-   {
-      children_.clear();
-      n_ = 0;
-      index_ = 0;
-      pRegistry_ = boost::make_shared<AddinRegistry>();
-      continuations_.clear();
-   }
-
-   // check for still running, if we aren't still running then complete
-   // our work and return false, otherwise return true
-   bool maybeFinishRunning()
-   {
-      if (!running())
-      {
-         // finalize by indexing current package
-         if (isDevtoolsLoadAllActive())
-         {
-            FilePath pkgPath = projects::projectContext().buildTargetPath();
-            FilePath addinPath = pkgPath.childPath("inst/rstudio/addins.dcf");
-            if (addinPath.exists())
-            {
-               std::string pkgName = projects::projectContext().packageInfo().name();
-               pRegistry_->add(pkgName, addinPath);
-            }
-         }
-         
-         // update the addin registry
-         updateAddinRegistry(pRegistry_);
-
-         // handle pending continuations
-         json::Object registryJson = addinRegistry().toJson();
-         BOOST_FOREACH(json::JsonRpcFunctionContinuation continuation, continuations_)
-         {
-            json::JsonRpcResponse response;
-            response.setResult(registryJson);
-            continuation(Success(), &response);
-         }
-
-         // clear instance data and return false
-         clear();
-         return false;
-      }
-      else
-      {
-         return true;
-      }
-   }
-   
-private:
-   std::vector<FilePath> children_;
-   std::size_t n_;
-   std::size_t index_;
    boost::shared_ptr<AddinRegistry> pRegistry_;
    std::vector<json::JsonRpcFunctionContinuation> continuations_;
 };
 
 AddinIndexer& addinIndexer()
 {
-   static AddinIndexer instance;
+   static AddinIndexer instance("rstudio/addins.dcf");
    return instance;
 }
 
 void indexLibraryPathsWithContinuation(
                         json::JsonRpcFunctionContinuation continuation)
 {
-   // get the libpaths
-   std::vector<FilePath> libPaths = module_context::getLibPaths();
-
-   // start if we arent' already running
+   if (continuation)
+      addinIndexer().addContinuation(continuation);
+   
    if (!addinIndexer().running())
-   {
-      // start indexer
-      addinIndexer().start(libPaths);
-
-      // register continuation if provided
-      if (continuation)
-         addinIndexer().addContinuation(continuation);
-
-      // schedule work
-      module_context::scheduleIncrementalWork(
-               boost::posix_time::milliseconds(300),
-               boost::posix_time::milliseconds(20),
-               boost::bind(&AddinIndexer::work, &addinIndexer()),
-               false);
-   }
-   else
-   {
-      // register continuation if provided
-      if (continuation)
-         addinIndexer().addContinuation(continuation);
-   }
+      addinIndexer().start();
 }
 
 void indexLibraryPaths()


### PR DESCRIPTION
NOTE: not quite ready for merge; needs some testing to ensure nothing is regressed on the addins side; we might also want to tweak the overall implementation as well depending on whether we're happy with the current separation of concerns.

---

This PR attempts to refactor the indexer we use for R addins into a more general base class that should be useful for handling of project templates provided by R packages.

Most of the machinery used in the R addins indexer has been moved to a more general class, which is tentatively called the 'package provided extension' indexer (or `ppe::Indexer` for short). The general idea is that users will subclass this indexer, implementing a couple of virtual methods to control how indexing is handled, and the classes will define a method that describes how to rebuild those objects from a file provided by an R package.