### PR TITLE
use 'etc/ldpaths' for rJava on macOS as well

### DIFF
--- a/src/cpp/desktop-mac/AppDelegate.mm
+++ b/src/cpp/desktop-mac/AppDelegate.mm
@@ -197,14 +197,17 @@ bool prepareEnvironment(Options& options)
    if (!whichROverride.empty())
       rWhichRPath = FilePath(whichROverride);
    
-   // determine rLdPaths script location
-   FilePath scriptsPath = options.scriptsPath();
-   
-   // NOTE: we check two paths just to support both development
-   // and package / install configurations
-   FilePath rLdScriptPath = scriptsPath.complete("r-ldpath");
+   // determine rLdPaths script location -- handle both debug
+   // and release configurations
+   FilePath rLdScriptPath = options.scriptsPath().complete("session/r-ldpath");
    if (!rLdScriptPath.exists())
-      rLdScriptPath = scriptsPath.complete("session/r-ldpath");
+   {
+      FilePath exePath;
+      Error error = core::system::executablePath(NULL, &exePath);
+      if (error)
+         LOG_ERROR(error);
+      rLdScriptPath = exePath.parent().complete("r-ldpath");
+   }
    
    // attempt to detect R environment
    std::string rScriptPath, rVersion, errMsg;

--- a/src/cpp/desktop-mac/AppDelegate.mm
+++ b/src/cpp/desktop-mac/AppDelegate.mm
@@ -198,10 +198,13 @@ bool prepareEnvironment(Options& options)
       rWhichRPath = FilePath(whichROverride);
    
    // determine rLdPaths script location
-   FilePath supportingFilePath = options.supportingFilePath();
-   FilePath rLdScriptPath = supportingFilePath.complete("bin/r-ldpath");
+   FilePath scriptsPath = options.scriptsPath();
+   
+   // NOTE: we check two paths just to support both development
+   // and package / install configurations
+   FilePath rLdScriptPath = scriptsPath.complete("r-ldpath");
    if (!rLdScriptPath.exists())
-      rLdScriptPath = supportingFilePath.complete("session/r-ldpath");
+      rLdScriptPath = scriptsPath.complete("session/r-ldpath");
    
    // attempt to detect R environment
    std::string rScriptPath, rVersion, errMsg;

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -392,9 +392,17 @@ target_link_libraries(rsession
 )
 
 # configure and install r-ldpaths script
-if(UNIX AND NOT APPLE)
+if(UNIX)
+
+   if(APPLE)
+     set(LIBRARY_PATH_ENVVAR "DYLD_FALLBACK_LIBRARY_PATH")
+   else()
+     set(LIBRARY_PATH_ENVVAR "LD_LIBRARY_PATH")
+   endif()
+
    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/r-ldpath.in
-                  ${CMAKE_CURRENT_BINARY_DIR}/r-ldpath)
+                  ${CMAKE_CURRENT_BINARY_DIR}/r-ldpath
+                  @ONLY)
    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/r-ldpath
            DESTINATION ${RSTUDIO_INSTALL_BIN})
 endif()

--- a/src/cpp/session/r-ldpath.in
+++ b/src/cpp/session/r-ldpath.in
@@ -17,5 +17,5 @@
 
 RHOME=$1
 . $RHOME/etc/ldpaths
-echo -n $LD_LIBRARY_PATH
+echo -n "${@LIBRARY_PATH_ENVVAR@}"
 


### PR DESCRIPTION
This PR fixes an issue where `rJava` can fail to load when running with R 3.4.0 under RStudio on macOS.

Although this issue was originally reported by a Homebrew R user, one can actually reproduce this with R 3.4.0 installed from CRAN, using the CRAN `rJava` binary as well. Compare:

```
kevin@cdrv:~/Library/R/3.4/library/rJava/libs
$ otool -L rJava.so
rJava.so:
        rJava.so (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libjvm.dylib (compatibility version 1.0.0, current version 1.0.0)
        /Library/Frameworks/R.framework/Versions/3.4/Resources/lib/libR.dylib (compatibility version 3.4.0, current version 3.4.0)
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1259.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1226.10.1)
```

```
kevin@cdrv:~/Library/R/3.3/library/rJava/libs
$ otool -L rJava.so
rJava.so:
        rJava.so (compatibility version 0.0.0, current version 0.0.0)
        /System/Library/Frameworks/JavaVM.framework/Versions/A/JavaVM (compatibility version 1.0.0, current version 1.0.0)
        /Library/Frameworks/R.framework/Versions/3.3/Resources/lib/libR.dylib (compatibility version 3.3.0, current version 3.3.0)
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 855.17.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1197.1.1)
```

If I understand correctly, `rJava` with R 3.3.x (and below) uses the system Java installation, while newer versions attempt to use `libjvm` from the `@rpath`. This is eventually discovered on the `DYLD_FALLBACK_LIBRARY_PATH` which is set when R is run from the console, but since RStudio (prior to this PR) was not harvesting this environment variable, it would now fail in RStudio.

Altogether, I think this implies that this PR could actually be a candidate for the patch release, since the underlying issue is that, with R 3.4.0 from CRAN, `rJava` does not work by default under RStudio.

