### PR TITLE
allow 'Activate Console' to activate active tab

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/FastSelectTable.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FastSelectTable.java
@@ -233,41 +233,63 @@ public class FastSelectTable<TItemInput, TItemOutput, TItemOutput2> extends Widg
       }
 
       sortSelectedRows();
-      int min = table_.getRows().getLength();
-      int max = -1;
-      if (selectedRows_.size() > 0)
-      {
-         min = selectedRows_.get(0).getRowIndex();
-         max = selectedRows_.get(selectedRows_.size() - 1).getRowIndex();
-      }
+      boolean clearSelection = modifiers != KeyboardShortcut.SHIFT;
 
       switch (event.getNativeKeyCode())
       {
          case KeyCodes.KEY_UP:
          {
-            Integer row = findNextValueRow(min, true);
-            if (row != null)
-            {
-               if (modifiers != KeyboardShortcut.SHIFT)
-                  clearSelection();
-               setSelectedPhysical(row, 1, true);
-               ensureRowVisible(row);
-            }
+            selectPreviousRow(clearSelection);
             break;
          }
          case KeyCodes.KEY_DOWN:
          {
-            Integer row = findNextValueRow(max, false);
-            if (row != null)
-            {
-               if (modifiers != KeyboardShortcut.SHIFT)
-                  clearSelection();
-               setSelectedPhysical(row, 1, true);
-               ensureRowVisible(row);
-            }
+            selectNextRow(clearSelection);
             break;
          }
       }
+   }
+   
+   private void selectPreviousRow(boolean clearSelection)
+   {
+      int min = selectedRows_.size() > 0
+            ? selectedRows_.get(0).getRowIndex()
+            : table_.getRows().getLength();
+            
+      Integer row = findNextValueRow(min, true);
+      if (row != null)
+      {
+         if (clearSelection)
+            clearSelection();
+         setSelectedPhysical(row, 1, true);
+         ensureRowVisible(row);
+      }
+   }
+   
+   public void selectPreviousRow()
+   {
+      selectPreviousRow(true);
+   }
+   
+   private void selectNextRow(boolean clearSelection)
+   {
+      int max = selectedRows_.size() > 0
+            ? selectedRows_.get(selectedRows_.size() - 1).getRowIndex()
+            : -1;
+            
+      Integer row = findNextValueRow(max, false);
+      if (row != null)
+      {
+         if (clearSelection)
+            clearSelection();
+         setSelectedPhysical(row, 1, true);
+         ensureRowVisible(row);
+      }
+   }
+   
+   public void selectNextRow()
+   {
+      selectNextRow(true);
    }
 
    private void ensureRowVisible(final int row)

--- a/src/gwt/src/org/rstudio/studio/client/common/sourcemarkers/SourceMarkerList.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/sourcemarkers/SourceMarkerList.java
@@ -149,6 +149,12 @@ public class SourceMarkerList extends Composite
       }
    }
    
+   public void ensureSelection()
+   {
+      if (errorTable_.getSelectedRowIndexes().isEmpty())
+         selectFirstItem();
+   }
+   
    public void selectFirstItem()
    {
       if (errorTable_.getRowCount() > 0)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -1107,6 +1107,11 @@ well as menu structures (for main menu and popup menus).
         label="Move Focus to Source"
         menuLabel="Move Focus to Sou_rce"/>
         
+   <cmd id="activateConsolePane"
+        label="Move Focus to Console Pane"
+        menuLabel="Move Focus to Console Pane"
+        windowMode="main"/>
+        
    <cmd id="activateConsole"
         label="Move Focus to Console"
         menuLabel="Move Focus to _Console"
@@ -1176,6 +1181,12 @@ well as menu structures (for main menu and popup menus).
         checkable="true"
         label="Zoom Source"
         menuLabel="Zoom Sou_rce"/>
+        
+   <cmd id="layoutZoomConsolePane"
+        checkable="true"
+        label="Zoom Console Pane"
+        menuLabel="Zoom Console Pane"
+        windowMode="main"/>
         
    <cmd id="layoutZoomConsole"
         checkable="true"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -612,7 +612,8 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="activateConsole" value="Alt+X" disableModes="default,vim"/>
          
          <shortcut refid="activateSource" value="Ctrl+1"/>
-         <shortcut refid="activateConsole" value="Ctrl+2"/>
+         <shortcut refid="activateConsole"/>
+         <shortcut refid="activateConsolePane" value="Ctrl+2"/>
          <shortcut refid="activateTerminal" value="Ctrl+Shift+T"/>
          <shortcut refid="activateHelp" value="Ctrl+3"/>
          <shortcut refid="activateHistory" value="Ctrl+4"/>
@@ -758,7 +759,7 @@ well as menu structures (for main menu and popup menus).
        -->
       <shortcutgroup name="Not Displayed">
          <shortcut refid="layoutZoomSource" value="Ctrl+Shift+1"/>
-         <shortcut refid="layoutZoomConsole" value="Ctrl+Shift+2"/>
+         <shortcut refid="layoutZoomConsolePane" value="Ctrl+Shift+2"/>
          <shortcut refid="layoutZoomHelp" value="Ctrl+Shift+3"/>
          <shortcut refid="layoutZoomHistory" value="Ctrl+Shift+4"/>
          <shortcut refid="layoutZoomFiles" value="Ctrl+Shift+5"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -198,7 +198,10 @@ public abstract class
    public abstract AppCommand restartRRunAllChunks();
    public abstract AppCommand terminateR();
    public abstract AppCommand activateConsole();
+   public abstract AppCommand activateConsolePane();
    public abstract AppCommand layoutZoomConsole();
+   public abstract AppCommand layoutZoomConsolePane();
+   public abstract AppCommand activateConsolePanePane();
 
    // Files
    public abstract AppCommand newFolder();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -418,7 +418,7 @@ public class PaneManager
    }
    
    @Handler
-   public void onActivateConsole()
+   public void onActivateConsolePane()
    {
       // The console tab panel is initialized lazily -- while a console
       // pane will always be available, the owning tab panel will only
@@ -443,7 +443,7 @@ public class PaneManager
    }
    
    @Handler
-   public void onLayoutZoomConsole()
+   public void onLayoutZoomConsolePane()
    {
       if (consoleTabPanel_.isEmpty())
          consolePane_.focus();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -420,11 +420,26 @@ public class PaneManager
    @Handler
    public void onActivateConsole()
    {
-      LogicalWindow activeWindow = getActiveLogicalWindow();
-      if (activeWindow.equals(getConsoleLogicalWindow()))
-         consoleTabPanel_.selectNextTab();
+      // The console tab panel is initialized lazily -- while a console
+      // pane will always be available, the owning tab panel will only
+      // be constructed once a neighbor (e.g. the Terminal) has been
+      // created.
+      if (consoleTabPanel_.isEmpty())
+      {
+         consolePane_.focus();
+      }
       else
-         consoleTabPanel_.selectTab(consoleTabPanel_.getSelectedIndex());
+      {
+         LogicalWindow activeWindow = getActiveLogicalWindow();
+         if (getConsoleLogicalWindow().equals(activeWindow))
+         {
+            consoleTabPanel_.selectNextTab();
+         }
+         else
+         {
+            consoleTabPanel_.selectTab(consoleTabPanel_.getSelectedIndex());
+         }
+      }
    }
    
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -445,7 +445,11 @@ public class PaneManager
    @Handler
    public void onLayoutZoomConsole()
    {
-      onActivateConsole();
+      if (consoleTabPanel_.isEmpty())
+         consolePane_.focus();
+      else
+         consoleTabPanel_.selectTab(consoleTabPanel_.getSelectedIndex());
+      
       eventBus_.fireEvent(new ZoomPaneEvent("Console"));
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -418,6 +418,23 @@ public class PaneManager
    }
    
    @Handler
+   public void onActivateConsole()
+   {
+      LogicalWindow activeWindow = getActiveLogicalWindow();
+      if (activeWindow.equals(getConsoleLogicalWindow()))
+         consoleTabPanel_.selectNextTab();
+      else
+         consoleTabPanel_.selectTab(consoleTabPanel_.getSelectedIndex());
+   }
+   
+   @Handler
+   public void onLayoutZoomConsole()
+   {
+      onActivateConsole();
+      eventBus_.fireEvent(new ZoomPaneEvent("Console"));
+   }
+   
+   @Handler
    public void onLayoutZoomCurrentPane()
    {
       LogicalWindow activeWindow = getActiveLogicalWindow();
@@ -883,19 +900,19 @@ public class PaneManager
       LogicalWindow logicalWindow =
             new LogicalWindow(frame, new MinimizedWindowFrame("Console"));
 
-      @SuppressWarnings("unused")
-      ConsoleTabPanel consoleTabPanel = new ConsoleTabPanel(frame,
-                                                            logicalWindow,
-                                                            consolePane_,
-                                                            compilePdfTab_,
-                                                            findOutputTab_,
-                                                            sourceCppTab_,
-                                                            renderRmdTab_,
-                                                            deployContentTab_,
-                                                            markersTab_,
-                                                            terminalTab_,
-                                                            eventBus_,
-                                                            goToWorkingDirButton);
+      consoleTabPanel_ = new ConsoleTabPanel(
+            frame,
+            logicalWindow,
+            consolePane_,
+            compilePdfTab_,
+            findOutputTab_,
+            sourceCppTab_,
+            renderRmdTab_,
+            deployContentTab_,
+            markersTab_,
+            terminalTab_,
+            eventBus_,
+            goToWorkingDirButton);
       
       return logicalWindow;
    }
@@ -1154,6 +1171,7 @@ public class PaneManager
    private DualWindowLayoutPanel left_;
    private DualWindowLayoutPanel right_;
    private ArrayList<LogicalWindow> panes_;
+   private ConsoleTabPanel consoleTabPanel_;
    private WorkbenchTabPanel tabSet1TabPanel_;
    private MinimizedModuleTabLayoutPanel tabSet1MinPanel_;
    private WorkbenchTabPanel tabSet2TabPanel_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchTabPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchTabPanel.java
@@ -242,6 +242,11 @@ class WorkbenchTabPanel
       }
    }
    
+   public boolean isEmpty()
+   {
+      return tabs_.isEmpty();
+   }
+   
    public WorkbenchTab getTab(int index)
    {
       return tabs_.get(index);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchTabPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchTabPanel.java
@@ -181,7 +181,23 @@ class WorkbenchTabPanel
          }
       });
    }
-
+   
+   public void selectNextTab()
+   {
+      selectTabRelative(1);
+   }
+   
+   public void selectPreviousTab()
+   {
+      selectTabRelative(-1);
+   }
+   
+   public void selectTabRelative(int offset)
+   {
+      int index = (getSelectedIndex() + offset) % tabs_.size();
+      selectTab(index);
+   }
+   
    public void selectTab(int tabIndex)
    {
       if (tabPanel_.getSelectedIndex() == tabIndex)
@@ -229,6 +245,11 @@ class WorkbenchTabPanel
    public WorkbenchTab getTab(int index)
    {
       return tabs_.get(index);
+   }
+   
+   public WorkbenchTab getSelectedTab()
+   {
+      return tabs_.get(getSelectedIndex());
    }
 
    public int getSelectedIndex()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/Console.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/Console.java
@@ -20,6 +20,7 @@ import com.google.gwt.user.client.ui.IsWidget;
 import com.google.inject.Inject;
 
 import org.rstudio.core.client.command.CommandBinder;
+import org.rstudio.core.client.command.Handler;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.layout.DelayFadeInHelper;
 import org.rstudio.core.client.widget.FocusContext;
@@ -27,6 +28,7 @@ import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.events.BusyEvent;
 import org.rstudio.studio.client.workbench.events.BusyHandler;
+import org.rstudio.studio.client.workbench.events.ZoomPaneEvent;
 import org.rstudio.studio.client.workbench.views.console.events.ConsoleActivateEvent;
 import org.rstudio.studio.client.workbench.views.console.events.ConsolePromptEvent;
 import org.rstudio.studio.client.workbench.views.console.events.ConsolePromptHandler;
@@ -140,6 +142,12 @@ public class Console
          }
       });
    }
+   
+   @Handler
+   void onActivateConsole()
+   {
+      activateConsole(true);
+   }
 
    private void activateConsole(boolean focusWindow)
    {
@@ -169,6 +177,13 @@ public class Console
             }
          }.schedule(100);
       }    
+   }
+   
+   @Handler
+   public void onLayoutZoomConsole()
+   {
+      onActivateConsole();
+      events_.fireEvent(new ZoomPaneEvent("Console"));
    }
    
    public Display getDisplay()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/Console.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/Console.java
@@ -20,7 +20,6 @@ import com.google.gwt.user.client.ui.IsWidget;
 import com.google.inject.Inject;
 
 import org.rstudio.core.client.command.CommandBinder;
-import org.rstudio.core.client.command.Handler;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.layout.DelayFadeInHelper;
 import org.rstudio.core.client.widget.FocusContext;
@@ -28,7 +27,6 @@ import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.events.BusyEvent;
 import org.rstudio.studio.client.workbench.events.BusyHandler;
-import org.rstudio.studio.client.workbench.events.ZoomPaneEvent;
 import org.rstudio.studio.client.workbench.views.console.events.ConsoleActivateEvent;
 import org.rstudio.studio.client.workbench.views.console.events.ConsolePromptEvent;
 import org.rstudio.studio.client.workbench.views.console.events.ConsolePromptHandler;
@@ -143,12 +141,6 @@ public class Console
       });
    }
 
-   @Handler
-   void onActivateConsole()
-   {
-      activateConsole(true);
-   }
-   
    private void activateConsole(boolean focusWindow)
    {
       // ensure we don't leave focus in the console
@@ -177,13 +169,6 @@ public class Console
             }
          }.schedule(100);
       }    
-   }
-   
-   @Handler
-   public void onLayoutZoomConsole()
-   {
-      onActivateConsole();
-      events_.fireEvent(new ZoomPaneEvent("Console"));
    }
    
    public Display getDisplay()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPane.java
@@ -166,6 +166,17 @@ public class FindOutputPane extends WorkbenchPane
       if (matchCount_ == 0)
          statusPanel_.setStatusText("(No results found)");
    }
+   
+   @Override
+   public void onSelected()
+   {
+      super.onSelected();
+      
+      table_.focus();
+      ArrayList<Integer> indices = table_.getSelectedRowIndexes();
+      if (indices.isEmpty())
+         table_.selectNextRow();
+   }
 
    @Override
    public void ensureVisible(boolean activate)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
@@ -278,7 +278,7 @@ public class FindOutputPresenter extends BasePresenter
       }
       view_.setStopSearchButtonVisible(false);
    }
-
+   
    private String currentFindHandle_;
 
    private FindInFilesDialog.State dialogState_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/markers/MarkersOutputPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/markers/MarkersOutputPane.java
@@ -111,6 +111,14 @@ public class MarkersOutputPane extends WorkbenchPane
       return clearButton_;
    }
    
+   @Override
+   public void onSelected()
+   {
+      super.onSelected();
+      markerList_.focus();
+      markerList_.ensureSelection();
+   }
+   
    private SourceMarkerList markerList_;
    private MarkerSetsToolbarButton markerSetsToolbarButton_;
    private ToolbarButton clearButton_;


### PR DESCRIPTION
This PR will ensure that e.g. `Ctrl + 2` activates the active tab in the Console pane, rather than always activating the Console 'tab' in the console pane. The intention here is to allow `Ctrl + 2` to focus the terminal, if that is what is currently active + visible to the user.

This PR also adds a secondary behavior -- pressing `Ctrl + 2` multiple times now toggles through the active tabs in the Console pane; this can be useful when e.g. using 'Find in Files' output. One can now type `Ctrl + 2` to focus that pane, then use the keyboard to navigate through + select entries in that pane.