### PR TITLE
disable local echo when not typing at the end of current line

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/AnsiCode.java
+++ b/src/gwt/src/org/rstudio/core/client/AnsiCode.java
@@ -565,7 +565,7 @@ public class AnsiCode
 
    // RegEx to match ansi escape codes copied from https://github.com/chalk/ansi-regex
    public static final String ANSI_REGEX = 
-         "[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-nqry=><]";
+         "[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-nqry=><@]";
    
    // Match both console-supported control characters and ansi escape sequences
    public static final Pattern ESC_CONTROL_PATTERN =

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
@@ -299,6 +299,8 @@ public class TerminalSessionSocket
    {
       if (localEcho)
          localEcho_.echo(input);
+      else
+         localEcho_.clear();
 
       switch (consoleProcess_.getChannelMode())
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
@@ -103,7 +103,32 @@ public class XTermNative extends JavaScriptObject
    public final native void addClass(String classStr) /*-{
       this.element.classList.add(classStr);
    }-*/;
+   
+   public final native int cursorX() /*-{
+      return this.x;
+   }-*/;
+   
+   public final native int cursorY() /*-{
+      return this.y;
+   }-*/;
  
+   public final native boolean altBufferActive() /*-{
+      return this.normal != null;
+   }-*/;
+   
+   public final native String currentLine() /*-{
+      lineBuf = this.lines.get(this.y + this.ybase);
+      if (!lineBuf) // resize may be in progress
+         return null;
+      current = "";
+      for (i = 0; i < this.cols; i++) {
+         if (!lineBuf[i])
+            return null;
+         current += lineBuf[i][1];
+      }
+      return current;
+   }-*/;
+   
    /**
     * Install a handler for user input (typing). Only one handler at a 
     * time may be installed. Previous handler will be overwritten.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -273,7 +273,67 @@ public class XTermWidget extends Widget implements RequiresResize,
       else
          terminal_.blur(); 
    }
-  
+   
+   /**
+    * @return Current cursor column
+    */
+   public int getCursorX()
+   {
+      return terminal_.cursorX();
+   }
+
+   /**
+    * @return Current cursor row
+    */
+   public int getCursorY()
+   {
+      return terminal_.cursorY();
+   }
+   
+   /**
+    * @return true if cursor at end of current line, false if not at EOL or
+    * terminal is showing alternate buffer
+    */
+   public boolean cursorAtEOL()
+   {
+      if (altBufferActive())
+      {
+         return false;
+      }
+      
+      String line = currentLine();
+      if (line == null)
+      {
+         return false;
+      }
+      
+      for (int i = getCursorX(); i < line.length(); i++)
+      {
+         if (line.charAt(i) != ' ')
+         {
+            return false;
+         }
+      }
+      return true;
+   }
+   
+   /**
+    * @return Text of current line buffer
+    */
+   public String currentLine()
+   {
+      return terminal_.currentLine();
+   }
+   
+   /**
+    * Is the terminal showing the alternate full-screen buffer?
+    * @return true if full-screen buffer is active
+    */
+   public boolean altBufferActive()
+   {
+      return terminal_.altBufferActive();
+   }
+   
    public static boolean isXTerm(Element el)
    {
       while (el != null)


### PR DESCRIPTION
- Disable local-echo if not typing at the end of a line.  
- Disable local-echo if terminal is showing the full-screen alt-buffer (in case "busy" state hasn't updated yet)
- Fix a missing case in ANSI code detection regex (wasn't catching ESC[1@ for inserting a character)