### PR TITLE
Reconnect terminals after session resume

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -19,6 +19,9 @@ import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.application.events.SessionSerializationEvent;
+import org.rstudio.studio.client.application.events.SessionSerializationHandler;
+import org.rstudio.studio.client.application.model.SessionSerializationAction;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.console.ConsoleOutputEvent;
 import org.rstudio.studio.client.common.console.ConsoleProcess;
@@ -44,7 +47,6 @@ import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.inject.Inject;
 
-
 /**
  * A connected Terminal session.
  */
@@ -53,7 +55,8 @@ public class TerminalSession extends XTermWidget
                                         ProcessExitEvent.Handler,
                                         ResizeTerminalEvent.Handler,
                                         TerminalDataInputEvent.Handler,
-                                        TerminalTitleEvent.Handler
+                                        TerminalTitleEvent.Handler,
+                                        SessionSerializationHandler
 {
    /**
     * 
@@ -71,7 +74,7 @@ public class TerminalSession extends XTermWidget
       setHeight("100%");
       setTitle("Terminal " + sequence_);
    }
-   
+
    @Inject
    private void initialize(WorkbenchServerOperations server,
                            EventBus events)
@@ -79,14 +82,18 @@ public class TerminalSession extends XTermWidget
       server_ = server;
       eventBus_ = events; 
    } 
-   
+
    /**
     * Create a terminal process and connect to it.
     */
    public void connect()
    {
+      if (connected_ || connecting_)
+         return;
+
+      connecting_ = true;
       setNewTerminal(getHandle() == null);
-      
+
       server_.startTerminal(80, 25, getHandle(), getTitle(), getSequence(),
                             new ServerRequestCallback<ConsoleProcess>()
       {
@@ -94,10 +101,11 @@ public class TerminalSession extends XTermWidget
          public void onResponseReceived(ConsoleProcess consoleProcess)
          {
             consoleProcess_ = consoleProcess;
-            
+
             if (getInteractionMode() != ConsoleProcessInfo.INTERACTION_ALWAYS)
             {
                writeError("Unsupported ConsoleProcess interaction mode");
+               disconnect();
                return;
             } 
 
@@ -106,41 +114,63 @@ public class TerminalSession extends XTermWidget
                addHandlerRegistration(consoleProcess_.addConsoleOutputHandler(TerminalSession.this));
                addHandlerRegistration(consoleProcess_.addProcessExitHandler(TerminalSession.this));
                addHandlerRegistration(addResizeTerminalHandler(TerminalSession.this));
-               addHandlerRegistration(addTerminalDataInputHandler(TerminalSession.this));
                addHandlerRegistration(addTerminalTitleHandler(TerminalSession.this));
+               addHandlerRegistration(eventBus_.addHandler(SessionSerializationEvent.TYPE, TerminalSession.this));
+               
+               // We keep this handler connected after a terminal disconnect so
+               // user input can wake up a suspended session
+               if (terminalInputHandler_ == null)
+                  terminalInputHandler_ = addTerminalDataInputHandler(TerminalSession.this);
 
                consoleProcess.start(new ServerRequestCallback<Void>()
                {
                   @Override
                   public void onResponseReceived(Void response)
                   {
+                     connected_ = true;
+                     connecting_ = false;
+                     flushQueuedInput();
                      eventBus_.fireEvent(new TerminalSessionStartedEvent(TerminalSession.this));
                   }
-                  
+
                   @Override
                   public void onError(ServerError error)
                   {
+                     disconnect();
                      writeError(error.getUserMessage());
                   }
                });
             }
          }
-      
+
          @Override
          public void onError(ServerError error)
          {
+            disconnect();
             writeError(error.getUserMessage());
          }
-         
+
       });
    }
-   
+
+   /**
+    * Disconnect a connected terminal. Allows for reconnection.
+    */
+   private void disconnect()
+   {
+      inputQueue_ = null;
+      registrations_.removeHandler();
+      consoleProcess_ = null;
+      connected_ = false;
+      connecting_ = false;
+   }
+
    @Override
    public void onConsoleOutput(ConsoleOutputEvent event)
    {
       write(event.getOutput());
    }
-   
+
    @Override
    public void onProcessExit(ProcessExitEvent event)
    {
@@ -149,10 +179,10 @@ public class TerminalSession extends XTermWidget
       {
          consoleProcess_.reap(new VoidServerRequestCallback());
       }
-     
+
       eventBus_.fireEvent(new TerminalSessionStoppedEvent(this));
    }
-   
+
    @Override
    public void onResizeTerminal(ResizeTerminalEvent event)
    {
@@ -167,25 +197,59 @@ public class TerminalSession extends XTermWidget
                }
             });
    }
-   
+
    @Override
    public void onTerminalDataInput(TerminalDataInputEvent event)
    {
-      secureInput_.secureString(event.getData(), new CommandWithArg<String>() 
+      if (!connected_)
+      {
+         if (inputQueue_ == null)
+         {
+            inputQueue_ = new StringBuilder();
+         }
+
+         // accumulate user input until we are connected, then play it back
+         inputQueue_.append(event.getData());
+         connect();
+         return;
+      }
+
+      String userInput;
+      if (inputQueue_ != null)
+      {
+         inputQueue_.append(event.getData());
+         userInput = inputQueue_.toString();
+         inputQueue_ = null;
+      }
+      else
+      {
+         userInput = event.getData();
+      }
+
+      sendUserInput(userInput);
+   }
+
+   /**
+    * Send user input to the server.
+    * @param userInput string to send
+    */
+   private void sendUserInput(String userInput)
+   {
+      secureInput_.secureString(userInput, new CommandWithArg<String>() 
       {
          @Override
          public void execute(String arg) // success
          {
             consoleProcess_.writeStandardInput(
-               ShellInput.create(arg,  true /* echo input*/), 
-               new VoidServerRequestCallback() {
-                  @Override
-                  public void onError(ServerError error)
-                  {
-                     writeln(error.getUserMessage());
-                  }
-               });
-          }
+                  ShellInput.create(arg,  true /* echo input*/), 
+                  new VoidServerRequestCallback() {
+                     @Override
+                     public void onError(ServerError error)
+                     {
+                        writeln(error.getUserMessage());
+                     }
+                  });
+         }
       },
       new CommandWithArg<String>()
       {
@@ -197,18 +261,31 @@ public class TerminalSession extends XTermWidget
       });
    }
    
+   /**
+    * Send queued user input to the server.
+    */
+   private void flushQueuedInput()
+   {
+      if (inputQueue_ != null)
+      {
+         String userInput = inputQueue_.toString();
+         inputQueue_ = null;
+         sendUserInput(userInput);
+      }
+   }
+
    @Override
    public void onTerminalTitle(TerminalTitleEvent event)
    {
       caption_ = event.getTitle();
       eventBus_.fireEvent(new TerminalCaptionEvent(this));
    }
-   
+
    public String getCaption()
    {
       return caption_;
    }
-   
+
    public void setCaption(String caption)
    {
       caption_ = caption;
@@ -226,10 +303,12 @@ public class TerminalSession extends XTermWidget
    {
       registrations_.add(reg);
    }
-   
+
    protected void unregisterHandlers()
    {
       registrations_.removeHandler();
+      terminalInputHandler_.removeHandler();
+      terminalInputHandler_ = null;
    }
 
    protected void writeError(String msg)
@@ -243,7 +322,7 @@ public class TerminalSession extends XTermWidget
       super.onDetach();
       unregisterHandlers();
    }
-  
+
    @Override
    public void setVisible(boolean isVisible)
    {
@@ -265,7 +344,7 @@ public class TerminalSession extends XTermWidget
          });
       }
    }
-   
+
    /**
     * A unique handle for this terminal instance. Corresponds to the 
     * server-side ConsoleProcess handle.
@@ -278,10 +357,10 @@ public class TerminalSession extends XTermWidget
       {
          return terminalHandle_;
       }
-      
-      return consoleProcess_.getProcessInfo().getHandle();
+      terminalHandle_ = consoleProcess_.getProcessInfo().getHandle();
+      return terminalHandle_;
    }
-   
+
    /**
     * The sequence number of the terminal, used in creation of the default
     * title, e.g. "Terminal 3".
@@ -291,7 +370,7 @@ public class TerminalSession extends XTermWidget
    {
       return sequence_;
    }
-   
+
    /**
     * Forcibly terminate the process associated with this terminal session.
     */
@@ -310,15 +389,37 @@ public class TerminalSession extends XTermWidget
       }
    }
 
+   @Override
+   public void onSessionSerialization(SessionSerializationEvent event)
+   {
+      switch(event.getAction().getType())
+      {
+      case SessionSerializationAction.SUSPEND_SESSION:
+         disconnect();
+         break;
+      }
+   }
+
+   /**
+    * @return true if terminal is connected to server, false if not
+    */
+   public boolean isConnected()
+   {
+      return connected_;
+   }
+
    private final ShellSecureInput secureInput_;
    private HandlerRegistrations registrations_ = new HandlerRegistrations();
+   private HandlerRegistration terminalInputHandler_;
    private ConsoleProcess consoleProcess_;
    private String caption_ = new String();
    private final int sequence_;
-   private final String terminalHandle_;
-   
+   private String terminalHandle_;
+   private boolean connected_;
+   private boolean connecting_;
+   private StringBuilder inputQueue_;
+
    // Injected ---- 
    private WorkbenchServerOperations server_; 
    private EventBus eventBus_;
-
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
@@ -96,8 +96,11 @@ public class TerminalTabPresenter extends BusyPresenter
    @Handler
    public void onActivateTerminal()
    {
-      uiPrefs_.showTerminalTab().setGlobalValue(true);
-      uiPrefs_.writeUIPrefs();
+      if (!uiPrefs_.showTerminalTab().getValue())
+      {
+         uiPrefs_.showTerminalTab().setGlobalValue(true);
+         uiPrefs_.writeUIPrefs();
+      }
       view_.activateTerminal();
    }
 
@@ -202,8 +205,11 @@ public class TerminalTabPresenter extends BusyPresenter
 
    private void shutDownTerminals()
    {
-      uiPrefs_.showTerminalTab().setGlobalValue(false);
-      uiPrefs_.writeUIPrefs();
+      if (uiPrefs_.showTerminalTab().getValue())
+      {
+         uiPrefs_.showTerminalTab().setGlobalValue(false);
+         uiPrefs_.writeUIPrefs();
+      }
       view_.terminateAllTerminals();
    }
 


### PR DESCRIPTION
- after a session resumes, existing terminals are now reconnected, as needed, to new server processes
- user input into an existing terminal will trigger a session resume, and the input is queued until it can be sent
- don't write uiPrefs to server unless they have changed