### PR TITLE
Restore panel animations under themes

### DIFF
--- a/src/cpp/session/resources/profiler/profiler.css
+++ b/src/cpp/session/resources/profiler/profiler.css
@@ -108,3 +108,7 @@
 .rstudio-themes-flat.rstudio-themes-dark .profvis-flamegraph .cell.highlighted.active .rect {
    fill: rgba(255,255,255,0.7);
 }
+
+.rstudio-themes-flat.rstudio-themes-dark .profvis-message div {
+   color: #FFF;
+}

--- a/src/cpp/session/resources/profiler/profiler.css
+++ b/src/cpp/session/resources/profiler/profiler.css
@@ -25,7 +25,7 @@
 }
 
 .rstudio-themes-flat.rstudio-themes-dark .profvis-table th {
-   background: rgba(255, 255, 255, 0.2);
+   background: rgba(255, 255, 255, 0.10);
    border-top: none;
    font-weight: 400;
 }

--- a/src/cpp/session/resources/profiler/profiler.css
+++ b/src/cpp/session/resources/profiler/profiler.css
@@ -66,7 +66,7 @@
 }
 
 .rstudio-themes-flat.rstudio-themes-dark .profvis-treetable th {
-   background: rgba(255, 255, 255, 0.2);
+   color: #FFF;
 }
 
 .rstudio-themes-flat.rstudio-themes-dark .profvis-treetable .treetable-collapse > div > div {

--- a/src/gwt/src/org/rstudio/core/client/layout/AnimationHelper.java
+++ b/src/gwt/src/org/rstudio/core/client/layout/AnimationHelper.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.core.client.layout;
 
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.layout.client.Layout;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -118,6 +119,8 @@ class AnimationHelper
 
    public void animate()
    {
+      Document.get().getBody().addClassName("rstudio-animating");
+      
       panel_.setSplitterVisible(false);
 
       if (startWidgetTop_ != animWidgetTop_)
@@ -172,6 +175,7 @@ class AnimationHelper
          setParentZindex(startWidgetBottom_, -10);
       setParentZindex(endWidgetBottom_, 0);
 
+      Document.get().getBody().removeClassName("rstudio-animating");
       panel_.onResize();
    }
 

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2430,3 +2430,10 @@ body.rstudio-themes-flat .rstudio-themes-alternate {
 .rstudio-themes-flat .rstudio-themes-scrollbars .com-google-gwt-user-client-ui-CustomScrollPanel-Style-customScrollPanelCorner {
    display: none;
 }
+
+/* AnimationHelper requires background to be set at -10 */
+body.rstudio-themes-flat .rstudio-themes-default,
+body.rstudio-themes-flat .rstudio-themes-dark-grey,
+body.rstudio-themes-flat .rstudio-themes-alternate {
+   z-index: -10;
+}

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -42,6 +42,8 @@
 
 @external rstudio-themes-background, rstudio-themes-inverts, rstudio-themes-scrollbars, rstudio-themes-darkens;
 
+@external rstudio-animating;
+
 @external dataGridSortedHeaderAscending, dataGridSortedHeaderDescending;
 
 @eval THEME_DEFAULT_BACKGROUND org.rstudio.core.client.theme.ThemeColors.defaultBackground;
@@ -2432,8 +2434,8 @@ body.rstudio-themes-flat .rstudio-themes-alternate {
 }
 
 /* AnimationHelper requires background to be set at -10 */
-body.rstudio-themes-flat .rstudio-themes-default,
-body.rstudio-themes-flat .rstudio-themes-dark-grey,
-body.rstudio-themes-flat .rstudio-themes-alternate {
+.rstudio-animating.rstudio-themes-flat .rstudio-themes-default,
+.rstudio-animating.rstudio-themes-flat .rstudio-themes-dark-grey,
+.rstudio-animating.rstudio-themes-flat .rstudio-themes-alternate {
    z-index: -10;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
@@ -96,16 +96,19 @@ public class ProfilerEditingTargetWidget extends Composite
          "}\n" +
          "\n" +
          ".rstudio-themes-flat.rstudio-themes-default .profvis-footer,\n" +
+         ".rstudio-themes-flat.rstudio-themes-default .profvis-treetable th,\n" +
          ".rstudio-themes-flat.rstudio-themes-default .profvis-status-bar {\n" +
          "   background-color: " + ThemeColors.defaultBackground + ";\n" +
          "}\n" +
          "\n" +
          ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-footer,\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-treetable th,\n" +
          ".rstudio-themes-flat.rstudio-themes-dark-grey .profvis-status-bar {\n" +
          "   background-color: " + ThemeColors.darkGreyBackground + ";\n" +
          "}\n" +
          "\n" +
          ".rstudio-themes-flat.rstudio-themes-alternate .profvis-footer,\n" +
+         ".rstudio-themes-flat.rstudio-themes-alternate .profvis-treetable th,\n" +
          ".rstudio-themes-flat.rstudio-themes-alternate .profvis-status-bar {\n" +
          "   background-color: " + ThemeColors.alternateBackground + ";\n" +
          "}\n" +


### PR DESCRIPTION
- Panel animations were lost under themes, this was caused by applying a background under themes that is not compatible with the way animations work (they change the parent `z-index` to `-10` which would leave them under the background).
- A few profiler color tweaks.