### PR TITLE
Avoid suggesting already-installed package connections

### DIFF
--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -452,7 +452,6 @@ options(connectionObserver = list(
 
    connectionList <- Filter(function(e) !is.null(e), connectionList)
 
-   connectionNames <- sapply(connectionList, function(e) e$name)
    supportedNotInstsalled <- Filter(function(e) {
       !.rs.isPackageVersionInstalled(e$package, e$version)
    }, .rs.connectionSupportedPackages())

--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -454,7 +454,7 @@ options(connectionObserver = list(
 
    connectionNames <- sapply(connectionList, function(e) e$name)
    supportedNotInstsalled <- Filter(function(e) {
-      !e$name %in% connectionNames
+      !.rs.isPackageVersionInstalled(e$package, e$version)
    }, .rs.connectionSupportedPackages())
 
    connectionList <- c(connectionList, lapply(supportedNotInstsalled, function(supportedPackage) {


### PR DESCRIPTION
Minor bug in New Connections dialog: We suggest `sparklyr` and `odbc` when no connections are available; however, once installed, we were filtering based on name not on package/version.