### PR TITLE
diagnostics dialog for terminal

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/BrowseCap.java
+++ b/src/gwt/src/org/rstudio/core/client/BrowseCap.java
@@ -1,7 +1,7 @@
 /*
  * BrowseCap.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -155,6 +155,32 @@ public class BrowseCap
          return Desktop.getFrame().devicePixelRatio();
       else
          return getDevicePixelRatio();
+   }
+
+   public static String getPlatformName()
+   {
+      if (BrowseCap.isMacintosh())
+         return "Mac";
+      else if (BrowseCap.isLinux())
+         return "Linux";
+      else if (BrowseCap.isWindows())
+         return "Windows";
+      else
+         return "Unknown";
+   }
+
+   public static String getBrowserName()
+   {
+      if (BrowseCap.isChrome())
+         return "Chrome";
+      else if (BrowseCap.isFirefox())
+         return "Firefox";
+      else if (BrowseCap.isSafari())
+         return "Safari";
+      else if (BrowseCap.INSTANCE.isInternetExplorer())
+         return "IE";
+      else
+         return "Unknown";
    }
    
    private static native final double getDevicePixelRatio() /*-{

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -83,7 +83,20 @@ public class StringUtil
       else 
          return (seconds / 3600) + " hour" + ((seconds / 3600) == 1 ? "" : "s");
    }
-   
+
+   // Return current time as a timestamp (yyyy/m/d hh:mm:ss)
+   public static native String getTimestamp() /*-{
+      var now = new Date();
+      var date = [ now.getFullYear(), now.getMonth() + 1, now.getDate() ];
+      var time = [ now.getHours(), now.getMinutes(), now.getSeconds() ];
+      for (var i = 1; i < 3; i++ ) {
+         if (time[i] < 10) {
+            time[i] = "0" + time[i];
+         }
+      }
+      return date.join("/") + " " + time.join(":");
+   }-*/;
+    
    // Given a raw size, convert it to a human-readable value 
    // (e.g. 11580 -> "11.3 KB"). Note that this routine must generally avoid
    // implicit casts and use only ints; GWT's JavaScript compiler will truncate

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -120,6 +120,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEdit
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionManager;
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionRequest;
 import org.rstudio.studio.client.workbench.views.source.model.CppCompletion;
+import org.rstudio.studio.client.workbench.views.terminal.TerminalInfoDialog;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalList;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalPopupMenu;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalSession;
@@ -228,6 +229,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(NewConnectionInstallPackagePage newConnectionInstallPackagePage);
    void injectMembers(ObjectExplorerEditingTargetWidget widget);
    void injectMembers(ObjectExplorerDataGrid widget);
+   void injectMembers(TerminalInfoDialog infoDialog);
    
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);
 

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -974,6 +974,7 @@ public class Application implements ApplicationEventHandlers
       commands_.clearTerminalScrollbackBuffer().remove();
       commands_.previousTerminal().remove();
       commands_.nextTerminal().remove();
+      commands_.showTerminalInfo().remove();
    }
 
    private final ApplicationView view_ ;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -434,12 +434,13 @@ well as menu structures (for main menu and popup menus).
             <cmd refid="newTerminal"/>
             <separator/>
             <cmd refid="renameTerminal"/>
-            <cmd refid="clearTerminalScrollbackBuffer"/>
+            <cmd refid="showTerminalInfo"/>
             <separator/>
             <cmd refid="activateTerminal"/>
             <cmd refid="previousTerminal"/>
             <cmd refid="nextTerminal"/>
             <separator/>
+            <cmd refid="clearTerminalScrollbackBuffer"/>
             <cmd refid="closeTerminal"/>
           </menu>
          <menu label="Addins">
@@ -2496,6 +2497,12 @@ well as menu structures (for main menu and popup menus).
         buttonLabel=""
         menuLabel="_Next Terminal"
         desc="Show next terminal"/>
+
+   <cmd id="showTerminalInfo"
+        label="Terminal Diagnostics..."
+        buttonLabel=""
+        menuLabel="Terminal _Diagnostics..."
+        desc="Show Info on Current Terminal"/>
  
    <cmd id="addinsMru0" visible="false" rebindable="false"/>
    <cmd id="addinsMru1" visible="false" rebindable="false"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -391,6 +391,7 @@ public abstract class
    public abstract AppCommand clearTerminalScrollbackBuffer();
    public abstract AppCommand previousTerminal();
    public abstract AppCommand nextTerminal();
+   public abstract AppCommand showTerminalInfo();
     
    // Help
    public abstract AppCommand helpBack();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
@@ -1,0 +1,105 @@
+/*
+ * TerminalInfoDialog.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.terminal;
+
+import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.theme.res.ThemeResources;
+import org.rstudio.core.client.widget.ModalDialogBase;
+import org.rstudio.core.client.widget.ThemedButton;
+import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.Desktop;
+import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.user.client.ui.HasHorizontalAlignment;
+import com.google.gwt.user.client.ui.TextArea;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.inject.Inject;
+
+public class TerminalInfoDialog extends ModalDialogBase
+{
+
+   public TerminalInfoDialog(TerminalSession session, TerminalSessionSocket socket)
+   {
+      RStudioGinjector.INSTANCE.injectMembers(this);
+
+      setText("Terminal Diagnostics - " + session.getCaption());
+
+      boolean localEchoEnabled = uiPrefs_.terminalLocalEcho().getValue() && 
+            !BrowseCap.isWindowsDesktop();
+      
+      StringBuilder diagnostics = new StringBuilder();
+      diagnostics.append("Terminal Session Information\n----------------------------\n");
+      diagnostics.append("Caption:    '" + session.getCaption() + "'\n");
+      diagnostics.append("Title:      '" + session.getTitle() + "'\n");
+      diagnostics.append("Shell:      '" + TerminalShellInfo.getShellName(session.getShellType()) + "'\n");
+      diagnostics.append("Handle:     '" + session.getHandle() + "'\n");
+      diagnostics.append("Sequence:   '" + session.getSequence() + "'\n");
+      diagnostics.append("Busy:       '" + session.getHasChildProcs() + "'\n");
+      diagnostics.append("Alt-Buffer: '" + session.altBufferActive() + "'\n");
+      diagnostics.append("Local-echo: '" + localEchoEnabled + "'\n"); 
+      diagnostics.append("WebSockets: '" + uiPrefs_.terminalUseWebsockets().getValue() + "'\n");
+      diagnostics.append("Report lag: '" + uiPrefs_.enableReportTerminalLag().getValue() + "'\n");
+
+      diagnostics.append("\nSystem Information\n------------------\n");
+      diagnostics.append("Desktop:    '" + Desktop.isDesktop() + "'\n");
+      diagnostics.append("Platform:   '" + BrowseCap.getPlatformName() + "'\n");
+      diagnostics.append("Browser:    '" + BrowseCap.getBrowserName() + "'\n");
+
+      diagnostics.append("\nConnection Information\n----------------------\n");
+      diagnostics.append(socket.getConnectionDiagnostics());
+      
+      diagnostics.append("\nLocal-echo Match Failures\n-------------------------\n");
+      if (!localEchoEnabled)
+         diagnostics.append("<Not applicable>\n");
+      else
+         diagnostics.append(socket.getLocalEchoDiagnostics());
+     
+      textArea_ = new TextArea();
+      textArea_.addStyleName(ThemeResources.INSTANCE.themeStyles().fixedWidthFont());
+      textArea_.setSize("600px", "400px");
+      textArea_.setReadOnly(true);
+      textArea_.setText(diagnostics.toString());
+
+      setButtonAlignment(HasHorizontalAlignment.ALIGN_CENTER);
+      ThemedButton closeButton = new ThemedButton("Close",
+                                                  new ClickHandler() {
+         public void onClick(ClickEvent event) {
+            closeDialog();
+         }
+      });
+      addOkButton(closeButton); 
+   }
+
+   @Inject
+   private void initialize(UIPrefs uiPrefs)
+   {
+      uiPrefs_ = uiPrefs;
+   } 
+
+   
+   @Override
+   protected Widget createMainWidget()
+   {
+      return textArea_;
+   }
+   
+   TextArea textArea_;
+
+   // Injected ---- 
+   private UIPrefs uiPrefs_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalLocalEcho.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalLocalEcho.java
@@ -17,8 +17,8 @@ package org.rstudio.studio.client.workbench.views.terminal;
 import java.util.LinkedList;
 
 import org.rstudio.core.client.AnsiCode;
-import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringSink;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.regex.Match;
 import org.rstudio.core.client.regex.Pattern;
 
@@ -132,11 +132,10 @@ public class TerminalLocalEcho
          // didn't match previously echoed text; delete local-input
          // queue so we don't get too far out of sync and write text as-is
          
-         // TODO (gary) temporary diagnostics to help isolate some cases
-         // where local-echo is still not matching as expected 
-         Debug.log("LocalEcho Match Failure: received '" + 
-               AnsiCode.prettyPrint(outputToMatch) + "' had: '" + 
-               AnsiCode.prettyPrint(lastOutput) + "'");
+         // diagnostics to help isolate cases where local-echo is 
+         // not matching as expected 
+         diagnostic("Received: '" + AnsiCode.prettyPrint(outputToMatch) + 
+               "' Had: '" + AnsiCode.prettyPrint(lastOutput) + "'");
          
          localEcho_.clear();
          writer_.write(outputToMatch);
@@ -171,13 +170,38 @@ public class TerminalLocalEcho
       }
    }
    
+   private void diagnostic(String msg)
+   {
+      if (diagnostic_ == null)
+         diagnostic_ = new StringBuilder();
+     
+      diagnostic_.append(StringUtil.getTimestamp());
+      diagnostic_.append(": ");
+      diagnostic_.append(msg);
+      diagnostic_.append("\n");
+   }
+
+   public String getDiagnostics()
+   {
+      if (diagnostic_ == null || diagnostic_.length() == 0)
+         return("<none>\n");
+      else
+         return diagnostic_.toString();
+   }
+
+   public void resetDiagnostics()
+   {
+      diagnostic_ = null;
+   }
+   
   // Matches ANSI control sequences or BS, CR, LF, DEL, BEL
    private static final Pattern ANSI_CTRL_PATTERN =
          Pattern.create("(?:" + AnsiCode.ANSI_REGEX + ")|(?:" + "[\b\n\r\177\7]" + ")");
 
    // Pause local-echo until this time
    private long stopEchoPause_;
-
+   private StringBuilder diagnostic_;
+   
    private final StringSink writer_;
    private LinkedList<String> localEcho_ = new LinkedList<String>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -118,6 +118,7 @@ public class TerminalPane extends WorkbenchPane
       commands_.renameTerminal().setEnabled(false);
       commands_.closeTerminal().setEnabled(false);
       commands_.clearTerminalScrollbackBuffer().setEnabled(false);
+      commands_.showTerminalInfo().setEnabled(false);
 
       return toolbar;
    }
@@ -353,6 +354,18 @@ public class TerminalPane extends WorkbenchPane
       activeTerminalToolbarButton_.nextTerminal();
    }
 
+   @Override
+   public void showTerminalInfo()
+   {
+      final TerminalSession visibleTerminal = getSelectedTerminal();
+      if (visibleTerminal == null)
+      {
+         return;
+      }
+
+      visibleTerminal.showTerminalInfo();
+   }
+   
    /**
     * Rename the currently visible terminal (client-side only).
     * 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
@@ -100,11 +100,12 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
          }
          addSeparator();
          addItem(commands_.renameTerminal().createMenuItem(false));
-         addItem(commands_.clearTerminalScrollbackBuffer().createMenuItem(false));
+         addItem(commands_.showTerminalInfo().createMenuItem(false));
          addSeparator();
          addItem(commands_.previousTerminal().createMenuItem(false));
          addItem(commands_.nextTerminal().createMenuItem(false));
          addSeparator();
+         addItem(commands_.clearTerminalScrollbackBuffer().createMenuItem(false));
          addItem(commands_.closeTerminal().createMenuItem(false));
       }
 
@@ -148,6 +149,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
       commands_.closeTerminal().setEnabled(haveActiveTerminal);
       commands_.renameTerminal().setEnabled(haveActiveTerminal);
       commands_.clearTerminalScrollbackBuffer().setEnabled(haveActiveTerminal);
+      commands_.showTerminalInfo().setEnabled(haveActiveTerminal);
 
       commands_.previousTerminal().setEnabled(getPreviousTerminalHandle() != null);
       commands_.nextTerminal().setEnabled(getNextTerminalHandle() != null);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -123,6 +123,8 @@ public class TerminalSession extends XTermWidget
 
       connecting_ = true;
       setNewTerminal(getHandle() == null);
+      
+      socket_.resetDiagnostics();
 
       server_.startTerminal(getShellType(),
             getCols(), getRows(), getHandle(), getCaption(), 
@@ -427,6 +429,14 @@ public class TerminalSession extends XTermWidget
       server_.processEraseBuffer(getHandle(), new SimpleRequestCallback<Void>());
    }
 
+   /**
+    * Show modal dialog with information about this terminal session.
+    */
+   public void showTerminalInfo()
+   {
+      new TerminalInfoDialog(this, socket_).showModal();
+   }
+   
    private int getInteractionMode()
    {
       if (consoleProcess_ != null)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalShellInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalShellInfo.java
@@ -33,6 +33,8 @@ public class TerminalShellInfo extends JavaScriptObject
    public static final int SHELL_PS32 = 5; // Powershell
    public static final int SHELL_PS64 = 6;
    // -- End Windows-only	
+   
+   public static final int SHELL_POSIX_BASH = 7;
 
    protected TerminalShellInfo() {}
 
@@ -42,5 +44,31 @@ public class TerminalShellInfo extends JavaScriptObject
 
    public final native String getShellName() /*-{
       return this.name;
-   }-*/;   
+   }-*/; 
+   
+   public static String getShellName(int shell)
+   {
+      switch (shell)
+      {
+      case SHELL_DEFAULT:
+         return "Default";
+      case SHELL_GITBASH:
+         return "Git Bash";
+      case SHELL_WSLBASH:
+         return "WSL";
+      case SHELL_CMD32:
+         return "Command Prompt (32-bit)";
+      case SHELL_CMD64:
+         return "Command Prompt (64-bit)";
+      case SHELL_PS32:
+         return "PowerShell (32-bit)";
+      case SHELL_PS64:
+         return "PowerShell (64-bit)";
+      case SHELL_POSIX_BASH:
+         return "Bash";
+      default:
+         return "Unknown";
+      }
+   }
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTab.java
@@ -60,6 +60,9 @@ public class TerminalTab extends DelayLoadWorkbenchTab<TerminalTabPresenter>
       @Handler
       public abstract void onNextTerminal();
 
+      @Handler
+      public abstract void onShowTerminalInfo();
+
       abstract void initialize();
       abstract void confirmClose(Command onConfirmed);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
@@ -81,6 +81,7 @@ public class TerminalTabPresenter extends BusyPresenter
       void clearTerminalScrollbackBuffer();
       void previousTerminal();
       void nextTerminal();
+      void showTerminalInfo();
    }
 
    @Inject
@@ -137,6 +138,12 @@ public class TerminalTabPresenter extends BusyPresenter
    public void onNextTerminal()
    {
       view_.nextTerminal();
+   }
+
+   @Handler
+   public void onShowTerminalInfo()
+   {
+      view_.showTerminalInfo();
    }
 
    public void initialize()


### PR DESCRIPTION
Created a modal info dialog to show various diagnostics about current terminal. This should be helpful in understanding issues customers might encounter (as well as current issues still under investigation). Put it all in a text field for easy copy/paste.

In addition to various settings and platform info, also shows if websocket connection was successful, and if local-echo matching failures are happening.

![image](https://cloud.githubusercontent.com/assets/10569626/25454621/f8ae41e6-2a81-11e7-8f94-4691787ea1a5.png)
