### PR TITLE
remove old Safari workarounds

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -42,7 +42,6 @@ import org.rstudio.core.client.dom.impl.DomUtilsImpl;
 import org.rstudio.core.client.dom.impl.NodeRelativePosition;
 import org.rstudio.core.client.regex.Match;
 import org.rstudio.core.client.regex.Pattern;
-import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.FontSizer;
 import org.rstudio.studio.client.application.Desktop;
 
@@ -1024,17 +1023,5 @@ public class DomUtils
             style);
    }
    
-   public static void toggleParentVisibility(Element el, boolean visible, ElementPredicate predicate)
-   {
-      Element parentEl = el.getParentElement();
-      if (parentEl == null)
-         return;
-      
-      if (predicate != null && !predicate.test(parentEl))
-         return;
-      
-      toggleClass(parentEl, ThemeStyles.INSTANCE.displayNone(), !visible);
-   }
-
    public static final int ESTIMATED_SCROLLBAR_WIDTH = 19;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/Toolbar.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/Toolbar.java
@@ -16,7 +16,6 @@ package org.rstudio.core.client.widget;
 
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
-import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Overflow;
 import com.google.gwt.dom.client.Style.Unit;
@@ -25,10 +24,7 @@ import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.HasVerticalAlignment.VerticalAlignmentConstant;
 
-import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.SeparatorManager;
-import org.rstudio.core.client.dom.DomUtils;
-import org.rstudio.core.client.dom.DomUtils.ElementPredicate;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.theme.res.ThemeStyles;
@@ -144,9 +140,6 @@ public class Toolbar extends Composite
             new ChildWidgetList(leftToolbarPanel_));
       new ToolbarSeparatorManager().manageSeparators(
             new ChildWidgetList(rightToolbarPanel_));
-      
-      updateStyles(leftToolbarPanel_);
-      updateStyles(rightToolbarPanel_);
    }
 
    public void invalidateSeparators()
@@ -164,34 +157,6 @@ public class Toolbar extends Composite
       }
    }
    
-   private void updateStyles(HorizontalPanel panel)
-   {
-      if (BrowseCap.isSafari())
-         updateStylesSafari(panel);
-   }
-   
-   // This is used to work around a button sizing issue on Safari where
-   // TD elements with a child element having 'display: none' might
-   // still take up some space, thereby messing with the layout
-   // when the DOM has a number of TD elements with undisplayed
-   // contents.
-   private void updateStylesSafari(HorizontalPanel panel)
-   {
-      for (int i = 0; i < panel.getWidgetCount(); i++)
-      {
-         Widget widget = panel.getWidget(i);
-         boolean visible = widget.isVisible();
-         DomUtils.toggleParentVisibility(widget.getElement(), visible, new ElementPredicate()
-         {
-            @Override
-            public boolean test(Element el)
-            {
-               return el.getTagName().toLowerCase().equals("td");
-            }
-         });
-      }
-   }
-
    public <TWidget extends Widget> TWidget addLeftWidget(TWidget widget)
    {
       leftToolbarPanel_.add(widget);


### PR DESCRIPTION
This PR removes a Safari workaround for the positioning of toolbar items, whereby the positioning of these icons was not consistent across different file types.

This should also resolve an issue wherein the pillbox associated with the 'Compile PDF' output was not visible. Because that pane toggled the visibility of separators + widgets manually, but not through `manageSeparators()`, the requisite update of the display of table cells never happened and so the table cells remained hidden even after compile finished.

(Note: `isSafari()` is a bit of a misnomer; it should really be `isAppleWebKit()` or `isSafariWebKit()` as those styles apply to our Desktop products, which use a fork of Apple WebKit and so do report `safari` in their user agent)

Note: this is a candidate for the patch release; since the only code changes here involve removing a (relatively hacky) workaround I think it should be safe to take.