### PR TITLE
Resolve a Terminal TODO - break up buffer fetch into chunks

### DIFF
--- a/src/cpp/session/SessionConsoleProcessPersist.cpp
+++ b/src/cpp/session/SessionConsoleProcessPersist.cpp
@@ -135,6 +135,9 @@ std::string getSavedBuffer(const std::string& handle, int maxLines)
       return content;
    }
 
+   if (maxLines < 1)
+      return content;
+
    // Trim the buffer based on maxLines. Otherwise it can grow without
    // bound until the terminal is closed or cleared.
    std::string trimmedOutput = content;

--- a/src/cpp/session/SessionConsoleProcessPersist.cpp
+++ b/src/cpp/session/SessionConsoleProcessPersist.cpp
@@ -200,7 +200,6 @@ void deleteOrphanedLogs(bool (*validHandle)(const std::string&))
    BOOST_FOREACH(const FilePath& child, children)
    {
       // Don't erase the INDEXnnn or any subfolders
-      // TODO (gary) see comment on kConsoleIndex above
       if (!child.filename().compare(kConsoleIndex) || child.isDirectory())
       {
          continue;

--- a/src/cpp/session/SessionConsoleProcessPersistTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessPersistTests.cpp
@@ -149,6 +149,21 @@ TEST_CASE("ConsoleProcess Persistence")
       CHECK(loaded.compare(expect) == 0);
    }
 
+   SECTION("Write more lines than maxLines then read it without trimming")
+   {
+      std::stringstream ss;
+      std::stringstream ss_expect;
+      for (size_t i = 0; i < maxLines * 2; i++)
+      {
+         ss << i << '\n';
+      }
+      std::string expect = ss.str();
+      std::string orig = ss.str();
+      console_persist::appendToOutputBuffer(handle2, orig);
+      std::string loaded = console_persist::getSavedBuffer(handle2, 0);
+      CHECK(loaded.compare(expect) == 0);
+   }
+
    SECTION("Delete unknown log files")
    {
       std::string orig1("hello how are you?\nthat is good\nhave a nice day");

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -118,7 +118,10 @@ public:
    void setCaption(std::string& caption) { procInfo_->setCaption(caption); }
    void setTitle(std::string& title) { procInfo_->setTitle(title); }
    void deleteLogFile() const;
-   std::string getSavedBuffer() const;
+
+   // Get the given (0-based) chunk of the saved buffer; if more is available
+   // after the requested chunk, *pMoreAvailable will be set to true
+   std::string getSavedBufferChunk(int chunk, bool* pMoreAvailable) const;
 
    void setShowOnOutput(bool showOnOutput) { procInfo_->setShowOnOutput(showOnOutput); }
 

--- a/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
@@ -40,6 +40,7 @@ enum InteractionMode
 extern const int kDefaultMaxOutputLines;
 extern const int kDefaultTerminalMaxOutputLines;
 extern const int kNoTerminal;
+extern const size_t kOutputBufferSize;
 
 // ConsoleProcess metadata that is persisted, and sent to the client on
 // create/reconnect
@@ -99,7 +100,7 @@ public:
    void appendToOutputBuffer(const std::string &str);
    void appendToOutputBuffer(char ch);
    std::string bufferedOutput() const;
-   std::string getSavedBuffer();
+   std::string getSavedBufferChunk(int chunk, bool* pMoreAvailable) const;
    void deleteLogFile() const;
 
    // Has the process exited, and what was the exit code?

--- a/src/cpp/session/include/session/SessionConsoleProcessPersist.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessPersist.hpp
@@ -36,7 +36,9 @@ std::string loadConsoleProcessMetadata();
 // Save the raw console process metadata for all known processes
 void saveConsoleProcesses(const std::string& metadata);
 
-// Get the saved buffer for the given ConsoleProcess
+// Get the saved buffer for the given ConsoleProcess. If maxLines > 0,
+// trims the saved buffer to the given number of lines and persists it,
+// then returns the trimmed buffer.
 std::string getSavedBuffer(const std::string& handle, int maxLines);
 
 // Add to the saved buffer for the given ConsoleProcess

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcess.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcess.java
@@ -31,6 +31,7 @@ import org.rstudio.studio.client.workbench.events.SessionInitEvent;
 import org.rstudio.studio.client.workbench.events.SessionInitHandler;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.views.console.model.ConsoleServerOperations;
+import org.rstudio.studio.client.workbench.views.console.model.ProcessBufferChunk;
 import org.rstudio.studio.client.workbench.views.vcs.common.ConsoleProgressDialog;
 
 import com.google.gwt.core.client.JsArray;
@@ -337,9 +338,9 @@ public class ConsoleProcess implements ConsoleOutputEvent.HasHandlers,
       server_.processSetShellSize(procInfo_.getHandle(), cols, rows, requestCallback);
    }
 
-   public void getTerminalBuffer(ServerRequestCallback<String> requestCallback)
+   public void getTerminalBufferChunk(int chunk, ServerRequestCallback<ProcessBufferChunk> requestCallback)
    {
-      server_.processGetBuffer(procInfo_.getHandle(), requestCallback);
+      server_.processGetBufferChunk(procInfo_.getHandle(), chunk, requestCallback);
    }
 
    public void interrupt(ServerRequestCallback<Void> requestCallback)

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -153,6 +153,7 @@ import org.rstudio.studio.client.workbench.views.buildtools.model.BookdownFormat
 import org.rstudio.studio.client.workbench.views.connections.model.ConnectionId;
 import org.rstudio.studio.client.workbench.views.connections.model.Field;
 import org.rstudio.studio.client.workbench.views.connections.model.NewConnectionContext;
+import org.rstudio.studio.client.workbench.views.console.model.ProcessBufferChunk;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.DataImportOptions;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportAssembleResponse;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportPreviewResponse;
@@ -687,12 +688,14 @@ public class RemoteServer implements Server
    }
 
    @Override
-   public void processGetBuffer(String handle,
-                                  ServerRequestCallback<String> requestCallback)
+   public void processGetBufferChunk(String handle,
+                                     int chunk,
+                                     ServerRequestCallback<ProcessBufferChunk> requestCallback)
    {
       JSONArray params = new JSONArray();
       params.set(0, new JSONString(StringUtil.notNull(handle)));
-      sendRequest(RPC_SCOPE, PROCESS_GET_BUFFER, params, requestCallback);   
+      params.set(1, new JSONNumber(chunk));
+      sendRequest(RPC_SCOPE, PROCESS_GET_BUFFER_CHUNK, params, requestCallback);
    }
 
    public void interrupt(ServerRequestCallback<Void> requestCallback)
@@ -5055,7 +5058,7 @@ public class RemoteServer implements Server
    private static final String PROCESS_SET_CAPTION = "process_set_caption";
    private static final String PROCESS_SET_TITLE = "process_set_title";
    private static final String PROCESS_ERASE_BUFFER = "process_erase_buffer";
-   private static final String PROCESS_GET_BUFFER = "process_get_buffer";
+   private static final String PROCESS_GET_BUFFER_CHUNK = "process_get_buffer_chunk";
 
    private static final String REMOVE_ALL_OBJECTS = "remove_all_objects";
    private static final String REMOVE_OBJECTS = "remove_objects";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/model/ConsoleServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/model/ConsoleServerOperations.java
@@ -54,8 +54,9 @@ public interface ConsoleServerOperations extends CodeToolsServerOperations,
    void processEraseBuffer(String handle,
                            ServerRequestCallback<Void> requestCallback);
 
-   void processGetBuffer(String handle,
-                         ServerRequestCallback<String> requestCallback);
+   void processGetBufferChunk(String handle,
+                              int chunk,
+                              ServerRequestCallback<ProcessBufferChunk> requestCallback);
 
    /**
     * Set/update the caption of given process.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/model/ProcessBufferChunk.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/model/ProcessBufferChunk.java
@@ -1,0 +1,37 @@
+/*
+ * ProcessBufferChunk.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.console.model;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+public class ProcessBufferChunk extends JavaScriptObject
+{
+   protected ProcessBufferChunk()
+   {
+   }
+
+   public final native String getChunk() /*-{
+      return this.chunk;
+   }-*/;
+
+   public final native int getChunkNumber() /*-{
+      return this.chunk_number;
+   }-*/;
+
+   public final native boolean getMoreAvailable() /*-{
+      return this.more_available;
+   }-*/;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -262,21 +262,21 @@ public class TerminalSession extends XTermWidget
       }
 
       consoleProcess_.writeStandardInput(
-    		  ShellInput.create(userInput,  true /* echo input*/), 
-    		  new VoidServerRequestCallback() {
+            ShellInput.create(userInput,  true /* echo input*/), 
+            new VoidServerRequestCallback() {
 
-    			  @Override
-    			  public void onResponseReceived(Void response)
-    			  {
-    				  sendUserInput();
-    			  }
+               @Override
+               public void onResponseReceived(Void response)
+               {
+                  sendUserInput();
+               }
 
-    			  @Override
-    			  public void onError(ServerError error)
-    			  {
-    				  writeln(error.getUserMessage());
-    			  }
-    		  });
+               @Override
+               public void onError(ServerError error)
+               {
+                  writeln(error.getUserMessage());
+               }
+            });
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -33,6 +33,7 @@ import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.workbench.model.WorkbenchServerOperations;
+import org.rstudio.studio.client.workbench.views.console.model.ProcessBufferChunk;
 import org.rstudio.studio.client.workbench.views.terminal.events.ResizeTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalDataInputEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStartedEvent;
@@ -514,32 +515,42 @@ public class TerminalSession extends XTermWidget
       }
       else
       {
-         Scheduler.get().scheduleDeferred(new ScheduledCommand()
-         {
-            @Override
-            public void execute()
-            {
-               onResize();
-               if (consoleProcess_ != null)
-               {
-                  consoleProcess_.getTerminalBuffer(new ServerRequestCallback<String>()
-                  {
-                     @Override
-                     public void onResponseReceived(String buffer)
-                     {
-                        write(buffer);
-                     }
+         fetchNextChunk(0);
+      }
+   }
 
-                     @Override
-                     public void onError(ServerError error)
+   private void fetchNextChunk(final int chunkToFetch)
+   {
+      Scheduler.get().scheduleDeferred(new ScheduledCommand()
+      {
+         @Override
+         public void execute()
+         {
+            onResize();
+            if (consoleProcess_ != null)
+            {
+               consoleProcess_.getTerminalBufferChunk(chunkToFetch,
+                     new ServerRequestCallback<ProcessBufferChunk>()
+               {
+                  @Override
+                  public void onResponseReceived(ProcessBufferChunk chunk)
+                  {
+                     write(chunk.getChunk());
+                     if (chunk.getMoreAvailable())
                      {
-                        writeError(error.getUserMessage());
+                        fetchNextChunk(chunk.getChunkNumber() + 1);
                      }
-                   });
-               }
+                  }
+
+                  @Override
+                  public void onError(ServerError error)
+                  {
+                     writeError(error.getUserMessage());
+                  }
+               });
             }
-         });
-       }
+         }
+      });
    }
 
    /**


### PR DESCRIPTION
Client now gets back chunks, with a flag telling it when it needs to fetch another chunk. This is to avoid overwhelming the client with a single massive data return when restoring terminals. We already trim the buffer to match the maximum number of lines supported by xterm, but if the buffer contained very long lines we could still be swamping it.