### PR TITLE
handle conflict w/remote when creating branch

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/Functional.java
+++ b/src/gwt/src/org/rstudio/core/client/Functional.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.JsArrayString;
 
 public class Functional
 {
@@ -37,6 +38,14 @@ public class Functional
    
    public static <T extends JavaScriptObject> T find(JsArray<T> array,
                                                      Predicate<T> predicate)
+   {
+      for (int i = 0, n = array.length(); i < n; i++)
+         if (predicate.test(array.get(i)))
+            return array.get(i);
+      return null;
+   }
+   
+   public static String find(JsArrayString array, Predicate<String> predicate)
    {
       for (int i = 0, n = array.length(); i < n; i++)
          if (predicate.test(array.get(i)))

--- a/src/gwt/src/org/rstudio/studio/client/common/dialog/DialogBuilderBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dialog/DialogBuilderBase.java
@@ -65,7 +65,7 @@ public abstract class DialogBuilderBase implements DialogBuilder
       defaultButton_ = index;
       return this;
    }
-
+   
    public abstract void showModal();
 
    protected final int type;

--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/GitServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/GitServerOperations.java
@@ -77,6 +77,10 @@ public interface GitServerOperations extends VCSServerOperations
 
    void gitCheckout(String id,
                     ServerRequestCallback<ConsoleProcess> requestCallback);
+   
+   void gitCheckoutRemote(String branch,
+                          String remote,
+                          ServerRequestCallback<ConsoleProcess> requestCallback);
 
    void gitCommit(String message,
                   boolean amend,

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -2189,6 +2189,18 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, GIT_CHECKOUT, id,
                   new ConsoleProcessCallbackAdapter(requestCallback));
    }
+   
+   @Override
+   public void gitCheckoutRemote(String branch,
+                                 String remote,
+                                 ServerRequestCallback<ConsoleProcess> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(branch));
+      params.set(1, new JSONString(remote));
+      sendRequest(RPC_SCOPE, GIT_CHECKOUT_REMOTE, params,
+            new ConsoleProcessCallbackAdapter(requestCallback));
+   }
 
    public void gitCommit(String message,
                          boolean amend,
@@ -5226,6 +5238,7 @@ public class RemoteServer implements Server
    private static final String GIT_LIST_REMOTES = "git_list_remotes";
    private static final String GIT_ADD_REMOTE = "git_add_remote";
    private static final String GIT_CHECKOUT = "git_checkout";
+   private static final String GIT_CHECKOUT_REMOTE = "git_checkout_remote";
    private static final String GIT_COMMIT = "git_commit";
    private static final String GIT_PUSH = "git_push";
    private static final String GIT_PUSH_BRANCH = "git_push_branch";


### PR DESCRIPTION
This PR adds handling for the case where the user tries to create a branch `branch`, but a remote branch called `branch` already exists.

Right now, the only actions made available to the user in this case is to check out that remote branch. We might also want to allow the user to explicitly create and overwrite the remote branch, but because this is a destructive operation I leave this unimplemented for now.