### PR TITLE
replace TerminalList.TerminalMetadata with ConsoleProcessInfo

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
@@ -25,6 +25,8 @@ public class ConsoleProcessInfo extends JavaScriptObject
    
    public static final int DEFAULT_COLS = 80;
    public static final int DEFAULT_ROWS = 25;
+
+   public static final int DEFAULT_MAX_OUTPUT_LINES = 1000;
    
    public static final int CHANNEL_RPC = 0;
    public static final int CHANNEL_WEBSOCKET = 1;
@@ -33,9 +35,128 @@ public class ConsoleProcessInfo extends JavaScriptObject
    public static final int AUTOCLOSE_DEFAULT = 0;
    public static final int AUTOCLOSE_ALWAYS = 1;
    public static final int AUTOCLOSE_NEVER = 2;
-   
+
+   public static final int SEQUENCE_NO_TERMINAL = 0;
+
    protected ConsoleProcessInfo() {}
 
+   public static final native ConsoleProcessInfo createNamedTerminalInfo(
+         int sequence,
+         String caption) /*-{
+
+      var procInfo = new Object();
+
+      procInfo.handle = null;
+      procInfo.caption = caption;
+      procInfo.show_on_output = false;
+      procInfo.interaction_mode = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::INTERACTION_ALWAYS;
+      procInfo.max_output_lines = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::DEFAULT_MAX_OUTPUT_LINES;
+      procInfo.buffered_output = "";
+      procInfo.exit_code = null;
+      procInfo.terminal_sequence = sequence;
+      procInfo.allow_restart = false;
+      procInfo.title = null;
+      procInfo.child_procs = true;
+      procInfo.shell_type = @org.rstudio.studio.client.workbench.views.terminal.TerminalShellInfo::SHELL_DEFAULT,
+      procInfo.channel_mode = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::CHANNEL_RPC;
+      procInfo.channel_id = "";
+      procInfo.alt_buffer = false;
+      procInfo.cwd = null;
+      procInfo.cols = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::DEFAULT_COLS;
+      procInfo.rows = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::DEFAULT_ROWS;
+      procInfo.restarted = false;
+      procInfo.autoclose = AUTOCLOSE_DEFAULT;
+      procInfo.zombie = false;
+
+      return procInfo;
+   }-*/;
+
+   public static final native ConsoleProcessInfo createNewTerminalInfo(int sequence) /*-{
+      var procInfo = new Object();
+
+      procInfo.handle = null;
+      procInfo.caption = null;
+      procInfo.show_on_output = false;
+      procInfo.interaction_mode = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::INTERACTION_ALWAYS;
+      procInfo.max_output_lines = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::DEFAULT_MAX_OUTPUT_LINES;
+      procInfo.buffered_output = "";
+      procInfo.exit_code = null;
+      procInfo.terminal_sequence = sequence;
+      procInfo.allow_restart = false;
+      procInfo.title = null;
+      procInfo.child_procs = true;
+      procInfo.shell_type = @org.rstudio.studio.client.workbench.views.terminal.TerminalShellInfo::SHELL_DEFAULT,
+      procInfo.channel_mode = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::CHANNEL_RPC;
+      procInfo.channel_id = "";
+      procInfo.alt_buffer = false;
+      procInfo.cwd = null;
+      procInfo.cols = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::DEFAULT_COLS;
+      procInfo.rows = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::DEFAULT_ROWS;
+      procInfo.restarted = false;
+      procInfo.autoclose = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::AUTOCLOSE_DEFAULT;
+      procInfo.zombie = false;
+
+      return procInfo;
+   }-*/;
+   
+   /**
+    * Creates an object with sufficient metadata to display UI to trigger
+    * recreation of a previous terminal.
+    * @param handle
+    * @param caption
+    * @param title
+    * @param sequence
+    * @param childProcs
+    * @param cols
+    * @param rows
+    * @param shellType
+    * @param altBufferActive
+    * @param cwd
+    * @param autoCloseMode
+    * @param zombie
+    * @return
+    */
+   public static final native ConsoleProcessInfo createTerminalMetadata(
+         String handle,
+         String caption,
+         String title,
+         int sequence,
+         boolean childProcs,
+         int cols,
+         int rows,
+         int shellType,
+         boolean altBufferActive,
+         String cwd,
+         int autoCloseMode,
+         boolean zombie) /*-{
+
+      var procInfo = new Object();
+
+      procInfo.handle = handle;
+      procInfo.caption = caption;
+      procInfo.show_on_output = false;
+      procInfo.interaction_mode = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::INTERACTION_ALWAYS;
+      procInfo.max_output_lines = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::DEFAULT_MAX_OUTPUT_LINES;
+      procInfo.buffered_output = "";
+      procInfo.exit_code = null;
+      procInfo.terminal_sequence = sequence;
+      procInfo.allow_restart = false;
+      procInfo.title = title;
+      procInfo.child_procs = childProcs;
+      procInfo.shell_type = shellType;
+      procInfo.channel_mode = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::CHANNEL_RPC;
+      procInfo.channel_id = "";
+      procInfo.alt_buffer = altBufferActive;
+      procInfo.cwd = cwd;
+      procInfo.cols = cols;
+      procInfo.rows = rows;
+      procInfo.restarted = false;
+      procInfo.autoclose = autoCloseMode;
+      procInfo.zombie = zombie;
+
+      return procInfo;
+   }-*/;
+   
    public final native String getHandle() /*-{
       return this.handle;
    }-*/;
@@ -122,9 +243,23 @@ public class ConsoleProcessInfo extends JavaScriptObject
       return this.zombie;
    }-*/;
 
-   public static final int SEQUENCE_NO_TERMINAL = 0;
-   
    public final native boolean isTerminal() /*-{
       return this.terminal_sequence > 0;
+   }-*/;
+
+   public final native void setTitle(String title) /*-{
+      this.title = title;
+   }-*/;
+
+   public final native void setHasChildProcs(boolean hasChildProcs) /*-{
+      this.child_procs = hasChildProcs;
+   }-*/;
+
+   public final native void setCwd(String currentWorkingDir) /*-{
+      this.cwd = currentWorkingDir;
+   }-*/;
+
+   public final native void setHandle(String handle) /*-{
+      this.handle = handle;
    }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -61,57 +61,35 @@ public class TerminalSession extends XTermWidget
                                         SessionSerializationHandler
 {
    /**
-    * 
-    * @param sequence number used as part of default terminal title
-    * @param handle terminal handle if reattaching, null if new terminal
-    * @param caption terminal caption if reattaching, null if new terminal
-    * @param title widget title
-    * @param hasChildProcs does session have child processes
-    * @param cols number of columns in terminal
-    * @param rows number of rows in terminal
+    * @param info terminal metadata
     * @param cursorBlink should terminal cursor blink
     * @param focus should terminal automatically get focus
-    * @param shellType type of shell to run
-    * @param cwd current working directory
-    * @param autoCloseMode should terminal close when process exits
-    * @param zombie is session just showing buffer for terminated process
     */
-   public TerminalSession(int sequence,
-                          String handle,
-                          String caption,
-                          String title,
-                          boolean hasChildProcs,
-                          int cols,
-                          int rows,
-                          boolean cursorBlink,
-                          boolean focus,
-                          int shellType,
-                          boolean altBufferActive,
-                          String cwd,
-                          int autoCloseMode,
-                          boolean zombie)
+   public TerminalSession(ConsoleProcessInfo info, 
+                          boolean cursorBlink, 
+                          boolean focus)
    {
       super(cursorBlink, focus);
       
       RStudioGinjector.INSTANCE.injectMembers(this);
-      sequence_ = sequence;
-      terminalHandle_ = handle;
-      hasChildProcs_ = new Value<Boolean>(hasChildProcs);
-      shellType_ = shellType;
-      cols_ = cols;
-      rows_ = rows;
-      altBufferActive_ = altBufferActive;
-      cwd_ = cwd;
-      autoCloseMode_ = autoCloseMode;
-      zombie_ = zombie;
+      sequence_ = info.getTerminalSequence();
+      terminalHandle_ = info.getHandle();
+      hasChildProcs_ = new Value<Boolean>(info.getHasChildProcs());
+      shellType_ = info.getShellType();
+      cols_ = info.getCols();
+      rows_ = info.getRows();
+      altBufferActive_ = info.getAltBufferActive();
+      cwd_ = info.getCwd();
+      autoCloseMode_ = info.getAutoCloseMode();
+      zombie_ = info.getZombie();
       
-      setTitle(title);
+      setTitle(info.getTitle());
       socket_ = new TerminalSessionSocket(this, this);
 
-      if (StringUtil.isNullOrEmpty(caption))
+      if (StringUtil.isNullOrEmpty(info.getCaption()))
          caption_ = "Terminal " + sequence_;
       else
-         caption_ = caption;
+         caption_ = info.getCaption();
 
       setHeight("100%");
    }
@@ -387,7 +365,7 @@ public class TerminalSession extends XTermWidget
       return 
             uiPrefs_.terminalLocalEcho().getValue() &&
             !BrowseCap.isWindowsDesktop() && 
-            !hasChildProcs_.getValue() &&
+            !getHasChildProcs() &&
             !altBufferActive() &&
             cursorAtEOL();
    }


### PR DESCRIPTION
Wanted to do this refactoring for a while, should make longer-term maintenance of the feature easier.

TerminalList has a private class, TerminalMetadata, which holds a subset of the metadata of ConsoleProcessInfo, and is used to track all known terminals, whether or not they have been connected or displayed in the current session.

This led to a bunch of parameter-laden constructors/methods for various scenarios, in both TerminalList and TerminalSession classes, such that adding one field to ConsoleProcessInfo ended up requiring modifications in a BUNCH of places.

Now I've added the necessary "create" calls to ConsoleProcessInfo itself, and pass instances of that class around instead.

Not perfect, there is still some duplication of metadata in TerminalSession, but I don't want to mess with that at this stage, as it's not purely mechanical like this current change.