### PR TITLE
Terminal input/output via websockets not keeping session alive

### DIFF
--- a/src/cpp/core/system/ChildProcess.hpp
+++ b/src/cpp/core/system/ChildProcess.hpp
@@ -69,6 +69,9 @@ public:
    // isn't configured to check for subprocesses.
    virtual bool hasSubprocess() const;
 
+   // Has this process generated any recent output?
+   virtual bool hasRecentOutput() const;
+
 protected:
    Error run();
 
@@ -209,6 +212,7 @@ public:
    virtual Error terminate();
 
    virtual bool hasSubprocess() const;
+   virtual bool hasRecentOutput() const;
 
 private:
 

--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -873,7 +873,10 @@ void AsyncChildProcess::poll()
       else
       {
          if (!err.empty() && callbacks_.onStderr)
+         {
+            pAsyncImpl_->hasRecentOutput_ = true;
             callbacks_.onStderr(*this, err);
+         }
 
          if (eof)
            pAsyncImpl_->finishedStderr_ = true;

--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -376,6 +376,12 @@ bool ChildProcess::hasSubprocess() const
    return true;
 }
 
+bool ChildProcess::hasRecentOutput() const
+{
+   // base class doesn't support output tracking; override to implement
+   return true;
+}
+
 Error ChildProcess::run()
 {  
    // declarations
@@ -691,7 +697,8 @@ struct AsyncChildProcess::AsyncImpl
         finishedStderr_(false),
         exited_(false),
         checkSubProc_(boost::posix_time::not_a_date_time),
-        hasSubprocess_(true)
+        hasSubprocess_(true),
+        hasRecentOutput_(true)
    {
    }
    bool calledOnStarted_;
@@ -704,6 +711,9 @@ struct AsyncChildProcess::AsyncImpl
 
    // result of last subprocess check
    bool hasSubprocess_;
+
+   // has there been output recently?
+   bool hasRecentOutput_;
 
    void initTimers(bool reportHasSubprocs)
    {
@@ -790,6 +800,11 @@ bool AsyncChildProcess::hasSubprocess() const
    return pAsyncImpl_->hasSubprocess_;
 }
 
+bool AsyncChildProcess::hasRecentOutput() const
+{
+   return pAsyncImpl_->hasRecentOutput_;
+}
+
 void AsyncChildProcess::poll()
 {
    // call onStarted if we haven't yet
@@ -834,7 +849,10 @@ void AsyncChildProcess::poll()
       else
       {
          if (!out.empty() && callbacks_.onStdout)
+         {
+            pAsyncImpl_->hasRecentOutput_ = true;
             callbacks_.onStdout(*this, out);
+         }
 
          if (eof)
            pAsyncImpl_->finishedStdout_ = true;
@@ -906,6 +924,7 @@ void AsyncChildProcess::poll()
    pAsyncImpl_->initTimers(options().reportHasSubprocs);
    if (pAsyncImpl_->checkChildCount())
    {
+      pAsyncImpl_->hasRecentOutput_ = false;
       pAsyncImpl_->hasSubprocess_ = pAsyncImpl_->computeHasSubProcess(pImpl_->pid);
       if (callbacks_.onHasSubprocs)
       {

--- a/src/cpp/core/system/Process.cpp
+++ b/src/cpp/core/system/Process.cpp
@@ -284,16 +284,16 @@ bool ProcessSupervisor::hasRunningChildren()
 
 namespace {
 
-bool has_childProcess(const boost::shared_ptr<AsyncChildProcess>& childProc)
+bool has_activity(const boost::shared_ptr<AsyncChildProcess>& childProc)
 {
-   return childProc->hasSubprocess();
+   return childProc->hasSubprocess() || childProc->hasRecentOutput();
 }
 
 } // anonymous namespace
 
 bool ProcessSupervisor::hasActiveChildren()
 {
-   return boost::algorithm::any_of(pImpl_->children, has_childProcess);
+   return boost::algorithm::any_of(pImpl_->children, has_activity);
 }
 
 bool ProcessSupervisor::poll()


### PR DESCRIPTION
The terminal websocket activity won't reset session timer, so if all you are doing is working in the terminal (but not doing a full-screen thing to make it "busy"), the session suspend timer will run out and sadness will occur.

Fixed to have output in a terminal treated as activity (at least, for a second), which will contribute to keeping the session alive.

Also put this in the Win32 implementation, just to keep symmetry with Posix code.