### PR TITLE
Explicitly qualify make_shared()

### DIFF
--- a/src/cpp/session/SessionConsoleProcessSocketTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessSocketTests.cpp
@@ -363,7 +363,7 @@ context("websocket for interactive terminals")
       expect_true(pSocket->ensureServerRunning());
 
       shared_ptr<SocketConnection> pConnection =
-            make_shared<SocketConnection>(handle1, pSocket);
+            boost::make_shared<SocketConnection>(handle1, pSocket);
       expect_true(pConnection->listen());
 
       expect_true(pConnection->stopListening());
@@ -375,8 +375,8 @@ context("websocket for interactive terminals")
       shared_ptr<SocketHarness> pSocket = make_shared<SocketHarness>();
       expect_true(pSocket->ensureServerRunning());
 
-      shared_ptr<SocketConnection> pConnection = make_shared<SocketConnection>(handle1, pSocket);
-      shared_ptr<SocketClient> pClient = make_shared<SocketClient>(handle1, pSocket->port());
+      shared_ptr<SocketConnection> pConnection = boost::make_shared<SocketConnection>(handle1, pSocket);
+      shared_ptr<SocketClient> pClient = boost::make_shared<SocketClient>(handle1, pSocket->port());
       expect_true(pConnection->listen());
       expect_true(pClient->connectToServer());
 
@@ -396,8 +396,8 @@ context("websocket for interactive terminals")
       shared_ptr<SocketHarness> pSocket = make_shared<SocketHarness>();
       expect_true(pSocket->ensureServerRunning());
 
-      shared_ptr<SocketConnection> pConnection = make_shared<SocketConnection>(handle1, pSocket);
-      shared_ptr<SocketClient> pClient = make_shared<SocketClient>(handle1, pSocket->port());
+      shared_ptr<SocketConnection> pConnection = boost::make_shared<SocketConnection>(handle1, pSocket);
+      shared_ptr<SocketClient> pClient = boost::make_shared<SocketClient>(handle1, pSocket->port());
       expect_true(pConnection->listen());
       expect_true(pClient->connectToServer());
 
@@ -420,8 +420,8 @@ context("websocket for interactive terminals")
       shared_ptr<SocketHarness> pSocket = make_shared<SocketHarness>();
       expect_true(pSocket->ensureServerRunning());
 
-      shared_ptr<SocketConnection> pConnection = make_shared<SocketConnection>(handle1, pSocket);
-      shared_ptr<SocketClient> pClient = make_shared<SocketClient>(handle1, pSocket->port());
+      shared_ptr<SocketConnection> pConnection = boost::make_shared<SocketConnection>(handle1, pSocket);
+      shared_ptr<SocketClient> pClient = boost::make_shared<SocketClient>(handle1, pSocket->port());
       expect_true(pConnection->listen());
       expect_true(pClient->connectToServer());
 
@@ -447,9 +447,9 @@ context("websocket for interactive terminals")
 
       // ---- first connection ----
       shared_ptr<SocketConnection> pConnection1 =
-            make_shared<SocketConnection>(handle1, pSocket);
+            boost::make_shared<SocketConnection>(handle1, pSocket);
 
-      shared_ptr<SocketClient> pClient1 = make_shared<SocketClient>(handle1, pSocket->port());
+      shared_ptr<SocketClient> pClient1 = boost::make_shared<SocketClient>(handle1, pSocket->port());
       expect_true(pConnection1->listen());
       expect_true(pClient1->connectToServer());
 
@@ -461,9 +461,9 @@ context("websocket for interactive terminals")
 
       // ---- second connection ----
       shared_ptr<SocketConnection> pConnection2 =
-            make_shared<SocketConnection>(handle2, pSocket);
+            boost::make_shared<SocketConnection>(handle2, pSocket);
 
-      shared_ptr<SocketClient> pClient2 = make_shared<SocketClient>(handle2, pSocket->port());
+      shared_ptr<SocketClient> pClient2 = boost::make_shared<SocketClient>(handle2, pSocket->port());
       expect_true(pConnection2->listen());
       expect_true(pClient2->connectToServer());
 


### PR DESCRIPTION
otherwise gcc complains ambiguity between std::make_shared() and boost::make_shared().

I'm pretty sure there are better ways, but this worked on my system (Ubuntu 16.10, stock gcc).

Related: http://stackoverflow.com/q/8356618/946850