### PR TITLE
Add openSuSE docker builder; replaces cross-building on CentOS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,18 +81,17 @@ messagePrefix = "Jenkins ${env.JOB_NAME} build: <${env.BUILD_URL}display/redirec
 try {
     timestamps {
         def containers = [
-          [os: 'precise', arch: 'amd64',  flavor: 'desktop', variant: 'trusty'],
-          [os: 'precise', arch: 'i386',   flavor: 'desktop', variant: 'trusty'],
-          [os: 'precise', arch: 'amd64',  flavor: 'server',  variant: ''],
-          [os: 'precise', arch: 'i386',   flavor: 'server',  variant: ''],
-          [os: 'centos6', arch: 'x86_64', flavor: 'server',  variant: ''],
-          [os: 'centos6', arch: 'i386',   flavor: 'server',  variant: ''],
-          [os: 'centos6', arch: 'x86_64', flavor: 'server',  variant: 'SLES'],
-          [os: 'centos6', arch: 'i386',   flavor: 'server',  variant: 'SLES'],
-          [os: 'centos7', arch: 'x86_64', flavor: 'desktop', variant: ''],
-          [os: 'centos7', arch: 'i386',   flavor: 'desktop', variant: ''],
-          [os: 'xenial',  arch: 'amd64',  flavor: 'desktop', variant: 'xenial'],
-          [os: 'xenial',  arch: 'i386',   flavor: 'desktop', variant: 'xenial']
+          [os: 'precise',  arch: 'amd64',  flavor: 'desktop', variant: 'trusty'],
+          [os: 'precise',  arch: 'i386',   flavor: 'desktop', variant: 'trusty'],
+          [os: 'precise',  arch: 'amd64',  flavor: 'server',  variant: ''],
+          [os: 'precise',  arch: 'i386',   flavor: 'server',  variant: ''],
+          [os: 'centos6',  arch: 'x86_64', flavor: 'server',  variant: ''],
+          [os: 'centos6',  arch: 'i386',   flavor: 'server',  variant: ''],
+          [os: 'centos7',  arch: 'x86_64', flavor: 'desktop', variant: ''],
+          [os: 'centos7',  arch: 'i386',   flavor: 'desktop', variant: ''],
+          [os: 'opensuse', arch: 'x86_64', flavor: 'server',  variant: 'SLES'],
+          [os: 'xenial',   arch: 'amd64',  flavor: 'desktop', variant: 'xenial'],
+          [os: 'xenial',   arch: 'i386',   flavor: 'desktop', variant: 'xenial']
         ]
         containers = limit_builds(containers)
         def parallel_containers = [:]

--- a/dependencies/linux/install-dependencies-zypper
+++ b/dependencies/linux/install-dependencies-zypper
@@ -39,7 +39,7 @@ sudo zypper --non-interactive in boost-devel
 sudo zypper --non-interactive in pango-devel
 
 # gwt prereqs
-sudo zypper --non-interactive in java-1_6_0-openjdk-devel
+sudo zypper --non-interactive in java-1_7_0-openjdk-devel
 sudo zypper --non-interactive in ant
 
 # overlay

--- a/docker/docker-compile.sh
+++ b/docker/docker-compile.sh
@@ -65,6 +65,9 @@ fi
 if [ "${IMAGE:0:6}" = "centos" ]; then
     PACKAGE=RPM
     INSTALLER=yum
+elif [ "${IMAGE:0:8}" = "opensuse" ]; then
+    PACKAGE=RPM
+    INSTALLER=zypper
 else
     PACKAGE=DEB
     INSTALLER=debian

--- a/docker/jenkins/Dockerfile.opensuse-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse-x86_64
@@ -1,0 +1,43 @@
+FROM opensuse:13.2
+
+# needed to build RPMs
+RUN zypper --non-interactive addrepo http://download.opensuse.org/repositories/systemsmanagement:wbem:deps/openSUSE_13.2/systemsmanagement:wbem:deps.repo
+
+# refresh repos and install required packages
+RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
+    zypper --non-interactive install -y \
+    ant \
+    boost-devel \
+    fakeroot \
+    gcc \
+    gcc-c++ \
+    git \
+    java-1_7_0-openjdk  \
+    libuuid-devel \
+    make \
+    openssl-devel \
+    pam-devel \
+    pango-devel \
+    R \
+    rpm-build \
+    sudo \
+    tar \
+    wget \
+    xml-commons-apis \
+    zlib-devel
+
+## run install-boost twice - boost exits 1 even though it has installed good enough for our uses.
+## https://github.com/rstudio/rstudio/blob/master/vagrant/provision-primary-user.sh#L12-L15
+COPY dependencies/common/install-boost /tmp/
+RUN bash /tmp/install-boost || bash /tmp/install-boost
+
+# install cmake
+COPY package/linux/install-dependencies /tmp/
+RUN bash /tmp/install-dependencies
+
+# create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
+ARG JENKINS_GID=999
+ARG JENKINS_UID=999
+RUN groupadd -g $JENKINS_GID jenkins && \
+    useradd -m -d /var/lib/jenkins -u $JENKINS_UID -g jenkins jenkins && \
+    echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers


### PR DESCRIPTION
Prior to this change, we built RStudio Server for SLES by re-using the CentOS 6 image. The resultant RPMs turned out not to be usable on SLES due to differences in the OpenSSL libraries we linked against. 

Rather than try to coerce the CentOS images to produce a binary that works on SLES, this change adds a new image which builds on openSuSE itself. 