### PR TITLE
Fix link color in iframes under classic theme

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/ambiance.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/ambiance.css
@@ -796,4 +796,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chaos.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chaos.css
@@ -729,4 +729,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chrome.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chrome.css
@@ -729,4 +729,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds.css
@@ -693,4 +693,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds_midnight.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/clouds_midnight.css
@@ -691,4 +691,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/cobalt.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/cobalt.css
@@ -712,4 +712,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/crimson_editor.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/crimson_editor.css
@@ -718,4 +718,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dawn.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dawn.css
@@ -705,4 +705,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dreamweaver.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/dreamweaver.css
@@ -751,4 +751,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/eclipse.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/eclipse.css
@@ -694,4 +694,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/idle_fingers.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/idle_fingers.css
@@ -691,4 +691,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/katzenmilch.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/katzenmilch.css
@@ -718,4 +718,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/kr_theme.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/kr_theme.css
@@ -702,4 +702,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/material.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/material.css
@@ -8,14 +8,7 @@
   background: #263238
 }
 
-.ace_editor {
-  background-color: #263238;
-  color: #C5C8C6
-}
-
-.ace_editor_theme,
-.rstudio-themes-flat.ace_editor_theme,
-.rstudio-themes-flat .ace_editor_theme  {
+.ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   background-color: #263238;
   color: #C5C8C6
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore.css
@@ -688,4 +688,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore_soft.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/merbivore_soft.css
@@ -689,4 +689,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/mono_industrial.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/mono_industrial.css
@@ -701,4 +701,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/monokai.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/monokai.css
@@ -700,4 +700,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/pastel_on_dark.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/pastel_on_dark.css
@@ -710,4 +710,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_dark.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_dark.css
@@ -679,4 +679,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_light.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/solarized_light.css
@@ -684,4 +684,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/textmate.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/textmate.css
@@ -730,4 +730,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow.css
@@ -700,4 +700,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night.css
@@ -700,4 +700,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_blue.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_blue.css
@@ -697,4 +697,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_bright.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_bright.css
@@ -716,4 +716,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_eighties.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/tomorrow_night_eighties.css
@@ -700,4 +700,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/twilight.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/twilight.css
@@ -706,4 +706,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/vibrant_ink.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/vibrant_ink.css
@@ -688,4 +688,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/xcode.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/xcode.css
@@ -681,4 +681,4 @@
 .xtermBgColor254 { background-color: #e4e4e4; }
 .xtermColor255 { color: #eeeeee; }
 .xtermBgColor255 { background-color: #eeeeee; }
-.editor_dark.ace_editor_theme a { color: #FFF !important; }
+.rstudio-themes-flat.editor_dark.ace_editor_theme a { color: #FFF !important; }

--- a/src/gwt/tools/compile-themes.R
+++ b/src/gwt/tools/compile-themes.R
@@ -799,7 +799,7 @@ create_xterm_color_rules <- function(background, foreground, isDark) {
 }
 
 themes_static_rules <- function() {
-  paste(".editor_dark.ace_editor_theme a {",
+  paste(".rstudio-themes-flat.editor_dark.ace_editor_theme a {",
         "color: #FFF !important;",
         "}")
 }


### PR DESCRIPTION
- Fix link color in iframes under classic theme
- Fix `metarial` theme since it requires manual updates.