### PR TITLE
provide API for restarting R

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -1,3 +1,7 @@
+.rs.addApiFunction("restartSession", function(command = NULL) {
+   command <- as.character(command)
+   invisible(.rs.restartR(command))
+})
 
 .rs.addApiFunction("versionInfo", function() {
   info <- list()


### PR DESCRIPTION
See associated implementation of `rs_restartR` at:

https://github.com/rstudio/rstudio/blob/eecd9388c4e97f4bf1867c80b33ef1042b038b5a/src/cpp/session/SessionModuleContext.cpp#L352-L360

We actually already export this function's use through the `restart` R option as well:

https://github.com/rstudio/rstudio/blob/eecd9388c4e97f4bf1867c80b33ef1042b038b5a/src/cpp/r/R/Options.R#L76-L77

but this makes it more explicitly available + makes it possible to use through `rstudioapi`.