### PR TITLE
tweak keyboard handling with History pane

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/BottomScrollPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/BottomScrollPanel.java
@@ -114,6 +114,11 @@ public class BottomScrollPanel extends ScrollPanel
 
       setHorizontalScrollPosition(hScroll_);
    }
+   
+   public boolean hasSavedScrollPosition()
+   {
+      return vScroll_ != null;
+   }
 
    private boolean scrolledToBottom_;
    private boolean scrolling_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/history/History.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/history/History.java
@@ -54,7 +54,6 @@ import org.rstudio.studio.client.workbench.views.BasePresenter;
 import org.rstudio.studio.client.workbench.views.console.events.ConsoleResetHistoryEvent;
 import org.rstudio.studio.client.workbench.views.console.events.ConsoleResetHistoryHandler;
 import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
-import org.rstudio.studio.client.workbench.views.history.History.Display.Mode;
 import org.rstudio.studio.client.workbench.views.history.events.FetchCommandsEvent;
 import org.rstudio.studio.client.workbench.views.history.events.FetchCommandsHandler;
 import org.rstudio.studio.client.workbench.views.history.events.HistoryEntriesAddedEvent;
@@ -416,8 +415,6 @@ public class History extends BasePresenter implements SelectionCommitHandler<Voi
    {
       super.onSelected();
       view_.focusSearch();
-      if (view_.getMode() == Mode.Recent)
-         view_.scrollToBottom();
    }
 
    private String getSelectedCommands()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/history/view/HistoryPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/history/view/HistoryPane.java
@@ -576,14 +576,20 @@ public class HistoryPane extends WorkbenchPane
       {
          public void onKeyDown(KeyDownEvent event)
          {
-            getActiveHistory().getKeyTarget().fireEvent(event);
-         }
-      });
-      searchWidget_.addSelectionCommitHandler(new SelectionCommitHandler<String>()
-      {
-         public void onSelectionCommit(SelectionCommitEvent<String> event)
-         {
-            fireEvent(event);
+            if (event.getNativeKeyCode() == KeyCodes.KEY_ENTER)
+            {
+               event.stopPropagation();
+               event.preventDefault();
+               
+               if (event.isShiftKeyDown())
+                  commands_.historySendToSource().execute();
+               else
+                  commands_.historySendToConsole().execute();
+            }
+            else
+            {
+               getActiveHistory().getKeyTarget().fireEvent(event);
+            }
          }
       });
       searchWidget_.addFocusHandler(new FocusHandler()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/history/view/HistoryPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/history/view/HistoryPane.java
@@ -113,7 +113,10 @@ public class HistoryPane extends WorkbenchPane
          @Override
          public void execute()
          {
-            recentScrollPanel_.restoreScrollPosition();
+            if (recentScrollPanel_.hasSavedScrollPosition())
+            {
+               recentScrollPanel_.restoreScrollPosition();
+            }
          }
       });
    }


### PR DESCRIPTION
This PR does a couple things:

1) Fixes the behavior of `Enter`, `Shift + Enter` when the History pane is focused through e.g. `Ctrl + 4`. Previously, `Shift + Enter` would still send code to the console rather than the source window.

2) Ensures that the vertical scroll position is not changed when activating the History pane. (Previously, pressing `Ctrl + 4` would always scroll the history output to the bottom, which was typically undesired)