### PR TITLE
Custom shell setting for terminal

### DIFF
--- a/src/cpp/session/SessionUserSettings.cpp
+++ b/src/cpp/session/SessionUserSettings.cpp
@@ -69,6 +69,8 @@ const char * const kRemoveHistoryDuplicates = "removeHistoryDuplicates";
 const char * const kLineEndings = "lineEndingConversion";
 const char * const kUseNewlineInMakefiles = "newlineInMakefiles";
 const char * const kDefaultTerminalShell = "defaultTerminalShell";
+const char * const kCustomShellCommand = "customShellCommand";
+const char * const kCustomShellOptions = "customShellOptions";
 
 template <typename T>
 T readPref(const json::Object& prefs,
@@ -597,6 +599,26 @@ void UserSettings::setDefaultTerminalShellValue(
       console_process::TerminalShell::TerminalShellType shell)
 {
    settings_.set(kDefaultTerminalShell, static_cast<int>(shell));
+}
+
+core::FilePath UserSettings::customShellCommand() const
+{
+   return core::FilePath(settings_.get(kCustomShellCommand, ""));
+}
+
+void UserSettings::setCustomShellCommand(const std::string& commandPath)
+{
+   settings_.set(kCustomShellCommand, commandPath);
+}
+
+std::string UserSettings::customShellOptions() const
+{
+   return settings_.get(kCustomShellOptions, "");
+}
+
+void UserSettings::setCustomShellOptions(const std::string& options)
+{
+   settings_.set(kCustomShellOptions, options);
 }
 
 core::FilePath UserSettings::initialWorkingDirectory() const

--- a/src/cpp/session/include/session/SessionTerminalShell.hpp
+++ b/src/cpp/session/include/session/SessionTerminalShell.hpp
@@ -43,6 +43,7 @@ struct TerminalShell
       PS64         = 6, // Win32: PowerShell (64-bit)
 
       PosixBash    = 7, // Posix: Bash
+      CustomShell  = 8, // User-specified shell command
 
       Max          = PosixBash
    };
@@ -101,6 +102,9 @@ public:
 
    // Get a standard system shell
    static bool getSystemShell(TerminalShell* pShellInfo);
+
+   // Get user-customizable shell
+   static bool getCustomShell(TerminalShell* pShellInfo);
 
 private:
    std::vector<TerminalShell> shells_;

--- a/src/cpp/session/include/session/SessionUserSettings.hpp
+++ b/src/cpp/session/include/session/SessionUserSettings.hpp
@@ -124,6 +124,12 @@ public:
    console_process::TerminalShell::TerminalShellType defaultTerminalShellValue() const;
    void setDefaultTerminalShellValue(console_process::TerminalShell::TerminalShellType shell);
 
+   core::FilePath customShellCommand() const;
+   void setCustomShellCommand(const std::string& commandPath);
+
+   std::string customShellOptions() const;
+   void setCustomShellOptions(const std::string& options);
+
    core::FilePath initialWorkingDirectory() const;
    std::string initialWorkingDirectory(const std::string& defaultStr) const;
    void setInitialWorkingDirectory(const core::FilePath& filePath);

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -13,7 +13,6 @@
  *
  */
 
-
 #include "SessionWorkbench.hpp"
 
 #include <algorithm>
@@ -470,13 +469,19 @@ Error setPrefs(const json::JsonRpcRequest& request, json::JsonRpcResponse*)
 
    // read and update terminal prefs
    int defaultTerminalShell;
+   std::string customShellPath;
+   std::string customShellOptions;
    error = json::readObject(terminalPrefs,
-                            "default_shell", &defaultTerminalShell);
+                            "default_shell", &defaultTerminalShell,
+                            "shell_exe_path", &customShellPath,
+                            "shell_exe_options", &customShellOptions);
    if (error)
       return error;
    userSettings().beginUpdate();
    userSettings().setDefaultTerminalShellValue(
       static_cast<console_process::TerminalShell::TerminalShellType>(defaultTerminalShell));
+   userSettings().setCustomShellCommand(customShellPath);
+   userSettings().setCustomShellOptions(customShellOptions);
    userSettings().endUpdate();
 
    // set ui prefs
@@ -600,7 +605,6 @@ Error getRPrefs(const json::JsonRpcRequest& request,
                   module_context::createAliasedPath(rsaSshKeyPath);
    sourceControlPrefs["have_rsa_key"] = rsaSshKeyPath.exists();
 
-
    // get compile pdf prefs
    json::Object compilePdfPrefs;
    compilePdfPrefs["clean_output"] = userSettings().cleanTexi2DviOutput();
@@ -609,6 +613,8 @@ Error getRPrefs(const json::JsonRpcRequest& request,
    // get terminal prefs
    json::Object terminalPrefs;
    terminalPrefs["default_shell"] = userSettings().defaultTerminalShellValue();
+   terminalPrefs["shell_exe_path"] = userSettings().customShellCommand().absolutePath();
+   terminalPrefs["shell_exe_options"] = userSettings().customShellOptions();
 
    // initialize and set result object
    json::Object result;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/TerminalPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/TerminalPrefs.java
@@ -13,7 +13,7 @@
  *
  */
 
- package org.rstudio.studio.client.workbench.prefs.model;
+package org.rstudio.studio.client.workbench.prefs.model;
 
 import com.google.gwt.core.client.JavaScriptObject;
 
@@ -21,13 +21,25 @@ public class TerminalPrefs extends JavaScriptObject
 {
    protected TerminalPrefs() {}
 
-   public static final native TerminalPrefs create(int defaultShell) /*-{
+   public static final native TerminalPrefs create(int defaultShell, 
+                                                   String customShellPath,
+                                                   String customShellOptions) /*-{
       var prefs = new Object();
       prefs.default_shell = defaultShell;
+      prefs.shell_exe_path = customShellPath;
+      prefs.shell_exe_options = customShellOptions;
       return prefs;
    }-*/;
 
    public native final int getDefaultTerminalShellValue() /*-{
       return this.default_shell;
+   }-*/;
+
+   public native final String getCustomTerminalShellPath() /*-{
+      return this.shell_exe_path;
+   }-*/;
+
+   public native final String getCustomTerminalShellOptions() /*-{
+      return this.shell_exe_options;
    }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/TerminalPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/TerminalPreferencesPane.java
@@ -17,7 +17,11 @@ package org.rstudio.studio.client.workbench.prefs.views;
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.core.client.widget.FileChooserTextBox;
+import org.rstudio.core.client.widget.HyperlinkLabel;
 import org.rstudio.core.client.widget.SelectWidget;
+import org.rstudio.core.client.widget.TextBoxWithButton;
+import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.server.Server;
 import org.rstudio.studio.client.server.ServerError;
@@ -31,9 +35,16 @@ import org.rstudio.studio.client.workbench.views.terminal.TerminalShellInfo;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.CheckBox;
+import com.google.gwt.user.client.ui.HasHorizontalAlignment;
+import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.TextBox;
 import com.google.inject.Inject;
 
 public class TerminalPreferencesPane extends PreferencesPane
@@ -43,6 +54,7 @@ public class TerminalPreferencesPane extends PreferencesPane
    public TerminalPreferencesPane(UIPrefs prefs,
                                   PreferencesDialogResources res,
                                   Session session,
+                                  final GlobalDisplay globalDisplay,
                                   final Server server)
    {
       prefs_ = prefs;
@@ -51,20 +63,73 @@ public class TerminalPreferencesPane extends PreferencesPane
       server_ = server;
 
       add(spaced(new Label("Use the terminal to run system commands, execute data-processing jobs, and more.")));
-      
-      if (haveTerminalShellPref())
+
+      Label shellLabel = headerLabel("Shell");
+      shellLabel.getElement().getStyle().setMarginTop(8, Unit.PX);
+      add(shellLabel);
+
+      terminalShell_ = new SelectWidget("New terminals open with:");
+      spaced(terminalShell_);
+      add(terminalShell_);
+      terminalShell_.setEnabled(false);
+      terminalShell_.addChangeHandler(new ChangeHandler() {
+         @Override
+         public void onChange(ChangeEvent event)
+         {
+            manageControlVisibility();
+         }
+      });
+
+      // custom shell path chooser  
+      Command onShellPathChosen = new Command()
       {
-         terminalShell_ = new SelectWidget("Default terminal shell:");
-         spaced(terminalShell_);
-         add(terminalShell_);
-         terminalShell_.setEnabled(false);
-      }
+         @Override
+         public void execute()
+         {
+            if (BrowseCap.isWindowsDesktop())
+            {
+               String exePath = customShellPathChooser_.getText();
+               if (!exePath.endsWith(".exe"))
+               {
+                  String message = "The program '" + exePath + "'" +
+                     " is unlikely to be a valid shell executable.\n" +
+                     "Please select an executable ending in '.exe'.";
+
+                  globalDisplay.showMessage(
+                        GlobalDisplay.MSG_WARNING,
+                        "Invalid Shell Executable",
+                        message);
+               }
+            }
+         }
+      };
+
+      customShellPathChooser_ = new FileChooserTextBox("",
+                                                  "(Default)",
+                                                  null,
+                                                  onShellPathChosen);
+      customShellPathLabel_ = new Label("Custom shell binary:");
+      addTextBoxChooser(customShellPathLabel_, null, null, customShellPathChooser_);
+      customShellOptionsLabel_ = new Label("Custom shell command-line options:");
+      add(spacedBefore(customShellOptionsLabel_));
+      customShellOptions_ = new TextBox();
+      customShellOptions_.getElement().setAttribute("spellcheck", "false");
+      customShellOptions_.setWidth("75%");
+      customShellOptions_.setEnabled(false);
+      add(customShellOptions_);
+
+      Label perfLabel = headerLabel("Connection");
+      perfLabel.getElement().getStyle().setMarginTop(8, Unit.PX);
+      add(perfLabel);
+ 
+      boolean showPerfLabel = false;
       if (haveLocalEchoPref())
       {
          CheckBox chkTerminalLocalEcho = checkboxPref("Local terminal echo",
                prefs_.terminalLocalEcho(), 
-               "Local echo is more responsive but may get out of sync with some line-editing modes.");
+               "Local echo is more responsive but may get out of sync with some line-editing modes or custom shells.");
          add(chkTerminalLocalEcho);
+         showPerfLabel = true;
       }
       if (haveWebsocketPref())
       {
@@ -72,13 +137,18 @@ public class TerminalPreferencesPane extends PreferencesPane
                prefs_.terminalUseWebsockets(), 
                "WebSockets are generally more responsive; try turning off if terminal won't connect.");
          add(chkTerminalWebsocket);
+         showPerfLabel = true;
       }
-      
+
+      perfLabel.setVisible(showPerfLabel);
+
       HelpLink helpLink = new HelpLink("Using the RStudio terminal", "rstudio_terminal", false);
       nudgeRight(helpLink); 
       helpLink.addStyleName(res_.styles().newSection()); 
       // TODO (gary) -- uncomment once we've published the support article
       //add(helpLink);
+
+      customShellPathChooser_.setEnabled(false);
    }
 
    @Override
@@ -98,81 +168,127 @@ public class TerminalPreferencesPane extends PreferencesPane
    {
       final TerminalPrefs terminalPrefs = prefs.getTerminalPrefs();
 
-      if (terminalShell_ != null)
+      Scheduler.get().scheduleDeferred(new ScheduledCommand()
       {
-         Scheduler.get().scheduleDeferred(new ScheduledCommand()
+         @Override
+         public void execute()
          {
-            @Override
-            public void execute()
+            server_.getTerminalShells(new ServerRequestCallback<JsArray<TerminalShellInfo>>()
             {
-               server_.getTerminalShells(new ServerRequestCallback<JsArray<TerminalShellInfo>>()
+               @Override
+               public void onResponseReceived(JsArray<TerminalShellInfo> shells)
                {
-                  @Override
-                  public void onResponseReceived(JsArray<TerminalShellInfo> shells)
+                  int currentShell = terminalPrefs.getDefaultTerminalShellValue();
+                  int currentShellIndex = 0;
+
+                  TerminalPreferencesPane.this.terminalShell_.getListBox().clear();
+
+                  for (int i = 0; i < shells.length(); i++)
                   {
-                     int currentShell = terminalPrefs.getDefaultTerminalShellValue();
-                     int currentShellIndex = 0;
-
-                     TerminalPreferencesPane.this.terminalShell_.getListBox().clear();
-
-                     for (int i = 0; i < shells.length(); i++)
-                     {
-                        TerminalShellInfo info = shells.get(i);
-                        TerminalPreferencesPane.this.terminalShell_.addChoice(
-                              info.getShellName(), Integer.toString(info.getShellType()));
-                        if (info.getShellType() == currentShell)
-                           currentShellIndex = i;
-                     }
-                     if (TerminalPreferencesPane.this.terminalShell_.getListBox().getItemCount() > 0)
-                     {
-                        TerminalPreferencesPane.this.terminalShell_.setEnabled((true));
-                        TerminalPreferencesPane.this.terminalShell_.getListBox().setSelectedIndex(currentShellIndex);
-                     }
+                     TerminalShellInfo info = shells.get(i);
+                     TerminalPreferencesPane.this.terminalShell_.addChoice(
+                           info.getShellName(), Integer.toString(info.getShellType()));
+                     if (info.getShellType() == currentShell)
+                        currentShellIndex = i;
+                  }
+                  if (TerminalPreferencesPane.this.terminalShell_.getListBox().getItemCount() > 0)
+                  {
+                     TerminalPreferencesPane.this.terminalShell_.setEnabled((true));
+                     TerminalPreferencesPane.this.terminalShell_.getListBox().setSelectedIndex(currentShellIndex);
                   }
 
-                  @Override
-                  public void onError(ServerError error) { }
-               });
-            }
-         });
-      }
+                  customShellPathChooser_.setText(
+                        terminalPrefs.getCustomTerminalShellPath());
+                  customShellPathChooser_.setEnabled(true);
+                  customShellOptions_.setText(terminalPrefs.getCustomTerminalShellOptions());
+                  customShellOptions_.setEnabled(true);
+                  manageControlVisibility();
+               }
+
+               @Override
+               public void onError(ServerError error) { }
+            });
+         }
+      });
    }
 
    @Override
    public boolean onApply(RPrefs rPrefs)
    {
       boolean restartRequired = super.onApply(rPrefs);
-      
-      int defaultShell = TerminalShellInfo.SHELL_DEFAULT;
-      if (terminalShell_ != null && terminalShell_.isEnabled())
-      {
-         int idx = terminalShell_.getListBox().getSelectedIndex();
-         String valStr = terminalShell_.getListBox().getValue(idx);
-         defaultShell = StringUtil.parseInt(valStr, TerminalShellInfo.SHELL_DEFAULT);
-      }
 
-      TerminalPrefs terminalPrefs = TerminalPrefs.create(defaultShell);
+      TerminalPrefs terminalPrefs = TerminalPrefs.create(selectedShellType(),
+            customShellPathChooser_.getText(),
+            customShellOptions_.getText());
       rPrefs.setTerminalPrefs(terminalPrefs);
 
       return restartRequired;
-   }
-
-   private boolean haveTerminalShellPref()
-   {
-      return BrowseCap.isWindowsDesktop();
    }
 
    private boolean haveLocalEchoPref()
    {
       return !BrowseCap.isWindowsDesktop();
    }
-   
+
    private boolean haveWebsocketPref()
    {
       return session_.getSessionInfo().getAllowTerminalWebsockets();
    }
+
+   private void addTextBoxChooser(Label captionLabel, HyperlinkLabel link,
+         String captionPanelStyle, TextBoxWithButton chooser)
+   {
+      String textWidth = "250px";
+
+      HorizontalPanel captionPanel = new HorizontalPanel();
+      captionPanel.setWidth(textWidth);
+      nudgeRight(captionPanel);
+      if (captionPanelStyle != null)
+         captionPanel.addStyleName(captionPanelStyle);
+
+      captionPanel.add(captionLabel);
+      captionPanel.setCellHorizontalAlignment(captionLabel,
+            HasHorizontalAlignment.ALIGN_LEFT);
+
+      if (link != null)
+      {
+         HorizontalPanel linkPanel = new HorizontalPanel();
+         linkPanel.add(link);
+         captionPanel.add(linkPanel);
+         captionPanel.setCellHorizontalAlignment(linkPanel,
+               HasHorizontalAlignment.ALIGN_RIGHT);
+
+      }
+
+      add(tight(captionPanel));
+
+      chooser.setTextWidth(textWidth);
+      nudgeRight(chooser);
+      textBoxWithChooser(chooser);
+      add(chooser);
+   }
+
+   private int selectedShellType()
+   {
+      int idx = terminalShell_.getListBox().getSelectedIndex();
+      String valStr = terminalShell_.getListBox().getValue(idx);
+      return StringUtil.parseInt(valStr, TerminalShellInfo.SHELL_DEFAULT);
+   }
+
+   private void manageControlVisibility()
+   {
+      boolean customEnabled = (selectedShellType() == TerminalShellInfo.SHELL_CUSTOM);
+      customShellPathLabel_.setVisible(customEnabled);
+      customShellPathChooser_.setVisible(customEnabled);
+      customShellOptionsLabel_.setVisible(customEnabled);
+      customShellOptions_.setVisible(customEnabled);
+   }
  
    private SelectWidget terminalShell_;
+   private Label customShellPathLabel_;
+   private TextBoxWithButton customShellPathChooser_;
+   private Label customShellOptionsLabel_;
+   private TextBox customShellOptions_;
 
    // Injected ----  
    private final UIPrefs prefs_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalShellInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalShellInfo.java
@@ -35,6 +35,7 @@ public class TerminalShellInfo extends JavaScriptObject
    // -- End Windows-only	
    
    public static final int SHELL_POSIX_BASH = 7;
+   public static final int SHELL_CUSTOM = 8;
 
    protected TerminalShellInfo() {}
 
@@ -66,9 +67,10 @@ public class TerminalShellInfo extends JavaScriptObject
          return "PowerShell (64-bit)";
       case SHELL_POSIX_BASH:
          return "Bash";
+      case SHELL_CUSTOM:
+         return "Custom";
       default:
          return "Unknown";
       }
    }
-   
 }


### PR DESCRIPTION
Provide option for user to customize the shell program launched by the terminal. There were already several options on Windows (git-bash, cmd, powershell, etc.), but previously only the default Bash on Mac/Linux/Server. Now that preferences dropdown is visible on non-Windows and includes a new "Custom" option which lets user specify a command and command-line arguments for that command.

For example, normal shell setting on non-Windows:
![2017-06-05_20-10-20](https://cloud.githubusercontent.com/assets/10569626/26812538/2192a78a-4a2d-11e7-9185-3552b8ca7051.png)

And a custom setting:
![2017-06-05_20-10-42](https://cloud.githubusercontent.com/assets/10569626/26812545/2a954248-4a2d-11e7-8197-5e4431939e49.png)

