### PR TITLE
save/load cursor position on restore

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -861,33 +861,6 @@ public class Source implements InsertSourceHandler,
             // next one
             if (sourceEditor == null)
                continue;
-
-            final EditingTarget editor = sourceEditor;
-            
-            // if this is a source window, check to see if it was opened to
-            // pop out a particular doc, and restore that doc's position if so
-            if (!SourceWindowManager.isMainSourceWindow())
-            {
-               final SourceWindow sourceWindow = 
-                     RStudioGinjector.INSTANCE.getSourceWindow();
-               if (sourceWindow.getInitialDocId() == doc.getId() &&
-                   sourceWindow.getInitialSourcePosition() != null)
-               {
-                  // restore position deferred; restoring it immediately after
-                  // instantiating the editor causes inaccurate scroll position
-                  // reads elsewhere
-                  Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand()
-                  {
-                     @Override
-                     public void execute()
-                     {
-                        editor.restorePosition(
-                              sourceWindow.getInitialSourcePosition());
-                        editor.ensureCursorVisible();
-                     }
-                  });
-               }
-            }
          }
       }
    }
@@ -1902,21 +1875,11 @@ public class Source implements InsertSourceHandler,
             {
                final EditingTarget target = addTab(doc, e.getPos());
                
-               // restore position deferred; restoring it immediately after
-               // instantiating the editor causes inaccurate scroll position
-               // reads elsewhere
                Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand()
                {
                   @Override
                   public void execute()
                   {
-                     // if we know the source position, restore it
-                     if (e.getParams() != null &&
-                         e.getParams().getSourcePosition() != null)
-                     {
-                        target.restorePosition(e.getParams().getSourcePosition());
-                        target.ensureCursorVisible();
-                     }
                      // if there was a collab session, resume it
                      if (collabParams != null)
                         target.beginCollabSession(e.getCollabParams());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -1946,6 +1946,22 @@ public class AceEditor implements DocDisplay,
       widget_.getEditor().retokenizeDocument();
    }
    
+   public void setScrollLeft(int x)
+   {
+      getSession().setScrollLeft(x);
+   }
+   
+   public void setScrollTop(int y)
+   {
+      getSession().setScrollTop(y);
+   }
+   
+   public void scrollTo(int x, int y)
+   {
+      getSession().setScrollLeft(x);
+      getSession().setScrollTop(y);
+   }
+   
    private native final void _setHighlightRFunctionCallsImpl(boolean highlight)
    /*-{
       var Mode = $wnd.require("mode/r_highlight_rules");
@@ -2442,6 +2458,12 @@ public class AceEditor implements DocDisplay,
    public void splitIntoLines()
    {
       widget_.getEditor().splitIntoLines();
+   }
+   
+   @Override
+   public int getFirstFullyVisibleRow()
+   {
+      return widget_.getEditor().getRenderer().getFirstFullyVisibleRow();
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -183,6 +183,10 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    void setScrollPastEndOfDocument(boolean enable);
    void setHighlightRFunctionCalls(boolean highlight);
    
+   void setScrollLeft(int x);
+   void setScrollTop(int y);
+   void scrollTo(int x, int y);
+   
    void enableSearchHighlight();
    void disableSearchHighlight();
    
@@ -384,6 +388,8 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    
    void blockOutdent();
    void splitIntoLines();
+   
+   int getFirstFullyVisibleRow();
    
    Rectangle getPositionBounds(Position position);
    Rectangle getRangeBounds(Range range);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1551,11 +1551,11 @@ public class TextEditingTarget implements
                HashMap<String, String> properties = new HashMap<String, String>();
                
                properties.put(
-                     "cursorPosition",
+                     PROPERTY_CURSOR_POSITION,
                      Position.serialize(docDisplay_.getCursorPosition()));
                
                properties.put(
-                     "scrollLine",
+                     PROPERTY_SCROLL_LINE,
                      String.valueOf(docDisplay_.getFirstFullyVisibleRow()));
                
                docUpdateSentinel_.modifyProperties(properties);
@@ -1574,19 +1574,17 @@ public class TextEditingTarget implements
          @Override
          public void execute()
          {
-            String cursorPosition = docUpdateSentinel_.getProperty("cursorPosition", "");
+            String cursorPosition = docUpdateSentinel_.getProperty(
+                  PROPERTY_CURSOR_POSITION,
+                  "");
+            
             if (StringUtil.isNullOrEmpty(cursorPosition))
                return;
             
-            Integer scrollLine = 0;
-            try
-            {
-               scrollLine = Integer.parseInt(docUpdateSentinel_.getProperty("scrollLine", "0"));
-            }
-            catch (Exception e)
-            {
-               Debug.logException(e);
-            }
+            
+            int scrollLine = StringUtil.parseInt(
+                  docUpdateSentinel_.getProperty(PROPERTY_SCROLL_LINE, "0"),
+                  0);
             
             Position position = Position.deserialize(cursorPosition);
             docDisplay_.setCursorPosition(position);
@@ -6588,4 +6586,7 @@ public class TextEditingTarget implements
 
       abstract void doExtract(final JsArrayString response);
    }
+   
+   private static final String PROPERTY_CURSOR_POSITION = "cursorPosition";
+   private static final String PROPERTY_SCROLL_LINE = "scrollLine";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/EditSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/EditSession.java
@@ -123,6 +123,10 @@ public class EditSession extends JavaScriptObject
       return this.getScreenLength();
    }-*/;
    
+   public native final void setScrollLeft(int left) /*-{
+      this.setScrollLeft(left);
+   }-*/;
+   
    public native final void setScrollTop(int top) /*-{
       this.setScrollTop(top);
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Position.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Position.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.text.ace;
 
+import org.rstudio.core.client.Debug;
+
 import com.google.gwt.core.client.JavaScriptObject;
 
 public class Position extends JavaScriptObject
@@ -91,6 +93,31 @@ public class Position extends JavaScriptObject
    public final String asString()
    {
       return "[" + getRow() + ", " + getColumn() + "]";
+   }
+   
+   public static final native String serialize(Position position) /*-{
+      return position.row + "," + position.column;
+   }-*/;
+   
+   public static final Position deserialize(String serialized)
+   {
+      String[] parts = serialized.split(",");
+      if (parts.length < 2)
+         return Position.create(0, 0);
+      
+      int row = 0;
+      int col = 0;
+      try
+      {
+         row = Integer.parseInt(parts[0]);
+         col = Integer.parseInt(parts[1]);
+      }
+      catch (Exception e)
+      {
+         Debug.logException(e);
+      }
+      
+      return Position.create(row, col);
    }
       
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Renderer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Renderer.java
@@ -191,4 +191,8 @@ public class Renderer extends JavaScriptObject
       return !!this.$scrollPastEnd;
    }-*/;
    
+   public final native int getFirstFullyVisibleRow() /*-{
+      return this.getFirstFullyVisibleRow();
+   }-*/;
+   
 }


### PR DESCRIPTION
This PR adds the cursor position and top scroll line as part of the document properties, and restores those when a document is opened (effectively, saving + loading the cursor position when closing and opening documents).