### PR TITLE
Fix: New clear console icon makes code hard to interrupt

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
@@ -311,17 +311,17 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
          {
             owner_.setMainWidget(consolePane_);
             owner_.addLeftWidget(goToWorkingDirButton_);
-            owner_.setContextButton(consoleInterrupt_,
-                                    consoleInterrupt_.getWidth(),
-                                    consoleInterrupt_.getHeight(),
-                                    0);
-            owner_.setContextButton(consoleInterruptProfiler_,
-                  consoleInterruptProfiler_.getWidth(),
-                  consoleInterruptProfiler_.getHeight(),
-                  1);
             owner_.setContextButton(consoleClearButton_,
                                     consoleClearButton_.getWidth(),
                                     consoleClearButton_.getHeight(),
+                                    0);
+            owner_.setContextButton(consoleInterrupt_,
+                                    consoleInterrupt_.getWidth(),
+                                    consoleInterrupt_.getHeight(),
+                                    1);
+            owner_.setContextButton(consoleInterruptProfiler_,
+                                    consoleInterruptProfiler_.getWidth(),
+                                    consoleInterruptProfiler_.getHeight(),
                                     2);
             consolePane_.onBeforeSelected();
             consolePane_.onSelected();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/Console.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/Console.java
@@ -80,16 +80,10 @@ public class Console
             if (event.isBusy())
             {
                interruptFadeInHelper_.beginShow();
-               clearFadeInHelper_.hide();
             }
-            else
-               clearFadeInHelper_.beginShow();
          }
       });
       
-      clearFadeInHelper_ = new DelayFadeInHelper(
-            view_.getConsoleClearButton().asWidget());
-
       profilerFadeInHelper_ = new DelayFadeInHelper(
             view_.getProfilerInterruptButton().asWidget());
       events.addHandler(RprofEvent.TYPE, new RprofEvent.Handler()
@@ -192,7 +186,6 @@ public class Console
    }
 
    private final DelayFadeInHelper interruptFadeInHelper_;
-   private final DelayFadeInHelper clearFadeInHelper_;
    private final DelayFadeInHelper profilerFadeInHelper_;
    private final EventBus events_;
    private final Display view_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleClearButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleClearButton.java
@@ -20,19 +20,15 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.inject.Inject;
 
-import org.rstudio.core.client.layout.DelayFadeInHelper;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.workbench.commands.Commands;
-import org.rstudio.studio.client.workbench.views.console.events.ConsoleBusyEvent;
 
 public class ConsoleClearButton extends Composite
 {
    @Inject
    public ConsoleClearButton(final EventBus events, Commands commands)
    {
-      fadeInHelper_ = new DelayFadeInHelper(this);
-
       // The SimplePanel wrapper is necessary for the toolbar button's "pushed"
       // effect to work.
       SimplePanel panel = new SimplePanel();
@@ -46,19 +42,7 @@ public class ConsoleClearButton extends Composite
       panel.setWidget(button);
 
       initWidget(panel);
-      setVisible(false);
-
-      events.addHandler(ConsoleBusyEvent.TYPE, new ConsoleBusyEvent.Handler()
-      {
-         @Override
-         public void onConsoleBusy(ConsoleBusyEvent event)
-         {
-            if (!event.isBusy())
-               fadeInHelper_.beginShow();
-            else
-               fadeInHelper_.hide();
-         }
-      });
+      setVisible(true);
    }
 
    public int getWidth()
@@ -71,7 +55,6 @@ public class ConsoleClearButton extends Composite
       return height_;
    }
    
-   private final DelayFadeInHelper fadeInHelper_;
    private final int width_;
    private final int height_;
    private final Commands commands_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
@@ -106,7 +106,7 @@ public class ConsolePane extends WorkbenchPane
       toolbar.addLeftWidget(commands_.goToWorkingDir().createToolbarButton());
       consoleInterruptButton_ = commands_.interruptR().createToolbarButton();
       consoleClearButton_ = commands_.consoleClear().createToolbarButton();
-      consoleClearButton_.setVisible(false);
+      consoleClearButton_.setVisible(true);
       
       profilerInterruptButton_ = ConsoleInterruptProfilerButton.CreateProfilerButton();
       profilerInterruptButton_.setVisible(false);


### PR DESCRIPTION
See case 6690.

Fix: Keep the clear console toolbar button always visible instead of fading it in when stop button fades out, and have it fixed to the right-side of toolbar.

By having clear button always visible, position stays fixed and the stop button fades in to its left, avoiding this issue of stop button moving around.

The clear console command is usable even when console is busy, so having the button fade out when stop appears wasn't necessary.