### PR TITLE
Submenus under dark themes show dark checkbox

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
@@ -477,7 +477,8 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
             shortcut, 
             null, 
             null,
-            null);
+            null,
+            styleName);
    }
    
    public static String formatMenuLabel(ImageResource icon, 
@@ -510,7 +511,8 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
                              shortcut, 
                              null, 
                              rightImage,
-                             rightImageDesc);
+                             rightImageDesc,
+                             null);
    }
    
    public static String formatMenuLabel(ImageResource icon, 
@@ -527,7 +529,7 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
                                         String shortcut, 
                                         Integer iconOffsetY)
    {
-      return formatMenuLabel(icon, label, html, shortcut, iconOffsetY, null, null);
+      return formatMenuLabel(icon, label, html, shortcut, iconOffsetY, null, null, null);
    }
    
    public static String formatMenuLabel(ImageResource icon, 
@@ -536,13 +538,21 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
                                          String shortcut, 
                                          Integer iconOffsetY,
                                          ImageResource rightImage,
-                                         String rightImageDesc)
+                                         String rightImageDesc,
+                                         String styleName)
    {
       StringBuilder text = new StringBuilder();
       int topOffset = -7;
       if (iconOffsetY != null)
          topOffset += iconOffsetY;
-      text.append("<table border=0 cellpadding=0 cellspacing=0 width='100%'><tr>");
+      text.append("<table ");
+      
+      if (styleName != null)
+      {
+         text.append("class='" + styleName + "' ");
+      }
+      
+      text.append("border=0 cellpadding=0 cellspacing=0 width='100%'><tr>");
 
       text.append("<td width=\"25\"><div style=\"width: 25px; margin-top: " +
                   topOffset + "px; margin-bottom: -10px\">");

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -443,7 +443,11 @@ pre {
 }
 
 .rstudio-themes-flat.rstudio-themes-dark-menus .menuCheckable img {
-   filter: inverts(100%);
+   -webkit-filter: invert(100%) brightness(120%);
+      -moz-filter: invert(100%) brightness(120%);
+       -ms-filter: invert(100%) brightness(120%);
+        -o-filter: invert(100%) brightness(120%);
+           filter: invert(100%) brightness(120%);
 }
 
 .highlight {
@@ -623,7 +627,9 @@ pre {
    background-color: #D6E9F8;
 }
 
-.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected {
+.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-MenuItem.gwt-MenuItem-selected,
+.rstudio-themes-flat.rstudio-themes-dark-menus .subMenuIcon-selected,
+.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-SuggestBoxPopup .item-selected {
    background-color: THEME_DARKGREY_MENU_SELECTED;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/widget/CheckableMenuItem.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/CheckableMenuItem.java
@@ -3,6 +3,7 @@ package org.rstudio.core.client.widget;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
+import org.rstudio.core.client.theme.res.ThemeStyles;
 
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
@@ -43,11 +44,11 @@ public abstract class CheckableMenuItem extends MenuItem
    
    private String getHTMLContent()
    {
-      return AppCommand.formatMenuLabel(
+      return AppCommand.formatMenuLabelWithStyle(
             isChecked() ? 
                   new ImageResource2x(ThemeResources.INSTANCE.menuCheck2x()) :
                   null,
-            getLabel(), "");
+            getLabel(), "", ThemeStyles.INSTANCE.menuCheckable());
       
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
@@ -39,7 +39,7 @@ public class RStudioThemes
       element.removeClassName("rstudio-themes-dark-grey");
       element.removeClassName("rstudio-themes-alternate");
       element.removeClassName("rstudio-themes-scrollbars");
-      element.removeClassName("rstudio-themes-dark-menus");
+      document.getBody().removeClassName("rstudio-themes-dark-menus");
       
       if (themeName == "default" || themeName == "dark-grey" || themeName == "alternate") {         
          document.getBody().addClassName("rstudio-themes-flat");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.dom.client.*;
 import com.google.gwt.event.logical.shared.CloseEvent;
@@ -43,6 +44,7 @@ import org.rstudio.core.client.command.ShortcutManager;
 import org.rstudio.core.client.events.SelectionCommitEvent;
 import org.rstudio.core.client.events.SelectionCommitHandler;
 import org.rstudio.core.client.widget.ThemedPopupPanel;
+import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.workbench.views.console.ConsoleResources;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.CompletionRequester.QualifiedName;
 import org.rstudio.studio.client.workbench.views.help.model.HelpInfo.ParsedInfo;
@@ -315,6 +317,9 @@ public class CompletionPopupPanel extends ThemedPopupPanel
       int left = getAbsoluteLeft();
       int bottom = top + getOffsetHeight();
       int width = getOffsetWidth();
+      
+      if (RStudioThemes.isFlat())
+         bottom += 9;
       
       if (!help_.isShowing())
          help_.show();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.css
@@ -29,6 +29,9 @@
    color: #eaeaea;
    background: #5e5e4e;
    border: 1px solid #92968e;
+}
+
+.rstudio-themes-flat .helpPopup {
    margin-left: 6px;
    margin-top: -3px;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.css
@@ -29,4 +29,6 @@
    color: #eaeaea;
    background: #5e5e4e;
    border: 1px solid #a3a89e;
+   margin-left: 6px;
+   margin-top: -3px;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.css
@@ -28,7 +28,7 @@
 .rstudio-themes-flat.rstudio-themes-dark-menus .helpPopup {
    color: #eaeaea;
    background: #5e5e4e;
-   border: 1px solid #a3a89e;
+   border: 1px solid #92968e;
    margin-left: 6px;
    margin-top: -3px;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.css
@@ -1,7 +1,12 @@
+@external rstudio-themes-flat, rstudio-themes-dark;
 
 .captionLabel {
    font-weight: bold;
    color: #494949;
+}
+
+.rstudio-themes-flat .rstudio-themes-dark .captionLabel {
+   color: #FFF;
 }
 
 .menuElement {
@@ -18,8 +23,16 @@
    padding-right: 6px;
 }
 
+.rstudio-themes-flat .rstudio-themes-dark .functionNamespace {
+   color: #DDD;
+}
+
 .dropDownImage {
    margin-bottom: 2px;
+}
+
+.rstudio-themes-flat .rstudio-themes-dark .dropDownImage {
+   filter: invert(100%) brightness(90%) saturate(90%);
 }
 
 .readOnly {


### PR DESCRIPTION
Invert submenu checks under dark menus:

<img width="438" alt="screen shot 2017-05-31 at 11 50 24 am" src="https://cloud.githubusercontent.com/assets/3478847/26648476/71d19ec0-45f7-11e7-92ef-7b6f049e0617.png">

