### PR TITLE
Don't try to trim terminal log file if it doesn't exist

### DIFF
--- a/src/cpp/session/SessionConsoleProcessPersist.cpp
+++ b/src/cpp/session/SessionConsoleProcessPersist.cpp
@@ -196,6 +196,9 @@ void deleteLogFile(const std::string &handle, bool lastLineOnly)
       return;
    }
 
+   if (!log.exists())
+      return;
+
    if (!lastLineOnly)
    {
       // blow away the file


### PR DESCRIPTION
@kevinushey saw message below in his server log, it would happen when recreating a terminal after a restart if the terminal's buffer file didn't exist (as happens after a Ctrl+L, for example). Fix is to short-circuit if the file doesn't exist rather than trying to do stuff with it.

`07 Jun 2017 23:13:22 [rsession-kevin] ERROR system error 2 (No such file or directory) [path=/Users/kevin/rstudio/.Rproj.user/4F86FB9D/console04/D3EC94E9]; OCCURRED AT: rstudio::core::Error rstudio::core::FilePath::open_r(boost::shared_ptr<std::istream> *) const /Users/kevin/rstudio/src/cpp/core/FilePath.cpp:1109; LOGGED FROM: void rstudio::session::console_process::console_persist::deleteLogFile(const std::string &, bool) /Users/kevin/rstudio/src/cpp/session/SessionConsoleProcessPersist.cpp:214`