### PR TITLE
Data import SPSS dropdown too big

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.ui.xml
@@ -32,6 +32,7 @@
         }
         .optionsRightBlock {
             margin-left: auto;
+            padding-top: 2px;
         }
     </ui:style>
     <g:HTMLPanel styleName="{style.mainPanel}">

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiSav.ui.xml
@@ -27,6 +27,8 @@
             -webkit-flex-direction: row;
             -ms-flex-direction: row;
             flex-direction: row;
+
+            height: 24px;
         }
         .optionsRightBlock {
             margin-left: auto;


### PR DESCRIPTION
The dropdown for SPSS was too tall and the data viewer checkbox not padded...

<img width="415" alt="screen shot 2017-05-31 at 3 52 39 pm" src="https://cloud.githubusercontent.com/assets/3478847/26657527/38e60e4e-4619-11e7-812b-775c2705af1f.png">
