### PR TITLE
Apply theme to scrollbars with "when scrolling" check in OS X

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2282,7 +2282,7 @@ body.rstudio-themes-flat .rstudio-themes-default {
 .rstudio-themes-flat .rstudio-themes-dark-grey .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
 .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelContent,
 .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanel,
-.rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar-thumb {
+.rstudio-themes-flat.rstudio-themes-scrollbars .rstudio-themes-dark-grey ::-webkit-scrollbar-thumb {
    background: THEME_DARKGREY_BACKGROUND;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -40,7 +40,7 @@
 
 @external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
 
-@external rstudio-themes-background, rstudio-themes-inverts;
+@external rstudio-themes-background, rstudio-themes-inverts, rstudio-themes-scrollbars;
 
 @external dataGridSortedHeaderAscending, dataGridSortedHeaderDescending;
 
@@ -2233,8 +2233,7 @@ body.ubuntu_mono .searchBox {
 .rstudio-themes-flat .rstudio-themes-default .secondaryToolbar,
 .rstudio-themes-flat .rstudio-themes-default .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelContent,
-.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanel,
-.rstudio-themes-flat .rstudio-themes-default ::-webkit-scrollbar-thumb {
+.rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanel {
    background: THEME_DEFAULT_BACKGROUND;
 }
 
@@ -2266,8 +2265,7 @@ body.rstudio-themes-flat .rstudio-themes-default {
 }
 
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
-.rstudio-themes-flat .rstudio-themes-default .minimizedWindowObject .center,
-.rstudio-themes-flat .rstudio-themes-default ::-webkit-scrollbar-track { 
+.rstudio-themes-flat .rstudio-themes-default .minimizedWindowObject .center { 
    background: THEME_DEFAULT_MOST_INACTIVE;
 }
 
@@ -2284,7 +2282,7 @@ body.rstudio-themes-flat .rstudio-themes-default {
 .rstudio-themes-flat .rstudio-themes-dark-grey .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
 .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelContent,
 .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanel,
-.rstudio-themes-flat .rstudio-themes-dark-grey ::-webkit-scrollbar-thumb {
+.rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar-thumb {
    background: THEME_DARKGREY_BACKGROUND;
 }
 
@@ -2317,7 +2315,8 @@ body.rstudio-themes-flat .rstudio-themes-dark-grey {
 
 .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstudio-themes-flat .rstudio-themes-dark-grey .minimizedWindowObject .center,
-.rstudio-themes-flat .rstudio-themes-dark-grey ::-webkit-scrollbar-track { 
+.rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar-track,
+.rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar-corner { 
    background: THEME_DARKGREY_MOST_INACTIVE;
 }
 
@@ -2333,8 +2332,7 @@ body.rstudio-themes-flat .rstudio-themes-dark-grey {
 .rstudio-themes-flat .rstudio-themes-alternate .secondaryToolbar,
 .rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
 .rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanelContent,
-.rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanel,
-.rstudio-themes-flat .rstudio-themes-alternate ::-webkit-scrollbar-thumb {
+.rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanel {
    background: THEME_ALTERNATE_BACKGROUND;
 }
 
@@ -2366,8 +2364,7 @@ body.rstudio-themes-flat .rstudio-themes-alternate {
 }
 
 .rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanelTabs,
-.rstudio-themes-flat .rstudio-themes-alternate .minimizedWindowObject .center,
-.rstudio-themes-flat .rstudio-themes-alternate ::-webkit-scrollbar-track {  
+.rstudio-themes-flat .rstudio-themes-alternate .minimizedWindowObject .center {  
    background: THEME_ALTERNATE_MOST_INACTIVE;
 }
 
@@ -2395,17 +2392,23 @@ body.rstudio-themes-flat .rstudio-themes-alternate {
 
 /* RSTUDIO THEMES END */
 
-.rstudio-themes-flat .rstudio-themes-dark ::-webkit-scrollbar {
+.rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar {
    background: #FFF;
+   width: 10px;
+   height: 10px;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark ::-webkit-scrollbar-thumb {
+.rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar-thumb {
    -webkit-border-radius: 10px;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark ::-webkit-scrollbar-track-piece {
+.rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar-track-piece {
 }
 
-.rstudio-themes-flat .rstudio-themes-dark ::-webkit-scrollbar-track {
+.rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar-track {
 }  
 
+@external com-google-gwt-user-client-ui-CustomScrollPanel-Style-customScrollPanelCorner;
+.rstudio-themes-flat.rstudio-themes-scrollbars .com-google-gwt-user-client-ui-CustomScrollPanel-Style-customScrollPanelCorner {
+   display: none;
+}

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2394,12 +2394,14 @@ body.rstudio-themes-flat .rstudio-themes-alternate {
 
 .rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar {
    background: #FFF;
-   width: 10px;
-   height: 10px;
 }
 
 .rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar-thumb {
    -webkit-border-radius: 10px;
+}
+
+.rstudio-themes-flat.rstudio-themes-scrollbars .rstudio-themes-dark-grey ::-webkit-scrollbar-thumb {
+   border: solid 3px THEME_DARKGREY_MOST_INACTIVE;
 }
 
 .rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar-track-piece {

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2234,7 +2234,7 @@ body.ubuntu_mono .searchBox {
 .rstudio-themes-flat .rstudio-themes-default .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelContent,
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanel,
-.rstudio-themes-flat.windows .rstudio-themes-default ::-webkit-scrollbar-thumb {
+.rstudio-themes-flat .rstudio-themes-default ::-webkit-scrollbar-thumb {
    background: THEME_DEFAULT_BACKGROUND;
 }
 
@@ -2267,7 +2267,7 @@ body.rstudio-themes-flat .rstudio-themes-default {
 
 .rstudio-themes-flat .rstudio-themes-default .gwt-TabLayoutPanelTabs,
 .rstudio-themes-flat .rstudio-themes-default .minimizedWindowObject .center,
-.rstudio-themes-flat.windows .rstudio-themes-default ::-webkit-scrollbar-track { 
+.rstudio-themes-flat .rstudio-themes-default ::-webkit-scrollbar-track { 
    background: THEME_DEFAULT_MOST_INACTIVE;
 }
 
@@ -2284,7 +2284,7 @@ body.rstudio-themes-flat .rstudio-themes-default {
 .rstudio-themes-flat .rstudio-themes-dark-grey .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
 .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelContent,
 .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanel,
-.rstudio-themes-flat.windows .rstudio-themes-dark-grey ::-webkit-scrollbar-thumb {
+.rstudio-themes-flat .rstudio-themes-dark-grey ::-webkit-scrollbar-thumb {
    background: THEME_DARKGREY_BACKGROUND;
 }
 
@@ -2317,7 +2317,7 @@ body.rstudio-themes-flat .rstudio-themes-dark-grey {
 
 .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstudio-themes-flat .rstudio-themes-dark-grey .minimizedWindowObject .center,
-.rstudio-themes-flat.windows .rstudio-themes-dark-grey ::-webkit-scrollbar-track { 
+.rstudio-themes-flat .rstudio-themes-dark-grey ::-webkit-scrollbar-track { 
    background: THEME_DARKGREY_MOST_INACTIVE;
 }
 
@@ -2334,7 +2334,7 @@ body.rstudio-themes-flat .rstudio-themes-dark-grey {
 .rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
 .rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanelContent,
 .rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanel,
-.rstudio-themes-flat.windows .rstudio-themes-alternate ::-webkit-scrollbar-thumb {
+.rstudio-themes-flat .rstudio-themes-alternate ::-webkit-scrollbar-thumb {
    background: THEME_ALTERNATE_BACKGROUND;
 }
 
@@ -2367,7 +2367,7 @@ body.rstudio-themes-flat .rstudio-themes-alternate {
 
 .rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanelTabs,
 .rstudio-themes-flat .rstudio-themes-alternate .minimizedWindowObject .center,
-.rstudio-themes-flat.windows .rstudio-themes-alternate ::-webkit-scrollbar-track {  
+.rstudio-themes-flat .rstudio-themes-alternate ::-webkit-scrollbar-track {  
    background: THEME_ALTERNATE_MOST_INACTIVE;
 }
 
@@ -2395,17 +2395,17 @@ body.rstudio-themes-flat .rstudio-themes-alternate {
 
 /* RSTUDIO THEMES END */
 
-.rstudio-themes-flat.windows .rstudio-themes-dark ::-webkit-scrollbar {
+.rstudio-themes-flat .rstudio-themes-dark ::-webkit-scrollbar {
    background: #FFF;
 }
 
-.rstudio-themes-flat.windows .rstudio-themes-dark ::-webkit-scrollbar-thumb {
+.rstudio-themes-flat .rstudio-themes-dark ::-webkit-scrollbar-thumb {
    -webkit-border-radius: 10px;
 }
 
-.rstudio-themes-flat.windows .rstudio-themes-dark ::-webkit-scrollbar-track-piece {
+.rstudio-themes-flat .rstudio-themes-dark ::-webkit-scrollbar-track-piece {
 }
 
-.rstudio-themes-flat.windows .rstudio-themes-dark ::-webkit-scrollbar-track {
+.rstudio-themes-flat .rstudio-themes-dark ::-webkit-scrollbar-track {
 }  
 

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
@@ -73,19 +73,21 @@ public class RStudioThemedFrame extends RStudioFrame
          if (customStyle == null) customStyle = "";
          
          customStyle += "\n" +
-         ".rstudio-themes-flat.windows.rstudio-themes-dark::-webkit-scrollbar,\n" +
-         ".rstudio-themes-flat.windows.rstudio-themes-dark ::-webkit-scrollbar {\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark::-webkit-scrollbar,\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark ::-webkit-scrollbar {\n" +
          "   background: #FFF;\n" +
+         "   width: 10px;\n" +
+         "   height: 10px;\n" +
          "}\n" +
          "\n" +
-         ".rstudio-themes-flat.windows.rstudio-themes-dark::-webkit-scrollbar-thumb,\n" +
-         ".rstudio-themes-flat.windows.rstudio-themes-dark ::-webkit-scrollbar-thumb {\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark::-webkit-scrollbar-thumb,\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark ::-webkit-scrollbar-thumb {\n" +
          "   -webkit-border-radius: 10px;\n" +
          "   background: " + ThemeColors.darkGreyBackground + ";\n" +
          "}\n" +
          "\n" +
-         ".rstudio-themes-flat.windows.rstudio-themes-dark::-webkit-scrollbar-track,\n" + 
-         ".rstudio-themes-flat.windows.rstudio-themes-dark ::-webkit-scrollbar-track {\n" + 
+         ".rstudio-themes-flat.rstudio-themes-dark::-webkit-scrollbar-track,\n" + 
+         ".rstudio-themes-flat.rstudio-themes-dark ::-webkit-scrollbar-track {\n" + 
          "   background: " + ThemeColors.darkGreyMostInactiveBackground + ";\n" +
          "}\n";
          

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
@@ -76,8 +76,6 @@ public class RStudioThemedFrame extends RStudioFrame
          ".rstudio-themes-flat.rstudio-themes-scrollbars::-webkit-scrollbar,\n" +
          ".rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar {\n" +
          "   background: #FFF;\n" +
-         "   width: 10px;\n" +
-         "   height: 10px;\n" +
          "}\n" +
          "\n" +
          ".rstudio-themes-flat.rstudio-themes-scrollbars::-webkit-scrollbar-thumb,\n" +
@@ -91,6 +89,10 @@ public class RStudioThemedFrame extends RStudioFrame
          ".rstudio-themes-flat.rstudio-themes-scrollbars::-webkit-scrollbar-corner,\n" +
          ".rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar-corner {\n" +
          "   background: " + ThemeColors.darkGreyMostInactiveBackground + ";\n" +
+         "}\n" + 
+         ".rstudio-themes-flat.rstudio-themes-scrollbars::-webkit-scrollbar-thumb,\n" +
+         ".rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar-thumb{\n" +
+         "   border: solid 3px " + ThemeColors.darkGreyMostInactiveBackground + ";" +
          "}\n";
          
          StyleElement style = document.createStyleElement();

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
@@ -73,21 +73,23 @@ public class RStudioThemedFrame extends RStudioFrame
          if (customStyle == null) customStyle = "";
          
          customStyle += "\n" +
-         ".rstudio-themes-flat.rstudio-themes-dark::-webkit-scrollbar,\n" +
-         ".rstudio-themes-flat.rstudio-themes-dark ::-webkit-scrollbar {\n" +
+         ".rstudio-themes-flat.rstudio-themes-scrollbars::-webkit-scrollbar,\n" +
+         ".rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar {\n" +
          "   background: #FFF;\n" +
          "   width: 10px;\n" +
          "   height: 10px;\n" +
          "}\n" +
          "\n" +
-         ".rstudio-themes-flat.rstudio-themes-dark::-webkit-scrollbar-thumb,\n" +
-         ".rstudio-themes-flat.rstudio-themes-dark ::-webkit-scrollbar-thumb {\n" +
+         ".rstudio-themes-flat.rstudio-themes-scrollbars::-webkit-scrollbar-thumb,\n" +
+         ".rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar-thumb {\n" +
          "   -webkit-border-radius: 10px;\n" +
          "   background: " + ThemeColors.darkGreyBackground + ";\n" +
          "}\n" +
          "\n" +
-         ".rstudio-themes-flat.rstudio-themes-dark::-webkit-scrollbar-track,\n" + 
-         ".rstudio-themes-flat.rstudio-themes-dark ::-webkit-scrollbar-track {\n" + 
+         ".rstudio-themes-flat.rstudio-themes-scrollbars::-webkit-scrollbar-track,\n" + 
+         ".rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar-track,\n" + 
+         ".rstudio-themes-flat.rstudio-themes-scrollbars::-webkit-scrollbar-corner,\n" +
+         ".rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar-corner {\n" +
          "   background: " + ThemeColors.darkGreyMostInactiveBackground + ";\n" +
          "}\n";
          

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
@@ -57,24 +57,33 @@ public class RStudioThemes
    }
    
    private static boolean usesScrollbars() {
-      if (!BrowseCap.isMacintosh()) return true;
+      if (usesScrollbars_ != null) return usesScrollbars_;
       
-      Element parent = Document.get().createElement("div");
-      parent.getStyle().setWidth(100, Unit.PX);
-      parent.getStyle().setHeight(100, Unit.PX);
-      parent.getStyle().setOverflow(Overflow.AUTO);
-      parent.getStyle().setVisibility(Visibility.HIDDEN);
-
-      Element content = Document.get().createElement("div");
-      content.getStyle().setWidth(100, Unit.PX);
-      content.getStyle().setHeight(200, Unit.PX);
-
-      parent.appendChild(content);
-      Document.get().getBody().appendChild(parent);
-
-      boolean hasScrollbars = parent.getOffsetWidth() - parent.getClientWidth() > 0;
-      //parent.removeFromParent();
+      if (!BrowseCap.isMacintosh()) {
+         usesScrollbars_ = true;
+      }
+      else {
+         Element parent = Document.get().createElement("div");
+         parent.getStyle().setWidth(100, Unit.PX);
+         parent.getStyle().setHeight(100, Unit.PX);
+         parent.getStyle().setOverflow(Overflow.AUTO);
+         parent.getStyle().setVisibility(Visibility.HIDDEN);
+   
+         Element content = Document.get().createElement("div");
+         content.getStyle().setWidth(100, Unit.PX);
+         content.getStyle().setHeight(200, Unit.PX);
+   
+         parent.appendChild(content);
+         Document.get().getBody().appendChild(parent);
+   
+         boolean hasScrollbars = parent.getOffsetWidth() - parent.getClientWidth() > 0;
+         parent.removeFromParent();
+         
+         usesScrollbars_ = hasScrollbars;
+      }
       
-      return hasScrollbars;
+      return usesScrollbars_;
    }
+   
+   private static Boolean usesScrollbars_ = null;
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
@@ -15,10 +15,15 @@
 
 package org.rstudio.studio.client.application.ui;
 
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style.Overflow;
+import com.google.gwt.dom.client.Style.Position;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.dom.client.Style.Visibility;
 
 public class RStudioThemes
 {
@@ -31,11 +36,17 @@ public class RStudioThemes
       element.removeClassName("rstudio-themes-default");
       element.removeClassName("rstudio-themes-dark-grey");
       element.removeClassName("rstudio-themes-alternate");
+      element.removeClassName("rstudio-themes-scrollbars");
       
-      if (themeName == "default" ||themeName == "dark-grey" || themeName == "alternate") {         
+      if (themeName == "default" || themeName == "dark-grey" || themeName == "alternate") {         
          document.getBody().addClassName("rstudio-themes-flat");
+         
          if (themeName.contains("dark")) {
             element.addClassName("rstudio-themes-dark");
+            
+            if (usesScrollbars()) {
+               document.getBody().addClassName("rstudio-themes-scrollbars");
+            }
          }
          element.addClassName("rstudio-themes-" + themeName);
       }
@@ -43,5 +54,27 @@ public class RStudioThemes
 
    public static boolean isFlat(UIPrefs prefs) {
       return prefs.getFlatTheme().getValue() != "classic"; 
+   }
+   
+   private static boolean usesScrollbars() {
+      if (!BrowseCap.isMacintosh()) return true;
+      
+      Element parent = Document.get().createElement("div");
+      parent.getStyle().setWidth(100, Unit.PX);
+      parent.getStyle().setHeight(100, Unit.PX);
+      parent.getStyle().setOverflow(Overflow.AUTO);
+      parent.getStyle().setVisibility(Visibility.HIDDEN);
+
+      Element content = Document.get().createElement("div");
+      content.getStyle().setWidth(100, Unit.PX);
+      content.getStyle().setHeight(200, Unit.PX);
+
+      parent.appendChild(content);
+      Document.get().getBody().appendChild(parent);
+
+      boolean hasScrollbars = parent.getOffsetWidth() - parent.getClientWidth() > 0;
+      //parent.removeFromParent();
+      
+      return hasScrollbars;
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
@@ -68,6 +68,9 @@ public class RStudioThemes
          parent.getStyle().setHeight(100, Unit.PX);
          parent.getStyle().setOverflow(Overflow.AUTO);
          parent.getStyle().setVisibility(Visibility.HIDDEN);
+         parent.getStyle().setPosition(Position.ABSOLUTE);
+         parent.getStyle().setLeft(-300, Unit.PX);
+         parent.getStyle().setTop(-300, Unit.PX);
    
          Element content = Document.get().createElement("div");
          content.getStyle().setWidth(100, Unit.PX);

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
@@ -68,7 +68,7 @@ public class RStudioThemes
          parent.getStyle().setHeight(100, Unit.PX);
          parent.getStyle().setOverflow(Overflow.AUTO);
          parent.getStyle().setVisibility(Visibility.HIDDEN);
-         parent.getStyle().setPosition(Position.ABSOLUTE);
+         parent.getStyle().setPosition(Position.FIXED);
          parent.getStyle().setLeft(-300, Unit.PX);
          parent.getStyle().setTop(-300, Unit.PX);
    


### PR DESCRIPTION
- OS X supports an "When scrolling" scrollbar option that this PR detects on boot. Detecting the state change of this property would require a timer that I believe makes sense to avoid since I don't see users changing this option continuously.
- Avoid changing `width`/`height` of scrollbars since data grids perform scrollbars computation that is not compatible with CSS styling of scrollbars; instead, added border and color changes to match the dark theme.

<img width="1436" alt="screen shot 2017-05-15 at 10 37 45 am" src="https://cloud.githubusercontent.com/assets/3478847/26071048/a02b50ca-395b-11e7-9b93-e8ddcb31cf39.png">
