### PR TITLE
use textbox instead of file picker for custom shell selection

### DIFF
--- a/src/cpp/session/modules/SessionTerminalShell.cpp
+++ b/src/cpp/session/modules/SessionTerminalShell.cpp
@@ -139,6 +139,7 @@ void scanAvailableShells(std::vector<TerminalShell>* pShells)
       }
    }
 
+#ifndef _WIN32
    // Add user-selectable shell command option
    TerminalShell customShell;
    if (AvailableTerminalShells::getCustomShell(&customShell))
@@ -147,6 +148,7 @@ void scanAvailableShells(std::vector<TerminalShell>* pShells)
                customShell.args, pShells,
                false /*checkPathExists*/);
    }
+#endif // !_WIN32
 }
 
 } // anonymous namespace

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/TerminalPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/TerminalPreferencesPane.java
@@ -76,7 +76,7 @@ public class TerminalPreferencesPane extends PreferencesPane
 
 
       String textboxWidth = "250px";
-      customShellPathLabel_ = new Label("Custom shell binary:");
+      customShellPathLabel_ = new Label("Custom shell binary (fully qualified path):");
       add(spacedBefore(customShellPathLabel_));
       customShellPath_ = new TextBox();
       customShellPath_.getElement().setAttribute("spellcheck", "false");


### PR DESCRIPTION
Use a textbox for entry of custom terminal shell. This is an advanced feature, and file pickers can make it hard to navigate to Unix-y paths (especially on Mac file picker), and may not deal well with soft-links.

Also turned off custom shell option for Windows. Not tested, and likely not very useful. Can reconsider if we get feedback on the subject.
![2017-06-07_12-23-44](https://user-images.githubusercontent.com/10569626/26897128-2df49cb8-4b7c-11e7-987f-b7f4c750ce6f.png)
