### PR TITLE
fix Win32 build break (missing comma)

### DIFF
--- a/src/cpp/core/include/core/system/Process.hpp
+++ b/src/cpp/core/include/core/system/Process.hpp
@@ -59,7 +59,7 @@ struct ProcessOptions
    ProcessOptions()
 #ifdef _WIN32
       : terminateChildren(false),
-        smartTerminal(false)
+        smartTerminal(false),
         detachProcess(false),
         createNewConsole(false),
         breakawayFromJob(false),


### PR DESCRIPTION
Haven't performed a Win32 build to validate, but pretty obvious this needs to be fixed. I'll do a build later today before you kick off the official just to be sure.