### PR TITLE
capture concrete terminal type in ConsoleProcessInfo

### DIFF
--- a/src/cpp/session/SessionConsoleProcessApi.cpp
+++ b/src/cpp/session/SessionConsoleProcessApi.cpp
@@ -154,6 +154,7 @@ SEXP rs_getTerminalContext(SEXP terminalSEXP)
    builder.add("caption", proc->getCaption());
    builder.add("title", proc->getTitle());
    builder.add("working_dir", module_context::createAliasedPath(proc->getCwd()));
+   builder.add("shell", proc->getShellName());
    builder.add("running", proc->isStarted());
    builder.add("busy", proc->getIsBusy());
    builder.add("connection", proc->getChannelMode());

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -121,11 +121,15 @@ public:
    static ConsoleProcessPtr createTerminalProcess(
          ConsoleProcessPtr proc);
 
+   // Configure ProcessOptions for a terminal and return it. Also sets
+   // the output param pSelectedShellType to indicate which shell type
+   // was actually configured (e.g. what did 'default' get mapped to?).
    static core::system::ProcessOptions createTerminalProcOptions(
-         TerminalShell::TerminalShellType shellType,
+         TerminalShell::TerminalShellType desiredShellType,
          int cols, int rows,
          int termSequence,
-         core::FilePath workingDir);
+         core::FilePath workingDir,
+         TerminalShell::TerminalShellType *pSelectedShellType);
 
    virtual ~ConsoleProcess() {}
 
@@ -166,6 +170,11 @@ public:
    bool getAltBufferActive() const { return procInfo_->getAltBufferActive(); }
    core::FilePath getCwd() const { return procInfo_->getCwd(); }
    bool getWasRestarted() const { return procInfo_->getRestarted(); }
+
+   std::string getShellName() const;
+   TerminalShell::TerminalShellType getShellType() const {
+      return procInfo_->getShellType();
+   }
 
    // Used to downgrade to RPC mode after failed attempt to connect websocket
    void setRpcMode();

--- a/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
@@ -132,10 +132,8 @@ public:
    bool getHasChildProcs() const { return childProcs_; }
 
    // What type of shell is this child process running in?
-   TerminalShell::TerminalShellType getShellType() const
-   {
-      return shellType_;
-   }
+   TerminalShell::TerminalShellType getShellType() const { return shellType_; }
+   void setShellType(TerminalShell::TerminalShellType type) { shellType_ = type; }
 
    // Type of channel for communicating input/output with client
    ChannelMode getChannelMode() const { return channelMode_; }

--- a/src/cpp/session/include/session/SessionTerminalShell.hpp
+++ b/src/cpp/session/include/session/SessionTerminalShell.hpp
@@ -80,6 +80,9 @@ struct TerminalShell
       }
       return shellType;
    }
+
+   // get a user-friendly name for the given shell type
+   static std::string getShellName(TerminalShellType type);
 };
 
 class AvailableTerminalShells

--- a/src/cpp/session/modules/SessionTerminalShell.cpp
+++ b/src/cpp/session/modules/SessionTerminalShell.cpp
@@ -149,6 +149,32 @@ core::json::Object TerminalShell::toJson() const
    return resultJson;
 }
 
+// keep in sync with TerminalShellInfo::getShellName in client code
+std::string TerminalShell::getShellName(TerminalShellType type)
+{
+   switch (type)
+   {
+   case DefaultShell:
+      return "Default";
+   case GitBash:
+      return "Git Bash";
+   case WSLBash:
+      return "WSL";
+   case Cmd32:
+      return "Command Prompt (32-bit)";
+   case Cmd64:
+      return "Command Prompt (64-bit)";
+   case PS32:
+      return "PowerShell (32-bit)";
+   case PS64:
+      return "PowerShell (64-bit)";
+   case PosixBash:
+      return "Bash";
+   default:
+      return "Unknown";
+   }
+}
+
 AvailableTerminalShells::AvailableTerminalShells()
 {
    scanAvailableShells(&shells_);

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -906,12 +906,13 @@ Error startTerminal(const json::JsonRpcRequest& request,
       cwd = module_context::resolveAliasedPath(currentDir);
    }
 
+   TerminalShell::TerminalShellType actualShellType;
    core::system::ProcessOptions options = ConsoleProcess::createTerminalProcOptions(
-         shellType, cols, rows, termSequence, cwd);
+         shellType, cols, rows, termSequence, cwd, &actualShellType);
 
    boost::shared_ptr<ConsoleProcessInfo> ptrProcInfo =
          boost::make_shared<ConsoleProcessInfo>(
-            termCaption, termTitle, termHandle, termSequence,  shellType,
+            termCaption, termTitle, termHandle, termSequence,  actualShellType,
             altBufferActive, cwd, cols, rows);
 
    boost::shared_ptr<ConsoleProcess> ptrProc =


### PR DESCRIPTION
When creating a terminal, the shell type is specified as `default` and the code picks the appropriate shell type (currently always bash on everything but Windows, but could be extended in the future on all platforms, e.g. to support custom user-shells, or shells that automatically launch Python, and so on).

Need to know what shell was actually selected by the code so I can display it via the API, implement some shell-type specific logic at runtime (needed to fix some shell-specific Windows issues, NYI), and support other future scenarios.