### PR TITLE
Update to WinPty 0.4.3

### DIFF
--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -20,7 +20,7 @@ set GNUGREP_FILE=gnugrep-2.5.4.zip
 set MSYS_SSH_FILE=msys-ssh-1000-18.zip
 set SUMATRA_PDF_FILE=SumatraPDF-3.1.1.zip
 set WINUTILS_FILE=winutils-1.0.zip
-set WINPTY_FILES=winpty-0.4.2-msys2-2.6.0.zip
+set WINPTY_FILES=winpty-0.4.3-msys2-2.7.0.zip
 
 set PANDOC_VERSION=1.19.2.1
 set PANDOC_NAME=pandoc-%PANDOC_VERSION%
@@ -92,7 +92,7 @@ if not exist winutils\1.0 (
   del "%WINUTILS_FILE%"
 )
 
-if not exist winpty-0.4.2-msys2-2.6.0 (
+if not exist winpty-0.4.3-msys2-2.7.0 (
   wget %WGET_ARGS% "%BASEURL%%WINPTY_FILES%"
   echo Unzipping %WINPTY_FILES%
   unzip %UNZIP_ARGS% "%WINPTY_FILES%"

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -210,7 +210,7 @@ if(WIN32)
         set(WINPTY_ARCH "32")
      endif()
 
-     set(WINPTY_ROOT "${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/winpty-0.4.2-msys2-2.6.0")
+     set(WINPTY_ROOT "${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/winpty-0.4.3-msys2-2.7.0")
      set(WINPTY_INCLUDEDIR "${WINPTY_ROOT}/${WINPTY_ARCH}/include")
      set(WINPTY_BINDIR_32 "${WINPTY_ROOT}/32/bin")
      set(WINPTY_BINDIR_64 "${WINPTY_ROOT}/64/bin")


### PR DESCRIPTION
Integrate WinPty 0.4.3. Relatively minor bug-fix release with no API signature changes. New package is up on rstudio-buildtools on AWS. Windows build machine requires updated dependencies.

Doing additional sanity testing now, including a 32-bit build.

**Don't merge until I give thumbs-up.**

https://github.com/rprichard/winpty/releases/tag/0.4.3