### PR TITLE
Flat menus and pupop-menus under flat theme

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.css
@@ -12,6 +12,9 @@
    suggestPopupContent;
 @external gwt-MenuBar-vertical;
 
+@external rstudio-themes-flat;
+@external menuPopupTop, menuPopupBottom, menuPopupMiddle;
+
 .themedPopupPanel {
    margin: -6px;
    margin-top: 0px;
@@ -65,4 +68,32 @@
    margin: -5px;
    margin-top: 0;
    z-index: 1000;
+}
+
+
+.rstudio-themes-flat .gwt-MenuBarPopup {
+   margin: 0px;
+   box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.rstudio-themes-flat .menuPopupMiddleCenter {
+   margin: 0px;
+   border: solid 1px #a3a8b2;
+   padding: 4px;
+}
+
+.rstudio-themes-flat .menuPopupTop {
+   display: none;
+}
+
+.rstudio-themes-flat .menuPopupMiddle .menuPopupMiddleLeft {
+   display: none;
+}
+
+.rstudio-themes-flat .menuPopupMiddle .menuPopupMiddleRight {
+   display: none;
+}
+
+.rstudio-themes-flat .menuPopupBottom {
+   display: none;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.css
@@ -14,6 +14,8 @@
 
 @external rstudio-themes-flat;
 @external menuPopupTop, menuPopupBottom, menuPopupMiddle;
+@external popupTop, popupBottom, popupMiddle;
+@external gwt-DecoratedPopupPanel;
 
 .themedPopupPanel {
    margin: -6px;
@@ -70,30 +72,33 @@
    z-index: 1000;
 }
 
-
-.rstudio-themes-flat .gwt-MenuBarPopup {
-   margin: 0px;
+.rstudio-themes-flat .gwt-MenuBarPopup,
+.rstudio-themes-flat .gwt-DecoratedPopupPanel {
    box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1);
 }
 
-.rstudio-themes-flat .menuPopupMiddleCenter {
-   margin: 0px;
+.rstudio-themes-flat .menuPopupMiddleCenter,
+.rstudio-themes-flat .popupMiddleCenter {
    border: solid 1px #a3a8b2;
    padding: 4px;
 }
 
-.rstudio-themes-flat .menuPopupTop {
+.rstudio-themes-flat .menuPopupTop,
+.rstudio-themes-flat .popupTop {
    display: none;
 }
 
-.rstudio-themes-flat .menuPopupMiddle .menuPopupMiddleLeft {
+.rstudio-themes-flat .menuPopupMiddle .menuPopupMiddleLeft,
+.rstudio-themes-flat .popupMiddle .popupMiddleLeft {
    display: none;
 }
 
-.rstudio-themes-flat .menuPopupMiddle .menuPopupMiddleRight {
+.rstudio-themes-flat .menuPopupMiddle .menuPopupMiddleRight,
+.rstudio-themes-flat .popupMiddle .popupMiddleRight {
    display: none;
 }
 
-.rstudio-themes-flat .menuPopupBottom {
+.rstudio-themes-flat .menuPopupBottom,
+.rstudio-themes-flat .popupBottom {
    display: none;
 }


### PR DESCRIPTION
Menu and popup-menu shadows are now rendered using CSS. Also, subtle dimming of shadows for flat theme. Default theme:

<img width="324" alt="screen shot 2017-04-21 at 3 30 08 pm" src="https://cloud.githubusercontent.com/assets/3478847/25298582/fc40bb16-26aa-11e7-98f1-8ca16c66e923.png">

Flat theme:

<img width="458" alt="screen shot 2017-04-21 at 3 35 53 pm" src="https://cloud.githubusercontent.com/assets/3478847/25298583/fc416ffc-26aa-11e7-8c1e-37c95170ace6.png">
