### PR TITLE
fix regression in r section folding

### DIFF
--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1298,7 +1298,7 @@ var RCodeModel = function(session, tokenizer,
              // Walk over matching braces -- this allows us to
              // e.g. skip function definitions (and hence, any
              // sub-sections within those functions).
-             if (it.fwdToMatchingToken())
+             if (token.value === "{" && it.fwdToMatchingToken())
                 continue;
          }
 


### PR DESCRIPTION
This PR fixes a regression in v1.0 where R sections are not properly folded between sections in some cases. To reproduce, try folding `S1` in the following document:

```R
# S1 ----
x < 1
# S2 ----
# S3 ----
# S4 ----
# S5 ----
x > 1
```

Since this is a regression between v0.99 and v1.0, we may want to take this for v1.0-patch.