### PR TITLE
Feature dark theme for sky theme

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
@@ -113,8 +113,9 @@ public class RStudioThemedFrame extends RStudioFrame
          {
             if (removeBodyStyle) body.removeAttribute("style");
             
-            String themeName = RStudioGinjector.INSTANCE.getUIPrefs().getFlatTheme().getValue();
-            RStudioThemes.initializeThemes(themeName, document, document.getBody());
+            RStudioThemes.initializeThemes(
+              RStudioGinjector.INSTANCE.getUIPrefs(),
+              document, document.getBody());
             
             body.addClassName("ace_editor_theme");
          }

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -620,7 +620,7 @@ public class Application implements ApplicationEventHandlers
    @Override
    public void onThemeChanged(ThemeChangedEvent event)
    {
-      RStudioThemes.initializeThemes(uiPrefs_.get().getFlatTheme().getValue(),
+      RStudioThemes.initializeThemes(uiPrefs_.get(),
                                      Document.get(),
                                      rootPanel_.getElement());
    }
@@ -717,7 +717,7 @@ public class Application implements ApplicationEventHandlers
    
    private void initializeWorkbench()
    {
-      RStudioThemes.initializeThemes(uiPrefs_.get().getFlatTheme().getValue(),
+      RStudioThemes.initializeThemes(uiPrefs_.get(),
                                      Document.get(),
                                      rootPanel_.getElement());
 

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
@@ -87,17 +87,6 @@ public class RStudioThemes
       return result != null ? "dark-grey" : rstudioTheme;
    }
 
-   public static String suggestThemeFromAceTheme(String aceTheme) {
-      RegExp keyReg = RegExp.compile(
-         "ambiance|chaos|clouds midnight|cobalt|idle fingers|kr theme|" +
-         "material|merbivore soft|merbivore|mono industrial|monokai|" +
-         "pastel on dark|solarized dark|tomorrow night blue|tomorrow night bright|" +
-         "tomorrow night 80s|tomorrow night|twilight|vibrant ink", "i");
-      
-      MatchResult result = keyReg.exec(aceTheme);
-      return result != null ? "dark-grey" : "default";
-   }
-
    public static String getThemeFromUiPrefs(UIPrefs prefs) {
       return suggestThemeFromAceTheme(
         prefs.theme().getGlobalValue(),

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
@@ -29,6 +29,14 @@ import com.google.gwt.regexp.shared.RegExp;
 
 public class RStudioThemes
 {
+   public static void initializeThemes(UIPrefs uiPrefs,
+                                       Document document,
+                                       Element element)
+   {
+      String themeName = getThemeFromUiPrefs(uiPrefs);
+      initializeThemes(themeName, document, element);
+   }
+
    public static void initializeThemes(String themeName,
                                        Document document,
                                        Element element)
@@ -68,6 +76,17 @@ public class RStudioThemes
       return Document.get().getBody().hasClassName("editor_dark");
    }
 
+   public static String suggestThemeFromAceTheme(String aceTheme, String rstudioTheme) {
+      RegExp keyReg = RegExp.compile(
+         "ambiance|chaos|clouds midnight|cobalt|idle fingers|kr theme|" +
+         "material|merbivore soft|merbivore|mono industrial|monokai|" +
+         "pastel on dark|solarized dark|tomorrow night blue|tomorrow night bright|" +
+         "tomorrow night 80s|tomorrow night|twilight|vibrant ink", "i");
+      
+      MatchResult result = keyReg.exec(aceTheme);
+      return result != null ? "dark-grey" : rstudioTheme;
+   }
+
    public static String suggestThemeFromAceTheme(String aceTheme) {
       RegExp keyReg = RegExp.compile(
          "ambiance|chaos|clouds midnight|cobalt|idle fingers|kr theme|" +
@@ -77,6 +96,13 @@ public class RStudioThemes
       
       MatchResult result = keyReg.exec(aceTheme);
       return result != null ? "dark-grey" : "default";
+   }
+
+   public static String getThemeFromUiPrefs(UIPrefs prefs) {
+      return suggestThemeFromAceTheme(
+        prefs.theme().getGlobalValue(),
+        prefs.getFlatTheme().getGlobalValue()
+      );
    }
    
    private static boolean usesScrollbars() {

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteManager.java
@@ -36,6 +36,7 @@ import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.CrossWindowEvent;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.ThemeChangedEvent;
+import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.common.GlobalDisplay.NewWindowOptions;
 import org.rstudio.studio.client.common.satellite.events.AllSatellitesClosingEvent;
 import org.rstudio.studio.client.common.satellite.events.SatelliteClosedEvent;
@@ -474,7 +475,7 @@ public class SatelliteManager implements CloseHandler<Window>
 
       // set themes
       events_.fireEventToSatellite(new ThemeChangedEvent(
-         pUIPrefs_.get().getFlatTheme().getGlobalValue()),
+         RStudioThemes.getThemeFromUiPrefs(pUIPrefs_.get())),
          satelliteWnd);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -650,8 +650,7 @@ public class UIPrefsAccessor extends Prefs
 
    public PrefValue<String> getFlatTheme()
    {
-      String flatTheme = RStudioThemes.suggestThemeFromAceTheme(theme().getValue());
-      return string("flat_theme", flatTheme);
+      return string("flat_theme", "default");
    }
    
    public PrefValue<Boolean> gitDiffIgnoreWhitespace()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -60,7 +60,7 @@ public class AppearancePreferencesPane extends PreferencesPane
       
       flatTheme_ = new SelectWidget("RStudio theme:",
                                 new String[]{"Classic", "Modern", "Sky"},
-                                new String[]{"classic", "modern", "alternate"},
+                                new String[]{"classic", "default", "alternate"},
                                 false);
       flatTheme_.addStyleName(res.styles().themeChooser());
       flatTheme_.getListBox().setWidth("95%");
@@ -81,7 +81,6 @@ public class AppearancePreferencesPane extends PreferencesPane
       });
 
       String themeAlias = uiPrefs_.getFlatTheme().getGlobalValue();
-      if (themeAlias == "default" || themeAlias ==  "dark-grey") themeAlias = "modern";
       flatTheme_.setValue(themeAlias);
 
       leftPanel.add(flatTheme_);
@@ -269,9 +268,6 @@ public class AppearancePreferencesPane extends PreferencesPane
       }
 
       String themeName = flatTheme_.getValue();
-      if (themeName == "modern") {
-         themeName = RStudioThemes.suggestThemeFromAceTheme(theme_.getValue());
-      }
 
       uiPrefs_.getFlatTheme().setGlobalValue(themeName);  
       ThemeChangedEvent themeChangedEvent = new ThemeChangedEvent(flatTheme_.getValue());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -56,8 +56,12 @@ public class AppearancePreferencesPane extends PreferencesPane
       infoBar_.setText("Relaunch RStudio to complete this change.");
       infoBar_.addStyleName(res_.styles().themeInfobar());
 
+      // dark-grey theme used to be derived from default, now also applies to sky
+      if (uiPrefs_.getFlatTheme().getValue() == "dark-grey")
+        uiPrefs_.getFlatTheme().setGlobalValue("default");
+
       final String originalTheme = uiPrefs_.getFlatTheme().getValue();
-      
+
       flatTheme_ = new SelectWidget("RStudio theme:",
                                 new String[]{"Classic", "Modern", "Sky"},
                                 new String[]{"classic", "default", "alternate"},


### PR DESCRIPTION
Themes under sky and dark editor do not look good; instead, use dark-grey theme for ace themes regardless of the rstudio theme selection.