### PR TITLE
Add macos jenkins pipeline

### DIFF
--- a/Jenkinsfile.macos
+++ b/Jenkinsfile.macos
@@ -1,0 +1,59 @@
+pipeline {
+  agent { label 'macos' }
+  options {
+    timestamps()
+    disableConcurrentBuilds()
+    buildDiscarder(logRotator(numToKeepStr: '100'))
+  }
+  parameters {
+      string(name: 'RSTUDIO_VERSION_MAJOR', defaultValue: '1', description: 'RStudio Major Version')
+      string(name: 'RSTUDIO_VERSION_MINOR', defaultValue: '1', description: 'RStudio Minor Version')
+      string(name: 'RSTUDIO_VERSION_PATCH', defaultValue: '0', description: 'RStudio Patch Version')
+      string(name: 'SLACK_CHANNEL', defaultValue: '@steve', description: 'Slack channel to publish build message.')
+  }
+  environment {
+    PATH = '/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
+  }
+
+  stages {
+    stage('dependencies') {
+      environment {
+        // boost won't compile without the brew version of openssl.
+        // only add it to the dep resolve step though, or the ide build will compile against the wrong openssl
+        PATH = '/usr/local/opt/openssl/bin:/usr/local/opt/openssl/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
+      }
+      steps {
+        sh 'cd dependencies/osx && ./install-dependencies-osx && cd ../..'
+      }
+    }
+    stage('build'){
+      steps {
+        script {
+          // unlock keychain to ensure build gets signed.
+          withCredentials([string(credentialsId: 'ide-keychain-passphrase', variable: 'KEYCHAIN_PASSPHRASE')]){
+            sh 'security unlock-keychain -p $KEYCHAIN_PASSPHRASE && security set-keychain-settings' // turn off timeout
+          }
+          def env = "RSTUDIO_VERSION_MAJOR=${RSTUDIO_VERSION_MAJOR} RSTUDIO_VERSION_MINOR=${RSTUDIO_VERSION_MINOR} RSTUDIO_VERSION_PATCH=${RSTUDIO_VERSION_PATCH}"
+          sh 'cd package/osx && ${env} ./make-package clean && cd ../..'
+        }
+      }
+    }
+    stage('upload') {
+      steps {
+        script {
+          // this job is going to run on a macOS slave, which cannot use an instance-profile
+          withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'jenkins-aws']]) {
+            sh 'aws s3 cp package/osx/build/RStudio-* s3://rstudio-ide-build/desktop/macos/'
+          }
+        }
+      }
+    }
+  }
+
+  post {
+    always {
+      deleteDir()
+      sendNotifications slack_channel: SLACK_CHANNEL
+    }
+  }
+}

--- a/package/osx/CMakeLists.txt
+++ b/package/osx/CMakeLists.txt
@@ -3,19 +3,19 @@
 if (RSTUDIO_PACKAGE_BUILD)
    INSTALL(CODE "
      list (APPEND CODESIGN_TARGETS \"\${CMAKE_INSTALL_PREFIX}/RStudio.app\")
-  
+
      file(GLOB_RECURSE CODESIGN_PLUGINS \"\${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/plugins\")
      list (APPEND CODESIGN_TARGETS \${CODESIGN_PLUGINS})
 
      file(GLOB_RECURSE CODESIGN_FRAMEWORKS \"\${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/Frameworks\")
      list (APPEND CODESIGN_TARGETS \${CODESIGN_FRAMEWORKS})
-  
+
      file(GLOB_RECURSE CODESIGN_MACOS \"\${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/MacOS\")
      list (APPEND CODESIGN_TARGETS \${CODESIGN_MACOS})
-  
+
      foreach(CODESIGN_TARGET \${CODESIGN_TARGETS})
-        execute_process(COMMAND codesign \"-s\" \"Developer ID Application: RStudio Inc. (FYF2F5GFX4)\" \"--deep\" \"-i\" \"org.rstudio.RStudio\" \"\${CODESIGN_TARGET}\")
-     endforeach()   
+        execute_process(COMMAND codesign \"-s\" \"8A388E005EF927A09B952C6E71B0E8F2F467AB26\" \"--deep\" \"-i\" \"org.rstudio.RStudio\" \"\${CODESIGN_TARGET}\")
+     endforeach()
      ")
 endif()
 


### PR DESCRIPTION
Using a separate pipeline file for now (macos can't be dockerized and the differences are a bit awkward to introduce to the main build file at this time).

This is a reasonable example of the new declarative pipeline syntax which keeps things a bit cleaner and more readable -- but loses some of that groovy ✨ 
