### PR TITLE
Handle out-of-order RPC calls for terminal input messages

### DIFF
--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -42,7 +42,7 @@ void saveConsoleProcesses();
 
 ConsoleProcess::ConsoleProcess(boost::shared_ptr<ConsoleProcessInfo> procInfo)
    : procInfo_(procInfo), interrupt_(false), newCols_(-1), newRows_(-1),
-     childProcsSent_(false), started_(false)
+     childProcsSent_(false), lastInputSequence_(kIgnoreSequence), started_(false)
 {
    regexInit();
 
@@ -56,7 +56,7 @@ ConsoleProcess::ConsoleProcess(const std::string& command,
                                boost::shared_ptr<ConsoleProcessInfo> procInfo)
    : command_(command), options_(options), procInfo_(procInfo),
      interrupt_(false), newCols_(-1), newRows_(-1), childProcsSent_(false),
-     started_(false)
+     lastInputSequence_(kIgnoreSequence), started_(false)
 {
    commonInit();
 }
@@ -67,7 +67,7 @@ ConsoleProcess::ConsoleProcess(const std::string& program,
                                boost::shared_ptr<ConsoleProcessInfo> procInfo)
    : program_(program), args_(args), options_(options), procInfo_(procInfo),
      interrupt_(false), newCols_(-1), newRows_(-1), childProcsSent_(false),
-     started_(false)
+     lastInputSequence_(kIgnoreSequence), started_(false)
 {
    commonInit();
 }
@@ -192,7 +192,83 @@ Error ConsoleProcess::start()
 
 void ConsoleProcess::enqueInput(const Input& input)
 {
-   inputQueue_.push(input);
+   if (input.sequence == kIgnoreSequence)
+   {
+      inputQueue_.push_back(input);
+      return;
+   }
+
+   if (input.sequence == kFlushSequence)
+   {
+      inputQueue_.push_back(input);
+
+      // set everything in queue to "ignore" so it will be pulled from
+      // queue as-is, even with gaps
+      for (std::deque<Input>::iterator it = inputQueue_.begin();
+           it != inputQueue_.end(); it++)
+      {
+         (*it).sequence = kIgnoreSequence;
+      }
+      lastInputSequence_ = kIgnoreSequence;
+      return;
+   }
+
+   // insert in order by sequence
+   for (std::deque<Input>::iterator it = inputQueue_.begin();
+        it != inputQueue_.end(); it++)
+   {
+      if (input.sequence < (*it).sequence)
+      {
+         inputQueue_.insert(it, input);
+         return;
+      }
+   }
+   inputQueue_.push_back(input);
+}
+
+ConsoleProcess::Input ConsoleProcess::dequeInput()
+{
+   // Pull next available Input from queue; return an empty Input
+   // if none available or if an out-of-sequence entry is
+   // reached; assumption is the missing item(s) will eventually
+   // arrive and unblock the backlog.
+   if (inputQueue_.empty())
+      return Input();
+
+   Input input = inputQueue_.front();
+   if (input.sequence == kIgnoreSequence || input.sequence == kFlushSequence)
+   {
+      inputQueue_.pop_front();
+      return input;
+   }
+
+   if (input.sequence == lastInputSequence_ + 1)
+   {
+      lastInputSequence_++;
+      inputQueue_.pop_front();
+      return input;
+   }
+
+   // Getting here means input is out of sequence. We want to prevent
+   // getting permanently stuck if a message gets lost and the
+   // gap(s) never get filled in. So we'll flush it if input piles up.
+   if (inputQueue_.size() >= kAutoFlushLength)
+   {
+      // set everything in queue to "ignore" so it will be pulled from
+      // queue as-is, even with gaps
+      for (std::deque<Input>::iterator it = inputQueue_.begin();
+           it != inputQueue_.end(); it++)
+      {
+         lastInputSequence_ = (*it).sequence;
+         (*it).sequence = kIgnoreSequence;
+      }
+
+      input.sequence = kIgnoreSequence;
+      inputQueue_.pop_front();
+      return input;
+   }
+
+   return Input();
 }
 
 void ConsoleProcess::enqueOutput(const std::string& output,
@@ -234,12 +310,9 @@ bool ConsoleProcess::onContinue(core::system::ProcessOperations& ops)
       return false;
 
    // process input queue
-   while (!inputQueue_.empty())
+   Input input = dequeInput();
+   while (!input.empty())
    {
-      // pop input
-      Input input = inputQueue_.front();
-      inputQueue_.pop();
-
       // pty interrupt
       if (input.interrupt)
       {
@@ -270,6 +343,8 @@ bool ConsoleProcess::onContinue(core::system::ProcessOperations& ops)
                procInfo_->appendToOutputBuffer("\n");
          }
       }
+
+      input = dequeInput();
    }
 
    if (newCols_ != -1 && newRows_ != -1)
@@ -520,6 +595,7 @@ Error procWriteStdin(const json::JsonRpcRequest& request,
 
    ConsoleProcess::Input input;
    error = json::readObjectParam(request.params, 1,
+                                 "sequence", &input.sequence,
                                  "interrupt", &input.interrupt,
                                  "text", &input.text,
                                  "echo_input", &input.echoInput);

--- a/src/cpp/session/SessionConsoleProcessTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessTests.cpp
@@ -1,0 +1,242 @@
+/*
+ * SessionConsoleProcess.cpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <session/SessionConsoleProcess.hpp>
+
+#include <boost/lexical_cast.hpp>
+#include <tests/TestThat.hpp>
+
+namespace rstudio {
+namespace session {
+namespace console_process {
+namespace tests {
+
+using namespace console_process;
+
+context("queue and fetch input")
+{
+   core::system::ProcessOptions procOptions;
+
+   boost::shared_ptr<ConsoleProcessInfo> pCPI =
+         boost::make_shared<ConsoleProcessInfo>(
+            "caption", "title", "" /*handle*/, kNoTerminal,
+            false /*allowRestart*/, InteractionNever);
+
+   boost::shared_ptr<ConsoleProcess> pCP =
+         ConsoleProcess::createTerminalProcess(procOptions, pCPI);
+
+   test_that("empty queue returns nothing")
+   {
+      ConsoleProcess::Input next = pCP->dequeInput();
+      expect_true(next.empty());
+   }
+
+   test_that("can queue and deque an interrupt")
+   {
+      ConsoleProcess::Input interrupt;
+      interrupt.interrupt = true;
+      pCP->enqueInput(interrupt);
+      ConsoleProcess::Input next = pCP->dequeInput();
+      expect_false(next.empty());
+      expect_true(next.interrupt);
+      next = pCP->dequeInput();
+      expect_true(next.empty());
+   }
+
+   test_that("unsequenced input is FIFO")
+   {
+      const std::string orig = "abcdefghijklmnopqrstuvwxyz";
+
+      for (int i = 0; i < orig.length(); i++)
+      {
+         std::string oneChar;
+         oneChar.push_back(orig[i]);
+         pCP->enqueInput(ConsoleProcess::Input(oneChar));
+      }
+
+      std::string result;
+      ConsoleProcess::Input next = pCP->dequeInput();
+      while (!next.empty())
+      {
+         expect_false(next.interrupt);
+         expect_true(next.sequence == kIgnoreSequence);
+         result += next.text;
+         next = pCP->dequeInput();
+      }
+
+      expect_true(!orig.compare(result));
+   }
+
+   test_that("in-order sequenced input is FIFO")
+   {
+      const std::string orig = "abcdefghijklmnopqrstuvwxyz";
+
+      for (int i = 0; i < orig.length(); i++)
+      {
+         std::string oneChar;
+         oneChar.push_back(orig[i]);
+         pCP->enqueInput(ConsoleProcess::Input(i, oneChar));
+      }
+
+      std::string result;
+      ConsoleProcess::Input next = pCP->dequeInput();
+      int seq = 0;
+      while (!next.empty())
+      {
+         expect_false(next.interrupt);
+         expect_true(next.sequence == seq++);
+         result += next.text;
+         next = pCP->dequeInput();
+      }
+
+      expect_true(!orig.compare(result));
+   }
+
+   test_that("mixed-up input is returned in correct order")
+   {
+      const std::string expected = "HELLO WORLD!";
+      std::vector<ConsoleProcess::Input> input;
+      input.push_back(ConsoleProcess::Input(1,  std::string("E")));
+      input.push_back(ConsoleProcess::Input(0,  std::string("H")));
+      input.push_back(ConsoleProcess::Input(2,  std::string("L")));
+      input.push_back(ConsoleProcess::Input(3,  std::string("L")));
+      input.push_back(ConsoleProcess::Input(4,  std::string("O")));
+      input.push_back(ConsoleProcess::Input(5,  std::string(" ")));
+      input.push_back(ConsoleProcess::Input(7,  std::string("O")));
+      input.push_back(ConsoleProcess::Input(6,  std::string("W")));
+      input.push_back(ConsoleProcess::Input(8,  std::string("R")));
+      input.push_back(ConsoleProcess::Input(9,  std::string("L")));
+      input.push_back(ConsoleProcess::Input(10, std::string("D")));
+      input.push_back(ConsoleProcess::Input(11, std::string("!")));
+
+      for (int i = 0; i < input.size(); i++)
+      {
+         pCP->enqueInput(input[i]);
+      }
+
+      std::string result;
+      ConsoleProcess::Input next = pCP->dequeInput();
+      int seq = 0;
+      while (!next.empty())
+      {
+         expect_false(next.interrupt);
+         expect_true(next.sequence == seq++);
+         result += next.text;
+         next = pCP->dequeInput();
+      }
+
+      expect_true(!expected.compare(result));
+   }
+
+   test_that("Autoflush kicks in when too much input with unresolved gap")
+   {
+      std::vector<ConsoleProcess::Input> input;
+      std::string expected;
+
+      // intentionally skipping item "0" to prevent pulling from queueA
+      int lastAdded = kIgnoreSequence;
+      for (int i = 1; i < kAutoFlushLength + 5; i++)
+      {
+         std::string item = boost::lexical_cast<std::string>(i);
+         expected += item;
+         input.push_back(ConsoleProcess::Input(i, item));
+         lastAdded = i;
+      }
+
+      for (int i = 0; i < input.size(); i++)
+      {
+         pCP->enqueInput(input[i]);
+      }
+
+      std::string result;
+      ConsoleProcess::Input next = pCP->dequeInput();
+      expect_false(next.empty());
+      while (!next.empty())
+      {
+         expect_false(next.interrupt);
+         result += next.text;
+         next = pCP->dequeInput();
+      }
+
+      expect_true(!expected.compare(result));
+
+      // make sure we can resume adding and removing
+      pCP->enqueInput(ConsoleProcess::Input(lastAdded + 1, "HELLO"));
+      pCP->enqueInput(ConsoleProcess::Input(lastAdded + 2, " WORLD"));
+
+      result.clear();
+      next = pCP->dequeInput();
+      expect_false(next.empty());
+      while (!next.empty())
+      {
+         result += next.text;
+         next = pCP->dequeInput();
+      }
+
+      expect_true(!result.compare("HELLO WORLD"));
+   }
+
+   test_that("Explicit flush returns input with gaps and resets sequence count")
+   {
+      std::vector<ConsoleProcess::Input> input;
+      std::string expected;
+
+      // intentionally skipping item "3" to prevent pulling from queue
+      for (int i = 1; i < 10; i++)
+      {
+         if (i != 3)
+         {
+            std::string item = boost::lexical_cast<std::string>(i);
+            expected += item;
+            input.push_back(ConsoleProcess::Input(i, item));
+         }
+      }
+      std::string flushText = "FLUSH"; // value not significant
+      input.push_back(ConsoleProcess::Input(kFlushSequence, flushText));
+      expected += flushText;
+      std::string postFlushText = "post-flush"; // value not significant
+      input.push_back(ConsoleProcess::Input(0, postFlushText));
+      expected += postFlushText;
+
+      for (int i = 0; i < input.size(); i++)
+      {
+         pCP->enqueInput(input[i]);
+      }
+
+      std::string result;
+      ConsoleProcess::Input next = pCP->dequeInput();
+      expect_false(next.empty());
+      int itemCount = 1;
+      while (!next.empty())
+      {
+         expect_false(next.interrupt);
+         result += next.text;
+
+         if (!next.text.compare(postFlushText))
+            expect_true(next.sequence == 0);
+         else
+            expect_true(next.sequence == kIgnoreSequence);
+
+         next = pCP->dequeInput();
+      }
+
+      expect_true(!expected.compare(result));
+   }
+}
+
+} // namespace tests
+} // namespace console_process
+} // namespace session
+} // namespace rstudio

--- a/src/cpp/session/SessionConsoleProcessTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessTests.cpp
@@ -1,5 +1,5 @@
 /*
- * SessionConsoleProcess.cpp
+ * SessionConsoleProcessTests.cpp
  *
  * Copyright (C) 2009-17 by RStudio, Inc.
  *

--- a/src/cpp/session/SessionConsoleProcessTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessTests.cpp
@@ -31,7 +31,7 @@ context("queue and fetch input")
 
    boost::shared_ptr<ConsoleProcessInfo> pCPI =
          boost::make_shared<ConsoleProcessInfo>(
-            "caption", "title", "" /*handle*/, kNoTerminal,
+            "test caption", "test title", "fakehandle", 9999 /*terminal*/,
             false /*allowRestart*/, InteractionNever);
 
    boost::shared_ptr<ConsoleProcess> pCP =

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellInput.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellInput.java
@@ -18,20 +18,38 @@ import com.google.gwt.core.client.JavaScriptObject;
 
 public class ShellInput extends JavaScriptObject
 {
+   // This tells server to flush any queued input, ignoring sequence. Used
+   // in the unlikely situation we need to wrap an int.
+   public static final int FLUSH_SEQUENCE = -2;
+   
+   // Tells server to ignore sequences and use the input as it arrives.
+   public static final int IGNORE_SEQUENCE = -1;
+
    protected ShellInput()
    {
    }
    
-   public native static ShellInput create(String text, boolean echoInput) /*-{
+   public native static ShellInput create(int sequence, String text, boolean echoInput) /*-{
       return {
+         sequence: sequence,
          interrupt: false,
          text: text,
          echo_input: echoInput
       };
    }-*/;
-   
+
+   public native static ShellInput create(String text, boolean echoInput) /*-{
+      return {
+         sequence: -1,
+         interrupt: false,
+         text: text,
+         echo_input: echoInput
+      };
+   }-*/;
+    
    public native static ShellInput createInterrupt() /*-{
       return {
+         sequence: -1,
          interrupt: true,
          text: "",
          echo_input: true
@@ -40,6 +58,10 @@ public class ShellInput extends JavaScriptObject
    
    
    
+   public native final boolean getSequence() /*-{
+      return this.sequence;
+   }-*/;
+
    public native final boolean getInterrupt() /*-{
       return this.interrupt;
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -268,7 +268,14 @@ public class TerminalSession extends XTermWidget
       // message so server can put messages back in order
       if (BrowseCap.isWindowsDesktop())
       {
-         if (inputSequence_ == ShellInput.FLUSH_SEQUENCE)
+         if (inputSequence_ == ShellInput.IGNORE_SEQUENCE)
+         {
+            // First message sent for this client-side terminal instance, start
+            // by flushing the server-side queue to reset server's "last-sequence"
+            // back to default.
+            inputSequence_ = ShellInput.FLUSH_SEQUENCE;
+         }
+         else if (inputSequence_ == ShellInput.FLUSH_SEQUENCE)
          {
             // Last message has flushed server, start tracking sequences again.
             inputSequence_ = 0;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client.workbench.views.terminal;
 
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -265,20 +266,23 @@ public class TerminalSession extends XTermWidget
       // On Windows, rapid typing sometimes causes RPC messages for writeStandardInput
       // to arrive out of sequence in the terminal; send a sequence number with each
       // message so server can put messages back in order
-      if (inputSequence_ == ShellInput.FLUSH_SEQUENCE)
+      if (BrowseCap.isWindowsDesktop())
       {
-         // Last message has flushed server, start tracking sequences again.
-         inputSequence_ = 0;
-      }
-      else if (inputSequence_ >= Integer.MAX_VALUE - 100)
-      {
-         // Very diligent typist!  Tell server to flush its input
-         // queue, temporarily ignoring sequences.
-         inputSequence_ = ShellInput.FLUSH_SEQUENCE;
-      }
-      else
-      {
-         inputSequence_++;
+         if (inputSequence_ == ShellInput.FLUSH_SEQUENCE)
+         {
+            // Last message has flushed server, start tracking sequences again.
+            inputSequence_ = 0;
+         }
+         else if (inputSequence_ >= Integer.MAX_VALUE - 100)
+         {
+            // Very diligent typist!  Tell server to flush its input
+            // queue, temporarily ignoring sequences.
+            inputSequence_ = ShellInput.FLUSH_SEQUENCE;
+         }
+         else
+         {
+            inputSequence_++;
+         }
       }
 
       consoleProcess_.writeStandardInput(
@@ -591,7 +595,7 @@ public class TerminalSession extends XTermWidget
    private boolean connecting_;
    private boolean terminating_;
    private StringBuilder inputQueue_ = new StringBuilder();
-   private int inputSequence_ = -1;
+   private int inputSequence_ = ShellInput.IGNORE_SEQUENCE;
    private boolean newTerminal_ = true;
    private int cols_ = ConsoleProcessInfo.DEFAULT_COLS;
    private int rows_ = ConsoleProcessInfo.DEFAULT_ROWS;;


### PR DESCRIPTION
Have only seen this happening on Windows IDE, where it is very easy to repro and user input is often messed up (e.g. echo shows up as ehco).

Each writeStandardInput call from the client now includes a sequence count (per terminal instance) which increments with each call. The server uses this to notice out-of-order messages, and waits until the gaps are filled before it releases the input from its queue.

For other existing use cases, a flag is sent for the sequence which triggers the original behavior with pure FIFO.

Watch for overflow of int on Java side, and send a flag telling server to flush and restart the expected sequence (highly unlikely, requires 2 billion+ keystrokes, but hey, who knows). On server, also prevent locking up the queue if an expected sequence never arrives, and just emit what we have. Unlikely, but not impossible, if a message gets dropped somehow.

Unit tests for the new behavior.