### PR TITLE
Partial terminal support for session suspend resume

### DIFF
--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -730,6 +730,11 @@ boost::shared_ptr<ConsoleProcess> ConsoleProcess::create(
       ProcTable::const_iterator pos = s_procs.find(terminalHandle);
       if (pos != s_procs.end() && pos->second->isStarted())
       {
+         // Jiggle the size of the pseudo-terminal, this will force the app
+         // to refresh itself; this does rely on the host performing a second
+         // resize to the actual available size. Clumsy, but so far this is
+         // the best I've come up with.
+         pos->second->resize(25, 5);
          return pos->second;
       }
       

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -82,24 +82,6 @@ ConsoleProcess::ConsoleProcess(const std::string& command,
    commonInit();
 }
 
-ConsoleProcess::ConsoleProcess(const std::string& command,
-                               const core::system::ProcessOptions& options,
-                               const std::string& caption,
-                               int terminalSequence,
-                               bool allowRestart,
-                               const std::string& handle,
-                               bool dialog,
-                               InteractionMode interactionMode,
-                               int maxOutputLines)
-   : command_(command), options_(options), caption_(caption), dialog_(dialog),
-     showOnOutput_(false),
-     interactionMode_(interactionMode), maxOutputLines_(maxOutputLines),
-     handle_(handle), started_(false), interrupt_(false), newCols_(-1), newRows_(-1),
-     terminalSequence_(terminalSequence), allowRestart_(allowRestart),
-     outputBuffer_(OUTPUT_BUFFER_SIZE)
-{
-   commonInit();
-}
    
 ConsoleProcess::ConsoleProcess(const std::string& program,
                                const std::vector<std::string>& args,
@@ -114,6 +96,25 @@ ConsoleProcess::ConsoleProcess(const std::string& program,
      showOnOutput_(false),
      interactionMode_(interactionMode), maxOutputLines_(maxOutputLines),
      started_(false),  interrupt_(false), newCols_(-1), newRows_(-1),
+     terminalSequence_(terminalSequence), allowRestart_(allowRestart),
+     outputBuffer_(OUTPUT_BUFFER_SIZE)
+{
+   commonInit();
+}
+
+ConsoleProcess::ConsoleProcess(const std::string& command,
+                               const core::system::ProcessOptions& options,
+                               const std::string& caption,
+                               int terminalSequence,
+                               bool allowRestart,
+                               const std::string& handle,
+                               bool dialog,
+                               InteractionMode interactionMode,
+                               int maxOutputLines)
+   : command_(command), options_(options), caption_(caption), dialog_(dialog),
+     showOnOutput_(false),
+     interactionMode_(interactionMode), maxOutputLines_(maxOutputLines),
+     handle_(handle), started_(false), interrupt_(false), newCols_(-1), newRows_(-1),
      terminalSequence_(terminalSequence), allowRestart_(allowRestart),
      outputBuffer_(OUTPUT_BUFFER_SIZE)
 {

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -66,23 +66,23 @@ private:
          int maxOutputLines);
   
    ConsoleProcess(
-         const std::string& command,
-         const core::system::ProcessOptions& options,
-         const std::string& caption,
-         int terminalSequence,
-         bool allowRestart,
-         const std::string& handle,
-         bool dialog,
-         InteractionMode mode,
-         int maxOutputLines);
-   
-   ConsoleProcess(
          const std::string& program,
          const std::vector<std::string>& args,
          const core::system::ProcessOptions& options,
          const std::string& caption,
          int terminalSequence,
          bool allowRestart,
+         bool dialog,
+         InteractionMode mode,
+         int maxOutputLines);
+   
+   ConsoleProcess(
+         const std::string& command,
+         const core::system::ProcessOptions& options,
+         const std::string& caption,
+         int terminalSequence,
+         bool allowRestart,
+         const std::string& handle,
          bool dialog,
          InteractionMode mode,
          int maxOutputLines);

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -45,6 +45,7 @@ enum InteractionMode
 };
 
 extern const int kDefaultMaxOutputLines;
+extern const int kNoTerminal;
 
 class ConsoleProcess : boost::noncopyable,
                        public boost::enable_shared_from_this<ConsoleProcess>
@@ -58,10 +59,11 @@ private:
          const std::string& command,
          const core::system::ProcessOptions& options,
          const std::string& caption,
+         int terminalSequence,
          bool dialog,
          InteractionMode mode,
          int maxOutputLines);
-
+   
    ConsoleProcess(
          const std::string& program,
          const std::vector<std::string>& args,
@@ -71,16 +73,6 @@ private:
          InteractionMode mode,
          int maxOutputLines);
 
-   ConsoleProcess(
-         const std::string& command,
-         const core::system::ProcessOptions& options,
-         const std::string& caption,
-         const std::string& terminalHandle,
-         int terminalSequence,
-         bool dialog,
-         InteractionMode mode,
-         int maxOutputLines);
-   
    void regexInit();
    void commonInit();
 
@@ -110,6 +102,7 @@ public:
          const std::string& command,
          core::system::ProcessOptions options,
          const std::string& caption,
+         int terminalSequence,
          bool dialog,
          InteractionMode mode,
          int maxOutputLines = kDefaultMaxOutputLines);
@@ -199,11 +192,8 @@ private:
    int newCols_; // -1 = no change
    int newRows_; // -1 = no change
 
-   // The handle of an associated terminal
-   std::string terminalHandle_;
-   
    // The sequence number of the associated terminal; used to control display
-   // order of terminal tabs
+   // order of terminal tabs; constant 'kNoTerminal' indicates a non-terminal
    int terminalSequence_;
    
    // Pending input (writes or ptyInterrupts)

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -60,6 +60,18 @@ private:
          const core::system::ProcessOptions& options,
          const std::string& caption,
          int terminalSequence,
+         bool allowRestart,
+         bool dialog,
+         InteractionMode mode,
+         int maxOutputLines);
+  
+   ConsoleProcess(
+         const std::string& command,
+         const core::system::ProcessOptions& options,
+         const std::string& caption,
+         int terminalSequence,
+         bool allowRestart,
+         const std::string& handle,
          bool dialog,
          InteractionMode mode,
          int maxOutputLines);
@@ -69,6 +81,8 @@ private:
          const std::vector<std::string>& args,
          const core::system::ProcessOptions& options,
          const std::string& caption,
+         int terminalSequence,
+         bool allowRestart,
          bool dialog,
          InteractionMode mode,
          int maxOutputLines);
@@ -103,6 +117,7 @@ public:
          core::system::ProcessOptions options,
          const std::string& caption,
          int terminalSequence,
+         bool allowRestart,
          bool dialog,
          InteractionMode mode,
          int maxOutputLines = kDefaultMaxOutputLines);
@@ -112,6 +127,8 @@ public:
          const std::vector<std::string>& args,
          core::system::ProcessOptions options,
          const std::string& caption,
+         int terminalSequence,
+         bool allowRestart,
          bool dialog,
          InteractionMode mode,
          int maxOutputLines = kDefaultMaxOutputLines);
@@ -122,6 +139,7 @@ public:
          const std::string& caption,
          const std::string& terminalHandle,
          const int terminalSequence,
+         bool allowRestart,
          bool dialog,
          InteractionMode mode,
          int maxOutputLines = kDefaultMaxOutputLines);
@@ -144,6 +162,8 @@ public:
    void enqueInput(const Input& input);
    void interrupt();
    void resize(int cols, int rows);
+   void onSuspend();
+   bool isStarted() { return started_; }
 
    void setShowOnOutput(bool showOnOutput) { showOnOutput_ = showOnOutput; }
 
@@ -196,6 +216,10 @@ private:
    // order of terminal tabs; constant 'kNoTerminal' indicates a non-terminal
    int terminalSequence_;
    
+   // Whether a ConsoleProcess object should start a new process on resume after
+   // its process has been killed by a suspend.
+   bool allowRestart_;
+   
    // Pending input (writes or ptyInterrupts)
    std::queue<Input> inputQueue_;
 
@@ -207,7 +231,6 @@ private:
 
    boost::function<bool(const std::string&, Input*)> onPrompt_;
    boost::signal<void(int)> onExit_;
-
 
    // regex for prompt detection
    boost::regex controlCharsPattern_;

--- a/src/cpp/session/modules/SessionDependencies.cpp
+++ b/src/cpp/session/modules/SessionDependencies.cpp
@@ -405,7 +405,9 @@ Error installDependencies(const json::JsonRpcRequest& request,
             args,
             options,
             "Installing Packages",
-            true,
+            console_process::kNoTerminal,
+            false /*allowRestart*/,
+            true /*dialog*/,
             console_process::InteractionNever);
 
    // return console process

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -324,6 +324,7 @@ protected:
       *ppCP = ConsoleProcess::create(git() << args.args(),
                                      options,
                                      caption,
+                                     kNoTerminal,
                                      dialog,
                                      console_process::InteractionNever,
                                      console_process::kDefaultMaxOutputLines);

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -317,6 +317,8 @@ protected:
                                      args.args(),
                                      options,
                                      caption,
+                                     kNoTerminal,
+                                     false /*allowRestart*/,
                                      dialog,
                                      console_process::InteractionNever,
                                      console_process::kDefaultMaxOutputLines);
@@ -325,6 +327,7 @@ protected:
                                      options,
                                      caption,
                                      kNoTerminal,
+                                     false /*allowRestart*/,
                                      dialog,
                                      console_process::InteractionNever,
                                      console_process::kDefaultMaxOutputLines);

--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -272,6 +272,7 @@ core::Error createConsoleProc(const ShellArgs& args,
    *ppCP = ConsoleProcess::create(command,
                                   options,
                                   caption,
+                                  kNoTerminal,
                                   dialog,
                                   InteractionPossible,
                                   kDefaultMaxOutputLines);

--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -273,6 +273,7 @@ core::Error createConsoleProc(const ShellArgs& args,
                                   options,
                                   caption,
                                   kNoTerminal,
+                                  false /*allowRestart*/,
                                   dialog,
                                   InteractionPossible,
                                   kDefaultMaxOutputLines);

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -876,7 +876,7 @@ Error startShellDialog(const json::JsonRpcRequest& request,
    std::string termTitle;
    
    // terminal sequence
-   int termSequence = 0;
+   int termSequence = kNoTerminal;
    
    Error error = json::readParams(request.params,
                                   &term,
@@ -921,6 +921,12 @@ Error startShellDialog(const json::JsonRpcRequest& request,
    core::system::setenv(&shellEnv, "GIT_EDITOR", s_editFileCommand);
    core::system::setenv(&shellEnv, "SVN_EDITOR", s_editFileCommand);
 
+   if (termSequence != kNoTerminal)
+   {
+      core::system::setenv(&shellEnv, "RSTUDIO_TERM",
+                           boost::lexical_cast<std::string>(termSequence));
+   }
+   
    // ammend shell paths as appropriate
    ammendShellPaths(&shellEnv);
 

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -878,6 +878,9 @@ Error startShellDialog(const json::JsonRpcRequest& request,
    // terminal sequence
    int termSequence = kNoTerminal;
    
+   // allow process restart with existing handle
+   bool allowRestart;
+   
    Error error = json::readParams(request.params,
                                   &term,
                                   &cols,
@@ -885,7 +888,8 @@ Error startShellDialog(const json::JsonRpcRequest& request,
                                   &isModalDialog,
                                   &termHandle,
                                   &termTitle,
-                                  &termSequence);
+                                  &termSequence,
+                                  &allowRestart);
    if (error)
       return error;
    
@@ -953,6 +957,7 @@ Error startShellDialog(const json::JsonRpcRequest& request,
                                       termTitle,
                                       termHandle,
                                       termSequence,
+                                      allowRestart,
                                       isModalDialog,
                                       InteractionAlways,
                                       console_process::kDefaultMaxOutputLines);

--- a/src/cpp/session/modules/connections/SessionConnections.cpp
+++ b/src/cpp/session/modules/connections/SessionConnections.cpp
@@ -508,7 +508,8 @@ Error installSpark(const json::JsonRpcRequest& request,
             args,
             options,
             "Installing Spark " + sparkVersion,
-            true,
+            console_process::kNoTerminal, false /*allowRestart*/,
+            true /*isDialog*/,
             console_process::InteractionNever);
 
    // return console process

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcess.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcess.java
@@ -75,7 +75,7 @@ public class ConsoleProcess implements ConsoleOutputEvent.HasHandlers,
                for (int i = 0; i < procs.length(); i++)
                {
                   final ConsoleProcessInfo proc = procs.get(i);
-                  if (!proc.isDialog())
+                  if (proc.isTerminal())
                   {
                      // non-modal processes represent terminals and are handled
                      // by the terminal UI

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
@@ -59,14 +59,21 @@ public class ConsoleProcessInfo extends JavaScriptObject
       return self.getInteger("exit_code");
    }
 
-   public final native int getTerminalSequence()  /*-{
+   public final native int getTerminalSequence() /*-{
       return this.terminal_sequence;
    }-*/;
-   
+
+   public final native boolean getAllowRestart() /*-{
+      return this.allow_restart;
+   }-*/;
+
+   public final native boolean getStarted() /*-{
+      return this.started;
+   }-*/;
+
    public static final int SEQUENCE_NO_TERMINAL = 0;
    
    public final native boolean isTerminal() /*-{
       return this.terminal_sequence > 0;
    }-*/;
-   
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
@@ -58,12 +58,15 @@ public class ConsoleProcessInfo extends JavaScriptObject
       JsObject self = this.cast();
       return self.getInteger("exit_code");
    }
-   
-   public final native String getTerminalHandle() /*-{
-      return this.terminal_handle;
-   }-*/;
 
    public final native int getTerminalSequence()  /*-{
       return this.terminal_sequence;
    }-*/;
+   
+   public static final int SEQUENCE_NO_TERMINAL = 0;
+   
+   public final native boolean isTerminal() /*-{
+      return this.terminal_sequence > 0;
+   }-*/;
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -475,7 +475,8 @@ public class RemoteServer implements Server
    {
       invokeStartShellDialog(ConsoleProcess.TerminalType.DUMB, true /*modal*/,
                              80, 1, null /*handle*/, null /*title*/, 
-                             0 /*sequence*/, requestCallback);
+                             ConsoleProcessInfo.SEQUENCE_NO_TERMINAL,
+                             requestCallback);
    }
    
    public void startTerminal(int cols, int rows,

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -476,7 +476,7 @@ public class RemoteServer implements Server
       invokeStartShellDialog(ConsoleProcess.TerminalType.DUMB, true /*modal*/,
                              80, 1, null /*handle*/, null /*title*/, 
                              ConsoleProcessInfo.SEQUENCE_NO_TERMINAL,
-                             requestCallback);
+                             false /*allowProcessRestart*/, requestCallback);
    }
    
    public void startTerminal(int cols, int rows,
@@ -484,7 +484,8 @@ public class RemoteServer implements Server
                              ServerRequestCallback<ConsoleProcess> requestCallback)
    {
       invokeStartShellDialog(ConsoleProcess.TerminalType.XTERM, false /*modal*/,
-                             cols, rows, handle, title, sequence, requestCallback);
+                             cols, rows, handle, title, sequence,
+                             true /*allowProcessRestart*/, requestCallback);
    }
    
    private void invokeStartShellDialog(
@@ -494,6 +495,7 @@ public class RemoteServer implements Server
                      String terminalHandle,
                      String terminalTitle,
                      int sequence,
+                     boolean allowProcessRestart,
                      ServerRequestCallback<ConsoleProcess> requestCallback)
    {
       JSONArray params = new JSONArray();
@@ -501,9 +503,10 @@ public class RemoteServer implements Server
       params.set(1, new JSONNumber(cols));
       params.set(2, new JSONNumber(rows));
       params.set(3, JSONBoolean.getInstance(isModalDialog));
-      params.set(4,  new JSONString(StringUtil.notNull(terminalHandle)));
-      params.set(5,  new JSONString(StringUtil.notNull(terminalTitle)));
-      params.set(6,  new JSONNumber(sequence));
+      params.set(4, new JSONString(StringUtil.notNull(terminalHandle)));
+      params.set(5, new JSONString(StringUtil.notNull(terminalTitle)));
+      params.set(6, new JSONNumber(sequence));
+      params.set(7, JSONBoolean.getInstance(allowProcessRestart));
       
       sendRequest(RPC_SCOPE,
                   START_SHELL_DIALOG,

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -488,7 +488,7 @@ public class RemoteServer implements Server
    
    private void invokeStartShellDialog(
                      ConsoleProcess.TerminalType terminalType,
-                     boolean isModalDialog, // TODO (gary) unnecessary?
+                     boolean isModalDialog,
                      int cols, int rows,
                      String terminalHandle,
                      String terminalTitle,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -374,13 +374,6 @@ public abstract class
    public abstract AppCommand renameTerminal();
    public abstract AppCommand closeTerminal();
    public abstract AppCommand clearTerminalScrollbackBuffer();
-   // TODO (gary) placeholders for what will become a dynamically
-   // generated list of user-created terminal(s)
-   public abstract AppCommand terminalSession1();
-   public abstract AppCommand terminalSession2();
-   public abstract AppCommand terminalSession3();
-   public abstract AppCommand terminalSession4();
-   public abstract AppCommand terminalSession5();
    
    // Help
    public abstract AppCommand helpBack();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/AnsiCode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/AnsiCode.java
@@ -1,0 +1,68 @@
+/*
+ * AnsiEscapeCode.java
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.terminal;
+
+/**
+ * Helpers for generating Ansi Escape Code strings for output to a terminal.
+ */
+public class AnsiCode
+{
+   // Ansi command constants
+   public static final String CSI = "\33[";
+   public static final String SGR = "m";
+   
+   public static final String DEFAULTCOLORS = CSI + "0;0" + SGR;
+
+   public static class ForeColor
+   {
+      public static final String BLACK        = CSI + "0;30" + SGR;
+      public static final String RED          = CSI + "0;31" + SGR;
+      public static final String GREEN        = CSI + "0;32" + SGR;
+      public static final String BROWN        = CSI + "0;33" + SGR;
+      public static final String BLUE         = CSI + "0;34" + SGR;
+      public static final String MAGENTA      = CSI + "0;35" + SGR;
+      public static final String CYAN         = CSI + "0;36" + SGR;
+      public static final String GRAY         = CSI + "0;37" + SGR;
+      public static final String DARKGRAY     = CSI + "1;30" + SGR;
+      public static final String LIGHTRED     = CSI + "1;31" + SGR;
+      public static final String LIGHTGREEN   = CSI + "1;32" + SGR;
+      public static final String YELLOW       = CSI + "1;33" + SGR;
+      public static final String LIGHTBLUE    = CSI + "1;34" + SGR;
+      public static final String LIGHTMAGENTA = CSI + "1;35" + SGR;
+      public static final String LIGHTCYAN    = CSI + "1:36" + SGR;
+      public static final String WHITE        = CSI + "1;37" + SGR;
+   }
+   
+   public static class BackColor
+   {
+      public static final String BLACK        = CSI + "0;40" + SGR;
+      public static final String RED          = CSI + "0;41" + SGR;
+      public static final String GREEN        = CSI + "0;42" + SGR;
+      public static final String BROWN        = CSI + "0;43" + SGR;
+      public static final String BLUE         = CSI + "0;44" + SGR;
+      public static final String MAGENTA      = CSI + "0;45" + SGR;
+      public static final String CYAN         = CSI + "0;46" + SGR;
+      public static final String GRAY         = CSI + "0;47" + SGR;
+      public static final String DARKGRAY     = CSI + "1;40" + SGR;
+      public static final String LIGHTRED     = CSI + "1;41" + SGR;
+      public static final String LIGHTGREEN   = CSI + "1;42" + SGR;
+      public static final String YELLOW       = CSI + "1;43" + SGR;
+      public static final String LIGHTBLUE    = CSI + "1;44" + SGR;
+      public static final String LIGHTMAGENTA = CSI + "1;45" + SGR;
+      public static final String LIGHTCYAN    = CSI + "1:46" + SGR;
+      public static final String WHITE        = CSI + "1;47" + SGR;
+   }
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
@@ -18,6 +18,8 @@ package org.rstudio.studio.client.workbench.views.terminal;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 
+import org.rstudio.studio.client.common.console.ConsoleProcessInfo;
+
 /**
  * List of terminals, with sufficient metadata to display a list of
  * available terminals and reconnect to them.
@@ -128,7 +130,7 @@ public class TerminalList implements Iterable<TerminalList.TerminalMetadata>
     */
    public int nextTerminalSequence()
    {
-      int maxNum = 0;
+      int maxNum = ConsoleProcessInfo.SEQUENCE_NO_TERMINAL;
       for (final java.util.Map.Entry<String, TerminalMetadata> item : terminals_.entrySet())
       {
          maxNum = Math.max(maxNum, item.getValue().getSequence());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -172,7 +172,7 @@ public class TerminalPane extends WorkbenchPane
       // loaded until selected via the dropdown
       for (ConsoleProcessInfo procInfo : procList)
       {
-         terminals_.addTerminal(new TerminalMetadata(procInfo.getTerminalHandle(),
+         terminals_.addTerminal(new TerminalMetadata(procInfo.getHandle(),
                                           procInfo.getCaption(), 
                                           procInfo.getTerminalSequence()));
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -260,7 +260,7 @@ public class TerminalPane extends WorkbenchPane
       String handle = event.getTerminalHandle();
 
       // If terminal was already loaded, just make it visible
-      TerminalSession terminal = terminalWithHandle(handle);
+      TerminalSession terminal = loadedTerminalWithHandle(handle);
       if (terminal != null)
       {
          terminalSessionsPanel_.showWidget(terminal);
@@ -318,7 +318,7 @@ public class TerminalPane extends WorkbenchPane
     * @param handle of TerminalSession to return
     * @return TerminalSession with that handle, or null
     */
-   public TerminalSession terminalWithHandle(String handle)
+   private TerminalSession loadedTerminalWithHandle(String handle)
    {
       int total = getLoadedTerminalCount();
       for (int i = 0; i < total; i++)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -103,11 +103,42 @@ public class TerminalPane extends WorkbenchPane
    @Override
    public void onSelected()
    {
+      // terminal tab was selected
       super.onSelected();
       activateTerminal();
       ensureTerminal();
    }
    
+   @Override
+   public void onBeforeUnselected()
+   {
+      // terminal tab being unselected
+      super.onBeforeUnselected();
+      
+      // current terminal needs to know it's not visible so it doesn't
+      // respond to resize requests (which will cause xterm.js to lose its
+      // mind)
+      TerminalSession currentTerminal = getSelectedTerminal();
+      if (currentTerminal != null)
+      {
+         currentTerminal.setVisible(false);
+      }
+   }
+
+   @Override
+   public void onBeforeSelected()
+   {
+      // terminal tab is about to become visible
+      super.onBeforeSelected();
+      
+      // make sure a previously hidden terminal is visible
+      TerminalSession currentTerminal = getSelectedTerminal();
+      if (currentTerminal != null)
+      {
+         currentTerminal.setVisible(true);
+      }
+  }
+
    @Override
    public void activateTerminal()
    {
@@ -123,7 +154,7 @@ public class TerminalPane extends WorkbenchPane
          // No terminals at all, create a new one
          createTerminal();
       }
-      else if (getVisibleTerminal() == null)
+      else if (getSelectedTerminal() == null)
       {
          // No terminal loaded, load the first terminal in the list
          String handle = terminals_.terminalHandleAtIndex(0);
@@ -181,7 +212,7 @@ public class TerminalPane extends WorkbenchPane
    @Override
    public void terminateCurrentTerminal()
    {
-      final TerminalSession visibleTerminal = getVisibleTerminal();
+      final TerminalSession visibleTerminal = getSelectedTerminal();
       if (visibleTerminal != null)
       {
          globalDisplay_.showYesNoMessage(GlobalDisplay.MSG_QUESTION,
@@ -282,7 +313,7 @@ public class TerminalPane extends WorkbenchPane
    @Override
    public void onTerminalCaption(TerminalCaptionEvent event)
    {
-      TerminalSession visibleTerm = getVisibleTerminal();
+      TerminalSession visibleTerm = getSelectedTerminal();
       TerminalSession captionTerm = event.getTerminalSession();
       if (visibleTerm != null && visibleTerm.getHandle().equals(
             captionTerm.getHandle()))
@@ -333,9 +364,9 @@ public class TerminalPane extends WorkbenchPane
    }
 
    /**
-    * @return Visible terminal, or null if there is no visible terminal.
+    * @return Selected terminal, or null if there is no selected terminal.
     */
-   public TerminalSession getVisibleTerminal()
+   public TerminalSession getSelectedTerminal()
    {
       Widget visibleWidget = terminalSessionsPanel_.getVisibleWidget();
       if (visibleWidget instanceof TerminalSession)
@@ -355,7 +386,7 @@ public class TerminalPane extends WorkbenchPane
             @Override
             public void execute()
             {
-               TerminalSession visibleTerminal = getVisibleTerminal();
+               TerminalSession visibleTerminal = getSelectedTerminal();
                if (visibleTerminal != null)
                {
                   visibleTerminal.setFocus(true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -273,11 +273,10 @@ public class TerminalSession extends XTermWidget
    }
    
    /**
-    * A unique handle for this terminal instance. Stays the same
-    * until Terminal is closed, even if the underlying process is killed and
-    * Terminal attached to a new one.
+    * A unique handle for this terminal instance. Corresponds to the 
+    * server-side ConsoleProcess handle.
     * @return Opaque string handle for this terminal instance, or null if
-    * terminal has never been attached to a process
+    * terminal has never been attached to a server ConsoleProcess.
     */
    public String getHandle()
    {
@@ -286,7 +285,7 @@ public class TerminalSession extends XTermWidget
          return terminalHandle_;
       }
       
-      return consoleProcess_.getProcessInfo().getTerminalHandle();
+      return consoleProcess_.getProcessInfo().getHandle();
    }
    
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -255,12 +255,6 @@ public class TerminalSession extends XTermWidget
          // terminal sessions and there was a resize.
          // A delay is needed to give the xterm.js implementation an
          // opportunity to be ready for this.
-         
-         // TODO (gary) I already debounce heavily in XTermWidget.onResize, not
-         // sure why this additional level of delay is needed, but without it
-         // there are issues with xterm.js losing its mind when it is resized
-         // after re-emerging from behind other terminals. Why? Is this delay
-         // the best solution?
          Scheduler.get().scheduleDeferred(new ScheduledCommand()
          {
             @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -234,7 +234,7 @@ public class TerminalSession extends XTermWidget
 
    protected void writeError(String msg)
    {
-      write(AnsiColor.RED +"Fatal Error: " + msg + AnsiColor.DEFAULT);
+      write(AnsiCode.ForeColor.RED + "Error: " + msg + AnsiCode.DEFAULTCOLORS);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
@@ -125,7 +125,7 @@ public class TerminalTabPresenter extends BusyPresenter
     * @param procInfo process to insert in the list
     */
    private void addTerminalProcInfo(ArrayList<ConsoleProcessInfo> procInfoList,
-                                           ConsoleProcessInfo procInfo)
+                                    ConsoleProcessInfo procInfo)
    {
       int newSequence = procInfo.getTerminalSequence();
       if (newSequence < 1)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
@@ -108,7 +108,7 @@ public class TerminalTabPresenter extends BusyPresenter
       for (int i = 0; i < procs.length(); i++)
       {
          final ConsoleProcessInfo proc = procs.get(i);
-         if (!proc.isDialog())
+         if (proc.isTerminal())
          {
             addTerminalProcInfo(procList, proc);
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
@@ -33,7 +33,6 @@ public class XTermNative extends JavaScriptObject
    /**
     * Remove event handlers and detach from parent node.
     */
-   // TODO: (gary) should be calling this
    public final native void destroy() /*-{
       this.destroy();
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
@@ -92,6 +92,10 @@ public class XTermNative extends JavaScriptObject
       this.scrollToBottom();
    }-*/;
 
+   public final native void reset() /*-{
+      this.reset();
+   }-*/;
+   
    /**
     * Install a handler for user input (typing). Only one handler at a 
     * time may be installed. Previous handler will be overwritten.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -85,9 +85,9 @@ public class XTermWidget extends Widget implements RequiresResize,
    }
    
    /**
-    * Show a greeting in the terminal
+    * Perform actions when the terminal is ready.
     */
-   private void showBanner()
+   private void terminalReady()
    {
       if (newTerminal_)
       {
@@ -96,11 +96,16 @@ public class XTermWidget extends Widget implements RequiresResize,
       }
       else
       {
-         // TODO (gary) this is temporary until buffer save and restore is done
-         writeln(AnsiCode.ForeColor.BLACK + AnsiCode.BackColor.BROWN +
-                 "Reconnected. Restoring buffer is not-yet-implemented.");
-         writeln("Hit <enter> for prompt." + AnsiCode.DEFAULTCOLORS);
-      }
+         terminal_.reset();
+         Scheduler.get().scheduleDeferred(new ScheduledCommand()
+         {
+            @Override
+            public void execute()
+            {
+               onResize();
+            }
+         });
+       }
    }
   
    /**
@@ -151,7 +156,7 @@ public class XTermWidget extends Widget implements RequiresResize,
             {
                terminal_.fit();
                terminal_.focus();
-               showBanner();
+               terminalReady();
             }
          });
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -21,6 +21,7 @@ import org.rstudio.core.client.ExternalJavaScriptLoader;
 import org.rstudio.core.client.ExternalJavaScriptLoader.Callback;
 import org.rstudio.core.client.resources.StaticDataResource;
 import org.rstudio.studio.client.common.SuperDevMode;
+import org.rstudio.studio.client.workbench.views.terminal.AnsiCode;
 import org.rstudio.studio.client.workbench.views.terminal.events.ResizeTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalDataInputEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalTitleEvent;
@@ -45,42 +46,10 @@ import com.google.gwt.user.client.ui.Widget;
  * Xterm-compatible terminal emulator
  */
 public class XTermWidget extends Widget implements RequiresResize,
-                                                   ResizeTerminalEvent.HasHandlers,
-                                                   TerminalDataInputEvent.HasHandlers,
+                                                   ResizeTerminalEvent.HasHandlers, TerminalDataInputEvent.HasHandlers,
                                                    TerminalTitleEvent.HasHandlers
 {
-   public enum AnsiColor
-   {
-      DEFAULT     ("0;0"),
-      BLACK       ("0;30"),
-      BLUE        ("0;34"),
-      GREEN       ("0;32"),
-      CYAN        ("0;36"),
-      RED         ("0;31"),
-      PURPLE      ("0;35"),
-      BROWN       ("0;33"),
-      LIGHTGRAY   ("0;37"),
-      DARKGRAY    ("1;30"),
-      LIGHTBLUE   ("1;34"),
-      LIGHTCYAN   ("1;32"),
-      LIGHTRED    ("1;31"),
-      LIGHTPURPLE ("1;35"), 
-      YELLOW      ("1;33"),
-      WHITE       ("1;37");
-      
-      private final String color;
-      AnsiColor(String color)
-      {
-         this.color = color;
-      }
-      
-      public String toString()
-      {
-         return "\33[" + color + "m";
-      }
-   }      
-   
-   /**
+  /**
     *  Creates an XTermWidget.
     */
    public XTermWidget()
@@ -122,15 +91,15 @@ public class XTermWidget extends Widget implements RequiresResize,
    {
       if (newTerminal_)
       {
-         writeln("Welcome to " + AnsiColor.LIGHTBLUE + "RStudio" +
-                 AnsiColor.DEFAULT + " terminal.");
+         writeln("Welcome to " + AnsiCode.ForeColor.LIGHTBLUE + "RStudio" +
+                 AnsiCode.DEFAULTCOLORS + " terminal.");
       }
       else
       {
          // TODO (gary) this is temporary until buffer save and restore is done
-         writeln("\33[30;43m" +
+         writeln(AnsiCode.ForeColor.BLACK + AnsiCode.BackColor.BROWN +
                  "Reconnected. Restoring buffer is not-yet-implemented.");
-         writeln("Hit <enter> for prompt." + AnsiColor.DEFAULT);
+         writeln("Hit <enter> for prompt." + AnsiCode.DEFAULTCOLORS);
       }
    }
   


### PR DESCRIPTION
Main changes
-------------

1. If a session is manually killed via Session/Suspend R Session, and there were open terminal(s), you can now refresh the IDE and those terminals will trigger creation of new terminal processes on the server (as needed). This doesn't yet bring back the terminal buffer, or capture changes to working directory and/or environment variables made in the processes before they were killed by the session. Also, if you don't refresh the browser, existing terminal panes don't yet know to trigger reattachment to new processes.

2. If reattaching to an existing process (i.e. browser set), refresh the pseudoterminal so it refreshes the screen and user can pick up where they left off (minus terminal history as in #1). But if running an ncurses program like vim, you get back to where you where, visually.

3. If terminal(s) are loaded, and you select another pane, such as Console, then resize RStudio panes, don't let xterm.js try to respond to resize requests while it is hidden, as it gets very sad.

Other changes
---------------
- set an environment variable in terminals, with the terminal instance number, e.g. RSTUDIO_TERM=1, RSTUDIO_TERM=2, etc.
- pulled out some ANSI color-code constants from XTermWidget to a separate class
- clean up some minor TODO’s
