### PR TITLE
Avoid attempting to decorate files outside git root folder

### DIFF
--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -2704,6 +2704,11 @@ bool isGitEnabled()
    return !s_git_.root().empty();
 }
 
+bool isWithinGitRoot(const core::FilePath& filePath)
+{
+   return isGitEnabled() && filePath.isWithin(s_git_.root());
+}
+
 FilePath detectedGitExePath()
 {
 #ifdef _WIN32

--- a/src/cpp/session/modules/SessionGit.hpp
+++ b/src/cpp/session/modules/SessionGit.hpp
@@ -54,6 +54,7 @@ private:
 
 bool isGitInstalled();
 bool isGitEnabled();
+bool isWithinGitRoot(const core::FilePath& filePath);
 
 bool isGitDirectory(const core::FilePath& workingDir);
 

--- a/src/cpp/session/modules/SessionVCS.cpp
+++ b/src/cpp/session/modules/SessionVCS.cpp
@@ -137,7 +137,7 @@ class NullFileDecorationContext : public FileDecorationContext
 boost::shared_ptr<FileDecorationContext> fileDecorationContext(
                                             const core::FilePath& rootDir)
 {
-   if (git::isGitEnabled())
+   if (git::isWithinGitRoot(rootDir))
    {
       return boost::shared_ptr<FileDecorationContext>(
                            new git::GitFileDecorationContext(rootDir));


### PR DESCRIPTION
This change eliminates a common source of spurious logged errors of the form:

    11 Nov 2016 21:49:20 [rsession-jmcphers] fatal: /Users/jmcphers/rmd/foo.Rmd: '/Users/jmcphers/rmd/foo.Rmd' is outside repository

To reproduce this error, open a project that uses Git, open a file outside the repository, change and then save the file.

The underlying problem is that, when using Git, we attempt to decorate every file change event with the file's Git status. Git emits an error when we try to do this for a file that is not in the repository. The fix is simply to make sure that the file is inside the Git repository before attempting to decorate it.