### PR TITLE
suppress warnings emitted during package install

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -437,18 +437,21 @@ assign(envir = .rs.Env, ".rs.getVar", function(name)
    # run the original function (f). setup condition handlers soley so that
    # we can correctly print the name of the function called in error
    # and warning messages -- otherwise R prints "original(...)"
-   withCallingHandlers(tryCatch(f(...), 
-                                error=function(e)
-                                {
-                                   cat("Error in ", name, " : ", e$message, 
-                                       "\n", sep="")
-                                }),
-                       warning=function(w)
-                       {
-                          cat("Warning in ", name, " :\n  ",  w$message, 
-                              "\n", sep="")
-                          invokeRestart("muffleWarning")
-                       })
+   withCallingHandlers(
+      tryCatch(
+         f(...),
+         error = function(e)
+         {
+            cat("Error in ", name, " : ", e$message, "\n", sep = "")
+         }
+      ),
+      warning = function(w)
+      {
+         if (getOption("warn") >= 0)
+            cat("Warning in ", name, " :\n  ",  w$message, "\n", sep = "")
+         invokeRestart("muffleWarning")
+      }
+   )
 })
 
 # replacing an internal R function


### PR DESCRIPTION
This PR suppresses warnings emitted by our `install.packages` hook of the form:

```
Warning in install.packages :
  cannot open URL 'https://cran.rstudio.com/bin/macosx/el-capitan/contrib/3.4/PACKAGES.rds': HTTP status was '404 Not Found'
```

Within `utils::install.packages()`, R attempts to silence warnings using `options(warn = -1L)`; however, this does not deactivate any existing warning handlers, which we do attach in all of our hooked functions.

The solution here is fortunately simple -- we just need to check the `warn` option in our handler, and only forward the warning when the value of that option is positive.