### PR TITLE
workaround Safari bug re: sizing of empty table cells

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1140,6 +1140,18 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
    white-space: nowrap;
 }
 
+/**
+ * Safari does not render empty table cells with 0 padding correctly --
+ * strangely, they still take up space, and affect the sizing of other
+ * cells within the table. Fortunately, setting the padding to a small,
+ * non-zero number seems to work as expected.
+ */
+@if user.agent safari {
+	.toolbar td {
+		padding: 0.0001px;
+	}
+}
+
 .toolbarWrapper {
 
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/LeftRightToggleButton.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/LeftRightToggleButton.css
@@ -21,7 +21,7 @@
    
 }
 
-@sprite .leftLeft {
+@sprite tr .leftLeft {
    gwt-image: 'leftToggleLeftOff';
    width: auto;
    padding-left: 7px;
@@ -51,7 +51,7 @@
    gwt-image: 'rightToggleLeftOn';
 }
 
-@sprite .rightRight {
+@sprite tr .rightRight {
    gwt-image: 'rightToggleRightOff';
    background-position: top right;
    width: auto;


### PR DESCRIPTION
This PR works around a Safari bug whereby empty table cells with `padding: 0` will affect the sizing + layout of other table cells contained within that table.

[Click here](https://output.jsbin.com/faxulaluxa) to see an example `jsbin` demonstrating the behavior, and compare the appearance with e.g. Chrome vs. Safari.

Safari: ![screen shot 2017-05-22 at 4 28 22 pm](https://cloud.githubusercontent.com/assets/1976582/26332487/bd2372c4-3f0b-11e7-8a79-2e85b7035bc4.png), Chrome: ![screen shot 2017-05-22 at 4 28 27 pm](https://cloud.githubusercontent.com/assets/1976582/26332488/bd25450e-3f0b-11e7-8bd9-8b7b66e08f4f.png)

Somewhat fortuitously, setting a very small, fractional padding seems to work around this particular issue.
