### PR TITLE
Classic theme regression fixes

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -898,8 +898,6 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
    float: left;
 }
 
-@def TABSTRIPHEIGHT 21px;
-
 /** Document tabs **/
 /*
 @def TABSTRIPHEIGHT 24px;

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -702,6 +702,9 @@ pre {
    top: 2px !important;
    right: 2px !important;
    bottom: 2px !important;
+
+   /* overflow-hidden with border-radius degrates under windows */
+   overflow: visible !important;
 }
 
 .rstudio-themes-flat .windowFrameObject.consoleOnlyWindowFrame {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/CallFramePanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/CallFramePanel.java
@@ -83,7 +83,7 @@ public class CallFramePanel extends ResizeComposite
       
       initWidget(GWT.<Binder>create(Binder.class).createAndBindUi(this));
 
-      addStyleName("ace_editor");
+      addStyleName("ace_editor_theme");
 
       Label tracebackTitle = new Label("Traceback");
       tracebackTitle.addStyleName(style.tracebackHeader());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/history/view/HistoryPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/history/view/HistoryPane.java
@@ -129,7 +129,7 @@ public class HistoryPane extends WorkbenchPane
    {
       mainPanel_ = new LayoutPanel();
 
-      mainPanel_.addStyleName("ace_editor");
+      mainPanel_.addStyleName("ace_editor_theme");
 
       VerticalPanel vpanel = new VerticalPanel();
       vpanel.setSize("100%", "100%");


### PR DESCRIPTION
Classic theme regression fixes:
- Fix environment pane spacing.
- Fix colors under call-stack and history.
- Fix severe performance degradation in rmarkdown under windows. Found this is somewhat related with applying `border-radius` with `overflow: hidden`. Setting `overflow` to `visible` seems to fix this, notice that scrollbars are not present since other elements will clip this anyways.