### PR TITLE
implement filtering of toolbar menus

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/BaseMenuBar.java
+++ b/src/gwt/src/org/rstudio/core/client/command/BaseMenuBar.java
@@ -15,6 +15,7 @@
 package org.rstudio.core.client.command;
 
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.ui.MenuBar;
@@ -80,10 +81,34 @@ public class BaseMenuBar extends MenuBar
    @Override
    public void onBrowserEvent(Event event)
    {
-      if (event.getTypeInt() == Event.ONCLICK ||
-          event.getTypeInt() == Event.ONKEYDOWN ||
+      if (event.getTypeInt() == Event.ONKEYDOWN ||
           event.getTypeInt() == Event.ONKEYPRESS ||
           event.getTypeInt() == Event.ONKEYUP)
+      {
+         // For 'left' and 'right' keypresses, if an input
+         // element is focused, we want to allow the default
+         // browser behavior for the keypress -- therefore,
+         // don't allow superclass handling of event in such
+         // a case.
+         int keyCode = event.getKeyCode();
+         switch (keyCode)
+         {
+         case KeyCodes.KEY_LEFT:
+         case KeyCodes.KEY_RIGHT:
+            break;
+         default:
+            // For other keypresses, allow superclass to handle
+            super.onBrowserEvent(event);
+            return;
+         }
+         
+         Element activeEl = DomUtils.getActiveElement();
+         if (activeEl.hasTagName("input"))
+            return;
+         
+         super.onBrowserEvent(event);
+      }
+      else if (event.getTypeInt() == Event.ONCLICK)
       {
          // By default, GWT handles click events by sending focus
          // to the menu bar instance, even when the target of the

--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -276,6 +276,30 @@ public class DomUtils
    {
       impl.focus(element, alwaysDriveSelection);
    }
+   
+   public static boolean isFocusable(Element element) 
+   {
+      // If it has a non-negative tab index, it can be focused
+      if (element.getTabIndex() >= 0)
+         return true;
+      
+      // Otherwise, determine whether an item can be focused based
+      // on its tag name.
+      String tagName = element.getTagName().toLowerCase();
+      if (tagName.equals("a"))
+      {
+         return element.hasAttribute("href");
+      }
+      else if (tagName.equals("input") || tagName.equals("select") ||
+               tagName.equals("textarea") || tagName.equals("button"))
+      {
+         return !element.hasAttribute("disabled");
+      }
+      else
+      {
+         return false;
+      }
+   }
 
    public static native boolean hasFocus(Element element) /*-{
       return element === $doc.activeElement;

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -277,6 +277,10 @@ button {
    cursor: pointer;
 }
 
+.rstudio-themes-flat.rstudio-themes-dark-menus hr {
+	border-color: THEME_DARK_CONTROL_BACKGROUND;
+}
+
 .handCursor {
    cursor: pointer;
 }
@@ -2237,6 +2241,27 @@ body.ubuntu_mono .searchBox {
 
 .rstudio-themes-flat .search .right {
    display: none;
+}
+
+.rstudio-themes-flat .searchMagGlass {
+   top: 2px;
+}
+
+.rstudio-themes-flat .clearSearch {
+   top: 3px;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark-menus .search {
+   border-color: THEME_DARK_CONTROL_BORDER;
+   background: THEME_DARK_CONTROL_BACKGROUND;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark-menus .search input {
+   color: white;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark-menus .search input::placeholder {
+   color: #CCC;
 }
 
 .rstudio-themes-flat .searchMagGlass {

--- a/src/gwt/src/org/rstudio/core/client/widget/CustomMenuItemSeparator.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/CustomMenuItemSeparator.java
@@ -14,25 +14,16 @@
  */
 package org.rstudio.core.client.widget;
 
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.MenuItemSeparator;
-import com.google.gwt.user.client.ui.Widget;
 
 public abstract class CustomMenuItemSeparator extends MenuItemSeparator
 {
-   // the actual widget to be used as a separator
-   public abstract Widget createMainWidget();
-   
-   public Widget getMainWidget()
-   {
-      return widget_;
-   }
+   public abstract Element createMainElement();
    
    public CustomMenuItemSeparator()
    {
-      widget_ = createMainWidget();
       getElement().removeAllChildren();
-      getElement().appendChild(widget_.getElement());
+      getElement().appendChild(createMainElement());
    }
-   
-   private final Widget widget_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/CustomMenuItemSeparator.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/CustomMenuItemSeparator.java
@@ -26,4 +26,5 @@ public abstract class CustomMenuItemSeparator extends MenuItemSeparator
       getElement().removeAllChildren();
       getElement().appendChild(createMainElement());
    }
+   
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ScrollableToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ScrollableToolbarPopupMenu.java
@@ -62,9 +62,9 @@ public class ScrollableToolbarPopupMenu extends ToolbarPopupMenu
    }
 
    @Override
-   protected Widget createMainWidget(Widget widget)
+   protected Widget createMainWidget()
    {
-      scrollPanel_ = new ScrollPanel(widget);
+      scrollPanel_ = new ScrollPanel(menuBar_);
       scrollPanel_.addStyleName(ThemeStyles.INSTANCE.scrollableMenuBar());
       scrollPanel_.getElement().getStyle().setOverflowY(Overflow.AUTO);
       scrollPanel_.getElement().getStyle().setOverflowX(Overflow.HIDDEN);

--- a/src/gwt/src/org/rstudio/core/client/widget/ScrollableToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ScrollableToolbarPopupMenu.java
@@ -62,9 +62,9 @@ public class ScrollableToolbarPopupMenu extends ToolbarPopupMenu
    }
 
    @Override
-   protected Widget wrapMenuBar(ToolbarMenuBar menuBar)
+   protected Widget createMainWidget(Widget widget)
    {
-      scrollPanel_ = new ScrollPanel(menuBar);
+      scrollPanel_ = new ScrollPanel(widget);
       scrollPanel_.addStyleName(ThemeStyles.INSTANCE.scrollableMenuBar());
       scrollPanel_.getElement().getStyle().setOverflowY(Overflow.AUTO);
       scrollPanel_.getElement().getStyle().setOverflowX(Overflow.HIDDEN);

--- a/src/gwt/src/org/rstudio/core/client/widget/ScrollableToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ScrollableToolbarPopupMenu.java
@@ -20,6 +20,7 @@ import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.*;
+
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;

--- a/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.java
@@ -30,7 +30,6 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.SuggestBox.DefaultSuggestionDisplay;
 import com.google.gwt.user.client.ui.SuggestBox.SuggestionDisplay;
-
 import org.rstudio.core.client.events.SelectionCommitEvent;
 import org.rstudio.core.client.events.SelectionCommitHandler;
 import org.rstudio.core.client.theme.res.ThemeResources;
@@ -73,6 +72,17 @@ public class SearchWidget extends Composite implements SearchDisplay
       }
    }
   
+   public SearchWidget()
+   {
+      this(new SuggestOracle()
+      {
+         @Override
+         public void requestSuggestions(Request request, Callback callback)
+         {
+            // no-op
+         }
+      });
+   }
 
    public SearchWidget(SuggestOracle oracle)
    {

--- a/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.java
@@ -17,6 +17,8 @@ package org.rstudio.core.client.widget;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.*;
 import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.CloseHandler;
@@ -30,6 +32,7 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.SuggestBox.DefaultSuggestionDisplay;
 import com.google.gwt.user.client.ui.SuggestBox.SuggestionDisplay;
+
 import org.rstudio.core.client.events.SelectionCommitEvent;
 import org.rstudio.core.client.events.SelectionCommitHandler;
 import org.rstudio.core.client.theme.res.ThemeResources;
@@ -118,7 +121,7 @@ public class SearchWidget extends Composite implements SearchDisplay
       close_.setVisible(false);
 
       ThemeStyles styles = ThemeResources.INSTANCE.themeStyles();
-
+      
       suggestBox_.setStylePrimaryName(styles.searchBox());
       suggestBox_.setAutoSelectEnabled(false) ;
       addKeyDownHandler(new KeyDownHandler() {
@@ -338,6 +341,16 @@ public class SearchWidget extends Composite implements SearchDisplay
    public boolean isFocused()
    {
       return focusTracker_.isFocused();
+   }
+   
+   private Element getSearchElement()
+   {
+      return getElement().getFirstChildElement();
+   }
+   
+   public void setWidth(double value, Unit unit)
+   {
+      getSearchElement().getStyle().setWidth(value, unit);
    }
 
    @UiField(provided=true)

--- a/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.java
@@ -17,8 +17,6 @@ package org.rstudio.core.client.widget;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.*;
 import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.CloseHandler;
@@ -343,16 +341,6 @@ public class SearchWidget extends Composite implements SearchDisplay
       return focusTracker_.isFocused();
    }
    
-   private Element getSearchElement()
-   {
-      return getElement().getFirstChildElement();
-   }
-   
-   public void setWidth(double value, Unit unit)
-   {
-      getSearchElement().getStyle().setWidth(value, unit);
-   }
-
    @UiField(provided=true)
    FocusSuggestBox suggestBox_;
    @UiField

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
@@ -20,26 +20,21 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.NativeEvent;
-import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.KeyCodes;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.Event.NativePreviewHandler;
-import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.MenuBar;
 import com.google.gwt.user.client.ui.MenuItem;
 import com.google.gwt.user.client.ui.MenuItemSeparator;
-import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.AppMenuItem;
 import org.rstudio.core.client.command.BaseMenuBar;
-import org.rstudio.core.client.theme.res.ThemeStyles;
 
 public class ToolbarPopupMenu extends ThemedPopupPanel
 {
@@ -52,36 +47,13 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
    {
       public void onPopupMenu(ToolbarPopupMenu menu);
    }
-   
-   public interface SearchHandler
-   {
-      public void onQuery(String query);
-   }
 
    public ToolbarPopupMenu()
    {
       super(true);
-      
       menuBar_ = createMenuBar();
-      searchWidget_ = new SearchWidget();
-      searchWidget_.addStyleName(ThemeStyles.INSTANCE.searchBox());
-      searchWidget_.setWidth(100, Unit.PCT);
-      searchWidget_.setVisible(isSearchEnabled());
-      
       Widget mainWidget = createMainWidget();
-      
-      if (isSearchEnabled())
-      {
-         VerticalPanel container = new VerticalPanel();
-         container.add(searchWidget_);
-         container.add(new HTML("<hr>"));
-         container.add(mainWidget);
-         setWidget(container);
-      }
-      else
-      {
-         setWidget(mainWidget);
-      }
+      setWidget(mainWidget);
    }
    
    public ToolbarPopupMenu(ToolbarPopupMenu parent)
@@ -100,16 +72,10 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
       return menuBar_;
    }
    
-   public boolean isSearchEnabled()
-   {
-      return false;
-   }
-
    @Override
    protected void onUnload()
    {
       super.onUnload();
-      searchWidget_.setValue(null);
       menuBar_.selectItem(null);
    }
    
@@ -241,24 +207,6 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
       }
       
       @Override
-      protected void onAttach()
-      {
-         super.onAttach();
-         
-         if (isSearchEnabled())
-         {
-            Scheduler.get().scheduleDeferred(new ScheduledCommand()
-            {
-               @Override
-               public void execute()
-               {
-                  searchWidget_.focus();
-               }
-            });
-         }
-      }
-
-      @Override
       protected void onUnload()
       {
          nativePreviewReg_.removeHandler();
@@ -276,9 +224,6 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
             {
                if (e.getTypeInt() == Event.ONKEYDOWN)
                {
-                  if (handleSearchKey(e.getNativeEvent()))
-                     return;
-                  
                   switch (e.getNativeEvent().getKeyCode())
                   {
                      case KeyCodes.KEY_ESCAPE:
@@ -389,44 +334,6 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
       private HandlerRegistration nativePreviewReg_;
    }
    
-   public void setSearchEnabled(boolean enabled)
-   {
-      searchEnabled_ = enabled;
-   }
-   
-   public HandlerRegistration addSearchValueChangeHandler(ValueChangeHandler<String> handler)
-   {
-      return searchWidget_.addValueChangeHandler(handler);
-   }
-   
-   private boolean handleSearchKey(NativeEvent event)
-   {
-      if (!searchEnabled_)
-         return false;
-    
-      int keyCode = event.getKeyCode();
-      if (!Character.isLetterOrDigit((char) keyCode))
-         return false;
-      
-      if (searchWidget_.isVisible())
-         return false;
-      
-      event.stopPropagation();
-      event.preventDefault();
-      
-      String initialValue = String.valueOf((char) keyCode);
-      if (!event.getShiftKey())
-         initialValue = initialValue.toLowerCase();
-      searchWidget_.setValue(initialValue);
-      
-      searchWidget_.setVisible(true);
-      searchWidget_.focus();
-      
-      return true;
-   }
-   
    protected ToolbarMenuBar menuBar_;
-   protected SearchWidget searchWidget_;
-   private boolean searchEnabled_;
    private ToolbarPopupMenu parent_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.css
@@ -1,0 +1,11 @@
+@CHARSET "UTF-8";
+
+@external rstudio-themes-flat;
+
+.searchWidget {
+	margin-left: 10px;
+}
+
+.rstudio-themes-flat .searchWidget {
+	margin-top: -2px;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
@@ -120,7 +120,6 @@ public class BranchToolbarButton extends ToolbarButton
                if (initialBranchMap_ != null)
                {
                   searchWidget_.setValue("");
-                  searchValue_ = "";
                   onSearchValueChange();
                }
                
@@ -392,8 +391,8 @@ public class BranchToolbarButton extends ToolbarButton
             if (!DomUtils.isDescendant(targetEl, searchEl))
                return;
             
-            searchValue_ = searchWidget_.getValue();
-            if (!searchValue_.equals(lastSearchValue_))
+            String searchValue = StringUtil.notNull(searchWidget_.getValue());
+            if (!searchValue.equals(lastSearchValue_))
                searchValueChangeTimer_.schedule(200);
          }
       });
@@ -403,11 +402,10 @@ public class BranchToolbarButton extends ToolbarButton
    
    private void onSearchValueChange()
    {
-      // update last search value
-      lastSearchValue_ = searchValue_;
+      lastSearchValue_ = searchWidget_.getValue();
       
       // fast path -- no query to use
-      String query = StringUtil.notNull(searchValue_).trim();
+      String query = StringUtil.notNull(lastSearchValue_).trim();
       if (query.isEmpty())
       {
          onBeforePopulateMenu(menu_);
@@ -482,7 +480,6 @@ public class BranchToolbarButton extends ToolbarButton
    private Element searchEl_;
    private HandlerRegistration previewHandler_;
    
-   private String searchValue_;
    private String lastSearchValue_;
    private final Timer searchValueChangeTimer_;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.workbench.views.vcs;
 
 import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
@@ -199,12 +200,12 @@ public class BranchToolbarButton extends ToolbarButton
       menu.addSeparator(new CustomMenuItemSeparator()
       {
          @Override
-         public Widget createMainWidget()
+         public Element createMainElement()
          {
             Label label = new Label(NO_BRANCHES_AVAILABLE);
             label.addStyleName(ThemeStyles.INSTANCE.menuSubheader());
             label.getElement().getStyle().setPaddingLeft(2, Unit.PX);
-            return separatorWithSearch(label);
+            return label.getElement();
          }
       });
    }
@@ -251,7 +252,7 @@ public class BranchToolbarButton extends ToolbarButton
             menu.addSeparator(new CustomMenuItemSeparator()
             {
                @Override
-               public Widget createMainWidget()
+               public Element createMainElement()
                {
                   String branchLabel = caption.equals(LOCAL_BRANCHES)
                         ? LOCAL_BRANCHES
@@ -259,12 +260,7 @@ public class BranchToolbarButton extends ToolbarButton
                   Label label = new Label(branchLabel);
                   label.addStyleName(ThemeStyles.INSTANCE.menuSubheader());
                   label.getElement().getStyle().setPaddingLeft(2, Unit.PX);
-                  
-                  Widget mainWidget = (separatorCount_++ == 0)
-                        ? separatorWithSearch(label)
-                        : label;
-                  
-                  return mainWidget;
+                  return label.getElement();
                }
             });
             menu.addSeparator();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
@@ -136,6 +136,16 @@ public class BranchToolbarButton extends ToolbarButton
                   }
                });
             }
+            else
+            {
+               if (previewHandler_ != null)
+               {
+                  previewHandler_.removeHandler();
+                  previewHandler_ = null;
+               }
+               
+               searchEl_ = null;
+            }
          }
       });
       
@@ -347,17 +357,19 @@ public class BranchToolbarButton extends ToolbarButton
       container.appendChild(labelEl);
       container.appendChild(searchEl);
       
+      searchEl_ = searchEl;
+      
+      // For some reason any attempts to click within the search box (when it
+      // lives as a separator in the menu) end up losing focus immediately after
+      // clicking, so we use a preview handler just to ensure focus doesn't leave
+      // the search widget on click events.
+      
       if (previewHandler_ != null)
       {
          previewHandler_.removeHandler();
          previewHandler_ = null;
       }
       
-      // For some reason any attempts to click within the search box (when it
-      // lives as a separator in the menu) end up losing focus immediately after
-      // clicking, so we use a preview handler just to ensure focus doesn't leave
-      // the search widget on click events.
-      searchEl_ = searchEl;
       previewHandler_ = Event.addNativePreviewHandler(new NativePreviewHandler()
       {
          @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
@@ -72,13 +72,22 @@ public class BranchToolbarButton extends ToolbarButton
       private final String branchLabel_;
       private final String branchValue_;
    }
+   
+   private static class Menu extends ScrollableToolbarPopupMenu
+   {
+      @Override
+      public boolean isSearchEnabled()
+      {
+         return true;
+      }
+   }
 
    @Inject
    public BranchToolbarButton(final Provider<GitState> pVcsState)
    {
       super("",
             StandardIcons.INSTANCE.empty_command(),
-            new ScrollableToolbarPopupMenu());
+            new Menu());
       pVcsState_ = pVcsState;
 
       setTitle("Switch branch");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
@@ -365,28 +365,12 @@ public class BranchToolbarButton extends ToolbarButton
          {
             switch (preview.getTypeInt())
             {
-            case Event.ONCLICK:
-            case Event.ONMOUSEUP:
-               onMouseEvent(preview);
-               break;
             case Event.ONKEYDOWN:
             case Event.ONKEYPRESS:
             case Event.ONKEYUP:
                onKeyEvent(preview);
                break;
             }
-         }
-         
-         private void onMouseEvent(NativePreviewEvent preview)
-         {
-            NativeEvent event = preview.getNativeEvent();
-            Element targetEl = event.getEventTarget().cast();
-            if (!DomUtils.isDescendant(targetEl, searchEl))
-               return;
-            
-            event.stopPropagation();
-            event.preventDefault();
-            focusSearch();
          }
          
          private void onKeyEvent(NativePreviewEvent preview)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.vcs;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
@@ -28,6 +29,8 @@ import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.resources.client.ClientBundle;
+import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Event;
@@ -349,8 +352,9 @@ public class BranchToolbarButton extends ToolbarButton
       
       labelEl.getStyle().setFloat(Style.Float.LEFT);
       searchEl.getStyle().setFloat(Style.Float.RIGHT);
-      searchEl.getStyle().setMarginLeft(10, Unit.PX);
-      searchEl.getStyle().setMarginTop(-2, Unit.PX);
+      
+      if (!searchEl.hasClassName(RES.styles().searchWidget()))
+         searchEl.addClassName(RES.styles().searchWidget());
       
       Element container = DOM.createDiv();
       container.appendChild(labelEl);
@@ -470,6 +474,17 @@ public class BranchToolbarButton extends ToolbarButton
       return tableNode.<Element>cast();
    }
 
+   public interface Styles extends CssResource
+   {
+      String searchWidget();
+   }
+
+   public interface Resources extends ClientBundle
+   {
+      @Source("BranchToolbarButton.css")
+      Styles styles();
+   }
+
    protected final Provider<GitState> pVcsState_;
    
    private final ToolbarPopupMenu menu_;
@@ -486,4 +501,10 @@ public class BranchToolbarButton extends ToolbarButton
    private static final String NO_BRANCH = "(no branch)";
    private static final String NO_BRANCHES_AVAILABLE = "(no branches available)";
    private static final String LOCAL_BRANCHES = "(local branches)";
+   
+   private static Resources RES = GWT.create(Resources.class);
+   static
+   {
+      RES.styles().ensureInjected();
+   }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
@@ -363,11 +363,6 @@ public class BranchToolbarButton extends ToolbarButton
          @Override
          public void onPreviewNativeEvent(NativePreviewEvent preview)
          {
-            NativeEvent event = preview.getNativeEvent();
-            Element targetEl = event.getEventTarget().cast();
-            if (!DomUtils.isDescendant(targetEl, searchEl))
-               return;
-            
             switch (preview.getTypeInt())
             {
             case Event.ONCLICK:
@@ -385,6 +380,10 @@ public class BranchToolbarButton extends ToolbarButton
          private void onMouseEvent(NativePreviewEvent preview)
          {
             NativeEvent event = preview.getNativeEvent();
+            Element targetEl = event.getEventTarget().cast();
+            if (!DomUtils.isDescendant(targetEl, searchEl))
+               return;
+            
             event.stopPropagation();
             event.preventDefault();
             focusSearch();
@@ -392,6 +391,11 @@ public class BranchToolbarButton extends ToolbarButton
          
          private void onKeyEvent(NativePreviewEvent preview)
          {
+            NativeEvent event = preview.getNativeEvent();
+            Element targetEl = event.getEventTarget().cast();
+            if (!DomUtils.isDescendant(targetEl, searchEl))
+               return;
+            
             searchValue_ = searchWidget_.getValue();
             if (!searchValue_.equals(lastSearchValue_))
                searchValueChangeTimer_.schedule(200);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
@@ -15,19 +15,27 @@
 package org.rstudio.studio.client.workbench.views.vcs;
 
 import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.dom.client.Node;
+import com.google.gwt.dom.client.NodeList;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.logical.shared.AttachEvent;
 import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Timer;
-import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.Event.NativePreviewEvent;
+import com.google.gwt.user.client.Event.NativePreviewHandler;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.MenuItem;
-import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
@@ -42,6 +50,8 @@ import java.util.Map;
 import org.rstudio.core.client.MapUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.WidgetHandlerRegistration;
+import org.rstudio.core.client.dom.DomUtils;
+import org.rstudio.core.client.dom.DomUtils.NodePredicate;
 import org.rstudio.core.client.js.JsUtil;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.CustomMenuItemSeparator;
@@ -99,17 +109,37 @@ public class BranchToolbarButton extends ToolbarButton
       
       menu_ = getMenu();
       menu_.setAutoHideRedundantSeparators(false);
-      
-      searchWidget_ = new SearchWidget();
-      searchWidget_.addValueChangeHandler(new ValueChangeHandler<String>()
+      menu_.addAttachHandler(new AttachEvent.Handler()
       {
          @Override
-         public void onValueChange(ValueChangeEvent<String> event)
+         public void onAttachOrDetach(AttachEvent event)
          {
-            lastSearchValue_ = event.getValue();
-            searchValueChangeTimer_.schedule(200);
+            if (event.isAttached())
+            {
+               // force a re-draw if necessary
+               if (initialBranchMap_ != null)
+               {
+                  searchWidget_.setValue("");
+                  searchValue_ = "";
+                  onSearchValueChange();
+               }
+               
+               Scheduler.get().scheduleDeferred(new ScheduledCommand()
+               {
+                  @Override
+                  public void execute()
+                  {
+                     focusSearch();
+                     Element tableEl = getMenuTableElement();
+                     if (tableEl != null)
+                        menuWidth_ = tableEl.getOffsetWidth();
+                  }
+               });
+            }
          }
       });
+      
+      searchWidget_ = new SearchWidget();
       
       searchValueChangeTimer_ = new Timer()
       {
@@ -184,17 +214,6 @@ public class BranchToolbarButton extends ToolbarButton
       populateMenu(menu_, branchMap);
    }
    
-   private Widget separatorWithSearch(Label label)
-   {
-      label.getElement().getStyle().setFloat(Style.Float.LEFT);
-      searchWidget_.getElement().getStyle().setFloat(Style.Float.RIGHT);
-      
-      FlowPanel container = new FlowPanel();
-      container.add(label);
-      container.add(searchWidget_);
-      return container;
-   }
-   
    private void populateEmptyMenu(final ToolbarPopupMenu menu)
    {
       menu.addSeparator(new CustomMenuItemSeparator()
@@ -205,7 +224,7 @@ public class BranchToolbarButton extends ToolbarButton
             Label label = new Label(NO_BRANCHES_AVAILABLE);
             label.addStyleName(ThemeStyles.INSTANCE.menuSubheader());
             label.getElement().getStyle().setPaddingLeft(2, Unit.PX);
-            return label.getElement();
+            return createSearchSeparator(label);
          }
       });
    }
@@ -260,7 +279,11 @@ public class BranchToolbarButton extends ToolbarButton
                   Label label = new Label(branchLabel);
                   label.addStyleName(ThemeStyles.INSTANCE.menuSubheader());
                   label.getElement().getStyle().setPaddingLeft(2, Unit.PX);
-                  return label.getElement();
+                  
+                  Element mainEl = (separatorCount_++ == 0)
+                        ? createSearchSeparator(label)
+                        : label.getElement();
+                  return mainEl;
                }
             });
             menu.addSeparator();
@@ -285,20 +308,111 @@ public class BranchToolbarButton extends ToolbarButton
             }
          }
       });
+      
+      if (menuWidth_ != 0)
+      {
+         Element tableEl = getMenuTableElement();
+         if (tableEl != null)
+            tableEl.getStyle().setWidth(menuWidth_, Unit.PX);
+      }
+      
+      menu.selectFirst();
    }
-
+   
    protected void onBeforePopulateMenu(ToolbarPopupMenu rootMenu)
    {
+      menu_.clearItems();
+      
+      Scheduler.get().scheduleDeferred(new ScheduledCommand()
+      {
+         @Override
+         public void execute()
+         {
+            focusSearch();
+         }
+      });
+   }
+   
+   private Element createSearchSeparator(Label label)
+   {
+      final Element searchEl = searchWidget_.getElement();
+      final Element labelEl = label.getElement();
+      
+      labelEl.getStyle().setFloat(Style.Float.LEFT);
+      searchEl.getStyle().setFloat(Style.Float.RIGHT);
+      searchEl.getStyle().setMarginLeft(10, Unit.PX);
+      searchEl.getStyle().setMarginTop(-2, Unit.PX);
+      
+      Element container = DOM.createDiv();
+      container.appendChild(labelEl);
+      container.appendChild(searchEl);
+      
+      if (previewHandler_ != null)
+      {
+         previewHandler_.removeHandler();
+         previewHandler_ = null;
+      }
+      
+      // For some reason any attempts to click within the search box (when it
+      // lives as a separator in the menu) end up losing focus immediately after
+      // clicking, so we use a preview handler just to ensure focus doesn't leave
+      // the search widget on click events.
+      searchEl_ = searchEl;
+      previewHandler_ = Event.addNativePreviewHandler(new NativePreviewHandler()
+      {
+         @Override
+         public void onPreviewNativeEvent(NativePreviewEvent preview)
+         {
+            NativeEvent event = preview.getNativeEvent();
+            Element targetEl = event.getEventTarget().cast();
+            if (!DomUtils.isDescendant(targetEl, searchEl))
+               return;
+            
+            switch (preview.getTypeInt())
+            {
+            case Event.ONCLICK:
+            case Event.ONMOUSEUP:
+               onMouseEvent(preview);
+               break;
+            case Event.ONKEYDOWN:
+            case Event.ONKEYPRESS:
+            case Event.ONKEYUP:
+               onKeyEvent(preview);
+               break;
+            }
+         }
+         
+         private void onMouseEvent(NativePreviewEvent preview)
+         {
+            NativeEvent event = preview.getNativeEvent();
+            event.stopPropagation();
+            event.preventDefault();
+            focusSearch();
+         }
+         
+         private void onKeyEvent(NativePreviewEvent preview)
+         {
+            searchValue_ = searchWidget_.getValue();
+            if (!searchValue_.equals(lastSearchValue_))
+               searchValueChangeTimer_.schedule(200);
+         }
+      });
+      
+      return container;
    }
    
    private void onSearchValueChange()
    {
+      // update last search value
+      lastSearchValue_ = searchValue_;
+      
       // fast path -- no query to use
-      String query = lastSearchValue_.trim();
+      String query = StringUtil.notNull(searchValue_).trim();
       if (query.isEmpty())
       {
          onBeforePopulateMenu(menu_);
          populateMenu(menu_, initialBranchMap_);
+         return;
       }
       
       // iterate through initial branch map and copy branches
@@ -322,13 +436,53 @@ public class BranchToolbarButton extends ToolbarButton
       onBeforePopulateMenu(menu_);
       populateMenu(menu_, branchMap);
    }
+   
+   private void focusSearch()
+   {
+      if (searchEl_ == null)
+         return;
+      
+      NodeList<Element> inputEls = searchEl_.getElementsByTagName("input");
+      if (inputEls == null || inputEls.getLength() != 1)
+         return;
+      
+      Element inputEl = inputEls.getItem(0);
+      inputEl.focus();
+   }
+   
+   Element getMenuTableElement()
+   {
+      Element menuEl = menu_.getWidget().getElement();
+      Node tableNode = DomUtils.findNode(menuEl, true, true, new NodePredicate()
+      {
+         @Override
+         public boolean test(Node node)
+         {
+            if (!(node instanceof Element))
+               return false;
+
+            Element el = (Element) node;
+            return el.hasTagName("table");
+         }
+      });
+      
+      if (tableNode == null)
+         return null;
+      
+      return tableNode.<Element>cast();
+   }
 
    protected final Provider<GitState> pVcsState_;
    
    private final ToolbarPopupMenu menu_;
+   private int menuWidth_ = 0;
    private final SearchWidget searchWidget_;
    private Map<String, List<String>> initialBranchMap_;
    
+   private Element searchEl_;
+   private HandlerRegistration previewHandler_;
+   
+   private String searchValue_;
    private String lastSearchValue_;
    private final Timer searchValueChangeTimer_;
 


### PR DESCRIPTION
This PR implements filtering of toolbar menus, and uses it with the Git branch toolbar menu to allow for quick search + selection of Git branches. I'm hoping this will become handy for other various toolbar menus we show where there are a large number of items to be displayed.

Feedback is welcome, especially what we can do to improve discoverability of this feature. Note that currently the search bar is activated simply by typing after the menu has been opened.

![branch-filter](https://cloud.githubusercontent.com/assets/1976582/26707865/9f0a4e86-46fc-11e7-87fd-2ef94ebbb197.gif)

I'll also need to make sure we appropriately theme + style the search widget here.