### PR TITLE
respect use of 'output.var' in chunk header

### DIFF
--- a/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.cpp
@@ -227,7 +227,7 @@ Error executeStanEngineChunk(const std::string& docId,
    
    // write code to file
    FilePath tempFile = module_context::tempFile("stan-", ".stan");
-   error = writeStringToFile(tempFile, code);
+   error = writeStringToFile(tempFile, code + "\n");
    if (error)
    {
       reportChunkExecutionError(
@@ -241,26 +241,26 @@ Error executeStanEngineChunk(const std::string& docId,
    }
    RemoveOnExitScope removeOnExitScope(tempFile, ERROR_LOCATION);
    
-   // ensure existence of 'engine.opts' with 'output.var' parameter
-   // ('x' also allowed for backwards compatibility)
-   if (!options.count("engine.opts"))
-   {
-      reportStanExecutionError(docId, chunkId, nbCtxId, targetPath);
-      return Success();
-   }
-   
    // evaluate engine options (so we can pass them through to stan call)
    r::sexp::Protect protect;
    SEXP engineOptsSEXP = R_NilValue;
-   error = r::exec::evaluateString(
-            options.at("engine.opts"),
-            &engineOptsSEXP,
-            &protect);
-   
-   if (error)
+   if (options.count("engine.opts"))
    {
-      reportStanExecutionError(docId, chunkId, nbCtxId, targetPath);
-      return Success();
+      error = r::exec::evaluateString(
+               options.at("engine.opts"),
+               &engineOptsSEXP,
+               &protect);
+
+      if (error)
+      {
+         reportStanExecutionError(docId, chunkId, nbCtxId, targetPath);
+         return Success();
+      }
+   }
+   else
+   {
+      // if no engine.opts available, just use a plain empty list
+      engineOptsSEXP = r::sexp::createList(std::vector<std::string>(), &protect);
    }
    
    // construct call to 'stan_model'
@@ -289,6 +289,11 @@ Error executeStanEngineChunk(const std::string& docId,
                engineOptsNames[i],
                VECTOR_ELT(engineOptsSEXP, i));
    }
+   
+   // if 'output.var' was provided as part of the chunk parameters
+   // (not as part of 'engine.opts') then use that here
+   if (options.count("output.var"))
+      modelName = options.at("output.var");
    
    // if no model name was set, return error message
    if (modelName.empty())


### PR DESCRIPTION
This PR resolves an issue where attempts to write a Stan chunk header of the following form could fail:

    ```{stan, output.var="output"}

Previously, we had assumed the `output.var` field would be specified as part of the `engine.opts` chunk option; it appears that `knitr` now also allows for `output.var` at the 'top level' for the chunk options. It looks like this behavior is also documented at http://rmarkdown.rstudio.com/authoring_knitr_engines.html#stan.