### PR TITLE
add jenkins pipeline (with platform containers) for linux desktop/server builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.git/objects/pack/*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,86 @@
+#!groovy
+
+properties([
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '',
+                              artifactNumToKeepStr: '10',
+                              daysToKeepStr: '',
+                              numToKeepStr: '20'))
+])
+
+def resolve_deps(type) {
+  switch ( type ) {
+      case "DEB":
+        sh 'cd dependencies/linux && ./install-dependencies-debian && cd ../..'
+        break
+      case "RPM":
+        sh 'cd dependencies/linux && ./install-dependencies-yum && cd ../..'
+        break
+  }
+}
+
+def compile_package_and_archive(type, flavor) {
+  sh "cd package/linux && ./make-${flavor}-package ${type} clean && cd ../.."
+  archiveArtifacts artifacts: 'package/linux/build-${flavor.capitalize()}-${type}/rstudio-*.${type.toLowerCase()}'
+}
+
+def s3_upload(type, flavor) {
+  sh "aws s3 mv package/linux/build-${flavor.capitalize()}-${type}/rstudio-*.${type.toLowerCase()} s3://rstudio-devops/opsworks/"
+}
+
+def gitClean() {
+ // rstudio/connect
+ sh 'git reset --hard'
+ sh 'git clean -ffdx'
+}
+
+def prepareWorkspace(){
+  step([$class: 'WsCleanup'])
+  checkout scm
+  gitClean() 
+}
+
+try {
+    timestamps {
+        def containers = [
+          [type: 'DEB', image: 'precise_64', flavor: 'desktop'],
+          [type: 'DEB', image: 'precise_32', flavor: 'desktop'],
+          [type: 'DEB', image: 'precise_64', flavor: 'server'],
+          [type: 'DEB', image: 'precise_32', flavor: 'server'],
+          [type: 'RPM', image: 'centos6_64', flavor: 'server'],
+          [type: 'RPM', image: 'centos6_32', flavor: 'server'],
+          [type: 'RPM', image: 'centos5_64', flavor: 'server'],
+          [type: 'RPM', image: 'centos5_32', flavor: 'server'],
+          [type: 'RPM', image: 'centos7_64', flavor: 'desktop'],
+          [type: 'RPM', image: 'centos7_32', flavor: 'desktop']
+
+        ]
+        def parallel_containers = [:]
+        for (int i = 0; i < containers.size(); i++) {
+            def index = i
+            parallel_containers["${containers[i].type}-${containers[i].image}-${containers[i].flavor}"] = {
+                def current_container = containers[index]
+                node('ide') {
+                    prepareWorkspace() // empties the existing workspace and checks out current commit.
+                    container = docker.build("rstudio-ide-${current_container.image}", "-f docker/jenkins/Dockerfile.${current_container.image} .")
+                    container.inside("-u 0:0") {
+                        stage('resolve deps'){
+                            resolve_deps(current_container.type)
+                        }
+                        stage('compile package') {
+                            compile_package_and_archive(current_container.type, current_container.flavor)
+                        }
+                    }
+                    stage('upload artifacts') {
+                        s3_upload(current_container.type, current_container.flavor)
+                    }
+                }
+            }
+        }
+        parallel parallel_containers
+        slackSend channel: '@steve', color: 'good', message: "RStudio ide build finished successfully."
+    }
+  
+} catch(err) {
+   slackSend channel: '@steve', color: 'bad', message: "failed: ${err}"
+   error("failed: ${err}")
+}

--- a/docker/jenkins/Dockerfile.centos5_32
+++ b/docker/jenkins/Dockerfile.centos5_32
@@ -1,0 +1,121 @@
+FROM stevenolen/centos5-i386
+
+RUN set -x \
+    && linux32 yum clean all && linux32 yum -y update \
+    && yum install epel-release -y
+
+RUN linux32 yum install -y \
+    ant \
+    boost-devel \
+    bzip2-devel \
+    cmake \
+    gcc \
+    gcc-c++ \
+    git \
+    gstreamer-devel \
+    gstreamer-plugins-base-devel \
+    java-1.6.0-openjdk  \
+    libffi \
+    libuuid-devel \
+    make \
+    openssl-devel \
+    pam-devel \
+    pango-devel \
+    rpmdevtools \
+    sudo \
+    tar \
+    wget \
+    xml-commons-apis \
+    yum-utils \
+    zlib-devel
+
+# need to run a recent openssl to get SAN support for when we compile wget
+RUN wget http://www.openssl.org/source/openssl-1.0.2j.tar.gz \
+    && tar xvf openssl-1.0.2j.tar.gz \
+    && cd openssl-1.0.2j \
+    && make clean \
+    && linux32 ./config shared --prefix=/usr --openssldir=/usr/local/openssl \
+    && linux32 make && linux32 make install
+
+# update the root ca bundle. no-check-certificate so ugly.
+RUN wget --no-check-certificate -O /usr/local/openssl/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem \
+  && ln -s /usr/local/openssl/certs/ca-bundle.crt /usr/local/openssl/cert.pem
+
+# centos5 wget is comically old and doesn't work with wildcard certs
+RUN wget http://ftp.gnu.org/gnu/wget/wget-1.16.tar.gz \
+    && yum -y remove wget \
+    && tar -xzvf wget-1.16.tar.gz \
+    && cd wget-1.16 \
+    && ./configure --with-ssl=openssl --with-libssl-prefix=/usr/lib/openssl --prefix=/usr \
+    && make && make install
+
+# sudo defaults to requiretty on centos5? 
+RUN sed -i  's/Defaults    requiretty/Defaults !requiretty/' /etc/sudoers
+
+## run install-boost twice - boost exits 1 even though it has installed good enough for our uses.
+## https://github.com/rstudio/rstudio/blob/master/vagrant/provision-primary-user.sh#L12-L15
+COPY dependencies/common/install-boost /tmp/
+RUN bash /tmp/install-boost || bash /tmp/install-boost
+
+# install cmake
+COPY package/linux/install-dependencies /tmp/
+RUN bash /tmp/install-dependencies
+
+##### R i686 from epel does not appear to handle latin1 -> ascii conversion with iconv. #####
+##### because of this, we're going to install R from source. because c'mon. why not?    #####
+
+# download a bunch of deps we need to get R from source. don't worry, we'll end up just using other versions anyway
+RUN yum-builddep -y R
+
+RUN wget http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.14.tar.gz \
+    && tar xvf libiconv-1.14.tar.gz \
+    && cd libiconv-1.14 \
+    && linux32 ./configure --prefix=/usr/local/ \
+    && linux32 make && linux32 make install \
+    && cd ..
+
+RUN wget http://zlib.net/zlib-1.2.8.tar.gz \
+    && tar xvf zlib-1.2.8.tar.gz \
+    && cd zlib-1.2.8 \
+    && linux32 ./configure --prefix=/usr/local/ \
+    && linux32 make && linux32 make install \
+    && cd ..
+
+RUN wget http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz \
+    && tar xvf bzip2-1.0.6.tar.gz \
+    && cd bzip2-1.0.6 \
+    && linux32 make -f Makefile-libbz2_so \
+    && linux32 make clean \
+    && linux32 make \
+    && linux32 make install \
+    && cd ..
+
+RUN wget http://tukaani.org/xz/xz-5.2.2.tar.gz \
+    && tar xvf xz-5.2.2.tar.gz \
+    && cd xz-5.2.2 \
+    && linux32 ./configure --prefix=/usr/local/ \
+    && linux32 make -j3 \
+    && linux32 make install \
+    && cd ..
+
+RUN wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.38.tar.gz \
+    && tar xvf pcre-8.38.tar.gz \
+    && cd pcre-8.38 \
+    && linux32 ./configure --prefix=/usr/local/ --enable-utf8 \
+    && linux32 make && linux32 make install \
+    && cd ..
+
+RUN wget https://curl.haxx.se/download/curl-7.47.1.tar.gz \
+    && tar xvf curl-7.47.1.tar.gz \
+    && cd curl-7.47.1 \
+    && linux32 ./configure --prefix=/usr/local/ \
+    && linux32 make -j3 \
+    && linux32 make install \
+    && cd ..
+
+RUN wget https://cran.rstudio.com/src/base/R-3/R-3.3.2.tar.gz \
+    && tar xvf R-3.3.2.tar.gz \
+    && cd R-3.3.2 \
+    && linux32 ./configure --prefix=/opt/R/3.3.2 --enable-R-shlib \
+    && linux32 make && linux32 make install \
+    && ln -s /opt/R/3.3.2/bin/R /usr/local/bin/R

--- a/docker/jenkins/Dockerfile.centos5_64
+++ b/docker/jenkins/Dockerfile.centos5_64
@@ -1,0 +1,60 @@
+FROM centos:5
+
+RUN set -x \
+    && yum install epel-release -y
+
+RUN yum install -y \
+    ant \
+    boost-devel \
+    bzip2-devel \
+    cmake \
+    gcc \
+    gcc-c++ \
+    git \
+    gstreamer-devel \
+    gstreamer-plugins-base-devel \
+    java-1.6.0-openjdk  \
+    libffi \
+    libuuid-devel \
+    make \
+    openssl-devel \
+    pam-devel \
+    pango-devel \
+    R \
+    rpmdevtools \
+    sudo \
+    wget \
+    xml-commons-apis \
+    zlib-devel
+
+# need to run a recent openssl to get SAN support for when we compile wget
+RUN wget http://www.openssl.org/source/openssl-1.0.2j.tar.gz \
+    && tar xvf openssl-1.0.2j.tar.gz \
+    && cd openssl-1.0.2j \
+    && make clean \
+    && ./config shared --prefix=/usr --openssldir=/usr/local/openssl \
+    && make && make install
+
+# update the root ca bundle. no-check-certificate so ugly.
+RUN wget --no-check-certificate -O /usr/local/openssl/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem \
+  && ln -s /usr/local/openssl/certs/ca-bundle.crt /usr/local/openssl/cert.pem
+
+# centos5 wget is comically old and doesn't work with wildcard certs
+RUN wget http://ftp.gnu.org/gnu/wget/wget-1.16.tar.gz \
+    && yum -y remove wget \
+    && tar -xzvf wget-1.16.tar.gz \
+    && cd wget-1.16 \
+    && ./configure --with-ssl=openssl --with-libssl-prefix=/usr/lib64/openssl --prefix=/usr \
+    && make && make install
+
+# sudo defaults to requiretty on centos5? 
+RUN sed -i  's/Defaults    requiretty/Defaults !requiretty/' /etc/sudoers
+
+## run install-boost twice - boost exits 1 even though it has installed good enough for our uses.
+## https://github.com/rstudio/rstudio/blob/master/vagrant/provision-primary-user.sh#L12-L15
+COPY dependencies/common/install-boost /tmp/
+RUN bash /tmp/install-boost || bash /tmp/install-boost
+
+# install cmake
+COPY package/linux/install-dependencies /tmp/
+RUN bash /tmp/install-dependencies

--- a/docker/jenkins/Dockerfile.centos6_32
+++ b/docker/jenkins/Dockerfile.centos6_32
@@ -1,0 +1,38 @@
+FROM stevenolen/centos6-i386
+
+RUN set -x \
+    && yum install epel-release -y
+
+RUN yum install -y \
+    ant \
+    boost-devel \
+    bzip2-devel \
+    cmake \
+    gcc \
+    gcc-c++ \
+    git \
+    gstreamer-devel \
+    gstreamer-plugins-base-devel \
+    java-1.6.0-openjdk  \
+    libffi \
+    libuuid-devel \
+    make \
+    openssl-devel \
+    pam-devel \
+    pango-devel \
+    R \
+    rpmdevtools \
+    sudo \
+    tar \
+    wget \
+    xml-commons-apis \
+    zlib-devel
+
+## run install-boost twice - boost exits 1 even though it has installed good enough for our uses.
+## https://github.com/rstudio/rstudio/blob/master/vagrant/provision-primary-user.sh#L12-L15
+COPY dependencies/common/install-boost /tmp/
+RUN bash /tmp/install-boost || bash /tmp/install-boost
+
+# install cmake
+COPY package/linux/install-dependencies /tmp/
+RUN bash /tmp/install-dependencies

--- a/docker/jenkins/Dockerfile.centos6_64
+++ b/docker/jenkins/Dockerfile.centos6_64
@@ -1,0 +1,37 @@
+FROM centos:6
+
+RUN set -x \
+    && yum install epel-release -y
+
+RUN yum install -y \
+    ant \
+    boost-devel \
+    bzip2-devel \
+    cmake \
+    gcc \
+    gcc-c++ \
+    git \
+    gstreamer-devel \
+    gstreamer-plugins-base-devel \
+    java-1.6.0-openjdk  \
+    libffi \
+    libuuid-devel \
+    make \
+    openssl-devel \
+    pam-devel \
+    pango-devel \
+    R \
+    rpmdevtools \
+    sudo \
+    wget \
+    xml-commons-apis \
+    zlib-devel
+
+## run install-boost twice - boost exits 1 even though it has installed good enough for our uses.
+## https://github.com/rstudio/rstudio/blob/master/vagrant/provision-primary-user.sh#L12-L15
+COPY dependencies/common/install-boost /tmp/
+RUN bash /tmp/install-boost || bash /tmp/install-boost
+
+# install cmake
+COPY package/linux/install-dependencies /tmp/
+RUN bash /tmp/install-dependencies

--- a/docker/jenkins/Dockerfile.centos7_32
+++ b/docker/jenkins/Dockerfile.centos7_32
@@ -1,0 +1,109 @@
+FROM stevenolen/centos:7-i686
+
+# no epel-release for centos7 32-bit.
+# we will install R from source.
+#RUN set -x \
+#    && yum install epel-release -y
+
+RUN set -x \
+    && linux32 yum install -y \
+       ant \
+       boost-devel \
+       bzip2-devel \
+       cmake \
+       fakeroot \
+       gcc \
+       gcc-c++ \
+       gcc-gfortran \
+       git \
+       gstreamer-devel \
+       gstreamer-plugins-base-devel \
+       java-1.6.0-openjdk  \
+       libffi \
+       libgfortran \
+       libuuid-devel \
+       libX11-devel \
+       libXt-devel \
+       make \
+       openssl-devel \
+       pam-devel \
+       pango-devel \
+       readline-devel \
+       rpmdevtools \
+       sharutils \
+       sudo \
+       wget \
+       xml-commons-apis \
+       zlib-devel
+
+# sudo defaults to requiretty on centos7
+RUN sed -i  's/Defaults    requiretty/Defaults !requiretty/' /etc/sudoers
+
+## run install-boost twice - boost exits 1 even though it has installed good enough for our uses.
+## https://github.com/rstudio/rstudio/blob/master/vagrant/provision-primary-user.sh#L12-L15
+COPY dependencies/common/install-boost /tmp/
+RUN bash /tmp/install-boost || bash /tmp/install-boost
+
+# install cmake
+COPY package/linux/install-dependencies /tmp/
+RUN bash /tmp/install-dependencies
+
+RUN wget http://ftp.gnu.org/gnu/wget/wget-1.16.tar.gz \
+    && yum -y remove wget \
+    && tar -xzvf wget-1.16.tar.gz \
+    && cd wget-1.16 \
+    && ./configure --with-ssl=openssl --with-libssl-prefix=/usr/lib/openssl --prefix=/usr \
+    && make && make install \
+    && cd ..
+
+RUN wget http://zlib.net/zlib-1.2.8.tar.gz \
+    && tar xvf zlib-1.2.8.tar.gz \
+    && cd zlib-1.2.8 \
+    && linux32 ./configure --prefix=/usr/local/ \
+    && linux32 make && linux32 make install \
+    && cd ..
+
+RUN wget http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz \
+    && tar xvf bzip2-1.0.6.tar.gz \
+    && cd bzip2-1.0.6 \
+    && linux32 make -f Makefile-libbz2_so \
+    && linux32 make clean \
+    && linux32 make \
+    && linux32 make install \
+    && cd ..
+
+RUN wget http://tukaani.org/xz/xz-5.2.2.tar.gz \
+    && tar xvf xz-5.2.2.tar.gz \
+    && cd xz-5.2.2 \
+    && linux32 ./configure --prefix=/usr/local/ \
+    && linux32 make -j3 \
+    && linux32 make install \
+    && cd ..
+
+RUN wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.38.tar.gz \
+    && tar xvf pcre-8.38.tar.gz \
+    && cd pcre-8.38 \
+    && linux32 ./configure --prefix=/usr/local/ --enable-utf8 \
+    && linux32 make && linux32 make install \
+    && cd ..
+
+RUN wget https://curl.haxx.se/download/curl-7.47.1.tar.gz \
+    && tar xvf curl-7.47.1.tar.gz \
+    && cd curl-7.47.1 \
+    && linux32 ./configure --prefix=/usr/local/ \
+    && linux32 make -j3 \
+    && linux32 make install \
+    && cd ..
+
+RUN wget https://cran.rstudio.com/src/base/R-3/R-3.3.2.tar.gz \
+    && tar xvf R-3.3.2.tar.gz \
+    && cd R-3.3.2 \
+    && linux32 ./configure --prefix=/opt/R/3.3.2 --enable-R-shlib \
+    && linux32 make && linux32 make install \
+    && ln -s /opt/R/3.3.2/bin/R /usr/local/bin/R
+
+# fakeroot is only in epel-release as well. compile from the src rpm
+RUN wget http://dl.fedoraproject.org/pub/epel/7/SRPMS/f/fakeroot-1.18.4-2.el7.src.rpm \
+    && linux32 rpmbuild --rebuild fakeroot-1.18.4-2.el7.src.rpm \
+    && rpm -ivh /root/rpmbuild/RPMS/i686/fakeroot-libs-1.18.4-2.el7.centos.i686.rpm \
+    && rpm -ivh /root/rpmbuild/RPMS/i686/fakeroot-1.18.4-2.el7.centos.i686.rpm

--- a/docker/jenkins/Dockerfile.centos7_64
+++ b/docker/jenkins/Dockerfile.centos7_64
@@ -1,0 +1,41 @@
+FROM centos:7
+
+RUN set -x \
+    && yum install epel-release -y
+
+RUN yum install -y \
+    ant \
+    boost-devel \
+    bzip2-devel \
+    cmake \
+    fakeroot \
+    gcc \
+    gcc-c++ \
+    git \
+    gstreamer-devel \
+    gstreamer-plugins-base-devel \
+    java-1.6.0-openjdk  \
+    libffi \
+    libuuid-devel \
+    make \
+    openssl-devel \
+    pam-devel \
+    pango-devel \
+    R \
+    rpmdevtools \
+    sudo \
+    wget \
+    xml-commons-apis \
+    zlib-devel
+
+# sudo defaults to requiretty on centos7
+RUN sed -i  's/Defaults    requiretty/Defaults !requiretty/' /etc/sudoers
+
+## run install-boost twice - boost exits 1 even though it has installed good enough for our uses.
+## https://github.com/rstudio/rstudio/blob/master/vagrant/provision-primary-user.sh#L12-L15
+COPY dependencies/common/install-boost /tmp/
+RUN bash /tmp/install-boost || bash /tmp/install-boost
+
+# install cmake
+COPY package/linux/install-dependencies /tmp/
+RUN bash /tmp/install-dependencies

--- a/docker/jenkins/Dockerfile.precise_32
+++ b/docker/jenkins/Dockerfile.precise_32
@@ -1,0 +1,50 @@
+FROM stevenolen/ubuntu12.04-i386
+
+ARG AWS_REGION=us-east-1
+
+# install needed packages. replace httpredir apt source with cloudfront
+RUN set -x \
+    && sed -i "s/archive.ubuntu.com/$AWS_REGION.ec2.archive.ubuntu.com/" /etc/apt/sources.list \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9 \
+    && echo 'deb http://cran.rstudio.com/bin/linux/ubuntu precise/' >> /etc/apt/sources.list \
+    && apt-get update
+
+RUN apt-get update \
+  && apt-get install -y \
+    ant \
+    apparmor-utils \
+    build-essential \
+    cmake \
+    fakeroot \
+    git-core \
+    libapparmor1 \
+    libbz2-dev \
+    libgl1-mesa-dev \
+    libgstreamer-plugins-base0.10-0 \
+    libgstreamer0.10-0 \
+    libjpeg62 \
+    libpam-dev \
+    libpango1.0-dev \
+    libssl-dev \
+    libxslt1-dev \
+    openjdk-7-jdk \
+    pkg-config \
+    r-base \
+    sudo \
+    unzip \
+    uuid-dev \
+    wget \
+    zlib1g-dev
+
+# precise defaults to java6, swap to java7
+RUN update-alternatives --set java /usr/lib/jvm/java-7-openjdk-i386/jre/bin/java
+
+## run install-boost twice - boost exits 1 even though it has installed good enough for our uses.
+## https://github.com/rstudio/rstudio/blob/master/vagrant/provision-primary-user.sh#L12-L15
+COPY dependencies/common/install-boost /tmp/
+RUN bash /tmp/install-boost || bash /tmp/install-boost
+
+# install cmake
+COPY package/linux/install-dependencies /tmp/
+RUN bash /tmp/install-dependencies

--- a/docker/jenkins/Dockerfile.precise_64
+++ b/docker/jenkins/Dockerfile.precise_64
@@ -1,0 +1,50 @@
+FROM ubuntu:precise
+
+ARG AWS_REGION=us-east-1
+
+# install needed packages. replace httpredir apt source with cloudfront
+RUN set -x \
+    && sed -i "s/archive.ubuntu.com/$AWS_REGION.ec2.archive.ubuntu.com/" /etc/apt/sources.list \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9 \
+    && echo 'deb http://cran.rstudio.com/bin/linux/ubuntu precise/' >> /etc/apt/sources.list \
+    && apt-get update
+
+RUN apt-get update \
+  && apt-get install -y \
+    ant \
+    apparmor-utils \
+    build-essential \
+    cmake \
+    fakeroot \
+    git-core \
+    libapparmor1 \
+    libbz2-dev \
+    libgl1-mesa-dev \
+    libgstreamer-plugins-base0.10-0 \
+    libgstreamer0.10-0 \
+    libjpeg62 \
+    libpam-dev \
+    libpango1.0-dev \
+    libssl-dev \
+    libxslt1-dev \
+    openjdk-7-jdk \
+    pkg-config \
+    r-base \
+    sudo \
+    unzip \
+    uuid-dev \
+    wget \
+    zlib1g-dev
+
+# precise defaults to java6, swap to java7
+RUN update-alternatives --set java /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java
+
+## run install-boost twice - boost exits 1 even though it has installed good enough for our uses.
+## https://github.com/rstudio/rstudio/blob/master/vagrant/provision-primary-user.sh#L12-L15
+COPY dependencies/common/install-boost /tmp/
+RUN bash /tmp/install-boost || bash /tmp/install-boost
+
+# install cmake
+COPY package/linux/install-dependencies /tmp/
+RUN bash /tmp/install-dependencies


### PR DESCRIPTION
Adds initial support for handling the linux builds in a jenkins pipeline with docker containers. 
Based on my chat with @jmcphers, I'll append the existing build script to also kick off builds in this environment for testing/comparison!

  * 32-bit builds supported in centos5,6,7 via non-official containers, but are re-producible as needed.
  * many deps are resolved/cached in the container build process to save some cycles, but the `install-dependencies` scripts are executed on each build to handle dependencies that are resolved within the src directories.
  * s3_upload bucket used is an example, used only for testing.
  * Outstanding builds: sles32, sles64, windows, osx, docs
