### PR TITLE
process events in both server, desktop configurations

### DIFF
--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -81,18 +81,14 @@ boost::posix_time::ptime timeoutTimeFromNow()
    }
 }
 
-void processDesktopGuiEvents()
+void processEvents()
 {
-   // keep R gui alive when we are in destkop mode
-   if (options().programMode() == kSessionProgramModeDesktop)
-   {
-      // execute safely since this can call arbitrary R code (and
-      // (can also cause jump_to_top if an interrupt is pending)
-      Error error = rstudio::r::exec::executeSafely(
-                        rstudio::r::session::event_loop::processEvents);
-      if (error)
-         LOG_ERROR(error);
-   }
+    // execute safely since this can call arbitrary R code (and
+    // (can also cause jump_to_top if an interrupt is pending)
+    Error error = rstudio::r::exec::executeSafely(
+                rstudio::r::session::event_loop::processEvents);
+    if (error)
+        LOG_ERROR(error);
 }
 
 bool parseAndValidateJsonRpcConnection(
@@ -410,8 +406,8 @@ bool waitForMethod(const std::string& method,
       // perform background processing (true for isIdle)
       module_context::onBackgroundProcessing(true);
 
-      // process pending events in desktop mode
-      processDesktopGuiEvents();
+      // process pending events
+      processEvents();
 
       if (ptrConnection)
       {


### PR DESCRIPTION
This fixes an issue wherein input handlers registered by the `later` package are never processed by RStudio. This PR deserves some extra scrutiny since it changes how often we process R events in server configurations, and there may be pitfalls in doing so.

@jjallaire, do you by any chance have any context for why we were only pumping events in desktop mode? From what I gather from hunting through the R sources, much of this was done primarily to ensure that events were processed while e.g. graphics devices are running, but it may well be fine just to ensure eager event processing in server configurations as well.