### PR TITLE
support debugger with R 3.4.0

### DIFF
--- a/src/cpp/core/include/core/type_traits/TypeTraits.hpp
+++ b/src/cpp/core/include/core/type_traits/TypeTraits.hpp
@@ -46,7 +46,7 @@ namespace type_traits {
 
 RS_GENERATE_HAS_TYPE_TRAIT(key_type);
 
-} // namespace algorithm
+} // namespace type_traits
 } // namespace core
 } // namespace rstudio
 

--- a/src/cpp/r/RCntxtUtils.cpp
+++ b/src/cpp/r/RCntxtUtils.cpp
@@ -13,6 +13,8 @@
  *
  */
 
+#define R_INTERNAL_FUNCTIONS
+
 #include <r/RCntxt.hpp>
 #include <r/RCntxtUtils.hpp>
 #include <r/RInterface.hpp>
@@ -22,7 +24,6 @@
 namespace rstudio {
 namespace r {
 namespace context {
-
 
 RCntxtVersion contextVersion()
 {
@@ -155,6 +156,18 @@ bool inDebugHiddenContext()
       }
    }
    return false;
+}
+
+bool isByteCodeContext(const RCntxt& cntxt)
+{
+   return isByteCodeSrcRef(cntxt.srcref());
+}
+
+bool isByteCodeSrcRef(SEXP srcref)
+{
+   return srcref &&
+         TYPEOF(srcref) == SYMSXP &&
+         ::strcmp(CHAR(PRINTNAME(srcref)), "<in-bc-interp>") == 0;
 }
 
 } // namespace context

--- a/src/cpp/r/include/r/RCntxtUtils.hpp
+++ b/src/cpp/r/include/r/RCntxtUtils.hpp
@@ -48,6 +48,9 @@ RCntxt getFunctionContext(const int depth,
                           int* pFoundDepth = NULL,
                           SEXP* pEnvironment = NULL);
 
+bool isByteCodeContext(const RCntxt& cntxt);
+bool isByteCodeSrcRef(SEXP srcref);
+
 } // namespace context
 } // namespace r
 } // namespace rstudio

--- a/src/cpp/r/include/r/RIntCntxt.hpp
+++ b/src/cpp/r/include/r/RIntCntxt.hpp
@@ -64,7 +64,7 @@ public:
       else
          return RCntxt(pCntxt_->nextcontext);
    }
-
+   
    bool isNull() const
    {
       return false;

--- a/src/cpp/r/include/r/RInterface.hpp
+++ b/src/cpp/r/include/r/RInterface.hpp
@@ -78,7 +78,14 @@ typedef struct RCNTXT_34 {
     SEXP handlerstack;
     SEXP restartstack;
     struct RPRSTACK *prstack;
-    SEXP *nodestack;
+    struct {
+       int tag;
+       union {
+          int ival;
+          double dval;
+          SEXP sxpval;
+       } u;
+    } *nodestack;
 #ifdef BC_INT_STACK
     IStackval *intstack;
 #endif

--- a/src/cpp/session/modules/environment/EnvironmentUtils.cpp
+++ b/src/cpp/session/modules/environment/EnvironmentUtils.cpp
@@ -15,6 +15,8 @@
 
 #include "EnvironmentUtils.hpp"
 
+#include <r/RCntxt.hpp>
+#include <r/RCntxtUtils.hpp>
 #include <r/RExec.hpp>
 #include <r/RJson.hpp>
 #include <core/FileSerializer.hpp>
@@ -227,7 +229,9 @@ bool functionDiffersFromSource(
 // from the source reference to the JSON object.
 void sourceRefToJson(const SEXP srcref, json::Object* pObject)
 {
-   if (srcref == NULL || r::sexp::isNull(srcref))
+   if (srcref == NULL ||
+       r::sexp::isNull(srcref) ||
+       r::context::isByteCodeSrcRef(srcref))
    {
       (*pObject)["line_number"] = 0;
       (*pObject)["end_line_number"] = 0;

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -158,7 +158,9 @@ json::Array callFramesAsJson(LineDebugState* pLineDebugState)
       // debugging in the environment of the callee. note that there may be
       // multiple srcrefs on the stack for a given closure; in this case we
       // always want to take the first one as it's the most current/specific.
-      if (isValidSrcref(context->srcref()) && !context->nextcontext().isNull())
+      if (!r::context::isByteCodeContext(*context) &&
+          isValidSrcref(context->srcref()) &&
+          !context->nextcontext().isNull())
       {
          SEXP env = context->nextcontext().cloenv();
          if (envSrcrefCtx.find(env) == envSrcrefCtx.end())


### PR DESCRIPTION
This PR tweaks the type used for the `nodestack` member of the RCNTXT struct, as per https://github.com/wch/r-source/blob/4a536ef5bcad75125fe3bab86e8db9d777d62dc8/src/include/Defn.h#L483-L511.