### PR TITLE
virtual console fixes related to \r and complex styles

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -276,9 +276,19 @@ public class VirtualConsole
             }
             else
             {
-               // reduce the original range and add ours (if not present)
+               // reduce the original range and add ours
+               boolean needTrimmed = overlap.length > delta;
                overlap.trimLeft(delta);
+               
                insertions.add(range);
+
+               // If our new range is shorter than the existing one, need to 
+               // re-add the shortened range at its new start position 
+               // otherwise our new range stomps it and prevents any more 
+               // operations on it
+               if (needTrimmed)
+                  insertions.add(overlap);
+               
                if (parent_ != null)
                   parent_.insertBefore(range.element, overlap.element);
               
@@ -304,18 +314,19 @@ public class VirtualConsole
                String text = overlap.text();
 
                // trim the original range
-               overlap.trimRight(overlap.length - (start - l));
+               int amountTrimmed = overlap.length - (start - l);
+               overlap.trimRight(amountTrimmed);
                
                // insert the new range
                insertions.add(range);
                if (parent_ != null)
                   parent_.insertAfter(range.element, overlap.element);
                
-               // add the new range
+               // add back the remainder
                ClassRange remainder = new ClassRange(
                      end,
                      overlap.clazz,
-                     text.substring((text.length() - range.length), 
+                     text.substring((text.length() - (amountTrimmed - range.length)), 
                                     text.length()));
                insertions.add(remainder);
                if (parent_ != null)

--- a/src/gwt/test/org/rstudio/studio/client/VirtualConsoleTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/VirtualConsoleTests.java
@@ -127,6 +127,57 @@ public class VirtualConsoleTests extends GWTTestCase
       Assert.assertEquals("<span>Sample4</span>", ele.getInnerHTML());
    }
 
+   public void testCarriageReturnWithStyleChange()
+   {
+      PreElement ele = Document.get().createPreElement();
+      VirtualConsole vc = new VirtualConsole(ele);
+
+      vc.submit("World", "a");
+
+      // replace first character of line with green 'X', then change
+      // second character to red 'Y'
+      vc.submit("\r\033[32mX\033[31mY\033[0m", "a");
+      Assert.assertEquals(
+            "<span class=\"a xtermColor2\">X</span>" + 
+            "<span class=\"a xtermColor1\">Y</span>" +
+            "<span class=\"a\">rld</span>", 
+            ele.getInnerHTML());
+   }
+
+   public void testCarriageReturnWithStyleChange2()
+   {
+      PreElement ele = Document.get().createPreElement();
+      VirtualConsole vc = new VirtualConsole(ele);
+
+      vc.submit("Hello\nWorld", "a");
+
+      // replace first character of current line with green 'X', then change
+      // second character to red 'Y'
+      vc.submit("\r\033[32mX\033[31mY\033[0m", "a");
+      Assert.assertEquals(
+            "<span class=\"a\">Hello\n</span>" +
+            "<span class=\"a xtermColor2\">X</span>" + 
+            "<span class=\"a xtermColor1\">Y</span>" +
+            "<span class=\"a\">rld</span>", 
+            ele.getInnerHTML());
+   }
+
+   public void testCarriageReturnWithStyleChange3()
+   {
+      PreElement ele = Document.get().createPreElement();
+      VirtualConsole vc = new VirtualConsole(ele);
+
+      vc.submit("Hello\nWorld", "a");
+
+      vc.submit("\r\033[32m123\033[31m45\033[0m", "a");
+      Assert.assertEquals(
+            "<span class=\"a\">Hello\n</span>" +
+            "<span class=\"a xtermColor2\">123</span>" + 
+            "<span class=\"a\"></span>" +
+            "<span class=\"a xtermColor1\">45</span>",
+            ele.getInnerHTML());
+   }
+    
    public void testAnsiColorStyleHelper()
    {
       Assert.assertEquals("xtermColor0", 


### PR DESCRIPTION
A couple of closely related VirtualConsole fixes. These were found by mixing \r and Ansi color codes. Added unit tests to catch/test these cases. Visual examples of fixes attached.
![2017-05-30_17-00-07](https://cloud.githubusercontent.com/assets/10569626/26609970/7efa8fa6-4559-11e7-8f9a-2d35b1b27e80.png)
