### PR TITLE
unit tests for ansi parsing, fix eclipse warnings, font code parsing

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -179,8 +179,7 @@ public class VirtualConsole
     * Appends text to the end of the virtual console.
     * 
     * @param text The text to append
-    * @param clazz The content to append to the text.
-    * same output style as this one.
+    * @param clazz Style of the text to append
     */
    private void appendText(String text, String clazz)
    {
@@ -348,7 +347,6 @@ public class VirtualConsole
     * Write text to DOM
     * @param text text to write
     * @param clazz text style
-    *  match this one
     */
    private void text(String text, String clazz)
    {
@@ -394,15 +392,15 @@ public class VirtualConsole
       // combine them with input class so they are ready to use if
       // there is text to output before any other ANSI codes in the
       // data (or there are no more ANSI codes).
-      if (ansiColorMode == ANSI_COLOR_ON && ansiCodeStyles_ != null)
+      if (ansiColorMode == ANSI_COLOR_ON && ansiCodeStyles_.inlineClazzes != null)
       {
          if (clazz != null)
          {
-            currentClazz = clazz + " " + ansiCodeStyles_;
+            currentClazz = clazz + " " + ansiCodeStyles_.inlineClazzes;
          }
          else
          {
-            currentClazz = ansiCodeStyles_;
+            currentClazz = ansiCodeStyles_.inlineClazzes;
          }
       }
 
@@ -465,11 +463,15 @@ public class VirtualConsole
                {
                   if (clazz != null)
                   {
-                     currentClazz = clazz + " " + ansiCodeStyles_;
+                     currentClazz = clazz;
+                     if (ansiCodeStyles_.inlineClazzes != null)
+                     {
+                        currentClazz = currentClazz + " " + ansiCodeStyles_.inlineClazzes;
+                     }
                   }
                   else
                   {
-                     currentClazz = ansiCodeStyles_;
+                     currentClazz = ansiCodeStyles_.inlineClazzes;
                   }
                }
                tail = pos + ansiMatch.getValue().length();
@@ -564,7 +566,7 @@ public class VirtualConsole
    private int cursor_ = 0;
    private AnsiCode ansi_;
    private String partialAnsiCode_;
-   private String ansiCodeStyles_;
+   private AnsiCode.AnsiClazzes ansiCodeStyles_ = new AnsiCode.AnsiClazzes();
    private int ansiColorMode_;
    
    // Injected ----

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilePathToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilePathToolbar.java
@@ -1,7 +1,7 @@
 /*
  * FilePathToolbar.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -29,8 +29,6 @@ import org.rstudio.core.client.files.filedialog.PathBreadcrumbWidget;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.studio.client.RStudioGinjector;
-import org.rstudio.studio.client.application.ui.RStudioThemes;
-import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.files.Files;
 
 public class FilePathToolbar extends Composite
@@ -68,8 +66,6 @@ public class FilePathToolbar extends Composite
 
    public FilePathToolbar(Files.Display.NavigationObserver navigationObserver)
    {
-      UIPrefs uiPrefs = RStudioGinjector.INSTANCE.getUIPrefs();
-      
       LayoutPanel layout = new LayoutPanel();
       layout.setSize("100%", "21px");
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -1,7 +1,7 @@
 /*
  * AceEditorWidget.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -42,7 +42,6 @@ import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.widget.FontSizer;
-import org.rstudio.core.client.widget.events.SelectionChangedEvent;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.Value;

--- a/src/gwt/test/org/rstudio/core/client/AnsiCodeTests.java
+++ b/src/gwt/test/org/rstudio/core/client/AnsiCodeTests.java
@@ -88,4 +88,97 @@ public class AnsiCodeTests extends GWTTestCase
       Assert.assertTrue(foundBackspace);
       Assert.assertTrue(foundCarriageReturn);
    }
+   
+   public void testBoldItalicOnOff()
+   {
+      AnsiCode ansi = new AnsiCode();
+
+      String boldOn = "\033[1m";
+      AnsiCode.AnsiClazzes newClazz = ansi.processCode(boldOn);
+      Assert.assertEquals("xtermBold", newClazz.inlineClazzes);
+      Assert.assertNull(newClazz.blockClazzes);
+      
+      String italicOn = "\033[3m";
+      newClazz = ansi.processCode(italicOn);
+      Assert.assertEquals("xtermBold xtermItalic", newClazz.inlineClazzes);
+      Assert.assertNull(newClazz.blockClazzes);
+      
+      String boldOff = "\033[22m";
+      newClazz = ansi.processCode(boldOff);
+      Assert.assertEquals("xtermItalic", newClazz.inlineClazzes);
+      Assert.assertNull(newClazz.blockClazzes);
+
+      String italicOff = "\033[23m";
+      newClazz = ansi.processCode(italicOff);
+      Assert.assertNull(newClazz.inlineClazzes);
+      Assert.assertNull(newClazz.blockClazzes);
+   }
+
+   public void testSimpleColors()
+   {
+      AnsiCode ansi = new AnsiCode();
+
+      String redFg = "\033[31m";
+      AnsiCode.AnsiClazzes newClazz = ansi.processCode(redFg);
+      Assert.assertEquals("xtermColor1", newClazz.inlineClazzes);
+      Assert.assertNull(newClazz.blockClazzes);
+      
+      String cyanFg = "\033[36m";
+      newClazz = ansi.processCode(cyanFg);
+      Assert.assertEquals("xtermColor6", newClazz.inlineClazzes);
+      Assert.assertNull(newClazz.blockClazzes);
+
+      String blueBg = "\033[44m";
+      newClazz = ansi.processCode(blueBg);
+      Assert.assertEquals("xtermColor6 xtermBgColor4", newClazz.inlineClazzes);
+      Assert.assertNull(newClazz.blockClazzes);
+
+      String resetFg = "\033[39m";
+      newClazz = ansi.processCode(resetFg);
+      Assert.assertEquals("xtermBgColor4", newClazz.inlineClazzes);
+      Assert.assertNull(newClazz.blockClazzes);
+
+      String resetBg = "\033[49m";
+      newClazz = ansi.processCode(resetBg);
+      Assert.assertNull(newClazz.inlineClazzes);
+      Assert.assertNull(newClazz.blockClazzes);
+   }
+
+   public void testFontNineOnOff()
+   {
+      AnsiCode ansi = new AnsiCode();
+
+      String fontNine = "\033[19m";
+      AnsiCode.AnsiClazzes newClazz = ansi.processCode(fontNine);
+      Assert.assertEquals("xtermFont9", newClazz.blockClazzes);
+      Assert.assertNull(newClazz.inlineClazzes);
+
+      String defaultFont = "\033[10m";
+      newClazz = ansi.processCode(defaultFont);
+      Assert.assertNull(newClazz.blockClazzes);
+      Assert.assertNull(newClazz.inlineClazzes);
+   } 
+
+   public void testFontNineWithColors()
+   {
+      AnsiCode ansi = new AnsiCode();
+
+      String redFg = "\033[31m";
+      AnsiCode.AnsiClazzes newClazz = ansi.processCode(redFg);
+ 
+      String fontNine = "\033[19m";
+      newClazz = ansi.processCode(fontNine);
+      Assert.assertEquals("xtermFont9", newClazz.blockClazzes);
+      Assert.assertEquals("xtermColor1", newClazz.inlineClazzes);
+
+      String defaultFont = "\033[10m";
+      newClazz = ansi.processCode(defaultFont);
+      Assert.assertNull(newClazz.blockClazzes);
+      Assert.assertEquals("xtermColor1", newClazz.inlineClazzes);
+      
+      String resetAll = "\033[0m";
+      newClazz = ansi.processCode(resetAll);
+      Assert.assertNull(newClazz.blockClazzes);
+      Assert.assertNull(newClazz.inlineClazzes);
+    } 
 }


### PR DESCRIPTION
- Added unit tests for ansi parsing (client-side)
- Added parsing for Ansi font escape sequences, but not using them for anything (idea was to support font9 to change line-height; not going to work on that anytime soon, probably not for 1.1, but had already done the parsing so getting it in). Note that line-height would have to apply on a block level, not on a span level, so ansi parsing now differentiates between inline and block styles.
- Fixed some Eclipse "unused" warnings