### PR TITLE
Apply themes to profiler and toolbar icons

### DIFF
--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -189,6 +189,7 @@ void httpServerAddHandlers()
    uri_handlers::add("/chunk_output", secureAsyncHttpHandler(proxyContentRequest, true)); 
    uri_handlers::add("/profiles", secureAsyncHttpHandler(proxyContentRequest, true));
    uri_handlers::add("/rmd_data", secureAsyncHttpHandler(proxyContentRequest, true));
+   uri_handlers::add("/profiler_resource", secureAsyncHttpHandler(proxyContentRequest, true));
 
    // proxy localhost if requested
    if (server::options().wwwProxyLocalhost())

--- a/src/cpp/session/modules/SessionProfiler.cpp
+++ b/src/cpp/session/modules/SessionProfiler.cpp
@@ -40,6 +40,9 @@ namespace {
 #define kProfilesCacheDir "profiles-cache"
 #define kProfilesUrlPath "profiles"
 
+#define kProfilerResource "profiler_resource"
+#define kProfilerResourceLocation "/" kProfilerResource "/"
+
 std::string profilesCacheDir() 
 {
    return module_context::scopedScratchPath().childPath(kProfilesCacheDir)
@@ -64,6 +67,16 @@ void handleProfilerResReq(const http::Request& request,
    core::FilePath profileResource = profilesPath.childPath(resourceName);
 
    pResponse->setCacheableFile(profileResource, request);
+}
+
+void handleProfilerResourceResReq(const http::Request& request,
+                            http::Response* pResponse)
+{
+   std::string path("profiler/");
+   path.append(http::util::pathAfterPrefix(request, kProfilerResourceLocation));
+
+   core::FilePath profilerResource = options().rResourcesPath().childPath(path);
+   pResponse->setCacheableFile(profilerResource, request);
 }
 
 void onDocPendingRemove(
@@ -95,7 +108,8 @@ Error initialize()
 
    initBlock.addFunctions()
       (boost::bind(module_context::sourceModuleRFile, "SessionProfiler.R"))
-      (boost::bind(module_context::registerUriHandler, "/" kProfilesUrlPath "/", handleProfilerResReq));
+      (boost::bind(module_context::registerUriHandler, "/" kProfilesUrlPath "/", handleProfilerResReq))
+      (boost::bind(module_context::registerUriHandler, kProfilerResourceLocation, handleProfilerResourceResReq));
 
    RS_REGISTER_CALL_METHOD(rs_profilesPath, 0);
 

--- a/src/cpp/session/resources/profiler/profiler.css
+++ b/src/cpp/session/resources/profiler/profiler.css
@@ -15,7 +15,8 @@
 
 .rstudio-themes-flat.rstudio-themes-dark .profvis-footer,
 .rstudio-themes-flat.rstudio-themes-dark .profvis-status-bar,
-.rstudio-themes-flat.rstudio-themes-dark .result-block-active {
+.rstudio-themes-flat.rstudio-themes-dark .result-block-active,
+.rstudio-themes-flat.rstudio-themes-dark .options-button {
    color: #FFF;
 }
 

--- a/src/cpp/session/resources/profiler/profiler.css
+++ b/src/cpp/session/resources/profiler/profiler.css
@@ -24,13 +24,13 @@
    color: inherit;
 }
 
-.rstudio-themes-flat .profvis-table th {
+.rstudio-themes-flat.rstudio-themes-dark .profvis-table th {
    background: rgba(255, 255, 255, 0.2);
    border-top: none;
    font-weight: 400;
 }
 
-.rstudio-themes-flat table.profvis-table tr.active {
+.rstudio-themes-flat.rstudio-themes-dark table.profvis-table tr.active {
    background: rgba(255, 255, 255, 0.05);
 }
 
@@ -53,4 +53,24 @@
 
 .rstudio-themes-flat .info-block {
    border-right: solid 1px #FFF;
+}
+
+.rstudio-themes-flat .profvis-treetable {
+   color: inherit;
+}
+
+.rstudio-themes-flat .profvis-treetable table tr {
+   background: inherit !important;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .profvis-treetable th {
+   background: rgba(255, 255, 255, 0.2);
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .profvis-treetable .treetable-collapse > div > div {
+   border-top: 6px solid #FFF;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .profvis-treetable .treetable-expand > div > div {
+   border-left: 6px solid #FFF;
 }

--- a/src/cpp/session/resources/profiler/profiler.css
+++ b/src/cpp/session/resources/profiler/profiler.css
@@ -13,10 +13,20 @@
  *
  */
 
-.rstudio-themes-flat.rstudio-themes-dark .profvis-footer {
+.rstudio-themes-flat.rstudio-themes-dark .profvis-footer,
+.rstudio-themes-flat.rstudio-themes-dark .profvis-status-bar,
+.rstudio-themes-flat.rstudio-themes-dark .result-block-active {
    color: #FFF;
 }
 
 .rstudio-themes-flat .profvis-splitbar-horizontal {
    background: none;
+}
+
+.rstudio-themes-flat .separator-block {
+   display: none;
+}
+
+.rstudio-themes-flat .info-block {
+   border-right: solid 1px #FFF;
 }

--- a/src/cpp/session/resources/profiler/profiler.css
+++ b/src/cpp/session/resources/profiler/profiler.css
@@ -20,6 +20,29 @@
    color: #FFF;
 }
 
+.rstudio-themes-flat span.identifier {
+   color: inherit;
+}
+
+.rstudio-themes-flat .profvis-table th {
+   background: rgba(255, 255, 255, 0.2);
+   border-top: none;
+   font-weight: 400;
+}
+
+.rstudio-themes-flat table.profvis-table tr.active {
+   background: rgba(255, 255, 255, 0.05);
+}
+
+.rstudio-themes-flat table.profvis-table .membar-right-cell,
+.rstudio-themes-flat table.profvis-table .timebar-cell {
+   border-color: #444;
+}
+
+.rstudio-themes-flat table.profvis-table tr {
+   border-top: none;
+}
+
 .rstudio-themes-flat .profvis-splitbar-horizontal {
    background: none;
 }

--- a/src/cpp/session/resources/profiler/profiler.css
+++ b/src/cpp/session/resources/profiler/profiler.css
@@ -16,3 +16,7 @@
 .rstudio-themes-flat.rstudio-themes-dark .profvis-footer {
    color: #FFF;
 }
+
+.rstudio-themes-flat .profvis-splitbar-horizontal {
+   background: none;
+}

--- a/src/cpp/session/resources/profiler/profiler.css
+++ b/src/cpp/session/resources/profiler/profiler.css
@@ -1,0 +1,18 @@
+/*
+ * profiler.css
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+.rstudio-themes-flat.rstudio-themes-dark .profvis-footer {
+   color: #FFF;
+}

--- a/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
@@ -1059,8 +1059,11 @@ public class DocTabLayoutPanel
          contentPanel_.setStylePrimaryName(styles_.tabLayoutCenter());
          contentPanel_.setVerticalAlignment(HasVerticalAlignment.ALIGN_MIDDLE);
 
-         if (icon != null)
-            contentPanel_.add(imageForIcon(icon));
+         if (icon != null) {
+            Image tabImage = imageForIcon(icon);
+            tabImage.addStyleName(ThemeStyles.INSTANCE.tabIcon());
+            contentPanel_.add(tabImage);
+         }
 
          label_ = new Label(title, false);
          label_.addStyleName(styles_.docTabLabel());

--- a/src/gwt/src/org/rstudio/core/client/theme/ThemeColors.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ThemeColors.java
@@ -22,6 +22,7 @@ public class ThemeColors
    public static String defaultMostInactiveBackground              = "rgb(231, 232, 234)";
    public static String defaultMostInactiveTransparentBackground   = "rgba(231, 232, 234, 0)";
    public static String defaultBorder                              = "rgb(214,218,220)";
+   public static String defaultBodyBackground                      = "rgb(246, 247, 249)";
 
    public static String darkGreyBackground                         = "rgb(78, 92, 104)";
    public static String darkGreyBackgroundTransparent              = "rgba(78, 92, 104, 0)";
@@ -29,6 +30,7 @@ public class ThemeColors
    public static String darkGreyMostInactiveBackground             = "rgb(47, 57, 65)";
    public static String darkGreyMostInactiveTransparentBackground  = "rgba(47, 57, 65, 0)";
    public static String darkGreyBorder                             = "rgb(12, 31, 48)";
+   public static String darkGreyBodyBackground                     = "rgb(50, 76, 99)";
 
    public static String alternateBackground                        = "rgb(210, 228, 237)";
    public static String alternateBackgroundTransparent             = "rgba(210, 228, 237, 0)";
@@ -36,6 +38,7 @@ public class ThemeColors
    public static String alternateMostInactiveBackground            = "rgb(158, 160, 187)";
    public static String alternateMostInactiveTransparentBackground = "rgba(158, 160, 187, 0)";
    public static String alternateBorder                            = "rgb(162, 197, 215)";
+   public static String alternateBodyBackground                    = "rgb(162, 197, 215)";
 
    public static String lightControlBackground                     = "#FFF";
    public static String lightControlBorder                         = "#d6dadc";

--- a/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
@@ -198,4 +198,6 @@ public interface ThemeStyles extends CssResource
    String consoleClearButton();
    String terminalClearButton();
    String refreshToolbarButton();
+
+   String tabIcon();
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
@@ -197,4 +197,5 @@ public interface ThemeStyles extends CssResource
 
    String consoleClearButton();
    String terminalClearButton();
+   String refreshToolbarButton();
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
@@ -194,4 +194,7 @@ public interface ThemeStyles extends CssResource
    String desktopGlobalToolbarWrapper();
 
    String progressPanel();
+
+   String consoleClearButton();
+   String terminalClearButton();
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2171,6 +2171,14 @@ body.ubuntu_mono .searchBox {
    opacity: 0.5;
 }
 
+.refreshToolbarButton {
+
+}
+
+.rstudio-themes-flat .rstudio-themes-dark .refreshToolbarButton {
+   opacity: 0.8;
+}
+
 /* RSTUDIO DEFAULT THEME */
 
 .rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background,

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1501,7 +1501,7 @@ body.ubuntu_mono .searchBox {
 }
 
 .rstudio-themes-flat td.environmentDataFrameCol {
-   background: none;
+   background-color: inherit;
 }
 
 @sprite td.environmentFunctionCol {

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1145,6 +1145,11 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
    height: 21px;
    overflow: hidden;
 }
+
+.rstudio-themes-flat .rstudio-themes-dark .toolbarButton {
+   filter: brightness(90%) saturate(90%);
+}
+
 .toolbarButton.noLabel {
    margin-right: 4px;
 }
@@ -1913,6 +1918,14 @@ body.ubuntu_mono .searchBox {
 
 .rstudio-themes-flat .rstudio-themes-dark .gwt-TabLayoutPanelTabs table.tabLayoutCenter {
    color: white;
+}
+
+.tabIcon {
+
+}
+
+.rstudio-themes-flat .rstudio-themes-dark .gwt-TabLayoutPanelTabs table.tabLayoutCenter img.tabIcon {
+   filter: brightness(90%) saturate(90%);
 }
 
 .rstudio-themes-flat .gwt-TabLayoutPanelTabs .tabLayoutCenter td,

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -70,6 +70,9 @@
 @eval THEME_DARK_CONTROL_BACKGROUND org.rstudio.core.client.theme.ThemeColors.darkControlBackground;
 @eval THEME_DARK_CONTROL_BORDER org.rstudio.core.client.theme.ThemeColors.darkControlBorder;
 
+@eval THEME_DEFAULT_BODY_BACKGROUND org.rstudio.core.client.theme.ThemeColors.defaultBodyBackground;
+@eval THEME_DARKGREY_BODY_BACKGROUND org.rstudio.core.client.theme.ThemeColors.darkGreyBodyBackground;
+@eval THEME_ALTERNATE_BODY_BACKGROUND org.rstudio.core.client.theme.ThemeColors.alternateBodyBackground;
 
 @external dialogTopLeft, dialogTopLeftInner,
       dialogTopCenter, dialogTopCenterInner,
@@ -2205,12 +2208,12 @@ body.ubuntu_mono .searchBox {
 }
 
 body.rstudio-themes-flat .rstudio-themes-default {
-   background: rgb(246, 247, 249);
+   background: THEME_DEFAULT_BODY_BACKGROUND;
 }
 
 .rstudio-themes-flat .gwt-SplitLayoutPanel-HDragger,
 .rstudio-themes-flat .gwt-SplitLayoutPanel-VDragger {
-   background: rgb(246, 247, 249) !important;
+   background: THEME_DEFAULT_BODY_BACKGROUND !important;
 }
 
 .rstudio-themes-flat .rstudio-themes-default table.header > tbody > tr > td,
@@ -2253,12 +2256,12 @@ body.rstudio-themes-flat .rstudio-themes-default {
 }
 
 body.rstudio-themes-flat .rstudio-themes-dark-grey {
-   background: rgb(50, 76, 99);
+   background: THEME_DARKGREY_BODY_BACKGROUND;
 }
 
 .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-HDragger,
 .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-SplitLayoutPanel-VDragger {
-   background: rgb(50, 76, 99) !important;
+   background: THEME_DARKGREY_BODY_BACKGROUND !important;
 }
 
 .rstudio-themes-flat .rstudio-themes-dark-grey table.header > tbody > tr > td,
@@ -2301,12 +2304,12 @@ body.rstudio-themes-flat .rstudio-themes-dark-grey {
 }
 
 body.rstudio-themes-flat .rstudio-themes-alternate {
-   background: rgb(162, 197, 215);
+   background: THEME_ALTERNATE_BODY_BACKGROUND;
 }
 
 .rstudio-themes-flat .rstudio-themes-alternate .gwt-SplitLayoutPanel-HDragger,
 .rstudio-themes-flat .rstudio-themes-alternate .gwt-SplitLayoutPanel-VDragger {
-   background: rgb(162, 197, 215) !important;
+   background: THEME_ALTERNATE_BODY_BACKGROUND !important;
 }
 
 .rstudio-themes-flat .rstudio-themes-alternate table.header > tbody > tr > td,

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2158,6 +2158,19 @@ body.ubuntu_mono .searchBox {
 
 }
 
+.consoleClearButton {
+
+}
+
+.terminalClearButton {
+
+}
+
+.rstudio-themes-flat .rstudio-themes-dark .consoleClearButton,
+.rstudio-themes-flat .rstudio-themes-dark .terminalClearButton {
+   opacity: 0.5;
+}
+
 /* RSTUDIO DEFAULT THEME */
 
 .rstudio-themes-flat .rstudio-themes-default .rstudio-themes-background,

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1578,6 +1578,10 @@ body.ubuntu_mono .searchBox {
    z-index: 10;
 }
 
+.rstudio-themes-flat .tabOverflowPopup {
+   z-index: 1000;
+}
+
 .tabOverflowPopup .gwt-MenuBar>table {
    width: 100%;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioFrame.java
@@ -50,7 +50,7 @@ public class RStudioFrame extends Frame
          setUrl(url);
    }
    
-   private void addThemesStyle(String customStyle, String urlStyle)
+   private void addThemesStyle(String customStyle, String urlStyle, boolean removeBodyStyle)
    {
       if (getWindow() != null && getWindow().getDocument() != null)
       {
@@ -74,6 +74,8 @@ public class RStudioFrame extends Frame
          BodyElement body = document.getBody();
          if (body != null)
          {
+            if (removeBodyStyle) body.removeAttribute("style");
+            
             String themeName = RStudioGinjector.INSTANCE.getUIPrefs().getFlatTheme().getValue();
             RStudioThemes.initializeThemes(themeName, document, document.getBody());
             
@@ -89,21 +91,22 @@ public class RStudioFrame extends Frame
    
    public void setAceThemeAndCustomStyle(final String customStyle)
    {
-      setAceThemeAndCustomStyle(customStyle, null);  
+      setAceThemeAndCustomStyle(customStyle, null, false);  
    }
 
    public void setAceThemeAndCustomStyle(
       final String customStyle,
-      final String urlStyle)
+      final String urlStyle,
+      final boolean removeBodyStyle)
    {
-      addThemesStyle(customStyle, urlStyle);
+      addThemesStyle(customStyle, urlStyle, removeBodyStyle);
       
       this.addLoadHandler(new LoadHandler()
       {      
          @Override
          public void onLoad(LoadEvent arg0)
          {
-            addThemesStyle(customStyle, urlStyle);
+            addThemesStyle(customStyle, urlStyle, removeBodyStyle);
          }
       });
    }

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioFrame.java
@@ -23,6 +23,7 @@ import org.rstudio.studio.client.application.ui.RStudioThemes;
 
 import com.google.gwt.dom.client.BodyElement;
 import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.LinkElement;
 import com.google.gwt.dom.client.StyleElement;
 import com.google.gwt.event.dom.client.LoadEvent;
 import com.google.gwt.event.dom.client.LoadHandler;
@@ -49,7 +50,7 @@ public class RStudioFrame extends Frame
          setUrl(url);
    }
    
-   private void addThemesStyle(String customStyle)
+   private void addThemesStyle(String customStyle, String urlStyle)
    {
       if (getWindow() != null && getWindow().getDocument() != null)
       {
@@ -59,6 +60,13 @@ public class RStudioFrame extends Frame
             StyleElement style = document.createStyleElement();
             style.setInnerHTML(customStyle);
             document.getHead().appendChild(style);
+         }
+         
+         if (urlStyle != null) {
+            LinkElement styleLink = document.createLinkElement();
+            styleLink.setHref(urlStyle);
+            styleLink.setRel("stylesheet");
+            document.getHead().appendChild(styleLink);
          }
          
          RStudioGinjector.INSTANCE.getAceThemes().applyTheme(document);
@@ -78,17 +86,24 @@ public class RStudioFrame extends Frame
    {
       setAceThemeAndCustomStyle(null);
    }
-
+   
    public void setAceThemeAndCustomStyle(final String customStyle)
    {
-      addThemesStyle(customStyle);
+      setAceThemeAndCustomStyle(customStyle, null);  
+   }
+
+   public void setAceThemeAndCustomStyle(
+      final String customStyle,
+      final String urlStyle)
+   {
+      addThemesStyle(customStyle, urlStyle);
       
       this.addLoadHandler(new LoadHandler()
       {      
          @Override
          public void onLoad(LoadEvent arg0)
          {
-            addThemesStyle(customStyle);
+            addThemesStyle(customStyle, urlStyle);
          }
       });
    }

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
@@ -155,8 +155,10 @@ public class HTMLPreviewPanel extends ResizeComposite
       });
       
       refreshButtonSeparator_ = toolbar.addRightSeparator();
-      refreshButton_ = toolbar.addRightWidget(
-                     commands.refreshHtmlPreview().createToolbarButton());
+
+      ToolbarButton refreshButton = commands.refreshHtmlPreview().createToolbarButton();
+      refreshButton.addStyleName(ThemeStyles.INSTANCE.refreshToolbarButton());
+      refreshButton_ = toolbar.addRightWidget(refreshButton);
       
       
       return toolbar;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsPane.java
@@ -612,7 +612,10 @@ public class ConnectionsPane extends WorkbenchPane
       toolbar_.addLeftWidget(commands_.disconnectConnection().createToolbarButton());
       
       toolbar_.addRightWidget(commands_.removeConnection().createToolbarButton());
-      toolbar_.addRightWidget(commands_.refreshConnection().createToolbarButton());
+
+      ToolbarButton refreshButton = commands_.refreshConnection().createToolbarButton();
+      refreshButton.addStyleName(ThemeStyles.INSTANCE.refreshToolbarButton());
+      toolbar_.addRightWidget(refreshButton);
       
       connectionName_.setText(connection.getDisplayName());
       connectionIcon_.setUrl(connection.getIconData());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleClearButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleClearButton.java
@@ -20,6 +20,7 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.inject.Inject;
 
+import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.workbench.commands.Commands;
@@ -37,6 +38,7 @@ public class ConsoleClearButton extends Composite
       commands_ = commands;
       ImageResource icon = commands_.consoleClear().getImageResource();
       ToolbarButton button = new ToolbarButton(icon, commands.consoleClear());
+      panel.addStyleName(ThemeStyles.INSTANCE.consoleClearButton());
       width_ = icon.getWidth() + 6;
       height_ = icon.getHeight();
       panel.setWidget(button);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
@@ -106,6 +106,7 @@ public class ConsolePane extends WorkbenchPane
       toolbar.addLeftWidget(commands_.goToWorkingDir().createToolbarButton());
       consoleInterruptButton_ = commands_.interruptR().createToolbarButton();
       consoleClearButton_ = commands_.consoleClear().createToolbarButton();
+      consoleClearButton_.addStyleName(ThemeStyles.INSTANCE.consoleClearButton());
       consoleClearButton_.setVisible(true);
       
       profilerInterruptButton_ = ConsoleInterruptProfilerButton.CreateProfilerButton();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -120,7 +120,10 @@ public class EnvironmentPane extends WorkbenchPane
       toolbar.addRightWidget(viewButton_);
       
       toolbar.addRightSeparator();
-      toolbar.addRightWidget(commands_.refreshEnvironment().createToolbarButton());
+
+      ToolbarButton refreshButton = commands_.refreshEnvironment().createToolbarButton();
+      refreshButton.addStyleName(ThemeStyles.INSTANCE.refreshToolbarButton());
+      toolbar.addRightWidget(refreshButton);
       
 
       return toolbar;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.css
@@ -79,7 +79,7 @@ td.valueCol
 
 .rstudio-themes-flat td.valueCol
 {
-   background: none;
+   background-color: inherit;
 }
 
 .widthSettingRow td.expandCol,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FileCommandToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FileCommandToolbar.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.views.files.ui;
 import com.google.inject.Inject;
 
 import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
@@ -60,6 +61,7 @@ public class FileCommandToolbar extends Toolbar
 
       // Refresh
       ToolbarButton refreshButton = commands.refreshFiles().createToolbarButton();
+      refreshButton.addStyleName(ThemeStyles.INSTANCE.refreshToolbarButton());
       addRightWidget(refreshButton);
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -56,6 +56,7 @@ import org.rstudio.core.client.widget.RStudioFrame;
 import org.rstudio.core.client.widget.SecondaryToolbar;
 import org.rstudio.core.client.widget.SmallButton;
 import org.rstudio.core.client.widget.Toolbar;
+import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.AutoGlassPanel;
 import org.rstudio.studio.client.common.GlobalDisplay;
@@ -329,9 +330,11 @@ public class HelpPane extends WorkbenchPane
       toolbar.addRightWidget(searchProvider_.get().getSearchWidget());
 
       toolbar.addRightSeparator();
-      toolbar.addRightWidget(commands_.refreshHelp().createToolbarButton());
+
+      ToolbarButton refreshButton = commands_.refreshHelp().createToolbarButton();
+      refreshButton.addStyleName(ThemeStyles.INSTANCE.refreshToolbarButton());
+      toolbar.addRightWidget(refreshButton);
     
-      
       return toolbar;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
@@ -22,6 +22,7 @@ import org.rstudio.core.client.cellview.ImageButtonColumn;
 import org.rstudio.core.client.cellview.LinkColumn;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
+import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.SearchWidget;
 import org.rstudio.core.client.widget.Toolbar;
@@ -282,8 +283,10 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
       toolbar.addRightWidget(searchWidget_);
       
       toolbar.addRightSeparator();
-      toolbar.addRightWidget(commands_.refreshPackages().createToolbarButton());
-      
+
+      ToolbarButton refreshButton = commands_.refreshPackages().createToolbarButton();
+      refreshButton.addStyleName(ThemeStyles.INSTANCE.refreshToolbarButton());
+      toolbar.addRightWidget(refreshButton);
       
       return toolbar;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/PlotsToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/PlotsToolbar.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.workbench.views.plots.ui;
 
 import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.HasCustomizableToolbar;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
@@ -78,7 +79,10 @@ public class PlotsToolbar extends Toolbar implements HasCustomizableToolbar
     
       // refresh
       addRightSeparator();
-      addRightWidget(commands_.refreshPlot().createToolbarButton());
+
+      ToolbarButton refreshButton = commands_.refreshPlot().createToolbarButton();
+      refreshButton.addStyleName(ThemeStyles.INSTANCE.refreshToolbarButton());
+      addRightWidget(refreshButton);
    }
    
    private final Commands commands_;   

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/presentation/PresentationPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/presentation/PresentationPane.java
@@ -147,8 +147,11 @@ public class PresentationPane extends WorkbenchPane implements Presentation.Disp
       }
       
       toolbar.addRightSeparator();
-      toolbar.addRightWidget(refreshButton_ = 
-                  commands_.refreshPresentation().createToolbarButton());
+
+      refreshButton_ = commands_.refreshPresentation().createToolbarButton();
+      refreshButton_.addStyleName(ThemeStyles.INSTANCE.refreshToolbarButton());
+      toolbar.addRightWidget(refreshButton_);
+
       progressButton_ = new ToolbarButton(
                               CoreResources.INSTANCE.progress_gray(),
                               new ClickHandler() {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
@@ -67,27 +67,33 @@ public class ProfilerEditingTargetWidget extends Composite
    private String getCustomStyle()
    {
       return
-         ".rstudio-themes-flat.rstudio-themes-default .profvis-footer {\n" +
+         ".rstudio-themes-flat.rstudio-themes-default .profvis-footer,\n" +
+         ".rstudio-themes-flat.rstudio-themes-default .info-block {\n" +
          "   border-color: " + ThemeColors.defaultBorder + ";\n" +
          "}\n" +
          "\n" +
-         ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-footer {\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-footer,\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark-grey .info-block {\n" +
          "   border-color: " + ThemeColors.darkGreyBorder + ";\n" +
          "}\n" +
          "\n" +
-         ".rstudio-themes-flat.rstudio-themes-alternate .profvis-footer {\n" +
+         ".rstudio-themes-flat.rstudio-themes-alternate .profvis-footer,\n" +
+         ".rstudio-themes-flat.rstudio-themes-alternate .info-block {\n" +
          "   border-color: " + ThemeColors.alternateBorder + ";\n" +
          "}\n" +
          "\n" +
-         ".rstudio-themes-flat.rstudio-themes-default .profvis-footer {\n" +
+         ".rstudio-themes-flat.rstudio-themes-default .profvis-footer,\n" +
+         ".rstudio-themes-flat.rstudio-themes-default .profvis-status-bar {\n" +
          "   background-color: " + ThemeColors.defaultBackground + ";\n" +
          "}\n" +
          "\n" +
-         ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-footer {\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-footer,\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-status-bar {\n" +
          "   background-color: " + ThemeColors.darkGreyBackground + ";\n" +
          "}\n" +
          "\n" +
-         ".rstudio-themes-flat.rstudio-themes-alternate .profvis-footer {\n" +
+         ".rstudio-themes-flat.rstudio-themes-alternate .profvis-footer,\n" +
+         ".rstudio-themes-flat.rstudio-themes-alternate .profvis-status-bar {\n" +
          "   background-color: " + ThemeColors.alternateBackground + ";\n" +
          "}\n" +
          "\n" +
@@ -101,6 +107,18 @@ public class ProfilerEditingTargetWidget extends Composite
          "\n" +
          ".rstudio-themes-flat.rstudio-themes-alternate .profvis-splitbar-horizontal {\n" +
          "   background-color: " + ThemeColors.alternateBodyBackground + ";\n" +
+         "}\n" +
+         "\n" +
+         ".rstudio-themes-flat.rstudio-themes-default .result-block-active {\n" +
+         "   background-color: " + ThemeColors.defaultMostInactiveBackground + ";\n" +
+         "}\n" +
+         "\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark-grey .result-block-active {\n" +
+         "   background-color: " + ThemeColors.darkGreyMostInactiveBackground + ";\n" +
+         "}\n" +
+         "\n" +
+         ".rstudio-themes-flat.rstudio-themes-alternate .result-block-active {\n" +
+         "   background-color: " + ThemeColors.alternateMostInactiveBackground + ";\n" +
          "}\n";
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
@@ -90,7 +90,18 @@ public class ProfilerEditingTargetWidget extends Composite
          ".rstudio-themes-flat.rstudio-themes-alternate .profvis-footer {\n" +
          "   background-color: " + ThemeColors.alternateBackground + ";\n" +
          "}\n" +
-         "\n";
+         "\n" +
+         ".rstudio-themes-flat.rstudio-themes-default .profvis-splitbar-horizontal {\n" +
+         "   background-color: " + ThemeColors.defaultBodyBackground + ";\n" +
+         "}\n" +
+         "\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-splitbar-horizontal {\n" +
+         "   background-color: " + ThemeColors.darkGreyBodyBackground + ";\n" +
+         "}\n" +
+         "\n" +
+         ".rstudio-themes-flat.rstudio-themes-alternate .profvis-splitbar-horizontal {\n" +
+         "   background-color: " + ThemeColors.alternateBodyBackground + ";\n" +
+         "}\n";
    }
 
    public void print()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
@@ -69,16 +69,19 @@ public class ProfilerEditingTargetWidget extends Composite
    {
       return
          ".rstudio-themes-flat.rstudio-themes-default .profvis-footer,\n" +
+         ".rstudio-themes-flat.rstudio-themes-default .profvis-status-bar,\n" +
          ".rstudio-themes-flat.rstudio-themes-default .info-block {\n" +
          "   border-color: " + ThemeColors.defaultBorder + ";\n" +
          "}\n" +
          "\n" +
          ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-footer,\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-status-bar,\n" +
          ".rstudio-themes-flat.rstudio-themes-dark-grey .info-block {\n" +
          "   border-color: " + ThemeColors.darkGreyBorder + ";\n" +
          "}\n" +
          "\n" +
          ".rstudio-themes-flat.rstudio-themes-alternate .profvis-footer,\n" +
+         ".rstudio-themes-flat.rstudio-themes-alternate .profvis-status-bar,\n" +
          ".rstudio-themes-flat.rstudio-themes-alternate .info-block {\n" +
          "   border-color: " + ThemeColors.alternateBorder + ";\n" +
          "}\n" +

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
@@ -48,7 +48,8 @@ public class ProfilerEditingTargetWidget extends Composite
       profilePage_ = new RStudioFrame();
       profilePage_.setAceThemeAndCustomStyle(
          getCustomStyle(),
-         "../profiler_resource/profiler.css");
+         "../profiler_resource/profiler.css",
+         true);
 
       profilePage_.setWidth("100%");
       profilePage_.setHeight("100%");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
@@ -20,6 +20,7 @@ import com.google.gwt.user.client.ui.Widget;
 
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.dom.WindowEx;
+import org.rstudio.core.client.theme.ThemeColors;
 import org.rstudio.core.client.widget.RStudioFrame;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.studio.client.rsconnect.RSConnect;
@@ -45,6 +46,10 @@ public class ProfilerEditingTargetWidget extends Composite
                                           panel);
 
       profilePage_ = new RStudioFrame();
+      profilePage_.setAceThemeAndCustomStyle(
+         getCustomStyle(),
+         "../profiler_resource/profiler.css");
+
       profilePage_.setWidth("100%");
       profilePage_.setHeight("100%");
       
@@ -57,6 +62,35 @@ public class ProfilerEditingTargetWidget extends Composite
          profilePage_.getElement().getParentElement().setAttribute("height", "100%");
       
       initWidget(mainPanel);
+   }
+
+   private String getCustomStyle()
+   {
+      return
+         ".rstudio-themes-flat.rstudio-themes-default .profvis-footer {\n" +
+         "   border-color: " + ThemeColors.defaultBorder + ";\n" +
+         "}\n" +
+         "\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-footer {\n" +
+         "   border-color: " + ThemeColors.darkGreyBorder + ";\n" +
+         "}\n" +
+         "\n" +
+         ".rstudio-themes-flat.rstudio-themes-alternate .profvis-footer {\n" +
+         "   border-color: " + ThemeColors.alternateBorder + ";\n" +
+         "}\n" +
+         "\n" +
+         ".rstudio-themes-flat.rstudio-themes-default .profvis-footer {\n" +
+         "   background-color: " + ThemeColors.defaultBackground + ";\n" +
+         "}\n" +
+         "\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-footer {\n" +
+         "   background-color: " + ThemeColors.darkGreyBackground + ";\n" +
+         "}\n" +
+         "\n" +
+         ".rstudio-themes-flat.rstudio-themes-alternate .profvis-footer {\n" +
+         "   background-color: " + ThemeColors.alternateBackground + ";\n" +
+         "}\n" +
+         "\n";
    }
 
    public void print()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
@@ -70,18 +70,24 @@ public class ProfilerEditingTargetWidget extends Composite
       return
          ".rstudio-themes-flat.rstudio-themes-default .profvis-footer,\n" +
          ".rstudio-themes-flat.rstudio-themes-default .profvis-status-bar,\n" +
+         ".rstudio-themes-flat.rstudio-themes-default .profvis-treetable td,\n" +
+         ".rstudio-themes-flat.rstudio-themes-default .profvis-treetable th,\n" +
          ".rstudio-themes-flat.rstudio-themes-default .info-block {\n" +
          "   border-color: " + ThemeColors.defaultBorder + ";\n" +
          "}\n" +
          "\n" +
          ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-footer,\n" +
          ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-status-bar,\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-treetable td,\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-treetable th,\n" +
          ".rstudio-themes-flat.rstudio-themes-dark-grey .info-block {\n" +
          "   border-color: " + ThemeColors.darkGreyBorder + ";\n" +
          "}\n" +
          "\n" +
          ".rstudio-themes-flat.rstudio-themes-alternate .profvis-footer,\n" +
          ".rstudio-themes-flat.rstudio-themes-alternate .profvis-status-bar,\n" +
+         ".rstudio-themes-flat.rstudio-themes-alternate .profvis-treetable td,\n" +
+         ".rstudio-themes-flat.rstudio-themes-alternate .profvis-treetable th,\n" +
          ".rstudio-themes-flat.rstudio-themes-alternate .info-block {\n" +
          "   border-color: " + ThemeColors.alternateBorder + ";\n" +
          "}\n" +

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -23,6 +23,7 @@ import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.ProgressOperationWithInput;
 import org.rstudio.core.client.widget.Toolbar;
+import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.SessionSerializationEvent;
 import org.rstudio.studio.client.application.events.SessionSerializationHandler;
@@ -110,7 +111,10 @@ public class TerminalPane extends WorkbenchPane
       terminalTitle_ = new Label();
       terminalTitle_.setStyleName(ThemeStyles.INSTANCE.subtitle());
       toolbar.addLeftWidget(terminalTitle_);
-      toolbar.addRightWidget(commands_.clearTerminalScrollbackBuffer().createToolbarButton());
+
+      ToolbarButton clearButton = commands_.clearTerminalScrollbackBuffer().createToolbarButton();
+      clearButton.addStyleName(ThemeStyles.INSTANCE.terminalClearButton());
+      toolbar.addRightWidget(clearButton);
 
       commands_.previousTerminal().setEnabled(false);
       commands_.nextTerminal().setEnabled(false);


### PR DESCRIPTION
- Applies themes to profiler (expect flamegraph which is rendered with SVG)
- Applies themes to toolbar icons to make to subtly reduce brightness

<img width="1440" alt="screen shot 2017-05-09 at 6 21 53 pm" src="https://cloud.githubusercontent.com/assets/3478847/25879114/88fbb668-34e4-11e7-959c-14be00d6fdb1.png">

<img width="1437" alt="screen shot 2017-05-09 at 6 21 38 pm" src="https://cloud.githubusercontent.com/assets/3478847/25879115/88fe40e0-34e4-11e7-8e52-8fb20d08ac2b.png">