### PR TITLE
fix previewing for irregular chunk labels

### DIFF
--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -149,7 +149,7 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
 {
    chunkDefns <- rnbData$chunk_info$chunk_definitions
    for (defn in chunkDefns) {
-      if (identical(defn$chunk_label, label))
+      if (identical(defn$options$label, label))
          return(defn$chunk_id)
    }
    return(NULL)


### PR DESCRIPTION
This PR fixes an issue wherein attempts to preview an R Notebook with an irregular chunk header could fail. For example, the following is a valid chunk header:

    ```{r, foo, bar, baz=1}

which has the (perhaps surprising) parsed label of `foo, bar`. That is, commas are technically accepted as part of a chunk labels; `rmarkdown::render()` / `knitr::knit()` both accept this.

Since the label parsed on the client side is incorrect for these cases, we instead compare with the label produced by `knitr` directly on the server side. This ensures that outputs for these chunks are discovered and produced correctly on preview.

