### PR TITLE
properly handle S4 objects subclassing environment

### DIFF
--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -91,6 +91,7 @@ bool isMatrix(SEXP object);
 bool isDataFrame(SEXP object);   
 bool isNull(SEXP object);
 bool isEnvironment(SEXP object);
+bool isPrimitiveEnvironment(SEXP object);
 
 // type coercions
 std::string asString(SEXP object);


### PR DESCRIPTION
This PR resolves a crash introduced by https://github.com/rstudio/rstudio/commit/4094fc2b3fb9729e56e706b4deb558544dfaee36. The crash is hard to reproduce, but can occasionally when the global environment contains many S4 objects extending 'environment' (e.g. Rcpp module objects)

The crash is caused by an attempt to call `R_findVarInFrame()` on an S4 object that subclasses environment, as opposed to a 'primitive' R environment object. The fix in this PR ensures that S4 environments are properly converted to 'primitive' environments when required.

Note that we may want to apply this commit to v1.0-patch; alternatively (and more likely) we may want to just revert https://github.com/rstudio/rstudio/commit/4094fc2b3fb9729e56e706b4deb558544dfaee36 on the patch release branch.

(For reference, that commit was introduced to avoid an issue where active bindings were fired on Rcpp module objects, since these are effectively S4 objects subclassing environment)