### PR TITLE
Use custom checkboxes under themes to enforce same rendering

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1691,7 +1691,8 @@ body.ubuntu_mono .searchBox {
 .linux .gwt-CheckBox input[type="checkbox"],
 .linux .gwt-RadioButton input[type="radio"],
 .windows-highdpi .gwt-CheckBox input[type="checkbox"],
-.windows-highdpi .gwt-RadioButton input[type="radio"] {
+.windows-highdpi .gwt-RadioButton input[type="radio"],
+.rstudio-themes-flat input[type="checkbox"] {
   -webkit-appearance: none;
   outline: none;
   width: 13px;
@@ -1702,14 +1703,15 @@ body.ubuntu_mono .searchBox {
   margin: 3px 3px 5px 3px;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .gwt-CheckBox input[type="checkbox"] {
+.rstudio-themes-flat .rstudio-themes-dark input[type="checkbox"] {
    background: #d3d8dc;
    border-color: rgb(45,60,75);
 }
 
 .macintosh .gwt-CheckBox input[type="checkbox"],
 .linux .gwt-CheckBox input[type="checkbox"],
-.windows-highdpi .gwt-CheckBox input[type="checkbox"] {
+.windows-highdpi .gwt-CheckBox input[type="checkbox"],
+.rstudio-themes-flat input[type="checkbox"] {
   -webkit-border-radius: 3px;
 }
 
@@ -1727,7 +1729,9 @@ body.ubuntu_mono .searchBox {
 .windows-highdpi .gwt-CheckBox input[type="checkbox"]:focus,
 .windows-highdpi .gwt-CheckBox input[type="checkbox"]:active,
 .windows-highdpi .gwt-RadioButton input[type="radio"]:focus,
-.windows-highdpi .gwt-RadioButton input[type="radio"]:active
+.windows-highdpi .gwt-RadioButton input[type="radio"]:active,
+.rstudio-themes-flat input[type="checkbox"]:focus,
+.rstudio-themes-flat input[type="checkbox"]:active
 {
   border-color: #707070;
 }
@@ -1736,14 +1740,16 @@ body.ubuntu_mono .searchBox {
 .linux .gwt-CheckBox input[type="checkbox"]:checked,
 .linux .gwt-RadioButton input[type="radio"]:checked,
 .windows-highdpi .gwt-CheckBox input[type="checkbox"]:checked,
-.windows-highdpi .gwt-RadioButton input[type="radio"]:checked
+.windows-highdpi .gwt-RadioButton input[type="radio"]:checked,
+.rstudio-themes-flat input[type="checkbox"]:checked
 {
   position: relative;
 }
 
 .macintosh .gwt-CheckBox input[type="checkbox"]:checked:before,
 .linux .gwt-CheckBox input[type="checkbox"]:checked:before, 
-.windows-highdpi .gwt-CheckBox input[type="checkbox"]:checked:before {
+.windows-highdpi .gwt-CheckBox input[type="checkbox"]:checked:before,
+.rstudio-themes-flat input[type="checkbox"]:checked:before {
   background: MACCHECK;
   background-size: 10px 9px;
 }
@@ -1758,7 +1764,8 @@ body.ubuntu_mono .searchBox {
 .linux .gwt-CheckBox input[type="checkbox"]:checked:before,
 .linux .gwt-RadioButton input[type="radio"]:checked:before,
 .windows-highdpi .gwt-CheckBox input[type="checkbox"]:checked:before,
-.windows-highdpi .gwt-RadioButton input[type="radio"]:checked:before {
+.windows-highdpi .gwt-RadioButton input[type="radio"]:checked:before,
+.rstudio-themes-flat input[type="checkbox"]:checked:before {
   content: '';
   display: block;
   position: absolute;
@@ -2353,6 +2360,72 @@ body.rstudio-themes-flat .rstudio-themes-dark-grey {
 }
 
 /* RSTUDIO ALTERNATE THEME */
+
+.rstudio-themes-flat .rstudio-themes-alternate .rstudio-themes-background,
+.rstudio-themes-flat .rstudio-themes-alternate .toolbarWrapper,
+.rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanelTabs .gwt-TabLayoutPanelTab-selected table.tabLayoutCenter,
+.rstudio-themes-flat .rstudio-themes-alternate .secondaryToolbar,
+.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
+.rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanelContent,
+.rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanel {
+   background: THEME_ALTERNATE_BACKGROUND;
+}
+
+body.rstudio-themes-flat .rstudio-themes-alternate {
+   background: THEME_ALTERNATE_BODY_BACKGROUND;
+}
+
+.rstudio-themes-flat .rstudio-themes-alternate .gwt-SplitLayoutPanel-HDragger,
+.rstudio-themes-flat .rstudio-themes-alternate .gwt-SplitLayoutPanel-VDragger {
+   background: THEME_ALTERNATE_BODY_BACKGROUND !important;
+}
+
+.rstudio-themes-flat .rstudio-themes-alternate table.header > tbody > tr > td,
+.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject > div:last-child,
+.rstudio-themes-flat .rstudio-themes-alternate .secondaryToolbar,
+.rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanel > div > div.gwt-TabLayoutPanelTabs,
+.rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
+.rstudio-themes-flat .rstudio-themes-alternate .minimizedWindowObject table.tabLayoutCenter,
+.rstudio-themes-flat .rstudio-themes-alternate .minimizedWindowObject  > div:last-child,
+.rstudio-themes-flat .rstudio-themes-alternate .toolbarWrapper,
+.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject.consoleOnlyWindowFrame div.consoleHeaderLayout .primaryWindowFrameHeader,
+.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject.consoleOnlyWindowFrame {
+   border-color: THEME_ALTERNATE_BORDER;
+}
+
+.rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanelTabs table.tabLayoutCenter,
+.rstudio-themes-flat .rstudio-themes-alternate .minimizedWindowObject table.tabLayoutCenter {
+   background: THEME_ALTERNATE_INACTIVE;
+}
+
+.rstudio-themes-flat .rstudio-themes-alternate .gwt-TabLayoutPanelTabs,
+.rstudio-themes-flat .rstudio-themes-alternate .minimizedWindowObject .center {  
+   background: THEME_ALTERNATE_MOST_INACTIVE;
+}
+
+.rstudio-themes-flat .rstudio-themes-alternate .windowframe .minimize,
+.rstudio-themes-flat .rstudio-themes-alternate .windowframe .maximize,
+.rstudio-themes-flat .rstudio-themes-alternate .windowframe-maximized .maximize,
+.rstudio-themes-flat .rstudio-themes-alternate .windowframe-exclusive .maximize,
+.rstudio-themes-flat .rstudio-themes-alternate .minimizedWindow .minimize,
+.rstudio-themes-flat .rstudio-themes-alternate .minimizedWindow .maximize {
+   filter: brightness(0.7);
+}
+
+.rstudio-themes-flat .rstudio-themes-alternate .windowframe .minimize:hover,
+.rstudio-themes-flat .rstudio-themes-alternate .windowframe .maximize:hover,
+.rstudio-themes-flat .rstudio-themes-alternate .windowframe-maximized .maximize:hover,
+.rstudio-themes-flat .rstudio-themes-alternate .windowframe-exclusive .maximize:hover,
+.rstudio-themes-flat .rstudio-themes-alternate .minimizedWindow .minimize:hover,
+.rstudio-themes-flat .rstudio-themes-alternate .minimizedWindow .maximize:hover {
+   filter: brightness(0.4);
+}
+
+.rstudio-themes-flat .rstudio-themes-alternate .multiPodUtilityArea {
+   background: linear-gradient(to right, THEME_ALTERNATE_MOST_INACTIVE_TRANSPARENT, THEME_ALTERNATE_MOST_INACTIVE 13%);
+}
+
+/* RSTUDIO CYBERPUNK THEME */
 
 .rstudio-themes-flat .rstudio-themes-alternate .rstudio-themes-background,
 .rstudio-themes-flat .rstudio-themes-alternate .toolbarWrapper,


### PR DESCRIPTION
Under dark themes, checkboxes are missing the background. Under linux with highDPI, checkboxes render at half the size. Looks to be the case that we would be better of drawing checkboxes everywhere; can we think of cases where we wouldn't want this?

OS X (retina):
<img width="750" alt="screen shot 2017-05-19 at 10 13 39 am" src="https://cloud.githubusercontent.com/assets/3478847/26259069/30d71226-3c7c-11e7-9ca4-ae134439aa94.png">

Linux (HighDPI):

<img width="564" alt="screen shot 2017-05-19 at 10 16 11 am" src="https://cloud.githubusercontent.com/assets/3478847/26259070/30d7b0a0-3c7c-11e7-88dc-75c3f31e2287.png">
