### PR TITLE
Fix: Bash not processing startup files in terminal tab

### DIFF
--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -1,7 +1,7 @@
 /*
  * PosixChildProcess.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -253,7 +253,10 @@ void ChildProcess::init(const ProcessOptions& options)
 
    std::vector<std::string> args;
    args.push_back("bash");
-   args.push_back("--norc");
+   if (!options.smartTerminal)
+      args.push_back("--norc"); // don't read .bashrc for interactive shell
+   else
+      args.push_back("-l"); // act like a login shell
    init("/usr/bin/env", args, options);
 }
 

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionWorkbench.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -917,11 +917,13 @@ Error startShellDialog(const json::JsonRpcRequest& request,
    core::system::setenv(&shellEnv, "TERM", smartTerm ? core::system::kSmartTerm :
                                                        core::system::kDumbTerm);
 
-   // set prompt
-   std::string path = module_context::createAliasedPath(
-                                 module_context::safeCurrentPath());
-   std::string prompt = (path.length() > 30) ? "\\W$ " : "\\w$ ";
-   core::system::setenv(&shellEnv, "PS1", prompt);
+   if (!smartTerm)
+   {
+      std::string path = module_context::createAliasedPath(
+               module_context::safeCurrentPath());
+      std::string prompt = (path.length() > 30) ? "\\W$ " : "\\w$ ";
+      core::system::setenv(&shellEnv, "PS1", prompt);
+   }
 
    // set xterm title to show current working directory after each command
    if (smartTerm)
@@ -1107,7 +1109,7 @@ Error initialize()
 }
 
 
-} // namepsace workbench
+} // namespace workbench
 } // namespace modules
 } // namesapce session
 } // namespace rstudio

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -1111,6 +1111,6 @@ Error initialize()
 
 } // namespace workbench
 } // namespace modules
-} // namesapce session
+} // namespace session
 } // namespace rstudio
 


### PR DESCRIPTION
In terminal tabs, start bash as an interactive login shell so regular startup file processing happens (versus launching with —norc and a pre-determined prompt, which still happens for non-terminal cases).