### PR TITLE
ensure Ace commands work in satellites

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorCommandDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorCommandDispatcher.java
@@ -19,7 +19,9 @@ import com.google.inject.Singleton;
 
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
+import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEditorCommandEvent.CommandType;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEditorCommandEvent.ExecutionPolicy;
@@ -133,7 +135,11 @@ public class AceEditorCommandDispatcher
    
    private void fireEvent(CommandType type, ExecutionPolicy policy)
    {
-      events_.fireEvent(new AceEditorCommandEvent(type, policy));
+      AceEditorCommandEvent event = new AceEditorCommandEvent(type, policy);
+      if (Satellite.isCurrentWindowSatellite())
+         events_.fireEventToSatellite(event, WindowEx.get());
+      else
+         events_.fireEvent(event);
    }
    
    // Private fields ----

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorCommandEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorCommandEvent.java
@@ -14,10 +14,13 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.text.ace;
 
-import com.google.gwt.event.shared.EventHandler;
-import com.google.gwt.event.shared.GwtEvent;
+import org.rstudio.core.client.js.JavaScriptSerializable;
+import org.rstudio.studio.client.application.events.CrossWindowEvent;
 
-public class AceEditorCommandEvent extends GwtEvent<AceEditorCommandEvent.Handler>
+import com.google.gwt.event.shared.EventHandler;
+
+@JavaScriptSerializable
+public class AceEditorCommandEvent extends CrossWindowEvent<AceEditorCommandEvent.Handler>
 {
    public static enum CommandType
    {
@@ -38,6 +41,12 @@ public class AceEditorCommandEvent extends GwtEvent<AceEditorCommandEvent.Handle
    {
       FOCUSED,
       ALWAYS;
+   }
+   
+   // Required for '@JavaScriptSerializable' but is otherwise unused
+   public AceEditorCommandEvent()
+   {
+      this(null, null);
    }
    
    public AceEditorCommandEvent(CommandType command, ExecutionPolicy policy)


### PR DESCRIPTION
This PR fixes an issue where Ace commands (e.g. 'kill line', `Ctrl + K`) don't work in satellite windows.

@jmcphers, can you sanity check?