### PR TITLE
Fix compiler warnings on non-Windows build

### DIFF
--- a/src/cpp/session/SessionConsoleProcessTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessTests.cpp
@@ -59,7 +59,7 @@ context("queue and fetch input")
    {
       const std::string orig = "abcdefghijklmnopqrstuvwxyz";
 
-      for (int i = 0; i < orig.length(); i++)
+      for (size_t i = 0; i < orig.length(); i++)
       {
          std::string oneChar;
          oneChar.push_back(orig[i]);
@@ -83,7 +83,7 @@ context("queue and fetch input")
    {
       const std::string orig = "abcdefghijklmnopqrstuvwxyz";
 
-      for (int i = 0; i < orig.length(); i++)
+      for (size_t i = 0; i < orig.length(); i++)
       {
          std::string oneChar;
          oneChar.push_back(orig[i]);
@@ -121,7 +121,7 @@ context("queue and fetch input")
       input.push_back(ConsoleProcess::Input(10, std::string("D")));
       input.push_back(ConsoleProcess::Input(11, std::string("!")));
 
-      for (int i = 0; i < input.size(); i++)
+      for (size_t i = 0; i < input.size(); i++)
       {
          pCP->enqueInput(input[i]);
       }
@@ -155,7 +155,7 @@ context("queue and fetch input")
          lastAdded = i;
       }
 
-      for (int i = 0; i < input.size(); i++)
+      for (size_t i = 0; i < input.size(); i++)
       {
          pCP->enqueInput(input[i]);
       }
@@ -210,7 +210,7 @@ context("queue and fetch input")
       input.push_back(ConsoleProcess::Input(0, postFlushText));
       expected += postFlushText;
 
-      for (int i = 0; i < input.size(); i++)
+      for (size_t i = 0; i < input.size(); i++)
       {
          pCP->enqueInput(input[i]);
       }

--- a/src/cpp/session/modules/SessionTerminalShell.cpp
+++ b/src/cpp/session/modules/SessionTerminalShell.cpp
@@ -31,6 +31,7 @@ namespace workbench {
 
 namespace {
 
+#ifdef _WIN32
 void addShell(const core::FilePath& expectedPath,
               TerminalShell::TerminalShellType type,
               const std::string& title,
@@ -47,6 +48,7 @@ void addShell(const std::string& expectedPath,
 {
    addShell(core::FilePath(expectedPath), type, title, pShells);
 }
+#endif
 
 void scanAvailableShells(std::vector<TerminalShell>* pShells)
 {
@@ -191,6 +193,8 @@ core::FilePath getGitBashShell()
    core::FilePath gitExePath = git::detectedGitExePath();
    if (!gitExePath.empty())
       return gitExePath.parent().childPath("sh.exe");
+   else
+       return core::FilePath();
 }
 
 } // namespace workbench

--- a/src/cpp/session/modules/SessionTerminalShell.hpp
+++ b/src/cpp/session/modules/SessionTerminalShell.hpp
@@ -81,7 +81,7 @@ public:
    bool getInfo(TerminalShell::TerminalShellType type, TerminalShell* pShellInfo) const;
 
    // Number of available shells (including pseudo-shell "default")
-   inline int count() const { return shells_.size(); }
+   inline size_t count() const { return shells_.size(); }
 
 private:
    std::vector<TerminalShell> shells_;

--- a/src/cpp/session/modules/SessionTerminalShellTests.cpp
+++ b/src/cpp/session/modules/SessionTerminalShellTests.cpp
@@ -41,7 +41,7 @@ context("session terminal shell tests")
    test_that("Can generate json array of shells")
    {
       AvailableTerminalShells shells;
-      int origCount = shells.count();
+      size_t origCount = shells.count();
       expect_true(origCount > 0);
       core::json::Array arr;
       shells.toJson(&arr);


### PR DESCRIPTION
Mostly several signed/unsigned issues, an unused-code warning, and an actual bug with no return from getGitBashShell( ) when git not found.