### PR TITLE
ensure paths sent to R with system encoding

### DIFF
--- a/src/cpp/session/modules/rmarkdown/NotebookData.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookData.cpp
@@ -93,8 +93,8 @@ core::Error DataCapture::connectDataCapture(
               const core::FilePath& outputFolder,
               const json::Object& chunkOptions)
 {
-   return r::exec::RFunction(".rs.initDataCapture", 
-         outputFolder.absolutePath(),
+   return r::exec::RFunction(".rs.initDataCapture",
+         string_utils::utf8ToSystem(outputFolder.absolutePath()),
          chunkOptions).call();
 }
 

--- a/src/cpp/session/modules/rmarkdown/NotebookHtmlWidgets.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookHtmlWidgets.cpp
@@ -93,8 +93,8 @@ core::Error HtmlCapture::connectHtmlCapture(
               const json::Object& chunkOptions)
 {
    return r::exec::RFunction(".rs.initHtmlCapture", 
-         outputFolder.absolutePath(),
-         outputFolder.complete(kChunkLibDir).absolutePath(),
+         string_utils::utf8ToSystem(outputFolder.absolutePath()),
+         string_utils::utf8ToSystem(outputFolder.complete(kChunkLibDir).absolutePath()),
          chunkOptions).call();
 }
 

--- a/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
@@ -147,8 +147,11 @@ void PlotCapture::saveSnapshot()
    FilePath outputFile = plotFolder_.complete(
          core::system::generateUuid(false) + kDisplayListExt);
 
-   Error error = r::exec::RFunction(".rs.saveNotebookGraphics", 
-         lastPlot_.get(), outputFile.absolutePath()).call();
+   Error error = r::exec::RFunction(
+         ".rs.saveNotebookGraphics",
+         lastPlot_.get(),
+         string_utils::utf8ToSystem(outputFile.absolutePath())).call();
+   
    if (error)
       LOG_ERROR(error);
    else
@@ -356,7 +359,8 @@ core::Error PlotCapture::setGraphicsOption()
    // the folder in which to place the rendered plots (this is a sibling of the
    // main chunk output folder)
    setOption.addParam(
-         plotFolder_.absolutePath() + "/" kPlotPrefix "%03d.png");
+            string_utils::utf8ToSystem(plotFolder_.absolutePath()) +
+            "/" kPlotPrefix "%03d.png");
 
    // device dimensions
    setOption.addParam(height_);


### PR DESCRIPTION
This PR should resolve issues seen by users of RStudio on Windows with accents in their username.