### PR TITLE
round-tripping of terminal size, fullscreen status

### DIFF
--- a/src/cpp/core/include/core/system/Process.hpp
+++ b/src/cpp/core/include/core/system/Process.hpp
@@ -39,6 +39,8 @@ namespace system {
 
 extern const char* const kSmartTerm;
 extern const char* const kDumbTerm;
+extern const int kDefaultCols;
+extern const int kDefaultRows;
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -84,16 +86,16 @@ struct ProcessOptions
         detachProcess(false),
         createNewConsole(false),
         breakawayFromJob(false),
-        cols(80),
-        rows(25),
+        cols(kDefaultCols),
+        rows(kDefaultRows),
         redirectStdErrToStdOut(false),
         reportHasSubprocs(false)
 #else
       : terminateChildren(false),
         smartTerminal(false),
         detachSession(false),
-        cols(80),
-        rows(25),
+        cols(kDefaultCols),
+        rows(kDefaultRows),
         redirectStdErrToStdOut(false),
         reportHasSubprocs(false)
 #endif

--- a/src/cpp/core/system/Process.cpp
+++ b/src/cpp/core/system/Process.cpp
@@ -37,6 +37,10 @@ namespace system {
 const char* const kSmartTerm = "xterm-256color";
 const char* const kDumbTerm = "dumb";
 
+// default rows/columns for a pseudoterminal
+const int kDefaultCols = 80;
+const int kDefaultRows = 25;
+
 Error runProgram(const std::string& executable,
                  const std::vector<std::string>& args,
                  const std::string& input,

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -1420,7 +1420,7 @@ boost::shared_ptr<ConsoleProcess> ConsoleProcess::createTerminalProcess(
             // to refresh itself; this does rely on the host performing a second
             // resize to the actual available size. Clumsy, but so far this is
             // the best I've come up with.
-            cp->resize(core::system::kDefaultCols / 2, system::kDefaultRows / 2);
+            cp->resize(core::system::kDefaultCols / 2, core::system::kDefaultRows / 2);
          }
       }
       else

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -279,6 +279,7 @@ SEXP rs_getTerminalContext(SEXP terminalSEXP)
    builder.add("cols", proc->getCols());
    builder.add("rows", proc->getRows());
    builder.add("pid", static_cast<int>(proc->getPid()));
+   builder.add("full_screen", proc->getAltBufferActive());
 
    return r::sexp::create(builder, &protect);
 }
@@ -493,7 +494,7 @@ core::system::ProcessOptions ConsoleProcess::createTerminalProcOptions(
 
 ConsoleProcess::ConsoleProcess(boost::shared_ptr<ConsoleProcessInfo> procInfo)
    : procInfo_(procInfo), interrupt_(false), newCols_(-1), newRows_(-1),
-     cols_(-1), rows_(-1), pid_(-1), childProcsSent_(false),
+     pid_(-1), childProcsSent_(false),
      lastInputSequence_(kIgnoreSequence), started_(false)
 {
    regexInit();
@@ -507,7 +508,7 @@ ConsoleProcess::ConsoleProcess(const std::string& command,
                                const core::system::ProcessOptions& options,
                                boost::shared_ptr<ConsoleProcessInfo> procInfo)
    : command_(command), options_(options), procInfo_(procInfo),
-     interrupt_(false), newCols_(-1), newRows_(-1), cols_(-1), rows_(-1), pid_(-1),
+     interrupt_(false), newCols_(-1), newRows_(-1), pid_(-1),
      childProcsSent_(false), lastInputSequence_(kIgnoreSequence), started_(false)
 {
    commonInit();
@@ -518,7 +519,7 @@ ConsoleProcess::ConsoleProcess(const std::string& program,
                                const core::system::ProcessOptions& options,
                                boost::shared_ptr<ConsoleProcessInfo> procInfo)
    : program_(program), args_(args), options_(options), procInfo_(procInfo),
-     interrupt_(false), newCols_(-1), newRows_(-1), cols_(-1), rows_(-1), pid_(-1),
+     interrupt_(false), newCols_(-1), newRows_(-1), pid_(-1),
      childProcsSent_(false),
      lastInputSequence_(kIgnoreSequence), started_(false)
 {
@@ -541,8 +542,6 @@ void ConsoleProcess::commonInit()
 
    if (interactionMode() != InteractionNever)
    {
-      rows_ = options_.rows;
-      cols_ = options_.cols;
 #ifdef _WIN32
       // NOTE: We use consoleio.exe here in order to make sure svn.exe password
       // prompting works properly
@@ -613,7 +612,8 @@ void ConsoleProcess::commonInit()
 
    // When we retrieve from outputBuffer, we only want complete lines. Add a
    // dummy \n so we can tell the first line is a complete line.
-   procInfo_->appendToOutputBuffer('\n');
+   if (!options_.smartTerminal)
+      procInfo_->appendToOutputBuffer('\n');
 }
 
 std::string ConsoleProcess::bufferedOutput() const
@@ -787,10 +787,11 @@ bool ConsoleProcess::onContinue(core::system::ProcessOperations& ops)
    if (newCols_ != -1 && newRows_ != -1)
    {
       ops.ptySetSize(newCols_, newRows_);
-      rows_ = newRows_;
-      cols_ = newCols_;
+      procInfo_->setCols(newCols_);
+      procInfo_->setRows(newRows_);
       newCols_ = -1;
       newRows_ = -1;
+      saveConsoleProcesses();
    }
 
    pid_ = ops.getPid();
@@ -860,8 +861,13 @@ std::string ConsoleProcess::getBuffer() const
 
 void ConsoleProcess::enqueOutputEvent(const std::string &output)
 {
+   bool currentAltBufferStatus = procInfo_->getAltBufferActive();
+
    // copy to output buffer
    procInfo_->appendToOutputBuffer(output);
+
+   if (procInfo_->getAltBufferActive() != currentAltBufferStatus)
+      saveConsoleProcesses();
 
    // If there's more output than the client can even show, then
    // truncate it to the amount that the client can show. Too much
@@ -1406,12 +1412,16 @@ boost::shared_ptr<ConsoleProcess> ConsoleProcess::createTerminalProcess(
       ConsoleProcessPtr proc = findProcByHandle(procInfo->getHandle());
       if (proc != NULL && proc->isStarted())
       {
-         // Jiggle the size of the pseudo-terminal, this will force the app
-         // to refresh itself; this does rely on the host performing a second
-         // resize to the actual available size. Clumsy, but so far this is
-         // the best I've come up with.
          cp = proc;
-         cp->resize(25, 5);
+
+         if (proc->procInfo_->getAltBufferActive())
+         {
+            // Jiggle the size of the pseudo-terminal, this will force the app
+            // to refresh itself; this does rely on the host performing a second
+            // resize to the actual available size. Clumsy, but so far this is
+            // the best I've come up with.
+            cp->resize(core::system::kDefaultCols / 2, system::kDefaultRows / 2);
+         }
       }
       else
       {

--- a/src/cpp/session/SessionConsoleProcessInfo.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfo.cpp
@@ -51,7 +51,7 @@ ConsoleProcessInfo::ConsoleProcessInfo(
          const int terminalSequence,
          TerminalShell::TerminalShellType shellType,
          bool altBufferActive,
-         core::FilePath cwd,
+         const core::FilePath& cwd,
          int cols, int rows)
    : caption_(caption), title_(title), handle_(handle),
      terminalSequence_(terminalSequence), allowRestart_(true),

--- a/src/cpp/session/SessionConsoleProcessInfo.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfo.cpp
@@ -15,6 +15,7 @@
 
 #include <session/SessionConsoleProcessInfo.hpp>
 
+#include <core/system/Process.hpp>
 #include <core/system/System.hpp>
 #include <core/text/TermBufferParser.hpp>
 
@@ -36,7 +37,7 @@ ConsoleProcessInfo::ConsoleProcessInfo()
      interactionMode_(InteractionNever), maxOutputLines_(kDefaultMaxOutputLines),
      showOnOutput_(false), outputBuffer_(kOutputBufferSize), childProcs_(true),
      altBufferActive_(false), shellType_(TerminalShell::DefaultShell),
-     channelMode_(Rpc)
+     channelMode_(Rpc), cols_(system::kDefaultCols), rows_(system::kDefaultRows)
 {
    // When we retrieve from outputBuffer, we only want complete lines. Add a
    // dummy \n so we can tell the first line is a complete line.
@@ -49,15 +50,15 @@ ConsoleProcessInfo::ConsoleProcessInfo(
          const std::string& handle,
          const int terminalSequence,
          TerminalShell::TerminalShellType shellType,
-         ChannelMode channelMode,
-         const std::string& channelId,
-         int maxOutputLines)
+         bool altBufferActive,
+         core::FilePath cwd,
+         int cols, int rows)
    : caption_(caption), title_(title), handle_(handle),
      terminalSequence_(terminalSequence), allowRestart_(true),
-     interactionMode_(InteractionAlways), maxOutputLines_(maxOutputLines),
+     interactionMode_(InteractionAlways), maxOutputLines_(kDefaultTerminalMaxOutputLines),
      showOnOutput_(false), outputBuffer_(kOutputBufferSize), childProcs_(true),
-     altBufferActive_(false), shellType_(shellType),
-     channelMode_(channelMode), channelId_(channelId)
+     altBufferActive_(altBufferActive), shellType_(shellType),
+     channelMode_(Rpc), cwd_(cwd), cols_(cols), rows_(rows)
 {
 }
 
@@ -69,7 +70,7 @@ ConsoleProcessInfo::ConsoleProcessInfo(
      interactionMode_(mode), maxOutputLines_(maxOutputLines),
      showOnOutput_(false), outputBuffer_(kOutputBufferSize), childProcs_(true),
      altBufferActive_(false), shellType_(TerminalShell::DefaultShell),
-     channelMode_(Rpc)
+     channelMode_(Rpc), cols_(system::kDefaultCols), rows_(system::kDefaultRows)
 {
 }
 
@@ -194,6 +195,10 @@ core::json::Object ConsoleProcessInfo::toJson() const
    result["shell_type"] = static_cast<int>(shellType_);
    result["channel_mode"] = static_cast<int>(channelMode_);
    result["channel_id"] = channelId_;
+   result["alt_buffer"] = altBufferActive_;
+   result["cwd"] = cwd_.absolutePath();
+   result["cols"] = cols_;
+   result["rows"] = rows_;
 
    return result;
 }
@@ -241,6 +246,13 @@ boost::shared_ptr<ConsoleProcessInfo> ConsoleProcessInfo::fromJson(core::json::O
    int channelModeInt = obj["channel_mode"].get_int();
    pProc->channelMode_ = static_cast<ChannelMode>(channelModeInt);
    pProc->channelId_ = obj["channel_id"].get_str();
+   pProc->altBufferActive_ = obj["alt_buffer"].get_bool();
+
+   FilePath cwd(obj["cwd"].get_str());
+   pProc->cwd_ = cwd;
+
+   pProc->cols_ = obj["cols"].get_int();
+   pProc->rows_ = obj["rows"].get_int();
 
    return pProc;
 }

--- a/src/cpp/session/SessionConsoleProcessInfoTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfoTests.cpp
@@ -12,6 +12,7 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
+#include <core/system/Process.hpp>
 #include <session/SessionConsoleProcessInfo.hpp>
 #include <boost/lexical_cast.hpp>
 
@@ -38,8 +39,13 @@ const InteractionMode mode = InteractionAlways;
 const TerminalShell::TerminalShellType shellType = TerminalShell::DefaultShell;
 const ChannelMode channelMode = Rpc;
 const std::string channelId("some channel Id");
+const bool altActive = false;
+const core::FilePath cwd("/usr/local");
+const core::FilePath altCwd("/usr/stuff");
+const int cols = core::system::kDefaultCols;
+const int rows = core::system::kDefaultRows;
 
-const size_t maxLines = 1000;
+const size_t maxLines = kDefaultTerminalMaxOutputLines;
 
 bool testHandle(const std::string& handle)
 {
@@ -61,7 +67,11 @@ bool sameCpi(const ConsoleProcessInfo& first, const ConsoleProcessInfo& second)
            first.getHasChildProcs() == second.getHasChildProcs() &&
            first.getShellType() == second.getShellType() &&
            first.getChannelMode() == second.getChannelMode() &&
-           !first.getChannelId().compare(second.getChannelId()));
+           !first.getChannelId().compare(second.getChannelId()) &&
+           first.getAltBufferActive() == second.getAltBufferActive() &&
+           first.getCwd() == second.getCwd() &&
+           first.getCols() == second.getCols() &&
+           first.getRows() == second.getRows());
 }
 
 } // anonymous namespace
@@ -72,7 +82,7 @@ TEST_CASE("ConsoleProcessInfo")
    SECTION("Create ConsoleProcessInfo and read properties")
    {
       ConsoleProcessInfo cpi(caption, title, handle1, sequence,
-                             shellType, channelMode, channelId, maxLines);
+                             shellType, altActive, cwd, cols, rows);
 
       CHECK_FALSE(caption.compare(cpi.getCaption()));
       CHECK_FALSE(title.compare(cpi.getTitle()));
@@ -86,8 +96,12 @@ TEST_CASE("ConsoleProcessInfo")
       CHECK_FALSE(cpi.getExitCode());
       CHECK(cpi.getHasChildProcs());
       CHECK(cpi.getShellType() == shellType);
-      CHECK(cpi.getChannelMode() == channelMode);
-      CHECK(cpi.getChannelId() == channelId);
+      CHECK(cpi.getChannelMode() == Rpc);
+      CHECK(cpi.getChannelId().empty());
+      CHECK(cpi.getAltBufferActive() == altActive);
+      CHECK(cpi.getCwd() == cwd);
+      CHECK(cpi.getCols() == cols);
+      CHECK(cpi.getRows() == rows);
    }
 
    SECTION("Generate a handle")
@@ -104,7 +118,7 @@ TEST_CASE("ConsoleProcessInfo")
    SECTION("Change properties")
    {
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             channelMode, channelId, maxLines);
+                             altActive, cwd, cols, rows);
 
       std::string altCaption("other caption");
       CHECK(altCaption.compare(caption));
@@ -129,7 +143,7 @@ TEST_CASE("ConsoleProcessInfo")
       cpi.setInteractionMode(altMode);
       CHECK(altMode == cpi.getInteractionMode());
 
-      size_t altMax = maxLines + 1;
+      int altMax = maxLines + 1;
       cpi.setMaxOutputLines(altMax);
       CHECK(altMax == cpi.getMaxOutputLines());
 
@@ -146,12 +160,15 @@ TEST_CASE("ConsoleProcessInfo")
       cpi.setChannelMode(altChannelMode, altChannelModeId);
       CHECK(altChannelMode == cpi.getChannelMode());
       CHECK(!altChannelModeId.compare(cpi.getChannelId()));
+
+      cpi.setCwd(altCwd);
+      CHECK(altCwd == cpi.getCwd());
    }
 
    SECTION("Change exit code")
    {
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             channelMode, channelId, maxLines);
+                             altActive, cwd, cols, rows);
 
       const int exitCode = 14;
       cpi.setExitCode(exitCode);
@@ -174,9 +191,9 @@ TEST_CASE("ConsoleProcessInfo")
    SECTION("Compare ConsoleProcInfos with different exit codes")
    {
       ConsoleProcessInfo cpiFirst(caption, title, handle1, sequence, shellType,
-                                  channelMode, channelId, maxLines);
+                                  altActive, cwd, cols, rows);
       ConsoleProcessInfo cpiSecond(caption, title, handle1, sequence, shellType,
-                                   channelMode, channelId, maxLines);
+                                   altActive, cwd, cols, rows);
 
       cpiFirst.setExitCode(1);
       cpiSecond.setExitCode(12);
@@ -186,7 +203,7 @@ TEST_CASE("ConsoleProcessInfo")
    SECTION("Persist and restore")
    {
       ConsoleProcessInfo cpiOrig(caption, title, handle1, sequence, shellType,
-                                 channelMode, channelId, maxLines);
+                                  altActive, cwd, cols, rows);
 
       core::json::Object origJson = cpiOrig.toJson();
       boost::shared_ptr<ConsoleProcessInfo> pCpiRestored =
@@ -232,7 +249,7 @@ TEST_CASE("ConsoleProcessInfo")
       // in the JSON. Same comment on the leaky abstractions here as for
       // previous non-terminal test.
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             channelMode, channelId, maxLines);
+                             altActive, cwd, cols, rows);
 
       // blow away anything that might have been left over from a previous
       // failed run
@@ -268,7 +285,7 @@ TEST_CASE("ConsoleProcessInfo")
    SECTION("Persist and restore terminals with multiple chunks")
    {
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             channelMode, channelId, maxLines);
+                             altActive, cwd, cols, rows);
 
       // blow away anything that might have been left over from a previous
       // failed run
@@ -333,9 +350,9 @@ TEST_CASE("ConsoleProcessInfo")
    SECTION("Delete unknown log files")
    {
       ConsoleProcessInfo cpiGood(caption, title, handle1, sequence, shellType,
-                                 channelMode, channelId, maxLines);
+                                 altActive, cwd, cols, rows);
       ConsoleProcessInfo cpiBad(caption, title, bogusHandle1, sequence, shellType,
-                                channelMode, channelId, maxLines);
+                                altActive, cwd, cols, rows);
 
       std::string orig1("hello how are you?\nthat is good\nhave a nice day");
       CHECK(orig1.length() < kOutputBufferSize);
@@ -371,7 +388,8 @@ TEST_CASE("ConsoleProcessInfo")
    {
       const int smallMaxLines = 5;
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             channelMode, channelId, smallMaxLines);
+                             altActive, cwd, cols, rows);
+      cpi.setMaxOutputLines(smallMaxLines);
 
       // blow away anything that might have been left over from a previous
       // failed run
@@ -412,7 +430,8 @@ TEST_CASE("ConsoleProcessInfo")
    {
       const int smallMaxLines = 3;
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             channelMode, channelId, smallMaxLines);
+                             altActive, cwd, cols, rows);
+      cpi.setMaxOutputLines(smallMaxLines);
 
       // blow away anything that might have been left over from a previous
       // failed run
@@ -455,7 +474,8 @@ TEST_CASE("ConsoleProcessInfo")
    {
       const int lines = 10;
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             channelMode, channelId, lines * 2);
+                             altActive, cwd, cols, rows);
+      cpi.setMaxOutputLines(lines * 2);
 
       // blow away anything that might have been left over from a previous
       // failed run

--- a/src/cpp/session/SessionConsoleProcessPersist.cpp
+++ b/src/cpp/session/SessionConsoleProcessPersist.cpp
@@ -43,7 +43,9 @@ namespace console_persist {
 // 2017/03/21 - console02 -> console03
 //                Added channel type and channel ID to allow distinction of
 //                using non-RPC-based communication channel back to client
-#define kConsoleDir "console03"
+// 2017/05/15 - console03 -> console04
+//                Added current-working directory, alt-buffer, cols, rows
+#define kConsoleDir "console04"
 
 namespace {
 

--- a/src/cpp/session/SessionConsoleProcessTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessTests.cpp
@@ -28,11 +28,13 @@ using namespace console_process;
 context("queue and fetch input")
 {
    core::system::ProcessOptions procOptions;
+   core::FilePath cwd("/usr/local");
 
    boost::shared_ptr<ConsoleProcessInfo> pCPI =
          boost::make_shared<ConsoleProcessInfo>(
             "test caption", "test title", "fakehandle", 9999 /*terminal*/,
-            TerminalShell::DefaultShell, console_process::Rpc, "");
+            TerminalShell::DefaultShell, false /*altBuffer*/, cwd,
+            core::system::kDefaultCols, core::system::kDefaultRows);
 
    boost::shared_ptr<ConsoleProcess> pCP =
          ConsoleProcess::createTerminalProcess(procOptions, pCPI, false /*enableWebsockets*/);

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -156,9 +156,10 @@ public:
    std::string getChannelMode() const;
    int getTerminalSequence() const { return procInfo_->getTerminalSequence(); }
    int getBufferLineCount() const { return procInfo_->getBufferLineCount(); }
-   int getCols() const { return cols_; }
-   int getRows() const { return rows_; }
+   int getCols() const { return procInfo_->getCols(); }
+   int getRows() const { return procInfo_->getRows(); }
    PidType getPid() const { return pid_; }
+   bool getAltBufferActive() const { return procInfo_->getAltBufferActive(); }
 
    // Used to downgrade to RPC mode after failed attempt to connect websocket
    void setRpcMode();
@@ -212,10 +213,6 @@ private:
    // Whether the tty should be notified of a resize
    int newCols_; // -1 = no change
    int newRows_; // -1 = no change
-
-   // Last known size of pseudo-tty
-   int cols_;
-   int rows_;
 
    // Last known PID of associated process
    PidType pid_;

--- a/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
@@ -18,6 +18,7 @@
 #include <boost/circular_buffer.hpp>
 #include <boost/enable_shared_from_this.hpp>
 
+#include <core/FilePath.hpp>
 #include <core/json/Json.hpp>
 
 #include <session/SessionTerminalShell.hpp>
@@ -69,9 +70,9 @@ public:
          const std::string& handle,
          int terminalSequence,
          TerminalShell::TerminalShellType shellType,
-         ChannelMode channelMode,
-         const std::string& channelId,
-         int maxOutputLines = kDefaultMaxOutputLines);
+         bool altBufferActive,
+         core::FilePath cwd,
+         int cols, int rows);
 
    // constructor for non-terminals
    ConsoleProcessInfo(
@@ -148,6 +149,20 @@ public:
       channelId_ = channelId;
    }
 
+   // Is terminal showing alt-buffer (a full-screen ncurses program)?
+   void setAltBufferActive(bool altBufferActive) { altBufferActive_ = altBufferActive; }
+   bool getAltBufferActive() const { return altBufferActive_; }
+
+   // Last-known current working directory
+   void setCwd(core::FilePath cwd) { cwd_ = cwd; }
+   core::FilePath getCwd() const { return cwd_; }
+
+   // Last-known terminal dimensions
+   void setCols(int cols) { cols_ = cols; }
+   void setRows(int rows) { rows_ = rows; }
+   int getCols() const { return cols_; }
+   int getRows() const { return rows_; }
+
    core::json::Object toJson() const;
    static boost::shared_ptr<ConsoleProcessInfo> fromJson(core::json::Object& obj);
 
@@ -171,6 +186,9 @@ private:
    TerminalShell::TerminalShellType shellType_;
    ChannelMode channelMode_;
    std::string channelId_;
+   core::FilePath cwd_;
+   int cols_;
+   int rows_;
 };
 
 } // namespace console_process

--- a/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
@@ -71,7 +71,7 @@ public:
          int terminalSequence,
          TerminalShell::TerminalShellType shellType,
          bool altBufferActive,
-         core::FilePath cwd,
+         const core::FilePath& cwd,
          int cols, int rows);
 
    // constructor for non-terminals

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -867,6 +867,8 @@ Error startTerminal(const json::JsonRpcRequest& request,
    std::string termCaption;
    std::string termTitle;
    int termSequence = kNoTerminal;
+   bool altBufferActive;
+   std::string currentDir;
    
    Error error = json::readParams(request.params,
                                   &shellTypeInt,
@@ -875,7 +877,9 @@ Error startTerminal(const json::JsonRpcRequest& request,
                                   &termHandle,
                                   &termCaption,
                                   &termTitle,
-                                  &termSequence);
+                                  &termSequence,
+                                  &altBufferActive,
+                                  &currentDir);
    if (error)
       return error;
 
@@ -896,14 +900,15 @@ Error startTerminal(const json::JsonRpcRequest& request,
                          ERROR_LOCATION);
    }
 
+   FilePath cwd(currentDir);
+
    core::system::ProcessOptions options = ConsoleProcess::createTerminalProcOptions(
          shellType, cols, rows, termSequence);
 
    boost::shared_ptr<ConsoleProcessInfo> ptrProcInfo =
          boost::make_shared<ConsoleProcessInfo>(
             termCaption, termTitle, termHandle, termSequence,  shellType,
-            console_process::Rpc, "" /*channelId*/,
-            console_process::kDefaultTerminalMaxOutputLines);
+            altBufferActive, cwd, cols, rows);
 
    boost::shared_ptr<ConsoleProcess> ptrProc =
                ConsoleProcess::createTerminalProcess(options, ptrProcInfo);

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
@@ -89,6 +89,22 @@ public class ConsoleProcessInfo extends JavaScriptObject
    public final native String getChannelId() /*-{
       return this.channel_id;
    }-*/;
+   
+   public final native boolean getAltBufferActive() /*-{
+      return this.alt_buffer;
+   }-*/;
+   
+   public final native String getCwd() /*-{
+      return this.cwd;
+   }-*/;
+   
+   public final native int getCols() /*-{
+      return this.cols;
+   }-*/;
+   
+   public final native int getRows() /*-{
+      return this.rows;
+   }-*/;
 
    public static final int SEQUENCE_NO_TERMINAL = 0;
    

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -498,6 +498,8 @@ public class RemoteServer implements Server
                      String caption,
                      String title,
                      int sequence,
+                     boolean altBufferActive,
+                     String cwd,
                      ServerRequestCallback<ConsoleProcess> requestCallback)
    {
       JSONArray params = new JSONArray();
@@ -508,6 +510,8 @@ public class RemoteServer implements Server
       params.set(4, new JSONString(StringUtil.notNull(caption)));
       params.set(5, new JSONString(StringUtil.notNull(title)));
       params.set(6, new JSONNumber(sequence));
+      params.set(7, JSONBoolean.getInstance(altBufferActive));
+      params.set(8, new JSONString(StringUtil.notNull(cwd)));
 
       sendRequest(RPC_SCOPE,
                   START_TERMINAL,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchServerOperations.java
@@ -145,10 +145,13 @@ public interface WorkbenchServerOperations extends ConsoleServerOperations,
     * @param caption caption associated with the terminal
     * @param title title associated with the terminal
     * @param sequence relative order of terminal creation (1-based)
+    * @param altBufferActive terminal showing alt-buffer (full-screen ncurses)
+    * @param cwd current working directory
     * @param requestCallback callback from server upon completion
     */
    void startTerminal(int shellType, int cols, int rows, String handle, 
                       String caption, String title, int sequence, 
+                      boolean altBufferActive, String cwd,
                       ServerRequestCallback<ConsoleProcess> requestCallback);
    
    void executeCode(String code, ServerRequestCallback<Void> requestCallback);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
@@ -57,7 +57,9 @@ public class TerminalList implements Iterable<String>,
                                boolean childProcs,
                                int cols,
                                int rows,
-                               int shellType)
+                               int shellType,
+                               boolean altBufferActive,
+                               String cwd)
       {
          handle_ = StringUtil.notNull(handle);
          caption_ = StringUtil.notNull(caption);
@@ -67,6 +69,8 @@ public class TerminalList implements Iterable<String>,
          cols_ = cols;
          rows_ = rows;
          shellType_ = shellType;
+         altBufferActive_ = altBufferActive;
+         cwd_ = cwd;
       }
 
       private TerminalMetadata(TerminalMetadata original,
@@ -79,7 +83,9 @@ public class TerminalList implements Iterable<String>,
               original.childProcs_,
               original.cols_,
               original.rows_,
-              original.shellType_);
+              original.shellType_,
+              original.altBufferActive_,
+              original.cwd_);
       }
 
       private TerminalMetadata(ConsoleProcessInfo procInfo)
@@ -91,7 +97,9 @@ public class TerminalList implements Iterable<String>,
               procInfo.getHasChildProcs(),
               ConsoleProcessInfo.DEFAULT_COLS,
               ConsoleProcessInfo.DEFAULT_ROWS,
-              procInfo.getShellType()
+              procInfo.getShellType(),
+              procInfo.getAltBufferActive(),
+              procInfo.getCwd()
               );
       }
 
@@ -104,7 +112,9 @@ public class TerminalList implements Iterable<String>,
               term.getHasChildProcs(),
               term.getCols(),
               term.getRows(),
-              term.getShellType());
+              term.getShellType(),
+              term.getAltBufferActive(),
+              term.getCwd());
       }
 
       /**
@@ -136,6 +146,8 @@ public class TerminalList implements Iterable<String>,
       public int getCols() { return cols_; }
       public int getRows() { return rows_; }
       public int getShellType() { return shellType_; }
+      public boolean getAltBufferActive() { return altBufferActive_; }
+      public String getCwd() { return cwd_; }
 
       private String handle_;
       private String caption_;
@@ -145,6 +157,8 @@ public class TerminalList implements Iterable<String>,
       private int cols_;
       private int rows_;
       private int shellType_;
+      private boolean altBufferActive_;
+      private String cwd_;
    }
 
    protected TerminalList() 
@@ -227,7 +241,9 @@ public class TerminalList implements Iterable<String>,
                childProcs,
                current.cols_,
                current.rows_,
-               current.shellType_));
+               current.shellType_,
+               current.altBufferActive_,
+               current.cwd_));
          return true;
       }
       return false;
@@ -362,7 +378,10 @@ public class TerminalList implements Iterable<String>,
                     true,  // childProcs
                     ConsoleProcessInfo.DEFAULT_COLS,
                     ConsoleProcessInfo.DEFAULT_ROWS,
-                    TerminalShellInfo.SHELL_DEFAULT);
+                    TerminalShellInfo.SHELL_DEFAULT,
+                    false, // altBufferActive
+                    null // cwd
+            );
    }
 
    /**
@@ -391,7 +410,10 @@ public class TerminalList implements Iterable<String>,
                     true,  // childProcs
                     ConsoleProcessInfo.DEFAULT_COLS,
                     ConsoleProcessInfo.DEFAULT_ROWS,
-                    TerminalShellInfo.SHELL_DEFAULT);
+                    TerminalShellInfo.SHELL_DEFAULT,
+                    false, // altBufferActive
+                    null // cwd
+            );
       return true;
    }
 
@@ -415,7 +437,9 @@ public class TerminalList implements Iterable<String>,
                     existing.getChildProcs(),
                     existing.getCols(),
                     existing.getRows(),
-                    existing.getShellType());
+                    existing.getShellType(),
+                    existing.getAltBufferActive(),
+                    existing.getCwd());
       return true;
    }
 
@@ -485,11 +509,14 @@ public class TerminalList implements Iterable<String>,
                              boolean hasChildProcs,
                              int cols,
                              int rows,
-                             int shellType)
+                             int shellType,
+                             boolean altBufferActive,
+                             String cwd)
    {
       TerminalSession newSession = new TerminalSession(
             sequence, terminalHandle, caption, title, hasChildProcs, 
-            cols, rows, uiPrefs_.blinkingCursor().getValue(), true /*focus*/, shellType);
+            cols, rows, uiPrefs_.blinkingCursor().getValue(), true /*focus*/, shellType,
+            altBufferActive, cwd);
       newSession.connect();
       updateTerminalBusyStatus();
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -79,7 +79,9 @@ public class TerminalSession extends XTermWidget
                           int rows,
                           boolean cursorBlink,
                           boolean focus,
-                          int shellType)
+                          int shellType,
+                          boolean altBufferActive,
+                          String cwd)
    {
       super(cursorBlink, focus);
       
@@ -88,6 +90,11 @@ public class TerminalSession extends XTermWidget
       terminalHandle_ = handle;
       hasChildProcs_ = hasChildProcs;
       shellType_ = shellType;
+      cols_ = cols;
+      rows_ = rows;
+      altBufferActive_ = altBufferActive;
+      cwd_ = cwd;
+      
       setTitle(title);
       socket_ = new TerminalSessionSocket(this, this);
 
@@ -130,7 +137,7 @@ public class TerminalSession extends XTermWidget
 
       server_.startTerminal(getShellType(),
             getCols(), getRows(), getHandle(), getCaption(), 
-            getTitle(), getSequence(), 
+            getTitle(), getSequence(), getAltBufferActive(), getCwd(),
             new ServerRequestCallback<ConsoleProcess>()
       {
          @Override
@@ -553,6 +560,16 @@ public class TerminalSession extends XTermWidget
    {
       return rows_;
    }
+   
+   public boolean getAltBufferActive()
+   {
+      return altBufferActive_;
+   }
+   
+   public String getCwd()
+   {
+      return cwd_;
+   }
 
    /**
     * Forcibly terminate the process associated with this terminal session.
@@ -689,8 +706,10 @@ public class TerminalSession extends XTermWidget
    private StringBuilder inputQueue_ = new StringBuilder();
    private int inputSequence_ = ShellInput.IGNORE_SEQUENCE;
    private boolean newTerminal_ = true;
-   private int cols_ = ConsoleProcessInfo.DEFAULT_COLS;
-   private int rows_ = ConsoleProcessInfo.DEFAULT_ROWS;;
+   private int cols_;
+   private int rows_;
+   private boolean altBufferActive_;
+   private String cwd_; 
 
    // Injected ---- 
    private WorkbenchServerOperations server_; 


### PR DESCRIPTION
Save and restore last known terminal size and alt-buffer status (full-screen). Allows for some improvements in restoring terminal buffers, especially during browser-refresh, and for returning alt-buffer status via getTerminalContext()$full_screen.

Additional WIP plumbing on tracking current working directory.