### PR TITLE
detect bookdown website in precedence to package

### DIFF
--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -213,9 +213,14 @@ std::string detectBuildType(const FilePath& projectFilePath,
                             RProjectConfig* pConfig)
 {
    FilePath projectDir = projectFilePath.parent();
-   if (r_util::isPackageDirectory(projectDir))
+   if (isWebsiteDirectory(projectDir))
    {
-      setBuildPackageDefaults("", buildDefaults ,pConfig);
+      pConfig->buildType = kBuildTypeWebsite;
+      pConfig->websitePath = "";
+   }
+   else if (r_util::isPackageDirectory(projectDir))
+   {
+      setBuildPackageDefaults("", buildDefaults, pConfig);
    }
    else if (projectDir.childPath("pkg/DESCRIPTION").exists())
    {
@@ -225,11 +230,6 @@ std::string detectBuildType(const FilePath& projectFilePath,
    {
       pConfig->buildType = kBuildTypeMakefile;
       pConfig->makefilePath = "";
-   }
-   else if (isWebsiteDirectory(projectDir))
-   {
-      pConfig->buildType = kBuildTypeWebsite;
-      pConfig->websitePath = "";
    }
    else
    {


### PR DESCRIPTION
This PR ensures that `bookdown` skeletons (as generated through the associated skeleton function in https://github.com/rstudio/bookdown/pull/280) use the 'Website'-style build UI.

Currently, we check for a `DESCRIPTION` file first, and because the `bookdown` skeleton comes with such a file (mainly for dependency installation?) RStudio assumes the generated project is an R package project.

The diff looks weird but all I'm doing here is ensuring that we check whether this is a website project before an R package project.