### PR TITLE
Terminal buffer save and restore

### DIFF
--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -306,7 +306,7 @@ bool ConsoleProcess::onContinue(core::system::ProcessOperations& ops)
    return true;
 }
 
-Error ConsoleProcess::getLogFile(FilePath* file) const
+Error ConsoleProcess::getLogFile(FilePath* pFile) const
 {
    Error error = s_consoleProcPath.ensureDirectory();
    if (error)
@@ -314,7 +314,7 @@ Error ConsoleProcess::getLogFile(FilePath* file) const
       return error;
    }
 
-   *file = s_consoleProcPath.complete(handle_);
+   *pFile = s_consoleProcPath.complete(handle_);
    return Success();
 }
 

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -25,6 +25,7 @@
 #include <core/system/Process.hpp>
 #include <core/Log.hpp>
 
+#include <core/FileSerializer.hpp>
 #include <core/json/Json.hpp>
 
 namespace rstudio {
@@ -172,6 +173,8 @@ public:
    bool isStarted() { return started_; }
    void setCaption(std::string& caption) { caption_ = caption; }
    void setTitle(std::string& title) { title_ = title; }
+   void deleteLogFile() const;
+   std::string getSavedBuffer() const;
 
    void setShowOnOutput(bool showOnOutput) { showOnOutput_ = showOnOutput; }
 
@@ -194,6 +197,7 @@ private:
                             const std::string& prompt);
    void maybeConsolePrompt(core::system::ProcessOperations& ops,
                            const std::string& output);
+   core::Error getLogFile(core::FilePath& file) const;
 
 private:
    // Command and options that will be used when start() is called

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -197,7 +197,7 @@ private:
                             const std::string& prompt);
    void maybeConsolePrompt(core::system::ProcessOperations& ops,
                            const std::string& output);
-   core::Error getLogFile(core::FilePath& file) const;
+   core::Error getLogFile(core::FilePath* file) const;
 
 private:
    // Command and options that will be used when start() is called

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
@@ -125,14 +125,26 @@ public class ApplicationQuit implements SaveActionChangedHandler,
                               final boolean forceSaveAll,
                               final QuitContext quitContext)
    {
+      boolean busy = workbenchContext_.isServerBusy() || workbenchContext_.isTerminalBusy();
+      String msg = null;
+      if (busy)
+      {
+         if (workbenchContext_.isServerBusy() && !workbenchContext_.isTerminalBusy())
+            msg = "The R session is currently busy.";
+         else if (workbenchContext_.isServerBusy() && workbenchContext_.isTerminalBusy())
+            msg = "The R session and the terminal are currently busy.";
+         else 
+            msg = "The terminal is currently busy.";
+      }
+
       eventBus_.fireEvent(new QuitInitiatedEvent());
       
-      if (workbenchContext_.isServerBusy() && !forceSaveAll)
+      if (busy && !forceSaveAll)
       {
          globalDisplay_.showYesNoMessage(
                MessageDialog.QUESTION,
                caption, 
-               "The R session is currently busy. Are you sure you want to quit?", 
+               msg + " Are you sure you want to quit?",
                new Operation() {
                   @Override
                   public void execute()
@@ -161,7 +173,6 @@ public class ApplicationQuit implements SaveActionChangedHandler,
       }
    }
    
-     
    private void handleUnsavedChanges(String caption, 
                                      boolean forceSaveAll,
                                      QuitContext quitContext)

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcess.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcess.java
@@ -361,7 +361,17 @@ public class ConsoleProcess implements ConsoleOutputEvent.HasHandlers,
    {
       server_.processSetShellSize(procInfo_.getHandle(), cols, rows, requestCallback);
    }
-   
+
+   public void eraseTerminalBuffer(ServerRequestCallback<Void> requestCallback)
+   {
+      server_.processEraseBuffer(procInfo_.getHandle(), requestCallback);
+   }
+
+   public void getTerminalBuffer(ServerRequestCallback<String> requestCallback)
+   {
+      server_.processGetBuffer(procInfo_.getHandle(), requestCallback);
+   }
+
    public void interrupt(ServerRequestCallback<Void> requestCallback)
    {
       server_.processInterrupt(procInfo_.getHandle(), requestCallback);

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -685,7 +685,25 @@ public class RemoteServer implements Server
       params.set(1, new JSONString(title));
       sendRequest(RPC_SCOPE, PROCESS_SET_TITLE, params, requestCallback);
    }
-   
+
+   @Override
+   public void processEraseBuffer(String handle,
+                                  ServerRequestCallback<Void> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(StringUtil.notNull(handle)));
+      sendRequest(RPC_SCOPE, PROCESS_ERASE_BUFFER, params, requestCallback);   
+   }
+
+   @Override
+   public void processGetBuffer(String handle,
+                                  ServerRequestCallback<String> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(StringUtil.notNull(handle)));
+      sendRequest(RPC_SCOPE, PROCESS_GET_BUFFER, params, requestCallback);   
+   }
+
    public void interrupt(ServerRequestCallback<Void> requestCallback)
    {
       sendRequest(RPC_SCOPE, INTERRUPT, requestCallback);
@@ -5022,6 +5040,8 @@ public class RemoteServer implements Server
    private static final String PROCESS_SET_SIZE = "process_set_size";
    private static final String PROCESS_SET_CAPTION = "process_set_caption";
    private static final String PROCESS_SET_TITLE = "process_set_title";
+   private static final String PROCESS_ERASE_BUFFER = "process_erase_buffer";
+   private static final String PROCESS_GET_BUFFER = "process_get_buffer";
 
    private static final String REMOVE_ALL_OBJECTS = "remove_all_objects";
    private static final String REMOVE_OBJECTS = "remove_objects";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/WorkbenchContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/WorkbenchContext.java
@@ -27,6 +27,7 @@ import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.SessionInfo;
 import org.rstudio.studio.client.workbench.views.console.events.WorkingDirChangedEvent;
 import org.rstudio.studio.client.workbench.views.console.events.WorkingDirChangedHandler;
+import org.rstudio.studio.client.workbench.views.terminal.events.TerminalBusyEvent;
 import org.rstudio.studio.client.workbench.views.vcs.git.model.GitState;
 
 import com.google.gwt.user.client.Timer;
@@ -107,6 +108,17 @@ public class WorkbenchContext
          public void onRVersionsChanged(RVersionsChangedEvent event)
          {
             rVersionsInfo_ = event.getRVersionsInfo();
+         }
+      });
+      
+      // track busy terminals
+      eventBus.addHandler(TerminalBusyEvent.TYPE,
+                          new TerminalBusyEvent.Handler()
+      {
+         @Override
+         public void onTerminalBusy(TerminalBusyEvent event)
+         {
+            isTerminalBusy_ = event.isBusy();
          }
       });
    }
@@ -211,6 +223,11 @@ public class WorkbenchContext
       return isServerBusy_;
    }
    
+   public boolean isTerminalBusy()
+   {
+      return isTerminalBusy_;
+   }
+   
    public boolean isRestartInProgress()
    {
       return isRestartInProgress_;
@@ -245,6 +262,7 @@ public class WorkbenchContext
    }
    
    private boolean isServerBusy_ = false;
+   private boolean isTerminalBusy_ = false;
    private boolean isRestartInProgress_ = false;
    private boolean isBuildInProgress_ = false;
    private FileSystemItem currentWorkingDir_ = FileSystemItem.home();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/model/ConsoleServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/model/ConsoleServerOperations.java
@@ -51,6 +51,12 @@ public interface ConsoleServerOperations extends CodeToolsServerOperations,
                             int height,
                             ServerRequestCallback<Void> requestCallback);
 
+   void processEraseBuffer(String handle,
+                           ServerRequestCallback<Void> requestCallback);
+
+   void processGetBuffer(String handle,
+                         ServerRequestCallback<String> requestCallback);
+
    /**
     * Set/update the caption of given process.
     * @param handle process handle

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
@@ -24,6 +24,7 @@ import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.console.ConsoleProcess.ConsoleProcessFactory;
 import org.rstudio.studio.client.common.console.ConsoleProcessInfo;
 import org.rstudio.studio.client.common.shell.ShellSecureInput;
+import org.rstudio.studio.client.workbench.views.terminal.events.TerminalBusyEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSubprocEvent;
 
 import com.google.inject.Inject;
@@ -208,6 +209,7 @@ public class TerminalList implements Iterable<String>,
    void removeTerminal(String handle)
    {
       terminals_.remove(handle);
+      updateTerminalBusyStatus();
    }
 
    /**
@@ -221,6 +223,7 @@ public class TerminalList implements Iterable<String>,
          pConsoleProcessFactory_.get().interruptAndReap(item.getValue().getHandle());
       }
       terminals_.clear();
+      updateTerminalBusyStatus();
    }
 
    /**
@@ -392,11 +395,18 @@ public class TerminalList implements Iterable<String>,
             getSecureInput(), sequence, terminalHandle, caption, title,
             hasChildProcs);
       newSession.connect();
+      updateTerminalBusyStatus();
    }
 
    private void addTerminal(TerminalMetadata terminal)
    {
       terminals_.put(terminal.getHandle(), terminal);
+      updateTerminalBusyStatus();
+   }
+
+   private void updateTerminalBusyStatus()
+   {
+      eventBus_.fireEvent(new TerminalBusyEvent(haveSubprocs()));
    }
 
    @Override
@@ -409,6 +419,7 @@ public class TerminalList implements Iterable<String>,
    public void onTerminalSubprocs(TerminalSubprocEvent event)
    {
       setChildProcs(event.getHandle(), event.hasSubprocs());
+      updateTerminalBusyStatus();
    }
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -329,7 +329,7 @@ public class TerminalPane extends WorkbenchPane
          return;
       }
 
-      visibleTerminal.clear();
+      visibleTerminal.clearBuffer();
    }
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/TerminalBusyEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/TerminalBusyEvent.java
@@ -1,0 +1,56 @@
+/*
+ * TerminalBusyEvent.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.terminal.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+/**
+ * Sent when overall state of terminal busy-ness changes. That is, if any
+ * terminal is busy, this event signals busy.
+ */
+public class TerminalBusyEvent extends GwtEvent<TerminalBusyEvent.Handler>
+{
+   public interface Handler extends EventHandler
+   {
+      void onTerminalBusy(TerminalBusyEvent event);
+   }
+
+   public TerminalBusyEvent(boolean busy)
+   {
+      busy_ = busy;
+   }
+
+   public boolean isBusy()
+   {
+      return busy_;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onTerminalBusy(this);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   private final boolean busy_;
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -22,7 +22,6 @@ import org.rstudio.core.client.ExternalJavaScriptLoader.Callback;
 import org.rstudio.core.client.resources.StaticDataResource;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.studio.client.common.SuperDevMode;
-import org.rstudio.studio.client.workbench.views.terminal.AnsiCode;
 import org.rstudio.studio.client.workbench.views.terminal.events.ResizeTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalDataInputEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.XTermTitleEvent;
@@ -89,27 +88,10 @@ public class XTermWidget extends Widget implements RequiresResize,
    /**
     * Perform actions when the terminal is ready.
     */
-   private void terminalReady()
+   protected void terminalReady()
    {
-      if (newTerminal_)
-      {
-         writeln("Welcome to " + AnsiCode.ForeColor.LIGHTBLUE + "RStudio" +
-                 AnsiCode.DEFAULTCOLORS + " terminal.");
-         setNewTerminal(false);
-      }
-      else
-      {
-         Scheduler.get().scheduleDeferred(new ScheduledCommand()
-         {
-            @Override
-            public void execute()
-            {
-               onResize();
-            }
-         });
-       }
    }
-  
+
    /**
     * One one line of text to the terminal.
     * @param str Text to write (CRLF will be appended)
@@ -324,15 +306,6 @@ public class XTermWidget extends Widget implements RequiresResize,
          }
      });
    }
-   
-   /**
-    * Set if connecting to a new terminal session.
-    * @param isNew true if a new connection, false if a reconnect
-    */
-   public void setNewTerminal(boolean isNew)
-   {
-      newTerminal_ = isNew;
-   }
 
    private static final ExternalJavaScriptLoader xtermLoader_ =
          getLoader(XTermResources.INSTANCE.xtermjs(), 
@@ -345,7 +318,6 @@ public class XTermWidget extends Widget implements RequiresResize,
    private XTermNative terminal_;
    private LinkElement currentStyleEl_;
    private boolean initialized_ = false;
-   private boolean newTerminal_ = true;
 
    private int previousRows_ = -1;
    private int previousCols_ = -1;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
@@ -59,6 +59,7 @@ public class GitPane extends WorkbenchPane implements Display
       moreMenu.addItem(commands_.vcsIgnore().createMenuItem(false));
       moreMenu.addSeparator();
       moreMenu.addItem(commands_.showShellDialog().createMenuItem(false));
+      moreMenu.addItem(commands_.newTerminal().createMenuItem(false));
 
       Toolbar toolbar = new Toolbar();
       toolbar.addLeftWidget(commands_.vcsDiff().createToolbarButton());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNPane.java
@@ -81,6 +81,7 @@ public class SVNPane extends WorkbenchPane implements Display
       moreMenu.addItem(commands_.vcsShowHistory().createMenuItem(false));
       moreMenu.addSeparator();
       moreMenu.addItem(commands_.showShellDialog().createMenuItem(false));
+      moreMenu.addItem(commands_.newTerminal().createMenuItem(false));
 
       toolbar.addLeftWidget(new ToolbarButton(
           "More",


### PR DESCRIPTION
- save and restore terminal buffers
- save and restore set of terminal sessions when switching projects (terminals are remembered per-session)
- warn user about busy terminals when closing current project
- add terminal commands to source-control pane dropdown menus
- opened TODO case to implement cleaning up orphaned terminal buffers on server after a session crash
- opened TODO case to consider giving user more details on which terminal(s) are busy when trying to close session