### PR TITLE
Support ODBC snippets provided by odbc-install

### DIFF
--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -250,8 +250,8 @@ options(connectionObserver = list(
 
          currentDriver <- drivers[drivers$attribute == "Driver" & drivers$name == driver, ]
 
-         snippetsPath <- file.path(dirname(currentDriver$value), "..", "..", "snippets")
-         snippetsFile <- file.path(snippetsPath, paste(driver, ".R", sep = ""))
+         basePath <- sub(paste(tolower(driver), ".*$", sep = ""), "", currentDriver$value)
+         snippetsFile <- file.path(basePath, tolower(driver), "snippets", paste(driver, ".R", sep = ""))
          if (file.exists(snippetsFile)) {
             snippet <- paste(readLines(snippetsFile), collapse = "\n")
          }

--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -247,11 +247,21 @@ options(connectionObserver = list(
       driversNoSnippet <- Filter(function(e) { !(e %in% names(snippets)) }, uniqueDrivers$name)
 
       connectionList <- c(connectionList, lapply(driversNoSnippet, function(driver) {
-         snippet <- paste(
-            "library(DBI)\n",
-            "con <- dbConnect(odbc::odbc(), .connection_string = \"", 
-            "Driver={", driver, "};${1:Parameters}\")",
-            sep = "")
+
+         currentDriver <- drivers[drivers$attribute == "Driver" & drivers$name == driver, ]
+
+         snippetsPath <- file.path(dirname(currentDriver$value), "..", "..", "snippets")
+         snippetsFile <- file.path(snippetsPath, paste(driver, ".R", sep = ""))
+         if (file.exists(snippetsFile)) {
+            snippet <- paste(readLines(snippetsFile), collapse = "\n")
+         }
+         else {
+            snippet <- paste(
+               "library(DBI)\n",
+               "con <- dbConnect(odbc::odbc(), .connection_string = \"", 
+               "Driver={", driver, "};${1:Parameters}\")",
+               sep = "")
+         }
 
          list(
             package = .rs.scalar(NULL),

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetHost.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetHost.java
@@ -387,5 +387,5 @@ public class NewConnectionSnippetHost extends Composite
    ArrayList<NewConnectionSnippetParts> snippetParts_;
    HashMap<String, String> partsKeyValues_ = new HashMap<String, String>();
 
-   static final String pattern_ = "\\$\\{([0-9]+):([^:=}]+)(=([^:}]+))?(:([^}]+))?\\}";
+   static final String pattern_ = "\\$\\{([0-9]+):([^:=}]+)(=([^:}]*))?(:([^}]+))?\\}";
 }


### PR DESCRIPTION
`odbc-install` installs the code snippets withing the driver folder under a `snippets` folder. Notice that currently `connections-path` and the `/etc/rstudio/connections/` location take precedence over the drivers `snippets` folder so one can easily override the ones provided by default.

Also, a minor fix to `snippets` syntax to allow explicit empty default values.