### PR TITLE
warn when attempting to commit large files

### DIFF
--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -384,6 +384,8 @@ void handleClientInit(const boost::function<void()>& initFunction,
    sessionInfo["drivers_support_licensing"] = options.supportsDriversLicensing();
 
    sessionInfo["quit_child_processes_on_exit"] = options.quitChildProcessesOnExit();
+   
+   sessionInfo["git_commit_large_file_size"] = options.gitCommitLargeFileSize();
 
    module_context::events().onSessionInfo(&sessionInfo);
 

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -357,6 +357,13 @@ core::ProgramStatus Options::read(int argc, char * const argv[])
       ("external-winpty-path",
         value<std::string>(&winptyPath_)->default_value("bin"),
          "Path to winpty binaries");
+   
+   // git options
+   options_description git("git");
+   git.add_options()
+         ("git-commit-large-file-size",
+          value<int>(&gitCommitLargeFileSize_)->default_value(5 * 1024 * 1024),
+          "warn when attempting to commit files larger than this size (in bytes; set 0 to disable)");
 
    // user options (default user identity to current username)
    std::string currentUsername = core::system::username();
@@ -402,6 +409,7 @@ core::ProgramStatus Options::read(int argc, char * const argv[])
    optionsDesc.commandLine.add(r);
    optionsDesc.commandLine.add(limits);
    optionsDesc.commandLine.add(external);
+   optionsDesc.commandLine.add(git);
    optionsDesc.commandLine.add(user);
    optionsDesc.commandLine.add(overlay);
 

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -278,6 +278,11 @@ public:
    {
       return core::FilePath(winptyPath_.c_str());
    }
+   
+   int gitCommitLargeFileSize() const
+   {
+      return gitCommitLargeFileSize_;
+   }
 
    core::FilePath hunspellDictionariesPath() const
    {
@@ -601,6 +606,9 @@ private:
    std::string libclangPath_;
    std::string libclangHeadersPath_;
    std::string winptyPath_;
+   
+   // git
+   int gitCommitLargeFileSize_;
 
    // root directory for locating resources
    core::FilePath resourcePath_;

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -3044,6 +3044,7 @@ Error statusToJson(const core::FilePath &path,
    obj["raw_path"] = module_context::createAliasedPath(path);
    obj["discardable"] = status.status()[1] != ' ' && status.status()[1] != '?';
    obj["is_directory"] = path.isDirectory();
+   obj["size"] = static_cast<double>(path.size());
    return Success();
 }
 

--- a/src/gwt/src/org/rstudio/core/client/MessageDisplay.java
+++ b/src/gwt/src/org/rstudio/core/client/MessageDisplay.java
@@ -36,7 +36,7 @@ public abstract class MessageDisplay
       public String input;
       public boolean extraOption;
    }
-
+   
    public abstract void promptForText(String title,
                                       String label,
                                       String initialValue,
@@ -276,7 +276,7 @@ public abstract class MessageDisplay
       dialog.setDefaultButton(defaultButton);
       dialog.showModal();
    }
-
+   
    public void showErrorMessage(String caption, String message)
    {
       createDialog(MSG_ERROR, caption, message).showModal();

--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/StatusAndPathInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/StatusAndPathInfo.java
@@ -44,6 +44,10 @@ public class StatusAndPathInfo extends JavaScriptObject
    public native final boolean isDirectory() /*-{
       return !!this.is_directory;
    }-*/;
+   
+   public native final double getFileSize() /*-{
+      return this.size || 0;
+   }-*/;
 
    public native static StatusAndPathInfo create(String status,
                                           String path,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -502,4 +502,8 @@ public class SessionInfo extends JavaScriptObject
    public final native boolean quitChildProcessesOnExit() /*-{
       return this.quit_child_processes_on_exit;
    }-*/;
+   
+   public final native int getGitCommitLargeFileSize() /*-{
+      return this.git_commit_large_file_size;
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPresenter.java
@@ -227,6 +227,7 @@ public class GitReviewPresenter implements ReviewPresenter
       globalDisplay_ = globalDisplay;
       gitState_ = gitState;
       vcsFileOpener_ = vcsFileOpener;
+      gitCommitLargeFileSize_ = session.getSessionInfo().getGitCommitLargeFileSize();
       
       binder.bind(commands, this);
 
@@ -558,7 +559,7 @@ public class GitReviewPresenter implements ReviewPresenter
                      
                      // warn if we're trying to commit a file >10MB in size
                      double size = info.getFileSize();
-                     if (size > 10 * 1024 * 1024)
+                     if (gitCommitLargeFileSize_ > 0 && size >= gitCommitLargeFileSize_)
                      {
                         onLargeFile();
                         return;
@@ -584,9 +585,10 @@ public class GitReviewPresenter implements ReviewPresenter
          
          private void onLargeFile()
          {
+            String prettySize = StringUtil.formatFileSize(gitCommitLargeFileSize_);
             String message =
                   "Some of the files to be committed are quite large " +
-                  "(> 10MB in size). Are you sure you want to commit these files?";
+                  "(>" + prettySize + " in size). Are you sure you want to commit these files?";
             
             globalDisplay_.showYesNoMessage(
                   GlobalDisplay.MSG_WARNING,
@@ -911,6 +913,7 @@ public class GitReviewPresenter implements ReviewPresenter
    private boolean initialized_;
    private static final String MODULE_GIT = "vcs_git";
    private static final String KEY_CONTEXT_LINES = "context_lines";
+   private final int gitCommitLargeFileSize_;
 
    private boolean overrideSizeWarning_ = false;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPresenter.java
@@ -574,6 +574,10 @@ public class GitReviewPresenter implements ReviewPresenter
                public void onError(ServerError error)
                {
                   Debug.logError(error);
+                  
+                  // although server errors here are unexpected,
+                  // make a best effort attempt to commit regardless
+                  onCommit();
                }
             });
          }


### PR DESCRIPTION
This PR shows the user a warning dialog when attempting to commit large files (> 10 megabytes in size), e.g.

![screen shot 2017-05-31 at 12 49 53 pm](https://cloud.githubusercontent.com/assets/1976582/26650861/ae4d01ac-45ff-11e7-9e71-4578de7b76fd.png)

Typically, once a large file has entered a Git repository, that repository will balloon in size and it can be quite difficult to remove that file + prune the repository (especially if more commits are made after the fact). This should hopefully act as a shield against the accidental commit of large files.