### PR TITLE
compiling from source on debian stretch

### DIFF
--- a/dependencies/linux/install-dependencies-debian
+++ b/dependencies/linux/install-dependencies-debian
@@ -69,8 +69,10 @@ if [ "$1" != "--exclude-qt-sdk" ]
 then
    # ubuntu server doesn't include gstreamer by default so ensure that these
    # libs are always available for desktop builds (required by QtWebKit 2.2)
-   sudo apt-get -y install libgstreamer0.10-0
-   sudo apt-get -y install libgstreamer-plugins-base0.10-0
+   #sudo apt-get -y install libgstreamer0.10-0
+   #sudo apt-get -y install libgstreamer-plugins-base0.10-0
+   sudo apt-get -y install libgstreamer1.0-0
+   sudo apt-get -y install libgstreamer-plugins-base1.0-0
 
    # Ubuntu 12.04 doesn't include libjpeg62 (and it's required by Qt 4.8)
    sudo apt-get -y install libjpeg62

--- a/src/cpp/core/http/SocketProxy.cpp
+++ b/src/cpp/core/http/SocketProxy.cpp
@@ -148,8 +148,9 @@ namespace {
 #ifndef _WIN32
 bool isSslShutdownError(const core::Error& error)
 {
-   return error.code().category() == boost::asio::error::get_ssl_category() &&
-          error.code().value() == ERR_PACK(ERR_LIB_SSL, 0, SSL_R_SHORT_READ);
+//   return error.code().category() == boost::asio::error::get_ssl_category() &&
+//          error.code().value() == ERR_PACK(ERR_LIB_SSL, 0, SSL_R_SHORT_READ);
+     return error.code() == boost::asio::ssl::error::stream_truncated;
 }
 #else
 bool isSslShutdownError(const core::Error& error)


### PR DESCRIPTION
Compiling from source on Debian 9.0 (kernel 4.8.0.2-amd64) I had two issues. 

First, the install-dependencies scripts required an old version 0.10 of the libgstreamer, not available in the debian stretch repository. 

Second, SocketProxy.cpp did not compile because it used SSL_R_SHORT_READ, apparently not available in openssl 1.1.0, the standard openssl version for debian stretch. I simply followed the patch to boost::asio ticket #12238: https://github.com/chriskohlhoff/asio/commit/92bfc623e6a71353dd2c783f4c9fef5591ac550d .

Best regards,
Witold