### PR TITLE
use '--no-save --no-restore' w/build_book()

### DIFF
--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -828,6 +828,12 @@ private:
       args.push_back("--vanilla");
       args.push_back("-e");
       args.push_back(command);
+      
+      // forward R_LIBS so the child process has access to the same libraries
+      // we do
+      std::string libPaths = module_context::libPathsString();
+      if (!libPaths.empty())
+         core::system::setenv(&pkgOptions.environment, "R_LIBS", libPaths);
 
       // run it
       module_context::processSupervisor().runProgram(


### PR DESCRIPTION
This PR intends to resolve an issue where calls to e.g. `build_book()` would fail for users who initialize their R library paths in a user startup file (e.g. `.Rprofile` or `.Renviron`). (In such a case, because the library paths will not contain an `rmarkdown` installation, attempts to load + call `rmarkdown` functions will fail)

Rather than executing the build commands in a plain new R session with `--vanilla --slave`, we instead use `--no-save --no-restore --slave` -- that is, we still ask R to load user startup files.