### PR TITLE
Don't save before knitting/rendering unless document is dirty

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -4980,7 +4980,8 @@ public class TextEditingTarget implements
          @Override
          public void execute()
          {
-            saveThenExecute(null, renderCommand);}
+            saveThenExecute(null, renderCommand);
+         }
       };
       
       // save before rendering if the document is dirty; otherwise render


### PR DESCRIPTION
This change fixes an issue wherein rendering an R Markdown document would save it unnecessarily, which is annoying for users who use external editors with RStudio (as the external editors then warn that the file has been changed when it hasn't). 