### PR TITLE
Fix issues related to chunk insertion from editor toolbar

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -4108,10 +4108,8 @@ public class TextEditingTarget implements
       InsertChunkInfo insertChunkInfo = docDisplay_.getInsertChunkInfo();
       if (insertChunkInfo != null)
       {
-         insertChunkInfo.setValue(chunkPlaceholder);
-         
          // inject the chunk skeleton
-         docDisplay_.insertCode(insertChunkInfo.getValue(), false);
+         docDisplay_.insertCode(chunkPlaceholder, false);
 
          // if we had text selected, inject it into the chunk
          if (!StringUtil.isNullOrEmpty(sel))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -290,6 +290,7 @@ public class TextEditingTargetWidget
       toolbar.addLeftSeparator();
       toolbar.addLeftWidget(commands_.synctexSearch().createToolbarButton());
 
+      // create menu of chunk skeletons based on common engine types
       ToolbarPopupMenu insertChunksMenu = new ToolbarPopupMenu();
       insertChunksMenu.addItem(commands_.insertChunkR().createMenuItem(false));
       insertChunksMenu.addSeparator();
@@ -303,12 +304,16 @@ public class TextEditingTargetWidget
       insertChunksMenu.addItem(commands_.insertChunkSQL().createMenuItem(false));
       insertChunksMenu.addItem(commands_.insertChunkStan().createMenuItem(false));
 
-      insertChunkButton_ = new ToolbarButton(
+      insertChunkMenu_ = new ToolbarButton(
                        "Insert",
                        commands_.insertChunk().getImageResource(),
                        insertChunksMenu,
                        true);
 
+      toolbar.addRightWidget(insertChunkMenu_);
+
+      // create button that just runs default chunk insertion
+      insertChunkButton_ = commands_.insertChunk().createToolbarButton(false);
       toolbar.addRightWidget(insertChunkButton_);
 
       toolbar.addRightWidget(runButton_ = commands_.executeCode().createToolbarButton(false));
@@ -548,8 +553,12 @@ public class TextEditingTargetWidget
             !isShinyFile());
       runLastButton_.setVisible(runButton_.isVisible() && !canExecuteChunks);
       
-      // chunk oriented buttons     
-      insertChunkButton_.setVisible(canExecuteChunks);
+      // show insertion options for various knitr engines in rmarkdown v2
+      insertChunkMenu_.setVisible(isRMarkdown2);
+      
+      // otherwise just show the regular insert chunk button
+      insertChunkButton_.setVisible(canExecuteChunks && !isRMarkdown2);
+
       goToPrevButton_.setVisible(fileType.canGoNextPrevSection());
       goToNextButton_.setVisible(fileType.canGoNextPrevSection());
       
@@ -1207,6 +1216,7 @@ public class TextEditingTargetWidget
    private ToolbarButton compilePdfButton_;
    private ToolbarButton previewHTMLButton_;
    private ToolbarButton knitDocumentButton_;
+   private ToolbarButton insertChunkMenu_;
    private ToolbarButton insertChunkButton_;
    private ToolbarButton goToPrevButton_;
    private ToolbarButton goToNextButton_;


### PR DESCRIPTION
This change fixes two issues related to the chunk insertion menu (added in v1.0):

- The menu exists in the toolbar on Sweave and R HTML documents, but it does not insert chunk skeletons which are compatible with those types. 

- Once a chunk with an alternate engine has been inserted, using the Insert Chunk shortcut will always insert chunks with that engine (even in other files, if they are of the same type). This appears to have been inadvertent. 

The fix is to remove the chunk insertion menu for non-R Markdown v2 files; for files which contain executable chunks but are not R Markdown, we now just show a bare Insert Chunk command (which does the right thing). 

@javierluraschi , could you review? This PR is against master but will be cherry picked back to the patch release.