### PR TITLE
Adds dataimport menu entries for csv using base

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
@@ -21,11 +21,15 @@ import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.dom.client.MouseOverEvent;
+import com.google.gwt.event.dom.client.MouseOverHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.Event.NativePreviewHandler;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.MenuBar;
 import com.google.gwt.user.client.ui.MenuItem;
 import com.google.gwt.user.client.ui.MenuItemSeparator;
@@ -86,6 +90,16 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
    public void addItem(SafeHtml html, MenuBar popup)
    {
       menuBar_.addItem(html, popup);
+   }
+   
+   public void addItem(MenuItem menuItem, MenuBar popup)
+   {
+      menuBar_.addItem(SafeHtmlUtils.fromTrustedString(menuItem.getHTML()), popup);
+   }
+   
+   public void setAutoOpen(boolean autoOpen)
+   {
+      menuBar_.setAutoOpen(autoOpen);
    }
    
    public void insertItem(MenuItem menuItem, int beforeIndex)

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
@@ -21,15 +21,12 @@ import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.dom.client.KeyCodes;
-import com.google.gwt.event.dom.client.MouseOverEvent;
-import com.google.gwt.event.dom.client.MouseOverHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.Event.NativePreviewHandler;
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.MenuBar;
 import com.google.gwt.user.client.ui.MenuItem;
 import com.google.gwt.user.client.ui.MenuItemSeparator;
@@ -55,6 +52,12 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
    {
       super(true);
       add(wrapMenuBar(menuBar_ = createMenuBar()));
+   }
+   
+   public ToolbarPopupMenu(ToolbarPopupMenu parent)
+   {
+      this();
+      parent_ = parent;
    }
 
    protected ToolbarMenuBar createMenuBar()
@@ -94,12 +97,12 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
       menuBar_.addItem(html, popup);
    }
    
-   public void addItem(MenuItem menuItem, MenuBar popup)
+   public void addItem(MenuItem menuItem, final ToolbarPopupMenu popup)
    {
-      menuBar_.addItem(SafeHtmlUtils.fromTrustedString(menuItem.getHTML()), popup);
+      menuBar_.addItem(SafeHtmlUtils.fromTrustedString(menuItem.getHTML()), popup.menuBar_);
    }
    
-   public void addItem(AppCommand command, MenuBar popup)
+   public void addItem(AppCommand command, ToolbarPopupMenu popup)
    {
       if (command.isEnabled())
          addItem(command.createMenuItem(false), popup);
@@ -183,6 +186,7 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
       {
          Scheduler.get().scheduleFinally(coreCommand_);
          hide();
+         if (parent_ != null) parent_.hide();
       }
    
       private ScheduledCommand coreCommand_;
@@ -322,5 +326,6 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
       private HandlerRegistration nativePreviewReg_;
    }
    
-   protected ToolbarMenuBar menuBar_ ;
+   protected ToolbarMenuBar menuBar_;
+   private ToolbarPopupMenu parent_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
@@ -34,6 +34,8 @@ import com.google.gwt.user.client.ui.MenuBar;
 import com.google.gwt.user.client.ui.MenuItem;
 import com.google.gwt.user.client.ui.MenuItemSeparator;
 import com.google.gwt.user.client.ui.Widget;
+
+import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.AppMenuItem;
 import org.rstudio.core.client.command.BaseMenuBar;
 
@@ -95,6 +97,12 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
    public void addItem(MenuItem menuItem, MenuBar popup)
    {
       menuBar_.addItem(SafeHtmlUtils.fromTrustedString(menuItem.getHTML()), popup);
+   }
+   
+   public void addItem(AppCommand command, MenuBar popup)
+   {
+      if (command.isEnabled())
+         addItem(command.createMenuItem(false), popup);
    }
    
    public void setAutoOpen(boolean autoOpen)

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -772,7 +772,7 @@ public class Application implements ApplicationEventHandlers
          commands_.importDatasetFromFile().remove();
          commands_.importDatasetFromURL().remove();
          
-         commands_.importDatasetFromCSV().setVisible(false);
+         commands_.importDatasetFromCsvUsingReadr().setVisible(false);
          commands_.importDatasetFromSAV().setVisible(false);
          commands_.importDatasetFromSAS().setVisible(false);
          commands_.importDatasetFromStata().setVisible(false);
@@ -785,7 +785,7 @@ public class Application implements ApplicationEventHandlers
             String rVersion = sessionInfo.getRVersionsInfo().getRVersion();
             if (ApplicationUtils.compareVersions(rVersion, "3.0.2") >= 0)
             {
-               commands_.importDatasetFromCSV().setVisible(true);
+               commands_.importDatasetFromCsvUsingReadr().setVisible(true);
             }
             if (ApplicationUtils.compareVersions(rVersion, "3.1.0") >= 0)
             {
@@ -817,7 +817,8 @@ public class Application implements ApplicationEventHandlers
       }
       else
       {
-         commands_.importDatasetFromCSV().remove();
+         commands_.importDatasetFromCsvUsingBase().remove();
+         commands_.importDatasetFromCsvUsingReadr().remove();
          commands_.importDatasetFromSAV().remove();
          commands_.importDatasetFromSAS().remove();
          commands_.importDatasetFromStata().remove();

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -817,6 +817,7 @@ public class Application implements ApplicationEventHandlers
       }
       else
       {
+         commands_.importDatasetFromCsv().remove();
          commands_.importDatasetFromCsvUsingBase().remove();
          commands_.importDatasetFromCsvUsingReadr().remove();
          commands_.importDatasetFromSAV().remove();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -102,9 +102,12 @@ well as menu structures (for main menu and popup menus).
          <cmd refid="shareProject"/>
          <separator/>
          <menu label="_Import Dataset">
+            <menu id="importCsvMenu" label="From CSV">
+               <cmd refid="importDatasetFromCsvUsingBase"/>
+               <cmd refid="importDatasetFromCsvUsingReadr"/>
+            </menu>
             <cmd refid="importDatasetFromFile"/>
             <cmd refid="importDatasetFromURL"/>
-            <cmd refid="importDatasetFromCSV"/>
             <separator/>
             <cmd refid="importDatasetFromXLS"/>
             <separator/>
@@ -2255,15 +2258,25 @@ well as menu structures (for main menu and popup menus).
         label="Import Dataset from File..."
         menuLabel="From _Local File..."
         windowMode="main"/>
-        
+
    <cmd id="importDatasetFromURL"
         label="Import Dataset from URL..."
         menuLabel="From _Web URL..."
         windowMode="main"/>
 
-   <cmd id="importDatasetFromCSV"
-        label="Import Dataset from CSV..."
-        menuLabel="From _CSV..."
+   <cmd id="importDatasetFromCsv"
+        label="From CSV"
+        menuLabel="From _CSV"
+        windowMode="main"/>
+
+   <cmd id="importDatasetFromCsvUsingReadr"
+        label="Using Readr..."
+        menuLabel="Using _Readr..."
+        windowMode="main"/>
+
+   <cmd id="importDatasetFromCsvUsingBase"
+        label="Using Base..."
+        menuLabel="Using _Base..."
         windowMode="main"/>
 
    <cmd id="importDatasetFromSAV"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -102,10 +102,8 @@ well as menu structures (for main menu and popup menus).
          <cmd refid="shareProject"/>
          <separator/>
          <menu label="_Import Dataset">
-            <menu id="importCsvMenu" label="From CSV">
-               <cmd refid="importDatasetFromCsvUsingBase"/>
-               <cmd refid="importDatasetFromCsvUsingReadr"/>
-            </menu>
+            <cmd refid="importDatasetFromCsvUsingBase"/>
+            <cmd refid="importDatasetFromCsvUsingReadr"/>
             <cmd refid="importDatasetFromFile"/>
             <cmd refid="importDatasetFromURL"/>
             <separator/>
@@ -2270,13 +2268,13 @@ well as menu structures (for main menu and popup menus).
         windowMode="main"/>
 
    <cmd id="importDatasetFromCsvUsingReadr"
-        label="Using Readr..."
-        menuLabel="Using _Readr..."
+        label="Import CSV (readr)..."
+        menuLabel="Import CSV (_readr)..."
         windowMode="main"/>
 
    <cmd id="importDatasetFromCsvUsingBase"
-        label="Using Base..."
-        menuLabel="Using _Base..."
+        label="Import CSV (base)..."
+        menuLabel="Import CSV (_base)..."
         windowMode="main"/>
 
    <cmd id="importDatasetFromSAV"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -2268,13 +2268,13 @@ well as menu structures (for main menu and popup menus).
         windowMode="main"/>
 
    <cmd id="importDatasetFromCsvUsingReadr"
-        label="Import Text (readr)..."
-        menuLabel="Import Text (_readr)..."
+        label="From Text (readr)..."
+        menuLabel="From Text (_readr)..."
         windowMode="main"/>
 
    <cmd id="importDatasetFromCsvUsingBase"
-        label="Import Text (base)..."
-        menuLabel="Import Text (_base)..."
+        label="From Text (base)..."
+        menuLabel="From Text (_base)..."
         windowMode="main"/>
 
    <cmd id="importDatasetFromSAV"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -2268,13 +2268,13 @@ well as menu structures (for main menu and popup menus).
         windowMode="main"/>
 
    <cmd id="importDatasetFromCsvUsingReadr"
-        label="Import CSV (readr)..."
-        menuLabel="Import CSV (_readr)..."
+        label="Import Text (readr)..."
+        menuLabel="Import Text (_readr)..."
         windowMode="main"/>
 
    <cmd id="importDatasetFromCsvUsingBase"
-        label="Import CSV (base)..."
-        menuLabel="Import CSV (_base)..."
+        label="Import Text (base)..."
+        menuLabel="Import Text (_base)..."
         windowMode="main"/>
 
    <cmd id="importDatasetFromSAV"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -306,7 +306,9 @@ public abstract class
    public abstract AppCommand loadWorkspace();
    public abstract AppCommand importDatasetFromFile();
    public abstract AppCommand importDatasetFromURL();
-   public abstract AppCommand importDatasetFromCSV();
+   public abstract AppCommand importDatasetFromCsv();
+   public abstract AppCommand importDatasetFromCsvUsingReadr();
+   public abstract AppCommand importDatasetFromCsvUsingBase();
    public abstract AppCommand importDatasetFromSAV();
    public abstract AppCommand importDatasetFromSAS();
    public abstract AppCommand importDatasetFromStata();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -425,7 +425,7 @@ public class EnvironmentPane extends WorkbenchPane
       importCsvMenu.addItem(commands_.importDatasetFromCsvUsingBase().createMenuItem(false));
       importCsvMenu.addItem(commands_.importDatasetFromCsvUsingReadr().createMenuItem(false));
    
-      menu.addItem(commands_.importDatasetFromCsv().createMenuItem(false), importCsvMenu);
+      menu.addItem(commands_.importDatasetFromCsv(), importCsvMenu);
       menu.addItem(commands_.importDatasetFromFile().createMenuItem(false));
       menu.addItem(commands_.importDatasetFromURL().createMenuItem(false));
       menu.addSeparator();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -417,14 +417,11 @@ public class EnvironmentPane extends WorkbenchPane
    {
       ToolbarPopupMenu menu = new ToolbarPopupMenu();
       menu.setAutoOpen(true);
-      
-      ToolbarPopupMenu importCsvMenu = new ToolbarPopupMenu(menu);
-      importCsvMenu.addItem(commands_.importDatasetFromCsvUsingBase().createMenuItem(false));
-      importCsvMenu.addItem(commands_.importDatasetFromCsvUsingReadr().createMenuItem(false));
    
       menu.addItem(commands_.importDatasetFromFile().createMenuItem(false));
       menu.addItem(commands_.importDatasetFromURL().createMenuItem(false));
-      menu.addItem(commands_.importDatasetFromCsv(), importCsvMenu);
+      menu.addItem(commands_.importDatasetFromCsvUsingBase().createMenuItem(false));
+      menu.addItem(commands_.importDatasetFromCsvUsingReadr().createMenuItem(false));
       menu.addSeparator();
       menu.addItem(commands_.importDatasetFromXLS().createMenuItem(false));
       menu.addSeparator();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import org.rstudio.core.client.DebugFilePosition;
 import org.rstudio.core.client.StringUtil;
-import org.rstudio.core.client.command.AppMenuItem;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.SearchWidget;
 import org.rstudio.core.client.widget.SecondaryToolbar;
@@ -56,8 +55,6 @@ import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.resources.client.ImageResource;
-import com.google.gwt.safehtml.shared.SafeHtml;
-import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.ui.MenuBar;
 import com.google.gwt.user.client.ui.MenuItem;
 import com.google.gwt.user.client.ui.SuggestOracle;
@@ -421,7 +418,7 @@ public class EnvironmentPane extends WorkbenchPane
       ToolbarPopupMenu menu = new ToolbarPopupMenu();
       menu.setAutoOpen(true);
       
-      MenuBar importCsvMenu = new MenuBar(true);
+      ToolbarPopupMenu importCsvMenu = new ToolbarPopupMenu(menu);
       importCsvMenu.addItem(commands_.importDatasetFromCsvUsingBase().createMenuItem(false));
       importCsvMenu.addItem(commands_.importDatasetFromCsvUsingReadr().createMenuItem(false));
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -422,9 +422,9 @@ public class EnvironmentPane extends WorkbenchPane
       importCsvMenu.addItem(commands_.importDatasetFromCsvUsingBase().createMenuItem(false));
       importCsvMenu.addItem(commands_.importDatasetFromCsvUsingReadr().createMenuItem(false));
    
-      menu.addItem(commands_.importDatasetFromCsv(), importCsvMenu);
       menu.addItem(commands_.importDatasetFromFile().createMenuItem(false));
       menu.addItem(commands_.importDatasetFromURL().createMenuItem(false));
+      menu.addItem(commands_.importDatasetFromCsv(), importCsvMenu);
       menu.addSeparator();
       menu.addItem(commands_.importDatasetFromXLS().createMenuItem(false));
       menu.addSeparator();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.rstudio.core.client.DebugFilePosition;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.command.AppMenuItem;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.SearchWidget;
 import org.rstudio.core.client.widget.SecondaryToolbar;
@@ -55,6 +56,9 @@ import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
+import com.google.gwt.user.client.ui.MenuBar;
 import com.google.gwt.user.client.ui.MenuItem;
 import com.google.gwt.user.client.ui.SuggestOracle;
 import com.google.gwt.user.client.ui.Widget;
@@ -415,8 +419,13 @@ public class EnvironmentPane extends WorkbenchPane
    private Widget createImportMenu()
    {
       ToolbarPopupMenu menu = new ToolbarPopupMenu();
+      menu.setAutoOpen(true);
       
-      menu.addItem(commands_.importDatasetFromCSV().createMenuItem(false));
+      MenuBar importCsvMenu = new MenuBar(true);
+      importCsvMenu.addItem(commands_.importDatasetFromCsvUsingBase().createMenuItem(false));
+      importCsvMenu.addItem(commands_.importDatasetFromCsvUsingReadr().createMenuItem(false));
+   
+      menu.addItem(commands_.importDatasetFromCsv().createMenuItem(false), importCsvMenu);
       menu.addItem(commands_.importDatasetFromFile().createMenuItem(false));
       menu.addItem(commands_.importDatasetFromURL().createMenuItem(false));
       menu.addSeparator();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -480,10 +480,15 @@ public class EnvironmentPresenter extends BasePresenter
               });
    }
 
-   void onImportDatasetFromCSV()
+   void onImportDatasetFromCsvUsingReadr()
    {
       view_.bringToFront();
       dataImportPresenter_.openImportDatasetFromCSV("");
+   }
+
+   void onImportDatasetFromCsvUsingBase()
+   {
+      onImportDatasetFromFile();
    }
    
    void onImportDatasetFromSAV()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentTab.java
@@ -46,7 +46,9 @@ public class EnvironmentTab extends DelayLoadWorkbenchTab<EnvironmentPresenter>
       @Handler
       public abstract void onImportDatasetFromURL();
       @Handler
-      public abstract void onImportDatasetFromCSV();
+      public abstract void onImportDatasetFromCsvUsingReadr();
+      @Handler
+      public abstract void onImportDatasetFromCsvUsingBase();
       @Handler
       public abstract void onImportDatasetFromSAV();
       @Handler


### PR DESCRIPTION
From user feedback, bringing back the `utils` package `read.table` import dialog:

<img width="535" alt="screen shot 2017-02-09 at 9 56 04 pm" src="https://cloud.githubusercontent.com/assets/3478847/22815809/dbcc726e-ef12-11e6-85eb-bf7157265d7c.png">

<img width="508" alt="screen shot 2017-02-09 at 9 56 12 pm" src="https://cloud.githubusercontent.com/assets/3478847/22815814/e2417c0c-ef12-11e6-820d-688fa4be16d7.png">
