### PR TITLE
look up function definitions in completion database

### DIFF
--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -2176,6 +2176,25 @@ Error getFunctionDefinition(const json::JsonRpcRequest& request,
             defJson["type"] = "data";
             defJson["data"] = "";
          }
+         else
+         {
+            // try finding in the completion database
+            using namespace r_util;
+            
+            BOOST_REVERSE_FOREACH(
+                     const std::string& package,
+                     RSourceIndex::getAllInferredPackages())
+            {
+               PackageInformation information = RSourceIndex::getPackageInformation(package);
+               if (information.functionInfo.count(token.name))
+               {
+                  defJson["type"] = "search_path_function";
+                  defJson["data"] = createFunctionDefinition(token.name, package);
+                  break;
+                  
+               }
+            }
+         }
       }
    }
 

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -149,7 +149,7 @@
    }
    else
    {
-     as.environment(namespaceName);
+     asNamespace(namespaceName)
    }
 
    tryCatch(eval(parse(text = name),


### PR DESCRIPTION
This PR ensures that function lookup succeeds in cases e.g.

```
library(shiny)
runApp()
```

where the user attempts to look up the definition of `runApp()`, when the `shiny` package is not actually loaded. Because we cache information about packages and the symbols they export as a background task, we can use that database to inform RStudio that we can successfully look this function up.