### PR TITLE
allow users to customize where lockfile log output is sent

### DIFF
--- a/src/cpp/core/file_lock/AdvisoryFileLock.cpp
+++ b/src/cpp/core/file_lock/AdvisoryFileLock.cpp
@@ -27,14 +27,14 @@
 
 #include <core/BoostErrors.hpp>
 
-#define DEBUG(__X__)                                                           \
+#define LOG(__X__)                                                             \
    do                                                                          \
    {                                                                           \
       if (::rstudio::core::FileLock::isLoggingEnabled())                       \
       {                                                                        \
          std::stringstream ss;                                                 \
-         ss << "(PID " << ::getpid() << "): " << __X__;                        \
-         LOG_DEBUG_MESSAGE(ss.str());                                          \
+         ss << "(PID " << ::getpid() << "): " << __X__ << std::endl;           \
+         ::rstudio::core::FileLock::log(ss.str());                             \
       }                                                                        \
    } while (0)
 
@@ -118,7 +118,7 @@ Error AdvisoryFileLock::acquire(const FilePath& lockFilePath)
 
       if (lock.try_lock())
       {
-         DEBUG("Acquired lock: " << lockFilePath.absolutePath());
+         LOG("Acquired lock: " << lockFilePath.absolutePath());
          // set members
          pImpl_->lockFilePath = lockFilePath;
          pImpl_->lock.swap(lock);
@@ -127,7 +127,7 @@ Error AdvisoryFileLock::acquire(const FilePath& lockFilePath)
       }
       else
       {
-         DEBUG("Failed to acquire lock: " << lockFilePath.absolutePath());
+         LOG("Failed to acquire lock: " << lockFilePath.absolutePath());
          return systemError(boost::system::errc::no_lock_available,
                             ERROR_LOCATION);
       }
@@ -168,7 +168,7 @@ Error AdvisoryFileLock::release()
    {
       pImpl_->lock.unlock();
       pImpl_->lock = BoostFileLock();
-      DEBUG("Released lock: " << pImpl_->lockFilePath.absolutePath());
+      LOG("Released lock: " << pImpl_->lockFilePath.absolutePath());
       pImpl_->lockFilePath = FilePath();
       return Success();
    }

--- a/src/cpp/core/file_lock/LinkBasedFileLock.cpp
+++ b/src/cpp/core/file_lock/LinkBasedFileLock.cpp
@@ -37,14 +37,14 @@
 #include <boost/foreach.hpp>
 #include <boost/system/error_code.hpp>
 
-#define DEBUG(__X__)                                                           \
+#define LOG(__X__)                                                             \
    do                                                                          \
    {                                                                           \
       if (::rstudio::core::FileLock::isLoggingEnabled())                       \
       {                                                                        \
          std::stringstream ss;                                                 \
-         ss << "(PID " << ::getpid() << "): " << __X__;                        \
-         LOG_DEBUG_MESSAGE(ss.str());                                          \
+         ss << "(PID " << ::getpid() << "): " << __X__ << std::endl;           \
+         ::rstudio::core::FileLock::log(ss.str());                             \
       }                                                                        \
    } while (0)
 
@@ -151,7 +151,7 @@ public:
       {
          BOOST_FOREACH(const FilePath& lockFilePath, registration_)
          {
-            DEBUG("Bumping write time: " << lockFilePath.absolutePath());
+            LOG("Bumping write time: " << lockFilePath.absolutePath());
             lockFilePath.setLastWriteTime();
          }
       }
@@ -167,7 +167,7 @@ public:
             Error error = lockFilePath.removeIfExists();
             if (error)
                LOG_ERROR(error);
-            DEBUG("Clearing lock: " << lockFilePath.absolutePath());
+            LOG("Clearing lock: " << lockFilePath.absolutePath());
          }
          registration_.clear();
       }
@@ -288,7 +288,7 @@ Error LinkBasedFileLock::acquire(const FilePath& lockFilePath)
       {
          // note that multiple processes may attempt to remove this
          // file at the same time, so errors shouldn't be fatal
-         DEBUG("Removing stale lockfile: " << lockFilePath.absolutePath());
+         LOG("Removing stale lockfile: " << lockFilePath.absolutePath());
          Error error = lockFilePath.remove();
          if (error)
             LOG_ERROR(error);
@@ -297,7 +297,7 @@ Error LinkBasedFileLock::acquire(const FilePath& lockFilePath)
       // ... it's not stale -- someone else has the lock, cannot proceed
       else
       {
-         DEBUG("No lock available: " << lockFilePath.absolutePath());
+         LOG("No lock available: " << lockFilePath.absolutePath());
          return systemError(boost::system::errc::no_lock_available,
                             ERROR_LOCATION);
       }
@@ -313,7 +313,7 @@ Error LinkBasedFileLock::acquire(const FilePath& lockFilePath)
    error = writeLockFile(lockFilePath);
    if (error)
    {
-      DEBUG("Failed to acquire lock (lost race?): " << lockFilePath.absolutePath());
+      LOG("Failed to acquire lock: " << lockFilePath.absolutePath());
       return systemError(boost::system::errc::no_lock_available,
                          error,
                          ERROR_LOCATION);
@@ -325,14 +325,14 @@ Error LinkBasedFileLock::acquire(const FilePath& lockFilePath)
    // register our lock (for refresh)
    pImpl_->lockFilePath = lockFilePath;
    lockRegistration().registerLock(lockFilePath);
-   DEBUG("Acquired lock: " << lockFilePath.absolutePath());
+   LOG("Acquired lock: " << lockFilePath.absolutePath());
    return Success();
 }
 
 Error LinkBasedFileLock::release()
 {
    const FilePath& lockFilePath = pImpl_->lockFilePath;
-   DEBUG("Released lock: " << lockFilePath.absolutePath());
+   LOG("Released lock: " << lockFilePath.absolutePath());
    
    Error error = lockFilePath.remove();
    if (error)

--- a/src/cpp/core/include/core/FileLock.hpp
+++ b/src/cpp/core/include/core/FileLock.hpp
@@ -82,6 +82,8 @@ public:
    virtual ~FileLock() {}
    
 public:
+   static void log(const std::string& message);
+   
    // getters only: set through 'initialize' method
    static LockType getDefaultType() { return s_defaultType; }
    static boost::posix_time::seconds getTimeoutInterval() { return s_timeoutInterval; }
@@ -97,6 +99,7 @@ protected:
    static boost::posix_time::seconds s_timeoutInterval;
    static boost::posix_time::seconds s_refreshRate;
    static bool s_loggingEnabled;
+   static FilePath s_logFile;
 };
 
 class AdvisoryFileLock : public FileLock


### PR DESCRIPTION
This PR adds the `log-file` parameter to `/etc/rstudio/file-locks`, allowing users to customize where lockfile logging entries are sent.