### PR TITLE
Client-side terminal refactoring prep for websockets

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -134,7 +134,7 @@ public class TerminalSession extends XTermWidget
                disconnect();
                return;
             } 
-            
+
             addHandlerRegistration(consoleProcess_.addConsoleOutputHandler(TerminalSession.this));
             addHandlerRegistration(consoleProcess_.addProcessExitHandler(TerminalSession.this));
             addHandlerRegistration(addResizeTerminalHandler(TerminalSession.this));
@@ -602,7 +602,7 @@ public class TerminalSession extends XTermWidget
    {
       newTerminal_ = isNew;
    }
-   
+
    private HandlerRegistrations registrations_ = new HandlerRegistrations();
    private HandlerRegistration terminalInputHandler_;
    private ConsoleProcess consoleProcess_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -134,6 +134,8 @@ public class TerminalSession extends XTermWidget
                disconnect();
                return;
             } 
+            
+            setUniqueId(consoleProcess_.getProcessInfo().getHandle());
 
             addHandlerRegistration(consoleProcess_.addConsoleOutputHandler(TerminalSession.this));
             addHandlerRegistration(consoleProcess_.addProcessExitHandler(TerminalSession.this));
@@ -209,6 +211,9 @@ public class TerminalSession extends XTermWidget
    @Override
    public void onResizeTerminal(ResizeTerminalEvent event)
    {
+      if (!eventForThisTerminal(event.getUniqueId()))
+         return;
+      
       cols_ = event.getCols();
       rows_ = event.getRows();
       consoleProcess_.resizeTerminal(
@@ -226,6 +231,9 @@ public class TerminalSession extends XTermWidget
    @Override
    public void onTerminalDataInput(TerminalDataInputEvent event)
    {
+      if (!eventForThisTerminal(event.getUniqueId()))
+         return;
+      
       if (event.getData() != null)
       {
          inputQueue_.append(event.getData());
@@ -317,6 +325,9 @@ public class TerminalSession extends XTermWidget
    @Override
    public void onXTermTitle(XTermTitleEvent event)
    {
+      if (!eventForThisTerminal(event.getUniqueId()))
+         return;
+      
       setTitle(event.getTitle());
       eventBus_.fireEvent(new TerminalTitleEvent(this));
    }
@@ -601,6 +612,19 @@ public class TerminalSession extends XTermWidget
    private void setNewTerminal(boolean isNew)
    {
       newTerminal_ = isNew;
+   }
+   
+   /**
+    * Check if an event's uniqueId matches our handle, being careful of nulls.
+    * @param uniqueId a uniqueId from an event fired by XTermWidget.
+    * @return true if an exact match for our handle
+    */
+   private boolean eventForThisTerminal(String uniqueId)
+   {
+      if (StringUtil.isNullOrEmpty(uniqueId) || StringUtil.isNullOrEmpty(getHandle()))
+         return false;
+         
+      return uniqueId.equals(getHandle());
    }
 
    private HandlerRegistrations registrations_ = new HandlerRegistrations();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -135,8 +135,6 @@ public class TerminalSession extends XTermWidget
                return;
             } 
             
-            setUniqueId(consoleProcess_.getProcessInfo().getHandle());
-
             addHandlerRegistration(consoleProcess_.addConsoleOutputHandler(TerminalSession.this));
             addHandlerRegistration(consoleProcess_.addProcessExitHandler(TerminalSession.this));
             addHandlerRegistration(addResizeTerminalHandler(TerminalSession.this));
@@ -211,9 +209,6 @@ public class TerminalSession extends XTermWidget
    @Override
    public void onResizeTerminal(ResizeTerminalEvent event)
    {
-      if (!eventForThisTerminal(event.getUniqueId()))
-         return;
-      
       cols_ = event.getCols();
       rows_ = event.getRows();
       consoleProcess_.resizeTerminal(
@@ -231,9 +226,6 @@ public class TerminalSession extends XTermWidget
    @Override
    public void onTerminalDataInput(TerminalDataInputEvent event)
    {
-      if (!eventForThisTerminal(event.getUniqueId()))
-         return;
-      
       if (event.getData() != null)
       {
          inputQueue_.append(event.getData());
@@ -325,9 +317,6 @@ public class TerminalSession extends XTermWidget
    @Override
    public void onXTermTitle(XTermTitleEvent event)
    {
-      if (!eventForThisTerminal(event.getUniqueId()))
-         return;
-      
       setTitle(event.getTitle());
       eventBus_.fireEvent(new TerminalTitleEvent(this));
    }
@@ -614,19 +603,6 @@ public class TerminalSession extends XTermWidget
       newTerminal_ = isNew;
    }
    
-   /**
-    * Check if an event's uniqueId matches our handle, being careful of nulls.
-    * @param uniqueId a uniqueId from an event fired by XTermWidget.
-    * @return true if an exact match for our handle
-    */
-   private boolean eventForThisTerminal(String uniqueId)
-   {
-      if (StringUtil.isNullOrEmpty(uniqueId) || StringUtil.isNullOrEmpty(getHandle()))
-         return false;
-         
-      return uniqueId.equals(getHandle());
-   }
-
    private HandlerRegistrations registrations_ = new HandlerRegistrations();
    private HandlerRegistration terminalInputHandler_;
    private ConsoleProcess consoleProcess_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
@@ -1,0 +1,154 @@
+/*
+ * TerminalSessionSocket.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.terminal;
+
+import org.rstudio.core.client.HandlerRegistrations;
+import org.rstudio.studio.client.common.console.ConsoleOutputEvent;
+import org.rstudio.studio.client.common.console.ConsoleProcess;
+import org.rstudio.studio.client.common.shell.ShellInput;
+import org.rstudio.studio.client.server.ServerRequestCallback;
+import org.rstudio.studio.client.server.VoidServerRequestCallback;
+import org.rstudio.studio.client.workbench.views.terminal.events.TerminalDataInputEvent;
+import org.rstudio.studio.client.workbench.views.terminal.xterm.XTermWidget;
+
+import com.google.gwt.event.shared.HandlerRegistration;
+
+/**
+ * Manages input and output for the terminal session.
+ * TODO Use a websocket to communicate with the server, falling back to RPC 
+ * if unable to establish a websocket connection.
+ */
+public class TerminalSessionSocket
+   implements ConsoleOutputEvent.Handler, 
+              TerminalDataInputEvent.Handler
+{
+   public interface Session
+   {
+      /**
+       * Called when there is user input to process.
+       * @param input user input
+       */
+      void receivedInput(String input);
+      
+      /**
+       * Called when there is output from the server.
+       * @param output output from server
+       */
+      void receivedOutput(String output);
+   }
+   
+   /**
+    * Constructor
+    * @param session Session to callback with user input and server output.
+    * @param xterm Terminal emulator that provides user input, and displays output.
+    */
+   public TerminalSessionSocket(Session session,
+                                XTermWidget xterm)
+   {
+      session_ = session;
+      xterm_ = xterm;
+   }
+   
+   /**
+    * Connect the input/output channel to the server. This requires that
+    * an rsession has already been started via RPC and the consoleProcess
+    * received.
+    * @param consoleProcess 
+    * @param callback returns true if using websockets, false for RPC
+    */
+   public void connect(ConsoleProcess consoleProcess, 
+                       ServerRequestCallback<Boolean> callback)
+   {
+      consoleProcess_ = consoleProcess;
+      
+      // We keep this handler connected after a disconnect so
+      // user input sent via RPC can wake up a suspended session
+      if (terminalInputHandler_ == null)
+         terminalInputHandler_ = xterm_.addTerminalDataInputHandler(this);
+
+      addHandlerRegistration(consoleProcess_.addConsoleOutputHandler(this));
+      
+      // TODO (gary) attempt websocket connection here
+      boolean haveWebsocket = false;
+      
+      callback.onResponseReceived(haveWebsocket);
+   }
+   
+   /**
+    * Send user input to the server.
+    * @param inputSequence used to fix out-of-order RPC calls
+    * @param input text to send
+    * @param requestCallback callback
+    */
+   public void dispatchInput(int inputSequence,
+                             String input,
+                             VoidServerRequestCallback requestCallback)
+   {
+      // TODO (gary) write to websocket here
+      
+      consoleProcess_.writeStandardInput(
+            ShellInput.create(inputSequence, input,  true /*echo input*/), 
+            requestCallback);
+   }
+   
+   /**
+    * Send output to the terminal emulator.
+    * @param output text to send to the terminal
+    */
+   public void dispatchOutput(String output)
+   {
+      xterm_.write(output);
+   }
+
+   @Override
+   public void onTerminalDataInput(TerminalDataInputEvent event)
+   {
+      session_.receivedInput(event.getData());
+   }
+
+   @Override
+   public void onConsoleOutput(ConsoleOutputEvent event)
+   {
+      session_.receivedOutput(event.getOutput());
+   }
+
+   private void addHandlerRegistration(HandlerRegistration reg)
+   {
+      registrations_.add(reg);
+   }
+
+   public void unregisterHandlers()
+   {
+      registrations_.removeHandler();
+      if (terminalInputHandler_ != null)
+      {
+         terminalInputHandler_.removeHandler();
+         terminalInputHandler_ = null;
+      }
+   }
+
+   public void disconnect()
+   {
+      consoleProcess_ = null;
+      registrations_.removeHandler();
+   }
+ 
+   private HandlerRegistrations registrations_ = new HandlerRegistrations();
+   private final Session session_;
+   private final XTermWidget xterm_;
+   private ConsoleProcess consoleProcess_;
+   private HandlerRegistration terminalInputHandler_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/ResizeTerminalEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/ResizeTerminalEvent.java
@@ -41,7 +41,6 @@ public class ResizeTerminalEvent extends GwtEvent<Handler>
    
    /**
     * Create a new terminal resize event 
-    * @param uniqueId terminal instance identifier
     * @param cols new number of columns
     * @param rows new number of rows
     */
@@ -62,7 +61,8 @@ public class ResizeTerminalEvent extends GwtEvent<Handler>
    {
       handler.onResizeTerminal(this);
    } 
-   
+
+
    /**
     * @return number of rows in resized terminal
     */

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/ResizeTerminalEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/ResizeTerminalEvent.java
@@ -41,11 +41,13 @@ public class ResizeTerminalEvent extends GwtEvent<Handler>
    
    /**
     * Create a new terminal resize event 
+    * @param uniqueId terminal instance identifier
     * @param cols new number of columns
     * @param rows new number of rows
     */
-   public ResizeTerminalEvent(int cols, int rows)
+   public ResizeTerminalEvent(String uniqueId, int cols, int rows)
    {
+      uniqueId_ = uniqueId;
       cols_ = cols;
       rows_ = rows;
    }
@@ -62,6 +64,13 @@ public class ResizeTerminalEvent extends GwtEvent<Handler>
       handler.onResizeTerminal(this);
    } 
    
+   /**
+    * @return unique terminal instance identifier
+    */
+   public String getUniqueId()
+   {
+      return uniqueId_;
+   }
    
    /**
     * @return number of rows in resized terminal
@@ -79,6 +88,7 @@ public class ResizeTerminalEvent extends GwtEvent<Handler>
       return cols_;
    }
    
+   private final String uniqueId_;
    private final int rows_;
    private final int cols_;
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/ResizeTerminalEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/ResizeTerminalEvent.java
@@ -45,9 +45,8 @@ public class ResizeTerminalEvent extends GwtEvent<Handler>
     * @param cols new number of columns
     * @param rows new number of rows
     */
-   public ResizeTerminalEvent(String uniqueId, int cols, int rows)
+   public ResizeTerminalEvent(int cols, int rows)
    {
-      uniqueId_ = uniqueId;
       cols_ = cols;
       rows_ = rows;
    }
@@ -65,14 +64,6 @@ public class ResizeTerminalEvent extends GwtEvent<Handler>
    } 
    
    /**
-    * @return unique terminal instance identifier
-    */
-   public String getUniqueId()
-   {
-      return uniqueId_;
-   }
-   
-   /**
     * @return number of rows in resized terminal
     */
    public int getRows()
@@ -88,7 +79,6 @@ public class ResizeTerminalEvent extends GwtEvent<Handler>
       return cols_;
    }
    
-   private final String uniqueId_;
    private final int rows_;
    private final int cols_;
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/TerminalDataInputEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/TerminalDataInputEvent.java
@@ -37,9 +37,8 @@ public class TerminalDataInputEvent extends GwtEvent<Handler>
       HandlerRegistration addTerminalDataInputHandler(Handler handler);
    }
    
-   public TerminalDataInputEvent(String uniqueId, String data)
+   public TerminalDataInputEvent(String data)
    {
-      uniqueId_ = uniqueId;
       data_ = data;
    }
 
@@ -55,17 +54,11 @@ public class TerminalDataInputEvent extends GwtEvent<Handler>
       handler.onTerminalDataInput(this);
    }
    
-   public String getUniqueId()
-   {
-      return uniqueId_;
-   }
-   
    public String getData()
    {
       return data_;
    }
   
-   private final String uniqueId_;
    private final String data_;
    
    public static final Type<Handler> TYPE = new Type<Handler>();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/TerminalDataInputEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/TerminalDataInputEvent.java
@@ -37,8 +37,9 @@ public class TerminalDataInputEvent extends GwtEvent<Handler>
       HandlerRegistration addTerminalDataInputHandler(Handler handler);
    }
    
-   public TerminalDataInputEvent(String data)
+   public TerminalDataInputEvent(String uniqueId, String data)
    {
+      uniqueId_ = uniqueId;
       data_ = data;
    }
 
@@ -54,12 +55,18 @@ public class TerminalDataInputEvent extends GwtEvent<Handler>
       handler.onTerminalDataInput(this);
    }
    
+   public String getUniqueId()
+   {
+      return uniqueId_;
+   }
+   
    public String getData()
    {
       return data_;
    }
   
-   private String data_;
+   private final String uniqueId_;
+   private final String data_;
    
    public static final Type<Handler> TYPE = new Type<Handler>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/XTermTitleEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/XTermTitleEvent.java
@@ -46,9 +46,8 @@ public class XTermTitleEvent extends GwtEvent<Handler>
       HandlerRegistration addXTermTitleHandler(Handler handler);
    }
    
-   public XTermTitleEvent(String uniqueId, String title)
+   public XTermTitleEvent(String title)
    {
-      uniqueId_ = uniqueId;
       title_ = title;
    }
 
@@ -63,18 +62,12 @@ public class XTermTitleEvent extends GwtEvent<Handler>
    {
       handler.onXTermTitle(this);
    }
-   
-   public String getUniqueId()
-   {
-      return uniqueId_;
-   }
-   
+  
    public String getTitle()
    {
       return title_;
    }
   
-   private final String uniqueId_; 
    private final String title_;
    
    public static final Type<Handler> TYPE = new Type<Handler>();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/XTermTitleEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/XTermTitleEvent.java
@@ -46,8 +46,9 @@ public class XTermTitleEvent extends GwtEvent<Handler>
       HandlerRegistration addXTermTitleHandler(Handler handler);
    }
    
-   public XTermTitleEvent(String title)
+   public XTermTitleEvent(String uniqueId, String title)
    {
+      uniqueId_ = uniqueId;
       title_ = title;
    }
 
@@ -63,12 +64,18 @@ public class XTermTitleEvent extends GwtEvent<Handler>
       handler.onXTermTitle(this);
    }
    
+   public String getUniqueId()
+   {
+      return uniqueId_;
+   }
+   
    public String getTitle()
    {
       return title_;
    }
   
-   private String title_;
+   private final String uniqueId_; 
+   private final String title_;
    
    public static final Type<Handler> TYPE = new Type<Handler>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/XTermTitleEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/XTermTitleEvent.java
@@ -62,7 +62,7 @@ public class XTermTitleEvent extends GwtEvent<Handler>
    {
       handler.onXTermTitle(this);
    }
-  
+ 
    public String getTitle()
    {
       return title_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -45,10 +45,25 @@ import com.google.gwt.user.client.ui.RequiresResize;
 import com.google.gwt.user.client.ui.Widget;
 
 /**
- * Xterm-compatible terminal emulator
+ * Xterm-compatible terminal emulator widget. This widget does no network
+ * communication.
+ * 
+ * To receive input (user typing), subscribe to TerminalDataInputEvent.
+ * 
+ * To send output to the terminal, use write() or writeln().
+ * 
+ * To receive notice of terminal resizes, subscribe to ResizeTerminalEvent.
+ * 
+ * For title changes (via escape sequences sent to terminal), subscribe to
+ * XTermTitleEvent.
+ * 
+ * If multiple instances of the widget are potentially active, supply a
+ * unique id via setUniqueId(), and it will be included with all events.
+ * 
  */
 public class XTermWidget extends Widget implements RequiresResize,
-                                                   ResizeTerminalEvent.HasHandlers, TerminalDataInputEvent.HasHandlers,
+                                                   ResizeTerminalEvent.HasHandlers,
+                                                   TerminalDataInputEvent.HasHandlers,
                                                    XTermTitleEvent.HasHandlers
 {
   /**
@@ -76,7 +91,7 @@ public class XTermWidget extends Widget implements RequiresResize,
       {
          public void execute(String data)
          {
-            fireEvent(new TerminalDataInputEvent(data));
+            fireEvent(new TerminalDataInputEvent(uniqueId_, data));
          }
       });
       
@@ -85,7 +100,7 @@ public class XTermWidget extends Widget implements RequiresResize,
       {
          public void execute(String title)
          {
-            fireEvent(new XTermTitleEvent(title));
+            fireEvent(new XTermTitleEvent(uniqueId_, title));
          }
       });
    }
@@ -231,7 +246,7 @@ public class XTermWidget extends Widget implements RequiresResize,
          previousCols_ = cols;
          previousRows_ = rows;
          
-         fireEvent(new ResizeTerminalEvent(cols, rows)); 
+         fireEvent(new ResizeTerminalEvent(uniqueId_, cols, rows)); 
       }
    };
    
@@ -267,6 +282,16 @@ public class XTermWidget extends Widget implements RequiresResize,
          el = el.getParentElement();
       }
       return false;
+   }
+   
+   /**
+    * Set unique id for this terminal instance. Will be included with all
+    * events to allow distinguishing between multiple XTermWidget instances.
+    * @param uniqueId
+    */
+   public void setUniqueId(String uniqueId)
+   {
+      uniqueId_ = uniqueId;
    }
    
    private static final ExternalJavaScriptLoader getLoader(StaticDataResource release,
@@ -332,6 +357,7 @@ public class XTermWidget extends Widget implements RequiresResize,
    private XTermNative terminal_;
    private LinkElement currentStyleEl_;
    private boolean initialized_ = false;
+   private String uniqueId_;
 
    private int previousRows_ = -1;
    private int previousCols_ = -1;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -56,10 +56,6 @@ import com.google.gwt.user.client.ui.Widget;
  * 
  * For title changes (via escape sequences sent to terminal), subscribe to
  * XTermTitleEvent.
- * 
- * If multiple instances of the widget are potentially active, supply a
- * unique id via setUniqueId(), and it will be included with all events.
- * 
  */
 public class XTermWidget extends Widget implements RequiresResize,
                                                    ResizeTerminalEvent.HasHandlers,
@@ -91,7 +87,7 @@ public class XTermWidget extends Widget implements RequiresResize,
       {
          public void execute(String data)
          {
-            fireEvent(new TerminalDataInputEvent(uniqueId_, data));
+            fireEvent(new TerminalDataInputEvent(data));
          }
       });
       
@@ -100,7 +96,7 @@ public class XTermWidget extends Widget implements RequiresResize,
       {
          public void execute(String title)
          {
-            fireEvent(new XTermTitleEvent(uniqueId_, title));
+            fireEvent(new XTermTitleEvent(title));
          }
       });
    }
@@ -246,7 +242,7 @@ public class XTermWidget extends Widget implements RequiresResize,
          previousCols_ = cols;
          previousRows_ = rows;
          
-         fireEvent(new ResizeTerminalEvent(uniqueId_, cols, rows)); 
+         fireEvent(new ResizeTerminalEvent(cols, rows)); 
       }
    };
    
@@ -282,16 +278,6 @@ public class XTermWidget extends Widget implements RequiresResize,
          el = el.getParentElement();
       }
       return false;
-   }
-   
-   /**
-    * Set unique id for this terminal instance. Will be included with all
-    * events to allow distinguishing between multiple XTermWidget instances.
-    * @param uniqueId
-    */
-   public void setUniqueId(String uniqueId)
-   {
-      uniqueId_ = uniqueId;
    }
    
    private static final ExternalJavaScriptLoader getLoader(StaticDataResource release,
@@ -357,7 +343,6 @@ public class XTermWidget extends Widget implements RequiresResize,
    private XTermNative terminal_;
    private LinkElement currentStyleEl_;
    private boolean initialized_ = false;
-   private String uniqueId_;
 
    private int previousRows_ = -1;
    private int previousCols_ = -1;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -48,7 +48,9 @@ import com.google.gwt.user.client.ui.Widget;
  * Xterm-compatible terminal emulator widget. This widget does no network
  * communication.
  * 
- * To receive input (user typing), subscribe to TerminalDataInputEvent.
+ * To receive input (user typing), subscribe to TerminalDataInputEvent, or
+ * use addDataEventHandler, which stops TerminalDataInputEvent from being 
+ * fired and makes a direct callback.
  * 
  * To send output to the terminal, use write() or writeln().
  * 


### PR DESCRIPTION
Pull out terminal session I/O into TerminalSessionSocket class, which currently encapulates the RPC-based input/output, but will be extended to also attempt the websocket connection and route through that if successful. 

Random whitespace/commenting tweaks.