### PR TITLE
Adjust 3px menu icon vertical space

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
@@ -519,7 +519,7 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
                                          String rightImageDesc)
    {
       StringBuilder text = new StringBuilder();
-      int topOffset = -10;
+      int topOffset = -7;
       if (iconOffsetY != null)
          topOffset += iconOffsetY;
       text.append("<table border=0 cellpadding=0 cellspacing=0 width='100%'><tr>");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -560,7 +560,7 @@ public class EnvironmentPane extends WorkbenchPane
                {
                   setObjectDisplayType(type);
                }
-            }, 2);
+            }, -1);
    }
    
    // An extension of the toolbar popup menu that gets environment names from


### PR DESCRIPTION
@kevinushey thanks for noticing this:

Without PR:

<img width="358" alt="screen shot 2017-03-13 at 11 39 47 am" src="https://cloud.githubusercontent.com/assets/3478847/23869929/08a4f99a-07e2-11e7-9e86-21f8556eb062.png">

With PR:

<img width="207" alt="screen shot 2017-03-13 at 11 39 12 am" src="https://cloud.githubusercontent.com/assets/3478847/23869930/08a80cf2-07e2-11e7-95ae-653f1cb879f4.png">

Tried with 4px adjustment but then some icons feel a bit low, so I rather keep them up. Feedback welcomed.