### PR TITLE
ui preference for chunk background highlighting

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -118,6 +118,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditing
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetCppHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetPresentationHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetRMarkdownHelper;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceBackgroundHighlighter;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEditorBackgroundLinkHighlighter;
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionManager;
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionRequest;
@@ -235,6 +236,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(TerminalInfoDialog infoDialog);
    void injectMembers(AceEditorMixins mixins);
    void injectMembers(RStudioThemedFrame frame);
+   void injectMembers(AceBackgroundHighlighter highlighter);
    
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
@@ -301,6 +301,10 @@ public class UIPrefs extends UIPrefsAccessor implements UiPrefsChangedHandler
          showInlineToolbarForRCodeChunks().setGlobalValue(
                newUiPrefs.showInlineToolbarForRCodeChunks().getGlobalValue());
          
+         // background highlighting
+         highlightCodeChunks().setGlobalValue(
+               newUiPrefs.highlightCodeChunks().getGlobalValue());
+         
          // save all before build
          saveAllBeforeBuild().setGlobalValue(
                              newUiPrefs.saveAllBeforeBuild().getGlobalValue());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -316,6 +316,11 @@ public class UIPrefsAccessor extends Prefs
       return bool("show_inline_toolbar_for_r_code_chunks", true);
    }
    
+   public PrefValue<Boolean> highlightCodeChunks()
+   {
+      return bool("highlight_code_chunks", true);
+   }
+   
    public PrefValue<Boolean> saveAllBeforeBuild()
    {
       return bool("save_files_before_build", false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/RMarkdownPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/RMarkdownPreferencesPane.java
@@ -41,6 +41,7 @@ public class RMarkdownPreferencesPane extends PreferencesPane
       
       add(checkboxPref("Show inline toolbar for R code chunks", prefs_.showInlineToolbarForRCodeChunks()));
       add(checkboxPref("Show document outline by default", prefs_.showDocumentOutlineRmd()));
+      add(checkboxPref("Highlight code chunks", prefs_.highlightCodeChunks()));
       
       docOutlineDisplay_ = new SelectWidget(
             "Show in Document Outline: ",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/RMarkdownPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/RMarkdownPreferencesPane.java
@@ -41,7 +41,6 @@ public class RMarkdownPreferencesPane extends PreferencesPane
       
       add(checkboxPref("Show inline toolbar for R code chunks", prefs_.showInlineToolbarForRCodeChunks()));
       add(checkboxPref("Show document outline by default", prefs_.showDocumentOutlineRmd()));
-      add(checkboxPref("Highlight code chunks", prefs_.highlightCodeChunks()));
       
       docOutlineDisplay_ = new SelectWidget(
             "Show in Document Outline: ",


### PR DESCRIPTION
This PR allows users to toggle background highlighting for code chunks on / off as desired.

The primary motivation for this feature is diagnostics -- a number of users are reporting editor sluggishness when editing in large documents; this PR is mainly added to help evaluate / diagnose that sluggishness.

If preferred, we can keep this as a 'hidden' preference and not expose to the user; let me know what you think.