### PR TITLE
build boost without python

### DIFF
--- a/dependencies/common/install-boost
+++ b/dependencies/common/install-boost
@@ -65,7 +65,7 @@ then
    cd $BOOST_VERSION
 
    # bootstrap boost
-   sudo ./bootstrap.sh  
+   sudo ./bootstrap.sh --without-libraries=python
 
    # build bcp helper
    sudo ./b2 tools/bcp
@@ -81,11 +81,12 @@ then
    cd rstudio
 
    # bootstrap again
-   sudo ./bootstrap.sh
+   sudo ./bootstrap.sh --without-libraries=python
    
    # special variation of build for osx
    if [ "$PLATFORM" == "Darwin" ]
    then
+
      # need flags for Mavericks and later instructing the compiler to target
      # the older libstdc++
      SYS_MAJOR_VER=`uname -r | cut -d "." -f -1`
@@ -98,15 +99,33 @@ then
         BJAM_LDFLAGS=""
      fi
 
-     sudo ./bjam ${BOOST_BJAM_FLAGS} --prefix=$BOOST_DIR toolset=clang ${BJAM_CXXFLAGS} ${BJAM_LDFLAGS} variant=release threading=multi link=static install
+     sudo ./bjam              \
+        "${BOOST_BJAM_FLAGS}" \
+        --prefix="$BOOST_DIR" \
+        toolset=clang         \
+        "${BJAM_CXXFLAGS}"    \
+        "${BJAM_LDFLAGS}"     \
+        --without-python      \
+        variant=release       \
+        threading=multi       \
+        link=static           \
+        install
    else
-     sudo ./bjam ${BOOST_BJAM_FLAGS} --prefix=$BOOST_DIR variant=release install
+      # plain old build for other platforms
+     sudo ./bjam              \
+        "${BOOST_BJAM_FLAGS}" \
+        --prefix="$BOOST_DIR" \
+        --without-python      \
+        variant=release       \
+        install
    fi
 
    # rename libraries in the boost install dir
    cd $BOOST_DIR/lib
    for file in librstudio*; do
-      sudo mv $file ${file/rstudio_/}
+      src=$file
+      tgt="$(echo $file | sed 's/rstudio_//')"
+      sudo mv "$src" "$tgt"
    done
 
    # go back to the original install dir and remove build dir

--- a/dependencies/windows/install-boost/install-boost.R
+++ b/dependencies/windows/install-boost/install-boost.R
@@ -81,7 +81,7 @@ invisible(lapply(docs, function(doc) {
 # bootstrap the boost build directory
 PATH$prepend(toolchain_32bit)
 section("Bootstrapping boost...")
-exec("cmd.exe", "/C call bootstrap.bat gcc")
+exec("cmd.exe", "/C call bootstrap.bat gcc --without-libraries=python")
 
 # create bcp executable (so we can create Boost
 # using a private namespace)
@@ -97,7 +97,7 @@ exec("bcp", args)
 
 # enter the 'rstudio' directory and re-bootstrap
 enter("rstudio")
-exec("cmd.exe", "/C call bootstrap.bat gcc")
+exec("cmd.exe", "/C call bootstrap.bat gcc --without-libraries=python")
 PATH$remove(toolchain_32bit)
 
 # construct common arguments for 32bit, 64bit boost builds
@@ -112,15 +112,7 @@ b2_build_args <- function(bitness) {
       "toolset=gcc",
       sprintf("address-model=%s", bitness),
       sprintf("--prefix=%s", prefix),
-      "--with-chrono",
-      "--with-date_time",
-      "--with-filesystem",
-      "--with-iostreams",
-      "--with-program_options",
-      "--with-regex",
-      "--with-signals",
-      "--with-system",
-      "--with-thread",
+      "--without-python",
       "variant=release",
       "link=static",
       "runtime-link=static",


### PR DESCRIPTION
This PR ensures that we build Boost without Python, to ensure installation succeeds on build machines that don't have a non-minimal Python installation available.

## Tested On
- [x] macOS
- [x] CentOS 7
- [x] Windows