### PR TITLE
RSTUDIO_CONSOLE_COLOR envvar when Ansi processing enabled for console

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1544,16 +1544,6 @@ int main (int argc, char * const argv[])
       // whether rstudio is running
       core::system::setenv("RSTUDIO", "1");
 
-      // environment variables so child processes know of ANSI color
-      // escape sequence support in console
-      if (userSettings().ansiConsoleMode() == core::text::AnsiColorOn)
-      {
-         if (options.defaultConsoleTerm().length() > 0)
-            core::system::setenv("TERM", options.defaultConsoleTerm());
-         if (options.defaultCliColorForce())
-            core::system::setenv("CLICOLOR_FORCE", "1");
-      }
-
       // set the rstudio user identity environment variable (can differ from
       // username in debug configurations). this is provided so that 
       // rpostback knows what local stream to connect back to

--- a/src/cpp/session/SessionUserSettings.cpp
+++ b/src/cpp/session/SessionUserSettings.cpp
@@ -203,6 +203,34 @@ SEXP rs_removeUiPref(SEXP prefName)
    return R_NilValue;
 }
 
+void syncConsoleColorEnv()
+{
+   // Use rsession alias to avoid collision with 'session'
+   // object brought in by Catch
+   namespace rsession = rstudio::session;
+   using namespace rsession;
+
+   // Mirror ansi_color_mode user preference with RSTUDIO_CONSOLE_COLOR
+   // environment variable so it can be inherited by spawned R processes, such
+   // as package builds, which cannot query RStudio IDE settings.
+   if (userSettings().ansiConsoleMode() == core::text::AnsiColorOn)
+   {
+      core::system::setenv("RSTUDIO_CONSOLE_COLOR", "256");
+
+      if (rsession::options().defaultConsoleTerm().length() > 0)
+         core::system::setenv("TERM", rsession::options().defaultConsoleTerm());
+      if (rsession::options().defaultCliColorForce())
+         core::system::setenv("CLICOLOR_FORCE", "1");
+   }
+   else
+   {
+      core::system::unsetenv("RSTUDIO_CONSOLE_COLOR");
+      core::system::unsetenv("TERM");
+      core::system::unsetenv("CLICOLOR_FORCE");
+   }
+}
+
+
 } // anonymous namespace
    
 UserSettings& userSettings()
@@ -932,33 +960,6 @@ bool UserSettings::reuseSessionsForProjectLinks() const
 void UserSettings::setReuseSessionsForProjectLinks(bool reuse)
 {
    settings_.set(kReuseSessionsForProjectLinksSettings, reuse);
-}
-
-void UserSettings::syncConsoleColorEnv()
-{
-   // Use rsession alias to avoid collision with 'session'
-   // object brought in by Catch
-   namespace rsession = rstudio::session;
-   using namespace rsession;
-
-   // Mirror ansi_color_mode user preference with RSTUDIO_CONSOLE_COLOR
-   // environment variable so it can be inherited by spawned R processes, such
-   // as package builds, which cannot query RStudio IDE settings.
-   if (userSettings().ansiConsoleMode() == core::text::AnsiColorOn)
-   {
-      core::system::setenv("RSTUDIO_CONSOLE_COLOR", "256");
-
-      if (rsession::options().defaultConsoleTerm().length() > 0)
-         core::system::setenv("TERM", rsession::options().defaultConsoleTerm());
-      if (rsession::options().defaultCliColorForce())
-         core::system::setenv("CLICOLOR_FORCE", "1");
-   }
-   else
-   {
-      core::system::unsetenv("RSTUDIO_CONSOLE_COLOR");
-      core::system::unsetenv("TERM");
-      core::system::unsetenv("CLICOLOR_FORCE");
-   }
 }
 
 } // namespace session

--- a/src/cpp/session/include/session/SessionUserSettings.hpp
+++ b/src/cpp/session/include/session/SessionUserSettings.hpp
@@ -237,8 +237,6 @@ private:
       return *pPref;
    }
 
-   static void syncConsoleColorEnv();
-
 private:
    core::FilePath settingsFilePath_;
    core::Settings settings_;

--- a/src/cpp/session/include/session/SessionUserSettings.hpp
+++ b/src/cpp/session/include/session/SessionUserSettings.hpp
@@ -237,6 +237,8 @@ private:
       return *pPref;
    }
 
+   static void syncConsoleColorEnv();
+
 private:
    core::FilePath settingsFilePath_;
    core::Settings settings_;

--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -57,26 +57,14 @@ public class VirtualConsole
       this(null);
    }
    
-   public VirtualConsole(Element parent)
-   {
-      this(parent, ANSI_COLOR_UNSET);
-   }
-
    /**
     * VirtualConsole constructor
     * @param parent parent element
-    * @param ansiColorMode ANSI_COLOR_OFF: don't process ANSI escapes,
-    * ANSI_COLOR_ON: translate ANSI escapes into css styles, ANSI_COLOR_STRIP:
-    * strip out ANSI escape sequences but don't apply styles
-    * sequences, otherwise just strip them out
     */
-   public VirtualConsole(Element parent, int ansiColorMode)
+   public VirtualConsole(Element parent)
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
       parent_ = parent;
-      if (ansiColorMode == ANSI_COLOR_UNSET)
-         ansiColorMode = prefs_.consoleAnsiMode().getValue();
-      ansiColorMode_ = ansiColorMode;
    }
     
    @Inject
@@ -381,7 +369,8 @@ public class VirtualConsole
       // combine them with input class so they are ready to use if
       // there is text to output before any other ANSI codes in the
       // data (or there are no more ANSI codes).
-      if (ansiColorMode_ == ANSI_COLOR_ON && ansiCodeStyles_ != null)
+      int ansiColorMode = prefs_.consoleAnsiMode().getValue();
+      if (ansiColorMode == ANSI_COLOR_ON && ansiCodeStyles_ != null)
       {
          if (clazz != null)
          {
@@ -393,7 +382,7 @@ public class VirtualConsole
          }
       }
 
-      Match match = (ansiColorMode_ == ANSI_COLOR_OFF) ?
+      Match match = (ansiColorMode == ANSI_COLOR_OFF) ?
             CONTROL.match(data, 0) :
             AnsiCode.CONTROL_PATTERN.match(data, 0);
       if (match == null)
@@ -442,7 +431,7 @@ public class VirtualConsole
                if (ansi_ == null)
                   ansi_ = new AnsiCode();
                ansiCodeStyles_ = ansi_.processCode(ansiMatch.getValue());
-               if (ansiColorMode_ == ANSI_COLOR_STRIP)
+               if (ansiColorMode == ANSI_COLOR_STRIP)
                {
                   currentClazz = clazz;
                }
@@ -550,7 +539,6 @@ public class VirtualConsole
    private AnsiCode ansi_;
    private String partialAnsiCode_;
    private String ansiCodeStyles_;
-   private int ansiColorMode_;
    
    // Injected ----
    private UIPrefs prefs_;


### PR DESCRIPTION
Set environment variable when Ansi processing is enabled for console:

RSTUDIO_CONSOLE_COLOR=256

When disabled, the env variable is unset.

Keep RSTUDIO_CONSOLE_COLOR, TERM, and CLICOLOR_FORCE variables in sync with preferences change.

On client, don't cache Ansi-enabled flag, but query preferences for it. Unlike regular console, the build pane reuses the same VirtualConsole so pref-changes weren't doing anything without a restart.