### PR TITLE
validate target path for new packages

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
+++ b/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
@@ -74,6 +74,7 @@ public class FileSystemItem extends JavaScriptObject
       return getNameFromPath(getRawPath());
    }
 
+   // NOTE: returns extension with '.' prefix.
    public final String getExtension()
    {
       return getExtensionFromPath(getName());

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -59,6 +59,7 @@ import org.rstudio.studio.client.htmlpreview.HTMLPreviewApplication;
 import org.rstudio.studio.client.notebook.CompileNotebookOptionsDialog;
 import org.rstudio.studio.client.projects.model.ProjectTemplateRegistryProvider;
 import org.rstudio.studio.client.projects.ui.newproject.CodeFilesList;
+import org.rstudio.studio.client.projects.ui.newproject.NewPackagePage;
 import org.rstudio.studio.client.projects.ui.prefs.ProjectPreferencesPane;
 import org.rstudio.studio.client.projects.ui.prefs.buildtools.BuildToolsPackagePanel;
 import org.rstudio.studio.client.rmarkdown.RmdOutputSatellite;
@@ -219,6 +220,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(RStudioAPI rstudioAPI);
    void injectMembers(NewConnectionSnippetHost newConnectionSnippetHost);
    void injectMembers(NewConnectionSnippetDialog newConnectionSnippetDialog);
+   void injectMembers(NewPackagePage page);
    
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);
 

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewPackagePage.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewPackagePage.java
@@ -14,12 +14,23 @@
  */
 package org.rstudio.studio.client.projects.ui.newproject;
 
+import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.js.JsUtil;
+import org.rstudio.core.client.widget.MessageDialog;
+import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.SelectWidget;
+import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.projects.Projects;
 import org.rstudio.studio.client.projects.model.NewPackageOptions;
 import org.rstudio.studio.client.projects.model.NewProjectInput;
+import org.rstudio.studio.client.projects.model.NewProjectResult;
+import org.rstudio.studio.client.server.ServerError;
+import org.rstudio.studio.client.server.ServerRequestCallback;
+import org.rstudio.studio.client.workbench.views.files.model.DirectoryListing;
+import org.rstudio.studio.client.workbench.views.files.model.FilesServerOperations;
 
+import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.event.dom.client.ChangeEvent;
@@ -27,6 +38,7 @@ import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.inject.Inject;
 
 
 public class NewPackagePage extends NewDirectoryPage
@@ -39,6 +51,7 @@ public class NewPackagePage extends NewDirectoryPage
             NewProjectResources.INSTANCE.packageIcon(),
             NewProjectResources.INSTANCE.packageIconLarge());
       
+      RStudioGinjector.INSTANCE.injectMembers(this);
       styles_ = NewProjectResources.INSTANCE.styles();
       
       txtProjectName_.addKeyDownHandler(new KeyDownHandler()
@@ -58,6 +71,12 @@ public class NewPackagePage extends NewDirectoryPage
          }
       });
       
+   }
+   
+   @Inject
+   private void initialize(FilesServerOperations server)
+   {
+      server_ = server;
    }
    
    protected boolean getOptionsSideBySide()
@@ -93,7 +112,6 @@ public class NewPackagePage extends NewDirectoryPage
       listCodeFiles_ = new CodeFilesList();
       addWidget(listCodeFiles_);
    }
-   
    
    @Override 
    protected void initialize(NewProjectInput input)
@@ -135,7 +153,102 @@ public class NewPackagePage extends NewDirectoryPage
       return Projects.PACKAGE_NAME_PATTERN.test(packageName);
    }
    
+   @Override
+   protected void validateAsync(final NewProjectResult input,
+                                final OperationWithInput<Boolean> onValidated)
+   {
+      // validate package name first
+      String packageName = txtProjectName_.getText().trim();
+      if (!isPackageNameValid(packageName))
+      {
+         globalDisplay_.showMessage(
+               MessageDialog.WARNING,
+               "Error",
+               "Invalid package name '" + packageName + "'. Package names " +
+               "should start with a letter, and contain only letters and numbers.");
+         onValidated.execute(false);
+         return;
+      }
+      
+      final FileSystemItem projFile = FileSystemItem.createFile(input.getProjectFile());
+      final FileSystemItem projDir = projFile.getParentPath();
+      server_.stat(projDir.getPath(), new ServerRequestCallback<FileSystemItem>()
+      {
+         @Override
+         public void onResponseReceived(final FileSystemItem item)
+         {
+            // no file at this path -- safe for use
+            if (!item.exists())
+            {
+               onValidated.execute(true);
+               return;
+            }
+            
+            // if it was a file, bail
+            if (!item.isDirectory())
+            {
+               globalDisplay_.showMessage(
+                     MessageDialog.WARNING,
+                     "Error",
+                     "A file already exists at path '" + item.getPath() + "'");
+               onValidated.execute(false);
+               return;
+            }
+            
+            // check if this directory is empty
+            server_.listFiles(item, false, new ServerRequestCallback<DirectoryListing>()
+            {
+               @Override
+               public void onResponseReceived(DirectoryListing listing)
+               {
+                  boolean ok = true;
+                  JsArray<FileSystemItem> children = listing.getFiles();
+                  for (FileSystemItem child : JsUtil.asIterable(children))
+                  {
+                     boolean canIgnore =
+                           child.getExtension().equals(".Rproj") ||
+                           child.getName().startsWith(".");
+                     
+                     if (canIgnore)
+                        continue;
+                     
+                     ok = false;
+                     break;
+                  }
+                  
+                  if (!ok)
+                  {
+                     globalDisplay_.showMessage(
+                          MessageDialog.WARNING,
+                          "Error",
+                          "Directory '" + item.getPath() + "' already exists and is not empty.");
+                  }
+                  
+                  onValidated.execute(ok);
+               }
+               
+               @Override
+               public void onError(ServerError error)
+               {
+                  Debug.logError(error);
+                  onValidated.execute(true);
+               }
+            });
+         }
+         
+         @Override
+         public void onError(ServerError error)
+         {
+            Debug.logError(error);
+            onValidated.execute(true);
+         }
+      });
+   }
+
    private SelectWidget listProjectType_;
    private CodeFilesList listCodeFiles_;
    private final NewProjectResources.Styles styles_;
+   
+   // Injected ----
+   private FilesServerOperations server_;
 }


### PR DESCRIPTION
This PR implements a bit of extra validation for the path chosen in new R package projects. The goal here is to avoid dismissing the 'New Package' dialog when an invalid path has been chosen.