### PR TITLE
Do not apply dark themes to install packages

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -35,6 +35,7 @@ import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.NativeWindow;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.ui.RStudioThemes;
 
 import java.util.ArrayList;
 
@@ -88,6 +89,8 @@ public abstract class ModalDialogBase extends DialogBox
             event.stopPropagation();
          }
       }, KeyDownEvent.getType());
+
+      RStudioThemes.disableDarkMenus();
    }
 
    @Override
@@ -125,6 +128,8 @@ public abstract class ModalDialogBase extends DialogBox
       shortcutDisableHandle_ = null;
 
       ModalDialogTracker.onHide(this);
+
+      RStudioThemes.enableDarkMenus();
 
       super.onUnload();
    }

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -89,8 +89,6 @@ public abstract class ModalDialogBase extends DialogBox
             event.stopPropagation();
          }
       }, KeyDownEvent.getType());
-
-      RStudioThemes.disableDarkMenus();
    }
 
    @Override
@@ -118,6 +116,8 @@ public abstract class ModalDialogBase extends DialogBox
       catch (Throwable e)
       {
       }
+
+      RStudioThemes.disableDarkMenus();
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
@@ -18,6 +18,7 @@ package org.rstudio.studio.client.application.ui;
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 
+import com.google.gwt.dom.client.BodyElement;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style.Overflow;
@@ -126,6 +127,24 @@ public class RStudioThemes
       }
       
       return usesScrollbars_;
+   }
+   
+   public static void disableDarkMenus()
+   {
+      BodyElement body = Document.get().getBody();
+      if (body.hasClassName("rstudio-themes-dark-menus")) {
+         body.removeClassName("rstudio-themes-dark-menus");
+         body.addClassName("rstudio-themes-dark-menus-disabled");
+      }
+   }
+   
+   public static void enableDarkMenus()
+   {
+      BodyElement body = Document.get().getBody();
+      if (body.hasClassName("rstudio-themes-dark-menus-disabled")) {
+         body.removeClassName("rstudio-themes-dark-menus-disabled");
+         body.addClassName("rstudio-themes-dark-menus");
+      }
    }
    
    private static Boolean usesScrollbars_ = null;

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
@@ -48,7 +48,9 @@ public class RStudioThemes
       element.removeClassName("rstudio-themes-dark-grey");
       element.removeClassName("rstudio-themes-alternate");
       element.removeClassName("rstudio-themes-scrollbars");
+
       document.getBody().removeClassName("rstudio-themes-dark-menus");
+      document.getBody().removeClassName("rstudio-themes-dark-menus-disabled");
       
       if (themeName == "default" || themeName == "dark-grey" || themeName == "alternate") {         
          document.getBody().addClassName("rstudio-themes-flat");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/InstallPackageDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/InstallPackageDialog.java
@@ -28,6 +28,7 @@ import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.ProgressOperationWithInput;
 import org.rstudio.core.client.widget.TextBoxWithButton;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.common.FileDialogs;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.server.ServerError;
@@ -72,6 +73,8 @@ public class InstallPackageDialog extends ModalDialog<PackageInstallRequest>
       defaultInstallOptions_ = defaultInstallOptions;
       server_ = server;
       globalDisplay_ = globalDisplay;
+
+      RStudioThemes.disableDarkMenus();
 
       setOkButtonCaption("Install");
 }
@@ -381,6 +384,13 @@ public class InstallPackageDialog extends ModalDialog<PackageInstallRequest>
    public static void ensureStylesInjected()
    {
       RESOURCES.styles().ensureInjected();
+   }
+
+   @Override
+   protected void onUnload()
+   {
+      super.onUnload();
+      RStudioThemes.enableDarkMenus();
    }
    
    private final PackageInstallContext installContext_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/InstallPackageDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/InstallPackageDialog.java
@@ -28,7 +28,6 @@ import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.ProgressOperationWithInput;
 import org.rstudio.core.client.widget.TextBoxWithButton;
 import org.rstudio.studio.client.RStudioGinjector;
-import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.common.FileDialogs;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.server.ServerError;
@@ -73,8 +72,6 @@ public class InstallPackageDialog extends ModalDialog<PackageInstallRequest>
       defaultInstallOptions_ = defaultInstallOptions;
       server_ = server;
       globalDisplay_ = globalDisplay;
-
-      RStudioThemes.disableDarkMenus();
 
       setOkButtonCaption("Install");
 }
@@ -384,13 +381,6 @@ public class InstallPackageDialog extends ModalDialog<PackageInstallRequest>
    public static void ensureStylesInjected()
    {
       RESOURCES.styles().ensureInjected();
-   }
-
-   @Override
-   protected void onUnload()
-   {
-      super.onUnload();
-      RStudioThemes.enableDarkMenus();
    }
    
    private final PackageInstallContext installContext_;


### PR DESCRIPTION
Dark suggestions are being displayed in packages dialog, disable dark menus for this dialog.

<img width="458" alt="screen shot 2017-06-16 at 9 30 54 pm" src="https://user-images.githubusercontent.com/3478847/27250269-405a9942-52df-11e7-8f53-9a09d559f15e.png">