### PR TITLE
support ANSI italic and strikethrough styles in console

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/AnsiCode.java
+++ b/src/gwt/src/org/rstudio/core/client/AnsiCode.java
@@ -42,7 +42,7 @@ public class AnsiCode
 
    public static final int ITALIC = 3;
    public static final int ITALIC_OFF = 23;
-   public static final String ITALIC_STYLE = "NYI";
+   public static final String ITALIC_STYLE = "xtermItalic";
 
    public static final int UNDERLINE = 4;
    public static final int UNDERLINE_OFF = 24;
@@ -64,7 +64,7 @@ public class AnsiCode
 
    public static final int STRIKETHROUGH = 9;
    public static final int STRIKETHROUGH_OFF = 29;
-   public static final String STROKETHROUGH_STYLE = "NYI";
+   public static final String STRIKETHROUGH_STYLE = "xtermStrike";
 
    public static final int FOREGROUND_MIN = 30;
    public static final int FOREGROUND_MAX = 37;
@@ -323,11 +323,11 @@ public class AnsiCode
          }
          else if (codeVal == ITALIC)
          {
-            // NYI clazzes_.add(ITALIC_STYLE);
+            clazzes_.add(ITALIC_STYLE);
          }
          else if (codeVal == ITALIC_OFF)
          {
-            // NYI clazzes_.remove(ITALIC_STYLE);
+            clazzes_.remove(ITALIC_STYLE);
          }
          else if (codeVal == UNDERLINE)
          {
@@ -381,11 +381,11 @@ public class AnsiCode
          }
          else if (codeVal == STRIKETHROUGH)
          {
-            // NYI clazzes_.add(STRIKETHROUGH_STYLE);
+            clazzes_.add(STRIKETHROUGH_STYLE);
          }
          else if (codeVal == STRIKETHROUGH_OFF)
          {
-            // NYI clazzes_.remove(STRIKETHROUGH_OFF);
+            clazzes_.remove(STRIKETHROUGH_STYLE);
          }
          else if (Color.isFgColorCode(codeVal))
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/ambiance.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/ambiance.css
@@ -282,6 +282,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chaos.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chaos.css
@@ -215,6 +215,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chrome.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chrome.css
@@ -215,6 +215,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds.css
@@ -179,6 +179,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds_midnight.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds_midnight.css
@@ -177,6 +177,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/cobalt.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/cobalt.css
@@ -198,6 +198,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/crimson_editor.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/crimson_editor.css
@@ -204,6 +204,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dawn.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dawn.css
@@ -191,6 +191,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dreamweaver.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dreamweaver.css
@@ -237,6 +237,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/eclipse.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/eclipse.css
@@ -180,6 +180,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/idle_fingers.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/idle_fingers.css
@@ -177,6 +177,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/katzenmilch.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/katzenmilch.css
@@ -204,6 +204,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/kr_theme.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/kr_theme.css
@@ -188,6 +188,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore.css
@@ -174,6 +174,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore_soft.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore_soft.css
@@ -175,6 +175,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/mono_industrial.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/mono_industrial.css
@@ -187,6 +187,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/monokai.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/monokai.css
@@ -186,6 +186,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/pastel_on_dark.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/pastel_on_dark.css
@@ -196,6 +196,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_dark.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_dark.css
@@ -165,6 +165,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_light.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_light.css
@@ -170,6 +170,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/textmate.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/textmate.css
@@ -216,6 +216,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow.css
@@ -186,6 +186,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night.css
@@ -186,6 +186,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_blue.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_blue.css
@@ -183,6 +183,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_bright.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_bright.css
@@ -202,6 +202,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_eighties.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_eighties.css
@@ -186,6 +186,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/twilight.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/twilight.css
@@ -192,6 +192,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/vibrant_ink.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/vibrant_ink.css
@@ -174,6 +174,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/xcode.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/xcode.css
@@ -167,6 +167,8 @@
 .xtermUnderline { text-decoration: underline; }
 .xtermBlink { text-decoration: blink; }
 .xtermHidden { visibility: hidden; }
+.xtermItalic { font-style: italic; }
+.xtermStrike { text-decoration: line-through; }
 .xtermColor0 { color: #2e3436; }
 .xtermBgColor0 { background-color: #2e3436; }
 .xtermColor1 { color: #cc0000; }

--- a/src/gwt/tools/compile-themes.R
+++ b/src/gwt/tools/compile-themes.R
@@ -282,6 +282,8 @@ create_xterm_color_rules <- function(background, foreground, isDark) {
       ".xtermUnderline { text-decoration: underline; }",
       ".xtermBlink { text-decoration: blink; }",
       ".xtermHidden { visibility: hidden; }",
+      ".xtermItalic { font-style: italic; }",
+      ".xtermStrike { text-decoration: line-through; }",
       ".xtermColor0 { color: #2e3436; }",
       ".xtermBgColor0 { background-color: #2e3436; }",
       ".xtermColor1 { color: #cc0000; }",


### PR DESCRIPTION
Requested by Hadley Wickham. Added support for italic ANSI sequence, and also added strikethrough.

![2017-05-03_17-39-05](https://cloud.githubusercontent.com/assets/10569626/25687025/bce6db68-3027-11e7-8f54-73ecd2dbe6f4.png)
