### PR TITLE
delegate to custom completer when available

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1772,8 +1772,16 @@ assign(x = ".rs.acCompletionTypes",
    # If custom completions have been set through
    # 'rc.options("custom.completions")',
    # then use the internal R completions instead.
-   if (.rs.isCustomCompletionsEnabled())
-      return(.rs.getCustomRCompletions(line))
+   if (.rs.isCustomCompletionsEnabled()) {
+      
+      completions <- tryCatch(
+         .rs.getCustomRCompletions(line),
+         error = identity
+      )
+      
+      if (!inherits(completions, "error"))
+         return(completions)
+   }
    
    # Get the currently active frame
    envir <- .rs.getActiveFrame()

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/CodeToolsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/CodeToolsServerOperations.java
@@ -46,6 +46,7 @@ public interface CodeToolsServerOperations extends HelpServerOperations,
          boolean chainExcludeArgsFromObject,
          String filePath,
          String documentId,
+         String line,
          ServerRequestCallback<Completions> completions);
    
    void getDplyrJoinCompletions(

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -896,6 +896,7 @@ public class RemoteServer implements Server
          boolean excludeArgsFromObject,
          String filePath,
          String documentId,
+         String line,
          ServerRequestCallback<Completions> requestCallback)
    {
       JSONArray params = new JSONArray();
@@ -910,6 +911,7 @@ public class RemoteServer implements Server
       params.set(8, JSONBoolean.getInstance(excludeArgsFromObject));
       params.set(9, new JSONString(filePath));
       params.set(10, new JSONString(documentId));
+      params.set(11, new JSONString(line));
       
       sendRequest(RPC_SCOPE,
                   GET_COMPLETIONS,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -335,6 +335,7 @@ public class CompletionRequester
          final boolean chainExcludeArgsFromObject,
          final String filePath,
          final String documentId,
+         final String line,
          final boolean implicit,
          final ServerRequestCallback<CompletionResult> callback)
    {
@@ -356,6 +357,7 @@ public class CompletionRequester
             chainExcludeArgsFromObject,
             filePath,
             documentId,
+            line,
             new ServerRequestCallback<Completions>()
       {
          @Override
@@ -634,6 +636,7 @@ public class CompletionRequester
          final boolean chainExcludeArgsFromObject,
          final String filePath,
          final String documentId,
+         final String line,
          final ServerRequestCallback<Completions> requestCallback)
    {
       int optionsStartOffset;
@@ -656,6 +659,7 @@ public class CompletionRequester
                chainExcludeArgsFromObject,
                filePath,
                documentId,
+               line,
                requestCallback);
       }
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1241,6 +1241,9 @@ public class RCompletionManager implements CompletionManager
       String filePath = getSourceDocumentPath();
       String docId = getSourceDocumentId();
       
+      // Provide 'line' for R custom completers
+      String line = docDisplay_.getCurrentLineUpToCursor();
+      
       requester_.getCompletions(
             context.getToken(),
             context.getAssocData(),
@@ -1253,6 +1256,7 @@ public class RCompletionManager implements CompletionManager
             infixData.getExcludeArgsFromObject(),
             filePath,
             docId,
+            line,
             implicit,
             context_);
 


### PR DESCRIPTION
This PR augments RStudio's completion system such that it delegates to the `custom.completer` R function when available.