### PR TITLE
avoid using 'list.dirs' (performance)

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -695,37 +695,6 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
    as.character(getRversion())
 })
 
-.rs.addFunction("listDirs", function(dir = ".", full.names = TRUE, recursive = FALSE)
-{
-   # Normalize directory path
-   if (!file.exists(dir))
-      return(character())
-   dir <- normalizePath(dir, winslash = "/", mustWork = TRUE)
-   
-   # Shortcut if we have 'list.dirs'.
-   if (exists("list.dirs", envir = .BaseNamespaceEnv))
-      return(list.dirs(dir, full.names = full.names, recursive = recursive))
-   
-   
-   # Otherwise, use 'list.files' and filter results.
-   hasIncludeDirs <- "include.dirs" %in% names(formals(base::list.files))
-   args <- if (hasIncludeDirs)
-   {
-      list(path = dir,
-           full.names = full.names,
-           recursive = recursive,
-           include.dirs = TRUE)
-   }
-   else
-   {
-      list(path = dir,
-           full.names = full.names,
-           recursive = recursive)
-   }
-   
-   do.call(base::list.files, args)
-})
-
 .rs.addFunction("listFilesFuzzy", function(directory, token)
 {
    pattern <- if (nzchar(token))

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -113,6 +113,7 @@ set (SESSION_SOURCE_FILES
    modules/SessionHistory.cpp
    modules/SessionHistoryArchive.cpp
    modules/SessionHTMLPreview.cpp
+   modules/SessionLibPathsIndexer.cpp
    modules/SessionLimits.cpp
    modules/SessionLists.cpp
    modules/SessionMarkers.cpp

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -161,6 +161,7 @@
 #include "modules/SessionUserCommands.hpp"
 #include "modules/SessionRAddins.hpp"
 #include "modules/mathjax/SessionMathJax.hpp"
+#include "modules/SessionLibPathsIndexer.hpp"
 
 #include <session/SessionProjectTemplate.hpp>
 
@@ -446,6 +447,7 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
       (modules::projects::templates::initialize)
       (modules::mathjax::initialize)
       (modules::rstudioapi::initialize)
+      (modules::libpaths::initialize)
 
       // workers
       (workers::web_request::initialize)

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -333,6 +333,8 @@ struct Events : boost::noncopyable
    boost::signal<void(bool)>                 onBackgroundProcessing;
    boost::signal<void(bool)>                 onShutdown;
    boost::signal<void ()>                    onQuit;
+   boost::signal<void (const std::vector<std::string>&)>
+                                             onLibPathsChanged;
    boost::signal<void (const std::string&)>  onPackageLoaded;
    boost::signal<void ()>                    onPackageLibraryMutated;
    boost::signal<void ()>                    onPreferencesSaved;

--- a/src/cpp/session/include/session/SessionPackageProvidedExtension.hpp
+++ b/src/cpp/session/include/session/SessionPackageProvidedExtension.hpp
@@ -52,6 +52,11 @@ public:
    virtual ~Worker() {}
    
 public:
+   
+   Worker()
+   {
+   }
+
    Worker(const std::string& resourcePath)
       : resourcePath_(resourcePath)
    {

--- a/src/cpp/session/modules/SessionLibPathsIndexer.cpp
+++ b/src/cpp/session/modules/SessionLibPathsIndexer.cpp
@@ -1,0 +1,81 @@
+/*
+ * SessionRAddins.cpp
+ *
+ * Copyright (C) 2009-16 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "SessionLibPathsIndexer.hpp"
+
+#include <vector>
+#include <map>
+
+#include <core/Error.hpp>
+#include <core/FilePath.hpp>
+
+#include <session/SessionPackageProvidedExtension.hpp>
+
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace libpaths {
+
+namespace {
+
+std::vector<FilePath> s_installedPackages_;
+
+class Worker : public ppe::Worker
+{
+   void onIndexingStarted()
+   {
+      s_installedPackages_.clear();
+   }
+   
+   void onWork(const std::string& pkgName, const FilePath& pkgPath)
+   {
+      s_installedPackages_.push_back(pkgPath);
+   }
+   
+   void onIndexingCompleted(json::Object* pPayload)
+   {
+      // no need to update client state
+   }
+   
+public:
+   
+   Worker() : ppe::Worker() {}
+};
+
+boost::shared_ptr<Worker>& worker()
+{
+   static boost::shared_ptr<Worker> instance(new Worker);
+   return instance;
+}
+
+} // end anonymous namespace
+
+const std::vector<FilePath>& getInstalledPackages()
+{
+   return s_installedPackages_;
+}
+
+Error initialize()
+{
+   ppe::indexer().addWorker(worker());
+   return Success();
+}
+
+} // end namespace libpaths
+} // end namespace modules
+} // end namespace session
+} // end namespace rstudio

--- a/src/cpp/session/modules/SessionLibPathsIndexer.hpp
+++ b/src/cpp/session/modules/SessionLibPathsIndexer.hpp
@@ -1,0 +1,44 @@
+/*
+ * SessionLibPathsIndexer.hpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef SESSION_MODULES_LIB_PATHS_INDEXER_HPP
+#define SESSION_MODULES_LIB_PATHS_INDEXER_HPP
+
+#include <vector>
+#include <map>
+
+namespace rstudio {
+namespace core {
+
+class Error;
+class FilePath;
+
+} // end namespace core
+} // end namespace rstudio
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace libpaths {
+
+const std::vector<core::FilePath>& getInstalledPackages();
+core::Error initialize();
+
+} // end namespace libpaths
+} // end namespace modules
+} // end namespace session
+} // end namespace rstudio
+
+#endif /* SESSION_MODULES_LIB_PATHS_INDEXER_HPP */

--- a/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
+++ b/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
@@ -227,8 +227,14 @@ void onConsoleInput(const std::string& input)
                   boost::posix_time::seconds(1),
                   boost::bind(reindex),
                   true);
+         return;
       }
    }
+}
+
+void onLibPathsChanged(const std::vector<std::string>& libPaths)
+{
+   reindex();
 }
 
 } // end anonymous namespace
@@ -240,6 +246,7 @@ Error initialize()
    
    events().onDeferredInit.connect(onDeferredInit);
    events().onConsoleInput.connect(onConsoleInput);
+   events().onLibPathsChanged.connect(onLibPathsChanged);
    
    return Success();
 }

--- a/src/cpp/session/modules/SessionPackages.cpp
+++ b/src/cpp/session/modules/SessionPackages.cpp
@@ -475,6 +475,7 @@ void detectLibPathsChanges()
       }
       else if (libPaths != s_lastLibPaths)
       {
+         module_context::events().onLibPathsChanged(libPaths);
          enquePackageStateChanged();
          s_lastLibPaths = libPaths;
       }

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1304,9 +1304,9 @@ assign(x = ".rs.acCompletionTypes",
                                                    quote = !appendColons)
 {
    # List all directories within the .libPaths()
-   allPackages <- Reduce(union, lapply(.libPaths(), function(libPath) {
-      .rs.listDirs(libPath, full.names = FALSE, recursive = FALSE)
-   }))
+   # NOTE: we don't filter based on file vs. directory as that
+   # query may be expensive on e.g. networked file systems
+   allPackages <- Reduce(union, lapply(.libPaths(), list.files))
    
    # Not sure why 'DESCRIPTION' might show up here, but let's take it out
    allPackages <- setdiff(allPackages, "DESCRIPTION")

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1298,15 +1298,17 @@ assign(x = ".rs.acCompletionTypes",
    
 })
 
+.rs.addFunction("listIndexedPackages", function()
+{
+   .Call("rs_listIndexedPackages")
+})
+
 .rs.addFunction("getCompletionsPackages", function(token,
                                                    appendColons = FALSE,
                                                    excludeOtherCompletions = FALSE,
                                                    quote = !appendColons)
 {
-   # List all directories within the .libPaths()
-   # NOTE: we don't filter based on file vs. directory as that
-   # query may be expensive on e.g. networked file systems
-   allPackages <- Reduce(union, lapply(.libPaths(), list.files))
+   allPackages <- basename(.rs.listIndexedPackages())
    
    # Not sure why 'DESCRIPTION' might show up here, but let's take it out
    allPackages <- setdiff(allPackages, "DESCRIPTION")

--- a/src/cpp/session/modules/SessionRCompletions.cpp
+++ b/src/cpp/session/modules/SessionRCompletions.cpp
@@ -39,6 +39,7 @@
 #include <session/SessionModuleContext.hpp>
 
 #include "SessionCodeSearch.hpp"
+#include "SessionLibPathsIndexer.hpp"
 
 using namespace rstudio::core;
 
@@ -475,6 +476,21 @@ SEXP rs_getKnitParamsForDocument(SEXP documentIdSEXP)
    return resultSEXP;
 }
 
+SEXP rs_listIndexedPackages()
+{
+   std::vector<std::string> pkgNames;
+   
+   const std::vector<FilePath>& pkgPaths = libpaths::getInstalledPackages();
+   pkgNames.reserve(pkgPaths.size());
+   BOOST_FOREACH(const FilePath& pkgPath, pkgPaths)
+   {
+      pkgNames.push_back(pkgPath.absolutePath());
+   }
+   
+   r::sexp::Protect protect;
+   return r::sexp::create(pkgNames, &protect);
+}
+
 } // end anonymous namespace
 
 Error initialize() {
@@ -487,6 +503,7 @@ Error initialize() {
    RS_REGISTER_CALL_METHOD(rs_getInferredCompletions, 1);
    RS_REGISTER_CALL_METHOD(rs_getNAMESPACEImportedSymbols, 1);
    RS_REGISTER_CALL_METHOD(rs_getKnitParamsForDocument, 1);
+   RS_REGISTER_CALL_METHOD(rs_listIndexedPackages, 0);
    
    using boost::bind;
    using namespace module_context;


### PR DESCRIPTION
This PR avoids using `list.dirs()` when retrieving package completions, as that call can be surprisingly expensive (especially on networked file systems). Even on my Macbook Pro (with an SSD), I see:

```
> system.time(list.files(.libPaths()))
   user  system elapsed 
  0.000   0.001   0.001 
> system.time(list.dirs(.libPaths()))
   user  system elapsed 
  0.067   0.135   0.202 
```

I'm not sure why `list.dirs` would be so much slower here, but we should avoid using it regardless.