### PR TITLE
Make bringtotop unsupported in Windows

### DIFF
--- a/src/cpp/r/session/REmbeddedWin32.cpp
+++ b/src/cpp/r/session/REmbeddedWin32.cpp
@@ -236,6 +236,7 @@ Error completeEmbeddedRInitialization(bool useInternet2)
    using namespace r::function_hook ;
    ExecBlock block ;
    block.addFunctions()
+      (bind(registerUnsupported, "bringToTop", "grDevices"))
       (bind(registerUnsupported, "winMenuAdd", "utils"))
       (bind(registerUnsupported, "winMenuAddItem", "utils"))
       (bind(registerUnsupported, "winMenuDel", "utils"))


### PR DESCRIPTION
Since `bringToTop` crashed in windows, this change marks this function as unsupported.

Some context: This is a `NULL` pointer dereference while running in `RGui` mode (https://github.com/wch/r-source/blob/17e4dd5b60a3a148aa0664f01590acafb104ab4a/src/include/R_ext/RStartup.h#L53), in which `RConsole` is set to `NULL` but never initialized (https://github.com/wch/r-source/blob/af7f52f70101960861e5d995d3a4bec010bc89e6/src/gnuwin32/rui.c#L50) Since there is no RGui in Linux, we don't have this crash outside Windows.

The commit that introduced this: https://github.com/rstudio/rstudio/commit/7f71b9727725d9812eec10dacb87601f085272cc

We could, potentially, revert the change above which would fix this issue and the `utils::timestamp` crash; however, that would be a risky change since other features might depend on running on `RGui` mode in Windows.

@jcheng5 out of curiosity, do you remember why it's important to run `RGui` in Windows?