### PR TITLE
Initial support for dark theme

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/FileDialogStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/FileDialogStyles.css
@@ -154,3 +154,22 @@
 
 .browse {
 }
+
+.rstudio-themes-flat .browse {
+   color: #000;
+   float: right;
+   padding-bottom: 5px;
+   padding-left: 5px;
+   padding-right: 5px;
+   border: none;
+   border-left: solid 1px #400909;
+   background: none;
+}
+
+.rstudio-themes-flat button.browse:focus {
+   outline:0;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .browse {
+   color: #FFF;
+}

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/FileDialogStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/FileDialogStyles.css
@@ -2,7 +2,7 @@
 @external gwt-DialogBox;
 @external gwt-MenuItem-selected;
 @external breadcrumb, breadcrumb-filepane;
-@external rstudio-themes-flat;
+@external rstudio-themes-flat, rstudio-themes-dark;
 
 @url DIRSEPARATOR dirseparator2x;
 @url HOME home2x;
@@ -118,6 +118,11 @@
 .breadcrumb table.path a
 {
    color: #0945bf;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .breadcrumb table.path a
+{
+   color: rgb(191,211,232);
 }
 
 .breadcrumb table.path .home {

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/FileDialogStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/FileDialogStyles.css
@@ -155,18 +155,18 @@
 .browse {
 }
 
-.rstudio-themes-flat .browse {
+.browse {
    color: #000;
    float: right;
    padding-bottom: 5px;
    padding-left: 5px;
    padding-right: 5px;
    border: none;
-   border-left: solid 1px #400909;
+   border-left: solid 1px #c2c7cb;
    background: none;
 }
 
-.rstudio-themes-flat button.browse:focus {
+button.browse:focus {
    outline:0;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/PathBreadcrumbWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/PathBreadcrumbWidget.java
@@ -103,7 +103,7 @@ public class PathBreadcrumbWidget
       frame_ = new DockLayoutPanel(Unit.PX);
       eastFrame_ = new FlowPanel();
 
-      Image browse = new Image(new ImageResource2x(RES.browse2x()));
+      Button browse = new Button("...");
       browse.setStyleName(STYLES.browse());
       browse.addStyleName(ThemeResources.INSTANCE.themeStyles().handCursor());
       browse.addClickHandler(new ClickHandler()
@@ -115,7 +115,7 @@ public class PathBreadcrumbWidget
       });
       browse.setTitle("Go to directory");
       eastFrame_.add(browse);
-      frame_.addEast(eastFrame_, browse.getWidth());
+      frame_.addEast(eastFrame_, 22);
       
       frame_.add(outer_);
       frame_.setStyleName(STYLES.breadcrumbFrame());

--- a/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
@@ -203,24 +203,15 @@
 
 .rstudio-themes-flat.rstudio-themes-default .dataGridHeader {
    background: THEME_DEFAULT_BACKGROUND;
-}
-
-.rstudio-themes-flat.rstudio-themes-dark-grey .dataGridHeader {
-   background: THEME_DARKGREY_BACKGROUND;
-}
-
-.rstudio-themes-flat.rstudio-themes-alternate .dataGridHeader {
-   background: THEME_ALTERNATE_BACKGROUND;
-}
-
-.rstudio-themes-flat.rstudio-themes-default .dataGridHeader {
    border-color: THEME_DEFAULT_BORDER;
 }
 
 .rstudio-themes-flat.rstudio-themes-dark-grey .dataGridHeader {
+   background: THEME_DARKGREY_BACKGROUND;
    border-color: THEME_DARKGREY_BORDER;
 }
 
 .rstudio-themes-flat.rstudio-themes-alternate .dataGridHeader {
+   background: THEME_ALTERNATE_BACKGROUND;
    border-color: THEME_ALTERNATE_BORDER;
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
@@ -57,6 +57,11 @@
   cursor: default;
 }
 
+.rstudio-themes-flat .dataGridHeader {
+   border-top: none;
+   border-left: none;
+}
+
 .rstudio-themes-flat.rstudio-themes-dark .dataGridHeader {
   border-top: 0px;
   border-left: 0px;

--- a/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
@@ -57,6 +57,7 @@
 .rstudio-themes-flat .dataGridHeader {
   border-top: 0px;
   border-left: 0px;
+  height: 16px;
 }
 
 .dataGridCell {

--- a/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
@@ -1,4 +1,4 @@
-@external rstudio-themes-flat;
+@external rstudio-themes-flat, rstudio-themes-dark;
 @external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
 
 @eval fixedWidthFont org.rstudio.core.client.theme.ThemeFonts.getFixedWidthFont();
@@ -6,6 +6,9 @@
 @eval THEME_DEFAULT_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getDefaultBackground();
 @eval THEME_DARKGREY_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getDarkGreyBackground();
 @eval THEME_ALTERNATE_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getAlternateBackground();
+@eval THEME_DEFAULT_BORDER org.rstudio.core.client.theme.ThemeColors.getDefaultBorder();
+@eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.getDarkGreyBorder();
+@eval THEME_ALTERNATE_BORDER org.rstudio.core.client.theme.ThemeColors.getAlternateBorder();
 
 @def selectionBorderWidth 1px;
 
@@ -54,9 +57,10 @@
   cursor: default;
 }
 
-.rstudio-themes-flat .dataGridHeader {
+.rstudio-themes-flat.rstudio-themes-dark .dataGridHeader {
   border-top: 0px;
   border-left: 0px;
+  color: white;
 }
 
 .dataGridCell {
@@ -207,4 +211,16 @@
 
 .rstudio-themes-flat.rstudio-themes-alternate .dataGridHeader {
    background: THEME_ALTERNATE_BACKGROUND;
+}
+
+.rstudio-themes-flat.rstudio-themes-default .dataGridHeader {
+   border-color: THEME_DEFAULT_BORDER;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark-grey .dataGridHeader {
+   border-color: THEME_DARKGREY_BORDER;
+}
+
+.rstudio-themes-flat.rstudio-themes-alternate .dataGridHeader {
+   border-color: THEME_ALTERNATE_BORDER;
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
@@ -1,6 +1,11 @@
 @external rstudio-themes-flat;
+@external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
 
 @eval fixedWidthFont org.rstudio.core.client.theme.ThemeFonts.getFixedWidthFont();
+
+@eval THEME_DEFAULT_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getDefaultBackground();
+@eval THEME_DARKGREY_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getDarkGreyBackground();
+@eval THEME_ALTERNATE_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getAlternateBackground();
 
 @def selectionBorderWidth 1px;
 
@@ -102,8 +107,29 @@
 .dataGridSortedHeaderAscending {
 
 }
+
+.rstudio-themes-flat .dataGridSortedHeaderAscending img {
+  width: 0px !important;
+  height: 0px !important;
+  background: none !important;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-bottom: 7px solid #818a98;
+  margin-left: 3px;
+}
+
 .dataGridSortedHeaderDescending {
 
+}
+
+.rstudio-themes-flat .dataGridSortedHeaderDescending img {
+  width: 0px !important;
+  height: 0px !important;
+  background: none !important;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 7px solid #818a98;
+  margin-left: 3px;
 }
 
 .dataGridEvenRow {
@@ -169,4 +195,16 @@
  */
 .dataGridKeyboardSelectedCell {
   border: selectionBorderWidth solid transparent;
+}
+
+.rstudio-themes-flat.rstudio-themes-default .dataGridHeader {
+   background: THEME_DEFAULT_BACKGROUND;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark-grey .dataGridHeader {
+   background: THEME_DARKGREY_BACKGROUND;
+}
+
+.rstudio-themes-flat.rstudio-themes-alternate .dataGridHeader {
+   background: THEME_ALTERNATE_BACKGROUND;
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
@@ -57,7 +57,6 @@
 .rstudio-themes-flat .dataGridHeader {
   border-top: 0px;
   border-left: 0px;
-  height: 16px;
 }
 
 .dataGridCell {

--- a/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
@@ -102,29 +102,8 @@
 .dataGridSortedHeaderAscending {
 
 }
-
-.rstudio-themes-flat .dataGridSortedHeaderAscending img {
-  width: 0px !important;
-  height: 0px !important;
-  background: none !important;
-  border-left: 5px solid transparent;
-  border-right: 5px solid transparent;
-  border-bottom: 7px solid #818a98;
-  margin-left: 3px;
-}
-
 .dataGridSortedHeaderDescending {
 
-}
-
-.rstudio-themes-flat .dataGridSortedHeaderDescending img {
-  width: 0px !important;
-  height: 0px !important;
-  background: none !important;
-  border-left: 5px solid transparent;
-  border-right: 5px solid transparent;
-  border-top: 7px solid #818a98;
-  margin-left: 3px;
 }
 
 .dataGridEvenRow {

--- a/src/gwt/src/org/rstudio/core/client/theme/ThemeColors.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ThemeColors.java
@@ -1,5 +1,5 @@
 /*
- * RStudioThemes.java
+ * ThemeColors.java
  *
  * Copyright (C) 2009-17 by RStudio, Inc.
  *
@@ -12,20 +12,22 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
+package org.rstudio.core.client.theme;
 
-package org.rstudio.studio.client.application.ui;
-
-import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
-
-import com.google.gwt.dom.client.Document;
-
-public class RStudioThemes
+public class ThemeColors
 {
-   public static void initializeThemes(UIPrefs uiPrefs, Document document)
+   public static String getDefaultBackground()
    {
-      if (uiPrefs.getUseFlatThemes().getGlobalValue()) {
-         document.getBody().addClassName("rstudio-themes-flat");
-         document.getBody().addClassName("rstudio-themes-default");
-      }
+      return "#F3F4F7";
+   }
+
+   public static String getDarkGreyBackground()
+   {
+      return "#4E5C68";
+   }
+
+   public static String getAlternateBackground()
+   {
+      return "#D2E4ED";
    }
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/ThemeColors.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ThemeColors.java
@@ -30,4 +30,19 @@ public class ThemeColors
    {
       return "#D2E4ED";
    }
+
+   public static String getDefaultBorder()
+   {
+      return "#D6DADC";
+   }
+
+   public static String getDarkGreyBorder()
+   {
+      return "rgb(12,31,48)";
+   }
+
+   public static String getAlternateBorder()
+   {
+      return "rgb(162,197,215)";
+   }
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1001,7 +1001,6 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
 }
 
 .rstudio-themes-flat .secondaryToolbar {
-   background: none;
    border-bottom: solid 1px #d6dadc;
    height: 24px;
 }
@@ -1845,20 +1844,20 @@ body.ubuntu_mono .searchBox {
 .rstudio-themes-flat.rstudio-themes-default .rstudio-themes-background,
 .rstudio-themes-flat.rstudio-themes-default .toolbar,
 .rstudio-themes-flat.rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
-.rstudio-themes-flat.rstudio-themes-default .gwt-TabLayoutPanelContent {
+.rstudio-themes-flat.rstudio-themes-default .secondaryToolbar {
    background: #F3F4F7;
 }
 
 .rstudio-themes-flat.rstudio-themes-dark-grey .rstudio-themes-background,
 .rstudio-themes-flat.rstudio-themes-dark-grey .toolbar,
 .rstudio-themes-flat.rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
-.rstudio-themes-flat.rstudio-themes-dark-grey .gwt-TabLayoutPanelContent {
+.rstudio-themes-flat.rstudio-themes-dark-grey .secondaryToolbar {
    background: #4E5C68;
 }
 
 .rstudio-themes-flat.rstudio-themes-alternate .rstudio-themes-background,
 .rstudio-themes-flat.rstudio-themes-alternate .toolbar,
 .rstudio-themes-flat.rstudio-themes-alternate .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
-.rstudio-themes-flat.rstudio-themes-alternate .gwt-TabLayoutPanelContent {
+.rstudio-themes-flat.rstudio-themes-alternate .secondaryToolbar {
    background: #D2E4ED;
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -989,6 +989,11 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
    max-height: 19px;
 }
 
+.rstudio-themes-flat.rstudio-themes-dark .toolbarSeparator {
+   filter: invert(100%);
+   transform: scaleX(-1);
+}
+
 .toolbarFileLabel {
    margin-right: 7px;
    white-space: nowrap;
@@ -1886,7 +1891,8 @@ body.rstudio-themes-flat.rstudio-themes-default {
 .rstudio-themes-flat.rstudio-themes-default .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs,
 .rstudio-themes-flat.rstudio-themes-default .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
 .rstudio-themes-flat.rstudio-themes-default .minimizedWindowObject table.tabLayoutCenter,
-.rstudio-themes-flat.rstudio-themes-default .minimizedWindowObject  > div:last-child {
+.rstudio-themes-flat.rstudio-themes-default .minimizedWindowObject  > div:last-child,
+.rstudio-themes-flat.rstudio-themes-default .toolbar {
    border-color: THEME_DEFAULT_BORDER;
 }
 
@@ -1910,7 +1916,8 @@ body.rstudio-themes-flat.rstudio-themes-dark-grey {
 .rstudio-themes-flat.rstudio-themes-dark-grey .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs,
 .rstudio-themes-flat.rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
 .rstudio-themes-flat.rstudio-themes-dark-grey .minimizedWindowObject table.tabLayoutCenter,
-.rstudio-themes-flat.rstudio-themes-dark-grey .minimizedWindowObject  > div:last-child {
+.rstudio-themes-flat.rstudio-themes-dark-grey .minimizedWindowObject  > div:last-child,
+.rstudio-themes-flat.rstudio-themes-dark-grey .toolbar {
    border-color: THEME_DARKGREY_BORDER;
 }
 
@@ -1934,6 +1941,7 @@ body.rstudio-themes-flat.rstudio-themes-alternate {
 .rstudio-themes-flat.rstudio-themes-alternate .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs,
 .rstudio-themes-flat.rstudio-themes-alternate .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
 .rstudio-themes-flat.rstudio-themes-alternate .minimizedWindowObject table.tabLayoutCenter,
-.rstudio-themes-flat.rstudio-themes-alternate .minimizedWindowObject  > div:last-child {
+.rstudio-themes-flat.rstudio-themes-alternate .minimizedWindowObject  > div:last-child,
+.rstudio-themes-flat.rstudio-themes-alternate .toolbar {
    border-color: THEME_DARKGREY_BORDER;
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -144,10 +144,6 @@ body {
    background: BACKGROUNDGRADIENT repeat-x top #e1e2e5;
 }
 
-body.rstudio-themes-flat {
-   background: rgb(247, 247, 247);
-}
-
 body {
    font-family: proportionalFont;
    font-size: 12px;
@@ -1875,6 +1871,10 @@ body.ubuntu_mono .searchBox {
    background: THEME_DEFAULT_BACKGROUND;
 }
 
+body.rstudio-themes-flat.rstudio-themes-default {
+   background: rgb(247, 247, 247);
+}
+
 .rstudio-themes-flat.rstudio-themes-dark-grey .rstudio-themes-background,
 .rstudio-themes-flat.rstudio-themes-dark-grey .toolbar,
 .rstudio-themes-flat.rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
@@ -1882,9 +1882,17 @@ body.ubuntu_mono .searchBox {
    background: THEME_DARKGREY_BACKGROUND;
 }
 
+body.rstudio-themes-flat.rstudio-themes-dark-grey {
+   background: rgb(50, 76, 99);
+}
+
 .rstudio-themes-flat.rstudio-themes-alternate .rstudio-themes-background,
 .rstudio-themes-flat.rstudio-themes-alternate .toolbar,
 .rstudio-themes-flat.rstudio-themes-alternate .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
 .rstudio-themes-flat.rstudio-themes-alternate .secondaryToolbar {
    background: THEME_ALTERNATE_BACKGROUND;
+}
+
+body.rstudio-themes-flat.rstudio-themes-alternate {
+   background: rgb(162, 197, 215);
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -46,6 +46,9 @@
 @eval THEME_DEFAULT_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getDefaultBackground();
 @eval THEME_DARKGREY_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getDarkGreyBackground();
 @eval THEME_ALTERNATE_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getAlternateBackground();
+@eval THEME_DEFAULT_BORDER org.rstudio.core.client.theme.ThemeColors.getDefaultBorder();
+@eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.getDarkGreyBorder();
+@eval THEME_ALTERNATE_BORDER org.rstudio.core.client.theme.ThemeColors.getAlternateBorder();
 
 @external dialogTopLeft, dialogTopLeftInner,
       dialogTopCenter, dialogTopCenterInner,
@@ -562,6 +565,7 @@ pre {
 .rstudio-themes-flat.rstudio-themes-dark .mainMenu .gwt-MenuItem {
    text-shadow: 0px 1px 0px #000;
    color: #FFF;
+   font-weight: 400;
 }
 
 .gwt-MenuItem-selected, .subMenuIcon-selected, .gwt-SuggestBoxPopup .item-selected {
@@ -1862,7 +1866,7 @@ body.ubuntu_mono .searchBox {
   margin-right: 3px;
 }
 
-/* rstudio-themes-flat background */
+/* RSTUDIO DEFAULT THEME */
 
 .rstudio-themes-flat.rstudio-themes-default .rstudio-themes-background,
 .rstudio-themes-flat.rstudio-themes-default .toolbar,
@@ -1875,6 +1879,19 @@ body.rstudio-themes-flat.rstudio-themes-default {
    background: rgb(247, 247, 247);
 }
 
+.rstudio-themes-flat.rstudio-themes-default .gwt-DialogBox .dialogTopCenter,
+.rstudio-themes-flat.rstudio-themes-default table.header > tbody > tr > td,
+.rstudio-themes-flat.rstudio-themes-default .windowFrameObject > div:last-child,
+.rstudio-themes-flat.rstudio-themes-default .secondaryToolbar,
+.rstudio-themes-flat.rstudio-themes-default .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs,
+.rstudio-themes-flat.rstudio-themes-default .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
+.rstudio-themes-flat.rstudio-themes-default .minimizedWindowObject table.tabLayoutCenter,
+.rstudio-themes-flat.rstudio-themes-default .minimizedWindowObject  > div:last-child {
+   border-color: THEME_DEFAULT_BORDER;
+}
+
+/* RSTUDIO DARK GREY THEME */
+
 .rstudio-themes-flat.rstudio-themes-dark-grey .rstudio-themes-background,
 .rstudio-themes-flat.rstudio-themes-dark-grey .toolbar,
 .rstudio-themes-flat.rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
@@ -1886,13 +1903,37 @@ body.rstudio-themes-flat.rstudio-themes-dark-grey {
    background: rgb(50, 76, 99);
 }
 
+.rstudio-themes-flat.rstudio-themes-dark-grey .gwt-DialogBox .dialogTopCenter,
+.rstudio-themes-flat.rstudio-themes-dark-grey table.header > tbody > tr > td,
+.rstudio-themes-flat.rstudio-themes-dark-grey .windowFrameObject > div:last-child,
+.rstudio-themes-flat.rstudio-themes-dark-grey .secondaryToolbar,
+.rstudio-themes-flat.rstudio-themes-dark-grey .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs,
+.rstudio-themes-flat.rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
+.rstudio-themes-flat.rstudio-themes-dark-grey .minimizedWindowObject table.tabLayoutCenter,
+.rstudio-themes-flat.rstudio-themes-dark-grey .minimizedWindowObject  > div:last-child {
+   border-color: THEME_DARKGREY_BORDER;
+}
+
+/* RSTUDIO ALTERNATE THEME */
+
 .rstudio-themes-flat.rstudio-themes-alternate .rstudio-themes-background,
 .rstudio-themes-flat.rstudio-themes-alternate .toolbar,
 .rstudio-themes-flat.rstudio-themes-alternate .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
-.rstudio-themes-flat.rstudio-themes-alternate .secondaryToolbar {
+.rstudio-themes-flat.rstudio-themes-alternate .secondaryToolbar,
    background: THEME_ALTERNATE_BACKGROUND;
 }
 
 body.rstudio-themes-flat.rstudio-themes-alternate {
    background: rgb(162, 197, 215);
+}
+
+.rstudio-themes-flat.rstudio-themes-alternate .gwt-DialogBox .dialogTopCenter,
+.rstudio-themes-flat.rstudio-themes-alternate table.header > tbody > tr > td,
+.rstudio-themes-flat.rstudio-themes-alternate .windowFrameObject > div:last-child,
+.rstudio-themes-flat.rstudio-themes-alternate .secondaryToolbar,
+.rstudio-themes-flat.rstudio-themes-alternate .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs,
+.rstudio-themes-flat.rstudio-themes-alternate .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
+.rstudio-themes-flat.rstudio-themes-alternate .minimizedWindowObject table.tabLayoutCenter,
+.rstudio-themes-flat.rstudio-themes-alternate .minimizedWindowObject  > div:last-child {
+   border-color: THEME_DARKGREY_BORDER;
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -743,8 +743,13 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
    cursor: default;
 }
 
-.rstudio-themes-dark .title,
-.rstudio-themes-dark .subtitle {
+.rstudio-themes-flat .title,
+.rstudio-themes-flat .subtitle {
+   text-shadow: #eef7fb 1px 0;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .title,
+.rstudio-themes-flat.rstudio-themes-dark .subtitle {
    color: white;
    text-shadow: none;
    font-weight: 400;

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1901,6 +1901,11 @@ body.rstudio-themes-flat.rstudio-themes-default {
    background: rgb(236, 237, 238);
 }
 
+.rstudio-themes-flat.rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-flat.rstudio-themes-default .minimizedWindowObject .center {
+   background: #e7e8ea;
+}
+
 /* RSTUDIO DARK GREY THEME */
 
 .rstudio-themes-flat.rstudio-themes-dark-grey .rstudio-themes-background,
@@ -1931,6 +1936,11 @@ body.rstudio-themes-flat.rstudio-themes-dark-grey {
    background: rgb(57, 67, 75);
 }
 
+.rstudio-themes-flat.rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-flat.rstudio-themes-dark-grey .minimizedWindowObject .center {
+   background: rgb(47, 57, 65);
+}
+
 /* RSTUDIO ALTERNATE THEME */
 
 .rstudio-themes-flat.rstudio-themes-alternate .rstudio-themes-background,
@@ -1959,4 +1969,9 @@ body.rstudio-themes-flat.rstudio-themes-alternate {
 .rstudio-themes-flat.rstudio-themes-alternate .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
 .rstudio-themes-flat.rstudio-themes-alternate .minimizedWindowObject table.tabLayoutCenter {
    background: rgb(148, 180, 197);
+}
+
+.rstudio-themes-flat.rstudio-themes-alternate .gwt-TabLayoutPanelTabs,
+.rstudio-themes-flat.rstudio-themes-alternate .minimizedWindowObject .center {
+   background: rgb(158, 160, 187);
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1981,7 +1981,7 @@ body.rstudio-themes-flat.rstudio-themes-dark-grey {
 .rstudio-themes-flat.rstudio-themes-alternate .rstudio-themes-background,
 .rstudio-themes-flat.rstudio-themes-alternate .toolbar,
 .rstudio-themes-flat.rstudio-themes-alternate .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
-.rstudio-themes-flat.rstudio-themes-alternate .secondaryToolbar,
+.rstudio-themes-flat.rstudio-themes-alternate .secondaryToolbar {
    background: THEME_ALTERNATE_BACKGROUND;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -733,6 +733,7 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
    margin-right: 10px;
    white-space: nowrap;
 }
+
 .title, .subtitle {
    display: inline;
    color: black;
@@ -741,6 +742,14 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
    text-shadow: white 0px 1px 0px;
    cursor: default;
 }
+
+.rstudio-themes-dark .title,
+.rstudio-themes-dark .subtitle {
+   color: white;
+   text-shadow: none;
+   font-weight: 400;
+}
+
 .subtitle {
    color: #999;
    margin-left: 6px;

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1896,6 +1896,11 @@ body.rstudio-themes-flat.rstudio-themes-default {
    border-color: THEME_DEFAULT_BORDER;
 }
 
+.rstudio-themes-flat.rstudio-themes-default .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
+.rstudio-themes-flat.rstudio-themes-default .minimizedWindowObject table.tabLayoutCenter {
+   background: rgb(236, 237, 238);
+}
+
 /* RSTUDIO DARK GREY THEME */
 
 .rstudio-themes-flat.rstudio-themes-dark-grey .rstudio-themes-background,
@@ -1921,6 +1926,11 @@ body.rstudio-themes-flat.rstudio-themes-dark-grey {
    border-color: THEME_DARKGREY_BORDER;
 }
 
+.rstudio-themes-flat.rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
+.rstudio-themes-flat.rstudio-themes-dark-grey .minimizedWindowObject table.tabLayoutCenter {
+   background: rgb(57, 67, 75);
+}
+
 /* RSTUDIO ALTERNATE THEME */
 
 .rstudio-themes-flat.rstudio-themes-alternate .rstudio-themes-background,
@@ -1944,4 +1954,9 @@ body.rstudio-themes-flat.rstudio-themes-alternate {
 .rstudio-themes-flat.rstudio-themes-alternate .minimizedWindowObject  > div:last-child,
 .rstudio-themes-flat.rstudio-themes-alternate .toolbar {
    border-color: THEME_DARKGREY_BORDER;
+}
+
+.rstudio-themes-flat.rstudio-themes-alternate .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
+.rstudio-themes-flat.rstudio-themes-alternate .minimizedWindowObject table.tabLayoutCenter {
+   background: rgb(148, 180, 197);
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1654,6 +1654,10 @@ body.ubuntu_mono .searchBox {
    display: none;
 }
 
+.rstudio-themes-flat.rstudio-themes-dark .minimizedWindowObject table.tabLayoutCenter {
+   color: #bfbfbf;
+}
+
 .rstudio-themes-flat .gwt-TabLayoutPanelTabs .tabLayoutLeft,
 .rstudio-themes-flat .minimizedWindowObject .tabLayoutLeft {
    display: none;

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -43,6 +43,10 @@
 @external rstudio-themes-background;
 @external dataGridSortedHeaderAscending, dataGridSortedHeaderDescending;
 
+@eval THEME_DEFAULT_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getDefaultBackground();
+@eval THEME_DARKGREY_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getDarkGreyBackground();
+@eval THEME_ALTERNATE_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getAlternateBackground();
+
 @external dialogTopLeft, dialogTopLeftInner,
       dialogTopCenter, dialogTopCenterInner,
       dialogTopRight, dialogTopRightInner,
@@ -1868,19 +1872,19 @@ body.ubuntu_mono .searchBox {
 .rstudio-themes-flat.rstudio-themes-default .toolbar,
 .rstudio-themes-flat.rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
 .rstudio-themes-flat.rstudio-themes-default .secondaryToolbar {
-   background: #F3F4F7;
+   background: THEME_DEFAULT_BACKGROUND;
 }
 
 .rstudio-themes-flat.rstudio-themes-dark-grey .rstudio-themes-background,
 .rstudio-themes-flat.rstudio-themes-dark-grey .toolbar,
 .rstudio-themes-flat.rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
 .rstudio-themes-flat.rstudio-themes-dark-grey .secondaryToolbar {
-   background: #4E5C68;
+   background: THEME_DARKGREY_BACKGROUND;
 }
 
 .rstudio-themes-flat.rstudio-themes-alternate .rstudio-themes-background,
 .rstudio-themes-flat.rstudio-themes-alternate .toolbar,
 .rstudio-themes-flat.rstudio-themes-alternate .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
 .rstudio-themes-flat.rstudio-themes-alternate .secondaryToolbar {
-   background: #D2E4ED;
+   background: THEME_ALTERNATE_BACKGROUND;
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -41,6 +41,7 @@
 @external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
 
 @external rstudio-themes-background;
+@external dataGridSortedHeaderAscending, dataGridSortedHeaderDescending;
 
 @external dialogTopLeft, dialogTopLeftInner,
       dialogTopCenter, dialogTopCenterInner,
@@ -1837,6 +1838,28 @@ body.ubuntu_mono .searchBox {
 
 .rstudio-themes-flat .clearSearch {
    top: 3px;
+}
+
+.rstudio-themes-flat .dataGridSortedHeaderAscending img {
+  width: 0px !important;
+  height: 0px !important;
+  background: none !important;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-bottom: 7px solid #818a98;
+  margin-left: 3px;
+  margin-right: 3px;
+}
+
+.rstudio-themes-flat .dataGridSortedHeaderDescending img {
+  width: 0px !important;
+  height: 0px !important;
+  background: none !important;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 7px solid #818a98;
+  margin-left: 3px;
+  margin-right: 3px;
 }
 
 /* rstudio-themes-flat background */

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1906,7 +1906,6 @@ body.rstudio-themes-flat.rstudio-themes-default {
    background: rgb(247, 247, 247);
 }
 
-.rstudio-themes-flat.rstudio-themes-default .gwt-DialogBox .dialogTopCenter,
 .rstudio-themes-flat.rstudio-themes-default table.header > tbody > tr > td,
 .rstudio-themes-flat.rstudio-themes-default .windowFrameObject > div:last-child,
 .rstudio-themes-flat.rstudio-themes-default .secondaryToolbar,
@@ -1941,7 +1940,6 @@ body.rstudio-themes-flat.rstudio-themes-dark-grey {
    background: rgb(50, 76, 99);
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-grey .gwt-DialogBox .dialogTopCenter,
 .rstudio-themes-flat.rstudio-themes-dark-grey table.header > tbody > tr > td,
 .rstudio-themes-flat.rstudio-themes-dark-grey .windowFrameObject > div:last-child,
 .rstudio-themes-flat.rstudio-themes-dark-grey .secondaryToolbar,
@@ -1976,7 +1974,6 @@ body.rstudio-themes-flat.rstudio-themes-alternate {
    background: rgb(162, 197, 215);
 }
 
-.rstudio-themes-flat.rstudio-themes-alternate .gwt-DialogBox .dialogTopCenter,
 .rstudio-themes-flat.rstudio-themes-alternate table.header > tbody > tr > td,
 .rstudio-themes-flat.rstudio-themes-alternate .windowFrameObject > div:last-child,
 .rstudio-themes-flat.rstudio-themes-alternate .secondaryToolbar,

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1838,6 +1838,19 @@ body.ubuntu_mono .searchBox {
    background: #FFF;
 }
 
+.rstudio-themes-flat.rstudio-themes-dark .search {
+   border-color: rgb(45,60,75);
+   background: rgb(145,154,161);
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .search input {
+   color: white;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .search input::placeholder {
+   color: #EEE;
+}
+
 .rstudio-themes-flat .search .left {
    display: none;
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -874,11 +874,6 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
    cursor: default;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .moduleTabPanel,
-.rstudio-themes-flat.rstudio-themes-dark .moduleTabPanel button {
-   color: white;
-}
-
 .moduleTabPanel .gwt-TabLayoutPanelTab {
    font-size: 11px;
    background: inherit;
@@ -1003,6 +998,11 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
 
 .toolbarSeparator {
    margin-right: 5px;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .toolbar,
+.rstudio-themes-flat.rstudio-themes-dark .toolbar button {
+   color: white;
 }
 
 .rstudio-themes-flat .toolbarSeparator {
@@ -1675,6 +1675,10 @@ body.ubuntu_mono .searchBox {
    padding-left: 9px;
    padding-right: 9px;
    margin-left: -1px;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .gwt-TabLayoutPanelTabs table.tabLayoutCenter {
+   color: white;
 }
 
 .rstudio-themes-flat .gwt-TabLayoutPanelTabs .tabLayoutCenter td,

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -873,6 +873,12 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
    background-color: white;
    cursor: default;
 }
+
+.rstudio-themes-flat.rstudio-themes-dark .moduleTabPanel,
+.rstudio-themes-flat.rstudio-themes-dark .moduleTabPanel button {
+   color: white;
+}
+
 .moduleTabPanel .gwt-TabLayoutPanelTab {
    font-size: 11px;
    background: inherit;
@@ -900,6 +906,11 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
    font-weight: bold;
    padding-top: 4px;
 }
+
+.rstudio-themes-flat.rstudio-themes-dark .moduleTabPanel .gwt-TabLayoutPanelTab .gwt-Label {
+   font-weight: 400;
+}
+
 .moduleTabPanel .gwt-TabLayoutPanelTab-selected .tabLayoutLeft {
    height: 24px;
    width: 6px;

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1997,7 +1997,7 @@ body.rstudio-themes-flat.rstudio-themes-alternate {
 .rstudio-themes-flat.rstudio-themes-alternate .minimizedWindowObject table.tabLayoutCenter,
 .rstudio-themes-flat.rstudio-themes-alternate .minimizedWindowObject  > div:last-child,
 .rstudio-themes-flat.rstudio-themes-alternate .toolbar {
-   border-color: THEME_DARKGREY_BORDER;
+   border-color: THEME_ALTERNATE_BORDER;
 }
 
 .rstudio-themes-flat.rstudio-themes-alternate .gwt-TabLayoutPanelTabs table.tabLayoutCenter,

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -58,6 +58,7 @@ import org.rstudio.studio.client.application.model.InvalidSessionInfo;
 import org.rstudio.studio.client.application.model.ProductInfo;
 import org.rstudio.studio.client.application.model.SessionSerializationAction;
 import org.rstudio.studio.client.application.ui.AboutDialog;
+import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.application.ui.RequestLogVisualization;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
@@ -704,10 +705,7 @@ public class Application implements ApplicationEventHandlers
    
    private void initializeWorkbench()
    {
-      if (uiPrefs_.get().getUseFlatThemes().getGlobalValue()) {
-        Document.get().getBody().addClassName("rstudio-themes-flat");
-        Document.get().getBody().addClassName("rstudio-themes-default");
-      }
+      RStudioThemes.initializeThemes(uiPrefs_.get(), Document.get());
 
       pAceThemes_.get();
 

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
@@ -1,0 +1,31 @@
+/*
+ * Application.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.application.ui;
+
+import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
+
+import com.google.gwt.dom.client.Document;
+
+public class RStudioThemes
+{
+   public static void initializeThemes(UIPrefs uiPrefs, Document document)
+   {
+      if (uiPrefs.getUseFlatThemes().getGlobalValue()) {
+         document.getBody().addClassName("rstudio-themes-flat");
+         document.getBody().addClassName("rstudio-themes-default");
+      }
+   }
+}

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
@@ -23,13 +23,13 @@ public class RStudioThemes
 {
    public static void initializeThemes(UIPrefs uiPrefs, Document document)
    {
-      if (uiPrefs.getUseFlatThemes().getGlobalValue()) {
-         document.getBody().removeClassName("rstudio-themes-flat");
-         document.getBody().removeClassName("rstudio-themes-dark");
-         document.getBody().removeClassName("rstudio-themes-default");
-         document.getBody().removeClassName("rstudio-themes-dark-grey");
-         document.getBody().removeClassName("rstudio-themes-alternate");
-         
+      document.getBody().removeClassName("rstudio-themes-flat");
+      document.getBody().removeClassName("rstudio-themes-dark");
+      document.getBody().removeClassName("rstudio-themes-default");
+      document.getBody().removeClassName("rstudio-themes-dark-grey");
+      document.getBody().removeClassName("rstudio-themes-alternate");
+      
+      if (uiPrefs.getUseFlatThemes().getGlobalValue()) {         
          String themeName = uiPrefs.getFlatTheme().getGlobalValue();
          document.getBody().addClassName("rstudio-themes-flat");
          if (themeName.contains("dark")) {

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
@@ -24,8 +24,18 @@ public class RStudioThemes
    public static void initializeThemes(UIPrefs uiPrefs, Document document)
    {
       if (uiPrefs.getUseFlatThemes().getGlobalValue()) {
+         document.getBody().removeClassName("rstudio-themes-flat");
+         document.getBody().removeClassName("rstudio-themes-dark");
+         document.getBody().removeClassName("rstudio-themes-default");
+         document.getBody().removeClassName("rstudio-themes-dark-grey");
+         document.getBody().removeClassName("rstudio-themes-alternate");
+         
+         String themeName = uiPrefs.getFlatTheme().getGlobalValue();
          document.getBody().addClassName("rstudio-themes-flat");
-         document.getBody().addClassName("rstudio-themes-default");
+         if (themeName.contains("dark")) {
+            document.getBody().addClassName("rstudio-themes-dark");
+         }
+         document.getBody().addClassName("rstudio-themes-" + themeName);
       }
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/header/HeaderPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/header/HeaderPanel.css
@@ -1,4 +1,9 @@
 @external rstudio-themes-flat;
+@external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
+
+@eval THEME_DEFAULT_BORDER org.rstudio.core.client.theme.ThemeColors.getDefaultBorder();
+@eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.getDarkGreyBorder();
+@eval THEME_ALTERNATE_BORDER org.rstudio.core.client.theme.ThemeColors.getAlternateBorder();
 
 .panel {
    width: 100%;
@@ -37,4 +42,16 @@
 
 .rstudio-themes-flat .right {
    display: none;
+}
+
+.rstudio-themes-flat.rstudio-themes-default .center {
+   border-color: THEME_DEFAULT_BORDER;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark-grey .center {
+   border-color: THEME_DARKGREY_BORDER;
+}
+
+.rstudio-themes-flat.rstudio-themes-alternate .center {
+   border-color: THEME_ALTERNATE_BORDER;
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/header/HeaderPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/header/HeaderPanel.css
@@ -1,4 +1,4 @@
-@external rstudio-themes-flat;
+@external rstudio-themes-flat, rstudio-themes-dark;
 @external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
 
 @eval THEME_DEFAULT_BORDER org.rstudio.core.client.theme.ThemeColors.getDefaultBorder();
@@ -42,6 +42,11 @@
 
 .rstudio-themes-flat .right {
    display: none;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .center,
+.rstudio-themes-flat.rstudio-themes-dark .center button {
+   color: white;
 }
 
 .rstudio-themes-flat.rstudio-themes-default .center {

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteManager.java
@@ -35,6 +35,7 @@ import org.rstudio.studio.client.application.ApplicationUncaughtExceptionHandler
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.CrossWindowEvent;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.common.GlobalDisplay.NewWindowOptions;
 import org.rstudio.studio.client.common.satellite.events.AllSatellitesClosingEvent;
 import org.rstudio.studio.client.common.satellite.events.SatelliteClosedEvent;
@@ -472,9 +473,7 @@ public class SatelliteManager implements CloseHandler<Window>
          callSetParams(satelliteWnd, params);
 
       // set themes
-      if (pUIPrefs_.get().getUseFlatThemes().getGlobalValue()) {
-         satellite.getWindow().getDocument().getBody().addClassName("rstudio-themes-flat");
-      }
+      RStudioThemes.initializeThemes(pUIPrefs_.get(), satellite.getWindow().getDocument());
    }
    
    // called to register child windows (not necessarily full-fledged 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -635,6 +635,11 @@ public class UIPrefsAccessor extends Prefs
    {
       return bool("use_flat_themes", false);
    }
+
+   public PrefValue<String> getFlatTheme()
+   {
+      return string("flat_theme", "classic");
+   }
    
    private String getDefaultPdfPreview()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.prefs.views;
 
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.SelectElement;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ChangeEvent;
@@ -33,6 +34,7 @@ import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.ThemeFonts;
 import org.rstudio.core.client.widget.SelectWidget;
 import org.rstudio.studio.client.application.Desktop;
+import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.workbench.prefs.model.RPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
@@ -159,17 +161,18 @@ public class AppearancePreferencesPane extends PreferencesPane
       leftPanel.add(theme_);
       theme_.setValue(themes.getEffectiveThemeName(uiPrefs_.theme().getGlobalValue()));
       
-      flatTheme_ = new CheckBox("Flat Themes", false);
-      flatTheme_.setValue(uiPrefs_.getUseFlatThemes().getGlobalValue());
-
-      flatTheme_.addValueChangeHandler(new ValueChangeHandler<Boolean>()
+      flatTheme_ = new SelectWidget("Global theme:",
+                                new String[]{"Classic", "Flat", "Dark", "Alternate"},
+                                new String[]{"classic", "default", "dark-grey", "alternate"},
+                                false);
+      flatTheme_.addStyleName(res.styles().themeChooser());
+      flatTheme_.getListBox().addChangeHandler(new ChangeHandler()
       {
-         @Override
-         public void onValueChange(ValueChangeEvent<Boolean> arg0)
+         public void onChange(ChangeEvent event)
          {
-            uiPrefs_.getUseFlatThemes().setGlobalValue(flatTheme_.getValue());
          }
       });
+      flatTheme_.setValue(uiPrefs_.getFlatTheme().getGlobalValue());
 
       leftPanel.add(flatTheme_);
 
@@ -241,6 +244,11 @@ public class AppearancePreferencesPane extends PreferencesPane
          }
       }
 
+      uiPrefs_.getUseFlatThemes().setGlobalValue(flatTheme_.getValue() != "classic");
+      uiPrefs_.getFlatTheme().setGlobalValue(flatTheme_.getValue());
+      
+      RStudioThemes.initializeThemes(uiPrefs_, Document.get());
+
       return restartRequired;
    }
 
@@ -259,7 +267,7 @@ public class AppearancePreferencesPane extends PreferencesPane
    private String initialFontFace_;
    private SelectWidget zoomLevel_;
    private String initialZoomLevel_;
-   private CheckBox flatTheme_;
+   private SelectWidget flatTheme_;
 
    private static final String CODE_SAMPLE =
          "# plotting of R objects\n" +

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectGrid.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectGrid.css
@@ -1,5 +1,11 @@
-@external rstudio-themes-flat;
+@external rstudio-themes-flat, rstudio-themes-dark;
+@external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
+
 @eval proportionalFont org.rstudio.core.client.theme.ThemeFonts.getProportionalFont();
+
+@eval THEME_DEFAULT_BORDER org.rstudio.core.client.theme.ThemeColors.getDefaultBorder();
+@eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.getDarkGreyBorder();
+@eval THEME_ALTERNATE_BORDER org.rstudio.core.client.theme.ThemeColors.getAlternateBorder();
 
 .objectGridColumn,
 .objectGridHeader
@@ -34,6 +40,10 @@ th.objectGridHeader
    padding-right: 2px;
 }
 
+.rstudio-themes-flat.rstudio-themes-dark th.objectGridHeader {
+   color: white;
+}
+
 .rstudio-themes-flat th.objectGridHeader:last-child {
    border-right: none;
 }
@@ -62,4 +72,16 @@ th.checkColumn
 .decoratedValueCol
 {
 	padding-right: 35px;
+}
+
+.rstudio-themes-flat.rstudio-themes-default .objectGridHeader {
+   border-color: THEME_DEFAULT_BORDER;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark-grey .objectGridHeader {
+   border-color: THEME_DARKGREY_BORDER;
+}
+
+.rstudio-themes-flat.rstudio-themes-alternate .objectGridHeader {
+   border-color: THEME_ALTERNATE_BORDER;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectGrid.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectGrid.css
@@ -29,7 +29,9 @@ th.objectGridHeader
 .rstudio-themes-flat th.objectGridHeader {
    border-top: none;
    border-left: none;
-   height: 16px;
+   padding: 0px;
+   padding-left: 2px;
+   padding-right: 2px;
 }
 
 .rstudio-themes-flat th.objectGridHeader:last-child {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectGrid.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectGrid.java
@@ -270,10 +270,15 @@ public class EnvironmentObjectGrid extends EnvironmentObjectDisplay
          // Render a header for each column
          for (int i = 0; i < columns_.size(); i++)
          {
+            String sortClassName = i == host_.getSortColumn() ? 
+              (host_.getAscendingSort() ? "dataGridSortedHeaderAscending" : "dataGridSortedHeaderDescending") : 
+              "";
+
             ObjectGridColumn col = columns_.get(i);
             TableCellBuilder cell = row.startTH();
             cell.className(style_.objectGridHeader() + " " +
-                           "rstudio-themes-background");
+                           "rstudio-themes-background" + " " +
+                           sortClassName);
             Cell.Context context = new Cell.Context(0, i, null);
             renderSortableHeader(cell, context, col.getHeader(), 
                   i == host_.getSortColumn(), 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGrid.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGrid.css
@@ -1,3 +1,10 @@
+@external rstudio-themes-flat;
+@external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
+
+@eval THEME_DEFAULT_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getDefaultBackground();
+@eval THEME_DARKGREY_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getDarkGreyBackground();
+@eval THEME_ALTERNATE_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getAlternateBackground();
+
 .dataGridFirstColumn
 {
 	text-align: center;
@@ -17,4 +24,16 @@
 .packageNotApplicableColumn
 {
 	color: #b0b0b0;
+}
+
+.rstudio-themes-flat.rstudio-themes-default .dataGridHeader {
+   background: THEME_DEFAULT_BACKGROUND;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark-grey .dataGridHeader {
+   background: THEME_DARKGREY_BACKGROUND;
+}
+
+.rstudio-themes-flat.rstudio-themes-alternate .dataGridHeader {
+   background: THEME_ALTERNATE_BACKGROUND;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGridCommon.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGridCommon.css
@@ -1,7 +1,12 @@
 @eval proportionalFont org.rstudio.core.client.theme.ThemeFonts.getProportionalFont();
 
 @external ubuntu_mono;
-@external rstudio-themes-flat;
+@external rstudio-themes-flat, rstudio-themes-dark;
+@external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
+
+@eval THEME_DEFAULT_BORDER org.rstudio.core.client.theme.ThemeColors.getDefaultBorder();
+@eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.getDarkGreyBorder();
+@eval THEME_ALTERNATE_BORDER org.rstudio.core.client.theme.ThemeColors.getAlternateBorder();
 
 /* Styles here are applied to every DataGrid involved in the Packrat/Packages
    workflow, including the Packages pane itself and the actions/conflict 
@@ -32,6 +37,10 @@
    border-top: none;
    border-left: none;
    height: 16px;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .dataGridHeader {
+   color: white;
 }
 
 .rstudio-themes-flat .dataGridHeader:last-child {
@@ -70,4 +79,16 @@
 body.ubuntu_mono .dataGridCell input[type=checkbox] {
    margin-top: 0;
    margin-bottom: 0;
+}
+
+.rstudio-themes-flat.rstudio-themes-default .dataGridHeader {
+   border-color: THEME_DEFAULT_BORDER;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark-grey .dataGridHeader {
+   border-color: THEME_DARKGREY_BORDER;
+}
+
+.rstudio-themes-flat.rstudio-themes-alternate .dataGridHeader {
+   border-color: THEME_ALTERNATE_BORDER;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarWidget.java
@@ -47,6 +47,7 @@ public class StatusBarWidget extends Composite
       Binder binder = GWT.create(Binder.class);
       panel_ = binder.createAndBindUi(this);
       panel_.setVerticalAlignment(HorizontalPanel.ALIGN_TOP);
+      panel_.addStyleName("rstudio-themes-background");
       
       panel_.setCellWidth(scope_, "100%");
       panel_.setCellWidth(message_, "100%");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarWidget.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarWidget.ui.xml
@@ -10,6 +10,13 @@
       @external gwt-Label;
       @external rstudio-themes-flat;
 
+      @external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
+
+      @eval THEME_DEFAULT_BORDER org.rstudio.core.client.theme.ThemeColors.getDefaultBorder();
+      @eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.getDarkGreyBorder();
+      @eval THEME_ALTERNATE_BORDER org.rstudio.core.client.theme.ThemeColors.getAlternateBorder();
+
+
       @sprite .statusBar {
          gwt-image: 'statusBarTile';
          width: 100%;
@@ -49,7 +56,7 @@
       }
       .rstudio-themes-flat .statusBar .element {
          background-image: none;
-         background: #F5F5F5;
+         background: none;
          border-right: solid 1px #d6dadc;
       }
       .statusBar .element.pos {
@@ -61,6 +68,18 @@
       }
       .rstudio-themes-flat .statusBar .element.last {
          border-right: none;
+      }
+      .rstudio-themes-flat.rstudio-themes-default .statusBar,
+      .rstudio-themes-flat.rstudio-themes-default .statusBar .element {
+         border-color: THEME_DEFAULT_BORDER;
+      }
+      .rstudio-themes-flat.rstudio-themes-dark-grey .statusBar,
+      .rstudio-themes-flat.rstudio-themes-dark-grey .statusBar .element {
+         border-color: THEME_DARKGREY_BORDER;
+      }
+      .rstudio-themes-flat.rstudio-themes-alternate .statusBar,
+      .rstudio-themes-flat.rstudio-themes-alternate .statusBar .element  {
+         border-color: THEME_ALTERNATE_BORDER;
       }
    </ui:style>
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ChangelistTableCellTableStyle.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ChangelistTableCellTableStyle.css
@@ -1,3 +1,10 @@
+@external rstudio-themes-flat;
+@external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
+
+@eval THEME_DEFAULT_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getDefaultBackground();
+@eval THEME_DARKGREY_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getDarkGreyBackground();
+@eval THEME_ALTERNATE_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getAlternateBackground();
+
 span.status {
    white-space: nowrap;
 }
@@ -26,4 +33,25 @@ span.status img:first-child {
 
 .cellTableSortableHeader > div {
    padding-left: 13px !important;
+}
+
+.rstudio-themes-flat .cellTableSortableHeader {
+   border-top: none;
+   border-left: none;
+}
+
+.rstudio-themes-flat .cellTableSortableHeader:last-child {
+   border-right: none;
+}
+
+.rstudio-themes-flat.rstudio-themes-default .cellTableSortableHeader {
+   background: THEME_DEFAULT_BACKGROUND;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark-grey .cellTableSortableHeader {
+   background: THEME_DARKGREY_BACKGROUND;
+}
+
+.rstudio-themes-flat.rstudio-themes-alternate .cellTableSortableHeader {
+   background: THEME_ALTERNATE_BACKGROUND;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ChangelistTableCellTableStyle.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ChangelistTableCellTableStyle.css
@@ -1,9 +1,12 @@
-@external rstudio-themes-flat;
+@external rstudio-themes-flat, rstudio-themes-dark;
 @external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
 
 @eval THEME_DEFAULT_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getDefaultBackground();
 @eval THEME_DARKGREY_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getDarkGreyBackground();
 @eval THEME_ALTERNATE_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getAlternateBackground();
+@eval THEME_DEFAULT_BORDER org.rstudio.core.client.theme.ThemeColors.getDefaultBorder();
+@eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.getDarkGreyBorder();
+@eval THEME_ALTERNATE_BORDER org.rstudio.core.client.theme.ThemeColors.getAlternateBorder();
 
 span.status {
    white-space: nowrap;
@@ -26,6 +29,10 @@ span.status img:first-child {
    margin-bottom: 0;
 }
 
+.rstudio-themes-flat.rstudio-themes-dark .cellTableSortableHeader {
+   color: white;
+}
+
 .cellTableSortableHeader img {
    background-size: 7px 4px !important;
    background-position: 2px 1px !important;
@@ -46,12 +53,15 @@ span.status img:first-child {
 
 .rstudio-themes-flat.rstudio-themes-default .cellTableSortableHeader {
    background: THEME_DEFAULT_BACKGROUND;
+   border-color: THEME_DEFAULT_BORDER;
 }
 
 .rstudio-themes-flat.rstudio-themes-dark-grey .cellTableSortableHeader {
    background: THEME_DARKGREY_BACKGROUND;
+   border-color: THEME_DARKGREY_BORDER;
 }
 
 .rstudio-themes-flat.rstudio-themes-alternate .cellTableSortableHeader {
    background: THEME_ALTERNATE_BACKGROUND;
+   border-color: THEME_ALTERNATE_BORDER;
 }


### PR DESCRIPTION
More work remaining (mostly to sync ACE colors with other panes, say the packages or files pane), but a good chunk of the functionality is made available with this change:

<img width="1435" alt="screen shot 2017-04-26 at 5 10 56 pm" src="https://cloud.githubusercontent.com/assets/3478847/25462375/67696748-2aa3-11e7-978f-66ca11a98a01.png">

<img width="1439" alt="screen shot 2017-04-26 at 5 20 28 pm" src="https://cloud.githubusercontent.com/assets/3478847/25462570/af65f0ec-2aa4-11e7-8edc-e5f0a5500c34.png">

Currently, there is a dropdown to select the theme, this will probably change soon:

<img width="672" alt="screen shot 2017-04-26 at 4 50 20 pm" src="https://cloud.githubusercontent.com/assets/3478847/25461906/7bec3798-2aa0-11e7-9491-b701fde1c35f.png">