### PR TITLE
Improvements for dark theme and history, viewer and connections pane

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/FileDialogStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/FileDialogStyles.css
@@ -125,7 +125,7 @@
    color: #0945bf;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .breadcrumb table.path a
+.rstudio-themes-flat .rstudio-themes-dark .breadcrumb table.path a
 {
    color: rgb(191,211,232);
 }
@@ -178,18 +178,18 @@ button.browse:focus {
    outline:0;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .browse {
+.rstudio-themes-flat .rstudio-themes-dark .browse {
    color: #FFF;
 }
 
-.rstudio-themes-flat.rstudio-themes-default .browse {
+.rstudio-themes-flat .rstudio-themes-default .browse {
    border-color: THEME_DEFAULT_BORDER;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-grey .browse {
+.rstudio-themes-flat .rstudio-themes-dark-grey .browse {
    border-color: THEME_DARKGREY_BORDER;
 }
 
-.rstudio-themes-flat.rstudio-themes-alternate .browse {
+.rstudio-themes-flat .rstudio-themes-alternate .browse {
    border-color: THEME_ALTERNATE_BORDER;
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
@@ -62,7 +62,7 @@
    border-left: none;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .dataGridHeader {
+.rstudio-themes-flat .rstudio-themes-dark .dataGridHeader {
   border-top: 0px;
   border-left: 0px;
   color: white;
@@ -206,17 +206,17 @@
   border: selectionBorderWidth solid transparent;
 }
 
-.rstudio-themes-flat.rstudio-themes-default .dataGridHeader {
+.rstudio-themes-flat .rstudio-themes-default .dataGridHeader {
    background: THEME_DEFAULT_BACKGROUND;
    border-color: THEME_DEFAULT_BORDER;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-grey .dataGridHeader {
+.rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
    background: THEME_DARKGREY_BACKGROUND;
    border-color: THEME_DARKGREY_BORDER;
 }
 
-.rstudio-themes-flat.rstudio-themes-alternate .dataGridHeader {
+.rstudio-themes-flat .rstudio-themes-alternate .dataGridHeader {
    background: THEME_ALTERNATE_BACKGROUND;
    border-color: THEME_ALTERNATE_BORDER;
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/ThemeColors.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ThemeColors.java
@@ -18,7 +18,7 @@ public class ThemeColors
 {
    public static String getDefaultBackground()
    {
-      return "#F3F4F7";
+      return "#F4F8F9";
    }
 
    public static String getDarkGreyBackground()
@@ -44,5 +44,10 @@ public class ThemeColors
    public static String getAlternateBorder()
    {
       return "rgb(162,197,215)";
+   }
+
+   public static String getInactiveBackground()
+   {
+      return "#ecedee";
    }
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
@@ -198,6 +198,9 @@ public class WindowFrame extends Composite
             ensureHeightRegistration_ =
                ((HasEnsureHeightHandlers)main_).addEnsureHeightHandler(this);
          }
+         
+         final ThemeStyles styles = ThemeResources.INSTANCE.themeStyles();
+         main_.addStyleName(styles.windowFrameWidget());
 
          frame_.add(main_);
          frame_.setWidgetLeftRight(

--- a/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
@@ -182,9 +182,9 @@ public interface ThemeStyles extends CssResource
    String minimizedWindowObject();
    String windowFrameWidget();
 
-   String consoleWindowFrame();
-   String consoleWidgetLayout();
-   String consoleHeaderLayout();
-   String consoleMinimizeLayout();
-   String consoleMaximizeLayout();
+   String consoleOnlyWindowFrame();
+   String consoleOnlyWidgetLayout();
+   String consoleOnlyHeaderLayout();
+   String consoleOnlyMinimizeLayout();
+   String consoleOnlyMaximizeLayout();
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
@@ -185,4 +185,6 @@ public interface ThemeStyles extends CssResource
    String consoleWindowFrame();
    String consoleWidgetLayout();
    String consoleHeaderLayout();
+   String consoleMinimizeLayout();
+   String consoleMaximizeLayout();
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
@@ -183,8 +183,8 @@ public interface ThemeStyles extends CssResource
    String windowFrameWidget();
 
    String consoleOnlyWindowFrame();
-   String consoleOnlyWidgetLayout();
-   String consoleOnlyHeaderLayout();
-   String consoleOnlyMinimizeLayout();
-   String consoleOnlyMaximizeLayout();
+   String consoleWidgetLayout();
+   String consoleHeaderLayout();
+   String consoleMinimizeLayout();
+   String consoleMaximizeLayout();
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
@@ -181,5 +181,7 @@ public interface ThemeStyles extends CssResource
    String windowFrameObject();
    String minimizedWindowObject();
    String windowFrameWidget();
-   String windowFrameConsoleLayout();
+
+   String consoleWidgetLayout();
+   String consoleHeaderLayout();
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
@@ -180,4 +180,6 @@ public interface ThemeStyles extends CssResource
 
    String windowFrameObject();
    String minimizedWindowObject();
+   String windowFrameWidget();
+   String windowFrameConsoleLayout();
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
@@ -182,6 +182,7 @@ public interface ThemeStyles extends CssResource
    String minimizedWindowObject();
    String windowFrameWidget();
 
+   String consoleWindowFrame();
    String consoleWidgetLayout();
    String consoleHeaderLayout();
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -664,6 +664,14 @@ pre {
 
 }
 
+.consoleMinimizeLayout {
+
+}
+
+.consoleMaximizeLayout {
+
+}
+
 .rstudio-themes-flat .windowFrameObject > div:last-child {
    border: solid 1px #d6dadc;
    border-radius: 3px 3px 0px 0px;
@@ -701,6 +709,15 @@ pre {
    top: 24px !important;
    right: 0px !important;
    bottom: 0px !important;
+}
+
+.rstudio-themes-flat .windowFrameObject.consoleWindowFrame .consoleMinimizeLayout {
+   top: 5px !important;
+   right: 25px !important;
+}
+.rstudio-themes-flat .windowFrameObject.consoleWindowFrame .consoleMaximizeLayout {
+   top: 5px !important;
+   right: 7px !important;
 }
 
 .macintosh #rstudio_console_input {

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -652,23 +652,23 @@ pre {
 
 }
 
-.consoleWidgetLayout {
+.consoleOnlyWidgetLayout {
 
 }
 
-.consoleHeaderLayout {
+.consoleOnlyHeaderLayout {
 
 }
 
-.consoleWindowFrame {
+.consoleOnlyWindowFrame {
 
 }
 
-.consoleMinimizeLayout {
+.consoleOnlyMinimizeLayout {
 
 }
 
-.consoleMaximizeLayout {
+.consoleOnlyMaximizeLayout {
 
 }
 
@@ -681,7 +681,7 @@ pre {
    bottom: 2px !important;
 }
 
-.rstudio-themes-flat .windowFrameObject.consoleWindowFrame {
+.rstudio-themes-flat .windowFrameObject.consoleOnlyWindowFrame {
    border: solid 1px #d6dadc;
    border-radius: 3px 3px 0px 0px;
    left: 2px !important;
@@ -690,20 +690,20 @@ pre {
    bottom: 2px !important;
 }
 
-.rstudio-themes-flat .windowFrameObject.consoleWindowFrame div.consoleHeaderLayout {
+.rstudio-themes-flat .windowFrameObject.consoleOnlyWindowFrame div.consoleOnlyHeaderLayout {
    left: 0px !important;
    top: 0px !important;
    right: 0px !important;
    bottom: 0px !important;
 }
 
-.rstudio-themes-flat .windowFrameObject.consoleWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader {
+.rstudio-themes-flat .windowFrameObject.consoleOnlyWindowFrame div.consoleOnlyHeaderLayout .primaryWindowFrameHeader {
    margin-right: 0px;
    margin-bottom: 2px;
    border-bottom: solid 1px #d6dadc;
 }
 
-.rstudio-themes-flat .windowFrameObject.consoleWindowFrame div.consoleWidgetLayout {
+.rstudio-themes-flat .windowFrameObject.consoleOnlyWindowFrame div.consoleOnlyWidgetLayout {
    border: none;
    left: 0px !important;
    top: 24px !important;
@@ -711,11 +711,11 @@ pre {
    bottom: 0px !important;
 }
 
-.rstudio-themes-flat .windowFrameObject.consoleWindowFrame .consoleMinimizeLayout {
+.rstudio-themes-flat .windowFrameObject.consoleOnlyWindowFrame .consoleOnlyMinimizeLayout {
    top: 5px !important;
    right: 25px !important;
 }
-.rstudio-themes-flat .windowFrameObject.consoleWindowFrame .consoleMaximizeLayout {
+.rstudio-themes-flat .windowFrameObject.consoleOnlyWindowFrame .consoleOnlyMaximizeLayout {
    top: 5px !important;
    right: 7px !important;
 }
@@ -2057,8 +2057,8 @@ body.rstudio-themes-flat .rstudio-themes-default {
 .rstudio-themes-flat .rstudio-themes-default .minimizedWindowObject table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-default .minimizedWindowObject  > div:last-child,
 .rstudio-themes-flat .rstudio-themes-default .toolbar,
-.rstudio-themes-flat .rstudio-themes-default .windowFrameObject.consoleWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
-.rstudio-themes-flat .rstudio-themes-default .windowFrameObject.consoleWindowFrame {
+.rstudio-themes-flat .rstudio-themes-default .windowFrameObject.consoleOnlyWindowFrame div.consoleOnlyHeaderLayout .primaryWindowFrameHeader,
+.rstudio-themes-flat .rstudio-themes-default .windowFrameObject.consoleOnlyWindowFrame {
    border-color: THEME_DEFAULT_BORDER;
 }
 
@@ -2097,8 +2097,8 @@ body.rstudio-themes-flat .rstudio-themes-dark-grey {
 .rstudio-themes-flat .rstudio-themes-dark-grey .minimizedWindowObject table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-dark-grey .minimizedWindowObject  > div:last-child,
 .rstudio-themes-flat .rstudio-themes-dark-grey .toolbar,
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowFrameObject.consoleWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowFrameObject.consoleWindowFrame {
+.rstudio-themes-flat .rstudio-themes-dark-grey .windowFrameObject.consoleOnlyWindowFrame div.consoleOnlyHeaderLayout .primaryWindowFrameHeader,
+.rstudio-themes-flat .rstudio-themes-dark-grey .windowFrameObject.consoleOnlyWindowFrame {
    border-color: THEME_DARKGREY_BORDER;
 }
 
@@ -2137,8 +2137,8 @@ body.rstudio-themes-flat .rstudio-themes-alternate {
 .rstudio-themes-flat .rstudio-themes-alternate .minimizedWindowObject table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-alternate .minimizedWindowObject  > div:last-child,
 .rstudio-themes-flat .rstudio-themes-alternate .toolbar,
-.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject.consoleWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
-.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject.consoleWindowFrame {
+.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject.consoleOnlyWindowFrame div.consoleOnlyHeaderLayout .primaryWindowFrameHeader,
+.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject.consoleOnlyWindowFrame {
    border-color: THEME_ALTERNATE_BORDER;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2028,3 +2028,21 @@ body.rstudio-themes-flat .rstudio-themes-alternate {
 .rstudio-themes-flat .rstudio-themes-alternate .minimizedWindowObject .center {
    background: rgb(158, 160, 187);
 }
+
+.rstudio-themes-flat .rstudio-themes-alternate .windowframe .minimize,
+.rstudio-themes-flat .rstudio-themes-alternate .windowframe .maximize,
+.rstudio-themes-flat .rstudio-themes-alternate .windowframe-maximized .maximize,
+.rstudio-themes-flat .rstudio-themes-alternate .windowframe-exclusive .maximize,
+.rstudio-themes-flat .rstudio-themes-alternate .minimizedWindow .minimize,
+.rstudio-themes-flat .rstudio-themes-alternate .minimizedWindow .maximize {
+   filter: brightness(0.7);
+}
+
+.rstudio-themes-flat .rstudio-themes-alternate .windowframe .minimize:hover,
+.rstudio-themes-flat .rstudio-themes-alternate .windowframe .maximize:hover,
+.rstudio-themes-flat .rstudio-themes-alternate .windowframe-maximized .maximize:hover,
+.rstudio-themes-flat .rstudio-themes-alternate .windowframe-exclusive .maximize:hover,
+.rstudio-themes-flat .rstudio-themes-alternate .minimizedWindow .minimize:hover,
+.rstudio-themes-flat .rstudio-themes-alternate .minimizedWindow .maximize:hover {
+   filter: brightness(0.4);
+}

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -50,6 +50,7 @@
 @eval THEME_DEFAULT_BORDER org.rstudio.core.client.theme.ThemeColors.getDefaultBorder();
 @eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.getDarkGreyBorder();
 @eval THEME_ALTERNATE_BORDER org.rstudio.core.client.theme.ThemeColors.getAlternateBorder();
+@eval THEME_GLOBAL_INACTIVE org.rstudio.core.client.theme.ThemeColors.getInactiveBackground();
 
 @external dialogTopLeft, dialogTopLeftInner,
       dialogTopCenter, dialogTopCenterInner,
@@ -1792,7 +1793,7 @@ body.ubuntu_mono .searchBox {
 .rstudio-themes-flat .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
 .rstudio-themes-flat .minimizedWindowObject table.tabLayoutCenter {
    background-image: none;
-   background: rgb(236, 237, 238);
+   background: THEME_GLOBAL_INACTIVE;
    border-right: solid 1px #d6dadc;
    border-left: solid 1px #d6dadc;
    border-radius: 3px 3px 0px 0px;
@@ -2066,7 +2067,7 @@ body.rstudio-themes-flat .rstudio-themes-default {
 
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-default .minimizedWindowObject table.tabLayoutCenter {
-   background: rgb(236, 237, 238);
+   background: THEME_GLOBAL_INACTIVE;
 }
 
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
@@ -2075,7 +2076,7 @@ body.rstudio-themes-flat .rstudio-themes-default {
 }
 
 .rstudio-themes-flat .rstudio-themes-default .multiPodUtilityArea {
-   background: linear-gradient(to right, rgba(0,0,0,0), rgb(236, 237, 238) 13%);
+   background: linear-gradient(to right, rgba(0,0,0,0), THEME_GLOBAL_INACTIVE 13%);
 }
 
 /* RSTUDIO DARK GREY THEME */

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -40,7 +40,8 @@
 
 @external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
 
-@external rstudio-themes-background;
+@external rstudio-themes-background, rstudio-themes-inverts;
+
 @external dataGridSortedHeaderAscending, dataGridSortedHeaderDescending;
 
 @eval THEME_DEFAULT_BACKGROUND org.rstudio.core.client.theme.ThemeColors.getDefaultBackground();

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1440,6 +1440,7 @@ body.ubuntu_mono .searchBox {
 
 .rstudio-themes-flat.rstudio-themes-dark .gwt-CheckBox input[type="checkbox"] {
    background: #d3d8dc;
+   border-color: rgb(45,60,75);
 }
 
 .macintosh .gwt-CheckBox input[type="checkbox"],

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -660,7 +660,20 @@ pre {
 
 }
 
-.rstudio-themes-flat .windowFrameObject {
+.consoleWindowFrame {
+
+}
+
+.rstudio-themes-flat .windowFrameObject > div:last-child {
+   border: solid 1px #d6dadc;
+   border-radius: 3px 3px 0px 0px;
+   left: 2px !important;
+   top: 2px !important;
+   right: 2px !important;
+   bottom: 2px !important;
+}
+
+.rstudio-themes-flat .windowFrameObject.consoleWindowFrame {
    border: solid 1px #d6dadc;
    border-radius: 3px 3px 0px 0px;
    left: 2px !important;
@@ -669,26 +682,21 @@ pre {
    bottom: 2px !important;
 }
 
-.rstudio-themes-flat .windowFrameObject > div:last-child {
+.rstudio-themes-flat .windowFrameObject.consoleWindowFrame div.consoleHeaderLayout {
    left: 0px !important;
    top: 0px !important;
    right: 0px !important;
    bottom: 0px !important;
 }
 
-.rstudio-themes-flat .windowFrameObject div.consoleHeaderLayout {
-   left: 0px !important;
-   top: 0px !important;
-   right: 0px !important;
-}
-
-.rstudio-themes-flat .windowFrameObject div.consoleHeaderLayout .primaryWindowFrameHeader {
+.rstudio-themes-flat .windowFrameObject.consoleWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader {
    margin-right: 0px;
    margin-bottom: 2px;
    border-bottom: solid 1px #d6dadc;
 }
 
-.rstudio-themes-flat .windowFrameObject div.consoleWidgetLayout {
+.rstudio-themes-flat .windowFrameObject.consoleWindowFrame div.consoleWidgetLayout {
+   border: none;
    left: 0px !important;
    top: 24px !important;
    right: 0px !important;
@@ -2032,7 +2040,8 @@ body.rstudio-themes-flat .rstudio-themes-default {
 .rstudio-themes-flat .rstudio-themes-default .minimizedWindowObject table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-default .minimizedWindowObject  > div:last-child,
 .rstudio-themes-flat .rstudio-themes-default .toolbar,
-.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject div.consoleHeaderLayout .primaryWindowFrameHeader {
+.rstudio-themes-flat .rstudio-themes-default .windowFrameObject.consoleWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
+.rstudio-themes-flat .rstudio-themes-default .windowFrameObject.consoleWindowFrame {
    border-color: THEME_DEFAULT_BORDER;
 }
 
@@ -2071,7 +2080,8 @@ body.rstudio-themes-flat .rstudio-themes-dark-grey {
 .rstudio-themes-flat .rstudio-themes-dark-grey .minimizedWindowObject table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-dark-grey .minimizedWindowObject  > div:last-child,
 .rstudio-themes-flat .rstudio-themes-dark-grey .toolbar,
-.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject div.consoleHeaderLayout .primaryWindowFrameHeader {
+.rstudio-themes-flat .rstudio-themes-dark-grey .windowFrameObject.consoleWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
+.rstudio-themes-flat .rstudio-themes-dark-grey .windowFrameObject.consoleWindowFrame {
    border-color: THEME_DARKGREY_BORDER;
 }
 
@@ -2110,7 +2120,8 @@ body.rstudio-themes-flat .rstudio-themes-alternate {
 .rstudio-themes-flat .rstudio-themes-alternate .minimizedWindowObject table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-alternate .minimizedWindowObject  > div:last-child,
 .rstudio-themes-flat .rstudio-themes-alternate .toolbar,
-.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject div.consoleHeaderLayout .primaryWindowFrameHeader {
+.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject.consoleWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
+.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject.consoleWindowFrame {
    border-color: THEME_ALTERNATE_BORDER;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -589,6 +589,15 @@ pre {
    z-index: 50;
    background-size: 14px 14px;
 }
+.rstudio-themes-flat .windowframe-maximized .maximize:hover,
+.rstudio-themes-flat .windowframe-exclusive .maximize:hover {
+   background-image: RESTORE;
+   filter: brightness(0.4);
+}
+.rstudio-themes-flat .rstudio-themes-dark .windowframe-maximized .maximize:hover,
+.rstudio-themes-flat .rstudio-themes-dark .windowframe-exclusive .maximize:hover {
+   filter: brightness(1.50);
+}
 .windowframe .minimize {
    background-image: MINIMIZE;
    z-index: 50;
@@ -598,14 +607,37 @@ pre {
    background-image: MAXIMIZESELECTED;
    background-size: 14px 14px;
 }
+.rstudio-themes-flat .windowframe .maximize:hover {
+   background-image: MAXIMIZE;
+   filter: brightness(0.4);
+}
+.rstudio-themes-flat .rstudio-themes-dark .windowframe .maximize:hover {
+   filter: brightness(1.50);
+}
 .windowframe-maximized .maximize:hover,
 .windowframe-exclusive .maximize:hover {
    background-image: RESTORESELECTED;
    background-size: 14px 14px;
 }
+.rstudio-themes-flat .windowframe-maximized .maximize:hover,
+.rstudio-themes-flat .windowframe-exclusive .maximize:hover {
+   background-image: RESTORE;
+   filter: brightness(0.4);
+}
+.rstudio-themes-flat .rstudio-themes-dark .windowframe-maximized .maximize:hover,
+.rstudio-themes-flat .rstudio-themes-dark .windowframe-exclusive .maximize:hover {
+   filter: brightness(1.50);
+}
 .windowframe .minimize:hover {
    background-image: MINIMIZESELECTED;
    background-size: 14px 14px;
+}
+.rstudio-themes-flat .windowframe .minimize:hover {
+   background-image: MINIMIZE;
+   filter: brightness(0.4);
+}
+.rstudio-themes-flat .rstudio-themes-dark .windowframe .minimize:hover {
+   filter: brightness(1.50);
 }
 
 .windowframe-exclusive .minimize {
@@ -692,9 +724,23 @@ pre {
    background-image: MAXIMIZESELECTED;
    background-size: 14px 14px;
 }
+.rstudio-themes-flat .minimizedWindow .maximize:hover {
+   background-image: MAXIMIZE;
+   filter: brightness(0.4);
+}
+.rstudio-themes-flat .rstudio-themes-dark .minimizedWindow .maximize:hover {
+   filter: brightness(1.50);
+}
 .minimizedWindow .minimize:hover {
    background-image: RESTORESELECTED;
    background-size: 14px 14px;
+}
+.rstudio-themes-flat .minimizedWindow .minimize:hover {
+   background-image: RESTORE;
+   filter: brightness(0.4);
+}
+.rstudio-themes-flat .rstudio-themes-dark .minimizedWindow .minimize:hover {
+   filter: brightness(1.50);
 }
 .minimizedWindow .center {
    background-image: PODMINIMIZEDTILE;

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1438,6 +1438,10 @@ body.ubuntu_mono .searchBox {
   margin: 3px 3px 5px 3px;
 }
 
+.rstudio-themes-flat.rstudio-themes-dark .gwt-CheckBox input[type="checkbox"] {
+   background: #d3d8dc;
+}
+
 .macintosh .gwt-CheckBox input[type="checkbox"],
 .linux .gwt-CheckBox input[type="checkbox"],
 .windows-highdpi .gwt-CheckBox input[type="checkbox"] {

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -652,7 +652,11 @@ pre {
 
 }
 
-.windowFrameConsoleLayout {
+.consoleWidgetLayout {
+
+}
+
+.consoleHeaderLayout {
 
 }
 
@@ -672,7 +676,19 @@ pre {
    bottom: 0px !important;
 }
 
-.rstudio-themes-flat .windowFrameObject div.windowFrameConsoleLayout {
+.rstudio-themes-flat .windowFrameObject div.consoleHeaderLayout {
+   left: 0px !important;
+   top: 0px !important;
+   right: 0px !important;
+}
+
+.rstudio-themes-flat .windowFrameObject div.consoleHeaderLayout .primaryWindowFrameHeader {
+   margin-right: 0px;
+   margin-bottom: 2px;
+   border-bottom: solid 1px #d6dadc;
+}
+
+.rstudio-themes-flat .windowFrameObject div.consoleWidgetLayout {
    left: 0px !important;
    top: 24px !important;
    right: 0px !important;
@@ -2015,7 +2031,8 @@ body.rstudio-themes-flat .rstudio-themes-default {
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-default .minimizedWindowObject table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-default .minimizedWindowObject  > div:last-child,
-.rstudio-themes-flat .rstudio-themes-default .toolbar {
+.rstudio-themes-flat .rstudio-themes-default .toolbar,
+.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject div.consoleHeaderLayout .primaryWindowFrameHeader {
    border-color: THEME_DEFAULT_BORDER;
 }
 
@@ -2053,7 +2070,8 @@ body.rstudio-themes-flat .rstudio-themes-dark-grey {
 .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-dark-grey .minimizedWindowObject table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-dark-grey .minimizedWindowObject  > div:last-child,
-.rstudio-themes-flat .rstudio-themes-dark-grey .toolbar {
+.rstudio-themes-flat .rstudio-themes-dark-grey .toolbar,
+.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject div.consoleHeaderLayout .primaryWindowFrameHeader {
    border-color: THEME_DARKGREY_BORDER;
 }
 
@@ -2091,7 +2109,8 @@ body.rstudio-themes-flat .rstudio-themes-alternate {
 .rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-alternate .minimizedWindowObject table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-alternate .minimizedWindowObject  > div:last-child,
-.rstudio-themes-flat .rstudio-themes-alternate .toolbar {
+.rstudio-themes-flat .rstudio-themes-alternate .toolbar,
+.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject div.consoleHeaderLayout .primaryWindowFrameHeader {
    border-color: THEME_ALTERNATE_BORDER;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -648,13 +648,35 @@ pre {
    -webkit-font-smoothing: subpixel-antialiased;
 }
 
-.rstudio-themes-flat .windowFrameObject > div:last-child {
+.windowFrameWidget {
+
+}
+
+.windowFrameConsoleLayout {
+
+}
+
+.rstudio-themes-flat .windowFrameObject {
    border: solid 1px #d6dadc;
    border-radius: 3px 3px 0px 0px;
    left: 2px !important;
-   top: 2px !important;
+   top: 3px !important;
    right: 2px !important;
    bottom: 2px !important;
+}
+
+.rstudio-themes-flat .windowFrameObject > div:last-child {
+   left: 0px !important;
+   top: 0px !important;
+   right: 0px !important;
+   bottom: 0px !important;
+}
+
+.rstudio-themes-flat .windowFrameObject div.windowFrameConsoleLayout {
+   left: 0px !important;
+   top: 24px !important;
+   right: 0px !important;
+   bottom: 0px !important;
 }
 
 .macintosh #rstudio_console_input {

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -652,23 +652,23 @@ pre {
 
 }
 
-.consoleOnlyWidgetLayout {
-
-}
-
-.consoleOnlyHeaderLayout {
-
-}
-
 .consoleOnlyWindowFrame {
 
 }
 
-.consoleOnlyMinimizeLayout {
+.consoleWidgetLayout {
 
 }
 
-.consoleOnlyMaximizeLayout {
+.consoleHeaderLayout {
+
+}
+
+.consoleMinimizeLayout {
+
+}
+
+.consoleMaximizeLayout {
 
 }
 
@@ -688,22 +688,23 @@ pre {
    top: 3px !important;
    right: 2px !important;
    bottom: 2px !important;
+   overflow: hidden;
 }
 
-.rstudio-themes-flat .windowFrameObject.consoleOnlyWindowFrame div.consoleOnlyHeaderLayout {
+.rstudio-themes-flat .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout {
    left: 0px !important;
    top: 0px !important;
    right: 0px !important;
    bottom: 0px !important;
 }
 
-.rstudio-themes-flat .windowFrameObject.consoleOnlyWindowFrame div.consoleOnlyHeaderLayout .primaryWindowFrameHeader {
+.rstudio-themes-flat .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader {
    margin-right: 0px;
    margin-bottom: 2px;
    border-bottom: solid 1px #d6dadc;
 }
 
-.rstudio-themes-flat .windowFrameObject.consoleOnlyWindowFrame div.consoleOnlyWidgetLayout {
+.rstudio-themes-flat .windowFrameObject.consoleOnlyWindowFrame div.consoleWidgetLayout {
    border: none;
    left: 0px !important;
    top: 24px !important;
@@ -711,11 +712,11 @@ pre {
    bottom: 0px !important;
 }
 
-.rstudio-themes-flat .windowFrameObject.consoleOnlyWindowFrame .consoleOnlyMinimizeLayout {
+.rstudio-themes-flat .windowFrameObject.consoleOnlyWindowFrame .consoleMinimizeLayout {
    top: 5px !important;
    right: 25px !important;
 }
-.rstudio-themes-flat .windowFrameObject.consoleOnlyWindowFrame .consoleOnlyMaximizeLayout {
+.rstudio-themes-flat .windowFrameObject.consoleOnlyWindowFrame .consoleMaximizeLayout {
    top: 5px !important;
    right: 7px !important;
 }
@@ -2041,7 +2042,8 @@ body.ubuntu_mono .searchBox {
 .rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background,
 .rstudio-themes-flat .rstudio-themes-default .toolbar,
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-default .secondaryToolbar {
+.rstudio-themes-flat .rstudio-themes-default .secondaryToolbar,
+.rstudio-themes-flat .rstudio-themes-default .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader {
    background: THEME_DEFAULT_BACKGROUND;
 }
 
@@ -2057,7 +2059,7 @@ body.rstudio-themes-flat .rstudio-themes-default {
 .rstudio-themes-flat .rstudio-themes-default .minimizedWindowObject table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-default .minimizedWindowObject  > div:last-child,
 .rstudio-themes-flat .rstudio-themes-default .toolbar,
-.rstudio-themes-flat .rstudio-themes-default .windowFrameObject.consoleOnlyWindowFrame div.consoleOnlyHeaderLayout .primaryWindowFrameHeader,
+.rstudio-themes-flat .rstudio-themes-default .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
 .rstudio-themes-flat .rstudio-themes-default .windowFrameObject.consoleOnlyWindowFrame {
    border-color: THEME_DEFAULT_BORDER;
 }
@@ -2081,7 +2083,8 @@ body.rstudio-themes-flat .rstudio-themes-default {
 .rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background,
 .rstudio-themes-flat .rstudio-themes-dark-grey .toolbar,
 .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-dark-grey .secondaryToolbar {
+.rstudio-themes-flat .rstudio-themes-dark-grey .secondaryToolbar,
+.rstudio-themes-flat .rstudio-themes-dark-grey .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader {
    background: THEME_DARKGREY_BACKGROUND;
 }
 
@@ -2097,7 +2100,7 @@ body.rstudio-themes-flat .rstudio-themes-dark-grey {
 .rstudio-themes-flat .rstudio-themes-dark-grey .minimizedWindowObject table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-dark-grey .minimizedWindowObject  > div:last-child,
 .rstudio-themes-flat .rstudio-themes-dark-grey .toolbar,
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowFrameObject.consoleOnlyWindowFrame div.consoleOnlyHeaderLayout .primaryWindowFrameHeader,
+.rstudio-themes-flat .rstudio-themes-dark-grey .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
 .rstudio-themes-flat .rstudio-themes-dark-grey .windowFrameObject.consoleOnlyWindowFrame {
    border-color: THEME_DARKGREY_BORDER;
 }
@@ -2121,7 +2124,8 @@ body.rstudio-themes-flat .rstudio-themes-dark-grey {
 .rstudio-themes-flat .rstudio-themes-alternate .rstudio-themes-background,
 .rstudio-themes-flat .rstudio-themes-alternate .toolbar,
 .rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
-.rstudio-themes-flat .rstudio-themes-alternate .secondaryToolbar {
+.rstudio-themes-flat .rstudio-themes-alternate .secondaryToolbar,
+.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader {
    background: THEME_ALTERNATE_BACKGROUND;
 }
 
@@ -2137,7 +2141,7 @@ body.rstudio-themes-flat .rstudio-themes-alternate {
 .rstudio-themes-flat .rstudio-themes-alternate .minimizedWindowObject table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-alternate .minimizedWindowObject  > div:last-child,
 .rstudio-themes-flat .rstudio-themes-alternate .toolbar,
-.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject.consoleOnlyWindowFrame div.consoleOnlyHeaderLayout .primaryWindowFrameHeader,
+.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
 .rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject.consoleOnlyWindowFrame {
    border-color: THEME_ALTERNATE_BORDER;
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1922,6 +1922,10 @@ body.ubuntu_mono .searchBox {
   margin-right: 3px;
 }
 
+.rstudio-themes-flat .rstudio-themes-dark .rstudio-themes-inverts {
+   filter: invert(100%);
+}
+
 /* RSTUDIO DEFAULT THEME */
 
 .rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background,

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -562,7 +562,7 @@ pre {
    opacity: 1.0;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .mainMenu .gwt-MenuItem {
+.rstudio-themes-flat .rstudio-themes-dark .mainMenu .gwt-MenuItem {
    text-shadow: 0px 1px 0px #000;
    color: #FFF;
    font-weight: 400;
@@ -748,8 +748,8 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
    text-shadow: #eef7fb 1px 0;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .title,
-.rstudio-themes-flat.rstudio-themes-dark .subtitle {
+.rstudio-themes-flat .rstudio-themes-dark .title,
+.rstudio-themes-flat .rstudio-themes-dark .subtitle {
    color: white;
    text-shadow: none;
    font-weight: 400;
@@ -907,7 +907,7 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
    padding-top: 4px;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .moduleTabPanel .gwt-TabLayoutPanelTab .gwt-Label {
+.rstudio-themes-flat .rstudio-themes-dark .moduleTabPanel .gwt-TabLayoutPanelTab .gwt-Label {
    font-weight: 400;
 }
 
@@ -1005,8 +1005,8 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
    margin-right: 5px;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .toolbar,
-.rstudio-themes-flat.rstudio-themes-dark .toolbar button {
+.rstudio-themes-flat .rstudio-themes-dark .toolbar,
+.rstudio-themes-flat .rstudio-themes-dark .toolbar button {
    color: white;
 }
 
@@ -1014,7 +1014,7 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
    max-height: 19px;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .toolbarSeparator {
+.rstudio-themes-flat .rstudio-themes-dark .toolbarSeparator {
    filter: invert(100%);
    transform: scaleX(-1);
 }
@@ -1438,7 +1438,7 @@ body.ubuntu_mono .searchBox {
   margin: 3px 3px 5px 3px;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .gwt-CheckBox input[type="checkbox"] {
+.rstudio-themes-flat .rstudio-themes-dark .gwt-CheckBox input[type="checkbox"] {
    background: #d3d8dc;
    border-color: rgb(45,60,75);
 }
@@ -1664,7 +1664,7 @@ body.ubuntu_mono .searchBox {
    display: none;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .minimizedWindowObject table.tabLayoutCenter {
+.rstudio-themes-flat .rstudio-themes-dark .minimizedWindowObject table.tabLayoutCenter {
    color: #bfbfbf;
 }
 
@@ -1691,7 +1691,7 @@ body.ubuntu_mono .searchBox {
    margin-left: -1px;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .gwt-TabLayoutPanelTabs table.tabLayoutCenter {
+.rstudio-themes-flat .rstudio-themes-dark .gwt-TabLayoutPanelTabs table.tabLayoutCenter {
    color: white;
 }
 
@@ -1867,16 +1867,16 @@ body.ubuntu_mono .searchBox {
    background: #FFF;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .search {
+.rstudio-themes-flat .rstudio-themes-dark .search {
    border-color: rgb(45,60,75);
    background: rgb(145,154,161);
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .search input {
+.rstudio-themes-flat .rstudio-themes-dark .search input {
    color: white;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .search input::placeholder {
+.rstudio-themes-flat .rstudio-themes-dark .search input::placeholder {
    color: #EEE;
 }
 
@@ -1924,102 +1924,102 @@ body.ubuntu_mono .searchBox {
 
 /* RSTUDIO DEFAULT THEME */
 
-.rstudio-themes-flat.rstudio-themes-default .rstudio-themes-background,
-.rstudio-themes-flat.rstudio-themes-default .toolbar,
-.rstudio-themes-flat.rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
-.rstudio-themes-flat.rstudio-themes-default .secondaryToolbar {
+.rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background,
+.rstudio-themes-flat .rstudio-themes-default .toolbar,
+.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
+.rstudio-themes-flat .rstudio-themes-default .secondaryToolbar {
    background: THEME_DEFAULT_BACKGROUND;
 }
 
-body.rstudio-themes-flat.rstudio-themes-default {
+body.rstudio-themes-flat .rstudio-themes-default {
    background: rgb(247, 247, 247);
 }
 
-.rstudio-themes-flat.rstudio-themes-default table.header > tbody > tr > td,
-.rstudio-themes-flat.rstudio-themes-default .windowFrameObject > div:last-child,
-.rstudio-themes-flat.rstudio-themes-default .secondaryToolbar,
-.rstudio-themes-flat.rstudio-themes-default .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs,
-.rstudio-themes-flat.rstudio-themes-default .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
-.rstudio-themes-flat.rstudio-themes-default .minimizedWindowObject table.tabLayoutCenter,
-.rstudio-themes-flat.rstudio-themes-default .minimizedWindowObject  > div:last-child,
-.rstudio-themes-flat.rstudio-themes-default .toolbar {
+.rstudio-themes-flat .rstudio-themes-default table.header > tbody > tr > td,
+.rstudio-themes-flat .rstudio-themes-default .windowFrameObject > div:last-child,
+.rstudio-themes-flat .rstudio-themes-default .secondaryToolbar,
+.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs,
+.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
+.rstudio-themes-flat .rstudio-themes-default .minimizedWindowObject table.tabLayoutCenter,
+.rstudio-themes-flat .rstudio-themes-default .minimizedWindowObject  > div:last-child,
+.rstudio-themes-flat .rstudio-themes-default .toolbar {
    border-color: THEME_DEFAULT_BORDER;
 }
 
-.rstudio-themes-flat.rstudio-themes-default .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
-.rstudio-themes-flat.rstudio-themes-default .minimizedWindowObject table.tabLayoutCenter {
+.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
+.rstudio-themes-flat .rstudio-themes-default .minimizedWindowObject table.tabLayoutCenter {
    background: rgb(236, 237, 238);
 }
 
-.rstudio-themes-flat.rstudio-themes-default .gwt-TabLayoutPanelTabs,
-.rstudio-themes-flat.rstudio-themes-default .minimizedWindowObject .center {
+.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
+.rstudio-themes-flat .rstudio-themes-default .minimizedWindowObject .center {
    background: #e7e8ea;
 }
 
 /* RSTUDIO DARK GREY THEME */
 
-.rstudio-themes-flat.rstudio-themes-dark-grey .rstudio-themes-background,
-.rstudio-themes-flat.rstudio-themes-dark-grey .toolbar,
-.rstudio-themes-flat.rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
-.rstudio-themes-flat.rstudio-themes-dark-grey .secondaryToolbar {
+.rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background,
+.rstudio-themes-flat .rstudio-themes-dark-grey .toolbar,
+.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
+.rstudio-themes-flat .rstudio-themes-dark-grey .secondaryToolbar {
    background: THEME_DARKGREY_BACKGROUND;
 }
 
-body.rstudio-themes-flat.rstudio-themes-dark-grey {
+body.rstudio-themes-flat .rstudio-themes-dark-grey {
    background: rgb(50, 76, 99);
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-grey table.header > tbody > tr > td,
-.rstudio-themes-flat.rstudio-themes-dark-grey .windowFrameObject > div:last-child,
-.rstudio-themes-flat.rstudio-themes-dark-grey .secondaryToolbar,
-.rstudio-themes-flat.rstudio-themes-dark-grey .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs,
-.rstudio-themes-flat.rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
-.rstudio-themes-flat.rstudio-themes-dark-grey .minimizedWindowObject table.tabLayoutCenter,
-.rstudio-themes-flat.rstudio-themes-dark-grey .minimizedWindowObject  > div:last-child,
-.rstudio-themes-flat.rstudio-themes-dark-grey .toolbar {
+.rstudio-themes-flat .rstudio-themes-dark-grey table.header > tbody > tr > td,
+.rstudio-themes-flat .rstudio-themes-dark-grey .windowFrameObject > div:last-child,
+.rstudio-themes-flat .rstudio-themes-dark-grey .secondaryToolbar,
+.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs,
+.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
+.rstudio-themes-flat .rstudio-themes-dark-grey .minimizedWindowObject table.tabLayoutCenter,
+.rstudio-themes-flat .rstudio-themes-dark-grey .minimizedWindowObject  > div:last-child,
+.rstudio-themes-flat .rstudio-themes-dark-grey .toolbar {
    border-color: THEME_DARKGREY_BORDER;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
-.rstudio-themes-flat.rstudio-themes-dark-grey .minimizedWindowObject table.tabLayoutCenter {
+.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
+.rstudio-themes-flat .rstudio-themes-dark-grey .minimizedWindowObject table.tabLayoutCenter {
    background: rgb(57, 67, 75);
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
-.rstudio-themes-flat.rstudio-themes-dark-grey .minimizedWindowObject .center {
+.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
+.rstudio-themes-flat .rstudio-themes-dark-grey .minimizedWindowObject .center {
    background: rgb(47, 57, 65);
 }
 
 /* RSTUDIO ALTERNATE THEME */
 
-.rstudio-themes-flat.rstudio-themes-alternate .rstudio-themes-background,
-.rstudio-themes-flat.rstudio-themes-alternate .toolbar,
-.rstudio-themes-flat.rstudio-themes-alternate .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
-.rstudio-themes-flat.rstudio-themes-alternate .secondaryToolbar {
+.rstudio-themes-flat .rstudio-themes-alternate .rstudio-themes-background,
+.rstudio-themes-flat .rstudio-themes-alternate .toolbar,
+.rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
+.rstudio-themes-flat .rstudio-themes-alternate .secondaryToolbar {
    background: THEME_ALTERNATE_BACKGROUND;
 }
 
-body.rstudio-themes-flat.rstudio-themes-alternate {
+body.rstudio-themes-flat .rstudio-themes-alternate {
    background: rgb(162, 197, 215);
 }
 
-.rstudio-themes-flat.rstudio-themes-alternate table.header > tbody > tr > td,
-.rstudio-themes-flat.rstudio-themes-alternate .windowFrameObject > div:last-child,
-.rstudio-themes-flat.rstudio-themes-alternate .secondaryToolbar,
-.rstudio-themes-flat.rstudio-themes-alternate .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs,
-.rstudio-themes-flat.rstudio-themes-alternate .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
-.rstudio-themes-flat.rstudio-themes-alternate .minimizedWindowObject table.tabLayoutCenter,
-.rstudio-themes-flat.rstudio-themes-alternate .minimizedWindowObject  > div:last-child,
-.rstudio-themes-flat.rstudio-themes-alternate .toolbar {
+.rstudio-themes-flat .rstudio-themes-alternate table.header > tbody > tr > td,
+.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject > div:last-child,
+.rstudio-themes-flat .rstudio-themes-alternate .secondaryToolbar,
+.rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs,
+.rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
+.rstudio-themes-flat .rstudio-themes-alternate .minimizedWindowObject table.tabLayoutCenter,
+.rstudio-themes-flat .rstudio-themes-alternate .minimizedWindowObject  > div:last-child,
+.rstudio-themes-flat .rstudio-themes-alternate .toolbar {
    border-color: THEME_ALTERNATE_BORDER;
 }
 
-.rstudio-themes-flat.rstudio-themes-alternate .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
-.rstudio-themes-flat.rstudio-themes-alternate .minimizedWindowObject table.tabLayoutCenter {
+.rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
+.rstudio-themes-flat .rstudio-themes-alternate .minimizedWindowObject table.tabLayoutCenter {
    background: rgb(148, 180, 197);
 }
 
-.rstudio-themes-flat.rstudio-themes-alternate .gwt-TabLayoutPanelTabs,
-.rstudio-themes-flat.rstudio-themes-alternate .minimizedWindowObject .center {
+.rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanelTabs,
+.rstudio-themes-flat .rstudio-themes-alternate .minimizedWindowObject .center {
    background: rgb(158, 160, 187);
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2007,6 +2007,10 @@ body.rstudio-themes-flat .rstudio-themes-default {
    background: #e7e8ea;
 }
 
+.rstudio-themes-flat .rstudio-themes-default .multiPodUtilityArea {
+   background: linear-gradient(to right, rgba(0,0,0,0), rgb(236, 237, 238) 13%);
+}
+
 /* RSTUDIO DARK GREY THEME */
 
 .rstudio-themes-flat .rstudio-themes-dark-grey .rstudio-themes-background,
@@ -2039,6 +2043,10 @@ body.rstudio-themes-flat .rstudio-themes-dark-grey {
 .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstudio-themes-flat .rstudio-themes-dark-grey .minimizedWindowObject .center {
    background: rgb(47, 57, 65);
+}
+
+.rstudio-themes-flat .rstudio-themes-dark-grey .multiPodUtilityArea {
+   background: linear-gradient(to right, rgba(0,0,0,0), rgb(47, 57, 65) 13%);
 }
 
 /* RSTUDIO ALTERNATE THEME */
@@ -2091,4 +2099,8 @@ body.rstudio-themes-flat .rstudio-themes-alternate {
 .rstudio-themes-flat .rstudio-themes-alternate .minimizedWindow .minimize:hover,
 .rstudio-themes-flat .rstudio-themes-alternate .minimizedWindow .maximize:hover {
    filter: brightness(0.4);
+}
+
+.rstudio-themes-flat .rstudio-themes-alternate .multiPodUtilityArea {
+   background: linear-gradient(to right, rgba(0,0,0,0), rgb(158, 160, 187) 13%);
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/SmallButton.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/SmallButton.css
@@ -1,4 +1,4 @@
-@external rstudio-themes-flat;
+@external rstudio-themes-flat, rstudio-themes-dark;
 
 .smallButton {
    display: block;
@@ -42,6 +42,10 @@
    overflow: hidden;
 }
 
+.rstudio-themes-flat.rstudio-themes-dark button.smallButton > table:first-child {
+   box-shadow: none;
+}
+
 .rstudio-themes-flat button.smallButton:active > table:first-child {
    background: #eaeaea;
 }
@@ -55,6 +59,19 @@
    font-size: 10px;
 }
 
+.rstudio-themes-flat.rstudio-themes-dark .buttonCenter {
+   color: white;
+}
+
 .rstudio-themes-flat .buttonRight {
    background: none;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark button.smallButton > table:first-child {
+   border-color: rgb(45,60,75);
+   background: rgb(145,154,161);
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .buttonContent {
+   color: white;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/SmallButton.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/SmallButton.css
@@ -42,7 +42,7 @@
    overflow: hidden;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark button.smallButton > table:first-child {
+.rstudio-themes-flat .rstudio-themes-dark button.smallButton > table:first-child {
    box-shadow: none;
 }
 
@@ -59,7 +59,7 @@
    font-size: 10px;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .buttonCenter {
+.rstudio-themes-flat .rstudio-themes-dark .buttonCenter {
    color: white;
 }
 
@@ -67,11 +67,11 @@
    background: none;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark button.smallButton > table:first-child {
+.rstudio-themes-flat .rstudio-themes-dark button.smallButton > table:first-child {
    border-color: rgb(45,60,75);
    background: rgb(145,154,161);
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .buttonContent {
+.rstudio-themes-flat .rstudio-themes-dark .buttonContent {
    color: white;
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -145,6 +145,7 @@ public class Application implements ApplicationEventHandlers
       events.addHandler(ServerOfflineEvent.TYPE, this);
       events.addHandler(InvalidSessionEvent.TYPE, this);
       events.addHandler(SwitchToRVersionEvent.TYPE, this);
+      events.addHandler(ThemeChangedEvent.TYPE, this);
       
       // register for uncaught exceptions
       uncaughtExHandler.register();
@@ -616,6 +617,14 @@ public class Application implements ApplicationEventHandlers
       view_.showSessionAbendWarning();
    }
    
+   @Override
+   public void onThemeChanged(ThemeChangedEvent event)
+   {
+      RStudioThemes.initializeThemes(uiPrefs_.get().getFlatTheme().getGlobalValue(),
+                                     Document.get(),
+                                     rootPanel_.getElement());
+   }
+   
    private void verifyAgreement(SessionInfo sessionInfo,
                               final Operation verifiedOperation)
    {
@@ -708,7 +717,9 @@ public class Application implements ApplicationEventHandlers
    
    private void initializeWorkbench()
    {
-      RStudioThemes.initializeThemes(uiPrefs_.get(), Document.get(), rootPanel_.getElement());
+      RStudioThemes.initializeThemes(uiPrefs_.get().getFlatTheme().getGlobalValue(),
+                                     Document.get(),
+                                     rootPanel_.getElement());
 
       pAceThemes_.get();
 

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -153,8 +153,11 @@ public class Application implements ApplicationEventHandlers
    public void go(final RootLayoutPanel rootPanel, 
                   final Command dismissLoadingProgress)
    {
+      rootPanel_ = rootPanel;
+
       Widget w = view_.getWidget();
       rootPanel.add(w);
+
       rootPanel.setWidgetTopBottom(w, 0, Style.Unit.PX, 0, Style.Unit.PX);
       rootPanel.setWidgetLeftRight(w, 0, Style.Unit.PX, 0, Style.Unit.PX);
 
@@ -705,7 +708,7 @@ public class Application implements ApplicationEventHandlers
    
    private void initializeWorkbench()
    {
-      RStudioThemes.initializeThemes(uiPrefs_.get(), Document.get());
+      RStudioThemes.initializeThemes(uiPrefs_.get(), Document.get(), rootPanel_.getElement());
 
       pAceThemes_.get();
 
@@ -994,4 +997,5 @@ public class Application implements ApplicationEventHandlers
    private final String CSRF_TOKEN_FIELD = "csrf-token";
 
    private ClientStateUpdater clientStateUpdaterInstance_;
+   private RootLayoutPanel rootPanel_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/events/ApplicationEventHandlers.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/ApplicationEventHandlers.java
@@ -27,6 +27,7 @@ public interface ApplicationEventHandlers extends LogoutRequestedHandler,
                                                   ClientDisconnectedHandler,
                                                   InvalidClientVersionHandler,
                                                   ServerOfflineHandler,
-                                                  InvalidSessionEvent.Handler
+                                                  InvalidSessionEvent.Handler,
+                                                  ThemeChangedEvent.Handler
 {
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/events/ThemeChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/ThemeChangedEvent.java
@@ -1,0 +1,58 @@
+/*
+ * ThemeChangedEvent.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.application.events;
+
+import org.rstudio.core.client.js.JavaScriptSerializable;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+@JavaScriptSerializable
+public class ThemeChangedEvent extends CrossWindowEvent<ThemeChangedEvent.Handler>
+{
+   public interface Handler extends EventHandler
+   {
+      void onThemeChanged(ThemeChangedEvent event);
+   }
+
+   public ThemeChangedEvent()
+   {
+   }
+   
+   public ThemeChangedEvent(String themeName)
+   {
+      themeName_ = themeName;
+   }
+
+   public String getName()
+   {
+      return themeName_;
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onThemeChanged(this);
+   }
+
+   private String themeName_;
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
@@ -18,16 +18,19 @@ package org.rstudio.studio.client.application.ui;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 
 import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
 
 public class RStudioThemes
 {
-   public static void initializeThemes(UIPrefs uiPrefs, Document document)
+   public static void initializeThemes(UIPrefs uiPrefs,
+                                       Document document,
+                                       Element element)
    {
       document.getBody().removeClassName("rstudio-themes-flat");
-      document.getBody().removeClassName("rstudio-themes-dark");
-      document.getBody().removeClassName("rstudio-themes-default");
-      document.getBody().removeClassName("rstudio-themes-dark-grey");
-      document.getBody().removeClassName("rstudio-themes-alternate");
+      element.removeClassName("rstudio-themes-dark");
+      element.removeClassName("rstudio-themes-default");
+      element.removeClassName("rstudio-themes-dark-grey");
+      element.removeClassName("rstudio-themes-alternate");
       
       if (uiPrefs.getUseFlatThemes().getGlobalValue()) {         
          String themeName = uiPrefs.getFlatTheme().getGlobalValue();
@@ -37,9 +40,9 @@ public class RStudioThemes
          
          document.getBody().addClassName("rstudio-themes-flat");
          if (themeName.contains("dark")) {
-            document.getBody().addClassName("rstudio-themes-dark");
+            element.addClassName("rstudio-themes-dark");
          }
-         document.getBody().addClassName("rstudio-themes-" + themeName);
+         element.addClassName("rstudio-themes-" + themeName);
       }
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
@@ -22,7 +22,7 @@ import com.google.gwt.dom.client.Element;
 
 public class RStudioThemes
 {
-   public static void initializeThemes(UIPrefs uiPrefs,
+   public static void initializeThemes(String themeName,
                                        Document document,
                                        Element element)
    {
@@ -32,17 +32,16 @@ public class RStudioThemes
       element.removeClassName("rstudio-themes-dark-grey");
       element.removeClassName("rstudio-themes-alternate");
       
-      if (uiPrefs.getUseFlatThemes().getGlobalValue()) {         
-         String themeName = uiPrefs.getFlatTheme().getGlobalValue();
-         
-         // upgrade classic theme when using flat themes
-         if (themeName == "classic") themeName = "default";
-         
+      if (themeName != "classic") {         
          document.getBody().addClassName("rstudio-themes-flat");
          if (themeName.contains("dark")) {
             element.addClassName("rstudio-themes-dark");
          }
          element.addClassName("rstudio-themes-" + themeName);
       }
+   }
+
+   public static boolean isFlat(UIPrefs prefs) {
+      return prefs.getFlatTheme().getValue() != "classic"; 
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -35,6 +35,7 @@ import org.rstudio.studio.client.application.model.ApplicationServerOperations;
 import org.rstudio.studio.client.application.model.UpdateCheckResult;
 import org.rstudio.studio.client.application.ui.ApplicationHeader;
 import org.rstudio.studio.client.application.ui.GlobalToolbar;
+import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.debugging.ErrorManager;
 import org.rstudio.studio.client.events.EditEvent;
@@ -116,7 +117,7 @@ public class DesktopApplicationHeader implements ApplicationHeader
          {
             final SessionInfo sessionInfo = session.getSessionInfo();
             
-            isFlatTheme_ = pUIPrefs_.get().getUseFlatThemes().getValue(); 
+            isFlatTheme_ = RStudioThemes.isFlat(pUIPrefs_.get()); 
             toolbar_.completeInitialization(sessionInfo);
             
             new JSObjectStateValue(

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/header/HeaderPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/header/HeaderPanel.css
@@ -44,19 +44,19 @@
    display: none;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .center,
-.rstudio-themes-flat.rstudio-themes-dark .center button {
+.rstudio-themes-flat .rstudio-themes-dark .center,
+.rstudio-themes-flat .rstudio-themes-dark .center button {
    color: white;
 }
 
-.rstudio-themes-flat.rstudio-themes-default .center {
+.rstudio-themes-flat .rstudio-themes-default .center {
    border-color: THEME_DEFAULT_BORDER;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-grey .center {
+.rstudio-themes-flat .rstudio-themes-dark-grey .center {
    border-color: THEME_DARKGREY_BORDER;
 }
 
-.rstudio-themes-flat.rstudio-themes-alternate .center {
+.rstudio-themes-flat .rstudio-themes-alternate .center {
    border-color: THEME_ALTERNATE_BORDER;
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteManager.java
@@ -473,7 +473,9 @@ public class SatelliteManager implements CloseHandler<Window>
          callSetParams(satelliteWnd, params);
 
       // set themes
-      RStudioThemes.initializeThemes(pUIPrefs_.get(), satellite.getWindow().getDocument());
+      RStudioThemes.initializeThemes(pUIPrefs_.get(),
+                                     satellite.getWindow().getDocument(),
+                                     satellite.getWindow().getDocument().getBody());
    }
    
    // called to register child windows (not necessarily full-fledged 

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteManager.java
@@ -35,6 +35,7 @@ import org.rstudio.studio.client.application.ApplicationUncaughtExceptionHandler
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.CrossWindowEvent;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.application.events.ThemeChangedEvent;
 import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.common.GlobalDisplay.NewWindowOptions;
 import org.rstudio.studio.client.common.satellite.events.AllSatellitesClosingEvent;
@@ -473,9 +474,9 @@ public class SatelliteManager implements CloseHandler<Window>
          callSetParams(satelliteWnd, params);
 
       // set themes
-      RStudioThemes.initializeThemes(pUIPrefs_.get(),
-                                     satellite.getWindow().getDocument(),
-                                     satellite.getWindow().getDocument().getBody());
+      events_.fireEventToSatellite(new ThemeChangedEvent(
+         pUIPrefs_.get().getFlatTheme().getGlobalValue()),
+         satelliteWnd);
    }
    
    // called to register child windows (not necessarily full-fledged 

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteWindow.java
@@ -20,6 +20,9 @@ import org.rstudio.core.client.widget.FontSizer;
 import org.rstudio.studio.client.application.events.ChangeFontSizeEvent;
 import org.rstudio.studio.client.application.events.ChangeFontSizeHandler;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.application.events.ThemeChangedEvent;
+import org.rstudio.studio.client.application.ui.RStudioThemes;
+import org.rstudio.studio.client.common.satellite.events.SatelliteWindowEventHandlers;
 import org.rstudio.studio.client.workbench.ui.FontSizeManager;
 
 import com.google.gwt.core.client.JavaScriptObject;
@@ -34,7 +37,8 @@ import com.google.inject.Provider;
 
 public abstract class SatelliteWindow extends Composite
                                       implements RequiresResize, 
-                                      ProvidesResize
+                                                 ProvidesResize,
+                                                 SatelliteWindowEventHandlers
 {
    public SatelliteWindow(Provider<EventBus> pEventBus,
                           Provider<FontSizeManager> pFontSizeManager)
@@ -42,6 +46,8 @@ public abstract class SatelliteWindow extends Composite
       // save references
       pEventBus_ = pEventBus;
       pFontSizeManager_ = pFontSizeManager;
+
+      pEventBus_.get().addHandler(ThemeChangedEvent.TYPE, this);
       
       // occupy full client area of the window
       if (!allowScrolling())
@@ -53,6 +59,15 @@ public abstract class SatelliteWindow extends Composite
        
       // init widget
       initWidget(mainPanel_);
+   }
+
+   @Override
+   public void onThemeChanged(ThemeChangedEvent event)
+   {
+      RStudioThemes.initializeThemes(
+         event.getName(),
+         Document.get(),
+         mainPanel_.getElement());
    }
 
    protected boolean allowScrolling()

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/events/SatelliteWindowEventHandlers.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/events/SatelliteWindowEventHandlers.java
@@ -1,0 +1,21 @@
+/*
+ * SatelliteWindowEventHandlers.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.common.satellite.events;
+
+import org.rstudio.studio.client.application.events.ThemeChangedEvent;
+
+public interface SatelliteWindowEventHandlers extends ThemeChangedEvent.Handler
+{
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -641,11 +641,6 @@ public class UIPrefsAccessor extends Prefs
    {
       return bool("wrap_tab_navigation", false);
    }
-   
-   public PrefValue<Boolean> getUseFlatThemes()
-   {
-      return bool("use_flat_themes", false);
-   }
 
    public PrefValue<String> getFlatTheme()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -14,15 +14,11 @@
  */
 package org.rstudio.studio.client.workbench.prefs.views;
 
-import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.SelectElement;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.resources.client.ImageResource;
-import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
@@ -34,7 +30,8 @@ import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.ThemeFonts;
 import org.rstudio.core.client.widget.SelectWidget;
 import org.rstudio.studio.client.application.Desktop;
-import org.rstudio.studio.client.application.ui.RStudioThemes;
+import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.application.events.ThemeChangedEvent;
 import org.rstudio.studio.client.workbench.prefs.model.RPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
@@ -44,10 +41,12 @@ public class AppearancePreferencesPane extends PreferencesPane
    @Inject
    public AppearancePreferencesPane(PreferencesDialogResources res,
                                     UIPrefs uiPrefs,
-                                    final AceThemes themes)
+                                    final AceThemes themes,
+                                    EventBus eventBus)
    {
       res_ = res;
       uiPrefs_ = uiPrefs;
+      eventBus_ = eventBus;
 
       VerticalPanel leftPanel = new VerticalPanel();
 
@@ -244,11 +243,11 @@ public class AppearancePreferencesPane extends PreferencesPane
          }
       }
 
-      uiPrefs_.getUseFlatThemes().setGlobalValue(flatTheme_.getValue() != "classic");
-      uiPrefs_.getFlatTheme().setGlobalValue(flatTheme_.getValue());
+      uiPrefs_.getFlatTheme().setGlobalValue(flatTheme_.getValue());  
+      ThemeChangedEvent themeChangedEvent = new ThemeChangedEvent(flatTheme_.getValue());
+      eventBus_.fireEvent(themeChangedEvent);
+      eventBus_.fireEventToAllSatellites(themeChangedEvent);
       
-      RStudioThemes.initializeThemes(uiPrefs_, Document.get(), Document.get().getBody());
-
       return restartRequired;
    }
 
@@ -300,4 +299,5 @@ public class AppearancePreferencesPane extends PreferencesPane
          "    UseMethod(\"plot\")\n" +
          "}\n";
 
+   EventBus eventBus_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -247,7 +247,7 @@ public class AppearancePreferencesPane extends PreferencesPane
       uiPrefs_.getUseFlatThemes().setGlobalValue(flatTheme_.getValue() != "classic");
       uiPrefs_.getFlatTheme().setGlobalValue(flatTheme_.getValue());
       
-      RStudioThemes.initializeThemes(uiPrefs_, Document.get());
+      RStudioThemes.initializeThemes(uiPrefs_, Document.get(), Document.get().getBody());
 
       return restartRequired;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
@@ -22,6 +22,7 @@ import org.rstudio.core.client.events.EnsureVisibleEvent;
 import org.rstudio.core.client.events.EnsureVisibleHandler;
 import org.rstudio.core.client.layout.LogicalWindow;
 import org.rstudio.core.client.theme.PrimaryWindowFrame;
+import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
@@ -36,6 +37,7 @@ import org.rstudio.studio.client.workbench.views.console.events.WorkingDirChange
 import org.rstudio.studio.client.workbench.views.output.find.FindOutputTab;
 import org.rstudio.studio.client.workbench.views.output.markers.MarkersOutputTab;
 
+import com.google.gwt.dom.client.Element;
 import com.google.inject.Inject;
 
 public class ConsoleTabPanel extends WorkbenchTabPanel
@@ -269,22 +271,22 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
       consoleOnly_ = terminalTabVisible_;
       managePanels();
    }
-   
-   public boolean consoleOnly()
-   {
-      return !terminalTabVisible_ &&
-             !compilePdfTabVisible_ && 
-             !findResultsTabVisible_ &&
-             !sourceCppTabVisible_ &&
-             !renderRmdTabVisible_ &&
-             !deployContentTabVisible_ &&
-             !markersTabVisible_;
-   }
 
    private void managePanels()
    {
-      boolean consoleOnly = consoleOnly();
-
+      boolean consoleOnly = !terminalTabVisible_ &&
+                            !compilePdfTabVisible_ && 
+                            !findResultsTabVisible_ &&
+                            !sourceCppTabVisible_ &&
+                            !renderRmdTabVisible_ &&
+                            !deployContentTabVisible_ &&
+                            !markersTabVisible_;
+      
+      if (consoleOnly)
+         owner_.addStyleName(ThemeResources.INSTANCE.themeStyles().consoleOnlyWindowFrame());
+      else
+         owner_.removeStyleName(ThemeResources.INSTANCE.themeStyles().consoleOnlyWindowFrame());
+      
       if (!consoleOnly)
       {
          ArrayList<WorkbenchTab> tabs = new ArrayList<WorkbenchTab>();
@@ -340,6 +342,39 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
             owner_.setContextButton(null, 0, 0, 1);
             owner_.setContextButton(null, 0, 0, 2);
          }
+      }
+      
+      addLayoutStyles(owner_.getElement());
+   }
+   
+   public void addLayoutStyles(Element parent)
+   {
+      // In order to be able to style the actual layout div that GWT uses internally
+      // to construct the WindowFrame layout, we need to assign it ourselves.
+      for (Element e = parent.getFirstChildElement(); e != null; e = e.getNextSiblingElement()) {
+         boolean hasWidgetClass = false;
+         boolean hasHeaderClass = false;
+         boolean hasMinimizeClass = false;
+         boolean hasMaximizeClass = false;
+         
+         for (Element c = e.getFirstChildElement(); c != null; c = c.getNextSiblingElement()) {
+            if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().windowFrameWidget()))
+               hasWidgetClass = true;
+            
+            if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().primaryWindowFrameHeader()))
+               hasHeaderClass = true;
+            
+            if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().minimize()))
+               hasMinimizeClass = true;
+            
+            if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().maximize()))
+               hasMaximizeClass = true;
+         }
+         
+         if (hasWidgetClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleWidgetLayout());
+         if (hasHeaderClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleHeaderLayout());
+         if (hasMinimizeClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleMinimizeLayout());
+         if (hasMaximizeClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleMaximizeLayout());
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
@@ -269,16 +269,21 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
       consoleOnly_ = terminalTabVisible_;
       managePanels();
    }
+   
+   public boolean consoleOnly()
+   {
+      return !terminalTabVisible_ &&
+             !compilePdfTabVisible_ && 
+             !findResultsTabVisible_ &&
+             !sourceCppTabVisible_ &&
+             !renderRmdTabVisible_ &&
+             !deployContentTabVisible_ &&
+             !markersTabVisible_;
+   }
 
    private void managePanels()
    {
-      boolean consoleOnly = !terminalTabVisible_ &&
-                            !compilePdfTabVisible_ && 
-                            !findResultsTabVisible_ &&
-                            !sourceCppTabVisible_ &&
-                            !renderRmdTabVisible_ &&
-                            !deployContentTabVisible_ &&
-                            !markersTabVisible_;
+      boolean consoleOnly = consoleOnly();
 
       if (!consoleOnly)
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -924,7 +924,7 @@ public class PaneManager
    private LogicalWindow createConsole()
    {
       PrimaryWindowFrame frame = new PrimaryWindowFrame("Console", null);
-
+      
       ToolbarButton goToWorkingDirButton =
             commands_.goToWorkingDir().createToolbarButton();
       goToWorkingDirButton.addStyleName(
@@ -946,6 +946,20 @@ public class PaneManager
             terminalTab_,
             eventBus_,
             goToWorkingDirButton);
+      
+      
+      
+      // In order to be able to style the actual layout div that GWT uses internally
+      // to construct the WindowFrame layout, we need to assign it ourselves.
+      for (Element e = frame.getElement().getFirstChildElement(); e != null; e = e.getNextSiblingElement()) {
+         boolean hasLookupClass = false;
+         for (Element c = e.getFirstChildElement(); c != null; c = c.getNextSiblingElement()) {
+            if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().windowFrameWidget()))
+               hasLookupClass = true;
+         }
+         
+         if (hasLookupClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().windowFrameConsoleLayout());
+      }
       
       return logicalWindow;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -947,18 +947,22 @@ public class PaneManager
             eventBus_,
             goToWorkingDirButton);
       
-      
-      
       // In order to be able to style the actual layout div that GWT uses internally
       // to construct the WindowFrame layout, we need to assign it ourselves.
       for (Element e = frame.getElement().getFirstChildElement(); e != null; e = e.getNextSiblingElement()) {
-         boolean hasLookupClass = false;
+         boolean hasWidgetClass = false;
+         boolean hasHeaderClass = false;
+         
          for (Element c = e.getFirstChildElement(); c != null; c = c.getNextSiblingElement()) {
             if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().windowFrameWidget()))
-               hasLookupClass = true;
+               hasWidgetClass = true;
+            
+            if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().primaryWindowFrameHeader()))
+               hasHeaderClass = true;
          }
          
-         if (hasLookupClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().windowFrameConsoleLayout());
+         if (hasWidgetClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleWidgetLayout());
+         if (hasHeaderClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleHeaderLayout());
       }
       
       return logicalWindow;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -953,6 +953,8 @@ public class PaneManager
       for (Element e = frame.getElement().getFirstChildElement(); e != null; e = e.getNextSiblingElement()) {
          boolean hasWidgetClass = false;
          boolean hasHeaderClass = false;
+         boolean hasMinimizeClass = false;
+         boolean hasMaximizeClass = false;
          
          for (Element c = e.getFirstChildElement(); c != null; c = c.getNextSiblingElement()) {
             if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().windowFrameWidget()))
@@ -960,10 +962,18 @@ public class PaneManager
             
             if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().primaryWindowFrameHeader()))
                hasHeaderClass = true;
+            
+            if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().minimize()))
+               hasMinimizeClass = true;
+            
+            if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().maximize()))
+               hasMaximizeClass = true;
          }
          
          if (hasWidgetClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleWidgetLayout());
          if (hasHeaderClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleHeaderLayout());
+         if (hasMinimizeClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleMinimizeLayout());
+         if (hasMaximizeClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleMaximizeLayout());
       }
       
       return logicalWindow;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -947,36 +947,7 @@ public class PaneManager
             eventBus_,
             goToWorkingDirButton);
       
-      if (consoleTabPanel_.consoleOnly()) {
-         // In order to be able to style the actual layout div that GWT uses internally
-         // to construct the WindowFrame layout, we need to assign it ourselves.
-         frame.addStyleName(ThemeResources.INSTANCE.themeStyles().consoleOnlyWindowFrame());
-         for (Element e = frame.getElement().getFirstChildElement(); e != null; e = e.getNextSiblingElement()) {
-            boolean hasWidgetClass = false;
-            boolean hasHeaderClass = false;
-            boolean hasMinimizeClass = false;
-            boolean hasMaximizeClass = false;
-            
-            for (Element c = e.getFirstChildElement(); c != null; c = c.getNextSiblingElement()) {
-               if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().windowFrameWidget()))
-                  hasWidgetClass = true;
-               
-               if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().primaryWindowFrameHeader()))
-                  hasHeaderClass = true;
-               
-               if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().minimize()))
-                  hasMinimizeClass = true;
-               
-               if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().maximize()))
-                  hasMaximizeClass = true;
-            }
-            
-            if (hasWidgetClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleOnlyWidgetLayout());
-            if (hasHeaderClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleOnlyHeaderLayout());
-            if (hasMinimizeClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleOnlyMinimizeLayout());
-            if (hasMaximizeClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleOnlyMaximizeLayout());
-         }
-      }
+      consoleTabPanel_.addLayoutStyles(frame.getElement());
       
       return logicalWindow;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -949,6 +949,7 @@ public class PaneManager
       
       // In order to be able to style the actual layout div that GWT uses internally
       // to construct the WindowFrame layout, we need to assign it ourselves.
+      frame.addStyleName(ThemeResources.INSTANCE.themeStyles().consoleWindowFrame());
       for (Element e = frame.getElement().getFirstChildElement(); e != null; e = e.getNextSiblingElement()) {
          boolean hasWidgetClass = false;
          boolean hasHeaderClass = false;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -947,33 +947,35 @@ public class PaneManager
             eventBus_,
             goToWorkingDirButton);
       
-      // In order to be able to style the actual layout div that GWT uses internally
-      // to construct the WindowFrame layout, we need to assign it ourselves.
-      frame.addStyleName(ThemeResources.INSTANCE.themeStyles().consoleWindowFrame());
-      for (Element e = frame.getElement().getFirstChildElement(); e != null; e = e.getNextSiblingElement()) {
-         boolean hasWidgetClass = false;
-         boolean hasHeaderClass = false;
-         boolean hasMinimizeClass = false;
-         boolean hasMaximizeClass = false;
-         
-         for (Element c = e.getFirstChildElement(); c != null; c = c.getNextSiblingElement()) {
-            if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().windowFrameWidget()))
-               hasWidgetClass = true;
+      if (consoleTabPanel_.consoleOnly()) {
+         // In order to be able to style the actual layout div that GWT uses internally
+         // to construct the WindowFrame layout, we need to assign it ourselves.
+         frame.addStyleName(ThemeResources.INSTANCE.themeStyles().consoleOnlyWindowFrame());
+         for (Element e = frame.getElement().getFirstChildElement(); e != null; e = e.getNextSiblingElement()) {
+            boolean hasWidgetClass = false;
+            boolean hasHeaderClass = false;
+            boolean hasMinimizeClass = false;
+            boolean hasMaximizeClass = false;
             
-            if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().primaryWindowFrameHeader()))
-               hasHeaderClass = true;
+            for (Element c = e.getFirstChildElement(); c != null; c = c.getNextSiblingElement()) {
+               if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().windowFrameWidget()))
+                  hasWidgetClass = true;
+               
+               if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().primaryWindowFrameHeader()))
+                  hasHeaderClass = true;
+               
+               if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().minimize()))
+                  hasMinimizeClass = true;
+               
+               if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().maximize()))
+                  hasMaximizeClass = true;
+            }
             
-            if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().minimize()))
-               hasMinimizeClass = true;
-            
-            if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().maximize()))
-               hasMaximizeClass = true;
+            if (hasWidgetClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleOnlyWidgetLayout());
+            if (hasHeaderClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleOnlyHeaderLayout());
+            if (hasMinimizeClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleOnlyMinimizeLayout());
+            if (hasMaximizeClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleOnlyMaximizeLayout());
          }
-         
-         if (hasWidgetClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleWidgetLayout());
-         if (hasHeaderClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleHeaderLayout());
-         if (hasMinimizeClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleMinimizeLayout());
-         if (hasMaximizeClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleMaximizeLayout());
       }
       
       return logicalWindow;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsListDataGridStyle.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsListDataGridStyle.css
@@ -2,10 +2,10 @@
   background: rgba(181, 213, 255, 0.5);
 }
 
-.dataGridHoveredRowCell {
-  border: selectionBorderWidth solid transparent;
+.dataGridCell {
+  border: 0px;
+  padding: 3px !important;
 }
-
 
 .statusColumn {
    color: #606060;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsPane.java
@@ -104,6 +104,7 @@ public class ConnectionsPane extends WorkbenchPane
       
       selectionModel_ = new SingleSelectionModel<Connection>();
       connectionsDataGrid_ = new DataGrid<Connection>(1000, RES, keyProvider_);
+      connectionsDataGrid_.addStyleName("ace_editor");
       connectionsDataGrid_.setSelectionModel(selectionModel_);
       selectionModel_.addSelectionChangeHandler(new SelectionChangeEvent.Handler()
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -28,6 +28,7 @@ import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.ImageMenuItem;
 import org.rstudio.studio.client.common.icons.StandardIcons;
@@ -154,7 +155,7 @@ public class EnvironmentPane extends WorkbenchPane
          }
       });
 
-      if (!prefs_.getUseFlatThemes().getValue()) {
+      if (!RStudioThemes.isFlat(prefs_)) {
          searchWidget.getElement().getStyle().setMarginTop(1, Unit.PX);
       }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectGrid.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectGrid.css
@@ -40,7 +40,7 @@ th.objectGridHeader
    padding-right: 2px;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark th.objectGridHeader {
+.rstudio-themes-flat .rstudio-themes-dark th.objectGridHeader {
    color: white;
 }
 
@@ -74,14 +74,14 @@ th.checkColumn
 	padding-right: 35px;
 }
 
-.rstudio-themes-flat.rstudio-themes-default .objectGridHeader {
+.rstudio-themes-flat .rstudio-themes-default .objectGridHeader {
    border-color: THEME_DEFAULT_BORDER;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-grey .objectGridHeader {
+.rstudio-themes-flat .rstudio-themes-dark-grey .objectGridHeader {
    border-color: THEME_DARKGREY_BORDER;
 }
 
-.rstudio-themes-flat.rstudio-themes-alternate .objectGridHeader {
+.rstudio-themes-flat .rstudio-themes-alternate .objectGridHeader {
    border-color: THEME_ALTERNATE_BORDER;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilePathToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilePathToolbar.java
@@ -29,6 +29,7 @@ import org.rstudio.core.client.files.filedialog.PathBreadcrumbWidget;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.files.Files;
 
@@ -70,7 +71,7 @@ public class FilePathToolbar extends Composite
       UIPrefs uiPrefs = RStudioGinjector.INSTANCE.getUIPrefs();
       
       LayoutPanel layout = new LayoutPanel();
-      String layoutPanelHeight = uiPrefs.getUseFlatThemes().getValue() ? "20px" : "21px";
+      String layoutPanelHeight = RStudioThemes.isFlat(uiPrefs) ? "20px" : "21px";
       layout.setSize("100%", layoutPanelHeight);
 
       initWidget(layout);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/history/view/HistoryPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/history/view/HistoryPane.java
@@ -129,6 +129,8 @@ public class HistoryPane extends WorkbenchPane
    {
       mainPanel_ = new LayoutPanel();
 
+      mainPanel_.addStyleName("ace_editor");
+
       VerticalPanel vpanel = new VerticalPanel();
       vpanel.setSize("100%", "100%");
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGrid.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGrid.css
@@ -26,14 +26,14 @@
 	color: #b0b0b0;
 }
 
-.rstudio-themes-flat.rstudio-themes-default .dataGridHeader {
+.rstudio-themes-flat .rstudio-themes-default .dataGridHeader {
    background: THEME_DEFAULT_BACKGROUND;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-grey .dataGridHeader {
+.rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
    background: THEME_DARKGREY_BACKGROUND;
 }
 
-.rstudio-themes-flat.rstudio-themes-alternate .dataGridHeader {
+.rstudio-themes-flat .rstudio-themes-alternate .dataGridHeader {
    background: THEME_ALTERNATE_BACKGROUND;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGridCommon.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGridCommon.css
@@ -39,7 +39,7 @@
    height: 16px;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .dataGridHeader {
+.rstudio-themes-flat .rstudio-themes-dark .dataGridHeader {
    color: white;
 }
 
@@ -81,14 +81,14 @@ body.ubuntu_mono .dataGridCell input[type=checkbox] {
    margin-bottom: 0;
 }
 
-.rstudio-themes-flat.rstudio-themes-default .dataGridHeader {
+.rstudio-themes-flat .rstudio-themes-default .dataGridHeader {
    border-color: THEME_DEFAULT_BORDER;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-grey .dataGridHeader {
+.rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
    border-color: THEME_DARKGREY_BORDER;
 }
 
-.rstudio-themes-flat.rstudio-themes-alternate .dataGridHeader {
+.rstudio-themes-flat .rstudio-themes-alternate .dataGridHeader {
    border-color: THEME_ALTERNATE_BORDER;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.css
@@ -69,6 +69,6 @@
    outline: 0;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .checkboxLabel {
+.rstudio-themes-flat .rstudio-themes-dark .checkboxLabel {
    color: white;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.css
@@ -1,6 +1,8 @@
 @external gwt-CheckBox;
 @external macintosh, windows, ubuntu_mono;
 
+@external rstudio-themes-flat, rstudio-themes-dark;
+
 .findReplaceBar div, .findReplaceBar td {
    white-space: nowrap;
 }
@@ -65,4 +67,8 @@
    padding: 0 !important;
    margin: 0 !important;
    outline: 0;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .checkboxLabel {
+   color: white;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.java
@@ -64,6 +64,7 @@ public class FindReplaceBar extends Composite implements Display, RequiresResize
       
       Shelf shelf = new Shelf(true);
       shelf.setWidth("100%");
+      shelf.addStyleName("rstudio-themes-background"); 
 
       VerticalPanel panel = new VerticalPanel();
       ElementIds.assignElementId(panel.getElement(), 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarWidget.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarWidget.ui.xml
@@ -69,16 +69,16 @@
       .rstudio-themes-flat .statusBar .element.last {
          border-right: none;
       }
-      .rstudio-themes-flat.rstudio-themes-default .statusBar,
-      .rstudio-themes-flat.rstudio-themes-default .statusBar .element {
+      .rstudio-themes-flat .rstudio-themes-default .statusBar,
+      .rstudio-themes-flat .rstudio-themes-default .statusBar .element {
          border-color: THEME_DEFAULT_BORDER;
       }
-      .rstudio-themes-flat.rstudio-themes-dark-grey .statusBar,
-      .rstudio-themes-flat.rstudio-themes-dark-grey .statusBar .element {
+      .rstudio-themes-flat .rstudio-themes-dark-grey .statusBar,
+      .rstudio-themes-flat .rstudio-themes-dark-grey .statusBar .element {
          border-color: THEME_DARKGREY_BORDER;
       }
-      .rstudio-themes-flat.rstudio-themes-alternate .statusBar,
-      .rstudio-themes-flat.rstudio-themes-alternate .statusBar .element  {
+      .rstudio-themes-flat .rstudio-themes-alternate .statusBar,
+      .rstudio-themes-flat .rstudio-themes-alternate .statusBar .element  {
          border-color: THEME_ALTERNATE_BORDER;
       }
    </ui:style>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarWidget.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarWidget.ui.xml
@@ -8,7 +8,7 @@
    <ui:style>
       @url SEPARATOR statusBarSeparator;
       @external gwt-Label;
-      @external rstudio-themes-flat;
+      @external rstudio-themes-flat, rstudio-themes-dark;
 
       @external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
 
@@ -68,6 +68,9 @@
       }
       .rstudio-themes-flat .statusBar .element.last {
          border-right: none;
+      }
+      .rstudio-themes-flat .rstudio-themes-dark .statusBar {
+         color: white;
       }
       .rstudio-themes-flat .rstudio-themes-default .statusBar,
       .rstudio-themes-flat .rstudio-themes-default .statusBar .element {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ChangelistTableCellTableStyle.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ChangelistTableCellTableStyle.css
@@ -29,7 +29,7 @@ span.status img:first-child {
    margin-bottom: 0;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark .cellTableSortableHeader {
+.rstudio-themes-flat .rstudio-themes-dark .cellTableSortableHeader {
    color: white;
 }
 
@@ -51,17 +51,17 @@ span.status img:first-child {
    border-right: none;
 }
 
-.rstudio-themes-flat.rstudio-themes-default .cellTableSortableHeader {
+.rstudio-themes-flat .rstudio-themes-default .cellTableSortableHeader {
    background: THEME_DEFAULT_BACKGROUND;
    border-color: THEME_DEFAULT_BORDER;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-grey .cellTableSortableHeader {
+.rstudio-themes-flat .rstudio-themes-dark-grey .cellTableSortableHeader {
    background: THEME_DARKGREY_BACKGROUND;
    border-color: THEME_DARKGREY_BORDER;
 }
 
-.rstudio-themes-flat.rstudio-themes-alternate .cellTableSortableHeader {
+.rstudio-themes-flat .rstudio-themes-alternate .cellTableSortableHeader {
    background: THEME_ALTERNATE_BACKGROUND;
    border-color: THEME_ALTERNATE_BORDER;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
@@ -142,6 +142,7 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
    {
       frame_ = new RStudioFrame() ;
       frame_.setSize("100%", "100%");
+      frame_.addStyleName("ace_editor");
       navigate(ABOUT_BLANK, false);
       return new AutoGlassPanel(frame_);
    }


### PR DESCRIPTION
More improvements for themes, the major ones:
- Increased contrast between tabs.
- Support for single-tab console (since the widget structure is changed under this mode, this required additional styles to be added dynamically).
- Dark theme.
- Find and replace under dark theme.
- Check boxes under dark theme.
- Avoid themes in dialog windows.
- Deprecated use of `use_flat_theme` preference, using `flat_theme` instead.
- Apply themes to satellite windows.
- Min/max under dark theme.
- Applied ace theme to history, viewer and connections pane.

<img width="1435" alt="screen shot 2017-04-30 at 4 02 27 pm" src="https://cloud.githubusercontent.com/assets/3478847/25568763/03a7ea76-2dbf-11e7-875c-7f9c84851228.png">

<img width="1436" alt="screen shot 2017-04-30 at 4 13 56 pm" src="https://cloud.githubusercontent.com/assets/3478847/25568795/0a4e6124-2dc0-11e7-8a27-85d756981f7a.png">
