### PR TITLE
refactoring, testing and diagnostics on winpty code

### DIFF
--- a/src/cpp/core/include/core/system/Process.hpp
+++ b/src/cpp/core/include/core/system/Process.hpp
@@ -51,12 +51,14 @@ struct Pseudoterminal
 #ifdef _WIN32
          const FilePath& winptyPath,
          bool plainText,
+         bool conerr,
 #endif
          int cols, int rows)
       :
 #ifdef _WIN32
         winptyPath(winptyPath),
         plainText(plainText),
+        conerr(conerr),
 #endif
         cols(cols), rows(rows)
    {
@@ -64,6 +66,7 @@ struct Pseudoterminal
 #ifdef _WIN32
    FilePath winptyPath;
    bool plainText;
+   bool conerr;
 #endif
    int cols;
    int rows;

--- a/src/cpp/core/include/core/system/System.hpp
+++ b/src/cpp/core/include/core/system/System.hpp
@@ -134,6 +134,7 @@ bool isWin7OrLater();
 Error makeFileHidden(const FilePath& path);
 Error copyMetafileToClipboard(const FilePath& path);
 void ensureLongPath(FilePath* pFilePath);
+Error expandEnvironmentVariables(std::string value, std::string* pResult);
 FilePath expandComSpec();
 
 // close a handle then set it to NULL (so we can call this function

--- a/src/cpp/core/system/RegistryKey.cpp
+++ b/src/cpp/core/system/RegistryKey.cpp
@@ -14,6 +14,7 @@
  */
 #include <core/system/RegistryKey.hpp>
 
+#include <core/system/System.hpp>
 #include <core/Error.hpp>
 #include <core/Log.hpp>
 
@@ -64,35 +65,6 @@ HKEY RegistryKey::handle()
 {
    return hKey_;
 }
-
-namespace {
-Error expandEnvironmentVariables(std::string value, std::string* pResult)
-{
-   if (value.empty())
-   {
-      *pResult = value;
-      return Success();
-   }
-
-   size_t sizeRequired = ::ExpandEnvironmentStrings(value.c_str(), NULL, 0);
-   if (!sizeRequired)
-      return systemError(GetLastError(), ERROR_LOCATION);
-
-   std::vector<char> buffer;
-   buffer.reserve(sizeRequired);
-   int result = ::ExpandEnvironmentStrings(value.c_str(),
-                                           &buffer[0],
-                                           buffer.capacity());
-
-   if (!result)
-      return systemError(GetLastError(), ERROR_LOCATION);
-   else if (result > buffer.capacity())
-      return systemError(ERROR_MORE_DATA, ERROR_LOCATION); // not expected
-
-   *pResult = std::string(&buffer[0]);
-   return Success();
-}
-} // anonymous namespace
 
 std::string RegistryKey::getStringValue(std::string name,
                                         std::string defaultValue)

--- a/src/cpp/core/system/Win32Pty.hpp
+++ b/src/cpp/core/system/Win32Pty.hpp
@@ -42,22 +42,19 @@ public:
 
    virtual ~WinPty();
 
-   void init(const std::string& exe,
-             const std::vector<std::string> args,
-             const ProcessOptions& options);
+   // Start the process specified by exe; it will do I/O via the returned
+   // handles. On success, caller is responsible for closing
+   // returned handles. On failure, handles will contain NULL.
+   Error start(const std::string& exe,
+               const std::vector<std::string> args,
+               const ProcessOptions& options,
+               HANDLE* pStdInWrite,
+               HANDLE* pStdOutRead,
+               HANDLE* pStdErrRead,
+               HANDLE* pProcess);
 
-   // Start the pty and return HANDLEs. On success, caller is responsible for
-   // closing returned HANDLEs; on failure, all returned HANDLEs will
-   // contain NULL.
-   Error startPty(HANDLE* pStdInWrite,
-                  HANDLE* pStdOutRead,
-                  HANDLE* pStdErrRead = NULL /*OPTIONAL*/);
+
    bool ptyRunning() const;
-
-   // Start the process specified by init(); it will do I/O via the handles
-   // returned by startPty. On success, caller is responsible for closing
-   // returned HANDLE. On failure, pProcess will contain NULL.
-   Error runProcess(HANDLE* pProcess = NULL /*OPTIONAL*/);
 
    // Change the size of the pseudoterminal
    Error setSize(int cols, int rows);
@@ -69,6 +66,8 @@ public:
    static Error readFromPty(HANDLE hPipe, std::string* pOutput);
 
 private:
+   Error startPty(HANDLE* pStdInWrite, HANDLE* pStdOutRead, HANDLE* pStdErrRead);
+   Error runProcess(HANDLE* pProcess);
    void stopPty();
 
 private:

--- a/src/cpp/core/system/Win32PtyTests.cpp
+++ b/src/cpp/core/system/Win32PtyTests.cpp
@@ -84,27 +84,15 @@ TEST_CASE("Win32PtyTests")
    options.pseudoterminal = core::system::Pseudoterminal(
             getWinPtyPath(),
             false /*plainText*/,
+            false /*connerr*/,
             options.cols,
             options.rows);
 
-   ProcessOptions plainOptions;
-   plainOptions.cols = kCols;
-   plainOptions.rows = kRows;
-   plainOptions.pseudoterminal = core::system::Pseudoterminal(
-            getWinPtyPath(),
-            true /*plainText*/,
-            plainOptions.cols,
-            plainOptions.rows);
+   FilePath cmd = expandComSpec();
+   std::string cmdExe = cmd.absolutePathNative();
 
    SECTION("Agent not running")
    {
-      CHECK_FALSE(pty.ptyRunning());
-   }
-
-   SECTION("Initialize")
-   {
-      CHECK_FALSE(pty.ptyRunning());
-      pty.init("cmd.exe", emptyArgs, options);
       CHECK_FALSE(pty.ptyRunning());
    }
 
@@ -113,42 +101,19 @@ TEST_CASE("Win32PtyTests")
       CHECK(getWinPtyPath().exists());
    }
 
-   SECTION("Start pty and get handles")
-   {
-      HANDLE hInWrite;
-      HANDLE hOutRead;
-      HANDLE hErrRead;
-
-      pty.init("cmd.exe", emptyArgs, options);
-      Error err = pty.startPty(&hInWrite, &hOutRead, &hErrRead);
-      CHECK(!err);
-      CHECK(hInWrite);
-      CHECK(hOutRead);
-      CHECK_FALSE(hErrRead);
-      CHECK(::CloseHandle(hInWrite));
-      CHECK(::CloseHandle(hOutRead));
-   }
-
    SECTION("Start pty and a process")
    {
       HANDLE hInWrite;
       HANDLE hOutRead;
       HANDLE hErrRead;
+      HANDLE hProcess;
 
-      FilePath cmd = expandComSpec();
-      CHECK(cmd.exists());
-      std::string exe = cmd.absolutePathNative();
-
-      pty.init(exe, emptyArgs, options);
-      Error err = pty.startPty(&hInWrite, &hOutRead, &hErrRead);
+      Error err = pty.start(cmdExe, emptyArgs, options,
+                            &hInWrite, &hOutRead, &hErrRead, &hProcess);
       CHECK(!err);
       CHECK(hInWrite);
       CHECK(hOutRead);
       CHECK_FALSE(hErrRead);
-
-      HANDLE hProcess;
-      err = pty.runProcess(&hProcess);
-      CHECK(!err);
       CHECK(hProcess);
 
       CHECK(::CloseHandle(hProcess));
@@ -156,52 +121,62 @@ TEST_CASE("Win32PtyTests")
       CHECK(::CloseHandle(hOutRead));
    }
 
-   SECTION("Start pty but fail to start process")
+   SECTION("Start pty and a process with conerr")
    {
       HANDLE hInWrite;
       HANDLE hOutRead;
       HANDLE hErrRead;
+      HANDLE hProcess;
 
-      pty.init("C:\\NoWindows\\system08\\huhcmd.exe", emptyArgs, options);
-      Error err = pty.startPty(&hInWrite, &hOutRead, &hErrRead);
+      ProcessOptions conerrOptions = options;
+      conerrOptions.pseudoterminal.get().conerr = true;
+      Error err = pty.start(cmdExe, emptyArgs, conerrOptions,
+                            &hInWrite, &hOutRead, &hErrRead, &hProcess);
       CHECK(!err);
       CHECK(hInWrite);
       CHECK(hOutRead);
-      CHECK_FALSE(hErrRead);
+      CHECK(hErrRead);
+      CHECK(hProcess);
 
-      HANDLE hProcess;
-      err = pty.runProcess(&hProcess);
-      CHECK(err);
-      CHECK_FALSE(hProcess);
+      CHECK(::CloseHandle(hProcess));
       CHECK(::CloseHandle(hInWrite));
+      CHECK(::CloseHandle(hErrRead));
       CHECK(::CloseHandle(hOutRead));
+   }
+
+   SECTION("Start pty but fail to start process")
+   {
+      HANDLE hInWrite;
+      HANDLE hOutRead;
+      HANDLE hProcess;
+
+      Error err = pty.start(
+               "C:\\NoWindows\\system08\\huhcmd.exe", emptyArgs, options,
+               &hInWrite, &hOutRead, NULL /*conerr*/, &hProcess);
+      CHECK(err);
+      CHECK_FALSE(hInWrite);
+      CHECK_FALSE(hOutRead);
+      CHECK_FALSE(hProcess);
    }
 
    SECTION("Capture output of a process")
    {
       HANDLE hInWrite;
       HANDLE hOutRead;
-      HANDLE hErrRead;
+      HANDLE hProcess;
       std::vector<std::string> args;
-
-      FilePath cmd = expandComSpec();
-      CHECK(cmd.exists());
-      std::string exe = cmd.absolutePathNative();
 
       args.push_back("/S");
       args.push_back("/C");
       args.push_back("\"echo Hello!\"");
 
-      pty.init(exe, args, plainOptions);
-      Error err = pty.startPty(&hInWrite, &hOutRead, &hErrRead);
+      ProcessOptions plainOptions = options;
+      plainOptions.pseudoterminal.get().plainText = true;
+      Error err = pty.start(cmdExe, args, plainOptions,
+                            &hInWrite, &hOutRead, NULL /*conerr*/, &hProcess);
       CHECK(!err);
       CHECK(hInWrite);
       CHECK(hOutRead);
-      CHECK_FALSE(hErrRead);
-
-      HANDLE hProcess;
-      err = pty.runProcess(&hProcess);
-      CHECK(!err);
       CHECK(hProcess);
 
       // Obnoxious, but need to give child some time to spin up
@@ -218,6 +193,80 @@ TEST_CASE("Win32PtyTests")
 
       stdOut = string_utils::trimWhitespace(stdOut);
       CHECK_FALSE(stdOut.compare("Hello!"));
+      CHECK(::CloseHandle(hProcess));
+      CHECK(::CloseHandle(hInWrite));
+      CHECK(::CloseHandle(hOutRead));
+   }
+
+   SECTION("Verify character-by-character send/receive")
+   {
+      HANDLE hInWrite;
+      HANDLE hOutRead;
+      HANDLE hProcess;
+
+      ProcessOptions plainOptions = options;
+      plainOptions.pseudoterminal.get().plainText = true;
+      Error err = pty.start(cmdExe, emptyArgs, plainOptions,
+                            &hInWrite, &hOutRead, NULL /*conerr*/, &hProcess);
+      CHECK(!err);
+      CHECK(hInWrite);
+      CHECK(hOutRead);
+      CHECK(hProcess);
+
+      // Obnoxious, but need to give child some time to spin up
+      // and get to prompt.
+      std::string stdOut;
+      int tries = 10;
+      while (tries)
+      {
+         ::Sleep(100);
+         err = WinPty::readFromPty(hOutRead, &stdOut);
+         CHECK(!err);
+         tries--;
+         // assume '>' means we're at a prompt; should really be setting
+         // this in temporary environment before starting pty to be
+         // deterministic
+         if (stdOut.find('>') != std::string::npos)
+            break;
+      }
+
+      stdOut.clear();
+      std::string line1 = "echo This was once a place where words and letters and 32 numbers lived!";
+
+      // console will word-wrap so set the console to twice width of our input string
+      // to account for the prompt as well
+      err = pty.setSize(line1.length() * 2, kRows);
+      CHECK(!err);
+
+      for (int i = 0; i < line1.length(); i++)
+      {
+         std::string typeThis;
+         typeThis.push_back(line1[i]);
+         err = WinPty::writeToPty(hInWrite,typeThis);
+         CHECK(!err);
+         ::Sleep(25);
+         err = WinPty::readFromPty(hOutRead, &stdOut);
+         CHECK(!err);
+      }
+
+      // try get all output
+      tries = 10;
+      while (tries && stdOut.length() < line1.length())
+      {
+         ::Sleep(100);
+         err = WinPty::readFromPty(hOutRead, &stdOut);
+         CHECK(!err);
+         tries--;
+      }
+
+      int result = stdOut.compare(line1);
+      if (result)
+      {
+         std::cout << line1 << std::endl;
+         std::cout << stdOut << std::endl;
+      }
+      CHECK_FALSE(result);
+
       CHECK(::CloseHandle(hProcess));
       CHECK(::CloseHandle(hInWrite));
       CHECK(::CloseHandle(hOutRead));

--- a/src/cpp/core/system/Win32SystemTests.cpp
+++ b/src/cpp/core/system/Win32SystemTests.cpp
@@ -16,6 +16,7 @@
 #ifdef _WIN32
 
 #include <core/system/System.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 
 #define RSTUDIO_NO_TESTTHAT_ALIASES
 #include <tests/TestThat.hpp>
@@ -35,6 +36,36 @@ TEST_CASE("Win32SystemTests")
    SECTION("Test Win7 or Later")
    {
       CHECK(isWin7OrLater());
+   }
+
+   SECTION("Expand Empty Environment Variable")
+   {
+      std::string orig;
+      std::string result;
+      Error err = expandEnvironmentVariables(orig, &result);
+      CHECK(!err);
+      CHECK(result.empty());
+   }
+
+   SECTION("Expand Bogus Env Variable")
+   {
+      std::string orig = "%oncetherewasafakevariable374732%";
+      std::string result;
+      Error err = expandEnvironmentVariables(orig, &result);
+      CHECK(!err);
+      CHECK_FALSE(result.compare(orig));
+   }
+
+   SECTION("Expand Real Environment Variable")
+   {
+      std::string first = "RoadOftenTravelled=";
+      std::string orig = first + "%path%";
+      std::string result;
+      Error err = expandEnvironmentVariables(orig, &result);
+      CHECK(!err);
+      CHECK(boost::algorithm::starts_with(result, first));
+      // assume non-empty path, seems safe
+      CHECK(result.length() > first.length());
    }
 
    SECTION("ComSpec")

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -120,6 +120,7 @@ void ConsoleProcess::commonInit()
          options_.pseudoterminal = core::system::Pseudoterminal(
                   session::options().winptyPath(),
                   false /*plainText*/,
+                  false /*conerr*/,
                   options_.cols,
                   options_.rows);
       }


### PR DESCRIPTION
Simplified the public interface of WinPty class to hide the steps involved in starting a pty (init/run agent/start process), making it a single "start" call. Easier usage, and easier to test.

Added some winpty diagnostic-related environment variables, one allows specifying a custom command to run when starting terminal (e.g. to try out different shell programs, like git-bash). Another turns on the winpty conerr channel, which I've yet to find a use for but was taking a stab in the dark that it might help with some issues I'm seeing, doesn't seem to be the case.

Pulled out some shared code for expanding Windows environment variables and made it a public function, wrote a couple of tests on that.

Wrote a test for WinPty that sends it a character at a time (with small pause between them) and verifies that the same characters get echo'd back, in the same order.