### PR TITLE
Trim terminal buffers on reload, reset caches, fix param order

### DIFF
--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -1,7 +1,7 @@
 /*
  * StringUtils.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -517,8 +517,9 @@ bool parseVersion(const std::string& str, uint64_t* pVersion)
    return true;
 }
 
-void trimLeadingLines(int maxLines, std::string* pLines)
+bool trimLeadingLines(int maxLines, std::string* pLines)
 {
+   bool didTrim = false;
    if (pLines->length() > static_cast<unsigned int>(maxLines*2))
    {
       int lineCount = 0;
@@ -531,11 +532,13 @@ void trimLeadingLines(int maxLines, std::string* pLines)
             if (++lineCount > maxLines)
             {
                pLines->erase(pLines->begin(), pos);
+               didTrim = true;
                break;
             }
          }
       }
    }
+   return didTrim;
 }
 
 std::string strippedOfBackQuotes(const std::string& string)

--- a/src/cpp/core/include/core/StringUtils.hpp
+++ b/src/cpp/core/include/core/StringUtils.hpp
@@ -1,7 +1,7 @@
 /*
  * StringUtils.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -218,7 +218,7 @@ inline bool stringNotEmpty(const std::string& str)
    return !str.empty();
 }
 
-void trimLeadingLines(int maxLines, std::string* pLines);
+bool trimLeadingLines(int maxLines, std::string* pLines);
 
 void stripQuotes(std::string* pStr);
 std::string strippedOfQuotes(const std::string& str);

--- a/src/cpp/core/include/core/text/TermBufferParser.hpp
+++ b/src/cpp/core/include/core/text/TermBufferParser.hpp
@@ -36,8 +36,8 @@ namespace text {
 // pass in true, then it is assumed the start of the buffer is already in alt-mode.
 //
 std::string stripSecondaryBuffer(
-      bool* pAltModeActive, // (optional in/out) is string "in" alt-buffer mode?
-      const std::string& str); // string to parse
+      const std::string& str, // string to parse
+      bool* pAltModeActive); // (optional in/out) is string "in" alt-buffer mode?
 
 } // namespace text
 } // namespace core

--- a/src/cpp/core/text/TermBufferParser.cpp
+++ b/src/cpp/core/text/TermBufferParser.cpp
@@ -181,7 +181,7 @@ struct ParseMetadata
 
 } // anonymous namespace
 
-std::string stripSecondaryBuffer(bool* pAltBufferActive, const std::string& strInput)
+std::string stripSecondaryBuffer(const std::string& strInput, bool* pAltBufferActive)
 {
    // XTerm.js supported alt-buffer start sequences:
    //

--- a/src/cpp/core/text/TermBufferParserTests.cpp
+++ b/src/cpp/core/text/TermBufferParserTests.cpp
@@ -34,7 +34,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
    SECTION("Empty input")
    {
       std::string input;
-      std::string newStr = core::text::stripSecondaryBuffer(NULL, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, NULL);
       CHECK(newStr.empty());
    }
 
@@ -42,7 +42,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
    {
       std::string input;
       bool altMode = true;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(altMode == true);
    }
 
@@ -50,7 +50,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
    {
       std::string input;
       bool altMode = false;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(altMode == false);
    }
 
@@ -58,7 +58,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
    {
       std::string input = "Hello World!\nHow are you today?";
       bool altMode = false;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(input.compare(newStr) == 0);
    }
 
@@ -66,7 +66,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
    {
       std::string input = "\033";
       bool altMode = false;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(input.compare(newStr) == 0);
    }
 
@@ -74,7 +74,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
    {
       std::string input = "\033\033\033\033\033";
       bool altMode = false;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(input.compare(newStr) == 0);
    }
 
@@ -82,7 +82,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
    {
       std::string input = "Hello World!\nHow \033[000l are you today?";
       bool altMode = false;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(input.compare(newStr) == 0);
    }
 
@@ -90,7 +90,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
    {
       std::string input = "Hello. How\033[?000l are you today?";
       bool altMode = false;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(input.compare(newStr) == 0);
    }
 
@@ -98,7 +98,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
    {
       std::string input = "Hello. How\033[?x047h are you today?";
       bool altMode = false;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(input.compare(newStr) == 0);
    }
 
@@ -106,7 +106,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
    {
       std::string input = "\033[?Hello World!\nHow \033[000l are you today?\033 Great!";
       bool altMode = false;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(input.compare(newStr) == 0);
    }
 
@@ -114,7 +114,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
    {
       std::string input = "None of this should be returned!";
       bool altMode = true;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(newStr.empty());
       CHECK(altMode == true);
    }
@@ -128,7 +128,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
       input.append(pStart3);
       input.append("The end.");
       bool altMode = true;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(newStr.empty());
       CHECK(altMode == true);
    }
@@ -142,7 +142,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
       std::string expect("Once upon a time.");
 
       bool altMode = false;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(newStr.compare(expect) == 0);
       CHECK(altMode == false);
    }
@@ -156,7 +156,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
       std::string expect("Once upon a time.");
 
       bool altMode = false;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(newStr.compare(expect) == 0);
       CHECK(altMode == false);
    }
@@ -170,7 +170,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
       std::string expect("Once upon a time.");
 
       bool altMode = false;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(newStr.compare(expect) == 0);
       CHECK(altMode == false);
    }
@@ -185,7 +185,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
       std::string expect("Once upon a time.");
 
       bool altMode = false;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(newStr.compare(expect) == 0);
       CHECK(altMode == false);
    }
@@ -202,7 +202,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
       std::string expect("Once upon a time.");
 
       bool altMode = false;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(newStr.compare(expect) == 0);
       CHECK(altMode == false);
    }
@@ -218,7 +218,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
       std::string expect("Once upon a time.");
 
       bool altMode = false;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(newStr.compare(expect) == 0);
       CHECK(altMode == false);
    }
@@ -228,7 +228,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
       std::string input = "Once upon a time.";
       input.append(pEnd3);
       bool altMode = true;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(newStr.empty());
       CHECK(altMode == false);
    }
@@ -240,7 +240,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
       input.append("Once upon a time.");
       std::string expect("Once upon a time.");
       bool altMode = true;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(expect.compare(newStr) == 0);
       CHECK(altMode == false);
    }
@@ -254,7 +254,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
       std::string expect("There was a cat.");
 
       bool altMode = true;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(expect.compare(newStr) == 0);
       CHECK(altMode == false);
    }
@@ -272,7 +272,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
       std::string expect("There was a cat. The end.");
 
       bool altMode = true;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(expect.compare(newStr) == 0);
       CHECK(altMode == false);
    }
@@ -292,7 +292,7 @@ TEST_CASE("Terminal Buffer Mode Parsing")
       std::string expect("Once upon a time. There was a cat. Meow.");
 
       bool altMode = false;
-      std::string newStr = core::text::stripSecondaryBuffer(&altMode, input);
+      std::string newStr = core::text::stripSecondaryBuffer(input, &altMode);
       CHECK(expect.compare(newStr) == 0);
       CHECK(altMode == false);
    }

--- a/src/cpp/session/SessionConsoleProcessInfo.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfo.cpp
@@ -85,7 +85,7 @@ void ConsoleProcessInfo::appendToOutputBuffer(const std::string &str)
    // For terminal tabs, store in a separate file, first removing any
    // output targeting the alternate terminal buffer.
    std::string mainBufferStr =
-         core::text::stripSecondaryBuffer(&altBufferActive_, str);
+         core::text::stripSecondaryBuffer(str, &altBufferActive_);
 
    console_persist::appendToOutputBuffer(handle_, mainBufferStr);
 }
@@ -97,7 +97,7 @@ void ConsoleProcessInfo::appendToOutputBuffer(char ch)
 
 std::string ConsoleProcessInfo::getSavedBuffer()
 {
-   return console_persist::getSavedBuffer(handle_);
+   return console_persist::getSavedBuffer(handle_, maxOutputLines_);
 }
 
 std::string ConsoleProcessInfo::bufferedOutput() const

--- a/src/cpp/session/include/session/SessionConsoleProcessPersist.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessPersist.hpp
@@ -37,7 +37,7 @@ std::string loadConsoleProcessMetadata();
 void saveConsoleProcesses(const std::string& metadata);
 
 // Get the saved buffer for the given ConsoleProcess
-std::string getSavedBuffer(const std::string& handle);
+std::string getSavedBuffer(const std::string& handle, int maxLines);
 
 // Add to the saved buffer for the given ConsoleProcess
 void appendToOutputBuffer(const std::string& handle, const std::string& buffer);


### PR DESCRIPTION
The server-side terminal buffers were growing without bound. Only way to get rid of them was to close the terminal, or use the RStudio clear command (the shell clear/cls commands only clear the client-side buffer, not the entire scrolling buffer). Now when a terminal is reloading after a browser refresh/reconnect or restart of the client app, I trim the buffer to match the number of lines of scrollback supported by xterm.js.

Also bumped the save folder for terminal/consoleproc metadata from "console" to "console01" so users get a clean set of terminal buffers (otherwise they were still seeing the persisted alt-buffer mess from prior runs).

Finally, put in/out parameter for stripSecondaryParser last instead of first.