### PR TITLE
session-use-terminal-websockets to control use of websockets

### DIFF
--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -204,7 +204,10 @@ core::ProgramStatus Options::read(int argc, char * const argv[])
        "default directory for new projects")
       ("show-help-home",
        value<bool>(&showHelpHome_)->default_value(false),
-         "show help home page at startup");
+         "show help home page at startup")
+      ("session-use-terminal-websockets",
+          value<bool>(&useTerminalWebsockets_)->default_value(true),
+          "try to communicate with terminal using websockets");
 
    // allow options
    options_description allow("allow");

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -164,6 +164,8 @@ public:
 
    bool showUserHomePage() const { return showUserHomePage_; }
    
+   bool useTerminalWebsockets() const { return useTerminalWebsockets_; }
+
    core::FilePath coreRSourcePath() const 
    { 
       return core::FilePath(coreRSourcePath_.c_str());
@@ -541,6 +543,7 @@ private:
    bool createProfile_;
    bool createPublicFolder_;
    bool rProfileOnResumeDefault_;
+   bool useTerminalWebsockets_;
    int saveActionDefault_;
    bool standalone_;
    std::string authRequiredUserGroup_;

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -960,8 +960,9 @@ Error startTerminal(const json::JsonRpcRequest& request,
             console_process::kDefaultTerminalMaxOutputLines);
 
    // run process
+   bool useWebsockets = session::options().useTerminalWebsockets();
    boost::shared_ptr<ConsoleProcess> ptrProc =
-               ConsoleProcess::createTerminalProcess(options, ptrProcInfo);
+               ConsoleProcess::createTerminalProcess(options, ptrProcInfo, useWebsockets);
 
    ptrProc->onExit().connect(boost::bind(
                               &source_control::enqueueRefreshEvent));


### PR DESCRIPTION
New session setting, determines if websockets will be tried for connecting to terminals. Default is true (1).

session-use-terminal-websockets=0  -- client will only use rpc to talk to terminals, won't even try websockets
