### PR TITLE
add desktop devmode

### DIFF
--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -138,6 +138,23 @@
          <param name="gwt.extra.args" value="${gwt.extra.args} -draftCompile" />
       </antcall>
    </target>
+
+   <target name="desktop" depends="acesupport,javac" description="Run development mode">
+      <java failonerror="true" fork="true" classname="com.google.gwt.dev.DevMode">
+         <classpath>
+            <pathelement location="src"/>
+            <path refid="project.class.path"/>
+         </classpath>
+         <jvmarg value="-Xmx2048M"/>
+         <arg value="-war"/>
+         <arg value="www"/>
+         <arg value="-noserver"/>
+         <arg value="-startupUrl"/>
+         <arg value="http://localhost:8787"/>
+         <arg line="-bindAddress 127.0.0.1"/>
+         <arg value="org.rstudio.studio.RStudioDesktopSuperDevMode"/>
+      </java>
+   </target>
 	
    <target name="devmode" depends="acesupport,javac" description="Run development mode">
       <java failonerror="true" fork="true" classname="com.google.gwt.dev.DevMode">

--- a/src/gwt/src/org/rstudio/studio/RStudioDesktopSuperDevMode.gwt.xml
+++ b/src/gwt/src/org/rstudio/studio/RStudioDesktopSuperDevMode.gwt.xml
@@ -1,0 +1,7 @@
+<module rename-to="rstudio">
+   <inherits name="org.rstudio.studio.RStudio" />
+   <set-property name="compiler.stackMode" value="native"/>
+   <set-property name="rstudio.desktop" value="true"/>
+   <set-property name="locale" value="default"/>
+</module>
+


### PR DESCRIPTION
There might be a reason why we didn't add this in the first place, but as far as I can see, this works (at least on macOS) for a devmode experience with the desktop product. With this PR, we can use

    ant desktop

to build the desktop version of the sources in the regular devmode configuration. One just needs to run a debug build of the desktop product, and things appear to work as expected.