### PR TITLE
ensure package extensions provided on init

### DIFF
--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -56,6 +56,7 @@
 #include <session/SessionHttpConnection.hpp>
 #include <session/SessionModuleContext.hpp>
 #include <session/SessionOptions.hpp>
+#include <session/SessionPackageProvidedExtension.hpp>
 #include <session/SessionPersistentState.hpp>
 #include <session/SessionUserSettings.hpp>
 #include <session/projects/SessionProjectSharing.hpp>
@@ -370,6 +371,7 @@ void handleClientInit(const boost::function<void()>& initFunction,
    sessionInfo["user_home_page_url"] = json::Value();
    
    sessionInfo["r_addins"] = modules::r_addins::addinRegistryAsJson();
+   sessionInfo["package_provided_extensions"] = modules::ppe::indexer().getPayload();
 
    sessionInfo["connections_enabled"] = modules::connections::connectionsEnabled();
    sessionInfo["activate_connections"] = modules::connections::activateConnections();

--- a/src/cpp/session/include/session/SessionPackageProvidedExtension.hpp
+++ b/src/cpp/session/include/session/SessionPackageProvidedExtension.hpp
@@ -75,6 +75,7 @@ public:
    virtual ~Indexer() {}
    
 public:
+   core::json::Object getPayload() { return payload_; }
    void addWorker(boost::shared_ptr<Worker> pWorker);
    void removeWorker(boost::shared_ptr<Worker> pWorker);
    
@@ -90,6 +91,7 @@ private:
 private:
    std::vector<boost::shared_ptr<Worker> > workers_;
    std::vector<core::FilePath> pkgDirs_;
+   core::json::Object payload_;
    std::size_t index_;
    std::size_t n_;
    bool running_;

--- a/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
+++ b/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
@@ -160,20 +160,21 @@ void Indexer::beginIndexing()
 void Indexer::endIndexing()
 {
    running_ = false;
+   payload_.clear();
    
-   json::Object payload;
    BOOST_FOREACH(boost::shared_ptr<Worker> pWorker, workers_)
    {
       try
       {
-         pWorker->onIndexingCompleted(&payload);
+         pWorker->onIndexingCompleted(&payload_);
       }
       CATCH_UNEXPECTED_EXCEPTION
    }
    
    ClientEvent event(
             client_events::kPackageExtensionIndexingCompleted,
-            payload);
+            payload_);
+   
    module_context::enqueClientEvent(event);
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/projects/events/PackageExtensionIndexingCompletedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/events/PackageExtensionIndexingCompletedEvent.java
@@ -14,42 +14,24 @@
  */
 package org.rstudio.studio.client.projects.events;
 
-import org.rstudio.studio.client.projects.model.ProjectTemplateRegistry;
-import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
-
-import com.google.gwt.core.client.JavaScriptObject;
+import org.rstudio.studio.client.projects.model.PackageProvidedExtensions;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 
 public class PackageExtensionIndexingCompletedEvent
       extends GwtEvent<PackageExtensionIndexingCompletedEvent.Handler>
 {
-   public static class Data extends JavaScriptObject
-   {
-      protected Data() {}
-      
-      public final native RAddins getAddinsRegistry()
-      /*-{
-         return this["addins_registry"];
-      }-*/;
-      
-      public final native ProjectTemplateRegistry getProjectTemplateRegistry()
-      /*-{
-         return this["project_templates_registry"];
-      }-*/;
-   }
-   
-   public PackageExtensionIndexingCompletedEvent(Data data)
+   public PackageExtensionIndexingCompletedEvent(PackageProvidedExtensions data)
    {
       data_ = data;
    }
    
-   public Data getData()
+   public PackageProvidedExtensions getExtensions()
    {
       return data_;
    }
    
-   private final Data data_;
+   private final PackageProvidedExtensions data_;
    
    // Boilerplate ----
    

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/PackageProvidedExtensions.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/PackageProvidedExtensions.java
@@ -1,0 +1,34 @@
+/*
+ * PackageProvidedExtensions.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.projects.model;
+
+import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+public class PackageProvidedExtensions extends JavaScriptObject
+{
+   protected PackageProvidedExtensions() {}
+
+   public final native RAddins getAddinsRegistry()
+   /*-{
+      return this["addins_registry"];
+   }-*/;
+
+   public final native ProjectTemplateRegistry getProjectTemplateRegistry()
+   /*-{
+      return this["project_templates_registry"];
+   }-*/;
+}

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -63,6 +63,7 @@ import org.rstudio.studio.client.projects.events.ProjectAccessRevokedEvent;
 import org.rstudio.studio.client.projects.events.ProjectTemplateRegistryUpdatedEvent;
 import org.rstudio.studio.client.projects.events.ProjectUserChangedEvent;
 import org.rstudio.studio.client.projects.model.OpenProjectError;
+import org.rstudio.studio.client.projects.model.PackageProvidedExtensions;
 import org.rstudio.studio.client.projects.model.ProjectTemplateRegistry;
 import org.rstudio.studio.client.projects.model.ProjectUser;
 import org.rstudio.studio.client.rmarkdown.events.ChunkExecStateChangedEvent;
@@ -863,7 +864,7 @@ public class ClientEventDispatcher
          }
          else if (type.equals(ClientEvent.PackageExtensionIndexingCompleted))
          {
-            PackageExtensionIndexingCompletedEvent.Data data = event.getData();
+            PackageProvidedExtensions data = event.getData();
             eventBus_.fireEvent(new PackageExtensionIndexingCompletedEvent(data));
          }
          else if (type.equals(ClientEvent.RStudioAPIShowDialog))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -24,6 +24,7 @@ import org.rstudio.studio.client.common.compilepdf.model.CompilePdfState;
 import org.rstudio.studio.client.common.console.ConsoleProcessInfo;
 import org.rstudio.studio.client.common.debugging.model.ErrorManagerState;
 import org.rstudio.studio.client.common.rnw.RnwWeave;
+import org.rstudio.studio.client.projects.model.PackageProvidedExtensions;
 import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
 import org.rstudio.studio.client.workbench.views.buildtools.model.BuildState;
 import org.rstudio.studio.client.workbench.views.connections.model.Connection;
@@ -484,5 +485,10 @@ public class SessionInfo extends JavaScriptObject
    
    public final native RAddins getAddins() /*-{
       return this.r_addins;
+   }-*/;
+   
+   public final native PackageProvidedExtensions getPackageProvidedExtensions()
+   /*-{
+      return this.package_provided_extensions;
    }-*/;
 }


### PR DESCRIPTION
This PR should hopefully resolve a bug spotted by @yihui where the set of 'New Project' entries may not be populated when connecting to an existing R session.

We resolve the issue by saving the JSON payload in memory, and passing that along as part of the session init bundle. If the indexer has not yet finished running, that payload will be empty, but a later incoming event would then provide the set of extensions (as per https://github.com/rstudio/rstudio/blob/1fcd843d8ab9ae9204674b69cb3d07bcb55fea64/src/cpp/session/modules/SessionPackageProvidedExtension.cpp#L174-L177).

Side note: is `SessionInitEvent` the correct thing to be attaching to / listening on here?