### PR TITLE
Make search suggestions flat and usable in dark theme

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.css
@@ -9,7 +9,7 @@
 @external gwt-SuggestBoxPopup, suggestPopupTopLeft, suggestPopupTopCenter, suggestPopupTopRight,
    suggestPopupMiddleLeft, suggestPopupMiddleCenter, suggestPopupMiddleRight,
    suggestPopupBottomLeft, suggestPopupBottomCenter, suggestPopupBottomRight,
-   suggestPopupContent;
+   suggestPopupContent, suggestPopupTop, suggestPopupBottom;
 @external gwt-MenuBar-vertical;
 
 @external rstudio-themes-flat;
@@ -78,38 +78,49 @@
 }
 
 .rstudio-themes-flat .gwt-MenuBarPopup,
-.rstudio-themes-flat .gwt-DecoratedPopupPanel {
+.rstudio-themes-flat .gwt-DecoratedPopupPanel,
+.rstudio-themes-flat .gwt-SuggestBoxPopup {
    box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1);
 }
 
 .rstudio-themes-flat .menuPopupMiddleCenter,
 .rstudio-themes-flat .popupMiddleCenter {
-   border: solid 1px #a3a8b2;
    padding: 4px;
 }
 
+.rstudio-themes-flat .menuPopupMiddleCenter,
+.rstudio-themes-flat .popupMiddleCenter,
+.rstudio-themes-flat .gwt-SuggestBoxPopup .suggestPopupMiddleCenter {
+   border: solid 1px #a3a8b2;
+}
+
 .rstudio-themes-flat .menuPopupTop,
-.rstudio-themes-flat .popupTop {
+.rstudio-themes-flat .popupTop,
+.rstudio-themes-flat .suggestPopupTop {
    display: none;
 }
 
 .rstudio-themes-flat .menuPopupMiddle .menuPopupMiddleLeft,
-.rstudio-themes-flat .popupMiddle .popupMiddleLeft {
+.rstudio-themes-flat .popupMiddle .popupMiddleLeft,
+.rstudio-themes-flat .suggestPopupMiddleLeft {
    display: none;
 }
 
 .rstudio-themes-flat .menuPopupMiddle .menuPopupMiddleRight,
-.rstudio-themes-flat .popupMiddle .popupMiddleRight {
+.rstudio-themes-flat .popupMiddle .popupMiddleRight,
+.rstudio-themes-flat .suggestPopupMiddleRight {
    display: none;
 }
 
 .rstudio-themes-flat .menuPopupBottom,
-.rstudio-themes-flat .popupBottom {
+.rstudio-themes-flat .popupBottom,
+.rstudio-themes-flat .suggestPopupBottom {
    display: none;
 }
 
 .rstudio-themes-flat.rstudio-themes-dark-menus .menuPopupMiddleCenter,
-.rstudio-themes-flat.rstudio-themes-dark-menus .themedPopupPanel .popupMiddleCenter {
+.rstudio-themes-flat.rstudio-themes-dark-menus .themedPopupPanel .popupMiddleCenter,
+.rstudio-themes-flat.rstudio-themes-dark-menus .gwt-SuggestBoxPopup .suggestPopupMiddleCenter {
    background: THEME_DARKGREY_MENU_BACKGROUND;
    border: solid 1px THEME_DARKGREY_MENU_BORDER;
    color: #f0f0f0;

--- a/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.css
@@ -83,6 +83,10 @@
    box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1);
 }
 
+.rstudio-themes-flat .gwt-SuggestBoxPopup {
+   margin-top: 3px;
+}
+
 .rstudio-themes-flat .menuPopupMiddleCenter,
 .rstudio-themes-flat .popupMiddleCenter {
    padding: 4px;


### PR DESCRIPTION
Suggestions popup was missing to be flat and selection hover was not working under dark theme:

<img width="392" alt="screen shot 2017-06-12 at 1 49 34 pm" src="https://user-images.githubusercontent.com/3478847/27054545-2bce4576-4f76-11e7-9f96-b0845e30d638.png">

<img width="382" alt="screen shot 2017-06-12 at 1 48 57 pm" src="https://user-images.githubusercontent.com/3478847/27054543-2bcb9e3e-4f76-11e7-9865-5dff81aa2d5f.png">

<img width="379" alt="screen shot 2017-06-12 at 1 47 52 pm" src="https://user-images.githubusercontent.com/3478847/27054544-2bcd0328-4f76-11e7-95ce-95135d8c2ff3.png">

