### PR TITLE
Implement scroll support to new connections wizard

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/Wizard.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/Wizard.css
@@ -66,7 +66,7 @@
 .wizardPageSelectorItemLeftIcon {
    max-width: 20px;
    max-height: 20px;
-   margin-left: 10px;
+   margin-left: 8px;
    margin-top: 8px;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/widget/Wizard.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/Wizard.css
@@ -58,6 +58,27 @@
    background: #DAE7F6;	
 }
 
+.wizardPageSelectorItemSize {
+   width: 100%;
+   height: 38px;
+}
+
+.wizardPageSelectorItemLeftIcon {
+   max-width: 20px;
+   max-height: 20px;
+   margin-left: 4px;
+   margin-top: 10px;
+}
+
+.wizardPageSelectorItemRightArrow {
+   margin-top: 12px;
+}
+
+.wizardPageSelectorItemLabel {
+   margin-top: 12px;
+   white-space: nowrap;
+}
+
 @sprite .wizardPageBackground {
    gwt-image: 'wizardPageBackground';
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/Wizard.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/Wizard.css
@@ -60,22 +60,22 @@
 
 .wizardPageSelectorItemSize {
    width: 100%;
-   height: 38px;
+   height: 34px;
 }
 
 .wizardPageSelectorItemLeftIcon {
    max-width: 20px;
    max-height: 20px;
    margin-left: 10px;
-   margin-top: 10px;
+   margin-top: 8px;
 }
 
 .wizardPageSelectorItemRightArrow {
-   margin-top: 12px;
+   margin-top: 10px;
 }
 
 .wizardPageSelectorItemLabel {
-   margin-top: 12px;
+   margin-top: 10px;
    margin-left: 8px;
    white-space: nowrap;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/Wizard.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/Wizard.css
@@ -66,7 +66,7 @@
 .wizardPageSelectorItemLeftIcon {
    max-width: 20px;
    max-height: 20px;
-   margin-left: 4px;
+   margin-left: 10px;
    margin-top: 10px;
 }
 
@@ -76,6 +76,7 @@
 
 .wizardPageSelectorItemLabel {
    margin-top: 12px;
+   margin-left: 8px;
    white-space: nowrap;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/widget/WizardResources.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/WizardResources.java
@@ -34,7 +34,11 @@ public interface WizardResources extends ClientBundle
       String wizardPageSelector();
       String wizardPageSelectorItem();
       String wizardPageSelectorItemFirst();
+      String wizardPageSelectorItemLabel();
       String wizardPageSelectorItemLast();
+      String wizardPageSelectorItemLeftIcon();
+      String wizardPageSelectorItemRightArrow();
+      String wizardPageSelectorItemSize();
       String wizardPageBackground();
       String wizardBackButton();
    }

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewDirectoryNavigationPage.css
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewDirectoryNavigationPage.css
@@ -1,17 +1,1 @@
 @CHARSET "UTF-8";
-
-.leftIcon {
-	max-width: 20px;
-	max-height: 20px;
-	margin-left: 4px;
-	margin-top: 3px;
-}
-
-.rightArrow {
-	margin-top: 5px;
-}
-
-.label {
-	margin-top: 5px;
-	white-space: nowrap;
-}

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewDirectoryNavigationPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewDirectoryNavigationPage.java
@@ -151,8 +151,6 @@ public class NewDirectoryNavigationPage
          panel.addStyleName(styles.wizardPageSelectorItem());
          panel.addStyleName(styles.wizardPageSelectorItemSize());
          
-         panel.setSize("100%", "38px");
-         
          Image rightArrow = new Image(WizardResources.INSTANCE.wizardDisclosureArrow());
          rightArrow.addStyleName(styles.wizardPageSelectorItemRightArrow());
          panel.addEast(rightArrow, 28);

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewDirectoryNavigationPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewDirectoryNavigationPage.java
@@ -149,11 +149,12 @@ public class NewDirectoryNavigationPage
          
          DockLayoutPanel panel = new DockLayoutPanel(Unit.PX);
          panel.addStyleName(styles.wizardPageSelectorItem());
+         panel.addStyleName(styles.wizardPageSelectorItemSize());
          
-         panel.setSize("100%", "24px");
+         panel.setSize("100%", "38px");
          
          Image rightArrow = new Image(WizardResources.INSTANCE.wizardDisclosureArrow());
-         rightArrow.addStyleName(RES.styles().rightArrow());
+         rightArrow.addStyleName(styles.wizardPageSelectorItemRightArrow());
          panel.addEast(rightArrow, 28);
          
          if (page.getImage() == null)
@@ -163,15 +164,15 @@ public class NewDirectoryNavigationPage
          else
          {
             Image icon = new Image(page.getImage());
-            icon.addStyleName(RES.styles().leftIcon());
+            icon.addStyleName(styles.wizardPageSelectorItemLeftIcon());
             panel.addWest(icon, 28);
          }
          
          Label mainLabel = new Label(page.getTitle());
-         mainLabel.addStyleName(RES.styles().label());
+         mainLabel.addStyleName(styles.wizardPageSelectorItemLabel());
          mainLabel.getElement().setAttribute("title", page.getSubTitle());
          panel.add(mainLabel);
-         
+
          panel.addDomHandler(handler, ClickEvent.getType());
          
          initWidget(panel);
@@ -180,9 +181,6 @@ public class NewDirectoryNavigationPage
    
    public interface Styles extends CssResource
    {
-      String leftIcon();
-      String rightArrow();
-      String label();
    }
 
    public interface Resources extends ClientBundle

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/NewConnectionContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/NewConnectionContext.java
@@ -53,16 +53,6 @@ public class NewConnectionContext extends JavaScriptObject
       return this.connectionsList[index];
    }-*/;
 
-   /*
-   public void setCurrentInfo(NewConnectionInfo currentInfo) {
-      currentInfo_ = currentInfo;
-   }
-
-   public NewConnectionInfo setCurrentInfo() {
-      return currentInfo;
-   }
-   */
-
    public final ArrayList<NewConnectionInfo> getConnectionsList()
    {
       ArrayList<NewConnectionInfo> result = new ArrayList<NewConnectionInfo>(getConnectionsLength());
@@ -71,6 +61,4 @@ public class NewConnectionContext extends JavaScriptObject
 
       return result;
    }
-
-   // private NewConnectionInfo currentInfo_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.css
@@ -1,18 +1,1 @@
 @CHARSET "UTF-8";
-
-.leftIcon {
-   max-width: 20px;
-   max-height: 20px;
-   margin-left: 4px;
-   margin-top: 3px;
-}
-
-.rightArrow {
-   margin-top: 12px;
-}
-
-.label {
-   margin-top: 12px;
-   white-space: nowrap;
-   font-weight: 600;
-}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.css
@@ -8,11 +8,11 @@
 }
 
 .rightArrow {
-   margin-top: 18px;
+   margin-top: 12px;
 }
 
 .label {
-   margin-top: 18px;
+   margin-top: 12px;
    white-space: nowrap;
    font-weight: 600;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.css
@@ -1,0 +1,18 @@
+@CHARSET "UTF-8";
+
+.leftIcon {
+   max-width: 20px;
+   max-height: 20px;
+   margin-left: 4px;
+   margin-top: 3px;
+}
+
+.rightArrow {
+   margin-top: 18px;
+}
+
+.label {
+   margin-top: 18px;
+   white-space: nowrap;
+   font-weight: 600;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.java
@@ -138,11 +138,10 @@ public class NewConnectionNavigationPage
          
          DockLayoutPanel panel = new DockLayoutPanel(Unit.PX);
          panel.addStyleName(styles.wizardPageSelectorItem());
-         
-         panel.setSize("100%", "38px");
+         panel.addStyleName(styles.wizardPageSelectorItemSize());
          
          Image rightArrow = new Image(WizardResources.INSTANCE.wizardDisclosureArrow());
-         rightArrow.addStyleName(RES.styles().rightArrow());
+         rightArrow.addStyleName(styles.wizardPageSelectorItemRightArrow());
          panel.addEast(rightArrow, 28);
          
          if (page.getImage() == null)
@@ -152,12 +151,12 @@ public class NewConnectionNavigationPage
          else
          {
             Image icon = new Image(page.getImage());
-            icon.addStyleName(RES.styles().leftIcon());
+            icon.addStyleName(styles.wizardPageSelectorItemLeftIcon());
             panel.addWest(icon, 28);
          }
          
          Label mainLabel = new Label(page.getTitle());
-         mainLabel.addStyleName(RES.styles().label());
+         mainLabel.addStyleName(WizardResources.INSTANCE.styles().wizardPageSelectorItemLabel());
          mainLabel.getElement().setAttribute("title", page.getSubTitle());
          panel.add(mainLabel);
          
@@ -166,12 +165,9 @@ public class NewConnectionNavigationPage
          initWidget(panel);
       }
    }
-   
-   public interface Styles extends CssResource
+
+    public interface Styles extends CssResource
    {
-      String leftIcon();
-      String rightArrow();
-      String label();
    }
    
    public interface Resources extends ClientBundle

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.java
@@ -16,13 +16,29 @@ package org.rstudio.studio.client.workbench.views.connections.ui;
 
 import java.util.ArrayList;
 
+import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.widget.HasWizardPageSelectionHandler;
 import org.rstudio.core.client.widget.WizardNavigationPage;
 import org.rstudio.core.client.widget.WizardPage;
+import org.rstudio.core.client.widget.WizardResources;
 import org.rstudio.studio.client.workbench.views.connections.model.ConnectionOptions;
 import org.rstudio.studio.client.workbench.views.connections.model.NewConnectionContext;
 import org.rstudio.studio.client.workbench.views.connections.model.NewConnectionContext.NewConnectionInfo;
 
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.resources.client.ClientBundle;
+import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.DockLayoutPanel;
+import com.google.gwt.user.client.ui.Image;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.ScrollPanel;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.gwt.user.client.ui.Widget;
 
 public class NewConnectionNavigationPage 
    extends WizardNavigationPage<NewConnectionContext, ConnectionOptions>
@@ -32,8 +48,20 @@ public class NewConnectionNavigationPage
                                       ImageResource icon,
                                       NewConnectionContext context)
    {
-      super(title, subTitle, "Create Connection", 
-            icon, null, createPages(context));
+      super(title, 
+            subTitle,
+            "Create Connection",
+            icon,
+            null, 
+            createPages(context),
+            new WizardNavigationPageProducer<NewConnectionContext, ConnectionOptions>()
+            {
+               @Override
+               public Widget createMainWidget(ArrayList<WizardPage<NewConnectionContext, ConnectionOptions>> pages)
+               {
+                  return createWidget(pages);
+               }
+            });
    }
    
    private static ArrayList<WizardPage<NewConnectionContext, 
@@ -53,4 +81,105 @@ public class NewConnectionNavigationPage
 
       return pages;
    }
+
+   private static Widget createWidget(ArrayList<WizardPage<NewConnectionContext, ConnectionOptions>> pages)
+   {
+      return new Selector(pages);
+   }
+
+   private static class Selector
+         extends Composite
+         implements HasWizardPageSelectionHandler<NewConnectionContext, ConnectionOptions>
+   {
+      public Selector(final ArrayList<WizardPage<NewConnectionContext, ConnectionOptions>> pages)
+      {
+         WizardResources.Styles styles = WizardResources.INSTANCE.styles();
+         
+         ScrollPanel scrollPanel = new ScrollPanel();
+         scrollPanel.setSize("100%", "100%");
+         scrollPanel.addStyleName(styles.wizardPageSelector());
+
+         VerticalPanel verticalPanel = new VerticalPanel();
+         verticalPanel.setSize("100%", "100%");
+
+         for (int i = 0, n = pages.size(); i < n; i++)
+         {
+            final WizardPage<NewConnectionContext, ConnectionOptions> page = pages.get(i);
+            SelectorItem item = new SelectorItem(page, new ClickHandler()
+            {
+               @Override
+               public void onClick(ClickEvent event)
+               {
+                  onSelected_.execute(page);
+               }
+            });
+            verticalPanel.add(item);
+         }
+
+         scrollPanel.add(verticalPanel);
+         initWidget(scrollPanel);
+      }
+      
+      @Override
+      public void setSelectionHandler(CommandWithArg<WizardPage<NewConnectionContext, ConnectionOptions>> onSelected)
+      {
+         onSelected_ = onSelected;
+      }
+      
+      private CommandWithArg<WizardPage<NewConnectionContext, ConnectionOptions>> onSelected_;
+   }
+   
+   private static class SelectorItem extends Composite
+   {
+      public SelectorItem(WizardPage<NewConnectionContext, ConnectionOptions> page,
+                          ClickHandler handler)
+      {
+         WizardResources.Styles styles = WizardResources.INSTANCE.styles();
+         
+         DockLayoutPanel panel = new DockLayoutPanel(Unit.PX);
+         panel.addStyleName(styles.wizardPageSelectorItem());
+         
+         panel.setSize("100%", "48px");
+         
+         Image rightArrow = new Image(WizardResources.INSTANCE.wizardDisclosureArrow());
+         rightArrow.addStyleName(RES.styles().rightArrow());
+         panel.addEast(rightArrow, 28);
+         
+         if (page.getImage() == null)
+         {
+            panel.addWest(new Label(""), 28);
+         }
+         else
+         {
+            Image icon = new Image(page.getImage());
+            icon.addStyleName(RES.styles().leftIcon());
+            panel.addWest(icon, 28);
+         }
+         
+         Label mainLabel = new Label(page.getTitle());
+         mainLabel.addStyleName(RES.styles().label());
+         mainLabel.getElement().setAttribute("title", page.getSubTitle());
+         panel.add(mainLabel);
+         
+         panel.addDomHandler(handler, ClickEvent.getType());
+         
+         initWidget(panel);
+      }
+   }
+   
+   public interface Styles extends CssResource
+   {
+      String leftIcon();
+      String rightArrow();
+      String label();
+   }
+   
+   public interface Resources extends ClientBundle
+   {
+      @Source("NewConnectionNavigationPage.css")
+      Styles styles();
+   }
+
+   private static Resources RES = GWT.create(Resources.class);
+   static { RES.styles().ensureInjected(); }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.java
@@ -139,7 +139,7 @@ public class NewConnectionNavigationPage
          DockLayoutPanel panel = new DockLayoutPanel(Unit.PX);
          panel.addStyleName(styles.wizardPageSelectorItem());
          
-         panel.setSize("100%", "48px");
+         panel.setSize("100%", "38px");
          
          Image rightArrow = new Image(WizardResources.INSTANCE.wizardDisclosureArrow());
          rightArrow.addStyleName(RES.styles().rightArrow());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyHost.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyHost.java
@@ -106,8 +106,6 @@ public class NewConnectionShinyHost extends Composite
       RStudioGinjector.INSTANCE.injectMembers(this);
       
       initWidget(createWidget());
-      
-      // setOkButtonCaption("Connect");
            
       HelpLink helpLink = new HelpLink(
             "Using Spark with RStudio",
@@ -159,25 +157,6 @@ public class NewConnectionShinyHost extends Composite
       // add the code panel     
       codePanel_ = new ConnectionCodePanel();
       codePanel_.addStyleName(RES.styles().dialogCodePanel());
-      final Command updateOKButtonCommand = new Command() {
-         @Override
-         public void execute()
-         {
-            // if (codePanel_.getConnectVia().equals(ConnectionOptions.CONNECT_COPY_TO_CLIPBOARD))
-            //   setOkButtonCaption("Copy");
-            //else
-            //   setOkButtonCaption("Connect");
-         }
-      };
-
-      updateOKButtonCommand.execute();
-      codePanel_.addConnectViaChangeHandler(new ChangeHandler() {
-         @Override
-         public void onChange(ChangeEvent event)
-         {
-            updateOKButtonCommand.execute();
-         }
-      });
       
       final Command updateCodeCommand = new Command() {
          @Override


### PR DESCRIPTION
Before,

<img width="529" alt="screen shot 2017-01-17 at 9 59 15 am" src="https://cloud.githubusercontent.com/assets/3478847/22025449/a2196f92-dc9b-11e6-966b-0fe17ab904a1.png">

after with scroll support:

<img width="530" alt="screen shot 2017-01-17 at 9 59 06 am" src="https://cloud.githubusercontent.com/assets/3478847/22025467/aa6dacc6-dc9b-11e6-9945-ef34eac65625.png">
