### PR TITLE
add ability to select next, previous marker / search result

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/FastSelectTable.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FastSelectTable.java
@@ -31,6 +31,7 @@ import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.NativeWindow;
 import org.rstudio.core.client.widget.events.SelectionChangedEvent;
 import org.rstudio.core.client.widget.events.SelectionChangedHandler;
+import org.rstudio.studio.client.workbench.views.source.events.SelectMarkerEvent;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -556,6 +557,26 @@ public class FastSelectTable<TItemInput, TItemOutput, TItemOutput2> extends Widg
       clearSelection();
       setSelected(rowToSelect, true);
       return true;
+   }
+   
+   public void onSelectMarker(SelectMarkerEvent event)
+   {
+      int index = event.getIndex();
+      boolean relative = event.isRelative();
+      
+      if (relative)
+      {
+         // discover the current selected row (handle
+         // the multiple selection case by choosing last)
+         int row = 0;
+         if (getSelectedRowIndexes().size() > 0)
+            row = getSelectedRowIndexes().get(getSelectedRowIndexes().size() - 1);
+         setSelected(row + index, 1, true);
+      }
+      else
+      {
+         setSelected(index, 1, true);
+      }
    }
 
    private TableRowElement getRow(int row)

--- a/src/gwt/src/org/rstudio/studio/client/common/sourcemarkers/SourceMarkerList.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/sourcemarkers/SourceMarkerList.java
@@ -22,6 +22,7 @@ import org.rstudio.core.client.events.SelectionCommitEvent;
 import org.rstudio.core.client.events.SelectionCommitHandler;
 import org.rstudio.core.client.widget.DoubleClickState;
 import org.rstudio.core.client.widget.FastSelectTable;
+import org.rstudio.studio.client.workbench.views.source.events.SelectMarkerEvent;
 
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.dom.client.Document;
@@ -204,6 +205,11 @@ public class SourceMarkerList extends Composite
    private void fireSelectionCommitedEvent(CodeNavigationTarget target)
    {
       SelectionCommitEvent.fire(this, target);
+   }
+   
+   public void onSelectMarker(SelectMarkerEvent event)
+   {
+      errorTable_.onSelectMarker(event);
    }
 
    private final SourceMarkerItemCodec codec_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/MarkerSelectionDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/MarkerSelectionDispatcher.java
@@ -1,0 +1,65 @@
+/*
+ * MarkerSelectionDispatcher.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench;
+
+import org.rstudio.core.client.command.CommandBinder;
+import org.rstudio.core.client.command.Handler;
+import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.workbench.views.source.events.SelectMarkerEvent;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+@Singleton
+public class MarkerSelectionDispatcher
+{
+   public interface Binder extends CommandBinder<Commands, MarkerSelectionDispatcher>
+   {
+   }
+   
+   @Inject
+   public MarkerSelectionDispatcher(Binder binder,
+                                    Commands commands,
+                                    EventBus events)
+   {
+      binder.bind(commands, this);
+      events_ = events;
+   }
+   
+   @Handler
+   public void onSelectNextMarker()
+   {
+      onSelectMarker(1, true);
+   }
+   
+   @Handler
+   public void onSelectPreviousMarker()
+   {
+      onSelectMarker(-1, true);
+   }
+   
+   public void selectMarkerRelative(int index)
+   {
+      onSelectMarker(index, true);
+   }
+   
+   public void onSelectMarker(int index, boolean relative)
+   {
+      events_.fireEvent(new SelectMarkerEvent(index, relative));
+   }
+
+   private final EventBus events_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
@@ -66,6 +66,7 @@ import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.choosefile.ChooseFile;
 import org.rstudio.studio.client.workbench.views.files.events.DirectoryNavigateEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.profiler.ProfilerPresenter;
+import org.rstudio.studio.client.workbench.views.source.events.SelectMarkerEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.CreateTerminalEvent;
 import org.rstudio.studio.client.workbench.views.vcs.common.events.VcsRefreshEvent;
 import org.rstudio.studio.client.workbench.views.vcs.common.events.VcsRefreshHandler;
@@ -429,6 +430,18 @@ public class Workbench implements BusyHandler,
    {
       if (Desktop.isDesktop() && Desktop.getFrame().supportsFullscreenMode())
          Desktop.getFrame().toggleFullscreenMode();
+   }
+   
+   @Handler
+   public void onSelectNextMarker()
+   {
+      eventBus_.fireEvent(new SelectMarkerEvent(1, true));
+   }
+   
+   @Handler
+   public void onSelectPreviousMarker()
+   {
+      eventBus_.fireEvent(new SelectMarkerEvent(-1, true));
    }
    
    private void checkForInitMessages()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -2526,6 +2526,16 @@ well as menu structures (for main menu and popup menus).
         windowMode="main"
         rebindable="false"/>
         
+   <cmd id="selectPreviousMarker"
+        menuLabel="Select Previous Marker"
+        desc="Select Previous Marker"
+        windowMode="main"/>
+        
+   <cmd id="selectNextMarker"
+        menuLabel="selectNextMarker"
+        desc="Select Next Marker"
+        windowMode="main"/>
+        
    <cmd id="browseAddins"
         label="Browse Addins"
         menuLabel="_Browse Addins..."

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -167,6 +167,8 @@ public abstract class
    public abstract AppCommand pasteLastYank();
    public abstract AppCommand insertAssignmentOperator();
    public abstract AppCommand insertPipeOperator();
+   public abstract AppCommand selectNextMarker();
+   public abstract AppCommand selectPreviousMarker();
  
    // Projects
    public abstract AppCommand newProject();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPane.java
@@ -58,31 +58,10 @@ public class FindOutputPane extends WorkbenchPane
       events_.addHandler(SelectMarkerEvent.TYPE, new SelectMarkerEvent.Handler()
       {
          @Override
-         public void onSelectMarkerResult(SelectMarkerEvent event)
+         public void onSelectMarker(SelectMarkerEvent event)
          {
-            int index = event.getIndex();
-            boolean relative = event.isRelative();
-            
-            if (relative)
-            {
-               if (index > 0)
-               {
-                  for (int i = 0; i < index; i++)
-                     table_.selectNextRow();
-               }
-               else
-               {
-                  index = -index;
-                  for (int i = 0; i < index; i++)
-                     table_.selectPreviousRow();
-               }
-            }
-            else
-            {
-               table_.setSelected(index, 1, true);
-            }
-            
-            fireSelectionCommitted();
+            if (active_)
+               table_.onSelectMarker(event);
          }
       });
    }
@@ -208,10 +187,18 @@ public class FindOutputPane extends WorkbenchPane
    {
       super.onSelected();
       
+      active_ = true;
       table_.focus();
       ArrayList<Integer> indices = table_.getSelectedRowIndexes();
       if (indices.isEmpty())
          table_.selectNextRow();
+   }
+   
+   @Override
+   public void onBeforeUnselected()
+   {
+      super.onBeforeUnselected();
+      active_ = false;
    }
 
    @Override
@@ -316,6 +303,7 @@ public class FindOutputPane extends WorkbenchPane
    private StatusPanel statusPanel_;
    private boolean overflow_ = false;
    private int matchCount_;
+   private boolean active_;
 
    // This must be the same as MAX_COUNT in SessionFind.cpp
    private static final int MAX_COUNT = 1000;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPane.java
@@ -37,7 +37,7 @@ import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.ui.WorkbenchPane;
 import org.rstudio.studio.client.workbench.views.output.find.model.FindResult;
-import org.rstudio.studio.client.workbench.views.source.events.SelectMarkerResultEvent;
+import org.rstudio.studio.client.workbench.views.source.events.SelectMarkerEvent;
 
 import java.util.ArrayList;
 
@@ -55,10 +55,10 @@ public class FindOutputPane extends WorkbenchPane
       events_ = events;
       ensureWidget();
       
-      events_.addHandler(SelectMarkerResultEvent.TYPE, new SelectMarkerResultEvent.Handler()
+      events_.addHandler(SelectMarkerEvent.TYPE, new SelectMarkerEvent.Handler()
       {
          @Override
-         public void onSelectMarkerResult(SelectMarkerResultEvent event)
+         public void onSelectMarkerResult(SelectMarkerEvent event)
          {
             int index = event.getIndex();
             boolean relative = event.isRelative();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/markers/MarkersOutputPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/markers/MarkersOutputPane.java
@@ -25,23 +25,37 @@ import org.rstudio.core.client.events.EnsureVisibleEvent;
 import org.rstudio.core.client.events.HasSelectionCommitHandlers;
 import org.rstudio.core.client.js.JsUtil;
 import org.rstudio.core.client.widget.*;
+import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.sourcemarkers.SourceMarkerList;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.ui.WorkbenchPane;
 import org.rstudio.studio.client.workbench.views.output.markers.model.MarkersSet;
 import org.rstudio.studio.client.workbench.views.output.markers.model.MarkersState;
+import org.rstudio.studio.client.workbench.views.source.events.SelectMarkerEvent;
 
 public class MarkersOutputPane extends WorkbenchPane
       implements MarkersOutputPresenter.Display
 {
    @Inject
-   public MarkersOutputPane(Commands commands)
+   public MarkersOutputPane(Commands commands,
+                            EventBus events)
    {
       super("Markers");
       markerSetsToolbarButton_ = new MarkerSetsToolbarButton();
       markerList_ = new SourceMarkerList();
       clearButton_ = new ToolbarButton(commands.clearPlots().getImageResource(),
                                        null);
+      
+      events.addHandler(SelectMarkerEvent.TYPE, new SelectMarkerEvent.Handler()
+      {
+         @Override
+         public void onSelectMarker(SelectMarkerEvent event)
+         {
+            if (active_)
+               markerList_.onSelectMarker(event);
+         }
+      });
+      
       ensureWidget();
    }
    
@@ -115,11 +129,20 @@ public class MarkersOutputPane extends WorkbenchPane
    public void onSelected()
    {
       super.onSelected();
+      active_ = true;
       markerList_.focus();
       markerList_.ensureSelection();
+   }
+   
+   @Override
+   public void onBeforeUnselected()
+   {
+      super.onBeforeUnselected();
+      active_ = false;
    }
    
    private SourceMarkerList markerList_;
    private MarkerSetsToolbarButton markerSetsToolbarButton_;
    private ToolbarButton clearButton_;
+   private boolean active_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -740,9 +740,9 @@ public class Source implements InsertSourceHandler,
       setPhysicalTabIndex(index);
    }
    
-   private void selectMarkerResultRelative(int index)
+   private void selectMarkerRelative(int index)
    {
-      events_.fireEvent(new SelectMarkerResultEvent(index, true));
+      events_.fireEvent(new SelectMarkerEvent(index, true));
    }
    
    private void closeAllTabs(boolean interactive)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -729,23 +729,7 @@ public class Source implements InsertSourceHandler,
    
    private void initVimCommands()
    {
-      vimCommands_.save(this);
-      vimCommands_.selectTabIndex(this);
-      vimCommands_.selectNextTab(this);
-      vimCommands_.selectPreviousTab(this);
-      vimCommands_.closeActiveTab(this);
-      vimCommands_.closeAllTabs(this);
-      vimCommands_.createNewDocument(this);
-      vimCommands_.saveAndCloseActiveTab(this);
-      vimCommands_.readFile(this, uiPrefs_.defaultEncoding().getValue());
-      vimCommands_.runRScript(this);
-      vimCommands_.reflowText(this);
-      vimCommands_.showVimHelp(
-            RStudioGinjector.INSTANCE.getShortcutViewer());
-      vimCommands_.showHelpAtCursor(this);
-      vimCommands_.reindent(this);
-      vimCommands_.expandShrinkSelection(this);
-      vimCommands_.addStarRegister();
+      vimCommands_.initialize(this, RStudioGinjector.INSTANCE.getShortcutViewer());
    }
    
    private void vimSetTabIndex(int index)
@@ -754,6 +738,11 @@ public class Source implements InsertSourceHandler,
       if (index >= tabCount)
          return;
       setPhysicalTabIndex(index);
+   }
+   
+   private void selectMarkerResultRelative(int index)
+   {
+      events_.fireEvent(new SelectMarkerResultEvent(index, true));
    }
    
    private void closeAllTabs(boolean interactive)
@@ -3710,11 +3699,12 @@ public class Source implements InsertSourceHandler,
       return temp.size() == 0;
    }
    
-   private void pasteFileContentsAtCursor(final String path, final String encoding)
+   private void pasteFileContentsAtCursor(final String path)
    {
       if (activeEditor_ != null && activeEditor_ instanceof TextEditingTarget)
       {
          final TextEditingTarget target = (TextEditingTarget) activeEditor_;
+         final String encoding = uiPrefs_.defaultEncoding().getValue();
          server_.getFileContents(path, encoding, new ServerRequestCallback<String>()
          {
             @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceVimCommands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceVimCommands.java
@@ -78,28 +78,28 @@ public class SourceVimCommands
          context: "normal"
       });
       
-      // Select next search result
-      Vim.defineAction("selectNextSearchResult", $entry(function(cm, args) {
-         source.@org.rstudio.studio.client.workbench.views.source.Source::selectMarkerResultRelative(I)(1);
+      // Select next marker
+      Vim.defineAction("selectNextMarker", $entry(function(cm, args) {
+         source.@org.rstudio.studio.client.workbench.views.source.Source::selectMarkerRelative(I)(1);
       }));
       
       Vim.mapCommand({
          keys: "]q",
          type: "action",
-         action: "selectNextSearchResult",
+         action: "selectNextMarker",
          isEdit: false,
          context: "normal"
       });
       
-      // Select previous search result
-      Vim.defineAction("selectPreviousSearchResult", $entry(function(cm, args) {
-         source.@org.rstudio.studio.client.workbench.views.source.Source::selectSearchResultRelative(I)(-1);
+      // Select previous marker
+      Vim.defineAction("selectPreviousMarker", $entry(function(cm, args) {
+         source.@org.rstudio.studio.client.workbench.views.source.Source::selectMarkerRelative(I)(-1);
       }));
       
       Vim.mapCommand({
          keys: "[q",
          type: "action",
-         action: "selectPreviousSearchResult",
+         action: "selectPreviousMarker",
          isEdit: false,
          context: "normal"
       });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SelectMarkerEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SelectMarkerEvent.java
@@ -42,7 +42,7 @@ public class SelectMarkerEvent extends GwtEvent<SelectMarkerEvent.Handler>
    
    public interface Handler extends EventHandler
    {
-      void onSelectMarkerResult(SelectMarkerEvent event);
+      void onSelectMarker(SelectMarkerEvent event);
    }
    
    @Override
@@ -54,13 +54,8 @@ public class SelectMarkerEvent extends GwtEvent<SelectMarkerEvent.Handler>
    @Override
    protected void dispatch(Handler handler)
    {
-      if (consumed_)
-         return;
-      
-      consumed_ = true;
-      handler.onSelectMarkerResult(this);
+      handler.onSelectMarker(this);
    }
 
    public static final Type<Handler> TYPE = new Type<Handler>();
-   private boolean consumed_ = false;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SelectMarkerEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SelectMarkerEvent.java
@@ -1,7 +1,7 @@
 /*
  * SelectMarkerResultEvent.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,9 +17,9 @@ package org.rstudio.studio.client.workbench.views.source.events;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 
-public class SelectMarkerResultEvent extends GwtEvent<SelectMarkerResultEvent.Handler>
+public class SelectMarkerEvent extends GwtEvent<SelectMarkerEvent.Handler>
 {
-   public SelectMarkerResultEvent(int index, boolean relative)
+   public SelectMarkerEvent(int index, boolean relative)
    {
       index_ = index;
       relative_ = relative;
@@ -42,7 +42,7 @@ public class SelectMarkerResultEvent extends GwtEvent<SelectMarkerResultEvent.Ha
    
    public interface Handler extends EventHandler
    {
-      void onSelectMarkerResult(SelectMarkerResultEvent event);
+      void onSelectMarkerResult(SelectMarkerEvent event);
    }
    
    @Override
@@ -54,8 +54,13 @@ public class SelectMarkerResultEvent extends GwtEvent<SelectMarkerResultEvent.Ha
    @Override
    protected void dispatch(Handler handler)
    {
+      if (consumed_)
+         return;
+      
+      consumed_ = true;
       handler.onSelectMarkerResult(this);
    }
 
    public static final Type<Handler> TYPE = new Type<Handler>();
+   private boolean consumed_ = false;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SelectMarkerResultEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SelectMarkerResultEvent.java
@@ -1,0 +1,61 @@
+/*
+ * SelectMarkerResultEvent.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class SelectMarkerResultEvent extends GwtEvent<SelectMarkerResultEvent.Handler>
+{
+   public SelectMarkerResultEvent(int index, boolean relative)
+   {
+      index_ = index;
+      relative_ = relative;
+   }
+   
+   public int getIndex()
+   {
+      return index_;
+   }
+   
+   public boolean isRelative()
+   {
+      return relative_;
+   }
+   
+   private final int index_;
+   private final boolean relative_;
+   
+   // Boilerplate ----
+   
+   public interface Handler extends EventHandler
+   {
+      void onSelectMarkerResult(SelectMarkerResultEvent event);
+   }
+   
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onSelectMarkerResult(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}


### PR DESCRIPTION
NOTE: Not yet ready for merge.

This PR attempts to add commands for selecting the next / previous output as part of the currently active tab in the console pane. The intention is to provide a command / keyboard shortcut that can be used to e.g. select the next marker output, or select the next find result, and so on.

Unfortunately, I don't understand the wiring between tabs and panes enough to understand how I can best write code that targets whatever tab is currently active. (As far as I can see, panes that live in the console have no notion of which tab owns them, nor whether that tab is currently active, and so all the solutions I can think of thus far will imply loads of code duplication, which I'd like to avoid).

@jmcphers @jjallaire if you can suggest a way forward, that would be hugely appreciated. The overall goal is to find a way of dispatching a command handler to whichever pane is associated with the active tab in the console pane.