### PR TITLE
Make panel splitters fully draggable

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/layout/DualWindowLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/layout/DualWindowLayoutPanel.java
@@ -366,7 +366,8 @@ public class DualWindowLayoutPanel extends SimplePanel
                                 Session session,
                                 String clientStateKeyName,
                                 final WindowState topWindowDefaultState,
-                                final int defaultSplitterPos)
+                                final int defaultSplitterPos,
+                                final int splitterSize)
    {
       windowA_ = windowA;
       windowB_ = windowB;
@@ -374,7 +375,7 @@ public class DualWindowLayoutPanel extends SimplePanel
       setSize("100%", "100%");
       layout_ = new BinarySplitLayoutPanel(new Widget[] {
             windowA.getNormal(), windowA.getMinimized(),
-            windowB.getNormal(), windowB.getMinimized()}, 3);
+            windowB.getNormal(), windowB.getMinimized()}, splitterSize);
       layout_.setSize("100%", "100%");
 
       topWindowStateChangeManager_ = new WindowStateChangeManager(session);

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -35,6 +35,7 @@
 
 @external gwt-TabLayoutPanel;
 @external gwt-TabLayoutPanelTabInner;
+@external gwt-SplitLayoutPanel-Workbench;
 
 @external rstudio-themes-flat, rstudio-themes-dark;
 
@@ -713,22 +714,31 @@ pre {
 .rstudio-themes-flat .windowFrameObject > div:last-child {
    border: solid 1px #d6dadc;
    border-radius: 3px 3px 0px 0px;
-   left: 2px !important;
-   top: 2px !important;
-   right: 2px !important;
-   bottom: 2px !important;
+   left: 0px !important;
+   top: 0px !important;
+   right: 0px !important;
+   bottom: 0px !important;
 
    /* overflow-hidden with border-radius degrates under windows */
    overflow: visible !important;
 }
 
+.gwt-SplitLayoutPanel-Workbench {
+   right: 2px !important;
+   left: 2px !important;
+   top: 2px !important;
+   bottom: 1px !important;
+   width: inherit !important;
+   height: inherit !important;
+}
+
 .rstudio-themes-flat .windowFrameObject.consoleOnlyWindowFrame {
    border: solid 1px #d6dadc;
    border-radius: 3px 3px 0px 0px;
-   left: 2px !important;
-   top: 3px !important;
-   right: 2px !important;
-   bottom: 2px !important;
+   left: 0px !important;
+   top: 1px !important;
+   right: 0px !important;
+   bottom: 0px !important;
    overflow: hidden;
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -30,6 +30,7 @@ import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.ThemeFonts;
+import org.rstudio.core.client.widget.InfoBar;
 import org.rstudio.core.client.widget.SelectWidget;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
@@ -51,7 +52,13 @@ public class AppearancePreferencesPane extends PreferencesPane
       eventBus_ = eventBus;
 
       VerticalPanel leftPanel = new VerticalPanel();
+      
+      infoBar_ = new InfoBar(InfoBar.WARNING);
+      infoBar_.setText("Relaunch RStudio to complete this change.");
+      infoBar_.addStyleName(res_.styles().themeInfobar());
 
+      final String originalTheme = uiPrefs_.getFlatTheme().getValue();
+      
       flatTheme_ = new SelectWidget("RStudio theme:",
                                 new String[]{"Classic", "Modern", "Sky"},
                                 new String[]{"classic", "modern", "alternate"},
@@ -62,6 +69,15 @@ public class AppearancePreferencesPane extends PreferencesPane
       {
          public void onChange(ChangeEvent event)
          {
+            preview_.setHeight(previewDefaultHeight_);
+            infoBar_.removeStyleName(res_.styles().themeInfobarShowing());
+            
+            if (originalTheme == "classic" && flatTheme_.getValue() != "classic" ||
+                flatTheme_.getValue() == "classic" && originalTheme != "classic")
+            {
+               preview_.setHeight("478px");
+               infoBar_.addStyleName(res_.styles().themeInfobarShowing());
+            }
          }
       });
 
@@ -184,9 +200,11 @@ public class AppearancePreferencesPane extends PreferencesPane
       leftPanel.add(theme_);
 
       FlowPanel previewPanel = new FlowPanel();
+      previewPanel.add(infoBar_);
+      
       previewPanel.setSize("100%", "100%");
       preview_ = new AceEditorPreview(CODE_SAMPLE);
-      preview_.setHeight("498px");
+      preview_.setHeight(previewDefaultHeight_);
       preview_.setWidth("278px");
       preview_.setTheme(themes.getThemeUrl(uiPrefs_.theme().getGlobalValue()));
       preview_.setFontSize(Double.parseDouble(fontSize_.getValue()));
@@ -281,12 +299,15 @@ public class AppearancePreferencesPane extends PreferencesPane
    private final UIPrefs uiPrefs_;
    private SelectWidget fontSize_;
    private SelectWidget theme_;
-   private AceEditorPreview preview_;
+   private final AceEditorPreview preview_;
    private SelectWidget fontFace_;
    private String initialFontFace_;
    private SelectWidget zoomLevel_;
    private String initialZoomLevel_;
-   private SelectWidget flatTheme_;
+   private final SelectWidget flatTheme_;
+   private EventBus eventBus_;
+   private final InfoBar infoBar_;
+   private static String previewDefaultHeight_ = "498px";
 
    private static final String CODE_SAMPLE =
          "# plotting of R objects\n" +
@@ -318,6 +339,4 @@ public class AppearancePreferencesPane extends PreferencesPane
          "  else \n" +
          "    UseMethod(\"plot\")\n" +
          "}\n";
-
-   EventBus eventBus_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.css
@@ -49,3 +49,17 @@
    overflow-x: hidden;
    overflow-y: scroll;
 }
+
+.themeInfobar {
+   border: solid 1px #ccc;
+   border-bottom: none;
+   display: none;
+}
+
+.themeInfobar > div {
+   border: none;
+}
+
+.themeInfobarShowing {
+   display: block;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialogResources.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialogResources.java
@@ -29,6 +29,8 @@ public interface PreferencesDialogResources extends ClientBundle
       String usingVcsHelp();
       String newSection();
       String alwaysCompletePanel();
+      String themeInfobar();
+      String themeInfobarShowing();
    }
 
    @Source("PreferencesDialog.css")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
@@ -25,10 +25,12 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.common.NotifyingSplitLayoutPanel;
 import org.rstudio.studio.client.workbench.model.ClientState;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.helper.JSObjectStateValue;
+import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 
 public class MainSplitPanel extends NotifyingSplitLayoutPanel
       implements SplitterResizedHandler
@@ -101,9 +103,13 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
 
    @Inject
    public MainSplitPanel(EventBus events,
-                         Session session)
+                         Session session,
+                         UIPrefs uiPrefs)
    {
-      super(3, events);
+      super(
+         RStudioThemes.isFlat(uiPrefs) ? 7 : 3,
+         events);
+      
       session_ = session;
       addSplitterResizedHandler(this);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -52,6 +52,7 @@ import org.rstudio.core.client.theme.WindowFrame;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.events.ZoomPaneEvent;
 import org.rstudio.studio.client.workbench.model.ClientState;
@@ -255,9 +256,11 @@ public class PaneManager
       PaneConfig config = validateConfig(uiPrefs.paneConfig().getValue());
       initPanes(config);
 
+      int splitterSize = RStudioThemes.isFlat(uiPrefs) ? 7 : 3;
+
       panes_ = createPanes(config);
-      left_ = createSplitWindow(panes_.get(0), panes_.get(1), "left", 0.4);
-      right_ = createSplitWindow(panes_.get(2), panes_.get(3), "right", 0.6);
+      left_ = createSplitWindow(panes_.get(0), panes_.get(1), "left", 0.4, splitterSize);
+      right_ = createSplitWindow(panes_.get(2), panes_.get(3), "right", 0.6, splitterSize);
 
       panel_ = pSplitPanel.get();
       panel_.initialize(left_, right_);
@@ -909,7 +912,8 @@ public class PaneManager
    private DualWindowLayoutPanel createSplitWindow(LogicalWindow top,
                                                    LogicalWindow bottom,
                                                    String name,
-                                                   double bottomDefaultPct)
+                                                   double bottomDefaultPct,
+                                                   int splitterSize)
    {
       return new DualWindowLayoutPanel(
             eventBus_,
@@ -918,7 +922,8 @@ public class PaneManager
             session_,
             name,
             WindowState.NORMAL,
-            (int) (Window.getClientHeight()*bottomDefaultPct));
+            (int) (Window.getClientHeight()*bottomDefaultPct),
+            splitterSize);
    }
 
    private LogicalWindow createConsole()


### PR DESCRIPTION
Currently (and also in Classic themes), the splitters are only `3px` wide; under the Modern theme, this is a bit worse since there is more space between the panels but only `3px` are draggable, this change increases this size to fully contain the spacing. However, since `SplitLayoutPanel` only allows setting the thickness during construction of this widget, this change requires closing/reopening the IDE for the change to take effect.

<img width="1440" alt="screen shot 2017-05-18 at 5 05 11 pm" src="https://cloud.githubusercontent.com/assets/3478847/26228209/9b4cca0a-3bec-11e7-9969-b3f28cb5d45d.png">
