### PR TITLE
Terminal tab can be closed

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcess.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcess.java
@@ -244,24 +244,17 @@ public class ConsoleProcess implements ConsoleOutputEvent.HasHandlers,
       
       /**
        * Terminate and reap a process
-       * @param procInfo process to terminate and reap
+       * @param handle process to kill and reap
        */
-      public void reap(final ConsoleProcessInfo procInfo)
+      public void interruptAndReap(final String handle)
       {
-         connectToProcess(
-               procInfo,
-               new ServerRequestCallback<ConsoleProcess>()
+         interrupt(handle,
+               new SimpleRequestCallback<Void>()
                {
-                  public void onResponseReceived( final ConsoleProcess cproc)
+                  @Override
+                  public void onResponseReceived(Void response)
                   {
-                     cproc.interrupt(new SimpleRequestCallback<Void>()
-                     {
-                        @Override
-                        public void onResponseReceived(Void response)
-                        {
-                           cproc.reap(new VoidServerRequestCallback());
-                        }
-                     }); 
+                    reap(handle, new VoidServerRequestCallback());
                   }
 
                   @Override
@@ -270,8 +263,28 @@ public class ConsoleProcess implements ConsoleOutputEvent.HasHandlers,
                      Debug.logError(error);
                   }
                });
-     }
+      }
 
+      /**
+       * Interrupt process with given handle.
+       * @param handle process to interrupt
+       * @param requestCallback callback to invoke when done
+       */
+      public void interrupt(final String handle, ServerRequestCallback<Void> requestCallback)
+      {
+         server_.processInterrupt(handle, requestCallback);
+      }
+      
+      /**
+       * Reap process with given handle
+       * @param handle process to reap
+       * @param requestCallback callback to invoke when done
+       */
+      public void reap(final String handle, ServerRequestCallback<Void> requestCallback)
+      {
+         server_.processReap(handle, requestCallback);
+      }
+      
       private final ConsoleServerOperations server_;
       private final CryptoServerOperations cryptoServer_;
       private final EventBus eventBus_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
@@ -417,7 +417,7 @@ public class Workbench implements BusyHandler,
    @Handler
    public void onNewTerminal()
    {
-         eventBus_.fireEvent(new CreateTerminalEvent());
+      eventBus_.fireEvent(new CreateTerminalEvent());
    }
       
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -591,6 +591,11 @@ public class UIPrefsAccessor extends Prefs
       return bool("enable_xterm", false);
    }
    
+   public PrefValue<Boolean> showTerminalTab()
+   {
+      return bool("show_terminal_tab", true);
+   }
+   
    public static final String KNIT_DIR_DEFAULT = "default";
    public static final String KNIT_DIR_CURRENT = "current";
    public static final String KNIT_DIR_PROJECT = "project";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
@@ -14,12 +14,19 @@
  */
 package org.rstudio.studio.client.workbench.ui;
 
-import org.rstudio.core.client.events.*;
+import java.util.ArrayList;
+
+import org.rstudio.core.client.events.EnsureHiddenEvent;
+import org.rstudio.core.client.events.EnsureHiddenHandler;
+import org.rstudio.core.client.events.EnsureVisibleEvent;
+import org.rstudio.core.client.events.EnsureVisibleHandler;
 import org.rstudio.core.client.layout.LogicalWindow;
 import org.rstudio.core.client.theme.PrimaryWindowFrame;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.workbench.model.Session;
+import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.console.ConsoleInterruptButton;
 import org.rstudio.studio.client.workbench.views.console.ConsoleInterruptProfilerButton;
 import org.rstudio.studio.client.workbench.views.console.ConsolePane;
@@ -30,16 +37,18 @@ import org.rstudio.studio.client.workbench.views.output.markers.MarkersOutputTab
 
 import com.google.inject.Inject;
 
-import java.util.ArrayList;
-
 public class ConsoleTabPanel extends WorkbenchTabPanel
 {
    @Inject
    public void initialize(ConsoleInterruptButton consoleInterrupt,
-                          ConsoleInterruptProfilerButton consoleInterruptProfiler)
+                          ConsoleInterruptProfilerButton consoleInterruptProfiler,
+                          UIPrefs uiPrefs,
+                          Session session)
    {
       consoleInterrupt_ = consoleInterrupt;
       consoleInterruptProfiler_ = consoleInterruptProfiler;
+      uiPrefs_ = uiPrefs;
+      session_ = session;
    }
    
    public ConsoleTabPanel(final PrimaryWindowFrame owner,
@@ -52,7 +61,6 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
                           WorkbenchTab deployContentTab,
                           MarkersOutputTab markersTab,
                           WorkbenchTab terminalTab,
-                          boolean enableTerminalTab,
                           EventBus events,
                           ToolbarButton goToWorkingDirButton)
    {
@@ -67,7 +75,6 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
       deployContentTab_ = deployContentTab;
       markersTab_ = markersTab;
       terminalTab_ = terminalTab;
-      enableTerminalTab_ = enableTerminalTab;
       
       RStudioGinjector.INSTANCE.injectMembers(this);
 
@@ -210,7 +217,30 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
                selectTab(0);
          }
       });
-      
+
+      terminalTab.addEnsureVisibleHandler(new EnsureVisibleHandler()
+      {
+         @Override
+         public void onEnsureVisible(EnsureVisibleEvent event)
+         {
+            terminalTabVisible_ = true;
+            managePanels();
+            if (event.getActivate())
+               selectTab(terminalTab_);
+         }
+      });
+      terminalTab.addEnsureHiddenHandler(new EnsureHiddenHandler()
+      {
+         @Override
+         public void onEnsureHidden(EnsureHiddenEvent event)
+         {
+            terminalTabVisible_ = false;
+            managePanels();
+            if (!consoleOnly_)
+               selectTab(0);
+         }
+      });
+
       events.addHandler(WorkingDirChangedEvent.TYPE, new WorkingDirChangedHandler()
       {
          @Override
@@ -224,13 +254,29 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
          }
       });
 
-      consoleOnly_ = enableTerminalTab_; 
+      // Determine initial visibility of terminal tab
+      terminalTabVisible_ = uiPrefs_.showTerminalTab().getValue();
+
+      // TODO (gary) this is a temporary feature gate
+      if (terminalTabVisible_ && !uiPrefs_.enableXTerm().getValue())
+      {
+         terminalTabVisible_ = false;
+      }
+
+      if (terminalTabVisible_ && !session_.getSessionInfo().getAllowShell())
+      {
+         terminalTabVisible_ = false;
+      }
+
+      // This ensures the logic in managePanels() works whether starting
+      // up with terminal tab on by default or not.
+      consoleOnly_ = terminalTabVisible_;
       managePanels();
    }
 
    private void managePanels()
    {
-      boolean consoleOnly = !enableTerminalTab_ &&
+      boolean consoleOnly = !terminalTabVisible_ &&
                             !compilePdfTabVisible_ && 
                             !findResultsTabVisible_ &&
                             !sourceCppTabVisible_ &&
@@ -242,7 +288,7 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
       {
          ArrayList<WorkbenchTab> tabs = new ArrayList<WorkbenchTab>();
          tabs.add(consolePane_);
-         if (enableTerminalTab_)
+         if (terminalTabVisible_)
             tabs.add(terminalTab_);
          if (compilePdfTabVisible_)
             tabs.add(compilePdfTab_);
@@ -305,10 +351,12 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
    private final MarkersOutputTab markersTab_;
    private boolean markersTabVisible_;
    private final WorkbenchTab terminalTab_;
-   private boolean enableTerminalTab_;
+   private boolean terminalTabVisible_;
    private ConsoleInterruptButton consoleInterrupt_;
    private ConsoleInterruptProfilerButton consoleInterruptProfiler_;
    private final ToolbarButton goToWorkingDirButton_;
    private boolean findResultsTabVisible_;
    private boolean consoleOnly_;
+   private UIPrefs uiPrefs_;
+   private Session session_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -883,14 +883,6 @@ public class PaneManager
       LogicalWindow logicalWindow =
             new LogicalWindow(frame, new MinimizedWindowFrame("Console"));
 
-      boolean enableTerminalTab = session_.getSessionInfo().getAllowShell();
-      
-      // TODO (gary): this is a temporary feature gate
-      if (enableTerminalTab && !uiPrefs_.enableXTerm().getValue())
-      {
-         enableTerminalTab = false;
-      }
-      
       @SuppressWarnings("unused")
       ConsoleTabPanel consoleTabPanel = new ConsoleTabPanel(frame,
                                                             logicalWindow,
@@ -902,7 +894,6 @@ public class PaneManager
                                                             deployContentTab_,
                                                             markersTab_,
                                                             terminalTab_,
-                                                            enableTerminalTab,
                                                             eventBus_,
                                                             goToWorkingDirButton);
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
@@ -137,6 +137,14 @@ public class TerminalList implements Iterable<TerminalList.TerminalMetadata>
       }
       return maxNum + 1;
    }
+   
+   /**
+    * Remove all terminals from the list
+    */
+   public void clear()
+   {
+      terminals_.clear();
+   }
 
    @Override
    public Iterator<TerminalMetadata> iterator()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -31,6 +31,7 @@ import org.rstudio.studio.client.workbench.views.terminal.events.SwitchToTermina
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalCaptionEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStartedEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStoppedEvent;
+import org.rstudio.studio.client.common.console.ConsoleProcess.ConsoleProcessFactory;
 
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
@@ -40,6 +41,7 @@ import com.google.gwt.user.client.ui.DeckLayoutPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 /**
  * Holds the contents of the Terminal pane, including the toolbar and
@@ -62,11 +64,14 @@ public class TerminalPane extends WorkbenchPane
                                      TerminalCaptionEvent.Handler
 {
    @Inject
-   protected TerminalPane(EventBus events, GlobalDisplay globalDisplay)
+   protected TerminalPane(EventBus events,
+                          GlobalDisplay globalDisplay,
+                          Provider<ConsoleProcessFactory> pConsoleProcessFactory)
    {
       super("Terminal");
-      globalDisplay_ = globalDisplay;
       events_ = events;
+      globalDisplay_ = globalDisplay;
+      pConsoleProcessFactory_ = pConsoleProcessFactory;
       events_.addHandler(TerminalSessionStartedEvent.TYPE, this);
       events_.addHandler(TerminalSessionStoppedEvent.TYPE, this);
       events_.addHandler(SwitchToTerminalEvent.TYPE, this);
@@ -86,7 +91,7 @@ public class TerminalPane extends WorkbenchPane
    {
       // TODO (gary) implement
    }
-   
+
    @Override
    protected Toolbar createMainToolbar()
    {
@@ -99,22 +104,21 @@ public class TerminalPane extends WorkbenchPane
       toolbar.addRightWidget(activeTerminalToolbarButton_.getToolbarButton());
       return toolbar;
    }
-  
+
    @Override
    public void onSelected()
    {
       // terminal tab was selected
       super.onSelected();
-      activateTerminal();
       ensureTerminal();
    }
-   
+
    @Override
    public void onBeforeUnselected()
    {
       // terminal tab being unselected
       super.onBeforeUnselected();
-      
+
       // current terminal needs to know it's not visible so it doesn't
       // respond to resize requests (which will cause xterm.js to lose its
       // mind)
@@ -130,14 +134,14 @@ public class TerminalPane extends WorkbenchPane
    {
       // terminal tab is about to become visible
       super.onBeforeSelected();
-      
+
       // make sure a previously hidden terminal is visible
       TerminalSession currentTerminal = getSelectedTerminal();
       if (currentTerminal != null)
       {
          currentTerminal.setVisible(true);
       }
-  }
+   }
 
    @Override
    public void activateTerminal()
@@ -145,9 +149,8 @@ public class TerminalPane extends WorkbenchPane
       ensureVisible();
       bringToFront();
    }
-   
-   @Override
-   public void ensureTerminal()
+
+   private void ensureTerminal()
    {
       if (terminals_.terminalCount() == 0)
       {
@@ -168,11 +171,15 @@ public class TerminalPane extends WorkbenchPane
          setFocusOnVisible();
       }
    }
-   
+
    @Override
    public void createTerminal()
    {
-     startTerminal(terminals_.nextTerminalSequence(), null);
+      if (creatingTerminal_)
+         return;
+
+      creatingTerminal_ = true;
+      startTerminal(terminals_.nextTerminalSequence(), null);
    }
 
    /**
@@ -186,7 +193,7 @@ public class TerminalPane extends WorkbenchPane
             getSecureInput(), sequence, terminalHandle);
       newSession.connect();
    }
-   
+
    @Override
    public void repopulateTerminals(ArrayList<ConsoleProcessInfo> procList)
    {
@@ -203,9 +210,11 @@ public class TerminalPane extends WorkbenchPane
       // loaded until selected via the dropdown
       for (ConsoleProcessInfo procInfo : procList)
       {
-         terminals_.addTerminal(new TerminalMetadata(procInfo.getHandle(),
-                                          procInfo.getCaption(), 
-                                          procInfo.getTerminalSequence()));
+         terminals_.addTerminal(
+               new TerminalMetadata(
+                     procInfo.getHandle(),
+                     procInfo.getCaption(), 
+                     procInfo.getTerminalSequence()));
       }
    }
 
@@ -219,7 +228,7 @@ public class TerminalPane extends WorkbenchPane
                "Close " + visibleTerminal.getTitle(),
                "Are you sure you want to exit the terminal named \"" +
                visibleTerminal.getTitle() + "\"? Any running jobs will be terminated.",
-               false, 
+               false,
                new Operation()
                {
                   @Override
@@ -248,20 +257,48 @@ public class TerminalPane extends WorkbenchPane
    }
 
    @Override
+   public int busyTerminalCount()
+   {
+      // TODO (gary) this should only count terminals where the
+      // shell (bash) has child processes; this requires more server-side
+      // work so for the moment all terminals are considered busy
+      return terminals_.terminalCount();
+   }
+
+   @Override
+   public void terminateAllTerminals()
+   {
+      // kill any terminal server processes, and remove them from the server-
+      // side list of known processes
+      for (final TerminalMetadata item : terminals_)
+      {
+         pConsoleProcessFactory_.get().interruptAndReap(item.getHandle());
+      }
+
+      // set client state back to startup values
+      terminals_.clear();
+      creatingTerminal_ = false;
+      activeTerminalToolbarButton_.setNoActiveTerminal();
+      setTerminalCaption("");
+   }
+
+   @Override
    public void onTerminalSessionStarted(TerminalSessionStartedEvent event)
    {
       TerminalSession terminal = event.getTerminalWidget();
-      
-      terminals_.addTerminal(new TerminalMetadata(
-            terminal.getHandle(),
-            terminal.getTitle(),
-            terminal.getSequence()));   
+
+      terminals_.addTerminal(
+            new TerminalMetadata(
+                  terminal.getHandle(),
+                  terminal.getTitle(),
+                  terminal.getSequence()));
 
       terminalSessionsPanel_.add(terminal);
       terminalSessionsPanel_.showWidget(terminal);
       setFocusOnVisible();
+      creatingTerminal_ = false;
    }
-   
+
    @Override
    public void onTerminalSessionStopped(TerminalSessionStoppedEvent event)
    {
@@ -269,7 +306,7 @@ public class TerminalPane extends WorkbenchPane
       // and remove the stopped terminal.
       TerminalSession currentTerminal = event.getTerminalWidget();
       String handle = currentTerminal.getHandle();
-      
+
       String newTerminalHandle = terminalToShowWhenClosing(handle);
       if (newTerminalHandle != null)
       {
@@ -309,7 +346,7 @@ public class TerminalPane extends WorkbenchPane
 
       Debug.logWarning("Tried to switch to unknown terminal handle");
    }
-   
+
    @Override
    public void onTerminalCaption(TerminalCaptionEvent event)
    {
@@ -321,7 +358,7 @@ public class TerminalPane extends WorkbenchPane
          setTerminalCaption(captionTerm.getCaption());
       }
    }
-   
+
    /**
     * @return number of terminals loaded into panes
     */
@@ -329,7 +366,7 @@ public class TerminalPane extends WorkbenchPane
    {
       return terminalSessionsPanel_.getWidgetCount();
    }
-   
+
    /**
     * @param i index of terminal to return
     * @return terminal at index, or null
@@ -343,7 +380,7 @@ public class TerminalPane extends WorkbenchPane
       }
       return null;
    }
-   
+
    /**
     * Find loaded terminal session for a given handle
     * @param handle of TerminalSession to return
@@ -375,29 +412,29 @@ public class TerminalPane extends WorkbenchPane
       }
       return null;
    }
-   
+
    /**
     * If a terminal is visible give it focus and update dropdown selection.
     */
    public void setFocusOnVisible()
    {
-         Scheduler.get().scheduleDeferred(new ScheduledCommand()
+      Scheduler.get().scheduleDeferred(new ScheduledCommand()
+      {
+         @Override
+         public void execute()
          {
-            @Override
-            public void execute()
+            TerminalSession visibleTerminal = getSelectedTerminal();
+            if (visibleTerminal != null)
             {
-               TerminalSession visibleTerminal = getSelectedTerminal();
-               if (visibleTerminal != null)
-               {
-                  visibleTerminal.setFocus(true);
-                  activeTerminalToolbarButton_.setActiveTerminal(
-                        visibleTerminal.getTitle(), visibleTerminal.getHandle());
-                  setTerminalCaption(visibleTerminal.getCaption());
-               }
+               visibleTerminal.setFocus(true);
+               activeTerminalToolbarButton_.setActiveTerminal(
+                     visibleTerminal.getTitle(), visibleTerminal.getHandle());
+               setTerminalCaption(visibleTerminal.getCaption());
             }
-         });
+         }
+      });
    }
-   
+
    /**
     * Handle of terminal to show after closing indicated terminal.
     * @param handle terminal being closed
@@ -413,12 +450,12 @@ public class TerminalPane extends WorkbenchPane
       else
          return null;
    }
-   
+
    private void setTerminalCaption(String caption)
    {
       terminalCaption_.setText(caption);
    }
-   
+
    private ShellSecureInput getSecureInput()
    {
       if (secureInput_ == null)
@@ -427,14 +464,16 @@ public class TerminalPane extends WorkbenchPane
       }
       return secureInput_;
    }
-   
+
    private DeckLayoutPanel terminalSessionsPanel_;
    private TerminalPopupMenu activeTerminalToolbarButton_;
    private final TerminalList terminals_ = new TerminalList();
    private Label terminalCaption_;
    private ShellSecureInput secureInput_;
+   private boolean creatingTerminal_;
 
    // Injected ----  
    private GlobalDisplay globalDisplay_;
    private EventBus events_;
+   private final Provider<ConsoleProcessFactory> pConsoleProcessFactory_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTab.java
@@ -28,6 +28,7 @@ import org.rstudio.studio.client.workbench.ui.DelayLoadTabShim;
 import org.rstudio.studio.client.workbench.ui.DelayLoadWorkbenchTab;
 import org.rstudio.studio.client.workbench.views.terminal.events.CreateTerminalEvent;
 
+import com.google.gwt.user.client.Command;
 import com.google.inject.Inject;
 
 public class TerminalTab extends DelayLoadWorkbenchTab<TerminalTabPresenter>
@@ -43,11 +44,12 @@ public class TerminalTab extends DelayLoadWorkbenchTab<TerminalTabPresenter>
    {
       @Handler
       public abstract void onActivateTerminal();
-      
+
       @Handler
       public abstract void onCloseTerminal();
-      
+
       abstract void initialize();
+      abstract void confirmClose(Command onConfirmed);
    }
 
    @Inject
@@ -59,12 +61,24 @@ public class TerminalTab extends DelayLoadWorkbenchTab<TerminalTabPresenter>
    {
       super("Terminal", shim);
       shim_ = shim;
-      
+
       binder.bind(commands, shim_);
       events.addHandler(CreateTerminalEvent.TYPE, shim_);
       events.addHandler(SessionInitEvent.TYPE, shim_);
-      
+
       shim_.initialize();
+   }
+
+   @Override
+   public boolean closeable()
+   {
+      return true;
+   }
+
+   @Override
+   public void confirmClose(Command onConfirmed)
+   {
+      shim_.confirmClose(onConfirmed);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
@@ -15,23 +15,27 @@
 
 package org.rstudio.studio.client.workbench.views.terminal;
 
-import com.google.gwt.core.client.JsArray;
-import com.google.inject.Inject;
-import com.google.inject.Provider;
-
 import java.util.ArrayList;
 
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
-import org.rstudio.studio.client.common.console.ConsoleProcessInfo;
+import org.rstudio.core.client.widget.Operation;
+import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.console.ConsoleProcess.ConsoleProcessFactory;
+import org.rstudio.studio.client.common.console.ConsoleProcessInfo;
 import org.rstudio.studio.client.workbench.WorkbenchView;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.events.SessionInitEvent;
 import org.rstudio.studio.client.workbench.model.Session;
+import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.BusyPresenter;
 import org.rstudio.studio.client.workbench.views.terminal.events.CreateTerminalEvent;
+
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.user.client.Command;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 public class TerminalTabPresenter extends BusyPresenter
 {
@@ -43,62 +47,76 @@ public class TerminalTabPresenter extends BusyPresenter
        * Ensure terminal pane is visible.
        */
       void activateTerminal();
-      
-      /**
-       *  Ensure terminal pane has at least one session loaded.
-       */
-      void ensureTerminal();
-      
+
       /**
        * Create a new terminal session.
        */
       void createTerminal();
-      
+
       /**
        * Terminate current terminal.
        */
       void terminateCurrentTerminal();
-      
+
       /**
        * Attach a list of server-side terminals to the pane.
        * @param event list of terminals on server
        */
       void repopulateTerminals(ArrayList<ConsoleProcessInfo> procList);
+
+      /**
+       * @return Number of busy terminals (a terminal where the shell has
+       * child processes is considered busy).
+       */
+      int busyTerminalCount();
+
+      /**
+       * Terminate all terminals, whether busy or not. This kills any server-side
+       * process and removes it from the list of known processes. This should
+       * only be invoked when the terminal tab itself is being unloaded.
+       */
+      void terminateAllTerminals();
    }
 
    @Inject
    public TerminalTabPresenter(final Display view,
                                final Session session,
+                               GlobalDisplay globalDisplay,
+                               UIPrefs uiPrefs,
                                Provider<ConsoleProcessFactory> pConsoleProcessFactory)
    {
       super(view);
       view_ = view;
       session_ = session;
+      globalDisplay_ = globalDisplay;
+      uiPrefs_ = uiPrefs;
       pConsoleProcessFactory_ = pConsoleProcessFactory;
    }
-  
+
    @Handler
    public void onActivateTerminal()
    {
+      uiPrefs_.showTerminalTab().setGlobalValue(true);
+      uiPrefs_.writeUIPrefs();
       view_.activateTerminal();
    }
-  
+
    @Handler
    public void onCloseTerminal()
    {
       view_.terminateCurrentTerminal();
    }
-   
+
    public void initialize()
    {
    }
-   
+
    public void onCreateTerminal(CreateTerminalEvent event)
    {
-      view_.activateTerminal();
+      onActivateTerminal();
       view_.createTerminal();
    }
-   
+
    public void onSessionInit(SessionInitEvent sie)
    {
       JsArray<ConsoleProcessInfo> procs =
@@ -132,7 +150,7 @@ public class TerminalTabPresenter extends BusyPresenter
       {
          Debug.logWarning("Invalid terminal sequence " + newSequence + 
                ", killing unrecognized process");
-         pConsoleProcessFactory_.get().reap(procInfo);
+         pConsoleProcessFactory_.get().interruptAndReap(procInfo.getHandle());
          return;
       }
 
@@ -144,7 +162,7 @@ public class TerminalTabPresenter extends BusyPresenter
          {
             Debug.logWarning("Duplicate terminal sequence " + newSequence + 
                   ", killing duplicate process");
-            pConsoleProcessFactory_.get().reap(procInfo);
+            pConsoleProcessFactory_.get().interruptAndReap(procInfo.getHandle());
             return;
          }
 
@@ -157,8 +175,42 @@ public class TerminalTabPresenter extends BusyPresenter
       procInfoList.add(procInfo);
    }
 
+   public void confirmClose(final Command onConfirmed)
+   {
+      if (view_.busyTerminalCount() > 0)
+      {
+         globalDisplay_.showYesNoMessage(GlobalDisplay.MSG_QUESTION, 
+               "Close Terminal(s) ", 
+               "Are you sure you want to close all terminals? Any running jobs " +
+                     "will be stopped.", false, 
+                     new Operation()
+         {
+            @Override
+            public void execute()
+            {
+               shutDownTerminals();
+               onConfirmed.execute();
+            }
+         }, null, null, "Close Terminals", "Cancel", true);
+      }
+      else
+      {
+         shutDownTerminals();
+         onConfirmed.execute(); 
+      }
+   }
+
+   private void shutDownTerminals()
+   {
+      uiPrefs_.showTerminalTab().setGlobalValue(false);
+      uiPrefs_.writeUIPrefs();
+      view_.terminateAllTerminals();
+   }
+
    // Injected ---- 
    private final Provider<ConsoleProcessFactory> pConsoleProcessFactory_;
    private final Display view_;
    private final Session session_;
+   private final GlobalDisplay globalDisplay_;
+   private final UIPrefs uiPrefs_;
 }


### PR DESCRIPTION
- terminal tab can be closed, and kills all terminal processes (after a warning)
- added show_terminal_tab uiPref to control if terminal tab shown at startup; defaults to true, but set to false if tab is closed, set back to true if tab is reopened via Tools menu
