### PR TITLE
Filter drivers that are marked as licensed

### DIFF
--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -380,6 +380,8 @@ void handleClientInit(const boost::function<void()>& initFunction,
 
    sessionInfo["session_id"] = module_context::activeSession().id();
 
+   sessionInfo["drivers_support_licensing"] = false;
+
    module_context::events().onSessionInfo(&sessionInfo);
 
    // send response  (we always set kEventsPending to false so that the client

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -380,7 +380,7 @@ void handleClientInit(const boost::function<void()>& initFunction,
 
    sessionInfo["session_id"] = module_context::activeSession().id();
 
-   sessionInfo["drivers_support_licensing"] = false;
+   sessionInfo["drivers_support_licensing"] = options.supportsDriversLicensing();
 
    module_context::events().onSessionInfo(&sessionInfo);
 

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -356,6 +356,11 @@ public:
       return allowOverlay() || allowPublish_;
    }
 
+   bool supportsDriversLicensing() const
+   {
+      return !allowOverlay();
+   }
+
    bool allowPresentationCommands() const
    {
       return allowPresentationCommands_;

--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -36,6 +36,7 @@
    .rs.validateParams(connection, 
        c("disconnect", "listObjects", "listColumns", "previewObject"),
        "function")
+   .rs.validateOdbcConnection(connection)
 })
 
 # create an environment which will host the known active connections
@@ -213,6 +214,18 @@ options(connectionObserver = list(
    }
 
    NULL
+})
+
+.rs.addFunction("validateOdbcConnection", function(connection) {
+   con <- .rs.findActiveConnection(connection$type, connection$host)
+   if (!is.null(con) && identical(class(con), "OdbcConnection")) {
+      if (.rs.isPackageInstalled("odbc") && exists("dbGetInfo", envir = asNamespace("odbc"))) {
+         dbGetInfo <- get("dbGetInfo", envir = asNamespace("odbc"))
+         info <- dbGetInfo(con)
+
+         if (grepl("Simba", info$drivername)) stop("This connection is not ssupported for this version of RStudio.")
+      }
+   }
 })
 
 .rs.addFunction("connectionReadSnippets", function() {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -490,4 +490,8 @@ public class SessionInfo extends JavaScriptObject
    public final native PackageProvidedExtensions.Data getPackageProvidedExtensions() /*-{
       return this.package_provided_extensions;
    }-*/;
+
+   public final native boolean getSupportDriverLicensing() /*-{
+      return this.drivers_support_licensing;
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/NewConnectionContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/NewConnectionContext.java
@@ -55,6 +55,10 @@ public class NewConnectionContext extends JavaScriptObject
       public final native String iconData() /*-{
          return this["iconData"];
       }-*/;
+
+      public final native boolean getLicensed() /*-{
+         return this["licensed"];
+      }-*/;
    }
 
    public final native int getConnectionsLength() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.java
@@ -17,11 +17,11 @@ package org.rstudio.studio.client.workbench.views.connections.ui;
 import java.util.ArrayList;
 
 import org.rstudio.core.client.CommandWithArg;
-import org.rstudio.core.client.resources.ImageResourceUrl;
 import org.rstudio.core.client.widget.HasWizardPageSelectionHandler;
 import org.rstudio.core.client.widget.WizardNavigationPage;
 import org.rstudio.core.client.widget.WizardPage;
 import org.rstudio.core.client.widget.WizardResources;
+import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.workbench.views.connections.model.ConnectionOptions;
 import org.rstudio.studio.client.workbench.views.connections.model.NewConnectionContext;
 import org.rstudio.studio.client.workbench.views.connections.model.NewConnectionContext.NewConnectionInfo;
@@ -33,7 +33,6 @@ import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.resources.client.ImageResource;
-import com.google.gwt.safehtml.shared.SafeUri;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.DockLayoutPanel;
 import com.google.gwt.user.client.ui.Image;
@@ -76,11 +75,16 @@ public class NewConnectionNavigationPage
                                                     ConnectionOptions>>();
 
       for(NewConnectionInfo connectionInfo: context.getConnectionsList()) {
-         if (connectionInfo.getType() == "Shiny") {
-            pages.add(new NewConnectionShinyPage(connectionInfo));
-         }
-         else if (connectionInfo.getType() == "Snippet") {
-            pages.add(new NewConnectionSnippetPage(connectionInfo));
+         if (!connectionInfo.getLicensed() || 
+             RStudioGinjector.INSTANCE.getSession().getSessionInfo().getSupportDriverLicensing()) {
+
+            if (connectionInfo.getType() == "Shiny") {
+               pages.add(new NewConnectionShinyPage(connectionInfo));
+            }
+            else if (connectionInfo.getType() == "Snippet") {
+               pages.add(new NewConnectionSnippetPage(connectionInfo));
+            }
+
          }
       }
 


### PR DESCRIPTION
This work allows driver providers to filter out drivers from RStudio by including a `license.lock` file in their driver distribution.