### PR TITLE
Terminal local-echo tweaks and fixes

### DIFF
--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -109,6 +109,7 @@ set (CORE_SOURCE_FILES
    spelling/HunspellCustomDictionaries.cpp
    spelling/HunspellDictionaryManager.cpp
    spelling/HunspellSpellingEngine.cpp
+   system/ChildProcessSubprocPoll.cpp
    system/Environment.cpp
    system/Process.cpp
    system/ShellUtils.cpp

--- a/src/cpp/core/system/ChildProcessSubprocPoll.cpp
+++ b/src/cpp/core/system/ChildProcessSubprocPoll.cpp
@@ -1,0 +1,122 @@
+/*
+ * ChildProcessSubprocPoll.cpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "ChildProcessSubprocPoll.hpp"
+
+namespace rstudio {
+namespace core {
+namespace system {
+
+namespace {
+
+boost::posix_time::ptime now()
+{
+   return boost::posix_time::microsec_clock::universal_time();
+}
+
+// how long does memory of "recent output" last?
+const boost::posix_time::seconds kResetRecentDelay =
+                                          boost::posix_time::seconds(1);
+
+// what is the minimum length of time before we check for subprocesses?
+const boost::posix_time::milliseconds kCheckSubprocDelay =
+                                          boost::posix_time::milliseconds(200);
+
+} // anonymous namespace
+
+ChildProcessSubprocPoll::ChildProcessSubprocPoll(PidType pid, boost::function<bool (PidType pid)> subProcCheck)
+   :
+     pid_(pid),
+     checkSubProcAfter_(boost::posix_time::not_a_date_time),
+     resetRecentOutputAfter_(boost::posix_time::not_a_date_time),
+     hasSubprocess_(true),
+     hasRecentOutput_(true),
+     stopped_(false),
+     subProcCheck_(subProcCheck)
+{
+}
+
+void ChildProcessSubprocPoll::poll(bool hadOutput)
+{
+   if (stopped_)
+      return;
+
+   boost::posix_time::ptime currentTime = now();
+
+   // Update state of "hasRecentOutput". We remember that we saw output for
+   // up to "kResetRecentDelay" milliseconds.
+   if (hadOutput)
+   {
+      hasRecentOutput_ = true;
+      resetRecentOutputAfter_ = boost::posix_time::not_a_date_time;
+   }
+
+   if (resetRecentOutputAfter_.is_not_a_date_time())
+   {
+      resetRecentOutputAfter_ = currentTime + kResetRecentDelay;
+   }
+   else if (currentTime > resetRecentOutputAfter_)
+   {
+      hasRecentOutput_ = false;
+      resetRecentOutputAfter_ = currentTime + kResetRecentDelay;
+   }
+
+   if (!subProcCheck_)
+      return;
+
+   // Update state of "hasSubprocesses". We do this no more often than every
+   // "kCheckSubprocDelay" milliseconds, and less if we haven't seen any
+   // recent output. The latter is to reduce load when nothing is happening,
+   // under the assumption that if all child processes are terminated, we
+   // will always see output in the form of the command prompt.
+   if (!hasRecentOutput())
+   {
+      checkSubProcAfter_ = currentTime + kCheckSubprocDelay;
+      return;
+   }
+
+   if (checkSubProcAfter_.is_not_a_date_time())
+   {
+      checkSubProcAfter_ = currentTime + kCheckSubprocDelay;
+      return;
+   }
+
+   if (currentTime <= checkSubProcAfter_)
+      return;
+
+   // Enough time has passed, update whether "pid" has subprocesses
+   // and restart the timer.
+   hasSubprocess_ = subProcCheck_(pid_);
+   checkSubProcAfter_ = currentTime + kCheckSubprocDelay;
+}
+
+void ChildProcessSubprocPoll::stop()
+{
+   stopped_ = true;
+}
+
+bool ChildProcessSubprocPoll::hasSubprocess() const
+{
+   return hasSubprocess_;
+}
+
+bool ChildProcessSubprocPoll::hasRecentOutput() const
+{
+   return hasRecentOutput_;
+}
+
+} // namespace system
+} // namespace core
+} // namespace rstudio

--- a/src/cpp/core/system/ChildProcessSubprocPoll.cpp
+++ b/src/cpp/core/system/ChildProcessSubprocPoll.cpp
@@ -48,10 +48,10 @@ ChildProcessSubprocPoll::ChildProcessSubprocPoll(PidType pid, boost::function<bo
 {
 }
 
-void ChildProcessSubprocPoll::poll(bool hadOutput)
+bool ChildProcessSubprocPoll::poll(bool hadOutput)
 {
    if (stopped_)
-      return;
+      return false;
 
    boost::posix_time::ptime currentTime = now();
 
@@ -74,7 +74,7 @@ void ChildProcessSubprocPoll::poll(bool hadOutput)
    }
 
    if (!subProcCheck_)
-      return;
+      return false;
 
    // Update state of "hasSubprocesses". We do this no more often than every
    // "kCheckSubprocDelay" milliseconds, and less if we haven't seen any
@@ -84,22 +84,23 @@ void ChildProcessSubprocPoll::poll(bool hadOutput)
    if (!hasRecentOutput())
    {
       checkSubProcAfter_ = currentTime + kCheckSubprocDelay;
-      return;
+      return false;
    }
 
    if (checkSubProcAfter_.is_not_a_date_time())
    {
       checkSubProcAfter_ = currentTime + kCheckSubprocDelay;
-      return;
+      return false;
    }
 
    if (currentTime <= checkSubProcAfter_)
-      return;
+      return false;
 
    // Enough time has passed, update whether "pid" has subprocesses
    // and restart the timer.
    hasSubprocess_ = subProcCheck_(pid_);
    checkSubProcAfter_ = currentTime + kCheckSubprocDelay;
+   return true;
 }
 
 void ChildProcessSubprocPoll::stop()

--- a/src/cpp/core/system/ChildProcessSubprocPoll.cpp
+++ b/src/cpp/core/system/ChildProcessSubprocPoll.cpp
@@ -55,7 +55,7 @@ bool ChildProcessSubprocPoll::poll(bool hadOutput)
    boost::posix_time::ptime currentTime = now();
 
    // Update state of "hasRecentOutput". We remember that we saw output for
-   // up to "kResetRecentDelay" milliseconds.
+   // up to "resetRecentDelay_" milliseconds.
    if (hadOutput)
    {
       hasRecentOutput_ = true;
@@ -76,7 +76,7 @@ bool ChildProcessSubprocPoll::poll(bool hadOutput)
       return false;
 
    // Update state of "hasSubprocesses". We do this no more often than every
-   // "kCheckSubprocDelay" milliseconds, and less often if we haven't seen any
+   // "checkSubprocDelay_" milliseconds, and less often if we haven't seen any
    // recent output. The latter is to reduce load when nothing is happening,
    // under the assumption that if all child processes are terminated, we
    // will always see output in the form of the command prompt.

--- a/src/cpp/core/system/ChildProcessSubprocPoll.hpp
+++ b/src/cpp/core/system/ChildProcessSubprocPoll.hpp
@@ -1,0 +1,65 @@
+/*
+ * ChildProcessSubprocPoll.hpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef CORE_SYSTEM_CHILD_PROCESS_SUBPROC_POLL_HPP
+#define CORE_SYSTEM_CHILD_PROCESS_SUBPROC_POLL_HPP
+
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/function.hpp>
+
+#include <core/system/System.hpp>
+
+namespace rstudio {
+namespace core {
+namespace system {
+
+// Updates two polling-based flags for a process.
+//
+// hasSubprocess(): does the process have any child processes?
+// hasRecentOutput(): did the process recently report receiving output
+//
+// Pass function to perform the actual subproc check to the constructor, or
+// NULL to not do any subprocess checking.
+//
+class ChildProcessSubprocPoll : boost::noncopyable
+{
+public:
+//   typedef bool (*hasSubprocCheck)(PidType);
+
+   ChildProcessSubprocPoll(PidType pid, boost::function<bool (PidType pid)> subProcCheck);
+
+   virtual ~ChildProcessSubprocPoll() {}
+
+   void poll(bool hadOutput);
+   void stop();
+
+   bool hasSubprocess() const;
+   bool hasRecentOutput() const;
+
+private:
+   PidType pid_;
+   boost::posix_time::ptime checkSubProcAfter_;
+   boost::posix_time::ptime resetRecentOutputAfter_;
+   bool hasSubprocess_;
+   bool hasRecentOutput_;
+   bool stopped_;
+   boost::function<bool (PidType pid)> subProcCheck_;
+};
+
+} // namespace system
+} // namespace core
+} // namespace rstudio
+
+#endif // CORE_SYSTEM_CHILD_PROCESS_SUBPROC_POLL_HPP

--- a/src/cpp/core/system/ChildProcessSubprocPoll.hpp
+++ b/src/cpp/core/system/ChildProcessSubprocPoll.hpp
@@ -42,7 +42,9 @@ public:
 
    virtual ~ChildProcessSubprocPoll() {}
 
-   void poll(bool hadOutput);
+   // returns true if subprocess polling was done
+   bool poll(bool hadOutput);
+
    void stop();
 
    bool hasSubprocess() const;

--- a/src/cpp/core/system/ChildProcessSubprocPollTests.cpp
+++ b/src/cpp/core/system/ChildProcessSubprocPollTests.cpp
@@ -95,9 +95,9 @@ context("ChildProcess polling support class")
       PidType pid = 12345;
       NoSubProcPollingFixture test(pid);
 
-      test.poller_.poll(true);
+      expect_false(test.poller_.poll(true));
       expect_true(test.poller_.hasRecentOutput());
-      test.poller_.poll(false);
+      expect_false(test.poller_.poll(false));
       expect_true(test.poller_.hasRecentOutput()); // timeout hasn't expired
    }
 
@@ -134,7 +134,7 @@ context("ChildProcess polling support class")
       test.poller_.poll(true);
       expect_false(test.checkCalled_); // polling timeout hasn't passed
       blockingwait(300); // longer than the timeout
-      test.poller_.poll(false); // still not longer than the recent output timeout!
+      expect_true(test.poller_.poll(false)); // still not longer than the recent output timeout!
       expect_true(test.checkCalled_);
       expect_true(test.poller_.hasSubprocess() == test.checkReturns_);
       expect_true(test.poller_.hasRecentOutput());

--- a/src/cpp/core/system/ChildProcessSubprocPollTests.cpp
+++ b/src/cpp/core/system/ChildProcessSubprocPollTests.cpp
@@ -1,0 +1,172 @@
+/*
+ * ChildProcessSubprocPollTests.cpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "ChildProcessSubprocPoll.hpp"
+
+#include <boost/bind.hpp>
+#include <boost/asio/deadline_timer.hpp>
+
+#include <tests/TestThat.hpp>
+
+namespace rstudio {
+namespace core {
+namespace system {
+namespace tests {
+
+namespace {
+
+void blockingwait(int ms)
+{
+   boost::asio::io_service io;
+   boost::asio::deadline_timer timer(io, boost::posix_time::milliseconds(ms));
+   timer.wait();
+}
+
+class NoSubProcPollingFixture
+{
+public:
+   NoSubProcPollingFixture(PidType pid)
+      :
+        poller_(pid, NULL)
+   {}
+
+   ChildProcessSubprocPoll poller_;
+};
+
+class SubProcPollingFixture
+{
+public:
+   SubProcPollingFixture(PidType pid)
+      :
+        poller_(pid, boost::bind(&SubProcPollingFixture::checkSubproc, this, _1)),
+        checkReturns_(false),
+        callerPid_(0),
+        checkCalled_(false)
+   {}
+
+   bool checkSubproc(PidType pid)
+   {
+      callerPid_ = pid;
+      checkCalled_ = true;
+      return checkReturns_;
+   }
+
+   void clearFlags()
+   {
+      callerPid_ = 0;
+      checkCalled_ = false;
+   }
+
+   ChildProcessSubprocPoll poller_;
+   bool checkReturns_;
+
+   PidType callerPid_;
+   bool checkCalled_;
+};
+
+} // anonymous namespace
+
+context("ChildProcess polling support class")
+{
+   test_that("initial state without subproc polling matches expectation")
+   {
+      PidType pid = 12345;
+      NoSubProcPollingFixture test(pid);
+
+      // we start with the flags set to true
+      expect_true(test.poller_.hasRecentOutput());
+      expect_true(test.poller_.hasSubprocess());
+   }
+
+   test_that("recent input state without subproc polling doesn't change immediately")
+   {
+      PidType pid = 12345;
+      NoSubProcPollingFixture test(pid);
+
+      test.poller_.poll(true);
+      expect_true(test.poller_.hasRecentOutput());
+      test.poller_.poll(false);
+      expect_true(test.poller_.hasRecentOutput()); // timeout hasn't expired
+   }
+
+   test_that("recent input state without subproc polling does change after timeout")
+   {
+      PidType pid = 12345;
+      NoSubProcPollingFixture test(pid);
+
+      test.poller_.poll(true);
+      expect_true(test.poller_.hasRecentOutput());
+      blockingwait(1100); // longer than timeout, but hate to do this in unit test
+      test.poller_.poll(false);
+      expect_false(test.poller_.hasRecentOutput()); // now it flips to false
+      test.poller_.poll(true);
+      expect_true(test.poller_.hasRecentOutput()); // but right back to true
+   }
+
+   test_that("initial state for subproc polling matches expectations")
+   {
+      PidType pid = 12345;
+      SubProcPollingFixture test(pid);
+
+      // we start with the flags set to true
+      expect_true(test.poller_.hasRecentOutput());
+      expect_true(test.poller_.hasSubprocess());
+   }
+
+   test_that("childproc checked when recent output and timeout expires")
+   {
+      PidType pid = 12345;
+      SubProcPollingFixture test(pid);
+
+      test.checkReturns_ = false;
+      test.poller_.poll(true);
+      expect_false(test.checkCalled_); // polling timeout hasn't passed
+      blockingwait(300); // longer than the timeout
+      test.poller_.poll(false); // still not longer than the recent output timeout!
+      expect_true(test.checkCalled_);
+      expect_true(test.poller_.hasSubprocess() == test.checkReturns_);
+      expect_true(test.poller_.hasRecentOutput());
+      expect_true(test.callerPid_ == pid);
+   }
+
+   test_that("lack of recent output prevents childproc checking")
+   {
+      PidType pid = 12345;
+      SubProcPollingFixture test(pid);
+
+      test.checkReturns_ = false;
+      test.poller_.poll(false);
+      expect_false(test.checkCalled_);
+      blockingwait(300); // long enough for childproc polling
+      test.poller_.poll(false); // not longer than the output timeout
+      expect_true(test.checkCalled_);
+      expect_true(test.poller_.hasSubprocess() == test.checkReturns_);
+      expect_true(test.poller_.hasRecentOutput());
+      expect_true(test.callerPid_ == pid);
+
+      test.clearFlags();
+      test.poller_.poll(false); // no recent output
+      blockingwait(800); // this plus earlier delay should timeout recent output
+      test.poller_.poll(false);
+      expect_false(test.checkCalled_); // because of no recent output
+      expect_false(test.poller_.hasRecentOutput());
+      expect_true(test.poller_.hasSubprocess() == test.checkReturns_);
+   }
+}
+
+} // namespace tests
+} // namespace system
+} // namespace core
+} // namespace rstudio

--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -55,6 +55,11 @@ const int READ = 0;
 const int WRITE = 1;
 const std::size_t READ_ERR = -1;
 
+const boost::posix_time::milliseconds kResetRecentDelay =
+                                         boost::posix_time::milliseconds(1000);
+const boost::posix_time::milliseconds kCheckSubprocDelay =
+                                         boost::posix_time::milliseconds(250);
+
 int resolveExitStatus(int status)
 {
    return WIFEXITED(status) ? WEXITSTATUS(status) : status;
@@ -783,6 +788,7 @@ void AsyncChildProcess::poll()
       // setup for subprocess polling
       pAsyncImpl_->pSubprocPoll_.reset(new ChildProcessSubprocPoll(
          pImpl_->pid,
+         kResetRecentDelay, kCheckSubprocDelay,
          options().reportHasSubprocs ? core::system::hasSubprocesses : NULL));
 
       if (callbacks_.onStarted)

--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "ChildProcess.hpp"
+#include "ChildProcessSubprocPoll.hpp"
 
 #include <fcntl.h>
 #include <signal.h>
@@ -695,61 +696,14 @@ struct AsyncChildProcess::AsyncImpl
       : calledOnStarted_(false),
         finishedStdout_(false),
         finishedStderr_(false),
-        exited_(false),
-        checkSubProc_(boost::posix_time::not_a_date_time),
-        hasSubprocess_(true),
-        hasRecentOutput_(true)
+        exited_(false)
    {
    }
    bool calledOnStarted_;
    bool finishedStdout_;
    bool finishedStderr_;
    bool exited_;
-
-   // when we next check subprocess count
-   boost::posix_time::ptime checkSubProc_;
-
-   // result of last subprocess check
-   bool hasSubprocess_;
-
-   // has there been output recently?
-   bool hasRecentOutput_;
-
-   void initTimers(bool reportHasSubprocs)
-   {
-      if (exited_)
-      {
-         checkSubProc_ = boost::posix_time::not_a_date_time;
-         return;
-      }
-
-      if (reportHasSubprocs && checkSubProc_.is_not_a_date_time())
-      {
-         checkSubProc_ = now() + boost::posix_time::seconds(1);
-      }
-   }
-
-   bool checkChildCount()
-   {
-      if (checkSubProc_.is_not_a_date_time())
-         return false;
-
-      bool fCheck = now() > checkSubProc_;
-
-      if (fCheck)
-         checkSubProc_ = boost::posix_time::not_a_date_time;
-      return fCheck;
-   }
-
-   bool computeHasSubProcess(PidType pid)
-   {
-      return core::system::hasSubprocesses(pid);
-   }
-
-   static boost::posix_time::ptime now()
-   {
-      return boost::posix_time::microsec_clock::universal_time();
-   }
+   boost::scoped_ptr<ChildProcessSubprocPoll> pSubprocPoll_;
 };
 
 AsyncChildProcess::AsyncChildProcess(const std::string& exe,
@@ -797,12 +751,18 @@ Error AsyncChildProcess::terminate()
 
 bool AsyncChildProcess::hasSubprocess() const
 {
-   return pAsyncImpl_->hasSubprocess_;
+   if (pAsyncImpl_->pSubprocPoll_)
+      return pAsyncImpl_->pSubprocPoll_->hasSubprocess();
+   else
+      return true;
 }
 
 bool AsyncChildProcess::hasRecentOutput() const
 {
-   return pAsyncImpl_->hasRecentOutput_;
+   if (pAsyncImpl_->pSubprocPoll_)
+      return pAsyncImpl_->pSubprocPoll_->hasRecentOutput();
+   else
+      return true;
 }
 
 void AsyncChildProcess::poll()
@@ -820,6 +780,11 @@ void AsyncChildProcess::poll()
       else
          setPipeNonBlocking(pImpl_->fdStderr);         
 
+      // setup for subprocess polling
+      pAsyncImpl_->pSubprocPoll_.reset(new ChildProcessSubprocPoll(
+         pImpl_->pid,
+         options().reportHasSubprocs ? core::system::hasSubprocesses : NULL));
+
       if (callbacks_.onStarted)
          callbacks_.onStarted(*this);
       pAsyncImpl_->calledOnStarted_ = true;
@@ -836,6 +801,8 @@ void AsyncChildProcess::poll()
       }
    }
 
+   bool hasRecentOutput = false;
+
    // check stdout and fire event if we got output
    if (!pAsyncImpl_->finishedStdout_)
    {
@@ -850,7 +817,7 @@ void AsyncChildProcess::poll()
       {
          if (!out.empty() && callbacks_.onStdout)
          {
-            pAsyncImpl_->hasRecentOutput_ = true;
+            hasRecentOutput = true;
             callbacks_.onStdout(*this, out);
          }
 
@@ -874,7 +841,7 @@ void AsyncChildProcess::poll()
       {
          if (!err.empty() && callbacks_.onStderr)
          {
-            pAsyncImpl_->hasRecentOutput_ = true;
+            hasRecentOutput = true;
             callbacks_.onStderr(*this, err);
          }
 
@@ -915,6 +882,7 @@ void AsyncChildProcess::poll()
       // set exited_ flag so that our exited function always
       // returns the right value
       pAsyncImpl_->exited_ = true;
+      pAsyncImpl_->pSubprocPoll_->stop();
 
       // if this is an error that isn't ECHILD then log it (we never
       // expect this to occur as the only documented error codes are
@@ -924,14 +892,11 @@ void AsyncChildProcess::poll()
    }
 
    // Perform optional periodic operations
-   pAsyncImpl_->initTimers(options().reportHasSubprocs);
-   if (pAsyncImpl_->checkChildCount())
+   if (pAsyncImpl_->pSubprocPoll_->poll(hasRecentOutput))
    {
-      pAsyncImpl_->hasRecentOutput_ = false;
-      pAsyncImpl_->hasSubprocess_ = pAsyncImpl_->computeHasSubProcess(pImpl_->pid);
       if (callbacks_.onHasSubprocs)
       {
-         callbacks_.onHasSubprocs(pAsyncImpl_->hasSubprocess_);
+         callbacks_.onHasSubprocs(hasSubprocess());
       }
    }
 }

--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -58,7 +58,7 @@ const std::size_t READ_ERR = -1;
 const boost::posix_time::milliseconds kResetRecentDelay =
                                          boost::posix_time::milliseconds(1000);
 const boost::posix_time::milliseconds kCheckSubprocDelay =
-                                         boost::posix_time::milliseconds(250);
+                                         boost::posix_time::milliseconds(200);
 
 int resolveExitStatus(int status)
 {

--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -41,7 +41,7 @@ namespace {
 const boost::posix_time::milliseconds kResetRecentDelay =
                                          boost::posix_time::milliseconds(1000);
 const boost::posix_time::milliseconds kCheckSubprocDelay =
-                                         boost::posix_time::milliseconds(250);
+                                         boost::posix_time::milliseconds(200);
 
 std::string findOnPath(const std::string& exe,
                        const std::string& appendExt = "")

--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -38,6 +38,10 @@ namespace system {
 
 namespace {
 
+const boost::posix_time::milliseconds kResetRecentDelay =
+                                         boost::posix_time::milliseconds(1000);
+const boost::posix_time::milliseconds kCheckSubprocDelay =
+                                         boost::posix_time::milliseconds(250);
 
 std::string findOnPath(const std::string& exe,
                        const std::string& appendExt = "")
@@ -611,6 +615,7 @@ void AsyncChildProcess::poll()
       // setup for subprocess polling
       pAsyncImpl_->pSubprocPoll_.reset(new ChildProcessSubprocPoll(
          pImpl_->pid,
+         kResetRecentDelay, kCheckSubprocDelay,
          options().reportHasSubprocs ? core::system::hasSubprocesses : NULL));
 
       if (callbacks_.onStarted)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/TerminalPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/TerminalPreferencesPane.java
@@ -18,7 +18,6 @@ import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.SelectWidget;
-import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.server.Server;
 import org.rstudio.studio.client.server.ServerError;
@@ -59,10 +58,13 @@ public class TerminalPreferencesPane extends PreferencesPane
          add(terminalShell_);
          terminalShell_.setEnabled(false);
       }
-      CheckBox chkTerminalLocalEcho = checkboxPref("Local terminal echo",
-            prefs_.terminalLocalEcho(), 
-            "Local echo is more responsive but may get out of sync with some line-editing modes.");
-      add(chkTerminalLocalEcho);
+      if (haveLocalEchoPref())
+      {
+         CheckBox chkTerminalLocalEcho = checkboxPref("Local terminal echo",
+               prefs_.terminalLocalEcho(), 
+               "Local echo is more responsive but may get out of sync with some line-editing modes.");
+         add(chkTerminalLocalEcho);
+      }
       
       HelpLink helpLink = new HelpLink("Using the RStudio terminal", "rstudio_terminal", false);
       nudgeRight(helpLink); 
@@ -149,7 +151,12 @@ public class TerminalPreferencesPane extends PreferencesPane
 
    private boolean haveTerminalShellPref()
    {
-      return Desktop.isDesktop() && BrowseCap.isWindows();
+      return BrowseCap.isWindowsDesktop();
+   }
+
+   private boolean haveLocalEchoPref()
+   {
+      return !BrowseCap.isWindowsDesktop();
    }
  
    private SelectWidget terminalShell_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalLocalEcho.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalLocalEcho.java
@@ -31,6 +31,9 @@ public class TerminalLocalEcho
    
    public void echo(String input)
    {
+      if (paused())
+         return;
+      
       // input longer than one character is likely a control sequence, or
       // pasted text; only local-echo and sync with single-character input
       if (input.length() == 1) 
@@ -138,9 +141,34 @@ public class TerminalLocalEcho
       localEcho_.clear();
    }
    
+   public void pause(int pauseMillis)
+   {
+      stopEchoPause_ = System.currentTimeMillis() + pauseMillis;
+      clear();
+   }
+   
+   public boolean paused()
+   {
+      if (stopEchoPause_ == 0)
+         return false;
+      
+      if (stopEchoPause_ > 0 && System.currentTimeMillis() < stopEchoPause_)
+      {
+         return true;
+      }
+      else
+      {
+         stopEchoPause_ = 0;
+         return false;
+      }
+   }
+   
   // Matches ANSI control sequences or BS, CR, LF, DEL, BEL
    private static final Pattern ANSI_CTRL_PATTERN =
          Pattern.create("(?:" + AnsiCode.ANSI_REGEX + ")|(?:" + "[\b\n\r\177\7]" + ")");
+
+   // Pause local-echo until this time
+   private long stopEchoPause_;
 
    private final StringSink writer_;
    private LinkedList<String> localEcho_ = new LinkedList<String>();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -242,7 +242,7 @@ public class TerminalSession extends XTermWidget
    @Override
    public void receivedOutput(String output)
    {
-      socket_.dispatchOutput(output, uiPrefs_.terminalLocalEcho().getValue()); 
+      socket_.dispatchOutput(output, doLocalEcho());
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
@@ -19,6 +19,7 @@ import java.util.LinkedList;
 
 import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.Stopwatch;
+import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.common.console.ConsoleOutputEvent;
@@ -326,7 +327,7 @@ public class TerminalSessionSocket
     */
    public void dispatchOutput(String output, boolean detectLocalEcho)
    {
-      if (detectLocalEcho && output.contains("Password:"))
+      if (detectLocalEcho && PASSWORD_PATTERN.test(output))
       {
          // If user is changing password, temporarily stop local-echo
          // to reduce chances of showing their password. Note that echo
@@ -401,6 +402,13 @@ public class TerminalSessionSocket
    private Websocket socket_;
    private TerminalLocalEcho localEcho_;
 
+   // RegEx to match common password prompts
+   private static final String PASSWORD_REGEX = 
+         "(?:password:)|(?:passphrase:)";
+   
+   public static final Pattern PASSWORD_PATTERN =
+         Pattern.create(PASSWORD_REGEX, "im");
+ 
    // Injected ---- 
    private UIPrefs uiPrefs_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
@@ -326,6 +326,18 @@ public class TerminalSessionSocket
     */
    public void dispatchOutput(String output, boolean detectLocalEcho)
    {
+      if (detectLocalEcho && output.contains("Password:"))
+      {
+         // If user is changing password, temporarily stop local-echo
+         // to reduce chances of showing their password. Note that echo
+         // stops automatically once the terminal enters "busy" state, but
+         // there's a delay before that happens. Also, if the user has 
+         // already started typing before the Password: prompt is sent back
+         // by the server, those characters will local-echo. Still, between
+         // the two mechanisms this reduces the chances of most or all of
+         // their typed password characters being echoed.
+          localEcho_.pause(1000);
+      }
       if (!detectLocalEcho || localEcho_.isEmpty())
       {
          xterm_.write(output);

--- a/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
+++ b/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
@@ -19,6 +19,7 @@ import org.rstudio.core.client.AnsiCodeTests;
 import org.rstudio.core.client.StringUtilTests;
 import org.rstudio.core.client.dom.DomUtilsTests;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalLocalEchoTests;
+import org.rstudio.studio.client.workbench.views.terminal.TerminalSessionSocketTests;
 
 import com.google.gwt.junit.tools.GWTTestSuite;
 
@@ -35,6 +36,7 @@ public class RStudioUnitTestSuite extends GWTTestSuite
         suite.addTestSuite(DomUtilsTests.class);
         suite.addTestSuite(AnsiCodeTests.class);
         suite.addTestSuite(TerminalLocalEchoTests.class);
+        suite.addTestSuite(TerminalSessionSocketTests.class);
         return suite;
     }
 }

--- a/src/gwt/test/org/rstudio/studio/client/workbench/views/terminal/TerminalLocalEchoTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/workbench/views/terminal/TerminalLocalEchoTests.java
@@ -319,4 +319,20 @@ public class TerminalLocalEchoTests extends GWTTestCase
       Assert.assertEquals(expected, output.getOutput());
    }
 
+   public void testEchoPause()
+   {
+      OutputCatcher output = new OutputCatcher();
+      TerminalLocalEcho echo = new TerminalLocalEcho(output);
+      
+      String password = "MySecretPassword!";
+      
+      Assert.assertFalse(echo.paused());
+      echo.pause(50);
+      
+      echoString(echo, password);
+      Assert.assertTrue(echo.paused());
+      Assert.assertTrue(echo.isEmpty());
+      Assert.assertTrue(output.isEmpty());
+   }
+
 }

--- a/src/gwt/test/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocketTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocketTests.java
@@ -1,0 +1,62 @@
+/*
+ * TerminalSessionSocketTests.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.terminal;
+
+import com.google.gwt.junit.client.GWTTestCase;
+import junit.framework.Assert;
+
+public class TerminalSessionSocketTests extends GWTTestCase
+{
+   @Override
+   public String getModuleName()
+   {
+      return "org.rstudio.studio.RStudioTests";
+   }
+
+   public void testCommonPasswordPrompts()
+   {
+      Assert.assertFalse(
+            TerminalSessionSocket.PASSWORD_PATTERN.test("Nothing to see here"));
+      Assert.assertTrue(
+            TerminalSessionSocket.PASSWORD_PATTERN.test("Password:"));
+      Assert.assertTrue(
+            TerminalSessionSocket.PASSWORD_PATTERN.test("password:"));
+      Assert.assertFalse(
+            TerminalSessionSocket.PASSWORD_PATTERN.test("Password"));
+      Assert.assertFalse(
+            TerminalSessionSocket.PASSWORD_PATTERN.test("password"));
+      Assert.assertTrue(
+            TerminalSessionSocket.PASSWORD_PATTERN.test("Passphrase:"));
+      Assert.assertTrue(
+            TerminalSessionSocket.PASSWORD_PATTERN.test("passphrase:"));
+      Assert.assertFalse(
+            TerminalSessionSocket.PASSWORD_PATTERN.test("Passphrase"));
+      Assert.assertFalse(
+            TerminalSessionSocket.PASSWORD_PATTERN.test("passphrase"));
+   }
+
+   public void testPasswordPromptsWithExtraGunk()
+   {
+      Assert.assertTrue(
+            TerminalSessionSocket.PASSWORD_PATTERN.test("My HappyPassword:  "));
+      Assert.assertTrue(
+            TerminalSessionSocket.PASSWORD_PATTERN.test("\n\rpassword:::"));
+      Assert.assertTrue(
+            TerminalSessionSocket.PASSWORD_PATTERN.test("The Passphrase: is here"));
+      Assert.assertTrue(
+            TerminalSessionSocket.PASSWORD_PATTERN.test("passphrasepasswordpassphrase: "));
+   }
+
+}


### PR DESCRIPTION
- factored out some common (and confusing) duplicate code from `PosixChildProcess` and `Win32ChildProcess` into a shared `ChildProcessSubprocPoll` class; still find it a bit confusing but at least the confusion is now encapsulated and has some tests
- this class tracks how often to check for subprocesses, and whether there has been recent terminal output
- new behavior: when there is no recent output, frequency of subprocess checks is reduced
- new behavior: hide the _local echo_ preference UI on Windows, which doesn't support local-echo
- new behavior: if Local Echo sees the literal text **Password:** written to the terminal, it briefly suspends local-echo, to reduce the chance of user's password local-echoing before local-echo is stopped by server reporting back that terminal is busy
- now that subprocess checking is more efficient on Mac (happening via API calls instead of shelling out commands), turn up default frequency of subprocess checks; this also helps reduce the problem of password-characters being local-echoed