### PR TITLE
Subprocess detection using procfs

### DIFF
--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -809,21 +809,33 @@ bool hasSubprocesses(PidType pid)
 
       size_t i = contents.find_last_of(')');
       if (i == std::string::npos)
+      {
+         LOG_ERROR_MESSAGE("no closing parenthesis");
          continue;
+      }
 
       i = contents.find_first_of("0123456789", i);
       if (i == std::string::npos)
+      {
+         LOG_ERROR_MESSAGE("no integer after closing parenthesis");
          continue;
+      }
 
       size_t j = contents.find_first_not_of("0123456789", i);
       if (j == std::string::npos)
+      {
+         LOG_ERROR_MESSAGE("no non-int after first int");
          continue;
+      }
 
       // extremely unexpected/unlikely, but make sure we don't have some funky
       // super-large integer here that could cause lexical_cast to throw
       size_t ppidLen = j - i;
       if (ppidLen > 9)
+      {
+         LOG_ERROR_MESSAGE("stat file ppid too large");
          continue;
+      }
       int ppid = boost::lexical_cast<int>(contents.substr(i, ppidLen));
       if (ppid == pid)
          return true;

--- a/src/cpp/core/system/PosixSystemTests.cpp
+++ b/src/cpp/core/system/PosixSystemTests.cpp
@@ -30,8 +30,21 @@ context("PosixSystemTests")
 
    test_that("No subprocess detected correctly")
    {
-      // This assumes this test program has no child processes!
-      expect_false(hasSubprocesses(getpid()));
+      pid_t pid = fork();
+      expect_false(pid == -1);
+
+      if (pid == 0)
+      {
+         execlp("sleep", "sleep", "5", NULL);
+         expect_true(false); // shouldn't get here!
+      }
+      else
+      {
+         // process we started doesn't have a subprocess
+         expect_false(hasSubprocesses(pid));
+
+         kill(pid, SIGKILL);
+      }
    }
 
    test_that("Subprocess detected correctly")


### PR DESCRIPTION
On systems with /proc, use that to detect subprocesses instead of shelling out to pgrep. Improve unit test for "no subprocess" case. Tested on Mac and Linux.