### PR TITLE
Tweak and bug fix for showing busy terminals, server unit tests

### DIFF
--- a/src/cpp/session/SessionConsoleProcessInfoTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfoTests.cpp
@@ -1,0 +1,283 @@
+/*
+ * SessionConsoleProcessInfoTests.cpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+#include <session/SessionConsoleProcessInfo.hpp>
+
+#define RSTUDIO_NO_TESTTHAT_ALIASES
+#include <tests/TestThat.hpp>
+
+namespace rstudio {
+namespace session {
+namespace console_process {
+namespace tests {
+
+using namespace console_process;
+
+namespace {
+
+const std::string emptyStr;
+const std::string caption("Terminal 1");
+const std::string title("/Users/roger/R");
+const std::string handle1("unit-test01");
+const std::string bogusHandle1("unit-test03");
+const int sequence = 1;
+const bool allowRestart = true;
+const InteractionMode mode = InteractionAlways;
+const size_t maxLines = 1000;
+
+bool testHandle(const std::string& handle)
+{
+   return !handle.compare(handle1);
+}
+
+// helper returns true if ConsoleProcessInfo objs have same field values
+bool sameCpi(const ConsoleProcessInfo& first, const ConsoleProcessInfo& second)
+{
+   return (!first.getCaption().compare(second.getCaption()) &&
+           !first.getTitle().compare(second.getTitle()) &&
+           !first.getHandle().compare(second.getHandle()) &&
+           first.getTerminalSequence() == second.getTerminalSequence() &&
+           first.getAllowRestart() == second.getAllowRestart() &&
+           first.getInteractionMode() == second.getInteractionMode() &&
+           first.getMaxOutputLines() == second.getMaxOutputLines() &&
+           first.getShowOnOutput() == second.getShowOnOutput() &&
+           first.getExitCode()  == second.getExitCode() &&
+           first.getHasChildProcs() == second.getHasChildProcs());
+}
+
+} // anonymous namespace
+
+
+TEST_CASE("ConsoleProcessInfo")
+{
+   SECTION("Create ConsoleProcessInfo and read properties")
+   {
+      ConsoleProcessInfo cpi(caption, title, handle1, sequence,
+                             allowRestart, mode, maxLines);
+
+      CHECK_FALSE(caption.compare(cpi.getCaption()));
+      CHECK_FALSE(title.compare(cpi.getTitle()));
+      CHECK_FALSE(handle1.compare(cpi.getHandle()));
+      CHECK(cpi.getTerminalSequence() == sequence);
+      CHECK(cpi.getAllowRestart() == allowRestart);
+      CHECK(cpi.getInteractionMode() == mode);
+      CHECK(cpi.getMaxOutputLines() == maxLines);
+
+      CHECK_FALSE(cpi.getShowOnOutput());
+      CHECK_FALSE(cpi.getExitCode());
+      CHECK(cpi.getHasChildProcs());
+   }
+
+   SECTION("Generate a handle")
+   {
+      ConsoleProcessInfo cpi(emptyStr /*caption*/, emptyStr /*title*/,
+                             emptyStr /*handle*/, kNoTerminal,
+                             false /*allowRestart*/, InteractionNever,
+                             0 /*maxLines*/);
+
+      std::string handle = cpi.getHandle();
+      CHECK(handle.empty());
+      cpi.ensureHandle();
+      handle = cpi.getHandle();
+      CHECK_FALSE(handle.empty());
+   }
+
+   SECTION("Change properties")
+   {
+      ConsoleProcessInfo cpi(caption, title, handle1, sequence,
+                             allowRestart, mode, maxLines);
+
+      std::string altCaption("other caption");
+      CHECK(altCaption.compare(caption));
+      cpi.setCaption(altCaption);
+      CHECK_FALSE(altCaption.compare(cpi.getCaption()));
+
+      std::string altTitle("other title");
+      CHECK(altTitle.compare(title));
+      cpi.setTitle(altTitle);
+      CHECK_FALSE(altTitle.compare(cpi.getTitle()));
+
+      int altSequence = sequence + 1;
+      cpi.setTerminalSequence(altSequence);
+      CHECK(altSequence == cpi.getTerminalSequence());
+
+      bool altAllowRestart = !allowRestart;
+      cpi.setAllowRestart(altAllowRestart);
+      CHECK(altAllowRestart == cpi.getAllowRestart());
+
+      InteractionMode altMode = InteractionNever;
+      CHECK_FALSE(altMode == mode);
+      cpi.setInteractionMode(altMode);
+      CHECK(altMode == cpi.getInteractionMode());
+
+      size_t altMax = maxLines + 1;
+      cpi.setMaxOutputLines(altMax);
+      CHECK(altMax == cpi.getMaxOutputLines());
+
+      bool altShowOnOutput = !cpi.getShowOnOutput();
+      cpi.setShowOnOutput(altShowOnOutput);
+      CHECK(altShowOnOutput == cpi.getShowOnOutput());
+
+      bool altHasChildProcs = !cpi.getHasChildProcs();
+      cpi.setHasChildProcs(altHasChildProcs);
+      CHECK(altHasChildProcs == cpi.getHasChildProcs());
+   }
+
+   SECTION("Create ConsoleProcessInfo and read properties")
+   {
+      ConsoleProcessInfo cpi(caption, title, handle1, sequence,
+                             allowRestart, mode, maxLines);
+
+      const int exitCode = 14;
+      cpi.setExitCode(exitCode);
+      CHECK(cpi.getExitCode());
+      CHECK(exitCode == *cpi.getExitCode());
+   }
+
+   SECTION("Save and load console proc metadata")
+   {
+      std::string orig = ConsoleProcessInfo::loadConsoleProcessMetadata();
+      std::string newMetadata = "once upon a time";
+      ConsoleProcessInfo::saveConsoleProcesses(newMetadata);
+      std::string newSaved = ConsoleProcessInfo::loadConsoleProcessMetadata();
+      CHECK_FALSE(newSaved.compare(newMetadata));
+      ConsoleProcessInfo::saveConsoleProcesses(orig);
+      newSaved = ConsoleProcessInfo::loadConsoleProcessMetadata();
+      CHECK_FALSE(newSaved.compare(orig));
+   }
+
+   SECTION("Compare ConsoleProcInfos with different exit codes")
+   {
+      ConsoleProcessInfo cpiFirst(caption, title, handle1, sequence,
+                                  allowRestart, mode, maxLines);
+      ConsoleProcessInfo cpiSecond(caption, title, handle1, sequence,
+                                   allowRestart, mode, maxLines);
+
+      cpiFirst.setExitCode(1);
+      cpiSecond.setExitCode(12);
+      CHECK_FALSE(sameCpi(cpiFirst, cpiSecond));
+   }
+
+   SECTION("Persist and restore")
+   {
+      ConsoleProcessInfo cpiOrig(caption, title, handle1, sequence,
+                                 allowRestart, mode, maxLines);
+
+      core::json::Object origJson = cpiOrig.toJson();
+      boost::shared_ptr<ConsoleProcessInfo> pCpiRestored =
+            ConsoleProcessInfo::fromJson(origJson);
+      CHECK(pCpiRestored);
+      CHECK(sameCpi(cpiOrig, *pCpiRestored));
+   }
+
+   SECTION("Persist and restore for non-terminals")
+   {
+      // kNoTerminal triggers the older non-terminal behavior where
+      // buffers are saved directly in this object and end up
+      // persisted to the JSON. So to validate this we need to save some
+      // output, persist to JSON, restore from JSON, and see that we get
+      // back what we saved (trimmed based on maxLines). Be nice to abstract
+      // all of this away, but bigger fish and all of that.
+      ConsoleProcessInfo cpi(caption, title, handle1, kNoTerminal,
+                             allowRestart, mode, maxLines);
+
+      // bufferedOutput is the accessor for the non-terminal buffer cache
+      std::string orig = cpi.bufferedOutput();
+      CHECK(orig.empty());
+
+      std::string strOrig("one\ntwo\nthree\n");
+
+      // kNoTerminal mode buffer returns everything after the first \n
+      // in the buffer
+      cpi.appendToOutputBuffer('\n');
+      cpi.appendToOutputBuffer(strOrig);
+      std::string loaded = cpi.bufferedOutput();
+      CHECK_FALSE(loaded.compare(strOrig));
+
+      // add some more
+      std::string orig2("four\nfive\nsix");
+      cpi.appendToOutputBuffer(orig2);
+      loaded = cpi.bufferedOutput();
+      strOrig.append(orig2);
+      CHECK_FALSE(loaded.compare(strOrig));
+   }
+
+   SECTION("Persist and restore for terminals")
+   {
+      // terminal sequence other than kNoTerminal triggers terminal
+      // behavior where buffer are saved to an external file instead of
+      // in the JSON. Same comment on the leaky abstractions here as for
+      // previous non-terminal test.
+      ConsoleProcessInfo cpi(caption, title, handle1, sequence,
+                             allowRestart, mode, maxLines);
+
+      // blow away anything that might have been left over from a previous
+      // failed run
+      cpi.deleteLogFile();
+
+      // getSavedBuffer is the accessor for the terminal buffer cache
+      std::string loaded = cpi.getSavedBuffer();
+      CHECK(loaded.empty());
+
+      std::string orig = "one\ntwo\nthree\nfour\nfive";
+      cpi.appendToOutputBuffer(orig);
+      loaded = cpi.getSavedBuffer();
+      CHECK_FALSE(loaded.compare(orig));
+
+      std::string orig2 = "\nsix\nseven\neight\nnine\nten\n";
+      cpi.appendToOutputBuffer(orig2);
+      loaded = cpi.getSavedBuffer();
+      orig.append(orig2);
+      CHECK_FALSE(loaded.compare(orig));
+
+      cpi.deleteLogFile();
+      loaded = cpi.getSavedBuffer();
+      CHECK(loaded.empty());
+   }
+
+   SECTION("Delete unknown log files")
+   {
+      ConsoleProcessInfo cpiGood(caption, title, handle1, sequence,
+                             allowRestart, mode, maxLines);
+      ConsoleProcessInfo cpiBad(caption, title, bogusHandle1, sequence,
+                             allowRestart, mode, maxLines);
+
+      std::string orig1("hello how are you?\nthat is good\nhave a nice day");
+      std::string bogus1("doom");
+
+      cpiGood.appendToOutputBuffer(orig1);
+      cpiBad.appendToOutputBuffer(bogus1);
+
+      std::string loadedGood = cpiGood.getSavedBuffer();
+      CHECK_FALSE(loadedGood.compare(orig1));
+      std::string loadedBad = cpiBad.getSavedBuffer();
+      CHECK_FALSE(loadedBad.compare(bogus1));
+
+      cpiGood.deleteOrphanedLogs(testHandle);
+      cpiBad.deleteOrphanedLogs(testHandle);
+
+      loadedGood = cpiGood.getSavedBuffer();
+      CHECK_FALSE(loadedGood.compare(orig1));
+      loadedBad = cpiBad.getSavedBuffer();
+      CHECK(loadedBad.empty());
+
+      cpiGood.deleteLogFile();
+      cpiBad.deleteLogFile();
+   }
+}
+
+} // end namespace tests
+} // end namespace console_process
+} // end namespace session
+} // end namespace rstudio

--- a/src/cpp/session/SessionConsoleProcessPersistTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessPersistTests.cpp
@@ -1,0 +1,107 @@
+/*
+ * SessionConsoleProcessPersistTests.cpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+#include <session/SessionConsoleProcessPersist.hpp>
+
+#define RSTUDIO_NO_TESTTHAT_ALIASES
+#include <tests/TestThat.hpp>
+
+namespace rstudio {
+namespace session {
+namespace console_process {
+namespace tests {
+
+const std::string handle1("unit-test01");
+const std::string handle2("unit-test02");
+const size_t maxLines = 1000;
+
+// These tests are running against an actual session, so try to save and
+// restore the Console persistence metadata so local client usage isn't
+// impacted by running the tests.
+class CleanupPeristTest
+{
+public:
+   CleanupPeristTest()
+      : origMetadata_(console_persist::loadConsoleProcessMetadata())
+   {
+      console_persist::deleteLogFile(handle1);
+      console_persist::deleteLogFile(handle2);
+   }
+
+   ~CleanupPeristTest()
+   {
+      console_persist::saveConsoleProcesses(origMetadata_);
+      console_persist::deleteLogFile(handle1);
+      console_persist::deleteLogFile(handle2);
+   }
+
+private:
+   std::string origMetadata_;
+};
+
+TEST_CASE("ConsoleProcess Persistence")
+{
+   CleanupPeristTest cleanup;
+
+   SECTION("Save and restore Console Process metadata")
+   {
+      std::string orig("Hello World this is some text.");
+      console_persist::saveConsoleProcesses(orig);
+
+      std::string loaded = console_persist::loadConsoleProcessMetadata();
+      CHECK(loaded.compare(orig) == 0);
+   }
+
+   SECTION("Save and restore empty Console Process metadata")
+   {
+      std::string orig;
+      console_persist::saveConsoleProcesses(orig);
+
+      std::string loaded = console_persist::loadConsoleProcessMetadata();
+      CHECK(loaded.compare(orig) == 0);
+   }
+
+   SECTION("Try to load a non-existent buffer")
+   {
+      std::string loaded = console_persist::getSavedBuffer(handle1, maxLines);
+
+      CHECK(loaded.empty());
+   }
+
+   SECTION("Write and load a buffer with no newlines")
+   {
+      std::string orig("hello how are you?");
+      console_persist::appendToOutputBuffer(handle1, orig);
+      std::string loaded = console_persist::getSavedBuffer(handle1, maxLines);
+      CHECK(loaded.compare(orig) == 0);
+   }
+
+
+/*
+// Add to the saved buffer for the given ConsoleProcess
+void appendToOutputBuffer(const std::string& handle, const std::string& buffer);
+
+// Delete the persisted saved buffer for the given ConsoleProcess
+void deleteLogFile(const std::string& handle);
+
+// Clean up ConsoleProcess buffer cache
+// Takes a function to see if a given handle represents a known process.
+void deleteOrphanedLogs(bool (*validHandle)(const std::string&));
+*/
+}
+
+} // end namespace tests
+} // end namespace console_process
+} // end namespace session
+} // end namespace rstudio

--- a/src/cpp/session/SessionConsoleProcessPersistTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessPersistTests.cpp
@@ -37,8 +37,6 @@ bool testHandle(const std::string& handle)
    return !handle.compare(handle1) || !handle.compare(handle2);
 }
 
-} // anonymous namespace
-
 // These tests are running against an actual session, so try to save and
 // restore the Console persistence metadata so local client usage isn't
 // impacted by running the tests.
@@ -62,6 +60,8 @@ public:
 private:
    std::string origMetadata_;
 };
+
+} // anonymous namespace
 
 TEST_CASE("ConsoleProcess Persistence")
 {

--- a/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
@@ -110,8 +110,6 @@ public:
    void setHasChildProcs(bool hasChildProcs) { childProcs_ = hasChildProcs; }
    bool getHasChildProcs() const { return childProcs_; }
 
-   void onSuspend();
-
    core::json::Object toJson() const;
    static boost::shared_ptr<ConsoleProcessInfo> fromJson(core::json::Object& obj);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
@@ -1,7 +1,7 @@
 /*
  * TerminalList.java
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -35,7 +35,6 @@ import com.google.inject.Provider;
  */
 public class TerminalList implements Iterable<String>,
                                      TerminalSubprocEvent.Handler
-
 {
    private static class TerminalMetadata
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -252,15 +252,6 @@ public class TerminalPane extends WorkbenchPane
    }
 
    @Override
-   public boolean busyTerminals()
-   {
-      // TODO (gary) implement busy detection, ideally treating long-running
-      // non-interactive programs as "busy" but not full-screen programs like
-      // text editors, tmux, etc.
-      return false;
-   }
-
-   @Override
    public void terminateAllTerminals()
    {
       // kill any terminal server processes, and remove them from the server-

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -34,9 +34,10 @@ import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.workbench.model.WorkbenchServerOperations;
 import org.rstudio.studio.client.workbench.ui.WorkbenchPane;
 import org.rstudio.studio.client.workbench.views.terminal.events.SwitchToTerminalEvent;
-import org.rstudio.studio.client.workbench.views.terminal.events.TerminalTitleEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStartedEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStoppedEvent;
+import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSubprocEvent;
+import org.rstudio.studio.client.workbench.views.terminal.events.TerminalTitleEvent;
 
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
@@ -63,7 +64,8 @@ public class TerminalPane extends WorkbenchPane
                                      TerminalSessionStoppedEvent.Handler,
                                      SwitchToTerminalEvent.Handler,
                                      TerminalTitleEvent.Handler,
-                                     SessionSerializationHandler
+                                     SessionSerializationHandler,
+                                     TerminalSubprocEvent.Handler
 {
    @Inject
    protected TerminalPane(EventBus events,
@@ -79,6 +81,8 @@ public class TerminalPane extends WorkbenchPane
       events_.addHandler(SwitchToTerminalEvent.TYPE, this);
       events_.addHandler(TerminalTitleEvent.TYPE, this);
       events_.addHandler(SessionSerializationEvent.TYPE, this);
+      events_.addHandler(TerminalSubprocEvent.TYPE, this);
+
       ensureWidget();
    }
 
@@ -599,6 +603,16 @@ public class TerminalPane extends WorkbenchPane
             terminal.connect();
          }
       });
+   }
+
+   @Override
+   public void onTerminalSubprocs(TerminalSubprocEvent event)
+   {
+      TerminalSession terminal = loadedTerminalWithHandle(event.getHandle());
+      if (terminal != null)
+      {
+         terminal.setHasChildProcs(event.hasSubprocs());
+      }
    }
 
    private DeckLayoutPanel terminalSessionsPanel_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
@@ -1,5 +1,5 @@
 /*
- * ActiveTerminalToolbarButton.java
+ * TerminalPopupMenu.java
  *
  * Copyright (C) 2009-17 by RStudio, Inc.
  *
@@ -23,6 +23,7 @@ import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.icons.StandardIcons;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.terminal.events.SwitchToTerminalEvent;
+import org.rstudio.studio.client.workbench.views.terminal.events.TerminalBusyEvent;
 
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.user.client.ui.MenuItem;
@@ -38,6 +39,16 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
       terminals_ = terminals;
+
+      eventBus_.addHandler(TerminalBusyEvent.TYPE,
+                          new TerminalBusyEvent.Handler()
+      {
+         @Override
+         public void onTerminalBusy(TerminalBusyEvent event)
+         {
+            refreshActiveTerminal();
+         }
+      });   
    }
 
    @Inject
@@ -76,10 +87,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
             }
 
             // visual indicator that terminal has processes running
-            if (terminals_.getHasSubprocs(handle))
-            {
-               caption = caption + "*";
-            }
+            caption = addBusyIndicator(caption, terminals_.getHasSubprocs(handle));
 
             String menuHtml = AppCommand.formatMenuLabel(
                   null,              /*icon*/
@@ -127,11 +135,29 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
     */
    public void setActiveTerminal(String caption, String handle)
    {
-      activeTerminalCaption_ = caption;
       activeTerminalHandle_ = handle;
-      toolbarButton_.setText(trimCaption(activeTerminalCaption_));
+      toolbarButton_.setText(addBusyIndicator(trimCaption(caption), 
+            terminals_.getHasSubprocs(handle)));
    }
-   
+
+   /**
+    * Refresh caption of active terminal based on busy status.
+    * @param caption caption of the active terminal
+    * @param handle handle of the active terminal
+    */
+   private void refreshActiveTerminal()
+   {
+      if (toolbarButton_ == null || activeTerminalHandle_ == null)
+         return;
+      
+      String caption = terminals_.getCaption(activeTerminalHandle_);
+      if (caption == null)
+         return;
+      
+      toolbarButton_.setText(addBusyIndicator(trimCaption(caption), 
+            terminals_.getHasSubprocs(activeTerminalHandle_)));
+   }
+    
    /**
     * set state to indicate no active terminals
     */
@@ -197,6 +223,19 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
          }
       }
    }
+   
+   /**
+    * Add indicator of busy status to a caption.
+    * @param caption
+    * @return Caption with busy indicator added.
+    */
+   private String addBusyIndicator(String caption, boolean busy)
+   {
+      if (busy == true)
+         return caption + " (busy)";
+      else
+         return caption;
+   }
 
    private String trimCaption(String caption)
    {
@@ -214,7 +253,6 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
    private ToolbarButton toolbarButton_;
    private Commands commands_;
    private EventBus eventBus_;
-   private String activeTerminalCaption_;
    private String activeTerminalHandle_;
    private TerminalList terminals_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
@@ -48,7 +48,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
          {
             refreshActiveTerminal();
          }
-      });   
+      });
    }
 
    @Inject
@@ -136,8 +136,12 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
    public void setActiveTerminal(String caption, String handle)
    {
       activeTerminalHandle_ = handle;
-      toolbarButton_.setText(addBusyIndicator(trimCaption(caption), 
-            terminals_.getHasSubprocs(handle)));
+      String trimmed = trimCaption(caption);
+      if (handle != null)
+      {
+         trimmed = addBusyIndicator(trimmed, terminals_.getHasSubprocs(handle));
+      }
+      toolbarButton_.setText(trimmed);
    }
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -1,7 +1,7 @@
 /*
  * TerminalSession.java
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -37,7 +37,6 @@ import org.rstudio.studio.client.workbench.views.terminal.events.ResizeTerminalE
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalDataInputEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStartedEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStoppedEvent;
-import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSubprocEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalTitleEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.XTermTitleEvent;
 import org.rstudio.studio.client.workbench.views.terminal.xterm.XTermWidget;
@@ -56,8 +55,7 @@ public class TerminalSession extends XTermWidget
                                         ResizeTerminalEvent.Handler,
                                         TerminalDataInputEvent.Handler,
                                         XTermTitleEvent.Handler,
-                                        SessionSerializationHandler,
-                                        TerminalSubprocEvent.Handler
+                                        SessionSerializationHandler
 {
    /**
     * 
@@ -131,7 +129,6 @@ public class TerminalSession extends XTermWidget
             addHandlerRegistration(addResizeTerminalHandler(TerminalSession.this));
             addHandlerRegistration(addXTermTitleHandler(TerminalSession.this));
             addHandlerRegistration(eventBus_.addHandler(SessionSerializationEvent.TYPE, TerminalSession.this));
-            addHandlerRegistration(eventBus_.addHandler(TerminalSubprocEvent.TYPE, TerminalSession.this));
 
             // We keep this handler connected after a terminal disconnect so
             // user input can wake up a suspended session
@@ -421,6 +418,16 @@ public class TerminalSession extends XTermWidget
    }
 
    /**
+    * Set state of hasChildProcs flag
+    * @param hasChildProcs new state for flag
+    */
+   public void setHasChildProcs(boolean hasChildProcs)
+   {
+      hasChildProcs_ = hasChildProcs;
+   }
+
+
+   /**
     * The sequence number of the terminal, used in creation of the default
     * title, e.g. "Terminal 3".
     * @return The sequence number that was passed to the constructor.
@@ -457,12 +464,6 @@ public class TerminalSession extends XTermWidget
          disconnect();
          break;
       }
-   }
-
-   @Override
-   public void onTerminalSubprocs(TerminalSubprocEvent event)
-   {
-      hasChildProcs_ = event.hasSubprocs();
    }
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
@@ -65,12 +65,6 @@ public class TerminalTabPresenter extends BusyPresenter
       void repopulateTerminals(ArrayList<ConsoleProcessInfo> procList);
 
       /**
-       * @return Are any terminals busy such that showing a progress 
-       * indicator makes sense.
-       */
-      boolean busyTerminals();
-
-      /**
        * @return Are any terminals active (a terminal whose shell has any
        * subprocesses is considered active and should not silently killed).
        */

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/TerminalSubprocEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/TerminalSubprocEvent.java
@@ -1,7 +1,7 @@
 /*
  * TerminalSubprocEvent.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then


### PR DESCRIPTION
- Show busy terminal status on the dropdown menu button (for current terminal), not just on the dropdown. Useful for user, and helpful in noticing/fixing busy detection bugs.
- Show busy by appending (busy) to the terminal caption instead of an asterisk
- Fix bug where busy status getting out of sync on client because I wasn't catching message for the specific terminal instance being targeted, but by all open terminal sessions
- Server-side unit tests for SessionConsoleProcessPersist and SessionConsoleProcessInfo