### PR TITLE
Provide LD_LIBRARY_PATH when querying R for its version

### DIFF
--- a/src/cpp/core/include/core/r_util/REnvironment.hpp
+++ b/src/cpp/core/include/core/r_util/REnvironment.hpp
@@ -1,7 +1,7 @@
 /*
  * REnvironment.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -50,6 +50,7 @@ std::string rLibraryPath(const FilePath& rHomePath,
 
 Error rVersion(const FilePath& rHomePath,
                const FilePath& rScriptPath,
+               const std::string& ldLibraryPath,
                std::string* pVersion);
 
 void ensureLang();

--- a/src/cpp/core/r_util/RVersionsPosix.cpp
+++ b/src/cpp/core/r_util/RVersionsPosix.cpp
@@ -204,6 +204,7 @@ std::vector<RVersion> enumerateRVersions(
             std::string versionNumber = version.number();
             Error error = rVersion(rHomePath,
                                    rBinaryPath,
+                                   ldLibraryPath,
                                    &versionNumber);
             if (error)
                LOG_ERROR(error);


### PR DESCRIPTION
This change fixes an issue experienced by an RStudio Server Pro user who was using a version of R not compiled with the system's default gcc. This version of R needed a special `LD_LIBRARY_PATH`  to run. Since we don't supply this when querying R for its version, RSP failed to determine the R version.

The fix is twofold:

1. Supply `LD_LIBRARY_PATH` to the R process when querying its version.

2. Log the output from standard error when we fail to determine R's version. (This would have made diagnosing the above issue dramatically simpler!)