### PR TITLE
reduce js exceptions when parsing console and terminal output JSON

### DIFF
--- a/src/cpp/core/json/spirit/json_spirit_writer_template.h
+++ b/src/cpp/core/json/spirit/json_spirit_writer_template.h
@@ -58,6 +58,12 @@ namespace json_spirit
             case '\t': s += to_str< String_type >( "\\t"  ); return true;
         }
 
+        // https://www.codeproject.com/Messages/5256071/Escaping-of-control-characters.aspx
+        const wint_t unsigned_c((c >= 0) ? c : 256 + c);
+        if (c < 0x20) {
+            s += non_printable_to_string< String_type >(unsigned_c);
+            return true;
+        }
         return false;
     }
 


### PR DESCRIPTION
When console or terminal are sending output with Ansi escape sequences to client via JSON client events, there is an exception throw by the strict JSON parser due to the embedded ESC (\033) that starts the sequences. This is caught, then parsing is re-done with the parseLenient parser.

I dig some digging and discovered this:

https://www.codeproject.com/Messages/5256071/Escaping-of-control-characters.aspx

Sure enough, when I applied the suggested fix to our copy of json_spirit, the ESC gets properly JSON encoded, making the strict parser happy and avoiding the exception and reparse.

This type of issue was mentioned a few years ago in `Case 3025 - console history produces json not parsable using JSON.parseStrict`.

I built and tried it on Mac (server and desktop), and Windows desktop. No more exceptions from the console or terminal when dealing with Ansi codes.

Caveat: this doesn't fix anything from the user perspective, other than perhaps some tiny bit of perf-improvement and less noise when doing Javascript debugging with "show caught exceptions" turned on.