### PR TITLE
Use matching I/O pattern for reads/writes of the winpty pipes

### DIFF
--- a/src/cpp/core/system/Win32Pty.hpp
+++ b/src/cpp/core/system/Win32Pty.hpp
@@ -65,6 +65,9 @@ public:
    // Send interrupt (Ctrl+C)
    Error interrupt();
 
+   static Error writeToPty(HANDLE hPipe, const std::string& input);
+   static Error readFromPty(HANDLE hPipe, std::string* pOutput);
+
 private:
    void stopPty();
 


### PR DESCRIPTION
Moved details of reading/writing to the pty into the wrapper class. Updated unit test.

The named pipes opened by the winpty agent process use FILE_FLAG_OVERLAPPED. Per MSDN, you should match this behavior when attaching to and using the pipes, and pass the OVERLAPPED structure when making read/write calls. Otherwise ReadFile/WriteFile can return inconsistent results.

I had hoped this might help with the intermittent "typing is out of order" glitch I'm seeing. It may have improved it a bit, but definitely didn't eliminate it.