### PR TITLE
Support for themes in files and packages panes

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/cellview/LinkColumn.css
+++ b/src/gwt/src/org/rstudio/core/client/cellview/LinkColumn.css
@@ -1,4 +1,5 @@
 @external rstudio-themes-flat, rstudio-themes-dark;
+@external editor_dark;
 
 .link {
 	overflow: hidden;
@@ -14,6 +15,6 @@
    text-decoration: underline;	
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .link {
+.rstudio-themes-flat.editor_dark .link {
    color: #b4b4d8;
 }

--- a/src/gwt/src/org/rstudio/core/client/cellview/LinkColumn.css
+++ b/src/gwt/src/org/rstudio/core/client/cellview/LinkColumn.css
@@ -1,3 +1,5 @@
+@external rstudio-themes-flat, rstudio-themes-dark;
+
 .link {
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -10,4 +12,8 @@
 
 .link:hover {
    text-decoration: underline;	
+}
+
+.rstudio-themes-flat .rstudio-themes-dark .link {
+   color: #b4b4d8;
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
@@ -22,7 +22,7 @@
    outline: none;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .dataGridWidget {
+.rstudio-themes-flat .dataGridWidget {
   background-color: inherit;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
@@ -22,6 +22,10 @@
    outline: none;
 }
 
+.rstudio-themes-flat .rstudio-themes-dark .dataGridWidget {
+  background-color: inherit;
+}
+
 .dataGridWidget > div {
 	/* Override GWT styling set on element */
 	min-height: 16px !important;

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1147,6 +1147,10 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
   border-bottom: 1px solid rgb(169,169,169);
 }
 
+.rstudio-themes-flat .rstudio-themes-dark .secondaryToolbarPanel {
+  background: #6c7a86;
+}
+
 .rstudio-themes-flat .secondaryToolbar {
    border-bottom: solid 1px #d6dadc;
    height: 24px;

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2053,7 +2053,7 @@ body.ubuntu_mono .searchBox {
 }
 
 body.rstudio-themes-flat .rstudio-themes-default {
-   background: rgb(247, 247, 247);
+   background: rgb(246, 247, 249);
 }
 
 .rstudio-themes-flat .rstudio-themes-default table.header > tbody > tr > td,

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioFrame.java
@@ -55,7 +55,7 @@ public class RStudioFrame extends Frame
          BodyElement body = getWindow().getDocument().getBody();
          if (body != null)
          {
-            body.addClassName("ace_editor");
+            body.addClassName("ace_editor_theme");
          }
       }
    }

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioFrame.java
@@ -18,7 +18,11 @@ package org.rstudio.core.client.widget;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.IFrameElementEx;
 import org.rstudio.core.client.dom.WindowEx;
+import org.rstudio.studio.client.RStudioGinjector;
 
+import com.google.gwt.dom.client.BodyElement;
+import com.google.gwt.event.dom.client.LoadEvent;
+import com.google.gwt.event.dom.client.LoadHandler;
 import com.google.gwt.user.client.ui.Frame;
 
 public class RStudioFrame extends Frame
@@ -40,6 +44,34 @@ public class RStudioFrame extends Frame
          getElement().setAttribute("sandbox", StringUtil.notNull(sandboxAllow));
       if (url != null)
          setUrl(url);
+   }
+   
+   private void addAceThemeStyle()
+   {
+      if (getWindow() != null && getWindow().getDocument() != null)
+      {
+         RStudioGinjector.INSTANCE.getAceThemes().applyTheme(getWindow().getDocument());
+         
+         BodyElement body = getWindow().getDocument().getBody();
+         if (body != null)
+         {
+            body.addClassName("ace_editor");
+         }
+      }
+   }
+
+   public void setAceTheme()
+   {
+      addAceThemeStyle();
+      
+      this.addLoadHandler(new LoadHandler()
+      {      
+         @Override
+         public void onLoad(LoadEvent arg0)
+         {
+            addAceThemeStyle();
+         }
+      });
    }
    
    public WindowEx getWindow()

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -129,6 +129,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.r.Signature
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.TextEditingTargetNotebook;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.display.ChunkOptionsPopupPanel;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.display.SetupChunkOptionsPopupPanel;
+import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
 import org.rstudio.studio.client.workbench.views.vcs.svn.SVNCommandHandler;
 import org.rstudio.studio.client.workbench.views.environment.ClearAllDialog;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.DataImport;
@@ -262,4 +263,5 @@ public interface RStudioGinjector extends Ginjector
    Server getServer();
    ChunkWindowManager getChunkWindowManager();
    ProjectTemplateRegistryProvider getProjectTemplateRegistryProvider();
+   AceThemes getAceThemes();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsPane.java
@@ -92,6 +92,7 @@ public class ConnectionsPane extends WorkbenchPane
       
       // create main panel
       mainPanel_ = new LayoutPanel();
+      mainPanel_.addStyleName("ace_editor_theme");
       
       // create data grid
       keyProvider_ = new ProvidesKey<Connection>() {
@@ -104,7 +105,6 @@ public class ConnectionsPane extends WorkbenchPane
       
       selectionModel_ = new SingleSelectionModel<Connection>();
       connectionsDataGrid_ = new DataGrid<Connection>(1000, RES, keyProvider_);
-      connectionsDataGrid_.addStyleName("ace_editor");
       connectionsDataGrid_.setSelectionModel(selectionModel_);
       selectionModel_.addSelectionChangeHandler(new SelectionChangeEvent.Handler()
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyHost.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyHost.css
@@ -1,6 +1,11 @@
 @external gwt-Image;
 @external macintosh;
 
+@external rstudio-themes-flat, rstudio-themes-dark;
+@external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
+
+@eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.getDarkGreyBorder();
+
 .infoPanel {
    width: 500px;
    margin-top: 8px;
@@ -31,6 +36,18 @@
    width: 100% !important;
    height: 75px !important;
    font-size: 9pt;
+}
+
+.codeViewer {
+   border: 1px solid #BBB !important;
+   background-color: #FFF;
+   width: 100% !important;
+   height: 75px !important;
+   font-size: 9pt;
+}
+
+.rstudio-themes-flat .rstudio-themes-dark-grey .codeViewer {
+   border: 1px solid THEME_DARKGREY_BORDER !important;
 }
 
 .dialogCodePanel {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/FilesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/FilesPane.java
@@ -291,6 +291,7 @@ public class FilesPane extends WorkbenchPane implements Files.Display
       DockLayoutPanel dockPanel = new DockLayoutPanel(Unit.PX);
       dockPanel.addNorth(filePathToolbar_, filePathToolbar_.getHeight());
       dockPanel.add(filesList_);
+      dockPanel.addStyleName("ace_editor_theme");
       
       // return container
       return dockPanel;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesListDataGridStyle.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesListDataGridStyle.css
@@ -1,5 +1,7 @@
 @def selectionBorderWidth 2px;
 
+@external rstudio-themes-flat, rstudio-themes-dark;
+
 .dataGridCell {
   padding: 0 1px;
 }
@@ -18,7 +20,20 @@
   color: #606060;
 }
 
-.dataGridEvenRowCell, .dataGridOddRowCell, .dataGridHoveredRowCell, .dataGridSelectedRowCell, .dataGridKeyboardSelectedRowCell, .dataGridKeyboardSelectedCell   {
-  border: selectionBorderWidth solid #ffffff;
-  color: #606060;
+.dataGridWidget {
+
+}
+
+.rstudio-themes-flat .dataGridCell {
+  padding: 0 1px;
+  border-color: transparent;
+}
+
+.rstudio-themes-flat .rstudio-themes-dark .dataGridEvenRow,
+.rstudio-themes-flat .rstudio-themes-dark .dataGridOddRow,
+.rstudio-themes-flat .rstudio-themes-dark .dataGridHoveredRow,
+.rstudio-themes-flat .rstudio-themes-dark .dataGridSelectedRow,
+.rstudio-themes-flat .rstudio-themes-dark .dataGridKeyboardSelectedRow {
+  background: inherit;
+  color: inherit;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesListDataGridStyle.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesListDataGridStyle.css
@@ -29,11 +29,11 @@
   border-color: transparent;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .dataGridEvenRow,
-.rstudio-themes-flat .rstudio-themes-dark .dataGridOddRow,
-.rstudio-themes-flat .rstudio-themes-dark .dataGridHoveredRow,
-.rstudio-themes-flat .rstudio-themes-dark .dataGridSelectedRow,
-.rstudio-themes-flat .rstudio-themes-dark .dataGridKeyboardSelectedRow {
+.rstudio-themes-flat .dataGridEvenRow,
+.rstudio-themes-flat .dataGridOddRow,
+.rstudio-themes-flat .dataGridHoveredRow,
+.rstudio-themes-flat .dataGridSelectedRow,
+.rstudio-themes-flat .dataGridKeyboardSelectedRow {
   background: inherit;
   color: inherit;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -101,8 +101,10 @@ public class HelpPane extends WorkbenchPane
    protected Widget createMainWidget()
    {
       frame_ = new RStudioFrame();
+      frame_.setAceTheme();
       frame_.setSize("100%", "100%");
       frame_.setStylePrimaryName("rstudio-HelpFrame");
+      frame_.addStyleName("ace_editor");
       ElementIds.assignElementId(frame_.getElement(), ElementIds.HELP_FRAME);
 
       return new AutoGlassPanel(frame_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -104,7 +104,7 @@ public class HelpPane extends WorkbenchPane
       frame_.setAceTheme();
       frame_.setSize("100%", "100%");
       frame_.setStylePrimaryName("rstudio-HelpFrame");
-      frame_.addStyleName("ace_editor");
+      frame_.addStyleName("ace_editor_theme");
       ElementIds.assignElementId(frame_.getElement(), ElementIds.HELP_FRAME);
 
       return new AutoGlassPanel(frame_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
@@ -322,7 +322,7 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
    {
       packagesDataProvider_ = new ListDataProvider<PackageInfo>();
       packagesTableContainer_ = new LayoutPanel();
-      packagesTableContainer_.addStyleName("ace_editor");
+      packagesTableContainer_.addStyleName("ace_editor_theme");
       return packagesTableContainer_;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
@@ -322,6 +322,7 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
    {
       packagesDataProvider_ = new ListDataProvider<PackageInfo>();
       packagesTableContainer_ = new LayoutPanel();
+      packagesTableContainer_.addStyleName("ace_editor");
       return packagesTableContainer_;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesCellTableStyle.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesCellTableStyle.css
@@ -33,6 +33,6 @@
 	color: #3c474d;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .libraryHeader h1 {
+.rstudio-themes-flat .libraryHeader h1 {
    color: inherit;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesCellTableStyle.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesCellTableStyle.css
@@ -1,6 +1,8 @@
 @def selectionBorderWidth 2px;
 @eval proportionalFont org.rstudio.core.client.theme.ThemeFonts.getProportionalFont();
 
+@external rstudio-themes-flat, rstudio-themes-dark;
+
 .cellTableCell input[type=checkbox] {
    margin-top: 0;
    margin-bottom: 0;
@@ -31,3 +33,6 @@
 	color: #3c474d;
 }
 
+.rstudio-themes-flat .rstudio-themes-dark .libraryHeader h1 {
+   color: inherit;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGridCommon.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGridCommon.css
@@ -49,7 +49,7 @@
 
 .dataGridCell
 {
-    padding: 1px 6px;
+   padding: 1px 6px;
 	vertical-align: top;
 	color: #606060;
 }
@@ -96,7 +96,9 @@ body.ubuntu_mono .dataGridCell input[type=checkbox] {
    margin-bottom: 0;
 }
 
-.rstudio-themes-flat .rstudio-themes-default .dataGridHeader {
+.rstudio-themes-flat .rstudio-themes-default .dataGridHeader,
+.rstudio-themes-flat .rstudio-themes-default .dataGridEvenRowCell,
+.rstudio-themes-flat .rstudio-themes-default .dataGridOddRowCell {
    border-color: THEME_DEFAULT_BORDER;
 }
 
@@ -104,6 +106,13 @@ body.ubuntu_mono .dataGridCell input[type=checkbox] {
    border-color: THEME_DARKGREY_BORDER;
 }
 
-.rstudio-themes-flat .rstudio-themes-alternate .dataGridHeader {
+.rstudio-themes-flat .rstudio-themes-dark-grey .dataGridEvenRowCell,
+.rstudio-themes-flat .rstudio-themes-dark-grey .dataGridOddRowCell {
+   border: none;
+}
+
+.rstudio-themes-flat .rstudio-themes-alternate .dataGridHeader,
+.rstudio-themes-flat .rstudio-themes-alternate .dataGridEvenRowCell,
+.rstudio-themes-flat .rstudio-themes-alternate .dataGridOddRowCell {
    border-color: THEME_ALTERNATE_BORDER;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGridCommon.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGridCommon.css
@@ -102,13 +102,10 @@ body.ubuntu_mono .dataGridCell input[type=checkbox] {
    border-color: THEME_DEFAULT_BORDER;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader {
-   border-color: THEME_DARKGREY_BORDER;
-}
-
+.rstudio-themes-flat .rstudio-themes-dark-grey .dataGridHeader,
 .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridEvenRowCell,
 .rstudio-themes-flat .rstudio-themes-dark-grey .dataGridOddRowCell {
-   border: none;
+   border-color: THEME_DARKGREY_BORDER;
 }
 
 .rstudio-themes-flat .rstudio-themes-alternate .dataGridHeader,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGridCommon.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGridCommon.css
@@ -54,14 +54,29 @@
 	color: #606060;
 }
 
+.rstudio-themes-flat .rstudio-themes-dark .dataGridCell
+{
+   color: inherit;
+}
+
 .dataGridOddRow
 {
 	background-color: white; 
 }
 
+.rstudio-themes-flat .rstudio-themes-dark .dataGridOddRow
+{
+   background-color: inherit;
+}
+
 .dataGridEvenRow
 {
 	background-color: white; 
+}
+
+.rstudio-themes-flat .rstudio-themes-dark .dataGridEvenRow
+{
+   background-color: inherit;
 }
 
 .dataGridEvenRowCell

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGridCommon.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackagesDataGridCommon.css
@@ -4,6 +4,8 @@
 @external rstudio-themes-flat, rstudio-themes-dark;
 @external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
 
+@external editor_dark;
+
 @eval THEME_DEFAULT_BORDER org.rstudio.core.client.theme.ThemeColors.getDefaultBorder();
 @eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.getDarkGreyBorder();
 @eval THEME_ALTERNATE_BORDER org.rstudio.core.client.theme.ThemeColors.getAlternateBorder();
@@ -39,7 +41,7 @@
    height: 16px;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .dataGridHeader {
+.rstudio-themes-flat .editor_dark .dataGridHeader {
    color: white;
 }
 
@@ -54,7 +56,7 @@
 	color: #606060;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .dataGridCell
+.rstudio-themes-flat .dataGridCell
 {
    color: inherit;
 }
@@ -64,7 +66,7 @@
 	background-color: white; 
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .dataGridOddRow
+.rstudio-themes-flat .dataGridOddRow
 {
    background-color: inherit;
 }
@@ -74,7 +76,7 @@
 	background-color: white; 
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .dataGridEvenRow
+.rstudio-themes-flat .dataGridEvenRow
 {
    background-color: inherit;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/PlotsPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/PlotsPane.java
@@ -110,6 +110,7 @@ public class PlotsPane extends WorkbenchPane implements Plots.Display,
    protected Widget createMainWidget()
    {
       panel_ = new LayoutPanel();
+      panel_.addStyleName("ace_editor");
       panel_.setSize("100%", "100%");
 
       frame_ = new ImageFrame();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/PlotsPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/PlotsPane.java
@@ -110,7 +110,7 @@ public class PlotsPane extends WorkbenchPane implements Plots.Display,
    protected Widget createMainWidget()
    {
       panel_ = new LayoutPanel();
-      panel_.addStyleName("ace_editor");
+      panel_.addStyleName("ace_editor_theme");
       panel_.setSize("100%", "100%");
 
       frame_ = new ImageFrame();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkSatelliteWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkSatelliteWindow.java
@@ -119,7 +119,7 @@ public class ChunkSatelliteWindow extends SatelliteWindow
 
       chunkOutputWidget_.getElement().getStyle().setHeight(100, Unit.PCT);
 
-      mainPanel.addStyleName("ace_editor");
+      mainPanel.addStyleName("ace_editor_theme");
 
       pEventBus_.get().addHandler(ChunkSatelliteCodeExecutingEvent.TYPE, this);
       pEventBus_.get().addHandler(ChunkSatelliteCacheEditorStyleEvent.TYPE, this);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.workbench.views.source.editors.text.themes;
 
 import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.LinkElement;
 import com.google.gwt.user.client.Timer;
 import com.google.inject.Inject;
@@ -146,15 +147,16 @@ public class AceThemes
    
    private void applyTheme(Document document, final String themeName)
    {
-      // add theme styles
-      if (currentStyleEl_ != null)
-         currentStyleEl_.removeFromParent();
+      Element oldStyleEl = document.getElementById(linkId_);
+      if (oldStyleEl != null)
+         oldStyleEl.removeFromParent();
       
-      currentStyleEl_ = document.createLinkElement();
-      currentStyleEl_.setType("text/css");
-      currentStyleEl_.setRel("stylesheet");
-      currentStyleEl_.setHref(getThemeUrl(themeName));
-      document.getBody().appendChild(currentStyleEl_);
+      LinkElement currentStyleEl = document.createLinkElement();
+      currentStyleEl.setType("text/css");
+      currentStyleEl.setRel("stylesheet");
+      currentStyleEl.setId(linkId_);
+      currentStyleEl.setHref(getThemeUrl(themeName));
+      document.getBody().appendChild(currentStyleEl);
       
       addDarkClassIfNecessary(themeName);
       
@@ -200,6 +202,5 @@ public class AceThemes
    private final HashMap<String, Boolean> darkThemes_;
    private final String defaultThemeName_ = TEXTMATE;
    private final Provider<UIPrefs> prefs_;
-   
-   private LinkElement currentStyleEl_;
+   private final String linkId_ = "rstudio-acethemes-linkelement";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
@@ -73,6 +73,7 @@ public class AceThemes
       themesByName_ = new HashMap<String, String>();
       darkThemes_ = new HashMap<String, Boolean>();
       events_ = events;
+      prefs_ = prefs;
       
       addTheme(AMBIANCE, res.ambiance(), true);
       addTheme(CHAOS, res.chaos(), true);
@@ -143,17 +144,17 @@ public class AceThemes
          return darkThemes_.containsKey(themeName);
    }
    
-   private void applyTheme(final String themeName)
+   private void applyTheme(Document document, final String themeName)
    {
       // add theme styles
       if (currentStyleEl_ != null)
          currentStyleEl_.removeFromParent();
       
-      currentStyleEl_ = Document.get().createLinkElement();
+      currentStyleEl_ = document.createLinkElement();
       currentStyleEl_.setType("text/css");
       currentStyleEl_.setRel("stylesheet");
       currentStyleEl_.setHref(getThemeUrl(themeName));
-      Document.get().getBody().appendChild(currentStyleEl_);
+      document.getBody().appendChild(currentStyleEl_);
       
       addDarkClassIfNecessary(themeName);
       
@@ -166,6 +167,16 @@ public class AceThemes
             events_.fireEvent(new EditorThemeChangedEvent(themeName));
          }
       }.schedule(100);
+   }
+
+   private void applyTheme(final String themeName)
+   {
+      applyTheme(Document.get(), themeName);
+   }
+
+   public void applyTheme(Document document)
+   {
+      applyTheme(document, prefs_.get().theme().getValue());
    }
    
    public void addDarkClassIfNecessary(String themeName)
@@ -188,6 +199,7 @@ public class AceThemes
    private final HashMap<String, String> themesByName_;
    private final HashMap<String, Boolean> darkThemes_;
    private final String defaultThemeName_ = TEXTMATE;
+   private final Provider<UIPrefs> prefs_;
    
    private LinkElement currentStyleEl_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/ambiance.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/ambiance.css
@@ -61,7 +61,7 @@
   box-shadow: inset 0 0 10px black;
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   color: #E6E1DC;
   background-color: #202020;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chaos.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chaos.css
@@ -23,7 +23,7 @@
   right: 0;
   background: #1D1D1D;
 }
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #161616;
   color: #E6E1DC;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chrome.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chrome.css
@@ -9,7 +9,7 @@
   background: #e8e8e8;
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #FFFFFF;
   color: black;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds.css
@@ -8,7 +8,7 @@
   background: #e8e8e8
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #FFFFFF;
   color: #000000
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds_midnight.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds_midnight.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #191919;
   color: #929292
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/cobalt.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/cobalt.css
@@ -8,7 +8,7 @@
   background: #246 ;
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #002240;
   color: #FFFFFF
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/crimson_editor.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/crimson_editor.css
@@ -14,7 +14,7 @@
   background: #e8e8e8;
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #FFFFFF;
   color: rgb(64, 64, 64);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dawn.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dawn.css
@@ -8,7 +8,7 @@
   background: #e8e8e8
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #F9F9F9;
   color: #080808
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dreamweaver.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dreamweaver.css
@@ -8,7 +8,7 @@
   background: #e8e8e8;
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #FFFFFF;
   color: black;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/eclipse.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/eclipse.css
@@ -9,7 +9,7 @@
   background: #ebebeb;
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #FFFFFF;
   color: black;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/idle_fingers.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/idle_fingers.css
@@ -8,7 +8,7 @@
   background: #555 ;
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #323232;
   color: #FFFFFF
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/katzenmilch.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/katzenmilch.css
@@ -11,7 +11,7 @@
   background: #e8e8e8
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #f3f2f3;
   color: rgba(15, 0, 9, 1.0)
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/kr_theme.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/kr_theme.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #0B0A09;
   color: #FCFFE0
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore.css
@@ -8,7 +8,7 @@
   background: #555651
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #161616;
   color: #E6E1DC
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore_soft.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore_soft.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #1C1C1C;
   color: #E6E1DC
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/mono_industrial.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/mono_industrial.css
@@ -8,7 +8,7 @@
   background: #555651
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #222C28;
   color: #FFFFFF
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/monokai.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/monokai.css
@@ -8,7 +8,7 @@
   background: #555651
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #272822;
   color: #F8F8F2
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/pastel_on_dark.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/pastel_on_dark.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #2C2828;
   color: #8F938F
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_dark.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_dark.css
@@ -8,7 +8,7 @@
   background: #33555E
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #002B36;
   color: #93A1A1
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_light.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_light.css
@@ -8,7 +8,7 @@
   background: #e8e8e8
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #FDF6E3;
   color: #586E75
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/textmate.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/textmate.css
@@ -12,7 +12,7 @@
     background-color: #6B72E6;
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #FFFFFF;
   color: black;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow.css
@@ -8,7 +8,7 @@
   background: #f6f6f6
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #FFFFFF;
   color: #4D4D4C
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night.css
@@ -8,7 +8,7 @@
   background: #444 ;
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #1D1F21;
   color: #C5C8C6
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_blue.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_blue.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #002451;
   color: #FFFFFF
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_bright.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_bright.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #000000;
   color: #DEDEDE
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_eighties.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_eighties.css
@@ -8,7 +8,7 @@
   background: #444 ;
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #2D2D2D;
   color: #CCCCCC
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/twilight.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/twilight.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #141414;
   color: #F8F8F8
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/vibrant_ink.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/vibrant_ink.css
@@ -8,7 +8,7 @@
   background: #444 ;
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #0F0F0F;
   color: #FFFFFF
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/xcode.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/xcode.css
@@ -10,7 +10,7 @@
   background: #e8e8e8
 }
 
-.ace_editor {
+.ace_editor, .ace_editor_theme {
   background-color: #FFFFFF;
   color: #000000
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
@@ -140,7 +140,8 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
    @Override 
    protected Widget createMainWidget()
    {
-      frame_ = new RStudioFrame() ;
+      frame_ = new RStudioFrame();
+      frame_.setAceTheme();
       frame_.setSize("100%", "100%");
       frame_.addStyleName("ace_editor");
       navigate(ABOUT_BLANK, false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
@@ -143,7 +143,7 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
       frame_ = new RStudioFrame();
       frame_.setAceTheme();
       frame_.setSize("100%", "100%");
-      frame_.addStyleName("ace_editor");
+      frame_.addStyleName("ace_editor_theme");
       navigate(ABOUT_BLANK, false);
       return new AutoGlassPanel(frame_);
    }

--- a/src/gwt/tools/compile-themes.R
+++ b/src/gwt/tools/compile-themes.R
@@ -825,6 +825,10 @@ for (file in themeFiles) {
    ## to preserve this theme, but apply it to the '.ace_editor' directly.
    regex <- paste("^\\s*", themeNameCssClass, "\\s*\\{\\s*$", sep = "")
    content <- gsub(regex, ".ace_editor {", content)
+
+   ## Copy ace_editor as ace_editor_theme
+   regex <- paste("^\\.ace_editor \\{$", sep = "")
+   content <- gsub(regex, ".ace_editor, .ace_editor_theme {", content)
    
    ## Strip the theme name rule from the CSS.
    regex <- paste("^\\", themeNameCssClass, "\\S*\\s+", sep = "")


### PR DESCRIPTION
Most relevant changes:
- Support for (dark) themes in files and packages pane.
- Apply themes to help, viewer panes within the content.
- Created new style `ace_editor_theme` to preserve only colors and not apply, say fonts.
- Support for themes in connections pane.
- Misc fixes requested by JJ and Hadley.

<img width="1433" alt="screen shot 2017-05-01 at 5 08 31 pm" src="https://cloud.githubusercontent.com/assets/3478847/25599400/d79740e4-2e90-11e7-895d-7e8415431acd.png">