### PR TITLE
fix up chunks with leading spaces in name

### DIFF
--- a/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.cpp
@@ -141,11 +141,50 @@ void emitOutputFinished(const std::string& docId, const std::string& chunkId,
    module_context::enqueClientEvent(event);
 }
 
+bool fixChunkFilename(int, const core::FilePath& path)
+{
+   std::string name = path.filename();
+   if (name.empty())
+      return true;
+   
+   // replace spaces at start of name with '0'
+   std::string transformed = name;
+   for (std::size_t i = 0, n = transformed.size(); i < n; ++i)
+   {
+      if (transformed[i] != ' ')
+         break;
+      
+      transformed[i] = '0';
+   }
+   
+   // rename file if we had to change it
+   if (transformed != name)
+   {
+      FilePath target = path.parent().childPath(transformed);
+      Error error = path.move(target);
+      if (error)
+         LOG_ERROR(error);
+   }
+   
+   // return true to continue traversal
+   return true;
+}
+
 void onChunkExecCompleted(const std::string& docId, 
                           const std::string& chunkId,
                           const std::string& nbCtxId)
 {
    emitOutputFinished(docId, chunkId, ExecScopeChunk);
+}
+
+void onDeferredInit(bool)
+{
+   // Fix up chunk entries in the cache that were generated
+   // with leading spaces on Windows
+   FilePath root = notebookCacheRoot();
+   Error error = root.childrenRecursive(fixChunkFilename);
+   if (error)
+      LOG_ERROR(error);
 }
 
 } // anonymous namespace
@@ -173,6 +212,8 @@ Error initialize()
    using namespace module_context;
 
    events().onChunkExecCompleted.connect(onChunkExecCompleted);
+   
+   module_context::events().onDeferredInit.connect(onDeferredInit);
 
    ExecBlock initBlock;
    initBlock.addFunctions()

--- a/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.cpp
@@ -179,12 +179,19 @@ void onChunkExecCompleted(const std::string& docId,
 
 void onDeferredInit(bool)
 {
+   FilePath root = notebookCacheRoot();
+   root.ensureDirectory();
+   
    // Fix up chunk entries in the cache that were generated
    // with leading spaces on Windows
-   FilePath root = notebookCacheRoot();
-   Error error = root.childrenRecursive(fixChunkFilename);
-   if (error)
-      LOG_ERROR(error);
+   FilePath patchPath = root.complete("patch-chunk-names");
+   if (!patchPath.exists())
+   {
+      patchPath.ensureFile();
+      Error error = root.childrenRecursive(fixChunkFilename);
+      if (error)
+         LOG_ERROR(error);
+   }
 }
 
 } // anonymous namespace


### PR DESCRIPTION
This PR fixes cache entries that were errantly written with leading spaces, rather than leading zeroes, by an older version of the IDE. This can cause a couple issues:

1. Notebook outputs are not populated in the generated `.nb.html` file when the name is incorrectly written in this way;

2. The IDE can actually crash if it attempts to construct a link to a non-existent cache resource; e.g. for `.png`s in the cache. (This is likely a toolchain interaction issue; if we attempt to serve content that doesn't exist, this causes a Qt exception that crashes)

This PR fixes up all file entries in the cache on init -- basically crawling for files whose names start with spaces, and changing those to be `0`s instead.

Note that the issue that could cause these incorrect cache entries to be generated was fixed with https://github.com/rstudio/rstudio/commit/546868c6b6ffd56a4961a513af64f0ff9cbef906, but we may still need this change for users who had generated notebooks with RStudio v1.0.44 (to fix an older, busted cache).