### PR TITLE
wait for 'index.lock' when running git commands

### DIFF
--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -225,14 +225,14 @@ bool waitForIndexLock(const FilePath& workingDir)
       retryCount = 0;
       return true;
    }
-      
+
 #ifndef _WIN32
-      // attempt to clear nfs cache -- don't log errors as this is done
-      // just to ensure that we have a 'fresh' view of the index.lock file
-      // in the later codepaths
-      struct stat info;
-      bool cleared;
-      core::system::nfs::statWithCacheClear(lockPath, &cleared, &info);
+   // attempt to clear nfs cache -- don't log errors as this is done
+   // just to ensure that we have a 'fresh' view of the index.lock file
+   // in the later codepaths
+   struct stat info;
+   bool cleared;
+   core::system::nfs::statWithCacheClear(lockPath, &cleared, &info);
 #endif
    
    // otherwise, retry for 1s


### PR DESCRIPTION
This PR should help alleviate an issue where git commands could fail (especially on networked filesystems) due to the presence of an `index.lock` file when attempting to run Git.

We accomplish this by polling on the presence of the `index.lock` file for one second (once every `100ms`). Although this won't be bullet-proof, it should still catch the vast majority of our git timing issues.