### PR TITLE
ensure extensions are discovered on init

### DIFF
--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -56,6 +56,7 @@
 #include <session/SessionHttpConnection.hpp>
 #include <session/SessionModuleContext.hpp>
 #include <session/SessionOptions.hpp>
+#include <session/SessionPackageProvidedExtension.hpp>
 #include <session/SessionPersistentState.hpp>
 #include <session/SessionUserSettings.hpp>
 #include <session/projects/SessionProjectSharing.hpp>
@@ -370,6 +371,7 @@ void handleClientInit(const boost::function<void()>& initFunction,
    sessionInfo["user_home_page_url"] = json::Value();
    
    sessionInfo["r_addins"] = modules::r_addins::addinRegistryAsJson();
+   sessionInfo["package_provided_extensions"] = modules::ppe::indexer().getPayload();
 
    sessionInfo["connections_enabled"] = modules::connections::connectionsEnabled();
    sessionInfo["activate_connections"] = modules::connections::activateConnections();

--- a/src/cpp/session/include/session/SessionPackageProvidedExtension.hpp
+++ b/src/cpp/session/include/session/SessionPackageProvidedExtension.hpp
@@ -81,6 +81,7 @@ public:
 public:
    void start();
    bool running() { return running_; }
+   core::json::Object getPayload() { return payload_; }
    
 private:
    void beginIndexing();
@@ -90,6 +91,8 @@ private:
 private:
    std::vector<boost::shared_ptr<Worker> > workers_;
    std::vector<core::FilePath> pkgDirs_;
+   core::json::Object payload_;
+   
    std::size_t index_;
    std::size_t n_;
    bool running_;

--- a/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
+++ b/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
@@ -20,6 +20,7 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <core/Algorithm.hpp>
+#include <core/Exec.hpp>
 #include <core/FileSerializer.hpp>
 #include <core/text/DcfParser.hpp>
 
@@ -90,7 +91,7 @@ void Indexer::start()
             boost::posix_time::milliseconds(300),
             boost::posix_time::milliseconds(20),
             boost::bind(&Indexer::work, this),
-            false);
+            true);
 }
 
 bool Indexer::work()
@@ -160,20 +161,21 @@ void Indexer::beginIndexing()
 void Indexer::endIndexing()
 {
    running_ = false;
+   payload_.clear();
    
-   json::Object payload;
    BOOST_FOREACH(boost::shared_ptr<Worker> pWorker, workers_)
    {
       try
       {
-         pWorker->onIndexingCompleted(&payload);
+         pWorker->onIndexingCompleted(&payload_);
       }
       CATCH_UNEXPECTED_EXCEPTION
    }
    
    ClientEvent event(
             client_events::kPackageExtensionIndexingCompleted,
-            payload);
+            payload_);
+   
    module_context::enqueClientEvent(event);
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinModule.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinModule.java
@@ -177,6 +177,7 @@ import org.rstudio.studio.client.workbench.views.output.compilepdf.CompilePdfOut
 import org.rstudio.studio.client.workbench.views.packages.Packages;
 import org.rstudio.studio.client.workbench.views.packages.PackagesPane;
 import org.rstudio.studio.client.workbench.views.packages.PackagesTab;
+import org.rstudio.studio.client.workbench.views.packages.model.PackageProvidedExtensions;
 import org.rstudio.studio.client.workbench.views.packages.model.PackagesServerOperations;
 import org.rstudio.studio.client.workbench.views.plots.Plots;
 import org.rstudio.studio.client.workbench.views.plots.PlotsPane;
@@ -277,6 +278,7 @@ public class RStudioGinModule extends AbstractGinModule
       bind(DataImportPresenter.class).in(Singleton.class);
       bind(MathJaxLoader.class).asEagerSingleton();
       bind(ProjectTemplateRegistryProvider.class).in(Singleton.class);
+      bind(PackageProvidedExtensions.class).asEagerSingleton();
 
       bind(ApplicationView.class).to(ApplicationWindow.class)
             .in(Singleton.class) ;

--- a/src/gwt/src/org/rstudio/studio/client/packages/events/PackageExtensionIndexingCompletedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/packages/events/PackageExtensionIndexingCompletedEvent.java
@@ -12,44 +12,27 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
-package org.rstudio.studio.client.projects.events;
+package org.rstudio.studio.client.packages.events;
 
-import org.rstudio.studio.client.projects.model.ProjectTemplateRegistry;
-import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
+import org.rstudio.studio.client.workbench.views.packages.model.PackageProvidedExtensions;
 
-import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 
 public class PackageExtensionIndexingCompletedEvent
       extends GwtEvent<PackageExtensionIndexingCompletedEvent.Handler>
 {
-   public static class Data extends JavaScriptObject
-   {
-      protected Data() {}
-      
-      public final native RAddins getAddinsRegistry()
-      /*-{
-         return this["addins_registry"];
-      }-*/;
-      
-      public final native ProjectTemplateRegistry getProjectTemplateRegistry()
-      /*-{
-         return this["project_templates_registry"];
-      }-*/;
-   }
-   
-   public PackageExtensionIndexingCompletedEvent(Data data)
+   public PackageExtensionIndexingCompletedEvent(PackageProvidedExtensions.Data data)
    {
       data_ = data;
    }
    
-   public Data getData()
+   public PackageProvidedExtensions.Data getData()
    {
       return data_;
    }
    
-   private final Data data_;
+   private final PackageProvidedExtensions.Data data_;
    
    // Boilerplate ----
    

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -56,9 +56,9 @@ import org.rstudio.studio.client.htmlpreview.events.HTMLPreviewCompletedEvent;
 import org.rstudio.studio.client.htmlpreview.events.HTMLPreviewOutputEvent;
 import org.rstudio.studio.client.htmlpreview.events.HTMLPreviewStartedEvent;
 import org.rstudio.studio.client.htmlpreview.model.HTMLPreviewResult;
+import org.rstudio.studio.client.packages.events.PackageExtensionIndexingCompletedEvent;
 import org.rstudio.studio.client.projects.events.FollowUserEvent;
 import org.rstudio.studio.client.projects.events.OpenProjectErrorEvent;
-import org.rstudio.studio.client.projects.events.PackageExtensionIndexingCompletedEvent;
 import org.rstudio.studio.client.projects.events.ProjectAccessRevokedEvent;
 import org.rstudio.studio.client.projects.events.ProjectTemplateRegistryUpdatedEvent;
 import org.rstudio.studio.client.projects.events.ProjectUserChangedEvent;
@@ -138,6 +138,7 @@ import org.rstudio.studio.client.workbench.views.output.sourcecpp.model.SourceCp
 import org.rstudio.studio.client.workbench.views.packages.events.PackageStateChangedEvent;
 import org.rstudio.studio.client.workbench.views.packages.events.LoadedPackageUpdatesEvent;
 import org.rstudio.studio.client.workbench.views.packages.events.PackageStatusChangedEvent;
+import org.rstudio.studio.client.workbench.views.packages.model.PackageProvidedExtensions;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageState;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageStatus;
 import org.rstudio.studio.client.workbench.views.plots.events.LocatorEvent;
@@ -863,7 +864,7 @@ public class ClientEventDispatcher
          }
          else if (type.equals(ClientEvent.PackageExtensionIndexingCompleted))
          {
-            PackageExtensionIndexingCompletedEvent.Data data = event.getData();
+            PackageProvidedExtensions.Data data = event.getData();
             eventBus_.fireEvent(new PackageExtensionIndexingCompletedEvent(data));
          }
          else if (type.equals(ClientEvent.RStudioAPIShowDialog))

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -999,7 +999,6 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, CHOOSE_FILE_COMPLETED, file, requestCallback);
    }
 
-
    public void getPackageState(
          boolean manual,
          ServerRequestCallback<PackageState> requestCallback)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -31,6 +31,7 @@ import org.rstudio.studio.client.workbench.views.connections.model.ConnectionId;
 import org.rstudio.studio.client.workbench.views.environment.model.EnvironmentContextData;
 import org.rstudio.studio.client.workbench.views.output.find.model.FindInFilesState;
 import org.rstudio.studio.client.workbench.views.output.markers.model.MarkersState;
+import org.rstudio.studio.client.workbench.views.packages.model.PackageProvidedExtensions;
 import org.rstudio.studio.client.workbench.views.presentation.model.PresentationState;
 import org.rstudio.studio.client.workbench.views.source.model.SourceDocument;
 
@@ -484,5 +485,9 @@ public class SessionInfo extends JavaScriptObject
    
    public final native RAddins getAddins() /*-{
       return this.r_addins;
+   }-*/;
+   
+   public final native PackageProvidedExtensions.Data getPackageProvidedExtensions() /*-{
+      return this.package_provided_extensions;
    }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -49,17 +49,12 @@ import org.rstudio.studio.client.packrat.model.PackratPackageAction;
 import org.rstudio.studio.client.packrat.model.PackratServerOperations;
 import org.rstudio.studio.client.packrat.ui.PackratActionDialog;
 import org.rstudio.studio.client.packrat.ui.PackratResolveConflictDialog;
-import org.rstudio.studio.client.projects.events.PackageExtensionIndexingCompletedEvent;
-import org.rstudio.studio.client.projects.events.ProjectTemplateRegistryUpdatedEvent;
-import org.rstudio.studio.client.projects.model.ProjectTemplateRegistry;
 import org.rstudio.studio.client.server.ServerDataSource;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.workbench.WorkbenchContext;
 import org.rstudio.studio.client.workbench.WorkbenchView;
-import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
-import org.rstudio.studio.client.workbench.addins.events.AddinRegistryUpdatedEvent;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.ClientState;
 import org.rstudio.studio.client.workbench.model.RemoteFileSystemContext;
@@ -102,7 +97,6 @@ public class Packages
       extends BasePresenter
       implements PackageStatusChangedHandler,
                  DeferredInitCompletedEvent.Handler,
-                 PackageExtensionIndexingCompletedEvent.Handler,
                  PackagesDisplayObserver
 {
    public interface Binder extends CommandBinder<Commands, Packages> {}
@@ -157,7 +151,6 @@ public class Packages
       binder.bind(commands, this);
       
       events.addHandler(PackageStatusChangedEvent.TYPE, this);
-      events.addHandler(PackageExtensionIndexingCompletedEvent.TYPE, this);
       
       // make the install options persistent
       new JSObjectStateValue("packages-pane", "installOptions", ClientState.PROJECT_PERSISTENT,
@@ -1290,22 +1283,6 @@ public class Packages
          pkgNames.add(actions.get(i).getPackage());
    }
    
-   @Override
-   public void onPackageExtensionIndexingCompleted(PackageExtensionIndexingCompletedEvent event)
-   {
-      PackageExtensionIndexingCompletedEvent.Data data = event.getData();
-      
-      // update addins
-      RAddins addinRegistry = data.getAddinsRegistry();
-      if (addinRegistry != null)
-         events_.fireEvent(new AddinRegistryUpdatedEvent(addinRegistry));
-      
-      // update project templates
-      ProjectTemplateRegistry ptRegistry = data.getProjectTemplateRegistry();
-      if (ptRegistry != null)
-         events_.fireEvent(new ProjectTemplateRegistryUpdatedEvent(ptRegistry));
-   }
-      
    private final Display view_;
    private final PackagesServerOperations server_;
    private final PackratServerOperations packratServer_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageProvidedExtensions.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageProvidedExtensions.java
@@ -1,0 +1,77 @@
+package org.rstudio.studio.client.workbench.views.packages.model;
+
+import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.packages.events.PackageExtensionIndexingCompletedEvent;
+import org.rstudio.studio.client.projects.events.ProjectTemplateRegistryUpdatedEvent;
+import org.rstudio.studio.client.projects.model.ProjectTemplateRegistry;
+import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
+import org.rstudio.studio.client.workbench.addins.events.AddinRegistryUpdatedEvent;
+import org.rstudio.studio.client.workbench.events.SessionInitEvent;
+import org.rstudio.studio.client.workbench.events.SessionInitHandler;
+import org.rstudio.studio.client.workbench.model.Session;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+@Singleton
+public class PackageProvidedExtensions
+      implements SessionInitHandler,
+                 PackageExtensionIndexingCompletedEvent.Handler
+
+{
+   public static class Data extends JavaScriptObject
+   {
+      protected Data() {}
+      
+      public final native RAddins getAddinsRegistry()
+      /*-{
+         return this["addins_registry"];
+      }-*/;
+      
+      public final native ProjectTemplateRegistry getProjectTemplateRegistry()
+      /*-{
+         return this["project_templates_registry"];
+      }-*/;
+   }
+   
+   @Inject
+   public PackageProvidedExtensions(Session session,
+                                    EventBus events)
+   {
+      session_ = session;
+      events_ = events;
+      
+      events_.addHandler(SessionInitEvent.TYPE, this);
+      events_.addHandler(PackageExtensionIndexingCompletedEvent.TYPE, this);
+   }
+   
+   @Override
+   public void onSessionInit(SessionInitEvent sie)
+   {
+      update(session_.getSessionInfo().getPackageProvidedExtensions());
+   }
+   
+   @Override
+   public void onPackageExtensionIndexingCompleted(PackageExtensionIndexingCompletedEvent event)
+   {
+      update(event.getData());
+   }
+   
+   private void update(PackageProvidedExtensions.Data data)
+   {
+      // update addins
+      RAddins addinRegistry = data.getAddinsRegistry();
+      if (addinRegistry != null)
+         events_.fireEvent(new AddinRegistryUpdatedEvent(addinRegistry));
+
+      // update project templates
+      ProjectTemplateRegistry ptRegistry = data.getProjectTemplateRegistry();
+      if (ptRegistry != null)
+         events_.fireEvent(new ProjectTemplateRegistryUpdatedEvent(ptRegistry));
+   }
+   
+   // Injected ----
+   private final Session session_;
+   private final EventBus events_;
+}


### PR DESCRIPTION
This is a second stab at ensuring package provided extensions are provided on session init.

Unfortunately, the previous PR had an issue -- the Packages tab is initialized lazily, and so the event handlers registered therein wouldn't actually receive the event unless the Packages tab was focused + initialized.

The fix here is to just use an eager singleton to register the necessary event handlers.