### PR TITLE
Set modern theme as default theme

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -620,7 +620,7 @@ public class Application implements ApplicationEventHandlers
    @Override
    public void onThemeChanged(ThemeChangedEvent event)
    {
-      RStudioThemes.initializeThemes(uiPrefs_.get().getFlatTheme().getGlobalValue(),
+      RStudioThemes.initializeThemes(uiPrefs_.get().getFlatTheme().getValue(),
                                      Document.get(),
                                      rootPanel_.getElement());
    }
@@ -717,7 +717,7 @@ public class Application implements ApplicationEventHandlers
    
    private void initializeWorkbench()
    {
-      RStudioThemes.initializeThemes(uiPrefs_.get().getFlatTheme().getGlobalValue(),
+      RStudioThemes.initializeThemes(uiPrefs_.get().getFlatTheme().getValue(),
                                      Document.get(),
                                      rootPanel_.getElement());
 

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
@@ -24,6 +24,8 @@ import com.google.gwt.dom.client.Style.Overflow;
 import com.google.gwt.dom.client.Style.Position;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.dom.client.Style.Visibility;
+import com.google.gwt.regexp.shared.MatchResult;
+import com.google.gwt.regexp.shared.RegExp;
 
 public class RStudioThemes
 {
@@ -54,6 +56,17 @@ public class RStudioThemes
 
    public static boolean isFlat(UIPrefs prefs) {
       return prefs.getFlatTheme().getValue() != "classic"; 
+   }
+
+   public static String suggestThemeFromAceTheme(String aceTheme) {
+      RegExp keyReg = RegExp.compile(
+         "ambiance|chaos|clouds midnight|cobalt|idle fingers|kr theme|" +
+         "material|merbivore soft|merbivore|mono industrial|monokai|" +
+         "pastel on dark|solarized dark|tomorrow night blue|tomorrow night bright|" +
+         "tomorrow night 80s|tomorrow night|twilight|vibrant ink", "i");
+      
+      MatchResult result = keyReg.exec(aceTheme);
+      return result != null ? "dark-grey" : "default";
    }
    
    private static boolean usesScrollbars() {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.prefs.model;
 import org.rstudio.core.client.VirtualConsole;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.studio.client.application.Desktop;
+import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.notebook.CompileNotebookPrefs;
 import org.rstudio.studio.client.notebookv2.CompileNotebookv2Prefs;
 import org.rstudio.studio.client.rmarkdown.RmdOutput;
@@ -649,7 +650,8 @@ public class UIPrefsAccessor extends Prefs
 
    public PrefValue<String> getFlatTheme()
    {
-      return string("flat_theme", "classic");
+      String flatTheme = RStudioThemes.suggestThemeFromAceTheme(theme().getValue());
+      return string("flat_theme", flatTheme);
    }
    
    private String getDefaultPdfPreview()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -18,8 +18,6 @@ import com.google.gwt.dom.client.SelectElement;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
-import com.google.gwt.regexp.shared.MatchResult;
-import com.google.gwt.regexp.shared.RegExp;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HorizontalPanel;
@@ -34,6 +32,7 @@ import org.rstudio.core.client.widget.SelectWidget;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.ThemeChangedEvent;
+import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.workbench.prefs.model.RPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
@@ -253,14 +252,7 @@ public class AppearancePreferencesPane extends PreferencesPane
 
       String themeName = flatTheme_.getValue();
       if (themeName == "modern") {
-         RegExp keyReg = RegExp.compile(
-            "ambiance|chaos|clouds midnight|cobalt|idle fingers|kr theme|" +
-            "material|merbivore soft|merbivore|mono industrial|monokai|" +
-            "pastel on dark|solarized dark|tomorrow night bluw|tomorrow night bright|" +
-            "tomorrow night 80s|tomorrow night|twilight|vibrant ink", "i");
-         
-         MatchResult result = keyReg.exec(theme_.getValue());
-         themeName = result != null ? "dark-grey" : "default";
+         themeName = RStudioThemes.suggestThemeFromAceTheme(theme_.getValue());
       }
 
       uiPrefs_.getFlatTheme().setGlobalValue(themeName);  


### PR DESCRIPTION
This PR makes the "modern" theme the default theme for all users, opt-out by switching back to "Classic" theme from appearance preferences dialog.

We can use this PR to discuss the right time to make this the default and merge afterwards.