### PR TITLE
Apply themes to loading panel and improvements

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/ThemeColors.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ThemeColors.java
@@ -36,4 +36,10 @@ public class ThemeColors
    public static String alternateMostInactiveBackground            = "rgb(158, 160, 187)";
    public static String alternateMostInactiveTransparentBackground = "rgba(158, 160, 187, 0)";
    public static String alternateBorder                            = "rgb(162, 197, 215)";
+
+   public static String lightControlBackground                     = "#FFF";
+   public static String lightControlBorder                         = "#d6dadc";
+
+   public static String darkControlBackground                      = "rgb(108,121,131)";
+   public static String darkControlBorder                          = "rgb(45,60,75)";
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
@@ -192,4 +192,6 @@ public interface ThemeStyles extends CssResource
    String toolbarWrapper();
    String webGlobalToolbarWrapper();
    String desktopGlobalToolbarWrapper();
+
+   String progressPanel();
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1059,17 +1059,24 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
    width: 6px;
    background: MULTIPODACTIVETABLEFT right top no-repeat;
 }
+
 .moduleTabPanel .gwt-TabLayoutPanelTab-selected .tabLayoutCenter {
    height: 24px;
    background: MULTIPODACTIVETABTILE top repeat-x;
    padding-left: 3px;
    padding-right: 3px;
 }
+
+.rstudio-themes-flat .moduleTabPanel .gwt-TabLayoutPanelTab-selected .tabLayoutCenter {
+   height: 25px;
+}
+
 .moduleTabPanel .gwt-TabLayoutPanelTab-selected .tabLayoutRight {
    height: 24px;
    width: 6px;
    background: MULTIPODACTIVETABRIGHT left top no-repeat;
 }
+
 .moduleTabPanel .toolbar {
    background-image: TOOLBARBACKGROUND2;
 }
@@ -2148,7 +2155,8 @@ body.ubuntu_mono .searchBox {
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-default .secondaryToolbar,
 .rstudio-themes-flat .rstudio-themes-default .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelContent {
+.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelContent,
+.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanel {
    background: THEME_DEFAULT_BACKGROUND;
 }
 
@@ -2195,7 +2203,8 @@ body.rstudio-themes-flat .rstudio-themes-default {
 .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-dark-grey .secondaryToolbar,
 .rstudio-themes-flat .rstudio-themes-dark-grey .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
-.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelContent {
+.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelContent,
+.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanel {
    background: THEME_DARKGREY_BACKGROUND;
 }
 
@@ -2242,7 +2251,8 @@ body.rstudio-themes-flat .rstudio-themes-dark-grey {
 .rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-alternate .secondaryToolbar,
 .rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
-.rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanelContent {
+.rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanelContent,
+.rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanel {
    background: THEME_ALTERNATE_BACKGROUND;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2147,7 +2147,8 @@ body.ubuntu_mono .searchBox {
 .rstudio-themes-flat .rstudio-themes-default .toolbarWrapper,
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-default .secondaryToolbar,
-.rstudio-themes-flat .rstudio-themes-default .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader {
+.rstudio-themes-flat .rstudio-themes-default .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
+.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelContent {
    background: THEME_DEFAULT_BACKGROUND;
 }
 
@@ -2193,7 +2194,8 @@ body.rstudio-themes-flat .rstudio-themes-default {
 .rstudio-themes-flat .rstudio-themes-dark-grey .toolbarWrapper,
 .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-dark-grey .secondaryToolbar,
-.rstudio-themes-flat .rstudio-themes-dark-grey .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader {
+.rstudio-themes-flat .rstudio-themes-dark-grey .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
+.rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelContent {
    background: THEME_DARKGREY_BACKGROUND;
 }
 
@@ -2239,7 +2241,8 @@ body.rstudio-themes-flat .rstudio-themes-dark-grey {
 .rstudio-themes-flat .rstudio-themes-alternate .toolbarWrapper,
 .rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-alternate .secondaryToolbar,
-.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader {
+.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
+.rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanelContent {
    background: THEME_ALTERNATE_BACKGROUND;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2137,6 +2137,10 @@ body.ubuntu_mono .searchBox {
            filter: invert(100%);
 }
 
+.progressPanel {
+
+}
+
 /* RSTUDIO DEFAULT THEME */
 
 .rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background,
@@ -2292,3 +2296,6 @@ body.rstudio-themes-flat .rstudio-themes-alternate {
 .rstudio-themes-flat .rstudio-themes-alternate .multiPodUtilityArea {
    background: linear-gradient(to right, THEME_ALTERNATE_MOST_INACTIVE_TRANSPARENT, THEME_ALTERNATE_MOST_INACTIVE 13%);
 }
+
+/* RSTUDIO THEMES END */
+

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -64,6 +64,12 @@
 @eval THEME_DARKGREY_MOST_INACTIVE_TRANSPARENT org.rstudio.core.client.theme.ThemeColors.darkGreyMostInactiveTransparentBackground;
 @eval THEME_ALTERNATE_MOST_INACTIVE_TRANSPARENT org.rstudio.core.client.theme.ThemeColors.alternateMostInactiveTransparentBackground;
 
+@eval THEME_LIGHT_CONTROL_BACKGROUND org.rstudio.core.client.theme.ThemeColors.lightControlBackground;
+@eval THEME_LIGHT_CONTROL_BORDER org.rstudio.core.client.theme.ThemeColors.lightControlBorder;
+
+@eval THEME_DARK_CONTROL_BACKGROUND org.rstudio.core.client.theme.ThemeColors.darkControlBackground;
+@eval THEME_DARK_CONTROL_BORDER org.rstudio.core.client.theme.ThemeColors.darkControlBorder;
+
 
 @external dialogTopLeft, dialogTopLeftInner,
       dialogTopCenter, dialogTopCenterInner,
@@ -2072,9 +2078,9 @@ body.ubuntu_mono .searchBox {
 .rstudio-themes-flat .search {
    top: 1px;
    height: 16px;
-   border: solid 1px #d6dadc;
+   border: solid 1px THEME_LIGHT_CONTROL_BORDER;
    border-radius: 3px;
-   background: #FFF;
+   background: THEME_LIGHT_CONTROL_BACKGROUND;
 }
 
 .rstudio-themes-flat .tallerToolbarWrapper .search {
@@ -2082,8 +2088,8 @@ body.ubuntu_mono .searchBox {
 }
 
 .rstudio-themes-flat .rstudio-themes-dark .search {
-   border-color: rgb(45,60,75);
-   background: rgb(108,121,131);
+   border-color: THEME_DARK_CONTROL_BORDER;
+   background: THEME_DARK_CONTROL_BACKGROUND;
 }
 
 .rstudio-themes-flat .rstudio-themes-dark .search input {

--- a/src/gwt/src/org/rstudio/core/client/widget/LeftRightToggleButton.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/LeftRightToggleButton.css
@@ -1,3 +1,16 @@
+@external rstudio-themes-flat, rstudio-themes-dark;
+@external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
+
+@eval THEME_DEFAULT_BACKGROUND org.rstudio.core.client.theme.ThemeColors.defaultBackground;
+@eval THEME_DARKGREY_BACKGROUND org.rstudio.core.client.theme.ThemeColors.darkGreyBackground;
+@eval THEME_ALTERNATE_BACKGROUND org.rstudio.core.client.theme.ThemeColors.alternateBackground;
+
+@eval THEME_LIGHT_CONTROL_BACKGROUND org.rstudio.core.client.theme.ThemeColors.lightControlBackground;
+@eval THEME_LIGHT_CONTROL_BORDER org.rstudio.core.client.theme.ThemeColors.lightControlBorder;
+
+@eval THEME_DARK_CONTROL_BACKGROUND org.rstudio.core.client.theme.ThemeColors.darkControlBackground;
+@eval THEME_DARK_CONTROL_BORDER org.rstudio.core.client.theme.ThemeColors.darkControlBorder;
+
 .container {
    display: inline-block;
    height: 20px;
@@ -52,3 +65,64 @@
    width: auto;
 }
 
+.rstudio-themes-flat .rightOn {
+   height: 16px;
+   border: solid 1px #FFF;
+   border-radius: 3px;
+   margin: 2px;
+   overflow: hidden;
+}
+
+.rstudio-themes-flat .rightOn,
+.rstudio-themes-flat .leftOn {
+   height: 16px;
+   border: solid 1px THEME_LIGHT_CONTROL_BORDER;
+   border-radius: 3px;
+   margin: 2px;
+   margin-top: 3px;
+   overflow: hidden;
+}
+
+.rstudio-themes-flat .rstudio-themes-dark .rightOn,
+.rstudio-themes-flat .rstudio-themes-dark .leftOn {
+   border: solid 1px THEME_DARK_CONTROL_BORDER;
+}
+
+.rstudio-themes-flat .leftLeft,
+.rstudio-themes-flat .rightRight {
+   height: 16px;
+   background: THEME_LIGHT_CONTROL_BACKGROUND;
+}
+
+.rstudio-themes-flat .rstudio-themes-dark .leftLeft,
+.rstudio-themes-flat .rstudio-themes-dark .rightRight {
+   background: THEME_DARK_CONTROL_BACKGROUND;
+}
+
+.rstudio-themes-flat .leftRight,
+.rstudio-themes-flat .rightLeft {
+   display: none;
+}
+
+.rstudio-themes-flat .rightRight {
+   border-left: solid 1px THEME_LIGHT_CONTROL_BORDER;
+}
+
+.rstudio-themes-flat .rstudio-themes-dark .rightRight {
+   border-left: solid 1px THEME_DARK_CONTROL_BORDER;
+}
+
+.rstudio-themes-flat .rstudio-themes-default .rightOn .leftLeft,
+.rstudio-themes-flat .rstudio-themes-default .leftOn .rightRight {
+   background: THEME_DEFAULT_BACKGROUND;
+}
+
+.rstudio-themes-flat .rstudio-themes-dark-grey .rightOn .leftLeft,
+.rstudio-themes-flat .rstudio-themes-dark-grey .leftOn .rightRight {
+   background: THEME_DARKGREY_BACKGROUND;
+}
+
+.rstudio-themes-flat .rstudio-themes-alternate .rightOn .leftLeft,
+.rstudio-themes-flat .rstudio-themes-alternate .leftOn .rightRight {
+   background: THEME_ALTERNATE_BACKGROUND;
+}

--- a/src/gwt/src/org/rstudio/core/client/widget/ProgressPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ProgressPanel.java
@@ -14,10 +14,13 @@
  */
 package org.rstudio.core.client.widget;
 
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
 
+import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.images.ProgressImages;
 
 public class ProgressPanel extends Composite
@@ -35,17 +38,31 @@ public class ProgressPanel extends Composite
    public ProgressPanel(Widget progressImage, int verticalOffset)
    { 
       progressImage_ = progressImage;
+
+      progressSpinner_ = new ProgressSpinner(getSpinnerColor());
+      progressSpinner_.getElement().getStyle().setWidth(32, Unit.PX);
+      progressSpinner_.getElement().getStyle().setHeight(32, Unit.PX);
+
       HorizontalCenterPanel progressPanel = new HorizontalCenterPanel(
-                                                            progressImage_, 
-                                                            verticalOffset);
+         progressSpinner_.isSupported() ? progressSpinner_ : progressImage_, 
+         verticalOffset);
+
       progressImage_.setVisible(false);
+      progressSpinner_.setVisible(false);
+
       progressPanel.setSize("100%", "100%");
+      progressPanel.addStyleName(ThemeStyles.INSTANCE.progressPanel());
+      progressPanel.addStyleName("ace_editor_theme");
+
       initWidget(progressPanel);
    }
    
    public void beginProgressOperation(int delayMs)
    {
       clearTimer();
+
+      progressSpinner_.setColorType(getSpinnerColor());
+      progressSpinner_.setVisible(false);
       progressImage_.setVisible(false);
 
       timer_ = new Timer() {
@@ -54,6 +71,7 @@ public class ProgressPanel extends Composite
                return; // This should never happen, but, just in case
 
             progressImage_.setVisible(true);
+            progressSpinner_.setVisible(true);
          }
       };
       timer_.schedule(delayMs);
@@ -63,6 +81,15 @@ public class ProgressPanel extends Composite
    {
       clearTimer();
       progressImage_.setVisible(false);
+      progressSpinner_.setVisible(true);
+   }
+
+   private int getSpinnerColor()
+   {
+      boolean isDark = Document.get().getBody().hasClassName("editor_dark") &&
+         Document.get().getBody().hasClassName("rstudio-themes-flat");
+
+      return isDark ? ProgressSpinner.COLOR_WHITE : ProgressSpinner.COLOR_BLACK;
    }
 
    private void clearTimer()
@@ -75,5 +102,6 @@ public class ProgressPanel extends Composite
    }
 
    private final Widget progressImage_ ;
+   private final ProgressSpinner progressSpinner_;
    private Timer timer_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ProgressSpinner.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ProgressSpinner.java
@@ -31,7 +31,7 @@ public class ProgressSpinner extends Composite
       // compute sizes
       outerRadius_ = (COORD_SIZE / 2) - 10;
       innerRadius_ = (outerRadius_ / 2) + 5;
-      color_ = color == COLOR_WHITE ? "255, 255, 255" : "0, 0, 0";
+      colorType_ = color;
 
       // create canvas host
       canvas_ = Canvas.createIfSupported();
@@ -61,14 +61,26 @@ public class ProgressSpinner extends Composite
          }
       }, FRAME_RATE_MS);
    }
+
+   public boolean isSupported()
+   {
+      return canvas_ != null;
+   }
    
    public void detach()
    {
       complete_ = true;
    }
+
+   public void setColorType(int color)
+   {
+      colorType_ = color;
+   }
    
    private void redraw()
    {
+      String color = colorType_ == COLOR_WHITE ? "255, 255, 255" : "0, 0, 0";
+
       Context2d ctx = canvas_.getContext2d();
       double center = COORD_SIZE / 2;
       // clear canvas (we draw with an alpha channel so otherwise would stack)
@@ -88,7 +100,7 @@ public class ProgressSpinner extends Composite
          // compute transparency for this blade
          double alpha = 1.0 - (((double)((i + frame_) % NUM_BLADES)) / 
                                ((double)NUM_BLADES));
-         ctx.setStrokeStyle("rgba(" + color_ + ", " + alpha + ")");
+         ctx.setStrokeStyle("rgba(" + color + ", " + alpha + ")");
          
          // draw the blade
          ctx.moveTo(center + sin * innerRadius_,
@@ -111,7 +123,7 @@ public class ProgressSpinner extends Composite
    private final int innerRadius_;
    private final int outerRadius_;
    private final Canvas canvas_;
-   private final String color_;
+   private int colorType_;
 
    private int frame_ = 0;
    private boolean complete_ = false;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/ambiance.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/ambiance.css
@@ -796,3 +796,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chaos.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chaos.css
@@ -729,3 +729,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chrome.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chrome.css
@@ -729,3 +729,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds.css
@@ -693,3 +693,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds_midnight.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds_midnight.css
@@ -691,3 +691,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/cobalt.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/cobalt.css
@@ -712,3 +712,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/crimson_editor.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/crimson_editor.css
@@ -718,3 +718,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dawn.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dawn.css
@@ -705,3 +705,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dreamweaver.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dreamweaver.css
@@ -751,3 +751,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/eclipse.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/eclipse.css
@@ -694,3 +694,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/idle_fingers.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/idle_fingers.css
@@ -691,3 +691,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/katzenmilch.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/katzenmilch.css
@@ -718,3 +718,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/kr_theme.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/kr_theme.css
@@ -702,3 +702,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/material.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/material.css
@@ -163,3 +163,6 @@
 .ace_console_error {
   background-color: #455054;
 }
+.editor_dark.ace_editor_theme a {
+  color: #FFF !important;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore.css
@@ -688,3 +688,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore_soft.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore_soft.css
@@ -689,3 +689,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/mono_industrial.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/mono_industrial.css
@@ -701,3 +701,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/monokai.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/monokai.css
@@ -700,3 +700,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/pastel_on_dark.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/pastel_on_dark.css
@@ -710,3 +710,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_dark.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_dark.css
@@ -679,3 +679,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_light.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_light.css
@@ -684,3 +684,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/textmate.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/textmate.css
@@ -730,3 +730,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow.css
@@ -700,3 +700,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night.css
@@ -700,3 +700,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_blue.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_blue.css
@@ -697,3 +697,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_bright.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_bright.css
@@ -716,3 +716,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_eighties.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_eighties.css
@@ -700,3 +700,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/twilight.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/twilight.css
@@ -706,3 +706,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/vibrant_ink.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/vibrant_ink.css
@@ -688,3 +688,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/xcode.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/xcode.css
@@ -681,3 +681,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
+.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/tools/compile-themes.R
+++ b/src/gwt/tools/compile-themes.R
@@ -798,6 +798,12 @@ create_xterm_color_rules <- function(background, foreground, isDark) {
       ".xtermBgColor255 { background-color: #eeeeee; }")
 }
 
+themes_static_rules <- function() {
+  paste(".editor_dark.ace_editor_theme a {",
+        "color: #FFF !important;",
+        "}")
+}
+
 ## Get the set of all theme .css files
 outDir <- "../src/org/rstudio/studio/client/workbench/views/source/editors/text/themes"
 themeDir <- "ace/lib/ace/theme"
@@ -1037,6 +1043,9 @@ for (file in themeFiles) {
    # Add xterm-256 colors for colorized console output
    content <- c(content,
                 create_xterm_color_rules(background, foreground, isDark)) 
+
+   # Theme rules
+   content <- add_content(content, themes_static_rules()) 
    
    ## Phew! Write it out.
    outputPath <- file.path(outDir, basename(file))


### PR DESCRIPTION
- Applies themes to the loading panel.
- Reduces flicker while switching to new tabs under dark theme.
- Reduces white border artifacts while zooming in with `command +`.
- Applies themes to toggle button.
- Applies visible font color to help links under dark theme.

<img width="936" alt="screen shot 2017-05-08 at 1 24 41 pm" src="https://cloud.githubusercontent.com/assets/3478847/25828396/cdccf850-3404-11e7-893b-df884830bf95.png">

<img width="667" alt="screen shot 2017-05-08 at 4 38 19 pm" src="https://cloud.githubusercontent.com/assets/3478847/25829713/ddcb3cbe-340c-11e7-825d-8336ff81a33c.png">

<img width="666" alt="screen shot 2017-05-08 at 5 06 44 pm" src="https://cloud.githubusercontent.com/assets/3478847/25830296/c61364da-3410-11e7-8860-1378587fb770.png">
