### PR TITLE
Fix console being stuck minimized after creating new notebook.

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/layout/DualWindowLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/layout/DualWindowLayoutPanel.java
@@ -318,18 +318,19 @@ public class DualWindowLayoutPanel extends SimplePanel
       @Override
       protected JsObject getValue()
       {
+         NormalHeight currentHeight = normalHeight_;
          if (layout_.isSplitterVisible())
          {
-            normalHeight_ = new NormalHeight(layout_.getSplitterBottom(),
+            currentHeight = new NormalHeight(layout_.getSplitterBottom(),
                                              layout_.getOffsetHeight(),
                                              Window.getClientHeight());
          }
 
          State state = JsObject.createJsObject().cast();
-         state.setSplitterPos(normalHeight_.getHeight());
+         state.setSplitterPos(currentHeight.getHeight());
          state.setTopWindowState(windowA_.getState().toString());
-         state.setPanelHeight(normalHeight_.getContainerHeight(getOffsetHeight()));
-         state.setWindowHeight(normalHeight_.getWindowHeight(Window.getClientHeight()));
+         state.setPanelHeight(currentHeight.getContainerHeight(getOffsetHeight()));
+         state.setWindowHeight(currentHeight.getWindowHeight(Window.getClientHeight()));
          return state.cast();
       }
 


### PR DESCRIPTION
1. Boot RStudio for the first time or close all documents.
2. Create a new notebook, console gets minimized.
3. Clicking restore console won't work.

The problem is that we eagerly update `normalHeight_` when we are saving the client state. In general, preserving the window state should not have a side effect to the panels state which currently does in some situations, like the one mentioned above.

This behavior has been this was since the first commit so worth waiting for feedback from @jjallaire before the merge.

Already performed some light testing with different panel configurations validating the panels change and the state is preserved.