### PR TITLE
temporarily disable centos5 builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,8 +98,8 @@ try {
           [os: 'precise', arch: 'i386', flavor: 'server'],
           [os: 'centos6', arch: 'x86_64', flavor: 'server'],
           [os: 'centos6', arch: 'i386', flavor: 'server'],
-          [os: 'centos5', arch: 'x86_64', flavor: 'server'],
-          [os: 'centos5', arch: 'i386', flavor: 'server'],
+          //[os: 'centos5', arch: 'x86_64', flavor: 'server'],
+          //[os: 'centos5', arch: 'i386', flavor: 'server'],
           [os: 'centos7', arch: 'x86_64', flavor: 'desktop'],
           [os: 'centos7', arch: 'i386', flavor: 'desktop']
 


### PR DESCRIPTION
The centos5 containers will need to be modified in order to continue functioning now that centos5 is EOL and the repos have removed update/extra content. Until that time, this disables the centos5 builds so the jenkins builds go back to passing.