### PR TITLE
provide APIs for creating / opening RStudio projects

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -18,7 +18,7 @@
       # ... and it's not a directory, bail
       if (!utils::file_test("-d", path))
       {
-         fmt <- "can't create project at path '%s'"
+         fmt <- "file '%s' exists and is not a directory"
          stop(sprintf(fmt, .rs.createAliasedPath(path)))
       }
    }

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -177,6 +177,7 @@ const int kTerminalCwd = 158;
 const int kAdminNotification = 159;
 const int kRequestDocumentSave = 160;
 const int kRequestDocumentSaveCompleted = 161;
+const int kRequestOpenProject = 162;
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -486,6 +487,8 @@ std::string ClientEvent::typeName() const
          return "request_document_save";
       case client_events::kRequestDocumentSaveCompleted:
          return "request_document_save_completed";
+      case client_events::kRequestOpenProject:
+         return "request_open_project";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -178,6 +178,7 @@ extern const int kTerminalCwd;
 extern const int kAdminNotification;
 extern const int kRequestDocumentSave;
 extern const int kRequestDocumentSaveCompleted;
+extern const int kRequestOpenProject;
 }
    
 class ClientEvent

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1909,3 +1909,17 @@
    setdiff(slots, "class")
  
 })
+
+.rs.addFunction("deparse", function(object)
+{
+   paste(deparse(object, width.cutoff = 500L), collapse = " ")
+})
+
+.rs.addFunction("ensureScalarCharacter", function(object)
+{
+   if (is.character(object) && length(object) == 1)
+      return(object)
+   
+   fmt <- "'%s' is not a length-one character vector"
+   stop(sprintf(fmt, .rs.deparse(substitute(object))), call. = FALSE)
+})

--- a/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
@@ -45,6 +45,7 @@ import org.rstudio.studio.client.projects.events.OpenProjectFileEvent;
 import org.rstudio.studio.client.projects.events.OpenProjectFileHandler;
 import org.rstudio.studio.client.projects.events.OpenProjectNewWindowEvent;
 import org.rstudio.studio.client.projects.events.OpenProjectNewWindowHandler;
+import org.rstudio.studio.client.projects.events.RequestOpenProjectEvent;
 import org.rstudio.studio.client.projects.events.SwitchToProjectEvent;
 import org.rstudio.studio.client.projects.events.SwitchToProjectHandler;
 import org.rstudio.studio.client.projects.events.NewProjectEvent;
@@ -84,7 +85,8 @@ public class Projects implements OpenProjectFileHandler,
                                  OpenProjectErrorHandler,
                                  OpenProjectNewWindowHandler,
                                  NewProjectEvent.Handler,
-                                 OpenProjectEvent.Handler
+                                 OpenProjectEvent.Handler,
+                                 RequestOpenProjectEvent.Handler
 {
    public interface Binder extends CommandBinder<Commands, Projects> {}
    
@@ -130,6 +132,7 @@ public class Projects implements OpenProjectFileHandler,
       eventBus.addHandler(OpenProjectNewWindowEvent.TYPE, this);
       eventBus.addHandler(NewProjectEvent.TYPE, this);
       eventBus.addHandler(OpenProjectEvent.TYPE, this);
+      eventBus.addHandler(RequestOpenProjectEvent.TYPE, this);
       
       eventBus.addHandler(SessionInitEvent.TYPE, new SessionInitHandler() {
          public void onSessionInit(SessionInitEvent sie)
@@ -603,6 +606,20 @@ public class Projects implements OpenProjectFileHandler,
       showOpenProjectDialog(ProjectOpener.PROJECT_TYPE_FILE,
                             event.getForceSaveAll(),
                             event.getAllowOpenInNewWindow());
+   }
+   
+   @Override
+   public void onRequestOpenProjectEvent(RequestOpenProjectEvent event)
+   {
+      String projFile = event.getProjectFile();
+      if (event.isNewSession())
+      {
+         eventBus_.fireEvent(new OpenProjectNewWindowEvent(projFile, null));
+      }
+      else
+      {
+         eventBus_.fireEvent(new SwitchToProjectEvent(projFile));
+      }
    }
    
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/projects/events/RequestOpenProjectEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/events/RequestOpenProjectEvent.java
@@ -1,0 +1,79 @@
+/*
+ * RequestOpenProjectActionEvent.java
+ *
+ * Copyright (C) 2009-15 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.projects.events;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class RequestOpenProjectEvent 
+   extends GwtEvent<RequestOpenProjectEvent.Handler>
+{
+   public static class Data extends JavaScriptObject
+   {
+      protected Data()
+      {
+      }
+      
+      public final native String getProjectFile()
+      /*-{
+         return this["project_file"];
+      }-*/;
+      
+      public final native boolean isNewSession()
+      /*-{
+         return this["new_session"];
+      }-*/;
+   }
+   
+   public RequestOpenProjectEvent(Data data)
+   {
+      data_ = data;
+   }
+   
+   public String getProjectFile()
+   {
+      return data_.getProjectFile();
+   }
+   
+   public boolean isNewSession()
+   {
+      return data_.isNewSession();
+   }
+   
+   private final Data data_;
+   
+   // Boilerplate ----
+   
+   public interface Handler extends EventHandler
+   {
+      void onRequestOpenProjectEvent(RequestOpenProjectEvent event);
+   }
+   
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onRequestOpenProjectEvent(this);
+   }
+   
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/projects/events/RequestOpenProjectEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/events/RequestOpenProjectEvent.java
@@ -1,7 +1,7 @@
 /*
  * RequestOpenProjectActionEvent.java
  *
- * Copyright (C) 2009-15 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -168,6 +168,7 @@ class ClientEvent extends JavaScriptObject
    public static final String TerminalCwd = "terminal_cwd";
    public static final String AdminNotification = "admin_notification";
    public static final String RequestDocumentSave = "request_document_save";
+   public static final String RequestOpenProject = "request_open_project";
    
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -62,6 +62,7 @@ import org.rstudio.studio.client.projects.events.OpenProjectErrorEvent;
 import org.rstudio.studio.client.projects.events.ProjectAccessRevokedEvent;
 import org.rstudio.studio.client.projects.events.ProjectTemplateRegistryUpdatedEvent;
 import org.rstudio.studio.client.projects.events.ProjectUserChangedEvent;
+import org.rstudio.studio.client.projects.events.RequestOpenProjectEvent;
 import org.rstudio.studio.client.projects.model.OpenProjectError;
 import org.rstudio.studio.client.projects.model.ProjectTemplateRegistry;
 import org.rstudio.studio.client.projects.model.ProjectUser;
@@ -917,6 +918,11 @@ public class ClientEventDispatcher
          {
             RequestDocumentSaveEvent.Data data = event.getData();
             eventBus_.fireEvent(new RequestDocumentSaveEvent(data));
+         }
+         else if (type.equals(ClientEvent.RequestOpenProject))
+         {
+            RequestOpenProjectEvent.Data data = event.getData();
+            eventBus_.fireEvent(new RequestOpenProjectEvent(data));
          }
          else
          {


### PR DESCRIPTION
This PR adds the `openProject()` API to RStudio, which allows users to open an existing project (when provided a `.Rproj` file), or create a new project (when provided a directory containing no `.Rproj` file).

Is it worth separating this into two functions (`createProject()`, `openProject()`)? Or is it fine to have `openProject()` handling the responsibilities of both 'create a new project and open it' vs. 'open an existing project'?