### PR TITLE
Add editor options in YAML front matter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,12 +8,15 @@
 ### R Markdown
 
 * Added option to specify the working directory when executing R Markdown chunks
+* Added option to set preview mode (in viewer, window, etc.) in YAML header
+* Added option to skip knitting before publishing in YAML header
 
 ### R Notebooks
 
 * Python chunks now respect virtualenv if present
 * 'Rename in Scope' now works within R chunks
 * Fixed an issue where non-R chunk output could become duplicated
+* Added option to set notebook mode in the document's YAML header
 
 ### Terminal
 

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/events/RenderRmdEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/events/RenderRmdEvent.java
@@ -40,7 +40,8 @@ public class RenderRmdEvent extends CrossWindowEvent<RenderRmdEvent.Handler>
                          boolean asTempfile,
                          int type,
                          String existingOutputFile,
-                         String workingDirectory)
+                         String workingDirectory,
+                         String viewerType)
    {
       sourceFile_ = sourceFile;
       sourceLine_ = sourceLine;
@@ -51,6 +52,7 @@ public class RenderRmdEvent extends CrossWindowEvent<RenderRmdEvent.Handler>
       type_ = type;
       existingOutputFile_ = existingOutputFile;
       workingDirectory_ = workingDirectory;
+      viewerType_ = viewerType;
    }
 
    public String getSourceFile()
@@ -97,6 +99,11 @@ public class RenderRmdEvent extends CrossWindowEvent<RenderRmdEvent.Handler>
    {
       return workingDirectory_;
    }
+   
+   public String getViewerType()
+   {
+      return viewerType_;
+   }
     
    @Override
    public Type<Handler> getAssociatedType()
@@ -119,6 +126,7 @@ public class RenderRmdEvent extends CrossWindowEvent<RenderRmdEvent.Handler>
    private int type_;
    private String existingOutputFile_;
    private String workingDirectory_;
+   private String viewerType_;
    
    public final static String WORKING_DIR_PROP = "working_dir";
 

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RMarkdownServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RMarkdownServerOperations.java
@@ -30,6 +30,7 @@ public interface RMarkdownServerOperations extends CryptoServerOperations
    void renderRmd(String file, int line, String format, String encoding,
                   String paramsFile, boolean asTempfile, int type,
                   String existingOutputFile, String workingDir,
+                  String viewerType,
                   ServerRequestCallback<Boolean> requestCallback);
    
    void renderRmdSource(String source,

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdEditorOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdEditorOptions.java
@@ -15,8 +15,6 @@
 
 package org.rstudio.studio.client.rmarkdown.model;
 
-import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
-
 public class RmdEditorOptions
 {
    public static boolean getBool(String yaml, String option,

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdEditorOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdEditorOptions.java
@@ -58,5 +58,10 @@ public class RmdEditorOptions
    
    private static String EDITOR_OPTION_KEY = "editor_options";
    
-   public static String PUBLISH_OUTPUT = "publish_output";
+   public static String PUBLISH_OUTPUT    = "publish_output";
+
+   public static String PREVIEW_IN        = "preview_in";
+   public static String PREVIEW_IN_WINDOW = "window";
+   public static String PREVIEW_IN_VIEWER = "viewer";
+   public static String PREVIEW_IN_NONE   = "none";
 }

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdEditorOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdEditorOptions.java
@@ -60,7 +60,7 @@ public class RmdEditorOptions
    
    public static String PUBLISH_OUTPUT    = "publish_output";
 
-   public static String PREVIEW_IN        = "preview_in";
+   public static String PREVIEW_IN        = "preview";
    public static String PREVIEW_IN_WINDOW = "window";
    public static String PREVIEW_IN_VIEWER = "viewer";
    public static String PREVIEW_IN_NONE   = "none";

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdEditorOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdEditorOptions.java
@@ -1,0 +1,64 @@
+/*
+ * RmdEditorOptions.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.rmarkdown.model;
+
+import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
+
+public class RmdEditorOptions
+{
+   public static boolean getBool(String yaml, String option,
+         Boolean defaultValue)
+   {
+      YamlTree yamlTree = new YamlTree(yaml);
+      String value = yamlTree.getChildValue(EDITOR_OPTION_KEY, option)
+                             .trim().toLowerCase();
+      if (!value.isEmpty())
+      {
+         // there are lots of ways to say "true" in YAML...
+         return value == "y"    || value == "yes" || 
+                value == "true" || value == "on";
+      }
+      return defaultValue;
+   }
+   
+   public static String getString(String yaml, String option,
+         String defaultValue)
+   {
+      YamlTree yamlTree = new YamlTree(yaml);
+      String value = yamlTree.getChildValue(EDITOR_OPTION_KEY, option);
+      if (value.isEmpty())
+         return defaultValue;
+      return value;
+   }
+   
+   public static String set(String yaml, String option, String value)
+   {
+      YamlTree yamlTree = new YamlTree(yaml);
+
+      // add editor option key if not yet present
+      if (!yamlTree.containsKey(EDITOR_OPTION_KEY))
+         yamlTree.addYamlValue(null, EDITOR_OPTION_KEY, "");
+      
+      // add new value to the key
+      yamlTree.addYamlValue(EDITOR_OPTION_KEY, option, value);
+
+      return yamlTree.toString();
+   }
+   
+   private static String EDITOR_OPTION_KEY = "editor_options";
+   
+   public static String KNIT_BEFORE_PUBLISH = "knit_before_publish";
+}

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdEditorOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdEditorOptions.java
@@ -58,5 +58,5 @@ public class RmdEditorOptions
    
    private static String EDITOR_OPTION_KEY = "editor_options";
    
-   public static String KNIT_BEFORE_PUBLISH = "knit_before_publish";
+   public static String PUBLISH_OUTPUT = "publish_output";
 }

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdRenderResult.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdRenderResult.java
@@ -81,6 +81,10 @@ public class RmdRenderResult extends RmdSlideNavigationInfo
       return this.force_maximize;
    }-*/;
    
+   public native final String getViewerType() /*-{
+      return this.viewer_type;
+   }-*/;
+   
    public final boolean isHtml()
    {
       return getOutputFile().toLowerCase().endsWith(".html");

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/YamlTree.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/YamlTree.java
@@ -200,9 +200,26 @@ public class YamlTree
       if (parentKey != null && !keyMap_.containsKey(parentKey))
          return;
       
-      String line = key + ": " + value;     
+      String line = key + ": " + value;
       YamlTreeNode parent = parentKey == null ? root_ : keyMap_.get(parentKey);
-      YamlTreeNode child = parentKey == null ? new YamlTreeNode(line) : 
+      
+      // check to see if we should be replacing a value rather than adding
+      YamlTreeNode child = null;
+      for (YamlTreeNode childNode: parent.children)
+      {
+         if (childNode.key == key)
+         {
+            // found an existing child node
+            child = childNode;
+            
+            // set its value to the one supplied by the caller and return
+            child.setValue(value);
+            return;
+         }
+      }
+      
+      // no existing value, create a wholly new node
+      child = parentKey == null ? new YamlTreeNode(line) : 
             new YamlTreeNode(parent.getIndent() + "  " + line);
       keyMap_.put(key, child);
       parent.addChild(child);
@@ -212,6 +229,24 @@ public class YamlTree
    {
       if (keyMap_.containsKey(key))
          return keyMap_.get(key).getValue();
+      return "";
+   }
+   
+   public String getChildValue(String parentKey, String childKey)
+   {
+      for (YamlTreeNode parent: root_.children)
+      {
+         if (parent.key == parentKey)
+         {
+            for (YamlTreeNode child: parent.children)
+            {
+               if (child.key == childKey)
+               {
+                  return child.getValue();
+               }
+            }
+         }
+      }
       return "";
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4242,6 +4242,7 @@ public class RemoteServer implements Server
    public void renderRmd(String file, int line, String format, String encoding,
                          String paramsFile, boolean asTempfile, int type,
                          String existingOutputFile, String workingDir,
+                         String viewerType,
          ServerRequestCallback<Boolean> requestCallback)
    {
       JSONArray params = new JSONArray();
@@ -4254,6 +4255,7 @@ public class RemoteServer implements Server
       params.set(6, new JSONNumber(type));
       params.set(7, new JSONString(StringUtil.notNull(existingOutputFile)));
       params.set(8, new JSONString(StringUtil.notNull(workingDir)));
+      params.set(9, new JSONString(StringUtil.notNull(viewerType)));
       sendRequest(RPC_SCOPE,
             RENDER_RMD,
             params,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -95,6 +95,7 @@ import org.rstudio.studio.client.rmarkdown.events.RmdOutputFormatChangedEvent;
 import org.rstudio.studio.client.rmarkdown.events.RmdRenderPendingEvent;
 import org.rstudio.studio.client.rmarkdown.model.NotebookQueueUnit;
 import org.rstudio.studio.client.rmarkdown.model.RMarkdownContext;
+import org.rstudio.studio.client.rmarkdown.model.RmdEditorOptions;
 import org.rstudio.studio.client.rmarkdown.model.RmdFrontMatter;
 import org.rstudio.studio.client.rmarkdown.model.RmdFrontMatterOutputOptions;
 import org.rstudio.studio.client.rmarkdown.model.RmdOutputFormat;
@@ -3713,14 +3714,22 @@ public class TextEditingTarget implements
          // update notebook-specific options
          if (isNotebook)
          {
-            // chunk output should always be inline in notebooks
-            String outputType = docUpdateSentinel_.getProperty(
-                  TextEditingTargetNotebook.CHUNK_OUTPUT_TYPE);
-            if (outputType != TextEditingTargetNotebook.CHUNK_OUTPUT_INLINE)
+            // if the user manually set the output to console in a notebook,
+            // respect that (even though it's weird)
+            String outputType = RmdEditorOptions.getString(
+                  YamlFrontMatter.getFrontMatter(docDisplay_),
+                  TextEditingTargetNotebook.CHUNK_OUTPUT_TYPE, null);
+            if (outputType != TextEditingTargetNotebook.CHUNK_OUTPUT_CONSOLE)
             {
-               docUpdateSentinel_.setProperty(
-                     TextEditingTargetNotebook.CHUNK_OUTPUT_TYPE,
-                     TextEditingTargetNotebook.CHUNK_OUTPUT_INLINE);
+               // chunk output should always be inline in notebooks
+               outputType = docUpdateSentinel_.getProperty(
+                     TextEditingTargetNotebook.CHUNK_OUTPUT_TYPE);
+               if (outputType != TextEditingTargetNotebook.CHUNK_OUTPUT_INLINE)
+               {
+                  docUpdateSentinel_.setProperty(
+                        TextEditingTargetNotebook.CHUNK_OUTPUT_TYPE,
+                        TextEditingTargetNotebook.CHUNK_OUTPUT_INLINE);
+               }
             }
             view_.setIsNotebookFormat();
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2586,6 +2586,9 @@ public class TextEditingTarget implements
       if (extendedType.equals(SourceDocument.XT_RMARKDOWN))
          updateRmdFormatList();
       extendedType_ = extendedType;
+
+      // extended type can affect publish options
+      syncPublishPath(docUpdateSentinel_.getPath());
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -4973,6 +4973,8 @@ public class TextEditingTarget implements
          public void execute()
          {
             boolean asTempfile = isPackageDocumentationFile();
+            String viewerType = RmdEditorOptions.getString(
+                  getRmdFrontMatter(), RmdEditorOptions.PREVIEW_IN, null);
 
             rmarkdownHelper_.renderRMarkdown(
                   docUpdateSentinel_.getPath(),
@@ -4983,7 +4985,8 @@ public class TextEditingTarget implements
                   asTempfile,
                   type,
                   false,
-                  rmarkdownHelper_.getKnitWorkingDir(docUpdateSentinel_));
+                  rmarkdownHelper_.getKnitWorkingDir(docUpdateSentinel_),
+                  viewerType);
          }
       };  
 
@@ -5246,7 +5249,7 @@ public class TextEditingTarget implements
             @Override
             public void execute()
             {
-               rmarkdownHelper_.renderNotebookv2(docUpdateSentinel_);
+               rmarkdownHelper_.renderNotebookv2(docUpdateSentinel_, null);
             }
          });
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
@@ -194,7 +194,8 @@ public class TextEditingTargetRMarkdownHelper
          });
    }
    
-   public void renderNotebookv2(final DocUpdateSentinel sourceDoc)
+   public void renderNotebookv2(final DocUpdateSentinel sourceDoc,
+         final String viewerType)
    { 
       withRMarkdownPackage("Compiling notebooks from R scripts",
                            false,
@@ -212,7 +213,7 @@ public class TextEditingTargetRMarkdownHelper
                         if (format == null)
                            renderNotebookv2WithDialog(sourceDoc);
                         else
-                           renderNotebookv2(sourceDoc, format);
+                           renderNotebookv2(sourceDoc, format, viewerType);
                      }
                });
             }
@@ -266,7 +267,7 @@ public class TextEditingTargetRMarkdownHelper
    }
    
    private void renderNotebookv2(final DocUpdateSentinel sourceDoc,
-                                 String format)
+                                 String format, String viewerType)
    {
       eventBus_.fireEvent(new RenderRmdEvent(sourceDoc.getPath(), 
                                              1, 
@@ -276,7 +277,8 @@ public class TextEditingTargetRMarkdownHelper
                                              false,
                                              RmdOutput.TYPE_STATIC,
                                              null,
-                                             getKnitWorkingDir(sourceDoc)));
+                                             getKnitWorkingDir(sourceDoc),
+                                             viewerType));
    }
    
    public String getKnitWorkingDir(DocUpdateSentinel sourceDoc)
@@ -317,7 +319,8 @@ public class TextEditingTargetRMarkdownHelper
                                final boolean asTempfile,
                                final int type,
                                final boolean asShiny,
-                               final String workingDir)
+                               final String workingDir,
+                               final String viewerType)
    {
       withRMarkdownPackage(type == RmdOutput.TYPE_NOTEBOOK ?
                               "R Notebook" :
@@ -336,7 +339,8 @@ public class TextEditingTargetRMarkdownHelper
                                                    asTempfile,
                                                    type,
                                                    null,
-                                                   workingDir));
+                                                   workingDir,
+                                                   viewerType));
          }
       });
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -57,6 +57,8 @@ import org.rstudio.studio.client.common.icons.StandardIcons;
 import org.rstudio.studio.client.rmarkdown.RmdOutput;
 import org.rstudio.studio.client.rmarkdown.events.RenderRmdEvent;
 import org.rstudio.studio.client.rmarkdown.events.RmdOutputFormatChangedEvent;
+import org.rstudio.studio.client.rmarkdown.model.RmdEditorOptions;
+import org.rstudio.studio.client.rmarkdown.model.YamlFrontMatter;
 import org.rstudio.studio.client.rsconnect.RSConnect;
 import org.rstudio.studio.client.rsconnect.ui.RSConnectPublishButton;
 import org.rstudio.studio.client.shiny.model.ShinyApplicationParams;
@@ -1021,7 +1023,22 @@ public class TextEditingTargetWidget
          }
          else if (type == SourceDocument.XT_RMARKDOWN)
          {
-            publishButton_.setRmd(publishPath, !isShiny_);
+            // assume static by default
+            boolean isStatic = true;
+            if (isShiny_)
+            {
+               // Shiny documents cannot be static
+               isStatic = false;
+            }
+            else if (!RmdEditorOptions.getBool(
+                  YamlFrontMatter.getFrontMatter(editor_), 
+                  RmdEditorOptions.KNIT_BEFORE_PUBLISH, true))
+            {
+               // it's also possible to mark a local document as non-static
+               // in order to avoid the requirement for pre-render
+               isStatic = false;
+            }
+            publishButton_.setRmd(publishPath, isStatic);
          }
          else 
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -1032,10 +1032,9 @@ public class TextEditingTargetWidget
             }
             else if (!RmdEditorOptions.getBool(
                   YamlFrontMatter.getFrontMatter(editor_), 
-                  RmdEditorOptions.KNIT_BEFORE_PUBLISH, true))
+                  RmdEditorOptions.PUBLISH_OUTPUT, true))
             {
-               // it's also possible to mark a local document as non-static
-               // in order to avoid the requirement for pre-render
+               // don't publish as static if explicitly asked not to
                isStatic = false;
             }
             publishButton_.setRmd(publishPath, isStatic);


### PR DESCRIPTION
This change adds a mechanism for controlling some RStudio behavior declaratively, using the YAML front matter in the document. The two options added in this change request are shown here:

    ---
    output: html_document
    editor_options:
      chunk_output_type: console
      publish_output: false
    ---

The `chunk_output_type` option controls whether R Markdown chunk output is directed to the console or to the editor. It mirrors, and is synchronized with, a document preference of the same name. The option exists as a result of feedback from instructors who wanted to be able to dictate whether an R Markdown document opens in notebook mode.

The `publish_output` option controls whether the output of the document should be published. When set to `false`, only the document's source code is published. This makes it possible to author and publish documents that for either resource or configuration issues cannot render locally (previously such documents were always knit prior to being published).
