### PR TITLE
Allow navigation to parent directory without project

### DIFF
--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -184,6 +184,12 @@ void handleClientInit(const boost::function<void()>& initFunction,
    // initial working directory
    std::string initialWorkingDir = module_context::createAliasedPath(
                                           dirs::getInitialWorkingDirectory());
+
+   // if we are on the home directory, use full dir to allow parent navigation.
+   if (initialWorkingDir == "~") {
+       initialWorkingDir = dirs::getInitialWorkingDirectory().absolutePath();
+   }
+
    sessionInfo["initial_working_dir"] = initialWorkingDir;
    std::string defaultWorkingDir = module_context::createAliasedPath(
                                           dirs::getDefaultWorkingDirectory());


### PR DESCRIPTION
In the file list, it is not possible to navigate up one level when the initial directory is set to home since the UI uses the path to parse the parent directory which can't be found since it's set to `~`. This PR considers initializing with a full path when launching without a project directly from the home.

Without this fix:

<img width="537" alt="screen shot 2017-02-15 at 6 39 41 pm" src="https://cloud.githubusercontent.com/assets/3478847/23004914/236326e6-f3ae-11e6-929a-a84a5c81bada.png">

With this fix:

<img width="534" alt="screen shot 2017-02-15 at 6 38 13 pm" src="https://cloud.githubusercontent.com/assets/3478847/23004903/1b1c1d12-f3ae-11e6-8f7e-ff23e5791759.png">
