### PR TITLE
Bug fix, non-busy terminals were reporting as busy in certain restart scenarios

### DIFF
--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -955,6 +955,16 @@ void deserializeConsoleProcs(const std::string& jsonStr)
    {
       boost::shared_ptr<ConsoleProcess> proc =
                                     ConsoleProcess::fromJson(it->get_obj());
+
+      // Deserializing consoleprocs list only happens during session
+      // initialization, therefore they do not represent an actual running
+      // async process, therefore are not busy. Mark as such, otherwise we
+      // can get false "busy" indications on the client after a restart, for
+      // example if a session was closed with busy terminal(s), then
+      // restarted. This is not hit if reconnecting to a still-running
+      // session.
+      proc->setNotBusy();
+
       s_procs[proc->handle()] = proc;
    }
 }

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -133,6 +133,7 @@ public:
    void setCaption(std::string& caption) { procInfo_->setCaption(caption); }
    void setTitle(std::string& title) { procInfo_->setTitle(title); }
    void deleteLogFile() const;
+   void setNotBusy() { procInfo_->setHasChildProcs(false); }
 
    // Get the given (0-based) chunk of the saved buffer; if more is available
    // after the requested chunk, *pMoreAvailable will be set to true


### PR DESCRIPTION
If you closed a session with a busy terminal (i.e. ignoring the warning), the terminal processes are killed (they die with the session) but metadata was still tracking the last-known busy state.

On restarting that session, the previous state was being reported, so you could get warned about terminal being busy even if you didn't have the terminal tab showing at all, or if you hadn't yet clicked on the tab and reopened the associated terminal session (which would spin up processes which would then update the busy-state flag).