### PR TITLE
Add support for JavaScript and CSS chunks in R notebooks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * Always show chunk output preferences (inline or console)
 * Add support for variable height HTML widgets (non-knitr figures)
 * Improve support for non-ASCII characters in chunk metadata and output
+* Add support for JavaScript and CSS chunks
 
 ### Data Import
 

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -296,9 +296,25 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
       # determine whether we include source code (respect chunk options)
       includeSource <- isTRUE(context$echo) && isTRUE(context$include)
       
-      # if we have no chunk outputs, just show source code (respecting
-      # chunk options as appropriate)
-      if (is.null(chunkId)) {
+      if (identical(context$engine, "js") || identical(context$engine, "css")) {
+         # these engines never show code; ensure they're marked for evaluation
+         # and then emit contents literally wrapped in the appropriate tags
+         htmlOutput <- ""
+         if (isTRUE(context$eval)) {
+            if (identical(context$engine, "js")) {
+               htmlOutput <- paste(
+                  c('<script type="text/javascript">', code, '</script>'),
+                    collapse = '\n')
+            } else if (identical(context$engine, "css")) {
+               htmlOutput <- paste(
+                  c('<style type="text/css">', code, '</style>'),
+                    collapse = '\n')
+            }
+         }
+         return(knitr::asis_output(htmlOutput))
+      } else if (is.null(chunkId)) {
+         # if we have no chunk outputs, just show source code (respecting
+         # chunk options as appropriate)
          if (includeSource) {
             attributes <- list(class = .rs.rnb.engineToCodeClass(context$engine))
             


### PR DESCRIPTION
This change enables the use of the `js` and `css` knitr engines in R Notebooks. As in knitr, chunks using these engines don't display their code, and have their contents emitted literally into the document (wrapped in the appropriate tags) at the chunk site. 

@kevinushey, would you be willing to review this?