### PR TITLE
Add option to keep terminal pane open after process exits

### DIFF
--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -253,7 +253,7 @@ void ConsoleProcess::setPromptHandler(
 
 Error ConsoleProcess::start()
 {
-   if (started_)
+   if (started_ || procInfo_->getZombie())
       return Success();
 
    Error error;
@@ -609,6 +609,19 @@ void ConsoleProcess::handleConsolePrompt(core::system::ProcessOperations& ops,
 void ConsoleProcess::onExit(int exitCode)
 {
    procInfo_->setExitCode(exitCode);
+
+   AutoCloseMode autoClose = procInfo_->getAutoClose();
+   if (autoClose == DefaultAutoClose)
+   {
+      if (session::userSettings().terminalAutoclose())
+         autoClose = AlwaysAutoClose;
+      else
+         autoClose = NeverAutoClose;
+   }
+
+   if (autoClose == NeverAutoClose)
+      procInfo_->setZombie(true);
+
    saveConsoleProcesses();
 
    json::Object data;

--- a/src/cpp/session/SessionConsoleProcessInfo.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfo.cpp
@@ -39,7 +39,7 @@ ConsoleProcessInfo::ConsoleProcessInfo()
      showOnOutput_(false), outputBuffer_(kOutputBufferSize), childProcs_(true),
      altBufferActive_(false), shellType_(TerminalShell::DefaultShell),
      channelMode_(Rpc), cols_(system::kDefaultCols), rows_(system::kDefaultRows),
-     restarted_(false)
+     restarted_(false), autoClose_(DefaultAutoClose)
 {
    // When we retrieve from outputBuffer, we only want complete lines. Add a
    // dummy \n so we can tell the first line is a complete line.
@@ -60,7 +60,8 @@ ConsoleProcessInfo::ConsoleProcessInfo(
      interactionMode_(InteractionAlways), maxOutputLines_(kDefaultTerminalMaxOutputLines),
      showOnOutput_(false), outputBuffer_(kOutputBufferSize), childProcs_(true),
      altBufferActive_(altBufferActive), shellType_(shellType),
-     channelMode_(Rpc), cwd_(cwd), cols_(cols), rows_(rows), restarted_(false)
+     channelMode_(Rpc), cwd_(cwd), cols_(cols), rows_(rows), restarted_(false),
+     autoClose_(DefaultAutoClose)
 {
 }
 
@@ -73,7 +74,7 @@ ConsoleProcessInfo::ConsoleProcessInfo(
      showOnOutput_(false), outputBuffer_(kOutputBufferSize), childProcs_(true),
      altBufferActive_(false), shellType_(TerminalShell::DefaultShell),
      channelMode_(Rpc), cols_(system::kDefaultCols), rows_(system::kDefaultRows),
-     restarted_(false)
+     restarted_(false), autoClose_(DefaultAutoClose)
 {
 }
 
@@ -203,6 +204,7 @@ core::json::Object ConsoleProcessInfo::toJson() const
    result["cols"] = cols_;
    result["rows"] = rows_;
    result["restarted"] = restarted_;
+   result["autoclose"] = static_cast<int>(autoClose_);
 
    return result;
 }
@@ -260,6 +262,8 @@ boost::shared_ptr<ConsoleProcessInfo> ConsoleProcessInfo::fromJson(core::json::O
    pProc->rows_ = obj["rows"].get_int();
 
    pProc->restarted_ = obj["restarted"].get_bool();
+   int autoCloseInt = obj["autoclose"].get_int();
+   pProc->autoClose_ = static_cast<AutoCloseMode>(autoCloseInt);
 
    return pProc;
 }

--- a/src/cpp/session/SessionConsoleProcessInfo.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfo.cpp
@@ -39,7 +39,7 @@ ConsoleProcessInfo::ConsoleProcessInfo()
      showOnOutput_(false), outputBuffer_(kOutputBufferSize), childProcs_(true),
      altBufferActive_(false), shellType_(TerminalShell::DefaultShell),
      channelMode_(Rpc), cols_(system::kDefaultCols), rows_(system::kDefaultRows),
-     restarted_(false), autoClose_(DefaultAutoClose)
+     restarted_(false), autoClose_(DefaultAutoClose), zombie_(false)
 {
    // When we retrieve from outputBuffer, we only want complete lines. Add a
    // dummy \n so we can tell the first line is a complete line.
@@ -54,14 +54,14 @@ ConsoleProcessInfo::ConsoleProcessInfo(
          TerminalShell::TerminalShellType shellType,
          bool altBufferActive,
          const core::FilePath& cwd,
-         int cols, int rows)
+         int cols, int rows, bool zombie)
    : caption_(caption), title_(title), handle_(handle),
      terminalSequence_(terminalSequence), allowRestart_(true),
      interactionMode_(InteractionAlways), maxOutputLines_(kDefaultTerminalMaxOutputLines),
      showOnOutput_(false), outputBuffer_(kOutputBufferSize), childProcs_(true),
      altBufferActive_(altBufferActive), shellType_(shellType),
      channelMode_(Rpc), cwd_(cwd), cols_(cols), rows_(rows), restarted_(false),
-     autoClose_(DefaultAutoClose)
+     autoClose_(DefaultAutoClose), zombie_(zombie)
 {
 }
 
@@ -74,7 +74,7 @@ ConsoleProcessInfo::ConsoleProcessInfo(
      showOnOutput_(false), outputBuffer_(kOutputBufferSize), childProcs_(true),
      altBufferActive_(false), shellType_(TerminalShell::DefaultShell),
      channelMode_(Rpc), cols_(system::kDefaultCols), rows_(system::kDefaultRows),
-     restarted_(false), autoClose_(DefaultAutoClose)
+     restarted_(false), autoClose_(DefaultAutoClose), zombie_(false)
 {
 }
 
@@ -205,6 +205,7 @@ core::json::Object ConsoleProcessInfo::toJson() const
    result["rows"] = rows_;
    result["restarted"] = restarted_;
    result["autoclose"] = static_cast<int>(autoClose_);
+   result["zombie"] = zombie_;
 
    return result;
 }
@@ -264,6 +265,7 @@ boost::shared_ptr<ConsoleProcessInfo> ConsoleProcessInfo::fromJson(core::json::O
    pProc->restarted_ = obj["restarted"].get_bool();
    int autoCloseInt = obj["autoclose"].get_int();
    pProc->autoClose_ = static_cast<AutoCloseMode>(autoCloseInt);
+   pProc->zombie_ = obj["zombie"].get_bool();
 
    return pProc;
 }

--- a/src/cpp/session/SessionConsoleProcessInfoTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfoTests.cpp
@@ -73,7 +73,8 @@ bool sameCpi(const ConsoleProcessInfo& first, const ConsoleProcessInfo& second)
            first.getCwd() == second.getCwd() &&
            first.getCols() == second.getCols() &&
            first.getRows() == second.getRows() &&
-           first.getRestarted() == second.getRestarted());
+           first.getRestarted() == second.getRestarted() &&
+           first.getAutoClose() == second.getAutoClose());
 }
 
 } // anonymous namespace
@@ -108,6 +109,10 @@ TEST_CASE("ConsoleProcessInfo")
       CHECK_FALSE(cpi.getRestarted());
       cpi.setRestarted(true);
       CHECK(cpi.getRestarted());
+
+      CHECK(cpi.getAutoClose() == DefaultAutoClose);
+      cpi.setAutoClose(NeverAutoClose);
+      CHECK(cpi.getAutoClose() == NeverAutoClose);
    }
 
    SECTION("Generate a handle")
@@ -169,6 +174,9 @@ TEST_CASE("ConsoleProcessInfo")
 
       cpi.setCwd(altCwd);
       CHECK(altCwd == cpi.getCwd());
+
+      cpi.setAutoClose(AlwaysAutoClose);
+      CHECK(cpi.getAutoClose() == AlwaysAutoClose);
    }
 
    SECTION("Change exit code")

--- a/src/cpp/session/SessionConsoleProcessInfoTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfoTests.cpp
@@ -45,6 +45,7 @@ const core::FilePath altCwd("/usr/stuff");
 const int cols = core::system::kDefaultCols;
 const int rows = core::system::kDefaultRows;
 const bool restarted = false;
+const bool zombie = false;
 
 const size_t maxLines = kDefaultTerminalMaxOutputLines;
 
@@ -74,7 +75,8 @@ bool sameCpi(const ConsoleProcessInfo& first, const ConsoleProcessInfo& second)
            first.getCols() == second.getCols() &&
            first.getRows() == second.getRows() &&
            first.getRestarted() == second.getRestarted() &&
-           first.getAutoClose() == second.getAutoClose());
+           first.getAutoClose() == second.getAutoClose() &&
+           first.getZombie() == second.getZombie());
 }
 
 } // anonymous namespace
@@ -85,7 +87,7 @@ TEST_CASE("ConsoleProcessInfo")
    SECTION("Create ConsoleProcessInfo and read properties")
    {
       ConsoleProcessInfo cpi(caption, title, handle1, sequence,
-                             shellType, altActive, cwd, cols, rows);
+                             shellType, altActive, cwd, cols, rows, zombie);
 
       CHECK_FALSE(caption.compare(cpi.getCaption()));
       CHECK_FALSE(title.compare(cpi.getTitle()));
@@ -113,6 +115,8 @@ TEST_CASE("ConsoleProcessInfo")
       CHECK(cpi.getAutoClose() == DefaultAutoClose);
       cpi.setAutoClose(NeverAutoClose);
       CHECK(cpi.getAutoClose() == NeverAutoClose);
+
+      CHECK(cpi.getZombie() == zombie);
    }
 
    SECTION("Generate a handle")
@@ -129,7 +133,7 @@ TEST_CASE("ConsoleProcessInfo")
    SECTION("Change properties")
    {
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             altActive, cwd, cols, rows);
+                             altActive, cwd, cols, rows, zombie);
 
       std::string altCaption("other caption");
       CHECK(altCaption.compare(caption));
@@ -177,12 +181,15 @@ TEST_CASE("ConsoleProcessInfo")
 
       cpi.setAutoClose(AlwaysAutoClose);
       CHECK(cpi.getAutoClose() == AlwaysAutoClose);
+
+      cpi.setZombie(true);
+      CHECK(cpi.getZombie());
    }
 
    SECTION("Change exit code")
    {
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             altActive, cwd, cols, rows);
+                             altActive, cwd, cols, rows, zombie);
 
       const int exitCode = 14;
       cpi.setExitCode(exitCode);
@@ -205,9 +212,9 @@ TEST_CASE("ConsoleProcessInfo")
    SECTION("Compare ConsoleProcInfos with different exit codes")
    {
       ConsoleProcessInfo cpiFirst(caption, title, handle1, sequence, shellType,
-                                  altActive, cwd, cols, rows);
+                                  altActive, cwd, cols, rows, zombie);
       ConsoleProcessInfo cpiSecond(caption, title, handle1, sequence, shellType,
-                                   altActive, cwd, cols, rows);
+                                   altActive, cwd, cols, rows, zombie);
 
       cpiFirst.setExitCode(1);
       cpiSecond.setExitCode(12);
@@ -217,7 +224,7 @@ TEST_CASE("ConsoleProcessInfo")
    SECTION("Persist and restore")
    {
       ConsoleProcessInfo cpiOrig(caption, title, handle1, sequence, shellType,
-                                  altActive, cwd, cols, rows);
+                                  altActive, cwd, cols, rows, zombie);
 
       core::json::Object origJson = cpiOrig.toJson();
       boost::shared_ptr<ConsoleProcessInfo> pCpiRestored =
@@ -263,7 +270,7 @@ TEST_CASE("ConsoleProcessInfo")
       // in the JSON. Same comment on the leaky abstractions here as for
       // previous non-terminal test.
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             altActive, cwd, cols, rows);
+                             altActive, cwd, cols, rows, zombie);
 
       // blow away anything that might have been left over from a previous
       // failed run
@@ -299,7 +306,7 @@ TEST_CASE("ConsoleProcessInfo")
    SECTION("Persist and restore terminals with multiple chunks")
    {
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             altActive, cwd, cols, rows);
+                             altActive, cwd, cols, rows, zombie);
 
       // blow away anything that might have been left over from a previous
       // failed run
@@ -364,9 +371,9 @@ TEST_CASE("ConsoleProcessInfo")
    SECTION("Delete unknown log files")
    {
       ConsoleProcessInfo cpiGood(caption, title, handle1, sequence, shellType,
-                                 altActive, cwd, cols, rows);
+                                 altActive, cwd, cols, rows, zombie);
       ConsoleProcessInfo cpiBad(caption, title, bogusHandle1, sequence, shellType,
-                                altActive, cwd, cols, rows);
+                                altActive, cwd, cols, rows, zombie);
 
       std::string orig1("hello how are you?\nthat is good\nhave a nice day");
       CHECK(orig1.length() < kOutputBufferSize);
@@ -402,7 +409,7 @@ TEST_CASE("ConsoleProcessInfo")
    {
       const int smallMaxLines = 5;
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             altActive, cwd, cols, rows);
+                             altActive, cwd, cols, rows, zombie);
       cpi.setMaxOutputLines(smallMaxLines);
 
       // blow away anything that might have been left over from a previous
@@ -444,7 +451,7 @@ TEST_CASE("ConsoleProcessInfo")
    {
       const int smallMaxLines = 3;
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             altActive, cwd, cols, rows);
+                             altActive, cwd, cols, rows, zombie);
       cpi.setMaxOutputLines(smallMaxLines);
 
       // blow away anything that might have been left over from a previous
@@ -488,7 +495,7 @@ TEST_CASE("ConsoleProcessInfo")
    {
       const int lines = 10;
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             altActive, cwd, cols, rows);
+                             altActive, cwd, cols, rows, zombie);
       cpi.setMaxOutputLines(lines * 2);
 
       // blow away anything that might have been left over from a previous

--- a/src/cpp/session/SessionConsoleProcessPersist.cpp
+++ b/src/cpp/session/SessionConsoleProcessPersist.cpp
@@ -45,7 +45,9 @@ namespace console_persist {
 //                using non-RPC-based communication channel back to client
 // 2017/05/15 - console03 -> console04
 //                Added current-working directory, alt-buffer, cols, rows
-#define kConsoleDir "console04"
+// 2017/06/8  - console04 -> console05
+//                Added autoClose
+#define kConsoleDir "console05"
 
 namespace {
 

--- a/src/cpp/session/SessionConsoleProcessPersist.cpp
+++ b/src/cpp/session/SessionConsoleProcessPersist.cpp
@@ -46,7 +46,7 @@ namespace console_persist {
 // 2017/05/15 - console03 -> console04
 //                Added current-working directory, alt-buffer, cols, rows
 // 2017/06/8  - console04 -> console05
-//                Added autoClose
+//                Added autoClose, zombie
 #define kConsoleDir "console05"
 
 namespace {

--- a/src/cpp/session/SessionConsoleProcessTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessTests.cpp
@@ -31,10 +31,11 @@ context("queue and fetch input")
    core::FilePath cwd("/usr/local");
 
    boost::shared_ptr<ConsoleProcessInfo> pCPI =
-         boost::make_shared<ConsoleProcessInfo>(
+         boost::shared_ptr<ConsoleProcessInfo>(new ConsoleProcessInfo(
             "test caption", "test title", "fakehandle", 9999 /*terminal*/,
             TerminalShell::DefaultShell, false /*altBuffer*/, cwd,
-            core::system::kDefaultCols, core::system::kDefaultRows);
+            core::system::kDefaultCols, core::system::kDefaultRows,
+            false /*zombie*/));
 
    boost::shared_ptr<ConsoleProcess> pCP =
          ConsoleProcess::createTerminalProcess(procOptions, pCPI, false /*enableWebsockets*/);

--- a/src/cpp/session/SessionUserSettings.cpp
+++ b/src/cpp/session/SessionUserSettings.cpp
@@ -431,6 +431,9 @@ void UserSettings::updatePrefsCache(const json::Object& prefs) const
    int terminalWebsockets = readPref<bool>(prefs, "terminal_websockets", true);
    pTerminalWebsockets_.reset(new bool(terminalWebsockets));
 
+   bool terminalAutoclose = readPref<bool>(prefs, "terminal_autoclose", true);
+   pTerminalAutoclose_.reset(new bool(terminalAutoclose));
+
    syncConsoleColorEnv();
 }
 
@@ -642,6 +645,11 @@ core::text::AnsiCodeMode UserSettings::ansiConsoleMode() const
 bool UserSettings::terminalWebsockets() const
 {
    return readUiPref<bool>(pTerminalWebsockets_);
+}
+
+bool UserSettings::terminalAutoclose() const
+{
+   return readUiPref<bool>(pTerminalAutoclose_);
 }
 
 CRANMirror UserSettings::cranMirror() const

--- a/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
@@ -47,6 +47,13 @@ enum ChannelMode
    NamedPipe = 2,
 };
 
+enum AutoCloseMode
+{
+   DefaultAutoClose = 0, // obey user preference
+   AlwaysAutoClose = 1, // always auto-close
+   NeverAutoClose = 2, // never auto-close
+};
+
 extern const int kDefaultMaxOutputLines;
 extern const int kDefaultTerminalMaxOutputLines;
 extern const int kNoTerminal;
@@ -165,6 +172,10 @@ public:
    void setRestarted(bool restarted) { restarted_ = restarted; }
    bool getRestarted() const { return restarted_; }
 
+   // Close terminal session after process exits?
+   void setAutoClose(AutoCloseMode autoClose) { autoClose_ = autoClose; }
+   AutoCloseMode getAutoClose() const { return autoClose_; }
+
    core::json::Object toJson() const;
    static boost::shared_ptr<ConsoleProcessInfo> fromJson(core::json::Object& obj);
 
@@ -192,6 +203,7 @@ private:
    int cols_;
    int rows_;
    bool restarted_;
+   AutoCloseMode autoClose_;
 };
 
 } // namespace console_process

--- a/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
@@ -79,7 +79,7 @@ public:
          TerminalShell::TerminalShellType shellType,
          bool altBufferActive,
          const core::FilePath& cwd,
-         int cols, int rows);
+         int cols, int rows, bool zombie);
 
    // constructor for non-terminals
    ConsoleProcessInfo(
@@ -176,6 +176,10 @@ public:
    void setAutoClose(AutoCloseMode autoClose) { autoClose_ = autoClose; }
    AutoCloseMode getAutoClose() const { return autoClose_; }
 
+   // Is terminal session a zombie (process exited but keeping buffer)
+   void setZombie(bool zombie) { zombie_ = zombie; }
+   bool getZombie() const { return zombie_; }
+
    core::json::Object toJson() const;
    static boost::shared_ptr<ConsoleProcessInfo> fromJson(core::json::Object& obj);
 
@@ -204,6 +208,7 @@ private:
    int rows_;
    bool restarted_;
    AutoCloseMode autoClose_;
+   bool zombie_;
 };
 
 } // namespace console_process

--- a/src/cpp/session/include/session/SessionUserSettings.hpp
+++ b/src/cpp/session/include/session/SessionUserSettings.hpp
@@ -105,6 +105,7 @@ public:
    bool enableRSConnectUI() const;
    core::text::AnsiCodeMode ansiConsoleMode() const;
    bool terminalWebsockets() const;
+   bool terminalAutoclose() const;
 
    bool rProfileOnResume() const;
    void setRprofileOnResume(bool rProfileOnResume);
@@ -264,7 +265,8 @@ private:
    mutable boost::scoped_ptr<bool> pEnableRSConnectUI_;
    mutable boost::scoped_ptr<int> pAnsiConsoleMode_;
    mutable boost::scoped_ptr<bool> pTerminalWebsockets_;
-   
+   mutable boost::scoped_ptr<bool> pTerminalAutoclose_;
+
    // diagnostic-related prefs
    mutable boost::scoped_ptr<bool> pLintRFunctionCalls_;
    mutable boost::scoped_ptr<bool> pCheckArgumentsToRFunctionCalls_;
@@ -272,7 +274,7 @@ private:
    mutable boost::scoped_ptr<bool> pWarnIfVariableDefinedButNotUsed_;
    mutable boost::scoped_ptr<bool> pEnableStyleDiagnostics_;
 };
-   
+
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -886,6 +886,7 @@ Error startTerminal(const json::JsonRpcRequest& request,
    int termSequence = kNoTerminal;
    bool altBufferActive;
    std::string currentDir;
+   bool zombie;
    
    Error error = json::readParams(request.params,
                                   &shellTypeInt,
@@ -896,7 +897,8 @@ Error startTerminal(const json::JsonRpcRequest& request,
                                   &termTitle,
                                   &termSequence,
                                   &altBufferActive,
-                                  &currentDir);
+                                  &currentDir,
+                                  &zombie);
    if (error)
       return error;
 
@@ -928,9 +930,9 @@ Error startTerminal(const json::JsonRpcRequest& request,
          shellType, cols, rows, termSequence, cwd, &actualShellType);
 
    boost::shared_ptr<ConsoleProcessInfo> ptrProcInfo =
-         boost::make_shared<ConsoleProcessInfo>(
-            termCaption, termTitle, termHandle, termSequence,  actualShellType,
-            altBufferActive, cwd, cols, rows);
+         boost::shared_ptr<ConsoleProcessInfo>(new ConsoleProcessInfo(
+            termCaption, termTitle, termHandle, termSequence, actualShellType,
+            altBufferActive, cwd, cols, rows, zombie));
 
    boost::shared_ptr<ConsoleProcess> ptrProc =
                ConsoleProcess::createTerminalProcess(options, ptrProcInfo);

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
@@ -117,6 +117,10 @@ public class ConsoleProcessInfo extends JavaScriptObject
    public final native int getAutoCloseMode() /*-{
       return this.autoclose;
    }-*/;
+   
+   public final native boolean getZombie() /*-{
+      return this.zombie;
+   }-*/;
 
    public static final int SEQUENCE_NO_TERMINAL = 0;
    

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
@@ -30,6 +30,10 @@ public class ConsoleProcessInfo extends JavaScriptObject
    public static final int CHANNEL_WEBSOCKET = 1;
    public static final int CHANNEL_PIPE = 2;
    
+   public static final int AUTOCLOSE_DEFAULT = 0;
+   public static final int AUTOCLOSE_ALWAYS = 1;
+   public static final int AUTOCLOSE_NEVER = 0;
+   
    protected ConsoleProcessInfo() {}
 
    public final native String getHandle() /*-{
@@ -109,7 +113,11 @@ public class ConsoleProcessInfo extends JavaScriptObject
    public final native boolean getRestarted() /*-{
       return this.restarted;
    }-*/;
- 
+
+   public final native int getAutoCloseMode() /*-{
+      return this.autoclose;
+   }-*/;
+
    public static final int SEQUENCE_NO_TERMINAL = 0;
    
    public final native boolean isTerminal() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
@@ -32,7 +32,7 @@ public class ConsoleProcessInfo extends JavaScriptObject
    
    public static final int AUTOCLOSE_DEFAULT = 0;
    public static final int AUTOCLOSE_ALWAYS = 1;
-   public static final int AUTOCLOSE_NEVER = 0;
+   public static final int AUTOCLOSE_NEVER = 2;
    
    protected ConsoleProcessInfo() {}
 

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -505,6 +505,7 @@ public class RemoteServer implements Server
                      int sequence,
                      boolean altBufferActive,
                      String cwd,
+                     boolean zombie,
                      ServerRequestCallback<ConsoleProcess> requestCallback)
    {
       JSONArray params = new JSONArray();
@@ -517,6 +518,7 @@ public class RemoteServer implements Server
       params.set(6, new JSONNumber(sequence));
       params.set(7, JSONBoolean.getInstance(altBufferActive));
       params.set(8, new JSONString(StringUtil.notNull(cwd)));
+      params.set(9, JSONBoolean.getInstance(zombie));
 
       sendRequest(RPC_SCOPE,
                   START_TERMINAL,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchServerOperations.java
@@ -149,11 +149,12 @@ public interface WorkbenchServerOperations extends ConsoleServerOperations,
     * @param sequence relative order of terminal creation (1-based)
     * @param altBufferActive terminal showing alt-buffer (full-screen ncurses)
     * @param cwd current working directory
+    * @param zombie if true, terminal buffer reloaded but no process created
     * @param requestCallback callback from server upon completion
     */
    void startTerminal(int shellType, int cols, int rows, String handle, 
                       String caption, String title, int sequence, 
-                      boolean altBufferActive, String cwd,
+                      boolean altBufferActive, String cwd, boolean zombie,
                       ServerRequestCallback<ConsoleProcess> requestCallback);
    
    void executeCode(String code, ServerRequestCallback<Void> requestCallback);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -616,6 +616,11 @@ public class UIPrefsAccessor extends Prefs
       return bool("terminal_websockets", true);
    }
    
+   public PrefValue<Boolean> terminalAutoClose()
+   {
+      return bool("terminal_autoclose", true);
+   }
+
    public static final String KNIT_DIR_DEFAULT = "default";
    public static final String KNIT_DIR_CURRENT = "current";
    public static final String KNIT_DIR_PROJECT = "project";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/TerminalPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/TerminalPreferencesPane.java
@@ -116,6 +116,16 @@ public class TerminalPreferencesPane extends PreferencesPane
 
       perfLabel.setVisible(showPerfLabel);
 
+      Label miscLabel = headerLabel("Miscellaneous");
+      miscLabel.getElement().getStyle().setMarginTop(8, Unit.PX);
+      add(miscLabel);
+      miscLabel.setVisible(true);
+
+      CheckBox chkTerminalAutoClose = checkboxPref("Close terminal when shell exits",
+            prefs_.terminalAutoClose(),
+            "Deselect this option to keep terminal pane open after shell exits.");
+      add(chkTerminalAutoClose);
+
       HelpLink helpLink = new HelpLink("Using the RStudio terminal", "rstudio_terminal", false);
       nudgeRight(helpLink); 
       helpLink.addStyleName(res_.styles().newSection()); 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
@@ -57,6 +57,7 @@ public class TerminalInfoDialog extends ModalDialogBase
       diagnostics.append("Sequence:    '" + session.getSequence() + "'\n");
       diagnostics.append("Busy:        '" + session.getHasChildProcs() + "'\n");
       diagnostics.append("Alt-Buffer:  '" + session.altBufferActive() + "'\n");
+      diagnostics.append("Zombie:      '" + session.getZombie() + "'\n");
       diagnostics.append("Local-echo:  '" + localEchoEnabled + "'\n"); 
       diagnostics.append("Working Dir: '" + cwd + "'\n"); 
       diagnostics.append("WebSockets:  '" + uiPrefs_.terminalUseWebsockets().getValue() + "'\n");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
@@ -183,6 +183,13 @@ public class TerminalSessionSocket
                        final ConnectCallback callback)
    {
       consoleProcess_ = consoleProcess;
+      
+      if (consoleProcess.getProcessInfo().getZombie())
+      {
+         diagnostic("Zombie, not reconnecting");
+         callback.onConnected();
+         return;
+      }
 
       // We keep this handler connected after a disconnect so
       // user input sent via RPC can wake up a suspended session
@@ -381,12 +388,16 @@ public class TerminalSessionSocket
       }
    }
 
-   public void disconnect()
+   public void disconnect(boolean permanent)
    {
-      diagnostic("Disconnected");
+      diagnostic(permanent ? "Permanently Disconnected" : "Disconnected");
       socket_.close();
       socket_ = null;
       registrations_.removeHandler();
+      if (permanent)
+      {
+         unregisterHandlers(); // gets rid of keyboard handler
+      }
    }
    
    public void resetDiagnostics()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
@@ -391,7 +391,8 @@ public class TerminalSessionSocket
    public void disconnect(boolean permanent)
    {
       diagnostic(permanent ? "Permanently Disconnected" : "Disconnected");
-      socket_.close();
+      if (socket_ != null)
+         socket_.close();
       socket_ = null;
       registrations_.removeHandler();
       if (permanent)


### PR DESCRIPTION
Added plumbing and user option to keep terminal panes open after process exits. This will make it easier to add capability to run a command in a terminal pane, without a shell, and keep pane around to show the results (this will be via a new rstudioapi, NYI).

FYI, this change added new ConsoleProcessInfo metadata, so I bumped up the storage revision number for saving open processes (console05); first time running this build you will lose any previously created terminals.

As a side effect, found and fixed a bug that had been seen occasionally before, where trying to close a terminal tab gave an error. Cause was websocket connection closing but terminal remaining open, which is much easier to get into with this work. Fix was to not dereference a null websocket object in the client.

![2017-06-09_10-06-33](https://user-images.githubusercontent.com/10569626/26986209-60ec5e28-4cfb-11e7-93ce-c10b236837e6.png)

![2017-06-09_10-07-22](https://user-images.githubusercontent.com/10569626/26986253-903982c8-4cfb-11e7-9748-769d4a619183.png)
