### PR TITLE
Add support for help links in wizards and connection extensions

### DIFF
--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -175,7 +175,8 @@ options(connectionObserver = list(
          package = .rs.scalar(con$package),
          name = .rs.scalar(con$name),
          type = .rs.scalar("Shiny"),
-         newConnection = paste(con$package, "::", .rs.scalar(con$shinyapp), "()", sep = "")
+         newConnection = paste(con$package, "::", .rs.scalar(con$shinyapp), "()", sep = ""),
+         help = .rs.scalar(con$help)
       )
    })
 

--- a/src/cpp/session/modules/connections/ConnectionsIndexer.cpp
+++ b/src/cpp/session/modules/connections/ConnectionsIndexer.cpp
@@ -66,14 +66,16 @@ public:
    
    ConnectionsIndexEntry(const std::string& name,
                          const std::string& package,
-                         const std::string& shinyapp)
-      : name_(name), package_(package), shinyapp_(shinyapp)
+                         const std::string& shinyapp,
+                         const std::string& help)
+      : name_(name), package_(package), shinyapp_(shinyapp), help_(help)
    {
    }
    
    const std::string& getName() const { return name_; }
    const std::string& getPackage() const { return package_; }
    const std::string& getShinyApp() const { return shinyapp_; }
+   const std::string& getHelp() const { return help_; }
 
    json::Object toJson() const
    {
@@ -81,7 +83,7 @@ public:
       
       object["name"] = name_;
       object["package"] = package_;
-      object["shinyapp"] = shinyapp_;
+      object["help"] = help_;
       
       return object;
    }
@@ -90,6 +92,7 @@ private:
    std::string name_;
    std::string package_;
    std::string shinyapp_;
+   std::string help_;
 };
 
 class ConnectionsRegistry : boost::noncopyable
@@ -107,7 +110,8 @@ public:
       add(pkgName, ConnectionsIndexEntry(
          fields["Name"],
          pkgName,
-         fields["ShinyApp"]));
+         fields["ShinyApp"],
+         fields["HelpUrl"]));
    }
 
    void add(const std::string& pkgName, const FilePath& connectionExtensionPath)

--- a/src/cpp/session/modules/connections/ConnectionsIndexer.cpp
+++ b/src/cpp/session/modules/connections/ConnectionsIndexer.cpp
@@ -83,6 +83,7 @@ public:
       
       object["name"] = name_;
       object["package"] = package_;
+      object["shinyapp"] = shinyapp_;
       object["help"] = help_;
       
       return object;

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -287,7 +287,11 @@ public abstract class ModalDialogBase extends DialogBox
    {
       leftButtonPanel_.add(widget);
    }
-   
+
+   protected void removeLeftWidget(Widget widget)
+   {
+      leftButtonPanel_.remove(widget);
+   }
 
    protected void addButton(ThemedButton button)
    {

--- a/src/gwt/src/org/rstudio/core/client/widget/Wizard.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/Wizard.css
@@ -84,3 +84,6 @@
    gwt-image: 'wizardPageBackground';
 }
 
+.helpLink {
+  margin-top: 6px;
+}

--- a/src/gwt/src/org/rstudio/core/client/widget/Wizard.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/Wizard.java
@@ -120,7 +120,7 @@ public class Wizard<I,T> extends ModalDialog<T>
       addActionButton(nextButton_);
    }
 
-   public void updateHelpLink(String caption, String link, boolean isRStudioLink) {
+   public void updateHelpLink(HelpLink helpLink) {
       if (helpLink_ == null) {
          WizardResources.Styles styles = WizardResources.INSTANCE.styles();
 
@@ -132,8 +132,8 @@ public class Wizard<I,T> extends ModalDialog<T>
          addLeftWidget(helpLink_);
       }
 
-      helpLink_.setCaption(caption);
-      helpLink_.setLink(link, isRStudioLink);
+      helpLink_.setCaption(helpLink.getCaption());
+      helpLink_.setLink(helpLink.getLink(), helpLink.isRStudioLink());
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/core/client/widget/Wizard.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/Wizard.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.theme.res.ThemeResources;
+import org.rstudio.studio.client.common.HelpLink;
 
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -117,6 +118,22 @@ public class Wizard<I,T> extends ModalDialog<T>
       });
       nextButton_.setVisible(false);
       addActionButton(nextButton_);
+   }
+
+   public void updateHelpLink(String caption, String link, boolean isRStudioLink) {
+      if (helpLink_ == null) {
+         WizardResources.Styles styles = WizardResources.INSTANCE.styles();
+
+         helpLink_ = new HelpLink(
+               "",
+               "",
+               false);
+         helpLink_.addStyleName(styles.helpLink());
+         addLeftWidget(helpLink_);
+      }
+
+      helpLink_.setCaption(caption);
+      helpLink_.setLink(link, isRStudioLink);
    }
 
    @Override
@@ -561,4 +578,5 @@ public class Wizard<I,T> extends ModalDialog<T>
    private WizardPage<I,T> activeParentNavigationPage_ = null;
    private boolean isAnimating_ = false;
    private boolean validating_ = false;
+   private HelpLink helpLink_ = null;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/Wizard.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/Wizard.java
@@ -121,6 +121,12 @@ public class Wizard<I,T> extends ModalDialog<T>
    }
 
    public void updateHelpLink(HelpLink helpLink) {
+      if (helpLink == null) {
+         if (helpLink_ != null) removeLeftWidget(helpLink_);
+         helpLink_ = null;
+         return;
+      }
+
       if (helpLink_ == null) {
          WizardResources.Styles styles = WizardResources.INSTANCE.styles();
 
@@ -469,6 +475,7 @@ public class Wizard<I,T> extends ModalDialog<T>
       
       activeParentNavigationPage_ = null;
       
+      onPageDeactivated(activePage_);
       activePage_.onDeactivate(new Operation() {
          public void execute() {
             animate(activePage_, toWidget, false, new Command() {
@@ -505,7 +512,10 @@ public class Wizard<I,T> extends ModalDialog<T>
    protected void onPageActivated(WizardPage<I,T> page, boolean okButtonVisible)
    {
    }
-    
+
+   protected void onPageDeactivated(WizardPage<I,T> page)
+   {
+   }
 
    protected void onSelectorActivated()
    {

--- a/src/gwt/src/org/rstudio/core/client/widget/WizardPage.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/WizardPage.java
@@ -16,6 +16,8 @@ package org.rstudio.core.client.widget;
 
 import java.util.ArrayList;
 
+import org.rstudio.studio.client.common.HelpLink;
+
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.Composite;
@@ -137,6 +139,11 @@ public abstract class WizardPage<I,T> extends Composite
    
    public void onWizardClosing()
    {
+   }
+
+   public HelpLink getHelpLink()
+   {
+      return null;
    }
    
    abstract protected Widget createWidget();

--- a/src/gwt/src/org/rstudio/core/client/widget/WizardResources.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/WizardResources.java
@@ -29,6 +29,7 @@ public interface WizardResources extends ClientBundle
       String mainWidget();
       String headerLabel();
       String headerPanel();
+      String helpLink();
       String subcaptionLabel();
       String wizardBodyPanel();
       String wizardPageSelector();

--- a/src/gwt/src/org/rstudio/studio/client/common/HelpLink.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/HelpLink.java
@@ -42,7 +42,8 @@ public class HelpLink extends Composite
                    String rstudioLink, 
                    final boolean withVersionInfo)
    {
-      rstudioLink_ = rstudioLink;
+      link_ = rstudioLink;
+      isRStudioLink_ = true;
       withVersionInfo_ = withVersionInfo;
 
       HorizontalPanel helpPanel = new HorizontalPanel();
@@ -54,9 +55,14 @@ public class HelpLink extends Composite
       helpLink_.addClickHandler(new ClickHandler() {
          public void onClick(ClickEvent event)
          {
+            if (isRStudioLink_) {
             RStudioGinjector.INSTANCE.getGlobalDisplay().openRStudioLink(
-                                                         rstudioLink_,
+                  link_,
                                                          withVersionInfo_);
+            }
+            else {
+               
+            }
          }  
       });
       helpPanel.add(helpLink_);
@@ -71,7 +77,14 @@ public class HelpLink extends Composite
    
    public void setLink(String link)
    {
-      rstudioLink_ = link;
+      link_ = link;
+      isRStudioLink_ = true;
+   }
+   
+   public void setLink(String link, Boolean isRStudioLink)
+   {
+      link_ = link;
+      isRStudioLink_ = isRStudioLink;
    }
    
    public void setWithVersionInfo(boolean withVersionInfo)
@@ -80,6 +93,7 @@ public class HelpLink extends Composite
    }
    
    private HyperlinkLabel helpLink_;
-   private String rstudioLink_;
+   private String link_;
+   private boolean isRStudioLink_;
    private boolean withVersionInfo_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/HelpLink.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/HelpLink.java
@@ -33,17 +33,25 @@ public class HelpLink extends Composite
       this("", "", true);
    }
    
-   public HelpLink(String caption, String rstudioLink)
+   public HelpLink(String caption, String link)
    {
-      this(caption, rstudioLink, true);
+      this(caption, link, true);
+   }
+   
+   public HelpLink(String caption,
+                   String link,
+                   final boolean withVersionInf)
+   {
+      this(caption, link, true, true);
    }
 
    public HelpLink(String caption, 
-                   String rstudioLink, 
-                   final boolean withVersionInfo)
+                   String link, 
+                   final boolean withVersionInfo,
+                   boolean isRStudioLink)
    {
-      link_ = rstudioLink;
-      isRStudioLink_ = true;
+      link_ = link;
+      isRStudioLink_ = isRStudioLink;
       withVersionInfo_ = withVersionInfo;
 
       HorizontalPanel helpPanel = new HorizontalPanel();
@@ -56,12 +64,12 @@ public class HelpLink extends Composite
          public void onClick(ClickEvent event)
          {
             if (isRStudioLink_) {
-            RStudioGinjector.INSTANCE.getGlobalDisplay().openRStudioLink(
+               RStudioGinjector.INSTANCE.getGlobalDisplay().openRStudioLink(
                   link_,
-                                                         withVersionInfo_);
+                  withVersionInfo_);
             }
             else {
-               
+               RStudioGinjector.INSTANCE.getGlobalDisplay().openWindow(link_);
             }
          }  
       });

--- a/src/gwt/src/org/rstudio/studio/client/common/HelpLink.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/HelpLink.java
@@ -74,6 +74,11 @@ public class HelpLink extends Composite
    {
       helpLink_.setText(caption);
    }
+
+   public String getCaption()
+   {
+      return helpLink_.getText();
+   }
    
    public void setLink(String link)
    {
@@ -85,6 +90,16 @@ public class HelpLink extends Composite
    {
       link_ = link;
       isRStudioLink_ = isRStudioLink;
+   }
+
+   public String getLink()
+   {
+      return link_;
+   }
+
+   public boolean isRStudioLink()
+   {
+      return isRStudioLink_;
    }
    
    public void setWithVersionInfo(boolean withVersionInfo)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/NewConnectionContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/NewConnectionContext.java
@@ -41,7 +41,11 @@ public class NewConnectionContext extends JavaScriptObject
       }-*/;
 
       public final native String getType() /*-{
-      	 return this["type"];
+         return this["type"];
+      }-*/;
+
+      public final native String getHelp() /*-{
+         return this["help"];
       }-*/;
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyHost.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyHost.java
@@ -106,13 +106,6 @@ public class NewConnectionShinyHost extends Composite
       RStudioGinjector.INSTANCE.injectMembers(this);
       
       initWidget(createWidget());
-           
-      HelpLink helpLink = new HelpLink(
-            "Using Spark with RStudio",
-            "using_spark",
-            false);
-      helpLink.addStyleName(RES.styles().helpLink());
-      // addLeftWidget(helpLink);
    }
 
    private void showError(String errorMessage)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyPage.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.connections.ui;
 
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.WizardPage;
@@ -71,9 +72,13 @@ public class NewConnectionShinyPage
    @Override
    public HelpLink getHelpLink()
    {
+      if (StringUtil.isNullOrEmpty(info_.getHelp()))
+         return null;
+
       return new HelpLink(
          "Using " + info_.getName(),
          info_.getHelp(),
+         false,
          false);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyPage.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.views.connections.ui;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.WizardPage;
+import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.workbench.views.connections.model.ConnectionOptions;
 import org.rstudio.studio.client.workbench.views.connections.model.NewConnectionContext;
 import org.rstudio.studio.client.workbench.views.connections.model.NewConnectionContext.NewConnectionInfo;
@@ -65,6 +66,15 @@ public class NewConnectionShinyPage
    @Override
    protected void initialize(NewConnectionContext initData)
    {
+   }
+
+   @Override
+   public HelpLink getHelpLink()
+   {
+      return new HelpLink(
+         "Using Spark with RStudio",
+         "using_spark",
+         false);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyPage.java
@@ -72,8 +72,8 @@ public class NewConnectionShinyPage
    public HelpLink getHelpLink()
    {
       return new HelpLink(
-         "Using Spark with RStudio",
-         "using_spark",
+         "Using " + info_.getName(),
+         info_.getHelp(),
          false);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionWizard.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionWizard.java
@@ -21,6 +21,7 @@ import org.rstudio.core.client.widget.WizardPage;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.connections.model.ConnectionOptions;
 import org.rstudio.studio.client.workbench.views.connections.model.ConnectionsServerOperations;
@@ -57,7 +58,8 @@ public class NewConnectionWizard extends Wizard<NewConnectionContext, Connection
                      WizardPage<NewConnectionContext, ConnectionOptions> page,
                      boolean okButtonVisible)
    {
-      updateHelpLink(page.getHelpLink());
+      HelpLink helpLink = page.getHelpLink();
+      if (helpLink != null) updateHelpLink(helpLink);
    }
    
    private static WizardPage<NewConnectionContext, ConnectionOptions>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionWizard.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionWizard.java
@@ -51,6 +51,14 @@ public class NewConnectionWizard extends Wizard<NewConnectionContext, Connection
 
       RStudioGinjector.INSTANCE.injectMembers(this); 
    }
+
+   @Override
+   protected void onPageActivated(
+                     WizardPage<NewConnectionContext, ConnectionOptions> page,
+                     boolean okButtonVisible)
+   {
+      updateHelpLink(page.getHelpLink());
+   }
    
    private static WizardPage<NewConnectionContext, ConnectionOptions>
       createFirstPage(NewConnectionContext input)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionWizard.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionWizard.java
@@ -58,8 +58,14 @@ public class NewConnectionWizard extends Wizard<NewConnectionContext, Connection
                      WizardPage<NewConnectionContext, ConnectionOptions> page,
                      boolean okButtonVisible)
    {
-      HelpLink helpLink = page.getHelpLink();
-      if (helpLink != null) updateHelpLink(helpLink);
+      updateHelpLink(page.getHelpLink());
+   }
+
+   @Override
+   protected void onPageDeactivated(
+                     WizardPage<NewConnectionContext, ConnectionOptions> page)
+   {
+      updateHelpLink(null);
    }
    
    private static WizardPage<NewConnectionContext, ConnectionOptions>


### PR DESCRIPTION
Add support for help links in wizards and connection extensions

 - [x] Add support for help link in wizards
 - [x] Add support for connections dialog
 - [x] Add support to specify help links from package

<img width="1011" alt="screen shot 2017-01-18 at 9 51 15 am" src="https://cloud.githubusercontent.com/assets/3478847/22068694/cecdd924-dd63-11e6-8f9b-307179b93db9.png">

New `DCF` fomat supports `HelpLink` as follows:

```
Name: Spark
ShinyApp: connection_spark_shinyapp
HelpUrl: http://spark.rstudio.com

Name: Spark NO URL
ShinyApp: connection_spark_shinyapp
```
