### PR TITLE
avoid spellcheck overflow when adding puncutation

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/spelling/CheckSpelling.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/spelling/CheckSpelling.java
@@ -199,8 +199,7 @@ public class CheckSpelling
    private void doReplacement(String replacement)
    {
       docDisplay_.replaceSelection(replacement);
-      // Spell check what we just replaced
-      currentPos_ = docDisplay_.getSelectionStart();
+      currentPos_ = docDisplay_.getSelectionEnd();
    }
 
    private void findNextMisspelling()


### PR DESCRIPTION
This PR should resolve an issue where attempting to replace a misspelled word with that same word + punctuation would cause a stack overflow.

![spellcheck](https://cloud.githubusercontent.com/assets/1976582/22847971/c54e607c-efa5-11e6-93e7-449e590ad0d3.gif)

Note that the stack overflow leaves the editor unusable (it seems to no longer responds to any input).

The fix ensures that the next spellcheck check starts after the replaced word, rather than with the replaced word.
