### PR TITLE
highlight TODO / FIXME comments in R mode

### DIFF
--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -74,6 +74,11 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
             next  : "rd-start"
          },
          {
+            token : ["comment", "comment.keyword.operator", "comment"],
+            regex : "(#+'?\\s*)(TODO|FIXME)\\b(.*)$",
+            next  : "start"
+         },
+         {
             token : "comment",
             regex : "#.*$",
             next  : "start"


### PR DESCRIPTION
This PR implements highlighting of `TODO` and `FIXME` comments in R code.

![screen shot 2017-02-02 at 3 09 15 pm](https://cloud.githubusercontent.com/assets/1976582/22572601/ad1c0e52-e959-11e6-9a7f-bc9aa5dd6d9d.png)

The visual effect is nice, but I'm not sure if we want to take this without assigning some actual real behaviors to discovered TODOs. @jmcphers, any thoughts?