### PR TITLE
Expose dialog apis as rstudioapis

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -332,7 +332,7 @@
   )
 })
 
-.rs.addFunction("showDialog", function(title, message, url = "") {
+.rs.addApiFunction("showDialog", function(title, message, url = "") {
    .Call("rs_showDialog",
       title = title,
       message = message,
@@ -344,7 +344,15 @@
       url = url)
 })
 
-.rs.addFunction("showPrompt", function(title, message, default = "") {
+.rs.addApiFunction("updateDialog", function(...)
+{
+   scalarValues <- lapply(list(...), .rs.scalar)
+   .rs.enqueClientEvent("update_new_connection_dialog", scalarValues)
+
+   invisible(NULL)
+})
+
+.rs.addApiFunction("showPrompt", function(title, message, default = "") {
    .Call("rs_showDialog",
       title = title,
       message = message,
@@ -356,7 +364,7 @@
       url = NULL)
 })
 
-.rs.addFunction("showQuestion", function(title, message, ok = "", cancel = "") {
+.rs.addApiFunction("showQuestion", function(title, message, ok = "", cancel = "") {
    .Call("rs_showDialog",
       title = title,
       message = message,
@@ -366,6 +374,15 @@
       ok = ok,
       cancel = cancel,
       url = NULL)
+})
+
+.rs.addApiFunction("writePreference", function(name, value) {
+  .rs.writeUiPref(paste("rstudioapi", name, sep = "_"), value)
+})
+
+.rs.addApiFunction("readPreference", function(name, default = NULL) {
+  value <- .rs.readUiPref(paste("rstudioapi", name, sep = "_"))
+  if (is.null(value)) default else value
 })
 
 .rs.addApiFunction("setPersistentValue", function(name, value) {

--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -312,12 +312,4 @@ options(connectionObserver = list(
    .rs.success()
 })
 
-.rs.addFunction("updateNewConnectionDialog", function(code)
-{
-   .rs.enqueClientEvent("update_new_connection_dialog", list(
-      "code" = .rs.scalar(code)
-   ))
-
-   NULL
-})
 


### PR DESCRIPTION
We are missing to expose the dialog apis as `.rs.api.*` functions to be consumable from `rstudioapi` package.

See also: https://github.com/rstudio/rstudioapi/pull/36