### PR TITLE
Implement question dialog for rstudioapi

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -308,9 +308,34 @@
 })
 
 .rs.addFunction("showDialog", function(title, message) {
-   .Call("rs_showDialog", title, message, prompt = FALSE, promptDefault = NULL)
+   .Call("rs_showDialog",
+      title = title,
+      message = message,
+      prompt = FALSE,
+      promptDefault = NULL,
+      question = FALSE,
+      ok = NULL,
+      cancel = NULL)
 })
 
 .rs.addFunction("showPrompt", function(title, message, default) {
-   .Call("rs_showDialog", title, message, prompt = TRUE, promptDefault = default)
+   .Call("rs_showDialog",
+      title = title,
+      message = message,
+      prompt = TRUE,
+      promptDefault = default,
+      question = FALSE,
+      ok = NULL,
+      cancel = NULL)
+})
+
+.rs.addFunction("showQuestion", function(title, message, ok, cancel) {
+   .Call("rs_showDialog",
+      title = title,
+      message = message,
+      prompt = FALSE,
+      promptDefault = NULL,
+      question = TRUE,
+      ok = ok,
+      cancel = cancel)
 })

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -307,7 +307,7 @@
    .rs.askForPassword(prompt)
 })
 
-.rs.addFunction("showDialog", function(title, message) {
+.rs.addFunction("showDialog", function(title, message, url = "") {
    .Call("rs_showDialog",
       title = title,
       message = message,
@@ -315,10 +315,11 @@
       promptDefault = NULL,
       question = FALSE,
       ok = NULL,
-      cancel = NULL)
+      cancel = NULL,
+      url = url)
 })
 
-.rs.addFunction("showPrompt", function(title, message, default) {
+.rs.addFunction("showPrompt", function(title, message, default = "") {
    .Call("rs_showDialog",
       title = title,
       message = message,
@@ -326,10 +327,11 @@
       promptDefault = default,
       question = FALSE,
       ok = NULL,
-      cancel = NULL)
+      cancel = NULL,
+      url = NULL)
 })
 
-.rs.addFunction("showQuestion", function(title, message, ok, cancel) {
+.rs.addFunction("showQuestion", function(title, message, ok = "", cancel = "") {
    .Call("rs_showDialog",
       title = title,
       message = message,
@@ -337,5 +339,6 @@
       promptDefault = NULL,
       question = TRUE,
       ok = ok,
-      cancel = cancel)
+      cancel = cancel,
+      url = NULL)
 })

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -307,13 +307,22 @@
    .rs.askForPassword(prompt)
 })
 
+.rs.addFunction("dialogIcon", function(name) {
+  list(
+    info = 1,
+    warning = 2,
+    error = 3,
+    question = 4
+  )
+})
+
 .rs.addFunction("showDialog", function(title, message, url = "") {
    .Call("rs_showDialog",
       title = title,
       message = message,
+      dialogIcon = .rs.dialogIcon()$info,
       prompt = FALSE,
       promptDefault = NULL,
-      question = FALSE,
       ok = NULL,
       cancel = NULL,
       url = url)
@@ -323,9 +332,9 @@
    .Call("rs_showDialog",
       title = title,
       message = message,
+      dialogIcon = .rs.dialogIcon()$info,
       prompt = TRUE,
       promptDefault = default,
-      question = FALSE,
       ok = NULL,
       cancel = NULL,
       url = NULL)
@@ -335,9 +344,9 @@
    .Call("rs_showDialog",
       title = title,
       message = message,
+      dialogIcon = .rs.dialogIcon()$question,
       prompt = FALSE,
       promptDefault = NULL,
-      question = TRUE,
       ok = ok,
       cancel = cancel,
       url = NULL)

--- a/src/cpp/session/modules/RStudioAPI.cpp
+++ b/src/cpp/session/modules/RStudioAPI.cpp
@@ -45,7 +45,8 @@ ClientEvent showDialogEvent(const std::string& title,
                             const std::string& promptDefault,
                             bool question,
                             const std::string& ok,
-                            const std::string& cancel)
+                            const std::string& cancel,
+                            const std::string& url)
 {
    json::Object data;
    data["title"] = title;
@@ -55,6 +56,7 @@ ClientEvent showDialogEvent(const std::string& title,
    data["question"] = question;
    data["ok"] = ok;
    data["cancel"] = cancel;
+   data["url"] = url;
    return ClientEvent(client_events::kRStudioAPIShowDialog, data);
 }
 
@@ -64,7 +66,8 @@ SEXP rs_showDialog(SEXP titleSEXP,
                    SEXP promptDefaultSEXP,
                    SEXP questionSEXP,
                    SEXP okSEXP,
-                   SEXP cancelSEXP)
+                   SEXP cancelSEXP,
+                   SEXP urlSEXP)
 {  
    try
    {
@@ -75,6 +78,7 @@ SEXP rs_showDialog(SEXP titleSEXP,
       bool question = r::sexp::asLogical(questionSEXP);
       std::string ok = r::sexp::asString(okSEXP);
       std::string cancel = r::sexp::asString(cancelSEXP);
+      std::string url = r::sexp::asString(urlSEXP);
       
       ClientEvent event = showDialogEvent(
          title,
@@ -83,7 +87,8 @@ SEXP rs_showDialog(SEXP titleSEXP,
          promptDefault,
          question,
          ok,
-         cancel);
+         cancel,
+         url);
 
       // wait for rstudioapi_show_dialog_completed 
       json::JsonRpcRequest request;
@@ -131,7 +136,7 @@ Error initialize()
    // register waitForMethod handler
    s_waitForShowDialog = module_context::registerWaitForMethod("rstudioapi_show_dialog_completed");
 
-   RS_REGISTER_CALL_METHOD(rs_showDialog, 7);
+   RS_REGISTER_CALL_METHOD(rs_showDialog, 8);
 
    return Success();
 }

--- a/src/cpp/session/modules/RStudioAPI.cpp
+++ b/src/cpp/session/modules/RStudioAPI.cpp
@@ -41,9 +41,9 @@ module_context::WaitForMethodFunction s_waitForShowDialog;
 
 ClientEvent showDialogEvent(const std::string& title,
                             const std::string& message,
+                            int dialogIcon,
                             bool prompt,
                             const std::string& promptDefault,
-                            bool question,
                             const std::string& ok,
                             const std::string& cancel,
                             const std::string& url)
@@ -51,9 +51,9 @@ ClientEvent showDialogEvent(const std::string& title,
    json::Object data;
    data["title"] = title;
    data["message"] = message;
+   data["dialogIcon"] = dialogIcon;
    data["prompt"] = prompt;
    data["default"] = promptDefault;
-   data["question"] = question;
    data["ok"] = ok;
    data["cancel"] = cancel;
    data["url"] = url;
@@ -62,9 +62,9 @@ ClientEvent showDialogEvent(const std::string& title,
 
 SEXP rs_showDialog(SEXP titleSEXP,
                    SEXP messageSEXP,
+                   SEXP dialogIconSEXP,
                    SEXP promptSEXP,
                    SEXP promptDefaultSEXP,
-                   SEXP questionSEXP,
                    SEXP okSEXP,
                    SEXP cancelSEXP,
                    SEXP urlSEXP)
@@ -73,9 +73,9 @@ SEXP rs_showDialog(SEXP titleSEXP,
    {
       std::string title = r::sexp::asString(titleSEXP);
       std::string message = r::sexp::asString(messageSEXP);
+      int dialogIcon = r::sexp::asInteger(dialogIconSEXP);
       bool prompt = r::sexp::asLogical(promptSEXP);
       std::string promptDefault = r::sexp::asString(promptDefaultSEXP);
-      bool question = r::sexp::asLogical(questionSEXP);
       std::string ok = r::sexp::asString(okSEXP);
       std::string cancel = r::sexp::asString(cancelSEXP);
       std::string url = r::sexp::asString(urlSEXP);
@@ -83,9 +83,9 @@ SEXP rs_showDialog(SEXP titleSEXP,
       ClientEvent event = showDialogEvent(
          title,
          message,
+         dialogIcon,
          prompt,
          promptDefault,
-         question,
          ok,
          cancel,
          url);
@@ -97,7 +97,7 @@ SEXP rs_showDialog(SEXP titleSEXP,
          return R_NilValue;
       }
 
-      if (question && !request.params[1].is_null()) {
+      if (dialogIcon == 4 && !request.params[1].is_null()) {
          bool result;
          Error error = json::readParam(request.params, 1, &result);
          if (error)

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/RStudioAPI.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/RStudioAPI.java
@@ -16,6 +16,7 @@
 package org.rstudio.studio.client.common.rstudioapi;
 
 import org.rstudio.core.client.MessageDisplay.PromptWithOptionResult;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.widget.HyperlinkLabel;
 import org.rstudio.core.client.widget.MessageDialog;
 import org.rstudio.core.client.widget.Operation;
@@ -90,7 +91,7 @@ public class RStudioAPI implements RStudioAPIShowDialogEvent.Handler
       msg.setWidth("100%");
       verticalPanel.add(msg);
       
-      if (url != null)
+      if (!StringUtil.isNullOrEmpty(url))
       {
          HyperlinkLabel link = new HyperlinkLabel(url, 
                new ClickHandler() {
@@ -125,6 +126,8 @@ public class RStudioAPI implements RStudioAPIShowDialogEvent.Handler
                            String message,
                            String prompt)
    {
+      if (StringUtil.isNullOrEmpty(prompt)) prompt = null;
+
       globalDisplay_.promptForTextWithOption(
          title, 
          message, 
@@ -156,6 +159,9 @@ public class RStudioAPI implements RStudioAPIShowDialogEvent.Handler
                              String ok,
                              String cancel)
    {
+      if (StringUtil.isNullOrEmpty(ok)) ok = null;
+      if (StringUtil.isNullOrEmpty(cancel)) cancel = null;
+
       globalDisplay_.showYesNoMessage(
          MessageDialog.QUESTION, 
          title,
@@ -199,7 +205,7 @@ public class RStudioAPI implements RStudioAPIShowDialogEvent.Handler
          showDialog(
             event.getTitle(), 
             event.getMessage(),
-            null);
+            event.getUrl());
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/RStudioAPI.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/RStudioAPI.java
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client.common.rstudioapi;
 
+import org.rstudio.core.client.MessageDisplay;
 import org.rstudio.core.client.MessageDisplay.PromptWithOptionResult;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.widget.HyperlinkLabel;
@@ -159,8 +160,8 @@ public class RStudioAPI implements RStudioAPIShowDialogEvent.Handler
                              String ok,
                              String cancel)
    {
-      if (StringUtil.isNullOrEmpty(ok)) ok = null;
-      if (StringUtil.isNullOrEmpty(cancel)) cancel = null;
+      if (StringUtil.isNullOrEmpty(ok)) ok = "OK";
+      if (StringUtil.isNullOrEmpty(cancel)) cancel = "Cancel";
 
       globalDisplay_.showYesNoMessage(
          MessageDialog.QUESTION, 
@@ -195,7 +196,7 @@ public class RStudioAPI implements RStudioAPIShowDialogEvent.Handler
             event.getTitle(), 
             event.getMessage(),
             event.getPromptDefault());
-      } else if (event.getQuestion()) {
+      } else if (event.getDialogIcon() == MessageDisplay.MSG_QUESTION) {
          showQuestion(
             event.getTitle(), 
             event.getMessage(),

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/RStudioAPI.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/RStudioAPI.java
@@ -115,7 +115,7 @@ public class RStudioAPI implements RStudioAPIShowDialogEvent.Handler
          @Override
          public void execute()
          {
-            server_.showDialogCompleted(null, new SimpleRequestCallback<Void>());
+            server_.showDialogCompleted(null, false, new SimpleRequestCallback<Void>());
          }
       }, true, false);
       dlg.showModal();
@@ -139,16 +139,46 @@ public class RStudioAPI implements RStudioAPIShowDialogEvent.Handler
             {
                indicator.onCompleted();
                
-               server_.showDialogCompleted(input.input, new SimpleRequestCallback<Void>());
+               server_.showDialogCompleted(input.input, false, new SimpleRequestCallback<Void>());
             }        
          }, 
          new Operation() {
             @Override
             public void execute()
             {
-               server_.showDialogCompleted(null, new SimpleRequestCallback<Void>());
+               server_.showDialogCompleted(null, false, new SimpleRequestCallback<Void>());
             }
          });
+   }
+
+   private void showQuestion(String title,
+                             String message,
+                             String ok,
+                             String cancel)
+   {
+      globalDisplay_.showYesNoMessage(
+         MessageDialog.QUESTION, 
+         title,
+         message,
+         false,
+         new Operation() {
+            public void execute() {
+               server_.showDialogCompleted(null, true, new SimpleRequestCallback<Void>());
+            }
+         },
+         new Operation() {
+            public void execute() {
+               server_.showDialogCompleted(null, false, new SimpleRequestCallback<Void>());
+            }
+         },
+         new Operation() {
+            public void execute() {
+               server_.showDialogCompleted(null, false, new SimpleRequestCallback<Void>());
+            }
+         },
+         ok,
+         cancel,
+         true);
    }
 
    @Override
@@ -159,6 +189,12 @@ public class RStudioAPI implements RStudioAPIShowDialogEvent.Handler
             event.getTitle(), 
             event.getMessage(),
             event.getPromptDefault());
+      } else if (event.getQuestion()) {
+         showQuestion(
+            event.getTitle(), 
+            event.getMessage(),
+            event.getOK(),
+            event.getCancel());
       } else {
          showDialog(
             event.getTitle(), 

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/events/RStudioAPIShowDialogEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/events/RStudioAPIShowDialogEvent.java
@@ -54,6 +54,10 @@ public class RStudioAPIShowDialogEvent extends GwtEvent<RStudioAPIShowDialogEven
       public final native String getCancel() /*-{
          return this.cancel;
       }-*/;
+
+      public final native String getUrl() /*-{
+         return this.url;
+      }-*/;
    }
 
    public interface Handler extends EventHandler
@@ -99,6 +103,11 @@ public class RStudioAPIShowDialogEvent extends GwtEvent<RStudioAPIShowDialogEven
    public String getCancel()
    {
       return data_.getCancel();
+   }
+
+   public String getUrl()
+   {
+      return data_.getUrl();
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/events/RStudioAPIShowDialogEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/events/RStudioAPIShowDialogEvent.java
@@ -42,6 +42,18 @@ public class RStudioAPIShowDialogEvent extends GwtEvent<RStudioAPIShowDialogEven
       public final native String getPromptDefault() /*-{
          return this["default"];
       }-*/;
+
+      public final native boolean getQuestion() /*-{
+         return this.question || false;
+      }-*/;
+
+      public final native String getOK() /*-{
+         return this.ok;
+      }-*/;
+
+      public final native String getCancel() /*-{
+         return this.cancel;
+      }-*/;
    }
 
    public interface Handler extends EventHandler
@@ -72,6 +84,21 @@ public class RStudioAPIShowDialogEvent extends GwtEvent<RStudioAPIShowDialogEven
    public String getPromptDefault()
    {
       return data_.getPromptDefault();
+   }
+
+   public boolean getQuestion()
+   {
+      return data_.getQuestion();
+   }
+
+   public String getOK()
+   {
+      return data_.getOK();
+   }
+
+   public String getCancel()
+   {
+      return data_.getCancel();
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/events/RStudioAPIShowDialogEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/events/RStudioAPIShowDialogEvent.java
@@ -35,16 +35,16 @@ public class RStudioAPIShowDialogEvent extends GwtEvent<RStudioAPIShowDialogEven
          return this.title;
       }-*/;
 
+      public final native int getDialogIcon() /*-{
+         return this.dialogIcon;
+      }-*/;
+
       public final native boolean getPrompt() /*-{
          return this.prompt || false;
       }-*/;
 
       public final native String getPromptDefault() /*-{
          return this["default"];
-      }-*/;
-
-      public final native boolean getQuestion() /*-{
-         return this.question || false;
       }-*/;
 
       public final native String getOK() /*-{
@@ -80,6 +80,11 @@ public class RStudioAPIShowDialogEvent extends GwtEvent<RStudioAPIShowDialogEven
       return data_.getTitle();
    }
 
+   public int getDialogIcon()
+   {
+      return data_.getDialogIcon();
+   }
+
    public boolean getPrompt()
    {
       return data_.getPrompt();
@@ -88,11 +93,6 @@ public class RStudioAPIShowDialogEvent extends GwtEvent<RStudioAPIShowDialogEven
    public String getPromptDefault()
    {
       return data_.getPromptDefault();
-   }
-
-   public boolean getQuestion()
-   {
-      return data_.getQuestion();
    }
 
    public String getOK()

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/model/RStudioAPIServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/model/RStudioAPIServerOperations.java
@@ -19,5 +19,7 @@ import org.rstudio.studio.client.server.Void;
 
 public interface RStudioAPIServerOperations
 {
-   void showDialogCompleted(String prompt, ServerRequestCallback<Void> callback);
+   void showDialogCompleted(String prompt,
+                            boolean ok,
+                            ServerRequestCallback<Void> callback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4944,12 +4944,14 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, LAUNCH_EMBEDDED_SHINY_CONNECTION_UI, params, callback);
    }
 
-   // @Override
+   @Override
    public void showDialogCompleted(String prompt,
+                                   boolean ok,
                                    ServerRequestCallback<Void> callback)
    {
       JSONArray params = new JSONArray();
       params.set(0, prompt == null ? JSONNull.getInstance() : new JSONString(prompt));
+      params.set(1, JSONBoolean.getInstance(ok));
       sendRequest(RPC_SCOPE, RSTUDIOAPI_SHOW_DIALOG_COMPLETED, params, true, callback);
    }
 


### PR DESCRIPTION
Implement question dialog and add support for `url` paramater:

<img width="698" alt="screen shot 2017-01-06 at 10 39 11 am" src="https://cloud.githubusercontent.com/assets/3478847/21728770/c1922d7a-d3fc-11e6-9d76-54c3d6e8bbbb.png">

To produce:

<img width="406" alt="screen shot 2017-01-06 at 10 39 00 am" src="https://cloud.githubusercontent.com/assets/3478847/21728777/c6b90daa-d3fc-11e6-947f-b1e9836634cb.png">

Using the URL parameter in `showDialog`:

<img width="530" alt="screen shot 2017-01-06 at 12 27 59 pm" src="https://cloud.githubusercontent.com/assets/3478847/21731974/fdda4434-d40b-11e6-89b6-11881f988877.png">


Planning to add this to `rstudioapi` as well at some point and use in `sparklyr` to trigger missing installation.