### PR TITLE
remove unused error parameter from ConsoleProcessOutput client event

### DIFF
--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -125,7 +125,6 @@ public:
    core::Error start();
    void enqueInput(const Input& input);
    Input dequeInput();
-   void enqueOutput(const std::string& output, bool error);
    void enquePrompt(const std::string& prompt);
    void interrupt();
    void resize(int cols, int rows);
@@ -153,7 +152,7 @@ private:
    void onHasSubprocs(bool hasSubProcs);
 
    std::string bufferedOutput() const;
-   void enqueOutputEvent(const std::string& output, bool error);
+   void enqueOutputEvent(const std::string& output);
    void enquePromptEvent(const std::string& prompt);
    void handleConsolePrompt(core::system::ProcessOperations& ops,
                             const std::string& prompt);

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleOutputEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleOutputEvent.java
@@ -1,7 +1,7 @@
 /*
  * ConsoleOutputEvent.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -31,20 +31,14 @@ public class ConsoleOutputEvent extends GwtEvent<Handler>
       HandlerRegistration addConsoleOutputHandler(Handler handler);
    }
 
-   public ConsoleOutputEvent(String output, boolean error)
+   public ConsoleOutputEvent(String output)
    {
       output_ = output;
-      error_ = error;
    }
 
    public String getOutput()
    {
       return output_;
-   }
-
-   public boolean isError()
-   {
-      return error_;
    }
 
    @Override
@@ -60,7 +54,6 @@ public class ConsoleOutputEvent extends GwtEvent<Handler>
    }
 
    private final String output_;
-   private final boolean error_;
 
    public static final Type<Handler> TYPE = new Type<Handler>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcess.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcess.java
@@ -281,8 +281,7 @@ public class ConsoleProcess implements ConsoleOutputEvent.HasHandlers,
                                              ServerConsoleOutputEvent event)
                {
                   if (event.getProcessHandle().equals(procInfo.getHandle()))
-                     fireEvent(new ConsoleOutputEvent(event.getOutput(),
-                                                      event.getError()));
+                     fireEvent(new ConsoleOutputEvent(event.getOutput()));
                }
             }));
       registrations_.add(eventBus.addHandler(

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ServerConsoleOutputEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ServerConsoleOutputEvent.java
@@ -1,7 +1,7 @@
 /*
  * ServerConsoleOutputEvent.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -32,18 +32,15 @@ public class ServerConsoleOutputEvent
 
       public native final String getHandle() /*-{ return this.handle; }-*/;
       public native final String getOutput() /*-{ return this.output; }-*/;
-      public native final boolean isError() /*-{ return this.error; }-*/;
    }
 
 
    public ServerConsoleOutputEvent(String procHandle,
-                                   String output,
-                                   boolean error)
+                                   String output)
    {
 
       procHandle_ = procHandle;
       output_ = output;
-      error_ = error;
    }
 
    public String getProcessHandle()
@@ -54,11 +51,6 @@ public class ServerConsoleOutputEvent
    public String getOutput()
    {
       return output_;
-   }
-
-   public boolean getError()
-   {
-      return error_;
    }
 
    @Override
@@ -75,7 +67,6 @@ public class ServerConsoleOutputEvent
 
    private final String procHandle_;
    private final String output_;
-   private final boolean error_;
 
    public static final Type<Handler> TYPE = new Type<Handler>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -1,7 +1,7 @@
 /*
  * ClientEventDispatcher.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -363,8 +363,7 @@ public class ClientEventDispatcher
          {
             ServerConsoleOutputEvent.Data data = event.getData();
             eventBus_.fireEvent(new ServerConsoleOutputEvent(data.getHandle(),
-                                                            data.getOutput(),
-                                                            data.isError()));
+                                                            data.getOutput()));
          }
          else if (type.equals(ClientEvent.ConsoleProcessPrompt))
          {


### PR DESCRIPTION
Noticed while working on other stuff.