### PR TITLE
allow both 'template.yml', 'template.yaml' for R Markdown templates

### DIFF
--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -134,8 +134,12 @@
    # check for required files
    templateYaml <- file.path(path, "template.yaml")
    skeletonPath <- file.path(path, "skeleton")
-   if (!file.exists(templateYaml))
-      return(NULL)
+   if (!file.exists(templateYaml)) {
+      templateYaml <- file.path(path, "template.yml")
+      if (!file.exists(templateYaml))
+         return(NULL)
+   }
+
    if (!file.exists(file.path(skeletonPath, "skeleton.Rmd")))
       return(NULL)
 


### PR DESCRIPTION
Currently, R Markdown templates look for a template YAML file called `template.yaml`. This PR allows users to define either `template.yml` or `template.yaml` for R Markdown templates.

The main motivation for this:

1. We've mainly standardized on using `.yml` as the extension for YAML files (e.g. `config.yml`, `_site.yml`)

2. The default extension used by RStudio for YAML files is `.yml`, making it somewhat easier to create a skeleton YAML file with the wrong extension.

