### PR TITLE
Flat themes firefox, linux and classic improvements

### DIFF
--- a/src/cpp/session/resources/grid/gridstyles.css
+++ b/src/cpp/session/resources/grid/gridstyles.css
@@ -337,6 +337,11 @@ div.DTS div.DTS_Loading.showLoading {
     height: 23px;
 }
 
+.editor_dark #rsGridData tbody tr.even, 
+.editor_dark #rsGridData tbody tr.odd {
+    background: none;
+}
+
 #rsGridData {
     display: block;
 }
@@ -396,3 +401,6 @@ table.dataTable thead th.columnClickable .columnTypeHeader {
     right: -28px;
 }
 
+div.dataTables_scroll div.dataTables_scrollHead {
+    background: none !important;
+}

--- a/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
@@ -187,4 +187,6 @@ public interface ThemeStyles extends CssResource
    String consoleHeaderLayout();
    String consoleMinimizeLayout();
    String consoleMaximizeLayout();
+
+   String secondaryTallerToolbar();
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -876,6 +876,8 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
    float: left;
 }
 
+@def TABSTRIPHEIGHT 21px;
+
 /** Document tabs **/
 /*
 @def TABSTRIPHEIGHT 24px;
@@ -1084,8 +1086,8 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
 }
 
 .rstudio-themes-flat .toolbar {
-   height: 22px;
    border-bottom: 1px solid #d6dadc;
+   height: 21px;
 }
 
 .toolbar * {
@@ -1163,7 +1165,7 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
 
 .secondaryToolbar {
    background: TABBACKGROUND bottom repeat-x;
-   height: TABSTRIPHEIGHT;
+   height: TABSTRIPHEIGHT !important;
 }
 
 .secondaryToolbarPanel {
@@ -1177,7 +1179,7 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
 
 .rstudio-themes-flat .secondaryToolbar {
    border-bottom: solid 1px #d6dadc;
-   height: 24px;
+   height: 20px !important;
 }
 
 .toolbarButtonRightImage {
@@ -1281,7 +1283,7 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
 
 .rstudio-themes-flat .webGlobalToolbar {
    border-bottom: 0;
-   height: 24px;
+   height: 22px;
 }
 
  @if user.agent gecko1_8 { .webGlobalToolbar {
@@ -1874,7 +1876,7 @@ body.ubuntu_mono .searchBox {
 }
 
 .rstudio-themes-flat .logoAnchor {
-   top: 3px !important;
+   top: 2px !important;
 }
 
 .rstudio-themes-flat .dialogTabPanel {

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1081,8 +1081,13 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
    width: 100%;
    height: 23px;
    background: TOOLBARBACKGROUND repeat-x top;
-   padding: 0 0 0 6px;
+   padding: 0;
    white-space: nowrap;
+}
+
+.toolbar > table {
+   width: 100%;
+   padding: 0 0 0 6px;
 }
 
 .rstudio-themes-flat .toolbar {

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -984,8 +984,14 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
 .dirtyTabIndicator {
    display: none;
 }
+
 .dirtyTab .dirtyTabIndicator {
    display: inline;
+}
+
+.rstudio-themes-flat .dirtyTab .dirtyTabIndicator {
+   display: inline-block;
+   padding-top: 4px;
 }
 
 /** Module tabs **/

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -902,7 +902,11 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
 }
 
 .rstudio-themes-flat .rstudio-themes-dark .closeTabButton {
-   filter: invert(100%) brightness(100%);
+   -webkit-filter: invert(100%) brightness(100%);
+      -moz-filter: invert(100%) brightness(100%);
+       -ms-filter: invert(100%) brightness(100%);
+        -o-filter: invert(100%) brightness(100%);
+           filter: invert(100%) brightness(100%);
 }
 
 .gwt-TabLayoutPanel-Workbench .gwt-TabLayoutPanelTab .closeTabButton {
@@ -1133,8 +1137,16 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
 }
 
 .rstudio-themes-flat .rstudio-themes-dark .toolbarSeparator {
-   filter: invert(100%);
-   transform: scaleX(-1);
+   -webkit-filter: invert(100%);
+      -moz-filter: invert(100%);
+       -ms-filter: invert(100%);
+        -o-filter: invert(100%);
+           filter: invert(100%);
+   -webkit-transform: scaleX(-1);
+      -moz-transform: scaleX(-1);
+       -ms-transform: scaleX(-1);
+        -o-transform: scaleX(-1);
+           transform: scaleX(-1);
 }
 
 .toolbarFileLabel {
@@ -2057,7 +2069,11 @@ body.ubuntu_mono .searchBox {
 }
 
 .rstudio-themes-flat .rstudio-themes-dark .rstudio-themes-inverts {
-   filter: invert(100%);
+   -webkit-filter: invert(100%);
+      -moz-filter: invert(100%);
+       -ms-filter: invert(100%);
+        -o-filter: invert(100%);
+           filter: invert(100%);
 }
 
 /* RSTUDIO DEFAULT THEME */

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1182,6 +1182,15 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
    height: 20px !important;
 }
 
+.secondaryTallerToolbar {
+
+}
+
+.rstudio-themes-flat .secondaryTallerToolbar {
+   border-bottom: solid 1px #d6dadc;
+   height: 23px !important;  
+}
+
 .toolbarButtonRightImage {
    display: none;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioFrame.java
@@ -21,6 +21,7 @@ import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.studio.client.RStudioGinjector;
 
 import com.google.gwt.dom.client.BodyElement;
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.event.dom.client.LoadEvent;
 import com.google.gwt.event.dom.client.LoadHandler;
 import com.google.gwt.user.client.ui.Frame;
@@ -55,6 +56,9 @@ public class RStudioFrame extends Frame
          BodyElement body = getWindow().getDocument().getBody();
          if (body != null)
          {
+            if (Document.get().getBody().hasClassName("rstudio-themes-flat"))
+               body.addClassName("rstudio-themes-flat");
+            
             body.addClassName("ace_editor_theme");
          }
       }

--- a/src/gwt/src/org/rstudio/core/client/widget/Toolbar.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/Toolbar.java
@@ -109,6 +109,8 @@ public class Toolbar extends Composite
    {
       super();
 
+      HTMLPanel borderWrapper = new HTMLPanel("");
+
       horizontalPanel_ = new HorizontalPanel();
       horizontalPanel_.setVerticalAlignment(HasVerticalAlignment.ALIGN_MIDDLE);
       leftToolbarPanel_ = new HorizontalPanel();
@@ -127,7 +129,8 @@ public class Toolbar extends Composite
                                           rightToolbarPanel_,
                                           HasHorizontalAlignment.ALIGN_RIGHT);
 
-      initWidget(horizontalPanel_);
+      borderWrapper.add(horizontalPanel_);
+      initWidget(borderWrapper);
       setStyleName(styles_.toolbar());
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
@@ -32,7 +32,7 @@ public class RStudioThemes
       element.removeClassName("rstudio-themes-dark-grey");
       element.removeClassName("rstudio-themes-alternate");
       
-      if (themeName != "classic") {         
+      if (themeName == "default" ||themeName == "dark-grey" || themeName == "alternate") {         
          document.getBody().addClassName("rstudio-themes-flat");
          if (themeName.contains("dark")) {
             element.addClassName("rstudio-themes-dark");

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/header/HeaderPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/header/HeaderPanel.css
@@ -14,7 +14,7 @@
 
 .rstudio-themes-flat .panel {
    padding: 0 8px 0 8px;
-   margin-top: 8px;
+   margin-top: 7px;
 }
 
 @sprite .left {

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteWindow.java
@@ -61,13 +61,20 @@ public abstract class SatelliteWindow extends Composite
       initWidget(mainPanel_);
    }
 
+   public boolean suportsThemes()
+   {
+      return false;
+   }
+
    @Override
    public void onThemeChanged(ThemeChangedEvent event)
    {
-      RStudioThemes.initializeThemes(
-         event.getName(),
-         Document.get(),
-         mainPanel_.getElement());
+      if (suportsThemes()) {
+         RStudioThemes.initializeThemes(
+            event.getName(),
+            Document.get(),
+            mainPanel_.getElement());
+      }
    }
 
    protected boolean allowScrolling()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -52,6 +52,26 @@ public class AppearancePreferencesPane extends PreferencesPane
 
       VerticalPanel leftPanel = new VerticalPanel();
 
+      flatTheme_ = new SelectWidget("RStudio theme:",
+                                new String[]{"Classic", "Modern", "Sky"},
+                                new String[]{"classic", "modern", "alternate"},
+                                false);
+      flatTheme_.addStyleName(res.styles().themeChooser());
+      flatTheme_.getListBox().getElement().<SelectElement>cast().setSize(3);
+      flatTheme_.getListBox().getElement().getStyle().setHeight(50, Unit.PX);
+      flatTheme_.getListBox().addChangeHandler(new ChangeHandler()
+      {
+         public void onChange(ChangeEvent event)
+         {
+         }
+      });
+
+      String themeAlias = uiPrefs_.getFlatTheme().getGlobalValue();
+      if (themeAlias == "default" || themeAlias ==  "dark-grey") themeAlias = "modern";
+      flatTheme_.setValue(themeAlias);
+
+      leftPanel.add(flatTheme_);
+
       if (Desktop.isDesktop())
       {
          // no zoom level on cocoa desktop
@@ -99,6 +119,7 @@ public class AppearancePreferencesPane extends PreferencesPane
          String[] fonts = Desktop.getFrame().getFixedWidthFontList().split("\\n");
 
          fontFace_ = new SelectWidget("Editor font:", fonts, fonts, false, false, false);
+         fontFace_.getListBox().setWidth("95%");
 
          String value = Desktop.getFrame().getFixedWidthFont();
          String label = Desktop.getFrame().getFixedWidthFont().replaceAll("\\\"",
@@ -133,7 +154,7 @@ public class AppearancePreferencesPane extends PreferencesPane
                                    labels,
                                    values,
                                    false);
-      fontSize_.getListBox().setWidth("100%");
+      fontSize_.getListBox().setWidth("95%");
       if (!fontSize_.setValue(uiPrefs.fontSize().getGlobalValue() + ""))
          fontSize_.getListBox().setSelectedIndex(3);
       fontSize_.getListBox().addChangeHandler(new ChangeHandler()
@@ -155,29 +176,11 @@ public class AppearancePreferencesPane extends PreferencesPane
             preview_.setTheme(themes.getThemeUrl(theme_.getValue()));
          }
       });
-      theme_.getListBox().getElement().<SelectElement>cast().setSize(10);
-      theme_.getListBox().getElement().getStyle().setHeight(300, Unit.PX);
+      theme_.getListBox().getElement().<SelectElement>cast().setSize(7);
+      theme_.getListBox().getElement().getStyle().setHeight(250, Unit.PX);
       theme_.addStyleName(res.styles().themeChooser());
       theme_.setValue(themes.getEffectiveThemeName(uiPrefs_.theme().getGlobalValue()));
       
-      flatTheme_ = new SelectWidget("RStudio theme:",
-                                new String[]{"Classic", "Modern", "Sky"},
-                                new String[]{"classic", "modern", "alternate"},
-                                false);
-      flatTheme_.addStyleName(res.styles().themeChooser());
-      flatTheme_.getListBox().getElement().<SelectElement>cast().setSize(3);
-      flatTheme_.getListBox().addChangeHandler(new ChangeHandler()
-      {
-         public void onChange(ChangeEvent event)
-         {
-         }
-      });
-
-      String themeAlias = uiPrefs_.getFlatTheme().getGlobalValue();
-      if (themeAlias == "default" || themeAlias ==  "dark-grey") themeAlias = "modern";
-      flatTheme_.setValue(themeAlias);
-
-      leftPanel.add(flatTheme_);
       leftPanel.add(fontSize_);
       leftPanel.add(theme_);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.rstudio.core.client.DebugFilePosition;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.SearchWidget;
 import org.rstudio.core.client.widget.SecondaryToolbar;
@@ -136,6 +137,9 @@ public class EnvironmentPane extends WorkbenchPane
             imageOfEnvironment(environmentName_, environmentIsLocal_),
             environmentMenu_);
       toolbar.addLeftWidget(environmentButton_);
+
+      ThemeStyles styles = ThemeStyles.INSTANCE;
+      toolbar.addStyleName(styles.secondaryTallerToolbar());
       
       SearchWidget searchWidget = new SearchWidget(new SuggestOracle() {
          @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesListDataGridStyle.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesListDataGridStyle.css
@@ -20,6 +20,11 @@
   color: #606060;
 }
 
+.dataGridEvenRowCell, .dataGridOddRowCell, .dataGridHoveredRowCell, .dataGridSelectedRowCell, .dataGridKeyboardSelectedRowCell, .dataGridKeyboardSelectedCell   {
+  border: selectionBorderWidth solid #ffffff;
+  color: #606060;
+}
+
 .dataGridWidget {
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -48,6 +48,7 @@ import org.rstudio.core.client.dom.IFrameElementEx;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.events.NativeKeyDownEvent;
 import org.rstudio.core.client.files.FileSystemItem;
+import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.CanFocus;
 import org.rstudio.core.client.widget.FindTextBox;
 import org.rstudio.core.client.widget.MessageDialog;
@@ -337,8 +338,11 @@ public class HelpPane extends WorkbenchPane
    @Override
    protected SecondaryToolbar createSecondaryToolbar()
    {
-      SecondaryToolbar toolbar = new SecondaryToolbar() ;
+      SecondaryToolbar toolbar = new SecondaryToolbar();
       toolbar.addLeftPopupMenu(title_ = new Label(), history_.getMenu());
+
+      ThemeStyles styles = ThemeStyles.INSTANCE;
+      toolbar.addStyleName(styles.secondaryTallerToolbar());
       
       if (isFindSupported())
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceSatelliteWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceSatelliteWindow.java
@@ -131,6 +131,12 @@ public class SourceSatelliteWindow extends SatelliteWindow
    {
       return this;
    }
+
+   @Override
+   public boolean suportsThemes()
+   {
+      return true;
+   }
    
    private final Provider<EventBus> pEventBus_;
    private final Provider<SourceSatellitePresenter> pPresenter_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTargetWidget.java
@@ -67,6 +67,7 @@ public class DataEditingTargetWidget extends Composite
       commands_ = commands;
 
       frame_ = new RStudioFrame(dataItem.getContentUrl());
+      frame_.setAceTheme();
       frame_.setSize("100%", "100%");
       table_ = new DataTable(this);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.css
@@ -31,6 +31,10 @@
    margin-top: 9px; 
 }
 
+.rstudio-themes-flat .optionsPanel {
+   margin-top: 7px; 
+}
+
 .checkboxLabel {
    margin-top: 4px;
    margin-right: 8px;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/ambiance.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/ambiance.css
@@ -61,7 +61,7 @@
   box-shadow: inset 0 0 10px black;
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   color: #E6E1DC;
   background-color: #202020;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/ambiance.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/ambiance.css
@@ -61,7 +61,7 @@
   box-shadow: inset 0 0 10px black;
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   color: #E6E1DC;
   background-color: #202020;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chaos.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chaos.css
@@ -23,7 +23,7 @@
   right: 0;
   background: #1D1D1D;
 }
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #161616;
   color: #E6E1DC;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chaos.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chaos.css
@@ -23,7 +23,7 @@
   right: 0;
   background: #1D1D1D;
 }
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #161616;
   color: #E6E1DC;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chrome.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chrome.css
@@ -9,7 +9,7 @@
   background: #e8e8e8;
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: black;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chrome.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chrome.css
@@ -9,7 +9,7 @@
   background: #e8e8e8;
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: black;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds.css
@@ -8,7 +8,7 @@
   background: #e8e8e8
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: #000000
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds.css
@@ -8,7 +8,7 @@
   background: #e8e8e8
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: #000000
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds_midnight.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds_midnight.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #191919;
   color: #929292
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds_midnight.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds_midnight.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #191919;
   color: #929292
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/cobalt.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/cobalt.css
@@ -8,7 +8,7 @@
   background: #246 ;
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #002240;
   color: #FFFFFF
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/cobalt.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/cobalt.css
@@ -8,7 +8,7 @@
   background: #246 ;
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #002240;
   color: #FFFFFF
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/crimson_editor.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/crimson_editor.css
@@ -14,7 +14,7 @@
   background: #e8e8e8;
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: rgb(64, 64, 64);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/crimson_editor.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/crimson_editor.css
@@ -14,7 +14,7 @@
   background: #e8e8e8;
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: rgb(64, 64, 64);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dawn.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dawn.css
@@ -8,7 +8,7 @@
   background: #e8e8e8
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #F9F9F9;
   color: #080808
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dawn.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dawn.css
@@ -8,7 +8,7 @@
   background: #e8e8e8
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #F9F9F9;
   color: #080808
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dreamweaver.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dreamweaver.css
@@ -8,7 +8,7 @@
   background: #e8e8e8;
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: black;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dreamweaver.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dreamweaver.css
@@ -8,7 +8,7 @@
   background: #e8e8e8;
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: black;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/eclipse.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/eclipse.css
@@ -9,7 +9,7 @@
   background: #ebebeb;
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: black;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/eclipse.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/eclipse.css
@@ -9,7 +9,7 @@
   background: #ebebeb;
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: black;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/idle_fingers.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/idle_fingers.css
@@ -8,7 +8,7 @@
   background: #555 ;
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #323232;
   color: #FFFFFF
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/idle_fingers.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/idle_fingers.css
@@ -8,7 +8,7 @@
   background: #555 ;
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #323232;
   color: #FFFFFF
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/katzenmilch.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/katzenmilch.css
@@ -11,7 +11,7 @@
   background: #e8e8e8
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #f3f2f3;
   color: rgba(15, 0, 9, 1.0)
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/katzenmilch.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/katzenmilch.css
@@ -11,7 +11,7 @@
   background: #e8e8e8
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #f3f2f3;
   color: rgba(15, 0, 9, 1.0)
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/kr_theme.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/kr_theme.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #0B0A09;
   color: #FCFFE0
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/kr_theme.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/kr_theme.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #0B0A09;
   color: #FCFFE0
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore.css
@@ -8,7 +8,7 @@
   background: #555651
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #161616;
   color: #E6E1DC
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore.css
@@ -8,7 +8,7 @@
   background: #555651
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #161616;
   color: #E6E1DC
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore_soft.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore_soft.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #1C1C1C;
   color: #E6E1DC
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore_soft.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore_soft.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #1C1C1C;
   color: #E6E1DC
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/mono_industrial.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/mono_industrial.css
@@ -8,7 +8,7 @@
   background: #555651
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #222C28;
   color: #FFFFFF
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/mono_industrial.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/mono_industrial.css
@@ -8,7 +8,7 @@
   background: #555651
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #222C28;
   color: #FFFFFF
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/monokai.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/monokai.css
@@ -8,7 +8,7 @@
   background: #555651
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #272822;
   color: #F8F8F2
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/monokai.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/monokai.css
@@ -8,7 +8,7 @@
   background: #555651
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #272822;
   color: #F8F8F2
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/pastel_on_dark.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/pastel_on_dark.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #2C2828;
   color: #8F938F
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/pastel_on_dark.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/pastel_on_dark.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #2C2828;
   color: #8F938F
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_dark.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_dark.css
@@ -8,7 +8,7 @@
   background: #33555E
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #002B36;
   color: #93A1A1
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_dark.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_dark.css
@@ -8,7 +8,7 @@
   background: #33555E
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #002B36;
   color: #93A1A1
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_light.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_light.css
@@ -8,7 +8,7 @@
   background: #e8e8e8
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FDF6E3;
   color: #586E75
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_light.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_light.css
@@ -8,7 +8,7 @@
   background: #e8e8e8
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FDF6E3;
   color: #586E75
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/textmate.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/textmate.css
@@ -12,7 +12,7 @@
     background-color: #6B72E6;
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: black;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/textmate.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/textmate.css
@@ -12,7 +12,7 @@
     background-color: #6B72E6;
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: black;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow.css
@@ -8,7 +8,7 @@
   background: #f6f6f6
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: #4D4D4C
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow.css
@@ -8,7 +8,7 @@
   background: #f6f6f6
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: #4D4D4C
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night.css
@@ -8,7 +8,7 @@
   background: #444 ;
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #1D1F21;
   color: #C5C8C6
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night.css
@@ -8,7 +8,7 @@
   background: #444 ;
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #1D1F21;
   color: #C5C8C6
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_blue.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_blue.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #002451;
   color: #FFFFFF
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_blue.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_blue.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #002451;
   color: #FFFFFF
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_bright.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_bright.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #000000;
   color: #DEDEDE
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_bright.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_bright.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #000000;
   color: #DEDEDE
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_eighties.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_eighties.css
@@ -8,7 +8,7 @@
   background: #444 ;
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #2D2D2D;
   color: #CCCCCC
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_eighties.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_eighties.css
@@ -8,7 +8,7 @@
   background: #444 ;
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #2D2D2D;
   color: #CCCCCC
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/twilight.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/twilight.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #141414;
   color: #F8F8F8
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/twilight.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/twilight.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #141414;
   color: #F8F8F8
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/vibrant_ink.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/vibrant_ink.css
@@ -8,7 +8,7 @@
   background: #444 ;
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #0F0F0F;
   color: #FFFFFF
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/vibrant_ink.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/vibrant_ink.css
@@ -8,7 +8,7 @@
   background: #444 ;
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #0F0F0F;
   color: #FFFFFF
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/xcode.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/xcode.css
@@ -10,7 +10,7 @@
   background: #e8e8e8
 }
 
-.ace_editor, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: #000000
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/xcode.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/xcode.css
@@ -10,7 +10,7 @@
   background: #e8e8e8
 }
 
-.ace_editor, .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: #000000
 }

--- a/src/gwt/tools/compile-themes.R
+++ b/src/gwt/tools/compile-themes.R
@@ -828,7 +828,7 @@ for (file in themeFiles) {
 
    ## Copy ace_editor as ace_editor_theme
    regex <- paste("^\\.ace_editor \\{$", sep = "")
-   content <- gsub(regex, ".ace_editor, .rstudio-themes-flat .ace_editor_theme {", content)
+   content <- gsub(regex, ".ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {", content)
    
    ## Strip the theme name rule from the CSS.
    regex <- paste("^\\", themeNameCssClass, "\\S*\\s+", sep = "")

--- a/src/gwt/tools/compile-themes.R
+++ b/src/gwt/tools/compile-themes.R
@@ -828,7 +828,7 @@ for (file in themeFiles) {
 
    ## Copy ace_editor as ace_editor_theme
    regex <- paste("^\\.ace_editor \\{$", sep = "")
-   content <- gsub(regex, ".ace_editor, .ace_editor_theme {", content)
+   content <- gsub(regex, ".ace_editor, .rstudio-themes-flat .ace_editor_theme {", content)
    
    ## Strip the theme name rule from the CSS.
    regex <- paste("^\\", themeNameCssClass, "\\S*\\s+", sep = "")


### PR DESCRIPTION
A bunch of small fixes for themes:
- Fix background color for some environment pane cells.
- Started work to apply ace theme to data viewer.
- Revert classic theme for dark theme panes, out of scope to support dark theme under classic theme.
- Polished appearance dialog to support only: Classic, Modern, and Sky. With modern handling dark themes contextually.
- Scope themes in satellites to only source satellites, this makes satellites consistent with dialogs, say for the git satellite.
- Fix dirty indicator in tabs spotted by @kevinushey 
- Linux had broken borders across panes under new themes and firefox rendered incorrectly some. Much improvements here, but a few corners still need polish.

<img width="1438" alt="screen shot 2017-05-03 at 8 20 14 pm" src="https://cloud.githubusercontent.com/assets/3478847/25689548/fe12c488-303d-11e7-9119-91e956a241fc.png">

<img width="1440" alt="screen shot 2017-05-03 at 8 20 35 pm" src="https://cloud.githubusercontent.com/assets/3478847/25689547/fe12af98-303d-11e7-8aa7-e13e12af0570.png">
