### PR TITLE
Use dataframe in listInstalledPackages 0c2c109

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -280,7 +280,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
 
    # get packages
    x <- suppressWarnings(library(lib.loc=uniqueLibPaths))
-   x <- x$results[x$results[, 1] != "base", ]
+   x <- x$results[x$results[, 1] != "base", , drop=FALSE]
    
    # extract/compute required fields 
    pkgs.name <- x[, 1]

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -280,7 +280,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
 
    # get packages
    x <- suppressWarnings(library(lib.loc=uniqueLibPaths))
-   x <- x$results[x$results[, 1] != "base", drop=FALSE]
+   x <- x$results[x$results[, 1] != "base", ]
    
    # extract/compute required fields 
    pkgs.name <- x[, 1]


### PR DESCRIPTION
I'm hitting this error when restarting the r session (which also makes the packages pane unusable for me):

```
ERROR r error 4 (R code execution error) [errormsg=Error in x[, 1] : 
incorrect number of dimensions
]; OCCURRED AT: rstudio::core::Error rstudio::r::exec::(anonymous 
namespace)::evaluateExpressionsUnsafe(SEXP, SEXP, SEXP *, 
sexp::Protect *, rstudio::r::exec::(anonymous namespace)::EvalType) 
/Users/javierluraschi/RStudio/rstudio/src/cpp/r/RExec.cpp:159; 
LOGGED FROM: rstudio::core::Error rstudio::session::modules::packages::
(anonymous namespace)::getPackageState(const json::JsonRpcRequest &, 
json::JsonRpcResponse *) 
/Users/javierluraschi/RStudio/rstudio/src/cpp/session/modules/SessionPackages.cpp:538
```

Seems caused by https://github.com/rstudio/rstudio/pull/1108.

For https://github.com/rstudio/rstudio/blame/d56bef280f4b9a002c1a81cadf701fef1ce9ca92/src/cpp/session/modules/SessionPackages.R#L283, without the change:

```
class(x$results[x$results[, 1] != "base", ])
[1] "matrix"
```

but with this change I get:

```
class(x$results[x$results[, 1] != "base", drop=FALSE])
[1] "character"
```

and the indexing breaks.

@kevinushey does reverting this piece look reasonable to you?