### PR TITLE
Prevent log chatter from terminateChildProcesses

### DIFF
--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -1818,7 +1818,15 @@ Error terminateChildProcesses()
     {
        if (::kill(process.pid, SIGTERM) != 0)
        {
-          LOG_ERROR(systemError(errno, ERROR_LOCATION));
+          // On the Mac some child processes exist as a side effect of the
+          // call to getChildProcesses (sh, ps, awk). This results in a
+          // regular stream of error messages at the dev console, so we
+          // suppress that particular error to prevent bogus error states.
+          Error error = systemError(errno, ERROR_LOCATION);
+#ifdef __APPLE__
+          if (error.code() != boost::system::errc::no_such_process)
+#endif
+            LOG_ERROR(error);
        }
     }
 


### PR DESCRIPTION
On the Mac some child processes exist as a side effect of the call to getChildProcesses (sh, ps, awk). This results in a regular stream of error messages at the dev console, so we suppress that particular error to prevent bogus error states.

While this could prevent our seeing a legitimate error, it will also prevent "log chatter" which can obstruct seeing real errors (i.e. we become so used to seeing errors logged that we start generally ignoring them). The latter is viewed a bigger problem than the former, especially given how unlikely it is in this case that we are masking a legit error condition.

We could further scope this check to development mode, however I think keeping "expected" errors out of production logs is also a good thing.

More intrusive and complex fixes are possible (i.e. trying to figure out the exact pids of the sh, ps, and awk processes) however I don't think those are worth the time and risk here.