### PR TITLE
Fix size/unsigned comparison warnings on Linux build.

### DIFF
--- a/src/cpp/session/SessionConsoleProcessTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessTests.cpp
@@ -150,7 +150,7 @@ context("queue and fetch input")
 
       // intentionally skipping item "0" to prevent pulling from queueA
       int lastAdded = kIgnoreSequence;
-      for (int i = 1; i < kAutoFlushLength + 5; i++)
+      for (size_t i = 1; i < kAutoFlushLength + 5; i++)
       {
          std::string item = boost::lexical_cast<std::string>(i);
          expected += item;

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -40,7 +40,7 @@ namespace console_process {
 
 const int kFlushSequence = -2; // see ShellInput.FLUSH_SEQUENCE
 const int kIgnoreSequence = -1; // see ShellInput.IGNORE_SEQUENCE
-const int kAutoFlushLength = 20;
+const size_t kAutoFlushLength = 20;
 
 class ConsoleProcess;
 typedef boost::shared_ptr<ConsoleProcess> ConsoleProcessPtr;


### PR DESCRIPTION
Warnings noticed during a build on Linux.