### PR TITLE
Fix terminal issues with build and reload, restart R

### DIFF
--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -609,18 +609,7 @@ void ConsoleProcess::handleConsolePrompt(core::system::ProcessOperations& ops,
 void ConsoleProcess::onExit(int exitCode)
 {
    procInfo_->setExitCode(exitCode);
-
-   AutoCloseMode autoClose = procInfo_->getAutoClose();
-   if (autoClose == DefaultAutoClose)
-   {
-      if (session::userSettings().terminalAutoclose())
-         autoClose = AlwaysAutoClose;
-      else
-         autoClose = NeverAutoClose;
-   }
-
-   if (autoClose == NeverAutoClose)
-      procInfo_->setZombie(true);
+   procInfo_->setHasChildProcs(false);
 
    saveConsoleProcesses();
 
@@ -682,6 +671,13 @@ void ConsoleProcess::setRpcMode()
 {
    s_terminalSocket.stopListening(handle());
    procInfo_->setChannelMode(Rpc, "");
+}
+
+void ConsoleProcess::setZombie()
+{
+   procInfo_->setZombie(true);
+   procInfo_->setHasChildProcs(false);
+   saveConsoleProcesses();
 }
 
 core::json::Object ConsoleProcess::toJson() const

--- a/src/cpp/session/SessionConsoleProcessApi.cpp
+++ b/src/cpp/session/SessionConsoleProcessApi.cpp
@@ -634,6 +634,28 @@ Error procNotifyVisible(const json::JsonRpcRequest& request,
    return Success();
 }
 
+Error procSetZombie(const json::JsonRpcRequest& request,
+                    json::JsonRpcResponse* pResponse)
+{
+   std::string handle;
+
+   Error error = json::readParams(request.params,
+                                  &handle);
+   if (error)
+      return error;
+
+   ConsoleProcessPtr proc = findProcByHandle(handle);
+   if (proc == NULL)
+      return systemError(boost::system::errc::invalid_argument,
+                         "Error setting process to zombie mode",
+                         ERROR_LOCATION);
+
+   // Set a process to zombie mode meaning we keep showing it and its buffer, but don't
+   // start its process
+   proc->setZombie();
+   return Success();
+}
+
 } // anonymous namespace
 
 Error initializeApi()
@@ -666,6 +688,7 @@ Error initializeApi()
       (bind(registerRpcMethod, "process_test_exists", procTestExists))
       (bind(registerRpcMethod, "process_use_rpc", procUseRpc))
       (bind(registerRpcMethod, "process_notify_visible", procNotifyVisible))
+      (bind(registerRpcMethod, "process_set_zombie", procSetZombie))
       (bind(registerRpcMethod, "process_interrupt_child", procInterruptChild));
 
    return initBlock.execute();

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -194,6 +194,8 @@ public:
 
    void onReceivedInput(const std::string& input);
 
+   void setZombie();
+
 private:
    core::system::ProcessCallbacks createProcessCallbacks();
    bool onContinue(core::system::ProcessOperations& ops);

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -747,6 +747,14 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, PROCESS_NOTIFY_VISIBLE, params, requestCallback);   
    }
 
+   @Override 
+   public void processSetZombie(String handle,
+                                ServerRequestCallback<Void> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(StringUtil.notNull(handle)));
+      sendRequest(RPC_SCOPE, PROCESS_SET_ZOMBIE, params, requestCallback);   
+   }
 
    public void interrupt(ServerRequestCallback<Void> requestCallback)
    {
@@ -5238,6 +5246,7 @@ public class RemoteServer implements Server
    private static final String PROCESS_TEST_EXISTS = "process_test_exists";
    private static final String PROCESS_NOTIFY_VISIBLE = "process_notify_visible";
    private static final String PROCESS_INTERRUPT_CHILD = "process_interrupt_child";
+   private static final String PROCESS_SET_ZOMBIE = "process_set_zombie";
 
    private static final String REMOVE_ALL_OBJECTS = "remove_all_objects";
    private static final String REMOVE_OBJECTS = "remove_objects";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/model/ConsoleServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/model/ConsoleServerOperations.java
@@ -113,4 +113,13 @@ public interface ConsoleServerOperations extends CodeToolsServerOperations,
     */
    void processInterruptChild(String handle,
                               ServerRequestCallback<Void> requestCallback);
+
+   /**
+    * Set zombie flag on a process. Server will keep this process's metadata and 
+    * buffer around, but won't restart the process.
+    * @param handle process handle
+    * @param requestCallback
+    */
+   void processSetZombie(String handle,
+                         ServerRequestCallback<Void> requestCallback);
 }


### PR DESCRIPTION
Some lingering issues with terminal when doing `build and reload` and `restart R` where made very obvious (and much worse) with the changes I added to support keeping terminal panes open after the process exited (`zombie terminals`).

First, during an R restart, the server was notifying the client that the terminal processes had died, and the client was closing the client-side pane and then trying to reap those ConsoleProcs (a call back to the server). This was wrong, because we don't want to reap the consoleProcs in that case; we want to keep them around so the terminals could be reconnected. This wasn't much of an issue on server, it seems, as communication was cut-off before these events got propagated. On desktop IDEs, the events would get through, at least partially, leading to a variety of inconsistent situations.

Fix 1: The client ignores client-events for terminal console-process exits if they arrive during a restart.

Fix 2: Server doesn't have quite enough info to decide if a ConsoleProc should have its `zombie` state turned on; this was causing existing terminals to exit into zombie state after an R restart (if the user-option to keep terminal panes open after processes exited was enabled); even worse, existing terminals would close during an R restart if that user-option was off (the default). Fix is to have client make the decision, and flip a ConsoleProc's zombie flag on via a server call.

Fix 3: A zombie pane would always show a "busy" stop-sign after a browser refresh, which is annoying and incorrect. Now I set the childProcs state to false after a pane has "gone zombie (tm)".