### PR TITLE
ability to display terminal type/display lag in JavaScript console

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/Stopwatch.java
+++ b/src/gwt/src/org/rstudio/core/client/Stopwatch.java
@@ -1,7 +1,7 @@
 /*
  * Stopwatch.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -26,10 +26,11 @@ public class Stopwatch
       startTime_ = System.currentTimeMillis();
    }
 
-   public void mark(String label)
+   public long mark(String label)
    {
       long stopTime = System.currentTimeMillis();
       Debug.log("[Stopwatch] " + label + ": " + (stopTime - startTime_) + " ms");
+      return stopTime - startTime_;
    }
 
    private long startTime_;

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -120,6 +120,7 @@ import org.rstudio.studio.client.workbench.views.source.model.CppCompletion;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalList;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalPopupMenu;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalSession;
+import org.rstudio.studio.client.workbench.views.terminal.TerminalSessionSocket;
 import org.rstudio.studio.client.workbench.views.source.editors.text.r.SignatureToolTipManager;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.TextEditingTargetNotebook;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.display.ChunkOptionsPopupPanel;
@@ -220,6 +221,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(NewConnectionSnippetHost newConnectionSnippetHost);
    void injectMembers(NewConnectionSnippetDialog newConnectionSnippetDialog);
    void injectMembers(NewPackagePage page);
+   void injectMembers(TerminalSessionSocket socket);
    
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -1,7 +1,7 @@
 /*
  * UIPrefsAccessor.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -587,6 +587,11 @@ public class UIPrefsAccessor extends Prefs
    public PrefValue<Boolean> showTerminalTab()
    {
       return bool("show_terminal_tab", true);
+   }
+   
+   public PrefValue<Boolean> enableReportTerminalLag()
+   {
+      return bool("enable_report_terminal_lag", false);
    }
    
    public static final String KNIT_DIR_DEFAULT = "default";


### PR DESCRIPTION
To help evaluate ongoing terminal-typing performance work. Enable with .rs.writeUiPref("enable_report_terminal_lag", TRUE) and restart. Console will show time in milliseconds between dispatching a keystroke and seeing it echoed, and a running average.