### PR TITLE
Bare-bones Windows terminal tab (warning: many of the bones are missing)

### DIFF
--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -854,13 +854,14 @@ void editFilePostback(const std::string& file,
 Error startShellDialog(const json::JsonRpcRequest& request,
                        json::JsonRpcResponse* pResponse)
 {
-#ifndef _WIN32
    using namespace session::module_context;
    using namespace session::console_process;
 
    // TERM setting, must correspond to one of the values in the
    // client-side enum TerminalType. For now we treat XTERM as a
    // "smart terminal" and anything else as DUMB (RStudio 1.0 behavior).
+   // On Win32, only "smart" is supported at the moment, and the
+   // TerminalType is ignored.
    std::string term;
    
    // initial size of the pseudo-terminal
@@ -897,12 +898,17 @@ Error startShellDialog(const json::JsonRpcRequest& request,
    if (error)
       return error;
    
+#ifndef _WIN32
    bool smartTerm = !term.compare("XTERM");
-   
+#else
+   bool smartTerm = true;
+#endif
+
    // configure environment for shell
    core::system::Options shellEnv;
    core::system::environment(&shellEnv);
 
+#ifndef _WIN32
    // set terminal
    core::system::setenv(&shellEnv, "TERM", smartTerm ? "xterm" : "dumb");
 
@@ -928,6 +934,7 @@ Error startShellDialog(const json::JsonRpcRequest& request,
    }
    core::system::setenv(&shellEnv, "GIT_EDITOR", s_editFileCommand);
    core::system::setenv(&shellEnv, "SVN_EDITOR", s_editFileCommand);
+#endif
 
    if (termSequence != kNoTerminal)
    {
@@ -943,16 +950,23 @@ Error startShellDialog(const json::JsonRpcRequest& request,
    options.workingDir = module_context::shellWorkingDirectory();
    options.environment = shellEnv;
    options.smartTerminal = smartTerm;
+#ifndef _WIN32
    options.cols = cols;
    options.rows = rows;
-   
+#endif
+
    if (termCaption.empty())
       termCaption = "Shell";
    
    // configure bash command
+#ifndef _WIN32
    core::shell_utils::ShellCommand bashCommand("/usr/bin/env");
    bashCommand << "bash";
    bashCommand << "--norc";
+#else
+   // TODO (gary) use %comspec% to locate cmd.exe
+   core::shell_utils::ShellCommand bashCommand("cmd.exe");
+#endif
 
    // run process
    boost::shared_ptr<ConsoleProcess> ptrProc =
@@ -973,9 +987,6 @@ Error startShellDialog(const json::JsonRpcRequest& request,
    pResponse->setResult(ptrProc->toJson());
 
    return Success();
-#else // not supported on Win32
-   return Error(json::errc::InvalidRequest, ERROR_LOCATION);
-#endif
 }
 
 Error setCRANMirror(const json::JsonRpcRequest& request,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -339,6 +339,7 @@ public class TerminalPane extends WorkbenchPane
                            {
                               // failed, put back original caption on client
                               renameVisibleTerminalInClient(origCaption);
+                              Debug.logError(error);
                            }
                         });
                }
@@ -486,6 +487,7 @@ public class TerminalPane extends WorkbenchPane
                   {
                      // failed; this might mean we show the wrong title after
                      // a reset, but it will update itself fairly quickly
+                     Debug.logError(error);
                   }
                });
       }


### PR DESCRIPTION
- add error logging to a couple of existing onError's
- on Windows desktop IDE, able to start a terminal and:
    - enter commands
    - see the output
    - type "exit" to get out of the shell
- plenty of issues with line wrapping, control sequences, scrolling
- goal was to have Windows terminal pane show more than a blank white rectangle when a new terminal is created