### PR TITLE
Flat theme for object grids and search boxes

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1776,3 +1776,31 @@ body.ubuntu_mono .searchBox {
 .rstudio-themes-flat .minimizedWindowObject .primaryWindowFrameHeader {
    padding-top: 1px;
 }
+
+.rstudio-themes-flat .search {
+   top: 1px;
+   height: 16px;
+   border: solid 1px #d6dadc;
+   border-radius: 3px;
+   background: #FFF;
+}
+
+.search .left {
+   display: none;
+}
+
+.search .center {
+   background: none;
+}
+
+.search .right {
+   display: none;
+}
+
+.rstudio-themes-flat .searchMagGlass {
+   top: 2px;
+}
+
+.rstudio-themes-flat .clearSearch {
+   top: 3px;
+}

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1785,15 +1785,15 @@ body.ubuntu_mono .searchBox {
    background: #FFF;
 }
 
-.search .left {
+.rstudio-themes-flat .search .left {
    display: none;
 }
 
-.search .center {
+.rstudio-themes-flat .search .center {
    background: none;
 }
 
-.search .right {
+.rstudio-themes-flat .search .right {
    display: none;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -994,6 +994,7 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
 .rstudio-themes-flat .secondaryToolbar {
    background: #eeeff1;
    border-bottom: solid 1px #d6dadc;
+   height: 24px;
 }
 
 .toolbarButtonRightImage {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/ui/CodeSearch.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/ui/CodeSearch.css
@@ -1,8 +1,13 @@
 
 @external search;
+@external rstudio-themes-flat;
 
 .codeSearchWidget .search {
    width: 145px;
+}
+
+.rstudio-themes-flat .codeSearchWidget .search {
+   top: 0px;
 }
 
 .fileImage {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -154,7 +154,10 @@ public class EnvironmentPane extends WorkbenchPane
          }
       });
 
-      searchWidget.getElement().getStyle().setMarginTop(1, Unit.PX);
+      if (!prefs_.getUseFlatThemes().getValue()) {
+         searchWidget.getElement().getStyle().setMarginTop(1, Unit.PX);
+      }
+
       toolbar.addRightWidget(searchWidget);
 
       return toolbar;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectGrid.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectGrid.css
@@ -1,3 +1,4 @@
+@external rstudio-themes-flat;
 @eval proportionalFont org.rstudio.core.client.theme.ThemeFonts.getProportionalFont();
 
 .objectGridColumn,
@@ -23,6 +24,16 @@ th.objectGridHeader
    text-align: left;
    border-collapse: separate;
    font-size: 11px;
+}
+
+.rstudio-themes-flat th.objectGridHeader {
+   border-top: none;
+   border-left: none;
+   height: 16px;
+}
+
+.rstudio-themes-flat th.objectGridHeader:last-child {
+   border-right: none;
 }
 
 .valueColumn

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGridCommon.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGridCommon.css
@@ -1,6 +1,7 @@
 @eval proportionalFont org.rstudio.core.client.theme.ThemeFonts.getProportionalFont();
 
 @external ubuntu_mono;
+@external rstudio-themes-flat;
 
 /* Styles here are applied to every DataGrid involved in the Packrat/Packages
    workflow, including the Packages pane itself and the actions/conflict 
@@ -25,6 +26,16 @@
    border-collapse: separate;
    font-size: 11px;
    text-shadow: none;
+}
+
+.rstudio-themes-flat .dataGridHeader {
+   border-top: none;
+   border-left: none;
+   height: 16px;
+}
+
+.rstudio-themes-flat .dataGridHeader:last-child {
+   border-right: none;
 }
 
 .dataGridCell


### PR DESCRIPTION
Couple (easy this time) 1px off fixes, flattening the environment/packages grid and the search boxes:

<img width="961" alt="screen shot 2017-04-21 at 3 01 54 pm" src="https://cloud.githubusercontent.com/assets/3478847/25297582/91d42116-26a3-11e7-8e41-83b7db1aec40.png">
