### PR TITLE
Ignore subdirectories inside chunk data folders

### DIFF
--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -1,7 +1,7 @@
 #
 # SessionRmdNotebook.R
 #
-# Copyright (C) 2009-16 by RStudio, Inc.
+# Copyright (C) 2009-17 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -104,6 +104,12 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    chunkDirs <- file.path(cachePath, names(chunkInfo$chunk_definitions))
    chunkData <- lapply(chunkDirs, function(dir) {
       files <- list.files(dir, full.names = TRUE)
+
+      # exclude directories
+      fileInfo <- file.info(files)
+      files <- files[!fileInfo$isdir]
+
+      # extract the contents from each regular file
       contents <- lapply(files, function(file) {
          .rs.readFile(
             file,


### PR DESCRIPTION
This is a speculative change that attempts to address a frequently reported issue in which error messages like the below appear when attempting to save a notebook:

    Warning message:
    In file(con, "rb") :
    cannot open file 'C:/Users/<username>/AppData/Local/RStudio-Desktop/notebooks/2F38416F-<project>/1/s/cplf5ref33onf/temp': Permission denied

I was not able to reproduce the problem, but I did find that

- this `temp` folder is created when plots are resized inside the chunk popout window;
- users who remove the folder don't see the error any more; and
- the code here attempts to read everything inside the chunk folder as though it were a regular file, which seems like a candidate for raising an R error such as the above.

@javierluraschi is there some mechanism that should be cleaning up the temp folder that I'm missing here? It isn't urgent but it'd be nice if that folder got cleaned up when the satellite closed so that the files don't stick around indefinitely. 

@kevinushey would you be willing to review this?