### PR TITLE
avoid collisions with 'major', 'minor' macro leakage

### DIFF
--- a/src/cpp/core/include/core/libclang/LibClang.hpp
+++ b/src/cpp/core/include/core/libclang/LibClang.hpp
@@ -42,34 +42,34 @@ namespace libclang {
 
 struct LibraryVersion
 {
-   LibraryVersion() : major_(0), minor_(0), patch_(0) {}
-   LibraryVersion(int major, int minor, int patch)
-      : major_(major), minor_(minor), patch_(patch)
+   LibraryVersion() : versionMajor_(0), versionMinor_(0), versionPatch_(0) {}
+   LibraryVersion(int versionMajor, int versionMinor, int versionPatch)
+      : versionMajor_(versionMajor), versionMinor_(versionMinor), versionPatch_(versionPatch)
    {
    }
 
 
-   bool empty() const { return major_ == 0; }
+   bool empty() const { return versionMajor_ == 0; }
 
-   int major() const { return major_; }
-   int minor() const { return minor_; }
-   int patch() const { return patch_; }
+   int versionMajor() const { return versionMajor_; }
+   int versionMinor() const { return versionMinor_; }
+   int versionPatch() const { return versionPatch_; }
 
    bool operator<(const LibraryVersion& other) const
    {
-      if (major_ == other.major_ && minor_ == other.minor_)
-         return patch_ < other.patch_;
-      else if (major_ == other.major_)
-         return minor_ < other.minor_;
+      if (versionMajor_ == other.versionMajor_ && versionMinor_ == other.versionMinor_)
+         return versionPatch_ < other.versionPatch_;
+      else if (versionMajor_ == other.versionMajor_)
+         return versionMinor_ < other.versionMinor_;
       else
-         return major_ < other.major_;
+         return versionMajor_ < other.versionMajor_;
    }
 
    bool operator==(const LibraryVersion& other) const
    {
-      return major_ == other.major_ &&
-             minor_ == other.minor_ &&
-             patch_ == other.patch_;
+      return versionMajor_ == other.versionMajor_ &&
+             versionMinor_ == other.versionMinor_ &&
+             versionPatch_ == other.versionPatch_;
    }
 
    bool operator!=(const LibraryVersion& other) const
@@ -80,13 +80,13 @@ struct LibraryVersion
    std::string asString() const
    {
       boost::format fmt("%1%.%2%.%3%");
-      return boost::str(fmt % major_ % minor_ % patch_);
+      return boost::str(fmt % versionMajor_ % versionMinor_ % versionPatch_);
    }
 
 private:
-   const int major_;
-   const int minor_;
-   const int patch_;
+   const int versionMajor_;
+   const int versionMinor_;
+   const int versionPatch_;
 };
 
 

--- a/src/cpp/core/include/core/r_util/RVersionInfo.hpp
+++ b/src/cpp/core/include/core/r_util/RVersionInfo.hpp
@@ -59,42 +59,42 @@ public:
       RVersionNumber ver;
       if (boost::regex_search(number, match, re, flags))
       {
-         ver.major_ = safe_convert::stringTo<int>(match[1], 0);
-         ver.minor_ = safe_convert::stringTo<int>(match[2], 0);
+         ver.versionMajor_ = safe_convert::stringTo<int>(match[1], 0);
+         ver.versionMinor_ = safe_convert::stringTo<int>(match[2], 0);
          std::string match3 = match[3];
          if (!match3.empty())
-            ver.patch_ = safe_convert::stringTo<int>(match3, 0);
+            ver.versionPatch_ = safe_convert::stringTo<int>(match3, 0);
       }
       return ver;
    }
 
    RVersionNumber()
-      : major_(0), minor_(0), patch_(0)
+      : versionMajor_(0), versionMinor_(0), versionPatch_(0)
    {
    }
 
 public:
-   bool empty() const { return major_ != 0; }
+   bool empty() const { return versionMajor_ != 0; }
 
-   int major() const { return major_; }
-   int minor() const { return minor_; }
-   int patch() const { return patch_; }
+   int versionMajor() const { return versionMajor_; }
+   int versionMinor() const { return versionMinor_; }
+   int versionPatch() const { return versionPatch_; }
 
    bool operator<(const RVersionNumber& other) const
    {
-      if (major() == other.major() && minor() == other.minor())
-         return patch() < other.patch();
-      else if (major() == other.major())
-         return minor() < other.minor();
+      if (versionMajor() == other.versionMajor() && versionMinor() == other.versionMinor())
+         return versionPatch() < other.versionPatch();
+      else if (versionMajor() == other.versionMajor())
+         return versionMinor() < other.versionMinor();
       else
-         return major() < other.major();
+         return versionMajor() < other.versionMajor();
    }
 
    bool operator==(const RVersionNumber& other) const
    {
-      return major() == other.major() &&
-             minor() == other.minor() &&
-             patch() == other.patch();
+      return versionMajor() == other.versionMajor() &&
+             versionMinor() == other.versionMinor() &&
+             versionPatch() == other.versionPatch();
    }
 
    bool operator!=(const RVersionNumber& other) const
@@ -103,14 +103,14 @@ public:
    }
 
 private:
-   int major_;
-   int minor_;
-   int patch_;
+   int versionMajor_;
+   int versionMinor_;
+   int versionPatch_;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const RVersionNumber& ver)
 {
-   os << ver.major() << "." << ver.minor() << "." << ver.patch();
+   os << ver.versionMajor() << "." << ver.versionMinor() << "." << ver.versionPatch();
    return os;
 }
 

--- a/src/cpp/core/r_util/RVersionsPosix.cpp
+++ b/src/cpp/core/r_util/RVersionsPosix.cpp
@@ -242,8 +242,8 @@ bool isVersion(const RVersionNumber& number,
 bool isMajorMinorVersion(const RVersionNumber& test, const RVersion& item)
 {
    RVersionNumber itemNumber = RVersionNumber::parse(item.number());
-   return (test.major() == itemNumber.major() &&
-           test.minor() == itemNumber.minor());
+   return (test.versionMajor() == itemNumber.versionMajor() &&
+           test.versionMinor() == itemNumber.versionMinor());
 }
 
 


### PR DESCRIPTION
On some systems, the `<sys/types.h>` header exports two function macros, `major()` and `minor()`. This can cause issues in translation units that attempt to use these as function, or variable, names. Unfortunately, it's not easy to see how this header can sneak in -- e.g. on some systems, attempting to include the `<iterator>` header pulls that in. 

This PR attempts to rename any usages of `major` or `minor` as `versionMajor` and `versionMinor`, respectively.

The overarching goal here is to ensure that RStudio can build on FreeBSD (as requested by some users).