### PR TITLE
Bug fix, refactoring, keyboard shortcuts

### DIFF
--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -64,6 +64,7 @@ set (SESSION_SOURCE_FILES
    SessionClientInit.cpp
    SessionConsoleInput.cpp
    SessionConsoleProcess.cpp
+   SessionConsoleProcessInfo.cpp
    SessionContentUrls.cpp
    SessionDirs.cpp
    SessionRpc.cpp

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -25,6 +25,7 @@
 #include <core/Exec.hpp>
 #include <core/SafeConvert.hpp>
 #include <core/Settings.hpp>
+#include <core/FileSerializer.hpp>
 
 #include <core/system/Environment.hpp>
 

--- a/src/cpp/session/SessionConsoleProcessInfo.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfo.cpp
@@ -1,0 +1,224 @@
+/*
+ * SessionConsoleProcessInfo.cpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <session/SessionConsoleProcessInfo.hpp>
+
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace session {
+namespace console_process_info {
+
+namespace {
+   const size_t OUTPUT_BUFFER_SIZE = 8192;
+} // anonymous namespace
+
+const int kDefaultMaxOutputLines = 500;
+const int kDefaultTerminalMaxOutputLines = 1000; // xterm.js scrollback constant
+const int kNoTerminal = 0; // terminal sequence number for a non-terminal
+
+ConsoleProcessInfo::ConsoleProcessInfo()
+   :
+     terminalSequence_(kNoTerminal),
+     allowRestart_(false),
+     dialog_(false),
+     interactionMode_(InteractionNever),
+     maxOutputLines_(kDefaultMaxOutputLines),
+     showOnOutput_(false),
+     outputBuffer_(OUTPUT_BUFFER_SIZE),
+     started_(true),
+     childProcs_(true)
+{
+   // When we retrieve from outputBuffer, we only want complete lines. Add a
+   // dummy \n so we can tell the first line is a complete line.
+   outputBuffer_.push_back('\n');
+}
+
+ConsoleProcessInfo::ConsoleProcessInfo(
+         const std::string& caption,
+         const std::string& title,
+         const std::string& handle,
+         const int terminalSequence,
+         bool allowRestart,
+         bool dialog,
+         InteractionMode mode,
+         int maxOutputLines)
+   :
+     caption_(caption),
+     title_(title),
+     handle_(handle),
+     terminalSequence_(terminalSequence),
+     allowRestart_(allowRestart),
+     dialog_(dialog),
+     interactionMode_(mode),
+     maxOutputLines_(maxOutputLines),
+     showOnOutput_(false),
+     outputBuffer_(OUTPUT_BUFFER_SIZE),
+     started_(false),
+     childProcs_(true)
+{
+}
+
+void ConsoleProcessInfo::setCaption(std::string& caption)
+{
+   caption_ = caption;
+}
+
+void ConsoleProcessInfo::setTitle(std::string& title)
+{
+   title_ = title;
+}
+
+void ConsoleProcessInfo::setHandle(std::string& handle)
+{
+   handle_ = handle;
+}
+
+void ConsoleProcessInfo::setTerminalSequence(int sequence)
+{
+   terminalSequence_ = sequence;
+}
+
+void ConsoleProcessInfo::setAllowRestart(bool allowRestart)
+{
+   allowRestart_ = allowRestart;
+}
+
+void ConsoleProcessInfo::setDialog(bool dialog)
+{
+   dialog_ = dialog;
+}
+
+void ConsoleProcessInfo::setInteractionMode(InteractionMode mode)
+{
+   interactionMode_ = mode;
+}
+
+void ConsoleProcessInfo::setMaxOutputLines(int maxOutputLines)
+{
+   maxOutputLines_ = maxOutputLines;
+}
+
+void ConsoleProcessInfo::setShowOnOutput(bool showOnOutput)
+{
+   showOnOutput_ = showOnOutput;
+}
+
+void ConsoleProcessInfo::clearExitCode()
+{
+   exitCode_.reset();
+}
+
+void ConsoleProcessInfo::setExitCode(int exitCode)
+{
+   exitCode_.reset(exitCode);
+}
+
+void ConsoleProcessInfo::setIsStarted(bool started)
+{
+   started_ = started;
+}
+
+void ConsoleProcessInfo::appendToOutputBuffer(const std::string &str)
+{
+   std::copy(str.begin(), str.end(), std::back_inserter(outputBuffer_));
+}
+
+std::string ConsoleProcessInfo::bufferedOutput() const
+{
+   boost::circular_buffer<char>::const_iterator pos =
+         std::find(outputBuffer_.begin(), outputBuffer_.end(), '\n');
+
+   std::string result;
+   if (pos != outputBuffer_.end())
+      pos++;
+   std::copy(pos, outputBuffer_.end(), std::back_inserter(result));
+   // Will be empty if the buffer was overflowed by a single line
+   return result;
+}
+
+core::json::Object ConsoleProcessInfo::toJson() const
+{
+   json::Object result;
+   result["handle"] = handle_;
+   result["caption"] = caption_;
+   result["dialog"] = dialog_;
+   result["show_on_output"] = showOnOutput_;
+   result["interaction_mode"] = static_cast<int>(interactionMode_);
+   result["max_output_lines"] = maxOutputLines_;
+   result["buffered_output"] = bufferedOutput();
+   if (exitCode_)
+      result["exit_code"] = *exitCode_;
+   else
+      result["exit_code"] = json::Value();
+
+   // newly added in v1.1
+   result["terminal_sequence"] = terminalSequence_;
+   result["allow_restart"] = allowRestart_;
+   result["started"] = started_;
+   result["title"] = title_;
+   result["childProcs"] = childProcs_;
+
+   return result;
+}
+
+boost::shared_ptr<ConsoleProcessInfo> ConsoleProcessInfo::fromJson(core::json::Object& obj)
+{
+   boost::shared_ptr<ConsoleProcessInfo> pProc(new ConsoleProcessInfo());
+   pProc->handle_ = obj["handle"].get_str();
+   pProc->caption_ = obj["caption"].get_str();
+   pProc->dialog_ = obj["dialog"].get_bool();
+
+   json::Value showOnOutput = obj["show_on_output"];
+   if (!showOnOutput.is_null())
+      pProc->showOnOutput_ = showOnOutput.get_bool();
+   else
+      pProc->showOnOutput_ = false;
+
+   json::Value mode = obj["interaction_mode"];
+   if (!mode.is_null())
+      pProc->interactionMode_ = static_cast<InteractionMode>(mode.get_int());
+   else
+      pProc->interactionMode_ = InteractionNever;
+
+   json::Value maxLines = obj["max_output_lines"];
+   if (!maxLines.is_null())
+      pProc->maxOutputLines_ = maxLines.get_int();
+   else
+      pProc->maxOutputLines_ = kDefaultMaxOutputLines;
+
+   std::string bufferedOutput = obj["buffered_output"].get_str();
+   std::copy(bufferedOutput.begin(), bufferedOutput.end(),
+             std::back_inserter(pProc->outputBuffer_));
+   json::Value exitCode = obj["exit_code"];
+   if (exitCode.is_null())
+      pProc->exitCode_.reset();
+   else
+      pProc->exitCode_.reset(exitCode.get_int());
+
+   // Newly added in v1.1; 1.1 is reading/writing this to a different place
+   // than pre 1.1, so don't worry about mismatched json.
+   pProc->terminalSequence_ = obj["terminal_sequence"].get_int();
+   pProc->allowRestart_ = obj["allow_restart"].get_bool();
+   pProc->started_ = obj["started"].get_bool();
+   pProc->title_ = obj["title"].get_str();
+   pProc->childProcs_ = obj["childProcs"].get_bool();
+
+   return pProc;
+}
+
+} // namespace console_process_info
+} // namespace session
+} // namespace rstudio

--- a/src/cpp/session/SessionConsoleProcessInfo.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfo.cpp
@@ -32,16 +32,11 @@ const int kDefaultTerminalMaxOutputLines = 1000; // xterm.js scrollback constant
 const int kNoTerminal = 0; // terminal sequence number for a non-terminal
 
 ConsoleProcessInfo::ConsoleProcessInfo()
-   :
-     terminalSequence_(kNoTerminal),
-     allowRestart_(false),
-     dialog_(false),
-     interactionMode_(InteractionNever),
+   : terminalSequence_(kNoTerminal), allowRestart_(false),
+     dialog_(false), interactionMode_(InteractionNever),
      maxOutputLines_(kDefaultMaxOutputLines),
-     showOnOutput_(false),
-     outputBuffer_(OUTPUT_BUFFER_SIZE),
-     started_(true),
-     childProcs_(true)
+     showOnOutput_(false), outputBuffer_(OUTPUT_BUFFER_SIZE),
+     started_(true), childProcs_(true)
 {
    // When we retrieve from outputBuffer, we only want complete lines. Add a
    // dummy \n so we can tell the first line is a complete line.
@@ -57,19 +52,11 @@ ConsoleProcessInfo::ConsoleProcessInfo(
          bool dialog,
          InteractionMode mode,
          int maxOutputLines)
-   :
-     caption_(caption),
-     title_(title),
-     handle_(handle),
-     terminalSequence_(terminalSequence),
-     allowRestart_(allowRestart),
-     dialog_(dialog),
-     interactionMode_(mode),
-     maxOutputLines_(maxOutputLines),
-     showOnOutput_(false),
-     outputBuffer_(OUTPUT_BUFFER_SIZE),
-     started_(false),
-     childProcs_(true)
+   : caption_(caption), title_(title), handle_(handle),
+     terminalSequence_(terminalSequence), allowRestart_(allowRestart),
+     dialog_(dialog), interactionMode_(mode), maxOutputLines_(maxOutputLines),
+     showOnOutput_(false), outputBuffer_(OUTPUT_BUFFER_SIZE),
+     started_(false), childProcs_(true)
 {
 }
 

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -25,10 +25,6 @@
 #include <boost/enable_shared_from_this.hpp>
 
 #include <core/system/Process.hpp>
-#include <core/Log.hpp>
-
-#include <core/FileSerializer.hpp>
-#include <core/json/Json.hpp>
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
@@ -1,0 +1,144 @@
+/*
+ * SessionConsoleProcessInfo.hpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+#ifndef SESSION_CONSOLE_PROCESS_INFO_HPP
+#define SESSION_CONSOLE_PROCESS_INFO_HPP
+
+#include <boost/circular_buffer.hpp>
+#include <boost/enable_shared_from_this.hpp>
+
+#include <core/json/Json.hpp>
+
+namespace rstudio {
+namespace core {
+   class Error;
+}
+}
+
+namespace rstudio {
+namespace session {
+namespace console_process_info {
+
+enum InteractionMode
+{
+   InteractionNever = 0,
+   InteractionPossible = 1,
+   InteractionAlways = 2
+};
+
+extern const int kDefaultMaxOutputLines;
+extern const int kDefaultTerminalMaxOutputLines;
+extern const int kNoTerminal;
+
+// ConsoleProcess metadata that is persisted, and sent to the client on
+// create/reconnect
+class ConsoleProcessInfo : boost::noncopyable,
+                           public boost::enable_shared_from_this<ConsoleProcessInfo>
+{
+private:
+   // This constructor is only for resurrecting orphaned processes (i.e. for
+   // suspend/resume scenarios)
+   ConsoleProcessInfo();
+
+public:
+   ConsoleProcessInfo(
+         const std::string& caption,
+         const std::string& title,
+         const std::string& handle,
+         const int terminalSequence,
+         bool allowRestart,
+         bool dialog,
+         InteractionMode mode,
+         int maxOutputLines = kDefaultMaxOutputLines);
+
+   virtual ~ConsoleProcessInfo() {}
+
+   // Caption is shown on terminal tabs, e.g. Terminal 1
+   void setCaption(std::string& caption);
+   std::string getCaption() const { return caption_; }
+
+   // Title is set by terminal escape sequence, typically to show current dir
+   void setTitle(std::string& title);
+   std::string getTitle() const { return title_; }
+
+   // Handle client uses to refer to this process
+   void setHandle(std::string& handle);
+   std::string getHandle() const { return handle_; }
+
+   // Sequence number of the associated terminal; used to control display
+   // order of terminal tabs; constant 'kNoTerminal' indicates a non-terminal
+   void setTerminalSequence(int sequence);
+   int getTerminalSequence() const { return terminalSequence_; }
+
+   // Whether a ConsoleProcess object should start a new process on resume after
+   // its process has been killed by a suspend.
+   void setAllowRestart(bool allowRestart);
+   bool getAllowRestart() const { return allowRestart_; }
+
+   // Whether process is being associate with a dialog
+   // TODO (gary) review if we still need this
+   void setDialog(bool dialog);
+   bool getDialog() const { return dialog_; }
+
+   void setInteractionMode(InteractionMode mode);
+   InteractionMode getInteractionMode() const { return interactionMode_; }
+
+   void setMaxOutputLines(int maxOutputLines);
+   int getMaxOutputLines() const { return maxOutputLines_; }
+
+   void setShowOnOutput(bool showOnOutput);
+   int getShowOnOutput() const { return showOnOutput_; }
+
+   // Buffer output in case client disconnects/reconnects and needs
+   // to recover some history. Used for modal dialog shell, not terminal
+   // tabs.
+   void appendToOutputBuffer(const std::string &str);
+   std::string bufferedOutput() const;
+
+   // Has the process exited, and what was the exit code?
+   void clearExitCode();
+   void setExitCode(int exitCode);
+   boost::optional<int> getExitCode() const { return exitCode_; }
+
+   // Whether the process has been successfully started
+   void setIsStarted(bool started);
+   bool isStarted() const { return started_; }
+
+   // Does this process have child processes?
+   void setHasChildProcs(bool hasChildProcs);
+   bool getHasChildProcs() const { return childProcs_; }
+   core::json::Object toJson() const;
+   static boost::shared_ptr<ConsoleProcessInfo> fromJson(core::json::Object& obj);
+
+private:
+   std::string caption_;
+   std::string title_;
+   std::string handle_;
+   int terminalSequence_;
+   bool allowRestart_;
+   bool dialog_;
+   InteractionMode interactionMode_;
+   int maxOutputLines_;
+   bool showOnOutput_;
+   boost::circular_buffer<char> outputBuffer_;
+   boost::optional<int> exitCode_;
+   bool started_;
+   bool childProcs_;
+};
+
+} // namespace console_process_info
+} // namespace session
+} // namespace rstudio
+
+#endif // SESSION_CONSOLE_PROCESS_INFO_HPP

--- a/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
@@ -28,7 +28,7 @@ namespace core {
 
 namespace rstudio {
 namespace session {
-namespace console_process_info {
+namespace console_process {
 
 enum InteractionMode
 {
@@ -65,59 +65,61 @@ public:
    virtual ~ConsoleProcessInfo() {}
 
    // Caption is shown on terminal tabs, e.g. Terminal 1
-   void setCaption(std::string& caption);
+   void setCaption(std::string& caption) { caption_ = caption; }
    std::string getCaption() const { return caption_; }
 
    // Title is set by terminal escape sequence, typically to show current dir
-   void setTitle(std::string& title);
+   void setTitle(std::string& title) { title_ = title; }
    std::string getTitle() const { return title_; }
 
    // Handle client uses to refer to this process
-   void setHandle(std::string& handle);
+   void ensureHandle();
    std::string getHandle() const { return handle_; }
 
    // Sequence number of the associated terminal; used to control display
    // order of terminal tabs; constant 'kNoTerminal' indicates a non-terminal
-   void setTerminalSequence(int sequence);
+   void setTerminalSequence(int sequence) { terminalSequence_ = sequence; }
    int getTerminalSequence() const { return terminalSequence_; }
 
    // Whether a ConsoleProcess object should start a new process on resume after
    // its process has been killed by a suspend.
-   void setAllowRestart(bool allowRestart);
+   void setAllowRestart(bool allowRestart) { allowRestart_ = allowRestart; }
    bool getAllowRestart() const { return allowRestart_; }
 
    // Whether process is being associate with a dialog
    // TODO (gary) review if we still need this
-   void setDialog(bool dialog);
+   void setDialog(bool dialog) { dialog_ = dialog; }
    bool getDialog() const { return dialog_; }
 
-   void setInteractionMode(InteractionMode mode);
+   void setInteractionMode(InteractionMode mode) { interactionMode_ = mode; }
    InteractionMode getInteractionMode() const { return interactionMode_; }
 
-   void setMaxOutputLines(int maxOutputLines);
+   void setMaxOutputLines(int maxOutputLines) { maxOutputLines_ = maxOutputLines; }
    int getMaxOutputLines() const { return maxOutputLines_; }
 
-   void setShowOnOutput(bool showOnOutput);
+   void setShowOnOutput(bool showOnOutput) { showOnOutput_ = showOnOutput; }
    int getShowOnOutput() const { return showOnOutput_; }
 
    // Buffer output in case client disconnects/reconnects and needs
-   // to recover some history. Used for modal dialog shell, not terminal
-   // tabs.
+   // to recover some history. Not used for terminal tabs.
    void appendToOutputBuffer(const std::string &str);
+   void appendToOutputBuffer(char ch);
    std::string bufferedOutput() const;
 
    // Has the process exited, and what was the exit code?
-   void clearExitCode();
    void setExitCode(int exitCode);
    boost::optional<int> getExitCode() const { return exitCode_; }
 
    // Whether the process has been successfully started
-   void setIsStarted(bool started);
+   void setIsStarted(bool started) { started_ = started; }
    bool isStarted() const { return started_; }
 
    // Does this process have child processes?
-   void setHasChildProcs(bool hasChildProcs);
+   void setHasChildProcs(bool hasChildProcs) { childProcs_ = hasChildProcs; }
    bool getHasChildProcs() const { return childProcs_; }
+
+   void onSuspend();
+
    core::json::Object toJson() const;
    static boost::shared_ptr<ConsoleProcessInfo> fromJson(core::json::Object& obj);
 
@@ -137,7 +139,7 @@ private:
    bool childProcs_;
 };
 
-} // namespace console_process_info
+} // namespace console_process
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/SessionDependencies.cpp
+++ b/src/cpp/session/modules/SessionDependencies.cpp
@@ -398,18 +398,23 @@ Error installDependencies(const json::JsonRpcRequest& request,
    args.push_back("-e");
    args.push_back(cmd);
 
+   boost::shared_ptr<console_process::ConsoleProcessInfo> pCPI =
+         boost::make_shared<console_process::ConsoleProcessInfo>(
+            "Installing Packages",
+            "" /*title*/,
+            "" /*handle*/,
+            console_process::kNoTerminal,
+            false /*allowRestart*/,
+            true /*dialog*/,
+            console_process::InteractionNever);
+
    // create and execute console process
    boost::shared_ptr<console_process::ConsoleProcess> pCP;
    pCP = console_process::ConsoleProcess::create(
             string_utils::utf8ToSystem(rProgramPath.absolutePath()),
             args,
             options,
-            "Installing Packages",
-            "" /*title*/,
-            console_process::kNoTerminal,
-            false /*allowRestart*/,
-            true /*dialog*/,
-            console_process::InteractionNever);
+            pCPI);
 
    // return console process
    pResponse->setResult(pCP->toJson());

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -312,27 +312,15 @@ protected:
       else if (!workingDir.get().empty())
          options.workingDir = workingDir.get();
 
+      boost::shared_ptr<ConsoleProcessInfo> pCPI =
+            boost::make_shared<ConsoleProcessInfo>(
+               caption, "" /*title*/, "" /*handle*/, kNoTerminal,
+               false /*allowRestart*/, dialog, console_process::InteractionNever);
+
 #ifdef _WIN32
-      *ppCP = ConsoleProcess::create(gitBin(),
-                                     args.args(),
-                                     options,
-                                     caption,
-                                     "" /*title*/,
-                                     kNoTerminal,
-                                     false /*allowRestart*/,
-                                     dialog,
-                                     console_process::InteractionNever,
-                                     console_process::kDefaultMaxOutputLines);
+      *ppCP = ConsoleProcess::create(gitBin(), args.args(), options, pCPI);
 #else
-      *ppCP = ConsoleProcess::create(git() << args.args(),
-                                     options,
-                                     caption,
-                                     "" /*title*/,
-                                     kNoTerminal,
-                                     false /*allowRestart*/,
-                                     dialog,
-                                     console_process::InteractionNever,
-                                     console_process::kDefaultMaxOutputLines);
+      *ppCP = ConsoleProcess::create(git() << args.args(), options, pCPI);
 #endif
 
       (*ppCP)->onExit().connect(boost::bind(&enqueueRefreshEvent));

--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -267,17 +267,13 @@ core::Error createConsoleProc(const ShellArgs& args,
    if (!outputFile.empty())
       options.stdOutFile = outputFile;
 
-   // create the process
    using namespace session::console_process;
-   *ppCP = ConsoleProcess::create(command,
-                                  options,
-                                  caption,
-                                  "" /*title*/,
-                                  kNoTerminal,
-                                  false /*allowRestart*/,
-                                  dialog,
-                                  InteractionPossible,
-                                  kDefaultMaxOutputLines);
+   boost::shared_ptr<ConsoleProcessInfo> pCPI = boost::make_shared<ConsoleProcessInfo>(
+            caption, "" /*title*/, "" /*handle*/, kNoTerminal,
+            false /*allowRestart*/, dialog, InteractionPossible);
+
+   // create the process
+   *ppCP = ConsoleProcess::create(command, options, pCPI);
 
    if (enqueueRefreshOnExit)
       (*ppCP)->onExit().connect(boost::bind(&enqueueRefreshEvent));

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -963,19 +963,16 @@ Error startShellDialog(const json::JsonRpcRequest& request,
 
    if (termCaption.empty())
       termCaption = "Shell";
-   
+
+   boost::shared_ptr<ConsoleProcessInfo> ptrProcInfo =
+         boost::make_shared<ConsoleProcessInfo>(
+            termCaption, termTitle, termHandle, termSequence, allowRestart,
+            isModalDialog, InteractionAlways,
+            console_process::kDefaultTerminalMaxOutputLines);
+
    // run process
    boost::shared_ptr<ConsoleProcess> ptrProc =
-               ConsoleProcess::createTerminalProcess(
-                                      options,
-                                      termCaption,
-                                      termTitle,
-                                      termHandle,
-                                      termSequence,
-                                      allowRestart,
-                                      isModalDialog,
-                                      InteractionAlways,
-                                      console_process::kDefaultTerminalMaxOutputLines);
+               ConsoleProcess::createTerminalProcess(options, ptrProcInfo);
 
    ptrProc->onExit().connect(boost::bind(
                               &source_control::enqueueRefreshEvent));

--- a/src/cpp/session/modules/connections/SessionConnections.cpp
+++ b/src/cpp/session/modules/connections/SessionConnections.cpp
@@ -460,17 +460,22 @@ Error installSpark(const json::JsonRpcRequest& request,
    args.push_back("-e");
    args.push_back(cmd);
 
+   boost::shared_ptr<console_process::ConsoleProcessInfo> pCPI =
+         boost::make_shared<console_process::ConsoleProcessInfo>(
+            "Installing Spark " + sparkVersion,
+            "" /*title*/,
+            "" /*handle*/,
+            console_process::kNoTerminal, false /*allowRestart*/,
+            true /*isDialog*/,
+            console_process::InteractionNever);
+
    // create and execute console process
    boost::shared_ptr<console_process::ConsoleProcess> pCP;
    pCP = console_process::ConsoleProcess::create(
             string_utils::utf8ToSystem(rProgramPath.absolutePath()),
             args,
             options,
-            "Installing Spark " + sparkVersion,
-            "" /*title*/,
-            console_process::kNoTerminal, false /*allowRestart*/,
-            true /*isDialog*/,
-            console_process::InteractionNever);
+            pCPI);
 
    // return console process
    pResponse->setResult(pCP->toJson());

--- a/src/gwt/src/org/rstudio/core/client/widget/ShortcutInfoPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ShortcutInfoPanel.java
@@ -83,7 +83,7 @@ public class ShortcutInfoPanel extends Composite
             new String[] { "Tabs", "Panes", "Files" },
             new String[] { "Source Navigation", "Execute" },
             new String[] { "Source Editor", "Debug" }, 
-            new String[] { "Source Control", "Build", "Console", "Other" }
+            new String[] { "Source Control", "Build", "Console", "Terminal", "Other" }
       };
       int pctWidth = 100 / groupNames.length;
       sb.appendHtmlConstant("<table width='100%'><tr>");

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcess.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcess.java
@@ -1,7 +1,7 @@
 /*
  * ConsoleProcess.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -219,29 +219,7 @@ public class ConsoleProcess implements ConsoleOutputEvent.HasHandlers,
                                                                eventBus_,
                                                                procInfo));
       }
-      
-      public ConsoleProgressDialog showConsoleProgressDialog(
-                                                ConsoleProcessInfo procInfo)
-      {
-         ConsoleProcess proc = new ConsoleProcess(server_,
-                                                  eventBus_,
-                                                  procInfo);
 
-         ConsoleProgressDialog dlg = new ConsoleProgressDialog(
-               procInfo.getCaption(),
-               proc,
-               procInfo.getBufferedOutput(),
-               procInfo.getExitCode(),
-               cryptoServer_);
-
-         if (procInfo.getShowOnOutput())
-            dlg.showOnOutput();
-         else
-            dlg.showModal();
-         
-         return dlg;
-      }
-      
       /**
        * Terminate and reap a process
        * @param handle process to kill and reap

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -603,6 +603,7 @@ well as menu structures (for main menu and popup menus).
          
          <shortcut refid="activateSource" value="Ctrl+1"/>
          <shortcut refid="activateConsole" value="Ctrl+2"/>
+         <shortcut refid="activateTerminal" value="Ctrl+Shift+T"/>
          <shortcut refid="activateHelp" value="Ctrl+3"/>
          <shortcut refid="activateHistory" value="Ctrl+4"/>
          <shortcut refid="activateFiles" value="Ctrl+5"/>
@@ -729,6 +730,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="showOptions" value="Meta+," if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="projectOptions" value="Shift+Meta+," if="org.rstudio.core.client.BrowseCap.isMacintosh()"/> 
          <shortcut refid="goToHelp" value="Ctrl+C Ctrl+V" disableModes="default,vim"/>
+         <shortcut refid="newTerminal" value="Alt+Shift+T"/>
       </shortcutgroup>
       <shortcutgroup name="Console">
          <shortcut refid="consoleClear" value="Ctrl+L" disableModes="emacs"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -429,7 +429,18 @@ well as menu structures (for main menu and popup menus).
          </menu>
          <separator/>
          <cmd refid="showShellDialog"/>
-         <cmd refid="newTerminal"/>
+         <menu label="Terminal">
+            <cmd refid="newTerminal"/>
+            <separator/>
+            <cmd refid="renameTerminal"/>
+            <cmd refid="clearTerminalScrollbackBuffer"/>
+            <separator/>
+            <cmd refid="activateTerminal"/>
+            <cmd refid="previousTerminal"/>
+            <cmd refid="nextTerminal"/>
+            <separator/>
+            <cmd refid="closeTerminal"/>
+          </menu>
          <menu label="Addins">
             <cmd refid="addinsMru0"/>
             <cmd refid="addinsMru1"/>
@@ -730,11 +741,17 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="showOptions" value="Meta+," if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="projectOptions" value="Shift+Meta+," if="org.rstudio.core.client.BrowseCap.isMacintosh()"/> 
          <shortcut refid="goToHelp" value="Ctrl+C Ctrl+V" disableModes="default,vim"/>
-         <shortcut refid="newTerminal" value="Alt+Shift+T"/>
       </shortcutgroup>
       <shortcutgroup name="Console">
          <shortcut refid="consoleClear" value="Ctrl+L" disableModes="emacs"/>
          <shortcut value="Cmd+Up" title="Popup Command History"/>
+      </shortcutgroup>
+      <shortcutgroup name="Terminal">
+         <shortcut refid="newTerminal" value="Alt+Shift+T"/>
+         <shortcut refid="renameTerminal" value="Alt+Shift+R"/>
+         <shortcut refid="clearTerminalScrollbackBuffer" value="Ctrl+Shift+L"/>
+         <shortcut refid="previousTerminal" value="Ctrl+Alt+F11"/>
+         <shortcut refid="nextTerminal" value="Ctrl+Alt+F12"/>
       </shortcutgroup>
 
       <!-- 

--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -759,6 +759,38 @@
     <td>Command+Shift+F10</td>
   </tr>
   <tr><td><br/></td></tr>
+  <tr><td colspan="3"><h3>Terminal</h3></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
+  <tr>
+    <td>New Terminal</td>
+    <td>Shift+Alt+T</td>
+    <td>Shift+Option+T</td>
+  </tr>
+  <tr>
+    <td>Rename Current Terminal</td>
+    <td>Shift+Alt+R</td>
+    <td>Shift+Option+R</td>
+  </tr>
+  <tr>
+    <td>Clear Current Terminal</td>
+    <td>Ctrl+Shift+L</td>
+    <td>Ctrl+Shift+L</td>
+  </tr>
+  <tr>
+    <td>Move Focus to Terminal</td>
+    <td>Ctrl+Shift+T</td>
+    <td>Ctrl+Shift+T</td>
+  </tr>
+  <tr>
+    <td>Previous Terminal</td>
+    <td>Ctrl+Alt+F11</td>
+    <td>Ctrl+Option+F11</td>
+  </tr>
+  <tr>
+    <td>Next Terminal</td>
+    <td>Ctrl+Alt+F12</td>
+    <td>Ctrl+Option+F12</td>
+  </tr>
+  <tr><td><br/></td></tr>
 </table>
 </div>
    


### PR DESCRIPTION
- Bug fix where extra terminal processes were being started after browser refresh.
- Factor out some code from ConsoleProcess class into ConsoleProcessInfo class.
- Add keyboard shortcuts to terminal commands.
- Add terminal commands to a new submenu off the Tools menu.