### PR TITLE
remove tibble dependency check since dependency was removed

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -217,7 +217,6 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       deps.add(Dependency.cranPackage("knitr", "1.14", true));
       deps.add(Dependency.cranPackage("jsonlite", "0.9.19"));
       deps.add(Dependency.cranPackage("base64enc", "0.1-3"));
-      deps.add(Dependency.cranPackage("tibble", "1.1"));
       deps.add(Dependency.cranPackage("rprojroot", "1.0"));
       deps.add(Dependency.embeddedPackage("rmarkdown"));
       return deps;


### PR DESCRIPTION
This commit https://github.com/rstudio/rstudio/commit/4ab5e3cb7827294587d2b8ba28a148a456790f31 also requires to remove the client installation check; otherwise, notebooks won't open in `3.1.0` since `tibble` is not available in CRAN. Was not able to catch this with previous commit since my environment had `tibble` installed from a local build.