### PR TITLE
Avoid duplicate drivers when description specified

### DIFF
--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -241,8 +241,10 @@ options(connectionObserver = list(
        exists("list_drivers", envir = asNamespace("odbc"))) {
       listDrivers <- get("list_drivers", envir = asNamespace("odbc"))
 
-      driversNoSnippet <- Filter(function(e) { !(e %in% names(snippets)) }, listDrivers()$name)
+      drivers <- listDrivers()
+      uniqueDrivers <- drivers[drivers$attribute == "Driver", ]
 
+      driversNoSnippet <- Filter(function(e) { !(e %in% names(snippets)) }, uniqueDrivers$name)
 
       connectionList <- c(connectionList, lapply(driversNoSnippet, function(driver) {
          snippet <- paste(


### PR DESCRIPTION
Avoid duplicate drivers when the `ODBCINST` has multiple entries, `odbc::list_drivers()` returns a table of properties not a table of drivers.