### PR TITLE
catch exceptions emitted by boost::regex_match

### DIFF
--- a/src/cpp/core/Backtrace.cpp
+++ b/src/cpp/core/Backtrace.cpp
@@ -14,6 +14,7 @@
  */
 
 #include <core/Backtrace.hpp>
+#include <core/RegexUtils.hpp>
 
 #ifndef _WIN32
 # include <core/Algorithm.hpp>
@@ -82,7 +83,7 @@ void printBacktrace(std::ostream& os)
    for (std::size_t i = 0; i < stackDepth; ++i)
    {
       std::string readyForPrinting = stackStrings[i];
-      if (boost::regex_match(stackStrings[i], match, reBacktrace))
+      if (regex_utils::match(stackStrings[i], match, reBacktrace))
       {
          std::size_t n = match.length();
          if (n >= 8)

--- a/src/cpp/core/BrowserUtils.cpp
+++ b/src/cpp/core/BrowserUtils.cpp
@@ -13,10 +13,10 @@
  *
  */
 
-#include <core/BrowserUtils.hpp>
-
 #include <boost/algorithm/string/predicate.hpp>
 
+#include <core/BrowserUtils.hpp>
+#include <core/RegexUtils.hpp>
 #include <core/SafeConvert.hpp>
 
 using namespace boost::algorithm;
@@ -33,7 +33,7 @@ bool hasRequiredBrowserVersion(const std::string& userAgent,
 {
    double detectedVersion = requiredVersion;
    boost::smatch match;
-   if (boost::regex_search(userAgent, match, versionRegEx))
+   if (regex_utils::search(userAgent, match, versionRegEx))
    {
       std::string versionString = match[1];
       detectedVersion = safe_convert::stringTo<double>(versionString,

--- a/src/cpp/core/ConfigUtils.cpp
+++ b/src/cpp/core/ConfigUtils.cpp
@@ -52,10 +52,14 @@ void extractToMap(const std::string& keyAndValue,
 void extractVariables(const std::string& vars, Variables* pVariables)
 {
    // scan for variables via regex iterator
-   boost::regex var("^([A-Za-z0-9_]+=[^\n]+)$");
-   boost::sregex_token_iterator it(vars.begin(), vars.end(), var, 0);
-   boost::sregex_token_iterator end;
-   std::for_each(it, end, boost::bind(extractToMap, _1, pVariables));
+   try
+   {
+      boost::regex var("^([A-Za-z0-9_]+=[^\n]+)$");
+      boost::sregex_token_iterator it(vars.begin(), vars.end(), var, 0);
+      boost::sregex_token_iterator end;
+      std::for_each(it, end, boost::bind(extractToMap, _1, pVariables));
+   }
+   CATCH_UNEXPECTED_EXCEPTION;
 }
 
 Error extractVariables(const FilePath& file, Variables* pVariables)

--- a/src/cpp/core/HtmlUtils.cpp
+++ b/src/cpp/core/HtmlUtils.cpp
@@ -23,6 +23,7 @@
 
 #include <core/Base64.hpp>
 #include <core/FileSerializer.hpp>
+#include <core/RegexUtils.hpp>
 #include <core/StringUtils.hpp>
 
 #include <core/http/Util.hpp>
@@ -45,7 +46,7 @@ std::string defaultTitle(const std::string& htmlContent)
 {
    boost::regex re("<[Hh]([1-6]).*?>(.*?)</[Hh]\\1>");
    boost::smatch match;
-   if (boost::regex_search(htmlContent, match, re))
+   if (regex_utils::search(htmlContent, match, re))
       return match[2];
    else
       return "";
@@ -160,14 +161,14 @@ void HtmlPreserver::preserve(std::string* pInput)
    {
       // look for begin marker
       boost::smatch m;
-      if (boost::regex_search(pos, inputEnd, m, beginPreserve))
+      if (regex_utils::search(pos, inputEnd, m, beginPreserve))
       {
          // set begin iterator
          std::string::const_iterator begin = m[0].first;
          std::string::const_iterator end = m[0].second;
 
          // look for end marker
-         if (boost::regex_search(end, inputEnd, m, endPreserve))
+         if (regex_utils::search(end, inputEnd, m, endPreserve))
          {
             // update end to be the end of the match
             end = m[0].second;

--- a/src/cpp/core/YamlUtil.cpp
+++ b/src/cpp/core/YamlUtil.cpp
@@ -18,9 +18,10 @@
 #include <boost/regex.hpp>
 
 #include <core/Error.hpp>
-#include <core/Log.hpp>
-
 #include <core/FileSerializer.hpp>
+#include <core/Log.hpp>
+#include <core/RegexUtils.hpp>
+
 
 namespace rstudio {
 namespace core {
@@ -28,7 +29,7 @@ namespace yaml {
 
 namespace {
 
-boost::regex& reYaml()
+const boost::regex& reYaml()
 {
    static boost::regex instance("^[\\s\\n]*---\\s*(.*?)---\\s*(?:$|\\n)");
    return instance;
@@ -48,7 +49,7 @@ bool hasYamlHeader(const FilePath& filePath)
 
 bool hasYamlHeader(const std::string& content)
 {
-   return boost::regex_search(content.begin(), content.end(), reYaml());
+   return regex_utils::search(content.begin(), content.end(), reYaml());
 }
 
 std::string extractYamlHeader(const FilePath& filePath)
@@ -66,7 +67,7 @@ std::string extractYamlHeader(const std::string& content)
    std::string result;
    boost::smatch match;
    
-   if (boost::regex_search(content.begin(), content.end(), match, reYaml()))
+   if (regex_utils::search(content.begin(), content.end(), match, reYaml()))
       if (match.size() >= 1)
          result = match[1];
    

--- a/src/cpp/core/gwt/GwtFileHandler.cpp
+++ b/src/cpp/core/gwt/GwtFileHandler.cpp
@@ -19,6 +19,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 
 #include <core/FilePath.hpp>
+#include <core/RegexUtils.hpp>
 #include <core/text/TemplateFilter.hpp>
 #include <core/system/System.hpp>
 #include <core/http/Request.hpp>
@@ -94,14 +95,14 @@ void handleFileRequest(const std::string& wwwLocalPath,
    }
    
    // case: files designated to be cached "forever"
-   if (regex_match(uri, boost::regex(".*\\.cache\\..*")))
+   if (regex_utils::match(uri, boost::regex(".*\\.cache\\..*")))
    {
       pResponse->setCacheForeverHeaders();
       pResponse->setFile(filePath, request);
    }
    
    // case: files designated to never be cached 
-   else if (regex_match(uri, boost::regex(".*\\.nocache\\..*")))
+   else if (regex_utils::match(uri, boost::regex(".*\\.nocache\\..*")))
    {
       pResponse->setNoCacheHeaders();
       pResponse->setFile(filePath, request);

--- a/src/cpp/core/gwt/GwtSymbolMaps.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMaps.cpp
@@ -27,6 +27,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 
 #include <core/Thread.hpp>
+#include <core/RegexUtils.hpp>
 #include <core/SafeConvert.hpp>
 #include <core/FileSerializer.hpp>
 
@@ -274,7 +275,7 @@ StackElement SymbolMaps::resymbolize(const StackElement& se,
       {
          boost::regex re("@?([^:]+)::([^(]+)(\\((.*)\\))?");
          boost::smatch match;
-         if (boost::regex_search(parts[0], match, re))
+         if (regex_utils::search(parts[0], match, re))
          {
             declaringClass = match[1];
             methodName = match[2];
@@ -327,7 +328,7 @@ StackElement SymbolMaps::resymbolize(const StackElement& se,
       // fragment identifier encoded in filename
       boost::regex re(".*(\\d+)\\.js");
       boost::smatch match;
-      if (boost::regex_search(steFilename, match, re))
+      if (regex_utils::search(steFilename, match, re))
       {
          fragmentId = safe_convert::stringTo<int>(match[1], fragmentId);
       }

--- a/src/cpp/core/http/Response.cpp
+++ b/src/cpp/core/http/Response.cpp
@@ -28,6 +28,7 @@
 #include <core/http/Util.hpp>
 #include <core/http/Cookie.hpp>
 #include <core/Hash.hpp>
+#include <core/RegexUtils.hpp>
 
 #include <core/FileSerializer.hpp>
 
@@ -206,7 +207,7 @@ void Response::setRangeableFile(const std::string& contents,
    std::string range = request.headerValue("Range");
    boost::regex re("bytes=(\\d*)\\-(\\d*)");
    boost::smatch match;
-   if (boost::regex_match(range, match, re))
+   if (regex_utils::match(range, match, re))
    {
       // specify partial content
       setStatusCode(http::status::PartialContent);

--- a/src/cpp/core/http/URL.cpp
+++ b/src/cpp/core/http/URL.cpp
@@ -14,6 +14,7 @@
  */
 
 #include <core/http/URL.hpp>
+#include <core/RegexUtils.hpp>
 
 #include <iostream>
 
@@ -29,7 +30,7 @@ URL::URL(const std::string& absoluteURL)
    std::string protocol, host, path;
    boost::regex re("(http|https)://([^/#?]+)(.*)", boost::regex::icase);
    boost::cmatch matches ;
-   if (boost::regex_match(absoluteURL.c_str(), matches, re))
+   if (regex_utils::match(absoluteURL.c_str(), matches, re))
    {
       protocol = matches[1];
       host = matches[2];

--- a/src/cpp/core/http/Util.cpp
+++ b/src/cpp/core/http/Util.cpp
@@ -31,6 +31,7 @@
 #include <core/Log.hpp>
 #include <core/Error.hpp>
 #include <core/FilePath.hpp>
+#include <core/RegexUtils.hpp>
 #include <core/system/System.hpp>
 
 namespace rstudio {
@@ -169,7 +170,7 @@ void parseMultipartForm(const std::string& contentType,
          // parse values out of content disposition
          std::string nameRegex("form-data; name=\"(.*)\"");
          boost::smatch nameMatch;
-         if (regex_match(cDisp, nameMatch, boost::regex(nameRegex)))
+         if (regex_utils::match(cDisp, nameMatch, boost::regex(nameRegex)))
          {
             // read the rest of the stream
             std::ostringstream valueStream ;
@@ -180,7 +181,7 @@ void parseMultipartForm(const std::string& contentType,
             // check for filename
             std::string filenameRegex(nameRegex + "; filename=\"(.*)\"");
             boost::smatch fileMatch;
-            if (regex_match(cDisp, fileMatch, boost::regex(filenameRegex)))
+            if (regex_utils::match(cDisp, fileMatch, boost::regex(filenameRegex)))
             {
                std::string name(fileMatch[1]);
                

--- a/src/cpp/core/include/core/RegexUtils.hpp
+++ b/src/cpp/core/include/core/RegexUtils.hpp
@@ -22,6 +22,9 @@
 #include <boost/regex.hpp>
 #include <boost/iostreams/filter/regex.hpp>
 
+#include <core/regex/RegexMatch.hpp>
+#include <core/regex/RegexSearch.hpp>
+
 namespace rstudio {
 namespace core {
 
@@ -61,7 +64,7 @@ bool match(const boost::regex& rePattern,
            const StringType& string,
            MatchType* pMatch)
 {
-   return boost::regex_match(string, *pMatch, rePattern);
+   return regex_utils::match(string, *pMatch, rePattern);
 }
 
 template <typename StringType, typename MatchType>
@@ -69,7 +72,7 @@ bool search(const boost::regex& rePattern,
             const StringType& string,
             MatchType* pMatch)
 {
-   return boost::regex_search(string, *pMatch, rePattern);
+   return regex_utils::search(string, *pMatch, rePattern);
 }
 
 } // namespace regex_utils

--- a/src/cpp/core/include/core/r_util/RTokenizer.hpp
+++ b/src/cpp/core/include/core/r_util/RTokenizer.hpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <sstream>
 
+#include <core/RegexUtils.hpp>
 #include <core/StringUtils.hpp>
 #include <core/collection/Position.hpp>
 
@@ -585,7 +586,7 @@ inline bool canFollowBinaryOperator(const RToken& rToken)
 inline bool isPipeOperator(const RToken& rToken)
 {
    static const boost::wregex rePipe(L"^%[^>]*>+[^>]*%$");
-   return boost::regex_match(rToken.begin(), rToken.end(), rePipe);
+   return regex_utils::match(rToken.begin(), rToken.end(), rePipe);
 }
 
 namespace {

--- a/src/cpp/core/include/core/r_util/RVersionInfo.hpp
+++ b/src/cpp/core/include/core/r_util/RVersionInfo.hpp
@@ -21,6 +21,7 @@
 
 #include <boost/regex.hpp>
 
+#include <core/RegexUtils.hpp>
 #include <core/SafeConvert.hpp>
 
 #define kRVersionDefault   "Default"
@@ -57,7 +58,7 @@ public:
                                      boost::match_continuous;
 
       RVersionNumber ver;
-      if (boost::regex_search(number, match, re, flags))
+      if (regex_utils::search(number, match, re, flags))
       {
          ver.versionMajor_ = safe_convert::stringTo<int>(match[1], 0);
          ver.versionMinor_ = safe_convert::stringTo<int>(match[2], 0);

--- a/src/cpp/core/include/core/regex/RegexCommon.hpp
+++ b/src/cpp/core/include/core/regex/RegexCommon.hpp
@@ -1,0 +1,83 @@
+/*
+ * RegexCommon.hpp
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef CORE_REGEX_REGEX_COMMON_HPP
+#define CORE_REGEX_REGEX_COMMON_HPP
+
+#include <string>
+
+#include <boost/format.hpp>
+#include <boost/regex.hpp>
+
+#include <core/StringUtils.hpp>
+
+
+namespace rstudio {
+namespace core {
+namespace regex_utils {
+
+namespace detail {
+
+inline std::string toString(const boost::regex& pattern)
+{
+   return pattern.str();
+}
+
+inline std::string toString(const boost::wregex& pattern)
+{
+   return string_utils::wideToUtf8(pattern.str());
+}
+
+inline std::string normalizeWhitespace(const std::string& string)
+{
+   boost::regex pattern("\n+");
+   std::string replacement(" ");
+   return boost::regex_replace(string, pattern, replacement);
+}
+
+template <typename PatternType>
+void reportException(const std::string& method,
+                     const PatternType& pattern,
+                     std::exception& e)
+{
+   // catch and report exceptions to the user
+   const char* fmt =
+         "caught exception emitted by %1% "
+         "[pattern='%2%' reason='%3%']";
+
+   boost::format formatter(fmt);
+   formatter
+         % method
+         % detail::toString(pattern)
+         % detail::normalizeWhitespace(e.what());
+
+   std::string message = formatter.str();
+
+   // write to error logs
+   LOG_WARNING_MESSAGE(message);
+
+   // log to console as well
+   std::cerr << "Warning: " << message << std::endl
+             << "Please report this error to http://support.rstudio.com"
+             << std::endl;
+}
+
+} // end namespace detail
+
+} // end namespace regex_utils
+} // end namespace core
+} // end namespace rstudio
+
+#endif /* CORE_REGEX_REGEX_COMMON_HPP */

--- a/src/cpp/core/include/core/regex/RegexMatch.hpp
+++ b/src/cpp/core/include/core/regex/RegexMatch.hpp
@@ -1,0 +1,119 @@
+/*
+ * RegexMatch.hpp
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef CORE_REGEX_REGEX_MATCH_HPP
+#define CORE_REGEX_REGEX_MATCH_HPP
+
+#include <string>
+#include <iostream>
+
+#include <boost/format.hpp>
+#include <boost/regex.hpp>
+
+#include <core/Error.hpp>
+#include <core/Log.hpp>
+#include <core/StringUtils.hpp>
+
+#include <core/regex/RegexCommon.hpp>
+
+namespace rstudio {
+namespace core {
+namespace regex_utils {
+
+
+template <class IteratorType, class MatchType, class PatternType>
+bool match(IteratorType begin,
+           IteratorType end,
+           MatchType& m,
+           const PatternType& pattern,
+           boost::match_flag_type flags = boost::match_default)
+{
+   bool result = false;
+   
+   try
+   {
+      result = boost::regex_match(begin, end, m, pattern, flags);
+   }
+   catch (std::exception& e)
+   {
+      detail::reportException(
+               "boost::regex_match()",
+               pattern,
+               e);
+   }
+   
+   return result;
+}
+
+template <class IteratorType, class PatternType>
+bool match(IteratorType begin,
+           IteratorType end,
+           const PatternType& pattern,
+           boost::match_flag_type flags = boost::match_default)
+{
+   boost::match_results<IteratorType> m;
+   return match(begin, end, m, pattern, flags | boost::regex_constants::match_any);
+}
+
+template <class CharType, class MatchType, class PatternType>
+bool match(const CharType* string,
+           MatchType& m,
+           const PatternType& pattern,
+           boost::match_flag_type flags = boost::match_default)
+{
+   return match(string, string + ::strlen(string), m, pattern, flags);
+}
+
+template <class CharType, class PatternType>
+bool match(const CharType* string,
+           const PatternType& pattern,
+           boost::match_flag_type flags = boost::match_default)
+{
+   boost::match_results<const CharType*> m;
+   return match(string, string + ::strlen(string), m, pattern, flags | boost::regex_constants::match_any);
+}
+
+template <class MatchType, class PatternType>
+bool match(const std::string& string,
+           MatchType& m,
+           const PatternType& pattern,
+           boost::match_flag_type flags = boost::match_default)
+{
+   return match(string.begin(), string.end(), m, pattern, flags);
+}
+
+template <class MatchType, class PatternType>
+bool match(const std::wstring& string,
+           MatchType& m,
+           const PatternType& pattern,
+           boost::match_flag_type flags = boost::match_default)
+{
+   return match(string.begin(), string.end(), m, pattern, flags);
+}
+
+template <class StringType, class PatternType>
+bool match(const StringType& string,
+           const PatternType& pattern,
+           boost::match_flag_type flags = boost::match_default)
+{
+   boost::match_results<typename StringType::const_iterator> m;
+   return match(string.begin(), string.end(), m, pattern, flags | boost::regex_constants::match_any);
+}
+
+} // end namespace regex_utils
+} // end namespace core
+} // end namespace rstudio
+
+#endif /* CORE_REGEX_REGEX_MATCH_HPP */

--- a/src/cpp/core/include/core/regex/regexsearch.hpp
+++ b/src/cpp/core/include/core/regex/regexsearch.hpp
@@ -1,0 +1,119 @@
+/*
+ * RegexSearch.hpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef CORE_REGEX_REGEX_SEARCH_HPP
+#define CORE_REGEX_REGEX_SEARCH_HPP
+
+#include <string>
+#include <iostream>
+
+#include <boost/format.hpp>
+#include <boost/regex.hpp>
+
+#include <core/Error.hpp>
+#include <core/Log.hpp>
+#include <core/StringUtils.hpp>
+
+#include <core/regex/RegexCommon.hpp>
+
+namespace rstudio {
+namespace core {
+namespace regex_utils {
+
+template <class IteratorType, class MatchType, class PatternType>
+bool search(IteratorType begin,
+            IteratorType end,
+            MatchType& m,
+            const PatternType& pattern,
+            boost::match_flag_type flags = boost::match_default)
+{
+   bool result = false;
+   
+   try
+   {
+      result = boost::regex_search(begin, end, m, pattern, flags);
+   }
+   catch (std::exception& e)
+   {
+      detail::reportException(
+               "boost::regex_search()",
+               pattern,
+               e);
+   }
+   
+   return result;
+}
+
+template <class IteratorType, class PatternType>
+bool search(IteratorType begin,
+            IteratorType end,
+            const PatternType& pattern,
+            boost::match_flag_type flags = boost::match_default)
+{
+   boost::match_results<IteratorType> m;
+   return search(begin, end, m, pattern, flags | boost::regex_constants::match_any);
+}
+
+
+template <class CharType, class MatchType, class PatternType>
+bool search(const CharType* string,
+            MatchType& m,
+            const PatternType& pattern,
+            boost::match_flag_type flags = boost::match_default)
+{
+   return search(string, string + ::strlen(string), m, pattern, flags);
+}
+
+template <class CharType, class PatternType>
+bool search(const CharType* string,
+            const PatternType& pattern,
+            boost::match_flag_type flags = boost::match_default)
+{
+   boost::match_results<const CharType*> m;
+   return search(string, string + ::strlen(string), m, pattern, flags | boost::regex_constants::match_any);
+}
+
+template <class MatchType, class PatternType>
+bool search(const std::string& string,
+            MatchType& m,
+            const PatternType& pattern,
+            boost::match_flag_type flags = boost::match_default)
+{
+   return search(string.begin(), string.end(), m, pattern, flags);
+}
+
+template <class MatchType, class PatternType>
+bool search(const std::wstring& string,
+            MatchType& m,
+            const PatternType& pattern,
+            boost::match_flag_type flags = boost::match_default)
+{
+   return search(string.begin(), string.end(), m, pattern, flags);
+}
+
+template <class StringType, class PatternType>
+bool search(const StringType& string,
+            const PatternType& pattern,
+            boost::match_flag_type flags = boost::match_default)
+{
+   boost::match_results<typename StringType::const_iterator> m;
+   return search(string.begin(), string.end(), m, pattern, flags | boost::regex_constants::match_any);
+}
+
+} // end namespace regex_utils
+} // end namespace core
+} // end namespace rstudio
+
+#endif /* CORE_REGEX_REGEX_SEARCH_HPP */

--- a/src/cpp/core/include/core/system/ShellUtils.hpp
+++ b/src/cpp/core/include/core/system/ShellUtils.hpp
@@ -22,6 +22,7 @@
 #include <boost/regex.hpp>
 
 #include <core/FilePath.hpp>
+#include <core/RegexUtils.hpp>
 #include <core/StringUtils.hpp>
 
 namespace rstudio {
@@ -64,7 +65,7 @@ public:
       : escapeMode_(EscapeAll)
    {
       boost::regex simpleCommand("^[a-zA-Z]+$");
-      if (boost::regex_match(program, simpleCommand))
+      if (regex_utils::match(program, simpleCommand))
          output_ = program;
       else
          output_ = escape(program);

--- a/src/cpp/core/libclang/LibClang.cpp
+++ b/src/cpp/core/libclang/LibClang.cpp
@@ -23,6 +23,7 @@
 
 #include <core/Log.hpp>
 #include <core/FilePath.hpp>
+#include <core/RegexUtils.hpp>
 #include <core/SafeConvert.hpp>
 
 #include <core/system/LibraryLoader.hpp>
@@ -512,7 +513,7 @@ LibraryVersion LibClang::version() const
    BOOST_FOREACH(boost::regex re, patterns)
    {
       boost::smatch match;
-      if (boost::regex_search(versionString, match, re))
+      if (regex_utils::search(versionString, match, re))
       {
          // default patch version if necessary
          std::string match3 = match[3];

--- a/src/cpp/core/markdown/Markdown.cpp
+++ b/src/cpp/core/markdown/Markdown.cpp
@@ -29,6 +29,7 @@
 #include <core/StringUtils.hpp>
 #include <core/FileSerializer.hpp>
 #include <core/HtmlUtils.hpp>
+#include <core/RegexUtils.hpp>
 
 #include "MathJax.hpp"
 
@@ -223,7 +224,7 @@ void stripMetadata(std::string* pInput)
       {
          continue;
       }
-      else if (boost::regex_search(line, frontMatterDelimiterRegex))
+      else if (regex_utils::search(line, frontMatterDelimiterRegex))
       {
          hasFrontMatter = true;
          break;
@@ -249,7 +250,7 @@ void stripMetadata(std::string* pInput)
          {
             continue;
          }
-         else if (boost::regex_search(line, frontMatterDelimiterRegex))
+         else if (regex_utils::search(line, frontMatterDelimiterRegex))
          {
             if (!inFrontMatter)
             {
@@ -261,8 +262,8 @@ void stripMetadata(std::string* pInput)
                break;
             }
          }
-         else if (!boost::regex_search(line, frontMatterFieldRegex) &&
-                  !boost::regex_search(line,frontMatterContinuationRegex))
+         else if (!regex_utils::search(line, frontMatterFieldRegex) &&
+                  !regex_utils::search(line,frontMatterContinuationRegex))
          {
             break;
          }
@@ -282,11 +283,11 @@ void stripMetadata(std::string* pInput)
          {
             continue;
          }
-         else if (boost::regex_search(line, titleBlockPercentRegex))
+         else if (regex_utils::search(line, titleBlockPercentRegex))
          {
             inTitleBlock = true;
          }
-         else if (boost::regex_search(line, titleBlockContinuationRegex) &&
+         else if (regex_utils::search(line, titleBlockContinuationRegex) &&
                   inTitleBlock)
          {
             continue;

--- a/src/cpp/core/markdown/MathJax.cpp
+++ b/src/cpp/core/markdown/MathJax.cpp
@@ -22,6 +22,7 @@
 #include <boost/foreach.hpp>
 #include <boost/algorithm/string.hpp>
 
+#include <core/RegexUtils.hpp>
 #include <core/system/System.hpp>
 
 namespace rstudio {
@@ -59,7 +60,7 @@ MathJaxFilter::MathJaxFilter(const std::vector<html_utils::ExcludePattern>& excl
       BOOST_FOREACH(const html_utils::ExcludePattern& pattern, excludePatterns)
       {
          boost::smatch m;
-         if (boost::regex_search(pos, inputEnd, m, pattern.begin))
+         if (regex_utils::search(pos, inputEnd, m, pattern.begin))
          {
             // set begin and end (may change if there is an end pattern)
             std::string::const_iterator begin = m[0].first;
@@ -68,7 +69,7 @@ MathJaxFilter::MathJaxFilter(const std::vector<html_utils::ExcludePattern>& excl
             // check for a second match
             if (!pattern.end.empty())
             {
-               if (boost::regex_search(end, inputEnd, m, pattern.end))
+               if (regex_utils::search(end, inputEnd, m, pattern.end))
                {
                   // update end to be the end of the match
                   end = m[0].second;
@@ -226,15 +227,15 @@ void MathJaxFilter::restore(
 bool requiresMathjax(const std::string& htmlOutput)
 {
    boost::regex inlineMathRegex("\\\\\\(([\\s\\S]+?)\\\\\\)");
-   if (boost::regex_search(htmlOutput, inlineMathRegex))
+   if (regex_utils::search(htmlOutput, inlineMathRegex))
       return true;
 
    boost::regex displayMathRegex("\\\\\\[([\\s\\S]+?)\\\\\\]");
-   if (boost::regex_search(htmlOutput, displayMathRegex))
+   if (regex_utils::search(htmlOutput, displayMathRegex))
       return true;
 
    boost::regex mathmlRegex("<math[>\\s](?s).*?</math>");
-   if (boost::regex_search(htmlOutput, mathmlRegex))
+   if (regex_utils::search(htmlOutput, mathmlRegex))
       return true;
 
    return false;

--- a/src/cpp/core/r_util/REnvironmentPosix.cpp
+++ b/src/cpp/core/r_util/REnvironmentPosix.cpp
@@ -28,6 +28,7 @@
 #include <core/Error.hpp>
 #include <core/FilePath.hpp>
 #include <core/ConfigUtils.hpp>
+#include <core/RegexUtils.hpp>
 #include <core/system/System.hpp>
 #include <core/system/Process.hpp>
 #include <core/system/Environment.hpp>
@@ -775,7 +776,7 @@ Error rVersion(const FilePath& rHomePath,
       std::string versionInfo = boost::algorithm::trim_copy(result.stdOut);
       boost::regex re("^([\\d\\.]+)$");
       boost::smatch match;
-      if (boost::regex_search(versionInfo, match, re))
+      if (regex_utils::search(versionInfo, match, re))
       {
          *pVersion = match[1];
          return Success();

--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -26,6 +26,7 @@
 #include <core/FilePath.hpp>
 #include <core/FileSerializer.hpp>
 #include <core/SafeConvert.hpp>
+#include <core/RegexUtils.hpp>
 #include <core/StringUtils.hpp>
 #include <core/YamlUtil.hpp>
 #include <core/text/DcfParser.hpp>
@@ -269,7 +270,7 @@ bool interpretRVersionValue(const std::string& value,
    RVersionInfo version = rVersionFromString(value);
 
    if (version.number != kRVersionDefault &&
-       !boost::regex_match(version.number, boost::regex("[\\d\\.]+")))
+       !regex_utils::match(version.number, boost::regex("[\\d\\.]+")))
    {
       return false;
    }
@@ -982,7 +983,7 @@ bool isWebsiteDirectory(const FilePath& projectDir)
       {
          static const boost::regex reSite("^site:.*$");
          std::string yaml = yaml::extractYamlHeader(indexFile);
-         return boost::regex_search(yaml.begin(), yaml.end(), reSite);
+         return regex_utils::search(yaml.begin(), yaml.end(), reSite);
       }
    }
    else

--- a/src/cpp/core/r_util/RSessionContext.cpp
+++ b/src/cpp/core/r_util/RSessionContext.cpp
@@ -238,7 +238,7 @@ void parseSessionUrl(const std::string& url,
    static boost::regex re("/s/([A-Fa-f0-9]{5})([A-Fa-f0-9]{8})([A-Fa-f0-9]{8})/");
 
    boost::smatch match;
-   if (boost::regex_search(url, match, re))
+   if (regex_utils::search(url, match, re))
    {
       if (pScope)
       {

--- a/src/cpp/core/r_util/RSourceIndex.cpp
+++ b/src/cpp/core/r_util/RSourceIndex.cpp
@@ -47,7 +47,7 @@ namespace {
 bool isValidRPackageName(const std::string& pkgName)
 {
    static const boost::regex rePkgName("[a-zA-Z][a-zA-Z0-9._]*");
-   return boost::regex_match(pkgName, rePkgName);
+   return regex_utils::match(pkgName, rePkgName);
 }
 
 std::wstring removeQuoteDelims(const std::wstring& input)

--- a/src/cpp/core/r_util/RTokenCursorTests.cpp
+++ b/src/cpp/core/r_util/RTokenCursorTests.cpp
@@ -17,6 +17,7 @@
 #include <core/r_util/RTokenCursor.hpp>
 
 namespace rstudio {
+namespace core {
 namespace unit_tests {
 
 using namespace core::r_util::token_cursor;
@@ -24,7 +25,7 @@ using namespace core::r_util::token_cursor;
 bool isPipeOperator(const std::wstring& string)
 {
    static const boost::wregex rePipe(L"^%[^>]*>+[^>]*%$");
-   return boost::regex_match(string.begin(), string.end(), rePipe);
+   return regex_utils::match(string.begin(), string.end(), rePipe);
 }
 
 context("RTokenCursor")
@@ -117,4 +118,5 @@ context("RTokenCursor")
 }
 
 } // namespace unit_tests
+} // namespace core
 } // namespace rstudio

--- a/src/cpp/core/r_util/RTokenizer.cpp
+++ b/src/cpp/core/r_util/RTokenizer.cpp
@@ -407,7 +407,7 @@ std::size_t RTokenizer::tokenLength(const boost::wregex& regex)
    boost::wsmatch match;
    std::wstring::const_iterator end = data_.end();
    boost::match_flag_type flg = boost::match_default | boost::match_continuous;
-   if (boost::regex_search(pos_, end, match, regex, flg))
+   if (regex_utils::search(pos_, end, match, regex, flg))
       return match.length();
    else
       return 0;
@@ -417,7 +417,7 @@ void RTokenizer::eatUntil(const boost::wregex& regex)
 {
    boost::wsmatch match;
    std::wstring::const_iterator end = data_.end();
-   if (boost::regex_search(pos_, end, match, regex))
+   if (regex_utils::search(pos_, end, match, regex))
    {
       pos_ = match[0].first;
    }

--- a/src/cpp/core/tex/TexLogParser.cpp
+++ b/src/cpp/core/tex/TexLogParser.cpp
@@ -23,6 +23,7 @@
 #include <core/Error.hpp>
 #include <core/FilePath.hpp>
 #include <core/FileSerializer.hpp>
+#include <core/RegexUtils.hpp>
 #include <core/SafeConvert.hpp>
 #include <core/system/System.hpp>
 
@@ -183,10 +184,10 @@ void unwrapLines(std::vector<std::string>* pLines,
          if (beginsWith(*nextPos, "LaTeX Warning:", "LaTeX Info:", "LaTeX2e <"))
             break;
 
-         if (boost::regex_search(*nextPos, regexAssignment))
+         if (regex_utils::search(*nextPos, regexAssignment))
             break;
 
-         if (boost::regex_search(*nextPos, regexLine))
+         if (regex_utils::search(*nextPos, regexLine))
             break;
 
          bool breakAfterAppend = nextPos->length() != 79;
@@ -364,7 +365,7 @@ Error parseLatexLog(const FilePath& logFilePath, LogEntries* pLogEntries)
 
          // Parse lines, if present
          boost::smatch overUnderfullLinesMatch;
-         if (boost::regex_search(line,
+         if (regex_utils::search(line,
                                  overUnderfullLinesMatch,
                                  regexOverUnderfullLines))
          {
@@ -421,7 +422,7 @@ Error parseLatexLog(const FilePath& logFilePath, LogEntries* pLogEntries)
          boost::smatch match;
          for (it++; it != lines.end(); it++)
          {
-            if (boost::regex_search(*it, match, regexLnn))
+            if (regex_utils::search(*it, match, regexLnn))
             {
                lineNum = safe_convert::stringTo<int>(match[1], -1);
                break;
@@ -447,7 +448,7 @@ Error parseLatexLog(const FilePath& logFilePath, LogEntries* pLogEntries)
       }
 
       boost::smatch warningMatch;
-      if (boost::regex_search(line, warningMatch, regexWarning))
+      if (regex_utils::search(line, warningMatch, regexWarning))
       {
          std::string warningMsg = warningMatch[1];
          int lineNum = -1;
@@ -456,7 +457,7 @@ Error parseLatexLog(const FilePath& logFilePath, LogEntries* pLogEntries)
             if (boost::algorithm::ends_with(warningMsg, "."))
             {
                boost::smatch warningEndMatch;
-               if (boost::regex_search(*it, warningEndMatch, regexWarningEnd))
+               if (regex_utils::search(*it, warningEndMatch, regexWarningEnd))
                {
                   lineNum = safe_convert::stringTo<int>(warningEndMatch[1], -1);
                }
@@ -487,7 +488,7 @@ Error parseLatexLog(const FilePath& logFilePath, LogEntries* pLogEntries)
       }
 
       boost::smatch cStyleErrorMatch;
-      if (boost::regex_search(line, cStyleErrorMatch, regexCStyleError))
+      if (regex_utils::search(line, cStyleErrorMatch, regexCStyleError))
       {
          FilePath cstyleFile = resolveFilename(rootDir, cStyleErrorMatch[1]);
          if (cstyleFile.exists())
@@ -523,7 +524,7 @@ Error parseBibtexLog(const FilePath& logFilePath, LogEntries* pLogEntries)
         it++)
    {
       boost::smatch match;
-      if (regex_match(*it, match, re))
+      if (regex_utils::match(*it, match, re))
       {
          pLogEntries->push_back(
                LogEntry(

--- a/src/cpp/core/tex/TexMagicComment.cpp
+++ b/src/cpp/core/tex/TexMagicComment.cpp
@@ -18,6 +18,7 @@
 #include <core/Error.hpp>
 #include <core/FilePath.hpp>
 #include <core/FileSerializer.hpp>
+#include <core/RegexUtils.hpp>
 
 #include <boost/foreach.hpp>
 #include <boost/algorithm/string/trim.hpp>
@@ -47,7 +48,7 @@ Error parseMagicComments(const FilePath& texFile,
       else if (boost::algorithm::starts_with(line, "%"))
       {
          boost::smatch match;
-         if (regex_match(line, match, mcRegex))
+         if (regex_utils::match(line, match, mcRegex))
          {
             pComments->push_back(
                         TexMagicComment(match[1], match[2], match[3]));

--- a/src/cpp/core/text/DcfParser.cpp
+++ b/src/cpp/core/text/DcfParser.cpp
@@ -26,12 +26,12 @@
 #include <boost/function.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/split.hpp>
-
 #include <boost/regex.hpp>
 
 #include <core/Error.hpp>
 #include <core/FilePath.hpp>
 #include <core/FileSerializer.hpp>
+#include <core/RegexUtils.hpp>
 
 
 namespace rstudio {
@@ -90,7 +90,7 @@ Error parseDcfFile(const std::string& dcfFileContents,
 
        // look for a key-value pair line
       boost::smatch keyValueMatch, continuationMatch;
-      if (regex_match(*it, keyValueMatch, keyValueRegx))
+      if (regex_utils::match(*it, keyValueMatch, keyValueRegx))
       {
          // if we have a pending key & value then resolve it
          if (!currentKey.empty())
@@ -111,7 +111,7 @@ Error parseDcfFile(const std::string& dcfFileContents,
 
       // look for a continuation
       else if (!currentKey.empty() &&
-               regex_match(*it, continuationMatch, continuationRegex))
+               regex_utils::match(*it, continuationMatch, continuationRegex))
       {
          currentValue.append("\n");
          currentValue.append(continuationMatch[1]);

--- a/src/cpp/desktop-mac/MainFrameController.mm
+++ b/src/cpp/desktop-mac/MainFrameController.mm
@@ -19,6 +19,7 @@
 #include <boost/algorithm/string/replace.hpp>
 
 #include <core/FilePath.hpp>
+#include <core/RegexUtils.hpp>
 #include <core/SafeConvert.hpp>
 #include "Options.hpp"
 
@@ -304,11 +305,13 @@ std::string jsEscape(std::string str)
 
 - (void) checkWebkitVersion: (NSString*) userAgent
 {
+   using namespace rstudio::core;
+   
    // parse version info out of user agent string
    boost::regex re("^.*?AppleWebKit/(\\d+).*$");
    boost::smatch match;
    std::string userAgentStr([userAgent UTF8String]);
-   if (boost::regex_match(userAgentStr, match, re))
+   if (regex_utils::match(userAgentStr, match, re))
    {
       int version = core::safe_convert::stringTo<int>(match[1], 0);
       if (version < 534)

--- a/src/cpp/desktop/DesktopSynctex.cpp
+++ b/src/cpp/desktop/DesktopSynctex.cpp
@@ -77,7 +77,7 @@ SynctexViewerInfo discoverViewer()
    // extract version
    boost::smatch match;
    boost::regex re("^.*(\\d+)\\.(\\d+)\\.(\\d)+$");
-   if (boost::regex_match(stdOut, match, re))
+   if (regex_utils::match(stdOut, match, re))
    {
       SynctexViewerInfo sv;
       sv.name = QString::fromUtf8("Evince");

--- a/src/cpp/r/RUtil.cpp
+++ b/src/cpp/r/RUtil.cpp
@@ -90,7 +90,7 @@ std::string rconsole2utf8(const std::string& encoded)
    std::string output;
    std::string::const_iterator pos = encoded.begin();
    boost::smatch m;
-   while (pos != encoded.end() && boost::regex_search(pos, encoded.end(), m, utf8))
+   while (pos != encoded.end() && regex_utils::search(pos, encoded.end(), m, utf8))
    {
       if (pos < m[0].first)
          output.append(string_utils::systemToUtf8(std::string(pos, m[0].first), codepage));

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -31,6 +31,7 @@
 #include <core/system/Environment.hpp>
 #include <core/FileSerializer.hpp>
 #include <core/FileUtils.hpp>
+#include <core/RegexUtils.hpp>
 #include <core/http/Util.hpp>
 
 #include <r/RExec.hpp>
@@ -649,7 +650,7 @@ bool consoleInputHook(const std::string& prompt,
    // check for user quit invocation
     boost::regex re("^\\s*(q|quit)\\s*\\(.*$");
     boost::smatch match;
-    if (boost::regex_match(input, match, re))
+    if (regex_utils::match(input, match, re))
    {
       if (!s_callbacks.handleUnsavedChanges())
       {

--- a/src/cpp/r/session/graphics/RGraphicsPlotManager.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsPlotManager.cpp
@@ -26,6 +26,7 @@
 #include <core/Log.hpp>
 #include <core/Error.hpp>
 #include <core/FileSerializer.hpp>
+#include <core/RegexUtils.hpp>
 
 #include <r/RExec.hpp>
 #include <r/RUtil.hpp>
@@ -630,7 +631,7 @@ Error PlotManager::restorePlotsState()
       // extract the id, width, and height
       plotInfo = plots[i];
       boost::cmatch matches ;
-      if (boost::regex_match(plotInfo.c_str(), matches, plotInfoRegex_) &&
+      if (regex_utils::match(plotInfo.c_str(), matches, plotInfoRegex_) &&
           (matches.size() > 3) )
       {
          plotStorageId = matches[1];

--- a/src/cpp/server/ServerSessionProxy.cpp
+++ b/src/cpp/server/ServerSessionProxy.cpp
@@ -35,6 +35,7 @@
 #include <core/Log.hpp>
 #include <core/Thread.hpp>
 #include <core/WaitUtils.hpp>
+#include <core/RegexUtils.hpp>
 
 #include <core/http/SocketUtils.hpp>
 #include <core/http/SocketProxy.hpp>
@@ -739,7 +740,7 @@ void proxyLocalhostRequest(
    // extract the port
    boost::regex re("/p/(\\d+)/");
    boost::smatch match;
-   if (!boost::regex_search(request.uri(), match, re))
+   if (!regex_utils::search(request.uri(), match, re))
    {
       ptrConnection->response().setNotFoundError(request.uri());
       return;

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -425,11 +425,11 @@ void ConsoleProcess::maybeConsolePrompt(core::system::ProcessOperations& ops,
    boost::smatch smatch;
 
    // treat special control characters as output rather than a prompt
-   if (boost::regex_search(output, smatch, controlCharsPattern_))
+   if (regex_utils::search(output, smatch, controlCharsPattern_))
       enqueOutputEvent(output);
 
    // make sure the output matches our prompt pattern
-   if (!boost::regex_match(output, smatch, promptPattern_))
+   if (!regex_utils::match(output, smatch, promptPattern_))
       enqueOutputEvent(output);
 
    // it is a prompt
@@ -818,7 +818,7 @@ bool PasswordManager::handlePrompt(const std::string& cpHandle,
 {
    // is this a password prompt?
    boost::smatch match;
-   if (boost::regex_match(prompt, match, promptPattern_))
+   if (regex_utils::match(prompt, match, promptPattern_))
    {
       // see if it matches any of our existing cached passwords
       std::vector<CachedPassword>::const_iterator it =

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1419,7 +1419,7 @@ bool ensureUtf8Charset()
    std::string name = ctypeEnvName();
    std::string ctype = core::system::getenv(name);
 
-   if (boost::regex_search(ctype, boost::regex("UTF-8$")))
+   if (regex_utils::search(ctype, boost::regex("UTF-8$")))
       return true;
 
 #if __APPLE__
@@ -1438,7 +1438,7 @@ bool ensureUtf8Charset()
       using namespace boost;
 
       smatch match;
-      if (regex_match(ctype, match, regex("(\\w+_\\w+)(\\.[^@]+)?(@.+)?")))
+      if (regex_utils::match(ctype, match, regex("(\\w+_\\w+)(\\.[^@]+)?(@.+)?")))
       {
          // Try to replace the charset while keeping everything else the same.
          newCType = match[1] + ".UTF-8" + match[3];

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1840,7 +1840,7 @@ bool portmapPathForLocalhostUrl(const std::string& url, std::string* pPath)
    // extract the port
    boost::regex re("http[s]?://(?:localhost|127\\.0\\.0\\.1):([0-9]+)(/.*)?");
    boost::smatch match;
-   if (boost::regex_search(url, match, re))
+   if (regex_utils::search(url, match, re))
    {
       // calculate the path
       std::string path = match[2];

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -1781,7 +1781,7 @@ public:
    {
       boost::regex pattern("^([^{]+)\\{([^}]+)\\}$");
       boost::smatch match;
-      if (boost::regex_search(name_, match, pattern))
+      if (regex_utils::search(name_, match, pattern))
       {
          // read method name
          methodName_ = match[1];
@@ -2088,7 +2088,7 @@ Error guessFunctionToken(const std::string& line,
    // see if it has a namespace qualifier
    boost::regex pattern("^([^:]+):{2,3}([^:]+)$");
    boost::smatch match;
-   if (boost::regex_search(token, match, pattern))
+   if (regex_utils::search(token, match, pattern))
    {
       pToken->package = match[1];
       pToken->name = match[2];

--- a/src/cpp/session/modules/SessionDependencies.cpp
+++ b/src/cpp/session/modules/SessionDependencies.cpp
@@ -80,7 +80,7 @@ EmbeddedPackage embeddedPackageInfo(const std::string& name)
    {
       boost::smatch match;
       std::string filename = child.filename();
-      if (boost::regex_match(filename, match, re))
+      if (regex_utils::match(filename, match, re))
       {
          EmbeddedPackage pkg;
          pkg.name = name;

--- a/src/cpp/session/modules/SessionDiagnostics.cpp
+++ b/src/cpp/session/modules/SessionDiagnostics.cpp
@@ -301,7 +301,7 @@ void addRcppExportedSymbols(const FilePath& filePath,
    for (std::size_t i = 0; i < n - 1; ++i)
    {
       const std::string& line = contents[i];
-      if (boost::regex_match(line, reRcppExport))
+      if (regex_utils::match(line, reRcppExport))
       {
          const std::string& next = contents[i + 1];
          std::size_t leftParenIndex = next.find('(');
@@ -546,7 +546,7 @@ void parseLintOption(const std::string& text, FileLocalLintOptions* pOptions)
    using namespace core::text;
    
    boost::regex reGlobals("^\\s*suppress\\s*=");
-   if (boost::regex_search(text, reGlobals))
+   if (regex_utils::search(text, reGlobals))
       return parseLintOptionGlobals(text, pOptions);
    
    ParsedCSVLine line = parseCsvLine(text.begin(), text.end(), true);
@@ -613,7 +613,7 @@ void setFileLocalParseOptions(const std::wstring& rCode,
    
    std::wstring::const_iterator start = rCode.begin();
    std::wstring::const_iterator end = rCode.end();
-   while (boost::regex_search(start, end, match, reLintComments))
+   while (regex_utils::search(start, end, match, reLintComments))
    {
       std::wstring::const_iterator matchBegin = match[0].second;
       std::wstring::const_iterator matchEnd   = std::find(matchBegin, end, L'\n');

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -272,7 +272,7 @@ private:
       const char* end = inputPos + pContent->size();
       
       boost::cmatch match;
-      while (boost::regex_search(inputPos, match, boost::regex("\x1B\\[(\\d\\d)?m(\x1B\\[K)?")))
+      while (regex_utils::search(inputPos, match, boost::regex("\x1B\\[(\\d\\d)?m(\x1B\\[K)?")))
       {
          // decode the current match, and append it
          std::string matchedString(inputPos, inputPos + match.position());
@@ -336,7 +336,7 @@ private:
          nextLineStart = pos + 1;
 
          boost::smatch match;
-         if (boost::regex_match(line, match, boost::regex("^((?:[a-zA-Z]:)?[^:]+):(\\d+):(.*)")))
+         if (regex_utils::match(line, match, boost::regex("^((?:[a-zA-Z]:)?[^:]+):(\\d+):(.*)")))
          {
             std::string file = module_context::createAliasedPath(
                   FilePath(string_utils::systemToUtf8(match[1])));

--- a/src/cpp/session/modules/SessionHTMLPreview.cpp
+++ b/src/cpp/session/modules/SessionHTMLPreview.cpp
@@ -710,7 +710,7 @@ Error createNotebook(const json::JsonRpcRequest& request,
 bool requiresHighlighting(const std::string& htmlOutput)
 {
    boost::regex hlRegex("<pre><code class=\"(r|cpp)\"");
-   return boost::regex_search(htmlOutput, hlRegex);
+   return regex_utils::search(htmlOutput, hlRegex);
 }
 
 

--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -200,7 +200,7 @@ bool handleRShowDocFile(const core::FilePath& filePath)
    std::string absPath = filePath.absolutePath();
    boost::regex manualRegx(".*/lib/R/(doc/manual/[A-Za-z0-9_\\-]*\\.html)");
    boost::smatch match;
-   if (regex_match(absPath, match, manualRegx))
+   if (regex_utils::match(absPath, match, manualRegx))
    {
       ClientEvent helpEvent(client_events::kShowHelp, match[1]);
       module_context::enqueClientEvent(helpEvent);
@@ -790,7 +790,7 @@ SEXP lookupCustomHandler(const std::string& uri)
    // pick name of handler out of uri
    boost::regex customRegx(".*/custom/([A-Za-z0-9_\\-]*).*");
    boost::smatch match;
-   if (regex_match(uri, match, customRegx))
+   if (regex_utils::match(uri, match, customRegx))
    {
       std::string handler = match[1];
 

--- a/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
+++ b/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
@@ -46,24 +46,28 @@ Error parseDcfResourceFile(
       return error;
 
    // attempt to parse as DCF -- multiple newlines used to separate records
-   boost::regex reSeparator("\\n{2,}");
-   boost::sregex_token_iterator it(contents.begin(), contents.end(), reSeparator, -1);
-   boost::sregex_token_iterator end;
-
-   for (; it != end; ++it)
+   try
    {
-      // invoke parser on current record
-      std::map<std::string, std::string> fields;
-      std::string errorMessage;
-      error = text::parseDcfFile(*it, true, &fields, &errorMessage);
-      if (error)
-         return error;
-      
-      // invoke callback on parsed dcf fields
-      error = callback(fields);
-      if (error)
-         return error;
+      boost::regex reSeparator("\\n{2,}");
+      boost::sregex_token_iterator it(contents.begin(), contents.end(), reSeparator, -1);
+      boost::sregex_token_iterator end;
+
+      for (; it != end; ++it)
+      {
+         // invoke parser on current record
+         std::map<std::string, std::string> fields;
+         std::string errorMessage;
+         error = text::parseDcfFile(*it, true, &fields, &errorMessage);
+         if (error)
+            return error;
+
+         // invoke callback on parsed dcf fields
+         error = callback(fields);
+         if (error)
+            return error;
+      }
    }
+   CATCH_UNEXPECTED_EXCEPTION;
    
    return Success();
 }

--- a/src/cpp/session/modules/SessionRAddins.cpp
+++ b/src/cpp/session/modules/SessionRAddins.cpp
@@ -209,14 +209,18 @@ public:
          return;
       }
 
-      boost::sregex_token_iterator it(contents.begin(), contents.end(), reSeparator, -1);
-      boost::sregex_token_iterator end;
-
-      for (; it != end; ++it)
+      try
       {
-         std::map<std::string, std::string> fields = parseAddinDcf(*it);
-         add(pkgName, fields);
+         boost::sregex_token_iterator it(contents.begin(), contents.end(), reSeparator, -1);
+         boost::sregex_token_iterator end;
+
+         for (; it != end; ++it)
+         {
+            std::map<std::string, std::string> fields = parseAddinDcf(*it);
+            add(pkgName, fields);
+         }
       }
+      CATCH_UNEXPECTED_EXCEPTION;
    }
    
    bool contains(const std::string& package, const std::string& name)

--- a/src/cpp/session/modules/SessionRSConnect.cpp
+++ b/src/cpp/session/modules/SessionRSConnect.cpp
@@ -200,7 +200,7 @@ private:
       // check for HTTP errors
       boost::regex re("Error: HTTP (\\d{3})\\s+\\w+\\s+(\\S+)");
       boost::smatch match;
-      if (boost::regex_search(output, match, re)) 
+      if (regex_utils::search(output, match, re)) 
       {
          json::Object failure;
          failure["http_status"] = (int)safe_convert::stringTo(match[1], 0);

--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -1828,7 +1828,7 @@ Error augmentSvnIgnore()
    else
    {
       // If svn:ignore exists, add .Rproj.user unless it's already there
-      if (boost::regex_search(svnIgnore, boost::regex("^\\.Rproj\\.user$")))
+      if (regex_utils::search(svnIgnore, boost::regex("^\\.Rproj\\.user$")))
          return Success();
 
       bool addExtraNewline = svnIgnore.size() > 0

--- a/src/cpp/session/modules/SessionShinyViewer.cpp
+++ b/src/cpp/session/modules/SessionShinyViewer.cpp
@@ -266,7 +266,7 @@ void onConsoleInput(const std::string& input)
    // names or attempt to balance quote styles, evaluate expressions, etc.
    // (it will primarily detect the output of getShinyRunCmd but we also want
    // to catch most user-entered source() expressions)
-   if (boost::regex_search(input, match,
+   if (regex_utils::search(input, match,
                  boost::regex("source\\s*\\(\\s*['\"]([^'\"]+)['\"]\\s*\\)")))
    {
       // source commands can result in the execution of Shiny app objects, 

--- a/src/cpp/session/modules/build/SessionBuildEnvironment.cpp
+++ b/src/cpp/session/modules/build/SessionBuildEnvironment.cpp
@@ -81,7 +81,7 @@ r_util::RToolsInfo scanPathForRTools()
    boost::algorithm::trim(contents);
    boost::regex pattern("Rtools version (\\d\\.\\d\\d)[\\d\\.]+$");
    boost::smatch match;
-   if (boost::regex_search(contents, match, pattern))
+   if (regex_utils::search(contents, match, pattern))
       return r_util::RToolsInfo(match[1],
                                 installPath,
                                 module_context::usingMingwGcc49());

--- a/src/cpp/session/modules/connections/ConnectionsIndexer.cpp
+++ b/src/cpp/session/modules/connections/ConnectionsIndexer.cpp
@@ -127,14 +127,18 @@ public:
          return;
       }
 
-      boost::sregex_token_iterator it(contents.begin(), contents.end(), reSeparator, -1);
-      boost::sregex_token_iterator end;
-
-      for (; it != end; ++it)
+      try
       {
-         std::map<std::string, std::string> fields = parseConnectionsDcf(*it);
-         add(pkgName, fields);
+         boost::sregex_token_iterator it(contents.begin(), contents.end(), reSeparator, -1);
+         boost::sregex_token_iterator end;
+
+         for (; it != end; ++it)
+         {
+            std::map<std::string, std::string> fields = parseConnectionsDcf(*it);
+            add(pkgName, fields);
+         }
       }
+      CATCH_UNEXPECTED_EXCEPTION;
    }
    
    bool contains(const std::string& package, const std::string& name)

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -166,8 +166,8 @@ bool isFilterSubset(const std::string& outer, const std::string& inner)
       // check the components for range inclusion
       boost::regex numFilter("(-?\\d+\\.?\\d*)_(-?\\d+\\.?\\d*)");
       boost::smatch innerMatch, outerMatch;
-      if (boost::regex_search(innerValue, innerMatch, numFilter) &&
-          boost::regex_search(outerValue, outerMatch, numFilter))
+      if (regex_utils::search(innerValue, innerMatch, numFilter) &&
+          regex_utils::search(outerValue, outerMatch, numFilter))
       {
          // for numeric filters, the inner is a subset if its lower bound (1)
          // is larger than the outer lower bound, and the upper bound (2) is

--- a/src/cpp/session/modules/presentation/SlideParser.cpp
+++ b/src/cpp/session/modules/presentation/SlideParser.cpp
@@ -151,7 +151,7 @@ std::vector<AtCommand> Slide::atCommands() const
    BOOST_FOREACH(const std::string& atField, atFields)
    {
       boost::smatch match;
-      if (boost::regex_match(atField, match, re))
+      if (regex_utils::match(atField, match, re))
       {
          std::string cmd = match[3];
          if (isAtCommandField(cmd))
@@ -396,7 +396,7 @@ Error SlideDeck::readSlides(const std::string& slides, const FilePath& baseDir)
    for (std::size_t i = 0; i<lines.size(); i++)
    {
       boost::smatch m;
-      if (boost::regex_match(lines[i], m, re))
+      if (regex_utils::match(lines[i], m, re))
          headerLines.push_back(i);
    }
 
@@ -441,7 +441,7 @@ Error SlideDeck::readSlides(const std::string& slides, const FilePath& baseDir)
       {
          if (inFields)
          {
-            if (boost::regex_match(lines[l], dcfFieldRegex))
+            if (regex_utils::match(lines[l], dcfFieldRegex))
             {
                fields += lines[l] + "\n";
             }

--- a/src/cpp/session/modules/presentation/SlideQuizRenderer.cpp
+++ b/src/cpp/session/modules/presentation/SlideQuizRenderer.cpp
@@ -51,7 +51,7 @@ std::string asFormInput(const boost::cmatch& match,
    boost::smatch m;
    std::string itemText = match[1];
    boost::regex re("\\[(.*?)\\]");
-   if (boost::regex_search(itemText, m, re))
+   if (regex_utils::search(itemText, m, re))
    {
       // trim the content
       feedback = m[1];

--- a/src/cpp/session/modules/presentation/SlideRenderer.cpp
+++ b/src/cpp/session/modules/presentation/SlideRenderer.cpp
@@ -94,7 +94,7 @@ std::string mediaClass(const std::string& html)
      "\\s*<p>\\s*<img src=\"([^\"]+)\"(?: [\\w]+=\"[^\"]*\")*/>\\s*</p>\\s*");
 
    boost::smatch match;
-   if (boost::regex_search(html, match, imageRegex))
+   if (regex_utils::search(html, match, imageRegex))
    {
       std::string::const_iterator begin = match[0].first;
       std::string::const_iterator end = match[0].second;
@@ -221,9 +221,9 @@ void computeColumnWidths(const Slide& slide,
 
    std::string slideLeft = slide.left();
    std::string slideRight = slide.right();
-   if (boost::regex_match(slideLeft, match, re))
+   if (regex_utils::match(slideLeft, match, re))
       computeColumnWidths(match[1], pLeftWidth, pRightWidth);
-   else if (boost::regex_match(slideRight, match, re))
+   else if (regex_utils::match(slideRight, match, re))
       computeColumnWidths(match[1], pRightWidth, pLeftWidth);
 }
 

--- a/src/cpp/session/modules/rmarkdown/RMarkdownPresentation.cpp
+++ b/src/cpp/session/modules/rmarkdown/RMarkdownPresentation.cpp
@@ -19,6 +19,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 
 #include <core/FileSerializer.hpp>
+#include <core/RegexUtils.hpp>
 
 using namespace rstudio::core;
 
@@ -101,7 +102,7 @@ void ammendResults(const std::string& formatName,
       const std::string& line = lines.at(i);
 
       // toggle code state
-      if (boost::regex_search(line, reCode))
+      if (regex_utils::search(line, reCode))
          inCode = !inCode;
 
       // bail if we are in code
@@ -111,7 +112,7 @@ void ammendResults(const std::string& formatName,
       // look for a title if we don't have one
       if (!haveTitle || inYaml)
       {
-         if (boost::regex_search(line, reYaml))
+         if (regex_utils::search(line, reYaml))
          {
             if (!inYaml)
             {
@@ -135,7 +136,7 @@ void ammendResults(const std::string& formatName,
          if (inYaml)
          {
             boost::smatch match;
-            if (boost::regex_search(line, match, reTitle))
+            if (regex_utils::search(line, match, reTitle))
             {
                std::string title = match[1];
                boost::algorithm::trim(title);
@@ -153,7 +154,7 @@ void ammendResults(const std::string& formatName,
       {
          // titled slides
          boost::smatch match;
-         if (boost::regex_search(line, match, reTitledSlide))
+         if (regex_utils::search(line, match, reTitledSlide))
          {
             std::string title = match[2];
             boost::algorithm::trim(title);
@@ -165,7 +166,7 @@ void ammendResults(const std::string& formatName,
             slideNavigationItems.push_back(item);
          }
          // untitled slides
-         else if (boost::regex_search(line, reUntitledSlide))
+         else if (regex_utils::search(line, reUntitledSlide))
          {
             SlideNavigationItem item("Untitled Slide", 1, totalSlides++, i+1);
             slideNavigationItems.push_back(item);

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -477,7 +477,7 @@ private:
          {
             const boost::regex shinyListening("^Listening on (http.*)$");
             boost::smatch matches;
-            if (boost::regex_match(outputLine, matches, shinyListening))
+            if (regex_utils::match(outputLine, matches, shinyListening))
             {
                json::Object startedJson;
                startedJson["target_file"] =
@@ -641,7 +641,7 @@ private:
          const boost::regex knitrErr(
                   "^Quitting from lines (\\d+)-(\\d+) \\(([^)]+)\\)(.*)");
          boost::smatch matches;
-         if (boost::regex_match(output, matches, knitrErr))
+         if (regex_utils::match(output, matches, knitrErr))
          {
             // looks like a knitr error; compose a compile error object and
             // emit it to the client when the render is complete

--- a/src/cpp/session/modules/shiny/SessionShiny.cpp
+++ b/src/cpp/session/modules/shiny/SessionShiny.cpp
@@ -393,7 +393,7 @@ ShinyFileType getShinyFileType(const FilePath& filePath,
    
    // Check for 'runtime: shiny' in a YAML header.
    std::string yamlHeader = yaml::extractYamlHeader(contents);
-   if (boost::regex_search(yamlHeader.begin(), yamlHeader.end(), reRuntimeShiny))
+   if (regex_utils::search(yamlHeader.begin(), yamlHeader.end(), reRuntimeShiny))
       return ShinyDocument;
    
    std::string filename = filePath.filename();
@@ -446,7 +446,7 @@ bool isShinyRMarkdownDocument(const FilePath& filePath)
    static const boost::regex reRuntimeShiny("runtime:\\s*shiny");
    
    std::string yamlHeader = yaml::extractYamlHeader(contents);
-   return boost::regex_search(yamlHeader.begin(), yamlHeader.end(), reRuntimeShiny);
+   return regex_utils::search(yamlHeader.begin(), yamlHeader.end(), reRuntimeShiny);
 }
 
 ShinyFileType getShinyFileType(const FilePath& filePath)

--- a/src/cpp/session/modules/tex/SessionPdfLatex.cpp
+++ b/src/cpp/session/modules/tex/SessionPdfLatex.cpp
@@ -210,7 +210,7 @@ FilePath programPath(const std::string& name, const std::string& envOverride)
 bool lineIncludes(const std::string& line, const boost::regex& regex)
 {
     boost::smatch match;
-    return boost::regex_search(line, match, regex);
+    return regex_utils::search(line, match, regex);
 }
 
 int countCitationMisses(const FilePath& logFilePath)

--- a/src/cpp/session/modules/tex/SessionRnwConcordance.cpp
+++ b/src/cpp/session/modules/tex/SessionRnwConcordance.cpp
@@ -105,7 +105,7 @@ Error Concordance::parse(const FilePath& sourceFile,
    // extract concordance structure
    boost::regex re("\\\\Sconcordance\\{([^\\}]+)\\}");
    boost::smatch match;
-   if (!boost::regex_match(concordance, match, re))
+   if (!regex_utils::match(concordance, match, re))
       return badFormatError(sourceFile, "body", ERROR_LOCATION);
 
    // split into sections
@@ -128,7 +128,7 @@ Error Concordance::parse(const FilePath& sourceFile,
    {
       boost::regex re("^ofs ([0-9]+)");
       boost::smatch match;
-      if (!boost::regex_match(sections[3], match, re))
+      if (!regex_utils::match(sections[3], match, re))
          return badFormatError(sourceFile, "offset", ERROR_LOCATION);
 
       offset_ = safe_convert::stringTo<std::size_t>(match[1], 0);

--- a/src/cpp/session/modules/tex/SessionRnwWeave.cpp
+++ b/src/cpp/session/modules/tex/SessionRnwWeave.cpp
@@ -138,14 +138,14 @@ public:
       std::vector<int> chunkLineNumbers;
       for (std::size_t i=0; i<lines.size(); i++)
       {
-         if (boost::regex_match(lines[i], match, re))
+         if (regex_utils::match(lines[i], match, re))
             chunkLineNumbers.push_back(i+1);
       }
 
       // determine chunk number and error message
       boost::regex cre(
          "[\\w]+:[\\s]+chunk[\\s]+(\\d+)[^\n]+\n[^:]+:[\\s]*[\n]?([^\n]+)\n");
-      if (boost::regex_search(output, match, cre))
+      if (regex_utils::search(output, match, cre))
       {
          std::string match1(match[1]);
          std::string match2(match[2]);
@@ -295,7 +295,7 @@ public:
                             "\\((.*?)\\)\\s*\\n(.*?)\\n");
 
       boost::smatch match;
-      if (boost::regex_search(output, match, errRe))
+      if (regex_utils::search(output, match, errRe))
       {
          // extract error info
          int lineBegin = safe_convert::stringTo<int>(match[1], -1);
@@ -304,7 +304,7 @@ public:
          // check to see if there is a parse error which provides more
          // precise pinpointing of the line
          boost::regex parseRe("^\\s*<text>:([0-9]+):[0-9]+: (.+)$");
-         if (boost::regex_match(message, match, parseRe))
+         if (regex_utils::match(message, match, parseRe))
          {
             lineBegin += safe_convert::stringTo<int>(match[1], -1);
             message = match[2];
@@ -319,7 +319,7 @@ public:
          pLogEntries->push_back(logEntry);
       }
 
-      else if (boost::regex_search(output, match, newErrRe))
+      else if (regex_utils::search(output, match, newErrRe))
       {
          // extract error info
          int lineBegin = safe_convert::stringTo<int>(match[1], -1);

--- a/src/cpp/tools/editor-settings/qt-license-template.txt
+++ b/src/cpp/tools/editor-settings/qt-license-template.txt
@@ -1,0 +1,14 @@
+/*
+ * %FILENAME%
+ *
+ * Copyright (C) 2009-%YEAR% by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */


### PR DESCRIPTION
Some users have reported crashes on startup with the following error message:

> Unexpected exception: The complexity of matching the regular expression exceeded predefined bounds.  Try refactoring the regular expression to make each choice made by the state machine unambiguous.  This exception is thrown to prevent "eternal" matches that take an indefinite period time to locate.

Unfortunately, we haven't been able to discover a root cause for this issue yet, but the most likely culprit is unintentional exponential backtracking in one of our regular expressions, followed by overly-long user input of some form.

This PR attempts to catch and swallow those errors, returning `false` regarding these matches in such a case.

Let me know if:

1. This is an approach worth pursuing,
2. Whether we should consider also printing a backtrace,
3. Whether we should re-throw the exception or just return `false` for such cases.