### PR TITLE
provide API for interacting with file dialogs

### DIFF
--- a/src/cpp/desktop-mac/GwtCallbacks.mm
+++ b/src/cpp/desktop-mac/GwtCallbacks.mm
@@ -1149,88 +1149,9 @@ enum RS_NSActivityOptions : uint64_t
 
 + (NSString *) webScriptNameForSelector: (SEL) sel
 {
-   if (sel == @selector(browseUrl:))
-      return @"browseUrl";
-   else if (sel == @selector(getOpenFileName:label:dir:filter:canChooseDirectories:))
-      return @"getOpenFileName";
-   else if (sel == @selector(getSaveFileName:label:dir:defaultExtension:forceDefaultExtension:))
-      return @"getSaveFileName";
-   else if (sel == @selector(getExistingDirectory:label:dir:))
-      return @"getExistingDirectory";
-   else if (sel == @selector(getUriForPath:))
-      return @"getUriForPath";
-   else if (sel == @selector(onWorkbenchInitialized:))
-      return @"onWorkbenchInitialized";
-   else if (sel == @selector(showFolder:))
-      return @"showFolder";
-   else if (sel == @selector(showFile:))
-      return @"showFile";
-   else if (sel == @selector(showWordDoc:))
-      return @"showWordDoc";
-   else if (sel == @selector(showPDF:pdfPage:))
-      return @"showPDF";
-   else if (sel == @selector(openMinimalWindow:url:width:height:))
-      return @"openMinimalWindow";
-   else if (sel == @selector(activateMinimalWindow:))
-      return @"activateMinimalWindow";
-   else if (sel == @selector(activateSatelliteWindow:))
-      return @"activateSatelliteWindow";
-   else if (sel == @selector(prepareForSatelliteWindow:x:y:width:height:))
-      return @"prepareForSatelliteWindow";
-   else if (sel == @selector(copyImageToClipboard:top:width:height:))
-      return @"copyImageToClipboard";
-   else if (sel == @selector(copyPageRegionToClipboard:top:width:height:))
-      return @"copyPageRegionToClipboard";
-   else if (sel == @selector(exportPageRegionToFile:format:left:top:width:height:))
-      return @"exportPageRegionToFile";
-   else if (sel == @selector(showMessageBox:caption:message:buttons:defaultButton:cancelButton:))
-      return @"showMessageBox";
-   else if (sel == @selector(promptForText:caption:defaultValue:usePasswordMask:rememberPasswordPrompt:rememberByDefault:numbersOnly:selectionStart:selectionLength:))
-      return @"promptForText";
-   else if (sel == @selector(cleanClipboard:))
-      return @"cleanClipboard";
-   else if (sel == @selector(setPendingQuit:))
-      return @"setPendingQuit";
-   else if (sel == @selector(openProjectInNewWindow:))
-      return @"openProjectInNewWindow";
-   else if (sel == @selector(openSessionInNewWindow:))
-      return @"openSessionInNewWindow";
-   else if (sel == @selector(openTerminal:workingDirectory:extraPathEntries:))
-      return @"openTerminal";
-   else if (sel == @selector(setFixedWidthFont:))
-      return @"setFixedWidthFont";
-   else if (sel == @selector(setZoomLevel:))
-      return @"setZoomLevel";
-   else if (sel == @selector(externalSynctexPreview:page:))
-      return @"externalSynctexPreview";
-   else if (sel == @selector(externalSynctexView:srcFile:line:column:))
-      return @"externalSynctexView";
-   else if (sel == @selector(launchSession:))
-      return @"launchSession";
-   else if (sel == @selector(setViewerUrl:))
-      return @"setViewerUrl";
-   else if (sel == @selector(setShinyDialogUrl:))
-      return @"setShinyDialogUrl";
-   else if (sel == @selector(filterText:))
-      return @"filterText";
-   else if (sel == @selector(setBusy:))
-      return @"setBusy";
-   else if (sel == @selector(setWindowTitle:))
-      return @"setWindowTitle";
-   else if (sel == @selector(reloadViewerZoomWindow:))
-      return @"reloadViewerZoomWindow";
-   else if (sel == @selector(prepareForNamedWindow:allowExternalNavigate:))
-      return @"prepareForNamedWindow";
-   else if (sel == @selector(closeNamedWindow:))
-      return @"closeNamedWindow";
-   else if (sel == @selector(undo:))
-      return @"undo";
-   else if (sel == @selector(redo:))
-      return @"redo";
-   else if (sel == @selector(setPendingProject:))
-      return @"setPendingProject";
-      
-   return nil;
+   NSString* selectorName = NSStringFromSelector(sel);
+   NSArray<NSString*>* parts = [selectorName componentsSeparatedByString: @":"];
+   return parts[0];
 }
 
 + (BOOL)isSelectorExcludedFromWebScript: (SEL) sel

--- a/src/cpp/desktop-mac/GwtCallbacks.mm
+++ b/src/cpp/desktop-mac/GwtCallbacks.mm
@@ -1151,11 +1151,11 @@ enum RS_NSActivityOptions : uint64_t
 {
    if (sel == @selector(browseUrl:))
       return @"browseUrl";
-   else if (sel == @selector(getOpenFileName:dir:filter:canChooseDirectories:))
+   else if (sel == @selector(getOpenFileName:label:dir:filter:canChooseDirectories:))
       return @"getOpenFileName";
-   else if (sel == @selector(getSaveFileName:dir:defaultExtension:forceDefaultExtension:))
+   else if (sel == @selector(getSaveFileName:label:dir:defaultExtension:forceDefaultExtension:))
       return @"getSaveFileName";
-   else if (sel == @selector(getExistingDirectory:dir:))
+   else if (sel == @selector(getExistingDirectory:label:dir:))
       return @"getExistingDirectory";
    else if (sel == @selector(getUriForPath:))
       return @"getUriForPath";

--- a/src/cpp/desktop-mac/GwtCallbacks.mm
+++ b/src/cpp/desktop-mac/GwtCallbacks.mm
@@ -156,6 +156,7 @@ private:
 
 
 - (NSString*) getOpenFileName: (NSString*) caption
+                        label: (NSString*) label
                           dir: (NSString*) dir
                        filter: (NSString*) filter
          canChooseDirectories: (Boolean) canChooseDirectories
@@ -164,6 +165,7 @@ private:
    
    NSOpenPanel *open = [NSOpenPanel openPanel];
    [open setTitle: caption];
+   [open setPrompt: label];
    [open setDirectoryURL: [NSURL fileURLWithPath:
                            [dir stringByStandardizingPath]]];
    [open setCanChooseDirectories: canChooseDirectories];
@@ -192,7 +194,7 @@ private:
 }
 
 - (NSString*) getSaveFileName: (NSString*) caption
-                  buttonLabel: (NSString*) buttonLabel
+                        label: (NSString*) label
                           dir: (NSString* ) dir
              defaultExtension: (NSString*) defaultExtension
         forceDefaultExtension: (Boolean) forceDefaultExtension
@@ -200,7 +202,7 @@ private:
    dir = resolveAliasedPath(dir);
    
    NSSavePanel *save = [NSSavePanel savePanel];
-   [save setPrompt: buttonLabel];
+   [save setPrompt: label];
    
    BOOL hasDefaultExtension = defaultExtension != nil &&
                               [defaultExtension length] > 0;
@@ -252,11 +254,14 @@ private:
    return [self runFileDialog: save];
 }
 
-- (NSString*) getExistingDirectory: (NSString*) caption dir: (NSString*) dir
+- (NSString*) getExistingDirectory: (NSString*) caption
+                             label: (NSString*) label
+                               dir: (NSString*) dir
 {
    dir = resolveAliasedPath(dir);
    NSOpenPanel *open = [NSOpenPanel openPanel];
    [open setTitle: caption];
+   [open setPrompt: label];
    [open setDirectoryURL: [NSURL fileURLWithPath:
                            [dir stringByStandardizingPath]]];
    [open setCanChooseFiles: false];

--- a/src/cpp/desktop-mac/GwtCallbacks.mm
+++ b/src/cpp/desktop-mac/GwtCallbacks.mm
@@ -192,13 +192,15 @@ private:
 }
 
 - (NSString*) getSaveFileName: (NSString*) caption
-              dir: (NSString* ) dir
-              defaultExtension: (NSString*) defaultExtension
-              forceDefaultExtension: (Boolean) forceDefaultExtension
+                  buttonLabel: (NSString*) buttonLabel
+                          dir: (NSString* ) dir
+             defaultExtension: (NSString*) defaultExtension
+        forceDefaultExtension: (Boolean) forceDefaultExtension
 {
    dir = resolveAliasedPath(dir);
    
    NSSavePanel *save = [NSSavePanel savePanel];
+   [save setPrompt: buttonLabel];
    
    BOOL hasDefaultExtension = defaultExtension != nil &&
                               [defaultExtension length] > 0;

--- a/src/cpp/desktop-mac/GwtCallbacks.mm
+++ b/src/cpp/desktop-mac/GwtCallbacks.mm
@@ -1150,8 +1150,11 @@ enum RS_NSActivityOptions : uint64_t
 + (NSString *) webScriptNameForSelector: (SEL) sel
 {
    NSString* selectorName = NSStringFromSelector(sel);
-   NSArray<NSString*>* parts = [selectorName componentsSeparatedByString: @":"];
-   return parts[0];
+   NSUInteger location = [selectorName rangeOfString: @":"].location;
+   if (location == NSNotFound)
+      location = [selectorName length];
+   NSString* methodName = [selectorName substringToIndex: location];
+   return methodName;
 }
 
 + (BOOL)isSelectorExcludedFromWebScript: (SEL) sel

--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -154,16 +154,24 @@ QString resolveAliasedPath(const QString& path)
 } // anonymous namespace
 
 QString GwtCallback::getOpenFileName(const QString& caption,
-                                    const QString& dir,
-                                    const QString& filter)
+                                     const QString& label,
+                                     const QString& dir,
+                                     const QString& filter)
 {
    QString resolvedDir = resolveAliasedPath(dir);
-   QString result = QFileDialog::getOpenFileName(pOwner_->asWidget(),
-                                                 caption,
-                                                 resolvedDir,
-                                                 filter,
-                                                 0,
-                                                 standardFileDialogOptions());
+
+   QFileDialog dialog(
+            pOwner_->asWidget(),
+            caption,
+            resolveAliasedPath(dir),
+            filter);
+
+   dialog.setFileMode(QFileDialog::ExistingFile);
+   dialog.setLabelText(QFileDialog::Accept, label);
+
+   QString result;
+   if (dialog.exec() == QDialog::Accepted)
+      result = dialog.selectedFiles().value(0);
 
    activateAndFocusOwner();
    return createAliasedPath(result);
@@ -245,11 +253,12 @@ QString GwtCallback::getSaveFileName(const QString& caption,
 }
 
 QString GwtCallback::getExistingDirectory(const QString& caption,
-                                         const QString& dir)
+                                          const QString& label,
+                                          const QString& dir)
 {
-   QString resolvedDir = resolveAliasedPath(dir);
-
    QString result;
+
+   // TODO: can we remove this code below?
 #ifdef _WIN32
    if (dir.isNull())
    {
@@ -269,16 +278,21 @@ QString GwtCallback::getExistingDirectory(const QString& caption,
          result = QString();
       else
          result = QString::fromWCharArray(szDir);
+      activateAndFocusOwner();
+      return createAliasedPath(result);
    }
-   else
-   {
-      result = QFileDialog::getExistingDirectory(pOwner_->asWidget(), caption, resolvedDir,
-                                                 QFileDialog::ShowDirsOnly | standardFileDialogOptions());
-   }
-#else
-   result = QFileDialog::getExistingDirectory(pOwner_->asWidget(), caption, resolvedDir,
-                                              QFileDialog::ShowDirsOnly | standardFileDialogOptions());
 #endif
+
+   QFileDialog dialog(
+            pOwner_->asWidget(),
+            caption,
+            resolveAliasedPath(dir));
+
+   dialog.setLabelText(QFileDialog::Accept, label);
+   dialog.setFileMode(QFileDialog::Directory);
+   dialog.setOption(QFileDialog::ShowDirsOnly, true);
+   if (dialog.exec() == QDialog::Accepted)
+      result = dialog.selectedFiles().value(0);
 
    activateAndFocusOwner();
    return createAliasedPath(result);

--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -169,7 +169,31 @@ QString GwtCallback::getOpenFileName(const QString& caption,
    return createAliasedPath(result);
 }
 
+namespace {
+
+QString getSaveFileNameImpl(QWidget* pParent,
+                            const QString& caption,
+                            const QString& label,
+                            const QString& dir,
+                            QFileDialog::Options options)
+{
+    // initialize dialog
+    QFileDialog dialog(pParent, caption, dir);
+    dialog.setOptions(options);
+    dialog.setLabelText(QFileDialog::Accept, label);
+    dialog.setAcceptMode(QFileDialog::AcceptSave);
+
+    // execute dialog and check for success
+    if (dialog.exec() == QDialog::Accepted)
+        return dialog.selectedFiles().value(0);
+
+    return QString();
+}
+
+} // end anonymous namespace
+
 QString GwtCallback::getSaveFileName(const QString& caption,
+                                     const QString& label,
                                      const QString& dir,
                                      const QString& defaultExtension,
                                      bool forceDefaultExtension)
@@ -178,8 +202,13 @@ QString GwtCallback::getSaveFileName(const QString& caption,
 
    while (true)
    {
-      QString result = QFileDialog::getSaveFileName(pOwner_->asWidget(), caption, resolvedDir,
-                                                    QString(), 0, standardFileDialogOptions());
+      QString result = getSaveFileNameImpl(
+                  pOwner_->asWidget(),
+                  caption,
+                  label,
+                  resolvedDir,
+                  standardFileDialogOptions());
+
       activateAndFocusOwner();
       if (result.isEmpty())
          return result;

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -56,15 +56,20 @@ public slots:
    QString fixedWidthFont();
    bool isCocoa();
    void browseUrl(QString url);
+
    QString getOpenFileName(const QString& caption,
+                           const QString& label,
                            const QString& dir,
                            const QString& filter);
+
    QString getSaveFileName(const QString& caption,
-                           const QString& buttonLabel,
+                           const QString& label,
                            const QString& dir,
                            const QString& defaultExtension,
                            bool forceDefaultExtension);
+
    QString getExistingDirectory(const QString& caption,
+                                const QString& label,
                                 const QString& dir);
 
    void onClipboardChanged(QClipboard::Mode mode);

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -60,6 +60,7 @@ public slots:
                            const QString& dir,
                            const QString& filter);
    QString getSaveFileName(const QString& caption,
+                           const QString& buttonLabel,
                            const QString& dir,
                            const QString& defaultExtension,
                            bool forceDefaultExtension);

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -623,8 +623,7 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
 .rs.addApiFunction("selectDirectory", function(
    caption = "Select Directory",
    label = "Select",
-   path = .rs.getProjectDirectory(),
-   existing = TRUE)
+   path = .rs.getProjectDirectory())
 {
    .Call("rs_openFileDialog",
          2L,
@@ -632,7 +631,7 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
          label,
          path,
          NULL,
-         existing,
+         TRUE,
          PACKAGE = "(embedding)")
 })
 

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -603,3 +603,40 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
                                 terminalSend = .rs.api.terminalSend))
 
 
+.rs.addApiFunction("openFile", function(
+   caption = "Open File",
+   path = .rs.getProjectDirectory(),
+   filter = NULL)
+{
+   .Call("rs_openFileDialog",
+         1L,
+         caption,
+         path,
+         filter,
+         PACKAGE = "(embedding)")
+})
+
+.rs.addApiFunction("openFolder", function(
+   caption = "Open Folder",
+   path = .rs.getProjectDirectory())
+{
+   .Call("rs_openFileDialog",
+         2L,
+         caption,
+         path,
+         NULL,
+         PACKAGE = "(embedding)")
+})
+
+.rs.addApiFunction("saveFile", function(
+   caption = "Save File",
+   path = .rs.getProjectDirectory())
+{
+   .Call("rs_openFileDialog",
+         3L,
+         caption,
+         path,
+         NULL,
+         PACKAGE = "(embedding)")
+})
+

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -603,40 +603,31 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
                                 terminalSend = .rs.api.terminalSend))
 
 
-.rs.addApiFunction("openFile", function(
+.rs.addApiFunction("selectFile", function(
    caption = "Open File",
    path = .rs.getProjectDirectory(),
-   filter = NULL)
+   filter = NULL,
+   existing = TRUE)
 {
    .Call("rs_openFileDialog",
          1L,
          caption,
          path,
          filter,
+         existing,
          PACKAGE = "(embedding)")
 })
 
-.rs.addApiFunction("openFolder", function(
-   caption = "Open Folder",
-   path = .rs.getProjectDirectory())
+.rs.addApiFunction("selectDirectory", function(
+   caption = "Open Directory",
+   path = .rs.getProjectDirectory(),
+   existing = TRUE)
 {
    .Call("rs_openFileDialog",
          2L,
          caption,
          path,
          NULL,
+         existing,
          PACKAGE = "(embedding)")
 })
-
-.rs.addApiFunction("saveFile", function(
-   caption = "Save File",
-   path = .rs.getProjectDirectory())
-{
-   .Call("rs_openFileDialog",
-         3L,
-         caption,
-         path,
-         NULL,
-         PACKAGE = "(embedding)")
-})
-

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -604,7 +604,8 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
 
 
 .rs.addApiFunction("selectFile", function(
-   caption = "Open File",
+   caption = "Select File",
+   label = "Select",
    path = .rs.getProjectDirectory(),
    filter = NULL,
    existing = TRUE)
@@ -612,6 +613,7 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
    .Call("rs_openFileDialog",
          1L,
          caption,
+         label,
          path,
          filter,
          existing,
@@ -619,15 +621,18 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
 })
 
 .rs.addApiFunction("selectDirectory", function(
-   caption = "Open Directory",
+   caption = "Select Directory",
+   label = "Select",
    path = .rs.getProjectDirectory(),
    existing = TRUE)
 {
    .Call("rs_openFileDialog",
          2L,
          caption,
+         label,
          path,
          NULL,
          existing,
          PACKAGE = "(embedding)")
 })
+

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -178,6 +178,7 @@ const int kAdminNotification = 159;
 const int kRequestDocumentSave = 160;
 const int kRequestDocumentSaveCompleted = 161;
 const int kRequestOpenProject = 162;
+const int kOpenFileDialog = 163;
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -489,6 +490,8 @@ std::string ClientEvent::typeName() const
          return "request_document_save_completed";
       case client_events::kRequestOpenProject:
          return "request_open_project";
+      case client_events::kOpenFileDialog:
+         return "open_file_dialog";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -179,6 +179,7 @@ extern const int kAdminNotification;
 extern const int kRequestDocumentSave;
 extern const int kRequestDocumentSaveCompleted;
 extern const int kRequestOpenProject;
+extern const int kOpenFileDialog;
 }
    
 class ClientEvent

--- a/src/cpp/session/modules/RStudioAPI.cpp
+++ b/src/cpp/session/modules/RStudioAPI.cpp
@@ -131,6 +131,7 @@ SEXP rs_showDialog(SEXP titleSEXP,
 
 SEXP rs_openFileDialog(SEXP typeSEXP,
                        SEXP captionSEXP,
+                       SEXP labelSEXP,
                        SEXP pathSEXP,
                        SEXP filterSEXP,
                        SEXP existingSEXP)
@@ -138,6 +139,7 @@ SEXP rs_openFileDialog(SEXP typeSEXP,
    // extract components
    int type = r::sexp::asInteger(typeSEXP);
    std::string caption = r::sexp::asString(captionSEXP);
+   std::string label = r::sexp::asString(labelSEXP);
    FilePath path = module_context::resolveAliasedPath(r::sexp::safeAsString(pathSEXP, ""));
    std::string filter = r::sexp::asString(filterSEXP);
    bool existing = r::sexp::asLogical(existingSEXP);
@@ -145,6 +147,7 @@ SEXP rs_openFileDialog(SEXP typeSEXP,
    json::Object data;
    data["type"] = type;
    data["caption"] = caption;
+   data["label"] = label;
    data["file"] = module_context::createFileSystemItem(path);
    data["filter"] = filter;
    data["existing"] = existing;
@@ -176,7 +179,7 @@ Error initialize()
    s_waitForOpenFileDialog = registerWaitForMethod("open_file_dialog_completed");
 
    RS_REGISTER_CALL_METHOD(rs_showDialog, 8);
-   RS_REGISTER_CALL_METHOD(rs_openFileDialog, 5);
+   RS_REGISTER_CALL_METHOD(rs_openFileDialog, 6);
 
    return Success();
 }

--- a/src/cpp/session/modules/RStudioAPI.cpp
+++ b/src/cpp/session/modules/RStudioAPI.cpp
@@ -132,19 +132,22 @@ SEXP rs_showDialog(SEXP titleSEXP,
 SEXP rs_openFileDialog(SEXP typeSEXP,
                        SEXP captionSEXP,
                        SEXP pathSEXP,
-                       SEXP filterSEXP)
+                       SEXP filterSEXP,
+                       SEXP existingSEXP)
 {
    // extract components
    int type = r::sexp::asInteger(typeSEXP);
    std::string caption = r::sexp::asString(captionSEXP);
    FilePath path = module_context::resolveAliasedPath(r::sexp::safeAsString(pathSEXP, ""));
    std::string filter = r::sexp::asString(filterSEXP);
+   bool existing = r::sexp::asLogical(existingSEXP);
    
    json::Object data;
    data["type"] = type;
    data["caption"] = caption;
    data["file"] = module_context::createFileSystemItem(path);
    data["filter"] = filter;
+   data["existing"] = existing;
    ClientEvent event(client_events::kOpenFileDialog, data);
    
    json::JsonRpcRequest request;
@@ -173,7 +176,7 @@ Error initialize()
    s_waitForOpenFileDialog = registerWaitForMethod("open_file_dialog_completed");
 
    RS_REGISTER_CALL_METHOD(rs_showDialog, 8);
-   RS_REGISTER_CALL_METHOD(rs_openFileDialog, 4);
+   RS_REGISTER_CALL_METHOD(rs_openFileDialog, 5);
 
    return Success();
 }

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/ChooseFolderDialog2.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/ChooseFolderDialog2.java
@@ -25,11 +25,12 @@ import java.util.ArrayList;
 public class ChooseFolderDialog2 extends FileSystemDialog
 {
    public ChooseFolderDialog2(String title,
+                              String label,
                               FileSystemContext context,
                               boolean allowFolderCreation,
                               ProgressOperationWithInput<FileSystemItem> operation)
    {
-      super(title, null, "Choose", context, "", allowFolderCreation, operation);
+      super(title, null, label, context, "", allowFolderCreation, operation);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/OpenFileDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/OpenFileDialog.java
@@ -23,14 +23,13 @@ import com.google.gwt.event.logical.shared.SelectionEvent;
 public class OpenFileDialog extends FileDialog
 {
    public OpenFileDialog(String title,
+                         String label,
                          FileSystemContext context,
                          String filter,
                          boolean canChooseDirectories,
                          ProgressOperationWithInput<FileSystemItem> operation)
    {
-      super(title, null, "Open", false, false, false, context, filter, 
-            operation);
-      
+      super(title, null, label, false, false, false, context, filter, operation);
       canChooseDirectories_ = canChooseDirectories;
    }
    

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/SaveFileDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/SaveFileDialog.java
@@ -24,12 +24,13 @@ import org.rstudio.core.client.widget.ProgressOperationWithInput;
 public class SaveFileDialog extends FileDialog
 {
    public SaveFileDialog(String title,
+                         String buttonLabel,
                          FileSystemContext context,
                          String defaultExtension,
                          boolean forceDefaultExtension,
                          ProgressOperationWithInput<FileSystemItem> operation)
    {
-      super(title, null, "Save", true, true, true, context, "", operation);
+      super(title, null, buttonLabel, true, true, true, context, "", operation);
       defaultExtension_ = defaultExtension;
       forceDefaultExtension_ = forceDefaultExtension;
    }

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/events/OpenFileDialogEvent.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/events/OpenFileDialogEvent.java
@@ -28,10 +28,11 @@ public class OpenFileDialogEvent extends GwtEvent<OpenFileDialogEvent.Handler>
       {
       }
       
-      public final native int getType()            /*-{ return this.type;    }-*/;
-      public final native String getCaption()      /*-{ return this.caption; }-*/;
-      public final native FileSystemItem getFile() /*-{ return this.file;    }-*/;
-      public final native String getFilter()       /*-{ return this.filter;  }-*/;
+      public final native int getType()            /*-{ return this.type;     }-*/;
+      public final native String getCaption()      /*-{ return this.caption;  }-*/;
+      public final native FileSystemItem getFile() /*-{ return this.file;     }-*/;
+      public final native String getFilter()       /*-{ return this.filter;   }-*/;
+      public final native boolean selectExisting() /*-{ return this.existing; }-*/;
    }
    
    public OpenFileDialogEvent(Data data)
@@ -39,16 +40,16 @@ public class OpenFileDialogEvent extends GwtEvent<OpenFileDialogEvent.Handler>
       data_ = data;
    }
    
-   public final int getType()            { return data_.getType();    }
-   public final String getCaption()      { return data_.getCaption(); }
-   public final FileSystemItem getFile() { return data_.getFile();    }
-   public final String getFilter()       { return data_.getFilter();  }
+   public final int getType()            { return data_.getType();        }
+   public final String getCaption()      { return data_.getCaption();     }
+   public final FileSystemItem getFile() { return data_.getFile();        }
+   public final String getFilter()       { return data_.getFilter();      }
+   public final boolean selectExisting() { return data_.selectExisting(); }
    
    private final Data data_;
    
-   public static final int TYPE_SELECT_EXISTING_FILE   = 1;
-   public static final int TYPE_SELECT_EXISTING_FOLDER = 2;
-   public static final int TYPE_SELECT_NEW_FILE        = 3;
+   public static final int TYPE_SELECT_FILE      = 1;
+   public static final int TYPE_SELECT_DIRECTORY = 2;
 
    // Boilerplate ----
 

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/events/OpenFileDialogEvent.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/events/OpenFileDialogEvent.java
@@ -1,0 +1,73 @@
+/*
+ * OpenFileDialogEvent.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.files.filedialog.events;
+
+import org.rstudio.core.client.files.FileSystemItem;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class OpenFileDialogEvent extends GwtEvent<OpenFileDialogEvent.Handler>
+{
+   public static class Data extends JavaScriptObject
+   {
+      protected Data()
+      {
+      }
+      
+      public final native int getType()            /*-{ return this.type;    }-*/;
+      public final native String getCaption()      /*-{ return this.caption; }-*/;
+      public final native FileSystemItem getFile() /*-{ return this.file;    }-*/;
+      public final native String getFilter()       /*-{ return this.filter;  }-*/;
+   }
+   
+   public OpenFileDialogEvent(Data data)
+   {
+      data_ = data;
+   }
+   
+   public final int getType()            { return data_.getType();    }
+   public final String getCaption()      { return data_.getCaption(); }
+   public final FileSystemItem getFile() { return data_.getFile();    }
+   public final String getFilter()       { return data_.getFilter();  }
+   
+   private final Data data_;
+   
+   public static final int TYPE_SELECT_EXISTING_FILE   = 1;
+   public static final int TYPE_SELECT_EXISTING_FOLDER = 2;
+   public static final int TYPE_SELECT_NEW_FILE        = 3;
+
+   // Boilerplate ----
+
+   public interface Handler extends EventHandler
+   {
+      void onOpenFileDialog(OpenFileDialogEvent event);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onOpenFileDialog(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/events/OpenFileDialogEvent.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/events/OpenFileDialogEvent.java
@@ -30,6 +30,7 @@ public class OpenFileDialogEvent extends GwtEvent<OpenFileDialogEvent.Handler>
       
       public final native int getType()            /*-{ return this.type;     }-*/;
       public final native String getCaption()      /*-{ return this.caption;  }-*/;
+      public final native String getLabel()        /*-{ return this.label;    }-*/;
       public final native FileSystemItem getFile() /*-{ return this.file;     }-*/;
       public final native String getFilter()       /*-{ return this.filter;   }-*/;
       public final native boolean selectExisting() /*-{ return this.existing; }-*/;
@@ -42,6 +43,7 @@ public class OpenFileDialogEvent extends GwtEvent<OpenFileDialogEvent.Handler>
    
    public final int getType()            { return data_.getType();        }
    public final String getCaption()      { return data_.getCaption();     }
+   public final String getLabel()        { return data_.getLabel();       }
    public final FileSystemItem getFile() { return data_.getFile();        }
    public final String getFilter()       { return data_.getFilter();      }
    public final boolean selectExisting() { return data_.selectExisting(); }

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -30,7 +30,8 @@ public interface DesktopFrame extends JavaScriptPassthrough
                           String dir,
                           String filter,
                           boolean canChooseDirectories);
-   String getSaveFileName(String caption, 
+   String getSaveFileName(String caption,
+                          String buttonLabel,
                           String dir, 
                           String defaultExtension, 
                           boolean forceDefaultExtension);

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -26,16 +26,23 @@ public interface DesktopFrame extends JavaScriptPassthrough
 {
    boolean isCocoa();
    void browseUrl(String url);
+   
    String getOpenFileName(String caption,
+                          String label,
                           String dir,
                           String filter,
                           boolean canChooseDirectories);
+   
    String getSaveFileName(String caption,
-                          String buttonLabel,
+                          String label,
                           String dir, 
                           String defaultExtension, 
                           boolean forceDefaultExtension);
-   String getExistingDirectory(String caption, String dir);
+   
+   String getExistingDirectory(String caption,
+                               String label,
+                               String dir);
+   
    void undo(boolean forAce);
    void redo(boolean forAce);
    void clipboardCut();

--- a/src/gwt/src/org/rstudio/studio/client/common/FileDialogs.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/FileDialogs.java
@@ -46,6 +46,14 @@ public interface FileDialogs
                  boolean forceDefaultExtension,
                  ProgressOperationWithInput<FileSystemItem> operation);
 
+   void saveFile(String caption,
+                 String buttonLabel,
+                 FileSystemContext fsContext,
+                 FileSystemItem initialFilePath,
+                 String defaultExtension,
+                 boolean forceDefaultExtension,
+                 ProgressOperationWithInput<FileSystemItem> operation);
+   
    void chooseFolder(String caption,
                      FileSystemContext fsContext,
                      FileSystemItem initialDir,

--- a/src/gwt/src/org/rstudio/studio/client/common/FileDialogs.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/FileDialogs.java
@@ -38,6 +38,13 @@ public interface FileDialogs
                  boolean canChooseDirectories,
                  ProgressOperationWithInput<FileSystemItem> operation);
    
+   void openFile(String caption,
+                 String label,
+                 FileSystemContext fsContext,
+                 FileSystemItem initialFilePath,
+                 String filter,
+                 boolean canChooseDirectories,
+                 ProgressOperationWithInput<FileSystemItem> operation);
 
    void saveFile(String caption,
                  FileSystemContext fsContext,
@@ -47,7 +54,7 @@ public interface FileDialogs
                  ProgressOperationWithInput<FileSystemItem> operation);
 
    void saveFile(String caption,
-                 String buttonLabel,
+                 String label,
                  FileSystemContext fsContext,
                  FileSystemItem initialFilePath,
                  String defaultExtension,
@@ -58,4 +65,11 @@ public interface FileDialogs
                      FileSystemContext fsContext,
                      FileSystemItem initialDir,
                      ProgressOperationWithInput<FileSystemItem> operation);
+   
+   void chooseFolder(String caption,
+                     String label,
+                     FileSystemContext fsContext,
+                     FileSystemItem initialDir,
+                     ProgressOperationWithInput<FileSystemItem> operation);
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/impl/DesktopFileDialogs.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/impl/DesktopFileDialogs.java
@@ -211,9 +211,9 @@ public class DesktopFileDialogs implements FileDialogs
       chooseFolder(caption, "Open", fsContext, initialDir, operation);
    }
    
-   public void chooseFolder(String caption,
-                            String label,
-                            FileSystemContext fsContext,
+   public void chooseFolder(final String caption,
+                            final String label,
+                            final FileSystemContext fsContext,
                             final FileSystemItem initialDir,
                             ProgressOperationWithInput<FileSystemItem> operation)
    {

--- a/src/gwt/src/org/rstudio/studio/client/common/impl/DesktopFileDialogs.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/impl/DesktopFileDialogs.java
@@ -120,8 +120,18 @@ public class DesktopFileDialogs implements FileDialogs
       openFile(caption, fsContext, initialFilePath, filter, false, operation);
    }
    
+   public void openFile(final String caption,
+                        final FileSystemContext fsContext,
+                        final FileSystemItem initialFilePath,
+                        final String filter,
+                        final boolean canChooseDirectories,
+                        final ProgressOperationWithInput<FileSystemItem> operation)
+   {
+      openFile(caption, "Open", fsContext, initialFilePath, filter, canChooseDirectories, operation);
+   }
    
    public void openFile(final String caption,
+                        final String label,
                         final FileSystemContext fsContext,
                         final FileSystemItem initialFilePath,
                         final String filter,
@@ -141,6 +151,7 @@ public class DesktopFileDialogs implements FileDialogs
          {
             String fileName = Desktop.getFrame().getOpenFileName(
                   caption,
+                  label,
                   dir,
                   filter,
                   canChooseDirectories);
@@ -197,6 +208,15 @@ public class DesktopFileDialogs implements FileDialogs
                             final FileSystemItem initialDir,
                             ProgressOperationWithInput<FileSystemItem> operation)
    {
+      chooseFolder(caption, "Open", fsContext, initialDir, operation);
+   }
+   
+   public void chooseFolder(String caption,
+                            String label,
+                            FileSystemContext fsContext,
+                            final FileSystemItem initialDir,
+                            ProgressOperationWithInput<FileSystemItem> operation)
+   {
       new FileDialogOperation()
       {
          @Override
@@ -204,6 +224,7 @@ public class DesktopFileDialogs implements FileDialogs
          {
             return Desktop.getFrame().getExistingDirectory(
                   caption,
+                  label,
                   initialDir != null ? initialDir.getPath() : null);
          }
       }.execute(caption, fsContext, null, operation);

--- a/src/gwt/src/org/rstudio/studio/client/common/impl/DesktopFileDialogs.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/impl/DesktopFileDialogs.java
@@ -161,13 +161,24 @@ public class DesktopFileDialogs implements FileDialogs
                         final boolean forceDefaultExtension,
                         final ProgressOperationWithInput<FileSystemItem> operation)
    {
+      saveFile(caption, "Save", fsContext, initialFilePath, defaultExtension, forceDefaultExtension, operation);
+   }
+   
+   public void saveFile(final String caption,
+                        final String buttonLabel,
+                        final FileSystemContext fsContext,
+                        final FileSystemItem initialFilePath,
+                        final String defaultExtension,
+                        final boolean forceDefaultExtension,
+                        final ProgressOperationWithInput<FileSystemItem> operation)
+   {
       new FileDialogOperation()
       {
          @Override
          String operation(String caption, String dir)
          {
             String fileName = Desktop.getFrame().getSaveFileName(
-                  caption, dir, defaultExtension, forceDefaultExtension);
+                  caption, buttonLabel, dir, defaultExtension, forceDefaultExtension);
 
             if (fileName != null)
             {

--- a/src/gwt/src/org/rstudio/studio/client/common/impl/WebFileDialogs.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/impl/WebFileDialogs.java
@@ -44,7 +44,6 @@ public class WebFileDialogs implements FileDialogs
       openFile(caption, fsContext, initialFilePath, filter, false, operation);
    }
    
-   
    public void openFile(String caption,
                         FileSystemContext fsContext,
                         FileSystemItem initialFilePath,
@@ -52,7 +51,19 @@ public class WebFileDialogs implements FileDialogs
                         boolean canChooseDirectories,
                         ProgressOperationWithInput<FileSystemItem> operation)
    {
+      openFile(caption, "Open", fsContext, initialFilePath, filter, canChooseDirectories, operation);
+   }
+   
+   public void openFile(String caption,
+                        String label,
+                        FileSystemContext fsContext,
+                        FileSystemItem initialFilePath,
+                        String filter,
+                        boolean canChooseDirectories,
+                        ProgressOperationWithInput<FileSystemItem> operation)
+   {
       OpenFileDialog dialog = new OpenFileDialog(caption,
+                                                 label,
                                                  fsContext,
                                                  filter,
                                                  canChooseDirectories,
@@ -112,7 +123,17 @@ public class WebFileDialogs implements FileDialogs
                             FileSystemItem initialDir,
                             ProgressOperationWithInput<FileSystemItem> operation)
    {
+      chooseFolder(caption, "Choose", fsContext, initialDir, operation);
+   }
+   
+   public void chooseFolder(String caption,
+                            String label,
+                            FileSystemContext fsContext,
+                            FileSystemItem initialDir,
+                            ProgressOperationWithInput<FileSystemItem> operation)
+   {
       ChooseFolderDialog2 dialog = new ChooseFolderDialog2(caption,
+                                                           label,
                                                            fsContext,
                                                            true,
                                                            operation);

--- a/src/gwt/src/org/rstudio/studio/client/common/impl/WebFileDialogs.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/impl/WebFileDialogs.java
@@ -84,7 +84,19 @@ public class WebFileDialogs implements FileDialogs
                         boolean forceDefaultExtension,
                         ProgressOperationWithInput<FileSystemItem> operation)
    {
+      saveFile(caption, "Save", fsContext, initialFilePath, defaultExtension, forceDefaultExtension, operation);
+   }
+   
+   public void saveFile(String caption,
+                        String buttonLabel,
+                        FileSystemContext fsContext,
+                        FileSystemItem initialFilePath,
+                        String defaultExtension,
+                        boolean forceDefaultExtension,
+                        ProgressOperationWithInput<FileSystemItem> operation)
+   {
       SaveFileDialog dialog = new SaveFileDialog(caption,
+                                                 buttonLabel,
                                                  fsContext,
                                                  defaultExtension,
                                                  forceDefaultExtension,

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -169,6 +169,7 @@ class ClientEvent extends JavaScriptObject
    public static final String AdminNotification = "admin_notification";
    public static final String RequestDocumentSave = "request_document_save";
    public static final String RequestOpenProject = "request_open_project";
+   public static final String OpenFileDialog = "open_file_dialog";
    
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -22,6 +22,7 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.RepeatingCommand;
 
 import org.rstudio.core.client.files.FileSystemItem;
+import org.rstudio.core.client.files.filedialog.events.OpenFileDialogEvent;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.jsonrpc.RpcObjectList;
 import org.rstudio.studio.client.application.events.*;
@@ -923,6 +924,11 @@ public class ClientEventDispatcher
          {
             RequestOpenProjectEvent.Data data = event.getData();
             eventBus_.fireEvent(new RequestOpenProjectEvent(data));
+         }
+         else if (type.equals(ClientEvent.OpenFileDialog))
+         {
+            OpenFileDialogEvent.Data data = event.getData();
+            eventBus_.fireEvent(new OpenFileDialogEvent(data));
          }
          else
          {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1058,6 +1058,16 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, CHOOSE_FILE_COMPLETED, file, requestCallback);
    }
 
+   public void openFileDialogCompleted(String selectedPath,
+                                       ServerRequestCallback<Void> requestCallback)
+   {
+      JSONArray params = new JSONArrayBuilder()
+            .add(selectedPath)
+            .get();
+      
+      sendRequest(RPC_SCOPE, OPEN_FILE_DIALOG_COMPLETED, params, requestCallback);
+   }
+
    public void getPackageState(
          boolean manual,
          ServerRequestCallback<PackageState> requestCallback)
@@ -2032,7 +2042,7 @@ public class RemoteServer implements Server
       params.set(1, new JSONString(encoding));
       sendRequest(RPC_SCOPE, REOPEN_WITH_ENCODING, params, requestCallback);
    }
-
+   
    public void removeContentUrl(String contentUrl,
                                 ServerRequestCallback<Void> requestCallback)
    {
@@ -5267,6 +5277,7 @@ public class RemoteServer implements Server
 
    private static final String EDIT_COMPLETED = "edit_completed";
    private static final String CHOOSE_FILE_COMPLETED = "choose_file_completed";
+   private static final String OPEN_FILE_DIALOG_COMPLETED = "open_file_dialog_completed";
 
    private static final String GET_PACKAGE_STATE = "get_package_state";
    private static final String AVAILABLE_PACKAGES = "available_packages";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
@@ -520,6 +520,7 @@ public class Workbench implements BusyHandler,
                              ProgressIndicator indicator)
          {
             indicator.onCompleted();
+            
             server_.openFileDialogCompleted(
                   input == null ? "" : input.getPath(),
                   new VoidServerRequestCallback());
@@ -528,20 +529,57 @@ public class Workbench implements BusyHandler,
       
       String caption = event.getCaption();
       int type = event.getType();
-      FileSystemItem initialFile = event.getFile();
+      FileSystemItem initialFilePath = event.getFile();
       String filter = event.getFilter();
+      boolean selectExisting = event.selectExisting();
       
-      if (type == OpenFileDialogEvent.TYPE_SELECT_EXISTING_FILE)
+      if (type == OpenFileDialogEvent.TYPE_SELECT_FILE)
       {
-         fileDialogs_.openFile(caption, fsContext_, initialFile, filter, onSelected);
+         if (selectExisting)
+         {
+            fileDialogs_.openFile(
+                  caption,
+                  fsContext_,
+                  initialFilePath,
+                  filter,
+                  onSelected);
+         }
+         else
+         {
+            fileDialogs_.saveFile(
+                  caption,
+                  fsContext_,
+                  initialFilePath,
+                  "",
+                  false,
+                  onSelected);
+         }
       }
-      else if (type == OpenFileDialogEvent.TYPE_SELECT_EXISTING_FOLDER)
+      else if (type == OpenFileDialogEvent.TYPE_SELECT_DIRECTORY)
       {
-         fileDialogs_.chooseFolder(caption, fsContext_, initialFile, onSelected);
+         if (selectExisting)
+         {
+            fileDialogs_.chooseFolder(
+                  caption,
+                  fsContext_,
+                  initialFilePath,
+                  onSelected);
+         }
+         else
+         {
+            fileDialogs_.saveFile(
+                  caption,
+                  fsContext_,
+                  initialFilePath,
+                  "",
+                  false,
+                  onSelected);
+         }
       }
-      else if (type == OpenFileDialogEvent.TYPE_SELECT_NEW_FILE)
+      else
       {
-         fileDialogs_.saveFile(caption, fsContext_, initialFile, filter, false, onSelected);
+         assert false: "unexpected file dialog type '" + type + "'";
+         server_.openFileDialogCompleted(null, new VoidServerRequestCallback());
       }
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
@@ -561,26 +561,12 @@ public class Workbench implements BusyHandler,
       }
       else if (type == OpenFileDialogEvent.TYPE_SELECT_DIRECTORY)
       {
-         if (selectExisting)
-         {
-            fileDialogs_.chooseFolder(
-                  caption,
-                  label,
-                  fsContext_,
-                  initialFilePath,
-                  onSelected);
-         }
-         else
-         {
-            fileDialogs_.saveFile(
-                  caption,
-                  label,
-                  fsContext_,
-                  initialFilePath,
-                  "",
-                  false,
-                  onSelected);
-         }
+         fileDialogs_.chooseFolder(
+               caption,
+               label,
+               fsContext_,
+               initialFilePath,
+               onSelected);
       }
       else
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
@@ -528,6 +528,7 @@ public class Workbench implements BusyHandler,
       };
       
       String caption = event.getCaption();
+      String label = event.getLabel();
       int type = event.getType();
       FileSystemItem initialFilePath = event.getFile();
       String filter = event.getFilter();
@@ -539,15 +540,18 @@ public class Workbench implements BusyHandler,
          {
             fileDialogs_.openFile(
                   caption,
+                  label,
                   fsContext_,
                   initialFilePath,
                   filter,
+                  false,
                   onSelected);
          }
          else
          {
             fileDialogs_.saveFile(
                   caption,
+                  label,
                   fsContext_,
                   initialFilePath,
                   "",
@@ -561,6 +565,7 @@ public class Workbench implements BusyHandler,
          {
             fileDialogs_.chooseFolder(
                   caption,
+                  label,
                   fsContext_,
                   initialFilePath,
                   onSelected);
@@ -569,6 +574,7 @@ public class Workbench implements BusyHandler,
          {
             fileDialogs_.saveFile(
                   caption,
+                  label,
                   fsContext_,
                   initialFilePath,
                   "",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchServerOperations.java
@@ -121,6 +121,8 @@ public interface WorkbenchServerOperations extends ConsoleServerOperations,
    
    void adminNotificationAcknowledged(String id, ServerRequestCallback<Void> requestCallback);
    
+   void openFileDialogCompleted(String path, ServerRequestCallback<Void> requestCallback);
+   
    void getTerminalOptions(
                      ServerRequestCallback<TerminalOptions> requestCallback);
   


### PR DESCRIPTION
This PR exposes three file dialogs, eventually to be used as part of the `rstudioapi` package. The three APIs provided:

1. `openFile()` -- select an existing file on the filesystem
1. `openFolder()` -- select an existing folder on the filesystem
1. `saveFile()` -- select a file to be used for an upcoming save operation

The names are sort of misnomers, since calling those functions does not actually open or save a file; rather, they just return the path to a file. Any thoughts on how the names here could be improved? Maybe just `show*Dialog()` or similar?