### PR TITLE
'formatR' no longer required by rmarkdown

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -205,7 +205,6 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       ArrayList<Dependency> deps = new ArrayList<Dependency>();
       deps.add(Dependency.cranPackage("evaluate", "0.8"));
       deps.add(Dependency.cranPackage("digest", "0.6"));
-      deps.add(Dependency.cranPackage("formatR", "1.1"));
       deps.add(Dependency.cranPackage("highr", "0.3"));
       deps.add(Dependency.cranPackage("markdown", "0.7"));
       deps.add(Dependency.cranPackage("stringr", "0.6"));


### PR DESCRIPTION
It looks like `formatR` is no longer required by `rmarkdown`; this PR removes it from the dependency list.