### PR TITLE
Grid header height, tab progress and git selectors under themes

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/ModuleTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ModuleTabLayoutPanel.java
@@ -14,7 +14,6 @@
  */
 package org.rstudio.core.client.theme;
 
-import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Unit;
@@ -122,8 +121,10 @@ public class ModuleTabLayoutPanel extends TabLayoutPanel
          }
          else
          {
-            if (busySpinner_ != null)
-               busySpinner_.setVisible(false);
+            if (busySpinner_ != null) {
+               busySpinner_.removeFromParent();
+               busySpinner_ = null;
+            }
             closeButton_.setVisible(true);
          }
       }

--- a/src/gwt/src/org/rstudio/core/client/theme/ModuleTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ModuleTabLayoutPanel.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.core.client.theme;
 
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Unit;
@@ -30,6 +31,7 @@ import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.DoubleClickState;
+import org.rstudio.core.client.widget.ProgressSpinner;
 import org.rstudio.core.client.widget.model.ProvidesBusy;
 import org.rstudio.studio.client.workbench.events.BusyEvent;
 import org.rstudio.studio.client.workbench.events.BusyHandler;
@@ -101,31 +103,34 @@ public class ModuleTabLayoutPanel extends TabLayoutPanel
       {
          if (isBusy)
          {
-            if (busyImage_ == null)
+            if (busySpinner_ == null)
             {
-               busyImage_ = new Image(ThemeResources.INSTANCE.busyTab());
-               busyImage_.setHeight("9px");
-               busyImage_.setWidth("9px");
-               busyImage_.getElement().getStyle().setMarginLeft(4, Unit.PX);
-               busyImage_.getElement().getStyle().setMarginTop(6, Unit.PX);
                HorizontalPanel center = (HorizontalPanel)closeButton_.getParent();
+               
+               busySpinner_ = new ProgressSpinner(center.getElement());
+               
+               busySpinner_.setHeight("9px");
+               busySpinner_.setWidth("9px");
+               busySpinner_.getElement().getStyle().setMarginLeft(4, Unit.PX);
+               busySpinner_.getElement().getStyle().setMarginTop(6, Unit.PX);
+               
                if (center != null)
-                  center.add(busyImage_);
+                  center.add(busySpinner_);
             }
             closeButton_.setVisible(false);
-            busyImage_.setVisible(true);
+            busySpinner_.setVisible(true);
          }
          else
          {
-            if (busyImage_ != null)
-              busyImage_.setVisible(false);
+            if (busySpinner_ != null)
+               busySpinner_.setVisible(false);
             closeButton_.setVisible(true);
          }
       }
 
       private HorizontalPanel layoutPanel_;
       private Image closeButton_;
-      private Image busyImage_;
+      private ProgressSpinner busySpinner_;
    }
 
    public ModuleTabLayoutPanel(final WindowFrame owner)

--- a/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/RStudioDataGridStyle.css
@@ -64,6 +64,7 @@
 .rstudio-themes-flat .dataGridHeader {
    border-top: none;
    border-left: none;
+   height: 16px;
 }
 
 .rstudio-themes-flat .rstudio-themes-dark .dataGridHeader {

--- a/src/gwt/src/org/rstudio/core/client/theme/ThemeColors.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ThemeColors.java
@@ -48,4 +48,5 @@ public class ThemeColors
 
    public static String darkRowSelected                            = "rgba(255, 255, 255, 0.15)";
    public static String darkRowFocused                             = "rgba(255, 255, 255, 0.20)";
+   public static String darkRowHovered                             = "rgba(255, 255, 255, 0.05)";
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1703,6 +1703,11 @@ body.ubuntu_mono .searchBox {
   margin: 3px 3px 5px 3px;
 }
 
+.rstudio-themes-flat input[type="checkbox"] {
+  margin: 0px;
+  margin-bottom: 2px;
+}
+
 .rstudio-themes-flat .rstudio-themes-dark input[type="checkbox"] {
    background: #d3d8dc;
    border-color: rgb(45,60,75);

--- a/src/gwt/src/org/rstudio/core/client/widget/ProgressSpinner.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ProgressSpinner.java
@@ -17,15 +17,37 @@ package org.rstudio.core.client.widget;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTMLPanel;
 
+import org.rstudio.core.client.ColorUtil;
 import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.dom.DomUtils;
 
 import com.google.gwt.canvas.client.Canvas;
 import com.google.gwt.canvas.dom.client.Context2d;
 import com.google.gwt.canvas.dom.client.Context2d.LineCap;
 import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style;
 
 public class ProgressSpinner extends Composite
 {
+   public ProgressSpinner(Element element)
+   {
+      this(colorFromStyle(element));
+   }
+   
+   private static int colorFromStyle(Element element)
+   {
+      Style style = DomUtils.getComputedStyles(element);
+      style.getBackgroundColor();
+      
+      ColorUtil.RGBColor bgColor = 
+         ColorUtil.RGBColor.fromCss(style.getBackgroundColor());
+      
+      return bgColor.isDark() ?
+         ProgressSpinner.COLOR_WHITE:
+         ProgressSpinner.COLOR_BLACK;
+   }
+   
    public ProgressSpinner(int color)
    {
       // compute sizes

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectGrid.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectGrid.css
@@ -38,6 +38,7 @@ th.objectGridHeader
    padding: 0px;
    padding-left: 2px;
    padding-right: 2px;
+   height: 16px;
 }
 
 .rstudio-themes-flat .rstudio-themes-dark th.objectGridHeader {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ChangelistTableCellTableStyle.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ChangelistTableCellTableStyle.css
@@ -8,6 +8,9 @@
 @eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.darkGreyBorder;
 @eval THEME_ALTERNATE_BORDER org.rstudio.core.client.theme.ThemeColors.alternateBorder;
 
+@eval THEME_DARK_ROW_SELECTED org.rstudio.core.client.theme.ThemeColors.darkRowSelected;
+@eval THEME_DARK_ROW_HOVERED org.rstudio.core.client.theme.ThemeColors.darkRowHovered;
+
 span.status {
    white-space: nowrap;
 }
@@ -64,4 +67,12 @@ span.status img:first-child {
 .rstudio-themes-flat .rstudio-themes-alternate .cellTableSortableHeader {
    background: THEME_ALTERNATE_BACKGROUND;
    border-color: THEME_ALTERNATE_BORDER;
+}
+
+.rstudio-themes-flat.editor_dark .cellTableSelectedRow {
+   background-color: THEME_DARK_ROW_SELECTED;
+}
+
+.rstudio-themes-flat.editor_dark .cellTableHoveredRow {
+   background-color: THEME_DARK_ROW_HOVERED;
 }


### PR DESCRIPTION
A few more improvements under themes:
- Fixed regression in headers height caused by checkboxes change.
- Add canvas based progress in document tab.
- Change colors of git row selectors to match themes.