### PR TITLE
ConsoleProcess metadata plumbing for non-RPC terminal channel

### DIFF
--- a/src/cpp/session/SessionConsoleProcessInfo.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfo.cpp
@@ -35,8 +35,8 @@ ConsoleProcessInfo::ConsoleProcessInfo()
    : terminalSequence_(kNoTerminal), allowRestart_(false),
      interactionMode_(InteractionNever), maxOutputLines_(kDefaultMaxOutputLines),
      showOnOutput_(false), outputBuffer_(kOutputBufferSize), childProcs_(true),
-     altBufferActive_(false),
-     shellType_(TerminalShell::DefaultShell)
+     altBufferActive_(false), shellType_(TerminalShell::DefaultShell),
+     channelMode_(Rpc)
 {
    // When we retrieve from outputBuffer, we only want complete lines. Add a
    // dummy \n so we can tell the first line is a complete line.
@@ -48,15 +48,16 @@ ConsoleProcessInfo::ConsoleProcessInfo(
          const std::string& title,
          const std::string& handle,
          const int terminalSequence,
-         bool allowRestart,
-         InteractionMode mode,
          TerminalShell::TerminalShellType shellType,
+         ChannelMode channelMode,
+         const std::string& channelId,
          int maxOutputLines)
    : caption_(caption), title_(title), handle_(handle),
-     terminalSequence_(terminalSequence), allowRestart_(allowRestart),
-     interactionMode_(mode), maxOutputLines_(maxOutputLines),
+     terminalSequence_(terminalSequence), allowRestart_(true),
+     interactionMode_(InteractionAlways), maxOutputLines_(maxOutputLines),
      showOnOutput_(false), outputBuffer_(kOutputBufferSize), childProcs_(true),
-     altBufferActive_(false), shellType_(shellType)
+     altBufferActive_(false), shellType_(shellType),
+     channelMode_(channelMode), channelId_(channelId)
 {
 }
 
@@ -67,7 +68,8 @@ ConsoleProcessInfo::ConsoleProcessInfo(
    : caption_(caption), terminalSequence_(kNoTerminal), allowRestart_(false),
      interactionMode_(mode), maxOutputLines_(maxOutputLines),
      showOnOutput_(false), outputBuffer_(kOutputBufferSize), childProcs_(true),
-     altBufferActive_(false), shellType_(TerminalShell::DefaultShell)
+     altBufferActive_(false), shellType_(TerminalShell::DefaultShell),
+     channelMode_(Rpc)
 {
 }
 
@@ -179,6 +181,8 @@ core::json::Object ConsoleProcessInfo::toJson() const
    result["title"] = title_;
    result["child_procs"] = childProcs_;
    result["shell_type"] = static_cast<int>(shellType_);
+   result["channel_mode"] = static_cast<int>(channelMode_);
+   result["channel_id"] = channelId_;
 
    return result;
 }
@@ -223,6 +227,9 @@ boost::shared_ptr<ConsoleProcessInfo> ConsoleProcessInfo::fromJson(core::json::O
    int shellTypeInt = obj["shell_type"].get_int();
    pProc->shellType_ =
       static_cast<TerminalShell::TerminalShellType>(shellTypeInt);
+   int channelModeInt = obj["channel_mode"].get_int();
+   pProc->channelMode_ = static_cast<ChannelMode>(channelModeInt);
+   pProc->channelId_ = obj["channel_id"].get_str();
 
    return pProc;
 }

--- a/src/cpp/session/SessionConsoleProcessPersist.cpp
+++ b/src/cpp/session/SessionConsoleProcessPersist.cpp
@@ -40,7 +40,10 @@ namespace console_persist {
 // 2017/03/08 - console01 -> console02
 //                Added shell type property to allow Windows to track
 //                multiple terminal types (cmd, powershell, git bash, etc.)
-#define kConsoleDir "console02"
+// 2017/03/21 - console02 -> console03
+//                Added channel type and channel ID to allow distinction of
+//                using non-RPC-based communication channel back to client
+#define kConsoleDir "console03"
 
 namespace {
 

--- a/src/cpp/session/SessionConsoleProcessTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessTests.cpp
@@ -32,8 +32,7 @@ context("queue and fetch input")
    boost::shared_ptr<ConsoleProcessInfo> pCPI =
          boost::make_shared<ConsoleProcessInfo>(
             "test caption", "test title", "fakehandle", 9999 /*terminal*/,
-            false /*allowRestart*/, InteractionNever,
-            TerminalShell::DefaultShell);
+            TerminalShell::DefaultShell, console_process::Rpc, "");
 
    boost::shared_ptr<ConsoleProcess> pCP =
          ConsoleProcess::createTerminalProcess(procOptions, pCPI);

--- a/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
@@ -39,6 +39,13 @@ enum InteractionMode
    InteractionAlways = 2
 };
 
+enum ChannelMode
+{
+   Rpc = 0,
+   Websocket = 1,
+   NamedPipe = 2,
+};
+
 extern const int kDefaultMaxOutputLines;
 extern const int kDefaultTerminalMaxOutputLines;
 extern const int kNoTerminal;
@@ -61,9 +68,9 @@ public:
          const std::string& title,
          const std::string& handle,
          int terminalSequence,
-         bool allowRestart,
-         InteractionMode mode,
          TerminalShell::TerminalShellType shellType,
+         ChannelMode channelMode,
+         const std::string& channelId,
          int maxOutputLines = kDefaultMaxOutputLines);
 
    // constructor for non-terminals
@@ -127,6 +134,18 @@ public:
       return shellType_;
    }
 
+   // Type of channel for communicating input/output with client
+   ChannelMode getChannelMode() const { return channelMode_; }
+
+   // Mode-dependent identifier for channel
+   std::string getChannelId() const { return channelId_; }
+
+   void setChannelMode(ChannelMode mode, const std::string& channelId)
+   {
+      channelMode_ = mode;
+      channelId_ = channelId;
+   }
+
    core::json::Object toJson() const;
    static boost::shared_ptr<ConsoleProcessInfo> fromJson(core::json::Object& obj);
 
@@ -148,6 +167,8 @@ private:
    bool childProcs_;
    bool altBufferActive_;
    TerminalShell::TerminalShellType shellType_;
+   ChannelMode channelMode_;
+   std::string channelId_;
 };
 
 } // namespace console_process

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -955,8 +955,9 @@ Error startTerminal(const json::JsonRpcRequest& request,
 
    boost::shared_ptr<ConsoleProcessInfo> ptrProcInfo =
          boost::make_shared<ConsoleProcessInfo>(
-            termCaption, termTitle, termHandle, termSequence, true /*allowRestart*/,
-            InteractionAlways, shellType, console_process::kDefaultTerminalMaxOutputLines);
+            termCaption, termTitle, termHandle, termSequence,  shellType,
+            console_process::Rpc, "" /*channelId*/,
+            console_process::kDefaultTerminalMaxOutputLines);
 
    // run process
    boost::shared_ptr<ConsoleProcess> ptrProc =

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
@@ -26,6 +26,10 @@ public class ConsoleProcessInfo extends JavaScriptObject
    public static final int DEFAULT_COLS = 80;
    public static final int DEFAULT_ROWS = 25;
    
+   public static final int CHANNEL_RPC = 0;
+   public static final int CHANNEL_WEBSOCKET = 1;
+   public static final int CHANNEL_PIPE = 2;
+   
    protected ConsoleProcessInfo() {}
 
    public final native String getHandle() /*-{
@@ -76,6 +80,14 @@ public class ConsoleProcessInfo extends JavaScriptObject
    
    public final native int getShellType() /*-{
       return this.shell_type;
+   }-*/;
+   
+   public final native int getChannelMode() /*-{
+      return this.channel_mode;
+   }-*/;
+   
+   public final native String getChannelId() /*-{
+      return this.channel_id;
    }-*/;
 
    public static final int SEQUENCE_NO_TERMINAL = 0;


### PR DESCRIPTION
ConsoleProcessInfo fields to indicate which type of connection a terminal instance is configured for on the server-side; still hardcoded to RPC. Working on websockets; not currently planning to do named pipes, but threw in a constant for it.