### PR TITLE
Feature/terminal

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -36,8 +36,9 @@ import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSession
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStoppedEvent;
 import org.rstudio.studio.client.workbench.views.terminal.xterm.XTermWidget;
 
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.Timer;
 import com.google.inject.Inject;
 
 
@@ -230,18 +231,16 @@ public class TerminalSession extends XTermWidget
          // there are issues with xterm.js losing its mind when it is resized
          // after re-emerging from behind other terminals. Why? Is this delay
          // the best solution?
-         sendOnResizeLocal_.schedule(5);
+         Scheduler.get().scheduleDeferred(new ScheduledCommand()
+         {
+            @Override
+            public void execute()
+            {
+               onResize();
+            }
+         });
       }
    }
-   
-   private Timer sendOnResizeLocal_ = new Timer()
-   {
-      @Override
-      public void run()
-      {
-         onResize();
-      }
-   };
    
    public String getTerminalTitle()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -37,6 +37,7 @@ import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSession
 import org.rstudio.studio.client.workbench.views.terminal.xterm.XTermWidget;
 
 import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.Timer;
 import com.google.inject.Inject;
 
 
@@ -211,6 +212,36 @@ public class TerminalSession extends XTermWidget
       super.onDetach();
       unregisterHandlers();
    }
+  
+   @Override
+   public void setVisible(boolean isVisible)
+   {
+      super.setVisible(isVisible);
+      if (isVisible)
+      {
+         // Inform the terminal that there may have been a resize. This could 
+         // happen on first display, or if the terminal was hidden behind other
+         // terminal sessions and there was a resize.
+         // A delay is needed to give the xterm.js implementation an
+         // opportunity to be ready for this.
+         
+         // TODO (gary) I already debounce heavily in XTermWidget.onResize, not
+         // sure why this additional level of delay is needed, but without it
+         // there are issues with xterm.js losing its mind when it is resized
+         // after re-emerging from behind other terminals. Why? Is this delay
+         // the best solution?
+         sendOnResizeLocal_.schedule(5);
+      }
+   }
+   
+   private Timer sendOnResizeLocal_ = new Timer()
+   {
+      @Override
+      public void run()
+      {
+         onResize();
+      }
+   };
    
    public String getTerminalTitle()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermDimensions.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermDimensions.java
@@ -17,10 +17,21 @@ package org.rstudio.studio.client.workbench.views.terminal.xterm;
 
 import com.google.gwt.core.client.JavaScriptObject;
 
+/**
+ * Size of xterm in rows and columns of text. A dimension will be returned
+ * as -1 if it could not be computed.
+ */
 public class XTermDimensions extends JavaScriptObject
 {
    protected XTermDimensions() {}
    
-   public final native int getCols() /*-{ return this.cols; }-*/;
-   public final native int getRows() /*-{ return this.rows; }-*/;
+   public final native int getCols() /*-{
+      if (this.cols !== this.cols) { return -1; } // isNaN
+      return this.cols;
+   }-*/;
+
+   public final native int getRows() /*-{
+      if (this.rows !== this.rows) { return -1; } // isNaN
+      return this.rows;
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -221,13 +221,13 @@ public class XTermWidget extends Widget implements RequiresResize,
          }
 
          // don't send same size multiple times
-         if (cols == previousCols && rows == previousRows)
+         if (cols == previousCols_ && rows == previousRows_)
          {
             return;
          }
          
-         previousCols = cols;
-         previousRows = rows;
+         previousCols_ = cols;
+         previousRows_ = rows;
          
          fireEvent(new ResizeTerminalEvent(cols, rows)); 
       }
@@ -323,6 +323,6 @@ public class XTermWidget extends Widget implements RequiresResize,
    private boolean initialized_ = false;
    private boolean hasTerminalDataInputHandler_ = false;
    
-   private int previousRows = -1;
-   private int previousCols = -1;
+   private int previousRows_ = -1;
+   private int previousCols_ = -1;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -21,6 +21,7 @@ import org.rstudio.core.client.ExternalJavaScriptLoader;
 import org.rstudio.core.client.ExternalJavaScriptLoader.Callback;
 import org.rstudio.core.client.resources.StaticDataResource;
 import org.rstudio.studio.client.common.SuperDevMode;
+import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkOutputUi;
 import org.rstudio.studio.client.workbench.views.terminal.events.ResizeTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalDataInputEvent;
 import org.rstudio.studio.client.workbench.views.terminal.xterm.XTermDimensions;
@@ -33,10 +34,9 @@ import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.LinkElement;
 import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.event.shared.GwtEvent;
-import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.RequiresResize;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -181,14 +181,59 @@ public class XTermWidget extends Widget implements RequiresResize,
    @Override
    public void onResize()
    {
+      if (!isVisible())
+      {
+         return;
+      }
+      
       // Notify the local terminal UI that it has resized so it computes new
-      // dimensions
-      terminal_.fit();
-      XTermDimensions size = getTerminalSize();
-     
-      fireEvent(new ResizeTerminalEvent(size.getCols(), size.getRows()));
+      // dimensions; debounce this slightly as it is somewhat expensive
+      resizeTerminalLocal_.schedule(50);
+      
+      // Notify the remove pseudo-terminal that it has resized; this is quite
+      // expensive so debounce more heavily; e.g. dragging the pane
+      // splitters or resizing the entire window
+      resizeTerminalRemote_.schedule(150);
    }
+   
+   private Timer resizeTerminalLocal_ = new Timer()
+   {
+      @Override
+      public void run()
+      {
+         terminal_.fit();
+      }
+   };
+   
+   private Timer resizeTerminalRemote_ = new Timer()
+   {
+      @Override
+      public void run()
+      {
+         XTermDimensions size = getTerminalSize();
+         
+         int cols = size.getCols();
+         int rows = size.getRows();
+         
+         // ignore if a reasonable size couldn't be computed
+         if (cols < 1 || rows < 1)
+         {
+            return;
+         }
 
+         // don't send same size multiple times
+         if (cols == previousCols && rows == previousRows)
+         {
+            return;
+         }
+         
+         previousCols = cols;
+         previousRows = rows;
+         
+         fireEvent(new ResizeTerminalEvent(cols, rows)); 
+      }
+   };
+   
    private void addDataEventHandler(CommandWithArg<String> handler)
    {
       terminal_.onTerminalData(handler);
@@ -219,7 +264,7 @@ public class XTermWidget extends Widget implements RequiresResize,
    @Override
    public HandlerRegistration addResizeTerminalHandler(ResizeTerminalEvent.Handler handler)
    {
-      return handlers_.addHandler(ResizeTerminalEvent.TYPE, handler);
+      return addHandler(handler, ResizeTerminalEvent.TYPE);
    }
    
    @Override
@@ -238,15 +283,9 @@ public class XTermWidget extends Widget implements RequiresResize,
       });
             
       hasTerminalDataInputHandler_ = true;
-      return handlers_.addHandler(TerminalDataInputEvent.TYPE, handler);
+      return addHandler(handler, TerminalDataInputEvent.TYPE);
    }
 
-   @Override
-   public void fireEvent(GwtEvent<?> event)
-   {
-      handlers_.fireEvent(event);
-   }
-   
    /**
     * Load resources for XTermWidget.
     * 
@@ -283,6 +322,8 @@ public class XTermWidget extends Widget implements RequiresResize,
    private XTermNative terminal_;
    private LinkElement currentStyleEl_;
    private boolean initialized_ = false;
-   protected final HandlerManager handlers_ = new HandlerManager(this);
    private boolean hasTerminalDataInputHandler_ = false;
+   
+   private int previousRows = -1;
+   private int previousCols = -1;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -21,7 +21,6 @@ import org.rstudio.core.client.ExternalJavaScriptLoader;
 import org.rstudio.core.client.ExternalJavaScriptLoader.Callback;
 import org.rstudio.core.client.resources.StaticDataResource;
 import org.rstudio.studio.client.common.SuperDevMode;
-import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkOutputUi;
 import org.rstudio.studio.client.workbench.views.terminal.events.ResizeTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalDataInputEvent;
 import org.rstudio.studio.client.workbench.views.terminal.xterm.XTermDimensions;


### PR DESCRIPTION
Fix terminal sizing issues
-------------------------

- initial size was not sent to the pseudo-terminal, so things like vim would not be the correct size unless you resized the IDE panes after opening the terminal
- if terminal pane was resized with terminals hidden behind other terminals, the hidden ones were not informed of the resize and would be wrong size when redisplayed
- too many sizing messages being sent, making redraw frequently stutter and often stop at the wrong size (add checks for duplicate size requests, invalid sizes (< 1 row or column), debounce both the local xterm resize, and the local pseudo-terminal resize messages)
- when hidden terminals running ncurses programs like vim were redisplayed after a resize, they would be very upset and often show as blank (though still responding to keyboard input); add another slight delay to dispatching the resize event when making the pane visible

Minor cleanup
--------------
XTermWidget subclass had its own HandlerManager, now just using the one inherited from Widget