### PR TITLE
roll back parts of packrat IDE integration

### DIFF
--- a/src/cpp/session/modules/SessionPackrat.cpp
+++ b/src/cpp/session/modules/SessionPackrat.cpp
@@ -55,7 +55,7 @@ using namespace rstudio::core;
 #define kPackratActionSnapshot "snapshot"
 
 #define kAutoSnapshotName "auto.snapshot"
-#define kAutoSnapshotDefault true
+#define kAutoSnapshotDefault false
 
 #define kInvalidHashValue "--------"
 
@@ -403,21 +403,13 @@ void pendingSnapshot(PendingSnapshotAction action)
 }
 
 
-// Checks Packrat options to see whether auto-snapshotting is enabled 
+// Checks Packrat options to see whether auto-snapshotting is enabled.
+// (In previous versions of the RStudio IDE, users could opt-in to
+// automatic snapshots -- we now disable this explicitly as this proved
+// too confusing and led to too many irreconcilable states)
 bool isAutoSnapshotEnabled()
 {
-   bool enabled = kAutoSnapshotDefault;
-   r::sexp::Protect rProtect;
-   SEXP optionsSEXP;
-   Error error = modules::packrat::getPackratOptions(&optionsSEXP, &rProtect);
-   if (!error)
-   {
-      error = r::sexp::getNamedListElement(optionsSEXP,
-                                           kAutoSnapshotName,
-                                           &enabled,
-                                           kAutoSnapshotDefault);
-   }
-   return enabled;
+   return false;
 }
 
 // Performs an automatic snapshot of the Packrat library, either immediately

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPackratPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPackratPreferencesPane.java
@@ -110,11 +110,6 @@ public class ProjectPackratPreferencesPane extends ProjectPreferencesPane
         spaced(chkUsePackrat_);
         add(chkUsePackrat_);
         
-        chkAutoSnapshot_ = new CheckBox("Automatically snapshot local changes");
-        chkAutoSnapshot_.setValue(packratOptions.getAutoSnapshot());
-        lessSpaced(chkAutoSnapshot_);
-        add(chkAutoSnapshot_);
-        
         String vcsName = session_.getSessionInfo().getVcsName();
         chkVcsIgnoreLib_ = new CheckBox(vcsName + " ignore packrat library"); 
         chkVcsIgnoreLib_.setValue(packratOptions.getVcsIgnoreLib());
@@ -173,7 +168,6 @@ public class ProjectPackratPreferencesPane extends ProjectPreferencesPane
    {
       boolean vcsActive = !session_.getSessionInfo().getVcsName().equals("");
       
-      chkAutoSnapshot_.setVisible(packified);
       chkUseCache_.setVisible(packified);
       panelExternalPackages_.setVisible(packified);
       widgetLocalRepos_.setVisible(packified);
@@ -186,7 +180,7 @@ public class ProjectPackratPreferencesPane extends ProjectPreferencesPane
    {
       RProjectPackratOptions packratOptions = options.getPackratOptions();
       packratOptions.setUsePackrat(chkUsePackrat_.getValue());
-      packratOptions.setAutoSnapshot(chkAutoSnapshot_.getValue());
+      packratOptions.setAutoSnapshot(false);
       packratOptions.setVcsIgnoreLib(chkVcsIgnoreLib_.getValue());
       packratOptions.setVcsIgnoreSrc(chkVcsIgnoreSrc_.getValue());
       packratOptions.setUseCache(chkUseCache_.getValue());
@@ -322,7 +316,6 @@ public class ProjectPackratPreferencesPane extends ProjectPreferencesPane
    private final DependencyManager dependencyManager_;
    
    private CheckBox chkUsePackrat_;
-   private CheckBox chkAutoSnapshot_;
    private CheckBox chkUseCache_;
    private CheckBox chkVcsIgnoreLib_;
    private CheckBox chkVcsIgnoreSrc_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -22,7 +22,6 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 
 import org.rstudio.core.client.Debug;
-import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
@@ -42,13 +41,9 @@ import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.mirrors.DefaultCRANMirror;
 import org.rstudio.studio.client.packrat.PackratUtil;
-import org.rstudio.studio.client.packrat.model.PackratConflictActions;
-import org.rstudio.studio.client.packrat.model.PackratConflictResolution;
 import org.rstudio.studio.client.packrat.model.PackratContext;
 import org.rstudio.studio.client.packrat.model.PackratPackageAction;
 import org.rstudio.studio.client.packrat.model.PackratServerOperations;
-import org.rstudio.studio.client.packrat.ui.PackratActionDialog;
-import org.rstudio.studio.client.packrat.ui.PackratResolveConflictDialog;
 import org.rstudio.studio.client.server.ServerDataSource;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
@@ -88,9 +83,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.TreeSet;
 
 public class Packages
@@ -994,210 +987,6 @@ public class Packages
       private final String buttonText_;
       private final Command onExecute_;
    }
-   
-   private void confirmPackratActions(JsArray<PackratPackageAction> actions, 
-                                      String actionTitle, 
-                                      final String packratFunction)
-   {
-      new PackratActionDialog(actionTitle, actions, 
-            new OperationWithInput<Void>()
-            {
-               @Override
-               public void execute(Void input)
-               {
-                  packratUtil_.executePackratFunction(packratFunction, 
-                        "prompt = FALSE");
-               }
-            }).showModal();
-   }
-   
-   private void resolvePackratConflicts(
-         JsArray<PackratPackageAction> restoreActions,
-         JsArray<PackratPackageAction> snapshotActions)
-   {
-      new PackratResolveConflictDialog(
-            createConflictsFromActions(restoreActions, snapshotActions), 
-            new OperationWithInput<PackratConflictResolution>()
-            {
-               @Override
-               public void execute(PackratConflictResolution input)
-               {
-                  if (input == PackratConflictResolution.Library)
-                  {
-                     packratUtil_.executePackratFunction("restore", 
-                           "prompt = FALSE");
-                  }
-                  else if (input == PackratConflictResolution.Snapshot)
-                  {
-                     packratUtil_.executePackratFunction("snapshot",
-                           "prompt = FALSE");
-                  }
-               }
-            }).showModal();
-   }
-   
-   private void setViewActions(final PackageState packageState)
-   {
-      ArrayList<Action> actions = new ArrayList<Action>();
-      // if we have both restore and snapshot actions possible, we need to 
-      // have the user manually pick one
-      if (packageState.getRestoreActions().length() > 0 &&
-          packageState.getSnapshotActions().length() > 0)
-      {
-         ArrayList<PackratPackageAction> allActions = 
-                 new ArrayList<PackratPackageAction>();
-         JsArrayUtil.fillList(packageState.getRestoreActions(), allActions);
-         JsArrayUtil.fillList(packageState.getSnapshotActions(), allActions);
-         actions.add(new Action(conflictMessageFromActions(allActions),
-               "Resolve...",
-               new Command() 
-               {
-                  @Override
-                  public void execute()
-                  {
-                     resolvePackratConflicts(
-                           packageState.getRestoreActions(),
-                           packageState.getSnapshotActions());
-                  }
-               }));
-      }
-      else if (packageState.getRestoreActions().length() > 0) 
-      {
-         actions.add(new Action(messageFromActions(
-               packageState.getRestoreActions()),
-               "Update Library...", 
-               new Command() {
-                  @Override
-                  public void execute()
-                  {
-                     confirmPackratActions(packageState.getRestoreActions(),
-                                           "Restore", "restore");
-                  }
-               }));
-      }
-      else if (packageState.getSnapshotActions().length() > 0) 
-      {
-         actions.add(new Action(messageFromActions(
-               packageState.getSnapshotActions()),
-               "Update Packrat...", 
-               new Command() {
-                  @Override
-                  public void execute()
-                  {
-                     confirmPackratActions(packageState.getSnapshotActions(),
-                                           "Snapshot", "snapshot");
-                  }
-               }));
-      }
-      view_.setActions(actions);
-   }
-   
-   private String conflictMessageFromActions(List<PackratPackageAction> actions)
-   {
-      // count the unique packages involved
-      Set<String> packageNames = new TreeSet<String>();
-      for (PackratPackageAction action: actions)
-      {
-         packageNames.add(action.getPackage());
-      }
-      
-      if (packageNames.size() == 1)
-         return "Package '" + actions.get(0).getPackage() + "' out of sync";
-      else
-         return packageNames.size() + " packages out of sync";
-   }
-   
-   private String messageFromActions(JsArray<PackratPackageAction> actions)
-   {
-      if (actions.length() == 1)
-      {
-         // If there's just one action, show it
-         PackratPackageAction action = actions.get(0);
-         return StringUtil.capitalize(action.getAction()) + " '" + 
-                action.getPackage() + "'";
-      }
-      else
-      {
-         return summarizeActions(actions);
-      }
-   }
-   
-   private String summarizeActions(JsArray<PackratPackageAction> actions)
-   {
-      String summary = "";
-      Map<String, Integer> actionCounts = new TreeMap<String, Integer>();
-      for (int i = 0; i < actions.length(); i++)
-      {
-         PackratPackageAction action = actions.get(i);
-         String actionName = action.getAction();
-         if (actionCounts.containsKey(actionName))
-            actionCounts.put(actionName, actionCounts.get(actionName) + 1);
-         else 
-            actionCounts.put(actionName, 1);
-      }
-      String actionNames[] = actionCounts.keySet().toArray(new String[]{});
-      for (int i = 0; i < actionNames.length; i++)
-      {
-         String actionName = actionNames[i];
-         if (i == 0)
-            summary += StringUtil.capitalize(actionName);
-         else
-            summary += actionName;
-         summary += " ";
-         if (actionCounts.get(actionName).equals(1))
-            summary += "1 package";
-         else
-            summary += actionCounts.get(actionName) + " packages";
-         if (i < actionNames.length - 2)
-            summary += ", ";
-         if (i == actionNames.length - 2)
-            summary += ", and ";
-      }
-      return summary;
-   }
-
-   private TreeMap<String, PackratPackageAction> createMapFromActions(
-         JsArray<PackratPackageAction> actions)
-   {
-      TreeMap<String, PackratPackageAction> result = 
-            new TreeMap<String, PackratPackageAction>();
-      for (int i = 0; i < actions.length(); i++)
-      {
-         result.put(actions.get(i).getPackage(), actions.get(i));
-      }
-      return result;
-   }
-
-   private ArrayList<PackratConflictActions> createConflictsFromActions(
-         JsArray<PackratPackageAction> restoreActions, 
-         JsArray<PackratPackageAction> snapshotActions)
-   {
-      // build a map of all the package actions
-      ArrayList<PackratConflictActions> conflicts = 
-            new ArrayList<PackratConflictActions>();
-      TreeMap<String, PackratPackageAction> restoreMap = 
-            createMapFromActions(restoreActions);
-      TreeMap<String, PackratPackageAction> snapshotMap = 
-            createMapFromActions(snapshotActions);
-
-      // build a union of all affected package names
-      Set<String> packageNames = new TreeSet<String>();
-      getPackageNamesFromActions(restoreActions, packageNames);
-      getPackageNamesFromActions(snapshotActions, packageNames);
-      
-      // find the action for each package
-      for (String packageName: packageNames)
-      {
-         conflicts.add(PackratConflictActions.create(
-               packageName,
-               snapshotMap.containsKey(packageName) ? 
-                     snapshotMap.get(packageName).getMessage() : "",
-               restoreMap.containsKey(packageName) ? 
-                     restoreMap.get(packageName).getMessage() : ""));
-      }
-
-      return conflicts;
-   }
 
    public void executeRemoveCommand(ArrayList<PackratPackageAction> actions)
    {
@@ -1269,7 +1058,6 @@ public class Packages
       packratContext_ = newState.getPackratContext();
       view_.setProgress(false);
       setViewPackageList();
-      setViewActions(newState);
    }
    
    private void getPackageNamesFromActions(


### PR DESCRIPTION
This PR rolls back some elements of the Packrat IDE integration. Currently, the following pieces are turned off:

- Automatic snapshotting is now disabled,
- The IDE / Packrat no longer notifies the user when it detects a change in the library (e.g. after a package is installed or removed).

We might want to add some buttons / menu items for explicitly snapshotting / restoring, just so that users can (explicitly) drive packrat through the IDE.