### PR TITLE
use Gabor's universal pandoc binary on Linux

### DIFF
--- a/dependencies/common/install-pandoc
+++ b/dependencies/common/install-pandoc
@@ -20,111 +20,54 @@ set -e
 source rstudio-tools
 
 # variables that control download + installation process
-PANDOC_URL_BASE=https://s3.amazonaws.com/rstudio-buildtools/pandoc/1.19.2.1
-PANDOC_VERSION=1.19.2.1-1
-PANDOC_VERSION_MACOS=1.19.2.1
-PANDOC_CITEPROC_VERSION=0.10.4-1
-PANDOC_CITEPROC_VERSION_MACOS=0.10.4
+PANDOC_VERSION="1.19.2.1"
+PANDOC_CITEPROC_VERSION="0.10.4"
+PANDOC_SUBDIR="pandoc/${PANDOC_VERSION}"
+PANDOC_URL_BASE="https://s3.amazonaws.com/rstudio-buildtools/pandoc/${PANDOC_VERSION}"
 
-if is-darwin; then
-  PANDOC_DIR="pandoc/${PANDOC_VERSION_MACOS}"
-else
-  PANDOC_DIR="pandoc/${PANDOC_VERSION}"
-fi
+# enter pandoc subdirectory
+mkdir -p "${PANDOC_SUBDIR}"
+pushd "${PANDOC_SUBDIR}"
 
-# remove patch version from pandoc directory (just for
-# ease-of-use with CMake installer scripts)
-PANDOC_DIR="$(echo "${PANDOC_DIR}" | cut -d"-" -f1)"
+# determine sub-directory based on platform
+case "$(uname)" in
 
-# exit early if pandoc already downloaded and installed
-if [ -d "${PANDOC_DIR}" ]; then
-  echo "Pandoc ${PANDOC_VERSION} already installed"
-  exit 0
-fi
+  "Darwin")
+    SUBDIR="macos"
+    FILES=(
+      "pandoc-${PANDOC_VERSION}.zip"
+      "pandoc-citeproc-${PANDOC_CITEPROC_VERSION}.zip"
+    )
+    ;;
 
-# construct download URL based on platform
-case "$(platform)" in
-
-  "centos")
-    CENTOS_VERSION="$(cat /etc/redhat-release | grep -oE '[0-9]+\.[0-9]+')"
-    CENTOS_VERSION_MAJOR="$(echo "${CENTOS_VERSION}" | cut -d"." -f1)"
-    PANDOC_URL_ARCH="${PANDOC_URL_BASE}/centos${CENTOS_VERSION_MAJOR}"
-    PANDOC_FILE="pandoc-${PANDOC_VERSION}.x86_64.rpm"
-    PANDOC_CITEPROC_FILE="pandoc-citeproc-${PANDOC_CITEPROC_VERSION}.x86_64.rpm"
-  ;;
-
-  "opensuse")
-    PANDOC_URL_ARCH="${PANDOC_URL_BASE}/opensuse-tumbleweed"
-    PANDOC_FILE="pandoc-${PANDOC_VERSION}.x86_64.rpm"
-    PANDOC_CITEPROC_FILE="pandoc-citeproc-${PANDOC_CITEPROC_VERSION}.x86_64.rpm"
-  ;;
-
-  "ubuntu")
-    UBUNTU_VERSION="$(. /etc/os-release; echo "${VERSION_ID}")"
-    PANDOC_URL_ARCH="${PANDOC_URL_BASE}/ubuntu-${UBUNTU_VERSION}/amd64"
-    PANDOC_FILE="pandoc_${PANDOC_VERSION}_amd64.deb"
-    PANDOC_CITEPROC_FILE="pandoc-citeproc_${PANDOC_CITEPROC_VERSION}_amd64.deb"
-  ;;
-
-  "darwin")
-    PANDOC_URL_ARCH="${PANDOC_URL_BASE}/macos"
-    PANDOC_FILE="pandoc-${PANDOC_VERSION_MACOS}.zip"
-    PANDOC_CITEPROC_FILE="pandoc-citeproc-${PANDOC_CITEPROC_VERSION_MACOS}.zip"
-  ;;
-
-  *)
-    echo "Unrecognized platform $(platform); exiting now"
-    exit 1
-
-esac
-
-# construct pandoc download URLs
-PANDOC_URL="${PANDOC_URL_ARCH}/${PANDOC_FILE}"
-PANDOC_CITEPROC_URL="${PANDOC_URL_ARCH}/${PANDOC_CITEPROC_FILE}"
-
-# enter pandoc directory
-mkdir -p "${PANDOC_DIR}"
-pushd "${PANDOC_DIR}"
-
-# download pandoc
-download "${PANDOC_URL}"
-download "${PANDOC_CITEPROC_URL}"
-
-# extract pandoc (delegate based on extension)
-case "${PANDOC_FILE}" in
-  *.rpm)
-
-    rpm2cpio "${PANDOC_FILE}" | cpio -idmv
-    rpm2cpio "${PANDOC_CITEPROC_FILE}" | cpio -idmv
-    cp usr/bin/pandoc .
-    cp usr/bin/pandoc-citeproc .
-    rm -rf usr
-  ;;
-
-  *.deb)
-
-    dpkg -x "${PANDOC_FILE}" .
-    dpkg -x "${PANDOC_CITEPROC_FILE}" .
-    cp usr/bin/pandoc .
-    cp usr/bin/pandoc-citeproc .
-    rm -rf usr
-  ;;
-
-  *.zip)
-    unzip -o "${PANDOC_FILE}"
-    unzip -o "${PANDOC_CITEPROC_FILE}"
-  ;;
-
-  *)
-    echo "Unrecognized download file format ${PANDOC_FILE}"
-    exit 1
+  "Linux")
+    SUBDIR="linux-$(getconf LONG_BIT)"
+    FILES=(
+      "pandoc.gz"
+      "pandoc-citeproc.gz"
+    )
   ;;
 
 esac
 
-# clean up downloaded archives
-rm "${PANDOC_FILE}"
-rm "${PANDOC_CITEPROC_FILE}"
+# enter sub-directory
+mkdir -p "${SUBDIR}"
+pushd "${SUBDIR}"
 
-# return home
+# download and extract files
+for FILE in "${FILES[@]}"; do
+  download "${PANDOC_URL_BASE}/${SUBDIR}/${FILE}" "${FILE}"
+  extract "${FILE}"
+  rm -f "${FILE}"
+done
+
+# copy pandoc binaries to parent folder
+cp pandoc* ..
 popd
+
+# remove transient download folder
+rm -rf "${SUBDIR}"
+
+# and we're done!
+popd
+

--- a/dependencies/common/install-pandoc
+++ b/dependencies/common/install-pandoc
@@ -74,6 +74,9 @@ popd
 # remove transient download folder
 rm -rf "${SUBDIR}"
 
+# make pandoc executable
+chmod 755 pandoc*
+
 # and we're done!
 popd
 

--- a/dependencies/common/install-pandoc
+++ b/dependencies/common/install-pandoc
@@ -30,22 +30,28 @@ mkdir -p "${PANDOC_SUBDIR}"
 pushd "${PANDOC_SUBDIR}"
 
 # determine sub-directory based on platform
-case "$(uname)" in
+case "$(uname)-$(getconf LONG_BIT)" in
 
-  "Darwin")
-    SUBDIR="macos"
-    FILES=(
-      "pandoc-${PANDOC_VERSION}.zip"
-      "pandoc-citeproc-${PANDOC_CITEPROC_VERSION}.zip"
-    )
-    ;;
+"Darwin-64")
+  SUBDIR="macos"
+  FILES=(
+    "pandoc-${PANDOC_VERSION}.zip"
+    "pandoc-citeproc-${PANDOC_CITEPROC_VERSION}.zip"
+  )
+  ;;
 
-  "Linux")
-    SUBDIR="linux-$(getconf LONG_BIT)"
-    FILES=(
-      "pandoc.gz"
-      "pandoc-citeproc.gz"
-    )
+"Linux-64")
+  SUBDIR="linux-64t"
+  FILES=(
+    "pandoc.gz"
+    "pandoc-citeproc.gz"
+  )
+  ;;
+
+*)
+  PLATFORM="$(platform)-$(getconf LONG_BIT)"
+  echo "Pandoc binaries not available for platform '${PLATFORM}'."
+  exit 0
   ;;
 
 esac

--- a/dependencies/common/rstudio-tools
+++ b/dependencies/common/rstudio-tools
@@ -61,9 +61,9 @@ download () {
 
 	# Invoke downloader
 	if has-command curl; then
-		curl -L -f "$SRC" > "$DST"
+		curl -L -f -C - "$SRC" > "$DST"
 	elif has-command wget; then
-		wget "$SRC" -O "$DST"
+		wget -c "$SRC" -O "$DST"
 	else
 		echo "no downloader detected on this system (requires 'curl' or 'wget')"
 		return 1
@@ -187,8 +187,7 @@ ubuntu-codename () {
 os-version () {
 
 	if [ -f /etc/os-release ]; then
-		local VERSION_ID
-		VERSION_ID="$(. /etc/os-release; echo "${VERSION_ID}")"
+		local VERSION_ID="$(. /etc/os-release; echo "${VERSION_ID}")"
 		if [ -n "${VERSION_ID}" ]; then
 			echo "${VERSION_ID}"
 			return 0
@@ -211,8 +210,7 @@ os-version () {
 }
 
 os-version-part () {
-	local VERSION
-	VERSION="$(os-version | cut -d"." -f"$1")"
+	local VERSION="$(os-version | cut -d"." -f"$1")"
 
 	if [ -n "${VERSION}" ]; then
 		echo "${VERSION}"

--- a/dependencies/common/rstudio-tools
+++ b/dependencies/common/rstudio-tools
@@ -16,6 +16,8 @@
 
 # Generic Tools ----
 
+# Aliases over 'pushd' and 'popd' just to suppress printing of
+# the directory stack on stdout
 pushd () {
 	command pushd "$@" > /dev/null
 }
@@ -24,20 +26,26 @@ popd () {
 	command popd "$@" > /dev/null
 }
 
+# Detect whether a command is available (e.g. program on the PATH,
+# Bash builtin, or otherwise)
 has-command () {
 	command -v "$1" &> /dev/null
 }
 
+is-verbose () {
+	[ -n "${VERBOSE}" ] && [ "${VERBOSE}" != "0" ]
+}
+
+# Download a single file
 download () {
 
 	if [ "$#" -eq 0 ]; then
-		echo "Usage: download src [dst]"
+		echo "usage: download src [dst]"
 		return 1
 	fi
 
 	# Compute source path
-	local SRC
-	SRC="$1"
+	local SRC="$1"
 
 	# Compute destination path
 	local DST
@@ -45,6 +53,10 @@ download () {
 		DST="$(basename "$SRC")"
 	else
 		DST="$2"
+	fi
+
+	if is-verbose; then
+		echo -e "Downloading:\n- '$SRC' -> '$DST'"
 	fi
 
 	# Invoke downloader
@@ -59,35 +71,49 @@ download () {
 
 }
 
+# Extract an archive
+extract () {
+	local FILE="$1"
+
+	if is-verbose; then
+		echo "Extracting '$FILE' ..."
+	fi
+
+	case "${FILE}" in
+
+		*.deb)
+			dpkg -x "${FILE}"
+		;;
+
+		*.rpm)
+			rpm2cpio "${FILE}" | cpio -idmv
+		;;
+
+		*.tar.gz)
+			tar -xf "${FILE}"
+		;;
+
+		*.tar.xz)
+			tar -xf "${FILE}"
+		;;
+
+		*.gz)
+			gunzip -k "${FILE}"
+		;;
+
+		*.zip)
+			unzip -o "${FILE}"
+		;;
+
+		*)
+			echo "Don't know how to extract file '${FILE}'"
+			return 1
+		;;
+
+	esac
+}
+
 # Platform Detection ----
-
-is-darwin () {
-	test "$(uname)" = "Darwin"
-}
-
-is-linux () {
-	test "$(uname)" = "Linux"
-}
-
-is-ubuntu () {
-	[ "$(. /etc/os-release; echo "${ID}")" = "ubuntu" ]
-}
-
-is-redhat () {
-	[ -f /etc/redhat-release ]
-}
-
-is-centos () {
-	grep -siq "centos" /etc/redhat-release
-}
-
-is-fedora () {
-	grep -siq "fedora" /etc/redhat-release
-}
-
-is-opensuse () {
-	[ "$(. /etc/os-release; echo "${ID}")" = "opensuse" ]
-}
 
 platform () {
 
@@ -99,20 +125,146 @@ platform () {
 
 	# Detect platform ID using /etc/os-release when available
 	if [ -f /etc/os-release ]; then
-		PLATFORM="$(. /etc/os-release; echo "${ID}")"
-		echo "${PLATFORM}"
-		return 0
+		local ID="$(. /etc/os-release; echo "$ID")"
+		if [ -n "${ID}" ]; then
+			echo "${ID}"
+			return 0
+		fi
 	fi
 
 	# Detect platform using /etc/redhat-release when available
 	if [ -f /etc/redhat-release ]; then
+
 		# Detect CentOS
 		if grep -siq "centos" /etc/redhat-release; then
 			echo "centos"
 			return 0
 		fi
+
+		# Detect Fedora
+		if grep -siq "fedora" /etc/redhat-release; then
+			echo "fedora"
+			return 0
+		fi
+
+		# Warn about other RedHat flavors we don't yet recognize
+		echo "unrecognized redhat variant '$(cat /etc/redhat-release)'"
+		return 1
 	fi
 
-	echo "Unrecognized platform detected" >&2
+	echo "unrecognized platform detected"
 	return 1
 }
+
+ubuntu-codename () {
+	# try reading codename from /etc/os-release
+	local CODENAME="$(. /etc/os-release; echo "${UBUNTU_CODENAME}")"
+	if [ -n "${CODENAME}" ]; then
+		echo "${CODENAME}"
+		return 0
+	fi
+
+	# hard-coded values for older Ubuntu
+	case "$(os-version)" in
+
+	12.04) echo "precise" ;;
+	12.10) echo "quantal" ;;
+	13.04) echo "raring"  ;;
+	13.10) echo "saucy"   ;;
+	14.04) echo "trusty"  ;;
+	14.10) echo "utopic"  ;;
+	15.04) echo "vivid"   ;;
+	15.10) echo "wily"    ;;
+	16.04) echo "xenial"  ;;
+	*)     echo "unknown"; return 1 ;;
+
+	esac
+
+	return 0
+}
+
+# Get the operating system version (as a number)
+os-version () {
+
+	if [ -f /etc/os-release ]; then
+		local VERSION_ID
+		VERSION_ID="$(. /etc/os-release; echo "${VERSION_ID}")"
+		if [ -n "${VERSION_ID}" ]; then
+			echo "${VERSION_ID}"
+			return 0
+		fi
+	fi
+
+	if [ -f /etc/redhat-release ]; then
+		grep -oE "[0-9]+([_.-][0-9]+)*" /etc/redhat-release
+		return 0
+	fi
+
+	if has-command sw_vers; then
+		sw_vers -productVersion
+		return 0
+	fi
+
+	echo "don't know how to infer OS version for platform '$(platform)'"
+	return 1
+
+}
+
+os-version-part () {
+	local VERSION
+	VERSION="$(os-version | cut -d"." -f"$1")"
+
+	if [ -n "${VERSION}" ]; then
+		echo "${VERSION}"
+		return 0
+	fi
+
+	echo "0"
+	return 0
+}
+
+os-version-major () {
+	os-version-part 1
+}
+
+os-version-minor () {
+	os-version-part 2
+}
+
+os-version-patch () {
+	os-version-part 3
+}
+
+# Helper functions for quickly checking paltform types
+is-mac () {
+	[ "$(uname)" = "Darwin" ]
+}
+
+is-darwin () {
+	[ "$(uname)" = "Darwin" ]
+}
+
+is-linux () {
+	[ "$(uname)" = "Linux" ]
+}
+
+is-redhat () {
+	[ -f /etc/redhat-release ]
+}
+
+is-centos () {
+	[ "$(platform)" = "centos" ]
+}
+
+is-fedora () {
+	[ "$(platform)" = "fedora" ]
+}
+
+is-opensuse () {
+	[ "$(platform)" = "opensuse" ]
+}
+
+is-ubuntu () {
+	[ "$(platform)" = "ubuntu" ]
+}
+


### PR DESCRIPTION
This PR uses Gabor's universal pandoc binary for 64bit Linux builds.

I also ported some of the old Bash helper functions from the old PR (just so we have it if we need it in the future) but note that most of that is unused in this PR.