### PR TITLE
Limit reverse-i-search to current project; exclude obvious dupes

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -2122,6 +2122,16 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, GET_HISTORY_ARCHIVE_ITEMS, params, requestCallback);
    }
    
+   public void searchHistory(
+         String query, 
+         long maxEntries,
+         ServerRequestCallback<RpcObjectList<HistoryEntry>> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(query));
+      params.set(1, new JSONNumber(maxEntries));
+      sendRequest(RPC_SCOPE, SEARCH_HISTORY, params, requestCallback);
+   }
   
    public void searchHistoryArchive(
          String query, 
@@ -5310,6 +5320,7 @@ public class RemoteServer implements Server
    private static final String REMOVE_HISTORY_ITEMS = "remove_history_items";
    private static final String CLEAR_HISTORY = "clear_history";
    private static final String GET_HISTORY_ARCHIVE_ITEMS = "get_history_archive_items";
+   private static final String SEARCH_HISTORY = "search_history";
    private static final String SEARCH_HISTORY_ARCHIVE = "search_history_archive";
    private static final String SEARCH_HISTORY_ARCHIVE_BY_PREFIX = "search_history_archive_by_prefix";
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HistoryCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HistoryCompletionManager.java
@@ -147,7 +147,7 @@ public class HistoryCompletionManager implements KeyDownPreviewHandler,
    
    public void beginSearch()
    {
-      server_.searchHistoryArchive(
+      server_.searchHistory(
             input_.getText(), 20, 
             new HistoryCallback(input_.getText(), PopupMode.PopupIncremental));
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/history/model/HistoryServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/history/model/HistoryServerOperations.java
@@ -45,6 +45,17 @@ public interface HistoryServerOperations
    
    
    /*
+    *  searchHistory - search the project history for the query  (return up to
+    *  maxEntries). the search is conducted beginning with the most recent
+    *  history items and returned in descending order (i.e. newest ones
+    *  first)
+    */
+   void searchHistory (
+         String query,
+         long maxEntries,
+         ServerRequestCallback<RpcObjectList<HistoryEntry>> requestCallback);
+
+   /*
     *  clearHistory -- clear the entire history 
     */
    void clearHistory(ServerRequestCallback<Void> requestCallback);


### PR DESCRIPTION
This change makes two improvements to Ctrl+R reverse incremental search:

- The scope of the search is now limited to the current project's console history (it does not search the entire history archive). This makes it much faster to find and to re-use commands inside the same project, at the expense of making it more difficult to re-use commands from other projects.

- The search results now exclude obvious duplicates (i.e. identical, consecutive commands).