### PR TITLE
Use CRAN release of rmarkdown when creating notebook

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/NotebookHtmlRenderer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/NotebookHtmlRenderer.java
@@ -156,7 +156,7 @@ public class NotebookHtmlRenderer
                                        final String outputPath)
    {
       dependencyManager_.withUnsatisfiedDependencies(
-            Dependency.embeddedPackage("rmarkdown"),
+            Dependency.cranPackage("rmarkdown", "1.2", true),
             new ServerRequestCallback<JsArray<Dependency>>()
             {
                @Override


### PR DESCRIPTION
This change completes the switch away from the embedded version of rmarkdown to the CRAN release (see https://github.com/rstudio/rstudio/commit/9aec5b0bb99716b8e5272dda4c4a25f234c31ca0). 