### PR TITLE
allow directory in Open Project dialog

### DIFF
--- a/src/cpp/desktop-mac/GwtCallbacks.mm
+++ b/src/cpp/desktop-mac/GwtCallbacks.mm
@@ -156,8 +156,9 @@ private:
 
 
 - (NSString*) getOpenFileName: (NSString*) caption
-              dir: (NSString*) dir
-              filter: (NSString*) filter
+                          dir: (NSString*) dir
+                       filter: (NSString*) filter
+         canChooseDirectories: (Boolean) canChooseDirectories
 {
    dir = resolveAliasedPath(dir);
    
@@ -165,6 +166,8 @@ private:
    [open setTitle: caption];
    [open setDirectoryURL: [NSURL fileURLWithPath:
                            [dir stringByStandardizingPath]]];
+   [open setCanChooseDirectories: canChooseDirectories];
+   
    // If the filter was specified and looks like a filter string
    // (i.e. "R Projects (*.RProj)"), extract just the extension ("RProj") to
    // pass to the open dialog.
@@ -1141,7 +1144,7 @@ enum RS_NSActivityOptions : uint64_t
 {
    if (sel == @selector(browseUrl:))
       return @"browseUrl";
-   else if (sel == @selector(getOpenFileName:dir:filter:))
+   else if (sel == @selector(getOpenFileName:dir:filter:canChooseDirectories:))
       return @"getOpenFileName";
    else if (sel == @selector(getSaveFileName:dir:defaultExtension:forceDefaultExtension:))
       return @"getSaveFileName";

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -47,6 +47,7 @@
 #include <session/SessionOptions.hpp>
 #include <session/SessionPersistentState.hpp>
 #include <session/SessionScopes.hpp>
+#include <session/projects/SessionProjects.hpp>
 
 using namespace rstudio::core;
 
@@ -533,10 +534,24 @@ void handleConnection(boost::shared_ptr<HttpConnection> ptrConnection,
                                            &hostPageUrl) ;
             if (error)
                LOG_ERROR(error);
-
+            
             // note switch to project
             if (!switchToProject.empty())
             {
+               // if we don't have a project file then create it (can
+               // occur when e.g. opening a project from a directory for
+               // which we don't yet have a .Rproj file)
+               FilePath projFile = module_context::resolveAliasedPath(switchToProject);
+               if (projFile.parent().exists() && !projFile.exists())
+               {
+                  Error error = r_util::writeProjectFile(
+                           projFile,
+                           projects::ProjectContext::buildDefaults(),
+                           projects::ProjectContext::defaultConfig());
+                  if (error)
+                     LOG_ERROR(error);
+               }
+
                if (options().switchProjectsWithUrl())
                {
                   using namespace module_context;
@@ -557,9 +572,7 @@ void handleConnection(boost::shared_ptr<HttpConnection> ptrConnection,
                   {
                      // extract the directory (aliased)
                      using namespace module_context;
-                     FilePath projFile = resolveAliasedPath(switchToProject);
                      projDir = createAliasedPath(projFile.parent());
-
                      scope = r_util::SessionScope::fromProject(
                               projDir,
                               options().sessionScope().id(),

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -541,15 +541,18 @@ void handleConnection(boost::shared_ptr<HttpConnection> ptrConnection,
                // if we don't have a project file then create it (can
                // occur when e.g. opening a project from a directory for
                // which we don't yet have a .Rproj file)
-               FilePath projFile = module_context::resolveAliasedPath(switchToProject);
-               if (projFile.parent().exists() && !projFile.exists())
+               if (switchToProject != kProjectNone)
                {
-                  Error error = r_util::writeProjectFile(
-                           projFile,
-                           projects::ProjectContext::buildDefaults(),
-                           projects::ProjectContext::defaultConfig());
-                  if (error)
-                     LOG_ERROR(error);
+                  FilePath projFile = module_context::resolveAliasedPath(switchToProject);
+                  if (projFile.parent().exists() && !projFile.exists())
+                  {
+                     Error error = r_util::writeProjectFile(
+                              projFile,
+                              projects::ProjectContext::buildDefaults(),
+                              projects::ProjectContext::defaultConfig());
+                     if (error)
+                        LOG_ERROR(error);
+                  }
                }
 
                if (options().switchProjectsWithUrl())
@@ -572,6 +575,7 @@ void handleConnection(boost::shared_ptr<HttpConnection> ptrConnection,
                   {
                      // extract the directory (aliased)
                      using namespace module_context;
+                     FilePath projFile = module_context::resolveAliasedPath(switchToProject);
                      projDir = createAliasedPath(projFile.parent());
                      scope = r_util::SessionScope::fromProject(
                               projDir,

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -236,6 +236,32 @@ Error createProject(const json::JsonRpcRequest& request,
    return Success();
 }
 
+Error createProjectFile(const json::JsonRpcRequest& request,
+                        json::JsonRpcResponse* pResponse)
+{
+   using namespace projects;
+   
+   std::string projFile;
+   Error error = json::readParams(request.params, &projFile);
+   if (error)
+      return error;
+   
+   FilePath projPath = module_context::resolveAliasedPath(projFile);
+   if (!projPath.exists())
+   {
+      Error error = r_util::writeProjectFile(
+               projPath,
+               ProjectContext::buildDefaults(),
+               ProjectContext::defaultConfig());
+      
+      if (error)
+         LOG_ERROR(error);
+   }
+   
+   pResponse->setResult(projPath.exists());
+   return Success();
+}
+
 json::Object projectConfigJson(const r_util::RProjectConfig& config)
 {
    json::Object configJson;
@@ -776,6 +802,7 @@ Error initialize()
       (bind(registerRpcMethod, "get_new_project_context", getNewProjectContext))
       (bind(registerRpcMethod, "get_project_file_path", getProjectFilePath))
       (bind(registerRpcMethod, "create_project", createProject))
+      (bind(registerRpcMethod, "create_project_file", createProjectFile))
       (bind(registerRpcMethod, "read_project_options", readProjectOptions))
       (bind(registerRpcMethod, "write_project_options", writeProjectOptions))
       (bind(registerRpcMethod, "write_project_vcs_options", writeProjectVcsOptions))

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/FileBrowserWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/FileBrowserWidget.java
@@ -168,6 +168,11 @@ public class FileBrowserWidget extends Composite
       return directory_.getSelectedItem();
    }
    
+   public FileSystemItem getCurrentDirectory()
+   {
+      return context_.pwdItem();
+   }
+   
    // Private methods ---------------------------------------------------------
 
    private Widget createTopWidget()

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/FileDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/FileDialog.java
@@ -15,6 +15,7 @@
 package org.rstudio.core.client.files.filedialog;
 
 import com.google.gwt.event.logical.shared.SelectionEvent;
+
 import org.rstudio.core.client.files.FileSystemContext;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.ProgressOperationWithInput;

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/OpenFileDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/OpenFileDialog.java
@@ -23,9 +23,33 @@ public class OpenFileDialog extends FileDialog
    public OpenFileDialog(String title,
                          FileSystemContext context,
                          String filter,
+                         boolean canChooseDirectories,
                          ProgressOperationWithInput<FileSystemItem> operation)
    {
       super(title, null, "Open", false, false, false, context, filter, 
             operation);
+      
+      canChooseDirectories_ = canChooseDirectories;
    }
+   
+   @Override
+   public boolean shouldAccept()
+   {
+      if (canChooseDirectories_)
+      {
+         FileSystemItem item = browser_.getSelectedItem();
+         if (item.isDirectory())
+            return true;
+      }
+      
+      return super.shouldAccept();
+   }
+   
+   @Override
+   protected FileSystemItem getSelectedItem()
+   {
+      return browser_.getSelectedItem();
+   }
+   
+   protected final boolean canChooseDirectories_;
 }

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/OpenFileDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/OpenFileDialog.java
@@ -38,7 +38,7 @@ public class OpenFileDialog extends FileDialog
       if (canChooseDirectories_)
       {
          FileSystemItem item = browser_.getSelectedItem();
-         if (item.isDirectory())
+         if (item == null || item.isDirectory())
             return true;
       }
       
@@ -48,7 +48,10 @@ public class OpenFileDialog extends FileDialog
    @Override
    protected FileSystemItem getSelectedItem()
    {
-      return browser_.getSelectedItem();
+      FileSystemItem item = browser_.getSelectedItem();
+      if (item == null)
+         item = browser_.getCurrentDirectory();
+      return item;
    }
    
    protected final boolean canChooseDirectories_;

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/OpenProjectDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/OpenProjectDialog.java
@@ -18,8 +18,11 @@ import org.rstudio.core.client.files.FileSystemContext;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.ProgressOperationWithInput;
+import org.rstudio.core.client.widget.ThemedButton;
 import org.rstudio.studio.client.projects.model.OpenProjectParams;
 
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.user.client.ui.CheckBox;
@@ -48,6 +51,16 @@ public class OpenProjectDialog extends FileDialog
                         indicator);
                }
             });
+      
+      ThemedButton createButton = new ThemedButton("Create", new ClickHandler()
+      {
+         @Override
+         public void onClick(ClickEvent event)
+         {
+            accept();
+         }
+      });
+      addButton(createButton);
       
       newSessionCheck_ = new CheckBox("Open in new session");
       newSessionCheck_.addValueChangeHandler(new ValueChangeHandler<Boolean>()

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -57,6 +57,7 @@ import org.rstudio.studio.client.common.spelling.SpellChecker;
 import org.rstudio.studio.client.common.spelling.ui.SpellingCustomDictionariesWidget;
 import org.rstudio.studio.client.htmlpreview.HTMLPreviewApplication;
 import org.rstudio.studio.client.notebook.CompileNotebookOptionsDialog;
+import org.rstudio.studio.client.projects.ProjectOpener;
 import org.rstudio.studio.client.projects.model.ProjectTemplateRegistryProvider;
 import org.rstudio.studio.client.projects.ui.newproject.CodeFilesList;
 import org.rstudio.studio.client.projects.ui.newproject.NewPackagePage;
@@ -220,6 +221,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(NewConnectionSnippetHost newConnectionSnippetHost);
    void injectMembers(NewConnectionSnippetDialog newConnectionSnippetDialog);
    void injectMembers(NewPackagePage page);
+   void injectMembers(ProjectOpener opener);
    
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);
 

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -26,7 +26,10 @@ public interface DesktopFrame extends JavaScriptPassthrough
 {
    boolean isCocoa();
    void browseUrl(String url);
-   String getOpenFileName(String caption, String dir, String filter);
+   String getOpenFileName(String caption,
+                          String dir,
+                          String filter,
+                          boolean canChooseDirectories);
    String getSaveFileName(String caption, 
                           String dir, 
                           String defaultExtension, 

--- a/src/gwt/src/org/rstudio/studio/client/common/FileDialogs.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/FileDialogs.java
@@ -30,6 +30,14 @@ public interface FileDialogs
                  FileSystemItem initialFilePath,
                  String filter,
                  ProgressOperationWithInput<FileSystemItem> operation);
+   
+   void openFile(String caption,
+                 FileSystemContext fsContext,
+                 FileSystemItem initialFilePath,
+                 String filter,
+                 boolean canChooseDirectories,
+                 ProgressOperationWithInput<FileSystemItem> operation);
+   
 
    void saveFile(String caption,
                  FileSystemContext fsContext,

--- a/src/gwt/src/org/rstudio/studio/client/common/impl/DesktopFileDialogs.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/impl/DesktopFileDialogs.java
@@ -108,13 +108,24 @@ public class DesktopFileDialogs implements FileDialogs
                         final FileSystemItem initialFilePath,
                         final ProgressOperationWithInput<FileSystemItem> operation)
    {
-      openFile(caption, fsContext, initialFilePath, "", operation);
+      openFile(caption, fsContext, initialFilePath, "", false, operation);
    }
    
    public void openFile(final String caption,
                         final FileSystemContext fsContext,
                         final FileSystemItem initialFilePath,
                         final String filter,
+                        final ProgressOperationWithInput<FileSystemItem> operation)
+   {
+      openFile(caption, fsContext, initialFilePath, filter, false, operation);
+   }
+   
+   
+   public void openFile(final String caption,
+                        final FileSystemContext fsContext,
+                        final FileSystemItem initialFilePath,
+                        final String filter,
+                        final boolean canChooseDirectories,
                         final ProgressOperationWithInput<FileSystemItem> operation)
    {
       new FileDialogOperation()
@@ -128,9 +139,12 @@ public class DesktopFileDialogs implements FileDialogs
          @Override
          String operation(String caption, String dir)
          {
-            String fileName = Desktop.getFrame().getOpenFileName(caption, 
-                                                                 dir, 
-                                                                 filter);
+            String fileName = Desktop.getFrame().getOpenFileName(
+                  caption,
+                  dir,
+                  filter,
+                  canChooseDirectories);
+            
             if (fileName != null)
             {
                updateWorkingDirectory(fileName, fsContext);

--- a/src/gwt/src/org/rstudio/studio/client/common/impl/WebFileDialogs.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/impl/WebFileDialogs.java
@@ -32,7 +32,7 @@ public class WebFileDialogs implements FileDialogs
                         FileSystemItem initialFilePath,
                         ProgressOperationWithInput<FileSystemItem> operation)
    {
-      openFile(caption, fsContext, initialFilePath, "", operation);
+      openFile(caption, fsContext, initialFilePath, "", false, operation);
    }
    
    public void openFile(String caption,
@@ -41,11 +41,23 @@ public class WebFileDialogs implements FileDialogs
                         String filter,
                         ProgressOperationWithInput<FileSystemItem> operation)
    {
+      openFile(caption, fsContext, initialFilePath, filter, false, operation);
+   }
+   
+   
+   public void openFile(String caption,
+                        FileSystemContext fsContext,
+                        FileSystemItem initialFilePath,
+                        String filter,
+                        boolean canChooseDirectories,
+                        ProgressOperationWithInput<FileSystemItem> operation)
+   {
       OpenFileDialog dialog = new OpenFileDialog(caption,
                                                  fsContext,
                                                  filter,
+                                                 canChooseDirectories,
                                                  operation);
-
+      
       dialog.setInvokeOperationEvenOnCancel(true);
 
       finishInit(fsContext, initialFilePath, dialog);

--- a/src/gwt/src/org/rstudio/studio/client/projects/ProjectOpener.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ProjectOpener.java
@@ -82,6 +82,10 @@ public class ProjectOpener
                      }
                   };
                   
+                  // null return values here imply a cancellation
+                  if (input == null)
+                     return;
+                  
                   if (input.isDirectory())
                   {
                      final String rprojPath = input.completePath(input.getName() + ".Rproj");

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/ProjectsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/ProjectsServerOperations.java
@@ -38,6 +38,9 @@ public interface ProjectsServerOperations extends PrefsServerOperations,
                       ProjectTemplateOptions projectTemplateOptions,
                       ServerRequestCallback<Void> callback);
    
+   void createProjectFile(String projectFile,
+                          ServerRequestCallback<Boolean> callback);
+   
    void packageSkeleton(String packageName,
                         String packageDirectory,
                         JsArrayString sourceFiles,

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1637,6 +1637,15 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, CREATE_PROJECT, params, requestCallback);
    }
    
+   @Override
+   public void createProjectFile(String projectFile,
+                                 ServerRequestCallback<Boolean> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(StringUtil.notNull(projectFile)));
+      sendRequest(RPC_SCOPE, CREATE_PROJECT_FILE, params, requestCallback);
+   }
+   
    public void getProjectTemplateRegistry(
          ServerRequestCallback<ProjectTemplateRegistry> requestCallback)
    {
@@ -5181,6 +5190,7 @@ public class RemoteServer implements Server
    private static final String SET_SESSION_LABEL = "set_session_label";
    private static final String GET_AVAILABLE_R_VERSIONS = "get_available_r_versions";
    private static final String CREATE_PROJECT = "create_project";
+   private static final String CREATE_PROJECT_FILE = "create_project_file";
    private static final String GET_PROJECT_TEMPLATE_REGISTRY = "get_project_template_registry";
    private static final String EXECUTE_PROJECT_TEMPLATE = "execute_project_template";
    private static final String READ_PROJECT_OPTIONS = "read_project_options";

--- a/src/gwt/www/webkit.nocache.html
+++ b/src/gwt/www/webkit.nocache.html
@@ -16,7 +16,7 @@
            desktop.collectPendingQuitRequest();
            desktop.workbenchInitialized();
            desktop.browseUrl("http://www.foo.bar");
-           document.write(desktop.getOpenFileName('caption', 'dir', 'filter'));
+           document.write(desktop.getOpenFileName('caption', 'dir', 'filter', false));
            document.write(desktop.getSaveFileName('caption', 'dir', 'cpp', true));
            desktop.undo();
            desktop.redo();


### PR DESCRIPTION
This PR makes it possible to open a directory as an RStudio project within the `Open Project` dialog, thereby making it possible to open directories as projects even if they do not have a `.Rproj` file yet.

The behavior in RStudio Server (ie, from a browser) is basically that explicitly clicking the `Open` button when a directory is selected will open that directory, while double-clicking on a directory will still navigate into that directory. I think this is inline with user expectations.

This is currently only implemented for RStudio Server + macOS Desktop. I'm not yet sure if it's possible to tell a QFileDialog to accept both directories and single files. (It's probably possible to do by e.g. subclassing `QFileDialog` and implementing behaviors as necessary; I'm going to explore that a bit)