### PR TITLE
Fix issue with traceback widget eating preceding console output

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -372,13 +372,9 @@ public class VirtualConsole
       {
          // short circuit common case in which we're just adding output
          if (cursor_ == output_.length() && !class_.isEmpty())
-         {
             appendText(text, clazz, forceNewRange);
-         }
          else
-         {
             insertText(new ClassRange(start, clazz, text));
-         }
       }
 
       output_.replace(start, end, text);
@@ -403,7 +399,7 @@ public class VirtualConsole
       }
      
       String currentClazz = clazz;
-            
+
       int ansiColorMode = (ansiColorMode_ == ANSI_COLOR_USE_PREF) ? 
             prefs_.consoleAnsiMode().getValue() : ansiColorMode_;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -1,7 +1,7 @@
 /*
  * ChunkOutputStream.java
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -82,7 +82,8 @@ public class ChunkOutputStream extends FlowPanel
       // flush any queued errors 
       flushQueuedErrors();
 
-      renderConsoleOutput(text, classOfOutput(ChunkConsolePage.CONSOLE_OUTPUT));
+      renderConsoleOutput(text, classOfOutput(ChunkConsolePage.CONSOLE_OUTPUT),
+            false /*isError*/);
    }
    
    @Override
@@ -121,11 +122,11 @@ public class ChunkOutputStream extends FlowPanel
             if (!queuedError_.isEmpty())
             {
                vconsole_.submit(queuedError_, classOfOutput(
-                     ChunkConsolePage.CONSOLE_ERROR));
+                     ChunkConsolePage.CONSOLE_ERROR), true /*isError*/);
                queuedError_ = "";
             }
 
-            vconsole_.submit(outputText, classOfOutput(outputType));
+            vconsole_.submit(outputText, classOfOutput(outputType), false /*isError*/);
          }
       }
    }
@@ -294,7 +295,7 @@ public class ChunkOutputStream extends FlowPanel
          if (idx > 0)
          {
             renderConsoleOutput(queuedError_.substring(0, idx), 
-                  classOfOutput(ChunkConsolePage.CONSOLE_ERROR));
+                  classOfOutput(ChunkConsolePage.CONSOLE_ERROR), true /*isError*/);
             initializeOutput(RmdChunkOutputUnit.TYPE_ERROR);
          }
          // leave messages following the error in the queue
@@ -586,7 +587,7 @@ public class ChunkOutputStream extends FlowPanel
       {
          initializeOutput(RmdChunkOutputUnit.TYPE_TEXT);
          renderConsoleOutput(queuedError_, classOfOutput(
-               ChunkConsolePage.CONSOLE_ERROR));
+               ChunkConsolePage.CONSOLE_ERROR), true /*isError*/);
          queuedError_ = "";
       }
    }
@@ -643,10 +644,10 @@ public class ChunkOutputStream extends FlowPanel
       addWithOrdinal(console_, maxOrdinal_ + 1);
    }
    
-   private void renderConsoleOutput(String text, String clazz)
+   private void renderConsoleOutput(String text, String clazz, boolean isError)
    {
       initializeOutput(RmdChunkOutputUnit.TYPE_TEXT);
-      vconsole_.submit(text, clazz);
+      vconsole_.submit(text, clazz, isError);
       onHeightChanged();
    }
    


### PR DESCRIPTION
The enhanced error widget was eating the previous span, which could contain not only the previous error, but additional errors before it. This is due to optimizations made in VirtualConsole to combine ranges with the same style.

Fix is to not do this for errors; always start a new output range for an error message (but still combine a single multi-line error message into a single span).

This does **not** fix several issues with Ansi codes in error messages, both in the console and in the error widget. That is tracked with a separate bug case.