### PR TITLE
fix printing of data.frame containing date

### DIFF
--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -170,7 +170,7 @@
                           factor = "fctr",
                           POSIXt = "dttm",
                           difftime = "time",
-                          Date = date,
+                          Date = "date",
                           data.frame = class(x)[[1]],
                           tbl_df = "tibble",
                           NULL


### PR DESCRIPTION
This PR resolves an issue where attempting to print a `data.frame` containing a date would fail in an R Notebook, e.g.

```
data.frame(x = as.Date("2017-01-01"))
```