### PR TITLE
Make new terminal instances obey the existing "blinking cursor" setting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,7 +38,7 @@
   * Command Prompt (cmd.exe), 32-bit and 64-bit depending on OS support
   * PowerShell, 32-bit and 64-bit depending on OS support
   * Bash on Windows Subsystem for Linux, if installed on 64-bit Windows 10
-* Default Windows terminal shell type set in Global Options/General
+* Default Windows terminal shell type set in new Global Options/Terminal preferences pane
 
 ### Miscellaneous
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
@@ -23,6 +23,7 @@ import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.console.ConsoleProcess.ConsoleProcessFactory;
 import org.rstudio.studio.client.common.console.ConsoleProcessInfo;
+import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalBusyEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSubprocEvent;
 
@@ -154,10 +155,12 @@ public class TerminalList implements Iterable<String>,
 
    @Inject
    private void initialize(Provider<ConsoleProcessFactory> pConsoleProcessFactory,
-                           EventBus events)
+                           EventBus events,
+                           UIPrefs uiPrefs)
    {
       pConsoleProcessFactory_ = pConsoleProcessFactory;
       eventBus_ = events;
+      uiPrefs_ = uiPrefs;
    }
 
    /**
@@ -420,7 +423,8 @@ public class TerminalList implements Iterable<String>,
                              int shellType)
    {
       TerminalSession newSession = new TerminalSession(
-            sequence, terminalHandle, caption, title, hasChildProcs, cols, rows, shellType);
+            sequence, terminalHandle, caption, title, hasChildProcs, 
+            cols, rows, uiPrefs_.blinkingCursor().getValue(), shellType);
       newSession.connect();
       updateTerminalBusyStatus();
    }
@@ -459,4 +463,5 @@ public class TerminalList implements Iterable<String>,
    // Injected ----  
    private Provider<ConsoleProcessFactory> pConsoleProcessFactory_;
    private EventBus eventBus_;
+   private UIPrefs uiPrefs_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -76,8 +76,11 @@ public class TerminalSession extends XTermWidget
                           boolean hasChildProcs,
                           int cols,
                           int rows,
+                          boolean cursorBlink,
                           int shellType)
    {
+      super(cursorBlink);
+      
       RStudioGinjector.INSTANCE.injectMembers(this);
       sequence_ = sequence;
       terminalHandle_ = handle;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -69,7 +69,7 @@ public class XTermWidget extends Widget implements RequiresResize,
   /**
     *  Creates an XTermWidget.
     */
-   public XTermWidget()
+   public XTermWidget(boolean cursorBlink)
    {
       // Create an element to hold the terminal widget
       setElement(Document.get().createDivElement());
@@ -82,7 +82,7 @@ public class XTermWidget extends Widget implements RequiresResize,
 
       // Create and attach the native terminal object to this Widget
       attachTheme(XTermThemeResources.INSTANCE.xtermcss());
-      terminal_ = XTermNative.createTerminal(getElement(), true);
+      terminal_ = XTermNative.createTerminal(getElement(), cursorBlink);
       terminal_.addClass("ace_editor");
       terminal_.addClass(FontSizer.getNormalFontSizeClass());
 


### PR DESCRIPTION
Terminal was hardcoded to have a blinking cursor. Now I use the existing Global Options/Code/Display/Blinking Cursor setting to determine if xterm blinks its cursor.

Existing terminals won't change until they are reloaded (setting "blink" is done during construction of xterm.js), but if someone hates blinking cursors, then this at least gives them a way to turn it off in new terminals.