### PR TITLE
depend on rmarkdown from CRAN

### DIFF
--- a/dependencies/common/install-packages
+++ b/dependencies/common/install-packages
@@ -65,7 +65,7 @@ mv $PACKAGE_ARCHIVE $PACKAGE_ARCHIVE_SHA1
 }
 
 install rsconnect master
-install rmarkdown master
+# install rmarkdown master
 
 # back to install-dir
 cd $INSTALL_DIR

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -213,11 +213,11 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       deps.add(Dependency.cranPackage("htmltools", "0.3.5"));
       deps.add(Dependency.cranPackage("caTools", "1.14"));
       deps.add(Dependency.cranPackage("bitops", "1.0-6"));
-      deps.add(Dependency.cranPackage("knitr", "1.14", true));
+      deps.add(Dependency.cranPackage("knitr", "1.14"));
       deps.add(Dependency.cranPackage("jsonlite", "0.9.19"));
       deps.add(Dependency.cranPackage("base64enc", "0.1-3"));
       deps.add(Dependency.cranPackage("rprojroot", "1.0"));
-      deps.add(Dependency.embeddedPackage("rmarkdown"));
+      deps.add(Dependency.cranPackage("rmarkdown", "1.6"));
       return deps;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/NotebookHtmlRenderer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/NotebookHtmlRenderer.java
@@ -156,7 +156,7 @@ public class NotebookHtmlRenderer
                                        final String outputPath)
    {
       dependencyManager_.withUnsatisfiedDependencies(
-            Dependency.embeddedPackage("rmarkdown"),
+            Dependency.cranPackage("rmarkdown", "1.6"),
             new ServerRequestCallback<JsArray<Dependency>>()
             {
                @Override


### PR DESCRIPTION
And stop bundling the `rmarkdown` package. (we should wait until the binaries have been built and propagated on the CRAN machines before merging)

As an aside, it looks like we're also bundling the `rsconnect` package -- do we want to continue bundling that, or can we depend CRAN release as well?

```
src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
155:      deps.add(Dependency.embeddedPackage("rsconnect"));
```