### PR TITLE
Make bringtotop unsupported in windows

### DIFF
--- a/src/cpp/r/session/REmbeddedWin32.cpp
+++ b/src/cpp/r/session/REmbeddedWin32.cpp
@@ -236,6 +236,7 @@ Error completeEmbeddedRInitialization(bool useInternet2)
    using namespace r::function_hook ;
    ExecBlock block ;
    block.addFunctions()
+      (bind(registerUnsupported, "bringToTop", "grDevices"))
       (bind(registerUnsupported, "winMenuAdd", "utils"))
       (bind(registerUnsupported, "winMenuAddItem", "utils"))
       (bind(registerUnsupported, "winMenuDel", "utils"))


### PR DESCRIPTION
Looks like I forgot to send a PR for this one. In windows, bringToTop() crashes.