### PR TITLE
fix bug where terminal was showing as 80x25 after session restart

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,7 @@
 * F2 in source editor opens data frame under cursor in a new tab
 * Highlight markdown inside ROxygen comments
 * Improve performance of autocompletion for installed packages
+* Add Clear Console button to top of Console pane
 * Server Pro: Add option to disable file uploads
 * Server Pro: Upgrade to TurboActivate 4.0; improves licensing
 * Server Pro: Add support for floating (lease-based) licenses

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
@@ -23,6 +23,9 @@ public class ConsoleProcessInfo extends JavaScriptObject
    public static final int INTERACTION_POSSIBLE = 1;
    public static final int INTERACTION_ALWAYS = 2;
    
+   public static final int DEFAULT_COLS = 80;
+   public static final int DEFAULT_ROWS = 25;
+   
    protected ConsoleProcessInfo() {}
 
    public final native String getHandle() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
@@ -49,13 +49,17 @@ public class TerminalList implements Iterable<String>,
                                String caption,
                                String title,
                                int sequence,
-                               boolean childProcs)
+                               boolean childProcs,
+                               int cols,
+                               int rows)
       {
          handle_ = StringUtil.notNull(handle);
          caption_ = StringUtil.notNull(caption);
          title_ = StringUtil.notNull(title);
          sequence_ = sequence;
          childProcs_ = childProcs;
+         cols_ = cols;
+         rows_ = rows;
       }
 
       private TerminalMetadata(TerminalMetadata original,
@@ -65,7 +69,9 @@ public class TerminalList implements Iterable<String>,
               original.caption_,
               newTitle,
               original.sequence_,
-              original.childProcs_);
+              original.childProcs_,
+              original.cols_,
+              original.rows_);
       }
 
       private TerminalMetadata(ConsoleProcessInfo procInfo)
@@ -74,7 +80,10 @@ public class TerminalList implements Iterable<String>,
               procInfo.getCaption(),
               procInfo.getTitle(),
               procInfo.getTerminalSequence(),
-              procInfo.getHasChildProcs());
+              procInfo.getHasChildProcs(),
+              ConsoleProcessInfo.DEFAULT_COLS,
+              ConsoleProcessInfo.DEFAULT_ROWS
+              );
       }
 
       private TerminalMetadata(TerminalSession term)
@@ -83,7 +92,9 @@ public class TerminalList implements Iterable<String>,
               term.getCaption(),
               term.getTitle(),
               term.getSequence(),
-              term.getHasChildProcs());
+              term.getHasChildProcs(),
+              term.getCols(),
+              term.getRows());
       }
 
       /**
@@ -111,12 +122,17 @@ public class TerminalList implements Iterable<String>,
        * @return true if terminal shell has child processes
        */
       public boolean getChildProcs() { return childProcs_; }
+      
+      public int getCols() { return cols_; }
+      public int getRows() { return rows_; }
 
       private String handle_;
       private String caption_;
       private String title_;
       private int sequence_;
       private boolean childProcs_;
+      private int cols_;
+      private int rows_;
    }
 
    protected TerminalList() 
@@ -194,7 +210,9 @@ public class TerminalList implements Iterable<String>,
                current.caption_,
                current.title_,
                current.sequence_,
-               childProcs));
+               childProcs,
+               current.cols_,
+               current.rows_));
          return true;
       }
       return false;
@@ -291,7 +309,9 @@ public class TerminalList implements Iterable<String>,
                     null,  // handle
                     null,  // caption
                     null,  // title
-                    true); // childProcs
+                    true,  // childProcs
+                    ConsoleProcessInfo.DEFAULT_COLS,
+                    ConsoleProcessInfo.DEFAULT_ROWS);
    }
 
    /**
@@ -311,7 +331,9 @@ public class TerminalList implements Iterable<String>,
                     handle,
                     existing.getCaption(),
                     existing.getTitle(),
-                    existing.getChildProcs());
+                    existing.getChildProcs(),
+                    existing.getCols(),
+                    existing.getRows());
       return true;
    }
 
@@ -378,10 +400,12 @@ public class TerminalList implements Iterable<String>,
                              String terminalHandle,
                              String caption,
                              String title,
-                             boolean hasChildProcs)
+                             boolean hasChildProcs,
+                             int cols,
+                             int rows)
    {
       TerminalSession newSession = new TerminalSession(
-            sequence, terminalHandle, caption, title, hasChildProcs);
+            sequence, terminalHandle, caption, title, hasChildProcs, cols, rows);
       newSession.connect();
       updateTerminalBusyStatus();
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -63,12 +63,17 @@ public class TerminalSession extends XTermWidget
     * @param handle terminal handle if reattaching, null if new terminal
     * @param caption terminal caption if reattaching, null if new terminal
     * @param title widget title
+    * @param hasChildProcs does session have child processes
+    * @param cols number of columns in terminal
+    * @param rows number of rows in terminal
     */
    public TerminalSession(int sequence,
                           String handle,
                           String caption,
                           String title,
-                          boolean hasChildProcs)
+                          boolean hasChildProcs,
+                          int cols,
+                          int rows)
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
       sequence_ = sequence;
@@ -103,8 +108,8 @@ public class TerminalSession extends XTermWidget
       connecting_ = true;
       setNewTerminal(getHandle() == null);
 
-      server_.startTerminal(80, 25, getHandle(), getCaption(), getTitle(), getSequence(),
-                            new ServerRequestCallback<ConsoleProcess>()
+      server_.startTerminal(getCols(), getRows(), getHandle(), getCaption(), 
+            getTitle(), getSequence(), new ServerRequestCallback<ConsoleProcess>()
       {
          @Override
          public void onResponseReceived(ConsoleProcess consoleProcess)
@@ -198,8 +203,10 @@ public class TerminalSession extends XTermWidget
    @Override
    public void onResizeTerminal(ResizeTerminalEvent event)
    {
+      cols_ = event.getCols();
+      rows_ = event.getRows();
       consoleProcess_.resizeTerminal(
-            event.getCols(), event.getRows(),
+            cols_, rows_,
             new VoidServerRequestCallback() 
             {
                @Override
@@ -437,6 +444,16 @@ public class TerminalSession extends XTermWidget
       return sequence_;
    }
 
+   public int getCols()
+   {
+      return cols_;
+   }
+
+   public int getRows()
+   {
+      return rows_;
+   }
+
    /**
     * Forcibly terminate the process associated with this terminal session.
     */
@@ -537,6 +554,8 @@ public class TerminalSession extends XTermWidget
    private boolean connecting_;
    private StringBuilder inputQueue_ = new StringBuilder();
    private boolean newTerminal_ = true;
+   private int cols_;
+   private int rows_;
 
    // Injected ---- 
    private WorkbenchServerOperations server_; 


### PR DESCRIPTION
When session restarted, a reconnecting terminal (TerminalSession.connect) was telling the server to use 80x25 dimensions, no matter what the actual size was. Now remember the size, and send that instead of the hardcoded values.