### PR TITLE
Support for minimized panels and fix to minimized debug stack for fla…

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/MinimizedWindowFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/MinimizedWindowFrame.java
@@ -54,6 +54,7 @@ public class MinimizedWindowFrame
 
       layout_ = new ClickDockLayoutPanel(Style.Unit.PX);
       layout_.setStylePrimaryName(themeStyles.minimizedWindow());
+      layout_.addStyleName(themeStyles.minimizedWindowObject());
 
       int leftPadding = title != null ? 8 : 4;
       layout_.addWest(createDiv(themeStyles.left()), leftPadding);

--- a/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
@@ -84,6 +84,7 @@ public class WindowFrame extends Composite
 
       frame_ = new LayoutPanel();
       frame_.setStylePrimaryName(styles.windowframe());
+      frame_.addStyleName(styles.windowFrameObject());
 
       frame_.add(borderPositioner_);
       frame_.setWidgetTopBottom(borderPositioner_, 0, Style.Unit.PX,

--- a/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
@@ -176,4 +176,7 @@ public interface ThemeStyles extends CssResource
    
    String displayNone();
    String logoAnchor();
+
+   String windowFrameObject();
+   String minimizedWindowObject();
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -600,7 +600,7 @@ pre {
    -webkit-font-smoothing: subpixel-antialiased;
 }
 
-.rstudio-themes-flat .windowframe > div:last-child {
+.rstudio-themes-flat .windowFrameObject > div:last-child {
    border: solid 1px #d6dadc;
    border-radius: 3px;
    left: 2px !important;
@@ -1581,6 +1581,12 @@ body.ubuntu_mono .searchBox {
 	display: none !important;
 }
 
+.windowFrameObject {
+}
+
+.minimizedWindowObject {
+}
+
 .rstudio-themes-flat .gwt-TabLayoutPanelTabs {
    background-image: none;
    background: #e7e8ea;
@@ -1726,4 +1732,46 @@ body.ubuntu_mono .searchBox {
 .rstudio-themes-flat .gwt-DialogBox .dialogContent {
    padding-left: 10px;
    padding-right: 10px;
+}
+
+.rstudio-themes-flat .minimizedWindowObject .left {
+   background: none;
+}
+
+.rstudio-themes-flat .minimizedWindowObject .right {
+   background: none;
+}
+
+.rstudio-themes-flat .minimizedWindowObject .center {
+   background: none;
+   background: #e7e8ea;
+}
+
+.rstudio-themes-flat .minimizedWindowObject  > div:last-child {
+   left: 3px !important;
+   top: 2px !important;
+   right: 3px !important;
+   bottom: 0px !important;
+   height: 23px;
+   border: solid 1px #d6dadc;
+   border-radius: 3px;
+   padding-top: 1px;
+}
+
+.rstudio-themes-flat .minimizedWindowObject .minimize {
+   padding-top: 0px;
+   margin-top: 1px;
+   width: 16px;
+   margin-right: 0px;
+}
+
+.rstudio-themes-flat .minimizedWindowObject .maximize {
+   padding-top: 0px;
+   margin-top: 1px;
+   width: 20px;
+   margin-right: 4px;
+}
+
+.rstudio-themes-flat .minimizedWindowObject .primaryWindowFrameHeader {
+   padding-top: 1px;
 }


### PR DESCRIPTION
1. Support for minimized panels in flat theme
2. The debug stack uses `windowframe` style but does not really behave like a `WindowFrame.java` and therefore, the flat theme styles are not applied for this object.

<img width="819" alt="screen shot 2017-04-20 at 5 52 48 pm" src="https://cloud.githubusercontent.com/assets/3478847/25258153/3b774d0e-25f2-11e7-947c-61afd3adaac0.png">
<img width="621" alt="screen shot 2017-04-20 at 5 53 03 pm" src="https://cloud.githubusercontent.com/assets/3478847/25258154/3b8b38e6-25f2-11e7-8075-dd54faf2f901.png">
