### PR TITLE
Implement readline-like "reverse-i-search" for R console

### DIFF
--- a/src/cpp/session/resources/grid/gridstyles.css
+++ b/src/cpp/session/resources/grid/gridstyles.css
@@ -1,7 +1,7 @@
 /*
  * gridstyles.css
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -304,7 +304,7 @@ th:focus {
     display: table;
 }
 
-.cell {
+.cell, .headerCell {
     position: relative;
 }
 
@@ -383,9 +383,16 @@ table.dataTable thead th.columnClickable .columnTypeHeader {
     position: absolute;
     height: 23px;   
     top: -4px;
-    right: -7px;
     width: 5px;
     cursor: ew-resize;
     z-index: 5;
+}
+
+.cell .resizer {
+    right: -7px;
+}
+
+.headerCell .resizer {
+    right: -28px;
 }
 

--- a/src/cpp/session/resources/grid/gridviewer.js
+++ b/src/cpp/session/resources/grid/gridviewer.js
@@ -730,10 +730,14 @@ var createFilterPopup = function() {
 var createHeader = function(idx, col) {
   var th = document.createElement("th");
 
+  // wrapper for cell contents
+  var interior = document.createElement("div");
+  interior.className = "headerCell";
+
   // add the title
   var title = document.createElement("div");
   title.textContent = col.col_name;
-  th.appendChild(title);
+  interior.appendChild(title);
   th.title = "column " + idx + ": " + col.col_type;
   if (col.col_type === "numeric") {
     th.title += " with range " + col.col_min + " - " + col.col_max;
@@ -751,8 +755,16 @@ var createHeader = function(idx, col) {
     label.className = "colLabel";  
     label.textContent = col.col_label;
     label.title = col.col_label;
-    th.appendChild(label);
+    interior.appendChild(label);
   }
+
+  // add a grabber for resizing
+  var resizer = document.createElement("div");
+  resizer.className = "resizer";
+  resizer.setAttribute("data-col", idx);
+  interior.appendChild(resizer);
+
+  th.appendChild(interior);
 
   return th;
 };
@@ -831,6 +843,7 @@ var initDataTable = function(resCols, data) {
       textCols.push(j);
     }
   }
+  addResizeHandlers(thead);
   var scrollHeight = window.innerHeight - (thead.clientHeight + 2);
 
   var dataTableAjax = null;
@@ -1054,6 +1067,7 @@ var addResizeHandlers = function(ele) {
          boundsExceeded = 0;
          $("#rsGridData td:nth-child(" + col + ")").css(
             "border-right-color", "#A0A0FF");
+         evt.preventDefault();
       }
    });
    $(ele).on("mousemove", function(evt) {
@@ -1061,12 +1075,20 @@ var addResizeHandlers = function(ele) {
          // if we have an active resize column, resize it by the amount given
          var original = evt.originalEvent;
          applyDelta(original.clientX - initX);
+         evt.preventDefault();
+      }
+   });
+   $(ele).on("click", function(evt) {
+      if (col !== null) {
+         // ignore clicks while resizing
+         evt.preventDefault();
       }
    });
    $(ele).on("mouseup", function(evt) {
       if (col !== null) {
          // end resizing if active
          endResize();
+         evt.preventDefault();
       }
    });
    $(ele).on("mouseleave", function(evt) {
@@ -1149,7 +1171,7 @@ var bootstrap = function(data) {
             var eWithNumber = e;
             eWithNumber[""] = idx + 1;
             return eWithNumber;
-          })
+          });
         }
         else {
           data.data = [

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellDisplay.java
@@ -20,13 +20,16 @@ import org.rstudio.studio.client.workbench.model.ConsoleAction;
 import org.rstudio.studio.client.workbench.views.console.shell.editor.InputEditorDisplay;
 
 import com.google.gwt.event.dom.client.HasKeyPressHandlers;
+import com.google.gwt.event.dom.client.HasKeyUpHandlers;
 import com.google.gwt.event.dom.client.KeyDownHandler;
+import com.google.gwt.event.dom.client.KeyUpHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Widget;
 
 public interface ShellDisplay extends ShellOutputWriter, 
                                       CanFocus, 
-                                      HasKeyPressHandlers
+                                      HasKeyPressHandlers,
+                                      HasKeyUpHandlers
 {
    void consoleWriteInput(String input, String console);
    void consoleWritePrompt(String prompt);
@@ -48,6 +51,7 @@ public interface ShellDisplay extends ShellOutputWriter,
    void setMaxOutputLines(int maxLines);
 
    HandlerRegistration addCapturingKeyDownHandler(KeyDownHandler handler);
+   HandlerRegistration addCapturingKeyUpHandler(KeyUpHandler handler);
    
    Widget getShellWidget();
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -673,7 +673,18 @@ public class ShellWidget extends Composite implements ShellDisplay,
       return input_.addKeyPressHandler(handler) ;
    }
    
-   
+   @Override
+   public HandlerRegistration addCapturingKeyUpHandler(KeyUpHandler handler)
+   {
+      return input_.addCapturingKeyUpHandler(handler);
+   }
+
+   @Override
+   public HandlerRegistration addKeyUpHandler(KeyUpHandler handler)
+   {
+      return input_.addKeyUpHandler(handler);
+   }
+
    public int getCharacterWidth()
    {
       return DomUtils.getCharacterWidth(getElement(), styles_.console());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleResources.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleResources.java
@@ -42,6 +42,7 @@ public interface ConsoleResources extends ClientBundle
       String paramInfoDesc();
       String promptFullHelp();
       String error();
+      String searchMatch();
       String selected();
       String paddedOutput();
       String packageName();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/consoleStyles.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/consoleStyles.css
@@ -89,6 +89,10 @@
    background-color: rgb(146, 193, 240);
 }
 
+.searchMatch {
+   background-color: rgb(190, 230, 255);
+}
+
 .functionInfo, .paramInfoName {
    padding: 2px 2px 2px 3px;
 
@@ -149,6 +153,8 @@
 	font-style: italic;
 	color: #888888;
 }
+
+
 
 .ace_tooltip {
 	max-width: 400px;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -1,7 +1,7 @@
 /*
  * Shell.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -25,6 +25,7 @@ import com.google.inject.Inject;
 
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.CommandBinder;
@@ -136,11 +137,13 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       keyDownPreviewHandlers_ = new ArrayList<KeyDownPreviewHandler>() ;
       keyPressPreviewHandlers_ = new ArrayList<KeyPressPreviewHandler>() ;
 
-      InputKeyDownHandler handler = new InputKeyDownHandler() ;
+      InputKeyHandler handler = new InputKeyHandler() ;
+
       // This needs to be a capturing key down handler or else Ace will have
       // handled the event before we had a chance to prevent it
-      view_.addCapturingKeyDownHandler(handler) ;
-      view_.addKeyPressHandler(handler) ;
+      view_.addCapturingKeyDownHandler(handler);
+      view_.addKeyPressHandler(handler);
+      view_.addCapturingKeyUpHandler(handler);
       
       eventBus.addHandler(ConsoleHistoryAddedEvent.TYPE, this);
       eventBus.addHandler(ConsoleInputEvent.TYPE, this); 
@@ -170,8 +173,9 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       addKeyDownPreviewHandler(completionManager) ;
       addKeyPressPreviewHandler(completionManager) ;
       
-      addKeyDownPreviewHandler(new HistoryCompletionManager(
-            view_.getInputEditorDisplay(), server));
+      historyCompletion_ = new HistoryCompletionManager(
+            view_.getInputEditorDisplay(), server);
+      addKeyDownPreviewHandler(historyCompletion_);
       
       // we need to explicitly connect a paste handler on Desktop
       // to ensure the completion popup is dismissed in shell on paste
@@ -482,14 +486,26 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
          historyManager_.addToHistory(event.getCode());
    }
 
-   private final class InputKeyDownHandler implements KeyDownHandler,
-                                                      KeyPressHandler
+   private final class InputKeyHandler implements KeyDownHandler,
+                                                  KeyPressHandler,
+                                                  KeyUpHandler
    {
       public void onKeyDown(KeyDownEvent event)
       {
          int keyCode = event.getNativeKeyCode();
+         
+         // typically we allow all the handlers to process the key; however,
+         // this behavior is suppressed when we're incrementally searching the
+         // history so we don't stack two kinds of completion popups
+         ArrayList<KeyDownPreviewHandler> handlers = keyDownPreviewHandlers_;
+         if (historyCompletion_.getMode() == 
+               HistoryCompletionManager.PopupMode.PopupIncremental)
+         {
+            handlers = new ArrayList<KeyDownPreviewHandler>();
+            handlers.add(historyCompletion_);
+         }
 
-         for (KeyDownPreviewHandler handler : keyDownPreviewHandlers_)
+         for (KeyDownPreviewHandler handler : handlers)
          {
             if (handler.previewKeyDown(event.getNativeEvent()))
             {
@@ -602,7 +618,18 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
 
       public void onKeyPress(KeyPressEvent event)
       {
-         for (KeyPressPreviewHandler handler : keyPressPreviewHandlers_)
+         // typically we allow all the handlers to process the key; however,
+         // this behavior is suppressed when we're incrementally searching the
+         // history so we don't stack two kinds of completion popups
+         ArrayList<KeyPressPreviewHandler> handlers = keyPressPreviewHandlers_;
+         if (historyCompletion_.getMode() == 
+               HistoryCompletionManager.PopupMode.PopupIncremental)
+         {
+            handlers = new ArrayList<KeyPressPreviewHandler>();
+            handlers.add(historyCompletion_);
+         }
+
+         for (KeyPressPreviewHandler handler : handlers)
          {
             if (handler.previewKeyPress(event.getCharCode()))
             {
@@ -610,6 +637,20 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
                event.stopPropagation() ;
                return;
             }
+         }
+      }
+
+      @Override
+      public void onKeyUp(KeyUpEvent event)
+      {
+         if (event.isAnyModifierKeyDown())
+            return;
+         if (KeyCodeEvent.isArrow(event.getNativeKeyCode()))
+            return;
+         if (historyCompletion_.getMode() == 
+               HistoryCompletionManager.PopupMode.PopupIncremental)
+         {
+            historyCompletion_.beginSearch();
          }
       }
 
@@ -684,6 +725,8 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    private final InputEditorDisplay input_ ;
    private final ArrayList<KeyDownPreviewHandler> keyDownPreviewHandlers_ ;
    private final ArrayList<KeyPressPreviewHandler> keyPressPreviewHandlers_ ;
+   private final HistoryCompletionManager historyCompletion_;
+   
    // indicates whether the next command should be added to history
    private boolean addToHistory_ ;
    private String lastPromptText_ ;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionListPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionListPopupPanel.java
@@ -20,23 +20,23 @@ import org.rstudio.core.client.events.HasSelectionCommitHandlers;
 import org.rstudio.core.client.events.SelectionCommitHandler;
 import org.rstudio.core.client.widget.ThemedPopupPanel;
 
-public class CompletionListPopupPanel extends ThemedPopupPanel
-   implements HasSelectionCommitHandlers<String>
+public class CompletionListPopupPanel<TItem> extends ThemedPopupPanel
+   implements HasSelectionCommitHandlers<TItem>
 {
-   public CompletionListPopupPanel(String[] entries)
+   public CompletionListPopupPanel(TItem[] entries)
    {
       super(true);
-      list_ = new CompletionList<String>(entries, 10, false, true);
+      list_ = new CompletionList<TItem>(entries, 10, true, true);
       setWidget(list_);
    }
 
    public HandlerRegistration addSelectionCommitHandler(
-         SelectionCommitHandler<String> handler)
+         SelectionCommitHandler<TItem> handler)
    {
       return list_.addSelectionCommitHandler(handler);
    }
 
-   public String getSelectedValue()
+   public TItem getSelectedValue()
    {
       if (list_ == null || !list_.isAttached())
          return null ;
@@ -86,5 +86,5 @@ public class CompletionListPopupPanel extends ThemedPopupPanel
       setWidget(html);
    }
 
-   private final CompletionList<String> list_;
+   private final CompletionList<TItem> list_;
 }


### PR DESCRIPTION
This change implements reverse incremental searching at the R console, a common request made by users who are used to this feature in bash and other Unix shells. 

![image](https://cloud.githubusercontent.com/assets/470418/22674784/b1bac15c-ec96-11e6-909f-8873a59f2a23.png)

The reverse incremental mode differs from the existing Cmd+Up behavior in that it doesn't self-dismiss once you add characters; instead, it stays up and filters in real time as you type. Just as in bash, it's toggled by pressing Ctrl+R (the existing Cmd+Up behavior has not changed).