### PR TITLE
Preserve terminal cwd after an R restart

### DIFF
--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -173,6 +173,7 @@ const int kSendToTerminal = 154;
 const int kClearTerminal = 155;
 const int kCreateNamedTerminal = 156;
 const int kActivateTerminal = 157;
+const int kTerminalCwd = 158;
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -474,6 +475,8 @@ std::string ClientEvent::typeName() const
          return "create_named_terminal";
       case client_events::kActivateTerminal:
          return "activate_terminal";
+      case client_events::kTerminalCwd:
+         return "terminal_cwd";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -625,6 +625,14 @@ void ConsoleProcess::reportCwd(const core::FilePath& cwd)
    if (procInfo_->getCwd() != cwd)
    {
       procInfo_->setCwd(cwd);
+
+      json::Object termCwd;
+      termCwd["handle"] = handle();
+      termCwd["cwd"] = module_context::createAliasedPath(cwd);
+      module_context::enqueClientEvent(
+            ClientEvent(client_events::kTerminalCwd, termCwd));
+      childProcsSent_ = true;
+
       saveConsoleProcesses();
    }
 }

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -166,6 +166,8 @@ SEXP rs_enqueClientEvent(SEXP nameSEXP, SEXP dataSEXP)
          type = session::client_events::kCreateNamedTerminal;
       else if (name == "activate_terminal")
          type = session::client_events::kActivateTerminal;
+      else if (name == "terminal_cwd")
+         type = session::client_events::kTerminalCwd;
 
       if (type != -1)
       {

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -174,6 +174,7 @@ extern const int kSendToTerminal;
 extern const int kClearTerminal;
 extern const int kCreateNamedTerminal;
 extern const int kActivateTerminal;
+extern const int kTerminalCwd;
 }
    
 class ClientEvent

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -165,7 +165,8 @@ class ClientEvent extends JavaScriptObject
    public static final String ClearTerminal = "clear_terminal";
    public static final String CreateNamedTerminal = "create_named_terminal";
    public static final String ActivateTerminal = "activate_terminal";
-
+   public static final String TerminalCwd = "terminal_cwd";
+   
    protected ClientEvent()
    {
    }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -166,6 +166,7 @@ import org.rstudio.studio.client.workbench.views.terminal.events.ActivateNamedTe
 import org.rstudio.studio.client.workbench.views.terminal.events.ClearTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.CreateNamedTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.SendToTerminalEvent;
+import org.rstudio.studio.client.workbench.views.terminal.events.TerminalCwdEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSubprocEvent;
 import org.rstudio.studio.client.workbench.views.vcs.common.events.AskPassEvent;
 import org.rstudio.studio.client.workbench.views.vcs.common.events.VcsRefreshEvent;
@@ -900,6 +901,11 @@ public class ClientEventDispatcher
          {
             ActivateNamedTerminalEvent.Data data = event.getData();
             eventBus_.fireEvent(new ActivateNamedTerminalEvent(data));
+         }
+         else if (type.equals(ClientEvent.TerminalCwd))
+         {
+            TerminalCwdEvent.Data data = event.getData();
+            eventBus_.fireEvent(new TerminalCwdEvent(data));
          }
          else
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -40,6 +40,7 @@ import org.rstudio.studio.client.workbench.ui.WorkbenchPane;
 import org.rstudio.studio.client.workbench.views.terminal.events.SwitchToTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStartedEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStoppedEvent;
+import org.rstudio.studio.client.workbench.views.terminal.events.TerminalCwdEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSubprocEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalTitleEvent;
 
@@ -70,7 +71,8 @@ public class TerminalPane extends WorkbenchPane
                                      SwitchToTerminalEvent.Handler,
                                      TerminalTitleEvent.Handler,
                                      SessionSerializationHandler,
-                                     TerminalSubprocEvent.Handler
+                                     TerminalSubprocEvent.Handler,
+                                     TerminalCwdEvent.Handler
 {
    @Inject
    protected TerminalPane(EventBus events,
@@ -90,6 +92,7 @@ public class TerminalPane extends WorkbenchPane
       events_.addHandler(TerminalTitleEvent.TYPE, this);
       events_.addHandler(SessionSerializationEvent.TYPE, this);
       events_.addHandler(TerminalSubprocEvent.TYPE, this);
+      events_.addHandler(TerminalCwdEvent.TYPE, this);
 
       ensureWidget();
    }
@@ -746,6 +749,16 @@ public class TerminalPane extends WorkbenchPane
       if (terminal != null)
       {
          terminal.setHasChildProcs(event.hasSubprocs());
+      }
+   }
+
+   @Override
+   public void onTerminalCwd(TerminalCwdEvent event)
+   {
+      TerminalSession terminal = loadedTerminalWithHandle(event.getHandle());
+      if (terminal != null)
+      {
+         terminal.setCwd(event.getCwd());
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -547,6 +547,14 @@ public class TerminalSession extends XTermWidget
       hasChildProcs_ = hasChildProcs;
    }
 
+   /**
+    * Update current-working-directory 
+    * @param cwd new directory
+    */
+   public void setCwd(String cwd)
+   {
+      cwd_ = cwd;
+   }
 
    /**
     * The sequence number of the terminal, used in creation of the default

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/TerminalCwdEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/TerminalCwdEvent.java
@@ -1,0 +1,82 @@
+/*
+ * TerminalCwdEvent.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.terminal.events;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+/**
+ * Sent when terminal shell program changes directory on server.
+ */
+public class TerminalCwdEvent extends GwtEvent<TerminalCwdEvent.Handler>
+{
+   public static class Data extends JavaScriptObject
+   {
+      protected Data()
+      {
+      }
+
+      /**
+       * @return Terminal handle
+       */
+      public final native String getHandle() /*-{
+            return this.handle;
+      }-*/;
+
+      /**
+       * @return Last-known current working directory
+       */
+      public final native String getCwd() /*-{
+            return this.cwd;
+      }-*/;
+   }
+
+   public interface Handler extends EventHandler
+   {
+      void onTerminalCwd(TerminalCwdEvent event);
+   }
+
+   public TerminalCwdEvent(Data data)
+   {
+      data_ = data;
+   }
+
+   public String getHandle()
+   {
+      return data_.getHandle();
+   }
+
+   public String getCwd()
+   {
+      return data_.getCwd();
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onTerminalCwd(this);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   private final Data data_;
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}


### PR DESCRIPTION
Previous preserve terminal cwd work missed the case where the UI isn't restarted but R session restarts; this was due to client not being notified of changes in cwd by server, so had stale metadata. Now that server listens to what directory the client wants to use, it started terminal with the old one.

Previous fix covered cases such as refreshing browser while a terminal was running, etc. Those queried the server for the metadata versus using the client-side metadata.

This covers all scenarios I've been able to find.