### PR TITLE
unification of package extension code

### DIFF
--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -104,6 +104,7 @@ set (SESSION_SOURCE_FILES
    modules/SessionLimits.cpp
    modules/SessionLists.cpp
    modules/SessionMarkers.cpp
+   modules/SessionPackageProvidedExtension.cpp
    modules/SessionPackages.cpp
    modules/SessionPackrat.cpp
    modules/SessionPath.cpp

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -164,8 +164,8 @@ const int kChunkExecStateChanged = 145;
 const int kNavigateShinyFrame = 146;
 const int kUpdateNewConnectionDialog = 147;
 const int kProjectTemplateRegistryUpdated = 148;
-const int kPackageExtensionIndexingCompleted = 149;
 const int kTerminalSubprocs = 149;
+const int kPackageExtensionIndexingCompleted = 150;
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -453,10 +453,10 @@ std::string ClientEvent::typeName() const
          return "update_new_connection_dialog";
       case client_events::kProjectTemplateRegistryUpdated:
          return "project_template_registry_updated";
-      case client_events::kPackageExtensionIndexingCompleted:
-         return "package_extension_indexing_completed";
       case client_events::kTerminalSubprocs:
          return "terminal_subprocs";
+      case client_events::kPackageExtensionIndexingCompleted:
+         return "package_extension_indexing_completed";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -164,6 +164,7 @@ const int kChunkExecStateChanged = 145;
 const int kNavigateShinyFrame = 146;
 const int kUpdateNewConnectionDialog = 147;
 const int kProjectTemplateRegistryUpdated = 148;
+const int kPackageExtensionIndexingCompleted = 149;
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -451,6 +452,8 @@ std::string ClientEvent::typeName() const
          return "update_new_connection_dialog";
       case client_events::kProjectTemplateRegistryUpdated:
          return "project_template_registry_updated";
+      case client_events::kPackageExtensionIndexingCompleted:
+         return "package_extension_indexing_completed";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -104,6 +104,7 @@ extern "C" const char *locale2charset(const char *);
 #include "SessionClientEventQueue.hpp"
 
 #include <session/SessionRUtil.hpp>
+#include <session/SessionPackageProvidedExtension.hpp>
 
 #include "modules/SessionAbout.hpp"
 #include "modules/SessionAgreement.hpp"
@@ -1809,6 +1810,7 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
       (modules::lists::initialize)
       (modules::path::initialize)
       (modules::limits::initialize)
+      (modules::ppe::initialize)
       (modules::ask_pass::initialize)
       (modules::agreement::initialize)
       (modules::console::initialize)

--- a/src/cpp/session/include/session/SessionPackageProvidedExtension.hpp
+++ b/src/cpp/session/include/session/SessionPackageProvidedExtension.hpp
@@ -38,6 +38,10 @@ namespace session {
 namespace modules {
 namespace ppe {
 
+core::Error parseResourceFile(
+      const core::FilePath& resourcePath,
+      std::vector<std::map<std::string, std::string> >* pOutput);
+
 class Worker : boost::noncopyable
 {
 public:
@@ -85,7 +89,7 @@ private:
    bool running_;
 };
 
-Indexer& indexer();
+void registerWorker(boost::shared_ptr<Worker> pWorker);
 core::Error initialize();
 
 } // end namespace ppe

--- a/src/cpp/session/include/session/SessionPackageProvidedExtension.hpp
+++ b/src/cpp/session/include/session/SessionPackageProvidedExtension.hpp
@@ -21,6 +21,7 @@
 
 #include <core/json/Json.hpp>
 
+#include <boost/function.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 
@@ -38,9 +39,9 @@ namespace session {
 namespace modules {
 namespace ppe {
 
-core::Error parseResourceFile(
+core::Error parseDcfResourceFile(
       const core::FilePath& resourcePath,
-      std::vector<std::map<std::string, std::string> >* pOutput);
+      boost::function<core::Error(const std::map<std::string, std::string>&)> callback);
 
 class Worker : boost::noncopyable
 {

--- a/src/cpp/session/include/session/SessionPackageProvidedExtension.hpp
+++ b/src/cpp/session/include/session/SessionPackageProvidedExtension.hpp
@@ -89,7 +89,7 @@ private:
    bool running_;
 };
 
-void registerWorker(boost::shared_ptr<Worker> pWorker);
+Indexer& indexer();
 core::Error initialize();
 
 } // end namespace ppe

--- a/src/cpp/session/include/session/SessionPackageProvidedExtension.hpp
+++ b/src/cpp/session/include/session/SessionPackageProvidedExtension.hpp
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+#include <core/json/Json.hpp>
+
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 
@@ -40,7 +42,7 @@ class Worker : boost::noncopyable
 {
 public:
    virtual void onIndexingStarted() = 0;
-   virtual void onIndexingCompleted() = 0;
+   virtual void onIndexingCompleted(core::json::Object* pPayload) = 0;
    virtual void onWork(const std::string& pkgName, const core::FilePath& resourcePath) = 0;
    virtual ~Worker() {}
    

--- a/src/cpp/session/include/session/SessionPackageProvidedExtension.hpp
+++ b/src/cpp/session/include/session/SessionPackageProvidedExtension.hpp
@@ -16,135 +16,74 @@
 #ifndef SESSION_MODULES_PACKAGE_PROVIDED_EXTENSION_HPP
 #define SESSION_MODULES_PACKAGE_PROVIDED_EXTENSION_HPP
 
-#include <cstddef>
-
 #include <string>
-#include <map>
+#include <vector>
 
-#include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 #include <boost/noncopyable.hpp>
+#include <boost/shared_ptr.hpp>
 
-#include <core/FilePath.hpp>
+namespace rstudio {
+namespace core {
 
-#include <session/SessionModuleContext.hpp>
+class Error;
+class FilePath;
+
+} // end namespace core
+} // end namespace rstudio
 
 namespace rstudio {
 namespace session {
 namespace modules {
 namespace ppe {
 
-class Indexer : public boost::noncopyable
+class Worker : boost::noncopyable
 {
+public:
    virtual void onIndexingStarted() = 0;
-   virtual void onWork(const std::string& pkgName, const core::FilePath& resourcePath) = 0;
    virtual void onIndexingCompleted() = 0;
+   virtual void onWork(const std::string& pkgName, const core::FilePath& resourcePath) = 0;
+   virtual ~Worker() {}
    
 public:
-   explicit Indexer(const std::string& resourcePath)
-      : resourcePath_(resourcePath),
-        index_(0),
-        n_(0),
-        running_(false)
+   Worker(const std::string& resourcePath)
+      : resourcePath_(resourcePath)
    {
    }
-   
-   virtual ~Indexer() {}
-   
-   void start()
-   {
-      if (running_)
-         return;
-      
-      running_ = true;
-      beginIndexing();
-      module_context::scheduleIncrementalWork(
-               boost::posix_time::milliseconds(300),
-               boost::posix_time::milliseconds(20),
-               boost::bind(&Indexer::work, this),
-               false);
-   }
-   
-   bool running()
-   {
-      return running_;
-   }
+
+   const std::string& resourcePath() const { return resourcePath_; }
    
 private:
-   
-   bool work()
-   {
-      // check whether we've run out of work items
-      if (index_ == n_)
-      {
-         endIndexing();
-         return false;
-      }
-      
-      std::size_t index = index_++;
-      
-      // discover path to package resource
-      const core::FilePath& pkgPath = pkgDirs_[index];
-      core::FilePath resourcePath = pkgPath.childPath(resourcePath_);
-      std::string pkgName = pkgPath.filename();
-      
-      // bail if the resource doesn't exist
-      if (!resourcePath.exists())
-         return true;
-      
-      // handle work item
-      onWork(pkgName, resourcePath);
-      return true;
-   }
-   
-   void beginIndexing()
-   {
-      // reset indexer state
-      pkgDirs_.clear();
-      index_ = 0;
-      
-      // discover packages available on the current library paths
-      std::vector<core::FilePath> libPaths = module_context::getLibPaths();
-      BOOST_FOREACH(const core::FilePath& libPath, libPaths)
-      {
-         if (!libPath.exists())
-            continue;
-         
-         std::vector<core::FilePath> pkgPaths;
-         core::Error error = libPath.children(&pkgPaths);
-         if (error)
-            LOG_ERROR(error);
-         
-         pkgDirs_.insert(
-                  pkgDirs_.end(),
-                  pkgPaths.begin(),
-                  pkgPaths.end());
-      }
-      
-      // store number of work items
-      n_ = pkgDirs_.size();
-      
-      // call subclass method
-      onIndexingStarted();
-   }
-   
-   void endIndexing()
-   {
-      running_ = false;
-      onIndexingCompleted();
-   }
-   
-   // Private Members ----
-   
    std::string resourcePath_;
+};
+
+class Indexer : boost::noncopyable
+{
+public:
+   explicit Indexer();
+   virtual ~Indexer() {}
    
-   // Indexer state
+public:
+   void addWorker(boost::shared_ptr<Worker> pWorker);
+   void removeWorker(boost::shared_ptr<Worker> pWorker);
+   
+public:
+   void start();
+   bool running() { return running_; }
+   
+private:
+   void beginIndexing();
+   bool work();
+   void endIndexing();
+   
+private:
+   std::vector<boost::shared_ptr<Worker> > workers_;
    std::vector<core::FilePath> pkgDirs_;
    std::size_t index_;
    std::size_t n_;
    bool running_;
 };
 
+Indexer& indexer();
 core::Error initialize();
 
 } // end namespace ppe

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -165,6 +165,7 @@ extern const int kChunkExecStateChanged;
 extern const int kNavigateShinyFrame;
 extern const int kUpdateNewConnectionDialog;
 extern const int kProjectTemplateRegistryUpdated;
+extern const int kPackageExtensionIndexingCompleted;
 }
    
 class ClientEvent

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -165,8 +165,8 @@ extern const int kChunkExecStateChanged;
 extern const int kNavigateShinyFrame;
 extern const int kUpdateNewConnectionDialog;
 extern const int kProjectTemplateRegistryUpdated;
-extern const int kPackageExtensionIndexingCompleted;
 extern const int kTerminalSubprocs;
+extern const int kPackageExtensionIndexingCompleted;
 }
    
 class ClientEvent

--- a/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
+++ b/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
@@ -201,7 +201,7 @@ void onConsoleInput(const std::string& input)
    if (module_context::disablePackages())
       return;
    
-   const char* const commands[] = {
+   static const char* const commands[] = {
       "install.packages",
       "utils::install.packages",
       "remove.packages",

--- a/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
+++ b/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
@@ -119,14 +119,21 @@ void Indexer::beginIndexing()
 void Indexer::endIndexing()
 {
    running_ = false;
+   
+   json::Object payload;
    BOOST_FOREACH(boost::shared_ptr<Worker> pWorker, workers_)
    {
       try
       {
-         pWorker->onIndexingCompleted();
+         pWorker->onIndexingCompleted(&payload);
       }
       CATCH_UNEXPECTED_EXCEPTION
    }
+   
+   ClientEvent event(
+            client_events::kPackageExtensionIndexingCompleted,
+            payload);
+   module_context::enqueClientEvent(event);
 }
 
 namespace {

--- a/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
+++ b/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
@@ -32,9 +32,9 @@ namespace session {
 namespace modules {
 namespace ppe {
 
-Error parseResourceFile(
+Error parseDcfResourceFile(
       const FilePath& resourcePath,
-      std::vector<std::map<std::string, std::string> > *pOutput)
+      boost::function<Error(const std::map<std::string, std::string>&)> callback)
 {
    Error error;
 
@@ -58,8 +58,10 @@ Error parseResourceFile(
       if (error)
          return error;
       
-      // add to output vector
-      pOutput->push_back(fields);
+      // invoke callback on parsed dcf fields
+      error = callback(fields);
+      if (error)
+         return error;
    }
    
    return Success();

--- a/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
+++ b/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
@@ -175,13 +175,13 @@ void Indexer::endIndexing()
    module_context::enqueClientEvent(event);
 }
 
-namespace {
-
 Indexer& indexer()
 {
    static Indexer instance;
    return instance;
 }
+
+namespace {
 
 void reindex()
 {

--- a/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
+++ b/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
@@ -1,0 +1,202 @@
+/*
+ * SessionPackageProvidedExtension.cpp
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <session/SessionPackageProvidedExtension.hpp>
+
+#include <boost/foreach.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+#include <core/Algorithm.hpp>
+
+#include <session/SessionModuleContext.hpp>
+
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace ppe {
+
+Indexer::Indexer() : index_(0), n_(0), running_(false) {}
+
+void Indexer::addWorker(boost::shared_ptr<Worker> pWorker)
+{
+   workers_.push_back(pWorker);
+}
+
+void Indexer::removeWorker(boost::shared_ptr<Worker> pWorker)
+{
+   core::algorithm::expel(workers_, pWorker);
+}
+
+void Indexer::start()
+{
+   if (running_)
+      return;
+
+   running_ = true;
+   beginIndexing();
+   module_context::scheduleIncrementalWork(
+            boost::posix_time::milliseconds(300),
+            boost::posix_time::milliseconds(20),
+            boost::bind(&Indexer::work, this),
+            false);
+}
+
+bool Indexer::work()
+{
+   // check whether we've run out of work items
+   if (index_ == n_)
+   {
+      endIndexing();
+      return false;
+   }
+
+   std::size_t index = index_++;
+
+   // invoke workers with package name + path
+   FilePath pkgPath = pkgDirs_[index];
+   std::string pkgName = pkgPath.filename();
+   BOOST_FOREACH(boost::shared_ptr<Worker> pWorker, workers_)
+   {
+      try
+      {
+         FilePath resourcePath = pkgPath.childPath(pWorker->resourcePath());
+         pWorker->onWork(pkgName, resourcePath);
+      }
+      CATCH_UNEXPECTED_EXCEPTION
+   }
+   return true;
+}
+
+void Indexer::beginIndexing()
+{
+   // reset indexer state
+   pkgDirs_.clear();
+   index_ = 0;
+
+   // discover packages available on the current library paths
+   std::vector<core::FilePath> libPaths = module_context::getLibPaths();
+   BOOST_FOREACH(const core::FilePath& libPath, libPaths)
+   {
+      if (!libPath.exists())
+         continue;
+
+      std::vector<core::FilePath> pkgPaths;
+      core::Error error = libPath.children(&pkgPaths);
+      if (error)
+         LOG_ERROR(error);
+
+      pkgDirs_.insert(
+               pkgDirs_.end(),
+               pkgPaths.begin(),
+               pkgPaths.end());
+   }
+   n_ = pkgDirs_.size();
+   
+   BOOST_FOREACH(boost::shared_ptr<Worker> pWorker, workers_)
+   {
+      try
+      {
+         pWorker->onIndexingStarted();
+      }
+      CATCH_UNEXPECTED_EXCEPTION
+   }
+}
+
+void Indexer::endIndexing()
+{
+   running_ = false;
+   BOOST_FOREACH(boost::shared_ptr<Worker> pWorker, workers_)
+   {
+      try
+      {
+         pWorker->onIndexingCompleted();
+      }
+      CATCH_UNEXPECTED_EXCEPTION
+   }
+}
+
+namespace {
+
+Indexer& indexer()
+{
+   static Indexer instance;
+   return instance;
+}
+
+void reindex()
+{
+   if (module_context::disablePackages())
+      return;
+   
+   indexer().start();
+}
+
+void onDeferredInit(bool)
+{
+   reindex();
+}
+
+void onConsoleInput(const std::string& input)
+{
+   if (module_context::disablePackages())
+      return;
+   
+   const char* const commands[] = {
+      "install.packages",
+      "utils::install.packages",
+      "remove.packages",
+      "utils::remove.packages",
+      "install_github",
+      "devtools::install_github",
+      "load_all",
+      "devtools::load_all",
+   };
+   
+   std::string inputTrimmed = boost::algorithm::trim_copy(input);
+   BOOST_FOREACH(const char* command, commands)
+   {
+      if (boost::algorithm::starts_with(inputTrimmed, command))
+      {
+         // we need to give R a chance to actually process the package library
+         // mutating command before we update the index. schedule delayed work
+         // with idleOnly = true so that it waits until the user has returned
+         // to the R prompt
+         module_context::scheduleDelayedWork(
+                  boost::posix_time::seconds(1),
+                  boost::bind(reindex),
+                  true);
+      }
+   }
+}
+
+} // end anonymous namespace
+
+Error initialize()
+{
+   using namespace module_context;
+   using boost::bind;
+   
+   events().onDeferredInit.connect(onDeferredInit);
+   events().onConsoleInput.connect(onConsoleInput);
+   
+   return Success();
+}
+
+} // end namespace ppe
+} // end namespace modules
+} // end namespace session
+} // end namespace rstudio

--- a/src/cpp/session/modules/SessionProjectTemplate.cpp
+++ b/src/cpp/session/modules/SessionProjectTemplate.cpp
@@ -713,6 +713,7 @@ Error initialize()
    
    RS_REGISTER_CALL_METHOD(rs_getProjectTemplateRegistry, 0);
    
+   // register worker
    ppe::indexer().addWorker(projectTemplateWorker());
    
    ExecBlock initBlock;

--- a/src/cpp/session/modules/SessionRAddins.cpp
+++ b/src/cpp/session/modules/SessionRAddins.cpp
@@ -308,7 +308,7 @@ AddinRegistry& addinRegistry()
    return *s_pCurrentRegistry;
 }
 
-class AddinIndexer : public ppe::Indexer
+class AddinWorker : public ppe::Worker
 {
    void onIndexingStarted()
    {
@@ -320,7 +320,7 @@ class AddinIndexer : public ppe::Indexer
       pRegistry_->add(pkgName, addinPath);
    }
    
-   void onIndexingCompleted()
+   void onIndexingCompleted(json::Object* pPayload)
    {
       // finalize by indexing current package
       if (isDevtoolsLoadAllActive())
@@ -345,16 +345,18 @@ class AddinIndexer : public ppe::Indexer
          response.setResult(registryJson);
          continuation(Success(), &response);
       }
+      
+      // provide registry as json
+      (*pPayload)["addin_registry"] = registryJson;
 
+      // reset
+      continuations_.clear();
       pRegistry_.reset();
    }
 
 public:
    
-   AddinIndexer(const std::string& resourcePath)
-      : ppe::Indexer(resourcePath)
-   {
-   }
+   AddinWorker() : ppe::Worker("rstudio/addins.dcf") {}
    
    void addContinuation(json::JsonRpcFunctionContinuation continuation)
    {
@@ -366,69 +368,17 @@ private:
    std::vector<json::JsonRpcFunctionContinuation> continuations_;
 };
 
-AddinIndexer& addinIndexer()
+boost::shared_ptr<AddinWorker>& addinWorker()
 {
-   static AddinIndexer instance("rstudio/addins.dcf");
+   static boost::shared_ptr<AddinWorker> instance(new AddinWorker);
    return instance;
 }
 
 void indexLibraryPathsWithContinuation(
-                        json::JsonRpcFunctionContinuation continuation)
+      json::JsonRpcFunctionContinuation continuation)
 {
    if (continuation)
-      addinIndexer().addContinuation(continuation);
-   
-   if (!addinIndexer().running())
-      addinIndexer().start();
-}
-
-void indexLibraryPaths()
-{
-   indexLibraryPathsWithContinuation(json::JsonRpcFunctionContinuation());
-}
-
-void onDeferredInit(bool)
-{
-   // re-index
-   indexLibraryPaths();
-}
-
-// re-index on package library mutating commands (however don't do so
-// if the packages pane is disabled)
-void onConsoleInput(const std::string& input)
-{
-   // check for packages pane disabled
-   if (module_context::disablePackages())
-      return;
-
-   // initialize commands if necessary
-   static std::vector<std::string> commands;
-   if (commands.empty())
-   {
-      commands.push_back("install.packages");
-      commands.push_back("remove.packages");
-      commands.push_back("devtools::install_github");
-      commands.push_back("install_github");
-      commands.push_back("devtools::load_all");
-      commands.push_back("load_all");
-   }
-
-   // check for package library mutating command
-   std::string trimmedInput = boost::algorithm::trim_copy(input);
-   BOOST_FOREACH(const std::string& command, commands)
-   {
-      if (boost::algorithm::starts_with(trimmedInput, command))
-      {
-         // we need to give R a chance to actually process the package library
-         // mutating command before we update the index. schedule delayed work
-         // with idleOnly = true so that it waits until the user has returned
-         // to the R prompt
-         module_context::scheduleDelayedWork(boost::posix_time::seconds(1),
-                                             indexLibraryPaths,
-                                             true); // idle only
-         return;
-      }
-   }
+      addinWorker()->addContinuation(continuation);
 }
 
 void getRAddins(const json::JsonRpcRequest& request,
@@ -531,9 +481,9 @@ Error initialize()
    
    // load cached registry
    loadAddinRegistry();
-
-   events().onDeferredInit.connect(onDeferredInit);
-   events().onConsoleInput.connect(onConsoleInput);
+   
+   // register worker
+   ppe::indexer().addWorker(addinWorker());
    
    ExecBlock initBlock;
    initBlock.addFunctions()

--- a/src/cpp/session/modules/connections/ConnectionsIndexer.cpp
+++ b/src/cpp/session/modules/connections/ConnectionsIndexer.cpp
@@ -258,23 +258,16 @@ boost::shared_ptr<ConnectionsWorker>& connectionsWorker()
    return instance;
 }
 
-}
+} // end anonymous namespace
 
 core::json::Value connectionsRegistryAsJson()
 {
    return connectionsRegistry().toJson();
 }
 
-void indexLibraryPathsWithContinuation(
-                        json::JsonRpcFunctionContinuation continuation)
+void registerConnectionsWorker()
 {
-   if (continuation)
-      connectionsWorker()->addContinuation(continuation);
-}
-
-void indexLibraryPaths()
-{
-   indexLibraryPathsWithContinuation(json::JsonRpcFunctionContinuation());
+   ppe::indexer().addWorker(connectionsWorker());
 }
 
 } // namespace connections

--- a/src/cpp/session/modules/connections/ConnectionsIndexer.hpp
+++ b/src/cpp/session/modules/connections/ConnectionsIndexer.hpp
@@ -24,9 +24,7 @@ namespace modules {
 namespace connections {
 
 core::json::Value connectionsRegistryAsJson();
-
-void onConsoleInput(const std::string& input);
-void indexLibraryPaths();
+void registerConnectionsWorker();
                        
 } // namespace connections
 } // namespace modules

--- a/src/cpp/session/modules/connections/SessionConnections.cpp
+++ b/src/cpp/session/modules/connections/SessionConnections.cpp
@@ -35,6 +35,7 @@
 #include <session/SessionConsoleProcess.hpp>
 #include <session/SessionModuleContext.hpp>
 #include <session/SessionUserSettings.hpp>
+#include <session/SessionPackageProvidedExtension.hpp>
 
 #include "ActiveConnections.hpp"
 #include "ConnectionHistory.hpp"
@@ -496,8 +497,6 @@ void onDeferredInit(bool newSession)
    {
       activeConnections().broadcastToClient();
    }
-
-   indexLibraryPaths();
 }
 
 void initEnvironment()
@@ -569,6 +568,9 @@ Error initialize()
 
    // initialize events for package indexer
    module_context::events().onDeferredInit.connect(onDeferredInit);
+   
+   // initialize connections index worker
+   registerConnectionsWorker();
 
    using boost::bind;
    using namespace module_context;

--- a/src/cpp/session/modules/connections/SessionConnections.cpp
+++ b/src/cpp/session/modules/connections/SessionConnections.cpp
@@ -562,16 +562,12 @@ Error initialize()
    if (error)
       return error;
 
-   // deferrred init for updating active connections
-   module_context::events().onDeferredInit.connect(onDeferredInit);
-
    // connect to events to track whether we should enable connections
    s_connectionsInitiallyEnabled = connectionsEnabled();
    module_context::events().onPackageLibraryMutated.connect(
                                              onInstalledPackagesChanged);
 
    // initialize events for package indexer
-   module_context::events().onConsoleInput.connect(onConsoleInput);
    module_context::events().onDeferredInit.connect(onDeferredInit);
 
    using boost::bind;

--- a/src/gwt/src/org/rstudio/studio/client/projects/events/PackageExtensionIndexingCompletedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/events/PackageExtensionIndexingCompletedEvent.java
@@ -1,0 +1,61 @@
+/*
+ * PackageExtensionIndexingCompletedEvent.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.projects.events;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class PackageExtensionIndexingCompletedEvent
+      extends GwtEvent<PackageExtensionIndexingCompletedEvent.Handler>
+{
+   public static class Data extends JavaScriptObject
+   {
+      protected Data() {}
+   }
+   
+   public PackageExtensionIndexingCompletedEvent(Data data)
+   {
+      data_ = data;
+   }
+   
+   public Data getData()
+   {
+      return data_;
+   }
+   
+   private final Data data_;
+   
+   // Boilerplate ----
+   
+   public interface Handler extends EventHandler
+   {
+      void onPackageExtensionIndexingCompleted(PackageExtensionIndexingCompletedEvent event);
+   }
+   
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onPackageExtensionIndexingCompleted(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/projects/events/PackageExtensionIndexingCompletedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/events/PackageExtensionIndexingCompletedEvent.java
@@ -14,6 +14,9 @@
  */
 package org.rstudio.studio.client.projects.events;
 
+import org.rstudio.studio.client.projects.model.ProjectTemplateRegistry;
+import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
+
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
@@ -24,6 +27,16 @@ public class PackageExtensionIndexingCompletedEvent
    public static class Data extends JavaScriptObject
    {
       protected Data() {}
+      
+      public final native RAddins getAddinsRegistry()
+      /*-{
+         return this["addins_registry"];
+      }-*/;
+      
+      public final native ProjectTemplateRegistry getProjectTemplateRegistry()
+      /*-{
+         return this["project_templates_registry"];
+      }-*/;
    }
    
    public PackageExtensionIndexingCompletedEvent(Data data)

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -156,6 +156,7 @@ class ClientEvent extends JavaScriptObject
    public static final String UpdateNewConnectionDialog = "update_new_connection_dialog";
    public static final String ProjectTemplateRegistryUpdated = "project_template_registry_updated";
    public static final String TerminalBusy = "terminal_busy";
+   public static final String PackageExtensionIndexingCompleted = "package_extension_indexing_completed";
 
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -57,6 +57,7 @@ import org.rstudio.studio.client.htmlpreview.events.HTMLPreviewStartedEvent;
 import org.rstudio.studio.client.htmlpreview.model.HTMLPreviewResult;
 import org.rstudio.studio.client.projects.events.FollowUserEvent;
 import org.rstudio.studio.client.projects.events.OpenProjectErrorEvent;
+import org.rstudio.studio.client.projects.events.PackageExtensionIndexingCompletedEvent;
 import org.rstudio.studio.client.projects.events.ProjectAccessRevokedEvent;
 import org.rstudio.studio.client.projects.events.ProjectTemplateRegistryUpdatedEvent;
 import org.rstudio.studio.client.projects.events.ProjectUserChangedEvent;
@@ -870,6 +871,11 @@ public class ClientEventDispatcher
          {
             TerminalBusyEvent.Data data = event.getData();
             eventBus_.fireEvent(new TerminalBusyEvent(data));
+         }
+         else if (type.equals(ClientEvent.PackageExtensionIndexingCompleted))
+         {
+            PackageExtensionIndexingCompletedEvent.Data data = event.getData();
+            eventBus_.fireEvent(new PackageExtensionIndexingCompletedEvent(data));
          }
          else
          {


### PR DESCRIPTION
This PR seeks to unify the code driving the various indexers into a single indexer object. The general idea is now that:

1. We have a single indexer object that is responsible for discovering installed packages + extensions within,

2. 'Workers' can be registered on this indexer object that, given a package directory, do some 'work' (ie -- reading + parsing a specific type of `.dcf` file).

The overall outcome -- rather than having multiple indexer objects individually crawling the R library for package extensions, we now have a single indexer crawling the R library, and this indexer delegates to the registered workers.

The code handling registries has not yet been unified; this is less of a priority since the main goal of this PR is to avoid having multiple indexers running in tandem.