### PR TITLE
Reduce 404 errors with NEWS

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -431,6 +431,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
       cranRep <- c(CRAN = repos[[1]])
    cranRepLen <- nchar(cranRep)
    isFromCRAN <- cranRep == substr(updates$Repository, 1, cranRepLen)
+   hasNEWS    <- file.exists(vapply(updates$Package, function(x) system.file("NEWS", package = x), character(1L)))
    newsURL <- character(nrow(updates))
    if (substr(cranRep, cranRepLen, cranRepLen) != "/")
       cranRep <- paste(cranRep, "/", sep="")
@@ -438,7 +439,8 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    newsURL[isFromCRAN] <- paste(cranRep,
                                 "web/packages/",
                                 updates$Package,
-                                "/NEWS", sep = "")[isFromCRAN]
+                                ifelse(hasNEWS, "/NEWS", "/news.html"),
+                                sep = "")[isFromCRAN]
    
    updates <- data.frame(packageName = updates$Package,
                          libPath = updates$LibPath,


### PR DESCRIPTION
As discussed on https://github.com/edzer/sfr/issues/262, it seems that not a few people get confused by 404 errors when they click NEWS icons in "Check for Package Updates...".

I guess there are no perfect way to determine the right URL of NEWS file in a package, except for actually accessing the package page on CRAN. That said, we can check if "NEWS" is included in `system.file` of a package. If the package doesn't have "NEWS", we'd better try "news.html" rather than letting 404 error by doing nothing. So, this PR does not fix the issue completely, but reduces the errors to some extent.