### PR TITLE
fix win32-specific rsession unit test failure

### DIFF
--- a/src/cpp/session/SessionConsoleProcessInfoTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfoTests.cpp
@@ -40,8 +40,15 @@ const TerminalShell::TerminalShellType shellType = TerminalShell::DefaultShell;
 const ChannelMode channelMode = Rpc;
 const std::string channelId("some channel Id");
 const bool altActive = false;
+
+#ifdef _WIN32
+const core::FilePath cwd("C:\\windows\\temp");
+const core::FilePath altCwd("C:\\windows\\system32");
+#else
 const core::FilePath cwd("/usr/local");
 const core::FilePath altCwd("/usr/stuff");
+#endif
+
 const int cols = core::system::kDefaultCols;
 const int rows = core::system::kDefaultRows;
 const bool restarted = false;


### PR DESCRIPTION
Failure in win32 unit test because `FilePath` class does some platform-specific normalization, and hardcoded paths in test were Posix-ish instead of Windows-ish. Paths don't actually have to exist for tests to pass, just behave consistently inside of `FilePath`.