### PR TITLE
Add support to import white space delimited tables in data import

### DIFF
--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -374,10 +374,16 @@
       "text" = function() {
          functionName <- ""
          functionReference <- readr::read_delim
-         if (is.null(dataImportOptions$delimiter) || identical(dataImportOptions$delimiter, ","))
+         if (is.null(dataImportOptions$delimiter)
+            || identical(dataImportOptions$delimiter, ","))
          {
             functionName <- "read_csv"
             functionReference <- readr::read_csv
+         }
+         else if (identical(dataImportOptions$delimiter, " "))
+         {
+            functionName <- "read_table"
+            functionReference <- readr::read_table
          }
          else
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.java
@@ -216,7 +216,7 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
                         }
 
                         int selectedIndex = delimiterListBox_.getSelectedIndex();
-                        delimiterListBox_.insertItem(otherDelimiter, otherDelimiter, selectedIndex - 1);
+                        delimiterListBox_.insertItem("Character " + otherDelimiter, otherDelimiter, selectedIndex - 1);
                         delimiterListBox_.setSelectedIndex(selectedIndex - 1);
 
                         updateEnabled();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.java
@@ -52,6 +52,7 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
    private final String escapeDouble_ = "double";
 
    private DataImportOptionsCsvLocale localeInfo_ = null;
+   private int lastDelimiterListBoxIndex_ = 0;
    
    interface DataImportOptionsCsvUiBinder extends UiBinder<HTMLPanel, DataImportOptionsUiCsv> {}
 
@@ -201,15 +202,18 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
             {
                globalDisplay_.promptForTextWithOption(
                   "Other Delimiter",
-                  "Please enter a single character custom delimiter.",
+                  "Please enter a single character delimiter.",
                   "",
                   false,
                   "",
                   false,
                   new ProgressOperationWithInput<PromptWithOptionResult>()
                   {
-                     private void dismissAndUpdate(ProgressIndicator indicator)
+                     private void dismissAndUpdate(ProgressIndicator indicator, int newSelectIndex)
                      {
+                        lastDelimiterListBoxIndex_ = newSelectIndex;
+                        delimiterListBox_.setSelectedIndex(newSelectIndex);
+
                         indicator.onCompleted();
 
                         updateEnabled();
@@ -228,17 +232,15 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
                         else {
                            for (int idxDelimiter = 0; idxDelimiter < delimiterListBox_.getItemCount(); idxDelimiter++) {
                               if (delimiterListBox_.getValue(idxDelimiter) == otherDelimiter) {
-                                 delimiterListBox_.setSelectedIndex(idxDelimiter);
-                                 dismissAndUpdate(indicator);
+                                 dismissAndUpdate(indicator, idxDelimiter);
                                  return;
                               }
                            }
 
                            int selectedIndex = delimiterListBox_.getSelectedIndex();
                            delimiterListBox_.insertItem("Character " + otherDelimiter, otherDelimiter, selectedIndex - 1);
-                           delimiterListBox_.setSelectedIndex(selectedIndex - 1);
                            
-                           dismissAndUpdate(indicator);
+                           dismissAndUpdate(indicator, selectedIndex - 1);
                         }
                      }
                   },
@@ -246,7 +248,7 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
                      @Override
                      public void execute()
                      {
-                        delimiterListBox_.setSelectedIndex(0);
+                        delimiterListBox_.setSelectedIndex(lastDelimiterListBoxIndex_);
                         updateEnabled();
                         triggerChange();
                      }
@@ -254,6 +256,8 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
                );        
             }
             else {
+               lastDelimiterListBoxIndex_ = delimiterListBox_.getSelectedIndex();
+
                updateEnabled();
                triggerChange();
             }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsvLocale.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsvLocale.ui.xml
@@ -21,6 +21,9 @@
       td.spacedCell {
         padding-left: 10px;
       }
+      .listBox {
+        width: 90px;
+      }
    </ui:style>
 
    <g:HTMLPanel styleName="{style.dialog}">
@@ -36,7 +39,7 @@
                 <g:Label text="Encoding:" />
             </td>
             <td>
-                <g:ListBox ui:field="encoding_" />
+                <g:ListBox styleName="{style.listBox}" ui:field="encoding_" />
             </td>
          </tr>
          <tr>


### PR DESCRIPTION
Users have reported the old import dialog allowed them to import tables like:

```
Column_1     Column_2     Column_3
       1            A            X
       2            B            Y
```

Which is currently not possible, but could be implemented using `readr::read_table`. Therefore, this PR:

 1. Replaces "Whitespace" delimiter to use `readr::read_table`
 2. Adds new `Other...` option for other characters and for those users that might want to use `read_read_delim` with a space.

Notice that other users have reported that they would like to use `read.table` to avoid installing `readr`, this is being tracked as a separate issue to consider separately.

<img width="1076" alt="screen shot 2017-02-08 at 10 45 25 am" src="https://cloud.githubusercontent.com/assets/3478847/22753537/4c134b60-edf1-11e6-9249-0507cf0c8d56.png">

<img width="1077" alt="screen shot 2017-02-08 at 11 21 14 am" src="https://cloud.githubusercontent.com/assets/3478847/22753509/36f241f0-edf1-11e6-850e-51079147d794.png">

<img width="1085" alt="screen shot 2017-02-08 at 11 05 19 am" src="https://cloud.githubusercontent.com/assets/3478847/22753522/3da1fcde-edf1-11e6-9b56-9c7ed33c8145.png">
