### PR TITLE
Fix border rendering issue in flat theme

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -602,7 +602,7 @@ pre {
 
 .rstudio-themes-flat .windowFrameObject > div:last-child {
    border: solid 1px #d6dadc;
-   border-radius: 3px;
+   border-radius: 3px 3px 0px 0px;
    left: 2px !important;
    top: 2px !important;
    right: 2px !important;
@@ -1754,7 +1754,7 @@ body.ubuntu_mono .searchBox {
    bottom: 0px !important;
    height: 23px;
    border: solid 1px #d6dadc;
-   border-radius: 3px;
+   border-radius: 3px 3px 0px 0px;
    padding-top: 1px;
 }
 


### PR DESCRIPTION
I was trying to fix this 1px off issue in the workbench panels under flat theme:

<img width="186" alt="screen shot 2017-04-21 at 1 28 21 pm" src="https://cloud.githubusercontent.com/assets/3478847/25295018/a608719e-2696-11e7-901e-4f0cc025f24d.png">

After investigating, found this happens to be a chromium issue (no repro in other browsers), opened an issue for them: https://bugs.chromium.org/p/chromium/issues/detail?id=714247

The workaround is to not use bottom borders, which is also consistent with dialogs in the latest design.

<img width="214" alt="screen shot 2017-04-21 at 1 32 19 pm" src="https://cloud.githubusercontent.com/assets/3478847/25295088/f7c24690-2696-11e7-95ba-1a5cda0c0c94.png">
