### PR TITLE
Case sensitivity in linux requires tolower snippets

### DIFF
--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -409,7 +409,13 @@ options(connectionObserver = list(
             currentDriver <- drivers[drivers$attribute == "Driver" & drivers$name == driver, ]
 
             basePath <- sub(paste(tolower(driver), ".*$", sep = ""), "", currentDriver$value)
-            snippetsFile <- file.path(basePath, tolower(driver), "snippets", paste(driver, ".R", sep = ""))
+            snippetsFile <- file.path(
+               basePath,
+               tolower(driver),
+               "snippets",
+               paste(tolower(driver), ".R", sep = "")
+            )
+            
             if (file.exists(snippetsFile)) {
                snippet <- paste(readLines(snippetsFile), collapse = "\n")
             }


### PR DESCRIPTION
Code snippets from bundled ODBC drivers not displaying in Linux, since Linux is case sensitive and OS X is not. Fix is, like the rest of the code in this function, make the driver lowercase.