### PR TITLE
Filter columns in data import instead of data viewer 87aacd3

### DIFF
--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -748,7 +748,11 @@
 
       columns <- list()
       if (ncol(data)) {
-         columns <- .rs.describeCols(data, maxCols, maxFactors)
+         columns <- .rs.describeCols(data, maxFactors)
+         if (ncol(data) > maxCols) {
+            columns <- head(columns, maxCols)
+            data <- data[, maxCols]
+         }
       }
       
       parsingErrors <- parsingErrorsFromMode(dataImportOptions$mode, data)


### PR DESCRIPTION
This fixes an issue blocking users to import CSVs, the issue was that `maxCols` was removed from the data viewer but still used by the data viewer hosted in the import dialog.