### PR TITLE
activateTerminal API work, error handling

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -434,6 +434,13 @@
    .Call("rs_isTerminalBusy", id)
 })
 
+.rs.addApiFunction("isTerminalRunning", function(id) {
+   if (is.null(id) || !is.character(id))
+      stop("'id' must be a character vector")
+
+   .Call("rs_isTerminalRunning", id)
+})
+
 .rs.addApiFunction("getAllTerminals", function() {
    .Call("rs_getAllTerminals")
 })
@@ -445,22 +452,23 @@
    .Call("rs_getTerminalContext", id)
 })
 
-.rs.addApiFunction("showTerminal", function(id = NULL) {
+.rs.addApiFunction("activateTerminal", function(id = NULL, show = TRUE) {
    if (is.null(id))
       id <- ""
 
-   if (!is.character(id))
+   if (!is.character(id) || (length(id) != 1))
       stop("'id' must be NULL or a character vector of length one")
 
-   data <- list(id = .rs.scalar(id))
+   if (!is.logical(show))
+     stop("'show' must be TRUE or FALSE")
 
-   .rs.enqueClientEvent("activate_terminal", data)
-   invisible(data)
+   .Call("rs_activateTerminal", id, show)
+   invisible(NULL)
 })
 
 .rs.addApiFunction("getTerminalBuffer", function(id, stripAnsi = NULL) {
-   if (is.null(id) || !is.character(id))
-      stop("'id' must be a character vector")
+   if (is.null(id) || !is.character(id) || (length(id) != 1))
+      stop("'id' must be a single element character vector")
 
    if (is.null(stripAnsi) || !is.logical(stripAnsi))
       stop("'stripAnsi' must be a logical vector")
@@ -479,3 +487,15 @@
 .rs.addApiFunction("getVisibleTerminal", function() {
    .Call("rs_getVisibleTerminal")
 })
+
+options(terminal.manager = list(activateTerminal = .rs.api.activateTerminal,
+                                createTerminal = .rs.api.createTerminal,
+                                clearTerminal = .rs.api.clearTerminal,
+                                getAllTerminals = .rs.api.getAllTerminals,
+                                getTerminalContext = .rs.api.getTerminalContext,
+                                getTerminalBuffer = .rs.api.getTerminalBuffer,
+                                getVisibleTerminal = .rs.api.getVisibleTerminal,
+                                isTerminalBusy = .rs.api.isTerminalBusy,
+                                isTerminalRunning = .rs.api.isTerminalRunning,
+                                killTerminal = .rs.api.killTerminal,
+                                sendToTerminal = .rs.api.sendToTerminal))

--- a/src/cpp/session/SessionUserSettings.cpp
+++ b/src/cpp/session/SessionUserSettings.cpp
@@ -385,6 +385,9 @@ void UserSettings::updatePrefsCache(const json::Object& prefs) const
 
    int ansiConsoleMode = readPref<int>(prefs, "ansi_console_mode", core::text::AnsiColorOn);
    pAnsiConsoleMode_.reset(new int(ansiConsoleMode));
+
+   int terminalWebsockets = readPref<bool>(prefs, "terminal_websockets", true);
+   pTerminalWebsockets_.reset(new bool(terminalWebsockets));
 }
 
 
@@ -562,6 +565,11 @@ core::FilePath UserSettings::initialWorkingDirectory() const
 core::text::AnsiCodeMode UserSettings::ansiConsoleMode() const
 {
    return static_cast<core::text::AnsiCodeMode>(readUiPref<int>(pAnsiConsoleMode_));
+}
+
+bool UserSettings::terminalWebsockets() const
+{
+   return readUiPref<bool>(pTerminalWebsockets_);
 }
 
 CRANMirror UserSettings::cranMirror() const

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -109,8 +109,20 @@ public:
    static boost::shared_ptr<ConsoleProcess> createTerminalProcess(
          core::system::ProcessOptions options,
          boost::shared_ptr<ConsoleProcessInfo> procInfo,
-         bool enableWebsockets = true);
-   
+         bool enableWebsockets);
+
+   static boost::shared_ptr<ConsoleProcess> createTerminalProcess(
+         core::system::ProcessOptions options,
+         boost::shared_ptr<ConsoleProcessInfo> procInfo);
+
+   static boost::shared_ptr<ConsoleProcess> createTerminalProcess(
+         boost::shared_ptr<ConsoleProcess> proc);
+
+   static core::system::ProcessOptions createTerminalProcOptions(
+         TerminalShell::TerminalShellType shellType,
+         int cols, int rows,
+         int termSequence);
+
    virtual ~ConsoleProcess() {}
 
    // set a custom prompt handler -- return true to indicate the prompt

--- a/src/cpp/session/include/session/SessionTerminalShell.hpp
+++ b/src/cpp/session/include/session/SessionTerminalShell.hpp
@@ -70,6 +70,16 @@ struct TerminalShell
    std::vector<std::string> args;
 
    core::json::Object toJson() const;
+
+   static TerminalShellType safeShellTypeFromInt(int shellTypeInt)
+   {
+      TerminalShellType shellType = static_cast<TerminalShellType>(shellTypeInt);
+      if (shellType < DefaultShell || shellType > TerminalShell::Max)
+      {
+         shellType = DefaultShell;
+      }
+      return shellType;
+   }
 };
 
 class AvailableTerminalShells

--- a/src/cpp/session/include/session/SessionUserSettings.hpp
+++ b/src/cpp/session/include/session/SessionUserSettings.hpp
@@ -104,6 +104,7 @@ public:
    int shinyViewerType() const;
    bool enableRSConnectUI() const;
    core::text::AnsiCodeMode ansiConsoleMode() const;
+   bool terminalWebsockets() const;
 
    bool rProfileOnResume() const;
    void setRprofileOnResume(bool rProfileOnResume);
@@ -255,6 +256,7 @@ private:
    mutable boost::scoped_ptr<int> pShinyViewerType_;
    mutable boost::scoped_ptr<bool> pEnableRSConnectUI_;
    mutable boost::scoped_ptr<int> pAnsiConsoleMode_;
+   mutable boost::scoped_ptr<bool> pTerminalWebsockets_;
    
    // diagnostic-related prefs
    mutable boost::scoped_ptr<bool> pLintRFunctionCalls_;

--- a/src/cpp/session/modules/SessionWorkbench.hpp
+++ b/src/cpp/session/modules/SessionWorkbench.hpp
@@ -18,6 +18,13 @@
 
 #include <string>
 
+#include <core/system/Environment.hpp>
+#include <session/SessionOptions.hpp>
+
+#include "SessionVCS.hpp"
+#include "SessionGit.hpp"
+#include "SessionSVN.hpp"
+
 namespace rstudio {
 namespace core {
    class Error;
@@ -32,7 +39,25 @@ namespace workbench {
 std::string editFileCommand();
 
 core::Error initialize();
-                       
+
+template <typename T>
+void ammendShellPaths(T* pTarget)
+{
+   // non-path git bin dir
+   std::string gitBinDir = git::nonPathGitBinDir();
+   if (!gitBinDir.empty())
+      core::system::addToPath(pTarget, gitBinDir);
+
+   // non-path svn bin dir
+   std::string svnBinDir = svn::nonPathSvnBinDir();
+   if (!svnBinDir.empty())
+      core::system::addToPath(pTarget, svnBinDir);
+
+   // msys_ssh path
+   core::system::addToPath(pTarget,
+                           session::options().msysSshPath().absolutePath());
+}
+
 } // namespace workbench
 } // namespace modules
 } // namespace session

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -497,7 +497,6 @@ public class RemoteServer implements Server
                      String terminalHandle,
                      String caption,
                      String title,
-                     boolean websocket,
                      int sequence,
                      ServerRequestCallback<ConsoleProcess> requestCallback)
    {
@@ -508,8 +507,7 @@ public class RemoteServer implements Server
       params.set(3, new JSONString(StringUtil.notNull(terminalHandle)));
       params.set(4, new JSONString(StringUtil.notNull(caption)));
       params.set(5, new JSONString(StringUtil.notNull(title)));
-      params.set(6, JSONBoolean.getInstance(websocket));
-      params.set(7, new JSONNumber(sequence));
+      params.set(6, new JSONNumber(sequence));
 
       sendRequest(RPC_SCOPE,
                   START_TERMINAL,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchServerOperations.java
@@ -144,12 +144,11 @@ public interface WorkbenchServerOperations extends ConsoleServerOperations,
     * @param handle initial terminal handle (pass empty or null string for new terminal)
     * @param caption caption associated with the terminal
     * @param title title associated with the terminal
-    * @param websocket try to connect via WebSocket
     * @param sequence relative order of terminal creation (1-based)
     * @param requestCallback callback from server upon completion
     */
    void startTerminal(int shellType, int cols, int rows, String handle, 
-                      String caption, String title, boolean websocket, int sequence, 
+                      String caption, String title, int sequence, 
                       ServerRequestCallback<ConsoleProcess> requestCallback);
    
    void executeCode(String code, ServerRequestCallback<Void> requestCallback);


### PR DESCRIPTION
- renamed `showTerminal` api to `activateTerminal`; it can be used both to ensure a terminal's process is started, and optionally for showing the terminal in the UI; the former is still a work-in-progress, working through glitches
- per JJ's recommendation made terminal APIs visible without needing `rstudioapi`, via `.Options$terminal.manager`
- added some extra error logging around some cases I've seen before and during this current work where server gets out of sync with client on console-processes and throws errors
- make it so closing a terminal in client works even if the latter issue has happened (server doesn't know about the process anymore), now it will go away in the client without showing cryptic error message
- centralized code that constructs ProcessOption structure for terminals, so it can be used both in starting a new terminal via client UI, and when using `activateTerminal` api
- remove the `websockets` flag from startTerminal RPC call, as the server already has access to the information needed to determine that setting