### PR TITLE
Have Clear Console shortcut clear the terminal when it has focus

### DIFF
--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -524,6 +524,10 @@ Error ChildProcess::run()
                // for smart terminals we need to echo back the user input
                termp.c_lflag |= ECHO;
                termp.c_oflag |= OPOST|ONLCR;
+
+               // Turn off XON/XOFF flow control so Ctrl+S can be used by
+               // the shell command-line editing instead of suspending output.
+               termp.c_iflag &= ~(IXON|IXOFF);
             }
 
             // Don't ignore signals -- this is done

--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
@@ -469,15 +469,23 @@ public class ShortcutManager implements NativePreviewHandler,
 
             if (XTermWidget.isXTerm(Element.as(event.getEventTarget())))
             {
-               // special case; we expect users will try to use Ctrl+L to
-               // clear the terminal, and don't want that to actually
-               // clear the currently hidden console instead
                if (binding.getId() == "consoleClear")
                {
+                  // special case; we expect users will try to use Ctrl+L to
+                  // clear the terminal, and don't want that to actually
+                  // clear the currently hidden console instead
                   event.stopPropagation();
                   commands_.clearTerminalScrollbackBuffer().execute();
                   return false;
                }
+               else if (binding.getId() == "closeSourceDoc")
+               {
+                  // special case: Ctrl+W is usually bound to closeSourceDoc, 
+                  // but this key sequence is frequently used in bash to kill 
+                  // the word behind the cursor; so we'll ignore this command 
+                  // when focus is in the terminal and let terminal see keys
+                  return false;
+               } 
                if (binding.getContext() != AppCommand.Context.Workbench &&
                      binding.getContext() != AppCommand.Context.Addin &&
                      binding.getContext() != AppCommand.Context.PackageDevelopment)

--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
@@ -474,6 +474,7 @@ public class ShortcutManager implements NativePreviewHandler,
                // clear the currently hidden console instead
                if (binding.getId() == "consoleClear")
                {
+                  event.stopPropagation();
                   commands_.clearTerminalScrollbackBuffer().execute();
                   return false;
                }

--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
@@ -38,6 +38,7 @@ import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.events.EditEvent;
 import org.rstudio.studio.client.workbench.addins.AddinsCommandManager;
+import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.commands.RStudioCommandExecutedFromShortcutEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEditorNative;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceKeyboardActivityEvent;
@@ -146,13 +147,15 @@ public class ShortcutManager implements NativePreviewHandler,
                            EditorCommandManager editorCommands,
                            UserCommandManager userCommands,
                            AddinsCommandManager addins,
-                           EventBus events)
+                           EventBus events,
+                           Commands commands)
    {
       appCommands_ = appCommands;
       editorCommands_ = editorCommands;
       userCommands_ = userCommands;
       addins_ = addins;
       events_ = events;
+      commands_ = commands;
    }
 
    public boolean isEnabled()
@@ -464,13 +467,23 @@ public class ShortcutManager implements NativePreviewHandler,
          {
             keyBuffer_.clear();
 
-            if (XTermWidget.isXTerm(Element.as(event.getEventTarget())) &&
-                  (binding.getContext() != AppCommand.Context.Workbench &&
-                   binding.getContext() != AppCommand.Context.Addin &&
-                   binding.getContext() != AppCommand.Context.PackageDevelopment))
+            if (XTermWidget.isXTerm(Element.as(event.getEventTarget())))
             {
-               // Let terminal see the keyboard input and don't execute command.
-               return false;
+               // special case; we expect users will try to use Ctrl+L to
+               // clear the terminal, and don't want that to actually
+               // clear the currently hidden console instead
+               if (binding.getId() == "consoleClear")
+               {
+                  commands_.clearTerminalScrollbackBuffer().execute();
+                  return false;
+               }
+               if (binding.getContext() != AppCommand.Context.Workbench &&
+                     binding.getContext() != AppCommand.Context.Addin &&
+                     binding.getContext() != AppCommand.Context.PackageDevelopment)
+               {
+                  // Let terminal see the keyboard input and don't execute command.
+                  return false;
+               }
             }
             event.stopPropagation();
             binding.execute();
@@ -681,5 +694,6 @@ public class ShortcutManager implements NativePreviewHandler,
    private ApplicationCommandManager appCommands_;
    private AddinsCommandManager addins_;
    private EventBus events_;
+   private Commands commands_;
    
 }


### PR DESCRIPTION
This was requested by Hadley and Darby. Users will be very used to Ctrl+L clearing the console, and might expect it to clear the terminal when it has focus.

There is a separate Terminal-specific shortcut, Ctrl+Shift+L, but setting it to Ctrl+L will, of course, upset the shortcut resolution, so doing special case just for this.