### PR TITLE
global option for console ANSI code behavior

### DIFF
--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -118,6 +118,7 @@ set (CORE_SOURCE_FILES
    tex/TexLogParser.cpp
    tex/TexMagicComment.cpp
    tex/TexSynctex.cpp
+   text/AnsiCodeParser.cpp
    text/DcfParser.cpp
    text/TemplateFilter.cpp
    text/TermBufferParser.cpp

--- a/src/cpp/core/include/core/text/AnsiCodeParser.hpp
+++ b/src/cpp/core/include/core/text/AnsiCodeParser.hpp
@@ -1,0 +1,40 @@
+/*
+ * AnsiCodeParser.hpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef ANSI_CODE_PARSER_HPP
+#define ANSI_CODE_PARSER_HPP
+
+namespace rstudio {
+namespace core {
+namespace text {
+
+enum AnsiCodeMode {
+   AnsiColorOff = 0,  // don't do any processing of ANSI escape codes
+   AnsiColorOn = 1,   // convert ANSI color escape codes into css styles
+   AnsiColorStrip = 2 // strip out ANSI escape sequences but don't apply styles
+};
+
+// Prevent build-time "no code" warning; this file will be used to implement
+// server-side ANSI code parser, which will be needed to ensure
+// notebook publishing can either ignore (strip-out) ANSI codes output by R
+// code using something like the Crayon package, or (ideally) implement
+// color support in the published output.
+bool ansiFuncPlaceholder();
+
+} // namespace text
+} // namespace core
+} // namespace rstudio
+
+#endif // ANSI_CODE_PARSER_HPP

--- a/src/cpp/core/text/AnsiCodeParser.cpp
+++ b/src/cpp/core/text/AnsiCodeParser.cpp
@@ -1,0 +1,29 @@
+/*
+ * AnsiCodeParser.cpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <core/text/AnsiCodeParser.hpp>
+
+namespace rstudio {
+namespace core {
+namespace text {
+
+bool ansiFuncPlaceholder()
+{
+   return true;
+}
+
+} // namespace text
+} // namespace core
+} // namespace rstudio

--- a/src/cpp/core/text/AnsiCodeParserTests.cpp
+++ b/src/cpp/core/text/AnsiCodeParserTests.cpp
@@ -1,0 +1,36 @@
+/*
+ * AnsiCodeParserTests.cpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <core/text/AnsiCodeParser.hpp>
+
+#include <tests/TestThat.hpp>
+
+namespace rstudio {
+namespace core {
+namespace text {
+namespace tests {
+
+context("Ansi Code Parsing")
+{
+   test_that("placeholder compiles")
+   {
+      expect_true(ansiFuncPlaceholder());
+   }
+}
+
+} // end namespace tests
+} // end namespace text
+} // end namespace core
+} // end namespace rstudio

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1546,10 +1546,13 @@ int main (int argc, char * const argv[])
 
       // environment variables so child processes know of ANSI color
       // escape sequence support in console
-      if (options.defaultConsoleTerm().length() > 0)
-         core::system::setenv("TERM", options.defaultConsoleTerm());
-      if (options.defaultCliColorForce())
-         core::system::setenv("CLICOLOR_FORCE", "1");
+      if (userSettings().ansiConsoleMode() == core::text::AnsiColorOn)
+      {
+         if (options.defaultConsoleTerm().length() > 0)
+            core::system::setenv("TERM", options.defaultConsoleTerm());
+         if (options.defaultCliColorForce())
+            core::system::setenv("CLICOLOR_FORCE", "1");
+      }
 
       // set the rstudio user identity environment variable (can differ from
       // username in debug configurations). this is provided so that 

--- a/src/cpp/session/SessionUserSettings.cpp
+++ b/src/cpp/session/SessionUserSettings.cpp
@@ -382,6 +382,9 @@ void UserSettings::updatePrefsCache(const json::Object& prefs) const
 
    bool enableStyleDiagnostics = readPref<bool>(prefs, "enable_style_diagnostics", false);
    pEnableStyleDiagnostics_.reset(new bool(enableStyleDiagnostics));
+
+   int ansiConsoleMode = readPref<int>(prefs, "ansi_console_mode", core::text::AnsiColorOn);
+   pAnsiConsoleMode_.reset(new int(ansiConsoleMode));
 }
 
 
@@ -554,6 +557,11 @@ void UserSettings::setDefaultTerminalShellValue(
 core::FilePath UserSettings::initialWorkingDirectory() const
 {
    return getWorkingDirectoryValue(kInitialWorkingDirectory);
+}
+
+core::text::AnsiCodeMode UserSettings::ansiConsoleMode() const
+{
+   return static_cast<core::text::AnsiCodeMode>(readUiPref<int>(pAnsiConsoleMode_));
 }
 
 CRANMirror UserSettings::cranMirror() const

--- a/src/cpp/session/include/session/SessionUserSettings.hpp
+++ b/src/cpp/session/include/session/SessionUserSettings.hpp
@@ -25,6 +25,7 @@
 #include <core/Settings.hpp>
 #include <core/FilePath.hpp>
 #include <core/StringUtils.hpp>
+#include <core/text/AnsiCodeParser.hpp>
 
 #include <core/json/Json.hpp>
 
@@ -102,6 +103,7 @@ public:
    bool handleErrorsInUserCodeOnly() const;
    int shinyViewerType() const;
    bool enableRSConnectUI() const;
+   core::text::AnsiCodeMode ansiConsoleMode() const;
 
    bool rProfileOnResume() const;
    void setRprofileOnResume(bool rProfileOnResume);
@@ -252,6 +254,7 @@ private:
    mutable boost::scoped_ptr<bool> pHandleErrorsInUserCodeOnly_;
    mutable boost::scoped_ptr<int> pShinyViewerType_;
    mutable boost::scoped_ptr<bool> pEnableRSConnectUI_;
+   mutable boost::scoped_ptr<int> pAnsiConsoleMode_;
    
    // diagnostic-related prefs
    mutable boost::scoped_ptr<bool> pLintRFunctionCalls_;

--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -41,6 +41,9 @@ import com.google.inject.Inject;
 public class VirtualConsole
 {
    // don't do any processing of ANSI escape codes
+    private final static int ANSI_COLOR_UNSET = -1;
+
+   // don't do any processing of ANSI escape codes
    public final static int ANSI_COLOR_OFF = 0;
    
    // convert ANSI color escape codes into css styles
@@ -51,12 +54,12 @@ public class VirtualConsole
   
    public VirtualConsole()
    {
-      this(null, ANSI_COLOR_ON);
+      this(null);
    }
    
    public VirtualConsole(Element parent)
    {
-      this(parent, ANSI_COLOR_ON);
+      this(parent, ANSI_COLOR_UNSET);
    }
 
    /**
@@ -71,6 +74,8 @@ public class VirtualConsole
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
       parent_ = parent;
+      if (ansiColorMode == ANSI_COLOR_UNSET)
+         ansiColorMode = prefs_.consoleAnsiMode().getValue();
       ansiColorMode_ = ansiColorMode;
    }
     

--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -40,8 +40,8 @@ import com.google.inject.Inject;
  */
 public class VirtualConsole
 {
-   // don't do any processing of ANSI escape codes
-    private final static int ANSI_COLOR_UNSET = -1;
+   // use preference to determine ANSI color behavior
+   private final static int ANSI_COLOR_UNSET = -1;
 
    // don't do any processing of ANSI escape codes
    public final static int ANSI_COLOR_OFF = 0;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
@@ -290,6 +290,10 @@ public class UIPrefs extends UIPrefsAccessor implements UiPrefsChangedHandler
          truncateLongLinesInConsoleHistory().setGlobalValue(
                              newUiPrefs.truncateLongLinesInConsoleHistory().getGlobalValue());
          
+         // console handling of ANSI escape codes
+         consoleAnsiMode().setGlobalValue(
+               newUiPrefs.consoleAnsiMode().getGlobalValue());
+         
          // chunk toolbar
          showInlineToolbarForRCodeChunks().setGlobalValue(
                newUiPrefs.showInlineToolbarForRCodeChunks().getGlobalValue());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.prefs.model;
 
+import org.rstudio.core.client.VirtualConsole;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.notebook.CompileNotebookPrefs;
@@ -303,6 +304,11 @@ public class UIPrefsAccessor extends Prefs
    public PrefValue<Integer> truncateLongLinesInConsoleHistory()
    {
       return integer("truncate_long_lines_in_console", 1000);
+   }
+   
+   public PrefValue<Integer> consoleAnsiMode()
+   {
+      return integer("ansi_console_mode", VirtualConsole.ANSI_COLOR_ON);
    }
    
    public PrefValue<Boolean> showInlineToolbarForRCodeChunks()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -29,6 +29,7 @@ import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.inject.Inject;
 
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.VirtualConsole;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.command.ShortcutManager;
 import org.rstudio.core.client.prefs.PreferencesDialogBaseResources;
@@ -216,7 +217,24 @@ public class EditingPreferencesPane extends PreferencesPane
       NumericValueWidget limitLengthPref =
             numericPref("Limit length of lines displayed in console to:", prefs_.truncateLongLinesInConsoleHistory());
       limitLengthPref.setWidth("36px");
-      displayPanel.add(limitLengthPref);
+      displayPanel.add(nudgeRightPlus(limitLengthPref));
+
+      consoleColorMode_ = new SelectWidget(
+            "ANSI Escape Codes:",
+            new String[] {
+                  "Show ANSI colors",
+                  "Remove ANSI codes",
+                  "Ignore ANSI codes (1.0 behavior)"
+            },
+            new String[] {
+                  Integer.toString(VirtualConsole.ANSI_COLOR_ON), 
+                  Integer.toString(VirtualConsole.ANSI_COLOR_STRIP),
+                  Integer.toString(VirtualConsole.ANSI_COLOR_OFF)
+            },
+            false,
+            true,
+            false);
+      displayPanel.add(consoleColorMode_);
       
       VerticalPanel savePanel = new VerticalPanel();
       
@@ -463,6 +481,7 @@ public class EditingPreferencesPane extends PreferencesPane
       // editing prefs
       EditingPrefs editingPrefs = prefs.getEditingPrefs();
       lineEndings_.setIntValue(editingPrefs.getLineEndings());
+      consoleColorMode_.setValue(Integer.toString(prefs_.consoleAnsiMode().getValue()));
       
       showCompletions_.setValue(prefs_.codeComplete().getValue());
       showCompletionsOther_.setValue(prefs_.codeCompleteOther().getValue());
@@ -485,6 +504,8 @@ public class EditingPreferencesPane extends PreferencesPane
       
       // editing prefs
       prefs.setEditingPrefs(EditingPrefs.create(lineEndings_.getIntValue()));
+      prefs_.consoleAnsiMode().setGlobalValue(StringUtil.parseInt(
+            consoleColorMode_.getValue(), VirtualConsole.ANSI_COLOR_ON));
                       
       prefs_.defaultEncoding().setGlobalValue(encodingValue_);
       
@@ -557,6 +578,7 @@ public class EditingPreferencesPane extends PreferencesPane
    private final SelectWidget showCompletionsOther_;
    private final SelectWidget editorMode_;
    private final SelectWidget foldMode_;
+   private final SelectWidget consoleColorMode_;
    private final SelectWidget delimiterSurroundWidget_;
    private final SelectWidget executionBehavior_;
    private final TextBoxWithButton encoding_;


### PR DESCRIPTION
New user preference to control Console's handling of ANSI escape characters. I'm not happy with the wording of these in the UI, so suggestions welcome as always:

1. Show ANSI Colors -- this is new default (at least at the moment) and converts ANSI style codes for colors, bold, etc. on Console output
2. Remove ANSI codes -- this still parses the ANSI codes, if present, but discards them rather than applying any styles
3. Ignore ANSI codes -- this is how RStudio 1.0 behaves; if ANSI codes are output to the console, they will be displayed as codes and not interpreted at all

Switching between these doesn't change anything already displayed, you need to refresh the IDE to have that happen, but will impact new output without refreshing.

Also added stub for server-side ANSI code processing; expect to implement this to have Notebooks deal with ANSI codes in published output (support them or at least strip them).

![image](https://cloud.githubusercontent.com/assets/10569626/25402024/5f0b3f06-29ac-11e7-9057-fe6d35167602.png)
