### PR TITLE
fix git-bash in Windows terminal

### DIFF
--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -117,6 +117,17 @@ void ConsoleProcess::commonInit()
       }
       else // terminal
       {
+         // undefine TERM, as it puts git-bash in a mode that winpty doesn't
+         // support; was set in SessionMain.cpp::main to support color in
+         // the R Console
+         if (!options_.environment)
+         {
+            core::system::Options childEnv;
+            core::system::environment(&childEnv);
+            options_.environment = childEnv;
+         }
+         core::system::unsetenv(&(options_.environment.get()), "TERM");
+
          // request a pseudoterminal if this is an interactive console process
          options_.pseudoterminal = core::system::Pseudoterminal(
                   session::options().winptyPath(),

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -914,9 +914,6 @@ Error startTerminal(const json::JsonRpcRequest& request,
    core::system::environment(&shellEnv);
 
 #ifndef _WIN32
-   // set terminal
-   core::system::setenv(&shellEnv, "TERM", core::system::kSmartTerm);
-
    // set xterm title to show current working directory after each command
    core::system::setenv(&shellEnv, "PROMPT_COMMAND",
                         "echo -ne \"\\033]0;${PWD/#${HOME}/~}\\007\"");


### PR DESCRIPTION
- unset TERM for the Win32 terminal subprocess; it was previously unset (before I started setting it for the R Session for color console) and that's how git-bash likes it; with TERM set git-bash and/or winpty does weird stuff; verified change with git-bash, cmd, powershell, and WSL
- remove redundant settings of TERM in SessionWorkbench.cpp::startTerminal, as ConsoleProcess also sets it; verified on Mac that TERM is still set as-expected in terminal shell