### PR TITLE
Support to switch between themes and apply themes to flamegraph

### DIFF
--- a/src/cpp/session/resources/profiler/profiler.css
+++ b/src/cpp/session/resources/profiler/profiler.css
@@ -74,3 +74,35 @@
 .rstudio-themes-flat.rstudio-themes-dark .profvis-treetable .treetable-expand > div > div {
    border-left: 6px solid #FFF;
 }
+
+.rstudio-themes-flat .profvis-flamegraph .background {
+   fill: rgba(249, 249, 250, 0);
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .profvis-flamegraph .tick {
+   fill: #FFF;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .profvis-flamegraph .tick line {
+   stroke: #FFF;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .profvis-flamegraph .domain {
+   stroke: #FFF;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .profvis-flamegraph .cell text {
+   fill: #FFF;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .profvis-flamegraph .cell rect {
+   fill: rgba(255,255,255,0.3);
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .profvis-flamegraph .cell.highlighted .rect {
+   fill: rgba(255,255,255,0.5);
+}
+
+.rstudio-themes-flat.rstudio-themes-dark .profvis-flamegraph .cell.highlighted.active .rect {
+   fill: rgba(255,255,255,0.7);
+}

--- a/src/cpp/session/resources/profiler/profiler.css
+++ b/src/cpp/session/resources/profiler/profiler.css
@@ -45,6 +45,8 @@
 
 .rstudio-themes-flat .profvis-splitbar-horizontal {
    background: none;
+   border-top: solid 1px #FFF;
+   border-bottom: solid 1px #FFF;
 }
 
 .rstudio-themes-flat .separator-block {

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioFrame.java
@@ -1,7 +1,7 @@
 /*
  * RStudioFrame.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -18,15 +18,7 @@ package org.rstudio.core.client.widget;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.IFrameElementEx;
 import org.rstudio.core.client.dom.WindowEx;
-import org.rstudio.studio.client.RStudioGinjector;
-import org.rstudio.studio.client.application.ui.RStudioThemes;
 
-import com.google.gwt.dom.client.BodyElement;
-import com.google.gwt.dom.client.Document;
-import com.google.gwt.dom.client.LinkElement;
-import com.google.gwt.dom.client.StyleElement;
-import com.google.gwt.event.dom.client.LoadEvent;
-import com.google.gwt.event.dom.client.LoadHandler;
 import com.google.gwt.user.client.ui.Frame;
 
 public class RStudioFrame extends Frame
@@ -48,67 +40,6 @@ public class RStudioFrame extends Frame
          getElement().setAttribute("sandbox", StringUtil.notNull(sandboxAllow));
       if (url != null)
          setUrl(url);
-   }
-   
-   private void addThemesStyle(String customStyle, String urlStyle, boolean removeBodyStyle)
-   {
-      if (getWindow() != null && getWindow().getDocument() != null)
-      {
-         Document document = getWindow().getDocument();
-         
-         if (customStyle != null) {
-            StyleElement style = document.createStyleElement();
-            style.setInnerHTML(customStyle);
-            document.getHead().appendChild(style);
-         }
-         
-         if (urlStyle != null) {
-            LinkElement styleLink = document.createLinkElement();
-            styleLink.setHref(urlStyle);
-            styleLink.setRel("stylesheet");
-            document.getHead().appendChild(styleLink);
-         }
-         
-         RStudioGinjector.INSTANCE.getAceThemes().applyTheme(document);
-         
-         BodyElement body = document.getBody();
-         if (body != null)
-         {
-            if (removeBodyStyle) body.removeAttribute("style");
-            
-            String themeName = RStudioGinjector.INSTANCE.getUIPrefs().getFlatTheme().getValue();
-            RStudioThemes.initializeThemes(themeName, document, document.getBody());
-            
-            body.addClassName("ace_editor_theme");
-         }
-      }
-   }
-   
-   public void setAceTheme()
-   {
-      setAceThemeAndCustomStyle(null);
-   }
-   
-   public void setAceThemeAndCustomStyle(final String customStyle)
-   {
-      setAceThemeAndCustomStyle(customStyle, null, false);  
-   }
-
-   public void setAceThemeAndCustomStyle(
-      final String customStyle,
-      final String urlStyle,
-      final boolean removeBodyStyle)
-   {
-      addThemesStyle(customStyle, urlStyle, removeBodyStyle);
-      
-      this.addLoadHandler(new LoadHandler()
-      {      
-         @Override
-         public void onLoad(LoadEvent arg0)
-         {
-            addThemesStyle(customStyle, urlStyle, removeBodyStyle);
-         }
-      });
    }
    
    public WindowEx getWindow()

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
@@ -1,0 +1,121 @@
+/*
+ * RStudioThemedFrame.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.core.client.widget;
+
+import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.application.events.ThemeChangedEvent;
+import org.rstudio.studio.client.application.ui.RStudioThemes;
+
+import com.google.gwt.dom.client.BodyElement;
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.LinkElement;
+import com.google.gwt.dom.client.StyleElement;
+import com.google.gwt.event.dom.client.LoadEvent;
+import com.google.gwt.event.dom.client.LoadHandler;
+import com.google.inject.Inject;
+
+public class RStudioThemedFrame extends RStudioFrame
+                                implements ThemeChangedEvent.Handler
+{
+   public RStudioThemedFrame()
+   {
+      this(null, null, null, false);
+   }
+
+   public RStudioThemedFrame(String url, String customStyle, String urlStyle, boolean removeBodyStyle)
+   {
+      super(url);
+      
+      customStyle_ = customStyle;
+      urlStyle_ = urlStyle;
+      removeBodyStyle_ = removeBodyStyle;
+      
+      RStudioGinjector.INSTANCE.injectMembers(this);
+
+      setAceThemeAndCustomStyle(customStyle_, urlStyle_, removeBodyStyle_);
+   }
+
+   @Inject
+   public void initialize(EventBus events)
+   {
+      events_ = events;
+
+      events_.addHandler(ThemeChangedEvent.TYPE, this);
+   }
+
+   @Override
+   public void onThemeChanged(ThemeChangedEvent event)
+   {
+      setAceThemeAndCustomStyle(customStyle_, urlStyle_, removeBodyStyle_);
+   }
+   
+   private void addThemesStyle(String customStyle, String urlStyle, boolean removeBodyStyle)
+   {
+      if (getWindow() != null && getWindow().getDocument() != null)
+      {
+         Document document = getWindow().getDocument();
+         
+         if (customStyle != null) {
+            StyleElement style = document.createStyleElement();
+            style.setInnerHTML(customStyle);
+            document.getHead().appendChild(style);
+         }
+         
+         if (urlStyle != null) {
+            LinkElement styleLink = document.createLinkElement();
+            styleLink.setHref(urlStyle);
+            styleLink.setRel("stylesheet");
+            document.getHead().appendChild(styleLink);
+         }
+         
+         RStudioGinjector.INSTANCE.getAceThemes().applyTheme(document);
+         
+         BodyElement body = document.getBody();
+         if (body != null)
+         {
+            if (removeBodyStyle) body.removeAttribute("style");
+            
+            String themeName = RStudioGinjector.INSTANCE.getUIPrefs().getFlatTheme().getValue();
+            RStudioThemes.initializeThemes(themeName, document, document.getBody());
+            
+            body.addClassName("ace_editor_theme");
+         }
+      }
+   }
+
+   private void setAceThemeAndCustomStyle(
+      final String customStyle,
+      final String urlStyle,
+      final boolean removeBodyStyle)
+   {
+      addThemesStyle(customStyle, urlStyle, removeBodyStyle);
+      
+      this.addLoadHandler(new LoadHandler()
+      {      
+         @Override
+         public void onLoad(LoadEvent arg0)
+         {
+            addThemesStyle(customStyle, urlStyle, removeBodyStyle);
+         }
+      });
+   }
+
+   private EventBus events_;
+   private String customStyle_;
+   private String urlStyle_;
+   private boolean removeBodyStyle_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -31,6 +31,7 @@ import org.rstudio.core.client.theme.WindowFrame;
 import org.rstudio.core.client.widget.CaptionWithHelp;
 import org.rstudio.core.client.widget.LocalRepositoriesWidget;
 import org.rstudio.core.client.widget.ModifyKeyboardShortcutsWidget;
+import org.rstudio.core.client.widget.RStudioThemedFrame;
 import org.rstudio.studio.client.application.Application;
 import org.rstudio.studio.client.application.ApplicationInterrupt;
 import org.rstudio.studio.client.application.events.EventBus;
@@ -231,6 +232,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(ObjectExplorerEditingTargetWidget widget);
    void injectMembers(ObjectExplorerDataGrid widget);
    void injectMembers(TerminalInfoDialog infoDialog);
+   void injectMembers(RStudioThemedFrame frame);
    
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -57,8 +57,7 @@ public class AppearancePreferencesPane extends PreferencesPane
                                 new String[]{"classic", "modern", "alternate"},
                                 false);
       flatTheme_.addStyleName(res.styles().themeChooser());
-      flatTheme_.getListBox().getElement().<SelectElement>cast().setSize(3);
-      flatTheme_.getListBox().getElement().getStyle().setHeight(50, Unit.PX);
+      flatTheme_.getListBox().setWidth("95%");
       flatTheme_.getListBox().addChangeHandler(new ChangeHandler()
       {
          public void onChange(ChangeEvent event)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -52,7 +52,7 @@ import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.CanFocus;
 import org.rstudio.core.client.widget.FindTextBox;
 import org.rstudio.core.client.widget.MessageDialog;
-import org.rstudio.core.client.widget.RStudioFrame;
+import org.rstudio.core.client.widget.RStudioThemedFrame;
 import org.rstudio.core.client.widget.SecondaryToolbar;
 import org.rstudio.core.client.widget.SmallButton;
 import org.rstudio.core.client.widget.Toolbar;
@@ -102,8 +102,7 @@ public class HelpPane extends WorkbenchPane
    @Override 
    protected Widget createMainWidget()
    {
-      frame_ = new RStudioFrame();
-      frame_.setAceTheme();
+      frame_ = new RStudioThemedFrame();
       frame_.setSize("100%", "100%");
       frame_.setStylePrimaryName("rstudio-HelpFrame");
       frame_.addStyleName("ace_editor_theme");
@@ -713,7 +712,7 @@ public class HelpPane extends WorkbenchPane
    private final ToolbarLinkMenu history_ ;
  
    private Label title_ ;
-   private RStudioFrame frame_ ;
+   private RStudioThemedFrame frame_ ;
    private FindTextBox findTextBox_;
    private final Provider<HelpSearch> searchProvider_ ;
    private GlobalDisplay globalDisplay_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTargetWidget.java
@@ -27,6 +27,7 @@ import org.rstudio.core.client.dom.IFrameElementEx;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.theme.ThemeColors;
 import org.rstudio.core.client.widget.RStudioFrame;
+import org.rstudio.core.client.widget.RStudioThemedFrame;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.studio.client.common.AutoGlassPanel;
 import org.rstudio.studio.client.dataviewer.DataTable;
@@ -114,8 +115,11 @@ public class DataEditingTargetWidget extends Composite
 
       commands_ = commands;
 
-      frame_ = new RStudioFrame(dataItem.getContentUrl());
-      frame_.setAceThemeAndCustomStyle(getCustomStyle());
+      frame_ = new RStudioThemedFrame(
+         dataItem.getContentUrl(),
+         getCustomStyle(),
+         null,
+         false);
       frame_.setSize("100%", "100%");
       table_ = new DataTable(this);
 
@@ -218,6 +222,6 @@ public class DataEditingTargetWidget extends Composite
    }
 
    private final Commands commands_;
-   private RStudioFrame frame_;
+   private RStudioThemedFrame frame_;
    private DataTable table_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
@@ -72,6 +72,7 @@ public class ProfilerEditingTargetWidget extends Composite
          ".rstudio-themes-flat.rstudio-themes-default .profvis-status-bar,\n" +
          ".rstudio-themes-flat.rstudio-themes-default .profvis-treetable td,\n" +
          ".rstudio-themes-flat.rstudio-themes-default .profvis-treetable th,\n" +
+         ".rstudio-themes-flat.rstudio-themes-default .profvis-splitbar-horizontal,\n" +
          ".rstudio-themes-flat.rstudio-themes-default .info-block {\n" +
          "   border-color: " + ThemeColors.defaultBorder + ";\n" +
          "}\n" +
@@ -80,6 +81,7 @@ public class ProfilerEditingTargetWidget extends Composite
          ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-status-bar,\n" +
          ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-treetable td,\n" +
          ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-treetable th,\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-splitbar-horizontal,\n" +
          ".rstudio-themes-flat.rstudio-themes-dark-grey .info-block {\n" +
          "   border-color: " + ThemeColors.darkGreyBorder + ";\n" +
          "}\n" +
@@ -88,6 +90,7 @@ public class ProfilerEditingTargetWidget extends Composite
          ".rstudio-themes-flat.rstudio-themes-alternate .profvis-status-bar,\n" +
          ".rstudio-themes-flat.rstudio-themes-alternate .profvis-treetable td,\n" +
          ".rstudio-themes-flat.rstudio-themes-alternate .profvis-treetable th,\n" +
+         ".rstudio-themes-flat.rstudio-themes-alternate .profvis-splitbar-horizontal,\n" +
          ".rstudio-themes-flat.rstudio-themes-alternate .info-block {\n" +
          "   border-color: " + ThemeColors.alternateBorder + ";\n" +
          "}\n" +

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
@@ -21,7 +21,7 @@ import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.theme.ThemeColors;
-import org.rstudio.core.client.widget.RStudioFrame;
+import org.rstudio.core.client.widget.RStudioThemedFrame;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.studio.client.rsconnect.RSConnect;
 import org.rstudio.studio.client.rsconnect.model.PublishHtmlSource;
@@ -34,7 +34,7 @@ public class ProfilerEditingTargetWidget extends Composite
                                          implements ProfilerPresenter.Display
               
 {
-   private RStudioFrame profilePage_;
+   private RStudioThemedFrame profilePage_;
    
    public ProfilerEditingTargetWidget(Commands commands, PublishHtmlSource publishHtmlSource)
    {
@@ -45,8 +45,8 @@ public class ProfilerEditingTargetWidget extends Composite
                                           createToolbar(commands, publishHtmlSource), 
                                           panel);
 
-      profilePage_ = new RStudioFrame();
-      profilePage_.setAceThemeAndCustomStyle(
+      profilePage_ = new RStudioThemedFrame(
+         null,
          getCustomStyle(),
          "../profiler_resource/profiler.css",
          true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/ambiance.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/ambiance.css
@@ -61,7 +61,7 @@
   box-shadow: inset 0 0 10px black;
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   color: #E6E1DC;
   background-color: #202020;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chaos.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chaos.css
@@ -23,7 +23,7 @@
   right: 0;
   background: #1D1D1D;
 }
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #161616;
   color: #E6E1DC;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chrome.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chrome.css
@@ -9,7 +9,7 @@
   background: #e8e8e8;
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: black;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds.css
@@ -8,7 +8,7 @@
   background: #e8e8e8
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: #000000
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds_midnight.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds_midnight.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #191919;
   color: #929292
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/cobalt.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/cobalt.css
@@ -8,7 +8,7 @@
   background: #246 ;
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #002240;
   color: #FFFFFF
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/crimson_editor.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/crimson_editor.css
@@ -14,7 +14,7 @@
   background: #e8e8e8;
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: rgb(64, 64, 64);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dawn.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dawn.css
@@ -8,7 +8,7 @@
   background: #e8e8e8
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #F9F9F9;
   color: #080808
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dreamweaver.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dreamweaver.css
@@ -8,7 +8,7 @@
   background: #e8e8e8;
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: black;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/eclipse.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/eclipse.css
@@ -9,7 +9,7 @@
   background: #ebebeb;
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: black;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/idle_fingers.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/idle_fingers.css
@@ -8,7 +8,7 @@
   background: #555 ;
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #323232;
   color: #FFFFFF
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/katzenmilch.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/katzenmilch.css
@@ -11,7 +11,7 @@
   background: #e8e8e8
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #f3f2f3;
   color: rgba(15, 0, 9, 1.0)
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/kr_theme.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/kr_theme.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #0B0A09;
   color: #FCFFE0
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore.css
@@ -8,7 +8,7 @@
   background: #555651
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #161616;
   color: #E6E1DC
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore_soft.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore_soft.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #1C1C1C;
   color: #E6E1DC
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/mono_industrial.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/mono_industrial.css
@@ -8,7 +8,7 @@
   background: #555651
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #222C28;
   color: #FFFFFF
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/monokai.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/monokai.css
@@ -8,7 +8,7 @@
   background: #555651
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #272822;
   color: #F8F8F2
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/pastel_on_dark.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/pastel_on_dark.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #2C2828;
   color: #8F938F
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_dark.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_dark.css
@@ -8,7 +8,7 @@
   background: #33555E
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #002B36;
   color: #93A1A1
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_light.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_light.css
@@ -8,7 +8,7 @@
   background: #e8e8e8
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FDF6E3;
   color: #586E75
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/textmate.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/textmate.css
@@ -12,7 +12,7 @@
     background-color: #6B72E6;
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: black;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow.css
@@ -8,7 +8,7 @@
   background: #f6f6f6
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: #4D4D4C
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night.css
@@ -8,7 +8,7 @@
   background: #444 ;
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #1D1F21;
   color: #C5C8C6
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_blue.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_blue.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #002451;
   color: #FFFFFF
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_bright.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_bright.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #000000;
   color: #DEDEDE
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_eighties.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_eighties.css
@@ -8,7 +8,7 @@
   background: #444 ;
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #2D2D2D;
   color: #CCCCCC
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/twilight.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/twilight.css
@@ -8,7 +8,7 @@
   background: #333 ;
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #141414;
   color: #F8F8F8
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/vibrant_ink.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/vibrant_ink.css
@@ -8,7 +8,7 @@
   background: #444 ;
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #0F0F0F;
   color: #FFFFFF
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/xcode.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/xcode.css
@@ -10,7 +10,7 @@
   background: #e8e8e8
 }
 
-.ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #FFFFFF;
   color: #000000
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
@@ -20,7 +20,7 @@ import org.rstudio.core.client.Size;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.URIUtils;
 import org.rstudio.core.client.resources.ImageResource2x;
-import org.rstudio.core.client.widget.RStudioFrame;
+import org.rstudio.core.client.widget.RStudioThemedFrame;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
@@ -140,8 +140,7 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
    @Override 
    protected Widget createMainWidget()
    {
-      frame_ = new RStudioFrame();
-      frame_.setAceTheme();
+      frame_ = new RStudioThemedFrame();
       frame_.setSize("100%", "100%");
       frame_.addStyleName("ace_editor_theme");
       navigate(ABOUT_BLANK, false);
@@ -266,7 +265,7 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
       events_.fireEvent(new ViewerNavigatedEvent(url, frame_));
    }
 
-   private RStudioFrame frame_;
+   private RStudioThemedFrame frame_;
    private String unmodifiedUrl_;
    private RmdPreviewParams rmdPreviewParams_;
    private final Commands commands_;

--- a/src/gwt/tools/compile-themes.R
+++ b/src/gwt/tools/compile-themes.R
@@ -836,7 +836,12 @@ for (file in themeFiles) {
 
    ## Copy ace_editor as ace_editor_theme
    regex <- paste("^\\.ace_editor \\{$", sep = "")
-   content <- gsub(regex, ".ace_editor, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {", content)
+   content <- gsub(regex, paste(
+      ".ace_editor",
+      ".rstudio-themes-flat.ace_editor_theme .profvis-flamegraph",
+      ".rstudio-themes-flat.ace_editor_theme", 
+      ".rstudio-themes-flat .ace_editor_theme {",
+      sep = ", "), content)
    
    ## Strip the theme name rule from the CSS.
    regex <- paste("^\\", themeNameCssClass, "\\S*\\s+", sep = "")

--- a/src/gwt/tools/compile-themes.R
+++ b/src/gwt/tools/compile-themes.R
@@ -1045,7 +1045,8 @@ for (file in themeFiles) {
                 create_xterm_color_rules(background, foreground, isDark)) 
 
    # Theme rules
-   content <- add_content(content, themes_static_rules()) 
+   content <- c(content,
+                themes_static_rules()) 
    
    ## Phew! Write it out.
    outputPath <- file.path(outDir, basename(file))


### PR DESCRIPTION
- Support for switching between themes and reapplying themes.
- Support for theming the flamegraph.
- Change appearance dialog theme back to combobox.
- Fix recent regression in compile-themes.R

<img width="1437" alt="screen shot 2017-05-10 at 1 07 38 pm" src="https://cloud.githubusercontent.com/assets/3478847/25919105/7b55b92a-3582-11e7-83cb-7c93e1f60ced.png">
