### PR TITLE
Fix to allow classic theme under dark editor

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
@@ -77,6 +77,8 @@ public class RStudioThemes
    }
 
    public static String suggestThemeFromAceTheme(String aceTheme, String rstudioTheme) {
+      if (rstudioTheme == "classic") return rstudioTheme;
+
       RegExp keyReg = RegExp.compile(
          "ambiance|chaos|clouds midnight|cobalt|idle fingers|kr theme|" +
          "material|merbivore soft|merbivore|mono industrial|monokai|" +


### PR DESCRIPTION
In the weekend builds, when a dark editor theme is selected, reverting to classic mode is not supported. The workaround is to use non-dark editor theme until build 1.1.269 is out.