### PR TITLE
Fix regression with terminal buffer trimming

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@
 * New Terminal tab for fluid shell interaction within the IDE
 * Support for xterm emulation including color output and full-screen console apps
 * Support for multiple terminals, each with persistent scrollback buffer
+* Web links in terminal can be clicked and opened in default browser (new tab for server)
 * Windows terminal supports multiple terminal shell types
   * Git Bash, if installed
   * Command Prompt (cmd.exe), 32-bit and 64-bit depending on OS support

--- a/src/cpp/session/SessionConsoleProcessInfo.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfo.cpp
@@ -105,7 +105,7 @@ std::string ConsoleProcessInfo::getSavedBufferChunk(
    // Read buffer (trims to maxOutputLines_ when chunk zero is requested)
    std::string buffer = console_persist::getSavedBuffer(
             handle_,
-            requestedChunk == 0 ? 0 : maxOutputLines_);
+            requestedChunk == 0 ? maxOutputLines_ : 0);
 
    *pMoreAvailable = false;
 

--- a/src/cpp/session/SessionConsoleProcessInfoTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfoTests.cpp
@@ -361,7 +361,7 @@ TEST_CASE("ConsoleProcessInfo")
    {
       const int smallMaxLines = 5;
       ConsoleProcessInfo cpi(caption, title, handle1, sequence,
-                             allowRestart, mode, smallMaxLines);
+                             allowRestart, mode, shellType, smallMaxLines);
 
       // blow away anything that might have been left over from a previous
       // failed run


### PR DESCRIPTION
When returning terminal buffer, it is supposed to be trimming down to the max lines supported by the terminal (currently 1000 lines). I introduced a (silly) regression with  https://github.com/rstudio/rstudio/pull/1023 in which the trimming didn't happen properly. 

Easy fix, and added a unit test that would have caught this.