### PR TITLE
Remove sudo from linux dependency installers

### DIFF
--- a/dependencies/common/install-boost
+++ b/dependencies/common/install-boost
@@ -43,19 +43,19 @@ then
    fi
    
    # remove existing boost installation
-   sudo rm -rf $BOOST_DIR
+   rm -rf $BOOST_DIR
   
    # untar source (remove existing)
-   sudo rm -rf $BOOST_BUILD_DIR
-   sudo mkdir -p $BOOST_BUILD_DIR
+   rm -rf $BOOST_BUILD_DIR
+   mkdir -p $BOOST_BUILD_DIR
    cd $BOOST_BUILD_DIR
-   sudo tar --bzip2 -xf ../$BOOST_TAR
+   tar --bzip2 -xf ../$BOOST_TAR
 
    # change to boost version folder
    cd $BOOST_VERSION
 
    # bootstrap boost
-   sudo ./bootstrap.sh  
+   ./bootstrap.sh  
    
    # special variation of build for osx
    if [ "$PLATFORM" == "Darwin" ]
@@ -70,15 +70,15 @@ then
         CXX_STDLIB_FLAGS=""
      fi
 
-     sudo ./bjam ${BOOST_BJAM_FLAGS} --prefix=$BOOST_DIR toolset=clang $CXX_STDLIB_FLAGS variant=release threading=multi link=static install
+     ./bjam ${BOOST_BJAM_FLAGS} --prefix=$BOOST_DIR toolset=clang $CXX_STDLIB_FLAGS variant=release threading=multi link=static install
    else
-     sudo ./bjam ${BOOST_BJAM_FLAGS} --prefix=$BOOST_DIR variant=release install
+     ./bjam ${BOOST_BJAM_FLAGS} --prefix=$BOOST_DIR variant=release install
    fi
 
    # go back to the original install dir and remove build dir
    cd $INSTALL_DIR
-   sudo rm -rf $BOOST_TAR
-   sudo rm -rf $BOOST_BUILD_DIR
+   rm -rf $BOOST_TAR
+   rm -rf $BOOST_BUILD_DIR
 
 else
 

--- a/dependencies/linux/install-dependencies-debian
+++ b/dependencies/linux/install-dependencies-debian
@@ -18,39 +18,31 @@
 set -e
 
 # build/development tools
-sudo apt-get -y install build-essential
-sudo apt-get -y install pkg-config
-sudo apt-get -y install fakeroot
-sudo apt-get -y install cmake
+apt-get -y install build-essential pkg-config fakeroot cmake
 
 # core system libraries
-sudo apt-get -y install uuid-dev
-sudo apt-get -y install libssl-dev
-sudo apt-get -y install libbz2-dev
-sudo apt-get -y install zlib1g-dev
-sudo apt-get -y install libpam-dev
+apt-get -y install uuid-dev libssl-dev libbz2-dev zlib1g-dev libpam-dev
 
 # needed for QtWebKit >= 5
-sudo apt-get -y install libxslt1-dev
+apt-get -y install libxslt1-dev
 
 # app armor dependencies no longer included in ubuntu >= 11.10
-sudo apt-get -y install libapparmor1 
-sudo apt-get -y install apparmor-utils
+apt-get -y install libapparmor1 apparmor-utils
 
 # boost
 ## This version of libboost-all-dev is now 1.55.0.2 in the current stable version of debian (jessie) [2015-12-04].
 ## This is further along than the version installed by the install-boost script also run by install-dependencies-debian.
 ## So comment this out to ensure only one version of boost is installed here and it is supported by rstudio.
-#sudo apt-get -y install libboost-all-dev
+#apt-get -y install libboost-all-dev
 
 # pango cairo
-sudo apt-get -y install libpango1.0-dev
+apt-get -y install libpango1.0-dev
 
 # gwt prereqs
 ## openjdk-6-jdk is no longer available in the current stable version of debian [2015-12-04]
 ## Also, ant no longer depends on openjdk-6-jdk
-# sudo apt-get -y install openjdk-6-jdk 
-sudo apt-get -y install ant
+#apt-get -y install openjdk-6-jdk 
+apt-get -y install ant
 
 # overlay
 if [ -e install-overlay-debian ]
@@ -59,7 +51,7 @@ then
 fi
 
 # common
-sudo apt-get -y install unzip
+apt-get -y install unzip
 cd ../common
 ./install-common
 cd ../linux
@@ -69,14 +61,13 @@ if [ "$1" != "--exclude-qt-sdk" ]
 then
    # ubuntu server doesn't include gstreamer by default so ensure that these
    # libs are always available for desktop builds (required by QtWebKit 2.2)
-   sudo apt-get -y install libgstreamer0.10-0
-   sudo apt-get -y install libgstreamer-plugins-base0.10-0
+   apt-get -y install libgstreamer0.10-0 libgstreamer-plugins-base0.10-0
 
    # Ubuntu 12.04 doesn't include libjpeg62 (and it's required by Qt 4.8)
-   sudo apt-get -y install libjpeg62
+   apt-get -y install libjpeg62
 
    # Need the OpenGL development libraries to build QtGui
-   sudo apt-get -y install libgl1-mesa-dev
+   apt-get -y install libgl1-mesa-dev
 
    # install Qt 4.8 SDK (into a private /opt/RStudio-QtSDK directory so as to 
    # not conflict with any other installed versions of Qt on the system)

--- a/dependencies/linux/install-dependencies-yum
+++ b/dependencies/linux/install-dependencies-yum
@@ -18,37 +18,37 @@
 set -e
 
 # build/development tools
-sudo yum install -y make
-sudo yum install -y gcc
-sudo yum install -y gcc-c++
-sudo yum install -y cmake
-sudo yum install -y rpmdevtools
-sudo yum install -y wget
+yum install -y make
+yum install -y gcc
+yum install -y gcc-c++
+yum install -y cmake
+yum install -y rpmdevtools
+yum install -y wget
 
 # core system libraries
-sudo yum install -y libuuid-devel
-sudo yum install -y openssl-devel
-sudo yum install -y bzip2-devel
-sudo yum install -y zlib-devel
-sudo yum install -y pam-devel
+yum install -y libuuid-devel
+yum install -y openssl-devel
+yum install -y bzip2-devel
+yum install -y zlib-devel
+yum install -y pam-devel
 
 # needed by Qt WebKit >= 5
-sudo yum install -y gstreamer-devel
-sudo yum install -y gstreamer-plugins-base-devel
+yum install -y gstreamer-devel
+yum install -y gstreamer-plugins-base-devel
 
 # pandoc depenencies
-sudo yum install -y libffi
+yum install -y libffi
 
 # boost
-sudo yum install -y boost-devel
+yum install -y boost-devel
 
 # pango cairo
-sudo yum install -y pango-devel
+yum install -y pango-devel
 
 # gwt prereqs
-sudo yum install -y java-1.6.0-openjdk 
-sudo yum install -y ant
-sudo yum install -y xml-commons-apis
+yum install -y java-1.6.0-openjdk 
+yum install -y ant
+yum install -y xml-commons-apis
 
 # overlay
 if [ -e install-overlay-yum ]

--- a/dependencies/linux/install-dependencies-zypper
+++ b/dependencies/linux/install-dependencies-zypper
@@ -18,29 +18,29 @@
 set -e
 
 # build/development tools
-sudo zypper --non-interactive in make
-sudo zypper --non-interactive in gcc
-sudo zypper --non-interactive in gcc-c++
-sudo zypper --non-interactive in gcc-fortran
-sudo zypper --non-interactive in build
-sudo zypper --non-interactive in cmake
+zypper --non-interactive in make
+zypper --non-interactive in gcc
+zypper --non-interactive in gcc-c++
+zypper --non-interactive in gcc-fortran
+zypper --non-interactive in build
+zypper --non-interactive in cmake
 
 # core system libraries
-sudo zypper --non-interactive in libbz2-devel
-sudo zypper --non-interactive in zlib-devel
-sudo zypper --non-interactive in libuuid-devel
-sudo zypper --non-interactive in libopenssl-devel
-sudo zypper --non-interactive in pam-devel
+zypper --non-interactive in libbz2-devel
+zypper --non-interactive in zlib-devel
+zypper --non-interactive in libuuid-devel
+zypper --non-interactive in libopenssl-devel
+zypper --non-interactive in pam-devel
 
 # boost
-sudo zypper --non-interactive in boost-devel
+zypper --non-interactive in boost-devel
 
 # pango cairo
-sudo zypper --non-interactive in pango-devel
+zypper --non-interactive in pango-devel
 
 # gwt prereqs
-sudo zypper --non-interactive in java-1_6_0-openjdk-devel
-sudo zypper --non-interactive in ant
+zypper --non-interactive in java-1_6_0-openjdk-devel
+zypper --non-interactive in ant
 
 # overlay
 if [ -e install-overlay-zypper ]
@@ -60,8 +60,8 @@ then
    ./install-qt-sdk
 
    # install headers needed by Qt 5 (GL, xslt)
-   sudo zypper --non-interactive in mesa-devel
-   sudo zypper --non-interactive in libxslt-devel
+   zypper --non-interactive in mesa-devel
+   zypper --non-interactive in libxslt-devel
 fi
 
 


### PR DESCRIPTION
Having each call to the packet manager prefixed with sudo adds overhead to installations in containers (there is usually no sudo installed), and may be inconvenient for enviroments with strict sudo rules (short or even no timeout).