### PR TITLE
Add Ubuntu Xenial builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,8 +101,9 @@ try {
           //[os: 'centos5', arch: 'x86_64', flavor: 'server'],
           //[os: 'centos5', arch: 'i386', flavor: 'server'],
           [os: 'centos7', arch: 'x86_64', flavor: 'desktop'],
-          [os: 'centos7', arch: 'i386', flavor: 'desktop']
-
+          [os: 'centos7', arch: 'i386', flavor: 'desktop'],
+          [os: 'xenial', arch: 'x86_64', flavor: 'server'],
+          [os: 'xenial', arch: 'i386', flavor: 'server']
         ]
         containers = limit_builds(containers)
         def parallel_containers = [:]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,10 +20,10 @@ def resolve_deps(type, arch) {
   def linux_bin = (arch=='i386') ? 'linux32' : '' // only required in centos-land.
   switch ( type ) {
       case "DEB":
-        sh "cd dependencies/linux && ./install-dependencies-debian && cd ../.."
+        sh "cd dependencies/linux && ./install-dependencies-debian --exclude-qt-sdk && cd ../.."
         break
       case "RPM":
-        sh "cd dependencies/linux && ${linux_bin} ./install-dependencies-yum && cd ../.."
+        sh "cd dependencies/linux && ${linux_bin} ./install-dependencies-yum --exclude-qt-sdk && cd ../.."
         break
   }
 }

--- a/dependencies/linux/install-qt-sdk
+++ b/dependencies/linux/install-qt-sdk
@@ -39,7 +39,7 @@ if ! test -e $QT_SDK_DIR
 then
    # download and install
    wget $QT_SDK_URL -O /tmp/$QT_SDK_BINARY
-   cd ~
+   cd `dirname $QT_SDK_DIR`
    tar xzf /tmp/$QT_SDK_BINARY
    rm /tmp/$QT_SDK_BINARY
 else

--- a/docker-compile.sh
+++ b/docker-compile.sh
@@ -28,10 +28,10 @@ REPO=$(basename $(pwd))
 # check to see if there's already a built image
 IMAGEID=`docker images $REPO:$IMAGE --format "{{.ID}}"`
 if [ -z "$IMAGEID" ]; then
-    echo "No image found for $REPO:$IMAGE; building..."
+    echo "No image found for $REPO:$IMAGE. Building..."
     docker build --tag "$REPO:$IMAGE" --file "docker/jenkins/Dockerfile.$IMAGE" .
 else
-    echo "Using image $IMAGEID for $REPO:$IMAGE."
+    echo "Found image $IMAGEID for $REPO:$IMAGE"
 fi
 
 # infer the package extension from the image name
@@ -48,8 +48,6 @@ if [ -n "$VERSION" ]; then
     ENV="RSTUDIO_VERSION_MAJOR=${SPLIT[0]} RSTUDIO_VERSION_MINOR=${SPLIT[1]} RSTUDIO_VERSION_PATCH=${SPLIT[2]}"
 fi
 
-echo $IMAGE $FLAVOR $VERSION $PACKAGE $INSTALLER $ENV
-
 # run compile step
-# docker run -v $(pwd):/src --user jenkins $REPO:$IMAGE bash -c "cd /src/dependencies/linux && ./install-dependencies-$INSTALLER --exclude-qt-sdk && cd /src/package/linux && ./make-$FLAVOR-package $PACKAGE"
+docker run -v $(pwd):/src --user jenkins $REPO:$IMAGE bash -c "cd /src/dependencies/linux && ./install-dependencies-$INSTALLER --exclude-qt-sdk && cd /src/package/linux && ./make-$FLAVOR-package $PACKAGE"
 

--- a/docker-compile.sh
+++ b/docker-compile.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# friendly names for arguments
+IMAGE=$1
+FLAVOR=$2
+VERSION=$3
+
+# abort on error
+set -e
+
+# print usage if no argument supplied
+if [ -z "$IMAGE" ] || [ -z "$FLAVOR" ]; then
+    echo -e "Compiles RStudio inside a Docker container."
+    echo -e "Usage: docker-compile image-name flavor-name [version]\n"
+    echo -e "Valid images:\n"
+    ls -f docker/jenkins/Dockerfile.* | sed -e 's/.*Dockerfile.//'
+    echo -e "\nValid flavors:\n"
+    echo -e "desktop"
+    echo -e "server"
+    exit 1
+fi
+
+# make sure we're running from the directory of this script, and infer the 
+# name of the repository
+cd "$(dirname ${BASH_SOURCE[0]})"
+REPO=$(basename $(pwd))
+
+# check to see if there's already a built image
+IMAGEID=`docker images $REPO:$IMAGE --format "{{.ID}}"`
+if [ -z "$IMAGEID" ]; then
+    echo "No image found for $REPO:$IMAGE; building..."
+    docker build --tag "$REPO:$IMAGE" --file "docker/jenkins/Dockerfile.$IMAGE" .
+else
+    echo "Using image $IMAGEID for $REPO:$IMAGE."
+fi
+
+# infer the package extension from the image name
+if [ "${IMAGE:0:6}" = "centos" ]; then
+    PACKAGE=RPM
+    INSTALLER=yum
+else
+    PACKAGE=DEB
+    INSTALLER=debian
+fi
+
+if [ -n "$VERSION" ]; then 
+    SPLIT=(${VERSION//\./ })
+    ENV="RSTUDIO_VERSION_MAJOR=${SPLIT[0]} RSTUDIO_VERSION_MINOR=${SPLIT[1]} RSTUDIO_VERSION_PATCH=${SPLIT[2]}"
+fi
+
+echo $IMAGE $FLAVOR $VERSION $PACKAGE $INSTALLER $ENV
+
+# run compile step
+# docker run -v $(pwd):/src --user jenkins $REPO:$IMAGE bash -c "cd /src/dependencies/linux && ./install-dependencies-$INSTALLER --exclude-qt-sdk && cd /src/package/linux && ./make-$FLAVOR-package $PACKAGE"
+

--- a/docker/docker-compile.sh
+++ b/docker/docker-compile.sh
@@ -75,5 +75,5 @@ if [ -n "$VERSION" ]; then
 fi
 
 # run compile step
-docker run -v $(pwd):/src $REPO:$IMAGE bash -c "cd /src/dependencies/linux && ./install-dependencies-$INSTALLER --exclude-qt-sdk && cd /src/package/linux && ./make-$FLAVOR-package $PACKAGE"
+docker run --rm -v $(pwd):/src $REPO:$IMAGE bash -c "cd /src/dependencies/linux && ./install-dependencies-$INSTALLER --exclude-qt-sdk && cd /src/package/linux && ./make-$FLAVOR-package $PACKAGE"
 

--- a/docker/docker-compile.sh
+++ b/docker/docker-compile.sh
@@ -21,6 +21,11 @@
 # will produce an RPM of RStudio Desktop from the 64bit CentOS 7 container, 
 # with build version 1.2.345, in your package/linux/ directory.
 #
+# For convenience, this script will build the required image if it doesn't
+# exist, but for efficiency, this script does not attempt rebuild the image if
+# it's already built. If you're iterating on the Dockerfiles themselves, you'll
+# want to use "docker build" directly until you're happy with the
+# configuration, then use this script to test a build under the new config.
 
 # friendly names for arguments
 IMAGE=$1
@@ -70,5 +75,5 @@ if [ -n "$VERSION" ]; then
 fi
 
 # run compile step
-docker run -v $(pwd):/src --user jenkins $REPO:$IMAGE bash -c "cd /src/dependencies/linux && ./install-dependencies-$INSTALLER --exclude-qt-sdk && cd /src/package/linux && ./make-$FLAVOR-package $PACKAGE"
+docker run -v $(pwd):/src $REPO:$IMAGE bash -c "cd /src/dependencies/linux && ./install-dependencies-$INSTALLER --exclude-qt-sdk && cd /src/package/linux && ./make-$FLAVOR-package $PACKAGE"
 

--- a/docker/docker-compile.sh
+++ b/docker/docker-compile.sh
@@ -1,5 +1,27 @@
 #!/usr/bin/env bash
 
+# RStudio Docker Compilation Helper
+#
+# The purpose of this script is to make it easy to compile under Docker on 
+# a development machine, so it's easy to iterate when making platform-specific
+# changes or configuration changes.
+# 
+# The syntax is as follows:
+#
+#     docker-compile.sh IMAGE-NAME FLAVOR-NAME [VERSION]
+#
+# where the image name is the platform and architecture, the flavor name is
+# the kind of package you wish to build (desktop or server), and the version
+# is the number to assign to the resulting build.
+#
+# For example:
+# 
+#     docker-compile.sh centos7-amd64 desktop 1.2.345
+#
+# will produce an RPM of RStudio Desktop from the 64bit CentOS 7 container, 
+# with build version 1.2.345, in your package/linux/ directory.
+#
+
 # friendly names for arguments
 IMAGE=$1
 FLAVOR=$2
@@ -8,10 +30,14 @@ VERSION=$3
 # abort on error
 set -e
 
+# move to the repo root (script's grandparent directory)
+cd "$(dirname ${BASH_SOURCE[0]})/.."
+REPO=$(basename $(pwd))
+
 # print usage if no argument supplied
 if [ -z "$IMAGE" ] || [ -z "$FLAVOR" ]; then
     echo -e "Compiles RStudio inside a Docker container."
-    echo -e "Usage: docker-compile image-name flavor-name [version]\n"
+    echo -e "Usage: docker-compile.sh image-name flavor-name [version]\n"
     echo -e "Valid images:\n"
     ls -f docker/jenkins/Dockerfile.* | sed -e 's/.*Dockerfile.//'
     echo -e "\nValid flavors:\n"
@@ -19,11 +45,6 @@ if [ -z "$IMAGE" ] || [ -z "$FLAVOR" ]; then
     echo -e "server"
     exit 1
 fi
-
-# make sure we're running from the directory of this script, and infer the 
-# name of the repository
-cd "$(dirname ${BASH_SOURCE[0]})"
-REPO=$(basename $(pwd))
 
 # check to see if there's already a built image
 IMAGEID=`docker images $REPO:$IMAGE --format "{{.ID}}"`

--- a/docker/jenkins/Dockerfile.centos7-i386
+++ b/docker/jenkins/Dockerfile.centos7-i386
@@ -111,6 +111,12 @@ RUN wget http://dl.fedoraproject.org/pub/epel/7/SRPMS/f/fakeroot-1.18.4-2.el7.sr
 # remove users/groups with colliding jenkins ids
 RUN userdel systemd-bus-proxy && userdel systemd-network && groupdel input
 
+# install Qt SDK
+COPY dependencies/linux/install-qt-sdk /tmp/
+RUN mkdir -p /opt/RStudio-QtSDK && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.4.0 && \
+    /tmp/install-qt-sdk
+
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
 ARG JENKINS_GID=999
 ARG JENKINS_UID=999

--- a/docker/jenkins/Dockerfile.centos7-x86_64
+++ b/docker/jenkins/Dockerfile.centos7-x86_64
@@ -43,6 +43,12 @@ RUN bash /tmp/install-dependencies
 # remove users/groups with colliding jenkins ids
 RUN userdel systemd-bus-proxy && userdel systemd-network && groupdel input
 
+# install Qt SDK
+COPY dependencies/linux/install-qt-sdk /tmp/
+RUN mkdir -p /opt/RStudio-QtSDK && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.4.0 && \
+    /tmp/install-qt-sdk
+
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
 ARG JENKINS_GID=999
 ARG JENKINS_UID=999

--- a/docker/jenkins/Dockerfile.precise-amd64
+++ b/docker/jenkins/Dockerfile.precise-amd64
@@ -49,6 +49,12 @@ RUN bash /tmp/install-boost || bash /tmp/install-boost
 COPY package/linux/install-dependencies /tmp/
 RUN bash /tmp/install-dependencies
 
+# install Qt SDK
+COPY dependencies/linux/install-qt-sdk /tmp/
+RUN mkdir -p /opt/RStudio-QtSDK && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.4.0 && \
+    /tmp/install-qt-sdk
+
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
 ARG JENKINS_GID=999
 ARG JENKINS_UID=999

--- a/docker/jenkins/Dockerfile.precise-i386
+++ b/docker/jenkins/Dockerfile.precise-i386
@@ -49,6 +49,12 @@ RUN bash /tmp/install-boost || bash /tmp/install-boost
 COPY package/linux/install-dependencies /tmp/
 RUN bash /tmp/install-dependencies
 
+# install Qt SDK
+COPY dependencies/linux/install-qt-sdk /tmp/
+RUN mkdir -p /opt/RStudio-QtSDK && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.4.0 && \
+    /tmp/install-qt-sdk
+
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
 ARG JENKINS_GID=999
 ARG JENKINS_UID=999

--- a/docker/jenkins/Dockerfile.xenial-amd64
+++ b/docker/jenkins/Dockerfile.xenial-amd64
@@ -1,0 +1,60 @@
+FROM ubuntu:xenial
+
+ARG AWS_REGION=us-east-1
+
+# install needed packages. replace httpredir apt source with cloudfront
+RUN set -x \
+    && sed -i "s/archive.ubuntu.com/$AWS_REGION.ec2.archive.ubuntu.com/" /etc/apt/sources.list \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9 \
+    && echo 'deb http://cran.rstudio.com/bin/linux/ubuntu xenial/' >> /etc/apt/sources.list \
+    && apt-get update
+
+RUN apt-get update \
+  && apt-get install -y \
+    ant \
+    apparmor-utils \
+    build-essential \
+    cmake \
+    fakeroot \
+    git-core \
+    libapparmor1 \
+    libbz2-dev \
+    libgl1-mesa-dev \
+    libgstreamer-plugins-base1.0-0 \
+    libgstreamer1.0-0 \
+    libjpeg62 \
+    libpam-dev \
+    libpango1.0-dev \
+    libssl-dev \
+    libxslt1-dev \
+    openjdk-8-jdk \
+    pkg-config \
+    r-base \
+    sudo \
+    unzip \
+    uuid-dev \
+    wget \
+    zlib1g-dev
+
+## run install-boost twice - boost exits 1 even though it has installed good enough for our uses.
+## https://github.com/rstudio/rstudio/blob/master/vagrant/provision-primary-user.sh#L12-L15
+COPY dependencies/common/install-boost /tmp/
+RUN bash /tmp/install-boost || bash /tmp/install-boost
+
+# install cmake
+COPY package/linux/install-dependencies /tmp/
+RUN /bin/bash /tmp/install-dependencies
+
+# install Qt SDK
+COPY dependencies/linux/install-qt-sdk /tmp/
+RUN mkdir -p /opt/RStudio-QtSDK && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.4.0 && \
+    /tmp/install-qt-sdk
+
+# create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
+ARG JENKINS_GID=999
+ARG JENKINS_UID=999
+RUN groupadd -g $JENKINS_GID jenkins && \
+    useradd -m -d /var/lib/jenkins -u $JENKINS_UID -g jenkins jenkins && \
+    echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers

--- a/docker/jenkins/Dockerfile.xenial-i386
+++ b/docker/jenkins/Dockerfile.xenial-i386
@@ -1,0 +1,60 @@
+FROM ioft/i386-ubuntu:i386
+
+ARG AWS_REGION=us-east-1
+
+# install needed packages. replace httpredir apt source with cloudfront
+RUN set -x \
+    && sed -i "s/archive.ubuntu.com/$AWS_REGION.ec2.archive.ubuntu.com/" /etc/apt/sources.list \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9 \
+    && echo 'deb http://cran.rstudio.com/bin/linux/ubuntu xenial/' >> /etc/apt/sources.list \
+    && apt-get update
+
+RUN apt-get update \
+  && apt-get install -y \
+    ant \
+    apparmor-utils \
+    build-essential \
+    cmake \
+    fakeroot \
+    git-core \
+    libapparmor1 \
+    libbz2-dev \
+    libgl1-mesa-dev \
+    libgstreamer-plugins-base1.0-0 \
+    libgstreamer1.0-0 \
+    libjpeg62 \
+    libpam-dev \
+    libpango1.0-dev \
+    libssl-dev \
+    libxslt1-dev \
+    openjdk-8-jdk \
+    pkg-config \
+    r-base \
+    sudo \
+    unzip \
+    uuid-dev \
+    wget \
+    zlib1g-dev
+
+## run install-boost twice - boost exits 1 even though it has installed good enough for our uses.
+## https://github.com/rstudio/rstudio/blob/master/vagrant/provision-primary-user.sh#L12-L15
+COPY dependencies/common/install-boost /tmp/
+RUN bash /tmp/install-boost || bash /tmp/install-boost
+
+# install cmake
+COPY package/linux/install-dependencies /tmp/
+RUN /bin/bash /tmp/install-dependencies
+
+# install Qt SDK
+COPY dependencies/linux/install-qt-sdk /tmp/
+RUN mkdir -p /opt/RStudio-QtSDK && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.4.0 && \
+    /tmp/install-qt-sdk
+
+# create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
+ARG JENKINS_GID=999
+ARG JENKINS_UID=999
+RUN groupadd -g $JENKINS_GID jenkins && \
+    useradd -m -d /var/lib/jenkins -u $JENKINS_UID -g jenkins jenkins && \
+    echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers

--- a/docker/jenkins/Dockerfile.xenial-i386
+++ b/docker/jenkins/Dockerfile.xenial-i386
@@ -1,4 +1,4 @@
-FROM ioft/i386-ubuntu:i386
+FROM ioft/i386-ubuntu:xenial
 
 ARG AWS_REGION=us-east-1
 

--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -44,7 +44,7 @@ if(NOT WIN32)
          endif()
       endif()
 
-      set(QMAKE_QT50_SDK "/opt/RStudio-QtSDK/${QT_VERSION}/${QT_COMPILER}")
+      set(QMAKE_QT50_SDK "/opt/RStudio-QtSDK/Qt${QT_VERSION}/${QT_VERSION_SUBDIR}/${QT_COMPILER}")
       if(EXISTS ${QMAKE_QT50_SDK})
          set(QT_QMAKE_EXECUTABLE "${QMAKE_QT50_SDK}/bin/qmake")
       else()


### PR DESCRIPTION
This change has three distinct parts:

### Support for newer Debian-based Linux systems

It's not straightforward to install RStudio on systems based on Debian Stretch and Ubuntu Xenial, due to the introduction of new, incompatible system libraries on these distributions. This change adds a server build; when we're able to resolve dependencies in Qt we'll add a desktop build as well.

### Docker compilation tool for developers

There's a new `docker-compile.sh` tool included here that's designed to make it easy for developers to simulate the builds that occur in the lab on their local machines, without installing Jenkins (or really any local software other than Docker itself).  

### Improved Qt caching behavior

Formerly, Qt was downloaded every time we built RStudio in a container. We now download Qt and install it to `/opt` as part of the container's build process, so it can be cached. 