### PR TITLE
local-echo mismatch diagnostics

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalLocalEcho.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalLocalEcho.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.views.terminal;
 import java.util.LinkedList;
 
 import org.rstudio.core.client.AnsiCode;
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringSink;
 import org.rstudio.core.client.regex.Match;
 import org.rstudio.core.client.regex.Pattern;
@@ -130,6 +131,12 @@ public class TerminalLocalEcho
       {
          // didn't match previously echoed text; delete local-input
          // queue so we don't get too far out of sync and write text as-is
+         
+         // TODO (gary) temporary diagnostics to help isolate some cases
+         // where local-echo is still not matching as expected 
+         Debug.log("LocalEcho Match Failure: received '" + outputToMatch + 
+               "' had: '" + lastOutput + "'");
+         
          localEcho_.clear();
          writer_.write(outputToMatch);
          return 0;


### PR DESCRIPTION
Darby sees issues with local-echo that I haven't been able to repro; putting in code that dumps the key info to the Javascript console to help identity what's going on. Expect to generate a forehead-slap "Oh, that's what's different on your machine" kinda thing.

Marked with a TODO and will remove when I make the actual fix.