### PR TITLE
Always show dock tile project label

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -79,6 +79,7 @@
 * Show disambiguation in overflow list when two editor tabs have the same filename
 * Respect control characters in error output; makes e.g. curl output correct
 * Add new cheat sheet links to Help: Data Import, Interfacing Spark
+* OS X: Always show project label on dock tiles
 * Server Pro: Add option to disable file uploads
 * Server Pro: Upgrade to TurboActivate 4.0; improves licensing
 * Server Pro: Add support for floating (lease-based) licenses

--- a/src/cpp/desktop-mac/DockTileView.h
+++ b/src/cpp/desktop-mac/DockTileView.h
@@ -18,10 +18,8 @@
 
 @interface DockTileView : NSView {
    NSString* label_;
-   BOOL showLabel_;
 }
 
 - (void) setLabel: (NSString*) label;
-- (void) setShowLabel: (BOOL) show;
 
 @end

--- a/src/cpp/desktop-mac/DockTileView.mm
+++ b/src/cpp/desktop-mac/DockTileView.mm
@@ -24,7 +24,6 @@
 {
    if (self = [super init])
    {
-      showLabel_ = FALSE;
    }
    return self;
 }
@@ -39,11 +38,6 @@
    }
 }
 
-- (void) setShowLabel: (BOOL) show
-{
-   showLabel_ = show;
-}
-
 - (void) drawRect: (NSRect)rect
 {
    // get the current bounds
@@ -56,7 +50,7 @@
            operation:NSCompositeCopy fraction:1.0];
    
    // draw the label if needed
-   if (showLabel_ && (label_ != nil))
+   if (label_ != nil)
    {
       // sizes all based on the containing bounds
       const CGFloat kBaseSize = 128;

--- a/src/cpp/desktop-mac/MainFrameController.mm
+++ b/src/cpp/desktop-mac/MainFrameController.mm
@@ -130,12 +130,6 @@ bool setWindowGeometry(NSWindow* window, NSString* geometry)
       NSString* userAgent = [webView_
                stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
       [self checkWebkitVersion: userAgent];
-      
-      // signup for changes in the list of running applications
-      [[NSWorkspace sharedWorkspace] addObserver:self
-                                      forKeyPath:@"runningApplications"
-                                         options:NSKeyValueObservingOptionNew
-                                         context:&kRunningApplicationsContext];
    }
    
    return self;
@@ -161,9 +155,6 @@ bool setWindowGeometry(NSWindow* window, NSString* geometry)
    // or reload for a new project context)
    quitConfirmed_ = NO;
 
-   // determine whether we should show a DockTile label
-   [self updateDockTileShowLabel];
-   
    // see if there is a project dir to display in the titlebar
    NSString* projectDir = [self evaluateJavaScript:
                                 @"window.desktopHooks.getActiveProjectDir()"] ;
@@ -204,38 +195,12 @@ bool setWindowGeometry(NSWindow* window, NSString* geometry)
 }
 
 
-// whenever the list of running applications changes then check to see
-// whether we should show project name labels on our dock tile (do it
-// if there is more than one instance of RStudio active)
-- (void)observeValueForKeyPath:(NSString *)keyPath
-                      ofObject:(id)object
-                        change:(NSDictionary *)change
-                       context:(void *)context
-{
-   if (context == &kRunningApplicationsContext)
-      [self updateDockTileShowLabel];
-}
-
-
 - (void) updateDockTile: (NSString*) projectDir
 {
    if (projectDir != nil)
       [dockTile_ setLabel: [projectDir lastPathComponent]];
    else
       [dockTile_ setLabel: nil];
-   
-   [[NSApp dockTile] display];
-}
-
-- (void) updateDockTileShowLabel
-{
-   if ([[NSRunningApplication runningApplicationsWithBundleIdentifier:
-         [[NSBundle mainBundle] bundleIdentifier]] count] > 1) {
-      [dockTile_ setShowLabel: TRUE];
-   }
-   else {
-      [dockTile_ setShowLabel: FALSE];
-   }
    
    [[NSApp dockTile] display];
 }


### PR DESCRIPTION
Formerly we wouldn't show the label if there was only one instance of the IDE open. However, it's still useful to know which project you have open with a single IDE instance. This change just removes the check for a single instance and always shows the label.