### PR TITLE
Feature/terminal bug fixes

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -729,6 +729,7 @@ public class Application implements ApplicationEventHandlers
       if (!uiPrefs_.get().enableXTerm().getValue())
       {
          commands_.newTerminal().remove();
+         commands_.activateTerminal().remove();
       }
       if (!sessionInfo.getAllowPackageInstallation())
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -144,7 +144,6 @@ public class TerminalSession extends XTermWidget
          consoleProcess_.reap(new VoidServerRequestCallback());
       }
      
-      consoleProcess_ = null;
       eventBus_.fireEvent(new TerminalSessionStoppedEvent(this));
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
@@ -60,7 +60,6 @@ public class TerminalTabPresenter extends BusyPresenter
    public void onActivateTerminal()
    {
       view_.activateTerminal();
-      view_.ensureTerminal();
    }
    
    public void initialize()


### PR DESCRIPTION
Bug fixes
---------
- hide View -> Move Focus to Terminal menu command if enable_xterm not turned on
- setting consoleProcess to null in TerminalSession:onProcessExit caused TerminalSession to return a null terminal handle (the terminal handle is held in ConsoleProcess object contained in TerminalSession), so the dropdown failed to remove the entry for the closing terminal from it's backing hashmap when handling TerminalSessionStoppedEvent
- stop sending extra ensureTerminal in handler for the Move Focus to Terminal command, was occasionally causing creation of two terminals at once