### PR TITLE
don't display welcome message in new terminal

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -509,8 +509,6 @@ public class TerminalSession extends XTermWidget
    {
       if (newTerminal_)
       {
-         writeln("Welcome to " + AnsiCode.ForeColor.LIGHTBLUE + "RStudio" +
-                 AnsiCode.DEFAULTCOLORS + " terminal.");
          setNewTerminal(false);
       }
       else


### PR DESCRIPTION
Injecting this message into xterm.js gets it out of sync with winpty's buffer.