### PR TITLE
support setting sql connection with knitr options

### DIFF
--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -356,14 +356,20 @@
   max.print <- if (is.null(options$max.print)) getOption("max.print", 1000) else as.numeric(options$max.print)
   max.print <- if (is.null(options$sql.max.print)) max.print else as.numeric(options$sql.max.print)
 
-  if (is.null(options$connection)) stop(
-    "The 'connection' option (DBI connection) is required for sql chunks."
-  )
+  if (is.null(options$connection)) {
+    chunkOptions <- get(".rs.knitr.chunkOptions", envir = .rs.toolsEnv())
+    conn <- chunkOptions$connection
 
-  conn <- get(options$connection, envir = globalenv())
-  if (is.null(conn)) stop(
-    "The 'connection' option must be a valid DBI connection."
-  )
+    if (is.null(conn))
+      stop("The 'connection' option (DBI connection) is required for sql chunks.")
+  }
+
+  if (is.character(options$connection)) {
+    conn <- get(options$connection, envir = globalenv())
+    if (is.null(conn)) stop(
+      "The 'connection' option must be a valid DBI connection."
+    )
+  }
 
   # Return char vector of sql interpolation param names
   varnames_from_sql <- function(conn, sql) {

--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -356,12 +356,15 @@
   max.print <- if (is.null(options$max.print)) getOption("max.print", 1000) else as.numeric(options$max.print)
   max.print <- if (is.null(options$sql.max.print)) max.print else as.numeric(options$sql.max.print)
 
-  if (is.null(options$connection)) {
-    chunkOptions <- get(".rs.knitr.chunkOptions", envir = .rs.toolsEnv())
-    conn <- chunkOptions$connection
+  conn <- options$connection
+  
+  if (is.numeric(options$connection)) {
+    chunkReferences <- get(".rs.knitr.chunkReferences", envir = .rs.toolsEnv())
+    conn <- chunkReferences[[chunkOptions$connection]]
+  }
 
-    if (is.null(conn))
-      stop("The 'connection' option (DBI connection) is required for sql chunks.")
+  if (is.null(conn)) {
+    stop("The 'connection' option (DBI connection) is required for sql chunks.")
   }
 
   if (is.character(options$connection)) {

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -1003,12 +1003,16 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    # get the current set of chunk options
    chunkOptions <- knitr::opts_chunk$get()
 
-   # replace connections with references
+   # make sure global connection lists exists
+   if (!exists(".rs.knitr.chunkReferences", envir = .rs.toolsEnv()))
+      assign(".rs.knitr.chunkReferences", list(), envir = .rs.toolsEnv())
+   
+   # assign connection
    chunkReferences <- get(".rs.knitr.chunkReferences", envir = .rs.toolsEnv())
-   if (!is.null(chunkOptions) && !is.character(chunkOptions$connection)) {
+   if (!is.null(chunkOptions$connection) && !is.character(chunkOptions$connection)) {
       idReference <- length(chunkReferences) + 1
       chunkReferences[[idReference]] <- chunkOptions$connection
-      chunkOptions$connection <- 
+      chunkOptions$connection <- idReference
    }
 
    # cache the current set of chunk options

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -1000,8 +1000,18 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
 
 .rs.addFunction("setDefaultChunkOptions", function()
 {
-   # cache the current set of chunk options
+   # get the current set of chunk options
    chunkOptions <- knitr::opts_chunk$get()
+
+   # replace connections with references
+   chunkReferences <- get(".rs.knitr.chunkReferences", envir = .rs.toolsEnv())
+   if (!is.null(chunkOptions) && !is.character(chunkOptions$connection)) {
+      idReference <- length(chunkReferences) + 1
+      chunkReferences[[idReference]] <- chunkOptions$connection
+      chunkOptions$connection <- 
+   }
+
+   # cache the current set of chunk options
    assign(".rs.knitr.chunkOptions", chunkOptions, envir = .rs.toolsEnv())
 
    # cache the set of external code


### PR DESCRIPTION
SQL chunks support referencing connection by object and name, as in ` ```{r options=db}` or ` ```{r options="db"}`. However, we currently only support setting this through `knitr::opts_chunk$set` as `knitr::opts_chunk$set(connection="db")`. The cause, I believe, is that we internally serialize the options when we prepare the setup chunk and when running the data chunk, the `connection` is no longer a default.

Repro:

    ```{r setup}
    library(DBI)
    db <- dbConnect(RSQLite::SQLite(), dbname = "sql.sqlite")
    knitr::opts_chunk$set(connection = db)
    ```

    ```{sql}
    SELECT 1
    ````

Instead of failing, this fix checks the cached version of the options `.rs.knitr.chunkOptions` before failing.