### PR TITLE
clean up left-behind 00LOCK directories

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1112,7 +1112,7 @@ std::vector<FilePath> getLibPaths()
    if (error)
       LOG_ERROR(error);
 
-   std::vector<FilePath> libPaths(libPathsString.size());
+   std::vector<FilePath> libPaths;
    BOOST_FOREACH(const std::string& path, libPathsString)
    {
       libPaths.push_back(module_context::resolveAliasedPath(path));


### PR DESCRIPTION
This PR ensures that stale `00LOCK` directories are cleaned up after an abnormally terminated build (e.g. if a package build is interrupted, it's possible that this `00LOCK` directory will be left behind).

It also fixes a bug whereby the `module_context::getLibPaths()` function would return a number of empty file paths -- whoops!