### PR TITLE
fix flashing when switching to terminal in dark editor themes

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -37,6 +37,7 @@ import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.WorkbenchServerOperations;
 import org.rstudio.studio.client.workbench.ui.WorkbenchPane;
+import org.rstudio.studio.client.workbench.views.console.ConsoleResources;
 import org.rstudio.studio.client.workbench.views.terminal.events.SwitchToTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStartedEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStoppedEvent;
@@ -98,6 +99,8 @@ public class TerminalPane extends WorkbenchPane
    protected Widget createMainWidget()
    {
       terminalSessionsPanel_ = new DeckLayoutPanel();
+      terminalSessionsPanel_.setStyleName(ConsoleResources.INSTANCE.consoleStyles().console());
+      terminalSessionsPanel_.getElement().addClassName("ace_editor");
       return terminalSessionsPanel_;
    }
 


### PR DESCRIPTION
When using an editor theme with dark background, and the classic style, the panel that holds the terminal widgets had no styles applied and would flash white everytime you switched to terminal tab from console, find, etc.

Fixed by applying same styles used by terminal itself.