### PR TITLE
Install rmarkdown and rsconnect from CRAN

### DIFF
--- a/dependencies/common/install-packages
+++ b/dependencies/common/install-packages
@@ -64,8 +64,5 @@ mv $PACKAGE_ARCHIVE $PACKAGE_ARCHIVE_SHA1
 
 }
 
-install rsconnect master
-install rmarkdown master
-
 # back to install-dir
 cd $INSTALL_DIR

--- a/dependencies/common/install-packages.cmd
+++ b/dependencies/common/install-packages.cmd
@@ -9,9 +9,6 @@ set "PATH=C:\Program Files (x86)\Git\bin;%PATH%"
 
 set PATH=%PATH%;%CD%\tools
 
-call:install rsconnect master --no-build-vignettes
-call:install rmarkdown master --no-build-vignettes
-
 GOTO:EOF
 
 :install

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -28,12 +28,6 @@ endif()
 if(NOT EXISTS "${RSTUDIO_DEPENDENCIES_DIR}/common/pandoc")
   message(FATAL_ERROR "pandoc not found (re-run install-dependencies script to install)")
 endif()
-if(NOT EXISTS "${RSTUDIO_DEPENDENCIES_DIR}/common/rmarkdown")
-  message(FATAL_ERROR "rmarkdown package not found (re-run install-dependencies script to install)")
-endif()
-if(NOT EXISTS "${RSTUDIO_DEPENDENCIES_DIR}/common/rsconnect")
-  message(FATAL_ERROR "rsconnect package not found (re-run install-dependencies script to install)")
-endif()
 
 # verify libclang is installed
 if(WIN32)
@@ -437,16 +431,6 @@ if (NOT RSTUDIO_SESSION_WIN64)
    install(FILES ${PANDOC_FILES}
            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
            DESTINATION  ${RSTUDIO_INSTALL_BIN}/pandoc)
-
-   # install rmarkdown package
-   file(GLOB RMARKDOWN_PACKAGE "${RSTUDIO_DEPENDENCIES_DIR}/common/rmarkdown*.tar.gz")
-   install(FILES ${RMARKDOWN_PACKAGE}
-           DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/R/packages)
-
-   # install rsconnect package
-   file(GLOB RSCONNECT_PACKAGE "${RSTUDIO_DEPENDENCIES_DIR}/common/rsconnect*.tar.gz")
-   install(FILES ${RSCONNECT_PACKAGE}
-           DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/R/packages)
 
    # install PDF.js
    install(DIRECTORY "resources/pdfjs"

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -152,7 +152,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       if (requiresRmarkdown)
          deps.addAll(rmarkdownDependencies());
       deps.add(Dependency.cranPackage("packrat", "0.4.8-1", true));
-      deps.add(Dependency.embeddedPackage("rsconnect"));
+      deps.add(Dependency.cranPackage("rsconnect", "0.6", true));
       
       withDependencies(
         "Publishing",
@@ -218,7 +218,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       deps.add(Dependency.cranPackage("jsonlite", "0.9.19"));
       deps.add(Dependency.cranPackage("base64enc", "0.1-3"));
       deps.add(Dependency.cranPackage("rprojroot", "1.0"));
-      deps.add(Dependency.embeddedPackage("rmarkdown"));
+      deps.add(Dependency.cranPackage("rmarkdown", "1.2", true));
       return deps;
    }
    


### PR DESCRIPTION
NOTE: We shouldn't take this PR until after both packages are accepted to CRAN (rmarkdown v1.2 has been accepted but rsconnect v0.6 is still pending).

This change is only for the patch branch (it shouldn't also be merged into master b/c master is by convention using the development version of both packages).