### PR TITLE
Use websocket for terminal i/o between client and server

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -151,6 +151,7 @@ list(APPEND BOOST_LIBS
    system
    thread
    chrono
+   random
 )
 
 # UNIX BOOST

--- a/src/cpp/core/include/core/Thread.hpp
+++ b/src/cpp/core/include/core/Thread.hpp
@@ -1,7 +1,7 @@
 /*
  * Thread.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -122,7 +122,7 @@ public:
          typename std::map<K,V>::const_iterator it = map_.find(key);
          if (it != map_.end())
          {
-            std::string val = it->second;
+            V val = it->second;
             map_.erase(key);
             return val;
          }
@@ -146,6 +146,15 @@ public:
       LOCK_MUTEX(mutex_)
       {
          map_.erase(key);
+      }
+      END_LOCK_MUTEX
+   }
+
+   void clear()
+   {
+      LOCK_MUTEX(mutex_)
+      {
+         map_.clear();
       }
       END_LOCK_MUTEX
    }

--- a/src/cpp/core/include/core/system/Process.hpp
+++ b/src/cpp/core/include/core/system/Process.hpp
@@ -19,6 +19,7 @@
 
 #include <vector>
 
+#include <boost/enable_shared_from_this.hpp>
 #include <boost/optional.hpp>
 #include <boost/utility.hpp>
 #include <boost/function.hpp>
@@ -235,7 +236,7 @@ Error runCommand(const std::string& command,
 //
 
 // Operations that can be performed from within ProcessCallbacks
-class ProcessOperations
+class ProcessOperations : public boost::enable_shared_from_this<ProcessOperations>
 {
 public:
    virtual ~ProcessOperations() {}
@@ -250,6 +251,11 @@ public:
 
    // Terminate the process (SIGTERM)
    virtual Error terminate() = 0;
+
+   boost::weak_ptr<ProcessOperations> getWeakPtr()
+   {
+      return weak_from_this();
+   }
 };
 
 // Callbacks for reporting various states and streaming output (note that

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -66,6 +66,7 @@ set (SESSION_SOURCE_FILES
    SessionConsoleProcess.cpp
    SessionConsoleProcessInfo.cpp
    SessionConsoleProcessPersist.cpp
+   SessionConsoleProcessSocket.cpp
    SessionContentUrls.cpp
    SessionDirs.cpp
    SessionRpc.cpp
@@ -312,6 +313,7 @@ include_directories(
    include
    ${LIBR_INCLUDE_DIRS}
    ${CORE_INCLUDE_DIRS}
+   ${EXT_SOURCE_DIR}
    ${MONITOR_SOURCE_DIR}/include
    ${R_SOURCE_DIR}/include
    ${CMAKE_CURRENT_BINARY_DIR}

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -36,6 +36,7 @@ namespace console_process {
 namespace {
    typedef std::map<std::string, boost::shared_ptr<ConsoleProcess> > ProcTable;
    ProcTable s_procs;
+   ConsoleProcessSocket s_terminalSocket;
 } // anonymous namespace
 
 void saveConsoleProcesses();
@@ -50,7 +51,7 @@ ConsoleProcess::ConsoleProcess(boost::shared_ptr<ConsoleProcessInfo> procInfo)
    // dummy \n so we can tell the first line is a complete line.
    procInfo_->appendToOutputBuffer('\n');
 }
-   
+
 ConsoleProcess::ConsoleProcess(const std::string& command,
                                const core::system::ProcessOptions& options,
                                boost::shared_ptr<ConsoleProcessInfo> procInfo)
@@ -60,7 +61,7 @@ ConsoleProcess::ConsoleProcess(const std::string& command,
 {
    commonInit();
 }
-   
+
 ConsoleProcess::ConsoleProcess(const std::string& program,
                                const std::vector<std::string>& args,
                                const core::system::ProcessOptions& options,
@@ -303,6 +304,35 @@ bool ConsoleProcess::onContinue(core::system::ProcessOperations& ops)
    if (interrupt_)
       return false;
 
+
+   if (procInfo_->getChannelMode() == Rpc)
+   {
+      processQueuedInput(ops);
+   }
+   else
+   {
+      // capture weak reference to the callbacks so websocket callback
+      // can use them
+      LOCK_MUTEX(mutex_)
+      {
+         pOps_ = ops.weak_from_this();
+      }
+      END_LOCK_MUTEX
+   }
+
+   if (newCols_ != -1 && newRows_ != -1)
+   {
+      ops.ptySetSize(newCols_, newRows_);
+      newCols_ = -1;
+      newRows_ = -1;
+   }
+   
+   // continue
+   return true;
+}
+
+void ConsoleProcess::processQueuedInput(core::system::ProcessOperations& ops)
+{
    // process input queue
    Input input = dequeInput();
    while (!input.empty())
@@ -343,16 +373,6 @@ bool ConsoleProcess::onContinue(core::system::ProcessOperations& ops)
 
       input = dequeInput();
    }
-
-   if (newCols_ != -1 && newRows_ != -1)
-   {
-      ops.ptySetSize(newCols_, newRows_);
-      newCols_ = -1;
-      newRows_ = -1;
-   }
-   
-   // continue
-   return true;
 }
 
 void ConsoleProcess::deleteLogFile() const
@@ -376,6 +396,13 @@ void ConsoleProcess::enqueOutputEvent(const std::string &output)
    std::string trimmedOutput = output;
    string_utils::trimLeadingLines(procInfo_->getMaxOutputLines(), &trimmedOutput);
 
+   if (procInfo_->getChannelMode() == Websocket)
+   {
+      s_terminalSocket.sendText(procInfo_->getHandle(), output);
+      return;
+   }
+
+   // Rpc
    json::Object data;
    data["handle"] = handle();
    data["output"] = trimmedOutput;
@@ -491,6 +518,12 @@ void ConsoleProcess::onHasSubprocs(bool hasSubprocs)
             ClientEvent(client_events::kTerminalSubprocs, subProcs));
       childProcsSent_ = true;
    }
+}
+
+void ConsoleProcess::setRpcMode()
+{
+   s_terminalSocket.stopListening(handle());
+   procInfo_->setChannelMode(Rpc, "");
 }
 
 core::json::Object ConsoleProcess::toJson() const
@@ -733,6 +766,25 @@ Error procGetBufferChunk(const json::JsonRpcRequest& request,
    return Success();
 }
 
+Error procUseRpc(const json::JsonRpcRequest& request,
+                 json::JsonRpcResponse* pResponse)
+{
+   std::string handle;
+
+   Error error = json::readParams(request.params,
+                                  &handle);
+   if (error)
+      return error;
+
+   ProcTable::const_iterator pos = s_procs.find(handle);
+   if (pos == s_procs.end())
+      return systemError(boost::system::errc::invalid_argument, ERROR_LOCATION);
+
+   // Used to downgrade to Rpc after client was unable to connect to Websocket
+   pos->second->setRpcMode();
+   return Success();
+}
+
 boost::shared_ptr<ConsoleProcess> ConsoleProcess::create(
       const std::string& command,
       core::system::ProcessOptions options,
@@ -764,8 +816,36 @@ boost::shared_ptr<ConsoleProcess> ConsoleProcess::create(
 // previously used handle
 boost::shared_ptr<ConsoleProcess> ConsoleProcess::createTerminalProcess(
       core::system::ProcessOptions options,
-      boost::shared_ptr<ConsoleProcessInfo> procInfo)
+      boost::shared_ptr<ConsoleProcessInfo> procInfo,
+      bool enableWebsockets)
 {
+   boost::shared_ptr<ConsoleProcess> cp;
+
+   // Use websocket as preferred communication channel; it can fail
+   // here if unable to establish the server-side of things, in which case
+   // fallback to using Rpc.
+   //
+   // It can also fail later when client tries to connect; fallback for that
+   // happens from the client-side via RPC call procUseRpc.
+   if (enableWebsockets)
+   {
+      Error error = s_terminalSocket.ensureServerRunning();
+      if (error)
+      {
+         procInfo->setChannelMode(Rpc, "");
+         LOG_ERROR(error);
+      }
+      else
+      {
+         std::string port = boost::lexical_cast<std::string>(s_terminalSocket.port());
+         procInfo->setChannelMode(Websocket, port);
+      }
+   }
+   else
+   {
+      procInfo->setChannelMode(Rpc, "");
+   }
+
    std::string command;
    if (procInfo->getAllowRestart() && !procInfo->getHandle().empty())
    {
@@ -777,21 +857,67 @@ boost::shared_ptr<ConsoleProcess> ConsoleProcess::createTerminalProcess(
          // to refresh itself; this does rely on the host performing a second
          // resize to the actual available size. Clumsy, but so far this is
          // the best I've come up with.
-         pos->second->resize(25, 5);
-         return pos->second;
+         cp = pos->second;
+         cp->resize(25, 5);
       }
-      
-      // Create new process with previously used handle
-      options.terminateChildren = true;
-      boost::shared_ptr<ConsoleProcess> ptrProc(
-            new ConsoleProcess(command, options, procInfo));
-      s_procs[ptrProc->handle()] = ptrProc;
-      saveConsoleProcesses();
-      return ptrProc;
+      else
+      {
+         // Create new process with previously used handle
+         options.terminateChildren = true;
+         cp.reset(new ConsoleProcess(command, options, procInfo));
+         s_procs[cp->handle()] = cp;
+         saveConsoleProcesses();
+      }
    }
-   
-   // otherwise create a new one
-   return create(command, options, procInfo);
+   else
+   {
+      // otherwise create a new one
+      cp =  create(command, options, procInfo);
+   }
+
+   if (cp->procInfo_->getChannelMode() == Websocket)
+   {
+      // start watching for websocket callbacks
+      s_terminalSocket.listen(cp->procInfo_->getHandle(),
+                              cp->createConsoleProcessSocketConnectionCallbacks());
+   }
+   return cp;
+}
+
+ConsoleProcessSocketConnectionCallbacks ConsoleProcess::createConsoleProcessSocketConnectionCallbacks()
+{
+   ConsoleProcessSocketConnectionCallbacks cb;
+   cb.onReceivedInput = boost::bind(&ConsoleProcess::onReceivedInput, ConsoleProcess::shared_from_this(), _1);
+   cb.onConnectionOpened = boost::bind(&ConsoleProcess::onConnectionOpened, ConsoleProcess::shared_from_this());
+   cb.onConnectionClosed = boost::bind(&ConsoleProcess::onConnectionClosed, ConsoleProcess::shared_from_this());
+   return cb;
+}
+
+// received input from websocket (e.g. user typing on client); called on
+// different thread
+void ConsoleProcess::onReceivedInput(const std::string& input)
+{
+   LOCK_MUTEX(mutex_)
+   {
+      enqueInput(Input(input));
+      boost::shared_ptr<core::system::ProcessOperations> ops = pOps_.lock();
+      if (ops)
+      {
+         processQueuedInput(*ops);
+      }
+   }
+   END_LOCK_MUTEX
+}
+
+// websocket connection closed; called on different thread
+void ConsoleProcess::onConnectionClosed()
+{
+   s_terminalSocket.stopListening(handle());
+}
+
+// websocket connection opened; called on different thread
+void ConsoleProcess::onConnectionOpened()
+{
 }
 
 void PasswordManager::attach(
@@ -1026,7 +1152,8 @@ Error initialize()
       (bind(registerRpcMethod, "process_set_caption", procSetCaption))
       (bind(registerRpcMethod, "process_set_title", procSetTitle))
       (bind(registerRpcMethod, "process_erase_buffer", procEraseBuffer))
-      (bind(registerRpcMethod, "process_get_buffer_chunk", procGetBufferChunk));
+      (bind(registerRpcMethod, "process_get_buffer_chunk", procGetBufferChunk))
+      (bind(registerRpcMethod, "process_use_rpc", procUseRpc));
 
    return initBlock.execute();
 }

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -837,7 +837,7 @@ boost::shared_ptr<ConsoleProcess> ConsoleProcess::createTerminalProcess(
       }
       else
       {
-         std::string port = boost::lexical_cast<std::string>(s_terminalSocket.port());
+         std::string port = safe_convert::numberToString(s_terminalSocket.port());
          procInfo->setChannelMode(Websocket, port);
       }
    }

--- a/src/cpp/session/SessionConsoleProcessSocket.cpp
+++ b/src/cpp/session/SessionConsoleProcessSocket.cpp
@@ -49,9 +49,7 @@ ConsoleProcessSocket::~ConsoleProcessSocket()
    {
       stopServer();
    }
-   catch (...)
-   {
-   }
+   CATCH_UNEXPECTED_EXCEPTION
 }
 
 Error ConsoleProcessSocket::ensureServerRunning()
@@ -93,15 +91,17 @@ Error ConsoleProcessSocket::ensureServerRunning()
       {
          try
          {
+            // TODO (gary) can we just try ipv6 without sniffing, then do
+            // ipv4 if ipv6 fails?
+#if !defined(_WIN32) && !defined(__APPLE__)
             if (core::FilePath("/proc/net/if_inet6").exists())
             {
                // listen will fail without ipv6 support on the machine so we
                // only use it for machines with a ipv6 stack
-               // TODO (gary) need a cross-platform way to do this? does it
-               // matter on Mac/Windows clients?
                pwsServer_->listen(port);
             }
             else
+#endif
             {
                // no ipv6 support, fall back to ipv4
                pwsServer_->listen(boost::asio::ip::tcp::v4(), port);
@@ -148,12 +148,8 @@ Error ConsoleProcessSocket::ensureServerRunning()
       return systemError(boost::system::errc::invalid_argument,
                             e.what(), ERROR_LOCATION);
    }
-   catch (...)
-   {
-      LOG_ERROR_MESSAGE("Unknown exception starting up terminal websocket");
-      return systemError(boost::system::errc::invalid_argument,
-                         "Unknown exception", ERROR_LOCATION);
-   }
+   CATCH_UNEXPECTED_EXCEPTION
+
    return Success();
 }
 
@@ -176,10 +172,7 @@ void ConsoleProcessSocket::stopServer()
    {
       LOG_ERROR_MESSAGE(e.what());
    }
-   catch (...)
-   {
-      LOG_ERROR_MESSAGE("Unknown exception stopping terminal websocket server");
-   }
+   CATCH_UNEXPECTED_EXCEPTION
 }
 
 Error ConsoleProcessSocket::listen(

--- a/src/cpp/session/SessionConsoleProcessSocket.cpp
+++ b/src/cpp/session/SessionConsoleProcessSocket.cpp
@@ -1,0 +1,336 @@
+/*
+ * SessionConsoleProcessSocket.cpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <session/SessionConsoleProcessSocket.hpp>
+
+#include <boost/make_shared.hpp>
+
+#include <core/FilePath.hpp>
+#include <core/json/Json.hpp>
+
+
+namespace rstudio {
+namespace session {
+namespace console_process {
+
+using namespace rstudio::core;
+
+namespace {
+
+// rapid reseeding via srand(time) causes same "random" sequence to be
+// returned by rand; only an issue for unit tests, really
+bool s_didSeedRand = false;
+
+} // anonymous namespace
+
+ConsoleProcessSocket::ConsoleProcessSocket()
+   :
+     port_(0),
+     serverRunning_(false),
+     activeConnections_(0)
+{
+}
+
+ConsoleProcessSocket::~ConsoleProcessSocket()
+{
+   try
+   {
+      stopServer();
+   }
+   catch (...)
+   {
+   }
+}
+
+Error ConsoleProcessSocket::ensureServerRunning()
+{
+   if (serverRunning_)
+      return Success();
+
+   long port = 0;
+   unsigned portRetries = 0;
+
+   // initialize seed for random port selection
+   if (!s_didSeedRand)
+   {
+      srand(time(NULL));
+      s_didSeedRand = true;
+   }
+
+   // no user-specified port; pick a random port
+   port = 3000 + (rand() % 5000);
+
+   try
+   {
+      pwsServer_.reset(new terminalServer());
+
+      pwsServer_->set_access_channels(websocketpp::log::alevel::none);
+      pwsServer_->init_asio();
+
+      pwsServer_->set_message_handler(
+               boost::bind(&ConsoleProcessSocket::onMessage, this, &*pwsServer_, _1, _2));
+      pwsServer_->set_http_handler(
+               boost::bind(&ConsoleProcessSocket::onHttp, this, &*pwsServer_, _1));
+      pwsServer_->set_close_handler(
+               boost::bind(&ConsoleProcessSocket::onClose, this, &*pwsServer_, _1));
+      pwsServer_->set_open_handler(
+               boost::bind(&ConsoleProcessSocket::onOpen, this, &*pwsServer_, _1));
+
+      // try to bind to the given port
+      do
+      {
+         try
+         {
+            if (core::FilePath("/proc/net/if_inet6").exists())
+            {
+               // listen will fail without ipv6 support on the machine so we
+               // only use it for machines with a ipv6 stack
+               // TODO (gary) need a cross-platform way to do this? does it
+               // matter on Mac/Windows clients?
+               pwsServer_->listen(port);
+            }
+            else
+            {
+               // no ipv6 support, fall back to ipv4
+               pwsServer_->listen(boost::asio::ip::tcp::v4(), port);
+            }
+
+            pwsServer_->start_accept();
+            break;
+         }
+         catch (websocketpp::exception const& e)
+         {
+            // fail if this isn't the code we're expecting
+            // (we're only trying to deal with address in use errors here)
+            if (e.code() != websocketpp::transport::asio::error::pass_through)
+            {
+               return systemError(boost::system::errc::invalid_argument,
+                                  e.what(), ERROR_LOCATION);
+            }
+
+            // try another random port
+            port = 3000 + (rand() % 5000);
+         }
+      }
+      while (++portRetries < 20);
+
+      // if we used up all our retries, abort now
+      if (portRetries == 20)
+      {
+         return systemError(boost::system::errc::not_supported,
+                            "Couldn't find an available port",
+                            ERROR_LOCATION);
+      }
+
+      // start server
+      core::thread::safeLaunchThread(
+               boost::bind(&ConsoleProcessSocket::watchSocket, this),
+               &websocketThread_);
+
+      port_ = port;
+      serverRunning_ = true;
+   }
+   catch (websocketpp::exception const& e)
+   {
+      LOG_ERROR_MESSAGE(e.what());
+      return systemError(boost::system::errc::invalid_argument,
+                            e.what(), ERROR_LOCATION);
+   }
+   catch (...)
+   {
+      LOG_ERROR_MESSAGE("Unknown exception starting up terminal websocket");
+      return systemError(boost::system::errc::invalid_argument,
+                         "Unknown exception", ERROR_LOCATION);
+   }
+   return Success();
+}
+
+void ConsoleProcessSocket::stopServer()
+{
+   try
+   {
+      if (serverRunning_)
+      {
+         releaseAllConnections();
+
+         pwsServer_->stop();
+         serverRunning_ = false;
+         port_ = 0;
+         pwsServer_.reset();
+         websocketThread_.join();
+      }
+   }
+   catch (websocketpp::exception const& e)
+   {
+      LOG_ERROR_MESSAGE(e.what());
+   }
+   catch (...)
+   {
+      LOG_ERROR_MESSAGE("Unknown exception stopping terminal websocket server");
+   }
+}
+
+Error ConsoleProcessSocket::listen(
+      const std::string& terminalHandle,
+      const ConsoleProcessSocketConnectionCallbacks& connectionCallbacks)
+{
+   if (!serverRunning_)
+   {
+      return systemError(boost::system::errc::not_connected,
+                         terminalHandle,
+                         ERROR_LOCATION);
+   }
+
+   ConsoleProcessSocketConnectionDetails details = connections_.get(terminalHandle);
+   details.handle_ = terminalHandle;
+   details.connectionCallbacks_ = connectionCallbacks;
+   connections_.set(terminalHandle, details);
+   return Success();
+}
+
+Error ConsoleProcessSocket::stopListening(const std::string& terminalHandle)
+{
+   ConsoleProcessSocketConnectionDetails details = connections_.get(terminalHandle);
+   if (details.handle_.compare(terminalHandle))
+   {
+      return systemError(boost::system::errc::invalid_argument,
+                         terminalHandle,
+                         ERROR_LOCATION);
+   }
+
+   details = connections_.collect(terminalHandle);
+   return Success();
+}
+
+Error ConsoleProcessSocket::sendText(const std::string& terminalHandle,
+                                     const std::string& message)
+{
+   // do we know about this handle?
+   ConsoleProcessSocketConnectionDetails details = connections_.get(terminalHandle);
+   if (details.handle_.compare(terminalHandle))
+   {
+      std::string msg = "Unknown handle: \"" + terminalHandle + "\"";
+      return systemError(boost::system::errc::not_connected, msg, ERROR_LOCATION);
+   }
+
+   // make sure this handle still refers to a connection before we try to
+   // send data over it
+   websocketpp::lib::error_code ec;
+   pwsServer_->get_con_from_hdl(details.hdl_, ec);
+   if (ec.value() > 0)
+   {
+      return systemError(boost::system::errc::not_connected,
+                         ec.message(), ERROR_LOCATION);
+   }
+
+   pwsServer_->send(details.hdl_, message, websocketpp::frame::opcode::text, ec);
+   if (ec)
+   {
+      return systemError(boost::system::errc::bad_message,
+                         ec.message(), ERROR_LOCATION);
+   }
+   return Success();
+}
+
+void ConsoleProcessSocket::releaseAllConnections()
+{
+   connections_.clear();
+}
+
+int ConsoleProcessSocket::port() const
+{
+   return port_;
+}
+
+void ConsoleProcessSocket::watchSocket()
+{
+   pwsServer_->run();
+}
+
+void ConsoleProcessSocket::onMessage(terminalServer* s,
+                                     websocketpp::connection_hdl hdl,
+                                     terminalMessage_ptr msg)
+{
+   std::string handle = getHandle(s, hdl);
+   if (handle.empty())
+      return;
+   ConsoleProcessSocketConnectionDetails details = connections_.get(handle);
+
+   std::string message = msg->get_payload();
+   if (details.connectionCallbacks_.onReceivedInput)
+      details.connectionCallbacks_.onReceivedInput(message);
+}
+
+void ConsoleProcessSocket::onClose(terminalServer* s, websocketpp::connection_hdl hdl)
+{
+   std::string handle = getHandle(s, hdl);
+   if (handle.empty())
+      return;
+
+   activeConnections_--;
+
+   ConsoleProcessSocketConnectionDetails details = connections_.get(handle);
+
+   if (details.connectionCallbacks_.onConnectionClosed)
+      details.connectionCallbacks_.onConnectionClosed();
+}
+
+void ConsoleProcessSocket::onOpen(terminalServer* s, websocketpp::connection_hdl hdl)
+{
+   std::string handle = getHandle(s, hdl);
+   if (handle.empty())
+      return;
+
+   activeConnections_++;
+
+   // add/update in connections map
+   ConsoleProcessSocketConnectionDetails details = connections_.get(handle);
+   details.handle_ = handle;
+   details.hdl_ = hdl;
+   connections_.set(handle, details);
+
+   // notify the specific connection, if available
+   if (details.connectionCallbacks_.onConnectionOpened)
+      details.connectionCallbacks_.onConnectionOpened();
+}
+
+void ConsoleProcessSocket::onHttp(terminalServer* s, websocketpp::connection_hdl hdl)
+{
+   // We could return diagnostics here if we had some, but for now just 404
+   terminalServer::connection_ptr con = s->get_con_from_hdl(hdl);
+   con->set_status(websocketpp::http::status_code::not_found);
+}
+
+std::string ConsoleProcessSocket::getHandle(terminalServer* s, websocketpp::connection_hdl hdl)
+{
+   // determine handle from last part of url, e.g. xxxxx from "terminal/xxxxx/"
+   terminalServer::connection_ptr con = s->get_con_from_hdl(hdl);
+   std::string resource = con->get_resource();
+   if (resource.empty() || resource[resource.length() - 1] != '/')
+      return std::string();
+
+   // remove mandatory trailing slash
+   resource.resize(resource.length() - 1);
+
+   // everything after remaining final slash is the handle
+   size_t lastSlash = resource.find_last_of('/');
+   if (lastSlash == std::string::npos || lastSlash + 1 >= resource.length())
+      return std::string();
+   return resource.substr(lastSlash + 1);
+}
+
+} // namespace console_process
+} // namespace session
+} // namespace rstudio

--- a/src/cpp/session/SessionConsoleProcessSocketTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessSocketTests.cpp
@@ -1,0 +1,307 @@
+/*
+ * SessionConsoleProcessSocketTests.cpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <session/SessionConsoleProcessSocket.hpp>
+
+#include <boost/bind.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/enable_shared_from_this.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include <websocketpp/config/asio_no_tls_client.hpp>
+#include <websocketpp/client.hpp>
+
+#include <tests/TestThat.hpp>
+
+namespace rstudio {
+namespace session {
+namespace console_process {
+
+using namespace console_process;
+
+namespace {
+
+// send this text and the receiver will close the websocket
+const std::string kCloseMessage = "CLOSE_CONNECTION";
+
+// convenience wrapper for ConsoleProcessSocket
+class SocketHarness : public boost::enable_shared_from_this<SocketHarness>
+{
+public:
+   SocketHarness() {}
+   ~SocketHarness() {}
+
+   bool ensureServerRunning()
+   {
+      core::Error err = socket_.ensureServerRunning();
+      return (!err);
+   }
+
+   void onSocketClosed()
+   {
+      LOG_ERROR_MESSAGE("onClosed");
+   }
+
+   void onReceivedInput(const std::string& input)
+   {
+      if (!input.compare(kCloseMessage))
+      {
+         socket_.stopListening("abcd");
+         socket_.sendText("abcd", kCloseMessage);
+         return;
+      }
+      receivedInput_.append(input);
+   }
+
+   bool listen(const std::string& terminalHandle,
+               const ConsoleProcessSocketConnectionCallbacks& callbacks)
+   {
+      core::Error err = socket_.listen(terminalHandle, callbacks);
+      return (!err);
+   }
+
+   bool stopListening(const std::string& terminalHandle)
+   {
+      core::Error err = socket_.stopListening(terminalHandle);
+      return (!err);
+   }
+
+   int port() { return socket_.port(); }
+   std::string receivedInput() { return receivedInput_; }
+
+private:
+   ConsoleProcessSocket socket_;
+   std::string receivedInput_;
+};
+
+typedef websocketpp::client<websocketpp::config::asio_client> client;
+typedef client::message_ptr message_ptr;
+
+// Client-side websocket utility for testing ConsoleProcessSocket server.
+class SocketClient
+{
+public:
+   SocketClient(const std::string& handle, boost::shared_ptr<SocketHarness> pServerSocket)
+      :
+        handle_(handle),
+        pServerSocket_(pServerSocket),
+        gotOpened_(false),
+        gotClosed_(false),
+        clientRunning_(false)
+   {}
+
+   ~SocketClient()
+   {
+      try
+      {
+         disconnectFromServer();
+      }
+      catch (...) {}
+   }
+
+   void on_message(client* c, websocketpp::connection_hdl hdl, message_ptr msg)
+   {
+      std::string message = msg->get_payload();
+   }
+
+   bool connectToServer()
+   {
+      using websocketpp::lib::placeholders::_1;
+      using websocketpp::lib::placeholders::_2;
+      using websocketpp::lib::bind;
+
+      try {
+         std::string uri = "http://localhost:" +
+               boost::lexical_cast<std::string>(pServerSocket_->port()) +
+               "/terminal/" + handle_ + "/";
+
+         // Set logging to be pretty verbose (everything except message payloads)
+         client_.set_access_channels(websocketpp::log::alevel::all);
+         client_.clear_access_channels(websocketpp::log::alevel::frame_payload);
+
+         // Initialize ASIO
+         client_.init_asio();
+
+         // Register our message handler
+         client_.set_message_handler(bind(&SocketClient::on_message, this,
+                                          &client_, ::_1, ::_2));
+
+         websocketpp::lib::error_code ec;
+         client::connection_ptr con = client_.get_connection(uri, ec);
+         if (ec)
+            return false;
+
+         // Note that connect here only requests a connection. No network
+         // messages are exchanged until the event loop starts running in
+         // the thread.
+         client_.connect(con);
+
+         // Start the ASIO io_service run loop in a separate thread; allows
+         // us to perform multiple operations as part of the test.
+         core::thread::safeLaunchThread(
+                  boost::bind(&SocketClient::watchSocket, this),
+                  &clientSocketThread_);
+      }
+      catch (websocketpp::exception const & e)
+      {
+         return false;
+      }
+      return true;
+   }
+
+   bool disconnectFromServer()
+   {
+      if (clientRunning_)
+      {
+         client_.stop();
+         clientRunning_ = false;
+         clientSocketThread_.join();
+      }
+      return true;
+   }
+
+   void onReceivedInput(const std::string& input)
+   {
+      input_.append(input);
+   }
+
+   void onConnectionOpened()
+   {
+//      scoped_lock guard(lock_);
+      gotOpened_ = true;
+      clientRunning_ = true;
+   }
+
+   void onConnectionClosed()
+   {
+//      scoped_lock guard(lock_);
+      gotClosed_ = true;
+      clientRunning_ = false;
+   }
+
+   ConsoleProcessSocketConnectionCallbacks createConsoleProcessSocketConnectionCallbacks()
+   {
+      ConsoleProcessSocketConnectionCallbacks cb;
+      cb.onReceivedInput = boost::bind(&SocketClient::onReceivedInput, this, _1);
+      cb.onConnectionOpened = boost::bind(&SocketClient::onConnectionOpened, this);
+      cb.onConnectionClosed = boost::bind(&SocketClient::onConnectionClosed, this);
+      return cb;
+   }
+
+   bool listen()
+   {
+      return pServerSocket_->listen(handle_, createConsoleProcessSocketConnectionCallbacks());
+   }
+
+   bool stopListening()
+   {
+      return pServerSocket_->stopListening(handle_);
+   }
+
+   bool sendMessage(const std::string& msg)
+   {
+      return true;
+   }
+
+   std::string getInput() { return input_; }
+   bool gotOpened() { return gotOpened_; }
+   bool gotClosed() { return gotClosed_; }
+
+private:
+   void watchSocket() { client_.run(); }
+
+   std::string handle_;
+   boost::shared_ptr<SocketHarness> pServerSocket_;
+   std::string input_;
+   bool gotOpened_;
+   bool gotClosed_;
+
+   client client_;
+   boost::thread clientSocketThread_;
+   bool clientRunning_;
+   websocketpp::connection_hdl hdl_;
+   websocketpp::lib::mutex lock_;
+};
+
+} // anonymous namespace
+
+context("websocket for interactive terminals")
+{
+   const std::string handle1 = "abcd";
+
+   test_that("port for new socket object is zero")
+   {
+      boost::shared_ptr<SocketHarness> pSocket = boost::make_shared<SocketHarness>();
+      expect_true(pSocket->port() == 0);
+   }
+
+   test_that("cannot listen if server is not running")
+   {
+      boost::shared_ptr<SocketHarness> pSocket = boost::make_shared<SocketHarness>();
+      SocketClient client(handle1, pSocket);
+      expect_false(client.listen());
+   }
+
+   test_that("server port returned correctly when started")
+   {
+      boost::shared_ptr<SocketHarness> pSocket = boost::make_shared<SocketHarness>();
+      expect_true(pSocket->ensureServerRunning());
+      expect_true(pSocket->port() > 0);
+   }
+
+   test_that("stop listening to unknown handle returns error")
+   {
+      boost::shared_ptr<SocketHarness> pSocket = boost::make_shared<SocketHarness>();
+      expect_true(pSocket->ensureServerRunning());
+      SocketClient client(handle1, pSocket);
+      expect_false(client.stopListening());
+   }
+
+   test_that("can start and stop listening to a handle")
+   {
+      boost::shared_ptr<SocketHarness> pSocket = boost::make_shared<SocketHarness>();
+      expect_true(pSocket->ensureServerRunning());
+      SocketClient client(handle1, pSocket);
+      expect_true(client.listen());
+   }
+
+//   test_that("can connect to server and send a message")
+//   {
+//      boost::shared_ptr<SocketHarness> pSocket = boost::make_shared<SocketHarness>();
+//      expect_true(pSocket->ensureServerRunning());
+//      SocketClient client(handle1, pSocket);
+//      expect_true(client.listen());
+//      expect_true(client.connectToServer());
+
+//      const std::string message = "Hello World!";
+
+//      expect_true(client.sendMessage(message));
+//      //expect_true(client.sendMessage(kCloseMessage));
+
+//      for (;;)
+//      {
+//         if (!pSocket->receivedInput.compare(message))
+//            break;
+//      }
+
+//      expect_true(client.disconnectFromServer());
+//      expect_true(pSocket->stopServer());
+//   }
+}
+
+} // namespace console_process
+} // namespace session
+} // namespace rstudio

--- a/src/cpp/session/SessionConsoleProcessTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessTests.cpp
@@ -35,7 +35,7 @@ context("queue and fetch input")
             TerminalShell::DefaultShell, console_process::Rpc, "");
 
    boost::shared_ptr<ConsoleProcess> pCP =
-         ConsoleProcess::createTerminalProcess(procOptions, pCPI);
+         ConsoleProcess::createTerminalProcess(procOptions, pCPI, false /*enableWebsockets*/);
 
    test_that("empty queue returns nothing")
    {

--- a/src/cpp/session/include/session/SessionConsoleProcessSocket.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessSocket.hpp
@@ -1,0 +1,128 @@
+/*
+ * SessionConsoleProcessSocket.hpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+#ifndef SESSION_CONSOLE_PROCESS_SOCKET_HPP
+#define SESSION_CONSOLE_PROCESS_SOCKET_HPP
+
+#include <string>
+
+#include <boost/function.hpp>
+#include <boost/scoped_ptr.hpp>
+#include <boost/asio.hpp>
+
+#include <core/Error.hpp>
+#include <core/Thread.hpp>
+
+#include <websocketpp/config/asio_no_tls.hpp>
+#include <websocketpp/server.hpp>
+#include <websocketpp/frame.hpp>
+
+namespace rstudio {
+namespace session {
+namespace console_process {
+
+// Overview: ConsoleProcessSocket manages a single websocket, and
+// multiple connections to that websocket, for the purpose of high-
+// speed communication of input/output for interactive terminals
+// spawned by the server, and displayed in the client.
+//
+// ConsoleProcessSocketConnectionCallbacks are related to connections.
+// Each connections made will supply a unique set of these callbacks,
+// and will receive callbacks only related to that connection.
+//
+// Each connection MUST be made with a URL ending with /xxxx/ where "xxxx"
+// is some textual unique handle for that connection. In practice, this is
+// the terminal handle string used elsewhere in the codebase. This uniqueId
+// is used to dispatch callbacks, and to send output to the right connection.
+//
+// IMPORTANT: Callbacks are dispatched on a background thread.
+
+struct ConsoleProcessSocketConnectionCallbacks
+{
+   // invoked when input arrives on the socket
+   boost::function<void (const std::string& input)> onReceivedInput;
+
+   // invoked when connection opens
+   boost::function<void()> onConnectionOpened;
+
+   // invoked when connection closes
+   boost::function<void ()> onConnectionClosed;
+};
+
+typedef websocketpp::server<websocketpp::config::asio> terminalServer;
+typedef terminalServer::message_ptr terminalMessage_ptr;
+
+struct ConsoleProcessSocketConnectionDetails
+{
+   std::string handle_;
+   ConsoleProcessSocketConnectionCallbacks connectionCallbacks_;
+   websocketpp::connection_hdl hdl_;
+};
+
+// Manages a websocket that channels input and output from client for
+// interactive terminals. Terminals are identified via a unique handle.
+class ConsoleProcessSocket : boost::noncopyable
+{
+public:
+   ConsoleProcessSocket();
+   ~ConsoleProcessSocket();
+
+   // start the websocket servicing thread
+   core::Error ensureServerRunning();
+
+   // start receiving callbacks for given connection; client should call
+   // before making the connection to ensure all callbacks are received
+   core::Error listen(const std::string& terminalHandle,
+                      const ConsoleProcessSocketConnectionCallbacks& callbacks);
+
+   // stop listening to given terminal handle
+   core::Error stopListening(const std::string& terminalHandle);
+
+   // send text to client
+   core::Error sendText(const std::string& terminalHandle,
+                        const std::string& message);
+
+   // network port for websocket listener; 0 means no port
+   int port() const;
+
+private:
+   void watchSocket();
+
+   void stopServer();
+   void releaseAllConnections();
+   std::string getHandle(terminalServer* s, websocketpp::connection_hdl hdl);
+   void onMessage(terminalServer* s, websocketpp::connection_hdl hdl,
+                  terminalMessage_ptr msg);
+   void onClose(terminalServer* s, websocketpp::connection_hdl hdl);
+   void onOpen(terminalServer* s, websocketpp::connection_hdl hdl);
+   void onHttp(terminalServer* s, websocketpp::connection_hdl hdl);
+
+   void onServerTimeout(boost::system::error_code ec);
+
+private:
+   core::thread::ThreadsafeMap<std::string, ConsoleProcessSocketConnectionDetails> connections_;
+
+   int port_;
+   boost::thread websocketThread_;
+   bool serverRunning_;
+   boost::shared_ptr<terminalServer> pwsServer_;
+
+   int activeConnections_;
+};
+
+} // namespace console_process
+} // namespace session
+} // namespace rstudio
+
+#endif // SESSION_CONSOLE_PROCESS_SOCKET_HPP

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcess.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcess.java
@@ -320,7 +320,15 @@ public class ConsoleProcess implements ConsoleOutputEvent.HasHandlers,
    {
       return procInfo_;
    }
-
+   
+   public int getChannelMode()
+   {
+      if (forceRpc_)
+         return ConsoleProcessInfo.CHANNEL_RPC;
+      
+      return procInfo_.getChannelMode(); 
+   }
+   
    public void start(ServerRequestCallback<Void> requestCallback)
    {
       server_.processStart(procInfo_.getHandle(), requestCallback);
@@ -340,6 +348,12 @@ public class ConsoleProcess implements ConsoleOutputEvent.HasHandlers,
    public void getTerminalBufferChunk(int chunk, ServerRequestCallback<ProcessBufferChunk> requestCallback)
    {
       server_.processGetBufferChunk(procInfo_.getHandle(), chunk, requestCallback);
+   }
+   
+   public void useRpcMode(ServerRequestCallback<Void> requestCallback)
+   {
+      forceRpc_ = true;
+      server_.processUseRpc(procInfo_.getHandle(), requestCallback);
    }
 
    public void interrupt(ServerRequestCallback<Void> requestCallback)
@@ -383,4 +397,5 @@ public class ConsoleProcess implements ConsoleOutputEvent.HasHandlers,
    private final HandlerManager handlers_ = new HandlerManager(this);
    private final ConsoleServerOperations server_;
    private final ConsoleProcessInfo procInfo_;
+   private boolean forceRpc_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -696,6 +696,15 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, PROCESS_GET_BUFFER_CHUNK, params, requestCallback);
    }
 
+   @Override 
+   public void processUseRpc(String handle,
+                             ServerRequestCallback<Void> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(StringUtil.notNull(handle)));
+      sendRequest(RPC_SCOPE, PROCESS_USE_RPC, params, requestCallback);   
+   }
+
    public void interrupt(ServerRequestCallback<Void> requestCallback)
    {
       sendRequest(RPC_SCOPE, INTERRUPT, requestCallback);
@@ -5128,6 +5137,7 @@ public class RemoteServer implements Server
    private static final String PROCESS_SET_TITLE = "process_set_title";
    private static final String PROCESS_ERASE_BUFFER = "process_erase_buffer";
    private static final String PROCESS_GET_BUFFER_CHUNK = "process_get_buffer_chunk";
+   private static final String PROCESS_USE_RPC = "process_use_rpc";
 
    private static final String REMOVE_ALL_OBJECTS = "remove_all_objects";
    private static final String REMOVE_OBJECTS = "remove_objects";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/model/ConsoleServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/model/ConsoleServerOperations.java
@@ -1,7 +1,7 @@
 /*
  * ConsoleServerOperations.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -57,6 +57,15 @@ public interface ConsoleServerOperations extends CodeToolsServerOperations,
    void processGetBufferChunk(String handle,
                               int chunk,
                               ServerRequestCallback<ProcessBufferChunk> requestCallback);
+   
+   /**
+    * Switch a server process to use Rpc mode after failing to connect to
+    * non-rpc channel such as websocket.
+    * @param handle process handle
+    * @param requestCallback
+    */
+   void processUseRpc(String handle,
+                      ServerRequestCallback<Void> requestCallback);
 
    /**
     * Set/update the caption of given process.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -144,10 +144,10 @@ public class TerminalSession extends XTermWidget
             addHandlerRegistration(addXTermTitleHandler(TerminalSession.this));
             addHandlerRegistration(eventBus_.addHandler(SessionSerializationEvent.TYPE, TerminalSession.this));
             
-            socket_.connect(consoleProcess_, new ServerRequestCallback<Boolean>()
+            socket_.connect(consoleProcess_, new TerminalSessionSocket.ConnectCallback()
             {
                @Override
-               public void onResponseReceived(Boolean isWebSocket)
+               public void onConnected()
                {
                   consoleProcess_.start(new ServerRequestCallback<Void>()
                   {
@@ -171,9 +171,9 @@ public class TerminalSession extends XTermWidget
                }
 
                @Override
-               public void onError(ServerError error)
+               public void onError(String errorMsg)
                {
-                  writeError(error.getUserMessage());
+                  writeError(errorMsg);
                   disconnect();
                   return;
                }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
@@ -192,7 +192,6 @@ public class TerminalSessionSocket
       switch (consoleProcess_.getChannelMode())
       {
       case ConsoleProcessInfo.CHANNEL_RPC:
-         Debug.devlog("Using RPC");
          callback.onConnected();
          break;
          
@@ -225,15 +224,12 @@ public class TerminalSessionSocket
             }
          }
 
-         Debug.devlog("Connecting to " + url);
          socket_ = new Websocket(url);
          socket_.addListener(new WebsocketListenerExt() 
          {
             @Override
             public void onClose(CloseEvent event)
             {
-               Debug.devlog("Disconnected websocket for " + 
-                     consoleProcess_.getProcessInfo().getHandle());
                socket_ = null;
             }
 
@@ -252,7 +248,6 @@ public class TerminalSessionSocket
             @Override
             public void onError()
             {
-               Debug.devlog("Unable to connect websocket, switching back to rpc");
                socket_ = null;
                
                // Unable to connect client to server via websocket; let server

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
@@ -17,25 +17,32 @@ package org.rstudio.studio.client.workbench.views.terminal;
 
 import java.util.LinkedList;
 
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.Stopwatch;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.common.console.ConsoleOutputEvent;
 import org.rstudio.studio.client.common.console.ConsoleProcess;
+import org.rstudio.studio.client.common.console.ConsoleProcessInfo;
 import org.rstudio.studio.client.common.shell.ShellInput;
+import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
+import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalDataInputEvent;
 import org.rstudio.studio.client.workbench.views.terminal.xterm.XTermWidget;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.inject.Inject;
+import com.sksamuel.gwt.websockets.CloseEvent;
+import com.sksamuel.gwt.websockets.Websocket;
+import com.sksamuel.gwt.websockets.WebsocketListenerExt;
 
 /**
  * Manages input and output for the terminal session.
- * TODO Use a websocket to communicate with the server, falling back to RPC 
- * if unable to establish a websocket connection.
  */
 public class TerminalSessionSocket
    implements ConsoleOutputEvent.Handler, 
@@ -56,7 +63,12 @@ public class TerminalSessionSocket
       void receivedOutput(String output);
    }
    
-  
+   public interface ConnectCallback
+   {
+      void onConnected();
+      void onError(String message);
+   }
+   
    // Monitor and report input/display lag to console
    class InputEchoTimeMonitor
    {
@@ -70,10 +82,11 @@ public class TerminalSessionSocket
 
          boolean matches(String input, long runningAverage)
          {
-            if (input != null && input_.equals(input))
+            // startsWith allows better chance of matching on Windows, where 
+            // winpty often follows each typed character with an escape sequence
+            if (input != null && input.startsWith(input_))
             {
-               duration_ = stopWatch_.mark("Average " + runningAverage + 
-                     " [" + input + "]");
+               duration_ = stopWatch_.mark("Average " + runningAverage);
                return true;
             }
             return false;
@@ -162,24 +175,114 @@ public class TerminalSessionSocket
     * an rsession has already been started via RPC and the consoleProcess
     * received.
     * @param consoleProcess 
-    * @param callback returns true if using websockets, false for RPC
+    * @param callback result of connect attempt
     */
    public void connect(ConsoleProcess consoleProcess, 
-                       ServerRequestCallback<Boolean> callback)
+                       final ConnectCallback callback)
    {
       consoleProcess_ = consoleProcess;
-      
+
       // We keep this handler connected after a disconnect so
       // user input sent via RPC can wake up a suspended session
       if (terminalInputHandler_ == null)
          terminalInputHandler_ = xterm_.addTerminalDataInputHandler(this);
 
       addHandlerRegistration(consoleProcess_.addConsoleOutputHandler(this));
-      
-      // TODO (gary) attempt websocket connection here
-      boolean haveWebsocket = false;
-      
-      callback.onResponseReceived(haveWebsocket);
+
+      switch (consoleProcess_.getChannelMode())
+      {
+      case ConsoleProcessInfo.CHANNEL_RPC:
+         Debug.devlog("Using RPC");
+         callback.onConnected();
+         break;
+         
+      case ConsoleProcessInfo.CHANNEL_WEBSOCKET:
+              
+         // For desktop IDE, talk directly to the websocket, anything else, go 
+         // through the server via the /p proxy.
+         String urlSuffix = consoleProcess_.getProcessInfo().getChannelId() + "/terminal/" + 
+               consoleProcess_.getProcessInfo().getHandle() + "/";
+         String url;
+         if (Desktop.isDesktop())
+         {
+            url = "ws://127.0.0.1:" + urlSuffix;
+         }
+         else
+         {
+            url = GWT.getHostPageBaseURL();
+            if (url.startsWith("https:"))
+            {
+               url = "wss:" + url.substring(6) + "p/" + urlSuffix;
+            } 
+            else if (url.startsWith("http:"))
+            {
+               url = "ws:" + url.substring(5) + "p/" + urlSuffix;
+            }
+            else
+            {
+               callback.onError("Unable to discover websocket protocol");
+               return;
+            }
+         }
+
+         Debug.devlog("Connecting to " + url);
+         socket_ = new Websocket(url);
+         socket_.addListener(new WebsocketListenerExt() 
+         {
+            @Override
+            public void onClose(CloseEvent event)
+            {
+               Debug.devlog("Disconnected websocket for " + 
+                     consoleProcess_.getProcessInfo().getHandle());
+               socket_ = null;
+            }
+
+            @Override
+            public void onMessage(String msg)
+            {
+               onConsoleOutput(new ConsoleOutputEvent(msg));
+            }
+
+            @Override
+            public void onOpen()
+            {
+               callback.onConnected();
+            }
+
+            @Override
+            public void onError()
+            {
+               Debug.devlog("Unable to connect websocket, switching back to rpc");
+               socket_ = null;
+               
+               // Unable to connect client to server via websocket; let server
+               // know we'll be using rpc, instead
+               consoleProcess_.useRpcMode(new ServerRequestCallback<Void>()
+               {
+                  @Override
+                  public void onResponseReceived(Void response)
+                  {
+                     callback.onConnected();
+                  }
+
+                  @Override
+                  public void onError(ServerError error)
+                  {
+                     callback.onError("Unable to switch back to Rpc mode");
+                  }
+               });
+               return;
+            }
+         });
+         
+         socket_.open();
+         break;
+         
+      case ConsoleProcessInfo.CHANNEL_PIPE:
+      default:
+         callback.onError("Channel type not implemented");
+         break;
+      }
    }
    
    /**
@@ -192,11 +295,22 @@ public class TerminalSessionSocket
                              String input,
                              VoidServerRequestCallback requestCallback)
    {
-      // TODO (gary) write to websocket here
+      switch (consoleProcess_.getChannelMode())
+      {
+      case ConsoleProcessInfo.CHANNEL_RPC:
+         consoleProcess_.writeStandardInput(
+               ShellInput.create(inputSequence, input,  true /*echo input*/), 
+               requestCallback);
+         break;
+      case ConsoleProcessInfo.CHANNEL_WEBSOCKET:
+         socket_.send(input);
+         requestCallback.onResponseReceived(null);
+         break;
+      case ConsoleProcessInfo.CHANNEL_PIPE:
+      default:
+         break;
+      }
       
-      consoleProcess_.writeStandardInput(
-            ShellInput.create(inputSequence, input,  true /*echo input*/), 
-            requestCallback);
    }
    
    /**
@@ -241,7 +355,8 @@ public class TerminalSessionSocket
 
    public void disconnect()
    {
-      consoleProcess_ = null;
+      socket_.close();
+      socket_ = null;
       registrations_.removeHandler();
    }
  
@@ -252,6 +367,7 @@ public class TerminalSessionSocket
    private HandlerRegistration terminalInputHandler_;
    private boolean reportTypingLag_;
    private InputEchoTimeMonitor inputEchoTiming_;
+   private Websocket socket_;
    
    // Injected ---- 
    private UIPrefs uiPrefs_;


### PR DESCRIPTION
RSession starts a thread running a websocket server, and terminal sessions use the websocket for sending input to the server, and receiving output from the server.

If unable to connect, the connection falls back to RPC.

Seeing a nice bump in responsiveness from the terminals with this approach. Typical response time between hitting key and getting it echo'd back was about 130ms (on a Mac dev setup); with changes this is about 30ms.