### PR TITLE
use '-z' for machine-parsable git status output

### DIFF
--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -485,13 +485,7 @@ public:
       // build shell arguments
       ShellArgs arguments;
       
-      // on some platforms, git will return paths which contain characters
-      // not in the ASCII set with a so-called 'quoted octal encoding'.
-      // this is controlled by the 'core.quotepath' configuration option;
-      // by setting this to off we ensure that git will return us a
-      // plain UTF-8 encoded path which requires no further processing
-      arguments << "-c" << "core.quotepath=off"
-                << "status" << "--porcelain" << "--" << dir;
+      arguments << "status" << "-z" << "--porcelain" << "--" << dir;
       
       std::string output;
       Error error = runGit(arguments, &output);
@@ -499,7 +493,8 @@ public:
          return error;
       
       // split and parse each line of status output
-      std::vector<std::string> lines = split(output);
+      std::vector<std::string> lines;
+      boost::algorithm::split(lines, output, boost::is_any_of("\0"));
 
       for (std::vector<std::string>::iterator it = lines.begin();
            it != lines.end();


### PR DESCRIPTION
This PR fixes a bug where paths containing backslashes would not be handled correctly in the RStudio Git interface.

`git` documents `core.quotepath` as (https://www.kernel.org/pub/software/scm/git/docs/git-config.html), emphasis mine:

> Commands that output paths (e.g. ls-files, diff), will quote "unusual" characters in the pathname by enclosing the pathname in double-quotes and escaping those characters with backslashes in the same way C escapes control characters (e.g. \t for TAB, \n for LF, \\ for backslash) or bytes with values larger than 0x80 (e.g. octal \302\265 for "micro" in UTF-8). If this variable is set to false, bytes higher than 0x80 are not considered "unusual" any more. **Double-quotes, backslash and control characters are always escaped regardless of the setting of this variable.** A simple space character is not considered "unusual". **Many commands can output pathnames completely verbatim using the -z option.** The default value is true.

Given that `-z` is effectively an alias for `--porcelain`, with the added bit of completely disabling path quoting, I think that's the right fix here.
