### PR TITLE
- fix bug: busy status on client-side can get out of sync with server

### DIFF
--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -225,8 +225,6 @@ Error ConsoleProcess::start()
    if (started_)
       return Success();
 
-   // toggle potentially cached (and incorrect) busy state, to ensure we
-   // send one notification to the client
    Error error;
    if (!command_.empty())
    {

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -236,6 +236,9 @@ private:
    // Does this process have child processes?
    bool childProcs_;
 
+   // Has client been notified of state of childProcs_ at least once?
+   bool childProcsSent_;
+
    // Pending input (writes or ptyInterrupts)
    std::queue<Input> inputQueue_;
 


### PR DESCRIPTION
Fix bug: client thinks terminal is busy but it isn't, after some restarts. Server thinks client already knows the truth and doesn't correct it. See IDE case 6456.