### PR TITLE
Paged table improvements and bug fix

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdTemplateData.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdTemplateData.java
@@ -38,7 +38,7 @@ public class RmdTemplateData
             format_extension: "html",
             format_options: [ "toc", "toc_depth", "highlight", "theme", "css", "fig_width", 
                               "fig_height", "fig_caption", "number_sections",
-                              "smart", "self_contained", "keep_md" ],
+                              "smart", "self_contained", "keep_md", "df_print" ],
             format_notes: "Recommended format for authoring (you can switch to PDF or Word output anytime)."
             },
             {
@@ -108,6 +108,16 @@ public class RmdTemplateData
             option_default: "default",
             option_list: [ "default", "tango", "pygments", "kate", "monochrome",
                            "espresso", "zenburn", "haddock", "textmate" ]
+            },
+            {
+            option_name: "df_print",
+            option_ui_name: "Print dataframes as:",
+            option_format: "html_document",
+            option_type: "choice", 
+            option_nullable: false,
+            option_default: "paged",
+            option_list: [ "default", "kable", "paged", "tibble" ],
+            option_add_header: true
             },
             {
             option_name: "smart",

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdTemplateData.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdTemplateData.java
@@ -111,7 +111,7 @@ public class RmdTemplateData
             },
             {
             option_name: "df_print",
-            option_ui_name: "Print dataframes as:",
+            option_ui_name: "Print dataframes as",
             option_format: "html_document",
             option_type: "choice", 
             option_nullable: false,

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdTemplateFormatOption.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdTemplateFormatOption.java
@@ -51,6 +51,10 @@ public class RmdTemplateFormatOption extends JavaScriptObject
       return this.option_transferable || false;
    }-*/;
 
+   public final native boolean isAddHeader() /*-{
+      return this.option_add_header || false;
+   }-*/;
+
    public final native boolean isNullable() /*-{
       return this.option_nullable || false;
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
@@ -1015,12 +1015,19 @@ public class TextEditingTargetRMarkdownHelper
       RmdFrontMatterOutputOptions result = RmdFrontMatterOutputOptions.create();
 
       // loop over each option applicable to the new format; if it's
-      // transferable, try to find it in one of the other formats 
+      // transferable, try to find it in one of the other formats. If
+      // it should be added to the header, add it.
       JsArrayString options = template.getFormat(format).getOptions();
       for (int i = 0; i < options.length(); i++)
       {
          String optionName = options.get(i);
          RmdTemplateFormatOption option = template.getOption(optionName);
+
+         if (option.isAddHeader()) {
+            String val = option.getDefaultValue();
+            result.setOptionValue(option, val);
+         }
+
          if (!option.isTransferable())
             continue;
          

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUi.java
@@ -229,9 +229,9 @@ public class ChunkContextUi implements ChunkContextToolbar.Host
       
       String engine = getEngine(row);
       if (!engine.toLowerCase().equals("r"))
-         return new CustomEngineChunkOptionsPopupPanel();
+         return new CustomEngineChunkOptionsPopupPanel(engine_);
       
-      return new DefaultChunkOptionsPopupPanel();
+      return new DefaultChunkOptionsPopupPanel(engine_);
    }
 
    private final TextEditingTarget target_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
@@ -245,6 +245,7 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
             "Use paged tables",
             "paged.print");
       panel_.add(printTableAsTextCb_);
+      printTableAsTextCb_.setVisible(false);
       
       useCustomFigureCheckbox_ = new ThemedCheckBox("Use custom figure size");
       useCustomFigureCheckbox_.addStyleName(RES.styles().checkBox());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/CustomEngineChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/CustomEngineChunkOptionsPopupPanel.java
@@ -16,9 +16,9 @@ package org.rstudio.studio.client.workbench.views.source.editors.text.rmd.displa
 
 public class CustomEngineChunkOptionsPopupPanel extends DefaultChunkOptionsPopupPanel
 {
-   public CustomEngineChunkOptionsPopupPanel()
+   public CustomEngineChunkOptionsPopupPanel(String engine)
    {
-      super();
+      super(engine);
       
       showWarningsInOutputCb_.setVisible(false);
       showMessagesInOutputCb_.setVisible(false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/DefaultChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/DefaultChunkOptionsPopupPanel.java
@@ -16,10 +16,11 @@ import java.util.Map;
 
 public class DefaultChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
 {
-   public DefaultChunkOptionsPopupPanel()
+   public DefaultChunkOptionsPopupPanel(String engine)
    {
       super(true);
       
+      engine_ = engine;
       enginePanel_.setVisible(false);
    }
    
@@ -30,6 +31,9 @@ public class DefaultChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
       parseChunkHeader(originalLine_, originalChunkOptions_);
       for (Map.Entry<String, String> pair : originalChunkOptions_.entrySet())
          chunkOptions_.put(pair.getKey(), pair.getValue());
+
+      if (engine_ == "r") printTableAsTextCb_.setVisible(true);
+
       afterInit.execute();
    }
    
@@ -220,6 +224,5 @@ public class DefaultChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
       while (cursor.moveToNextCharacter());
    }
    
-   
-
+   private String engine_;
 }


### PR DESCRIPTION
A few paged table fixes and improvements:

1. Make paged tables the default option while knitting to html. Otherwise, notebooks preview does not match html output since we use paged tables in notebooks by default.

<img width="247" alt="screen shot 2017-06-16 at 4 52 32 pm" src="https://user-images.githubusercontent.com/3478847/27248131-46f3427a-52b4-11e7-8e46-b607e50aba7f.png">

2. Add `df_print` option to notebook settings to allow users to switch to and away from `paged` with ease.

<img width="443" alt="screen shot 2017-06-16 at 4 58 20 pm" src="https://user-images.githubusercontent.com/3478847/27248193-0de6396e-52b5-11e7-8631-16adcb4fd6e4.png">

3. Made "Use paged tables" option under chunk settings opoup only visible under r chunks.

<img width="392" alt="screen shot 2017-06-16 at 4 59 38 pm" src="https://user-images.githubusercontent.com/3478847/27248234-96dc7044-52b5-11e7-8827-075ce3332f94.png">

4. Fix to `rmarkdown` to support row names in the same way as notebooks. https://github.com/rstudio/rmarkdown/pull/1086

5. Improvements to `rmarkdown.rstudio.com` to show all options and demonstrate paged tables in the actual section. https://github.com/rstudio/rmarkdown/pull/1087

<img width="1359" alt="screen shot 2017-06-16 at 4 52 48 pm" src="https://user-images.githubusercontent.com/3478847/27248132-46ff5a88-52b4-11e7-8437-fc37a72b6523.png">