### PR TITLE
use Ace public API for non-blinking cursor

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -2009,7 +2009,8 @@ public class AceEditor implements DocDisplay,
 
    public void setBlinkingCursor(boolean blinking)
    {
-      widget_.getEditor().getRenderer().setBlinkingCursor(blinking);
+      String style = blinking ? "ace" : "wide";
+      widget_.getEditor().setOption("cursorStyle", style);
    }
 
    public void setShowPrintMargin(boolean on)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -2010,7 +2010,7 @@ public class AceEditor implements DocDisplay,
    public void setBlinkingCursor(boolean blinking)
    {
       String style = blinking ? "ace" : "wide";
-      widget_.getEditor().setOption("cursorStyle", style);
+      widget_.getEditor().setCursorStyle(style);
    }
 
    public void setShowPrintMargin(boolean on)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -601,8 +601,8 @@ public class AceEditorNative extends JavaScriptObject {
       this.execCommand(commandName);
    }-*/;
    
-   public final native <T> void setOption(String key, T value) /*-{
-      this.setOption(key, value);
+   public final native void setCursorStyle(String style) /*-{
+      this.setOption("cursorStyle", style);
    }-*/;
    
    private static final native void initialize()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -601,6 +601,10 @@ public class AceEditorNative extends JavaScriptObject {
       this.execCommand(commandName);
    }-*/;
    
+   public final native <T> void setOption(String key, T value) /*-{
+      this.setOption(key, value);
+   }-*/;
+   
    private static final native void initialize()
    /*-{
       // Remove the 'Return' keybinding associated with Emacs.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Renderer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Renderer.java
@@ -99,10 +99,6 @@ public class Renderer extends JavaScriptObject
       this.setDisplayIndentGuides(show); 
    }-*/;
    
-   public native final void setBlinkingCursor(boolean blinking) /*-{
-      this.$cursorLayer.setBlinking(blinking);
-   }-*/;
-
    public native final void setPadding(int padding) /*-{
       this.setPadding(padding);
    }-*/;


### PR DESCRIPTION
This PR fixes an issue where the cursor would start blinking after highlighting a region of text using the mouse, even if the user had opted in to using no blinking cursor.

The `$cursorLayer` APIs are somewhat private (and toggled internally by Ace during mouse drag events); the suggested mechanism for controlling this is through an editor option.