### PR TITLE
Implement paragraph-style code execution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,8 @@
 * F2 in source editor opens data frame under cursor in a new tab
 * Highlight markdown inside ROxygen comments
 * Improve performance of autocompletion for installed packages
+* Add option to run multiple consecutive lines of R with Ctrl+Enter
+* Add commands to run a line, statement, or consecutive lines 
 * Server Pro: Add option to disable file uploads
 * Server Pro: Upgrade to TurboActivate 4.0; improves licensing
 * Server Pro: Add support for floating (lease-based) licenses

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -1453,7 +1453,25 @@ well as menu structures (for main menu and popup menus).
         menuLabel="Re-Run _Previous"
         desc="Re-run the previous code region"
         context="r"/>
-        
+
+   <cmd id="executeCurrentLine"
+        label="Execute Current Line"
+        menuLabel="Execute Current _Line"
+        desc="Execute the line which contains the cursor"
+        context="r"/>
+
+   <cmd id="executeCurrentStatement"
+        label="Execute Current Statement"
+        menuLabel="Execute Current _Statement"
+        desc="Execute the entire R statement which contains the cursor."
+        context="r"/>
+
+   <cmd id="executeCurrentParagraph"
+        label="Execute Current Paragraph"
+        menuLabel="Execute Current _Paragraph"
+        desc="Execute the current paragraph of code, delimited by blank lines."
+        context="r"/>
+
    <cmd id="insertChunk"
         menuLabel="_Insert Chunk"
         desc="Insert a new code chunk"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -60,6 +60,9 @@ public abstract class
    public abstract AppCommand executeCurrentFunction();
    public abstract AppCommand executeCurrentSection();
    public abstract AppCommand executeLastCode();
+   public abstract AppCommand executeCurrentLine();
+   public abstract AppCommand executeCurrentStatement();
+   public abstract AppCommand executeCurrentParagraph();
    public abstract AppCommand insertChunk();
    public abstract AppCommand insertChunkR();
    public abstract AppCommand insertChunkBash();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -575,9 +575,13 @@ public class UIPrefsAccessor extends Prefs
       return bool("hide_console_on_chunk_execute", true);
    }
    
-   public PrefValue<Boolean> executeMultiLineStatements()
+   public static final String EXECUTE_LINE      = "line";
+   public static final String EXECUTE_STATEMENT = "statement";
+   public static final String EXECUTE_PARAGRAPH = "paragraph";
+   
+   public PrefValue<String> executionBehavior()
    {
-      return bool("execute_multi_line_statements", true);
+      return string("execution_behavior", EXECUTE_STATEMENT);
    }
    
    public PrefValue<Boolean> enableXTerm()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -138,7 +138,7 @@ public class EditingPreferencesPane extends PreferencesPane
             new String[] {
                "Current line",
                "Multi-line R statement",
-               "Paragraph separated by blank lines"
+               "Multiple consecutive R lines"
             },
             new String[] {
                UIPrefsAccessor.EXECUTE_LINE,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -132,7 +132,23 @@ public class EditingPreferencesPane extends PreferencesPane
       executionLabel.getElement().getStyle().setMarginTop(8, Unit.PX);
       editingPanel.add(checkboxPref("Always save R scripts before sourcing", prefs.saveBeforeSourcing()));
       editingPanel.add(checkboxPref("Focus console after executing from source", prefs_.focusConsoleAfterExec()));
-      editingPanel.add(checkboxPref("Execute all lines in a statement", prefs_.executeMultiLineStatements()));
+      
+      executionBehavior_ = new SelectWidget(
+            "Ctrl+Enter executes: ", 
+            new String[] {
+               "Current line",
+               "Multi-line R statement",
+               "Paragraph separated by blank lines"
+            },
+            new String[] {
+               UIPrefsAccessor.EXECUTE_LINE,
+               UIPrefsAccessor.EXECUTE_STATEMENT,
+               UIPrefsAccessor.EXECUTE_PARAGRAPH
+            },
+            false,
+            true,
+            false);
+      editingPanel.add(executionBehavior_);
       
       Label snippetsLabel = headerLabel("Snippets");
       snippetsLabel.getElement().getStyle().setMarginTop(8, Unit.PX);
@@ -454,6 +470,7 @@ public class EditingPreferencesPane extends PreferencesPane
       
       foldMode_.setValue(prefs_.foldStyle().getValue());
       delimiterSurroundWidget_.setValue(prefs_.surroundSelection().getValue());
+      executionBehavior_.setValue(prefs_.executionBehavior().getValue());
    }
    
    @Override
@@ -485,6 +502,7 @@ public class EditingPreferencesPane extends PreferencesPane
            
       prefs_.foldStyle().setGlobalValue(foldMode_.getValue());
       prefs_.surroundSelection().setGlobalValue(delimiterSurroundWidget_.getValue());
+      prefs_.executionBehavior().setGlobalValue(executionBehavior_.getValue());
       
       return reload;
    }
@@ -535,8 +553,7 @@ public class EditingPreferencesPane extends PreferencesPane
    private final SelectWidget editorMode_;
    private final SelectWidget foldMode_;
    private final SelectWidget delimiterSurroundWidget_;
+   private final SelectWidget executionBehavior_;
    private final TextBoxWithButton encoding_;
    private String encodingValue_;
-   
-   
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
@@ -241,7 +241,7 @@ public class EditingTargetCodeExecution
       Range range;
       
       // by default the range can encompass the whole document
-      int startRowLimit = 1;
+      int startRowLimit = 0;
       int endRowLimit = docDisplay_.getRowCount();
       
       // limit range to chunk if we're inside one

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
@@ -22,6 +22,7 @@ import org.rstudio.studio.client.common.mathjax.MathJaxUtil;
 import org.rstudio.studio.client.rmarkdown.events.SendToChunkConsoleEvent;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
+import org.rstudio.studio.client.workbench.prefs.model.UIPrefsAccessor;
 import org.rstudio.studio.client.workbench.views.console.events.ConsoleExecutePendingInputEvent;
 import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
@@ -114,12 +115,20 @@ public class EditingTargetCodeExecution
             Scope scope = docDisplay_.getCurrentChunk();
             if (scope == null)
             {
-               if (prefs_.executeMultiLineStatements().getValue())
+               if (prefs_.executionBehavior().getValue() == 
+                     UIPrefsAccessor.EXECUTE_STATEMENT)
                {
                   // no scope to guard region, check the document itself to find
                   // the region to execute
                   selectionRange = docDisplay_.getMultiLineExpr(
                         docDisplay_.getCursorPosition(), 1,
+                        docDisplay_.getRowCount());
+               }
+               else if (prefs_.executionBehavior().getValue() == 
+                     UIPrefsAccessor.EXECUTE_PARAGRAPH)
+               {
+                  selectionRange = docDisplay_.getParagraph(
+                        docDisplay_.getCursorPosition(), 1, 
                         docDisplay_.getRowCount());
                }
                else

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
@@ -112,42 +112,9 @@ public class EditingTargetCodeExecution
          }
          else
          {
-            Scope scope = docDisplay_.getCurrentChunk();
-            if (scope == null)
-            {
-               if (prefs_.executionBehavior().getValue() == 
-                     UIPrefsAccessor.EXECUTE_STATEMENT)
-               {
-                  // no scope to guard region, check the document itself to find
-                  // the region to execute
-                  selectionRange = docDisplay_.getMultiLineExpr(
-                        docDisplay_.getCursorPosition(), 1,
-                        docDisplay_.getRowCount());
-               }
-               else if (prefs_.executionBehavior().getValue() == 
-                     UIPrefsAccessor.EXECUTE_PARAGRAPH)
-               {
-                  selectionRange = docDisplay_.getParagraph(
-                        docDisplay_.getCursorPosition(), 1, 
-                        docDisplay_.getRowCount());
-               }
-               else
-               {
-                  // single-line execution
-                  selectionRange = Range.fromPoints(
-                        Position.create(row, 0),
-                        Position.create(row, docDisplay_.getLength(row)));
-               }
-            }
-            else
-            {
-               // inside a chunk, always execute multiple lines (bounded by the
-               // chunk)
-               selectionRange = docDisplay_.getMultiLineExpr(
-                     docDisplay_.getCursorPosition(),
-                     scope.getBodyStart().getRow(),
-                     scope.getEnd().getRow() - 1);
-            }
+            // if no selection, follow UI pref to see what to execute
+            selectionRange = getRangeFromBehavior(
+                  prefs_.executionBehavior().getValue());
          }
          
          // if we failed to discover a range, bail
@@ -174,11 +141,7 @@ public class EditingTargetCodeExecution
       // advance if there is no current selection
       if (noSelection && moveCursorAfter)
       {
-         docDisplay_.setCursorPosition(Position.create(
-               selectionRange.getEnd().getRow(), 0));
-         if (!docDisplay_.moveSelectionToNextLine(true))
-            docDisplay_.moveSelectionToBlankLine();
-         docDisplay_.scrollCursorIntoViewIfNecessary(3);
+         moveCursorAfterExecution(selectionRange);
       }
    }
    
@@ -264,6 +227,53 @@ public class EditingTargetCodeExecution
                                   code, 
                                   true, 
                                   prefs_.focusConsoleAfterExec().getValue()));
+   }
+   
+   public void executeBehavior(String executionBehavior)
+   {
+      Range range = getRangeFromBehavior(executionBehavior);
+      executeRange(range, null, false);
+      moveCursorAfterExecution(range);
+   }
+   
+   private Range getRangeFromBehavior(String executionBehavior)
+   {
+      Range range;
+      
+      // by default the range can encompass the whole document
+      int startRowLimit = 1;
+      int endRowLimit = docDisplay_.getRowCount();
+      
+      // limit range to chunk if we're inside one
+      Scope scope = docDisplay_.getCurrentChunk();
+      if (scope != null)
+      {
+        
+         startRowLimit = scope.getBodyStart().getRow();
+         endRowLimit = scope.getEnd().getRow() - 1;
+      }
+  
+      if (executionBehavior == UIPrefsAccessor.EXECUTE_STATEMENT)
+      {
+         // no scope to guard region, check the document itself to find
+         // the region to execute
+         range = docDisplay_.getMultiLineExpr(
+               docDisplay_.getCursorPosition(), startRowLimit, endRowLimit);
+      }
+      else if (executionBehavior == UIPrefsAccessor.EXECUTE_PARAGRAPH)
+      {
+         range = docDisplay_.getParagraph(
+               docDisplay_.getCursorPosition(), startRowLimit, endRowLimit);
+      }
+      else
+      {
+         // single-line execution
+         int row = docDisplay_.getCursorPosition().getRow();
+         range = Range.fromPoints(
+               Position.create(row, 0),
+               Position.create(row, docDisplay_.getLength(row)));
+      }
+      return range;
    }
    
    public void executeLastCode()
@@ -398,6 +408,15 @@ public class EditingTargetCodeExecution
       
       inlineChunkExecutor_.execute(range);
       return true;
+   }
+   
+   private void moveCursorAfterExecution(Range selectionRange)
+   {
+      docDisplay_.setCursorPosition(Position.create(
+            selectionRange.getEnd().getRow(), 0));
+      if (!docDisplay_.moveSelectionToNextLine(true))
+         docDisplay_.moveSelectionToBlankLine();
+      docDisplay_.scrollCursorIntoViewIfNecessary(3);
    }
    
    private final DocDisplay docDisplay_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -3130,6 +3130,36 @@ public class AceEditor implements DocDisplay,
    }
 
    @Override
+   public Range getParagraph(Position pos, int startRowLimit, int endRowLimit)
+   {
+      // assume start, end at current position
+      int startRow = pos.getRow();
+      int endRow   = pos.getRow();
+      
+      // walk backwards to beginning of paragraph
+      for (int i = pos.getRow() - 1; i >= startRowLimit; i--)
+      {
+         if (getLine(i).trim().isEmpty())
+         {
+            startRow = i + 1;
+            break;
+         }
+      }
+      
+      // walk forwards to end of paragraph
+      for (int j = pos.getRow() + 1; j <= endRowLimit; j++)
+      {
+         if (getLine(j).trim().isEmpty())
+         {
+            endRow = j - 1;
+            break;
+         }
+      }
+      
+      return Range.create(startRow, 0, endRow + 1, 0);
+   }
+
+   @Override
    public Range getMultiLineExpr(Position pos, int startRowLimit, int endRowLimit)
    {
       if (!DocumentMode.isSelectionInRMode(this))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -3128,35 +3128,40 @@ public class AceEditor implements DocDisplay,
       
       return false;
    }
+   
+   /**
+    * Finds the last non-empty line starting at the given line.
+    * 
+    * @param initial Row to start on
+    * @param limit Row at which to stop searching
+    * @return Index of last non-empty line, or limit line if no empty lines
+    *   were found.
+    */
+   private int findParagraphBoundary(int initial, int limit)
+   {
+      // no work to do if already at limit
+      if (initial == limit)
+         return initial;
+      
+      // walk towards limit
+      int delta = limit > initial ? 1 : -1;
+      for (int row = initial + delta; row != limit; row += delta)
+      {
+         if (getLine(row).trim().isEmpty())
+            return row - delta;
+      }
+      
+      // didn't find boundary
+      return limit;
+   }
 
    @Override
    public Range getParagraph(Position pos, int startRowLimit, int endRowLimit)
    {
-      // assume start, end at current position
-      int startRow = pos.getRow();
-      int endRow   = pos.getRow();
-      
-      // walk backwards to beginning of paragraph
-      for (int i = pos.getRow() - 1; i >= startRowLimit; i--)
-      {
-         if (getLine(i).trim().isEmpty())
-         {
-            startRow = i + 1;
-            break;
-         }
-      }
-      
-      // walk forwards to end of paragraph
-      for (int j = pos.getRow() + 1; j <= endRowLimit; j++)
-      {
-         if (getLine(j).trim().isEmpty())
-         {
-            endRow = j - 1;
-            break;
-         }
-      }
-      
-      return Range.create(startRow, 0, endRow + 1, 0);
+      // find upper and lower paragraph boundaries
+      return Range.create(
+            findParagraphBoundary(pos.getRow(), startRowLimit), 0,
+            findParagraphBoundary(pos.getRow(), endRowLimit)+ 1, 0);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -343,6 +343,7 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    int getEndOfCurrentStatement();
 
    Range getMultiLineExpr(Position pos, int startRow, int endRow);
+   Range getParagraph(Position pos, int startRow, int endRow);
    
    void highlightDebugLocation(
          SourcePosition startPos,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3970,6 +3970,24 @@ public class TextEditingTarget implements
    {
       codeExecution_.executeSelection(true);
    }
+   
+   @Handler
+   void onExecuteCurrentLine()
+   {
+      codeExecution_.executeBehavior(UIPrefsAccessor.EXECUTE_LINE);
+   }
+
+   @Handler
+   void onExecuteCurrentStatement()
+   {
+      codeExecution_.executeBehavior(UIPrefsAccessor.EXECUTE_STATEMENT);
+   }
+
+   @Handler
+   void onExecuteCurrentParagraph()
+   {
+      codeExecution_.executeBehavior(UIPrefsAccessor.EXECUTE_PARAGRAPH);
+   }
 
    @Override
    public String extractCode(DocDisplay docDisplay, Range range)


### PR DESCRIPTION
This change implements a common (on forums and in person!) user request: the ability to execute a region of lines bounded by blank lines, or a "paragraph". 

    # This is a paragraph of code
    data(cars)
    summary(cars)
    
    # This begins a second paragraph of code

There is now a new option to execute paragraphs rather than statements with the Run Selection command.

![image](https://cloud.githubusercontent.com/assets/470418/22996033/1bf10724-f382-11e6-8aa2-2245c8e53ae5.png)

Finally, the change adds three commands which, regardless of the current selection or user preference, always execute a line, statement, or paragraph. This makes it possible for power users to create key bindings so they can mix and match execution behaviors; for instance, users might wish Ctrl+Enter to normally execute a paragraph, but also bind a key to step one line at a time, or the reverse.