### PR TITLE
shell detection for win32 terminal

### DIFF
--- a/src/cpp/core/include/core/system/System.hpp
+++ b/src/cpp/core/include/core/system/System.hpp
@@ -128,9 +128,16 @@ void safePosixCall(const boost::function<T()>& func,
 #endif
 
 #ifdef _WIN32
+
+// Is 64-bit Windows?
 bool isWin64();
+
+// Is calling process 64-bit?
+bool isCurrentProcessWin64();
+
 bool isVistaOrLater();
 bool isWin7OrLater();
+bool isWin10OrLater();
 Error makeFileHidden(const FilePath& path);
 Error copyMetafileToClipboard(const FilePath& path);
 void ensureLongPath(FilePath* pFilePath);

--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -199,29 +199,7 @@ void ChildProcess::init(const ProcessOptions& options)
 {
    options_ = options;
 
-   // RSTUDIO_PTY_CONERR runtime enabling of CONERR channel with
-   // winpty agent. For testing/debugging.
-   std::string envVar = "%RSTUDIO_PTY_CONERR%";
-   std::string conErr;
-   Error err = expandEnvironmentVariables(envVar, &conErr);
-   if (!err && !conErr.compare("1"))
-      options_.pseudoterminal.get().conerr = true;
-
    // TODO (gary) runtime selection of cmd.exe vs. powershell.exe
-
-   // RSTUDIO_PTY_TERM environment variable for easier testing of
-   // other potential terminal shell programs. The path must be
-   // in the context of a 32-bit application, even if running 64-bit
-   // rsession. So, for example, 64-bit PowerShell would be
-   // %windir%\sysnative\windowspowershell\v1.0\powershell.exe
-   envVar = "%RSTUDIO_PTY_TERM%";
-   std::string rstudioTerm;
-   err = expandEnvironmentVariables(envVar, &rstudioTerm);
-   if (!err && rstudioTerm.compare(envVar))
-   {
-      exe_ = rstudioTerm;
-      return;
-   }
 
    FilePath cmd = expandComSpec();
    if (!cmd.exists())

--- a/src/cpp/core/system/Win32System.cpp
+++ b/src/cpp/core/system/Win32System.cpp
@@ -222,7 +222,12 @@ void log(LogLevel logLevel, const std::string& message)
 bool isWin64()
 {
    return !getenv("PROCESSOR_ARCHITEW6432").empty()
-         || getenv("PROCESSOR_ARCHITECTURE") == "AMD64";
+      || getenv("PROCESSOR_ARCHITECTURE") == "AMD64";
+}
+
+bool isCurrentProcessWin64()
+{
+   return getenv("PROCESSOR_ARCHITECTURE") == "AMD64";
 }
 
 bool isVistaOrLater()
@@ -253,6 +258,23 @@ bool isWin7OrLater()
       // 6.0 Vista, 6.1 Win7, 6.2 Win8, 6.3 Win8.1, >6 is Win10+
       return osVersion.dwMajorVersion > 6 ||
              osVersion.dwMajorVersion == 6 && osVersion.dwMinorVersion > 0;
+   }
+   else
+   {
+      LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+      return false;
+   }
+}
+
+bool isWin10OrLater()
+{
+   OSVERSIONINFOA osVersion;
+   ZeroMemory(&osVersion, sizeof(OSVERSIONINFOA));
+   osVersion.dwOSVersionInfoSize = sizeof(OSVERSIONINFOA);
+
+   if (::GetVersionExA(&osVersion))
+   {
+      return osVersion.dwMajorVersion > 6;
    }
    else
    {

--- a/src/cpp/core/system/Win32SystemTests.cpp
+++ b/src/cpp/core/system/Win32SystemTests.cpp
@@ -16,6 +16,7 @@
 #ifdef _WIN32
 
 #include <core/system/System.hpp>
+#include <core/FilePath.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
 #define RSTUDIO_NO_TESTTHAT_ALIASES
@@ -35,7 +36,19 @@ TEST_CASE("Win32SystemTests")
 
    SECTION("Test Win7 or Later")
    {
-      CHECK(isWin7OrLater());
+      if (isWin7OrLater())
+      {
+         CHECK(isVistaOrLater());
+      }
+   }
+
+   SECTION("Test Win10 or Later")
+   {
+      if (isWin10OrLater())
+      {
+         CHECK(isWin7OrLater());
+         CHECK(isVistaOrLater());
+      }
    }
 
    SECTION("Expand Empty Environment Variable")
@@ -73,6 +86,38 @@ TEST_CASE("Win32SystemTests")
       FilePath command = expandComSpec();
       CHECK_FALSE(command.empty());
       CHECK(command.exists());
+   }
+
+   SECTION("Windows architecture bitness assumptions")
+   {
+      std::string windir;
+      Error err = expandEnvironmentVariables("%windir%", &windir);
+      FilePath windirPath(windir);
+      CHECK(windirPath.exists());
+
+      core::FilePath sysWowPath(windir + "\\" + "syswow64");
+      core::FilePath sysNativePath(windir + "\\" + "sysnative");
+      core::FilePath sys32Path(windir + "\\" + "system32");
+
+      CHECK(sys32Path.exists());
+
+      if (!isWin64())
+      {
+         CHECK_FALSE(isCurrentProcessWin64());
+         CHECK_FALSE(sysWowPath.exists());
+         CHECK_FALSE(sysNativePath.exists());
+      }
+      else
+      {
+         if (isCurrentProcessWin64())
+         {
+            CHECK(sysWowPath.exists());
+         }
+         else
+         {
+            CHECK(sysNativePath.exists());
+         }
+      }
    }
 }
 

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -134,6 +134,7 @@ set (SESSION_SOURCE_FILES
    modules/SessionSnippets.cpp
    modules/SessionSource.cpp
    modules/SessionSpelling.cpp
+   modules/SessionTerminalShell.cpp
    modules/SessionSVN.cpp
    modules/SessionUpdates.cpp
    modules/SessionVCS.cpp

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -329,7 +329,10 @@ bool ConsoleProcess::onContinue(core::system::ProcessOperations& ops)
       {
          std::string inputText = input.text;
 #ifdef _WIN32
-         string_utils::convertLineEndings(&inputText, string_utils::LineEndingWindows);
+         if (!options_.smartTerminal)
+         {
+            string_utils::convertLineEndings(&inputText, string_utils::LineEndingWindows);
+         }
 #endif
          Error error = ops.writeToStdin(inputText, false);
          if (error)

--- a/src/cpp/session/modules/SessionTerminalShell.cpp
+++ b/src/cpp/session/modules/SessionTerminalShell.cpp
@@ -1,0 +1,77 @@
+/*
+ * SessionTerminalShell.cpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "SessionTerminalShell.hpp"
+
+#include <boost/foreach.hpp>
+
+namespace rstudio {
+namespace session {
+namespace modules { 
+namespace workbench {
+
+namespace {
+
+void scanAvailableShells(std::vector<TerminalShell>* pShells)
+{
+   pShells->push_back(TerminalShell());
+
+#ifdef _WIN32
+   // TODO (gary)
+#endif
+}
+
+} // anonymous namespace
+
+core::json::Object TerminalShell::toJson() const
+{
+   core::json::Object resultJson;
+   resultJson["type"] = type;
+   resultJson["name"] = name;
+   return resultJson;
+}
+
+AvailableTerminalShells::AvailableTerminalShells()
+{
+   scanAvailableShells(&shells_);
+}
+
+void AvailableTerminalShells::toJson(core::json::Array* pArray) const
+{
+   BOOST_FOREACH(const TerminalShell& shell, shells_)
+   {
+      pArray->push_back(shell.toJson());
+   }
+}
+
+bool AvailableTerminalShells::getInfo(TerminalShell::TerminalShellType type,
+                                      TerminalShell* pShellInfo) const
+{
+   BOOST_FOREACH(const TerminalShell& shell, shells_)
+   {
+      if (shell.type == type)
+      {
+         *pShellInfo = shell;
+         return true;
+      }
+   }
+   return false;
+}
+
+} // namespace workbench
+} // namespace modules
+} // namesapce session
+} // namespace rstudio
+

--- a/src/cpp/session/modules/SessionTerminalShell.hpp
+++ b/src/cpp/session/modules/SessionTerminalShell.hpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include <core/json/JsonRpc.hpp>
+#include <core/FilePath.hpp>
 
 namespace rstudio {
 namespace session {
@@ -50,9 +51,19 @@ struct TerminalShell
         type(DefaultShell)
    {}
 
+   TerminalShell(
+         TerminalShellType type,
+         std::string name,
+         core::FilePath path)
+      :
+        type(type),
+        name(name),
+        path(path)
+   {}
+
    TerminalShellType type;
    std::string name;
-   std::string path;
+   core::FilePath path;
    std::vector<std::string> args;
 
    core::json::Object toJson() const;
@@ -69,9 +80,15 @@ public:
    // Get details on one type; returns false if type not available
    bool getInfo(TerminalShell::TerminalShellType type, TerminalShell* pShellInfo) const;
 
+   // Number of available shells (including pseudo-shell "default")
+   inline int count() const { return shells_.size(); }
+
 private:
    std::vector<TerminalShell> shells_;
 };
+
+// If we are using git bash then return its path
+core::FilePath getGitBashShell();
 
 } // namespace workbench
 } // namespace handlers

--- a/src/cpp/session/modules/SessionTerminalShell.hpp
+++ b/src/cpp/session/modules/SessionTerminalShell.hpp
@@ -1,0 +1,81 @@
+/*
+ * SessionTerminalShell.hpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef SESSION_MODULES_TERMINAL_SHELL_HPP
+#define SESSION_MODULES_TERMINAL_SHELL_HPP
+
+#include <vector>
+
+#include <core/json/JsonRpc.hpp>
+
+namespace rstudio {
+namespace session {
+namespace modules {      
+namespace workbench {
+
+// Information describing one shell type for embedded interactive terminal
+struct TerminalShell
+{
+   // Identifiers for discovered shell options; for Windows there are several
+   // possibilities, depending on what's installed, and the bit-ness of the
+   // OS. For all others, only bash is supported.
+   enum TerminalShellType
+   {
+      DefaultShell = 0, // Bash (Mac/Linux), %comspec% on Windows
+
+#if defined(_WIN32)
+      GitBash      = 1, // Bash from Windows Git
+      WSLBash      = 2, // Windows Services for Linux (64-bit Windows-10 only)
+      Cmd32        = 3, // Windows command shell (32-bit)
+      Cmd64        = 4, // Windows command shell (64-bit)
+      PS32         = 5, // PowerShell (32-bit)
+      PS64         = 6  // PowerShell (64-bit)
+#endif
+   };
+
+   TerminalShell()
+      :
+        type(DefaultShell)
+   {}
+
+   TerminalShellType type;
+   std::string name;
+   std::string path;
+   std::vector<std::string> args;
+
+   core::json::Object toJson() const;
+};
+
+class AvailableTerminalShells
+{
+public:
+   AvailableTerminalShells();
+
+   // JSON encode list of available types
+   void toJson(core::json::Array* pArray) const;
+
+   // Get details on one type; returns false if type not available
+   bool getInfo(TerminalShell::TerminalShellType type, TerminalShell* pShellInfo) const;
+
+private:
+   std::vector<TerminalShell> shells_;
+};
+
+} // namespace workbench
+} // namespace handlers
+} // namespace session
+} // namespace rstudio
+
+#endif // SESSION_MODULES_TERMINAL_SHELL_HPP

--- a/src/cpp/session/modules/SessionTerminalShellTests.cpp
+++ b/src/cpp/session/modules/SessionTerminalShellTests.cpp
@@ -15,6 +15,8 @@
 
 #include "SessionTerminalShell.hpp"
 
+#include <core/system/System.hpp>
+
 #include <tests/TestThat.hpp>
 
 namespace rstudio {
@@ -30,11 +32,96 @@ context("session terminal shell tests")
    test_that("have default shell")
    {
       AvailableTerminalShells shells;
+      expect_true(shells.count() > 0);
       TerminalShell shell;
       expect_true(shells.getInfo(TerminalShell::DefaultShell, &shell));
       expect_true(shell.type == TerminalShell::DefaultShell);
    }
 
+   test_that("Can generate json array of shells")
+   {
+      AvailableTerminalShells shells;
+      int origCount = shells.count();
+      expect_true(origCount > 0);
+      core::json::Array arr;
+      shells.toJson(&arr);
+      expect_true(origCount == arr.size());
+   }
+
+#ifdef _WIN32
+   test_that("Windows has 32-bit command prompt")
+   {
+      AvailableTerminalShells shells;
+      expect_true(shells.count() > 1);
+      TerminalShell shell;
+      expect_true(shells.getInfo(TerminalShell::Cmd32, &shell));
+      expect_true(shell.type == TerminalShell::Cmd32);
+      expect_true(shell.path.exists());
+   }
+
+   test_that("Windows has 32-bit powershell")
+   {
+      AvailableTerminalShells shells;
+      expect_true(shells.count() > 1);
+      TerminalShell shell;
+      expect_true(shells.getInfo(TerminalShell::PS32, &shell));
+      expect_true(shell.type == TerminalShell::PS32);
+      expect_true(shell.path.exists());
+   }
+
+   test_that("64-bit Windows has 64-bit command prompt")
+   {
+      if (core::system::isWin64())
+      {
+         AvailableTerminalShells shells;
+         expect_true(shells.count() > 1);
+         TerminalShell shell;
+         expect_true(shells.getInfo(TerminalShell::Cmd64, &shell));
+         expect_true(shell.type == TerminalShell::Cmd64);
+         expect_true(shell.path.exists());
+      }
+   }
+
+   test_that("64-bit Windows has 64-bit powershell")
+   {
+      if (core::system::isWin64())
+      {
+         AvailableTerminalShells shells;
+         expect_true(shells.count() > 1);
+         TerminalShell shell;
+         expect_true(shells.getInfo(TerminalShell::PS64, &shell));
+         expect_true(shell.type == TerminalShell::PS64);
+         expect_true(shell.path.exists());
+      }
+   }
+
+   test_that("WSL Bash on 64-bit Windows-10 is detected if installed")
+   {
+      if (core::system::isWin64() && core::system::isWin10OrLater())
+      {
+         AvailableTerminalShells shells;
+         expect_true(shells.count() > 1);
+         TerminalShell shell;
+         if (shells.getInfo(TerminalShell::WSLBash, &shell))
+         {
+            expect_true(shell.type == TerminalShell::WSLBash);
+            expect_true(shell.path.exists());
+         }
+      }
+   }
+
+   test_that("Git Bash is detected if installed")
+   {
+      AvailableTerminalShells shells;
+      TerminalShell shell;
+      if (shells.getInfo(TerminalShell::GitBash, &shell))
+      {
+         expect_true(shell.type == TerminalShell::GitBash);
+         expect_true(shell.path.exists());
+      }
+   }
+
+#endif
 }
 
 } // namespace tests

--- a/src/cpp/session/modules/SessionTerminalShellTests.cpp
+++ b/src/cpp/session/modules/SessionTerminalShellTests.cpp
@@ -1,0 +1,44 @@
+/*
+ * SessionTerminalShellTests.cpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "SessionTerminalShell.hpp"
+
+#include <tests/TestThat.hpp>
+
+namespace rstudio {
+namespace session {
+namespace modules { 
+namespace workbench {
+namespace tests {
+
+using namespace workbench;
+
+context("session terminal shell tests")
+{
+   test_that("have default shell")
+   {
+      AvailableTerminalShells shells;
+      TerminalShell shell;
+      expect_true(shells.getInfo(TerminalShell::DefaultShell, &shell));
+      expect_true(shell.type == TerminalShell::DefaultShell);
+   }
+
+}
+
+} // namespace tests
+} // namespace workbench
+} // namespace modules
+} // namespace session
+} // namespace rstudio

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -51,6 +51,7 @@
 #include "SessionVCS.hpp"
 #include "SessionGit.hpp"
 #include "SessionSVN.hpp"
+#include "SessionTerminalShell.hpp"
 
 #include "SessionSpelling.hpp"
 
@@ -633,9 +634,7 @@ Error getTerminalOptions(const json::JsonRpcRequest& request,
    // if we are using git bash then return its path
    if (git::isGitEnabled() && userSettings().vcsUseGitBash())
    {
-      FilePath gitExePath = git::detectedGitExePath();
-      if (!gitExePath.empty())
-         terminalPath = gitExePath.parent().childPath("sh.exe");
+      terminalPath = getGitBashShell();
    }
 
 #elif defined(__APPLE__)
@@ -660,6 +659,20 @@ Error getTerminalOptions(const json::JsonRpcRequest& request,
                   module_context::shellWorkingDirectory().absolutePath();
    optionsJson["extra_path_entries"] = extraPathEntries;
    pResponse->setResult(optionsJson);
+
+   return Success();
+}
+
+Error getTerminalShells(const json::JsonRpcRequest& request,
+                        json::JsonRpcResponse* pResponse)
+{
+   AvailableTerminalShells availableShells;
+   json::Array shells;
+   availableShells.toJson(&shells);
+
+   json::Object results;
+   results["shells"] = shells;
+   pResponse->setResult(results);
 
    return Success();
 }
@@ -1091,6 +1104,7 @@ Error initialize()
       (bind(registerRpcMethod, "get_r_prefs", getRPrefs))
       (bind(registerRpcMethod, "set_cran_mirror", setCRANMirror))
       (bind(registerRpcMethod, "get_terminal_options", getTerminalOptions))
+      (bind(registerRpcMethod, "get_terminal_shells", getTerminalShells))
       (bind(registerRpcMethod, "create_ssh_key", createSshKey))
       (bind(registerRpcMethod, "start_shell_dialog", startShellDialog))
       (bind(registerRpcMethod, "execute_code", executeCode));


### PR DESCRIPTION
New rpc, get_terminal_shells, returns list of detected shells on Windows; not being used yet; client will invoke to populate list of available shells in preferences, menus, etc.