### PR TITLE
Hide run document menu button by default

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -278,6 +278,7 @@ public class TextEditingTargetWidget
       runDocumentMenuButton_.addSeparator();
       runDocumentMenuButton_.addMenuItem(commands_.clearPrerenderedOutput().createMenuItem(false), "");     
       toolbar.addLeftWidget(runDocumentMenuButton_);
+      runDocumentMenuButton_.setVisible(false);
       
       ToolbarPopupMenu rmdOptionsMenu = new ToolbarPopupMenu();
       rmdOptionsMenu.addItem(commands_.editRmdFormatOptions().createMenuItem(false));


### PR DESCRIPTION
This fixes an issue whereby the Run Document button's ancillary menu was showing by default in R scripts (first referenced here: https://github.com/rstudio/rstudio/pull/1019 ). It looks like all state is managed correctly for the button, but I had neglected to hide it by default at the outset.