### PR TITLE
Add a 'create branch' dialog

### DIFF
--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -15,10 +15,10 @@
 
 #include <core/StringUtils.hpp>
 
+#include <algorithm>
 #include <map>
 #include <ostream>
 
-#include <algorithm>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/algorithm/string/classification.hpp>
@@ -311,6 +311,13 @@ std::string systemToUtf8(const std::string& str, int codepage)
 std::string systemToUtf8(const std::string& str)
 {
    return systemToUtf8(str, CP_ACP);
+}
+
+std::string toUpper(const std::string& str)
+{
+   std::string upper = str;
+   std::transform(upper.begin(), upper.end(), upper.begin(), ::toupper);
+   return upper;
 }
 
 std::string toLower(const std::string& str)

--- a/src/cpp/core/include/core/StringUtils.hpp
+++ b/src/cpp/core/include/core/StringUtils.hpp
@@ -80,6 +80,7 @@ std::string systemToUtf8(const std::string& str);
 std::string systemToUtf8(const std::string& str, int codepage);
 
 std::string toLower(const std::string& str);
+std::string toUpper(const std::string& str);
 std::string textToHtml(const std::string& str);
 
 std::string htmlEscape(const std::string& str, bool isAttributeValue = false);

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -187,6 +187,27 @@ void ConsoleProcess::enqueInput(const Input& input)
    inputQueue_.push(input);
 }
 
+void ConsoleProcess::enqueOutput(const std::string& output,
+                                 bool error = false)
+{
+   enqueOutputEvent(output, error);
+}
+
+void ConsoleProcess::enquePromptEvent(const std::string& prompt)
+{
+   // enque a prompt event
+   json::Object data;
+   data["handle"] = handle();
+   data["prompt"] = prompt;
+   module_context::enqueClientEvent(
+         ClientEvent(client_events::kConsoleProcessPrompt, data));
+}
+
+void ConsoleProcess::enquePrompt(const std::string& prompt)
+{
+   enquePromptEvent(prompt);
+}
+
 void ConsoleProcess::interrupt()
 {
    interrupt_ = true;
@@ -360,15 +381,9 @@ void ConsoleProcess::handleConsolePrompt(core::system::ProcessOperations& ops,
 
          return;
       }
-
    }
-
-   // enque a prompt event
-   json::Object data;
-   data["handle"] = handle();
-   data["prompt"] = prompt;
-   module_context::enqueClientEvent(
-         ClientEvent(client_events::kConsoleProcessPrompt, data));
+   
+   enquePromptEvent(prompt);
 }
 
 void ConsoleProcess::onExit(int exitCode)

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -111,6 +111,8 @@ public:
 
    core::Error start();
    void enqueInput(const Input& input);
+   void enqueOutput(const std::string& output, bool error);
+   void enquePrompt(const std::string& prompt);
    void interrupt();
    void resize(int cols, int rows);
    void onSuspend();
@@ -135,6 +137,7 @@ private:
 
    std::string bufferedOutput() const;
    void enqueOutputEvent(const std::string& output, bool error);
+   void enquePromptEvent(const std::string& prompt);
    void handleConsolePrompt(core::system::ProcessOperations& ops,
                             const std::string& prompt);
    void maybeConsolePrompt(core::system::ProcessOperations& ops,

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -228,6 +228,23 @@ Error gitExec(const ShellArgs& args,
 #endif
 }
 
+std::string gitText(const ShellArgs& args)
+{
+   std::stringstream ss;
+   
+   ss << ">>> ";
+   
+   if (s_gitExePath.empty())
+      ss << "git ";
+   else
+      ss << s_gitExePath << " ";
+   
+   std::string arguments = core::algorithm::join(args, " ");
+   ss << arguments << "\n";
+   
+   return ss.str();
+}
+
 bool commitIsMatch(const std::vector<std::string>& patterns,
                    const CommitInfo& commit)
 {
@@ -315,13 +332,14 @@ protected:
             boost::make_shared<ConsoleProcessInfo>(
                caption, "" /*title*/, "" /*handle*/, kNoTerminal,
                false /*allowRestart*/, console_process::InteractionNever);
-
+      
 #ifdef _WIN32
       *ppCP = ConsoleProcess::create(gitBin(), args.args(), options, pCPI);
 #else
       *ppCP = ConsoleProcess::create(git() << args.args(), options, pCPI);
 #endif
-
+      
+      (*ppCP)->enquePrompt(gitText(args));
       (*ppCP)->onExit().connect(boost::bind(&enqueueRefreshEvent));
 
       return Success();

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -575,7 +575,7 @@ public:
    {
       return createConsoleProc(
                ShellArgs() << "checkout" << "-B" << branch,
-               "Git Checkout " + branch,
+               "Git Create Branch " + branch,
                ppCP);
    }
 
@@ -633,22 +633,22 @@ public:
             // otherwise just check out our local copy
             if (core::algorithm::contains(s_branches, localBranch))
             {
-               args << "checkout" << localBranch << "--";
+               args << "checkout" << localBranch;
             }
             else
             {
-               args << "checkout" << "-b" << localBranch << remoteBranch << "--";
+               args << "checkout" << "-b" << localBranch << remoteBranch;
             }
          }
          else
          {
             // shouldn't happen, but provide valid shell command regardless
-            args << "checkout" << id << "--";
+            args << "checkout" << id;
          }
       }
       else
       {
-         args << "checkout" << id << "--";
+         args << "checkout" << id;
       }
       
       return createConsoleProc(args,

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -575,7 +575,7 @@ public:
    {
       return createConsoleProc(
                ShellArgs() << "checkout" << "-B" << branch,
-               "Git Create Branch " + branch,
+               "Git Branch",
                ppCP);
    }
 
@@ -1472,8 +1472,6 @@ Error vcsUnstage(const json::JsonRpcRequest& request,
 Error vcsCreateBranch(const json::JsonRpcRequest& request,
                       json::JsonRpcResponse* pResponse)
 {
-   RefreshOnExit scope;
-   
    Error error;
    std::string branch;
    
@@ -1659,7 +1657,7 @@ Error vcsPushBranch(const json::JsonRpcRequest& request,
 Error vcsPull(const json::JsonRpcRequest& request,
               json::JsonRpcResponse* pResponse)
 {
-    boost::shared_ptr<ConsoleProcess> pCP;
+   boost::shared_ptr<ConsoleProcess> pCP;
    Error error = s_git_.pull(&pCP);
    if (error)
       return error;

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -612,7 +612,9 @@ public:
       if (error)
          return error;
       
-      *pRemotes = split(output);
+      std::string trimmed = string_utils::trimWhitespace(output);
+      if (!trimmed.empty())
+         *pRemotes = split(trimmed);
       return Success();
    }
 

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -305,7 +305,8 @@ protected:
       if (pExitCode)
          *pExitCode = result.exitStatus;
 
-      if (result.exitStatus != EXIT_SUCCESS)
+      if (result.exitStatus != EXIT_SUCCESS &&
+          !result.stdErr.empty())
       {
          LOG_DEBUG_MESSAGE(result.stdErr);
       }

--- a/src/gwt/src/org/rstudio/core/client/Functional.java
+++ b/src/gwt/src/org/rstudio/core/client/Functional.java
@@ -1,0 +1,46 @@
+/*
+ * Functional.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client;
+
+import java.util.Collection;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArray;
+
+public class Functional
+{
+   public interface Predicate<T>
+   {
+      public boolean test(T t);
+   }
+   
+   public static <T> T find(Collection<T> collection,
+                            Predicate<T> predicate)
+   {
+      for (T t : collection)
+         if (predicate.test(t))
+            return t;
+      return null;
+   }
+   
+   public static <T extends JavaScriptObject> T find(JsArray<T> array,
+                                                     Predicate<T> predicate)
+   {
+      for (int i = 0, n = array.length(); i < n; i++)
+         if (predicate.test(array.get(i)))
+            return array.get(i);
+      return null;
+   }
+}

--- a/src/gwt/src/org/rstudio/core/client/ListUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/ListUtil.java
@@ -17,9 +17,18 @@ package org.rstudio.core.client;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.JsArrayString;
+
 public class ListUtil
 {
    public interface FilterPredicate<T>
+   {
+      public boolean test(T object);
+   }
+   
+   public interface SearchPredicate<T>
    {
       public boolean test(T object);
    }
@@ -33,11 +42,35 @@ public class ListUtil
       return filtered;
    }
    
+   public static <T> T find(List<T> list, SearchPredicate<T> predicate)
+   {
+      for (T t : list)
+         if (predicate.test(t))
+            return t;
+      return null;
+   }
+   
    @SuppressWarnings("unchecked")
    public static <T> List<T> create(T... ts)
    {
       List<T> result = new ArrayList<T>(ts.length);
       for (T t : ts) result.add(t);
       return result;
+   }
+   
+   public static List<String> create(JsArrayString array)
+   {
+      List<String> list = new ArrayList<String>();
+      for (int i = 0, n = array.length(); i < n; i++)
+         list.add(array.get(i));
+      return list;
+   }
+   
+   public static <T extends JavaScriptObject> List<T> create(JsArray<T> array)
+   {
+      List<T> list = new ArrayList<T>();
+      for (int i = 0, n = array.length(); i < n; i++)
+         list.add(array.get(i));
+      return list;
    }
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ProgressDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ProgressDialog.java
@@ -155,6 +155,11 @@ public abstract class ProgressDialog extends ModalDialogBase
       label_.setText(text);
    }
    
+   protected void showProgress()
+   {
+      progressAnim_.getElement().getStyle().setDisplay(Style.Display.INITIAL);
+   }
+   
    protected void hideProgress()
    {
       progressAnim_.getElement().getStyle().setDisplay(Style.Display.NONE);

--- a/src/gwt/src/org/rstudio/core/client/widget/SelectWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SelectWidget.java
@@ -29,7 +29,12 @@ import com.google.gwt.user.client.ui.Panel;
 import com.google.gwt.user.client.ui.Widget;
 
 public class SelectWidget extends Composite
-{   
+{
+   public SelectWidget(String label)
+   {
+      this(label, null, false);
+   }
+   
    public SelectWidget(String label, String[] options)
    {
       this(label, options, false);
@@ -72,8 +77,15 @@ public class SelectWidget extends Composite
 
       listBox_ = new ListBox();
       listBox_.setMultipleSelect(isMultipleSelect);
-      for (int i = 0; i < options.length; i++)
-         listBox_.addItem(options[i], values[i]);
+      if (options == null)
+      {
+         listBox_.addItem("(None)", "(None)");
+      }
+      else
+      {
+         for (int i = 0; i < options.length; i++)
+            listBox_.addItem(options[i], values[i]);
+      }
       
       Panel panel = null;
       if (horizontalLayout)

--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/GitServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/GitServerOperations.java
@@ -65,6 +65,9 @@ public interface GitServerOperations extends VCSServerOperations
    void gitFullStatus(
          ServerRequestCallback<JsArray<StatusAndPathInfo>> requestCallback);
 
+   void gitCreateBranch(String branch,
+                        ServerRequestCallback<ConsoleProcess> requestCallback);
+   
    void gitListBranches(ServerRequestCallback<BranchesInfo> requestCallback);
 
    void gitCheckout(String id,

--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/GitServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/GitServerOperations.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.common.vcs;
 
 import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.JsArrayString;
 
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.jsonrpc.RpcObjectList;
@@ -69,6 +70,8 @@ public interface GitServerOperations extends VCSServerOperations
                         ServerRequestCallback<ConsoleProcess> requestCallback);
    
    void gitListBranches(ServerRequestCallback<BranchesInfo> requestCallback);
+   
+   void gitListRemotes(ServerRequestCallback<JsArrayString> requestCallback);
 
    void gitCheckout(String id,
                     ServerRequestCallback<ConsoleProcess> requestCallback);
@@ -123,6 +126,10 @@ public interface GitServerOperations extends VCSServerOperations
                       ServerRequestCallback<Void> requestCallback);
 
    void gitPush(ServerRequestCallback<ConsoleProcess> requestCallback);
+   
+   void gitPushBranch(String branch,
+                      String remote,
+                      ServerRequestCallback<ConsoleProcess> requestCallback);
 
    void gitPull(ServerRequestCallback<ConsoleProcess> requestCallback);
    

--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/GitServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/GitServerOperations.java
@@ -15,8 +15,6 @@
 package org.rstudio.studio.client.common.vcs;
 
 import com.google.gwt.core.client.JsArray;
-import com.google.gwt.core.client.JsArrayString;
-
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.jsonrpc.RpcObjectList;
 import org.rstudio.studio.client.common.console.ConsoleProcess;
@@ -71,7 +69,11 @@ public interface GitServerOperations extends VCSServerOperations
    
    void gitListBranches(ServerRequestCallback<BranchesInfo> requestCallback);
    
-   void gitListRemotes(ServerRequestCallback<JsArrayString> requestCallback);
+   void gitListRemotes(ServerRequestCallback<JsArray<RemotesInfo>> requestCallback);
+   
+   void gitAddRemote(String name,
+                     String url,
+                     ServerRequestCallback<JsArray<RemotesInfo>> requestCallback);
 
    void gitCheckout(String id,
                     ServerRequestCallback<ConsoleProcess> requestCallback);

--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/RemotesInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/RemotesInfo.java
@@ -1,0 +1,26 @@
+/*
+ * RemotesInfo.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.common.vcs;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+public class RemotesInfo extends JavaScriptObject
+{
+   protected RemotesInfo() {}
+   
+   public final native String getRemote() /*-{ return this["remote"]; }-*/;
+   public final native String getUrl()    /*-{ return this["url"]; }-*/;
+   public final native String getType()   /*-{ return this["type"]; }-*/;
+}

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -78,6 +78,7 @@ import org.rstudio.studio.client.common.vcs.CreateKeyOptions;
 import org.rstudio.studio.client.common.vcs.CreateKeyResult;
 import org.rstudio.studio.client.common.vcs.DiffResult;
 import org.rstudio.studio.client.common.vcs.ProcessResult;
+import org.rstudio.studio.client.common.vcs.RemotesInfo;
 import org.rstudio.studio.client.common.vcs.StatusAndPathInfo;
 import org.rstudio.studio.client.common.vcs.VcsCloneOptions;
 import org.rstudio.studio.client.events.GetEditorContextEvent;
@@ -2155,9 +2156,20 @@ public class RemoteServer implements Server
    }
    
    @Override
-   public void gitListRemotes(ServerRequestCallback<JsArrayString> requestCallback)
+   public void gitListRemotes(ServerRequestCallback<JsArray<RemotesInfo>> requestCallback)
    {
       sendRequest(RPC_SCOPE, GIT_LIST_REMOTES, requestCallback);
+   }
+   
+   @Override
+   public void gitAddRemote(String name,
+                            String url,
+                            ServerRequestCallback<JsArray<RemotesInfo>> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(name));
+      params.set(1, new JSONString(url));
+      sendRequest(RPC_SCOPE, GIT_ADD_REMOTE, params, requestCallback);
    }
 
    @Override
@@ -5199,6 +5211,7 @@ public class RemoteServer implements Server
    private static final String GIT_CREATE_BRANCH = "git_create_branch";
    private static final String GIT_LIST_BRANCHES = "git_list_branches";
    private static final String GIT_LIST_REMOTES = "git_list_remotes";
+   private static final String GIT_ADD_REMOTE = "git_add_remote";
    private static final String GIT_CHECKOUT = "git_checkout";
    private static final String GIT_COMMIT = "git_commit";
    private static final String GIT_PUSH = "git_push";

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -2153,6 +2153,12 @@ public class RemoteServer implements Server
    {
       sendRequest(RPC_SCOPE, GIT_LIST_BRANCHES, requestCallback);
    }
+   
+   @Override
+   public void gitListRemotes(ServerRequestCallback<JsArrayString> requestCallback)
+   {
+      sendRequest(RPC_SCOPE, GIT_LIST_REMOTES, requestCallback);
+   }
 
    @Override
    public void gitCheckout(String id,
@@ -2205,6 +2211,18 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, GIT_PUSH,
                   new ConsoleProcessCallbackAdapter(requestCallback));
    }
+   
+   public void gitPushBranch(String branch,
+                             String remote,
+                             ServerRequestCallback<ConsoleProcess> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(branch));
+      params.set(1, new JSONString(remote));
+      sendRequest(RPC_SCOPE, GIT_PUSH_BRANCH, params,
+                  new ConsoleProcessCallbackAdapter(requestCallback));
+   }
+   
 
    @Override
    public void vcsClone(VcsCloneOptions options,
@@ -5180,9 +5198,11 @@ public class RemoteServer implements Server
    private static final String GIT_FULL_STATUS = "git_full_status";
    private static final String GIT_CREATE_BRANCH = "git_create_branch";
    private static final String GIT_LIST_BRANCHES = "git_list_branches";
+   private static final String GIT_LIST_REMOTES = "git_list_remotes";
    private static final String GIT_CHECKOUT = "git_checkout";
    private static final String GIT_COMMIT = "git_commit";
    private static final String GIT_PUSH = "git_push";
+   private static final String GIT_PUSH_BRANCH = "git_push_branch";
    private static final String GIT_PULL = "git_pull";
    private static final String ASKPASS_COMPLETED = "askpass_completed";
    private static final String CREATE_SSH_KEY = "create_ssh_key";

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -2137,6 +2137,16 @@ public class RemoteServer implements Server
    {
       sendRequest(RPC_SCOPE, GIT_FULL_STATUS, requestCallback);
    }
+   
+   @Override
+   public void gitCreateBranch(String branch,
+                               ServerRequestCallback<ConsoleProcess> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(branch));
+      sendRequest(RPC_SCOPE, GIT_CREATE_BRANCH, params,
+            new ConsoleProcessCallbackAdapter(requestCallback));
+   }
 
    @Override
    public void gitListBranches(ServerRequestCallback<BranchesInfo> requestCallback)
@@ -5168,6 +5178,7 @@ public class RemoteServer implements Server
    private static final String GIT_UNSTAGE = "git_unstage";
    private static final String GIT_ALL_STATUS = "git_all_status";
    private static final String GIT_FULL_STATUS = "git_full_status";
+   private static final String GIT_CREATE_BRANCH = "git_create_branch";
    private static final String GIT_LIST_BRANCHES = "git_list_branches";
    private static final String GIT_CHECKOUT = "git_checkout";
    private static final String GIT_COMMIT = "git_commit";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/AddRemoteDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/AddRemoteDialog.java
@@ -55,7 +55,7 @@ public class AddRemoteDialog extends ModalDialog<AddRemoteDialog.Input>
                           OperationWithInput<Input> operation)
    {
       super(caption, operation);
-      setOkButtonCaption("Add Remote");
+      setOkButtonCaption("Add");
       
       container_ = new VerticalPanel();
       lblName_ = label("Remote Name:");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/AddRemoteDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/AddRemoteDialog.java
@@ -1,0 +1,109 @@
+/*
+ * AddRemoteDialog.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.vcs;
+
+import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.widget.ModalDialog;
+import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.core.client.widget.VerticalSpacer;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.TextBox;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.gwt.user.client.ui.Widget;
+
+public class AddRemoteDialog extends ModalDialog<AddRemoteDialog.Input>
+{
+   public static class Input
+   {
+      public Input(String name, String url)
+      {
+         name_ = name;
+         url_ = url;
+      }
+      
+      public final String getName() { return name_; }
+      public final String getUrl() { return url_; }
+      
+      private final String name_;
+      private final String url_;
+   }
+
+   @Override
+   protected Input collectInput()
+   {
+      return new Input(
+            tbName_.getValue().trim(),
+            tbUrl_.getValue().trim());
+   }
+   
+   public AddRemoteDialog(String caption,
+                          String defaultUrl,
+                          OperationWithInput<Input> operation)
+   {
+      super(caption, operation);
+      setOkButtonCaption("Add Remote");
+      
+      container_ = new VerticalPanel();
+      lblName_ = label("Remote Name:");
+      lblUrl_ = label("Remote URL:");
+      tbName_ = textBox();
+      tbUrl_ = textBox();
+      
+      tbUrl_.setValue(StringUtil.notNull(defaultUrl));
+      
+      container_.add(lblName_);
+      container_.add(tbName_);
+      container_.add(new VerticalSpacer("6px"));
+      container_.add(lblUrl_);
+      container_.add(tbUrl_);
+      container_.add(new VerticalSpacer("6px"));
+   }
+
+   @Override
+   protected Widget createMainWidget()
+   {
+      return container_;
+   }
+   
+   @Override
+   public void showModal()
+   {
+      super.showModal();
+      tbName_.setFocus(true);
+   }
+   
+   private TextBox textBox()
+   {
+      TextBox textBox = new TextBox();
+      textBox.setWidth("260px");
+      textBox.getElement().getStyle().setMarginBottom(6, Unit.PX);
+      return textBox;
+   }
+   
+   private Label label(String text)
+   {
+      Label label = new Label(text);
+      label.getElement().getStyle().setMarginBottom(4, Unit.PX);
+      return label;
+   }
+   
+   private final Label lblName_;
+   private final Label lblUrl_;
+   private final TextBox tbName_;
+   private final TextBox tbUrl_;
+   private final VerticalPanel container_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchDialog.java
@@ -1,0 +1,6 @@
+package org.rstudio.studio.client.workbench.views.vcs;
+
+public class CreateBranchDialog
+{
+
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchDialog.java
@@ -16,10 +16,13 @@ package org.rstudio.studio.client.workbench.views.vcs;
 
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.core.client.widget.SelectWidget;
 import org.rstudio.core.client.widget.VerticalSpacer;
 
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.Grid;
 import com.google.gwt.user.client.ui.Label;
@@ -61,10 +64,10 @@ public class CreateBranchDialog extends ModalDialog<CreateBranchDialog.Input>
    @Override
    protected Input collectInput()
    {
-      return new Input(
-            tbBranch_.getValue().trim(),
-            tbRemote_.getValue().trim(),
-            cbPush_.getValue());
+      String branch = tbBranch_.getValue().trim();
+      String remote = sbRemote_.getValue().trim();
+      boolean push = cbPush_.isVisible() ? cbPush_.getValue() : false;
+      return new Input(branch, remote, push);
    }
    
    public CreateBranchDialog(final String caption,
@@ -77,22 +80,39 @@ public class CreateBranchDialog extends ModalDialog<CreateBranchDialog.Input>
       
       container_ = new VerticalPanel();
       tbBranch_ = createTextBox();
-      tbRemote_ = createTextBox();
+      tbBranch_.getElement().setAttribute("placeholder", "Branch name");
+      
+      String[] remoteLabels = new String[remotes.length() + 1];
+      for (int i = 0; i < remotes.length(); i++)
+         remoteLabels[i] = remotes.get(i);
+      remoteLabels[remotes.length()] = REMOTE_NONE;
+      
+      sbRemote_ = new SelectWidget("Remote:", remoteLabels);
+      sbRemote_.setValue(remoteLabels[0]);
+      sbRemote_.addChangeHandler(new ChangeHandler()
+      {
+         @Override
+         public void onChange(ChangeEvent event)
+         {
+            boolean isNone = sbRemote_.getValue().equals(REMOTE_NONE);
+            cbPush_.setVisible(!isNone);
+         }
+      });
+      
+      final String remote = remotes.length() == 0 ? "(None)" : remotes.get(0);
+      sbRemote_.setValue(remote);
+      
       cbPush_ = new CheckBox("Push branch to remote");
-      
-      final String remote = remotes.length() == 0 ? "origin" : remotes.get(0);
-      tbRemote_.setValue(remote);
-      
+      cbPush_.setVisible(!sbRemote_.getValue().equals(REMOTE_NONE));
       cbPush_.setValue(true);
       
-      Grid grid = new Grid(2, 2);
+      Grid grid = new Grid(1, 2);
       grid.setWidget(0, 0, new Label("Branch:"));
-      grid.setWidget(0, 1, tbBranch_);
-      grid.setWidget(1, 0, new Label("Remote:"));
-      grid.setWidget(1, 1, tbRemote_);
+      grid.setWidget(0, 1, tbBranch_);;
       
       container_.add(grid);
-      container_.add(new VerticalSpacer("12px"));
+      container_.add(new VerticalSpacer("6px"));
+      container_.add(sbRemote_);
       container_.add(cbPush_);
    }
 
@@ -122,6 +142,8 @@ public class CreateBranchDialog extends ModalDialog<CreateBranchDialog.Input>
    
    private final VerticalPanel container_;
    private final TextBox tbBranch_;
-   private final TextBox tbRemote_;
+   private final SelectWidget sbRemote_;
    private final CheckBox cbPush_;
+   
+   private static final String REMOTE_NONE = "(None)";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchDialog.java
@@ -16,8 +16,10 @@ package org.rstudio.studio.client.workbench.views.vcs;
 
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.core.client.widget.VerticalSpacer;
 
 import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.Grid;
 import com.google.gwt.user.client.ui.Label;
@@ -74,8 +76,8 @@ public class CreateBranchDialog extends ModalDialog<CreateBranchDialog.Input>
       setOkButtonCaption("Create");
       
       container_ = new VerticalPanel();
-      tbBranch_ = new TextBox();
-      tbRemote_ = new TextBox();
+      tbBranch_ = createTextBox();
+      tbRemote_ = createTextBox();
       cbPush_ = new CheckBox("Push branch to remote");
       
       final String remote = remotes.length() == 0 ? "origin" : remotes.get(0);
@@ -90,6 +92,7 @@ public class CreateBranchDialog extends ModalDialog<CreateBranchDialog.Input>
       grid.setWidget(1, 1, tbRemote_);
       
       container_.add(grid);
+      container_.add(new VerticalSpacer("12px"));
       container_.add(cbPush_);
    }
 
@@ -104,6 +107,17 @@ public class CreateBranchDialog extends ModalDialog<CreateBranchDialog.Input>
    {
       super.showModal();
       tbBranch_.setFocus(true);
+   }
+   
+   private TextBox createTextBox()
+   {
+      TextBox textBox = new TextBox();
+      textBox.setWidth("200px");
+      textBox.getElement().getStyle().setPaddingLeft(3, Unit.PX);
+      textBox.getElement().getStyle().setPaddingRight(3, Unit.PX);
+      textBox.getElement().getStyle().setPaddingBottom(2, Unit.PX);
+      textBox.getElement().getStyle().setPaddingTop(2, Unit.PX);
+      return textBox;
    }
    
    private final VerticalPanel container_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchDialog.java
@@ -1,6 +1,113 @@
+/*
+ * CreateBranchDialog.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
 package org.rstudio.studio.client.workbench.views.vcs;
 
-public class CreateBranchDialog
-{
+import org.rstudio.core.client.widget.ModalDialog;
+import org.rstudio.core.client.widget.OperationWithInput;
 
+import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.user.client.ui.CheckBox;
+import com.google.gwt.user.client.ui.Grid;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.TextBox;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.gwt.user.client.ui.Widget;
+
+public class CreateBranchDialog extends ModalDialog<CreateBranchDialog.Input>
+{
+   public static class Input
+   {
+      public Input(String branch, String remote, boolean push)
+      {
+         branch_ = branch;
+         remote_ = remote;
+         push_ = push;
+      }
+      
+      public final String getBranch()
+      {
+         return branch_;
+      }
+      
+      public final String getRemote()
+      {
+         return remote_;
+      }
+      
+      public final boolean getPush()
+      {
+         return push_;
+      }
+      
+      private final String branch_;
+      private final String remote_;
+      private final boolean push_;
+   }
+
+   @Override
+   protected Input collectInput()
+   {
+      return new Input(
+            tbBranch_.getValue().trim(),
+            tbRemote_.getValue().trim(),
+            cbPush_.getValue());
+   }
+   
+   public CreateBranchDialog(final String caption,
+                             final JsArrayString remotes,
+                             final OperationWithInput<Input> operation)
+   {
+      super(caption, operation);
+      
+      setOkButtonCaption("Create");
+      
+      container_ = new VerticalPanel();
+      tbBranch_ = new TextBox();
+      tbRemote_ = new TextBox();
+      cbPush_ = new CheckBox("Push branch to remote");
+      
+      final String remote = remotes.length() == 0 ? "origin" : remotes.get(0);
+      tbRemote_.setValue(remote);
+      
+      cbPush_.setValue(true);
+      
+      Grid grid = new Grid(2, 2);
+      grid.setWidget(0, 0, new Label("Branch:"));
+      grid.setWidget(0, 1, tbBranch_);
+      grid.setWidget(1, 0, new Label("Remote:"));
+      grid.setWidget(1, 1, tbRemote_);
+      
+      container_.add(grid);
+      container_.add(cbPush_);
+   }
+
+   @Override
+   protected Widget createMainWidget()
+   {
+      return container_;
+   }
+   
+   @Override
+   public void showModal()
+   {
+      super.showModal();
+      tbBranch_.setFocus(true);
+   }
+   
+   private final VerticalPanel container_;
+   private final TextBox tbBranch_;
+   private final TextBox tbRemote_;
+   private final CheckBox cbPush_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchDialog.java
@@ -28,6 +28,7 @@ import org.rstudio.core.client.widget.VerticalSpacer;
 import org.rstudio.studio.client.common.vcs.RemotesInfo;
 
 import com.google.gwt.core.client.JsArray;
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
@@ -107,8 +108,6 @@ public class CreateBranchDialog extends ModalDialog<CreateBranchDialog.Input>
       setRemotes(remotesInfo);
       
       btnAddRemote_ = new SmallButton("Add Remote...");
-      btnAddRemote_.getElement().getStyle().setMarginLeft(12, Unit.PX);
-      btnAddRemote_.getElement().getStyle().setMarginTop(1, Unit.PX);
       btnAddRemote_.addClickHandler(new ClickHandler()
       {
          @Override
@@ -146,17 +145,26 @@ public class CreateBranchDialog extends ModalDialog<CreateBranchDialog.Input>
       cbPush_.setVisible(!sbRemote_.getValue().equals(REMOTE_NONE));
       cbPush_.setValue(true);
       
-      Grid grid = new Grid(1, 2);
-      grid.setWidget(0, 0, new Label("Branch:"));
-      grid.setWidget(0, 1, tbBranch_);
+      Grid ctrBranch = new Grid(1, 2);
+      ctrBranch.setWidth("100%");
+      ctrBranch.setWidget(0, 0, new Label("Branch:"));
+      ctrBranch.setWidget(0, 1, tbBranch_);
       
-      HorizontalPanel remotePanel = new HorizontalPanel();
-      remotePanel.add(sbRemote_);
-      remotePanel.add(btnAddRemote_);
+      HorizontalPanel ctrRemote = new HorizontalPanel();
+      ctrRemote.setWidth("100%");
+      ctrRemote.add(sbRemote_);
+      sbRemote_.getElement().getStyle().setFloat(Style.Float.LEFT);
+      ctrRemote.add(btnAddRemote_);
+      btnAddRemote_.getElement().getStyle().setFloat(Style.Float.RIGHT);
+      btnAddRemote_.getElement().getStyle().setMarginTop(2, Unit.PX);
+      btnAddRemote_.getElement().getStyle().setMarginRight(3, Unit.PX);
       
-      container_.add(grid);
-      container_.add(new VerticalSpacer("6px"));
-      container_.add(remotePanel);
+      VerticalPanel panel = new VerticalPanel();
+      panel.add(ctrBranch);
+      panel.add(new VerticalSpacer("6px"));
+      panel.add(ctrRemote);
+      
+      container_.add(panel);
       container_.add(cbPush_);
    }
    
@@ -203,11 +211,7 @@ public class CreateBranchDialog extends ModalDialog<CreateBranchDialog.Input>
    private TextBox textBox()
    {
       TextBox textBox = new TextBox();
-      textBox.setWidth("220px");
-      textBox.getElement().getStyle().setPaddingLeft(3, Unit.PX);
-      textBox.getElement().getStyle().setPaddingRight(3, Unit.PX);
-      textBox.getElement().getStyle().setPaddingBottom(2, Unit.PX);
-      textBox.getElement().getStyle().setPaddingTop(2, Unit.PX);
+      textBox.getElement().getStyle().setProperty("minWidth", "200px");
       return textBox;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchToolbarButton.java
@@ -1,0 +1,199 @@
+/*
+ * CreateBranchToolbarButton.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.vcs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.js.JsUtil;
+import org.rstudio.core.client.widget.MessageDialog;
+import org.rstudio.core.client.widget.Operation;
+import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.common.console.ConsoleProcess;
+import org.rstudio.studio.client.common.icons.StandardIcons;
+import org.rstudio.studio.client.common.vcs.BranchesInfo;
+import org.rstudio.studio.client.common.vcs.GitServerOperations;
+import org.rstudio.studio.client.server.ServerError;
+import org.rstudio.studio.client.server.ServerRequestCallback;
+import org.rstudio.studio.client.workbench.views.vcs.common.ConsoleProgressDialog;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.inject.Inject;
+
+public class CreateBranchToolbarButton extends ToolbarButton
+                                       implements ClickHandler
+{
+   @Inject
+   public CreateBranchToolbarButton(GlobalDisplay globalDisplay,
+                                    GitServerOperations gitServer)
+   {
+      super("Create Branch",
+            StandardIcons.INSTANCE.mermaid(),
+            (ClickHandler) null);
+      
+      globalDisplay_ = globalDisplay;
+      gitServer_ = gitServer;
+      
+      addClickHandler(this);
+   }
+   
+   @Override
+   public void onClick(ClickEvent event)
+   {
+      globalDisplay_.promptForText(
+            "Create Branch",
+            "Create a new branch:",
+            "",
+            new OperationWithInput<String>()
+            {
+               @Override
+               public void execute(String newBranch)
+               {
+                  onCreateBranch(newBranch);
+               }
+            });
+   }
+   
+   private void onCreateBranch(final String newBranch)
+   {
+      gitServer_.gitListBranches(
+            new ServerRequestCallback<BranchesInfo>()
+            {
+               @Override
+               public void onResponseReceived(BranchesInfo branchesInfo)
+               {
+                  onBranchInfoReceived(newBranch, branchesInfo);
+               }
+               
+               @Override
+               public void onError(ServerError error)
+               {
+                  Debug.logError(error);
+               }
+            });
+   }
+   
+   private void onBranchInfoReceived(final String newBranch,
+                                     final BranchesInfo branchesInfo)
+   {
+      // If we have a branch of this name already, prompt the
+      // user and ask whether they'd like to check out a
+      // new branch (overwriting the previous one) or if they'd
+      // like to just check out that branch.
+      boolean hasBranch = false;
+      for (String branch : JsUtil.asIterable(branchesInfo.getBranches()))
+      {
+         if (branch.equals(newBranch))
+         {
+            hasBranch = true;
+            break;
+         }
+      }
+      
+      if (hasBranch)
+      {
+         String message =
+               "A branch named '" + newBranch + "' already exists. Would " +
+               "you like to check out that branch, or overwrite that branch?";
+         
+         List<String> labels = new ArrayList<String>();
+         labels.add("Checkout");
+         labels.add("Overwrite");
+         
+         List<Operation> operations = new ArrayList<Operation>();
+         operations.add(new Operation()
+         {
+            @Override
+            public void execute()
+            {
+               onCheckout(newBranch);
+            }
+         });
+         operations.add(new Operation()
+         {
+            @Override
+            public void execute()
+            {
+               onCreate(newBranch);
+            }
+         });
+         
+         globalDisplay_.showGenericDialog(
+               MessageDialog.INFO,
+               "Branch Already Exists",
+               message,
+               labels,
+               operations,
+               1);
+      }
+      else
+      {
+         onCreate(newBranch);
+      }
+   }
+   
+   private void onCreate(final String newBranch)
+   {
+      gitServer_.gitCreateBranch(
+            newBranch,
+            new ServerRequestCallback<ConsoleProcess>()
+            {
+               @Override
+               public void onResponseReceived(ConsoleProcess process)
+               {
+                  showConsoleProcessDialog(process);
+               }
+               
+               @Override
+               public void onError(ServerError error)
+               {
+                  Debug.logError(error);
+               }
+               
+            });
+   }
+   
+   private void onCheckout(final String newBranch)
+   {
+      gitServer_.gitCheckout(
+            newBranch,
+            new ServerRequestCallback<ConsoleProcess>()
+            {
+               @Override
+               public void onResponseReceived(ConsoleProcess process)
+               {
+                  showConsoleProcessDialog(process);
+               }
+
+               @Override
+               public void onError(ServerError error)
+               {
+                  Debug.logError(error);
+               }
+            });
+   }
+   
+   private void showConsoleProcessDialog(ConsoleProcess process)
+   {
+      new ConsoleProgressDialog(process, gitServer_).showModal();
+   }
+   
+   private final GlobalDisplay globalDisplay_;
+   private final GitServerOperations gitServer_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchToolbarButton.java
@@ -133,7 +133,7 @@ public class CreateBranchToolbarButton extends ToolbarButton
       {
          String message =
                "A branch named '" + input.getBranch() + "' already exists. Would " +
-               "you like to check out that branch, or overwrite that branch?";
+               "you like to check out that branch, or overwrite it?";
          
          List<String> labels = new ArrayList<String>();
          labels.add("Checkout");
@@ -183,7 +183,7 @@ public class CreateBranchToolbarButton extends ToolbarButton
                   final ConsoleProgressDialog dialog =
                         new ConsoleProgressDialog(process, gitServer_);
                   dialog.showModal();
-                  dialog.writePrompt("> git checkout -B '" + input.getBranch() + "'\n");
+                  
                   process.addProcessExitHandler(new ProcessExitEvent.Handler()
                   {
                      @Override
@@ -209,7 +209,6 @@ public class CreateBranchToolbarButton extends ToolbarButton
    {
       if (event.getExitCode() == 0 && input.getPush())
       {
-         dialog.writePrompt("> git push -u " + input.getRemote() + " " + input.getBranch() + "\n");
          gitServer_.gitPushBranch(
                input.getBranch(),
                input.getRemote(),

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressDialog.java
@@ -101,20 +101,6 @@ public class ConsoleProgressDialog extends ProgressDialog
       if (exitCode != null)
          setExitCode(exitCode);
      
-      // interaction-always mode is a shell -- customize ui accordingly
-      if (getInteractionMode() == ConsoleProcessInfo.INTERACTION_ALWAYS)
-      {
-         stopButton().setText("Close");
-         
-         hideProgress();
-         
-         int height = Window.getClientHeight() - 150;
-         int width = Math.min(800, Window.getClientWidth() - 150);
-         Style style = display_.getShellWidget().getElement().getStyle();
-         style.setHeight(height, Unit.PX);
-         style.setWidth(width, Unit.PX);
-      }
-      
       attachToProcess(consoleProcess);
    }
    
@@ -131,7 +117,24 @@ public class ConsoleProgressDialog extends ProgressDialog
    {
       consoleProcess_ = consoleProcess;
       
-      stopButton().setText("Stop");
+      // interaction-always mode is a shell -- customize ui accordingly
+      if (getInteractionMode() == ConsoleProcessInfo.INTERACTION_ALWAYS)
+      {
+         hideProgress();
+         stopButton().setText("Close");
+         
+         int height = Window.getClientHeight() - 150;
+         int width = Math.min(800, Window.getClientWidth() - 150);
+         Style style = display_.getShellWidget().getElement().getStyle();
+         style.setHeight(height, Unit.PX);
+         style.setWidth(width, Unit.PX);
+      }
+      else
+      {
+         showProgress();
+         stopButton().setText("Stop");
+      }
+      
       stopButton().addClickHandler(this);
       
       if (consoleProcess != null)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
@@ -32,6 +32,7 @@ import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.ui.WorkbenchPane;
 import org.rstudio.studio.client.workbench.views.vcs.CheckoutBranchToolbarButton;
+import org.rstudio.studio.client.workbench.views.vcs.CreateBranchToolbarButton;
 import org.rstudio.studio.client.workbench.views.vcs.git.GitPresenter.Display;
 
 import java.util.ArrayList;
@@ -42,12 +43,14 @@ public class GitPane extends WorkbenchPane implements Display
    public GitPane(GitChangelistTablePresenter changelistTablePresenter,
                   Session session,
                   Commands commands,
-                  CheckoutBranchToolbarButton branchToolbarButton)
+                  CheckoutBranchToolbarButton switchBranchToolbarButton,
+                  CreateBranchToolbarButton createBranchToolbarButton)
    {
       super(session.getSessionInfo().getVcsName());
       commands_ = commands;
-      branchToolbarButton_ = branchToolbarButton;
-
+      switchBranchToolbarButton_ = switchBranchToolbarButton;
+      createBranchToolbarButton_ = createBranchToolbarButton;     
+      
       table_ = changelistTablePresenter.getView();
    }
 
@@ -76,7 +79,8 @@ public class GitPane extends WorkbenchPane implements Display
             StandardIcons.INSTANCE.more_actions(),
             moreMenu));
 
-      toolbar.addRightWidget(branchToolbarButton_);
+      toolbar.addRightWidget(createBranchToolbarButton_);
+      toolbar.addRightWidget(switchBranchToolbarButton_);
       
       toolbar.addRightSeparator();
       
@@ -123,10 +127,11 @@ public class GitPane extends WorkbenchPane implements Display
       if (width == 0)
          return;
       
-      pullButton_.setText(width > 500 ? "Pull" : "");
-      pushButton_.setText(width > 500 ? "Push" : "");
-      historyButton_.setText(width > 580 ? "History" : "");
-      moreButton_.setText(width > 580 ? "More" : "");
+      pullButton_.setText(width > 600 ? "Pull" : "");
+      pushButton_.setText(width > 600 ? "Push" : "");
+      historyButton_.setText(width > 680 ? "History" : "");
+      moreButton_.setText(width > 680 ? "More" : "");
+      createBranchToolbarButton_.setText(width > 780 ? "Create Branch" : "");
       
    }
 
@@ -205,6 +210,7 @@ public class GitPane extends WorkbenchPane implements Display
    private ToolbarButton pushButton_;
    
    private final Commands commands_;
-   private final CheckoutBranchToolbarButton branchToolbarButton_;
+   private final CheckoutBranchToolbarButton switchBranchToolbarButton_;
+   private final CreateBranchToolbarButton createBranchToolbarButton_;
    private GitChangelistTable table_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
@@ -132,7 +132,6 @@ public class GitPane extends WorkbenchPane implements Display
       historyButton_.setText(width > 680 ? "History" : "");
       moreButton_.setText(width > 680 ? "More" : "");
       createBranchToolbarButton_.setText(width > 780 ? "Create Branch" : "");
-      
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
@@ -80,6 +80,9 @@ public class GitPane extends WorkbenchPane implements Display
             moreMenu));
 
       toolbar.addRightWidget(createBranchToolbarButton_);
+      
+      toolbar.addRightSeparator();
+      
       toolbar.addRightWidget(switchBranchToolbarButton_);
       
       toolbar.addRightSeparator();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
@@ -130,11 +130,11 @@ public class GitPane extends WorkbenchPane implements Display
       if (width == 0)
          return;
       
-      pullButton_.setText(width > 600 ? "Pull" : "");
-      pushButton_.setText(width > 600 ? "Push" : "");
-      historyButton_.setText(width > 680 ? "History" : "");
-      moreButton_.setText(width > 680 ? "More" : "");
-      createBranchToolbarButton_.setText(width > 780 ? "Create Branch" : "");
+      pullButton_.setText(width > 550 ? "Pull" : "");
+      pushButton_.setText(width > 550 ? "Push" : "");
+      historyButton_.setText(width > 630 ? "History" : "");
+      moreButton_.setText(width > 630 ? "More" : "");
+      createBranchToolbarButton_.setText(width > 680 ? "New Branch" : "");
    }
 
    @Override


### PR DESCRIPTION
Note: not ready for merge, pending UI feedback.

---

This PR adds a simple 'create branch' dialog, intended to make it possible to create and checkout a new branch without popping into the shell. A quick preview of what the UI looks like so far:

<img width="809" alt="screen shot 2017-02-14 at 11 31 01 am" src="https://cloud.githubusercontent.com/assets/1976582/22945467/2f34333a-f2a9-11e6-90d7-3b68b08f68fc.png">

<img width="344" alt="screen shot 2017-02-14 at 11 31 24 am" src="https://cloud.githubusercontent.com/assets/1976582/22945474/359ef458-f2a9-11e6-9d80-19ca83952fec.png">

When a branch of the same name already exists, we prompt the user as to whether they'd like to check out that branch, or overwrite it with a fresh branch from their current checkout.

<img width="387" alt="screen shot 2017-02-14 at 11 31 30 am" src="https://cloud.githubusercontent.com/assets/1976582/22945477/39c3d0a8-f2a9-11e6-88ee-5ca5883e3129.png">

## Comments

Should we allow the user to set an upstream remote as well? E.g. with a dialog like:

```
Create Branch: < ___ >
Set Upstream: < ___ >
[ ] Push to remote
```

I'm trying to imagine a workflow where we attempt to set an upstream remote (if one exists); otherwise, we automatically push the repository to the remote and automatically set the upstream. Does something like that make sense?

We probably also want a dedicated branch icon (I'm reusing the mermaid icon as it fits somewhat well as a placeholder)