### PR TITLE
Stop buffer reload for Windows cmd and powershell

### DIFF
--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -771,6 +771,17 @@ ConsoleProcessPtr ConsoleProcess::createTerminalProcess(
          options.terminateChildren = true;
          cp.reset(new ConsoleProcess(command, options, procInfo));
          addConsoleProcess(cp);
+
+         // Windows Command Prompt and PowerShell don't support reloading
+         // buffers, so delete the buffer before we start the new process.
+         if (cp->getShellType() == TerminalShell::Cmd32 ||
+             cp->getShellType() == TerminalShell::Cmd64 ||
+             cp->getShellType() == TerminalShell::PS32 ||
+             cp->getShellType() == TerminalShell::PS64)
+         {
+            cp->deleteLogFile();
+         }
+
          saveConsoleProcesses();
       }
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -678,13 +678,7 @@ public class TerminalSession extends XTermWidget
    private void fetchNextChunk(final int chunkToFetch)
    {
       if (!shellSupportsReload())
-      {
-         server_.processEraseBuffer(
-               getHandle(), 
-               false /*lastLineOnly*/,
-               new SimpleRequestCallback<Void>("Clearing Buffer at reload"));
          return;
-      }
 
       Scheduler.get().scheduleDeferred(new ScheduledCommand()
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -655,8 +655,37 @@ public class TerminalSession extends XTermWidget
       }
    }
 
+   private boolean shellSupportsReload()
+   {
+      if (consoleProcess_ == null)
+         return false;
+      
+      switch (consoleProcess_.getProcessInfo().getShellType())
+      {
+      // Windows command-prompt and PowerShell don't support buffer reloading
+      // due to limitations of how they work with WinPty.
+      case TerminalShellInfo.SHELL_CMD32:
+      case TerminalShellInfo.SHELL_CMD64:
+      case TerminalShellInfo.SHELL_PS32:
+      case TerminalShellInfo.SHELL_PS64:
+         return false;
+
+      default:
+         return true;
+      }
+   }
+   
    private void fetchNextChunk(final int chunkToFetch)
    {
+      if (!shellSupportsReload())
+      {
+         server_.processEraseBuffer(
+               getHandle(), 
+               false /*lastLineOnly*/,
+               new SimpleRequestCallback<Void>("Clearing Buffer at reload"));
+         return;
+      }
+
       Scheduler.get().scheduleDeferred(new ScheduledCommand()
       {
          @Override


### PR DESCRIPTION
Reloading buffer into a new Command Prompt or PowerShell session in Windows terminal causes WinPty and the underlying console to get confused. Per discussion a while back, I'm just disabling buffer reload into these terminal types.
