### PR TITLE
Simplify extraction of formals from primitive functions

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -498,8 +498,7 @@
    {
       ## Only closures have formals, not primitive functions.
       result <- tryCatch({
-         parsed <- suppressWarnings(parse(text = capture.output(print(object)))[[1L]])
-         names(parsed[[2]])
+        names(formals(args(object)))
       }, error = function(e) {
          character()
       })


### PR DESCRIPTION
As mentioned in `?formals` the formals of primitive functions can be
retrieved with `formals(args(.))`.

The previous behavior caused an unfortunate interaction between
RStudio's completion engine and the [lookup
package](https://github.com/jimhester/lookup), which uses a custom
`print.function` when **lookup** is attached, and was being
inadvertently called during argument completion.

Fixes https://github.com/jimhester/lookup/issues/14

I think the `tryCatch()` could probably be removed as well, `formals(args(fun))` should work for all primitive functions as far as I am aware. 

I did not build the IDE to test this change.