### PR TITLE
Flat dialogs for flat theme

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1672,7 +1672,7 @@ body.ubuntu_mono .searchBox {
    border-radius: 5px 5px 5px 5px;
    background: #F3F4F4;
    overflow: hidden !important;
-   box-shadow: 0 2px 20px rgba(0, 0, 0, 0.25);
+   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.15);
 }
 
 .rstudio-themes-flat .gwt-DialogBox .dialogMiddleCenter {
@@ -1685,7 +1685,7 @@ body.ubuntu_mono .searchBox {
 
 .rstudio-themes-flat .gwt-DialogBox .dialogTopCenterInner .Caption {
    margin-top: 1px;
-   margin-left: 7px;
+   margin-left: 9px;
    padding-top: 0px;
 }
 
@@ -1720,7 +1720,7 @@ body.ubuntu_mono .searchBox {
 
 .rstudio-themes-flat .gwt-DialogBox .dialogBottomPanel {
    margin-top: 0px;
-   padding: 10px 10px 12px 4px;
+   padding: 10px 2px 12px 4px;
 }
 
 .rstudio-themes-flat .gwt-DialogBox .dialogContent {

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -42,7 +42,8 @@
       dialogTopRight, dialogTopRightInner,
       dialogMiddleLeft, dialogMiddleCenter,
       dialogMiddleCenterInner, dialogMiddleRight, dialogBottomLeft,
-      dialogBottomCenter, dialogBottomRight;
+      dialogBottomCenter, dialogBottomRight,
+      dialogContent;
 
 @external popupTopLeft, popupTopLeftInner,
       popupTopCenter, popupTopCenterInner,
@@ -1664,4 +1665,65 @@ body.ubuntu_mono .searchBox {
 
 .rstudio-themes-flat .dialogTabPanel > div:last-child {
    top: 14px !important;
+}
+
+.rstudio-themes-flat .gwt-DialogBox {
+   border: solid 1px #d6dadc;
+   border-radius: 5px 5px 5px 5px;
+   background: #F3F4F4;
+   overflow: hidden !important;
+   box-shadow: 0 2px 20px rgba(0, 0, 0, 0.25);
+}
+
+.rstudio-themes-flat .gwt-DialogBox .dialogMiddleCenter {
+   background: none;
+}
+
+.rstudio-themes-flat .gwt-DialogBox .dialogTopCenter {
+   height: 24px;  
+}
+
+.rstudio-themes-flat .gwt-DialogBox .dialogTopCenterInner .Caption {
+   margin-top: 1px;
+   margin-left: 7px;
+   padding-top: 0px;
+}
+
+.rstudio-themes-flat .gwt-DialogBox .dialogTopLeft {
+   display: none;
+}
+
+.rstudio-themes-flat .gwt-DialogBox .dialogMiddleLeft {
+   display: none;
+}
+
+.rstudio-themes-flat .gwt-DialogBox .dialogBottomLeft {
+   display: none;
+}
+
+.rstudio-themes-flat .gwt-DialogBox .dialogTopRight {
+   display: none;
+}
+
+.rstudio-themes-flat .gwt-DialogBox .dialogMiddleRight {
+   display: none;
+}
+
+.rstudio-themes-flat .gwt-DialogBox .dialogBottomRight {
+   display: none;
+}
+
+.rstudio-themes-flat .gwt-DialogBox .dialogTopCenter {
+   background: #e1e2e5;
+   border-bottom: solid 1px #d6dadc;
+}
+
+.rstudio-themes-flat .gwt-DialogBox .dialogBottomPanel {
+   margin-top: 0px;
+   padding: 10px 10px 12px 4px;
+}
+
+.rstudio-themes-flat .gwt-DialogBox .dialogContent {
+   padding-left: 10px;
+   padding-right: 10px;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/Wizard.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/Wizard.css
@@ -1,3 +1,5 @@
+@external rstudio-themes-flat;
+
 .mainWidget {
    width: 510px;
    height: 300px;
@@ -14,6 +16,10 @@
    height: 42px;	
 }
 
+.rstudio-themes-flat .headerPanel {
+   margin-left: 5px;
+}
+
 .subcaptionLabel {
    font-size: 12px;
    color: #707070;
@@ -27,6 +33,11 @@
    height: 244px;
    margin-left: -10px;
    margin-right: -13px;
+}
+
+.rstudio-themes-flat .wizardBodyPanel {
+   margin-left: -10px;
+   margin-right: -10px;
 }
 
 .wizardPageSelector {
@@ -49,6 +60,10 @@
 
 @sprite .wizardPageSelectorItemFirst {
    gwt-image: 'wizardPageSelectorBackgroundFirst';
+}
+
+@sprite .rstudio-themes-flat .wizardPageSelectorItemFirst {
+   gwt-image: 'wizardPageSelectorBackground';
 }
 
 @sprite .wizardPageSelectorItemLast {


### PR DESCRIPTION
My original plan was to remove shadow, gradients and use css borders. However, not having a shadow made the UI look off, instead, I'm reducing the shadow effect significantly but enough to add volume to the dialog.

### Browser

<img width="964" alt="screen shot 2017-04-17 at 4 08 39 pm" src="https://cloud.githubusercontent.com/assets/3478847/25108093/4c822018-2388-11e7-85fd-dab5ce860ee1.png">
<img width="964" alt="screen shot 2017-04-17 at 4 08 52 pm" src="https://cloud.githubusercontent.com/assets/3478847/25108092/4c822630-2388-11e7-85cd-73381599f7df.png">
<img width="962" alt="screen shot 2017-04-17 at 4 09 08 pm" src="https://cloud.githubusercontent.com/assets/3478847/25108094/4c83aaf0-2388-11e7-847c-9303b82fe857.png">
<img width="961" alt="screen shot 2017-04-17 at 4 09 22 pm" src="https://cloud.githubusercontent.com/assets/3478847/25108096/4c83dea8-2388-11e7-9cfe-01e532b92530.png">
<img width="961" alt="screen shot 2017-04-17 at 4 09 30 pm" src="https://cloud.githubusercontent.com/assets/3478847/25108095/4c83d048-2388-11e7-9941-bf3e97a0b862.png">


### Desktop

<img width="961" alt="screen shot 2017-04-17 at 4 01 34 pm" src="https://cloud.githubusercontent.com/assets/3478847/25107968/6a3dbb90-2387-11e7-98ec-588d150ab7e3.png">
<img width="962" alt="screen shot 2017-04-17 at 4 01 43 pm" src="https://cloud.githubusercontent.com/assets/3478847/25107969/6a414620-2387-11e7-91c1-a95e6b8ed093.png">
<img width="962" alt="screen shot 2017-04-17 at 4 01 51 pm" src="https://cloud.githubusercontent.com/assets/3478847/25107970/6a419bca-2387-11e7-9c43-fb1b6846eef1.png">
<img width="961" alt="screen shot 2017-04-17 at 4 02 03 pm" src="https://cloud.githubusercontent.com/assets/3478847/25107972/6a476cf8-2387-11e7-97b0-f6a28e9df086.png">
<img width="960" alt="screen shot 2017-04-17 at 4 02 17 pm" src="https://cloud.githubusercontent.com/assets/3478847/25107973/6a534352-2387-11e7-98c5-31f8683a2b2e.png">
