### PR TITLE
Add support for RCNTXT layout changes in R 3.3.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,7 @@
 * Ctrl+P/Ctrl+N to visit previous/next console history line (like readline)
 * Ctrl+R to search console history incrementally (like readline)
 * New "Copy To" command in Files pane to copy and rename in one step
+* Debugger support for R 3.3.3 and above
 * Server Pro: Add option to disable file uploads
 
 ### Bug Fixes

--- a/src/cpp/r/RCntxt.cpp
+++ b/src/cpp/r/RCntxt.cpp
@@ -39,9 +39,12 @@ RCntxt::RCntxt(void *rawCntxt)
 {
    if (rawCntxt == NULL)
       return;
-   else if (contextVersion() == RVersion33)
-      pCntxt_ = boost::make_shared<RIntCntxt<RCNTXT_33> >(
-                                   static_cast<RCNTXT_33*>(rawCntxt));
+   else if (contextVersion() == RVersion333)
+      pCntxt_ = boost::make_shared<RIntCntxt<RCNTXT_333> >(
+                                   static_cast<RCNTXT_333*>(rawCntxt));
+   else if (contextVersion() == RVersion330)
+      pCntxt_ = boost::make_shared<RIntCntxt<RCNTXT_330> >(
+                                   static_cast<RCNTXT_330*>(rawCntxt));
    else
       pCntxt_ = boost::make_shared<RIntCntxt<RCNTXT_32> >(
                                    static_cast<RCNTXT_32*>(rawCntxt));

--- a/src/cpp/r/RCntxtUtils.cpp
+++ b/src/cpp/r/RCntxtUtils.cpp
@@ -32,11 +32,13 @@ RCntxtVersion contextVersion()
 
    if (s_rCntxtVersion == RVersionUnknown)
    {
-      // currently there are only two known memory layouts for the R context
-      // structure (see RCntxtVersion enum)
-      s_rCntxtVersion = r::util::hasRequiredVersion("3.3") ? 
-         RVersion33 : 
-         RVersion32;
+      // use current R version to divine the memory layout 
+      if (r::util::hasRequiredVersion("3.3.3"))
+         s_rCntxtVersion = RVersion333;
+      else if (r::util::hasRequiredVersion("3.3"))
+         s_rCntxtVersion = RVersion330;
+      else 
+         s_rCntxtVersion = RVersion32;
    }
    return s_rCntxtVersion;
 }

--- a/src/cpp/r/include/r/RCntxtUtils.hpp
+++ b/src/cpp/r/include/r/RCntxtUtils.hpp
@@ -28,8 +28,9 @@ namespace context {
 // represents the version of the memory layout of the RCNTXT structure
 enum RCntxtVersion
 {
-   RVersion33, // R 3.3.0 and above
-   RVersion32, // R 3.2.5 and below
+   RVersion333, // R 3.3.3 and above
+   RVersion330, // R 3.3.0 - R 3.3.3
+   RVersion32,  // R 3.2.5 and below
    RVersionUnknown 
 };
 

--- a/src/cpp/r/include/r/RInterface.hpp
+++ b/src/cpp/r/include/r/RInterface.hpp
@@ -46,8 +46,51 @@ typedef struct SEXPREC *SEXP;
 
 #endif
 
-typedef struct RCNTXT_33 {
-    struct RCNTXT_33 *nextcontext;
+typedef struct RCNTXT_333 {
+    struct RCNTXT_333 *nextcontext;
+    int callflag;
+#ifdef _WIN32
+    struct
+    {
+      jmp_buf buf;
+      int sigmask;
+      int savedmask;
+    } cjumpbuf;
+#else
+    sigjmp_buf cjmpbuf;
+#endif
+    int cstacktop;
+    int evaldepth;
+    SEXP promargs;
+    SEXP callfun;
+    SEXP sysparent;
+    SEXP call;
+    SEXP cloenv;
+    SEXP conexit;
+    void (*cend)(void *);
+    void *cenddata;
+    void *vmax;
+    int intsusp;
+    int gcenabled;
+    int bcintactive;
+    SEXP bcbody;
+    void *bcpc;
+    SEXP handlerstack;
+    SEXP restartstack;
+    struct RPRSTACK *prstack;
+    SEXP *nodestack;
+#ifdef BC_INT_STACK
+    IStackval *intstack;
+#endif
+    SEXP srcref;
+    int browserfinish;
+    SEXP returnValue;
+    struct RCNTXT_333 *jumptarget;
+    int jumpmask;
+} RCNTXT_333;
+
+typedef struct RCNTXT_330 {
+    struct RCNTXT_330 *nextcontext;
     int callflag;
 #ifdef _WIN32
     struct
@@ -80,7 +123,11 @@ typedef struct RCNTXT_33 {
     IStackval *intstack;
 #endif
     SEXP srcref;
-} RCNTXT_33;
+    int browserfinish;
+    SEXP returnValue;
+    struct RCNTXT_330 *jumptarget;
+    int jumpmask;
+} RCNTXT_330;
 
 typedef struct RCNTXT_32 {
     struct RCNTXT_32 *nextcontext;


### PR DESCRIPTION
RStudio's debugger relies on knowledge of the layout of the `RCNTXT` structure in memory. Unfortunately, this will change again in R 3.3.3. This change adds the new layout, and uses it if the R version is >= 3.3.3. 