### PR TITLE
convert paths to system encoding for shell commands

### DIFF
--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -515,7 +515,11 @@ core::Error beginFind(const json::JsonRpcRequest& request,
    }
 
    cmd << shell_utils::EscapeFilesOnly << "--" << shell_utils::EscapeAll;
-   cmd << module_context::resolveAliasedPath(directory);
+   
+   // Filepaths received from the client will be UTF-8 encoded;
+   // convert to system encoding here.
+   FilePath dirPath = module_context::resolveAliasedPath(directory);
+   cmd << string_utils::utf8ToSystem(dirPath.absolutePath());
 
    // Clear existing results
    findResults().clear();


### PR DESCRIPTION
This PR fixes an issue where e.g. 'Find in Files' did not work on Windows when executed within a path containing non-ASCII characters. (Note that this implies that 'Find in Files' will still not work when in a path that's not representable in the system encoding, but that's a bigger bugfix).

Let me know if this feels like too broad a fix and it would be better to target the 'Find in Files' code directly.