### PR TITLE
use curl to match readr download behavior

### DIFF
--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -354,11 +354,11 @@
          cacheDataCode <- append(cacheDataCode, list(
             paste(
                downloadCondition,
-               "download.file(",
+               "curl::curl_download(",
                cacheUrlName,
                ", ",
                cacheVariableName,
-               ", method = \"curl\")",
+               ")",
                sep = ""
             )
          ))

--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -358,7 +358,7 @@
                cacheUrlName,
                ", ",
                cacheVariableName,
-               ")",
+               ", method = \"curl\")",
                sep = ""
             )
          ))

--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -354,7 +354,7 @@
          cacheDataCode <- append(cacheDataCode, list(
             paste(
                downloadCondition,
-               "curl::curl_download(",
+               if (.rs.isPackageInstalled("curl")) "curl::curl_download(" else "download.file(",
                cacheUrlName,
                ", ",
                cacheVariableName,


### PR DESCRIPTION
The preview to import CSV form https://data.consumerfinance.gov/api/views/s6ew-h6mp/rows.csv?accessType=DOWNLOAD does not work but the file can be imported.

The problem is that `download.file` fails from the IDE, while this works from `readr` since readr appears to be using curls: https://github.com/tidyverse/readr/blob/3715a2d0bcd7e028b4c0ffe03fce0fd7063ede18/R/source.R#L105

Fix is to match `readr` behavior in the IDE to allow us to download this file for preview purpuses.