### PR TITLE
Support new readxl features and help links

### DIFF
--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -502,6 +502,11 @@
          optionTypes[["col_types"]] <- "columnDefinitionsReadXl"
          optionTypes[["range"]] <- "character"
 
+         if (!is.null(options[["range"]]) && nchar(options[["range"]]) > 0) {
+            options[["skip"]] <- NULL
+            options[["n_max"]] <- NULL
+         }
+
          return(list(
             name = "read_excel",
             reference = readxl::read_excel,

--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -491,6 +491,8 @@
          options[["col_names"]] <- dataImportOptions$columnNames
          options[["skip"]] <- dataImportOptions$skip
          options[["col_types"]] <- dataImportOptions$columnDefinitions
+         options[["n_max"]] <- dataImportOptions$nMax
+         options[["range"]] <- dataImportOptions$range
 
          # set special parameter types
          optionTypes <- list()
@@ -498,6 +500,7 @@
          optionTypes[["sheet"]] <- "character"
          optionTypes[["na"]] <- "character"
          optionTypes[["col_types"]] <- "columnDefinitionsReadXl"
+         optionTypes[["range"]] <- "character"
 
          return(list(
             name = "read_excel",
@@ -622,6 +625,16 @@
       ),
       collapse = "\n"
    )
+
+   packageNameFromOptions <- list(
+      "text" = "readr",
+      "statistics" = "haven",
+      "xls" = "readxl"
+   )
+
+   importInfo$packageVersion <- as.character(packageVersion(
+      packageNameFromOptions[[dataImportOptions$mode]]
+   ))
 
    importInfo
 })

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialog.java
@@ -15,6 +15,7 @@
 package org.rstudio.core.client.widget;
 
 import org.rstudio.core.client.Debug;
+import org.rstudio.studio.client.common.HelpLink;
 
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
@@ -165,7 +166,17 @@ public abstract class ModalDialog<T> extends ModalDialogBase
    {
       onValidated.execute(validate(input));
    }
+
+   protected void setHelpLink(HelpLink helpLink) {
+      if (helpLink_ != null) removeLeftWidget(helpLink_);
+
+      if (helpLink != null) {
+         helpLink_ = helpLink;
+         addLeftWidget(helpLink_);
+      }
+   }
   
    private final ProgressIndicator progressIndicator_;
    private boolean validating_ = false;
+   private HelpLink helpLink_ = null;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/Wizard.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/Wizard.java
@@ -21,7 +21,6 @@ import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
-import org.rstudio.studio.client.common.HelpLink;
 
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -118,28 +117,6 @@ public class Wizard<I,T> extends ModalDialog<T>
       });
       nextButton_.setVisible(false);
       addActionButton(nextButton_);
-   }
-
-   public void updateHelpLink(HelpLink helpLink) {
-      if (helpLink == null) {
-         if (helpLink_ != null) removeLeftWidget(helpLink_);
-         helpLink_ = null;
-         return;
-      }
-
-      if (helpLink_ == null) {
-         WizardResources.Styles styles = WizardResources.INSTANCE.styles();
-
-         helpLink_ = new HelpLink(
-               "",
-               "",
-               false);
-         helpLink_.addStyleName(styles.helpLink());
-         addLeftWidget(helpLink_);
-      }
-
-      helpLink_.setCaption(helpLink.getCaption());
-      helpLink_.setLink(helpLink.getLink(), helpLink.isRStudioLink());
    }
 
    @Override
@@ -593,5 +570,4 @@ public class Wizard<I,T> extends ModalDialog<T>
    private WizardPage<I,T> activeParentNavigationPage_ = null;
    private boolean isAnimating_ = false;
    private boolean validating_ = false;
-   private HelpLink helpLink_ = null;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionWizard.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionWizard.java
@@ -58,11 +58,12 @@ public class NewConnectionWizard extends Wizard<NewConnectionContext, Connection
          operation
       );
 
-      updateHelpLink(new HelpLink(
+      mainHelpLink_ = new HelpLink(
          "Using RStudio Connections",
          "rstudio_connections",
          false,
-         true));
+         true);
+      setHelpLink(mainHelpLink_);
 
       RStudioGinjector.INSTANCE.injectMembers(this); 
    }
@@ -72,14 +73,14 @@ public class NewConnectionWizard extends Wizard<NewConnectionContext, Connection
                      WizardPage<NewConnectionContext, ConnectionOptions> page,
                      boolean okButtonVisible)
    {
-      updateHelpLink(page.getHelpLink());
+      setHelpLink(page.getHelpLink());
    }
 
    @Override
    protected void onPageDeactivated(
                      WizardPage<NewConnectionContext, ConnectionOptions> page)
    {
-      updateHelpLink(null);
+      setHelpLink(mainHelpLink_);
    }
 
    @Override
@@ -123,4 +124,6 @@ public class NewConnectionWizard extends Wizard<NewConnectionContext, Connection
    {
       RES.styles().ensureInjected();
    }
+   
+   private HelpLink mainHelpLink_ = null;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -27,6 +27,7 @@ import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.ProgressIndicatorDelay;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.common.reditor.EditorLanguage;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
@@ -723,4 +724,8 @@ public class DataImport extends Composite
          return !column.col_name && column.col_type != 'rownames';
       });
    }-*/;
+   
+   public HelpLink getHelpLink() {
+      return dataImportOptionsUi_.getHelpLink();
+   }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportDialog.java
@@ -19,6 +19,7 @@ import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.common.HelpLink;
 
 import com.google.gwt.user.client.ui.Widget;
 
@@ -38,6 +39,8 @@ public class DataImportDialog extends ModalDialog<String>
       
       setOkButtonCaption("Import");
       setEnterDisabled(true);
+      
+      setHelpLink(dataImport_.getHelpLink());
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUi.java
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client.workbench.views.environment.dataimport;
 
+import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportAssembleResponse;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportPreviewResponse;
 
@@ -73,6 +74,11 @@ public class DataImportOptionsUi extends Composite implements HasValueChangeHand
    public void fireEvent(GwtEvent<?> event)
    {
       handlerManager_.fireEvent(event);
+   }
+   
+   public HelpLink getHelpLink()
+   {
+      return null;
    }
    
    @UiField

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.java
@@ -22,6 +22,7 @@ import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.ProgressOperationWithInput;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportAssembleResponse;
 import org.rstudio.studio.client.workbench.views.source.model.SourceServerOperations;
 
@@ -319,6 +320,16 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
          escapeListBox_.getElement().removeAttribute("disabled");
          quotesListBox_.getElement().removeAttribute("disabled");
       }
+   }
+   
+   @Override
+   public HelpLink getHelpLink()
+   {
+      return new HelpLink(
+         "Reading rectangular data using readr",
+         "http://readr.tidyverse.org/",
+         false,
+         false);
    }
    
    @UiField

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiCsv.java
@@ -327,9 +327,9 @@ public class DataImportOptionsUiCsv extends DataImportOptionsUi
    {
       return new HelpLink(
          "Reading rectangular data using readr",
-         "http://readr.tidyverse.org/",
+         "import_readr",
          false,
-         false);
+         true);
    }
    
    @UiField

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.java
@@ -124,7 +124,7 @@ public class DataImportOptionsUiSav extends DataImportOptionsUi
    public HelpLink getHelpLink()
    {
       return new HelpLink(
-         "Reading statistical data using haven",
+         "Reading data using haven",
          "import_haven",
          false,
          true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.java
@@ -125,9 +125,9 @@ public class DataImportOptionsUiSav extends DataImportOptionsUi
    {
       return new HelpLink(
          "Reading statistical data using haven",
-         "http://haven.tidyverse.org/",
+         "import_haven",
          false,
-         false);
+         true);
    }
    
    @UiFactory

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.java
@@ -16,6 +16,7 @@
 package org.rstudio.studio.client.workbench.views.environment.dataimport;
 
 import org.rstudio.core.client.widget.Operation;
+import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportAssembleResponse;
 
 import com.google.gwt.core.client.GWT;
@@ -117,6 +118,16 @@ public class DataImportOptionsUiSav extends DataImportOptionsUi
             }
          }
       }
+   }
+   
+   @Override
+   public HelpLink getHelpLink()
+   {
+      return new HelpLink(
+         "Reading statistical data using haven",
+         "http://haven.tidyverse.org/",
+         false,
+         false);
    }
    
    @UiFactory

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
@@ -47,6 +47,8 @@ public class DataImportOptionsUiXls extends DataImportOptionsUi
       
       initDefaults();
       initEvents();
+
+      rangeTextBox_.getElement().setPropertyString("placeholder", "A1:D10");
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
@@ -75,10 +75,7 @@ public class DataImportOptionsUiXls extends DataImportOptionsUi
 
       if (ApplicationUtils.compareVersions(response.getPackageVersion(), "1.0.0") < 0) {
          maxTextBox_.setEnabled(false);
-         maxTextBox_.getElement().setPropertyString("placeholder", "(readxl 1.0)");
-
          rangeTextBox_.setEnabled(false);
-         rangeTextBox_.getElement().setPropertyString("placeholder", "(requires readxl 1.0)");
       }
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client.workbench.views.environment.dataimport;
 
+import org.rstudio.studio.client.application.ApplicationUtils;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportAssembleResponse;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportPreviewResponse;
 
@@ -61,8 +62,8 @@ public class DataImportOptionsUiXls extends DataImportOptionsUi
          columnNamesCheckBox_.getValue().booleanValue(),
          !naListBox_.getSelectedValue().isEmpty() ? naListBox_.getSelectedValue() : null,
          openDataViewerCheckBox_.getValue().booleanValue(),
-         Integer.parseInt(maxTextBox_.getValue()),
-         rangeTextBox_.getValue()
+         !maxTextBox_.getValue().isEmpty() ? Integer.parseInt(maxTextBox_.getValue()) : null,
+         !rangeTextBox_.getValue().isEmpty() ? rangeTextBox_.getValue() : null
       );
    }
    
@@ -70,6 +71,14 @@ public class DataImportOptionsUiXls extends DataImportOptionsUi
    public void setAssembleResponse(DataImportAssembleResponse response)
    {
       nameTextBox_.setText(response.getDataName());
+
+      if (ApplicationUtils.compareVersions(response.getPackageVersion(), "1.0.0") < 0) {
+         maxTextBox_.setEnabled(false);
+         maxTextBox_.getElement().setPropertyString("placeholder", "(readxl 1.0)");
+
+         rangeTextBox_.setEnabled(false);
+         rangeTextBox_.getElement().setPropertyString("placeholder", "(requires readxl 1.0)");
+      }
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
@@ -162,6 +162,12 @@ public class DataImportOptionsUiXls extends DataImportOptionsUi
 
    @UiField
    CheckBox openDataViewerCheckBox_;
+
+   @UiField
+   TextBox maxTextBox_;
+
+   @UiField
+   TextBox rangeTextBox_;
    
    private static native final String[] getSheetsFromResponse(DataImportPreviewResponse response) /*-{
       return response && response.options && response.options.sheets ? response.options.sheets : [];

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
@@ -152,6 +152,18 @@ public class DataImportOptionsUiXls extends DataImportOptionsUi
             triggerChange();
          }
       };
+
+      ValueChangeHandler<String> rangeChangeHandler = new ValueChangeHandler<String>()
+      {
+         
+         @Override
+         public void onValueChange(ValueChangeEvent<String> arg0)
+         {
+            maxTextBox_.setEnabled(rangeTextBox_.getValue().isEmpty());
+            skipTextBox_.setEnabled(rangeTextBox_.getValue().isEmpty());
+            triggerChange();
+         }
+      };
       
       nameTextBox_.addValueChangeHandler(valueChangeHandler);
       sheetListBox_.addChangeHandler(changeHandler);
@@ -160,7 +172,7 @@ public class DataImportOptionsUiXls extends DataImportOptionsUi
       naListBox_.addChangeHandler(changeHandler);
       skipTextBox_.addValueChangeHandler(valueChangeHandler);
       maxTextBox_.addValueChangeHandler(valueChangeHandler);
-      rangeTextBox_.addValueChangeHandler(valueChangeHandler);
+      rangeTextBox_.addValueChangeHandler(rangeChangeHandler);
    }
    
    @UiField

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
@@ -16,6 +16,7 @@
 package org.rstudio.studio.client.workbench.views.environment.dataimport;
 
 import org.rstudio.studio.client.application.ApplicationUtils;
+import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportAssembleResponse;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportPreviewResponse;
 
@@ -103,6 +104,16 @@ public class DataImportOptionsUiXls extends DataImportOptionsUi
       nameTextBox_.setText("");
       sheetListBox_.clear();
       sheetListBox_.addItem("Default", "");
+   }
+   
+   @Override
+   public HelpLink getHelpLink()
+   {
+      return new HelpLink(
+         "Reading Excel files using readxl",
+         "http://readxl.tidyverse.org/",
+         false,
+         false);
    }
    
    void initDefaults()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
@@ -60,7 +60,9 @@ public class DataImportOptionsUiXls extends DataImportOptionsUi
          Integer.parseInt(skipTextBox_.getValue()),
          columnNamesCheckBox_.getValue().booleanValue(),
          !naListBox_.getSelectedValue().isEmpty() ? naListBox_.getSelectedValue() : null,
-         openDataViewerCheckBox_.getValue().booleanValue()
+         openDataViewerCheckBox_.getValue().booleanValue(),
+         Integer.parseInt(maxTextBox_.getValue()),
+         rangeTextBox_.getValue()
       );
    }
    
@@ -148,6 +150,8 @@ public class DataImportOptionsUiXls extends DataImportOptionsUi
       openDataViewerCheckBox_.addValueChangeHandler(booleanValueChangeHandler);
       naListBox_.addChangeHandler(changeHandler);
       skipTextBox_.addValueChangeHandler(valueChangeHandler);
+      maxTextBox_.addValueChangeHandler(valueChangeHandler);
+      rangeTextBox_.addValueChangeHandler(valueChangeHandler);
    }
    
    @UiField

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
@@ -111,9 +111,9 @@ public class DataImportOptionsUiXls extends DataImportOptionsUi
    {
       return new HelpLink(
          "Reading Excel files using readxl",
-         "http://readxl.tidyverse.org/",
+         "import_readxl",
          false,
-         false);
+         true);
    }
    
    void initDefaults()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.ui.xml
@@ -52,8 +52,22 @@
                     <g:ListBox ui:field="sheetListBox_" styleName="{style.optionsGrowListBox}"/>
                 </div>
                 <div class="{style.optionsRow} {style.otherRow}">
+                    <div class="{style.optionLabel} {style.nameLabel}">Range:</div>
+                    <g:TextBox ui:field="rangeTextBox_" styleName="{style.nameTextBox}"/>
+                </div>
+            </div>
+            <div class="{style.optionsColumn}">
+                <div class="{style.optionsRow} {style.firstRow}">
+                    <div class="{style.optionLabel}">Max:</div>
+                    <g:TextBox ui:field="maxTextBox_" styleName="{style.skipTextBox}"/>
+                </div>
+                <div class="{style.optionsRow} {style.otherRow}">
                     <div class="{style.optionLabel}">Skip:</div>
                     <g:TextBox ui:field="skipTextBox_" styleName="{style.skipTextBox}"/>
+                </div>
+                <div class="{style.optionsRow} {style.otherRow}">
+                    <div class="{style.optionLabel}">NA:</div>
+                    <g:ListBox ui:field="naListBox_" styleName="{style.naListBox}"/>
                 </div>
             </div>
             <div class="{style.optionsColumn}">
@@ -61,11 +75,9 @@
                     <g:CheckBox ui:field="columnNamesCheckBox_" text="First Row as Names"/>
                 </div>
                 <div class="{style.optionsRow} {style.otherRow}">
-                    <div class="{style.naLabel}">NA:</div>
-                    <g:ListBox ui:field="naListBox_" styleName="{style.naListBox}"/>
+                    <g:CheckBox ui:field="openDataViewerCheckBox_" text="Open Data Viewer"/>
                 </div>
                 <div class="{style.optionsRow} {style.otherRow}">
-                    <g:CheckBox ui:field="openDataViewerCheckBox_" text="Open Data Viewer"/>
                 </div>
             </div>
         </div>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.ui.xml
@@ -58,7 +58,7 @@
             </div>
             <div class="{style.optionsColumn}">
                 <div class="{style.optionsRow} {style.firstRow}">
-                    <div class="{style.optionLabel}">Max:</div>
+                    <div class="{style.optionLabel}">Max Rows:</div>
                     <g:TextBox ui:field="maxTextBox_" styleName="{style.skipTextBox}"/>
                 </div>
                 <div class="{style.optionsRow} {style.otherRow}">

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsXls.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsXls.java
@@ -27,7 +27,9 @@ public class DataImportOptionsXls extends DataImportOptions
       int skip,
       boolean colNames,
       String na,
-      boolean openDataViewer
+      boolean openDataViewer,
+      int nMax,
+      String range
       ) /*-{
          return {
             "mode": "xls",
@@ -36,7 +38,9 @@ public class DataImportOptionsXls extends DataImportOptions
             "skip": skip,
             "columnNames": colNames,
             "na": na,
-            "openDataViewer": openDataViewer
+            "openDataViewer": openDataViewer,
+            "nMax": nMax,
+            "range": range
        }
    }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsXls.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsXls.java
@@ -28,7 +28,7 @@ public class DataImportOptionsXls extends DataImportOptions
       boolean colNames,
       String na,
       boolean openDataViewer,
-      int nMax,
+      Integer nMax,
       String range
       ) /*-{
          return {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportAssembleResponse.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportAssembleResponse.java
@@ -42,4 +42,8 @@ public class DataImportAssembleResponse extends JavaScriptObject
    public final native JavaScriptObject getLocalFiles() /*-{
       return this.localFiles;
    }-*/;
+
+   public final native String getPackageVersion() /*-{
+      return this.packageVersion ? this.packageVersion.join(' ') : null;
+   }-*/;
 }


### PR DESCRIPTION
This PR adds support for `n_max` and `range` fields available now in `readxl 1.0`, disabled unsupported fields for older version of `readxl `. Refactored help links from `Wizard` to `ModalBase` and added links as follows:
- Reading Excel files using readxl -> http://readxl.tidyverse.org/
- Reading rectangular data using readr -> http://readr.tidyverse.org/
- Reading statistical data using haven -> http://haven.tidyverse.org/

@jennybc Feel free to post feedback on this PR or after trying this out in tomorrows build, thanks!

<img width="1088" alt="screen shot 2017-05-02 at 1 42 38 pm" src="https://cloud.githubusercontent.com/assets/3478847/25638439/461c514c-2f3d-11e7-9d81-b3f13457c7ec.png">

`n_max` and `skip` get disabled when `range` is specified.

<img width="1084" alt="screen shot 2017-05-02 at 1 27 45 pm" src="https://cloud.githubusercontent.com/assets/3478847/25638386/1947eaf0-2f3d-11e7-89db-b21fe154e07b.png">

`n_max` and `range` are disabled when `readxl < 1.0` is installed.

<img width="1079" alt="screen shot 2017-05-02 at 1 47 02 pm" src="https://cloud.githubusercontent.com/assets/3478847/25638626/de602aa0-2f3d-11e7-842c-cb0f0488c4c9.png">
