### PR TITLE
Fix bug that assumes all libraries have at least two packages

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -312,7 +312,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
                          desc=pkgs.desc,
                          url=pkgs.url,
                          loaded=pkgs.loaded,
-                         check.rows = FALSE,
+                         check.rows = TRUE,
                          stringsAsFactors = FALSE)
 
    # sort and return

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -298,12 +298,9 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
 
    # build up vector of package versions
    instPkgs <- as.data.frame(installed.packages(), stringsAsFactors=F)
-   pkgs.version <- character(length=length(pkgs.name))
-   for (i in 1:length(pkgs.name)) {
-      pkgs.version[[i]] <- .rs.packageVersion(pkgs.name[[i]],
-                                              pkgs.library[[i]],
-                                              instPkgs)
-   }
+   pkgs.version <- sapply(seq_along(pkgs.name), function(i){
+     .rs.packageVersion(pkgs.name[[i]], pkgs.library[[i]], instPkgs)
+   })
    
    # alias library paths for the client
    pkgs.library <- .rs.createAliasedPath(pkgs.library)

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -280,7 +280,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
 
    # get packages
    x <- suppressWarnings(library(lib.loc=uniqueLibPaths))
-   x <- x$results[x$results[, 1] != "base", ]
+   x <- x$results[x$results[, 1] != "base", drop=FALSE]
    
    # extract/compute required fields 
    pkgs.name <- x[, 1]
@@ -315,7 +315,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
                          desc=pkgs.desc,
                          url=pkgs.url,
                          loaded=pkgs.loaded,
-                         check.rows = TRUE,
+                         check.rows = FALSE,
                          stringsAsFactors = FALSE)
 
    # sort and return


### PR DESCRIPTION
This is a fix for the bug originally reported at https://support.rstudio.com/hc/communities/public/questions/203052576-setting-libpath-in-Rstudio

To replicate the error, use:

```r
loc <- normalizePath(tempdir())
assign(".lib.loc", loc, envir = environment(.libPaths))
```

The resulting error message is:

```
Error in pkgs.name[[i]] : subscript out of bounds
```

This happens because the code simplifies the result of `installed.packages()`, and if the library contains zero or one row, the simplification results in a vector, not a data frame.

The fix is to set `drop=FALSE` when returning columns of the data frame.

This bug manifests in the [`checkpoint` package on CRAN](https://cran.r-project.org/package=checkpoint). In the package is a workaround to fix this bug, and this has been working without problem for the best part of two years.  See the [checkpoint repo](https://github.com/RevolutionAnalytics/checkpoint/blob/master/R/fixRstudioBug.R).

