### PR TITLE
Two paged table fixes from rmarkdown and "Use paged table" option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,7 @@
 * Fixed an issue where non-R chunk output could become duplicated
 * Added option to set notebook mode in the document's YAML header
 * Allow setting default chunk connection option to raw connection object
+* Added an 'Use paged tables' checkbox under chunk options popup
 
 ### Miscellaneous
 
@@ -114,4 +115,4 @@
 * Fixed issues arising from restoring a session suspended with a different R version
 * Wait for index.lock file to clear before performing git operations (with recovery)
 * Server Pro: Fix issue with dirty indicator/saving after collaborative editing ends
-
+* Fixed an issue in which notebook tables would not print data with lists of lists

--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -236,10 +236,14 @@
     paste0(" [", dim_desc(x), "]" )
   }
 
+  obj_sum.default <- function(x) {
+    paste0(type_sum(x), size_sum(x))
+  }
+
   obj_sum <- function(x) {
     switch(class(x)[[1]],
       POSIXlt = rep("POSIXlt", length(x)),
-      list = vapply(x, obj_sum, character(1L)),
+      list = vapply(x, obj_sum.default, character(1L)),
       paste0(type_sum(x), size_sum(x))
     )
   }

--- a/src/cpp/session/resources/pagedtable/pagedtable.js
+++ b/src/cpp/session/resources/pagedtable/pagedtable.js
@@ -357,7 +357,11 @@ var PagedTable = function (pagedTable) {
 
     me.calculateWidths = function(measures) {
       columns.forEach(function(column) {
-        var maxChars = column.label.toString().length;
+        var maxChars = Math.max(
+          column.label.toString().length,
+          column.type.toString().length
+        );
+
         for (var idxRow = 0; idxRow < Math.min(widthsLookAhead, data.length); idxRow++) {
           maxChars = Math.max(maxChars, data[idxRow][column.name.toString()].length);
         }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
@@ -239,8 +239,12 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
       showMessagesInOutputCb_ = makeTriStateCheckBox(
             "Show messages",
             "message");
-      
       panel_.add(showMessagesInOutputCb_);
+
+      printTableAsTextCb_ = makeTriStateCheckBox(
+            "Use paged tables",
+            "paged.print");
+      panel_.add(printTableAsTextCb_);
       
       useCustomFigureCheckbox_ = new ThemedCheckBox("Use custom figure size");
       useCustomFigureCheckbox_.addStyleName(RES.styles().checkBox());
@@ -562,6 +566,9 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
 
             if (has("message"))
                showMessagesInOutputCb_.setValue(getBoolean("message"));
+
+            if (has("paged.print"))
+               printTableAsTextCb_.setValue(getBoolean("paged.print"));
             
             if (has("engine.path"))
             {
@@ -659,6 +666,7 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
    protected final ThemedCheckBox useCustomFigureCheckbox_;
    protected final TriStateCheckBox showWarningsInOutputCb_;
    protected final TriStateCheckBox showMessagesInOutputCb_;
+   protected final TriStateCheckBox printTableAsTextCb_;
    
    protected String originalLine_;
    protected String chunkPreamble_;


### PR DESCRIPTION
1. Porting two fixes performed already in `rmarkdown` see https://github.com/rstudio/rmarkdown/pull/1056
2. Adds "Use paged tables" to chunk options popup. While paged tables have been working correctly in most cases, for cases like (1), users can be completely blocked from viewing data unless they know about the `paged.print=FALSE` option, which is unlikely.

<img width="841" alt="screen shot 2017-05-24 at 3 01 37 pm" src="https://cloud.githubusercontent.com/assets/3478847/26427557/20a5844a-4092-11e7-9f17-1b0c3cf25ec1.png">

