### PR TITLE
A handful of minor flat theme dark improvements

### DIFF
--- a/src/cpp/session/resources/R.css
+++ b/src/cpp/session/resources/R.css
@@ -57,6 +57,16 @@ h6 {
    font-style: italic;
 }
 
+.rstudio-themes-flat.rstudio-themes-dark-grey h1,
+.rstudio-themes-flat.rstudio-themes-dark-grey h2,
+.rstudio-themes-flat.rstudio-themes-dark-grey h3,
+.rstudio-themes-flat.rstudio-themes-dark-grey h4,
+.rstudio-themes-flat.rstudio-themes-dark-grey h5,
+.rstudio-themes-flat.rstudio-themes-dark-grey h6 {
+   color: inherit;
+}
+
+
 img.toplogo {
    max-width: 4em;
    vertical-align: middle;

--- a/src/cpp/session/resources/R.css
+++ b/src/cpp/session/resources/R.css
@@ -66,6 +66,11 @@ h6 {
    color: inherit;
 }
 
+.rstudio-themes-flat.rstudio-themes-dark-grey *::selection,
+.rstudio-themes-flat.rstudio-themes-dark-grey *::selection {
+   background: rgba(255, 255, 255, 0.15);
+   color: #FFF;
+}
 
 img.toplogo {
    max-width: 4em;

--- a/src/cpp/session/resources/grid/gridstyles.css
+++ b/src/cpp/session/resources/grid/gridstyles.css
@@ -306,6 +306,11 @@ th:focus {
     position: relative;
 }
 
+.rstudio-themes-flat.rstudio-themes-dark-grey *::selection {
+    background: rgba(255, 255, 255, 0.15);
+    color: #FFF;
+}
+
 .autoSize .numberCell, .autoSize .textCell {
     max-width: 300px; 
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/InfoBar.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/InfoBar.ui.xml
@@ -5,11 +5,19 @@
 
 
    <ui:style>
+      @external rstudio-themes-flat, rstudio-themes-dark-grey;
+      @eval THEME_DARKGREY_BACKGROUND org.rstudio.core.client.theme.ThemeColors.darkGreyBackground;
+      @eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.darkGreyBorder;
+
       .outer {
          width: 100%;
          height: 18px;
          background-color: #ffd;
          border-bottom: 1px solid #bcc1c5;
+      }
+      .rstudio-themes-flat .rstudio-themes-dark-grey .outer {
+         background-color: THEME_DARKGREY_BACKGROUND !important;
+         border-bottom: 1px solid THEME_DARKGREY_BORDER !important;
       }
       .icon {
          margin-top: 2px;
@@ -20,12 +28,15 @@
          margin-top: 2px;
          color: #555;
       }
+      .rstudio-themes-flat .rstudio-themes-dark-grey .label {
+         color: #FFF;
+      }
       .dismiss {
          margin-top: 4px;
          margin-right: 4px;
          width: 9px;
          height: 9px;
-   }
+      }
    </ui:style>
 
    <g:FlowPanel>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.css
@@ -20,6 +20,10 @@
    margin-bottom: 4px;
 }
 
+.rstudio-themes-flat.rstudio-themes-dark-menus .helpBodyText a {
+   color: #FFF;
+}
+
 .snippetText {
    font-family: fixedWidthFont;
    white-space: pre-wrap;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/pastel_on_dark.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/pastel_on_dark.css
@@ -135,7 +135,7 @@
   border: 0 !important;
   background-color: rgba(128, 128, 128, 0.5);
 }
-.ace_editor {
+.ace_editor, rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
   color: #EAEAEA !important;
 }
 .ace_marker-layer .ace_foreign_line {

--- a/src/gwt/tools/compile-themes.R
+++ b/src/gwt/tools/compile-themes.R
@@ -1004,7 +1004,13 @@ for (file in themeFiles) {
       foreground <- "#EAEAEA"
       content <- add_content(
          content,
-         ".ace_editor {",
+         paste(
+            ".ace_editor, ",
+            "rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, ",
+            ".rstudio-themes-flat.ace_editor_theme, ", 
+            ".rstudio-themes-flat .ace_editor_theme {",
+            sep = ""
+         ),
          "  color: %s !important;",
          "}",
          replace = foreground


### PR DESCRIPTION
- Warning bars under dark theme
- Help titles
- Selection under help and data viewer
- Apply existing "pastel on dark" color tweak to help
- Autocomplete help links

<img width="594" alt="screen shot 2017-06-13 at 11 15 52 am" src="https://user-images.githubusercontent.com/3478847/27100929-a4d30830-5034-11e7-9651-01feb674bd4b.png">

<img width="600" alt="screen shot 2017-06-13 at 11 55 26 am" src="https://user-images.githubusercontent.com/3478847/27100930-a4e95de2-5034-11e7-98df-94448a75ba4e.png">

<img width="658" alt="screen shot 2017-06-13 at 12 32 47 pm" src="https://user-images.githubusercontent.com/3478847/27100956-bb2fc4e2-5034-11e7-92fb-103a3b8f2d91.png">



