### PR TITLE
always use 'core.quotepath=off' with git

### DIFF
--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -410,16 +410,13 @@ public:
       // build shell arguments
       ShellArgs arguments;
       
-#ifdef _WIN32
-      // by default on Windows, git will return paths which contain characters
+      // on some platforms, git will return paths which contain characters
       // not in the ASCII set with a so-called 'quoted octal encoding'.
       // this is controlled by the 'core.quotepath' configuration option;
       // by setting this to off we ensure that git will return us a
       // plain UTF-8 encoded path which requires no further processing
-      arguments << "-c" << "core.quotepath=off";
-#endif
-      
-      arguments << "status" << "--porcelain" << "--" << dir;
+      arguments << "-c" << "core.quotepath=off"
+                << "status" << "--porcelain" << "--" << dir;
       
       std::string output;
       Error error = runGit(arguments, &output);


### PR DESCRIPTION
This PR should resolve a bug spotted by Darby, whereby paths containing non-ASCII characters would be quoted with Git's so-called quoted octal notation. (I previously thought this issue was unique to Windows, but it actually seems to occur everywhere except macOS!)

It should be safe to just unilaterally force `core.quotepath=off`, to ensure Git returns us UTF-8 paths all the time.