### PR TITLE
Stale ConsoleProcess handles on client cause error messages

### DIFF
--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -137,6 +137,7 @@ public:
    void setTitle(std::string& title) { procInfo_->setTitle(title); }
    void deleteLogFile() const;
    void setNotBusy() { procInfo_->setHasChildProcs(false); }
+   bool getAllowRestart() { return procInfo_->getAllowRestart(); }
 
    // Used to downgrade to RPC mode after failed attempt to connect websocket
    void setRpcMode();

--- a/src/gwt/src/org/rstudio/studio/client/application/events/ThemeChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/ThemeChangedEvent.java
@@ -17,7 +17,6 @@ package org.rstudio.studio.client.application.events;
 import org.rstudio.core.client.js.JavaScriptSerializable;
 
 import com.google.gwt.event.shared.EventHandler;
-import com.google.gwt.event.shared.GwtEvent;
 
 @JavaScriptSerializable
 public class ThemeChangedEvent extends CrossWindowEvent<ThemeChangedEvent.Handler>

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteManager.java
@@ -1,7 +1,7 @@
 /*
  * SatelliteManager.java
  *
- * Copyright (C) 2009-15 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -36,7 +36,6 @@ import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.CrossWindowEvent;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.ThemeChangedEvent;
-import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.common.GlobalDisplay.NewWindowOptions;
 import org.rstudio.studio.client.common.satellite.events.AllSatellitesClosingEvent;
 import org.rstudio.studio.client.common.satellite.events.SatelliteClosedEvent;

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -709,6 +709,15 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, PROCESS_USE_RPC, params, requestCallback);   
    }
 
+   @Override 
+   public void processTestExists(String handle,
+                                 ServerRequestCallback<Boolean> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(StringUtil.notNull(handle)));
+      sendRequest(RPC_SCOPE, PROCESS_TEST_EXISTS, params, requestCallback);   
+   }
+
    public void interrupt(ServerRequestCallback<Void> requestCallback)
    {
       sendRequest(RPC_SCOPE, INTERRUPT, requestCallback);
@@ -5183,6 +5192,7 @@ public class RemoteServer implements Server
    private static final String PROCESS_ERASE_BUFFER = "process_erase_buffer";
    private static final String PROCESS_GET_BUFFER_CHUNK = "process_get_buffer_chunk";
    private static final String PROCESS_USE_RPC = "process_use_rpc";
+   private static final String PROCESS_TEST_EXISTS = "process_test_exists";
 
    private static final String REMOVE_ALL_OBJECTS = "remove_all_objects";
    private static final String REMOVE_OBJECTS = "remove_objects";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/model/ConsoleServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/model/ConsoleServerOperations.java
@@ -66,6 +66,16 @@ public interface ConsoleServerOperations extends CodeToolsServerOperations,
     */
    void processUseRpc(String handle,
                       ServerRequestCallback<Void> requestCallback);
+   
+   /**
+    * Test if server knows about a given process handle. Doesn't mean process
+    * is necessarily running, just that the server has it in the ConsoleProcess
+    * table and additional operations can safely be attempted.
+    * @param handle handle to test
+    * @param requestCallback
+    */
+   public void processTestExists(String handle,
+                                 ServerRequestCallback<Boolean> requestCallback);
 
    /**
     * Set/update the caption of given process.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportDialog.java
@@ -1,7 +1,7 @@
 /*
  * DataImportDialog.java
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,7 +19,6 @@ import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.studio.client.RStudioGinjector;
-import org.rstudio.studio.client.common.HelpLink;
 
 import com.google.gwt.user.client.ui.Widget;
 


### PR DESCRIPTION
# Scenario
On the server, the table of ConsoleProcess objects (s_procs) is used to map incoming console-process RPC calls to the appropriate metadata. If an RPC is made with a handle that's not in the server-side table, an error is shown. This table is used to track both terminal sessions, and non-terminal processes such as git commands, etc.

The client tries to bring up a ConsoleProgressDialog during session-init, if it sees one that isn't a terminal, and has output to show. The console-proc list on the client can get out of sync with the server, especially in cases such as closing or refreshing a window (main or satellite) containing an existing ConsoleProgressDialog modal dialog. This causes an error to be shown of the form "Error: Invalid argument." See attached animation for an example scenario, this one in Mac IDE 1.0.

# Fixes
- when a process exits on the server and sets an exit status, I wasn't flushing the console-process cache; this caused processes to be reported to the client as still running when they had actually exited; fixed by flushing in onExit
- only save terminal-related ConsoleProcs on server when shutting down; still saves all when suspending; this provides cleanup of stray console-proc entries
- when looping through non-terminal ConsoleProcs during session init on client, use new RPC call to test if a given process handle is known by the server; if not, discard it rather than trying to bring up a ConsoleProgressDialog
- cleanup some Eclipse warnings about unused import 

![invalid-argument-errors](https://cloud.githubusercontent.com/assets/10569626/25684048/156d2eae-3014-11e7-8dcd-d749ef3a15e2.gif)
