### PR TITLE
Add UI pref to control tab wraparound behavior

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -621,6 +621,11 @@ public class UIPrefsAccessor extends Prefs
       return string("latex_preview_on_cursor_idle", LATEX_PREVIEW_SHOW_ALWAYS);
    }
    
+   public PrefValue<Boolean> wrapTabNavigation()
+   {
+      return bool("wrap_tab_navigation", false);
+   }
+   
    private String getDefaultPdfPreview()
    {
       if (Desktop.isDesktop())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -199,6 +199,12 @@ public class GeneralPreferencesPane extends PreferencesPane
          add(chkTracebacks);
       }
       
+      CheckBox chkTabNavigation = checkboxPref(
+            "Wrap around when navigating to previous/next tab",
+            prefs_.wrapTabNavigation());
+      spaced(chkTabNavigation);
+      add(chkTabNavigation);
+      
       // provide check for updates option in desktop mode when not
       // already globally disabled
       if (Desktop.isDesktop() && 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -1772,13 +1772,13 @@ public class Source implements InsertSourceHandler,
    @Handler
    public void onPreviousTab()
    {
-      switchToTab(-1, false);
+      switchToTab(-1, uiPrefs_.wrapTabNavigation().getValue());
    }
 
    @Handler
    public void onNextTab()
    {
-      switchToTab(1, false);
+      switchToTab(1, uiPrefs_.wrapTabNavigation().getValue());
    }
 
    @Handler


### PR DESCRIPTION
Some users prefer tab navigation commands to wrap around, by e.g. selecting the first tab if they invoke Next Tab with the last tab selected. This capability already exists; this change simply exposes it in a UI pref, preserving the existing default.