### PR TITLE
Generalize new connections wizard to use rpc

### DIFF
--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -161,9 +161,16 @@ options(connectionObserver = list(
 })
 
 .rs.addJsonRpcHandler("get_new_connection_context", function() {
-  context <- list()
+   context <- list(
+      connectionsList = list(
+         list(
+            name = .rs.scalar("Spark"),
+            type = .rs.scalar("Shiny")
+         )
+      )
+   )
 
-  context
+   context
 })
 
 .rs.addFunction("embeddedViewer", function(url)

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4909,10 +4909,12 @@ public class RemoteServer implements Server
 
    @Override
    public void launchEmbeddedShinyConnectionUI(String packageName, 
+                                               String connectionName,
                                                ServerRequestCallback<RResult<Void>> callback)
    {
       JSONArray params = new JSONArray();
       params.set(0, new JSONString(packageName));
+      params.set(1, new JSONString(connectionName));
       sendRequest(RPC_SCOPE, LAUNCH_EMBEDDED_SHINY_CONNECTION_UI, params, callback);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/ConnectionsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/ConnectionsServerOperations.java
@@ -53,5 +53,6 @@ public interface ConnectionsServerOperations extends CryptoServerOperations
                      ServerRequestCallback<ConsoleProcess> callback);
 
    void launchEmbeddedShinyConnectionUI(String packageName,
+                                        String connectionName,
                                         ServerRequestCallback<RResult<Void>> serverRequestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/NewConnectionContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/NewConnectionContext.java
@@ -32,12 +32,16 @@ public class NewConnectionContext extends JavaScriptObject
       {
       }
 
+      public final native String getPackage() /*-{
+         return this["package"];
+      }-*/;
+
       public final native String getName() /*-{
-         return this.name;
+         return this["name"];
       }-*/;
 
       public final native String getType() /*-{
-      	 return this.type;
+      	 return this["type"];
       }-*/;
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/NewConnectionContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/NewConnectionContext.java
@@ -17,18 +17,44 @@ package org.rstudio.studio.client.workbench.views.connections.model;
 
 
 import java.util.ArrayList;
-import java.util.List;
-
-import org.rstudio.core.client.StringUtil;
-import org.rstudio.studio.client.application.Desktop;
 
 import com.google.gwt.core.client.JavaScriptObject;
-import com.google.gwt.core.client.JsArray;
-import com.google.gwt.core.client.JsArrayString;
 
 public class NewConnectionContext extends JavaScriptObject
 {
    protected NewConnectionContext()
    {
+   }
+
+   public static class NewConnectionInfo extends JavaScriptObject
+   {
+      protected NewConnectionInfo()
+      {
+      }
+
+      public final native String getName() /*-{
+         return this.name;
+      }-*/;
+
+      public final native String getType() /*-{
+      	 return this.type;
+      }-*/;
+   }
+
+   public final native int getConnectionsLength() /*-{
+      return this.connectionsList.length;
+   }-*/;
+   
+   public final native NewConnectionInfo getConnectionsItem(int index) /*-{
+      return this.connectionsList[index];
+   }-*/;
+
+   public final ArrayList<NewConnectionInfo> getConnectionsList()
+   {
+      ArrayList<NewConnectionInfo> result = new ArrayList<NewConnectionInfo>(getConnectionsLength());
+      for (int i = 0; i < getConnectionsLength(); i++)
+         result.add(getConnectionsItem(i));
+
+      return result;
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/NewConnectionContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/NewConnectionContext.java
@@ -53,6 +53,16 @@ public class NewConnectionContext extends JavaScriptObject
       return this.connectionsList[index];
    }-*/;
 
+   /*
+   public void setCurrentInfo(NewConnectionInfo currentInfo) {
+      currentInfo_ = currentInfo;
+   }
+
+   public NewConnectionInfo setCurrentInfo() {
+      return currentInfo;
+   }
+   */
+
    public final ArrayList<NewConnectionInfo> getConnectionsList()
    {
       ArrayList<NewConnectionInfo> result = new ArrayList<NewConnectionInfo>(getConnectionsLength());
@@ -61,4 +71,6 @@ public class NewConnectionContext extends JavaScriptObject
 
       return result;
    }
+
+   // private NewConnectionInfo currentInfo_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.java
@@ -20,6 +20,7 @@ import org.rstudio.core.client.widget.WizardNavigationPage;
 import org.rstudio.core.client.widget.WizardPage;
 import org.rstudio.studio.client.workbench.views.connections.model.ConnectionOptions;
 import org.rstudio.studio.client.workbench.views.connections.model.NewConnectionContext;
+import org.rstudio.studio.client.workbench.views.connections.model.NewConnectionContext.NewConnectionInfo;
 
 import com.google.gwt.resources.client.ImageResource;
 
@@ -29,22 +30,28 @@ public class NewConnectionNavigationPage
    public NewConnectionNavigationPage(String title,
                                       String subTitle,
                                       ImageResource icon,
-                                      NewConnectionContext input)
+                                      NewConnectionContext context)
    {
       super(title, subTitle, "Create Connection", 
-            icon, null, createPages(input));
+            icon, null, createPages(context));
    }
    
    private static ArrayList<WizardPage<NewConnectionContext, 
                                        ConnectionOptions>> 
-           createPages(NewConnectionContext input)
+           createPages(NewConnectionContext context)
    {
       ArrayList<WizardPage<NewConnectionContext, 
                            ConnectionOptions>> pages =
                            new ArrayList<WizardPage<NewConnectionContext, 
                                                     ConnectionOptions>>();
 
-      pages.add(new NewConnectionShinyPage("Spark"));
+      for(NewConnectionInfo connectionInfo: context.getConnectionsList()) {
+         switch(connectionInfo.getType()) {
+            case "Shiny":
+              pages.add(new NewConnectionShinyPage(connectionInfo.getName()));
+              break;
+         }
+      }
 
       return pages;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.java
@@ -46,10 +46,8 @@ public class NewConnectionNavigationPage
                                                     ConnectionOptions>>();
 
       for(NewConnectionInfo connectionInfo: context.getConnectionsList()) {
-         switch(connectionInfo.getType()) {
-            case "Shiny":
-              pages.add(new NewConnectionShinyPage(connectionInfo.getName()));
-              break;
+         if (connectionInfo.getType() == "Shiny") {
+            pages.add(new NewConnectionShinyPage(connectionInfo));
          }
       }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyHost.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyHost.java
@@ -38,6 +38,7 @@ import org.rstudio.studio.client.workbench.views.connections.events.NewConnectio
 import org.rstudio.studio.client.workbench.views.connections.model.ConnectionOptions;
 import org.rstudio.studio.client.workbench.views.connections.model.ConnectionsServerOperations;
 import org.rstudio.studio.client.workbench.views.connections.model.NewConnectionContext;
+import org.rstudio.studio.client.workbench.views.connections.model.NewConnectionContext.NewConnectionInfo;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ChangeEvent;
@@ -71,12 +72,12 @@ public class NewConnectionShinyHost extends Composite
       applicationInterrupt_ = applicationInterrupt;
    }
 
-   public void onBeforeActivate(Operation operation)
+   public void onBeforeActivate(Operation operation, NewConnectionInfo info)
    {
       events_.addHandler(ShinyFrameNavigatedEvent.TYPE, this);
       events_.addHandler(NewConnectionDialogUpdatedEvent.TYPE, this);
       
-      initialize(operation);
+      initialize(operation, info);
    }
    
    public void onActivate(ProgressIndicator indicator)
@@ -101,11 +102,9 @@ public class NewConnectionShinyHost extends Composite
       terminateShinyApp(operation);
    }
    
-   public NewConnectionShinyHost(NewConnectionContext context)
+   public NewConnectionShinyHost()
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
-      
-      context_ = context;
       
       initWidget(createWidget());
       
@@ -124,10 +123,10 @@ public class NewConnectionShinyHost extends Composite
       globalDisplay_.showErrorMessage("Error", errorMessage);
    }
    
-   private void initialize(final Operation operation)
+   private void initialize(final Operation operation, final NewConnectionInfo info)
    {
       // initialize miniUI
-      server_.launchEmbeddedShinyConnectionUI("sparklyr", "Spark", new ServerRequestCallback<RResult<Void>>()
+      server_.launchEmbeddedShinyConnectionUI(info.getPackage(), info.getName(), new ServerRequestCallback<RResult<Void>>()
       {
          @Override
          public void onResponseReceived(RResult<Void> response)
@@ -250,8 +249,6 @@ public class NewConnectionShinyHost extends Composite
    {
       RES.styles().ensureInjected();
    }
-   
-   private final NewConnectionContext context_;
    
    private ConnectionCodePanel codePanel_;
      

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyHost.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyHost.java
@@ -127,7 +127,7 @@ public class NewConnectionShinyHost extends Composite
    private void initialize(final Operation operation)
    {
       // initialize miniUI
-      server_.launchEmbeddedShinyConnectionUI("sparklyr", new ServerRequestCallback<RResult<Void>>()
+      server_.launchEmbeddedShinyConnectionUI("sparklyr", "Spark", new ServerRequestCallback<RResult<Void>>()
       {
          @Override
          public void onResponseReceived(RResult<Void> response)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyPage.java
@@ -20,15 +20,17 @@ import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.WizardPage;
 import org.rstudio.studio.client.workbench.views.connections.model.ConnectionOptions;
 import org.rstudio.studio.client.workbench.views.connections.model.NewConnectionContext;
+import org.rstudio.studio.client.workbench.views.connections.model.NewConnectionContext.NewConnectionInfo;
 
 import com.google.gwt.user.client.ui.Widget;
 
 public class NewConnectionShinyPage 
    extends WizardPage<NewConnectionContext, ConnectionOptions>
 {
-   public NewConnectionShinyPage(String connectionName)
+   public NewConnectionShinyPage(NewConnectionInfo info)
    {
-      super(connectionName, "", connectionName + " Connection", null, null);
+      super(info.getName(), "", info.getName() + " Connection", null, null);
+      info_ = info;
    }
 
    @Override
@@ -39,7 +41,7 @@ public class NewConnectionShinyPage
    @Override
    public void onBeforeActivate(Operation operation)
    {
-      contents_.onBeforeActivate(operation);
+      contents_.onBeforeActivate(operation, info_);
    }
    
    @Override
@@ -56,7 +58,7 @@ public class NewConnectionShinyPage
    @Override
    protected Widget createWidget()
    {
-      contents_ = new NewConnectionShinyHost(context_);
+      contents_ = new NewConnectionShinyHost();
 
       return contents_;
    }
@@ -64,7 +66,6 @@ public class NewConnectionShinyPage
    @Override
    protected void initialize(NewConnectionContext initData)
    {
-      context_ = initData;
    }
 
    @Override
@@ -74,5 +75,5 @@ public class NewConnectionShinyPage
    }
    
    private NewConnectionShinyHost contents_;
-   private NewConnectionContext context_;
+   private NewConnectionInfo info_;
 }


### PR DESCRIPTION
Couple changes to generalize the new connections dialog to use the `get_new_connection_context` rpc. Next step would be to use the package indexer in the RPC. We can consider merging this one to keep working in master.