### PR TITLE
Allow F2 to open data frames

### DIFF
--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -707,3 +707,13 @@
   assign(cacheKey, obj, .rs.WorkingDataEnv)
 })
 
+.rs.addFunction("findGlobalData", function(name)
+{
+  if (exists(name, envir = globalenv()))
+  {
+    if (inherits(get(name, envir = globalenv()), "data.frame"))
+       return(name)
+  }
+  invisible(NULL)
+})
+

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -132,7 +132,7 @@ import org.rstudio.studio.client.shiny.model.ShinyRunCmd;
 import org.rstudio.studio.client.shiny.model.ShinyViewerType;
 import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
 import org.rstudio.studio.client.workbench.codesearch.model.CodeSearchResults;
-import org.rstudio.studio.client.workbench.codesearch.model.FunctionDefinition;
+import org.rstudio.studio.client.workbench.codesearch.model.ObjectDefinition;
 import org.rstudio.studio.client.workbench.codesearch.model.SearchPathFunctionDefinition;
 import org.rstudio.studio.client.workbench.exportplot.model.SavePlotAsImageContext;
 import org.rstudio.studio.client.workbench.model.Agreement;
@@ -537,10 +537,10 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, SEARCH_CODE, params, requestCallback);
    }
    
-   public void getFunctionDefinition(
+   public void getObjectDefinition(
          String line, 
          int pos,
-         ServerRequestCallback<FunctionDefinition> requestCallback)
+         ServerRequestCallback<ObjectDefinition> requestCallback)
    {
       JSONArray params = new JSONArray();
       params.set(0, new JSONString(line));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/model/CodeSearchServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/model/CodeSearchServerOperations.java
@@ -27,27 +27,18 @@ public interface CodeSearchServerOperations
          int maxResults,
          ServerRequestCallback<CodeSearchResults> requestCallback);
    
-   /*
-    * Get the definition of the specified function (if known).
+   /**
+    * Get the definition of the specified object (if known).
     * We pass a line and pos rather than a function name because that is
     * the level of fidelity we have in the editor -- we use R on the server
-    * to sort out the name of the token to lookup. Fields in the
-    * FunctionDefinition will be as follows on return
-    *     - getFunctionName     -- the parsed token from line/pos or
-    *                              null if no token could be parsed
-    *                              
-    *     - getFile/getPosition -- file location if one of the files we
-    *                              are managing has the definition, else null
-    *                             
-    *     - getSearchPathFunctionDefinition 
-    *                           -- name/namespace/code if the function was
-    *                              found on the search path, else null. this
-    *                              is mutually exclusive with getFile
+    * to sort out the name of the token to lookup. Possible return types 
+    * include functions defined on the search path, functions in the source
+    * index, and data frames.
     */
-   void getFunctionDefinition(
+   void getObjectDefinition(
          String line, 
          int pos,
-         ServerRequestCallback<FunctionDefinition> requestCallback);
+         ServerRequestCallback<ObjectDefinition> requestCallback);
 
     /* 
      * Find the passed function in the search path (searching starting

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/model/DataDefinition.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/model/DataDefinition.java
@@ -1,0 +1,26 @@
+/*
+ * DataDefinition.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.codesearch.model;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+public class DataDefinition extends JavaScriptObject
+{
+   protected DataDefinition()
+   {
+   }
+   
+   public final static String OBJECT_TYPE = "data";
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/model/FileFunctionDefinition.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/model/FileFunctionDefinition.java
@@ -1,7 +1,7 @@
 /*
- * FunctionDefinition.java
+ * FileFunctionDefinition.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,39 +19,19 @@ import org.rstudio.core.client.files.FileSystemItem;
 
 import com.google.gwt.core.client.JavaScriptObject;
 
-public class FunctionDefinition extends JavaScriptObject
+public class FileFunctionDefinition extends JavaScriptObject
 {
-   protected FunctionDefinition()
+   protected FileFunctionDefinition()
    {
-      
    }
 
-   /*
-    *  Name of function -- can be null if no function token could be
-    *  ascertained from the line and pos passed to the server
-    */
-   public final native String getFunctionName() /*-{
-      return this.function_name;
-   }-*/;
-  
-   /*
-    *  File position where the definition of the function is. Can be null
-    *  if no indexed file defining the function was found
-    */
    public final native FileSystemItem getFile() /*-{
       return this.file;
    }-*/;
+
    public final native FilePosition getPosition()/*-{
       return this.position;
    }-*/;
    
-   /*
-    *  A definition of the function from the current search path. Can be null
-    *  if the function was found in an indexed file
-    */
-   public final native SearchPathFunctionDefinition 
-                                 getSearchPathFunctionDefinition() /*-{
-      return this.search_path_definition;
-   }-*/;
-   
+   public final static String OBJECT_TYPE = "file_function";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/model/ObjectDefinition.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/model/ObjectDefinition.java
@@ -1,0 +1,36 @@
+/*
+ * ObjectDefinition.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.codesearch.model;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+public class ObjectDefinition extends JavaScriptObject
+{
+   protected ObjectDefinition()
+   {
+   }
+   
+   public final native String getObjectName() /*-{
+      return this.name;
+   }-*/;
+   
+   public final native String getObjectType() /*-{
+      return this.type;
+   }-*/;
+   
+   public final native JavaScriptObject getObjectData() /*-{
+      return this.data;
+   }-*/;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/model/SearchPathFunctionDefinition.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/model/SearchPathFunctionDefinition.java
@@ -1,7 +1,7 @@
 /*
  * SearchPathFunctionDefinition.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -58,4 +58,6 @@ public class SearchPathFunctionDefinition extends JavaScriptObject
    public final native boolean isActiveDebugCode() /*-{
       return this.active_debug_code ? true : false;
    }-*/;
+   
+   public final static String OBJECT_TYPE = "search_path_function";
 }


### PR DESCRIPTION
This change implements a suggestion to allow F2 to open data frames in addition to functions. It is designed for use in traditional R scripts wherein the data is present in the global environment, and invokes `View()` on the data if found (just like clicking on it in the Environment pane).