### PR TITLE
improve RStudio's ability to recover crashed sessions

### DIFF
--- a/src/cpp/core/file_lock/LinkBasedFileLock.cpp
+++ b/src/cpp/core/file_lock/LinkBasedFileLock.cpp
@@ -96,6 +96,8 @@ bool isLockFileStale(const FilePath& lockFilePath)
 
 bool isLockFileOrphaned(const FilePath& lockFilePath)
 {
+#ifndef _WIN32
+   
    Error error;
    
    // attempt to read pid from lockfile
@@ -137,6 +139,8 @@ bool isLockFileOrphaned(const FilePath& lockFilePath)
    // then this lockfile has been orphaned
    if (result.exitStatus != EXIT_SUCCESS)
       return true;
+   
+#endif /* _WIN32 */
    
    // assume the process is not orphaned if all previous checks failed
    return false;

--- a/src/cpp/core/file_lock/LinkBasedFileLock.cpp
+++ b/src/cpp/core/file_lock/LinkBasedFileLock.cpp
@@ -32,6 +32,7 @@
 #include <core/Log.hpp>
 #include <core/FilePath.hpp>
 #include <core/FileSerializer.hpp>
+#include <core/system/Process.hpp>
 #include <core/system/System.hpp>
 
 #include <boost/foreach.hpp>
@@ -93,10 +94,63 @@ bool isLockFileStale(const FilePath& lockFilePath)
    return LinkBasedFileLock::isLockFileStale(lockFilePath);
 }
 
+bool isLockFileOrphaned(const FilePath& lockFilePath)
+{
+   Error error;
+   
+   // attempt to read pid from lockfile
+   std::string pid;
+   error = core::readStringFromFile(lockFilePath, &pid);
+   if (error)
+   {
+      LOG_ERROR(error);
+      return false;
+   }
+   pid = string_utils::trimWhitespace(pid);
+   
+#ifdef __linux__
+   
+   // on linux, we can check the proc filesystem for an associated
+   // process -- if there is no such directory, then we assume that
+   // this lockfile has been orphaned
+   FilePath procPath("/proc/" + pid);
+   if (!procPath.exists())
+      return true;
+   
+#endif
+   
+   // call 'ps' to attempt to see if a process associated
+   // with this process id exists (and get information about it)
+   using namespace core::system;
+   std::string command = "ps -p " + pid;
+   ProcessOptions options;
+   ProcessResult result;
+   error = core::system::runCommand(command, options, &result);
+   if (error)
+   {
+      LOG_ERROR(error);
+      return false;
+   }
+   
+   // ps will return a non-zero exit status if no process with
+   // the requested id is available -- if there is no process,
+   // then this lockfile has been orphaned
+   if (result.exitStatus != EXIT_SUCCESS)
+      return true;
+   
+   // assume the process is not orphaned if all previous checks failed
+   return false;
+   
+}
+
 } // end anonymous namespace
 
 bool LinkBasedFileLock::isLockFileStale(const FilePath& lockFilePath)
 {
+   // check for orphaned lockfile
+   if (isLockFileOrphaned(lockFilePath))
+      return true;
+   
    double seconds = s_timeoutInterval.total_seconds();
    double diff = ::difftime(::time(NULL), lockFilePath.lastWriteTime());
    return diff >= seconds;
@@ -203,7 +257,7 @@ Error writeLockFile(const FilePath& lockFilePath)
    
    // ensure the proxy file is created, and remove it when we're done
    RemoveOnExitScope scope(proxyPath, ERROR_LOCATION);
-   error = proxyPath.ensureFile();
+   error = core::writeStringToFile(proxyPath, pidString());
    if (error)
    {
       // log the error since it isn't expected and could get swallowed


### PR DESCRIPTION
This PR allows us to check whether a link-based lockfile is orphaned; that is, generated by an `rsession` process that no longer exists. (This typically occurs when an `rsession` process crashes, and hence is unable to clean up the lockfile on exit.)

We accomplish this by writing the process ID of the active R session to the generated lockfile, and allowing other processes to check the PID in that lockfile when determining whether the lockfile is active or stale / orphaned.

This PR should ensure that users who see their R session crash are able to promptly reconnect to the previous session, and in particular should fix bogus 'File not found' errors that can pop up during file autosave when this underlying 'session disconnect' has occurred.

Currently, the PR is relatively conservative about the process id check -- in theory, since we don't check whether the existing process is an RStudio process of some kind, it's possible that another non-RStudio process could be generated with the same PID as seen in the lockfile, and we would then fail to detect that as orphaned. In practice, this should almost never occur.