### PR TITLE
Terminal session switching support

### DIFF
--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -479,19 +479,19 @@ boost::shared_ptr<ConsoleProcess> ConsoleProcess::fromJson(
    else
       pProc->exitCode_.reset(exitCode.get_int());
 
-   // Newly added in v1.1; do checked access below here
-   //-------------------------------------------------
-   json::Value terminalHandle = obj["terminal_handle"];
-   if (!terminalHandle.is_null())
-      pProc->terminalHandle_ = obj["terminal_handle"].get_str();
-   else
+   // Newly added in v1.1
+   Error error = json::readObject(
+                     obj,
+                     "terminal_handle", &pProc->terminalHandle_,
+                     "terminal_sequence", &pProc->terminalSequence_);
+   if (error)
+   {
+      // Possibly unarchiving a pre 1.1 session; ensure defaults are set
+      // and continue
+      LOG_ERROR(error);
       pProc->terminalHandle_.clear();
-   
-   json::Value terminalSequence = obj["terminal_sequence"];
-   if (!terminalSequence.is_null())
-      pProc->terminalSequence_ = static_cast<InteractionMode>(terminalSequence.get_int());
-   else
       pProc->terminalSequence_ = 0;
+   }
    
    return pProc;
 }

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -53,7 +53,7 @@ const int kDefaultMaxOutputLines = 500;
 ConsoleProcess::ConsoleProcess()
    : dialog_(false), showOnOutput_(false), interactionMode_(InteractionNever),
      maxOutputLines_(kDefaultMaxOutputLines), started_(true),
-     interrupt_(false), newCols_(-1), newRows_(-1),
+     interrupt_(false), newCols_(-1), newRows_(-1), terminalSequence_(0),
      outputBuffer_(OUTPUT_BUFFER_SIZE)
 {
    regexInit();
@@ -72,7 +72,7 @@ ConsoleProcess::ConsoleProcess(const std::string& command,
    : command_(command), options_(options), caption_(caption), dialog_(dialog),
      showOnOutput_(false),
      interactionMode_(interactionMode), maxOutputLines_(maxOutputLines),
-     started_(false), interrupt_(false), newCols_(-1), newRows_(-1),
+     started_(false), interrupt_(false), newCols_(-1), newRows_(-1), terminalSequence_(0),
      outputBuffer_(OUTPUT_BUFFER_SIZE)
 {
    commonInit();
@@ -88,7 +88,7 @@ ConsoleProcess::ConsoleProcess(const std::string& program,
    : program_(program), args_(args), options_(options), caption_(caption), dialog_(dialog),
      showOnOutput_(false),
      interactionMode_(interactionMode), maxOutputLines_(maxOutputLines),
-     started_(false),  interrupt_(false), newCols_(-1), newRows_(-1),
+     started_(false),  interrupt_(false), newCols_(-1), newRows_(-1), terminalSequence_(0),
      outputBuffer_(OUTPUT_BUFFER_SIZE)
 {
    commonInit();
@@ -410,6 +410,10 @@ core::json::Object ConsoleProcess::toJson() const
       result["exit_code"] = *exitCode_;
    else
       result["exit_code"] = json::Value();
+
+   // newly added in v1.1
+   result["terminal_handle"] = terminalHandle_;
+   result["terminal_sequence"] = terminalSequence_;
    return result;
 }
 
@@ -448,6 +452,20 @@ boost::shared_ptr<ConsoleProcess> ConsoleProcess::fromJson(
    else
       pProc->exitCode_.reset(exitCode.get_int());
 
+   // Newly added in v1.1; do checked access below here
+   //-------------------------------------------------
+   json::Value terminalHandle = obj["terminal_handle"];
+   if (!terminalHandle.is_null())
+      pProc->terminalHandle_ = obj["terminal_handle"].get_str();
+   else
+      pProc->terminalHandle_.clear();
+   
+   json::Value terminalSequence = obj["terminal_sequence"];
+   if (!terminalSequence.is_null())
+      pProc->terminalSequence_ = static_cast<InteractionMode>(terminalSequence.get_int());
+   else
+      pProc->terminalSequence_ = 0;
+   
    return pProc;
 }
 

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -293,7 +293,12 @@ bool ConsoleProcess::onContinue(core::system::ProcessOperations& ops)
 
 void ConsoleProcess::appendToOutputBuffer(const std::string &str)
 {
-   std::copy(str.begin(), str.end(), std::back_inserter(outputBuffer_));
+   // TODO (gary) for terminals we won't store output history
+   // in the SessionInfo; this will be stored separately, keyed by
+   // Terminal Handle; as a prelude to that stop storing the old way
+   // if we have the terminal handle
+   if (terminalHandle_.empty())
+      std::copy(str.begin(), str.end(), std::back_inserter(outputBuffer_));
 }
 
 void ConsoleProcess::enqueOutputEvent(const std::string &output, bool error)

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -179,6 +179,13 @@ private:
    int newCols_; // -1 = no change
    int newRows_; // -1 = no change
 
+   // The handle of an associated terminal
+   std::string terminalHandle_;
+   
+   // The sequence number of the associated terminal; used to control display
+   // order of terminal tabs
+   int terminalSequence_;
+   
    // Pending input (writes or ptyInterrupts)
    std::queue<Input> inputQueue_;
 

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -71,6 +71,16 @@ private:
          InteractionMode mode,
          int maxOutputLines);
 
+   ConsoleProcess(
+         const std::string& command,
+         const core::system::ProcessOptions& options,
+         const std::string& caption,
+         const std::string& terminalHandle,
+         int terminalSequence,
+         bool dialog,
+         InteractionMode mode,
+         int maxOutputLines);
+   
    void regexInit();
    void commonInit();
 
@@ -113,6 +123,16 @@ public:
          InteractionMode mode,
          int maxOutputLines = kDefaultMaxOutputLines);
 
+   static boost::shared_ptr<ConsoleProcess> create(
+         const std::string& command,
+         core::system::ProcessOptions options,
+         const std::string& caption,
+         const std::string& terminalHandle,
+         const int terminalSequence,
+         bool dialog,
+         InteractionMode mode,
+         int maxOutputLines = kDefaultMaxOutputLines);
+   
    virtual ~ConsoleProcess() {}
 
    // set a custom prompt handler -- return true to indicate the prompt

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -869,11 +869,23 @@ Error startShellDialog(const json::JsonRpcRequest& request,
    // is terminal hosted in a modal dialog? (false means modeless, e.g. a tab)
    bool isModalDialog;
    
+   // terminal handle (empty string if starting a new terminal)
+   std::string termHandle;
+   
+   // terminal title
+   std::string termTitle;
+   
+   // terminal sequence
+   int termSequence = 0;
+   
    Error error = json::readParams(request.params,
                                   &term,
                                   &cols,
                                   &rows,
-                                  &isModalDialog);
+                                  &isModalDialog,
+                                  &termHandle,
+                                  &termTitle,
+                                  &termSequence);
    if (error)
       return error;
    
@@ -912,6 +924,9 @@ Error startShellDialog(const json::JsonRpcRequest& request,
    options.smartTerminal = smartTerm;
    options.cols = cols;
    options.rows = rows;
+   
+   if (termTitle.empty())
+      termTitle = "Shell";
 
    // configure bash command
    core::shell_utils::ShellCommand bashCommand("/usr/bin/env");
@@ -922,7 +937,9 @@ Error startShellDialog(const json::JsonRpcRequest& request,
    boost::shared_ptr<ConsoleProcess> ptrProc =
                ConsoleProcess::create(bashCommand,
                                       options,
-                                      "Shell",
+                                      termTitle,
+                                      termHandle,
+                                      termSequence,
                                       isModalDialog,
                                       InteractionAlways,
                                       console_process::kDefaultMaxOutputLines);

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -904,7 +904,7 @@ Error startShellDialog(const json::JsonRpcRequest& request,
    std::string prompt = (path.length() > 30) ? "\\W$ " : "\\w$ ";
    core::system::setenv(&shellEnv, "PS1", prompt);
 
-   // set xterm title to show current working direction after each command
+   // set xterm title to show current working directory after each command
    if (smartTerm)
    {
       core::system::setenv(&shellEnv, "PROMPT_COMMAND",

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -904,7 +904,14 @@ Error startShellDialog(const json::JsonRpcRequest& request,
    std::string prompt = (path.length() > 30) ? "\\W$ " : "\\w$ ";
    core::system::setenv(&shellEnv, "PS1", prompt);
 
-   // disable screen oriented facillites		
+   // set xterm title to show current working direction after each command
+   if (smartTerm)
+   {
+      core::system::setenv(&shellEnv, "PROMPT_COMMAND",
+                           "echo -ne \"\\033]0;${PWD/#${HOME}/~}\\007\"");
+   }
+   
+   // disable screen oriented facillites
    if (!smartTerm)
    {
       core::system::unsetenv(&shellEnv, "EDITOR");

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -211,7 +211,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(TerminalSession widget);
    void injectMembers(ShellSecureInput userInputEncryption);
    void injectMembers(TerminalPopupMenu menu);
-
+   
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);
 
    Application getApplication() ;

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -114,6 +114,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEdit
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionManager;
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionRequest;
 import org.rstudio.studio.client.workbench.views.source.model.CppCompletion;
+import org.rstudio.studio.client.workbench.views.terminal.TerminalPopupMenu;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalSession;
 import org.rstudio.studio.client.workbench.views.source.editors.text.r.SignatureToolTipManager;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.TextEditingTargetNotebook;
@@ -209,7 +210,8 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(DataImportFileChooser dataImportFileChooser);
    void injectMembers(TerminalSession widget);
    void injectMembers(ShellSecureInput userInputEncryption);
-   
+   void injectMembers(TerminalPopupMenu menu);
+
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);
 
    Application getApplication() ;

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
@@ -58,4 +58,12 @@ public class ConsoleProcessInfo extends JavaScriptObject
       JsObject self = this.cast();
       return self.getInteger("exit_code");
    }
+   
+   public final native String getTerminalHandle() /*-{
+      return this.terminal_handle;
+   }-*/;
+
+   public final native int getTerminalSequence()  /*-{
+      return this.terminal_sequence;
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellSecureInput.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellSecureInput.java
@@ -84,6 +84,15 @@ public class ShellSecureInput
       }
    }
    
+   /**
+    * Release public key so next secureString request will establish new 
+    * encryption credentials.
+    */
+   public void releasePublicKey()
+   {
+      publicKeyInfo_ = null;
+   }
+   
    private PublicKeyInfo publicKeyInfo_ = null;
    
    // Injected ----

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellSecureInput.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellSecureInput.java
@@ -18,6 +18,10 @@ package org.rstudio.studio.client.common.shell;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.Desktop;
+import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.application.events.SessionSerializationEvent;
+import org.rstudio.studio.client.application.events.SessionSerializationHandler;
+import org.rstudio.studio.client.application.model.SessionSerializationAction;
 import org.rstudio.studio.client.common.crypto.CryptoServerOperations;
 import org.rstudio.studio.client.common.crypto.PublicKeyInfo;
 import org.rstudio.studio.client.common.crypto.RSAEncrypt;
@@ -30,17 +34,20 @@ import com.google.inject.Inject;
  * On desktop, this is a no-op.
  * For client/server, the string will be encrypted.
  */
-public class ShellSecureInput
+public class ShellSecureInput implements SessionSerializationHandler
 {
    public ShellSecureInput()
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
+      eventBus_.addHandler(SessionSerializationEvent.TYPE, this);
    }
    
    @Inject
-   private void initialize(CryptoServerOperations server)
+   private void initialize(CryptoServerOperations server,
+                           EventBus events)
    {
       server_ = server;
+      eventBus_ = events;
    }
    
    /**
@@ -93,8 +100,21 @@ public class ShellSecureInput
       publicKeyInfo_ = null;
    }
    
+   @Override
+   public void onSessionSerialization(SessionSerializationEvent event)
+   {
+      switch(event.getAction().getType())
+      {
+      case SessionSerializationAction.SUSPEND_SESSION:
+         releasePublicKey();
+         break;
+      }
+   }
+   
    private PublicKeyInfo publicKeyInfo_ = null;
    
    // Injected ----
    private CryptoServerOperations server_;
+   private EventBus eventBus_;
+
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -500,8 +500,8 @@ public class RemoteServer implements Server
       params.set(1, new JSONNumber(cols));
       params.set(2, new JSONNumber(rows));
       params.set(3, JSONBoolean.getInstance(isModalDialog));
-      params.set(4,  new JSONString(terminalHandle == null ? "" : terminalHandle));
-      params.set(5,  new JSONString(terminalTitle == null ? "" : terminalTitle));
+      params.set(4,  new JSONString(StringUtil.notNull(terminalHandle)));
+      params.set(5,  new JSONString(StringUtil.notNull(terminalTitle)));
       params.set(6,  new JSONNumber(sequence));
       
       sendRequest(RPC_SCOPE,

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -469,17 +469,41 @@ public class RemoteServer implements Server
    {
       sendRequest(RPC_SCOPE, GET_TERMINAL_OPTIONS, requestCallback);
    }
+
    
-   public void startShellDialog(ConsoleProcess.TerminalType terminalType,
-                                int cols, int rows,
-                                boolean isModalDialog,
-                                ServerRequestCallback<ConsoleProcess> requestCallback)
+   public void startShellDialog(ServerRequestCallback<ConsoleProcess> requestCallback)
+   {
+      invokeStartShellDialog(ConsoleProcess.TerminalType.DUMB, true /*modal*/,
+                             80, 1, null /*handle*/, null /*title*/, 
+                             0 /*sequence*/, requestCallback);
+   }
+   
+   public void startTerminal(int cols, int rows,
+                             String handle, String title, int sequence,
+                             ServerRequestCallback<ConsoleProcess> requestCallback)
+   {
+      invokeStartShellDialog(ConsoleProcess.TerminalType.XTERM, false /*modal*/,
+                             cols, rows, handle, title, sequence, requestCallback);
+   }
+   
+   private void invokeStartShellDialog(
+                     ConsoleProcess.TerminalType terminalType,
+                     boolean isModalDialog, // TODO (gary) unnecessary?
+                     int cols, int rows,
+                     String terminalHandle,
+                     String terminalTitle,
+                     int sequence,
+                     ServerRequestCallback<ConsoleProcess> requestCallback)
    {
       JSONArray params = new JSONArray();
       params.set(0, new JSONString(terminalType.toString()));
       params.set(1, new JSONNumber(cols));
       params.set(2, new JSONNumber(rows));
       params.set(3, JSONBoolean.getInstance(isModalDialog));
+      params.set(4,  new JSONString(terminalHandle == null ? "" : terminalHandle));
+      params.set(5,  new JSONString(terminalTitle == null ? "" : terminalTitle));
+      params.set(6,  new JSONNumber(sequence));
+      
       sendRequest(RPC_SCOPE,
                   START_SHELL_DIALOG,
                   params,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
@@ -396,10 +396,7 @@ public class Workbench implements BusyHandler,
          final ProgressIndicator indicator = new GlobalProgressDelayer(
                globalDisplay_, 500, "Starting shell...").getIndicator();
          
-         server_.startShellDialog(ConsoleProcess.TerminalType.DUMB, 
-                                  80, 1, 
-                                  true, /* modal dialog */
-                                  new ServerRequestCallback<ConsoleProcess>() 
+         server_.startShellDialog(new ServerRequestCallback<ConsoleProcess>() 
          {
             @Override
             public void onResponseReceived(ConsoleProcess proc)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchServerOperations.java
@@ -119,10 +119,19 @@ public interface WorkbenchServerOperations extends ConsoleServerOperations,
                      ServerRequestCallback<TerminalOptions> requestCallback);
    
    
-   void startShellDialog(ConsoleProcess.TerminalType terminalType,
-                         int cols, int rows,
-                         boolean isModalDialog,
-                         ServerRequestCallback<ConsoleProcess> requestCallback);
+   void startShellDialog(ServerRequestCallback<ConsoleProcess> requestCallback);
+    
+   /**
+    * Start a terminal session
+    * @param cols initial number of text columns for pseudoterminal
+    * @param rows initial number of text rows for pseudoterminal
+    * @param handle initial terminal handle (pass empty or null string for new terminal)
+    * @param title title associated with the terminal
+    * @param sequence relative order of terminal creation (1-based)
+    * @param requestCallback callback from server upon completion
+    */
+   void startTerminal(int cols, int rows, String handle, String title, int sequence,
+                      ServerRequestCallback<ConsoleProcess> requestCallback);
    
    void executeCode(String code, ServerRequestCallback<Void> requestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -190,7 +190,7 @@ public class TerminalPane extends WorkbenchPane
    public TerminalSession getTerminalAtIndex(int i)
    {
       Widget widget = terminalSessionsPanel_.getWidget(i);
-      if (widget != null)
+      if (widget instanceof TerminalSession)
       {
          return (TerminalSession)widget;
       }
@@ -208,7 +208,7 @@ public class TerminalPane extends WorkbenchPane
       for (int i = 0; i < total; i++)
       {
          TerminalSession t = getTerminalAtIndex(i);
-         if (t.getHandle().equals(handle))
+         if (t != null && t.getHandle().equals(handle))
          {
             return t;
          }
@@ -222,11 +222,11 @@ public class TerminalPane extends WorkbenchPane
    public TerminalSession getVisibleTerminal()
    {
       Widget visibleWidget = terminalSessionsPanel_.getVisibleWidget();
-      if (visibleWidget == null)
+      if (visibleWidget instanceof TerminalSession)
       {
-         return null;
+         return (TerminalSession)visibleWidget;
       }
-      return (TerminalSession)visibleWidget;
+      return null;
    }
    
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -139,8 +139,6 @@ public class TerminalPane extends WorkbenchPane
 
       if (terminalSessionsPanel_.getWidgetCount() < 1)
       {
-         // closed all terminals, establish new secure channel next time we need it
-         secureInput_.releasePublicKey();
          activeTerminalToolbarButton_.setNoActiveTerminal();
       }
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -113,7 +113,7 @@ public class TerminalPane extends WorkbenchPane
                                                        nextTerminalSequence());
       newSession.connect();
    }
-   
+
    @Override
    public void onTerminalSessionStarted(TerminalSessionStartedEvent event)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
@@ -15,41 +15,80 @@
 
 package org.rstudio.studio.client.workbench.views.terminal;
 
+import java.util.HashMap;
+
+import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
+import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.icons.StandardIcons;
 import org.rstudio.studio.client.workbench.commands.Commands;
-import org.rstudio.studio.client.workbench.model.SessionInfo;
+import org.rstudio.studio.client.workbench.views.terminal.events.SwitchToTerminalEvent;
+import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStartedEvent;
+import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStoppedEvent;
+
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.user.client.ui.MenuItem;
+import com.google.inject.Inject;
 
 public class TerminalPopupMenu extends ToolbarPopupMenu
+                               implements TerminalSessionStartedEvent.Handler,
+                                          TerminalSessionStoppedEvent.Handler
 {
-   public TerminalPopupMenu(SessionInfo sessionInfo, Commands commands)
+   public TerminalPopupMenu()
+   {
+      RStudioGinjector.INSTANCE.injectMembers(this);
+      eventBus_.addHandler(TerminalSessionStartedEvent.TYPE, this);
+      eventBus_.addHandler(TerminalSessionStoppedEvent.TYPE, this);
+   }
+
+   @Inject
+   private void initialize(Commands commands,
+                           EventBus events)
    {
       commands_ = commands;
-      //sessionInfo_ = sessionInfo;
-      
-      // TODO (gary) Read active terminal from session, or always revert to
-      // first terminal in list?
-      activeTerminal_ = null;
+      eventBus_ = events;
    }
-   
+
    @Override
    public void getDynamicPopupMenu(final DynamicPopupMenuCallback callback)
    { 
       // clean out existing entries
       clearItems(); 
-      
       addItem(commands_.newTerminal().createMenuItem(false));
-
-      // ensure the menu doesn't get too narrow
-      addSeparator(225);
-
-      // TODO (gary) dynamically create based on open terminals
-       
-      addItem(commands_.renameTerminal().createMenuItem(false));
-      addItem(commands_.clearTerminalScrollbackBuffer().createMenuItem(false));
       addSeparator();
-      addItem(commands_.closeTerminal().createMenuItem(false));
+
+      if (terminals_.size() > 0)
+      {
+         for (final java.util.Map.Entry<String, String> item : terminals_.entrySet())
+         {
+            Scheduler.ScheduledCommand cmd = new Scheduler.ScheduledCommand()
+            {
+               @Override
+               public void execute()
+               {
+                  eventBus_.fireEvent(new SwitchToTerminalEvent( item.getKey()));
+               }
+            };
+
+            String menuHtml = AppCommand.formatMenuLabel(
+                  null,            /*icon*/
+                  item.getValue(), /*label*/
+                  false,           /*html*/
+                  null,            /*shortcut*/
+                  null,            /*rightImage*/
+                  null);           /*rightImageDesc*/
+            addItem(new MenuItem(menuHtml, true, cmd));
+         }
+         addSeparator();
+      }
+
+      // TODO (gary) put these back once implemented
+      // addItem(commands_.renameTerminal().createMenuItem(false));
+      // addItem(commands_.clearTerminalScrollbackBuffer().createMenuItem(false));
+      // addSeparator();
+      // addItem(commands_.closeTerminal().createMenuItem(false));
       callback.onPopupMenu(this);
    }
    
@@ -57,26 +96,78 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
    {
       if (toolbarButton_ == null)
       {
-         // TODO (gary) flesh this out
          String buttonText = "Terminal";
-          
+
          toolbarButton_ = new ToolbarButton(
                 buttonText, 
                 StandardIcons.INSTANCE.empty_command(),
                 this, 
                 false);
-          
-         if (activeTerminal_ != null)
-         {
-            toolbarButton_.setTitle(activeTerminal_);
-         }
+
+         setNoActiveTerminal();
       }
-       
-       return toolbarButton_;
+      return toolbarButton_;
+   }
+   
+   /**
+    *       
+    * @param title title of the active terminal
+    * @param handle handle of the active terminal
+    */
+   public void setActiveTerminal(String title, String handle)
+   {
+      activeTerminalTitle_ = title;
+      activeTerminalHandle_ = handle;
+      toolbarButton_.setText(activeTerminalTitle_);
+   }
+   
+   /**
+    * set state to indicate no active terminals
+    */
+   public void setNoActiveTerminal()
+   {
+      setActiveTerminal("Terminal", null);
+   }
+
+   private void addTerminal(String title, String handle)
+   {
+      terminals_.put(handle, title);
+   }
+   
+   private void removeTerminal(String handle)
+   {
+      terminals_.remove(handle);
+   }
+   
+   @Override
+   public void onTerminalSessionStarted(TerminalSessionStartedEvent event)
+   {
+      addTerminal(event.getTerminalWidget().getTitle(),
+            event.getTerminalWidget().getHandle());
+   }
+    
+   @Override
+   public void onTerminalSessionStopped(TerminalSessionStoppedEvent event)
+   {
+      removeTerminal(event.getTerminalWidget().getHandle());
+   }
+   
+   /**
+    * @return Handle of active terminal, or null if no active terminal.
+    */
+   public String getActiveTerminalHandle()
+   {
+      return activeTerminalHandle_;
    }
    
    private ToolbarButton toolbarButton_;
-   private final Commands commands_;
-   //private final SessionInfo sessionInfo_;
-   private String activeTerminal_;
+   private Commands commands_;
+   private EventBus eventBus_;
+   private String activeTerminalTitle_;
+   private String activeTerminalHandle_;
+   
+   /**
+    * map of terminal handles to titles
+    */
+   private HashMap<String, String> terminals_ = new HashMap<String, String>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
@@ -50,7 +50,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
       commands_ = commands;
       eventBus_ = events;
    }
-
+   
    @Override
    public void getDynamicPopupMenu(final DynamicPopupMenuCallback callback)
    { 
@@ -68,7 +68,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
                @Override
                public void execute()
                {
-                  eventBus_.fireEvent(new SwitchToTerminalEvent( item.getKey()));
+                  eventBus_.fireEvent(new SwitchToTerminalEvent(item.getKey()));
                }
             };
 
@@ -97,7 +97,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
       if (toolbarButton_ == null)
       {
          String buttonText = "Terminal";
-
+         
          toolbarButton_ = new ToolbarButton(
                 buttonText, 
                 StandardIcons.INSTANCE.empty_command(),

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -31,7 +31,9 @@ import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.workbench.model.WorkbenchServerOperations;
 import org.rstudio.studio.client.workbench.views.terminal.events.ResizeTerminalEvent;
+import org.rstudio.studio.client.workbench.views.terminal.events.TerminalCaptionEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalDataInputEvent;
+import org.rstudio.studio.client.workbench.views.terminal.events.TerminalTitleEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStartedEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStoppedEvent;
 import org.rstudio.studio.client.workbench.views.terminal.xterm.XTermWidget;
@@ -49,7 +51,8 @@ public class TerminalSession extends XTermWidget
                              implements ConsoleOutputEvent.Handler, 
                                         ProcessExitEvent.Handler,
                                         ResizeTerminalEvent.Handler,
-                                        TerminalDataInputEvent.Handler
+                                        TerminalDataInputEvent.Handler,
+                                        TerminalTitleEvent.Handler
 {
    /**
     * 
@@ -98,6 +101,7 @@ public class TerminalSession extends XTermWidget
                addHandlerRegistration(consoleProcess_.addProcessExitHandler(TerminalSession.this));
                addHandlerRegistration(addResizeTerminalHandler(TerminalSession.this));
                addHandlerRegistration(addTerminalDataInputHandler(TerminalSession.this));
+               addHandlerRegistration(addTerminalTitleHandler(TerminalSession.this));
 
                consoleProcess.start(new ServerRequestCallback<Void>()
                {
@@ -188,6 +192,23 @@ public class TerminalSession extends XTermWidget
       });
    }
    
+   @Override
+   public void onTerminalTitle(TerminalTitleEvent event)
+   {
+      caption_ = event.getTitle();
+      eventBus_.fireEvent(new TerminalCaptionEvent(this));
+   }
+   
+   public String getCaption()
+   {
+      return caption_;
+   }
+   
+   public void setCaption(String caption)
+   {
+      caption_ = caption;
+   }
+
    private int getInteractionMode()
    {
       if (consoleProcess_ != null)
@@ -208,7 +229,7 @@ public class TerminalSession extends XTermWidget
 
    protected void writeError(String msg)
    {
-      write(AnsiColor.RED +"Fatal Error: " + msg);
+      write(AnsiColor.RED +"Fatal Error: " + msg + AnsiColor.DEFAULT);
    }
 
    @Override
@@ -277,9 +298,11 @@ public class TerminalSession extends XTermWidget
    private HandlerRegistrations registrations_ = new HandlerRegistrations();
    
    private ConsoleProcess consoleProcess_;
+   private String caption_ = new String();
    private final int sequence_;
    
    // Injected ---- 
    private WorkbenchServerOperations server_; 
    private EventBus eventBus_;
+
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -92,7 +92,7 @@ public class TerminalSession extends XTermWidget
             {
                writeError("Unsupported ConsoleProcess interaction mode");
                return;
-            }
+            } 
 
             if (consoleProcess_ != null)
             {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -78,10 +78,8 @@ public class TerminalSession extends XTermWidget
     */
    public void connect()
    {
-      server_.startShellDialog(ConsoleProcess.TerminalType.XTERM, 
-                               80, 25,
-                               false, /* not a modal dialog */
-                               new ServerRequestCallback<ConsoleProcess>()
+      server_.startTerminal(80, 25, getHandle(), getTitle(), getSequence(),
+                            new ServerRequestCallback<ConsoleProcess>()
       {
          @Override
          public void onResponseReceived(ConsoleProcess consoleProcess)
@@ -257,20 +255,12 @@ public class TerminalSession extends XTermWidget
     */
    public String getHandle()
    {
-      if (handle_ == null)
+      if (consoleProcess_ == null)
       {
-         if (consoleProcess_ == null)
-         {
-            return null; // no terminal handle available
-         }
-         
-         // Though we use the handle of the attached process as the terminal
-         // handle, if the terminal's process is killed and restarted, the
-         // terminal retains the original handle. We just use the process
-         // handle as a convenient way to get a uuid.
-         handle_ = consoleProcess_.getProcessInfo().getHandle();
+         return null; // no terminal handle available
       }
-      return handle_;
+      
+      return consoleProcess_.getProcessInfo().getTerminalHandle();
    }
    
    /**
@@ -288,7 +278,6 @@ public class TerminalSession extends XTermWidget
    
    private ConsoleProcess consoleProcess_;
    private final int sequence_;
-   private String handle_;
    
    // Injected ---- 
    private WorkbenchServerOperations server_; 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -71,7 +71,7 @@ public class TerminalSession extends XTermWidget
    {
       server_ = server;
       eventBus_ = events; 
-   }
+   } 
    
    /**
     * Create a terminal process and connect to it.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/SwitchToTerminalEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/SwitchToTerminalEvent.java
@@ -33,9 +33,9 @@ public class SwitchToTerminalEvent extends CrossWindowEvent<Handler>
    {
    }
    
-   public SwitchToTerminalEvent(String terminalName)
+   public SwitchToTerminalEvent(String handle)
    {
-      terminalName_ = terminalName;
+      terminalHandle_ = handle;
    }
 
    @Override
@@ -50,12 +50,12 @@ public class SwitchToTerminalEvent extends CrossWindowEvent<Handler>
       handler.onSwitchToTerminal(this);
    }
    
-   public String getTerminalName()
+   public String getTerminalHandle()
    {
-      return terminalName_;
+      return terminalHandle_;
    }
   
-   private String terminalName_;
+   private String terminalHandle_;
    
    public static final Type<Handler> TYPE = new Type<Handler>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/TerminalCaptionEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/TerminalCaptionEvent.java
@@ -1,0 +1,60 @@
+/*
+ * TerminalCaptionEvent.java
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.terminal.events;
+
+import org.rstudio.studio.client.workbench.views.terminal.TerminalSession;
+import org.rstudio.studio.client.workbench.views.terminal.events.TerminalCaptionEvent.Handler;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+/**
+ * Send by an XTermSession that has processed an xterm.js title-change event 
+ * and updated its caption property.
+ */
+public class TerminalCaptionEvent extends GwtEvent<Handler>
+{
+   public interface Handler extends EventHandler
+   {
+      void onTerminalCaption(TerminalCaptionEvent event);
+   }
+   
+   public TerminalCaptionEvent(TerminalSession terminalSession)
+   {
+      terminalSession_ = terminalSession;
+   }
+
+   @Override
+   public com.google.gwt.event.shared.GwtEvent.Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onTerminalCaption(this);
+   }
+   
+   public TerminalSession getTerminalSession()
+   {
+      return terminalSession_;
+   }
+  
+   private TerminalSession terminalSession_;
+   
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/TerminalSessionStartedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/TerminalSessionStartedEvent.java
@@ -17,10 +17,10 @@ package org.rstudio.studio.client.workbench.views.terminal.events;
 
 import org.rstudio.core.client.js.JavaScriptSerializable;
 import org.rstudio.studio.client.application.events.CrossWindowEvent;
+import org.rstudio.studio.client.workbench.views.terminal.TerminalSession;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStartedEvent.Handler;
 
 import com.google.gwt.event.shared.EventHandler;
-import com.google.gwt.user.client.ui.Widget;
 
 @JavaScriptSerializable
 public class TerminalSessionStartedEvent extends CrossWindowEvent<Handler>
@@ -34,9 +34,8 @@ public class TerminalSessionStartedEvent extends CrossWindowEvent<Handler>
    {
    }
    
-   public TerminalSessionStartedEvent(String terminalName, Widget terminalWidget)
+   public TerminalSessionStartedEvent(TerminalSession terminalWidget)
    {
-      terminalName_ = terminalName;
       terminalWidget_ = terminalWidget;
    }
 
@@ -52,18 +51,12 @@ public class TerminalSessionStartedEvent extends CrossWindowEvent<Handler>
       handler.onTerminalSessionStarted(this);
    }
    
-   public String getTerminalName()
-   {
-      return terminalName_;
-   }
-   
-   public Widget getTerminalWidget()
+   public TerminalSession getTerminalWidget()
    {
       return terminalWidget_;
    }
   
-   private String terminalName_;
-   private Widget terminalWidget_;
+   private TerminalSession terminalWidget_;
    
    public static final Type<Handler> TYPE = new Type<Handler>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/TerminalSessionStoppedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/TerminalSessionStoppedEvent.java
@@ -17,10 +17,10 @@ package org.rstudio.studio.client.workbench.views.terminal.events;
 
 import org.rstudio.core.client.js.JavaScriptSerializable;
 import org.rstudio.studio.client.application.events.CrossWindowEvent;
+import org.rstudio.studio.client.workbench.views.terminal.TerminalSession;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStoppedEvent.Handler;
 
 import com.google.gwt.event.shared.EventHandler;
-import com.google.gwt.user.client.ui.Widget;
 
 @JavaScriptSerializable
 public class TerminalSessionStoppedEvent extends CrossWindowEvent<Handler>
@@ -39,9 +39,8 @@ public class TerminalSessionStoppedEvent extends CrossWindowEvent<Handler>
    {
    }
    
-   public TerminalSessionStoppedEvent(String terminalName, Widget terminalWidget)
+   public TerminalSessionStoppedEvent(TerminalSession terminalWidget)
    {
-      terminalName_ = terminalName;
       terminalWidget_ = terminalWidget;
    } 
    
@@ -57,18 +56,12 @@ public class TerminalSessionStoppedEvent extends CrossWindowEvent<Handler>
       handler.onTerminalSessionStopped(this);
    }
    
-   public String getTerminalName()
-   {
-      return terminalName_;
-   }
-   
-   public Widget getTerminalWidget()
+   public TerminalSession getTerminalWidget()
    {
       return terminalWidget_;
    }
   
-   private String terminalName_;
-   private Widget terminalWidget_;
+   private TerminalSession terminalWidget_;
    
    public static final Type<Handler> TYPE = new Type<Handler>(); 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/TerminalTitleEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/TerminalTitleEvent.java
@@ -1,0 +1,69 @@
+/*
+ * TerminalTitleEvent.java
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.terminal.events;
+
+import org.rstudio.studio.client.workbench.views.terminal.events.TerminalTitleEvent.Handler;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * Send when xterm sees a standard title escape sequence. The string value
+ * of the command is sent.
+ * 
+ * ESC]0;stringBEL -- Set window title to string, example:
+ * 
+ * echo -ne "\033]0;${USER}@${HOSTNAME}: ${PWD}\007"
+ */
+public class TerminalTitleEvent extends GwtEvent<Handler>
+{
+   public interface Handler extends EventHandler
+   {
+      void onTerminalTitle(TerminalTitleEvent event);
+   }
+   
+   public interface HasHandlers extends com.google.gwt.event.shared.HasHandlers
+   {
+      HandlerRegistration addTerminalTitleHandler(Handler handler);
+   }
+   
+   public TerminalTitleEvent(String title)
+   {
+      title_ = title;
+   }
+
+   @Override
+   public com.google.gwt.event.shared.GwtEvent.Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onTerminalTitle(this);
+   }
+   
+   public String getTitle()
+   {
+      return title_;
+   }
+  
+   private String title_;
+   
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
@@ -104,7 +104,18 @@ public class XTermNative extends JavaScriptObject
             command.@org.rstudio.core.client.CommandWithArg::execute(Ljava/lang/Object;)(data);
          });
    }-*/;
-   
+
+   /**
+    * Install a handler for title events (via escape sequence).
+    * @param command handler for title text
+    */
+   public final native void onTitleData(CommandWithArg<String> command) /*-{
+      this.handleTitle = 
+         $entry(function(title) {
+            command.@org.rstudio.core.client.CommandWithArg::execute(Ljava/lang/Object;)(title);
+         });
+   }-*/;
+
    /**
     * Factory to create a native Javascript terminal object.
     *  


### PR DESCRIPTION
New Work
========

- show current working directory in toolbar area above current visible terminal
- server round-trips additional SessionInfo data for a process associated with a terminal
    - terminal title
    - terminal handle (a uuid initially generated on server, used later to reassociate a process with a terminal instance on the client)
    - terminal sequence (1-based integer used to keep knowledge of relative order of terminal creation, will allow repopulation of dropdown in same order on reload)
- server no longer storing terminal output in SessionInfo; currently dropping it on floor with a TODO indicating where additional work is needed
- ShellSecureInput class clears its private key if there has been a session suspend so it knows to request a new one next time it needs it
- start_shell_dialog RPC has new arguments to communicate additional terminal info; added convenience wrapper on top of it to differentiate invoking the modal shell and modeless terminal cases
- terminal pane dropdown now populates with actual created terminals, with “Terminal 1”, “Terminal 2” names; later work will allow these names to be customized by user
- terminal pane dropdown stays in sync with opened and closed terminals
- clicking on terminal dropdown item switches to that terminal
- keyboard focus goes to newly opened terminals, or terminal made visible via closing another or dropdown

Up Next
=======
On reload of page, leverage new round-tripped metadata to reload the terminal pane dropdown and reassociate with the existing process when each session is displayed. After that, terminal buffer save/restore is on deck.