### PR TITLE
fix issue 6854, terminal clipped at bottom

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -99,7 +99,6 @@ public class TerminalPane extends WorkbenchPane
    protected Widget createMainWidget()
    {
       terminalSessionsPanel_ = new DeckLayoutPanel();
-      terminalSessionsPanel_.setStyleName(ConsoleResources.INSTANCE.consoleStyles().console());
       terminalSessionsPanel_.getElement().addClassName("ace_editor");
       return terminalSessionsPanel_;
    }


### PR DESCRIPTION
Regression I introduced fixing issue 6837, terminal flashes when switching tabs with dark background. Easy to fix, remove unnecessary setStyleName, leaving the addClassName that actually fixed the issue.