### PR TITLE
add 'ignore whitespace' checkbox for git diff

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/GitServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/GitServerOperations.java
@@ -91,6 +91,7 @@ public interface GitServerOperations extends VCSServerOperations
                     PatchMode patchMode,
                     int contextLines,
                     boolean noSizeWarning,
+                    boolean ignoreWhitespace,
                     ServerRequestCallback<DiffResult> requestCallback);
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -2435,6 +2435,7 @@ public class RemoteServer implements Server
                            PatchMode mode,
                            int contextLines,
                            boolean noSizeWarning,
+                           boolean ignoreWhitespace,
                            ServerRequestCallback<DiffResult> requestCallback)
    {
       JSONArray params = new JSONArray();
@@ -2442,6 +2443,7 @@ public class RemoteServer implements Server
       params.set(1, new JSONNumber(mode.getValue()));
       params.set(2, new JSONNumber(contextLines));
       params.set(3, JSONBoolean.getInstance(noSizeWarning));
+      params.set(4, JSONBoolean.getInstance(ignoreWhitespace));
       sendRequest(RPC_SCOPE, GIT_DIFF_FILE, params, requestCallback);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
@@ -468,6 +468,10 @@ public class UIPrefs extends UIPrefsAccessor implements UiPrefsChangedHandler
          // show improved data import dialog
          useDataImport().setGlobalValue(
                newUiPrefs.useDataImport().getGlobalValue());
+         
+         // ignore whitespace in git diff
+         gitDiffIgnoreWhitespace().setGlobalValue(
+               newUiPrefs.gitDiffIgnoreWhitespace().getGlobalValue());
       }
       else if (e.getType().equals(UiPrefsChangedEvent.PROJECT_TYPE))
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
@@ -510,6 +510,9 @@ public class UIPrefs extends UIPrefsAccessor implements UiPrefsChangedHandler
          
          // use roxygen
          useRoxygen().setProjectValue(newUiPrefs.useRoxygen().getValue());
+         
+         // ignore whitespace in git diff
+         gitDiffIgnoreWhitespace().setProjectValue(newUiPrefs.gitDiffIgnoreWhitespace().getValue());
       }
       else
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
@@ -514,9 +514,6 @@ public class UIPrefs extends UIPrefsAccessor implements UiPrefsChangedHandler
          
          // use roxygen
          useRoxygen().setProjectValue(newUiPrefs.useRoxygen().getValue());
-         
-         // ignore whitespace in git diff
-         gitDiffIgnoreWhitespace().setProjectValue(newUiPrefs.gitDiffIgnoreWhitespace().getValue());
       }
       else
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -654,6 +654,11 @@ public class UIPrefsAccessor extends Prefs
       return string("flat_theme", flatTheme);
    }
    
+   public PrefValue<Boolean> gitDiffIgnoreWhitespace()
+   {
+      return bool("git_diff_ignore_whitespace", false);
+   }
+   
    private String getDefaultPdfPreview()
    {
       if (Desktop.isDesktop())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.css
@@ -145,3 +145,11 @@
 .rstudio-themes-flat .commitButton {
    margin-right: 0;
 }
+
+.ignoreWhitespace {
+	margin-left: 10px;
+}
+
+.ignoreWhitespace label {
+	margin-left: 4px;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
@@ -112,6 +112,7 @@ public class GitReviewPanel extends ResizeComposite implements Display
       String commitButton();
 
       String splitPanelCommit();
+      String ignoreWhitespace();
    }
 
    @SuppressWarnings("unused")
@@ -516,6 +517,12 @@ public class GitReviewPanel extends ResizeComposite implements Display
    {
       return unstagedCheckBox_;
    }
+   
+   @Override
+   public HasValue<Boolean> getIgnoreWhitespaceCheckBox()
+   {
+      return ignoreWhitespaceCheckbox_;
+   }
 
    @Override
    public LineTablePresenter.Display getLineTableDisplay()
@@ -668,6 +675,8 @@ public class GitReviewPanel extends ResizeComposite implements Display
    FlowPanel diffViewOptions_;
    @UiField
    HorizontalPanel toolbarWrapper_;
+   @UiField
+   CheckBox ignoreWhitespaceCheckbox_;
 
    private ListBoxAdapter listBoxAdapter_;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.ui.xml
@@ -62,6 +62,10 @@
                         <g:item value="50">50 line</g:item>
                         <g:item value="-1">All lines</g:item>
                      </g:ListBox>
+                  	 <g:CheckBox ui:field="ignoreWhitespaceCheckbox_"
+                  	             text="Ignore Whitespace"
+                  	             checked="false"
+                  	             styleName="{res.styles.ignoreWhitespace}"/>
                   </g:FlowPanel>
                   <rs_widget:Toolbar ui:field="diffToolbar_"/>
                </g:HorizontalPanel>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPresenter.java
@@ -18,15 +18,12 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.dom.client.*;
-import com.google.gwt.event.logical.shared.CloseEvent;
-import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.event.logical.shared.HasAttachHandlers;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.json.client.JSONNumber;
 import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.HasText;
 import com.google.gwt.user.client.ui.HasValue;
 import com.google.gwt.user.client.ui.IsWidget;
@@ -289,15 +286,6 @@ public class GitReviewPresenter implements ReviewPresenter
             });
          }
       };
-      
-      Window.addCloseHandler(new CloseHandler<Window>()
-      {
-         @Override
-         public void onClose(CloseEvent<Window> event)
-         {
-            session.persistClientState();
-         }
-      });
       
       view_.getChangelistTable().addSelectionChangeHandler(new SelectionChangeEvent.Handler()
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPresenter.java
@@ -515,6 +515,7 @@ public class GitReviewPresenter implements ReviewPresenter
                {
                   boolean value = event.getValue();
                   uiPrefs_.gitDiffIgnoreWhitespace().setProjectValue(value);
+                  uiPrefs_.writeUIPrefs();
                   updateDiff(false);
                }
             });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPresenter.java
@@ -505,7 +505,7 @@ public class GitReviewPresenter implements ReviewPresenter
             });
       
       view_.getIgnoreWhitespaceCheckBox().setValue(
-            uiPrefs_.gitDiffIgnoreWhitespace().getValue());
+            uiPrefs_.gitDiffIgnoreWhitespace().getGlobalValue());
       
       view_.getIgnoreWhitespaceCheckBox().addValueChangeHandler(
             new ValueChangeHandler<Boolean>()
@@ -514,7 +514,7 @@ public class GitReviewPresenter implements ReviewPresenter
                public void onValueChange(ValueChangeEvent<Boolean> event)
                {
                   boolean value = event.getValue();
-                  uiPrefs_.gitDiffIgnoreWhitespace().setProjectValue(value);
+                  uiPrefs_.gitDiffIgnoreWhitespace().setGlobalValue(value);
                   uiPrefs_.writeUIPrefs();
                   updateDiff(false);
                }


### PR DESCRIPTION
This PR adds an 'Ignore Whitespace' checkbox to the Git diff view, allowing users to toggle off / on whitespace-only diffs. Compare e.g.

![screen shot 2017-05-31 at 2 10 50 pm](https://cloud.githubusercontent.com/assets/1976582/26654280/154cc8be-460b-11e7-8b07-f36cc88731fe.png)

![screen shot 2017-05-31 at 2 10 55 pm](https://cloud.githubusercontent.com/assets/1976582/26654283/16efdc9c-460b-11e7-9032-4c1896970d9f.png)
