### PR TITLE
tweaks to save/delete of terminal buffers and metadata

### DIFF
--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -779,7 +779,7 @@ AsyncChildProcess::AsyncChildProcess(const std::string& exe,
    init(exe, args, options);
    if (!options.stdOutFile.empty() || !options.stdErrFile.empty())
    {
-      LOG_ERROR_MESSAGE(
+      LOG_WARNING_MESSAGE(
                "stdOutFile/stdErrFile options cannot be used with runProgram");
    }
 }


### PR DESCRIPTION
- save terminal metadata more frequently, be more aggressive in cleaning up buffer files including looking for orphaned buffer files
- don’t delete buffer files when suspending, only when reaping