### PR TITLE
Feature: Close child processes on exit

### DIFF
--- a/src/cpp/core/include/core/r_util/RProjectFile.hpp
+++ b/src/cpp/core/include/core/r_util/RProjectFile.hpp
@@ -85,7 +85,8 @@ struct RProjectConfig
         makefilePath(),
         websitePath(),
         customScriptPath(),
-        tutorialPath()
+        tutorialPath(),
+        quitChildProcessesOnExit(DefaultValue)
    {
    }
 
@@ -116,6 +117,7 @@ struct RProjectConfig
    std::string websitePath;
    std::string customScriptPath;
    std::string tutorialPath;
+   int quitChildProcessesOnExit;
 };
 
 

--- a/src/cpp/core/include/core/system/PosixSystem.hpp
+++ b/src/cpp/core/include/core/system/PosixSystem.hpp
@@ -183,6 +183,8 @@ core::Error launchChildProcess(std::string path,
                                ProcessConfigFilter configFilter,
                                PidType* pProcessId ) ;
 
+Error getChildProcesses(std::vector<rstudio::core::system::ProcessInfo> *pOutProcesses);
+
 bool isUserNotFoundError(const core::Error& error);
 
 core::Error userBelongsToGroup(const user::User& user,

--- a/src/cpp/core/include/core/system/PosixSystem.hpp
+++ b/src/cpp/core/include/core/system/PosixSystem.hpp
@@ -94,13 +94,17 @@ core::Error pidof(const std::string& process, std::vector<PidType>* pPids);
 
 struct ProcessInfo
 {
-   ProcessInfo() : pid(0) {}
+   ProcessInfo() : pid(0), ppid(0), pgrp(0) {}
    PidType pid;
+   PidType ppid;
+   PidType pgrp;
    std::string username;
 };
 
+typedef boost::function<bool (const ProcessInfo&)> ProcessFilter;
 core::Error processInfo(const std::string& process,
-                        std::vector<ProcessInfo>* pInfo);
+                        std::vector<ProcessInfo>* pInfo,
+                        ProcessFilter filter = ProcessFilter());
 
 bool isProcessRunning(pid_t pid);
 

--- a/src/cpp/core/include/core/system/System.hpp
+++ b/src/cpp/core/include/core/system/System.hpp
@@ -163,7 +163,6 @@ private:
 };
 
 
-
 #endif
 
 void initHook();
@@ -283,6 +282,8 @@ bool hasSubprocesses(PidType pid);
 // Get current-working directory of a process; returns empty FilePath
 // if unable to determine cwd
 FilePath currentWorkingDir(PidType pid);
+
+Error terminateChildProcesses();
    
 } // namespace system
 } // namespace core 

--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -698,6 +698,19 @@ Error readProjectFile(const FilePath& projectFilePath,
       pConfig->tutorialPath = "";
    }
 
+   // extract quit child processes on exit
+   it = dcfFields.find("QuitChildProcessesOnExit");
+   if (it != dcfFields.end())
+   {
+      if (!interpretYesNoAskValue(it->second, false, &(pConfig->quitChildProcessesOnExit)))
+         return requiredFieldError("QuitChildProcessesOnExit", pUserErrMsg);
+   }
+   else
+   {
+      pConfig->quitChildProcessesOnExit = defaultConfig.quitChildProcessesOnExit;
+      *pProvidedDefaults = true;
+   }
+
    return Success();
 }
 
@@ -719,14 +732,15 @@ Error writeProjectFile(const FilePath& projectFilePath,
       "RestoreWorkspace: %3%\n"
       "SaveWorkspace: %4%\n"
       "AlwaysSaveHistory: %5%\n"
+      "QuitChildProcessesOnExit: %6%\n"
       "\n"
-      "EnableCodeIndexing: %6%\n"
-      "UseSpacesForTab: %7%\n"
-      "NumSpacesForTab: %8%\n"
-      "Encoding: %9%\n"
+      "EnableCodeIndexing: %7%\n"
+      "UseSpacesForTab: %8%\n"
+      "NumSpacesForTab: %9%\n"
+      "Encoding: %10%\n"
       "\n"
-      "RnwWeave: %10%\n"
-      "LaTeX: %11%\n");
+      "RnwWeave: %11%\n"
+      "LaTeX: %12%\n");
 
    std::string contents = boost::str(fmt %
         boost::io::group(std::fixed, std::setprecision(1), config.version) %
@@ -734,6 +748,7 @@ Error writeProjectFile(const FilePath& projectFilePath,
         yesNoAskValueToString(config.restoreWorkspace) %
         yesNoAskValueToString(config.saveWorkspace) %
         yesNoAskValueToString(config.alwaysSaveHistory) %
+        yesNoAskValueToString(config.quitChildProcessesOnExit) %
         boolValueToString(config.enableCodeIndexing) %
         boolValueToString(config.useSpacesForTab) %
         config.numSpacesForTab %

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -1306,7 +1306,7 @@ Error processInfo(const std::string& process, std::vector<ProcessInfo>* pInfo, P
    // we use a colon as the separator as it is not a valid path character in OSX
    std::string cmd = process.empty() ? "ps acxj | awk '{OFS=\":\"; print $1,$2,$3,$4,$10}'"
                                      : "ps acxj | awk '{OFS=\":\"; if ($10==\"" +
-                                        process + "\") print $1,$2,$3,$4,$10}'"
+                                        process + "\") print $1,$2,$3,$4,$10}'";
 
    core::system::ProcessResult result;
    Error error = core::system::runCommand(cmd,
@@ -1323,6 +1323,8 @@ Error processInfo(const std::string& process, std::vector<ProcessInfo>* pInfo, P
 
    BOOST_FOREACH(const std::string& line, lines)
    {
+      if (line.empty()) continue;
+       
       std::vector<std::string> lineInfo;
       boost::algorithm::split(lineInfo,
                               line,
@@ -1333,7 +1335,6 @@ Error processInfo(const std::string& process, std::vector<ProcessInfo>* pInfo, P
       procInfo.pid = safe_convert::stringTo<pid_t>(lineInfo[1], 0);
       procInfo.ppid = safe_convert::stringTo<pid_t>(lineInfo[2], 0);
       procInfo.pgrp = safe_convert::stringTo<pid_t>(lineInfo[3], 0);
-      procInfo.procname = lineInfo[4];
 
       // check to see if this process info passes the filter criteria
       if (!filter || filter(procInfo))

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -1224,7 +1224,7 @@ Error processInfo(const std::string& process, std::vector<ProcessInfo>* pInfo, P
                continue;
             }
 
-            // read the stat fields for other relevant process infostd::string str;
+            // read the stat fields for other relevant process info
             std::string statStr;
             error = core::readStringFromFile(statFile, &statStr);
             if (error)
@@ -1237,6 +1237,12 @@ Error processInfo(const std::string& process, std::vector<ProcessInfo>* pInfo, P
             boost::algorithm::split(statFields, statStr,
                                     boost::is_any_of(" "),
                                     boost::algorithm::token_compress_on);
+
+            if (statFields.size() < 5)
+            {
+               LOG_WARNING_MESSAGE("Expected at least 5 stat fields but read: " + safe_convert::numberToString<size_t>(statFields.size()));
+               continue;
+            }
 
             // get process parent id
             std::string ppidStr = statFields[3];
@@ -1329,6 +1335,12 @@ Error processInfo(const std::string& process, std::vector<ProcessInfo>* pInfo, P
       boost::algorithm::split(lineInfo,
                               line,
                               boost::algorithm::is_any_of(":"));
+
+      if (lineInfo.size() < 5)
+      {
+         LOG_WARNING_MESSAGE("Exepcted 5 items from ps output but received: " + safe_convert::numberToString<size_t>(lineInfo.size()));
+         continue;
+      }
 
       ProcessInfo procInfo;
       procInfo.username = lineInfo[0];
@@ -1745,7 +1757,7 @@ Error launchChildProcess(std::string path,
 }
 
 bool filterNonChildProcesses(pid_t pid, pid_t ppid, pid_t pgrp,
-                             const rstudio::core::system::ProcessInfo& process)
+                             const core::system::ProcessInfo& process)
 {
    // remove all but child processes
    // remove this process's parent and remove

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -1771,7 +1771,7 @@ bool filterNonChildProcesses(pid_t pid, pid_t ppid, pid_t pgrp,
 Error getChildProcesses(std::vector<rstudio::core::system::ProcessInfo> *pOutProcesses)
 {
    if (!pOutProcesses)
-      return;
+      return systemError(EINVAL, ERROR_LOCATION);
 
    // get the process group of this process
    pid_t pgrp = ::getpgrp();

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -383,6 +383,8 @@ void handleClientInit(const boost::function<void()>& initFunction,
 
    sessionInfo["drivers_support_licensing"] = options.supportsDriversLicensing();
 
+   sessionInfo["quit_child_processes_on_exit"] = options.quitChildProcessesOnExit();
+
    module_context::events().onSessionInfo(&sessionInfo);
 
    // send response  (we always set kEventsPending to false so that the client

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -228,7 +228,7 @@ void terminateAllChildProcesses()
    if (!quitChildProcesses())
       return;
 
-   Error error = rstudio::core::system::terminateChildProcesses();
+   Error error = system::terminateChildProcesses();
    if (error)
       LOG_ERROR(error);
 }

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -62,6 +62,7 @@
 #include <core/system/Process.hpp>
 #include <core/system/Environment.hpp>
 #include <core/system/ParentProcessMonitor.hpp>
+#include <core/system/PosixSystem.hpp>
 #include <core/system/FileMonitor.hpp>
 #include <core/text/TemplateFilter.hpp>
 #include <core/r_util/RSessionContext.hpp>
@@ -197,6 +198,117 @@ using namespace rsession::client_events;
 // forward-declare overlay methods
 namespace rstudio {
 namespace session {
+
+#ifndef _WIN32
+// functions for killing child processes
+// not applicable on windows
+
+bool filterNonChildProcesses(pid_t pid, pid_t ppid, pid_t pgrp,
+                             const rstudio::core::system::ProcessInfo& process)
+{
+   // remove all but child processes of this session
+   // remove this processe's parent and remove
+   // processes not part of the group
+   if (process.pgrp != pgrp)
+   {
+      return false;
+   }
+
+   if (process.pid == ppid)
+   {
+      return false;
+   }
+
+   if (process.pid == pid)
+   {
+      return false;
+   }
+
+   return true;
+}
+
+void getChildProcesses(std::vector<rstudio::core::system::ProcessInfo> *pOutProcesses)
+{
+   using namespace rstudio::core::system;
+
+   if (!pOutProcesses)
+      return;
+
+   // get the process group of this session process
+   pid_t pgrp = ::getpgrp();
+
+   // get the parent process of this session process
+   pid_t ppid = ::getppid();
+
+   // get this session's pid
+   pid_t pid = ::getpid();
+
+   // get all child processes
+   std::vector<ProcessInfo> processes;
+   Error error = processInfo("",
+                             pOutProcesses,
+                             boost::bind(&filterNonChildProcesses,
+                                         pid,
+                                         ppid,
+                                         pgrp,
+                                         boost::placeholders::_1));
+
+   if (error)
+      LOG_ERROR(error);
+}
+
+bool quitChildProcesses()
+{
+   // allow project override
+   const projects::ProjectContext& projContext = projects::projectContext();
+   if (projContext.hasProject())
+   {
+      switch(projContext.config().quitChildProcessesOnExit)
+      {
+      case r_util::YesValue:
+         return true;
+      case r_util::NoValue:
+         return false;
+      default:
+         // fall through
+         break;
+      }
+   }
+
+   // no project override
+   return rsession::options().quitChildProcessesOnExit();
+}
+
+#endif // end kill child process functions
+
+// terminates all child processes, including those unknown to us
+// no waiting is done to ensure the children shutdown
+// this is merely a best effort to stop children
+void terminateAllChildProcesses()
+{
+   // on windows, all child processes are automatically killed
+   // when the parent stops
+#ifdef _WIN32
+   return;
+#endif
+
+   using namespace rstudio::core::system;
+
+   if (!quitChildProcesses())
+      return;
+
+   std::vector<ProcessInfo> childProcesses;
+   getChildProcesses(&childProcesses);
+
+   BOOST_FOREACH(const ProcessInfo& process, childProcesses)
+   {
+      if (::kill(process.pid, SIGTERM) != 0)
+      {
+         LOG_ERROR(systemError(errno, ERROR_LOCATION));
+      }
+   }
+}
+
 namespace overlay {
 Error initialize();
 } // namespace overlay
@@ -1057,6 +1169,10 @@ void rCleanup(bool terminatedNormally)
       // terminate known child processes
       terminateAllChildren(&module_context::processSupervisor(),
                            ERROR_LOCATION);
+
+      // terminate unknown child processes
+      // processes launched by means we do not control
+      terminateAllChildProcesses();
    }
    CATCH_UNEXPECTED_EXCEPTION
 

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -210,7 +210,10 @@ core::ProgramStatus Options::read(int argc, char * const argv[])
        "default TERM setting for R console")
       ("session-default-clicolor-force",
        value<bool>(&defaultCliColorForce_)->default_value(true),
-       "default CLICOLOR_FORCE setting for R console");
+       "default CLICOLOR_FORCE setting for R console")
+      ("session-quit-child-processes-on-exit",
+       value<bool>(&quitChildProcessesOnExit_)->default_value(false),
+       "quit child processes on session exit");
 
    // allow options
    options_description allow("allow");

--- a/src/cpp/session/http/SessionHttpConnectionUtils.cpp
+++ b/src/cpp/session/http/SessionHttpConnectionUtils.cpp
@@ -32,6 +32,7 @@
 
 #include <core/r_util/RSessionContext.hpp>
 
+#include <session/SessionMain.hpp>
 #include <session/SessionOptions.hpp>
 #include <session/projects/ProjectsSettings.hpp>
 
@@ -151,6 +152,9 @@ bool checkForAbort(boost::shared_ptr<HttpConnection> ptrConnection,
       catch(...)
       {
       }
+
+      // kill child processes before going down
+      terminateAllChildProcesses();
 
       // abort
       ::abort();

--- a/src/cpp/session/include/session/SessionMain.hpp
+++ b/src/cpp/session/include/session/SessionMain.hpp
@@ -19,6 +19,7 @@
 namespace rstudio {
 namespace session {
 
+void terminateAllChildProcesses();
 
 }
 }

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -500,6 +500,11 @@ public:
 
    bool getBoolOverlayOption(const std::string& name);
 
+   bool quitChildProcessesOnExit() const
+   {
+      return quitChildProcessesOnExit_;
+   }
+
 private:
    void resolvePath(const core::FilePath& resourcePath,
                     std::string* pPath);
@@ -559,6 +564,7 @@ private:
    bool showUserHomePage_;
    std::string defaultConsoleTerm_;
    bool defaultCliColorForce_;
+   bool quitChildProcessesOnExit_;
 
    // r
    std::string coreRSourcePath_;

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -295,6 +295,8 @@ json::Object projectConfigJson(const r_util::RProjectConfig& config)
    configJson["website_path"] = config.websitePath;
    configJson["custom_script_path"] = config.customScriptPath;
    configJson["tutorial_path"] = config.tutorialPath;
+   configJson["quit_child_processes_on_exit"] = config.quitChildProcessesOnExit;
+
    return configJson;
 }
 
@@ -472,7 +474,8 @@ Error writeProjectOptions(const json::JsonRpcRequest& request,
                     "default_encoding", &(config.encoding),
                     "default_sweave_engine", &(config.defaultSweaveEngine),
                     "default_latex_program", &(config.defaultLatexProgram),
-                    "root_document", &(config.rootDocument));
+                    "root_document", &(config.rootDocument),
+                    "quit_child_processes_on_exit", &(config.quitChildProcessesOnExit));
    if (error)
       return error;
 

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
@@ -77,7 +77,7 @@ public class RProjectConfig extends JavaScriptObject
       return this.quit_child_processes_on_exit;
    }-*/;  
    
-   public native final int setQuitChildProcessesOnExit(int quitChildProcessesOnExit) /*-{
+   public native final void setQuitChildProcessesOnExit(int quitChildProcessesOnExit) /*-{
       this.quit_child_processes_on_exit = quitChildProcessesOnExit;
    }-*/;  
    

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
@@ -73,6 +73,14 @@ public class RProjectConfig extends JavaScriptObject
       this.always_save_history = alwaysSaveHistory;
    }-*/;   
    
+   public native final int getQuitChildProcessesOnExit() /*-{
+      return this.quit_child_processes_on_exit;
+   }-*/;  
+   
+   public native final int setQuitChildProcessesOnExit(int quitChildProcessesOnExit) /*-{
+      this.quit_child_processes_on_exit = quitChildProcessesOnExit;
+   }-*/;  
+   
    public native final boolean getEnableCodeIndexing() /*-{
       return this.enable_code_indexing;
    }-*/;  

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectGeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectGeneralPreferencesPane.java
@@ -92,11 +92,11 @@ public class ProjectGeneralPreferencesPane extends ProjectPreferencesPane
       
       switch (quitChildProcessesOnExit)
       {
-      case 1:
-         quitChildProcessesChecked = true; // yes
+      case YES_VALUE:
+         quitChildProcessesChecked = true;
          break;
-      case 2:
-         quitChildProcessesChecked = false; // no
+      case NO_VALUE:
+         quitChildProcessesChecked = false;
          break;
       }
       
@@ -120,7 +120,7 @@ public class ProjectGeneralPreferencesPane extends ProjectPreferencesPane
       int quitChildProcessesOnExit = 0;
       if (quitChildProcessesChecked != sessionInfo_.quitChildProcessesOnExit())
       {
-         quitChildProcessesOnExit = (quitChildProcessesChecked ? 1 : 2);
+         quitChildProcessesOnExit = (quitChildProcessesChecked ? YES_VALUE : NO_VALUE);
       }
       
       config.setQuitChildProcessesOnExit(quitChildProcessesOnExit);
@@ -153,7 +153,9 @@ public class ProjectGeneralPreferencesPane extends ProjectPreferencesPane
    
    private static final String USE_DEFAULT = "(Default)";
    private static final String YES = "Yes";
+   private static final int YES_VALUE = 1;
    private static final String NO = "No";
+   private static final int NO_VALUE = 2;
    private static final String ASK ="Ask";
    
    private YesNoAskDefault restoreWorkspace_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -498,4 +498,8 @@ public class SessionInfo extends JavaScriptObject
    public final native boolean getSupportDriverLicensing() /*-{
       return this.drivers_support_licensing;
    }-*/;
+   
+   public final native boolean quitChildProcessesOnExit() /*-{
+      return this.quit_child_processes_on_exit;
+   }-*/;
 }


### PR DESCRIPTION
This pull request adds a new feature than can be toggled on or off to control whether or not child processes of the session are closed when the session is exited.  The default setting is false. It can be set as a session-wide setting in rsession.conf, and can be overridden in each project via a project setting.

A few tweaks were made to PosixSystem to get additional process info I needed, such as the ppid and pgrp. 