### PR TITLE
Delay read of uiprefs for desktop application header

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -116,6 +116,7 @@ public class DesktopApplicationHeader implements ApplicationHeader
          {
             final SessionInfo sessionInfo = session.getSessionInfo();
             
+            isFlatTheme_ = pUIPrefs_.get().getUseFlatThemes().getValue(); 
             toolbar_.completeInitialization(sessionInfo);
             
             new JSObjectStateValue(
@@ -267,7 +268,7 @@ public class DesktopApplicationHeader implements ApplicationHeader
    public int getPreferredHeight()
    {
       if (toolbar_.isVisible())
-         return 32;
+         return isFlatTheme_ ? 29 : 32;
       else
          return 5;
    }
@@ -410,4 +411,5 @@ public class DesktopApplicationHeader implements ApplicationHeader
    private IgnoredUpdates ignoredUpdates_;
    private boolean ignoredUpdatesDirty_ = false;
    private ApplicationQuit appQuit_; 
+   private Boolean isFlatTheme_ = false;
 }


### PR DESCRIPTION
Follow up to https://github.com/rstudio/rstudio/commit/0c49308e68e6d8a4f612cb8e73320dcd91363a1b, need to delay ready the uiPrefs to prevent hangs in desktop versions.