### PR TITLE
Fix websocket unit tests on Windows and Linux

### DIFF
--- a/src/cpp/session/SessionConsoleProcessSocket.cpp
+++ b/src/cpp/session/SessionConsoleProcessSocket.cpp
@@ -164,8 +164,8 @@ void ConsoleProcessSocket::stopServer()
          pwsServer_->stop();
          serverRunning_ = false;
          port_ = 0;
-         pwsServer_.reset();
          websocketThread_.join();
+         pwsServer_.reset();
       }
    }
    catch (websocketpp::exception const& e)


### PR DESCRIPTION
Running unit tests on Windows revealed an issue not found on Mac; needed to use shared_ptr when binding unit-test specific callbacks or they could be called after deletion. On Linux, found an order-of-operation issue in shutting down websocket server class; fixed and reverified on all 3 platforms.