### PR TITLE
implement column resize for object explorer

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/events/MouseDragHandler.java
+++ b/src/gwt/src/org/rstudio/core/client/events/MouseDragHandler.java
@@ -67,15 +67,15 @@ public abstract class MouseDragHandler
       public MouseCoordinates getMouseDelta()
       {
          return new MouseCoordinates(
-               lastCoordinates_.getMouseX() - event_.getClientX(),
-               lastCoordinates_.getMouseY() - event_.getClientY());
+               event_.getClientX() - lastCoordinates_.getMouseX(),
+               event_.getClientY() - lastCoordinates_.getMouseY());
       }
       
       public MouseCoordinates getTotalDelta()
       {
          return new MouseCoordinates(
-               initialCoordinates_.getMouseX() - event_.getClientX(),
-               initialCoordinates_.getMouseY() - event_.getClientY());
+               event_.getClientX() - initialCoordinates_.getMouseX(),
+               event_.getClientY() - initialCoordinates_.getMouseY());
       }
       
       public MouseCoordinates getInitialCoordinates()
@@ -103,17 +103,25 @@ public abstract class MouseDragHandler
       private final MouseCoordinates lastCoordinates_;
    }
    
-   // Must be overriden
+   // The action to take before a drag session begins.
+   // Return 'false' to cancel the drag request.
+   public abstract boolean beginDrag(MouseDownEvent event);
+   
+   // The action to take during drag (in response to
+   // mouse move events while the mouse button is held down)
    public abstract void onDrag(MouseDragEvent event);
    
-   // Optional to override
-   public void beginDrag(MouseDownEvent event) {}
-   public void endDrag() {}
+   // The action to take after the drag session has finished
+   // (after the user has released the mouse cursor).
+   public abstract void endDrag();
    
    // Privates ----
    
    private void beginDragImpl(MouseDownEvent event)
    {
+      if (!beginDrag(event))
+         return;
+      
       didDrag_ = false;
       
       initialCoordinates_ = lastCoordinates_ =
@@ -148,8 +156,6 @@ public abstract class MouseDragHandler
             }
          }
       });
-      
-      beginDrag(event);
    }
    
    private void addClickSuppressor()

--- a/src/gwt/src/org/rstudio/core/client/events/MouseDragHandler.java
+++ b/src/gwt/src/org/rstudio/core/client/events/MouseDragHandler.java
@@ -1,7 +1,7 @@
 /*
- * NativeKeyDownHandler.java
+ * MouseDragHandler.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/studio/client/ResizableHeader.css
+++ b/src/gwt/src/org/rstudio/studio/client/ResizableHeader.css
@@ -1,0 +1,10 @@
+@CHARSET "UTF-8";
+
+.splitter {
+	position: absolute;
+	width: 6px;
+	height: 100%;
+	cursor: col-resize;
+	margin-left: -5px;
+	margin-top: -2px;
+}

--- a/src/gwt/src/org/rstudio/studio/client/ResizableHeader.css
+++ b/src/gwt/src/org/rstudio/studio/client/ResizableHeader.css
@@ -2,9 +2,8 @@
 
 .splitter {
 	position: absolute;
-	width: 6px;
-	height: 100%;
+	width: 7px;
+	height: 18px;
 	cursor: col-resize;
-	margin-left: -5px;
 	margin-top: -2px;
 }

--- a/src/gwt/src/org/rstudio/studio/client/ResizableHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/ResizableHeader.java
@@ -17,7 +17,6 @@ package org.rstudio.studio.client;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.SafeHtmlUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
@@ -92,8 +91,6 @@ public class ResizableHeader extends Header<String>
       table_ = table;
       text_ = text;
       index_ = table.getColumnCount();
-      
-      Debug.logToRConsole("Index: " + index_);
       
       MouseDragHandler.addHandler(table_, new MouseDragHandler()
       {

--- a/src/gwt/src/org/rstudio/studio/client/ResizableHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/ResizableHeader.java
@@ -145,14 +145,20 @@ public class ResizableHeader extends Header<String>
             // discover the change in column widths
             int delta = event.getTotalDelta().getMouseX();
             
-            // update column widths
-            table_.setColumnWidth(
-                  index_ - 1,
-                  (columnWidths_.get(index_ - 1) + delta) + "px");
+            // compute the right column width
+            int leftWidth = columnWidths_.get(index_ - 1) + delta;
+            int rightWidth = columnWidths_.get(index_) - delta;
             
-            table_.setColumnWidth(
-                  index_,
-                  (columnWidths_.get(index_) - delta) + "px");
+            // avoid issues with resizing too small
+            if (leftWidth < 0)
+            {
+               rightWidth = rightWidth + leftWidth;
+               leftWidth = 0;
+            }
+            
+            // update column widths
+            table_.setColumnWidth(index_ - 1, leftWidth + "px");
+            table_.setColumnWidth(index_, rightWidth + "px");
          }
          
          @Override

--- a/src/gwt/src/org/rstudio/studio/client/ResizableHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/ResizableHeader.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.SafeHtmlUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
@@ -35,43 +36,35 @@ import com.google.gwt.user.cellview.client.Header;
 
 public class ResizableHeader<T> extends Header<String>
 {
-   private static class ResizableHeaderCell extends AbstractCell<String>
+   private static class ResizableHeaderCell<U> extends AbstractCell<U>
    {
-      public ResizableHeaderCell(int index)
-      {
-         super();
-         index_ = index;
-      }
-      
       @Override
       public void render(Context context,
-                         String string,
+                         U content,
                          SafeHtmlBuilder builder)
       {
          SafeHtml splitter = SafeHtmlUtil.createOpenTag("div",
                "class", RES.styles().splitter(),
-               "data-index", "" + index_);
+               "data-index", "" + context.getColumn());
          
          builder
             .append(splitter)
             .appendHtmlConstant("</div>")
             .appendHtmlConstant("<div>")
-            .appendEscaped(string)
+            .appendEscaped(content.toString())
             .appendHtmlConstant("</div>");
       }
-      
-      private final int index_;
    }
    
-   public ResizableHeader(AbstractCellTable<T> table,
-                          String text,
-                          int index)
+   public ResizableHeader(AbstractCellTable<T> table, String text)
    {
-      super(new ResizableHeaderCell(index));
+      super(new ResizableHeaderCell<String>());
       
       table_ = table;
       text_ = text;
-      index_ = index;
+      index_ = table.getColumnCount();
+      
+      Debug.logToRConsole("Index: " + index_);
       
       MouseDragHandler.addHandler(table_, new MouseDragHandler()
       {

--- a/src/gwt/src/org/rstudio/studio/client/ResizableHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/ResizableHeader.java
@@ -1,0 +1,154 @@
+/*
+ * ResizableHeader.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client;
+
+import org.rstudio.core.client.SafeHtmlUtil;
+import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.dom.DomUtils;
+import org.rstudio.core.client.dom.DomUtils.ElementPredicate;
+import org.rstudio.core.client.events.MouseDragHandler;
+import com.google.gwt.cell.client.AbstractCell;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.event.dom.client.MouseDownEvent;
+import com.google.gwt.resources.client.ClientBundle;
+import com.google.gwt.resources.client.CssResource;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.user.cellview.client.AbstractCellTable;
+import com.google.gwt.user.cellview.client.Header;
+
+public class ResizableHeader extends Header<String>
+{
+   private static class ResizableHeaderCell extends AbstractCell<String>
+   {
+      public ResizableHeaderCell(int index)
+      {
+         super();
+         index_ = index;
+      }
+      
+      @Override
+      public void render(Context context,
+                         String string,
+                         SafeHtmlBuilder builder)
+      {
+         SafeHtml splitter = SafeHtmlUtil.createOpenTag("div",
+               "class", RES.styles().splitter(),
+               "data-index", "" + index_);
+         
+         builder
+            .append(splitter)
+            .appendHtmlConstant("</div>")
+            .appendHtmlConstant("<div>")
+            .appendEscaped(string)
+            .appendHtmlConstant("</div>");
+      }
+      
+      private final int index_;
+   }
+   
+   public ResizableHeader(AbstractCellTable<?> table,
+                          String text,
+                          int index)
+   {
+      super(new ResizableHeaderCell(index));
+      
+      table_ = table;
+      text_ = text;
+      index_ = index;
+      
+      MouseDragHandler.addHandler(table_, new MouseDragHandler()
+      {
+         int leftColumnWidth_ = -1;
+         int rightColumnWidth_ = -1;
+         
+         @Override
+         public boolean beginDrag(MouseDownEvent event)
+         {
+            // detect a click on this splitter
+            Element targetEl = event.getNativeEvent().getEventTarget().cast();
+            if (!targetEl.hasClassName(RES.styles().splitter()))
+               return false;
+            
+            int index = StringUtil.parseInt(targetEl.getAttribute("data-index"), -1);
+            if (index != index_)
+               return false;
+            
+            // find the parent table row element
+            Element rowEl = DomUtils.findParentElement(
+                  targetEl,
+                  new ElementPredicate()
+                  {
+                     @Override
+                     public boolean test(Element el)
+                     {
+                        return el.hasTagName("tr");
+                     }
+                  });
+            
+            if (rowEl == null)
+               return false;
+            
+            // initialize column widths 
+            leftColumnWidth_  = rowEl.getChild(index_ - 1).<Element>cast().getOffsetWidth();
+            rightColumnWidth_ = rowEl.getChild(index_).<Element>cast().getOffsetWidth();
+            return true;
+         }
+         
+         @Override
+         public void onDrag(MouseDragEvent event)
+         {
+            int delta = event.getTotalDelta().getMouseX();
+            table_.setColumnWidth(index_ - 1, (leftColumnWidth_ + delta) + "px");
+            table_.setColumnWidth(index_, (rightColumnWidth_ - delta) + "px");
+         }
+         
+         @Override
+         public void endDrag()
+         {
+         }
+         
+      });
+   }
+   
+   @Override
+   public String getValue()
+   {
+      return text_;
+   }
+   
+   private final AbstractCellTable<?> table_;
+   private final String text_;
+   private final int index_;
+   
+   // Resources, etc ----
+   public interface Resources extends ClientBundle
+   {
+      @Source("ResizableHeader.css")
+      Styles styles();
+   }
+   
+   public interface Styles extends CssResource
+   {
+      String splitter();
+   }
+   
+   private static final Resources RES = GWT.create(Resources.class);
+   
+   static {
+      RES.styles().ensureInjected();
+   }
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesList.java
@@ -26,6 +26,7 @@ import org.rstudio.core.client.cellview.LinkColumn;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.studio.client.ResizableHeader;
 import org.rstudio.studio.client.common.filetypes.FileIconResources;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.workbench.views.files.Files;
@@ -223,7 +224,7 @@ public class FilesList extends Composite
          } 
       };  
       sizeColumn.setSortable(true);
-      filesDataGrid_.addColumn(sizeColumn, "Size");
+      filesDataGrid_.addColumn(sizeColumn, new ResizableHeader(filesDataGrid_, "Size"));
       filesDataGrid_.setColumnWidth(sizeColumn, SIZE_COLUMN_WIDTH_PIXELS, Unit.PX);
       
       sortHandler_.setComparator(sizeColumn, new FoldersOnBottomComparator() {
@@ -251,7 +252,7 @@ public class FilesList extends Composite
          } 
       };  
       modColumn.setSortable(true);
-      filesDataGrid_.addColumn(modColumn, "Modified");
+      filesDataGrid_.addColumn(modColumn, new ResizableHeader(filesDataGrid_, "Modified"));
       filesDataGrid_.setColumnWidth(modColumn, MODIFIED_COLUMN_WIDTH_PIXELS, Unit.PX); 
       
       sortHandler_.setComparator(modColumn, new FoldersOnBottomComparator() {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerDataGrid.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerDataGrid.java
@@ -566,14 +566,14 @@ public class ObjectExplorerDataGrid
       // add columns
       nameColumn_ = new IdentityColumn<Data>(new NameCell());
       addColumn(nameColumn_, new TextHeader("Name"));
-      setColumnWidth(nameColumn_, NAME_COLUMN_WIDTH + "px");
       
       typeColumn_ = new IdentityColumn<Data>(new TypeCell());
       addColumn(typeColumn_, new ResizableHeader(this, "Type"));
-      setColumnWidth(typeColumn_, TYPE_COLUMN_WIDTH + "px");
       
       valueColumn_ = new IdentityColumn<Data>(new ValueCell());
       addColumn(valueColumn_, new ResizableHeader(this, "Column"));
+      
+      initializeColumnWidths();
       
       // set updater
       dataProvider_ = new ListDataProvider<Data>();
@@ -602,6 +602,7 @@ public class ObjectExplorerDataGrid
    
    public void refresh()
    {
+      initializeColumnWidths();
       initializeRoot();
    }
    
@@ -1098,6 +1099,13 @@ public class ObjectExplorerDataGrid
                   Debug.logError(error);
                }
             });
+   }
+   
+   private void initializeColumnWidths()
+   {
+      setColumnWidth(nameColumn_, NAME_COLUMN_WIDTH + "px");
+      setColumnWidth(typeColumn_, TYPE_COLUMN_WIDTH + "px");
+      setColumnWidth(valueColumn_, null);
    }
    
    private void initializeRoot()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerDataGrid.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerDataGrid.java
@@ -1103,8 +1103,8 @@ public class ObjectExplorerDataGrid
    
    private void initializeColumnWidths()
    {
-      setColumnWidth(nameColumn_, NAME_COLUMN_WIDTH + "px");
-      setColumnWidth(typeColumn_, TYPE_COLUMN_WIDTH + "px");
+      setColumnWidth(nameColumn_, DEFAULT_NAME_COLUMN_WIDTH + "px");
+      setColumnWidth(typeColumn_, DEFAULT_TYPE_COLUMN_WIDTH + "px");
       setColumnWidth(valueColumn_, null);
    }
    
@@ -1290,8 +1290,8 @@ public class ObjectExplorerDataGrid
    private EventBus events_;
    
    // Static Members ----
-   private static final int NAME_COLUMN_WIDTH = 180;
-   private static final int TYPE_COLUMN_WIDTH = 180;
+   private static final int DEFAULT_NAME_COLUMN_WIDTH = 180;
+   private static final int DEFAULT_TYPE_COLUMN_WIDTH = 180;
    
    private static final int DEFAULT_ROW_LIMIT = 200;
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerDataGrid.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerDataGrid.java
@@ -569,11 +569,11 @@ public class ObjectExplorerDataGrid
       setColumnWidth(nameColumn_, NAME_COLUMN_WIDTH + "px");
       
       typeColumn_ = new IdentityColumn<Data>(new TypeCell());
-      addColumn(typeColumn_, new ResizableHeader(this, "Type", 1));
+      addColumn(typeColumn_, new ResizableHeader<Data>(this, "Type", 1));
       setColumnWidth(typeColumn_, TYPE_COLUMN_WIDTH + "px");
       
       valueColumn_ = new IdentityColumn<Data>(new ValueCell());
-      addColumn(valueColumn_, new ResizableHeader(this, "Column", 2));
+      addColumn(valueColumn_, new ResizableHeader<Data>(this, "Column", 2));
       
       // set updater
       dataProvider_ = new ListDataProvider<Data>();
@@ -817,6 +817,14 @@ public class ObjectExplorerDataGrid
       if (containingRowEl == null)
          return;
       
+      // compute the width of each table cell element minus last
+      int otherWidth = 0;
+      for (int i = 0, n = hoveredRow_.getChildCount() - 1; i < n; i++)
+      {
+         Element childEl = hoveredRow_.getChild(i).cast();
+         otherWidth += childEl.getScrollWidth();
+      }
+      
       // TODO: do a better job of automatically computing these widths,
       // rather than hard-coding them
       int buttonWidth = 0;
@@ -827,12 +835,7 @@ public class ObjectExplorerDataGrid
          buttonWidth = 48;
 
       int totalWidth = getOffsetWidth();
-      int remainingWidth =
-            totalWidth -
-            NAME_COLUMN_WIDTH -
-            TYPE_COLUMN_WIDTH -
-            buttonWidth -
-            20;
+      int remainingWidth = totalWidth - otherWidth - buttonWidth - 20;
       
       Element parentEl = valueDescEl.getParentElement();
       parentEl.getStyle().setPropertyPx("width", Math.max(0, remainingWidth));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerDataGrid.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerDataGrid.java
@@ -569,11 +569,11 @@ public class ObjectExplorerDataGrid
       setColumnWidth(nameColumn_, NAME_COLUMN_WIDTH + "px");
       
       typeColumn_ = new IdentityColumn<Data>(new TypeCell());
-      addColumn(typeColumn_, new ResizableHeader<Data>(this, "Type"));
+      addColumn(typeColumn_, new ResizableHeader(this, "Type"));
       setColumnWidth(typeColumn_, TYPE_COLUMN_WIDTH + "px");
       
       valueColumn_ = new IdentityColumn<Data>(new ValueCell());
-      addColumn(valueColumn_, new ResizableHeader<Data>(this, "Column"));
+      addColumn(valueColumn_, new ResizableHeader(this, "Column"));
       
       // set updater
       dataProvider_ = new ListDataProvider<Data>();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerDataGrid.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerDataGrid.java
@@ -16,6 +16,7 @@ package org.rstudio.studio.client.workbench.views.source.editors.explorer.view;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.JsVectorString;
 import org.rstudio.core.client.ListUtil;
@@ -28,6 +29,7 @@ import org.rstudio.core.client.theme.RStudioDataGridResources;
 import org.rstudio.core.client.theme.RStudioDataGridStyle;
 import org.rstudio.core.client.widget.VirtualizedDataGrid;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.ResizableHeader;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
@@ -330,14 +332,6 @@ public class ObjectExplorerDataGrid
       return generateExtractingRCode(data, handle_.getTitle());
    }
    
-   private static final int getParentLimit(Data data)
-   {
-      Data parent = data.getParentData();
-      if (parent == null)
-         return DEFAULT_ROW_LIMIT;
-      return parent.getMaximumChildRowsShown();
-   }
-   
    private class NameCell extends AbstractCell<Data>
    {
       public NameCell()
@@ -575,11 +569,11 @@ public class ObjectExplorerDataGrid
       setColumnWidth(nameColumn_, NAME_COLUMN_WIDTH + "px");
       
       typeColumn_ = new IdentityColumn<Data>(new TypeCell());
-      addColumn(typeColumn_, new TextHeader("Type"));
+      addColumn(typeColumn_, new ResizableHeader(this, "Type", 1));
       setColumnWidth(typeColumn_, TYPE_COLUMN_WIDTH + "px");
       
       valueColumn_ = new IdentityColumn<Data>(new ValueCell());
-      addColumn(valueColumn_, new TextHeader("Value"));
+      addColumn(valueColumn_, new ResizableHeader(this, "Column", 2));
       
       // set updater
       dataProvider_ = new ListDataProvider<Data>();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerDataGrid.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerDataGrid.java
@@ -569,11 +569,11 @@ public class ObjectExplorerDataGrid
       setColumnWidth(nameColumn_, NAME_COLUMN_WIDTH + "px");
       
       typeColumn_ = new IdentityColumn<Data>(new TypeCell());
-      addColumn(typeColumn_, new ResizableHeader<Data>(this, "Type", 1));
+      addColumn(typeColumn_, new ResizableHeader<Data>(this, "Type"));
       setColumnWidth(typeColumn_, TYPE_COLUMN_WIDTH + "px");
       
       valueColumn_ = new IdentityColumn<Data>(new ValueCell());
-      addColumn(valueColumn_, new ResizableHeader<Data>(this, "Column", 2));
+      addColumn(valueColumn_, new ResizableHeader<Data>(this, "Column"));
       
       // set updater
       dataProvider_ = new ListDataProvider<Data>();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -152,9 +152,10 @@ public class TextEditingTargetWidget
                double initialWidth_ = 0;
                
                @Override
-               public void beginDrag(MouseDownEvent event)
+               public boolean beginDrag(MouseDownEvent event)
                {
                   initialWidth_ = editorPanel_.getWidgetSize(docOutlineWidget_);
+                  return true;
                }
                
                @Override
@@ -162,7 +163,7 @@ public class TextEditingTargetWidget
                {
                   double initialWidth = initialWidth_;
                   double xDiff = event.getTotalDelta().getMouseX();
-                  double newSize = initialWidth + xDiff;
+                  double newSize = initialWidth - xDiff;
                   
                   // We allow an extra pixel here just to 'hide' the border
                   // if the outline is maximized, since the 'separator'


### PR DESCRIPTION
This PR makes it possible to resize columns within the object explorer, and also provides a `ResizableHeader` class that can be used with other DataGrid objects.

This is accomplished by drawing 'splitter' divs that intentionally overflow over the table header's borders, and attaches click handlers to those elements that can be used to update the column width. For users that accidentally drag themselves into a weird state, the 'refresh' button restores the default column widths (used when the table was initialized).

