### PR TITLE
support R graphics engine v12

### DIFF
--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -57,7 +57,7 @@ struct ROptions
 {
    ROptions() :
          useInternet2(true),
-         rCompatibleGraphicsEngineVersion(9),
+         rCompatibleGraphicsEngineVersion(12),
          serverMode(false),
          autoReloadSource(false),
          restoreWorkspace(true),

--- a/src/cpp/r/session/graphics/RGraphicsDevDesc.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsDevDesc.cpp
@@ -345,6 +345,104 @@ struct DevDescVersion8
    char reserved[64];
 };
 
+// NOTE: compatible with graphics engine versions 9, 10, 11
+struct DevDescVersion9
+{
+   double left;
+   double right;
+   double bottom;
+   double top;
+   double clipLeft;
+   double clipRight;
+   double clipBottom;
+   double clipTop;
+   double xCharOffset;
+   double yCharOffset;
+   double yLineBias;
+   double ipr[2];
+   double cra[2];
+   double gamma;
+   Rboolean canClip;
+   Rboolean canChangeGamma;
+   int canHAdj;
+   double startps;
+   int startcol;
+   int startfill;
+   int startlty;
+   int startfont;
+   double startgamma;
+   void *deviceSpecific;
+   Rboolean displayListOn;
+   Rboolean canGenMouseDown;
+   Rboolean canGenMouseMove;
+   Rboolean canGenMouseUp;
+   Rboolean canGenKeybd;
+   Rboolean gettingEvent;
+
+   void (*activate)(const pDevDesc );
+   void (*circle)(double x, double y, double r, const pGEcontext gc, pDevDesc dd);
+   void (*clip)(double x0, double x1, double y0, double y1, pDevDesc dd);
+   void (*close)(pDevDesc dd);
+   void (*deactivate)(pDevDesc );
+   Rboolean (*locator)(double *x, double *y, pDevDesc dd);
+   void (*line)(double x1, double y1, double x2, double y2,
+       const pGEcontext gc, pDevDesc dd);
+   void (*metricInfo)(int c, const pGEcontext gc,
+             double* ascent, double* descent, double* width,
+             pDevDesc dd);
+   void (*mode)(int mode, pDevDesc dd);
+   void (*newPage)(const pGEcontext gc, pDevDesc dd);
+   void (*polygon)(int n, double *x, double *y, const pGEcontext gc, pDevDesc dd);
+   void (*polyline)(int n, double *x, double *y, const pGEcontext gc, pDevDesc dd);
+   void (*rect)(double x0, double y0, double x1, double y1,
+       const pGEcontext gc, pDevDesc dd);
+
+
+   // dev_Path added in version 8
+   void (*path)(double *x, double *y,
+                  int npoly, int *nper,
+                  Rboolean winding,
+                  const pGEcontext gc, pDevDesc dd);
+
+   // dev_Raster and dev_Cap added in version 6
+   void (*raster)(unsigned int *raster, int w, int h,
+                double x, double y,
+                double width, double height,
+                double rot,
+                Rboolean interpolate,
+                const pGEcontext gc, pDevDesc dd);
+   SEXP (*cap)(pDevDesc dd);
+
+   void (*size)(double *left, double *right, double *bottom, double *top,
+    pDevDesc dd);
+   double (*strWidth)(const char *str, const pGEcontext gc, pDevDesc dd);
+   void (*text)(double x, double y, const char *str, double rot,
+    double hadj, const pGEcontext gc, pDevDesc dd);
+   void (*onExit)(pDevDesc dd);
+   SEXP (*getEvent)(SEXP, const char *);
+   Rboolean (*newFrameConfirm)(pDevDesc dd);
+
+   Rboolean hasTextUTF8; /* and strWidthUTF8 */
+   void (*textUTF8)(double x, double y, const char *str, double rot,
+        double hadj, const pGEcontext gc, pDevDesc dd);
+   double (*strWidthUTF8)(const char *str, const pGEcontext gc, pDevDesc dd);
+   Rboolean wantSymbolUTF8;
+   Rboolean useRotatedTextInContour;
+
+   // eventEnv and eventHelper added in version 7
+   SEXP eventEnv;
+   void (*eventHelper)(pDevDesc dd, int code);
+
+   // holdFlush and have* added in version 9 (R 2.14)
+   int (*holdflush)(pDevDesc dd, int level);
+   int haveTransparency;
+   int haveTransparentBg;
+   int haveRaster;
+   int haveCapture, haveLocator;
+
+   char reserved[64];
+};
+
 } // extern C
 
 namespace rstudio {
@@ -357,7 +455,7 @@ namespace dev_desc {
 namespace {
 
 template <typename T>
-void copyCommonMembers(const DevDescVersion9& sourceDevDesc,
+void copyCommonMembers(const DevDescVersion12& sourceDevDesc,
                           T* pTargetDevDesc)
 {
    pTargetDevDesc->left = sourceDevDesc.left;
@@ -422,16 +520,16 @@ void copyCommonMembers(const DevDescVersion9& sourceDevDesc,
 }
 
 template <typename T>
-T* allocAndInitCommonMembers(const DevDescVersion9& devDescVersion9)
+T* allocAndInitCommonMembers(const DevDescVersion12& devDescVersion12)
 {
    T* pDevDesc = (T*) std::calloc(1, sizeof(T));
-   copyCommonMembers(devDescVersion9, pDevDesc);
+   copyCommonMembers(devDescVersion12, pDevDesc);
    return pDevDesc;
 }
 
 } // anonymous namespace
 
-pDevDesc allocate(const DevDescVersion9& devDescVersion9)
+pDevDesc allocate(const DevDescVersion12& devDescVersion12)
 {
    int engineVersion = ::R_GE_getVersion();
    switch(engineVersion)
@@ -439,17 +537,17 @@ pDevDesc allocate(const DevDescVersion9& devDescVersion9)
    case 5:
    {
       DevDescVersion5* pDD = allocAndInitCommonMembers<DevDescVersion5>(
-                                                          devDescVersion9);
+                                                          devDescVersion12);
       return (pDevDesc)pDD;
    }
 
    case 6:
    {
       DevDescVersion6* pDD = allocAndInitCommonMembers<DevDescVersion6>(
-                                                            devDescVersion9);
+                                                            devDescVersion12);
 
-      pDD->raster = devDescVersion9.raster;
-      pDD->cap = devDescVersion9.cap;
+      pDD->raster = devDescVersion12.raster;
+      pDD->cap = devDescVersion12.cap;
 
       return (pDevDesc)pDD;
    }
@@ -457,12 +555,12 @@ pDevDesc allocate(const DevDescVersion9& devDescVersion9)
    case 7:
    {
       DevDescVersion7* pDD = allocAndInitCommonMembers<DevDescVersion7>(
-                                                            devDescVersion9);
+                                                            devDescVersion12);
 
-      pDD->raster = devDescVersion9.raster;
-      pDD->cap = devDescVersion9.cap;
-      pDD->eventEnv = devDescVersion9.eventEnv;
-      pDD->eventHelper = devDescVersion9.eventHelper;
+      pDD->raster = devDescVersion12.raster;
+      pDD->cap = devDescVersion12.cap;
+      pDD->eventEnv = devDescVersion12.eventEnv;
+      pDD->eventHelper = devDescVersion12.eventHelper;
 
       return (pDevDesc)pDD;
    }
@@ -471,26 +569,48 @@ pDevDesc allocate(const DevDescVersion9& devDescVersion9)
    case 8:
    {
       DevDescVersion8* pDD = allocAndInitCommonMembers<DevDescVersion8>(
-                                                            devDescVersion9);
+                                                            devDescVersion12);
 
-      pDD->path = devDescVersion9.path;
-      pDD->raster = devDescVersion9.raster;
-      pDD->cap = devDescVersion9.cap;
-      pDD->eventEnv = devDescVersion9.eventEnv;
-      pDD->eventHelper = devDescVersion9.eventHelper;
+      pDD->path = devDescVersion12.path;
+      pDD->raster = devDescVersion12.raster;
+      pDD->cap = devDescVersion12.cap;
+      pDD->eventEnv = devDescVersion12.eventEnv;
+      pDD->eventHelper = devDescVersion12.eventHelper;
 
       return (pDevDesc)pDD;
    }
 
-   // NOTE: graphics device won't be initialized unless we confirm
-   // that the current graphics engine version is v9 compatible
    case 9:
+   case 10:
+   case 11:
+   {
+      DevDescVersion9* pDD = allocAndInitCommonMembers<DevDescVersion9>(
+                                                            devDescVersion12);
+
+      pDD->path = devDescVersion12.path;
+      pDD->raster = devDescVersion12.raster;
+      pDD->cap = devDescVersion12.cap;
+      pDD->eventEnv = devDescVersion12.eventEnv;
+      pDD->eventHelper = devDescVersion12.eventHelper;
+      
+      pDD->holdflush = devDescVersion12.holdflush;
+      pDD->haveTransparency = devDescVersion12.haveTransparency;
+      pDD->haveTransparentBg = devDescVersion12.haveTransparentBg;
+      pDD->haveRaster = devDescVersion12.haveRaster;
+      pDD->haveCapture = devDescVersion12.haveCapture;
+      pDD->haveLocator = devDescVersion12.haveLocator;
+
+      return (pDevDesc)pDD;
+   }
+      
+   // NOTE: graphics device won't be initialized unless we confirm
+   // that the current graphics engine version is v12 compatible
+   case 12:
    default:
    {
-      DevDescVersion9* pDD = (DevDescVersion9*) std::calloc(
-                                             1, sizeof(DevDescVersion9));
-      *pDD = devDescVersion9;
-
+      DevDescVersion12* pDD =
+            (DevDescVersion12*) std::calloc(1, sizeof(DevDescVersion12));
+      *pDD = devDescVersion12;
       return (pDevDesc)pDD;
    }
 
@@ -517,8 +637,13 @@ void setSize(pDevDesc pDD)
       pSizeFn = ((DevDescVersion8*)pDD)->size;
       break;
    case 9:
-   default:
+   case 10:
+   case 11:
       pSizeFn = ((DevDescVersion9*)pDD)->size;
+      break;
+   case 12:
+   default:
+      pSizeFn = ((DevDescVersion12*)pDD)->size;
       break;
    }
 
@@ -535,6 +660,536 @@ void setSize(pDevDesc pDD)
            &(pDD->clipBottom),
            &(pDD->clipTop),
            pDD);
+}
+
+namespace {
+
+template <typename T>
+void setCommonDeviceAttributes(T pDev, T pShadow)
+{
+   pDev->left = pShadow->left;
+   pDev->top = pShadow->top;
+   pDev->right = pShadow->right;
+   pDev->bottom = pShadow->bottom;
+   pDev->clipLeft = pShadow->clipLeft;
+   pDev->clipTop = pShadow->clipTop;
+   pDev->clipRight = pShadow->clipRight;
+   pDev->clipBottom = pShadow->clipBottom;
+   
+   pDev->cra[0] = pShadow->cra[0];
+   pDev->cra[1] = pShadow->cra[1];
+   pDev->startps = pShadow->startps;
+   pDev->ipr[0] = pShadow->ipr[0];
+   pDev->ipr[1] = pShadow->ipr[1];
+   pDev->xCharOffset = pShadow->xCharOffset;
+   pDev->yCharOffset = pShadow->yCharOffset;
+   pDev->yLineBias = pShadow->yLineBias;
+
+   pDev->canClip = pShadow->canClip;
+   pDev->canHAdj = pShadow->canHAdj;
+   pDev->canChangeGamma = pShadow->canChangeGamma;
+   pDev->startcol = pShadow->startcol;
+   pDev->startfill = pShadow->startfill;
+   pDev->startlty = pShadow->startlty;
+   pDev->startfont = pShadow->startfont;
+   pDev->startps = pShadow->startps;
+   pDev->startgamma = pShadow->startgamma;
+   pDev->displayListOn = TRUE;
+
+   // no support for events yet
+   pDev->canGenMouseDown = FALSE;
+   pDev->canGenMouseMove = FALSE;
+   pDev->canGenMouseUp = FALSE;
+   pDev->canGenKeybd = FALSE;
+   pDev->gettingEvent = FALSE;
+}
+
+} // end anonymous namespace
+
+void setDeviceAttributes(pDevDesc pDev, pDevDesc pShadow)
+{
+   int engineVersion = ::R_GE_getVersion();
+   switch (engineVersion)
+   {
+   case 5:
+      setCommonDeviceAttributes((DevDescVersion5*) pDev, (DevDescVersion5*) pShadow);
+      break;
+   case 6:
+      setCommonDeviceAttributes((DevDescVersion6*) pDev, (DevDescVersion6*) pShadow);
+      break;
+   case 7:
+      setCommonDeviceAttributes((DevDescVersion7*) pDev, (DevDescVersion7*) pShadow);
+      break;
+   case 8:
+      setCommonDeviceAttributes((DevDescVersion8*) pDev, (DevDescVersion8*) pShadow);
+      break;
+   case 9:
+   case 10:
+   case 11:
+      setCommonDeviceAttributes((DevDescVersion9*) pDev, (DevDescVersion9*) pShadow);
+      break;
+   case 12:
+   default:
+      setCommonDeviceAttributes((DevDescVersion12*) pDev, (DevDescVersion12*) pShadow);
+      pDev->canGenIdle = pShadow->canGenIdle;
+      break;
+   }
+}
+
+void activate(const pDevDesc dd)
+{
+   // get pointer to activate function
+   void (*pActivateFn)(const pDevDesc);
+
+   int engineVersion = ::R_GE_getVersion();
+   switch (engineVersion)
+   {
+   case 5:
+      pActivateFn = ((DevDescVersion5*)dd)->activate;
+      break;
+   case 6:
+      pActivateFn = ((DevDescVersion6*)dd)->activate;
+      break;
+   case 7:
+      pActivateFn = ((DevDescVersion7*)dd)->activate;
+      break;
+   case 8:
+      pActivateFn = ((DevDescVersion8*)dd)->activate;
+      break;
+   case 9:
+   case 10:
+   case 11:
+      pActivateFn = ((DevDescVersion9*)dd)->activate;
+      break;
+   case 12:
+   default:
+      pActivateFn = ((DevDescVersion12*)dd)->activate;
+      break;
+   }
+
+   // call it
+   pActivateFn(dd);
+}
+
+void circle(double x, double y, double r, const pGEcontext gc, pDevDesc dd)
+{
+   // get pointer to circle function
+   void (*pCircleFn)(double x, double y, double r, const pGEcontext gc, pDevDesc dd);
+
+   int engineVersion = ::R_GE_getVersion();
+   switch (engineVersion)
+   {
+   case 5:
+      pCircleFn = ((DevDescVersion5*)dd)->circle;
+      break;
+   case 6:
+      pCircleFn = ((DevDescVersion6*)dd)->circle;
+      break;
+   case 7:
+      pCircleFn = ((DevDescVersion7*)dd)->circle;
+      break;
+   case 8:
+      pCircleFn = ((DevDescVersion8*)dd)->circle;
+      break;
+   case 9:
+   case 10:
+   case 11:
+      pCircleFn = ((DevDescVersion9*)dd)->circle;
+      break;
+   case 12:
+   default:
+      pCircleFn = ((DevDescVersion12*)dd)->circle;
+      break;
+   }
+
+   // call it
+   pCircleFn(x, y, r, gc, dd);
+}
+
+void clip(double x0, double x1, double y0, double y1, pDevDesc dd)
+{
+   // get pointer to clip function
+   void (*pClipFn)(double x0, double x1, double y0, double y1, pDevDesc dd);
+
+   int engineVersion = ::R_GE_getVersion();
+   switch (engineVersion)
+   {
+   case 5:
+      pClipFn = ((DevDescVersion5*)dd)->clip;
+      break;
+   case 6:
+      pClipFn = ((DevDescVersion6*)dd)->clip;
+      break;
+   case 7:
+      pClipFn = ((DevDescVersion7*)dd)->clip;
+      break;
+   case 8:
+      pClipFn = ((DevDescVersion8*)dd)->clip;
+      break;
+   case 9:
+   case 10:
+   case 11:
+      pClipFn = ((DevDescVersion9*)dd)->clip;
+      break;
+   case 12:
+   default:
+      pClipFn = ((DevDescVersion12*)dd)->clip;
+      break;
+   }
+
+   // call it
+   pClipFn(x0, x1, y0, y1, dd);
+}
+
+void close(pDevDesc dd)
+{
+   // get pointer to close function
+   void (*pCloseFn)(pDevDesc dd);
+
+   int engineVersion = ::R_GE_getVersion();
+   switch (engineVersion)
+   {
+   case 5:
+      pCloseFn = ((DevDescVersion5*)dd)->close;
+      break;
+   case 6:
+      pCloseFn = ((DevDescVersion6*)dd)->close;
+      break;
+   case 7:
+      pCloseFn = ((DevDescVersion7*)dd)->close;
+      break;
+   case 8:
+      pCloseFn = ((DevDescVersion8*)dd)->close;
+      break;
+   case 9:
+   case 10:
+   case 11:
+      pCloseFn = ((DevDescVersion9*)dd)->close;
+      break;
+   case 12:
+   default:
+      pCloseFn = ((DevDescVersion12*)dd)->close;
+      break;
+   }
+
+   // call it
+   pCloseFn(dd);
+}
+
+void deactivate(pDevDesc dd)
+{
+   // get pointer to deactivate function
+   void (*pDeactivateFn)(pDevDesc dd);
+
+   int engineVersion = ::R_GE_getVersion();
+   switch (engineVersion)
+   {
+   case 5:
+      pDeactivateFn = ((DevDescVersion5*)dd)->deactivate;
+      break;
+   case 6:
+      pDeactivateFn = ((DevDescVersion6*)dd)->deactivate;
+      break;
+   case 7:
+      pDeactivateFn = ((DevDescVersion7*)dd)->deactivate;
+      break;
+   case 8:
+      pDeactivateFn = ((DevDescVersion8*)dd)->deactivate;
+      break;
+   case 9:
+   case 10:
+   case 11:
+      pDeactivateFn = ((DevDescVersion9*)dd)->deactivate;
+      break;
+   case 12:
+   default:
+      pDeactivateFn = ((DevDescVersion12*)dd)->deactivate;
+      break;
+   }
+
+   // call it
+   pDeactivateFn(dd);
+}
+
+Rboolean locator(double *x, double *y, pDevDesc dd)
+{
+   // get pointer to locator function
+   Rboolean (*pLocatorFn)(double *x, double *y, pDevDesc dd);
+
+   int engineVersion = ::R_GE_getVersion();
+   switch (engineVersion)
+   {
+   case 5:
+      pLocatorFn = ((DevDescVersion5*)dd)->locator;
+      break;
+   case 6:
+      pLocatorFn = ((DevDescVersion6*)dd)->locator;
+      break;
+   case 7:
+      pLocatorFn = ((DevDescVersion7*)dd)->locator;
+      break;
+   case 8:
+      pLocatorFn = ((DevDescVersion8*)dd)->locator;
+      break;
+   case 9:
+   case 10:
+   case 11:
+      pLocatorFn = ((DevDescVersion9*)dd)->locator;
+      break;
+   case 12:
+   default:
+      pLocatorFn = ((DevDescVersion12*)dd)->locator;
+      break;
+   }
+
+   // call it
+   return pLocatorFn(x, y, dd);
+}
+
+void line(double x1, double y1, double x2, double y2, const pGEcontext gc, pDevDesc dd)
+{
+   // get pointer to line function
+   void (*pLineFn)(double x1, double y1, double x2, double y2, const pGEcontext gc, pDevDesc dd);
+
+   int engineVersion = ::R_GE_getVersion();
+   switch (engineVersion)
+   {
+   case 5:
+      pLineFn = ((DevDescVersion5*)dd)->line;
+      break;
+   case 6:
+      pLineFn = ((DevDescVersion6*)dd)->line;
+      break;
+   case 7:
+      pLineFn = ((DevDescVersion7*)dd)->line;
+      break;
+   case 8:
+      pLineFn = ((DevDescVersion8*)dd)->line;
+      break;
+   case 9:
+   case 10:
+   case 11:
+      pLineFn = ((DevDescVersion9*)dd)->line;
+      break;
+   case 12:
+   default:
+      pLineFn = ((DevDescVersion12*)dd)->line;
+      break;
+   }
+
+   // call it
+   pLineFn(x1, y1, x2, y2, gc, dd);
+}
+
+void metricInfo(int c, const pGEcontext gc, double *ascent, double *descent, double *width, pDevDesc dd)
+{
+   // get pointer to metricInfo function
+   void (*pMetricInfoFn)(int c, const pGEcontext gc, double *ascent, double *descent, double *width, pDevDesc dd);
+
+   int engineVersion = ::R_GE_getVersion();
+   switch (engineVersion)
+   {
+   case 5:
+      pMetricInfoFn = ((DevDescVersion5*)dd)->metricInfo;
+      break;
+   case 6:
+      pMetricInfoFn = ((DevDescVersion6*)dd)->metricInfo;
+      break;
+   case 7:
+      pMetricInfoFn = ((DevDescVersion7*)dd)->metricInfo;
+      break;
+   case 8:
+      pMetricInfoFn = ((DevDescVersion8*)dd)->metricInfo;
+      break;
+   case 9:
+   case 10:
+   case 11:
+      pMetricInfoFn = ((DevDescVersion9*)dd)->metricInfo;
+      break;
+   case 12:
+   default:
+      pMetricInfoFn = ((DevDescVersion12*)dd)->metricInfo;
+      break;
+   }
+
+   // call it
+   pMetricInfoFn(c, gc, ascent, descent, width, dd);
+}
+
+void mode(int mode, pDevDesc dd)
+{
+   // get pointer to mode function
+   void (*pModeFn)(int mode, pDevDesc dd);
+
+   int engineVersion = ::R_GE_getVersion();
+   switch (engineVersion)
+   {
+   case 5:
+      pModeFn = ((DevDescVersion5*)dd)->mode;
+      break;
+   case 6:
+      pModeFn = ((DevDescVersion6*)dd)->mode;
+      break;
+   case 7:
+      pModeFn = ((DevDescVersion7*)dd)->mode;
+      break;
+   case 8:
+      pModeFn = ((DevDescVersion8*)dd)->mode;
+      break;
+   case 9:
+   case 10:
+   case 11:
+      pModeFn = ((DevDescVersion9*)dd)->mode;
+      break;
+   case 12:
+   default:
+      pModeFn = ((DevDescVersion12*)dd)->mode;
+      break;
+   }
+
+   // call it
+   if (pModeFn != NULL)
+      pModeFn(mode, dd);
+}
+
+void newPage(const pGEcontext gc, pDevDesc dd)
+{
+   // get pointer to newPage function
+   void (*pNewPageFn)(const pGEcontext gc, pDevDesc dd);
+
+   int engineVersion = ::R_GE_getVersion();
+   switch (engineVersion)
+   {
+   case 5:
+      pNewPageFn = ((DevDescVersion5*)dd)->newPage;
+      break;
+   case 6:
+      pNewPageFn = ((DevDescVersion6*)dd)->newPage;
+      break;
+   case 7:
+      pNewPageFn = ((DevDescVersion7*)dd)->newPage;
+      break;
+   case 8:
+      pNewPageFn = ((DevDescVersion8*)dd)->newPage;
+      break;
+   case 9:
+   case 10:
+   case 11:
+      pNewPageFn = ((DevDescVersion9*)dd)->newPage;
+      break;
+   case 12:
+   default:
+      pNewPageFn = ((DevDescVersion12*)dd)->newPage;
+      break;
+   }
+
+   // call it
+   pNewPageFn(gc, dd); 
+}
+
+void polygon(int n, double *x, double *y, const pGEcontext gc, pDevDesc dd)
+{
+   // get pointer to polygon function
+   void (*pPolygonFn)(int n, double *x, double *y, const pGEcontext gc, pDevDesc dd);
+
+   int engineVersion = ::R_GE_getVersion();
+   switch (engineVersion)
+   {
+   case 5:
+      pPolygonFn = ((DevDescVersion5*)dd)->polygon;
+      break;
+   case 6:
+      pPolygonFn = ((DevDescVersion6*)dd)->polygon;
+      break;
+   case 7:
+      pPolygonFn = ((DevDescVersion7*)dd)->polygon;
+      break;
+   case 8:
+      pPolygonFn = ((DevDescVersion8*)dd)->polygon;
+      break;
+   case 9:
+   case 10:
+   case 11:
+      pPolygonFn = ((DevDescVersion9*)dd)->polygon;
+      break;
+   case 12:
+   default:
+      pPolygonFn = ((DevDescVersion12*)dd)->polygon;
+      break;
+   }
+
+   // call it
+   pPolygonFn(n, x, y, gc, dd);
+}
+
+void polyline(int n, double *x, double *y, const pGEcontext gc, pDevDesc dd)
+{
+   // get pointer to polyline function
+   void (*pPolylineFn)(int n, double *x, double *y, const pGEcontext gc, pDevDesc dd);
+
+   int engineVersion = ::R_GE_getVersion();
+   switch (engineVersion)
+   {
+   case 5:
+      pPolylineFn = ((DevDescVersion5*)dd)->polyline;
+      break;
+   case 6:
+      pPolylineFn = ((DevDescVersion6*)dd)->polyline;
+      break;
+   case 7:
+      pPolylineFn = ((DevDescVersion7*)dd)->polyline;
+      break;
+   case 8:
+      pPolylineFn = ((DevDescVersion8*)dd)->polyline;
+      break;
+   case 9:
+   case 10:
+   case 11:
+      pPolylineFn = ((DevDescVersion9*)dd)->polyline;
+      break;
+   case 12:
+   default:
+      pPolylineFn = ((DevDescVersion12*)dd)->polyline;
+      break;
+   }
+
+   // call it
+   pPolylineFn(n, x, y, gc, dd); 
+}
+
+void rect(double x0, double y0, double x1, double y1, const pGEcontext gc, pDevDesc dd)
+{
+   // get pointer to rect function
+   void (*pRectFn)(double x0, double y0, double x1, double y1, const pGEcontext gc, pDevDesc dd);
+
+   int engineVersion = ::R_GE_getVersion();
+   switch(engineVersion)
+   {
+   case 5:
+      pRectFn = ((DevDescVersion5*)dd)->rect;
+      break;
+   case 6:
+      pRectFn = ((DevDescVersion6*)dd)->rect;
+      break;
+   case 7:
+      pRectFn = ((DevDescVersion7*)dd)->rect;
+      break;
+   case 8:
+      pRectFn = ((DevDescVersion8*)dd)->rect;
+      break;
+   case 9:
+   case 10:
+   case 11:
+      pRectFn = ((DevDescVersion9*)dd)->rect;
+      break;
+   case 12:
+   default:
+      pRectFn = ((DevDescVersion12*)dd)->rect;
+      break;
+   }
+
+   // call it
+   pRectFn(x0, y0, x1, y1, gc, dd); 
 }
 
 void path(double *x,
@@ -556,8 +1211,13 @@ void path(double *x,
       pPathFn = ((DevDescVersion8*)dd)->path;
       break;
    case 9:
-   default:
+   case 10:
+   case 11:
       pPathFn = ((DevDescVersion9*)dd)->path;
+      break;
+   case 12:
+   default:
+      pPathFn = ((DevDescVersion12*)dd)->path;
       break;
    }
 
@@ -593,13 +1253,83 @@ void raster(unsigned int *raster,
       pRasterFn = ((DevDescVersion8*)dd)->raster;
       break;
    case 9:
-   default:
+   case 10:
+   case 11:
       pRasterFn = ((DevDescVersion9*)dd)->raster;
+      break;
+   case 12:
+   default:
+      pRasterFn = ((DevDescVersion12*)dd)->raster;
       break;
    }
 
    // call it
    pRasterFn(raster, w, h, x, y, width, height, rot, interpolate, gc, dd);
+}
+
+SEXP cap(pDevDesc dd)
+{
+   // get pointer to cap function
+   SEXP (*pCapFn)(pDevDesc dd);
+   int engineVersion = ::R_GE_getVersion();
+   switch(engineVersion)
+   {
+   case 6:
+      pCapFn = ((DevDescVersion6*)dd)->cap;
+      break;
+   case 7:
+      pCapFn = ((DevDescVersion7*)dd)->cap;
+      break;
+   case 8:
+      pCapFn = ((DevDescVersion8*)dd)->cap;
+      break;
+   case 9:
+   case 10:
+   case 11:
+      pCapFn = ((DevDescVersion9*)dd)->cap;
+      break;
+   case 12:
+   default:
+      pCapFn = ((DevDescVersion12*)dd)->cap;
+      break;
+   }
+
+   // call it
+   return pCapFn(dd);
+}
+
+void size(double *left, double *right, double *bottom, double *top, pDevDesc dd)
+{
+   // get pointer to size function
+   void (*pSizeFn)(double *left, double *right, double *bottom, double *top, pDevDesc dd);
+   int engineVersion = ::R_GE_getVersion();
+   switch(engineVersion)
+   {
+   case 5:
+      pSizeFn = ((DevDescVersion5*)dd)->size;
+      break;
+   case 6:
+      pSizeFn = ((DevDescVersion6*)dd)->size;
+      break;
+   case 7:
+      pSizeFn = ((DevDescVersion7*)dd)->size;
+      break;
+   case 8:
+      pSizeFn = ((DevDescVersion8*)dd)->size;
+      break;
+   case 9:
+   case 10:
+   case 11:
+      pSizeFn = ((DevDescVersion9*)dd)->size;
+      break;
+   case 12:
+   default:
+      pSizeFn = ((DevDescVersion12*)dd)->size;
+      break;
+   }
+
+   // call it
+   pSizeFn(left, right, bottom, top, dd); 
 }
 
 double strWidth(const char *str, const pGEcontext gc, pDevDesc dev)
@@ -622,8 +1352,13 @@ double strWidth(const char *str, const pGEcontext gc, pDevDesc dev)
       pStrWidthFn = ((DevDescVersion8*)dev)->strWidth;
       break;
    case 9:
-   default:
+   case 10:
+   case 11:
       pStrWidthFn = ((DevDescVersion9*)dev)->strWidth;
+      break;
+   case 12:
+   default:
+      pStrWidthFn = ((DevDescVersion12*)dev)->strWidth;
       break;
    }
 
@@ -658,8 +1393,13 @@ void text(double x,
       pTextFn = ((DevDescVersion8*)dev)->text;
       break;
    case 9:
-   default:
+   case 10:
+   case 11:
       pTextFn = ((DevDescVersion9*)dev)->text;
+      break;
+   case 12:
+   default:
+      pTextFn = ((DevDescVersion12*)dev)->text;
       break;
    }
 

--- a/src/cpp/r/session/graphics/RGraphicsDevDesc.hpp
+++ b/src/cpp/r/session/graphics/RGraphicsDevDesc.hpp
@@ -24,7 +24,7 @@
 
 extern "C" {
 
-struct DevDescVersion9
+struct DevDescVersion12
 {
    double left;
    double right;
@@ -55,6 +55,7 @@ struct DevDescVersion9
    Rboolean canGenMouseMove;
    Rboolean canGenMouseUp;
    Rboolean canGenKeybd;
+   Rboolean canGenIdle; // version 12
    Rboolean gettingEvent;
 
    void (*activate)(const pDevDesc );
@@ -130,40 +131,44 @@ namespace graphics {
 namespace handler {
 namespace dev_desc {
 
-pDevDesc allocate(const DevDescVersion9& devDescVersion9);
+pDevDesc allocate(const DevDescVersion12& devDescVersion12);
+void setSize(pDevDesc pDD);
+void setDeviceAttributes(pDevDesc pDev, pDevDesc pShadow);
 
-void setSize(pDevDesc pDevDesc);
-
-void path(double *x,
-          double *y,
-          int npoly,
-          int *nper,
+/* Wrapper methods for graphics engine */
+void activate(const pDevDesc dd);
+void circle(double x, double y, double r, const pGEcontext gc, pDevDesc dd);
+void clip(double x0, double x1, double y0, double y1, pDevDesc dd);
+void close(pDevDesc dd);
+void deactivate(pDevDesc dd);
+Rboolean locator(double *x, double *y, pDevDesc dd);
+void line(double x1, double y1, double x2, double y2,
+          const pGEcontext gc, pDevDesc dd);
+void metricInfo(int c, const pGEcontext gc,
+                double* ascent, double* descent, double* width,
+                pDevDesc dd);
+void mode(int mode, pDevDesc dd);
+void newPage(const pGEcontext gc, pDevDesc dd);
+void polygon(int n, double *x, double *y, const pGEcontext gc, pDevDesc dd);
+void polyline(int n, double *x, double *y, const pGEcontext gc, pDevDesc dd);
+void rect(double x0, double y0, double x1, double y1,
+          const pGEcontext gc, pDevDesc dd);
+void path(double *x, double *y, 
+          int npoly, int *nper,
           Rboolean winding,
-          const pGEcontext gc,
-          pDevDesc dd);
-
-void raster(unsigned int *raster,
-            int w,
-            int h,
-            double x,
-            double y,
-            double width,
-            double height,
-            double rot,
+          const pGEcontext gc, pDevDesc dd);
+void raster(unsigned int *raster, int w, int h,
+            double x, double y, 
+            double width, double height,
+            double rot, 
             Rboolean interpolate,
-            const pGEcontext gc,
-            pDevDesc dd);
-
-double strWidth(const char *str, const pGEcontext gc, pDevDesc dev);
-
-void text(double x,
-          double y,
-          const char *str,
-          double rot,
-          double hadj,
-          const pGEcontext gc,
-          pDevDesc dev);
-
+            const pGEcontext gc, pDevDesc dd);
+SEXP cap(pDevDesc dd);
+void size(double *left, double *right, double *bottom, double *top,
+          pDevDesc dd);
+double strWidth(const char *str, const pGEcontext gc, pDevDesc dd);
+void text(double x, double y, const char *str, double rot,
+          double hadj, const pGEcontext gc, pDevDesc dd);
 
 } // namespace dev_desc
 } // namespace handler

--- a/src/cpp/r/session/graphics/RGraphicsDevice.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsDevice.cpp
@@ -454,8 +454,8 @@ SEXP createGD()
    
    BEGIN_SUSPEND_INTERRUPTS 
    {
-      // initialize v9 structure
-      DevDescVersion9 devDesc;
+      // initialize v12 structure
+      DevDescVersion12 devDesc;
 
       // device functions
       devDesc.activate = GD_Activate;

--- a/src/cpp/r/session/graphics/RGraphicsUtils.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsUtils.cpp
@@ -40,7 +40,7 @@ namespace graphics {
 
 namespace {
 
-int s_compatibleEngineVersion = 8;
+int s_compatibleEngineVersion = 12;
 
 #ifdef __APPLE__
 class QuartzStatus : boost::noncopyable

--- a/src/cpp/r/session/graphics/RShadowPngGraphicsHandler.cpp
+++ b/src/cpp/r/session/graphics/RShadowPngGraphicsHandler.cpp
@@ -248,41 +248,7 @@ void setDeviceAttributes(pDevDesc pDev)
    if (shadowDev == NULL)
       return;
    
-   pDev->left = shadowDev->left;
-   pDev->top = shadowDev->top;
-   pDev->right = shadowDev->right;
-   pDev->bottom = shadowDev->bottom;
-   pDev->clipLeft = shadowDev->clipLeft;
-   pDev->clipTop = shadowDev->clipTop;
-   pDev->clipRight = shadowDev->clipRight;
-   pDev->clipBottom = shadowDev->clipBottom;
-   
-   pDev->cra[0] = shadowDev->cra[0];
-   pDev->cra[1] = shadowDev->cra[1];
-   pDev->startps = shadowDev->startps;
-   pDev->ipr[0] = shadowDev->ipr[0];
-   pDev->ipr[1] = shadowDev->ipr[1];
-   pDev->xCharOffset = shadowDev->xCharOffset;
-   pDev->yCharOffset = shadowDev->yCharOffset;
-   pDev->yLineBias = shadowDev->yLineBias;
-
-   pDev->canClip = shadowDev->canClip;
-   pDev->canHAdj = shadowDev->canHAdj;
-   pDev->canChangeGamma = shadowDev->canChangeGamma;
-   pDev->startcol = shadowDev->startcol;
-   pDev->startfill = shadowDev->startfill;
-   pDev->startlty = shadowDev->startlty;
-   pDev->startfont = shadowDev->startfont;
-   pDev->startps = shadowDev->startps;
-   pDev->startgamma = shadowDev->startgamma;
-   pDev->displayListOn = TRUE;
-
-   // no support for events yet
-   pDev->canGenMouseDown = FALSE;
-   pDev->canGenMouseMove = FALSE;
-   pDev->canGenMouseUp = FALSE;
-   pDev->canGenKeybd = FALSE;
-   pDev->gettingEvent = FALSE;
+   dev_desc::setDeviceAttributes(pDev, shadowDev);
 }
 
 // the shadow device is created during creation of the main RStudio
@@ -366,7 +332,7 @@ void circle(double x,
    if (pngDevDesc == NULL)
       return;
    
-   pngDevDesc->circle(x, y, r, gc, pngDevDesc);
+   dev_desc::circle(x, y, r, gc, pngDevDesc);
 }
 
 void line(double x1,
@@ -379,8 +345,8 @@ void line(double x1,
    pDevDesc pngDevDesc = shadowDevDesc(dev);
    if (pngDevDesc == NULL)
       return;
-   
-   pngDevDesc->line(x1, y1, x2, y2, gc, pngDevDesc);
+ 
+   dev_desc::line(x1, y1, x2, y2, gc, pngDevDesc);
 }
 
 void polygon(int n,
@@ -393,7 +359,7 @@ void polygon(int n,
    if (pngDevDesc == NULL)
       return;
    
-   pngDevDesc->polygon(n, x, y, gc, pngDevDesc);
+   dev_desc::polygon(n, x, y, gc, pngDevDesc);
 }
 
 void polyline(int n,
@@ -406,7 +372,7 @@ void polyline(int n,
    if (pngDevDesc == NULL)
       return;
    
-   pngDevDesc->polyline(n, x, y, gc, pngDevDesc);
+   dev_desc::polyline(n, x, y, gc, pngDevDesc);
 }
 
 void rect(double x0,
@@ -420,7 +386,7 @@ void rect(double x0,
    if (pngDevDesc == NULL)
       return;
    
-   pngDevDesc->rect(x0, y0, x1, y1, gc, pngDevDesc);
+   dev_desc::rect(x0, y0, x1, y1, gc, pngDevDesc);
 }
 
 void path(double *x,
@@ -432,6 +398,9 @@ void path(double *x,
           pDevDesc dd)
 {
    pDevDesc pngDevDesc = shadowDevDesc(dd);
+   if (pngDevDesc == NULL)
+      return;
+   
    dev_desc::path(x, y, npoly, nper, winding, gc, pngDevDesc);
 }
 
@@ -448,6 +417,9 @@ void raster(unsigned int *raster,
             pDevDesc dd)
 {
    pDevDesc pngDevDesc = shadowDevDesc(dd);
+   if (pngDevDesc == NULL)
+      return;
+   
    dev_desc::raster(raster,
                     w,
                     h,
@@ -463,10 +435,12 @@ void raster(unsigned int *raster,
 
 SEXP cap(pDevDesc dd)
 {
-   return R_NilValue;
-}
-
+   pDevDesc pngDevDesc = shadowDevDesc(dd);
+   if (pngDevDesc == NULL)
+      return R_NilValue;
    
+   return dev_desc::cap(pngDevDesc);
+}
 
 void metricInfo(int c,
                 const pGEcontext gc,
@@ -479,12 +453,15 @@ void metricInfo(int c,
    if (pngDevDesc == NULL)
       return;
    
-   pngDevDesc->metricInfo(c, gc, ascent, descent, width, pngDevDesc);
+   dev_desc::metricInfo(c, gc, ascent, descent, width, pngDevDesc);
 }
 
 double strWidth(const char *str, const pGEcontext gc, pDevDesc dev)
 {
    pDevDesc pngDevDesc = shadowDevDesc(dev);
+   if (pngDevDesc == NULL)
+      return ::strlen(str);
+   
    return dev_desc::strWidth(str, gc, pngDevDesc);
 }
    
@@ -497,6 +474,9 @@ void text(double x,
           pDevDesc dev)
 {   
    pDevDesc pngDevDesc = shadowDevDesc(dev);
+   if (pngDevDesc == NULL)
+      return;
+   
    dev_desc::text(x, y, str, rot, hadj, gc, pngDevDesc);
 }
    
@@ -506,7 +486,7 @@ void clip(double x0, double x1, double y0, double y1, pDevDesc dev)
    if (pngDevDesc == NULL)
       return;
    
-   pngDevDesc->clip(x0, x1, y0, y1, pngDevDesc);
+   dev_desc::clip(x0, x1, y0, y1, pngDevDesc);
 }
    
 void newPage(const pGEcontext gc, pDevDesc dev)
@@ -515,7 +495,7 @@ void newPage(const pGEcontext gc, pDevDesc dev)
    if (pngDevDesc == NULL)
       return;
    
-   pngDevDesc->newPage(gc, pngDevDesc);
+   dev_desc::newPage(gc, pngDevDesc);
 }
 
 void mode(int mode, pDevDesc dev)
@@ -524,8 +504,7 @@ void mode(int mode, pDevDesc dev)
    if (pngDevDesc == NULL)
       return;
    
-   if (pngDevDesc->mode != NULL)
-      pngDevDesc->mode(mode, pngDevDesc);
+   dev_desc::mode(mode, pngDevDesc);
 }
 
 void onBeforeExecute(DeviceContext* pDC)

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -274,7 +274,7 @@ core::ProgramStatus Options::read(int argc, char * const argv[])
          value<bool>(&autoReloadSource_)->default_value(false),
          "Reload R source if it changes during the session")
       ("r-compatible-graphics-engine-version",
-         value<int>(&rCompatibleGraphicsEngineVersion_)->default_value(11),
+         value<int>(&rCompatibleGraphicsEngineVersion_)->default_value(12),
          "Maximum graphics engine version we are compatible with")
       ("r-resources-path",
          value<std::string>(&rResourcesPath_)->default_value("resources"),


### PR DESCRIPTION
NOTE: not quite ready for merge (pending a bit of extra local testing + review).

This PR is a second stab at support for the new layout of the R graphics engine. Unfortunately, because the graphics device layout has changed relatively early in its definition, we now require indirection for effectively all of the graphics device functions -- hence why this PR has blown up with a large number of methods.

cc: @jjallaire 