### PR TITLE
Apply flat theme to dialog grids

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.css
@@ -12,6 +12,13 @@
 	border-right: 1px solid #FFF !important;
 }
 
+.rstudio-themes-flat .dataGridKeyboardSelectedRowCell, .dataGridKeyboardSelectedRowCell:active,
+.rstudio-themes-flat .dataGridKeyboardSelectedRowCell:hover, .dataGridKeyboardSelectedRowCell:focus {
+	border-top: 0px solid #FFF !important;
+	border-left: 0px solid #FFF !important;
+	border-right: 0px solid #FFF !important;
+}
+
 .dataGridKeyboardSelectedRowCell:first-child {
 	border-left: 2px solid #0AF !important;
 }
@@ -22,6 +29,10 @@
 
 .dataGridWidget > div {
 	min-height: 18px !important;
+}
+
+.rstudio-themes-flat .dataGridWidget thead > tr {
+	height: 18px;
 }
 
 .dataGridWidget td > div {
@@ -81,7 +92,31 @@
 	box-shadow: 0 0 4px #8BF;
 }
 
+.rstudio-themes-flat .dataGridWidget {
+	background: #FFF;
+}
+
 .rstudio-themes-flat .dataGridOddRowCell,
 .rstudio-themes-flat .dataGridEvenRowCell {
   border: none;
+}
+
+.rstudio-themes-flat .dataGridCell:first-child {
+	border-left: 2px solid #FFF;
+}
+
+.rstudio-themes-flat .dataGridCell:first-child div {
+	margin-left: -1px;
+}
+
+.rstudio-themes-flat .dataGridKeyboardSelectedRowCell:first-child, .dataGridKeyboardSelectedRowCell:first-child:active,
+.rstudio-themes-flat .dataGridKeyboardSelectedRowCell:first-child:hover, .dataGridKeyboardSelectedRowCell:first-child:focus {
+	border-left: 2px solid #0AF !important;
+}
+
+.rstudio-themes-flat .dataGridKeyboardSelectedRowCell:first-child div {
+}
+
+.rstudio-themes-flat .dataGridWidget {
+  border: 1px solid #ddd;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.css
@@ -1,0 +1,19 @@
+@external rstudio-themes-flat;
+
+.rstudio-themes-flat .dataGridCell {
+   border: none;
+   border-bottom: 1px solid #ddd;
+}
+
+.rstudio-themes-flat .dataGridWidget {
+   border: solid 1px #ddd;
+   background: #FFF;
+}
+
+.rstudio-themes-flat .dataGridWidget table {
+   border-collapse: collapse;
+}
+
+.rstudio-themes-flat .dataGridWidget .dataGridSelectedRow {
+   background: #eeeff1
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
@@ -351,7 +351,7 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
    // Resources, etc ----
    public interface Resources extends RStudioDataGridResources
    {
-      @Source({RStudioDataGridStyle.RSTUDIO_DEFAULT_CSS})
+      @Source({RStudioDataGridStyle.RSTUDIO_DEFAULT_CSS, "BrowseAddinsDialog.css"})
       Styles dataGridStyle();
    }
    


### PR DESCRIPTION
Minor tweaks to dialogs hosting grids under modern theme. They were missing backgrounds, borders and correct separators:

<img width="763" alt="screen shot 2017-05-18 at 10 53 19 am" src="https://cloud.githubusercontent.com/assets/3478847/26217519/8ce53aae-3bbc-11e7-8654-14db6dad5f8f.png">
<img width="562" alt="screen shot 2017-05-18 at 10 53 34 am" src="https://cloud.githubusercontent.com/assets/3478847/26217517/8caee6c0-3bbc-11e7-9fe2-790ac92f9c4e.png">
<img width="755" alt="screen shot 2017-05-18 at 10 56 11 am" src="https://cloud.githubusercontent.com/assets/3478847/26217518/8cc1817c-3bbc-11e7-954d-debd2a7b4c9b.png">
