### PR TITLE
Add support for knitting in alternate directories

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,4 +7,5 @@
 ### Miscellaneous
 
 * Implement support for changing editor tabs with the mouse wheel
+* Add option to knit in current working directory or project directory
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -686,6 +686,9 @@ void handleClientInit(const boost::function<void()>& initFunction,
    sessionInfo["knit_params_available"] =
          modules::rmarkdown::knitParamsAvailable();
 
+   sessionInfo["knit_working_dir_available"] = 
+         modules::rmarkdown::knitWorkingDirAvailable();
+
    sessionInfo["clang_available"] = modules::clang::isAvailable();
 
    // don't show help home until we figure out a sensible heuristic

--- a/src/cpp/session/modules/rmarkdown/NotebookDocQueue.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookDocQueue.hpp
@@ -40,7 +40,8 @@ class NotebookDocQueue : boost::noncopyable
 {
 public:
    NotebookDocQueue(const std::string& docId, const std::string& jobDesc,
-         CommitMode commitMode, int pixelWith, int charWidth, int maxUnits);
+         const std::string& workingDir, CommitMode commitMode, int pixelWith, 
+         int charWidth, int maxUnits);
 
    static core::Error fromJson(const core::json::Object& source,
       boost::shared_ptr<NotebookDocQueue>* pQueue);

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -417,7 +417,6 @@ private:
       allOutput_.clear();
       if (existingOutputFile.empty())
       {
-         std::cerr << cmd << std::endl;
          async_r::AsyncRProcess::start(cmd.c_str(), environment, targetFile_.parent(),
                                        async_r::R_PROCESS_NO_RDATA);
       }

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -1370,6 +1370,10 @@ bool knitParamsAvailable()
           module_context::isPackageVersionInstalled("knitr", "1.10.18");
 }
 
+bool knitWorkingDirAvailable()
+{
+   return module_context::isPackageVersionInstalled("rmarkdown", "1.1.9017");
+}
 
 bool rmarkdownPackageAvailable()
 {

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.hpp
@@ -37,6 +37,8 @@ bool rmarkdownPackageAvailable();
 
 bool knitParamsAvailable();
 
+bool knitWorkingDirAvailable();
+
 core::Error evaluateRmdParams(const std::string& docId);
 
 core::Error initialize();

--- a/src/gwt/src/org/rstudio/core/client/widget/DocShadowPropMenuItem.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/DocShadowPropMenuItem.java
@@ -1,0 +1,79 @@
+/*
+ * DocShadowPropMenuItem.java
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.widget;
+
+import org.rstudio.studio.client.workbench.prefs.model.Prefs.PrefValue;
+import org.rstudio.studio.client.workbench.views.source.model.DocUpdateSentinel;
+
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
+
+/**
+ * DocShadowPropMenuItem is a menu item representing a local document property
+ * that shadows (overrides) a global property. 
+ */
+public class DocShadowPropMenuItem extends DocPropMenuItem
+{
+   /**
+    * Creates a new shadowed document property menu item.
+    * 
+    * @param label The label for the menu item
+    * @param docUpdate The update sentinel 
+    * @param pref The global preference to track
+    * @param propName The name of the document property to track
+    * @param targetValue The value of the document property when the menu item
+    *   is checked.
+    */
+   public DocShadowPropMenuItem(String label, DocUpdateSentinel docUpdate,
+         PrefValue<String> pref, String propName, String targetValue)
+   {
+      super(label, 
+            docUpdate, 
+            docUpdate.getProperty(propName, pref.getValue()) == targetValue,
+            propName,
+            targetValue);
+      
+      propName_ = propName;
+      sentinel_ = docUpdate;
+      pref_ = pref;
+      target_ = targetValue;
+      
+      pref_.addValueChangeHandler(new ValueChangeHandler<String>()
+      {
+         @Override
+         public void onValueChange(ValueChangeEvent<String> event)
+         {
+            onStateChanged();
+         }
+      });
+      onStateChanged();
+   }
+   
+   @Override
+   public boolean isChecked()
+   {
+      if (sentinel_ == null)
+         return false;
+      else if (sentinel_.hasProperty(propName_))
+         return super.isChecked();
+      else
+         return pref_.getValue() == target_;
+   }
+   
+   private final String propName_;
+   private final String target_;
+   private final DocUpdateSentinel sentinel_;
+   private final PrefValue<String> pref_;
+}

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
@@ -1,7 +1,7 @@
 /*
  * ToolbarPopupMenu.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-16 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -22,9 +22,11 @@ import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.Event.NativePreviewHandler;
+import com.google.gwt.user.client.ui.MenuBar;
 import com.google.gwt.user.client.ui.MenuItem;
 import com.google.gwt.user.client.ui.MenuItemSeparator;
 import com.google.gwt.user.client.ui.Widget;
@@ -79,6 +81,11 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
       if (command != null)
          menuItem.setScheduledCommand(new ToolbarPopupMenuCommand(command));
       menuBar_.addItem(menuItem);
+   }
+   
+   public void addItem(SafeHtml html, MenuBar popup)
+   {
+      menuBar_.addItem(html, popup);
    }
    
    public void insertItem(MenuItem menuItem, int beforeIndex)

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenuButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenuButton.java
@@ -1,7 +1,7 @@
 /*
  * ToolbarPopupMenuButton.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-16 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -21,7 +21,9 @@ import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.ui.MenuBar;
 import com.google.gwt.user.client.ui.MenuItem;
 
 public class ToolbarPopupMenuButton extends ToolbarButton
@@ -72,6 +74,15 @@ public class ToolbarPopupMenuButton extends ToolbarButton
          }
       });
       getMenu().addItem(item);
+   }
+   
+   public void addMenuItem(MenuBar subMenu, String label)
+   {
+      SafeHtmlBuilder html = new SafeHtmlBuilder();
+      html.appendHtmlConstant("<span style=\"margin-left: 25px;\">");
+      html.appendEscaped(label);
+      html.appendHtmlConstant("</span>");
+      getMenu().addItem(html.toSafeHtml(), subMenu);
    }
    
    public void addSeparator()

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/RmdOutput.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/RmdOutput.java
@@ -241,7 +241,8 @@ public class RmdOutput implements RmdRenderStartedEvent.Handler,
            null,
            false,
            RmdOutput.TYPE_STATIC,
-           event.getOutputFile());
+           event.getOutputFile(),
+           null);
       events_.fireEvent(renderEvent);
    }
    
@@ -263,6 +264,7 @@ public class RmdOutput implements RmdRenderStartedEvent.Handler,
                               event.asTempfile(),
                               event.getType(),
                               event.getExistingOutputFile(),
+                              event.getWorkingDir(),
                   new SimpleRequestCallback<Boolean>() {
                        @Override 
                        public void onError(ServerError error)
@@ -407,6 +409,7 @@ public class RmdOutput implements RmdRenderStartedEvent.Handler,
             null,
             false,
             RmdOutput.TYPE_STATIC,
+            null,
             null);
        events_.fireEvent(renderEvent);
    }
@@ -535,7 +538,7 @@ public class RmdOutput implements RmdRenderStartedEvent.Handler,
       events_.fireEvent(new RenderRmdEvent(
             result.getTargetFile(), result.getTargetLine(), 
             null, result.getTargetEncoding(), null, false, 
-            RmdOutput.TYPE_SHINY, null));
+            RmdOutput.TYPE_SHINY, null, null));
    }
    
    private void displayRenderResult(final RmdRenderResult result)

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/events/RenderRmdEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/events/RenderRmdEvent.java
@@ -39,7 +39,8 @@ public class RenderRmdEvent extends CrossWindowEvent<RenderRmdEvent.Handler>
                          String paramsFile,
                          boolean asTempfile,
                          int type,
-                         String existingOutputFile)
+                         String existingOutputFile,
+                         String workingDirectory)
    {
       sourceFile_ = sourceFile;
       sourceLine_ = sourceLine;
@@ -49,6 +50,7 @@ public class RenderRmdEvent extends CrossWindowEvent<RenderRmdEvent.Handler>
       asTempfile_ = asTempfile;
       type_ = type;
       existingOutputFile_ = existingOutputFile;
+      workingDirectory_ = workingDirectory;
    }
 
    public String getSourceFile()
@@ -90,6 +92,11 @@ public class RenderRmdEvent extends CrossWindowEvent<RenderRmdEvent.Handler>
    {
       return existingOutputFile_;
    }
+   
+   public String getWorkingDir()
+   {
+      return workingDirectory_;
+   }
     
    @Override
    public Type<Handler> getAssociatedType()
@@ -111,6 +118,9 @@ public class RenderRmdEvent extends CrossWindowEvent<RenderRmdEvent.Handler>
    private boolean asTempfile_;
    private int type_;
    private String existingOutputFile_;
+   private String workingDirectory_;
+   
+   public final static String WORKING_DIR_PROP = "working_dir";
 
    public static final Type<Handler> TYPE = new Type<Handler>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/NotebookDocQueue.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/NotebookDocQueue.java
@@ -24,11 +24,12 @@ public class NotebookDocQueue extends JavaScriptObject
    }
    
    public static final native NotebookDocQueue create(
-         String docId, String jobDesc, int commitMode, 
+         String docId, String jobDesc, String workingDir, int commitMode, 
          int pixelWidth, int charWidth) /*-{
       return {
          doc_id:          docId,
          job_desc:        jobDesc,
+         working_dir:     workingDir,
          commit_mode:     commitMode,
          pixel_width:     pixelWidth,
          char_width:      charWidth,

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RMarkdownServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RMarkdownServerOperations.java
@@ -29,7 +29,7 @@ public interface RMarkdownServerOperations extends CryptoServerOperations
        
    void renderRmd(String file, int line, String format, String encoding,
                   String paramsFile, boolean asTempfile, int type,
-                  String existingOutputFile,
+                  String existingOutputFile, String workingDir,
                   ServerRequestCallback<Boolean> requestCallback);
    
    void renderRmdSource(String source,

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4142,7 +4142,7 @@ public class RemoteServer implements Server
    @Override
    public void renderRmd(String file, int line, String format, String encoding,
                          String paramsFile, boolean asTempfile, int type,
-                         String existingOutputFile,
+                         String existingOutputFile, String workingDir,
          ServerRequestCallback<Boolean> requestCallback)
    {
       JSONArray params = new JSONArray();
@@ -4154,6 +4154,7 @@ public class RemoteServer implements Server
       params.set(5, JSONBoolean.getInstance(asTempfile));
       params.set(6, new JSONNumber(type));
       params.set(7, new JSONString(StringUtil.notNull(existingOutputFile)));
+      params.set(8, new JSONString(StringUtil.notNull(workingDir)));
       sendRequest(RPC_SCOPE,
             RENDER_RMD,
             params,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -406,6 +406,10 @@ public class SessionInfo extends JavaScriptObject
       return this.knit_params_available;
    }-*/;
    
+   public final native boolean getKnitWorkingDirAvailable() /*-{
+      return this.knit_working_dir_available;
+   }-*/;
+   
    public final native boolean getClangAvailable() /*-{
       return this.clang_available;
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -591,9 +591,13 @@ public class UIPrefsAccessor extends Prefs
       return bool("enable_xterm", false);
    }
    
-   public PrefValue<Boolean> knitInWorkingDir()
+   public static final String KNIT_DIR_DEFAULT = "default";
+   public static final String KNIT_DIR_CURRENT = "current";
+   public static final String KNIT_DIR_PROJECT = "project";
+   
+   public PrefValue<String> knitWorkingDir()
    {
-      return bool("knit_in_working_dir", false);
+      return string("knit_working_dir", KNIT_DIR_DEFAULT);
    }
    
    public static final String DOC_OUTLINE_SHOW_SECTIONS_ONLY = "show_sections_only";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -591,6 +591,11 @@ public class UIPrefsAccessor extends Prefs
       return bool("enable_xterm", false);
    }
    
+   public PrefValue<Boolean> knitInWorkingDir()
+   {
+      return bool("knit_in_working_dir", false);
+   }
+   
    public static final String DOC_OUTLINE_SHOW_SECTIONS_ONLY = "show_sections_only";
    public static final String DOC_OUTLINE_SHOW_SECTIONS_AND_NAMED_CHUNKS = "show_sections_and_chunks";
    public static final String DOC_OUTLINE_SHOW_ALL = "show_all";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/RMarkdownPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/RMarkdownPreferencesPane.java
@@ -1,7 +1,7 @@
 /*
  * RMarkdownPreferencesPane.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-16 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -21,6 +21,7 @@ import com.google.inject.Inject;
 import org.rstudio.core.client.widget.SelectWidget;
 import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.rmarkdown.RmdOutput;
+import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.prefs.model.RPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefsAccessor;
@@ -29,7 +30,8 @@ public class RMarkdownPreferencesPane extends PreferencesPane
 {
    @Inject
    public RMarkdownPreferencesPane(UIPrefs prefs,
-                                   PreferencesDialogResources res)
+                                   PreferencesDialogResources res,
+                                   Session session)
    {
       prefs_ = prefs;
       res_ = res;
@@ -98,22 +100,29 @@ public class RMarkdownPreferencesPane extends PreferencesPane
             false);
       add(latexPreviewWidget_);
       
-      knitWorkingDir_ = new SelectWidget(
-            "Evaluate chunks in directory: ",
-            new String[] {
-                  "Document",
-                  "Current",
-                  "Project"
-            },
-            new String[] {
-                  UIPrefsAccessor.KNIT_DIR_DEFAULT,
-                  UIPrefsAccessor.KNIT_DIR_CURRENT,
-                  UIPrefsAccessor.KNIT_DIR_PROJECT
-            },
-            false,
-            true,
-            false);
-      add(knitWorkingDir_);
+      if (session.getSessionInfo().getKnitWorkingDirAvailable())
+      {
+         knitWorkingDir_ = new SelectWidget(
+               "Evaluate chunks in directory: ",
+               new String[] {
+                     "Document",
+                     "Current",
+                     "Project"
+               },
+               new String[] {
+                     UIPrefsAccessor.KNIT_DIR_DEFAULT,
+                     UIPrefsAccessor.KNIT_DIR_CURRENT,
+                     UIPrefsAccessor.KNIT_DIR_PROJECT
+               },
+               false,
+               true,
+               false);
+         add(knitWorkingDir_);
+      }
+      else
+      {
+         knitWorkingDir_ = null;
+      }
       
       add(spacedBefore(headerLabel("R Notebooks")));
 
@@ -173,10 +182,12 @@ public class RMarkdownPreferencesPane extends PreferencesPane
       prefs_.showLatexPreviewOnCursorIdle().setGlobalValue(
             latexPreviewWidget_.getValue());
       
-      prefs_.knitWorkingDir().setGlobalValue(
-            knitWorkingDir_.getValue());
+      if (knitWorkingDir_ != null)
+      {
+         prefs_.knitWorkingDir().setGlobalValue(
+               knitWorkingDir_.getValue());
+      }
       
-                 
       return requiresRestart;
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/RMarkdownPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/RMarkdownPreferencesPane.java
@@ -98,8 +98,22 @@ public class RMarkdownPreferencesPane extends PreferencesPane
             false);
       add(latexPreviewWidget_);
       
-      add(checkboxPref("Knit in current working directory", 
-            prefs_.knitInWorkingDir()));
+      knitWorkingDir_ = new SelectWidget(
+            "Evaluate chunks in directory: ",
+            new String[] {
+                  "Document",
+                  "Current",
+                  "Project"
+            },
+            new String[] {
+                  UIPrefsAccessor.KNIT_DIR_DEFAULT,
+                  UIPrefsAccessor.KNIT_DIR_CURRENT,
+                  UIPrefsAccessor.KNIT_DIR_PROJECT
+            },
+            false,
+            true,
+            false);
+      add(knitWorkingDir_);
       
       add(spacedBefore(headerLabel("R Notebooks")));
 
@@ -158,6 +172,10 @@ public class RMarkdownPreferencesPane extends PreferencesPane
       
       prefs_.showLatexPreviewOnCursorIdle().setGlobalValue(
             latexPreviewWidget_.getValue());
+      
+      prefs_.knitWorkingDir().setGlobalValue(
+            knitWorkingDir_.getValue());
+      
                  
       return requiresRestart;
    }
@@ -169,4 +187,5 @@ public class RMarkdownPreferencesPane extends PreferencesPane
    private final SelectWidget rmdViewerMode_;
    private final SelectWidget docOutlineDisplay_;
    private final SelectWidget latexPreviewWidget_;
+   private final SelectWidget knitWorkingDir_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/RMarkdownPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/RMarkdownPreferencesPane.java
@@ -98,6 +98,9 @@ public class RMarkdownPreferencesPane extends PreferencesPane
             false);
       add(latexPreviewWidget_);
       
+      add(checkboxPref("Knit in current working directory", 
+            prefs_.knitInWorkingDir()));
+      
       add(spacedBefore(headerLabel("R Notebooks")));
 
       // auto-execute the setup chunk

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -4988,7 +4988,8 @@ public class TextEditingTarget implements
                         paramsFile,
                         asTempfile,
                         type,
-                        false);
+                        false,
+                        rmarkdownHelper_.getKnitWorkingDir(docUpdateSentinel_));
                }
             });  
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
@@ -72,6 +72,7 @@ import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.WorkbenchContext;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
+import org.rstudio.studio.client.workbench.prefs.model.UIPrefsAccessor;
 import org.rstudio.studio.client.workbench.views.files.model.FilesServerOperations;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 import org.rstudio.studio.client.workbench.views.source.events.FileEditEvent;
@@ -280,12 +281,25 @@ public class TextEditingTargetRMarkdownHelper
    
    public String getKnitWorkingDir(DocUpdateSentinel sourceDoc)
    {
-      if (sourceDoc.getBoolProperty(RenderRmdEvent.WORKING_DIR_PROP, 
-                                    prefs_.knitInWorkingDir().getValue()))
+      // compute desired working directory type
+      String workingDirType = sourceDoc.getProperty(
+            RenderRmdEvent.WORKING_DIR_PROP,
+            prefs_.knitWorkingDir().getValue());
+
+      String workingDir = null;
+      if (workingDirType == UIPrefsAccessor.KNIT_DIR_PROJECT)
       {
-         return workbenchContext_.getCurrentWorkingDir().getPath();
+         // get the project directory, but if we don't have one (e.g. no
+         // project) use the default working directory for the session
+         workingDir = session_.getSessionInfo().getActiveProjectDir().getPath();
+         if (StringUtil.isNullOrEmpty(workingDir))
+            workingDir = session_.getSessionInfo().getDefaultWorkingDir();
       }
-      return null;
+      else if (workingDirType == UIPrefsAccessor.KNIT_DIR_CURRENT)
+      {
+         workingDir = workbenchContext_.getCurrentWorkingDir().getPath();
+      }
+      return workingDir;
    }
    
    public void renderRMarkdown(final String sourceFile, 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
@@ -274,7 +274,18 @@ public class TextEditingTargetRMarkdownHelper
                                              null,
                                              false,
                                              RmdOutput.TYPE_STATIC,
-                                             null));
+                                             null,
+                                             getKnitWorkingDir(sourceDoc)));
+   }
+   
+   public String getKnitWorkingDir(DocUpdateSentinel sourceDoc)
+   {
+      if (sourceDoc.getBoolProperty(RenderRmdEvent.WORKING_DIR_PROP, 
+                                    prefs_.knitInWorkingDir().getValue()))
+      {
+         return workbenchContext_.getCurrentWorkingDir().getPath();
+      }
+      return null;
    }
    
    public void renderRMarkdown(final String sourceFile, 
@@ -284,7 +295,8 @@ public class TextEditingTargetRMarkdownHelper
                                final String paramsFile,
                                final boolean asTempfile,
                                final int type,
-                               final boolean asShiny)
+                               final boolean asShiny,
+                               final String workingDir)
    {
       withRMarkdownPackage(type == RmdOutput.TYPE_NOTEBOOK ?
                               "R Notebook" :
@@ -302,7 +314,8 @@ public class TextEditingTargetRMarkdownHelper
                                                    paramsFile,
                                                    asTempfile,
                                                    type,
-                                                   null));
+                                                   null,
+                                                   workingDir));
          }
       });
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
@@ -281,6 +281,10 @@ public class TextEditingTargetRMarkdownHelper
    
    public String getKnitWorkingDir(DocUpdateSentinel sourceDoc)
    {
+      // shortcut if we don't support manually specified working directories
+      if (!session_.getSessionInfo().getKnitWorkingDirAvailable())
+         return null;
+      
       // compute desired working directory type
       String workingDirType = sourceDoc.getProperty(
             RenderRmdEvent.WORKING_DIR_PROP,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -887,16 +887,31 @@ public class TextEditingTargetWidget
       
       }
       
-      DocPropMenuItem knitInWorkingDir = new DocPropMenuItem(
-            "Knit in Working Directory", 
+      rmdFormatButton_.addSeparator();
+      DocPropMenuItem knitInDocDir = new DocShadowPropMenuItem(
+            "Knit in Document Directory", 
             docUpdateSentinel_, 
-            docUpdateSentinel_.getBoolProperty(
-                  RenderRmdEvent.WORKING_DIR_PROP, 
-                  uiPrefs_.knitInWorkingDir().getValue()), 
-            RenderRmdEvent.WORKING_DIR_PROP, 
-            DocUpdateSentinel.PROPERTY_TRUE);
-      rmdFormatButton_.addMenuItem(knitInWorkingDir, 
-            knitInWorkingDir.getLabel());
+            uiPrefs_.knitWorkingDir(), 
+            RenderRmdEvent.WORKING_DIR_PROP,
+            UIPrefsAccessor.KNIT_DIR_DEFAULT);
+      rmdFormatButton_.addMenuItem(knitInDocDir, 
+            knitInDocDir.getLabel());
+      DocPropMenuItem knitInCurrentDir = new DocShadowPropMenuItem(
+            "Knit in Current Directory", 
+            docUpdateSentinel_, 
+            uiPrefs_.knitWorkingDir(), 
+            RenderRmdEvent.WORKING_DIR_PROP,
+            UIPrefsAccessor.KNIT_DIR_CURRENT);
+      rmdFormatButton_.addMenuItem(knitInCurrentDir, 
+            knitInCurrentDir.getLabel());
+      DocPropMenuItem knitInProjectDir = new DocShadowPropMenuItem(
+            "Knit in Project Directory", 
+            docUpdateSentinel_, 
+            uiPrefs_.knitWorkingDir(), 
+            RenderRmdEvent.WORKING_DIR_PROP,
+            UIPrefsAccessor.KNIT_DIR_PROJECT);
+      rmdFormatButton_.addMenuItem(knitInProjectDir, 
+            knitInProjectDir.getLabel());
       
       addClearKnitrCacheMenu(rmdFormatButton_);
           

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -1,7 +1,7 @@
 /*
  * TextEditingTargetWidget.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-16 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -268,7 +268,7 @@ public class TextEditingTargetWidget
       knitDocumentButton_.getElement().getStyle().setMarginRight(0, Unit.PX);
       toolbar.addLeftWidget(knitDocumentButton_);
       toolbar.addLeftWidget(compilePdfButton_ = commands_.compilePDF().createToolbarButton());
-      rmdFormatButton_ = new ToolbarPopupMenuButton(false, false);
+      rmdFormatButton_ = new ToolbarPopupMenuButton(false, true);
       toolbar.addLeftWidget(rmdFormatButton_);
       
       runDocumentMenuButton_ = new ToolbarPopupMenuButton(false, true);
@@ -888,31 +888,31 @@ public class TextEditingTargetWidget
       
       if (session_.getSessionInfo().getKnitWorkingDirAvailable())
       {
-         rmdFormatButton_.addSeparator();
+         MenuBar knitDirMenu = new MenuBar(true);
          DocPropMenuItem knitInDocDir = new DocShadowPropMenuItem(
-               "Knit in Document Directory", 
+               "Document Directory", 
                docUpdateSentinel_, 
                uiPrefs_.knitWorkingDir(), 
                RenderRmdEvent.WORKING_DIR_PROP,
                UIPrefsAccessor.KNIT_DIR_DEFAULT);
-         rmdFormatButton_.addMenuItem(knitInDocDir, 
-               knitInDocDir.getLabel());
+         knitDirMenu.addItem(knitInDocDir);
          DocPropMenuItem knitInCurrentDir = new DocShadowPropMenuItem(
-               "Knit in Current Directory", 
+               "Current Directory", 
                docUpdateSentinel_, 
                uiPrefs_.knitWorkingDir(), 
                RenderRmdEvent.WORKING_DIR_PROP,
                UIPrefsAccessor.KNIT_DIR_CURRENT);
-         rmdFormatButton_.addMenuItem(knitInCurrentDir, 
-               knitInCurrentDir.getLabel());
+         knitDirMenu.addItem(knitInCurrentDir);
          DocPropMenuItem knitInProjectDir = new DocShadowPropMenuItem(
-               "Knit in Project Directory", 
+               "Project Directory", 
                docUpdateSentinel_, 
                uiPrefs_.knitWorkingDir(), 
                RenderRmdEvent.WORKING_DIR_PROP,
                UIPrefsAccessor.KNIT_DIR_PROJECT);
-         rmdFormatButton_.addMenuItem(knitInProjectDir, 
-               knitInProjectDir.getLabel());
+         knitDirMenu.addItem(knitInProjectDir);
+
+         rmdFormatButton_.addSeparator();
+         rmdFormatButton_.addMenuItem(knitDirMenu, "Knit Directory");
       }
       
       addClearKnitrCacheMenu(rmdFormatButton_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -55,6 +55,7 @@ import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.common.icons.StandardIcons;
 import org.rstudio.studio.client.rmarkdown.RmdOutput;
+import org.rstudio.studio.client.rmarkdown.events.RenderRmdEvent;
 import org.rstudio.studio.client.rmarkdown.events.RmdOutputFormatChangedEvent;
 import org.rstudio.studio.client.rsconnect.RSConnect;
 import org.rstudio.studio.client.rsconnect.ui.RSConnectPublishButton;
@@ -885,6 +886,17 @@ public class TextEditingTargetWidget
          rmdFormatButton_.addMenuItem(item, knitWithParams.getMenuLabel(false));
       
       }
+      
+      DocPropMenuItem knitInWorkingDir = new DocPropMenuItem(
+            "Knit in Working Directory", 
+            docUpdateSentinel_, 
+            docUpdateSentinel_.getBoolProperty(
+                  RenderRmdEvent.WORKING_DIR_PROP, 
+                  uiPrefs_.knitInWorkingDir().getValue()), 
+            RenderRmdEvent.WORKING_DIR_PROP, 
+            DocUpdateSentinel.PROPERTY_TRUE);
+      rmdFormatButton_.addMenuItem(knitInWorkingDir, 
+            knitInWorkingDir.getLabel());
       
       addClearKnitrCacheMenu(rmdFormatButton_);
           

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -268,7 +268,7 @@ public class TextEditingTargetWidget
       knitDocumentButton_.getElement().getStyle().setMarginRight(0, Unit.PX);
       toolbar.addLeftWidget(knitDocumentButton_);
       toolbar.addLeftWidget(compilePdfButton_ = commands_.compilePDF().createToolbarButton());
-      rmdFormatButton_ = new ToolbarPopupMenuButton(false, true);
+      rmdFormatButton_ = new ToolbarPopupMenuButton(false, false);
       toolbar.addLeftWidget(rmdFormatButton_);
       
       runDocumentMenuButton_ = new ToolbarPopupMenuButton(false, true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -884,34 +884,36 @@ public class TextEditingTargetWidget
                                       true,
                                       cmd); 
          rmdFormatButton_.addMenuItem(item, knitWithParams.getMenuLabel(false));
-      
       }
       
-      rmdFormatButton_.addSeparator();
-      DocPropMenuItem knitInDocDir = new DocShadowPropMenuItem(
-            "Knit in Document Directory", 
-            docUpdateSentinel_, 
-            uiPrefs_.knitWorkingDir(), 
-            RenderRmdEvent.WORKING_DIR_PROP,
-            UIPrefsAccessor.KNIT_DIR_DEFAULT);
-      rmdFormatButton_.addMenuItem(knitInDocDir, 
-            knitInDocDir.getLabel());
-      DocPropMenuItem knitInCurrentDir = new DocShadowPropMenuItem(
-            "Knit in Current Directory", 
-            docUpdateSentinel_, 
-            uiPrefs_.knitWorkingDir(), 
-            RenderRmdEvent.WORKING_DIR_PROP,
-            UIPrefsAccessor.KNIT_DIR_CURRENT);
-      rmdFormatButton_.addMenuItem(knitInCurrentDir, 
-            knitInCurrentDir.getLabel());
-      DocPropMenuItem knitInProjectDir = new DocShadowPropMenuItem(
-            "Knit in Project Directory", 
-            docUpdateSentinel_, 
-            uiPrefs_.knitWorkingDir(), 
-            RenderRmdEvent.WORKING_DIR_PROP,
-            UIPrefsAccessor.KNIT_DIR_PROJECT);
-      rmdFormatButton_.addMenuItem(knitInProjectDir, 
-            knitInProjectDir.getLabel());
+      if (session_.getSessionInfo().getKnitWorkingDirAvailable())
+      {
+         rmdFormatButton_.addSeparator();
+         DocPropMenuItem knitInDocDir = new DocShadowPropMenuItem(
+               "Knit in Document Directory", 
+               docUpdateSentinel_, 
+               uiPrefs_.knitWorkingDir(), 
+               RenderRmdEvent.WORKING_DIR_PROP,
+               UIPrefsAccessor.KNIT_DIR_DEFAULT);
+         rmdFormatButton_.addMenuItem(knitInDocDir, 
+               knitInDocDir.getLabel());
+         DocPropMenuItem knitInCurrentDir = new DocShadowPropMenuItem(
+               "Knit in Current Directory", 
+               docUpdateSentinel_, 
+               uiPrefs_.knitWorkingDir(), 
+               RenderRmdEvent.WORKING_DIR_PROP,
+               UIPrefsAccessor.KNIT_DIR_CURRENT);
+         rmdFormatButton_.addMenuItem(knitInCurrentDir, 
+               knitInCurrentDir.getLabel());
+         DocPropMenuItem knitInProjectDir = new DocShadowPropMenuItem(
+               "Knit in Project Directory", 
+               docUpdateSentinel_, 
+               uiPrefs_.knitWorkingDir(), 
+               RenderRmdEvent.WORKING_DIR_PROP,
+               UIPrefsAccessor.KNIT_DIR_PROJECT);
+         rmdFormatButton_.addMenuItem(knitInProjectDir, 
+               knitInProjectDir.getLabel());
+      }
       
       addClearKnitrCacheMenu(rmdFormatButton_);
           

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -896,13 +896,6 @@ public class TextEditingTargetWidget
                RenderRmdEvent.WORKING_DIR_PROP,
                UIPrefsAccessor.KNIT_DIR_DEFAULT);
          knitDirMenu.addItem(knitInDocDir);
-         DocPropMenuItem knitInCurrentDir = new DocShadowPropMenuItem(
-               "Current Directory", 
-               docUpdateSentinel_, 
-               uiPrefs_.knitWorkingDir(), 
-               RenderRmdEvent.WORKING_DIR_PROP,
-               UIPrefsAccessor.KNIT_DIR_CURRENT);
-         knitDirMenu.addItem(knitInCurrentDir);
          DocPropMenuItem knitInProjectDir = new DocShadowPropMenuItem(
                "Project Directory", 
                docUpdateSentinel_, 
@@ -910,6 +903,13 @@ public class TextEditingTargetWidget
                RenderRmdEvent.WORKING_DIR_PROP,
                UIPrefsAccessor.KNIT_DIR_PROJECT);
          knitDirMenu.addItem(knitInProjectDir);
+         DocPropMenuItem knitInCurrentDir = new DocShadowPropMenuItem(
+               "Current Working Directory", 
+               docUpdateSentinel_, 
+               uiPrefs_.knitWorkingDir(), 
+               RenderRmdEvent.WORKING_DIR_PROP,
+               UIPrefsAccessor.KNIT_DIR_CURRENT);
+         knitDirMenu.addItem(knitInCurrentDir);
 
          rmdFormatButton_.addSeparator();
          rmdFormatButton_.addMenuItem(knitDirMenu, "Knit Directory");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/NotebookQueueState.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/NotebookQueueState.java
@@ -41,6 +41,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
 import org.rstudio.studio.client.workbench.views.source.editors.text.Scope;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ScopeList;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTarget;
+import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetRMarkdownHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetScopeHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.LineWidget;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
@@ -64,6 +65,7 @@ public class NotebookQueueState implements NotebookRangeExecutedEvent.Handler,
       notebook_ = notebook;
       editingTarget_ = editingTarget;
       scopeHelper_ = new TextEditingTargetScopeHelper(display);
+      rmdHelper_ = new TextEditingTargetRMarkdownHelper();
       
       events_.addHandler(NotebookRangeExecutedEvent.TYPE, this);
       events_.addHandler(ChunkExecStateChangedEvent.TYPE, this);
@@ -548,6 +550,7 @@ public class NotebookQueueState implements NotebookRangeExecutedEvent.Handler,
       
       // create new queue
       queue_ = NotebookDocQueue.create(sentinel_.getId(), jobDesc, 
+            StringUtil.notNull(rmdHelper_.getKnitWorkingDir(sentinel_)),
             notebook_.getCommitMode(), notebook_.getPlotWidth(), charWidth_);
    }
    
@@ -624,6 +627,7 @@ public class NotebookQueueState implements NotebookRangeExecutedEvent.Handler,
    private final EventBus events_;
    private final TextEditingTargetScopeHelper scopeHelper_;
    private final TextEditingTarget editingTarget_;
+   private final TextEditingTargetRMarkdownHelper rmdHelper_;
    
    private int pixelWidth_;
    private int charWidth_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
@@ -753,7 +753,7 @@ public class DocUpdateSentinel
    {
       return sourceDoc_.getId();
    }
-
+   
    private boolean changesPending_ = false;
    private final ChangeTracker changeTracker_;
    private final SourceServerOperations server_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
@@ -578,6 +578,13 @@ public class DocUpdateSentinel
       return properties.getString(propertyName);
    }
    
+   public String getProperty(String propertyName, String defaultValue)
+   {
+      if (hasProperty(propertyName))
+         return getProperty(propertyName);
+      return defaultValue;
+   }
+   
    public boolean getBoolProperty(String propertyName, boolean defaultValue)
    {
       if (hasProperty(propertyName))


### PR DESCRIPTION
This change addresses one of the largest points of confusion surrounding the notebook release; specifically that executing R Markdown chunks interactively used to evaluate the code in the current working directory, but now evaluates it in the document directory.

After the change, it's possible to choose (both per document and globally) where you'd like the chunks executed. For example:

![image](https://cloud.githubusercontent.com/assets/470418/20451054/49ea4302-adaa-11e6-9857-5fbcf9fda226.png)

The chosen directory is used to evaluate chunks both when the document is rendered with R Markdown and when chunks are run interactively. These new preferences are roughly an interactive analog to the new global `knitr.use.cwd` option. It's worth noting that this parallel implementation does not read `knitr.use.cwd`, and takes precedence over it.

The new UX is only displayed and used when a suitable version of the `rmarkdown` package is installed (i.e. one with support for the `knit_root_dir` parameter). 