### PR TITLE
Roll up large directories in publish dialog

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/DirEntryCheckBox.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/DirEntryCheckBox.java
@@ -1,0 +1,84 @@
+/*
+ * DirEntryCheckBox.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.rsconnect.ui;
+
+import org.rstudio.core.client.files.FileSystemItem;
+import org.rstudio.studio.client.RStudioGinjector;
+
+import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.user.client.ui.AbstractImagePrototype;
+import com.google.gwt.user.client.ui.CheckBox;
+import com.google.gwt.user.client.ui.Composite;
+
+public class DirEntryCheckBox extends Composite
+{
+   public DirEntryCheckBox(String path)
+   {
+      // create the appropriate filesystem object for the path
+      FileSystemItem fsi = null;
+      if (path.endsWith("/"))
+      {
+         path = path.substring(0, path.length() - 1);
+         fsi = FileSystemItem.createDir(path);
+      }
+      else
+      {
+         fsi = FileSystemItem.createFile(path);
+      }
+      path_ = path;
+      
+      
+      // add an icon representing the file
+      ImageResource icon = 
+            RStudioGinjector.INSTANCE.getFileTypeRegistry().getIconForFile(fsi);
+      SafeHtmlBuilder hb = new SafeHtmlBuilder();
+      hb.append(AbstractImagePrototype.create(icon).getSafeHtml());
+      
+      // insert the file/dir name into the checkbox
+      hb.appendEscaped(path_);
+      checkbox_ = new CheckBox(hb.toSafeHtml());
+      
+      initWidget(checkbox_);
+   }
+   
+   public boolean getValue()
+   {
+      return checkbox_.getValue();
+   }
+   
+   public void setValue(boolean checked)
+   {
+      checkbox_.setValue(checked);
+   }
+   
+   public String getPath()
+   {
+      return path_;
+   }
+   
+   public void setEnabled(boolean enabled)
+   {
+      checkbox_.setEnabled(enabled);
+   }
+   
+   public boolean isEnabled()
+   {
+      return checkbox_.isEnabled();
+   }
+   
+   private final String path_;
+   private final CheckBox checkbox_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.css
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.css
@@ -84,6 +84,14 @@
    white-space: nowrap;
 }
 
+.fileList .gwt-CheckBox img
+{
+   background-size: 100% auto !important;
+   vertical-align: middle;
+   margin-left: 2px;
+   margin-right: 4px;
+}
+
 .deployLabel
 {
    font-weight: bold;

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -567,7 +567,7 @@ public class RSConnectDeploy extends Composite
    private void setFileList(ArrayList<String> files,
          ArrayList<String> additionalFiles, ArrayList<String> ignoredFiles)
    {
-      fileChecks_ = new ArrayList<CheckBox>();
+      fileChecks_ = new ArrayList<DirEntryCheckBox>();
       
       // clear existing file list
       fileListPanel_.clear(); 
@@ -869,7 +869,7 @@ public class RSConnectDeploy extends Composite
 
    private void addFile(String path, boolean checked)
    {
-      CheckBox fileCheck = new CheckBox(path);
+      DirEntryCheckBox fileCheck = new DirEntryCheckBox(path);
       fileCheck.setValue(checked);
       fileListPanel_.add(fileCheck);
       fileChecks_.add(fileCheck);
@@ -884,7 +884,7 @@ public class RSConnectDeploy extends Composite
       {
          if (fileChecks_.get(i).getValue() == checked)
          {
-            files.add(fileChecks_.get(i).getText());
+            files.add(fileChecks_.get(i).getPath());
          }
       }
       return files;
@@ -945,8 +945,8 @@ public class RSConnectDeploy extends Composite
 
       for (int i = 0; i < fileChecks_.size(); i++)
       {
-         CheckBox fileCheck = fileChecks_.get(i);
-         if (fileCheck.getText().equals(path))
+         DirEntryCheckBox fileCheck = fileChecks_.get(i);
+         if (fileCheck.getPath().equals(path))
          {
             // don't allow the user to unselect the primary file
             fileCheck.setEnabled(false);
@@ -1127,10 +1127,10 @@ public class RSConnectDeploy extends Composite
    private void checkUncheckAll()
    {
       allChecked_ = !allChecked_;
-      for (CheckBox box: fileChecks_)
+      for (DirEntryCheckBox box: fileChecks_)
       {
          // don't toggle state for disabled boxes, or common Shiny .R filenames
-         String file = box.getText().toLowerCase();
+         String file = box.getPath().toLowerCase();
          if (box.isEnabled() &&
              file != "ui.r" &&
              file != "server.r" &&
@@ -1169,7 +1169,7 @@ public class RSConnectDeploy extends Composite
    @UiField(provided=true) RSConnectAccountList accountList_;
    @UiField(provided=true) AppNameTextbox appName_;
    
-   private ArrayList<CheckBox> fileChecks_;
+   private ArrayList<DirEntryCheckBox> fileChecks_;
    private ArrayList<String> filesAddedManually_ = 
          new ArrayList<String>();
    


### PR DESCRIPTION
This change addresses a frequently reported usability issue in the publish dialog; namely, that when publishing apps that have a lot of files, the list of files displayed to deploy is too long and awkward.

There are two components to the change:

1. Any subdirectory which contains more than 5 files (recursive total) has its full file list hidden and replaced with simply the name of the directory. 

2. To help distinguish directories from ordinary files (as the dialog can now contain both), file type icons have been added to the dialog.

The result:

![image](https://cloud.githubusercontent.com/assets/470418/24777690/6154331a-1adb-11e7-96a6-f5c6ca1da287.png)

