### PR TITLE
Fix timestamp crash and signature in Windows

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -629,13 +629,18 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
   })
 
   # timestamp
-  .rs.registerReplaceHook("timestamp", "utils", function(original, ...)
+  .rs.registerReplaceHook("timestamp", "utils", function(
+    original,
+    stamp = date(),
+    prefix = "##------ ",
+    suffix = " ------##",
+    quiet = FALSE)
   {
     invisible(.Call("rs_timestamp",
-      stamp = date(),
-      prefix = "##------ ",
-      suffix = " ------##", 
-      quiet = FALSE))
+      stamp,
+      prefix,
+      suffix, 
+      quiet))
   }, namespace = TRUE)
 })
 

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -638,6 +638,10 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
   {
     stamp <- paste(prefix, stamp, suffix, sep = "")
 
+    lapply(stamp, function(s) {
+      invisible(.Call("rs_timestamp", s)
+    })
+
     if (!quiet)
         cat(stamp, sep = "\n")
 

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -639,7 +639,7 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
     stamp <- paste(prefix, stamp, suffix, sep = "")
 
     lapply(stamp, function(s) {
-      invisible(.Call("rs_timestamp", s)
+      invisible(.Call("rs_timestamp", s))
     })
 
     if (!quiet)

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -452,7 +452,7 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
 })
 
 # replacing an internal R function
-.rs.addFunction( "registerReplaceHook", function(name, package, hook, keepOriginal, namespace)
+.rs.addFunction( "registerReplaceHook", function(name, package, hook, keepOriginal, namespace = FALSE)
 {
    hookFactory <- function(original) function(...) .rs.callAs(name,
                                                              hook, 
@@ -619,19 +619,23 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
                                                            file = ".Rhistory")
   {
     invisible(.Call("rs_loadHistory", file))
-  }, namespace = TRUE)
+  })
   
   # savehistory
   .rs.registerReplaceHook("savehistory", "utils", function(original, 
                                                            file = ".Rhistory")
   {
     invisible(.Call("rs_saveHistory", file))
-  }, namespace = TRUE)
+  })
 
   # timestamp
   .rs.registerReplaceHook("timestamp", "utils", function(original, ...)
   {
-    invisible(.Call("rs_timestamp", date()))
+    invisible(.Call("rs_timestamp",
+      stamp = date(),
+      prefix = "##------ ",
+      suffix = " ------##", 
+      quiet = FALSE))
   }, namespace = TRUE)
 })
 

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -452,13 +452,13 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
 })
 
 # replacing an internal R function
-.rs.addFunction( "registerReplaceHook", function(name, package, hook, keepOriginal)
+.rs.addFunction( "registerReplaceHook", function(name, package, hook, keepOriginal, namespace)
 {
    hookFactory <- function(original) function(...) .rs.callAs(name,
                                                              hook, 
                                                              original,
                                                              ...);
-   .rs.registerHook(name, package, hookFactory);
+   .rs.registerHook(name, package, hookFactory, namespace);
 })
 
 # notification that an internal R function was called
@@ -619,20 +619,20 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
                                                            file = ".Rhistory")
   {
     invisible(.Call("rs_loadHistory", file))
-  })
+  }, namespace = TRUE)
   
   # savehistory
   .rs.registerReplaceHook("savehistory", "utils", function(original, 
                                                            file = ".Rhistory")
   {
     invisible(.Call("rs_saveHistory", file))
-  })
+  }, namespace = TRUE)
 
   # timestamp
   .rs.registerReplaceHook("timestamp", "utils", function(original, ...)
   {
     invisible(.Call("rs_timestamp", date()))
-  })
+  }, namespace = TRUE)
 })
 
 

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -636,11 +636,12 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
     suffix = " ------##",
     quiet = FALSE)
   {
-    invisible(.Call("rs_timestamp",
-      stamp,
-      prefix,
-      suffix, 
-      quiet))
+    stamp <- paste(prefix, stamp, suffix, sep = "")
+
+    if (!quiet)
+        cat(stamp, sep = "\n")
+
+    invisible(stamp)
   }, namespace = TRUE)
 })
 

--- a/src/cpp/session/modules/SessionHistory.cpp
+++ b/src/cpp/session/modules/SessionHistory.cpp
@@ -364,11 +364,9 @@ void onHistoryAdd(const std::string& command)
 SEXP rs_timestamp(SEXP stampSEXP, SEXP prefixSEXP, SEXP suffixSEXP, SEXP quietSEXP)
 {
    std::string prefix = r::sexp::safeAsString(prefixSEXP);
-   
-   std::string suffix = r::sexp::safeAsString(prefixSEXP);
+   std::string suffix = r::sexp::safeAsString(suffixSEXP);
 
-   boost::format fmt(prefix + "%1%" + suffix);
-   std::string ts = boost::str(fmt % r::sexp::safeAsString(stampSEXP));
+   std::string ts = prefix + r::sexp::safeAsString(stampSEXP) + suffix;
    r::session::consoleHistory().add(ts);
 
    if (!r::sexp::asLogical(quietSEXP)) {

--- a/src/cpp/session/modules/SessionHistory.cpp
+++ b/src/cpp/session/modules/SessionHistory.cpp
@@ -361,21 +361,6 @@ void onHistoryAdd(const std::string& command)
    module_context::enqueClientEvent(event);
 }
 
-SEXP rs_timestamp(SEXP stampSEXP, SEXP prefixSEXP, SEXP suffixSEXP, SEXP quietSEXP)
-{
-   std::string prefix = r::sexp::safeAsString(prefixSEXP);
-   std::string suffix = r::sexp::safeAsString(suffixSEXP);
-
-   std::string ts = prefix + r::sexp::safeAsString(stampSEXP) + suffix;
-   r::session::consoleHistory().add(ts);
-
-   if (!r::sexp::asLogical(quietSEXP)) {
-      module_context::consoleWriteOutput(ts + "\n");
-   }
-
-   return R_NilValue;
-}
-
 } // anonymous namespace
    
    
@@ -386,13 +371,6 @@ Error initialize()
    
    // connect to console history add event
    r::session::consoleHistory().connectOnAdd(onHistoryAdd);   
-   
-   // register timestamp function
-   R_CallMethodDef methodDef;
-   methodDef.name = "rs_timestamp" ;
-   methodDef.fun = (DL_FUNC) rs_timestamp;
-   methodDef.numArgs = 4;
-   r::routines::addCallMethod(methodDef);
 
    // install handlers
    using boost::bind;

--- a/src/cpp/session/modules/SessionHistory.cpp
+++ b/src/cpp/session/modules/SessionHistory.cpp
@@ -393,7 +393,7 @@ Error initialize()
    R_CallMethodDef methodDef;
    methodDef.name = "rs_timestamp" ;
    methodDef.fun = (DL_FUNC) rs_timestamp;
-   methodDef.numArgs = 1;
+   methodDef.numArgs = 4;
    r::routines::addCallMethod(methodDef);
 
    // install handlers

--- a/src/cpp/session/modules/SessionHistory.cpp
+++ b/src/cpp/session/modules/SessionHistory.cpp
@@ -361,6 +361,13 @@ void onHistoryAdd(const std::string& command)
    module_context::enqueClientEvent(event);
 }
 
+SEXP rs_timestamp(SEXP stampSEXP) {
+   std::string stamp = r::sexp::safeAsString(stampSEXP);
+   r::session::consoleHistory().add(stamp);
+
+   return R_NilValue;
+}
+
 } // anonymous namespace
    
    
@@ -370,7 +377,14 @@ Error initialize()
    HistoryArchive::migrateRhistoryIfNecessary();
    
    // connect to console history add event
-   r::session::consoleHistory().connectOnAdd(onHistoryAdd);   
+   r::session::consoleHistory().connectOnAdd(onHistoryAdd);
+
+   // register timestamp function
+   R_CallMethodDef methodDef;
+   methodDef.name = "rs_timestamp" ;
+   methodDef.fun = (DL_FUNC) rs_timestamp;
+   methodDef.numArgs = 1;
+   r::routines::addCallMethod(methodDef);   
 
    // install handlers
    using boost::bind;

--- a/src/cpp/session/modules/SessionHistory.cpp
+++ b/src/cpp/session/modules/SessionHistory.cpp
@@ -361,12 +361,20 @@ void onHistoryAdd(const std::string& command)
    module_context::enqueClientEvent(event);
 }
 
-SEXP rs_timestamp(SEXP dateSEXP)
+SEXP rs_timestamp(SEXP stampSEXP, SEXP prefixSEXP, SEXP suffixSEXP, SEXP quietSEXP)
 {
-   boost::format fmt("##------ %1% ------##");
-   std::string ts = boost::str(fmt % r::sexp::safeAsString(dateSEXP));
+   std::string prefix = r::sexp::safeAsString(prefixSEXP);
+   
+   std::string suffix = r::sexp::safeAsString(prefixSEXP);
+
+   boost::format fmt(prefix + "%1%" + suffix);
+   std::string ts = boost::str(fmt % r::sexp::safeAsString(stampSEXP));
    r::session::consoleHistory().add(ts);
-   module_context::consoleWriteOutput(ts + "\n");
+
+   if (!r::sexp::asLogical(quietSEXP)) {
+      module_context::consoleWriteOutput(ts + "\n");
+   }
+
    return R_NilValue;
 }
 


### PR DESCRIPTION
Two fixes for `timestamp()`:

 1. Avoid crashing while using the namespace `utils::timestamp`
 2. Add missing support for `stamp`, `prefix`, `suffix` and `quiet` parameters.

Somewhat related to: https://github.com/rstudio/rstudio/pull/1029