### PR TITLE
Allow building with OpenSSL 1.1

### DIFF
--- a/src/cpp/core/system/PosixCrypto.cpp
+++ b/src/cpp/core/system/PosixCrypto.cpp
@@ -288,7 +288,7 @@ core::Error rsaInit()
       int rc = ::RSA_generate_key_ex(s_pRSA, KEY_SIZE, bn, NULL);
       if (rc != 1) {
         return lastCryptoError(ERROR_LOCATION);
-        OPENSSL_free(s_pRSA)
+        OPENSSL_free(s_pRSA);
       }
       BN_clear_free(bn);
    

--- a/src/cpp/core/system/PosixCrypto.cpp
+++ b/src/cpp/core/system/PosixCrypto.cpp
@@ -288,7 +288,7 @@ core::Error rsaInit()
       int rc = ::RSA_generate_key_ex(s_pRSA, KEY_SIZE, bn, NULL);
       if (rc != 1) {
         return lastCryptoError(ERROR_LOCATION);
-        OPENSSL_free(s_pRSA);
+        RSA_free(s_pRSA);
       }
       BN_clear_free(bn);
    

--- a/src/cpp/core/system/PosixCrypto.cpp
+++ b/src/cpp/core/system/PosixCrypto.cpp
@@ -289,8 +289,8 @@ core::Error rsaInit()
       int rc = ::RSA_generate_key_ex(s_pRSA, KEY_SIZE, bn, NULL);
       BN_clear_free(bn);
       if (rc != 1) {
-        return lastCryptoError(ERROR_LOCATION);
         RSA_free(s_pRSA);
+        return lastCryptoError(ERROR_LOCATION);
       }
    
       RSA_get0_key(s_pRSA, &bn_n, &bn_e, NULL);

--- a/src/cpp/core/system/PosixCrypto.cpp
+++ b/src/cpp/core/system/PosixCrypto.cpp
@@ -257,8 +257,6 @@ core::Error rsaInit()
    const int KEY_SIZE = 1024;
    const int ENTROPY_BYTES = 4096;
 
-   BIGNUM *bn = BN_new();
-   BN_set_word(bn, RSA_F4);
    const BIGNUM *bn_n;
    const BIGNUM *bn_e;
 
@@ -283,9 +281,10 @@ core::Error rsaInit()
 
       bn_n = s_pRSA->n;
       bn_e = s_pRSA->e;
-
-      BN_clear_free(bn);
    #else
+      BIGNUM *bn = BN_new();
+      BN_set_word(bn, RSA_F4);
+ 
       s_pRSA = RSA_new();
       int rc = ::RSA_generate_key_ex(s_pRSA, KEY_SIZE, bn, NULL);
       BN_clear_free(bn);

--- a/src/cpp/core/system/PosixCrypto.cpp
+++ b/src/cpp/core/system/PosixCrypto.cpp
@@ -283,14 +283,16 @@ core::Error rsaInit()
 
       bn_n = s_pRSA->n;
       bn_e = s_pRSA->e;
+
+      BN_clear_free(bn);
    #else
       s_pRSA = RSA_new();
       int rc = ::RSA_generate_key_ex(s_pRSA, KEY_SIZE, bn, NULL);
+      BN_clear_free(bn);
       if (rc != 1) {
         return lastCryptoError(ERROR_LOCATION);
         RSA_free(s_pRSA);
       }
-      BN_clear_free(bn);
    
       RSA_get0_key(s_pRSA, &bn_n, &bn_e, NULL);
    #endif

--- a/src/cpp/core/system/PosixCrypto.cpp
+++ b/src/cpp/core/system/PosixCrypto.cpp
@@ -257,6 +257,11 @@ core::Error rsaInit()
    const int KEY_SIZE = 1024;
    const int ENTROPY_BYTES = 4096;
 
+   BIGNUM *bn = BN_new();
+   BN_set_word(bn, RSA_F4);
+   const BIGNUM *bn_n;
+   const BIGNUM *bn_e;
+
    int rnd = ::open("/dev/urandom", O_RDONLY);
    if (rnd == -1)
       return systemError(errno, ERROR_LOCATION);
@@ -271,14 +276,29 @@ core::Error rsaInit()
 
    RAND_seed(entropy, ENTROPY_BYTES);
 
-   s_pRSA = ::RSA_generate_key(KEY_SIZE, 0x10001, NULL, NULL);
-   if (!s_pRSA)
-      return lastCryptoError(ERROR_LOCATION);
+   #if OPENSSL_VERSION_NUMBER < 0x10100000L
+      s_pRSA = ::RSA_generate_key(KEY_SIZE, 0x10001, NULL, NULL);
+      if (!s_pRSA)
+         return lastCryptoError(ERROR_LOCATION);
 
-   char* n = BN_bn2hex(s_pRSA->n);
+      bn_n = s_pRSA->n;
+      bn_e = s_pRSA->e;
+   #else
+      s_pRSA = RSA_new();
+      int rc = ::RSA_generate_key_ex(s_pRSA, KEY_SIZE, bn, NULL);
+      if (rc != 1) {
+        return lastCryptoError(ERROR_LOCATION);
+        OPENSSL_free(s_pRSA)
+      }
+      BN_clear_free(bn);
+   
+      RSA_get0_key(s_pRSA, &bn_n, &bn_e, NULL);
+   #endif
+
+   char* n = BN_bn2hex(bn_n);
    s_modulo = n;
    OPENSSL_free(n);
-   char* e = BN_bn2hex(s_pRSA->e);
+   char* e = BN_bn2hex(bn_e);
    s_exponent = e;
    OPENSSL_free(e);
 


### PR DESCRIPTION
This PR should enable building RStudio with OpenSSL <= 1.1 (at least it works with OpenSSL 1.1). I could not yet check this actual PR but a similar version located in my Arch Linux PKBGUILD [1]. To be completely able to build RStudio with OpenSSL 1.1 you are still required to patch around the missing `SSL_R_SHORT_READ`. Locally I use a modified version of #1063. 
Possibly this requires further tweaking and I feel a bit uneasy messing around with ssl. For now it is just what works in my non public environment. 

[1] https://github.com/JanMarvin/rstudio-archlinuxpkg/blob/master/rstudio-server/openssl11.diff