### PR TITLE
user option and feature limit for terminal websockets vs. RPC

### DIFF
--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -312,6 +312,7 @@ void handleClientInit(const boost::function<void()>& initFunction,
    sessionInfo["allow_vcs"] = options.allowVcs();
    sessionInfo["allow_pkg_install"] = options.allowPackageInstallation();
    sessionInfo["allow_shell"] = options.allowShell();
+   sessionInfo["allow_terminal_websockets"] = options.allowTerminalWebsockets();
    sessionInfo["allow_file_download"] = options.allowFileDownloads();
    sessionInfo["allow_file_upload"] = options.allowFileUploads();
    sessionInfo["allow_remove_public_folder"] = options.allowRemovePublicFolder();

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -205,9 +205,6 @@ core::ProgramStatus Options::read(int argc, char * const argv[])
       ("show-help-home",
        value<bool>(&showHelpHome_)->default_value(false),
          "show help home page at startup")
-      ("session-use-terminal-websockets",
-          value<bool>(&useTerminalWebsockets_)->default_value(true),
-          "try to communicate with terminal using websockets")
       ("session-default-console-term",
        value<std::string>(&defaultConsoleTerm_)->default_value("xterm-256color"),
        "default TERM setting for R console")
@@ -233,6 +230,9 @@ core::ProgramStatus Options::read(int argc, char * const argv[])
       ("allow-shell",
          value<bool>(&allowShell_)->default_value(true),
          "allow access to shell dialog")
+      ("allow-terminal-websockets",
+         value<bool>(&allowTerminalWebsockets_)->default_value(true),
+         "allow connection to terminal sessions with websockets")
       ("allow-file-downloads",
          value<bool>(&allowFileDownloads_)->default_value(true),
          "allow file downloads from the files pane")

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -164,8 +164,6 @@ public:
 
    bool showUserHomePage() const { return showUserHomePage_; }
    
-   bool useTerminalWebsockets() const { return useTerminalWebsockets_; }
-
    std::string defaultConsoleTerm() const { return defaultConsoleTerm_; }
    bool defaultCliColorForce() const { return defaultCliColorForce_; }
 
@@ -319,6 +317,11 @@ public:
    bool allowShell() const
    {
       return allowOverlay() || allowShell_;
+   }
+
+   bool allowTerminalWebsockets() const
+   {
+      return allowOverlay() || allowTerminalWebsockets_;
    }
 
    bool allowPackageInstallation() const
@@ -546,7 +549,6 @@ private:
    bool createProfile_;
    bool createPublicFolder_;
    bool rProfileOnResumeDefault_;
-   bool useTerminalWebsockets_;
    int saveActionDefault_;
    bool standalone_;
    std::string authRequiredUserGroup_;
@@ -600,6 +602,7 @@ private:
    bool allowFileDownloads_;
    bool allowFileUploads_;
    bool allowShell_;
+   bool allowTerminalWebsockets_;
    bool allowPackageInstallation_;
    bool allowVcs_;
    bool allowCRANReposEdit_;

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -889,6 +889,7 @@ Error startTerminal(const json::JsonRpcRequest& request,
    std::string termHandle; // empty if starting a new terminal
    std::string termCaption;
    std::string termTitle;
+   bool useWebsockets;
    int termSequence = kNoTerminal;
    
    Error error = json::readParams(request.params,
@@ -898,6 +899,7 @@ Error startTerminal(const json::JsonRpcRequest& request,
                                   &termHandle,
                                   &termCaption,
                                   &termTitle,
+                                  &useWebsockets,
                                   &termSequence);
    if (error)
       return error;
@@ -970,9 +972,9 @@ Error startTerminal(const json::JsonRpcRequest& request,
             console_process::kDefaultTerminalMaxOutputLines);
 
    // run process
-   bool useWebsockets = session::options().useTerminalWebsockets();
+   bool websockets = session::options().allowTerminalWebsockets() && useWebsockets;
    boost::shared_ptr<ConsoleProcess> ptrProc =
-               ConsoleProcess::createTerminalProcess(options, ptrProcInfo, useWebsockets);
+               ConsoleProcess::createTerminalProcess(options, ptrProcInfo, websockets);
 
    ptrProc->onExit().connect(boost::bind(
                               &source_control::enqueueRefreshEvent));

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -496,6 +496,7 @@ public class RemoteServer implements Server
                      String terminalHandle,
                      String caption,
                      String title,
+                     boolean websocket,
                      int sequence,
                      ServerRequestCallback<ConsoleProcess> requestCallback)
    {
@@ -506,7 +507,8 @@ public class RemoteServer implements Server
       params.set(3, new JSONString(StringUtil.notNull(terminalHandle)));
       params.set(4, new JSONString(StringUtil.notNull(caption)));
       params.set(5, new JSONString(StringUtil.notNull(title)));
-      params.set(6, new JSONNumber(sequence));
+      params.set(6, JSONBoolean.getInstance(websocket));
+      params.set(7, new JSONNumber(sequence));
 
       sendRequest(RPC_SCOPE,
                   START_TERMINAL,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -350,6 +350,10 @@ public class SessionInfo extends JavaScriptObject
    public final native boolean getAllowShell() /*-{
       return this.allow_shell;
    }-*/;
+
+   public final native boolean getAllowTerminalWebsockets() /*-{
+      return this.allow_terminal_websockets;
+   }-*/;
    
    public final native boolean getAllowFileDownloads() /*-{
       return this.allow_file_download;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchServerOperations.java
@@ -144,11 +144,12 @@ public interface WorkbenchServerOperations extends ConsoleServerOperations,
     * @param handle initial terminal handle (pass empty or null string for new terminal)
     * @param caption caption associated with the terminal
     * @param title title associated with the terminal
+    * @param websocket try to connect via WebSocket
     * @param sequence relative order of terminal creation (1-based)
     * @param requestCallback callback from server upon completion
     */
    void startTerminal(int shellType, int cols, int rows, String handle, 
-                      String caption, String title, int sequence, 
+                      String caption, String title, boolean websocket, int sequence, 
                       ServerRequestCallback<ConsoleProcess> requestCallback);
    
    void executeCode(String code, ServerRequestCallback<Void> requestCallback);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/TerminalPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/TerminalPrefs.java
@@ -24,7 +24,7 @@ public class TerminalPrefs extends JavaScriptObject
    public static final native TerminalPrefs create(int defaultShell) /*-{
       var prefs = new Object();
       prefs.default_shell = defaultShell;
-      return prefs ;
+      return prefs;
    }-*/;
 
    public native final int getDefaultTerminalShellValue() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
@@ -209,6 +209,9 @@ public class UIPrefs extends UIPrefsAccessor implements UiPrefsChangedHandler
          terminalLocalEcho().setGlobalValue(
                                  newUiPrefs.terminalLocalEcho().getGlobalValue());
          
+         terminalUseWebsockets().setGlobalValue(
+                                 newUiPrefs.terminalUseWebsockets().getGlobalValue());
+         
          /* Diagnostics */
          
          // R Diagnostics

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -605,6 +605,11 @@ public class UIPrefsAccessor extends Prefs
       return bool("terminal_local_echo", true);
    }
    
+   public PrefValue<Boolean> terminalUseWebsockets()
+   {
+      return bool("terminal_websockets", true);
+   }
+   
    public static final String KNIT_DIR_DEFAULT = "default";
    public static final String KNIT_DIR_CURRENT = "current";
    public static final String KNIT_DIR_PROJECT = "project";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/TerminalPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/TerminalPreferencesPane.java
@@ -47,6 +47,7 @@ public class TerminalPreferencesPane extends PreferencesPane
    {
       prefs_ = prefs;
       res_ = res;
+      session_ = session;
       server_ = server;
 
       add(spaced(new Label("Use the terminal to run system commands, execute data-processing jobs, and more.")));
@@ -64,6 +65,13 @@ public class TerminalPreferencesPane extends PreferencesPane
                prefs_.terminalLocalEcho(), 
                "Local echo is more responsive but may get out of sync with some line-editing modes.");
          add(chkTerminalLocalEcho);
+      }
+      if (haveWebsocketPref())
+      {
+         CheckBox chkTerminalWebsocket = checkboxPref("Connect with WebSockets",
+               prefs_.terminalUseWebsockets(), 
+               "WebSockets are generally more responsive; try turning off if terminal won't connect.");
+         add(chkTerminalWebsocket);
       }
       
       HelpLink helpLink = new HelpLink("Using the RStudio terminal", "rstudio_terminal", false);
@@ -158,11 +166,17 @@ public class TerminalPreferencesPane extends PreferencesPane
    {
       return !BrowseCap.isWindowsDesktop();
    }
+   
+   private boolean haveWebsocketPref()
+   {
+      return session_.getSessionInfo().getAllowTerminalWebsockets();
+   }
  
    private SelectWidget terminalShell_;
 
    // Injected ----  
    private final UIPrefs prefs_;
    private final PreferencesDialogResources res_;
+   private final Session session_;
    private final Server server_;
  }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -126,7 +126,8 @@ public class TerminalSession extends XTermWidget
 
       server_.startTerminal(getShellType(),
             getCols(), getRows(), getHandle(), getCaption(), 
-            getTitle(), getSequence(), new ServerRequestCallback<ConsoleProcess>()
+            getTitle(), uiPrefs_.terminalUseWebsockets().getValue(), 
+            getSequence(), new ServerRequestCallback<ConsoleProcess>()
       {
          @Override
          public void onResponseReceived(ConsoleProcess consoleProcess)


### PR DESCRIPTION
- Add user preference for turning off websockets when connecting terminals
- Add feature limit (allow-terminal-websockets) for server-wide disabling of websockets
- User preference checkbox hidden if websockets are disabled on server
![image](https://cloud.githubusercontent.com/assets/10569626/25414376/0fab225c-29e6-11e7-9af2-abdec5cde8f0.png)
