### PR TITLE
Missing top border in connections dialog wizard

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.css
@@ -1,0 +1,3 @@
+.wizardPageSelector {
+   top: -1px !important;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.java
@@ -100,6 +100,7 @@ public class NewConnectionNavigationPage
          
          ScrollPanel scrollPanel = new ScrollPanel();
          scrollPanel.setSize("100%", "100%");
+         scrollPanel.addStyleName(RES.styles().wizardPageSelector());
          scrollPanel.addStyleName(styles.wizardPageSelector());
 
          VerticalPanel verticalPanel = new VerticalPanel();
@@ -171,6 +172,7 @@ public class NewConnectionNavigationPage
 
    public interface Styles extends CssResource
    {
+      String wizardPageSelector();
    }
    
    public interface Resources extends ClientBundle

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionWizard.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionWizard.css
@@ -8,6 +8,7 @@
    height: 274px;
    margin-left: -10px;
    margin-right: -13px;
+   border-top: 1px solid #dcdcdc;
 }
 
 @sprite .newConnectionWizardBackground {


### PR DESCRIPTION
Top border dividing wizard caption is missing in connections dialog.