### PR TITLE
Fix notebook errors on some mounted filesystems

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,7 @@
 * Use Windows proxy settings to serve requests made by htmlwidgets
 * Fix cross-domain error when opening a link to RStudio Server in a new window
 * Fix comment toggling for ROxygen comments
+* Fix notebook resource problems occurring in projects on mounted filesystems
 * Server Pro: Allow server user to have group name differing from user name
 * Server Pro: Don't require LDAP to support user enumeration when `auth-required-user-group` is set
 

--- a/src/cpp/core/FilePath.cpp
+++ b/src/cpp/core/FilePath.cpp
@@ -708,9 +708,14 @@ Error FilePath::move(const FilePath& targetPath, MoveType type) const
 
 Error FilePath::moveIndirect(const FilePath& targetPath) const 
 {
+   // when target is a directory, moving has the effect of moving *into* the
+   // directory (rather than *replacing* it); simulate that behavior here
+   FilePath target = targetPath.isDirectory() ?
+      targetPath.complete(filename()) : targetPath;
+
    // copy the file or directory to the new location
    Error error = isDirectory() ? 
-      copyDirectoryRecursive(targetPath) : copy(targetPath);
+      copyDirectoryRecursive(target) : copy(target);
    if (error)
       return error;
 

--- a/src/cpp/core/FilePath.cpp
+++ b/src/cpp/core/FilePath.cpp
@@ -683,7 +683,7 @@ Error FilePath::removeIfExists() const
       return Success();
 }
 
-Error FilePath::move(const FilePath& targetPath) const
+Error FilePath::move(const FilePath& targetPath, MoveType type) const
 {
    try
    {
@@ -692,6 +692,13 @@ Error FilePath::move(const FilePath& targetPath) const
    }
    catch(const boost::filesystem::filesystem_error& e)
    {
+      if (type == MoveCrossDevice &&
+          e.code() == boost::system::errc::cross_device_link)
+      {
+         // this error implies that we're trying to move a file from one 
+         // device to another; in this case, fall back to copy/delete
+         return moveIndirect(targetPath);
+      }
       Error error(e.code(), ERROR_LOCATION) ;
       addErrorProperties(pImpl_->path, &error) ;
       error.addProperty("target-path", targetPath.absolutePath()) ;
@@ -699,6 +706,22 @@ Error FilePath::move(const FilePath& targetPath) const
    }
 }
 
+Error FilePath::moveIndirect(const FilePath& targetPath) const 
+{
+   // copy the file or directory to the new location
+   Error error = isDirectory() ? 
+      copyDirectoryRecursive(targetPath) : copy(targetPath);
+   if (error)
+      return error;
+
+   // delete the original copy of the file or directory (not considered a fatal
+   // error)
+   error = remove();
+   if (error)
+      LOG_ERROR(error);
+
+   return Success();
+}
 
 Error FilePath::copy(const FilePath& targetPath) const
 {

--- a/src/cpp/core/include/core/FilePath.hpp
+++ b/src/cpp/core/include/core/FilePath.hpp
@@ -132,9 +132,21 @@ public:
    Error remove() const ;
    Error removeIfExists() const;
    
-   // move to path
-   Error move(const FilePath& targetPath) const ;
+   // move to path; optionally with resiliency for cross-device 
+   enum MoveType 
+   {
+      // attempt to perform an ordinary move
+      MoveDirect,
+
+      // perform an ordinary move, but fallback to copy/delete on cross-device
+      // errors 
+      MoveCrossDevice
+   };
+   Error move(const FilePath& targetPath, MoveType type = MoveDirect) const;
    
+   // explicitly perform a two-stage move (copy/delete)
+   Error moveIndirect(const FilePath& target) const;
+
    // copy to path
    Error copy(const FilePath& targetPath) const;
 
@@ -195,6 +207,7 @@ public:
    bool operator < (const FilePath& other) const ;
 
 private:
+
    friend class RecursiveDirectoryIterator;
 
 private:

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
@@ -293,7 +293,7 @@ void ChunkExecContext::onFileOutput(const FilePath& file,
    // have a canonical extension
    target = target.parent().complete(target.stem() + file.extension());
 
-   Error error = file.move(target);
+   Error error = file.move(target, FilePath::MoveCrossDevice);
    if (error)
    {
       LOG_ERROR(error);
@@ -320,7 +320,7 @@ void ChunkExecContext::onFileOutput(const FilePath& file,
    if (!sidecar.empty())
    {
       sidecar.move(target.parent().complete(
-               target.stem() + sidecar.extension()));
+               target.stem() + sidecar.extension()), FilePath::MoveCrossDevice);
    }
 
    // serialize metadata if provided


### PR DESCRIPTION
This change resolves a problem which can occur when the notebook lives inside a project on a mounted filesystem. It is possible in some situations for the notebook to consume files from a different device, and errors occur when an attempt is made to move those files into the cache.

The fix is to augment `FilePath::move()` with a parameter that indicates that the move may be cross-device. In this case, we recover from the system error with a two-stage move (copy, then delete). This allows us to do two-stage moves only when needed, a considerable performance gain over doing them whenever it is suspected that the source and target may be on different file systems.

It is my opinion that there are few downsides to having this resiliency, and that we should make the new behavior the default, but that's a larger change than I'd like to make in the patch release. 