### PR TITLE
avoid injection within ProjectOpener class

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -57,7 +57,6 @@ import org.rstudio.studio.client.common.spelling.SpellChecker;
 import org.rstudio.studio.client.common.spelling.ui.SpellingCustomDictionariesWidget;
 import org.rstudio.studio.client.htmlpreview.HTMLPreviewApplication;
 import org.rstudio.studio.client.notebook.CompileNotebookOptionsDialog;
-import org.rstudio.studio.client.projects.ProjectOpener;
 import org.rstudio.studio.client.projects.model.ProjectTemplateRegistryProvider;
 import org.rstudio.studio.client.projects.ui.newproject.CodeFilesList;
 import org.rstudio.studio.client.projects.ui.newproject.NewPackagePage;
@@ -221,7 +220,6 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(NewConnectionSnippetHost newConnectionSnippetHost);
    void injectMembers(NewConnectionSnippetDialog newConnectionSnippetDialog);
    void injectMembers(NewPackagePage page);
-   void injectMembers(ProjectOpener opener);
    
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);
 

--- a/src/gwt/src/org/rstudio/studio/client/projects/ProjectOpener.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ProjectOpener.java
@@ -29,19 +29,18 @@ import org.rstudio.studio.client.projects.model.ProjectsServerOperations;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 
-import com.google.inject.Inject;
-
 public class ProjectOpener
 {
    public final static int PROJECT_TYPE_FILE   = 0;
    public final static int PROJECT_TYPE_SHARED = 1;
    
-   @Inject
-   private void initialize(ProjectsServerOperations server)
+   private void initialize()
    {
-      server_ = server;
+      if (initialized_) return;
+      initialized_ = true;
+      server_ = RStudioGinjector.INSTANCE.getServer();
    }
-
+   
    public void showOpenProjectDialog(
                   FileSystemContext fsContext,
                   ProjectsServerOperations server,
@@ -50,7 +49,7 @@ public class ProjectOpener
                   boolean showNewSession,
                   final ProgressOperationWithInput<OpenProjectParams> onCompleted)
    {
-      RStudioGinjector.INSTANCE.injectMembers(this);
+      initialize();
       
       // use the default dialog on desktop mode or single-session mode
       FileDialogs dialogs = RStudioGinjector.INSTANCE.getFileDialogs();
@@ -126,5 +125,6 @@ public class ProjectOpener
    }
    
    // Injected ----
+   private boolean initialized_;
    private ProjectsServerOperations server_;
 }


### PR DESCRIPTION
This should hopefully resolve build errors on RStudio Pro -- the issue, if I understand correctly, is that `ProjectOpener` is rebound to a separate class `ProjectOpenerPro` and so the typical injection fails there.