### PR TITLE
turn on terminal except on Windows where it remains behind feature key

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -1,7 +1,7 @@
 /*
  * Application.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -720,17 +720,31 @@ public class Application implements ApplicationEventHandlers
 
       // disable commands
       SessionInfo sessionInfo = session_.getSessionInfo();
-      if (!sessionInfo.getAllowShell())
+      
+      // TODO (gary) temporary windows-only logic for Shell/Terminal; remove
+      // once terminal is ready on all platforms
+      if (BrowseCap.isWindowsDesktop())
+      {
+         if (!uiPrefs_.get().enableXTerm().getValue())
+         {
+            commands_.newTerminal().remove();
+            commands_.activateTerminal().remove();
+         }
+         else
+         {
+            commands_.showShellDialog().remove();
+         }
+      }
+      else
       {
          commands_.showShellDialog().remove();
+         if (!sessionInfo.getAllowShell())
+         {
+            commands_.newTerminal().remove();
+            commands_.activateTerminal().remove();
+         }
       }
-      
-      // TODO (gary) temporary feature gate, switch to getAllowShell
-      if (!uiPrefs_.get().enableXTerm().getValue())
-      {
-         commands_.newTerminal().remove();
-         commands_.activateTerminal().remove();
-      }
+
       if (!sessionInfo.getAllowPackageInstallation())
       {
          commands_.installPackage().remove();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
@@ -1,7 +1,7 @@
 /*
  * ConsoleTabPanel.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,6 +16,7 @@ package org.rstudio.studio.client.workbench.ui;
 
 import java.util.ArrayList;
 
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.events.EnsureHiddenEvent;
 import org.rstudio.core.client.events.EnsureHiddenHandler;
 import org.rstudio.core.client.events.EnsureVisibleEvent;
@@ -258,7 +259,8 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
       terminalTabVisible_ = uiPrefs_.showTerminalTab().getValue();
 
       // TODO (gary) this is a temporary feature gate
-      if (terminalTabVisible_ && !uiPrefs_.enableXTerm().getValue())
+      if (terminalTabVisible_ && BrowseCap.isWindowsDesktop() && 
+            !uiPrefs_.enableXTerm().getValue())
       {
          terminalTabVisible_ = false;
       }


### PR DESCRIPTION
- Feature key "enable_xterm" now only applies on Windows desktop IDE; terminal is now on for IDE on all other platforms
- removed the modal Shell dialog entry points from the IDE (except, temporarily, in Windows, where it remains unless terminal is enabled)