### PR TITLE
Fix TERM setting for console, add to NEWS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,7 @@
 
 ### Miscellaneous
 
+* ANSI escape code support in console for colored output
 * New high-DPI icons throughout
 * Add support for custom, user-provided project templates
 * Add support for creating new Git branches and adding remotes

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -209,7 +209,7 @@ core::ProgramStatus Options::read(int argc, char * const argv[])
           value<bool>(&useTerminalWebsockets_)->default_value(true),
           "try to communicate with terminal using websockets")
       ("session-default-console-term",
-       value<std::string>(&defaultConsoleTerm_)->default_value("vt100-256color"),
+       value<std::string>(&defaultConsoleTerm_)->default_value("xterm-256color"),
        "default TERM setting for R console")
       ("session-default-clicolor-force",
        value<bool>(&defaultCliColorForce_)->default_value(true),


### PR DESCRIPTION
Oops, meant that to be xterm-256color, not vt100-256color.