### PR TITLE
Implements DSNs for new connections wizard

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetHost.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetHost.java
@@ -183,6 +183,7 @@ public class NewConnectionSnippetHost extends Composite
             TextArea textarea = new TextArea();
             textarea.setVisibleLines(7);
             textarea.addStyleName(RES.styles().textarea());
+            textarea.setText(snippetParts.get(idxParams).getValue());
             connGrid.setWidget(idxRow, 1, textarea);
             textboxBase = textarea;
          }


### PR DESCRIPTION
Implement DSNs for new connections wizard:

<img width="570" alt="screen shot 2017-04-06 at 5 31 40 pm" src="https://cloud.githubusercontent.com/assets/3478847/24780860/bb84075c-1aef-11e7-9f0a-809d57c5444c.png">

<img width="573" alt="screen shot 2017-04-06 at 5 31 49 pm" src="https://cloud.githubusercontent.com/assets/3478847/24780861/bba18764-1aef-11e7-98da-5a872eecf607.png">

This assuming the `ODBC.ini` file is configured as:

```
[Customers]
Description     = Test to Postgres
Driver          = PostgreSQL

[Supliers]
Description     = Test to Postgres
Driver          = PostgreSQL

[Invoices]
Description     = Test to Postgres
Driver          = PostgreSQL
```