### PR TITLE
guard against incompatible R versions on restore

### DIFF
--- a/src/cpp/core/VersionTests.cpp
+++ b/src/cpp/core/VersionTests.cpp
@@ -1,0 +1,57 @@
+/*
+ * VersionTests.cpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <tests/TestThat.hpp>
+
+#include <core/Version.hpp>
+
+namespace rstudio {
+namespace core {
+namespace {
+
+void compareVersionLessThan(const std::string& lhs, const std::string& rhs)
+{
+   Version vl(lhs);
+   Version vr(rhs);
+   
+   expect_true(vl <  vr);
+   expect_true(vl <= vr);
+   expect_true(vl != vr);
+   expect_true(vr >  vl);
+   expect_true(vr >= vl);
+}
+
+void compareVersionEqual(const std::string& lhs, const std::string& rhs)
+{
+   expect_true(Version(lhs) == Version(rhs));
+}
+
+context("Version")
+{
+   test_that("Various versions are compared correctly")
+   {
+      compareVersionLessThan("3.2.0", "3.3.0");
+      compareVersionLessThan("3.2", "3.3.1");
+      compareVersionLessThan("3", "3.0.1");
+      compareVersionLessThan("3.3.0", "3.3.1");
+      
+      compareVersionEqual("3.0.0", "3.0.0.0");
+      compareVersionEqual("3", "3.0-0");
+   }
+}
+
+} // end anonymous namespace
+} // end namespace core
+} // end namespace rstudio

--- a/src/cpp/core/include/core/Version.hpp
+++ b/src/cpp/core/include/core/Version.hpp
@@ -1,0 +1,146 @@
+/*
+ * Version.hpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef CORE_VERSION_HPP
+#define CORE_VERSION_HPP
+
+#include <string>
+
+#include <boost/regex.hpp>
+
+#include <core/Error.hpp>
+#include <core/SafeConvert.hpp>
+#include <core/StringUtils.hpp>
+
+namespace rstudio {
+namespace core {
+
+class Version
+{
+   
+public:
+   Version(std::string version)
+   {
+      try
+      {
+         // split version into components
+         static boost::regex reVersion("[._-]+");
+         version = core::string_utils::trimWhitespace(version);
+         boost::sregex_token_iterator it(version.begin(), version.end(), reVersion, -1);
+         boost::sregex_token_iterator end;
+         for (; it != end; ++it)
+         {
+            std::string component = *it;
+            int value = core::safe_convert::stringTo<int>(component, 0);
+            pieces_.push_back(value);
+         }
+      }
+      CATCH_UNEXPECTED_EXCEPTION;
+   }
+   
+   Version(int versionMajor, int versionMinor, int versionPatch)
+   {
+      pieces_.push_back(versionMajor);
+      pieces_.push_back(versionMinor);
+      pieces_.push_back(versionPatch);
+   }
+   
+   int versionMajor() const
+   {
+      return extractVersion(0);
+   }
+   
+   int versionMinor() const
+   {
+      return extractVersion(1);
+   }
+   
+   int versionPatch() const
+   {
+      return extractVersion(2);
+   }
+   
+   int extractVersion(std::size_t index) const
+   {
+      if (index < pieces_.size())
+         return pieces_[index];
+      
+      return 0;
+   }
+   
+   int compare(const Version& other) const
+   {
+      return compare(*this, other);
+   }
+   
+private:
+   
+   int compare(Version lhs, Version rhs) const
+   {
+      std::size_t n = std::max(lhs.size(), rhs.size());
+      
+      for (std::size_t i = 0; i < n; ++i)
+      {
+         int vl = lhs.extractVersion(i);
+         int vr = rhs.extractVersion(i);
+         if (vl < vr)
+            return -1;
+         else if (vl > vr)
+            return 1;
+      }
+      
+      return 0;
+   }
+   
+   std::size_t size() const { return pieces_.size(); }
+   
+   std::vector<int> pieces_;
+};
+
+bool operator <(const Version& lhs, const Version& rhs)
+{
+   return lhs.compare(rhs) == -1;
+}
+
+bool operator <=(const Version& lhs, const Version& rhs)
+{
+   return lhs.compare(rhs) <= 0;
+}
+
+bool operator ==(const Version& lhs, const Version& rhs)
+{
+   return lhs.compare(rhs) == 0;
+}
+
+bool operator !=(const Version& lhs, const Version& rhs)
+{
+   return lhs.compare(rhs) != 0;
+}
+
+bool operator >=(const Version& lhs, const Version& rhs)
+{
+   return lhs.compare(rhs) >= 0;
+}
+
+bool operator >(const Version& lhs, const Version& rhs)
+{
+   return lhs.compare(rhs) > 0;
+}
+
+
+} // end namespace core
+} // end namespace rstudio
+
+#endif /* CORE_VERSION_HPP */

--- a/src/cpp/core/include/core/Version.hpp
+++ b/src/cpp/core/include/core/Version.hpp
@@ -20,6 +20,7 @@
 
 #include <boost/regex.hpp>
 
+#include <core/Algorithm.hpp>
 #include <core/Error.hpp>
 #include <core/SafeConvert.hpp>
 #include <core/StringUtils.hpp>
@@ -31,6 +32,11 @@ class Version
 {
    
 public:
+   
+   Version()
+   {
+   }
+
    Version(std::string version)
    {
       try
@@ -85,6 +91,22 @@ public:
       return compare(*this, other);
    }
    
+   operator std::string() const
+   {
+      if (pieces_.empty())
+         return std::string();
+      
+      std::stringstream ss;
+      ss << boost::lexical_cast<std::string>(pieces_[0]);
+      for (std::size_t i = 1, n = pieces_.size(); i < n; ++i)
+      {
+         ss << ".";
+         ss << boost::lexical_cast<std::string>(pieces_[i]);
+      }
+      
+      return ss.str();
+   }
+   
 private:
    
    int compare(Version lhs, Version rhs) const
@@ -109,32 +131,32 @@ private:
    std::vector<int> pieces_;
 };
 
-bool operator <(const Version& lhs, const Version& rhs)
+inline bool operator  <(const Version& lhs, const Version& rhs)
 {
-   return lhs.compare(rhs) == -1;
+   return lhs.compare(rhs) < 0;
 }
 
-bool operator <=(const Version& lhs, const Version& rhs)
+inline bool operator <=(const Version& lhs, const Version& rhs)
 {
    return lhs.compare(rhs) <= 0;
 }
 
-bool operator ==(const Version& lhs, const Version& rhs)
+inline bool operator ==(const Version& lhs, const Version& rhs)
 {
    return lhs.compare(rhs) == 0;
 }
 
-bool operator !=(const Version& lhs, const Version& rhs)
+inline bool operator !=(const Version& lhs, const Version& rhs)
 {
    return lhs.compare(rhs) != 0;
 }
 
-bool operator >=(const Version& lhs, const Version& rhs)
+inline bool operator >=(const Version& lhs, const Version& rhs)
 {
    return lhs.compare(rhs) >= 0;
 }
 
-bool operator >(const Version& lhs, const Version& rhs)
+inline bool operator  >(const Version& lhs, const Version& rhs)
 {
    return lhs.compare(rhs) > 0;
 }

--- a/src/cpp/r/include/r/session/RSessionState.hpp
+++ b/src/cpp/r/include/r/session/RSessionState.hpp
@@ -21,6 +21,7 @@
 #include <boost/function.hpp>
 
 #include <core/Error.hpp>
+#include <core/Version.hpp>
 
 namespace rstudio {
 namespace core {
@@ -32,7 +33,13 @@ namespace rstudio {
 namespace r {
 namespace session {
 namespace state {
-        
+
+struct SessionStateInfo
+{
+   core::Version suspendedRVersion;
+   core::Version activeRVersion;
+};
+
 bool save(const core::FilePath& statePath,
           bool serverMode,
           bool excludePackages,
@@ -52,6 +59,8 @@ bool restore(const core::FilePath& statePath,
              std::string* pErrorMessages); 
    
 bool destroy(const core::FilePath& statePath);
+
+SessionStateInfo getSessionStateInfo();
      
 } // namespace state
 } // namespace session

--- a/src/cpp/r/session/RRestartContext.cpp
+++ b/src/cpp/r/session/RRestartContext.cpp
@@ -23,7 +23,7 @@
 #include <core/FileUtils.hpp>
 #include <core/system/System.hpp>
 
-#include "RSessionState.hpp"
+#include <r/session/RSessionState.hpp>
 
 using namespace rstudio::core ;
 

--- a/src/cpp/r/session/RSearchPath.cpp
+++ b/src/cpp/r/session/RSearchPath.cpp
@@ -326,13 +326,9 @@ Error saveGlobalEnvironment(const FilePath& statePath)
    return saveGlobalEnvironmentToFile(environmentFile);
 }
 
-Error restore(const FilePath& statePath)
+Error restoreSearchPath(const FilePath& statePath)
 {
-   // restore global environment
-   FilePath environmentFile = statePath.complete(kEnvironmentFile);
-   Error error = restoreGlobalEnvironment(environmentFile);
-   if (error)
-      return error;
+   Error error;
    
    // attempt to restore the search path if one has been saved
    FilePath searchPathDir = statePath.complete(kSearchPathDir);
@@ -402,7 +398,27 @@ Error restore(const FilePath& statePath)
    
    return Success();
 }
+
+Error restore(const FilePath& statePath, bool isCompatibleSessionState)
+{
+   // restore global environment
+   FilePath environmentFile = statePath.complete(kEnvironmentFile);
+   Error error = restoreGlobalEnvironment(environmentFile);
+   if (error)
+      return error;
    
+   // only restore the search path if we have a compatible R version
+   // (guard against attempts to attach incompatible packages to this
+   // R session)
+   if (isCompatibleSessionState)
+   {
+      Error error = restoreSearchPath(statePath);
+      if (error)
+         return error;
+   }
+   
+   return Success();
+}
    
 } // namespace search_path
 } // namespace session

--- a/src/cpp/r/session/RSearchPath.hpp
+++ b/src/cpp/r/session/RSearchPath.hpp
@@ -30,7 +30,7 @@ namespace search_path {
 
 core::Error save(const core::FilePath& statePath);
 core::Error saveGlobalEnvironment(const core::FilePath& statePath);
-core::Error restore(const core::FilePath& statePath);
+core::Error restore(const core::FilePath& statePath, bool isCompatibleSessionState = true);
    
 } // namespace search_path
 } // namespace session

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -41,6 +41,7 @@
 #include <r/RRoutines.hpp>
 #include <r/RInterface.hpp>
 #include <r/RFunctionHook.hpp>
+#include <r/session/RSessionState.hpp>
 #include <r/session/RConsoleActions.hpp>
 #include <r/session/RConsoleHistory.hpp>
 #include <r/session/RClientState.hpp>
@@ -48,7 +49,6 @@
 #include <r/session/RDiscovery.hpp>
 
 #include "RClientMetrics.hpp"
-#include "RSessionState.hpp"
 #include "RRestartContext.hpp"
 #include "REmbedded.hpp"
 

--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -504,24 +504,6 @@ Error deferredRestore(const FilePath& statePath, bool serverMode)
    if (error)
       return error;
    
-   // report incompatible R version
-   if (!s_isCompatibleSessionState)
-   {
-      if (!s_activeRVersion.empty() &&
-          !s_suspendedRVersion.empty())
-      {
-         std::stringstream ss;
-         ss << "Failed to restore R session state ("
-            << "R version mismatch "
-            << "[active=" << s_activeRVersion << "; "
-            << "suspended=" << s_suspendedRVersion << "])";
-         
-         std::string message = ss.str();
-         LOG_ERROR_MESSAGE(message);
-         REprintf((message + "\n").c_str());
-      }
-   }
-
    // if we are in server mode we just need to read the plots state
    // file (because the location of the graphics directory is stable)
    if (serverMode)

--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -613,17 +613,17 @@ bool restore(const FilePath& statePath,
    if (error)
       reportError(kRestoring, kWorkingDirectory, error, ERROR_LOCATION, er);
    
+   // restore options
+   FilePath optionsPath = statePath.complete(kOptionsFile);
+   if (optionsPath.exists())
+   {
+      error = r::options::restoreOptions(optionsPath);
+      if (error)
+         reportError(kRestoring, kOptionsFile, error, ERROR_LOCATION, er);
+   }
+      
    if (s_isCompatibleSessionState)
    {
-      // restore options
-      FilePath optionsPath = statePath.complete(kOptionsFile);
-      if (optionsPath.exists())
-      {
-         error = r::options::restoreOptions(optionsPath);
-         if (error)
-            reportError(kRestoring, kOptionsFile, error, ERROR_LOCATION, er);
-      }
-
       // restore libpaths -- but only if packrat mode is off
       bool packratModeOn = settings.getBool(kPackratModeOn, false);
       if (!packratModeOn)

--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -23,6 +23,7 @@
 #include <core/Error.hpp>
 #include <core/FilePath.hpp>
 #include <core/Settings.hpp>
+#include <core/Version.hpp>
 #include <core/Log.hpp>
 #include <core/FileSerializer.hpp>
 #include <core/system/Environment.hpp>
@@ -55,6 +56,7 @@ namespace {
 const char * const kSettingsFile = "settings";
 const char * const kConsoleActionsFile = "console_actions";
 const char * const kOptionsFile = "options";
+const char * const kRVersion = "rversion";
 const char * const kEnvironmentVars = "environment_vars";
 const char * const kLibPathsFile = "libpaths";
 const char * const kHistoryFile = "history";
@@ -69,6 +71,10 @@ const char * const kDevModeOn = "dev_mode_on";
 const char * const kPackratModeOn = "packrat_mode_on";
 const char * const kRProfileOnRestore = "r_profile_on_restore";
 
+// is the suspended session state compatible with the active R version?
+std::string s_activeRVersion;
+std::string s_suspendedRVersion;
+bool s_isCompatibleSessionState = true;
 
 Error saveLibPaths(const FilePath& libPathsFile)
 {
@@ -92,6 +98,30 @@ bool isRLocationVariable(const std::string& name)
          name == "R_DOC_DIR" ||
          name == "R_INCLUDE_DIR" ||
          name == "R_SHARE_DIR";
+}
+
+Error saveRVersion(const FilePath& filePath)
+{
+   Error error;
+   
+   // remove pre-existing file
+   error = filePath.removeIfExists();
+   if (error)
+      return error;
+   
+   // ask R for the current version
+   std::string version;
+   error = RFunction(".rs.rVersionString").call(&version);
+   if (error)
+      return error;
+   
+   // write to file
+   error = core::writeStringToFile(filePath, version);
+   if (error)
+      return error;
+   
+   // success!
+   return Success();
 }
 
 Error saveEnvironmentVars(const FilePath& envFile)
@@ -302,9 +332,17 @@ bool save(const FilePath& statePath,
 
    // set r profile on restore (always run the .Rprofile in packrat mode)
    settings.set(kRProfileOnRestore, !excludePackages || packratModeOn);
+   
+   // save r version
+   Error error = saveRVersion(statePath.complete(kRVersion));
+   if (error)
+   {
+      reportError(kSaving, kRVersion, error, ERROR_LOCATION);
+      saved = false;
+   }
 
    // save environment variables
-   Error error = saveEnvironmentVars(statePath.complete(kEnvironmentVars));
+   error = saveEnvironmentVars(statePath.complete(kEnvironmentVars));
    if (error)
    {
       reportError(kSaving, kEnvironmentVars, error, ERROR_LOCATION);
@@ -462,9 +500,32 @@ bool packratModeEnabled(const core::FilePath& statePath)
 Error deferredRestore(const FilePath& statePath, bool serverMode)
 {
    // search path
-   Error error = search_path::restore(statePath);
-   if (error)
-      return error;
+   if (s_isCompatibleSessionState)
+   {
+      Error error = search_path::restore(statePath);
+      if (error)
+         return error;
+   }
+   
+   // report incompatible R version
+   if (!s_isCompatibleSessionState)
+   {
+      s_isCompatibleSessionState = true;
+      
+      if (!s_activeRVersion.empty() &&
+          !s_suspendedRVersion.empty())
+      {
+         std::stringstream ss;
+         ss << "Failed to restore R session state ("
+            << "R version mismatch "
+            << "[active=" << s_activeRVersion << "; "
+            << "suspended=" << s_suspendedRVersion << "])";
+         
+         std::string message = ss.str();
+         LOG_ERROR_MESSAGE(message);
+         REprintf((message + "\n").c_str());
+      }
+   }
 
    // if we are in server mode we just need to read the plots state
    // file (because the location of the graphics directory is stable)
@@ -481,18 +542,64 @@ Error deferredRestore(const FilePath& statePath, bool serverMode)
          return Success();
    }
 }
+
+namespace {
+
+bool validateRestoredRVersion(const FilePath& filePath)
+{
+   Error error;
+   
+   // assume we're okay if no file exists
+   if (!filePath.exists())
+      return Success();
+   
+   // read version from file
+   std::string suspendedRVersion;
+   error = core::readStringFromFile(
+            filePath,
+            &suspendedRVersion);
+   if (error)
+      return error;
+   suspendedRVersion = core::string_utils::trimWhitespace(suspendedRVersion);
+   s_suspendedRVersion = suspendedRVersion;
+   
+   // read active R version
+   std::string activeRVersion;
+   error = RFunction(".rs.rVersionString").call(&activeRVersion);
+   if (error)
+      return error;
+   activeRVersion = core::string_utils::trimWhitespace(activeRVersion);
+   s_activeRVersion = activeRVersion;
+   
+   // construct and compare versions
+   core::Version suspended(suspendedRVersion);
+   core::Version active(activeRVersion);
+   
+   // if both major and minor versions are equal, we're okay
+   return
+         suspended.versionMajor() == active.versionMajor() &&
+         suspended.versionMinor() == active.versionMinor();
+}
+
+} // end anonymous namespace
    
 bool restore(const FilePath& statePath,
              bool serverMode,
              boost::function<Error()>* pDeferredRestoreAction,
              std::string* pErrorMessages)
 {
+   Error error;
+   
    // setup error buffer
    ErrorRecorder er(pErrorMessages);
    
+   // detect incompatible r version (don't restore some parts of session state
+   // in this case as it could cause a crash on startup)
+   s_isCompatibleSessionState = validateRestoredRVersion(statePath.complete(kRVersion));
+   
    // init session settings (used below)
    Settings settings ;
-   Error error = settings.initialize(statePath.complete(kSettingsFile));
+   error = settings.initialize(statePath.complete(kSettingsFile));
    if (error)
       reportError(kRestoring, kSettingsFile, error, ERROR_LOCATION, er);
    
@@ -509,29 +616,32 @@ bool restore(const FilePath& statePath,
    if (error)
       reportError(kRestoring, kWorkingDirectory, error, ERROR_LOCATION, er);
    
-   // restore options
-   FilePath optionsPath = statePath.complete(kOptionsFile);
-   if (optionsPath.exists())
+   if (s_isCompatibleSessionState)
    {
-      error = r::options::restoreOptions(optionsPath);
-      if (error)
-         reportError(kRestoring, kOptionsFile, error, ERROR_LOCATION, er);
-   }
+      // restore options
+      FilePath optionsPath = statePath.complete(kOptionsFile);
+      if (optionsPath.exists())
+      {
+         error = r::options::restoreOptions(optionsPath);
+         if (error)
+            reportError(kRestoring, kOptionsFile, error, ERROR_LOCATION, er);
+      }
 
-   // restore libpaths -- but only if packrat mode is off
-   bool packratModeOn = settings.getBool(kPackratModeOn, false);
-   if (!packratModeOn)
-   {
-      error = restoreLibPaths(statePath.complete(kLibPathsFile));
-      if (error)
-         reportError(kRestoring, kLibPathsFile, error, ERROR_LOCATION, er);
-   }
+      // restore libpaths -- but only if packrat mode is off
+      bool packratModeOn = settings.getBool(kPackratModeOn, false);
+      if (!packratModeOn)
+      {
+         error = restoreLibPaths(statePath.complete(kLibPathsFile));
+         if (error)
+            reportError(kRestoring, kLibPathsFile, error, ERROR_LOCATION, er);
+      }
 
-   // restore devmode
-   if (settings.getBool(kDevModeOn, false))
-   {
-      // ignore error -- will occur if devtools isn't installed
-      error = r::exec::RFunction("devtools:::dev_mode", true).call();
+      // restore devmode
+      if (settings.getBool(kDevModeOn, false))
+      {
+         // ignore error -- will occur if devtools isn't installed
+         error = r::exec::RFunction("devtools:::dev_mode", true).call();
+      }
    }
 
    // restore client_metrics (must execute after restore of options for
@@ -553,8 +663,7 @@ bool restore(const FilePath& statePath,
    // process that are potentially highly latent. this allows clients
    // to bring their UI up and then receive an event indicating that the
    // latent deserialization actions are taking place
-   *pDeferredRestoreAction = boost::bind(deferredRestore,
-                                             statePath, serverMode);
+   *pDeferredRestoreAction = boost::bind(deferredRestore, statePath, serverMode);
    
    // return true if there were no error messages
    return pErrorMessages->empty();

--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -500,12 +500,9 @@ bool packratModeEnabled(const core::FilePath& statePath)
 Error deferredRestore(const FilePath& statePath, bool serverMode)
 {
    // search path
-   if (s_isCompatibleSessionState)
-   {
-      Error error = search_path::restore(statePath);
-      if (error)
-         return error;
-   }
+   Error error = search_path::restore(statePath, s_isCompatibleSessionState);
+   if (error)
+      return error;
    
    // report incompatible R version
    if (!s_isCompatibleSessionState)

--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -13,7 +13,7 @@
  *
  */
 
-#include "RSessionState.hpp"
+#include <r/session/RSessionState.hpp>
 
 #include <algorithm>
 
@@ -507,8 +507,6 @@ Error deferredRestore(const FilePath& statePath, bool serverMode)
    // report incompatible R version
    if (!s_isCompatibleSessionState)
    {
-      s_isCompatibleSessionState = true;
-      
       if (!s_activeRVersion.empty() &&
           !s_suspendedRVersion.empty())
       {
@@ -679,9 +677,15 @@ bool destroy(const FilePath& statePath)
       return true;
    }
 }
-   
-   
-      
+
+SessionStateInfo getSessionStateInfo()
+{
+   SessionStateInfo info;
+   info.suspendedRVersion = core::Version(s_suspendedRVersion);
+   info.activeRVersion = core::Version(s_activeRVersion);
+   return info;
+}
+
 } // namespace state
 } // namespace session   
 } // namespace r

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -567,8 +567,8 @@ void notifyIfRVersionChanged()
    if (info.activeRVersion != info.suspendedRVersion)
    {
       const char* fmt =
-            "Detected R version change [%1% -> %2%]: "
-            "not restoring all session state\n";
+            "R version change [%1% -> %2%] detected when restoring session; "
+            "search path not restored\n";
       
       boost::format formatter(fmt);
       formatter


### PR DESCRIPTION
NOTE: not quite ready for merge; likely needs some tweaking re: how the message is reported to the user.

This PR fixes an issue where R could crash on startup when attempting to restore an workspace associated with a different version of R than the currently active version of R.

The fix is mostly straightforward -- on suspend, we now write the R version to a file; on restore, we validate against that version, and abort the restore if either the major or minor versions differ.

This should hopefully reduce some headaches that we might see with the introduction of R 3.4.0.

Right now, the error message is just plainly reported to the console:

![screen shot 2017-03-22 at 12 49 02 pm](https://cloud.githubusercontent.com/assets/1976582/24217741/1816069e-0efe-11e7-9fdb-485d775326f6.png)

but we might want to tweak this (e.g. just change the error message, or provide a modal dialog information the user, or otherwise)