### PR TITLE
Prevent incorrect terminal process state after crash/forced shutdown

### DIFF
--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -114,7 +114,7 @@ public:
    void interrupt();
    void resize(int cols, int rows);
    void onSuspend();
-   bool isStarted() { return procInfo_->isStarted(); }
+   bool isStarted() { return started_; }
    void setCaption(std::string& caption) { procInfo_->setCaption(caption); }
    void setTitle(std::string& title) { procInfo_->setTitle(title); }
    void deleteLogFile() const;
@@ -169,6 +169,9 @@ private:
    // regex for prompt detection
    boost::regex controlCharsPattern_;
    boost::regex promptPattern_;
+
+   // is the underlying process started?
+   bool started_;
 };
 
 

--- a/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
@@ -58,7 +58,6 @@ public:
          const std::string& handle,
          const int terminalSequence,
          bool allowRestart,
-         bool dialog,
          InteractionMode mode,
          int maxOutputLines = kDefaultMaxOutputLines);
 
@@ -86,11 +85,6 @@ public:
    void setAllowRestart(bool allowRestart) { allowRestart_ = allowRestart; }
    bool getAllowRestart() const { return allowRestart_; }
 
-   // Whether process is being associate with a dialog
-   // TODO (gary) review if we still need this
-   void setDialog(bool dialog) { dialog_ = dialog; }
-   bool getDialog() const { return dialog_; }
-
    void setInteractionMode(InteractionMode mode) { interactionMode_ = mode; }
    InteractionMode getInteractionMode() const { return interactionMode_; }
 
@@ -110,10 +104,6 @@ public:
    void setExitCode(int exitCode);
    boost::optional<int> getExitCode() const { return exitCode_; }
 
-   // Whether the process has been successfully started
-   void setIsStarted(bool started) { started_ = started; }
-   bool isStarted() const { return started_; }
-
    // Does this process have child processes?
    void setHasChildProcs(bool hasChildProcs) { childProcs_ = hasChildProcs; }
    bool getHasChildProcs() const { return childProcs_; }
@@ -129,13 +119,11 @@ private:
    std::string handle_;
    int terminalSequence_;
    bool allowRestart_;
-   bool dialog_;
    InteractionMode interactionMode_;
    int maxOutputLines_;
    bool showOnOutput_;
    boost::circular_buffer<char> outputBuffer_;
    boost::optional<int> exitCode_;
-   bool started_;
    bool childProcs_;
 };
 

--- a/src/cpp/session/modules/SessionDependencies.cpp
+++ b/src/cpp/session/modules/SessionDependencies.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionDependencies.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -405,7 +405,6 @@ Error installDependencies(const json::JsonRpcRequest& request,
             "" /*handle*/,
             console_process::kNoTerminal,
             false /*allowRestart*/,
-            true /*dialog*/,
             console_process::InteractionNever);
 
    // create and execute console process

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionGit.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -297,7 +297,6 @@ protected:
 
    core::Error createConsoleProc(const ShellArgs& args,
                                  const std::string& caption,
-                                 bool dialog,
                                  boost::shared_ptr<ConsoleProcess>* ppCP,
                                  const boost::optional<FilePath>& workingDir=boost::optional<FilePath>())
    {
@@ -315,7 +314,7 @@ protected:
       boost::shared_ptr<ConsoleProcessInfo> pCPI =
             boost::make_shared<ConsoleProcessInfo>(
                caption, "" /*title*/, "" /*handle*/, kNoTerminal,
-               false /*allowRestart*/, dialog, console_process::InteractionNever);
+               false /*allowRestart*/, console_process::InteractionNever);
 
 #ifdef _WIN32
       *ppCP = ConsoleProcess::create(gitBin(), args.args(), options, pCPI);
@@ -616,7 +615,6 @@ public:
       
       return createConsoleProc(args,
                                "Git Checkout " + id,
-                               true,
                                ppCP);
    }
 
@@ -696,7 +694,6 @@ public:
 
       return createConsoleProc(args,
                                "Git Commit",
-                               true,
                                ppCP);
    }
 
@@ -710,7 +707,6 @@ public:
       return
             createConsoleProc(ShellArgs() << "clone" << "--progress" << url << dirName,
                               "Clone Repository",
-                              true,
                               ppCP,
                               boost::optional<FilePath>(parentPath));
    }
@@ -785,13 +781,13 @@ public:
          args << remote << merge;
       }
 
-      return createConsoleProc(args, "Git Push", true, ppCP);
+      return createConsoleProc(args, "Git Push", ppCP);
    }
 
    core::Error pull(boost::shared_ptr<ConsoleProcess>* ppCP)
    {
       return createConsoleProc(ShellArgs() << "pull",
-                               "Git Pull", true, ppCP);
+                               "Git Pull", ppCP);
    }
 
    core::Error doDiffFile(const FilePath& filePath,

--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionSVN.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -244,7 +244,6 @@ core::Error createConsoleProc(const ShellArgs& args,
                               const boost::optional<FilePath>& workingDir,
                               const std::string& caption,
                               bool requiresSsh,
-                              bool dialog,
                               bool enqueueRefreshOnExit,
                               boost::shared_ptr<ConsoleProcess>* ppCP)
 {
@@ -270,7 +269,7 @@ core::Error createConsoleProc(const ShellArgs& args,
    using namespace session::console_process;
    boost::shared_ptr<ConsoleProcessInfo> pCPI = boost::make_shared<ConsoleProcessInfo>(
             caption, "" /*title*/, "" /*handle*/, kNoTerminal,
-            false /*allowRestart*/, dialog, InteractionPossible);
+            false /*allowRestart*/, InteractionPossible);
 
    // create the process
    *ppCP = ConsoleProcess::create(command, options, pCPI);
@@ -284,7 +283,6 @@ core::Error createConsoleProc(const ShellArgs& args,
 core::Error createConsoleProc(const ShellArgs& args,
                               const std::string& caption,
                               bool requiresSsh,
-                              bool dialog,
                               bool enqueueRefreshOnExit,
                               boost::shared_ptr<ConsoleProcess>* ppCP)
 {
@@ -293,7 +291,6 @@ core::Error createConsoleProc(const ShellArgs& args,
                             boost::optional<FilePath>(),
                             caption,
                             requiresSsh,
-                            dialog,
                             enqueueRefreshOnExit,
                             ppCP);
 }
@@ -347,7 +344,6 @@ void runSvnAsync(const ShellArgs& args,
                                    boost::optional<FilePath>(),
                                    caption,
                                    s_isSvnSshRepository,
-                                   true,
                                    enqueueRefreshOnExit,
                                    &pCP);
    if (error)
@@ -993,7 +989,6 @@ Error svnUpdate(const json::JsonRpcRequest& request,
                                    "SVN Update",
                                    s_isSvnSshRepository,
                                    true,
-                                   true,
                                    &pCP);
    if (error)
       return error;
@@ -1064,7 +1059,6 @@ Error svnCommit(const json::JsonRpcRequest& request,
    error = createConsoleProc(args,
                              "SVN Commit",
                              s_isSvnSshRepository,
-                             true,
                              true,
                              &pCP);
    if (error)
@@ -1730,7 +1724,6 @@ Error checkout(const std::string& url,
                                    parentPath,
                                    "SVN Checkout",
                                    requiresSsh,
-                                   true,
                                    true,
                                    ppCP);
 

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -867,9 +867,6 @@ Error startShellDialog(const json::JsonRpcRequest& request,
    // initial size of the pseudo-terminal
    int cols, rows;
    
-   // is terminal hosted in a modal dialog? (false means modeless, e.g. a tab)
-   bool isModalDialog;
-   
    // terminal handle (empty string if starting a new terminal)
    std::string termHandle;
    
@@ -892,7 +889,6 @@ Error startShellDialog(const json::JsonRpcRequest& request,
                                   &term,
                                   &cols,
                                   &rows,
-                                  &isModalDialog,
                                   &termHandle,
                                   &termCaption,
                                   &termTitle,
@@ -969,8 +965,7 @@ Error startShellDialog(const json::JsonRpcRequest& request,
    boost::shared_ptr<ConsoleProcessInfo> ptrProcInfo =
          boost::make_shared<ConsoleProcessInfo>(
             termCaption, termTitle, termHandle, termSequence, allowRestart,
-            isModalDialog, InteractionAlways,
-            console_process::kDefaultTerminalMaxOutputLines);
+            InteractionAlways, console_process::kDefaultTerminalMaxOutputLines);
 
    // run process
    boost::shared_ptr<ConsoleProcess> ptrProc =

--- a/src/cpp/session/modules/connections/SessionConnections.cpp
+++ b/src/cpp/session/modules/connections/SessionConnections.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionConnections.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -466,7 +466,6 @@ Error installSpark(const json::JsonRpcRequest& request,
             "" /*title*/,
             "" /*handle*/,
             console_process::kNoTerminal, false /*allowRestart*/,
-            true /*isDialog*/,
             console_process::InteractionNever);
 
    // create and execute console process

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -721,12 +721,6 @@ public class Application implements ApplicationEventHandlers
       // disable commands
       SessionInfo sessionInfo = session_.getSessionInfo();
 
-      if (!Desktop.isDesktop())
-      {
-         // Shell command only works on desktop IDEs
-         commands_.showShellDialog().remove();
-      }
-
       // TODO (gary) temporary windows-only logic for Shell/Terminal; remove
       // once terminal is ready on all platforms
       if (BrowseCap.isWindowsDesktop() && !uiPrefs_.get().enableXTerm().getValue())

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -720,29 +720,24 @@ public class Application implements ApplicationEventHandlers
 
       // disable commands
       SessionInfo sessionInfo = session_.getSessionInfo();
-      
+
+      if (!Desktop.isDesktop())
+      {
+         // Shell command only works on desktop IDEs
+         commands_.showShellDialog().remove();
+      }
+
       // TODO (gary) temporary windows-only logic for Shell/Terminal; remove
       // once terminal is ready on all platforms
-      if (BrowseCap.isWindowsDesktop())
+      if (BrowseCap.isWindowsDesktop() && !uiPrefs_.get().enableXTerm().getValue())
       {
-         if (!uiPrefs_.get().enableXTerm().getValue())
-         {
-            commands_.newTerminal().remove();
-            commands_.activateTerminal().remove();
-         }
-         else
-         {
-            commands_.showShellDialog().remove();
-         }
+         removeTerminalCommands();
       }
-      else
+
+      if (!sessionInfo.getAllowShell())
       {
          commands_.showShellDialog().remove();
-         if (!sessionInfo.getAllowShell())
-         {
-            commands_.newTerminal().remove();
-            commands_.activateTerminal().remove();
-         }
+         removeTerminalCommands();
       }
 
       if (!sessionInfo.getAllowPackageInstallation())
@@ -971,6 +966,17 @@ public class Application implements ApplicationEventHandlers
       navigateWindowTo("auth-sign-in");
    }
    
+   private void removeTerminalCommands()
+   {
+      commands_.newTerminal().remove();
+      commands_.activateTerminal().remove();
+      commands_.renameTerminal().remove();
+      commands_.closeTerminal().remove();
+      commands_.clearTerminalScrollbackBuffer().remove();
+      commands_.previousTerminal().remove();
+      commands_.nextTerminal().remove();
+   }
+
    private final ApplicationView view_ ;
    private final GlobalDisplay globalDisplay_ ;
    private final EventBus events_;

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcess.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcess.java
@@ -89,7 +89,6 @@ public class ConsoleProcess implements ConsoleOutputEvent.HasHandlers,
                            public void onResponseReceived(
                                  final ConsoleProcess cproc)
                            {
-                              assert(proc.isDialog());
                               // first determine whether to create and/or
                               // show the dialog immediately
                               boolean createDialog = false;

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
@@ -1,7 +1,7 @@
 /*
  * ConsoleProcessInfo.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -33,10 +33,6 @@ public class ConsoleProcessInfo extends JavaScriptObject
       return this.caption;
    }-*/;
 
-   public final native boolean isDialog() /*-{
-      return this.dialog;
-   }-*/;
-   
    public final native boolean getShowOnOutput() /*-{
       return this.show_on_output;
    }-*/;
@@ -65,10 +61,6 @@ public class ConsoleProcessInfo extends JavaScriptObject
 
    public final native boolean getAllowRestart() /*-{
       return this.allow_restart;
-   }-*/;
-
-   public final native boolean getStarted() /*-{
-      return this.started;
    }-*/;
 
    public final native String getTitle() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1,7 +1,7 @@
 /*
  * RemoteServer.java
  *
- * Copyright (C) 2009-15 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -475,7 +475,7 @@ public class RemoteServer implements Server
                              String handle, String caption, String title, int sequence,
                              ServerRequestCallback<ConsoleProcess> requestCallback)
    {
-      invokeStartShellDialog(ConsoleProcess.TerminalType.XTERM, false /*modal*/,
+      invokeStartShellDialog(ConsoleProcess.TerminalType.XTERM,
                              cols, rows, handle, caption, title, sequence,
                              true /*allowProcessRestart*/,
                              true /*reportChildCount*/,
@@ -484,7 +484,6 @@ public class RemoteServer implements Server
    
    private void invokeStartShellDialog(
                      ConsoleProcess.TerminalType terminalType,
-                     boolean isModalDialog,
                      int cols, int rows,
                      String terminalHandle,
                      String caption,
@@ -498,13 +497,12 @@ public class RemoteServer implements Server
       params.set(0, new JSONString(terminalType.toString()));
       params.set(1, new JSONNumber(cols));
       params.set(2, new JSONNumber(rows));
-      params.set(3, JSONBoolean.getInstance(isModalDialog));
-      params.set(4, new JSONString(StringUtil.notNull(terminalHandle)));
-      params.set(5, new JSONString(StringUtil.notNull(caption)));
-      params.set(6, new JSONString(StringUtil.notNull(title)));
-      params.set(7, new JSONNumber(sequence));
-      params.set(8, JSONBoolean.getInstance(allowProcessRestart));
-      params.set(9, JSONBoolean.getInstance(reportChildCount));
+      params.set(3, new JSONString(StringUtil.notNull(terminalHandle)));
+      params.set(4, new JSONString(StringUtil.notNull(caption)));
+      params.set(5, new JSONString(StringUtil.notNull(title)));
+      params.set(6, new JSONNumber(sequence));
+      params.set(7, JSONBoolean.getInstance(allowProcessRestart));
+      params.set(8, JSONBoolean.getInstance(reportChildCount));
 
       sendRequest(RPC_SCOPE,
                   START_SHELL_DIALOG,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
@@ -67,6 +67,7 @@ import org.rstudio.studio.client.workbench.views.choosefile.ChooseFile;
 import org.rstudio.studio.client.workbench.views.files.events.DirectoryNavigateEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.profiler.ProfilerPresenter;
 import org.rstudio.studio.client.workbench.views.terminal.events.CreateTerminalEvent;
+import org.rstudio.studio.client.workbench.views.terminal.events.SwitchToTerminalEvent;
 import org.rstudio.studio.client.workbench.views.vcs.common.events.VcsRefreshEvent;
 import org.rstudio.studio.client.workbench.views.vcs.common.events.VcsRefreshHandler;
 import org.rstudio.studio.client.workbench.views.vcs.git.model.GitState;
@@ -378,16 +379,23 @@ public class Workbench implements BusyHandler,
    @Handler
    public void onShowShellDialog()
    {
-      server_.getTerminalOptions(new SimpleRequestCallback<TerminalOptions>()
+      if (Desktop.isDesktop())
       {
-         @Override
-         public void onResponseReceived(TerminalOptions options)
+         server_.getTerminalOptions(new SimpleRequestCallback<TerminalOptions>()
          {
-            Desktop.getFrame().openTerminal(options.getTerminalPath(),
-                  options.getWorkingDirectory(),
-                  options.getExtraPathEntries());
-         }
-      });
+            @Override
+            public void onResponseReceived(TerminalOptions options)
+            {
+               Desktop.getFrame().openTerminal(options.getTerminalPath(),
+                     options.getWorkingDirectory(),
+                     options.getExtraPathEntries());
+            }
+         });
+      }
+      else
+      {
+         onNewTerminal();
+      }
    }
    
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
@@ -378,7 +378,6 @@ public class Workbench implements BusyHandler,
    @Handler
    public void onShowShellDialog()
    {
-      // TODO (gary) this goes away once terminal is turned on for Windows
       server_.getTerminalOptions(new SimpleRequestCallback<TerminalOptions>()
       {
          @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
@@ -59,7 +59,6 @@ public class GitPane extends WorkbenchPane implements Display
       moreMenu.addItem(commands_.vcsIgnore().createMenuItem(false));
       moreMenu.addSeparator();
       moreMenu.addItem(commands_.showShellDialog().createMenuItem(false));
-      moreMenu.addItem(commands_.newTerminal().createMenuItem(false));
 
       Toolbar toolbar = new Toolbar();
       toolbar.addLeftWidget(commands_.vcsDiff().createToolbarButton());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNPane.java
@@ -81,7 +81,6 @@ public class SVNPane extends WorkbenchPane implements Display
       moreMenu.addItem(commands_.vcsShowHistory().createMenuItem(false));
       moreMenu.addSeparator();
       moreMenu.addItem(commands_.showShellDialog().createMenuItem(false));
-      moreMenu.addItem(commands_.newTerminal().createMenuItem(false));
 
       toolbar.addLeftWidget(new ToolbarButton(
           "More",


### PR DESCRIPTION
The "started" process state was being persisted with the ConsoleProcessInfo, which was unnecessary and could get in the wrong state. If session is loading ConsoleProcessInfo, then by definition the ConsoleProcess's represented by any remembered ConsoleProcessInfo's are not running yet.

Also removed the redundant "isDialog" flag from ConsoleProcessInfo.

Switched to shortened GUIDs for ConsoleProcess handles.

Changed ConsoleProcessInfo persistence filename from INDEX to INDEX001 so I don't have to deal with the previous JSON incarnation. Means previous sets of tabs will be lost, but not worried about that this far out from shipping.

Put the Tools/Shell command back, got feedback that some users will still want ability to launch native terminal to the project directory on desktop IDE. Also, leave it there on Server, too, for consistency, but have it go to the terminal tab. Finally, now that Shell command is back, remove Terminal from the Git/SVN dropdown menus, since they do the same thing.