### PR TITLE
InputDialog not checking for zero-length input like web/Mac do.

### DIFF
--- a/src/cpp/desktop/DesktopInputDialog.cpp
+++ b/src/cpp/desktop/DesktopInputDialog.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "DesktopInputDialog.hpp"
+#include "DesktopUtils.hpp"
 #include "ui_DesktopInputDialog.h"
 
 #include <QPushButton>
@@ -101,4 +102,19 @@ void InputDialog::setExtraOption(bool extraOption)
 bool InputDialog::extraOption()
 {
    return ui->extraOption->checkState() == Qt::Checked;
+}
+
+void InputDialog::done(int r)
+{
+   if (QDialog::Accepted == r) // ok was pressed
+   {
+      if (ui->lineEdit->text().size() == 0)
+      {
+         rstudio::desktop::showWarning(this,
+                     QString::fromUtf8("Error"),
+                     QString::fromUtf8("You must enter a value."));
+         return;
+       }
+   }
+   QDialog::done(r);
 }

--- a/src/cpp/desktop/DesktopInputDialog.hpp
+++ b/src/cpp/desktop/DesktopInputDialog.hpp
@@ -44,6 +44,8 @@ public:
     void setExtraOption(bool extraOption);
     bool extraOption();
 
+    void done(int r);
+
 private:
     Ui::InputDialog *ui;
     QPushButton* pOK_;


### PR DESCRIPTION
This was a discrepancy between the web text entry dialog implementation, and the desktop/Qt one. Case 5415.