### PR TITLE
Unit test terminal websocket class

### DIFF
--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -204,7 +204,7 @@ private:
    // is the underlying process started?
    bool started_;
 
-   // cached point to process options, for use in websocket thread callbacks
+   // cached pointer to process options, for use in websocket thread callbacks
    boost::weak_ptr<core::system::ProcessOperations> pOps_;
    boost::mutex mutex_;
 };

--- a/src/cpp/session/include/session/SessionConsoleProcessSocket.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessSocket.hpp
@@ -85,6 +85,9 @@ public:
    // start the websocket servicing thread
    core::Error ensureServerRunning();
 
+   // stop the websocket servicing thread
+   void stopServer();
+
    // start receiving callbacks for given connection; client should call
    // before making the connection to ensure all callbacks are received
    core::Error listen(const std::string& terminalHandle,
@@ -103,7 +106,6 @@ public:
 private:
    void watchSocket();
 
-   void stopServer();
    void releaseAllConnections();
    std::string getHandle(terminalServer* s, websocketpp::connection_hdl hdl);
    void onMessage(terminalServer* s, websocketpp::connection_hdl hdl,


### PR DESCRIPTION
Created test harness for the server websocket used by terminal feature, and write some tests.

These are fairly heavyweight as unit-tests go, creating multiple threads, watching network ports, etc. Should pay off in reducing risks of modifying this fairly complex code, stress-testing it (the tests rapidly create and destroy instances of the tested class a lot more than the server typically does), and in validating new drops of websocketpp, should we ever do that.

It also exercises the client-side of websocketpp a bit, which we don't currently use in the production code, only in these tests.