### PR TITLE
fix regression in data viewer from f7794e by making column sortable

### DIFF
--- a/src/cpp/session/resources/grid/gridviewer.js
+++ b/src/cpp/session/resources/grid/gridviewer.js
@@ -875,7 +875,7 @@ var initDataTable = function(resCols, data) {
         "targets": 0,
         "sClass": "first-child",
         "width": "4em",
-        "orderable": false
+        "orderable": true
       }];
   }
   else {


### PR DESCRIPTION
Run `View(mtcars)`, sort by column, click on top-left cell to clear formatting, observe it no longer works. Updated also support article form "right-top cell" to "left-top cell".