### PR TITLE
terminal fixes for pane configuration scenarios

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -268,6 +268,12 @@ public class TerminalPane extends WorkbenchPane
       creatingTerminal_ = false;
       activeTerminalToolbarButton_.setNoActiveTerminal();
       setTerminalTitle("");
+
+      // remove all widgets
+      while (terminalSessionsPanel_.getWidgetCount() > 0)
+      {
+         terminalSessionsPanel_.remove(0);
+      }
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
@@ -93,6 +93,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
          addSeparator();
          addItem(commands_.renameTerminal().createMenuItem(false));
          addItem(commands_.clearTerminalScrollbackBuffer().createMenuItem(false));
+         addSeparator();
          addItem(commands_.closeTerminal().createMenuItem(false));
       }
 
@@ -147,6 +148,9 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
 
    private String trimCaption(String caption)
    {
+      // TODO (gary) look at doing this via css text-overflow
+      // when I do the theming work
+
       // Enforce a sane visual limit on terminal captions
       if (caption.length() > 32)
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -364,9 +364,17 @@ public class TerminalSession extends XTermWidget
    }
 
    @Override
+   protected void onLoad()
+   {
+      super.onLoad();
+      connect();
+   }
+
+   @Override
    protected void onDetach()
    {
       super.onDetach();
+      disconnect();
       unregisterHandlers();
    }
 
@@ -376,6 +384,8 @@ public class TerminalSession extends XTermWidget
       super.setVisible(isVisible);
       if (isVisible)
       {
+         connect();
+
          // Inform the terminal that there may have been a resize. This could 
          // happen on first display, or if the terminal was hidden behind other
          // terminal sessions and there was a resize.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -95,10 +95,10 @@ public class XTermWidget extends Widget implements RequiresResize,
       {
          writeln("Welcome to " + AnsiCode.ForeColor.LIGHTBLUE + "RStudio" +
                  AnsiCode.DEFAULTCOLORS + " terminal.");
+         setNewTerminal(false);
       }
       else
       {
-         terminal_.reset();
          Scheduler.get().scheduleDeferred(new ScheduledCommand()
          {
             @Override
@@ -130,6 +130,9 @@ public class XTermWidget extends Widget implements RequiresResize,
       terminal_.write(str);
    }
 
+   /**
+    * Clear terminal buffer.
+    */
    public void clear()
    {
       terminal_.clear();
@@ -186,7 +189,6 @@ public class XTermWidget extends Widget implements RequiresResize,
             public void execute()
             {
                terminal_.blur();
-               terminal_.destroy();
             }
          });
       }
@@ -332,15 +334,6 @@ public class XTermWidget extends Widget implements RequiresResize,
       newTerminal_ = isNew;
    }
 
-   /**
-    * Indicates if connecting to a new terminal session.
-    * @return true if a new connection, false if a reconnect
-    */
-   public boolean newTerminal()
-   {
-      return newTerminal_;
-   }
-   
    private static final ExternalJavaScriptLoader xtermLoader_ =
          getLoader(XTermResources.INSTANCE.xtermjs(), 
                    XTermResources.INSTANCE.xtermjsUncompressed());


### PR DESCRIPTION
- Fix terminal breaking when panes reconfigured via View->Panes->Console on Left/Right, and also when adding/removing other tabs in the console pane (e.g. Markers)

- Prevent zombie widgets living on after closing all terminals via the tab [x]

- add a separator to terminal menu

- Comment tweaks, remove unused method
