### PR TITLE
ensure async autocompletion system doesn't open graphics device

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1144,6 +1144,12 @@
 # extraction implementation there as well.
 .rs.addFunction("getPackageInformation", function(...)
 {
+   # force 'rgl' to use the NULL graphics device (avoid inadvertently
+   # opening a graphics device / XQuartz window when retrieving completions)
+   rgl.useNULL <- getOption("rgl.useNULL")
+   options(rgl.useNULL = TRUE)
+   on.exit(options(rgl.useNULL = rgl.useNULL), add = TRUE)
+   
    invisible(lapply(list(...), function(x) {
       tryCatch({
          


### PR DESCRIPTION
This PR resolves an issue where RStudio could end up opening a blank graphics device (e.g. XQuartz window) behind the scenes when a document contained the code `library(rgl)`.

This may be a candidate for v1.0-patch given that it should be quite safe; however, it does fix a fairly esoteric bug (although we have had reports to this effect in the past).

(spotted by and repro'ed together with @jcheng5)