### PR TITLE
enable request log (ctrl+tick) in satellite windows

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteApplication.java
@@ -14,14 +14,24 @@
  */
 package org.rstudio.studio.client.common.satellite;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.RunAsyncCallback;
 import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.logical.shared.CloseEvent;
+import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.RootLayoutPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Provider;
 import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.command.AppCommand;
+import org.rstudio.core.client.command.CommandHandler;
 import org.rstudio.studio.client.application.ApplicationUncaughtExceptionHandler;
+import org.rstudio.studio.client.application.ui.RequestLogVisualization;
+import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
 
 public class SatelliteApplication
@@ -35,23 +45,55 @@ public class SatelliteApplication
                         SatelliteApplicationView view,
                         Satellite satellite,
                         Provider<AceThemes> pAceThemes,
-                        ApplicationUncaughtExceptionHandler uncaughtExHandler)
+                        ApplicationUncaughtExceptionHandler uncaughtExHandler,
+                        Commands commands)
    {
-      initialize(name, view, satellite, pAceThemes, uncaughtExHandler);
+      initialize(name, view, satellite, pAceThemes, uncaughtExHandler, commands);
    }
-
+   
    public void initialize(
                         String name,
                         SatelliteApplicationView view,
                         Satellite satellite,
                         Provider<AceThemes> pAceThemes,
-                        ApplicationUncaughtExceptionHandler uncaughtExHandler)
+                        ApplicationUncaughtExceptionHandler uncaughtExHandler,
+                        Commands commands)
    {
       name_ = name;
       view_ = view;
       satellite_ = satellite;
       pAceThemes_ = pAceThemes;
       uncaughtExHandler_ = uncaughtExHandler;
+      
+      commands.showRequestLog().addHandler(new CommandHandler()
+      {
+         public void onCommand(AppCommand command)
+         {
+            GWT.runAsync(new RunAsyncCallback()
+            {
+               public void onFailure(Throwable reason)
+               {
+                  Window.alert(reason.toString());
+               }
+
+               public void onSuccess()
+               {
+                  final RequestLogVisualization viz = new RequestLogVisualization();
+                  final RootLayoutPanel root = RootLayoutPanel.get();
+                  root.add(viz);
+                  root.setWidgetTopBottom(viz, 10, Unit.PX, 10, Unit.PX);
+                  root.setWidgetLeftRight(viz, 10, Unit.PX, 10, Unit.PX);
+                  viz.addCloseHandler(new CloseHandler<RequestLogVisualization>()
+                  {
+                     public void onClose(CloseEvent<RequestLogVisualization> event)
+                     {
+                        root.remove(viz);
+                     }
+                  });
+               }
+            });
+         }
+      });
    }
    
 

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/HTMLPreviewApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/HTMLPreviewApplication.java
@@ -18,6 +18,7 @@ import org.rstudio.studio.client.application.ApplicationUncaughtExceptionHandler
 import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.common.satellite.SatelliteApplication;
 import org.rstudio.studio.client.htmlpreview.ui.HTMLPreviewApplicationView;
+import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
 
 import com.google.inject.Inject;
@@ -33,8 +34,9 @@ public class HTMLPreviewApplication extends SatelliteApplication
    public HTMLPreviewApplication(HTMLPreviewApplicationView view,
                                  Satellite satellite,
                                  Provider<AceThemes> pAceThemes,
-                                 ApplicationUncaughtExceptionHandler exHandler)
+                                 ApplicationUncaughtExceptionHandler exHandler,
+                                 Commands commands)
    {
-      super(NAME, view, satellite, pAceThemes, exHandler);
+      super(NAME, view, satellite, pAceThemes, exHandler, commands);
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/RmdOutputSatellite.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/RmdOutputSatellite.java
@@ -18,6 +18,7 @@ package org.rstudio.studio.client.rmarkdown;
 import org.rstudio.studio.client.application.ApplicationUncaughtExceptionHandler;
 import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.common.satellite.SatelliteApplication;
+import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
 
 import com.google.inject.Inject;
@@ -33,8 +34,9 @@ public class RmdOutputSatellite extends SatelliteApplication
    public RmdOutputSatellite(RmdOutputView view,
                              Satellite satellite,
                              Provider<AceThemes> pAceThemes,
-                             ApplicationUncaughtExceptionHandler exHandler)
+                             ApplicationUncaughtExceptionHandler exHandler,
+                             Commands commands)
    {
-      super(NAME, view, satellite, pAceThemes, exHandler);
+      super(NAME, view, satellite, pAceThemes, exHandler, commands);
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApplicationSatellite.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApplicationSatellite.java
@@ -18,6 +18,7 @@ import org.rstudio.studio.client.application.ApplicationUncaughtExceptionHandler
 import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.common.satellite.SatelliteApplication;
 import org.rstudio.studio.client.shiny.ui.ShinyApplicationView;
+import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
 
 import com.google.inject.Inject;
@@ -33,8 +34,9 @@ public class ShinyApplicationSatellite extends SatelliteApplication
    public ShinyApplicationSatellite(ShinyApplicationView view,
                                     Satellite satellite,
                                     Provider<AceThemes> pAceThemes,
-                                    ApplicationUncaughtExceptionHandler exHandler)
+                                    ApplicationUncaughtExceptionHandler exHandler,
+                                    Commands commands)
    {
-      super(NAME, view, satellite, pAceThemes, exHandler);
+      super(NAME, view, satellite, pAceThemes, exHandler, commands);
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/vcs/VCSApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/vcs/VCSApplication.java
@@ -18,6 +18,7 @@ import org.rstudio.studio.client.application.ApplicationUncaughtExceptionHandler
 import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.common.satellite.SatelliteApplication;
 import org.rstudio.studio.client.common.vcs.AskPassManager;
+import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
 
 import com.google.inject.Inject;
@@ -32,9 +33,10 @@ public class VCSApplication extends SatelliteApplication
                          Satellite satellite,
                          Provider<AceThemes> pAceThemes,
                          ApplicationUncaughtExceptionHandler uncaughtExHandler,
-                         AskPassManager askPassManager) // force gin to create
+                         AskPassManager askPassManager, // force gin to create
+                         Commands commands)
    {
-      super(NAME, view, satellite, pAceThemes, uncaughtExHandler);
+      super(NAME, view, satellite, pAceThemes, uncaughtExHandler, commands);
    }
 
    public final static String NAME = "review_changes";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceSatellite.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceSatellite.java
@@ -19,6 +19,7 @@ import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.ApplicationUncaughtExceptionHandler;
 import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.common.satellite.SatelliteApplication;
+import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
 
 import com.google.inject.Inject;
@@ -40,9 +41,10 @@ public class SourceSatellite extends SatelliteApplication
    public void initialize(SourceSatelliteView view,
                           Satellite satellite,
                           Provider<AceThemes> pAceThemes,
-                          ApplicationUncaughtExceptionHandler exHandler)
+                          ApplicationUncaughtExceptionHandler exHandler,
+                          Commands commands)
    {
-      initialize(name_, view, satellite, pAceThemes, exHandler);
+      initialize(name_, view, satellite, pAceThemes, exHandler, commands);
    }
    
    private final String name_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkSatellite.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkSatellite.java
@@ -19,6 +19,7 @@ import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.ApplicationUncaughtExceptionHandler;
 import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.common.satellite.SatelliteApplication;
+import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
 
 import com.google.inject.Inject;
@@ -38,9 +39,10 @@ public class ChunkSatellite extends SatelliteApplication
    public void initialize(ChunkSatelliteView view,
                           Satellite satellite,
                           Provider<AceThemes> pAceThemes,
-                          ApplicationUncaughtExceptionHandler exHandler)
+                          ApplicationUncaughtExceptionHandler exHandler,
+                          Commands commands)
    {
-      initialize(name_, view, satellite, pAceThemes, exHandler);
+      initialize(name_, view, satellite, pAceThemes, exHandler, commands);
    }
    
    private final String name_;


### PR DESCRIPTION
Implemented request logs in satellite windows to narrow down a concurrent issue in satellite chunks:

<img width="1166" alt="screen shot 2017-02-10 at 6 58 24 pm" src="https://cloud.githubusercontent.com/assets/3478847/22850687/04a6cec2-efc3-11e6-9f1e-a46c40b4893c.png">
