### PR TITLE
Flat theme for code tabs in options dialog

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1659,6 +1659,7 @@ body.ubuntu_mono .searchBox {
    border-bottom: none;
    height: 23px;
    background: none;
+   top: 0px;
 }
 
 .rstudio-themes-flat .dialogTabPanel > div:last-child {

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1650,3 +1650,17 @@ body.ubuntu_mono .searchBox {
 .rstudio-themes-flat .logoAnchor {
    top: 3px !important;
 }
+
+.rstudio-themes-flat .dialogTabPanel {
+   background: none;
+}
+
+.rstudio-themes-flat .dialogTabPanel > div > div.gwt-TabLayoutPanelTabs {
+   border-bottom: none;
+   height: 23px;
+   background: none;
+}
+
+.rstudio-themes-flat .dialogTabPanel > div:last-child {
+   top: 14px !important;
+}


### PR DESCRIPTION
Code tabs in options dialog require subclassing for flat theme to look properly.

<img width="622" alt="screen shot 2017-04-17 at 12 12 13 pm" src="https://cloud.githubusercontent.com/assets/3478847/25100969/2ca349f0-2367-11e7-8802-7d06c45c4764.png">
