### PR TITLE
suppress synthesized mouse events on modifier keys

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/MouseTracker.java
+++ b/src/gwt/src/org/rstudio/core/client/MouseTracker.java
@@ -1,7 +1,7 @@
 /*
  * MouseTracker.java
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -30,14 +30,62 @@ public class MouseTracker
          @Override
          public void onPreviewNativeEvent(NativePreviewEvent preview)
          {
-            if ((preview.getTypeInt() & Event.MOUSEEVENTS) == 0)
+            int type = preview.getTypeInt();
+            if ((type & Event.MOUSEEVENTS) == 0)
+            {
+               lastEventType_ = type;
                return;
+            }
             
             NativeEvent event = preview.getNativeEvent();
+            
+            // Safari triggers certain mouse events when modifier keys are
+            // pressed. Suppress those as they can cause unexpected behavior
+            // when e.g. typing in a textbox while the mouse happens to lie
+            // over a popup panel (e.g. C++ completions, Find in Files)
+            if (isSafariModifierKeyCausingMouseEvent(event, type))
+            {
+               event.stopPropagation();
+               event.preventDefault();
+            }
+            
+            lastEventType_ = type;
             lastMouseX_ = event.getClientX();
             lastMouseY_ = event.getClientY();
          }
       });
+   }
+   
+   private boolean isSafariModifierKeyCausingMouseEvent(NativeEvent event,
+                                                        int type)
+   {
+      if (!IS_SAFARI)
+         return false;
+      
+      // If the last event was a key event, and we just got a mouse event,
+      // suppress it. (The intention here is to suppress a 'mouseout' or
+      // 'mouseover' event synthesized in respond to a modifier keypress.
+      //
+      // Note that these events can be emitted in response to a keyup as
+      // well; in such a case the associated modifier key will no longer
+      // be held down and so we just globally suppress 'mouseover' and
+      // 'mouseout' following a keyevent.
+      if ((lastEventType_ & Event.KEYEVENTS) != 0 &&
+          (type == Event.ONMOUSEOVER || type == Event.ONMOUSEOUT))
+      {
+         suppressing_ = true;
+         return true;
+      }
+      
+      // Stop suppressing once we get a new non-mouseover/mouseout event.
+      else if (type != Event.ONMOUSEOVER && type != Event.ONMOUSEOUT)
+      {
+         suppressing_ = false;
+         return false;
+      }
+      
+      // For other intermediate events, return status of suppressing flag.
+      return suppressing_;
    }
    
    public int getLastMouseX()
@@ -52,4 +100,10 @@ public class MouseTracker
    
    private int lastMouseX_;
    private int lastMouseY_;
+   
+   private int lastEventType_;
+   private boolean suppressing_;
+   
+   private static final boolean IS_SAFARI =
+         BrowseCap.isSafari() || BrowseCap.isMacintoshDesktop();
 }


### PR DESCRIPTION
The issue here is a bit fiddly, so I'll try to explain what's going on...

With Safari WebKit, when a modifier key is pressed, the mouse cursor position is updated (the cursor is shown) and associated mouse events are emitted. This can cause a problem while typing in a textbox that has an associated completion list popup (e.g. Find in Files, C++ autocompletion popups) -- if the mouse cursor happens to lie over the generated popup, pressing a modifier key effectively moves focus to that menu item. (You can imagine trying to type a capital letter, and then seeing the mouse suddenly appear and set the selection / steal focus away from where you are typing.)

This PR attempts to resolve that issue by attempting to detect those synthesized events, and suppress them. If the last event was a key event (the user was typing), and the current event is a mouseover or mouseout with an associated modifier key (detecting a synthesized mouse event), then we eat that event, and any other future non-mousemove events for that short session.