### PR TITLE
Bug fixes for terminal local-echo matching

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/StringSink.java
+++ b/src/gwt/src/org/rstudio/core/client/StringSink.java
@@ -1,0 +1,20 @@
+/*
+ * StringSink.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client;
+
+public interface StringSink
+{
+   void write(String str);
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/AnsiCode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/AnsiCode.java
@@ -562,13 +562,13 @@ public class AnsiCode
    }
 
    // Control characters handled by R console
-   private static final String CONTROL_REGEX = "[\r\b\f\n]";
+   public static final String CONTROL_REGEX = "[\r\b\f\n]";
 
    // RegEx to match ansi escape codes copied from https://github.com/chalk/ansi-regex
-   private static final String ANSI_REGEX = 
+   public static final String ANSI_REGEX = 
          "[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-nqry=><]";
    
-   // Match both console control characters and ansi escape sequences
+   // Match both console-supported control characters and ansi escape sequences
    public static final Pattern ESC_CONTROL_PATTERN =
          Pattern.create("(?:" + CONTROL_REGEX + ")|(?:" + ANSI_REGEX + ")");
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalLocalEcho.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalLocalEcho.java
@@ -1,0 +1,146 @@
+/*
+ * TerminalSessionSocket.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.terminal;
+
+import java.util.LinkedList;
+
+import org.rstudio.core.client.StringSink;
+import org.rstudio.core.client.regex.Match;
+import org.rstudio.core.client.regex.Pattern;
+
+public class TerminalLocalEcho
+{
+   public TerminalLocalEcho(StringSink writer)
+   {
+      writer_ = writer;
+      
+   }
+   
+   public void echo(String input)
+   {
+      // input longer than one character is likely a control sequence, or
+      // pasted text; only local-echo and sync with single-character input
+      if (input.length() == 1) 
+      {
+         int ch = input.charAt(0);
+         if (ch >= 32 /*space*/ && ch <= 126 /*tilde*/)
+         {
+            localEcho_.add(input);
+            writer_.write(input);
+         }
+      }
+   }
+   
+   public boolean isEmpty()
+   {
+      return localEcho_.isEmpty();
+   }
+   
+   public void write(String output)
+   {
+      // Rapid typing with intermixed backspaces can cause shell
+      // to insert ^H and ESC[K into the already-local-echoed output.
+      // Also, typing and backspacing at the start of a line can cause
+      // shell to return a BEL (^G) mixed with previously echoed output.
+      // 
+      // Thus remove ANSI control sequences from output when matching or we 
+      // can easily get out of sync and orphan deleted characters in the 
+      // local buffer.
+      //
+      // This manifests as characters you can't backspace over, but aren't
+      // seen by the shell process when you press enter.
+      int chunkStart = 0;
+      int chunkEnd = output.length();
+      Match match = ANSI_CTRL_PATTERN.match(output,  0);
+      while (match != null)
+      {
+         chunkEnd = match.getIndex();
+
+         // try to match local-echoed text up to this ignored sequence
+         String outputToMatch = output.substring(chunkStart, chunkEnd);
+         if (outputToMatch.length() > 0)
+         {
+            int matchLen = outputNonEchoed(outputToMatch);
+            if (matchLen == 0)
+            {
+               // didn't match previously echoed text at all; write 
+               // everything after that chunk
+               writer_.write(output.substring(chunkEnd));
+               return;
+            }
+            // Otherwise completely or partially matched; at this point
+            // we've echoed everything necessary up to the end of currently
+            // chunk and can move onto next one.
+         }
+
+         writer_.write(match.getValue()); // write special sequence
+         
+         chunkStart = chunkEnd + match.getValue().length();
+         chunkEnd = output.length();
+         match = match.nextMatch();
+      }
+
+      outputNonEchoed(output.substring(chunkStart, chunkEnd));
+   }
+   
+   /**
+    * Skip any previously local-echoed output, write out any trailing text
+    * that wasn't previously echoed. Only exact-match from beginning of string.
+    * @param outputToMatch text to match against previously echoed text
+    * @return length of matched sequence
+    */
+   private int outputNonEchoed(String outputToMatch)
+   {
+      String lastOutput = "";
+      while (!localEcho_.isEmpty() && lastOutput.length() < outputToMatch.length())
+      {
+         lastOutput += localEcho_.poll();
+      }
+
+      if (lastOutput.equals(outputToMatch))
+      {
+         // all matched, nothing to output
+         return outputToMatch.length();
+      }
+
+      else if (outputToMatch.startsWith(lastOutput))
+      {
+         // output is superset of what was local-echoed; write out the
+         // unmatched part
+         writer_.write(outputToMatch.substring(lastOutput.length()));
+         return lastOutput.length();
+      }
+      else
+      {
+         // didn't match previously echoed text; delete local-input
+         // queue so we don't get too far out of sync and write text as-is
+         localEcho_.clear();
+         writer_.write(outputToMatch);
+         return 0;
+      }
+   }
+   
+   public void clear()
+   {
+      localEcho_.clear();
+   }
+   
+  // Matches ANSI control sequences or BS, CR, LF, DEL, BEL
+   private static final Pattern ANSI_CTRL_PATTERN =
+         Pattern.create("(?:" + AnsiCode.ANSI_REGEX + ")|(?:" + "[\b\n\r\177\7]" + ")");
+
+   private final StringSink writer_;
+   private LinkedList<String> localEcho_ = new LinkedList<String>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalLocalEcho.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalLocalEcho.java
@@ -1,5 +1,5 @@
 /*
- * TerminalSessionSocket.java
+ * TerminalLocalEcho.java
  *
  * Copyright (C) 2009-17 by RStudio, Inc.
  *

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
@@ -479,9 +479,9 @@ public class TerminalSessionSocket
    private Websocket socket_;
    private LinkedList<String> localEcho_ = new LinkedList<String>();
 
-   // Matches ANSI control sequences or backspace or DEL or BEL
+   // Matches ANSI control sequences or BS, CR, LF, DEL, BEL
    private static final Pattern ANSI_CTRL_PATTERN =
-         Pattern.create("(?:" + AnsiCode.ANSI_REGEX + ")|(?:" + "[\b\177\7]" + ")");
+         Pattern.create("(?:" + AnsiCode.ANSI_REGEX + ")|(?:" + "[\b\n\r\177\7]" + ")");
 
    // Injected ---- 
    private UIPrefs uiPrefs_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
@@ -19,8 +19,6 @@ import java.util.LinkedList;
 
 import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.Stopwatch;
-import org.rstudio.core.client.regex.Match;
-import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.common.console.ConsoleOutputEvent;
@@ -153,6 +151,7 @@ public class TerminalSessionSocket
 
       session_ = session;
       xterm_ = xterm;
+      localEcho_ = new TerminalLocalEcho(xterm_);
 
       // Show delay between receiving a keystroke and sending it to the 
       // terminal emulator; for diagnostics on laggy typing. Intended for
@@ -299,19 +298,7 @@ public class TerminalSessionSocket
                              VoidServerRequestCallback requestCallback)
    {
       if (localEcho)
-      {
-         // input longer than one character is likely a control sequence, or
-         // pasted text; only local-echo and sync with single-character input
-         if (input.length() == 1) 
-         {
-            int ch = input.charAt(0);
-            if (ch >= 32 /*space*/ && ch <= 126 /*tilde*/)
-            {
-               localEcho_.add(input);
-               xterm_.write(input);
-            }
-         }
-      }
+         localEcho_.echo(input);
 
       switch (consoleProcess_.getChannelMode())
       {
@@ -342,87 +329,8 @@ public class TerminalSessionSocket
          xterm_.write(output);
          return;
       }
-
-      // Rapid typing with intermixed backspaces can cause shell
-      // to insert ^H and ESC[K into the already-local-echoed output.
-      // Also, typing and backspacing at the start of a line can cause
-      // shell to return a BEL (^G) mixed with previously echoed output.
-      // 
-      // Thus remove ANSI control sequences from output when matching or we 
-      // can easily get out of sync and orphan deleted characters in the 
-      // local buffer.
-      //
-      // This manifests as characters you can't backspace over, but aren't
-      // seen by the shell process when you press enter.
-      int chunkStart = 0;
-      int chunkEnd = output.length();
-      Match match = ANSI_CTRL_PATTERN.match(output,  0);
-      while (match != null)
-      {
-         chunkEnd = match.getIndex();
-
-         // try to match local-echoed text up to this ignored sequence
-         String outputToMatch = output.substring(chunkStart, chunkEnd);
-         if (outputToMatch.length() > 0)
-         {
-            int matchLen = outputNonEchoed(outputToMatch);
-            if (matchLen == 0)
-            {
-               // didn't match previously echoed text at all; write 
-               // everything after that chunk
-               xterm_.write(output.substring(chunkEnd));
-               return;
-            }
-            // Otherwise completely or partially matched; at this point
-            // we've echoed everything necessary up to the end of currently
-            // chunk and can move onto next one.
-         }
-
-         xterm_.write(match.getValue()); // write special sequence
-         
-         chunkStart = chunkEnd + match.getValue().length();
-         chunkEnd = output.length();
-         match = match.nextMatch();
-      }
-
-      outputNonEchoed(output.substring(chunkStart, chunkEnd));
-   }
-   
-   /**
-    * Skip any previously local-echoed output, write out any trailing text
-    * that wasn't previously echoed. Only exact-match from beginning of string.
-    * @param outputToMatch text to match against previously echoed text
-    * @return length of matched sequence
-    */
-   private int outputNonEchoed(String outputToMatch)
-   {
-      String lastOutput = "";
-      while (!localEcho_.isEmpty() && lastOutput.length() < outputToMatch.length())
-      {
-         lastOutput += localEcho_.poll();
-      }
-
-      if (lastOutput.equals(outputToMatch))
-      {
-         // all matched, nothing to output
-         return outputToMatch.length();
-      }
-
-      else if (outputToMatch.startsWith(lastOutput))
-      {
-         // output is superset of what was local-echoed; write out the
-         // unmatched part
-         xterm_.write(outputToMatch.substring(lastOutput.length()));
-         return lastOutput.length();
-      }
-      else
-      {
-         // didn't match previously echoed text; delete local-input
-         // queue so we don't get too far out of sync and write text as-is
-         localEcho_.clear();
-         xterm_.write(outputToMatch);
-         return 0;
-      }
+      
+      localEcho_.write(output);
    }
    
    @Override
@@ -477,11 +385,7 @@ public class TerminalSessionSocket
    private boolean reportTypingLag_;
    private InputEchoTimeMonitor inputEchoTiming_;
    private Websocket socket_;
-   private LinkedList<String> localEcho_ = new LinkedList<String>();
-
-   // Matches ANSI control sequences or BS, CR, LF, DEL, BEL
-   private static final Pattern ANSI_CTRL_PATTERN =
-         Pattern.create("(?:" + AnsiCode.ANSI_REGEX + ")|(?:" + "[\b\n\r\177\7]" + ")");
+   private TerminalLocalEcho localEcho_;
 
    // Injected ---- 
    private UIPrefs uiPrefs_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
@@ -368,21 +368,14 @@ public class TerminalSessionSocket
             int matchLen = outputNonEchoed(outputToMatch);
             if (matchLen == 0)
             {
-               // didn't match previously echoed text; delete local-input
-               // queue so we don't get too far out of sync and write 
-               // remaining text as-is
-               localEcho_.clear();
-               xterm_.write(output.substring(chunkStart));
+               // didn't match previously echoed text at all; write 
+               // everything after that chunk
+               xterm_.write(output.substring(chunkEnd));
                return;
             }
-            else if (matchLen < outputToMatch.length())
-            {
-               // partial match; output is a superset of what was already
-               // locally echoed
-               xterm_.write(match.getValue());
-               return;
-            }
-            // otherwise completely matched
+            // Otherwise completely or partially matched; at this point
+            // we've echoed everything necessary up to the end of currently
+            // chunk and can move onto next one.
          }
 
          xterm_.write(match.getValue()); // write special sequence

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -18,6 +18,7 @@ package org.rstudio.studio.client.workbench.views.terminal.xterm;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.ExternalJavaScriptLoader;
 import org.rstudio.core.client.ExternalJavaScriptLoader.Callback;
+import org.rstudio.core.client.StringSink;
 import org.rstudio.core.client.resources.StaticDataResource;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.FontSizer;
@@ -62,7 +63,8 @@ import com.google.gwt.user.client.ui.Widget;
 public class XTermWidget extends Widget implements RequiresResize,
                                                    ResizeTerminalEvent.HasHandlers,
                                                    TerminalDataInputEvent.HasHandlers,
-                                                   XTermTitleEvent.HasHandlers
+                                                   XTermTitleEvent.HasHandlers,
+                                                   StringSink
 {
   /**
     *  Creates an XTermWidget.
@@ -124,6 +126,7 @@ public class XTermWidget extends Widget implements RequiresResize,
     * Write text to the terminal.
     * @param str Text to write
     */
+   @Override
    public void write(String str)
    {
       terminal_.scrollToBottom();

--- a/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
+++ b/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
@@ -18,6 +18,7 @@ import org.rstudio.studio.client.common.r.RTokenizerTests;
 import org.rstudio.core.client.StringUtilTests;
 import org.rstudio.core.client.dom.DomUtilsTests;
 import org.rstudio.studio.client.workbench.views.terminal.AnsiCodeTests;
+import org.rstudio.studio.client.workbench.views.terminal.TerminalLocalEchoTests;
 
 import com.google.gwt.junit.tools.GWTTestSuite;
 
@@ -33,6 +34,7 @@ public class RStudioUnitTestSuite extends GWTTestSuite
         suite.addTestSuite(StringUtilTests.class);
         suite.addTestSuite(DomUtilsTests.class);
         suite.addTestSuite(AnsiCodeTests.class);
+        suite.addTestSuite(TerminalLocalEchoTests.class);
         return suite;
     }
 }

--- a/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
+++ b/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client;
 import org.rstudio.studio.client.common.r.RTokenizerTests;
 import org.rstudio.core.client.StringUtilTests;
 import org.rstudio.core.client.dom.DomUtilsTests;
+import org.rstudio.studio.client.workbench.views.terminal.AnsiCodeTests;
 
 import com.google.gwt.junit.tools.GWTTestSuite;
 
@@ -31,6 +32,7 @@ public class RStudioUnitTestSuite extends GWTTestSuite
         suite.addTestSuite(VirtualConsoleTests.class);
         suite.addTestSuite(StringUtilTests.class);
         suite.addTestSuite(DomUtilsTests.class);
+        suite.addTestSuite(AnsiCodeTests.class);
         return suite;
     }
 }

--- a/src/gwt/test/org/rstudio/studio/client/workbench/views/terminal/AnsiCodeTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/workbench/views/terminal/AnsiCodeTests.java
@@ -1,0 +1,78 @@
+/*
+ * AnsiCodeTests.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.terminal;
+
+import org.rstudio.core.client.regex.Match;
+import org.rstudio.core.client.regex.Pattern;
+
+import com.google.gwt.junit.client.GWTTestCase;
+import junit.framework.Assert;
+
+public class AnsiCodeTests extends GWTTestCase
+{
+   @Override
+   public String getModuleName()
+   {
+      return "org.rstudio.studio.RStudioTests";
+   }
+
+   public void testConsoleControlCharacterParse()
+   {
+      // console only supports \n, \f, \b, \r; other control characters
+      // or non-control characters should pass through 
+      boolean foundLinefeed = false;
+      boolean foundFormfeed = false;
+      boolean foundBackspace = false;
+      boolean foundCarriageReturn = false;
+
+      Pattern ConsoleCtrlPattern = Pattern.create(AnsiCode.CONTROL_REGEX);
+      
+      String data = "A\nBC\fD\7EF\bG\rH";
+      Match match = ConsoleCtrlPattern.match(data, 0);
+      Assert.assertNotNull(match);
+      while (match != null)
+      {
+         if (match.getValue().compareTo("\n") == 0)
+         {
+            Assert.assertFalse(foundLinefeed);
+            Assert.assertEquals(1, match.getIndex());
+            foundLinefeed = true;
+         }
+         else if (match.getValue().compareTo("\f") == 0)
+         {
+            Assert.assertFalse(foundFormfeed);
+            Assert.assertEquals(4, match.getIndex());
+            foundFormfeed = true;
+         }
+         else if (match.getValue().compareTo("\b") == 0)
+         {
+            Assert.assertFalse(foundBackspace);
+            Assert.assertEquals(9, match.getIndex());
+            foundBackspace = true;
+         }
+         else if (match.getValue().compareTo("\r") == 0)
+         {
+            Assert.assertFalse(foundCarriageReturn);
+            Assert.assertEquals(11, match.getIndex());
+            foundCarriageReturn = true;
+         }
+         match = match.nextMatch();
+      }
+      Assert.assertTrue(foundLinefeed);
+      Assert.assertTrue(foundFormfeed);
+      Assert.assertTrue(foundBackspace);
+      Assert.assertTrue(foundCarriageReturn);
+   }
+}

--- a/src/gwt/test/org/rstudio/studio/client/workbench/views/terminal/TerminalLocalEchoTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/workbench/views/terminal/TerminalLocalEchoTests.java
@@ -1,0 +1,111 @@
+/*
+ * TerminalLocalEchoTests.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.terminal;
+
+import org.rstudio.core.client.StringSink;
+
+import com.google.gwt.junit.client.GWTTestCase;
+import junit.framework.Assert;
+
+public class TerminalLocalEchoTests extends GWTTestCase
+{
+   static class OutputCatcher implements StringSink
+   {
+
+      @Override
+      public void write(String str)
+      {
+         output_ = output_ + str;
+      }
+      
+      public String getOutput()
+      {
+         return output_;
+      }
+      
+      public boolean isEmpty()
+      {
+         return output_.length() == 0;
+      }
+      
+      public void clear()
+      {
+         output_ = "";
+      }
+
+      private String output_ = "";
+   }
+   
+   private void echoString(TerminalLocalEcho echo, String output)
+   {
+      for (char c : output.toCharArray()) 
+      {
+         echo.echo(String.valueOf(c));
+      }
+   }
+   
+   @Override
+   public String getModuleName()
+   {
+      return "org.rstudio.studio.RStudioTests";
+   }
+
+   public void testFixtureAssumptions()
+   {
+      OutputCatcher output = new OutputCatcher();
+      TerminalLocalEcho echo = new TerminalLocalEcho(output);
+      
+      Assert.assertTrue(output.isEmpty());
+      output.write("abc");
+      Assert.assertEquals("abc", output.getOutput());
+      output.clear();
+      Assert.assertTrue(output.isEmpty());
+      Assert.assertTrue(echo.isEmpty());
+   }      
+      
+   public void testSimpleTextEcho()
+   {
+      OutputCatcher output = new OutputCatcher();
+      TerminalLocalEcho echo = new TerminalLocalEcho(output);
+      
+      String expected = "Hello World";
+      
+      echoString(echo, expected);
+      Assert.assertFalse(echo.isEmpty());
+      Assert.assertEquals(expected, output.getOutput());
+      output.clear();
+      
+      echo.write(expected);
+      Assert.assertTrue(echo.isEmpty());
+      Assert.assertTrue(output.isEmpty());
+   }
+
+   public void testSimpleUnmatchedText()
+   {
+      OutputCatcher output = new OutputCatcher();
+      TerminalLocalEcho echo = new TerminalLocalEcho(output);
+      
+      String written = "Hello World";
+      String read = "This differs";
+      
+      echoString(echo, written);
+      output.clear();
+      
+      echo.write(read);
+      Assert.assertTrue(echo.isEmpty());
+      Assert.assertEquals(read, output.getOutput());
+   }
+
+}


### PR DESCRIPTION
Local-echo was confused by embedded escape sequences and control characters, causing it to fail on matching output that had already been echoed. Most obvious symptom was doing lots of typing and backspacing then finding characters that can't be deleted, though they aren't really there if you press Enter.

Make matching smarter, causing it to recognize and step over ANSI escape sequences (but still write them out), as well as common control characters DEL, BS, BEL, NL, CR.

Also added a unit test source file for the AnsiCode class, but only a simple test so far.