### PR TITLE
Enable flat theme in satellite windows and imrpvements

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
@@ -99,8 +99,28 @@
 
 }
 
+.rstudio-themes-flat .dataGridSortedHeaderAscending img {
+  width: 0px !important;
+  height: 0px !important;
+  background: none !important;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-bottom: 7px solid #818a98;
+  margin-left: 3px;
+}
+
 .dataGridSortedHeaderDescending {
 
+}
+
+.rstudio-themes-flat .dataGridSortedHeaderDescending img {
+  width: 0px !important;
+  height: 0px !important;
+  background: none !important;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 7px solid #818a98;
+  margin-left: 3px;
 }
 
 .dataGridEvenRow {

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1681,11 +1681,11 @@ body.ubuntu_mono .searchBox {
 }
 
 .rstudio-themes-flat .gwt-DialogBox {
-   border: solid 1px #d6dadc;
+   border: solid 1px #bbbcbe;
    border-radius: 5px 5px 0px 0px;
    background: #F3F4F4;
    overflow: hidden !important;
-   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.15);
+   box-shadow: 0 30px 30px rgba(0, 0, 0, 0.20);
 }
 
 .rstudio-themes-flat .gwt-DialogBox .dialogMiddleCenter {

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1607,7 +1607,8 @@ body.ubuntu_mono .searchBox {
    display: none;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .tabLayoutLeft {
+.rstudio-themes-flat .gwt-TabLayoutPanelTabs .tabLayoutLeft,
+.rstudio-themes-flat .minimizedWindowObject .tabLayoutLeft {
    display: none;
 }
 
@@ -1615,7 +1616,8 @@ body.ubuntu_mono .searchBox {
    display: none;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs table.tabLayoutCenter {
+.rstudio-themes-flat .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
+.rstudio-themes-flat .minimizedWindowObject table.tabLayoutCenter {
    background-image: none;
    background: rgb(236, 237, 238);
    border-right: solid 1px #d6dadc;
@@ -1631,7 +1633,8 @@ body.ubuntu_mono .searchBox {
    background: #f3f4f7;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .tabLayoutCenter td {
+.rstudio-themes-flat .gwt-TabLayoutPanelTabs .tabLayoutCenter td,
+.rstudio-themes-flat .minimizedWindowObject .gwt-TabLayoutPanelTabs .tabLayoutCenter td {
    vertical-align: top !important;
 }
 
@@ -1647,7 +1650,8 @@ body.ubuntu_mono .searchBox {
    padding-top: 3px;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .tabLayoutRight {
+.rstudio-themes-flat .gwt-TabLayoutPanelTabs .tabLayoutRight,
+.rstudio-themes-flat .minimizedWindowObject .tabLayoutRight  {
    display: none;
 }
 
@@ -1748,6 +1752,10 @@ body.ubuntu_mono .searchBox {
    background: #e7e8ea;
 }
 
+.rstudio-themes-flat .moduleTabPanel.minimizedWindowObject .center {
+   padding-top: 0px;
+}
+
 .rstudio-themes-flat .minimizedWindowObject  > div:last-child {
    left: 3px !important;
    top: 2px !important;
@@ -1766,11 +1774,19 @@ body.ubuntu_mono .searchBox {
    margin-right: 0px;
 }
 
+.rstudio-themes-flat .moduleTabPanel.minimizedWindowObject .minimize {
+   padding-top: 6px;
+}
+
 .rstudio-themes-flat .minimizedWindowObject .maximize {
    padding-top: 0px;
    margin-top: 1px;
    width: 20px;
    margin-right: 4px;
+}
+
+.rstudio-themes-flat .moduleTabPanel.minimizedWindowObject .maximize {
+   padding-top: 6px;
 }
 
 .rstudio-themes-flat .minimizedWindowObject .primaryWindowFrameHeader {

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1681,11 +1681,11 @@ body.ubuntu_mono .searchBox {
 }
 
 .rstudio-themes-flat .gwt-DialogBox {
-   border: solid 1px #bbbcbe;
+   border: solid 1px #9D9D9D;
    border-radius: 5px 5px 0px 0px;
    background: #F3F4F4;
    overflow: hidden !important;
-   box-shadow: 0 30px 30px rgba(0, 0, 0, 0.20);
+   box-shadow: 0 21px 21px rgba(0, 0, 0, 0.35);
 }
 
 .rstudio-themes-flat .gwt-DialogBox .dialogMiddleCenter {

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1777,6 +1777,10 @@ body.ubuntu_mono .searchBox {
    padding-top: 1px;
 }
 
+.rstudio-themes-flat .minimizedWindowObject .primaryWindowFrameHeader .title {
+   text-shadow: none;
+}
+
 .rstudio-themes-flat .search {
    top: 1px;
    height: 16px;

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1603,7 +1603,8 @@ body.ubuntu_mono .searchBox {
    top: 23px !important;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner > table > tbody > tr > td:first-child {
+.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner > table > tbody > tr > td:first-child,
+.rstudio-themes-flat .moduleTabPanel.minimizedWindowObject table.gwt-TabLayoutPanelTab > tbody > tr > td:first-child {
    display: none;
 }
 
@@ -1612,7 +1613,8 @@ body.ubuntu_mono .searchBox {
    display: none;
 }
 
-.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner > table > tbody > tr > td:last-child {
+.rstudio-themes-flat .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTabInner > table > tbody > tr > td:last-child,
+.rstudio-themes-flat .moduleTabPanel.minimizedWindowObject table.gwt-TabLayoutPanelTab > tbody > tr > td:last-child {
    display: none;
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteManager.java
@@ -42,6 +42,7 @@ import org.rstudio.studio.client.common.satellite.events.WindowClosedEvent;
 import org.rstudio.studio.client.common.satellite.events.WindowOpenedEvent;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.SessionInfo;
+import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.source.SourceWindowManager;
 
 import com.google.gwt.core.client.JavaScriptObject;
@@ -60,10 +61,12 @@ public class SatelliteManager implements CloseHandler<Window>
          Session session,
          EventBus events,
          Provider<SourceWindowManager> pSourceWindowManager,
-         Provider<ApplicationUncaughtExceptionHandler> pUncaughtExceptionHandler)
+         Provider<ApplicationUncaughtExceptionHandler> pUncaughtExceptionHandler,
+         Provider<UIPrefs> pUIPrefs)
    {
       session_ = session;
       events_ = events;
+      pUIPrefs_ = pUIPrefs;
       pSourceWindowManager_ = pSourceWindowManager;
       pUncaughtExceptionHandler_ = pUncaughtExceptionHandler;
       initializeCommonCallbacks();
@@ -278,6 +281,7 @@ public class SatelliteManager implements CloseHandler<Window>
                 !satellite.getWindow().isClosed())
             {
                satellite.getWindow().focus();
+
                break;
             }
          }   
@@ -466,6 +470,11 @@ public class SatelliteManager implements CloseHandler<Window>
       JavaScriptObject params = satelliteParams_.get(name);
       if (params != null)
          callSetParams(satelliteWnd, params);
+
+      // set themes
+      if (pUIPrefs_.get().getUseFlatThemes().getGlobalValue()) {
+         satellite.getWindow().getDocument().getBody().addClassName("rstudio-themes-flat");
+      }
    }
    
    // called to register child windows (not necessarily full-fledged 
@@ -709,7 +718,8 @@ public class SatelliteManager implements CloseHandler<Window>
       private final String name_;
       private final WindowEx window_;
    }
-   
+ 
+   private final Provider<UIPrefs> pUIPrefs_;
 }
 
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.css
@@ -2,6 +2,7 @@
 @eval fixedWidthFont org.rstudio.core.client.theme.ThemeFonts.getFixedWidthFont();
 
 @external gwt-SplitLayoutPanel-VDragger, gwt-SplitLayoutPanel-HDragger;
+@external rstudio-themes-flat;
 
 /** BEGIN SHARED BETWEEN HISTORY AND REVIEW PANELS **/
 
@@ -81,4 +82,8 @@
 .commitButton {
    float: right;
    margin-right: -1px;
+}
+
+.rstudio-themes-flat .commitButton {
+   margin-right: 0;
 }


### PR DESCRIPTION
A few more flat theme improvements.

1. Support for satellite windows:

<img width="933" alt="screen shot 2017-04-24 at 3 56 31 pm" src="https://cloud.githubusercontent.com/assets/3478847/25363100/15d91578-290d-11e7-875f-35dd1b3a8908.png">

2. Fix minimized panel tabs:

<img width="451" alt="screen shot 2017-04-24 at 3 56 44 pm" src="https://cloud.githubusercontent.com/assets/3478847/25363098/15d7e662-290d-11e7-8b5a-956b2527bf50.png">

3. 2x css triangle for file list grid:

<img width="177" alt="screen shot 2017-04-24 at 4 39 53 pm" src="https://cloud.githubusercontent.com/assets/3478847/25363099/15d81182-290d-11e7-8563-c3a90b70e662.png">

4. Adjust dialog shadow:

<img width="636" alt="screen shot 2017-04-24 at 9 11 27 pm" src="https://cloud.githubusercontent.com/assets/3478847/25368640/bd34b442-2932-11e7-823c-68e4583b4a57.png">

and fix to git commit button.