### PR TITLE
allow 'navigateToFile' to preserve position

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -143,11 +143,18 @@
    if (!file.exists(filePath)) {
       stop(filePath, " does not exist.")
    }
+   
+   # transform numeric line, column values to integer
+   if (is.numeric(line))
+      line <- as.integer(line)
+   
+   if (is.numeric(col))
+      col <- as.integer(col)
 
    # validate line/col arguments
    if (!is.integer(line) || length(line) != 1 ||
        !is.integer(col)  || length(col) != 1) {
-      stop("line and column must be integer values.")
+      stop("line and column must be numeric values.")
    }
 
    # expand and alias for client

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -2595,7 +2595,14 @@ public class Source implements InsertSourceHandler,
          @Override
          public void execute(EditingTarget target)
          {
-            if (position != null)
+            // the rstudioapi package can use the proxy (-1, -1) position to
+            // indicate that source navigation should not occur; ie, we should
+            // preserve whatever position was used in the document earlier
+            boolean navigateToPosition =
+                  position != null &&
+                  (position.getLine() != -1 && position.getColumn() != -1);
+            
+            if (navigateToPosition)
             {
                SourcePosition endPosition = null;
                if (isDebugNavigation)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -2600,7 +2600,7 @@ public class Source implements InsertSourceHandler,
             // preserve whatever position was used in the document earlier
             boolean navigateToPosition =
                   position != null &&
-                  (position.getLine() != -1 && position.getColumn() != -1);
+                  (position.getLine() != -1 || position.getColumn() != -1);
             
             if (navigateToPosition)
             {


### PR DESCRIPTION
This PR allows for API calls of the form:

    .rs.api.navigateToFile("file", -1L, -1L)

to preserve the preserve cursor position when the file "file" is opened. A corresponding change in the `rstudioapi` package will be made to take advantage of this behavior.

https://github.com/rstudio/rstudioapi/pull/48