### PR TITLE
Play console actions back in regular order

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -1,7 +1,7 @@
 /*
  * StringUtil.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -1137,7 +1137,12 @@ public class StringUtil
 
       return ((crc ^ (-1)) >>> 0).toString(16);
    }-*/;
-   
+
+   // Count newlines in a string
+   public static native int newlineCount(String str) /*-{
+      return (str.match(/\n/g)||[]).length;
+   }-*/;
+    
    private static final NumberFormat FORMAT = NumberFormat.getFormat("0.#");
    private static final NumberFormat PRETTY_NUMBER_FORMAT = NumberFormat.getFormat("#,##0.#####");
    private static final DateTimeFormat DATE_FORMAT

--- a/src/gwt/test/org/rstudio/core/client/StringUtilTests.java
+++ b/src/gwt/test/org/rstudio/core/client/StringUtilTests.java
@@ -135,6 +135,21 @@ public class StringUtilTests extends GWTTestCase
 	   // MMM d, yyyy, h:mm AM
 	   assertTrue(result.length() >= 20);
    }
+   
+   public void testNewlineCount()
+   {
+      String input = "hello\nworld\n";
+      assertEquals(2, StringUtil.newlineCount(input));
+      
+      input = "nothing here";
+      assertEquals(0, StringUtil.newlineCount(input));
+      
+      input = "\n\n\nzoom\n";
+      assertEquals(4, StringUtil.newlineCount(input));
+      
+      input = "";
+      assertEquals(0, StringUtil.newlineCount(input));
+   }
 
    // -----------------------------------------------------------------------
 


### PR DESCRIPTION
Previously when refreshing UI, we played the ConsoleActions back in reverse order, until our maximum number of console lines was displayed. Server keeps up to 1000 console actions, but each console action can generate multiple lines of output, this is why it was done this way.

This reverse playback made client Ansi parsing more difficult, often breaking reload of console with Ansi color output, and the resulting DOM had many more nodes than the DOM created during regular usage of the console, impacting performance. Another consequence was any special parsing done on console DOM had to account for both possible structures (regular and reloaded). There are some bugs in that area, and wanted to do this change before getting to those.

Now we do an initial pass through the ConsoleActions in reverse order and count newlines to determine line count, but don't output anything to the DOM. Then do a forward pass starting where it will stop at maximum desired console length (plus potential slight overrage due to size of final action's output). That is written out in normal order, thus using the same output logic as regular console output. Finally trim any excess when the reload is done.

Anecdotally, the reduced simplicity of the resulting DOM should easily overcomes the cost of doing the initial counting pass, and in general I expect this to help with reloading large console buffers.

This does fix the Ansi code parsing issue on reload.