### PR TITLE
Turn on terminal busy detection for Linux

### DIFF
--- a/src/cpp/core/include/core/system/Process.hpp
+++ b/src/cpp/core/include/core/system/Process.hpp
@@ -121,6 +121,9 @@ struct ProcessOptions
 
    // create the process with CREATE_BREAKAWAY_FROM_JOB
    bool breakawayFromJob;
+
+   // consoleio command path
+   std::string consoleIoPath;
 #endif
 
    bool redirectStdErrToStdOut;

--- a/src/cpp/core/include/core/system/Process.hpp
+++ b/src/cpp/core/include/core/system/Process.hpp
@@ -297,6 +297,11 @@ public:
                     const ProcessOptions& options,
                     const ProcessCallbacks& callbacks);
 
+   // Run an interactive terminal asynchronously (same as above but uses
+   // platform-specific implementation to determine what to execute).
+   Error runTerminal(const ProcessOptions& options,
+                     const ProcessCallbacks& callbacks);
+
    // Run a child asynchronously, invoking the completed callback when the
    // process exits. Note that if input is provided then then the standard
    // input stream is closed (so EOF is sent) after the input is written.

--- a/src/cpp/core/system/ChildProcess.hpp
+++ b/src/cpp/core/system/ChildProcess.hpp
@@ -45,6 +45,9 @@ protected:
    void init(const std::string& command,
              const ProcessOptions& options);
 
+   // init for an interactive terminal
+   void init(const ProcessOptions& options);
+
 public:
    virtual ~ChildProcess();
 
@@ -180,6 +183,7 @@ public:
                      const ProcessOptions& options);
    AsyncChildProcess(const std::string& command,
                      const ProcessOptions& options);
+   AsyncChildProcess(const ProcessOptions& options);
    virtual ~AsyncChildProcess();
 
    // run process asynchronously

--- a/src/cpp/core/system/Process.cpp
+++ b/src/cpp/core/system/Process.cpp
@@ -127,6 +127,17 @@ Error ProcessSupervisor::runCommand(const std::string& command,
    return runChild(pChild, &(pImpl_->children), callbacks);
 }
 
+Error ProcessSupervisor::runTerminal(const ProcessOptions& options,
+                                     const ProcessCallbacks& callbacks)
+{
+   // create the child
+   boost::shared_ptr<AsyncChildProcess> pChild(
+                                 new AsyncChildProcess(options));
+
+   // run the child
+   return runChild(pChild, &(pImpl_->children), callbacks);
+}
+
 namespace {
 
 // class which implements all of the callbacks

--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -225,7 +225,8 @@ void ChildProcess::init(const std::string& command,
 // initialize for an interactive terminal
 void ChildProcess::init(const ProcessOptions& options)
 {
-    init("cmd.exe", options);
+    std::string command = options_.consoleIoPath + " cmd.exe";
+    init(command, options);
 }
 
 ChildProcess::~ChildProcess()
@@ -656,9 +657,6 @@ void AsyncChildProcess::poll()
       if (callbacks_.onExit)
          callbacks_.onExit(exitStatus);
    }
-
-   // Perform optional periodic operations
-   // TODO (gary) - NYI for Win32 (see PosixChildProcess, computeHasSubProcess)
 }
 
 bool AsyncChildProcess::exited()

--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -222,6 +222,12 @@ void ChildProcess::init(const std::string& command,
    options_ = options;
 }
 
+// initialize for an interactive terminal
+void ChildProcess::init(const ProcessOptions& options)
+{
+    init("cmd.exe", options);
+}
+
 ChildProcess::~ChildProcess()
 {
 }
@@ -546,6 +552,12 @@ AsyncChildProcess::AsyncChildProcess(const std::string& command,
    init(command, options);
 }
 
+AsyncChildProcess::AsyncChildProcess(const ProcessOptions& options)
+      : ChildProcess(), pAsyncImpl_(new AsyncImpl())
+{
+   init(options);
+}
+
 AsyncChildProcess::~AsyncChildProcess()
 {
 }
@@ -644,6 +656,9 @@ void AsyncChildProcess::poll()
       if (callbacks_.onExit)
          callbacks_.onExit(exitStatus);
    }
+
+   // Perform optional periodic operations
+   // TODO (gary) - NYI for Win32 (see PosixChildProcess, computeHasSubProcess)
 }
 
 bool AsyncChildProcess::exited()

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -164,9 +164,13 @@ void ConsoleProcess::commonInit()
          args_ = args;
       }
       // if this is a runCommand then prepend consoleio.exe to the command
-      else
+      else if (!command_.empty())
       {
          command_ = shell_utils::escape(consoleIoPath) + " " + command_;
+      }
+      else // terminal
+      {
+         options_.consoleIoPath = shell_utils::escape(consoleIoPath);
       }
 #else
       // request a pseudoterminal if this is an interactive console process

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -139,8 +139,7 @@ public:
          InteractionMode mode,
          int maxOutputLines = kDefaultMaxOutputLines);
 
-   static boost::shared_ptr<ConsoleProcess> create(
-         const std::string& command,
+   static boost::shared_ptr<ConsoleProcess> createTerminalProcess(
          core::system::ProcessOptions options,
          const std::string& caption,
          const std::string& title,
@@ -197,7 +196,7 @@ private:
                             const std::string& prompt);
    void maybeConsolePrompt(core::system::ProcessOperations& ops,
                            const std::string& output);
-   core::Error getLogFile(core::FilePath* file) const;
+   core::Error getLogFilePath(core::FilePath* file) const;
 
 private:
    // Command and options that will be used when start() is called

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -964,19 +964,9 @@ Error startShellDialog(const json::JsonRpcRequest& request,
    if (termCaption.empty())
       termCaption = "Shell";
    
-   // configure bash command
-#ifndef _WIN32
-   core::shell_utils::ShellCommand bashCommand("/usr/bin/env");
-   bashCommand << "bash";
-   bashCommand << "--norc";
-#else
-   // TODO (gary) use %comspec% to locate cmd.exe
-   core::shell_utils::ShellCommand bashCommand("cmd.exe");
-#endif
-
    // run process
    boost::shared_ptr<ConsoleProcess> ptrProc =
-               ConsoleProcess::create(bashCommand,
+               ConsoleProcess::createTerminalProcess(
                                       options,
                                       termCaption,
                                       termTitle,


### PR DESCRIPTION
- Launch bash directly via /usr/bin/env, instead of using /bin/sh to launch /usr/bin/env to launch bash. Prevents leaving /bin/sh running as the parent of bash, which was messing up subprocess counting.

- Turn pgrep-based subprocess counting back on for Linux (not just Mac) until I get the procfs approach implemented. Allows sessions to suspend on Linux, and shows asterisk after terminal name in dropdown when it is busy.

- Don’t try to open a terminal buffer save file that isn’t there, avoiding an unnecessary error message on the server.