### PR TITLE
fix: terminal clear and terminate commands when session suspended

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcess.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcess.java
@@ -337,11 +337,6 @@ public class ConsoleProcess implements ConsoleOutputEvent.HasHandlers,
       server_.processSetShellSize(procInfo_.getHandle(), cols, rows, requestCallback);
    }
 
-   public void eraseTerminalBuffer(ServerRequestCallback<Void> requestCallback)
-   {
-      server_.processEraseBuffer(procInfo_.getHandle(), requestCallback);
-   }
-
    public void getTerminalBuffer(ServerRequestCallback<String> requestCallback)
    {
       server_.processGetBuffer(procInfo_.getHandle(), requestCallback);


### PR DESCRIPTION
Prior to this, a terminal clear or terminate while session was suspended didn't work. It was a no-op for terminate, and for clear it would clear client-side buffer but not server-side buffer.