### PR TITLE
Support dark scrollbars in autocomplete popups

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2389,7 +2389,8 @@ body.rstudio-themes-flat .rstudio-themes-default {
 }
 
 @if user.agent safari {
-.rstudio-themes-flat .rstudio-themes-scrollbars.rstudio-themes-dark-grey ::-webkit-scrollbar-thumb {
+.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar-thumb,
+.rstudio-themes-flat .rstudio-themes-scrollbars::-webkit-scrollbar-thumb {
    background: THEME_DARKGREY_BACKGROUND;
 }
 }
@@ -2428,7 +2429,9 @@ body.rstudio-themes-flat .rstudio-themes-dark-grey {
 
 @if user.agent safari {
 .rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar-track,
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar-corner { 
+.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar-corner,
+.rstudio-themes-flat .rstudio-themes-scrollbars::-webkit-scrollbar-track,
+.rstudio-themes-flat .rstudio-themes-scrollbars::-webkit-scrollbar-corner { 
    background: THEME_DARKGREY_MOST_INACTIVE;
 }
 }
@@ -2506,15 +2509,18 @@ body.rstudio-themes-flat .rstudio-themes-alternate {
 /* RSTUDIO THEMES END */
 
 @if user.agent safari {
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar {
+.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-flat .rstudio-themes-scrollbars::-webkit-scrollbar {
    background: #FFF;
 }
 
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar-thumb {
+.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar-thumb,
+.rstudio-themes-flat .rstudio-themes-scrollbars::-webkit-scrollbar-thumb {
    -webkit-border-radius: 10px;
 }
 
-.rstudio-themes-flat .rstudio-themes-scrollbars.rstudio-themes-dark-grey ::-webkit-scrollbar-thumb {
+.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar-thumb,
+.rstudio-themes-flat .rstudio-themes-scrollbars::-webkit-scrollbar-thumb {
    border: solid 3px THEME_DARKGREY_MOST_INACTIVE;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.core.client.widget;
 
+import org.rstudio.studio.client.application.ui.RStudioThemes;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
@@ -75,6 +77,9 @@ public class ThemedPopupPanel extends DecoratedPopupPanel
    private void commonInit(Resources res)
    {
       addStyleName(res.styles().themedPopupPanel());
+
+      if (RStudioThemes.usesScrollbars())
+         addStyleName("rstudio-themes-scrollbars");
    }
 
    private static Resources RES = GWT.create(Resources.class);

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
@@ -96,7 +96,7 @@ public class RStudioThemes
       );
    }
    
-   private static boolean usesScrollbars() {
+   public static boolean usesScrollbars() {
       if (usesScrollbars_ != null) return usesScrollbars_;
       
       if (!BrowseCap.isMacintosh()) {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.css
@@ -3,7 +3,7 @@
 @external gwt-Image, gwt-Label;
 @external fixedWidthFont;
 
-@external rstudio-themes-flat, rstudio-themes-dark-menus;
+@external rstudio-themes-flat, rstudio-themes-dark-menus, rstudio-themes-scrollbars;
 
 .helpPopup {
    color: #000023;
@@ -34,4 +34,27 @@
 .rstudio-themes-flat .helpPopup {
    margin-left: 6px;
    margin-top: -3px;
+}
+
+@if user.agent safari {
+.rstudio-themes-flat .rstudio-themes-scrollbars.helpPopup *::-webkit-scrollbar {
+   background: #FFF;
+}
+
+.rstudio-themes-flat .rstudio-themes-scrollbars.helpPopup *::-webkit-scrollbar-thumb {
+   border: solid 3px rgb(94, 94, 78);
+   background: rgb(111, 111, 95);
+   -webkit-border-radius: 10px;
+}
+
+.rstudio-themes-flat .rstudio-themes-scrollbars.helpPopup *::-webkit-scrollbar-track,
+.rstudio-themes-flat .rstudio-themes-scrollbars.helpPopup *::-webkit-scrollbar-corner { 
+   background: rgb(94, 94, 78);
+}
+
+.rstudio-themes-flat .rstudio-themes-scrollbars.helpPopup *::-webkit-scrollbar-track-piece {
+}
+
+.rstudio-themes-flat .rstudio-themes-scrollbars.helpPopup *::-webkit-scrollbar-track {
+}
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.java
@@ -20,6 +20,7 @@ import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.*;
 
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.workbench.views.console.ConsoleResources;
 import org.rstudio.studio.client.workbench.views.help.model.HelpInfo;
 
@@ -44,6 +45,9 @@ public class HelpInfoPopupPanel extends PopupPanel
       setWidget(outer) ;
       setVisible(false);
       setStylePrimaryName(RES.styles().helpPopup());
+      
+      if (RStudioThemes.usesScrollbars())
+         addStyleName("rstudio-themes-scrollbars");
       
       timer_ = new Timer() {
          public void run()


### PR DESCRIPTION
Add support for dark scrollbars within autocomplete popups (otherwise they render light grey/default):

<img width="370" alt="screen shot 2017-06-12 at 3 56 10 pm" src="https://user-images.githubusercontent.com/3478847/27059467-7202f0f4-4f8b-11e7-95f8-e991db1c8c85.png">

<img width="451" alt="screen shot 2017-06-12 at 4 18 07 pm" src="https://user-images.githubusercontent.com/3478847/27059468-7204e99a-4f8b-11e7-86e2-833b6352caf0.png">
