### PR TITLE
Save and restore terminal environment variables

### DIFF
--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -115,6 +115,7 @@ set (CORE_SOURCE_FILES
    system/ShellUtils.cpp
    system/System.cpp
    system/file_monitor/FileMonitor.cpp
+   terminal/PrivateCommand.cpp
    tex/TexLogParser.cpp
    tex/TexMagicComment.cpp
    tex/TexSynctex.cpp

--- a/src/cpp/core/include/core/terminal/PrivateCommand.hpp
+++ b/src/cpp/core/include/core/terminal/PrivateCommand.hpp
@@ -53,9 +53,9 @@ class PrivateCommand : boost::noncopyable
 public:
    PrivateCommand(
          const std::string& command,
-         int privateCommandDelayMs = 3000, // min delay between private commands
+         int privateCommandDelayMs = 2000, // min delay between private commands
          int waitAfterCommandDelayMs = 1500, // min delay after user command
-         int privateCommandTimeoutMs = 1000, // timeout for private command
+         int privateCommandTimeoutMs = 1200, // timeout for private command
          bool oncePerUserCommand = true); // only run private command after user has hit <enter>
 
    // Give private command opportunity to capture terminal; returns true if it does (or already did).

--- a/src/cpp/core/include/core/terminal/PrivateCommand.hpp
+++ b/src/cpp/core/include/core/terminal/PrivateCommand.hpp
@@ -82,7 +82,7 @@ public:
    std::string getEOM() const { return outputEOM_; }
 
 private:
-   void completeCapture();
+   void resetParse();
 
 private:
    std::string command_;
@@ -109,8 +109,11 @@ private:
    std::string commandAfter_;
    std::string fullCommand_;
 
-   // Text output by the private command
+   // Raw text output by the private command
    std::string privateCommandOutput_;
+
+   // Processed text from the private command, only available once complete
+   std::string output_;
 
    // minimum delay between private command executions
    boost::posix_time::milliseconds privateCommandDelay_;

--- a/src/cpp/core/include/core/terminal/PrivateCommand.hpp
+++ b/src/cpp/core/include/core/terminal/PrivateCommand.hpp
@@ -90,17 +90,16 @@ private:
    // If true, only run private command after user has hit <enter> (and only once per-user <enter>)
    bool oncePerUserCommand_;
 
-   // Are we in private command mode? Has to be thread-safe because websocket input callback
-   // reads this from separate thread. This should be a C++11 std::atomic<bool>.
+   // Are we in private command mode?
    bool privateCommandLoop_;
 
    // When did we last perform a private command?
    boost::posix_time::ptime lastPrivateCommand_;
 
-   // When did user last hit Enter at the end of a line of input? Protect with inputQueueMutex_.
+   // When did user last hit Enter at the end of a line of input?
    boost::posix_time::ptime lastEnterTime_;
 
-   // Is there a partially-typed command? Protect with inputQueueMutex_.
+   // Is there a partially-typed command?
    bool pendingCommand_;
 
    std::string outputBOM_;

--- a/src/cpp/core/include/core/terminal/PrivateCommand.hpp
+++ b/src/cpp/core/include/core/terminal/PrivateCommand.hpp
@@ -1,0 +1,76 @@
+/*
+ * PrivateCommand.hpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef PRIVATE_COMMAND_HPP
+#define PRIVATE_COMMAND_HPP
+
+#include <string>
+
+#include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <boost/noncopyable.hpp>
+
+#include <core/system/Process.hpp>
+
+namespace rstudio {
+namespace core {
+namespace terminal {
+
+class PrivateCommand : boost::noncopyable
+{
+public:
+   PrivateCommand(const std::string& command);
+
+   // Give private command opportunity to capture terminal; returns true if it does (or already did).
+   bool onTryCapture(core::system::ProcessOperations& ops, bool hasChildProcs);
+
+   bool hasCaptured() const;
+
+   // user input, used to determine when a private command can be executed
+   void userInput(const std::string& input);
+
+   // returns true if private command parser consumed the output
+   bool output(const std::string& output);
+
+private:
+   std::string command_;
+
+   // Are we in private command mode? Has to be thread-safe because websocket input callback
+   // reads this from separate thread. This should be a C++11 std::atomic<bool>.
+   bool privateCommandLoop_;
+
+   // When did we last perform a private command?
+   boost::posix_time::ptime lastPrivateCommand_;
+
+   // When did user last hit Enter at the end of a line of input? Protect with inputQueueMutex_.
+   boost::posix_time::ptime lastEnterTime_;
+
+   // Is there a partially-typed command? Protect with inputQueueMutex_.
+   bool pendingCommand_;
+
+   std::string outputBOM_;
+   std::string outputEOM_;
+   std::string commandBefore_;
+   std::string commandAfter_;
+   std::string fullCommand_;
+
+   std::string privateCommandOutput_;
+
+};
+
+} // namespace terminal
+} // namespace core
+} // namespace terminal
+
+#endif // PRIVATE_COMMAND_HPP

--- a/src/cpp/core/include/core/terminal/PrivateCommand.hpp
+++ b/src/cpp/core/include/core/terminal/PrivateCommand.hpp
@@ -29,23 +29,39 @@ namespace terminal {
 
 /*
  * The PrivateCommand class is used by terminal to silently run a command in the terminal
- * without the user seeing the input or output. Current use case is to grab the terminal's
- * environment so we can persist it. So, we don't run the private command until after the user
- * has run a command in the terminal (otherwise the terminal's environment hasn't changed). To
- * generalize this class for other private command scenarios, need to make this behavior
- * optional so the private command runs even if user hasn't entered a new command.
+ * without the user seeing the input or output. It only runs if the terminal has no child
+ * processes and if the user doesn't seem to be in the middle of typing a command.
+ *
+ * Host must frequently call onTryCapture() to possibly fire the command, userInput() so
+ * PrivateCommand can analyze if user has entered a command or is potentially in the middle of
+ * typing a command, and output() to let PrivateCommand analyze output from a private command
+ * it issued so it capture it and end the private-command mode.
+ *
+ * If oncePerUserCommand is true, the private command will only run after the user has hit
+ * <enter>, so has potentially run a command. It will not run again until user has hit
+ * <enter> again. Idea here is to only capture changes that can be made by a user command, such
+ * as changing the environment.
+ *
+ * If oncePerUserCommand is false, then the private command can run as often as every
+ * privateCommandTimeoutMs.
+ *
+ * Once PrivateCommand::hasCaptured() returns false, the output of the private command is available
+ * via getPrivateOutput().
  */
 class PrivateCommand : boost::noncopyable
 {
 public:
-   PrivateCommand(const std::string& command,
-                  int privateCommandDelayMs = 3000, // min delay between private commands
-                  int waitAfterCommandDelayMs = 1500, // min delay after user command
-                  int privateCommandTimeoutMs = 1000); // timeout for private command
+   PrivateCommand(
+         const std::string& command,
+         int privateCommandDelayMs = 3000, // min delay between private commands
+         int waitAfterCommandDelayMs = 1500, // min delay after user command
+         int privateCommandTimeoutMs = 1000, // timeout for private command
+         bool oncePerUserCommand = true); // only run private command after user has hit <enter>
 
    // Give private command opportunity to capture terminal; returns true if it does (or already did).
    bool onTryCapture(core::system::ProcessOperations& ops, bool hasChildProcs);
 
+   // If true, a private command was fired, but still receiving the output.
    bool hasCaptured() const;
 
    // user input, used to determine when a private command can be executed
@@ -54,11 +70,11 @@ public:
    // returns true if private command parser consumed the output
    bool output(const std::string& output);
 
-   // get output of last private command
-   std::string getPrivateOutput() const;
+   // get output of last private command; output is reset after it is returned
+   std::string getPrivateOutput();
 
    // force exit of private capture
-   void endCapture();
+   void terminateCapture();
 
    // following are aids for testing; hate to have these but alternatives were uglier
    std::string getFullCommand() const { return fullCommand_; }
@@ -66,7 +82,13 @@ public:
    std::string getEOM() const { return outputEOM_; }
 
 private:
+   void completeCapture();
+
+private:
    std::string command_;
+
+   // If true, only run private command after user has hit <enter> (and only once per-user <enter>)
+   bool oncePerUserCommand_;
 
    // Are we in private command mode? Has to be thread-safe because websocket input callback
    // reads this from separate thread. This should be a C++11 std::atomic<bool>.
@@ -98,6 +120,11 @@ private:
 
    // how long after a private command is started do we allow for the result to be delivered?
    boost::posix_time::milliseconds privateCommandTimeout_;
+
+   // parse details
+   size_t firstBOM_; // BOM in the echo'd command
+   size_t firstEOM_; // EOM in the echo'd command
+   size_t outputStart_; // start of output
 };
 
 } // namespace terminal

--- a/src/cpp/core/terminal/PrivateCommand.cpp
+++ b/src/cpp/core/terminal/PrivateCommand.cpp
@@ -60,13 +60,13 @@ bool PrivateCommand::onTryCapture(core::system::ProcessOperations& ops, bool has
    boost::posix_time::ptime currentTime = now();
    if (privateCommandLoop_)
    {
-      // already running private command
-
-      // TODO (gary)
-      // safeguard timeout here to exit private command loop if parsing fails after
-      // a couple of seconds!
-
-      return true;
+      // try to prevent private command from getting stuck
+      if (currentTime - lastPrivateCommand_ > privateCommandTimeout_)
+      {
+         endCapture();
+         ops.ptyInterrupt();
+         return false;
+      }
    }
    else
    {

--- a/src/cpp/core/terminal/PrivateCommand.cpp
+++ b/src/cpp/core/terminal/PrivateCommand.cpp
@@ -30,19 +30,34 @@ boost::posix_time::ptime now()
 
 } // anonymous namespace
 
+/*
+ * Implementation note: private command output is detected by echoing start and end
+ * marker (uuids) around the output, e.g. the command "ls -l" would be issued as:
+ *
+ * echo BOM && ls -l && EOM
+ *
+ * where BOM and EOM would be actual uuids. This assumes our shell supports && for
+ * issuing sequential commands.
+ */
+
 PrivateCommand::PrivateCommand(const std::string& command,
                                int privateCommandDelayMs,
                                int waitAfterCommandDelayMs,
-                               int privateCommandTimeoutMs)
+                               int privateCommandTimeoutMs,
+                               bool oncePerUserCommand)
    :
      command_(command),
+     oncePerUserCommand_(oncePerUserCommand),
      privateCommandLoop_(false),
      lastPrivateCommand_(boost::posix_time::not_a_date_time),
      lastEnterTime_(boost::posix_time::not_a_date_time),
-     pendingCommand_(true),
+     pendingCommand_(false),
      privateCommandDelay_(privateCommandDelayMs),
      waitForCommandDelay_(waitAfterCommandDelayMs),
-     privateCommandTimeout_(privateCommandTimeoutMs)
+     privateCommandTimeout_(privateCommandTimeoutMs),
+     firstBOM_(std::string::npos),
+     firstEOM_(std::string::npos),
+     outputStart_(std::string::npos)
 {
    outputBOM_ = core::system::generateUuid(false);
    outputEOM_ = core::system::generateUuid(true);
@@ -63,24 +78,27 @@ bool PrivateCommand::onTryCapture(core::system::ProcessOperations& ops, bool has
       // try to prevent private command from getting stuck
       if (currentTime - lastPrivateCommand_ > privateCommandTimeout_)
       {
-         endCapture();
+         terminateCapture();
          ops.ptyInterrupt();
          return false;
       }
+
+      return true;
    }
    else
    {
       if (hasChildProcs)
          return false;
 
-      if (pendingCommand_ || lastEnterTime_.is_not_a_date_time())
+      if (pendingCommand_ || (oncePerUserCommand_ && lastEnterTime_.is_not_a_date_time()))
       {
          // We don't start a private command if something is being typed, or a command has never
-         // been run. Environment hasn't changed in either of those cases.
+         // been run.
          return false;
       }
 
-      if (currentTime - waitForCommandDelay_ <= lastEnterTime_)
+      if (!lastEnterTime_.is_not_a_date_time() &&
+          (currentTime - waitForCommandDelay_ <= lastEnterTime_))
       {
          // not enough time has elapsed since last command was submitted
          return false;
@@ -93,7 +111,8 @@ bool PrivateCommand::onTryCapture(core::system::ProcessOperations& ops, bool has
          return false;
       }
 
-      if (!lastPrivateCommand_.is_not_a_date_time() &&
+      if (oncePerUserCommand_ &&
+          !lastPrivateCommand_.is_not_a_date_time() &&
           lastPrivateCommand_ > lastEnterTime_)
       {
          // Hasn't been a new command executed since our last private command, no need
@@ -145,17 +164,77 @@ bool PrivateCommand::output(const std::string& output)
    }
 
    privateCommandOutput_.append(output);
-   return true;
+
+   // find the first BOM (from the command echo)
+   if (firstBOM_ == std::string::npos)
+   {
+      firstBOM_ = privateCommandOutput_.find(outputBOM_, 0);
+      if (firstBOM_ == std::string::npos)
+      {
+         return true;
+      }
+      firstBOM_ += outputBOM_.length();
+   }
+
+   // find the first EOM (from the command echo)
+   if (firstEOM_ == std::string::npos)
+   {
+      firstEOM_ = privateCommandOutput_.find(outputEOM_, firstBOM_);
+      if (firstEOM_ == std::string::npos)
+      {
+         return true;
+      }
+      firstEOM_ = firstEOM_ + outputEOM_.length();
+   }
+
+   // find the start of output
+   if (outputStart_ == std::string::npos)
+   {
+      std::string bomLine = outputBOM_ + "\n";
+      outputStart_ = privateCommandOutput_.find(bomLine, firstEOM_);
+      if (outputStart_ == std::string::npos)
+      {
+         return true;
+      }
+      outputStart_ += bomLine.length();
+   }
+
+   // find the end of output
+   std::string eomLine = outputEOM_ + "\n";
+   size_t outputEnd = privateCommandOutput_.find(eomLine, outputStart_);
+   if (outputEnd == std::string::npos)
+   {
+      return true;
+   }
+
+   // extract the command output
+   privateCommandOutput_ = privateCommandOutput_.substr(outputStart_, outputEnd - outputStart_);
+
+   completeCapture();
+   return false;
 }
 
-std::string PrivateCommand::getPrivateOutput() const
+std::string PrivateCommand::getPrivateOutput()
 {
-   return privateCommandOutput_;
+   if (hasCaptured()) // still in-process
+      return "";
+
+   std::string result = privateCommandOutput_;
+   privateCommandOutput_.clear();
+   return result;
 }
 
-void PrivateCommand::endCapture()
+void PrivateCommand::completeCapture()
 {
    privateCommandLoop_ = false;
+   firstBOM_ = std::string::npos;
+   firstEOM_ = std::string::npos;
+   outputStart_ = std::string::npos;
+}
+
+void PrivateCommand::terminateCapture()
+{
+   completeCapture();
    privateCommandOutput_.clear();
 }
 

--- a/src/cpp/core/terminal/PrivateCommand.cpp
+++ b/src/cpp/core/terminal/PrivateCommand.cpp
@@ -94,6 +94,7 @@ bool PrivateCommand::onTryCapture(core::system::ProcessOperations& ops, bool has
       {
          // We don't start a private command if something is being typed, or a command has never
          // been run.
+         lastPrivateCommand_ = currentTime;
          return false;
       }
 

--- a/src/cpp/core/terminal/PrivateCommand.cpp
+++ b/src/cpp/core/terminal/PrivateCommand.cpp
@@ -1,0 +1,157 @@
+/*
+ * PrivateCommand.cpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <core/terminal/PrivateCommand.hpp>
+
+#include <core/system/System.hpp>
+
+namespace rstudio {
+namespace core {
+namespace terminal {
+
+// minimum delay between private command executions
+const boost::posix_time::milliseconds kPrivateCommandDelay = boost::posix_time::milliseconds(3000);
+
+// how long after a command is started do we delay before considering running a private command
+const boost::posix_time::milliseconds kWaitForCommandDelay = boost::posix_time::milliseconds(1500);
+
+// how long after a private command is started do we allow for the result to be delivered?
+const boost::posix_time::milliseconds kPrivateCommandMaxDuration = boost::posix_time::milliseconds(1000);
+
+namespace {
+
+boost::posix_time::ptime now()
+{
+   return boost::posix_time::microsec_clock::universal_time();
+}
+
+} // anonymous namespace
+
+PrivateCommand::PrivateCommand(const std::string& command)
+   :
+     command_(command),
+     privateCommandLoop_(false),
+     lastPrivateCommand_(boost::posix_time::not_a_date_time),
+     lastEnterTime_(boost::posix_time::not_a_date_time),
+     pendingCommand_(true)
+
+{
+   outputBOM_ = core::system::generateUuid(false);
+   outputEOM_ = core::system::generateUuid(true);
+
+   std::string commandBefore_ = "echo ";
+   commandBefore_ += outputBOM_;
+   std::string commandAfter_ = "echo ";
+   commandAfter_ += outputEOM_;
+
+   fullCommand_ = commandBefore_ + " && " + command + " && " + commandAfter_ + "\n";
+}
+
+bool PrivateCommand::onTryCapture(core::system::ProcessOperations& ops, bool hasChildProcs)
+{
+   boost::posix_time::ptime currentTime = now();
+   if (privateCommandLoop_)
+   {
+      // already running private command
+
+      // TODO (gary)
+      // safeguard timeout here to exit private command loop if parsing fails after
+      // a couple of seconds!
+
+      return true;
+   }
+   else
+   {
+      if (hasChildProcs)
+         return false;
+
+      if (pendingCommand_ || lastEnterTime_.is_not_a_date_time())
+      {
+         // We don't start a private command if something is being typed, or a command has never
+         // been run. Environment hasn't changed in either of those cases.
+         return false;
+      }
+
+      if (currentTime - kWaitForCommandDelay <= lastEnterTime_)
+      {
+         // not enough time has elapsed since last command was submitted
+         return false;
+      }
+
+      if (!lastPrivateCommand_.is_not_a_date_time() &&
+          currentTime - kPrivateCommandDelay <= lastPrivateCommand_)
+      {
+         // not enough time has elapsed since last private command ran
+         return false;
+      }
+
+      if (!lastPrivateCommand_.is_not_a_date_time() &&
+          lastPrivateCommand_ > lastEnterTime_)
+      {
+         // Hasn't been a new command executed since our last private command, no need
+         // to run it.
+         return false;
+      }
+
+      lastPrivateCommand_ = currentTime;
+      privateCommandOutput_.clear();
+      privateCommandLoop_ = true;
+
+      // send the command
+      Error error = ops.writeToStdin(fullCommand_, false);
+      if (error)
+      {
+         LOG_ERROR(error);
+         privateCommandLoop_ = false;
+         lastPrivateCommand_ = boost::posix_time::pos_infin; // disable private commands
+         return false;
+      }
+      return true;
+   }
+   return false;
+}
+
+bool PrivateCommand::hasCaptured() const
+{
+   return privateCommandLoop_;
+}
+
+void PrivateCommand::userInput(const std::string& input)
+{
+   if (!input.empty() && (*input.rbegin() == '\r' || *input.rbegin() == '\n'))
+   {
+      lastEnterTime_ = now();
+      pendingCommand_ = false;
+   }
+   else
+   {
+      pendingCommand_ = true;
+   }
+}
+
+bool PrivateCommand::output(const std::string& output)
+{
+   if (!hasCaptured())
+   {
+      return false;
+   }
+
+   privateCommandOutput_.append(output);
+   return true;
+}
+
+} // namespace terminal
+} // namespace core
+} // namespace rstudio

--- a/src/cpp/core/terminal/PrivateCommandTests.cpp
+++ b/src/cpp/core/terminal/PrivateCommandTests.cpp
@@ -1,0 +1,36 @@
+/*
+ * PrivateCommandTests.cpp
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <core/terminal/PrivateCommand.hpp>
+
+#include <tests/TestThat.hpp>
+
+namespace rstudio {
+namespace core {
+namespace terminal {
+namespace tests {
+
+context("Private Terminal Command Tests")
+{
+   test_that("stuff happens")
+   {
+      expect_true(true);
+   }
+}
+
+} // end namespace tests
+} // end namespace terminal
+} // end namespace core
+} // end namespace rstudio

--- a/src/cpp/core/terminal/PrivateCommandTests.cpp
+++ b/src/cpp/core/terminal/PrivateCommandTests.cpp
@@ -15,18 +15,194 @@
 
 #include <core/terminal/PrivateCommand.hpp>
 
+#include <vector>
+
 #include <tests/TestThat.hpp>
+
+#include <core/BoostThread.hpp>
+
+using namespace boost::posix_time;
+using namespace boost::system;
 
 namespace rstudio {
 namespace core {
 namespace terminal {
 namespace tests {
 
+namespace {
+
+} // anonymous namespace
+
 context("Private Terminal Command Tests")
 {
-   test_that("stuff happens")
+   class OpsHarness : public system::ProcessOperations
    {
-      expect_true(true);
+   public:
+      virtual Error writeToStdin(const std::string& input, bool eof)
+      {
+         writes.push_back(input);
+         writesEof.push_back(eof);
+         return Success();
+      }
+
+      virtual Error ptySetSize(int cols, int rows)
+      {
+         return systemError(boost::system::errc::invalid_argument,
+                            ERROR_LOCATION);
+      }
+
+      virtual Error ptyInterrupt()
+      {
+         return systemError(boost::system::errc::invalid_argument,
+                            ERROR_LOCATION);
+      }
+
+      virtual Error terminate()
+      {
+         return systemError(boost::system::errc::invalid_argument,
+                            ERROR_LOCATION);
+      }
+
+      virtual PidType getPid()
+      {
+         return -1;
+      }
+
+      // capture data from calls to writeToStdin
+      std::vector<std::string> writes;
+      std::vector<bool> writesEof;
+
+   } ops;
+
+   const std::string kCommand = "sample_command";
+   const bool kHasChildProcess = true;
+   const bool kNoChildProcess = false;
+   const int kPrivate = 10;
+   const int kUser = 10;
+   const int kTimeout = 10;
+
+   test_that("no capture if terminal has child process")
+   {
+      PrivateCommand cmd(kCommand);
+
+      expect_false(cmd.hasCaptured());
+      expect_false(cmd.onTryCapture(ops, kHasChildProcess));
+      expect_false(cmd.hasCaptured());
+      expect_true(cmd.getPrivateOutput().empty());
+   }
+
+   test_that("no capture if user is in the middle of typing but hasn't hit <enter>")
+   {
+      PrivateCommand cmd(kCommand);
+
+      expect_false(cmd.hasCaptured());
+      cmd.userInput("partial user command");
+      expect_false(cmd.onTryCapture(ops, kNoChildProcess));
+      expect_false(cmd.hasCaptured());
+      expect_true(cmd.getPrivateOutput().empty());
+   }
+
+   test_that("no capture if user is in the middle of typing but hasn't hit <enter> in child proc")
+   {
+      PrivateCommand cmd(kCommand);
+
+      expect_false(cmd.hasCaptured());
+      cmd.userInput("partial user command");
+      expect_false(cmd.onTryCapture(ops, kHasChildProcess));
+      expect_false(cmd.hasCaptured());
+      expect_true(cmd.getPrivateOutput().empty());
+   }
+
+   test_that("no capture if user has entered a command but there is a child process")
+   {
+      PrivateCommand cmd(kCommand);
+
+      expect_false(cmd.hasCaptured());
+      cmd.userInput("user command\n");
+      expect_false(cmd.onTryCapture(ops, kHasChildProcess));
+      expect_false(cmd.hasCaptured());
+      expect_true(cmd.getPrivateOutput().empty());
+   }
+
+   test_that("no command issued if user has entered a command and no child process, but too soon")
+   {
+      PrivateCommand cmd(kCommand);
+
+      expect_false(cmd.hasCaptured());
+      cmd.userInput("user command\n");
+      expect_false(cmd.onTryCapture(ops, kNoChildProcess));
+      expect_false(cmd.hasCaptured());
+      expect_true(cmd.getPrivateOutput().empty());
+   }
+
+   test_that("command issued if user has entered a command and post-user-command timeout expired")
+   {
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout);
+
+      expect_false(cmd.hasCaptured());
+      cmd.userInput("user command\n");
+      boost::this_thread::sleep(milliseconds(kUser * 2));
+
+      expect_true(cmd.onTryCapture(ops, kNoChildProcess));
+      expect_true(cmd.hasCaptured());
+      expect_true(ops.writes.size() == 1);
+      expect_true(ops.writesEof.size() == ops.writes.size());
+      std::string sentCommand = ops.writes[0];
+      expect_true(*sentCommand.rbegin() == '\r' || *sentCommand.rbegin() == '\n');
+      expect_true(cmd.getPrivateOutput().empty());
+   }
+
+   test_that("command not issued if user hasn't entered a new command since last private comand")
+   {
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout);
+
+      expect_false(cmd.hasCaptured());
+      cmd.userInput("user command one\n");
+      boost::this_thread::sleep(milliseconds(kUser * 2));
+
+      expect_true(cmd.onTryCapture(ops, kNoChildProcess));
+      expect_true(cmd.hasCaptured());
+      cmd.endCapture();
+
+      // no new user command entered, and enough time has passed for the private command delay
+      boost::this_thread::sleep(milliseconds(kPrivate * 2));
+      expect_false(cmd.onTryCapture(ops, kNoChildProcess));
+      expect_false(cmd.hasCaptured());
+   }
+
+   test_that("command not issued if private command interval hasn't expired")
+   {
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout);
+
+      expect_false(cmd.hasCaptured());
+      cmd.userInput("user command one\n");
+      boost::this_thread::sleep(milliseconds(kUser * 2));
+
+      expect_true(cmd.onTryCapture(ops, kNoChildProcess));
+      expect_true(cmd.hasCaptured());
+      cmd.endCapture();
+
+      cmd.userInput("user command two\n");
+      expect_false(cmd.onTryCapture(ops, kNoChildProcess));
+      expect_false(cmd.hasCaptured());
+   }
+
+   test_that("command issued if private command interval has expired")
+   {
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout);
+
+      expect_false(cmd.hasCaptured());
+      cmd.userInput("user command one\n");
+      boost::this_thread::sleep(milliseconds(kUser * 2));
+
+      expect_true(cmd.onTryCapture(ops, kNoChildProcess));
+      expect_true(cmd.hasCaptured());
+      cmd.endCapture();
+
+      cmd.userInput("user command two\n");
+      boost::this_thread::sleep(milliseconds(kPrivate * 2));
+      expect_true(cmd.onTryCapture(ops, kNoChildProcess));
+      expect_true(cmd.hasCaptured());
    }
 }
 

--- a/src/cpp/core/terminal/PrivateCommandTests.cpp
+++ b/src/cpp/core/terminal/PrivateCommandTests.cpp
@@ -106,7 +106,7 @@ context("Private Terminal Command Tests")
       // mimic shell echoing back the command
       cmd.output(cmd.getFullCommand());
       cmd.output(cmd.getBOM());
-      cmd.output("\n");
+      cmd.output("\r\n");
       cmd.output(results);
 
       // verify we can't get results until EOM is seen
@@ -114,12 +114,9 @@ context("Private Terminal Command Tests")
 
       // close off the output
       cmd.output(cmd.getEOM());
-      cmd.output("\n");
+      cmd.output("\r\n");
 
-      // capture should now be done
-      expect_false(cmd.hasCaptured());
-
-      // trying to capture again should fail (not enough time has gone by)
+      // trying to capture now should return false, meaning we can get the output
       expect_false(cmd.onTryCapture(ops, kNoChildProcess));
 
       // verify the captured output

--- a/src/cpp/core/terminal/PrivateCommandTests.cpp
+++ b/src/cpp/core/terminal/PrivateCommandTests.cpp
@@ -35,6 +35,7 @@ namespace {
 
 context("Private Terminal Command Tests")
 {
+   // ProcessOptions impl that tracks calls
    class OpsHarness : public system::ProcessOperations
    {
    public:
@@ -84,71 +85,132 @@ context("Private Terminal Command Tests")
    } ops;
 
    const std::string kCommand = "sample_command";
+   const std::string kPrompt = "fake-prompt someuser$ ";
    const bool kHasChildProcess = true;
    const bool kNoChildProcess = false;
-   const int kPrivate = 10;
-   const int kUser = 10;
-   const int kTimeout = 10;
+   const int kPrivate = 25;
+   const int kUser = 25;
+   const int kTimeout = 25;
+   const bool kOncePerUserEnter = true;
+   const bool kNotOncePerUserEnter = false;
+
+   // this tests the overall functionality of the expected usage pattern
+   test_that("command output successfully parsed and returned")
+   {
+      PrivateCommand cmd(kCommand, kPrivate * 2, kUser, kTimeout, kNotOncePerUserEnter);
+
+      std::string results = "one=two\nthree=four\nfive=six\n";
+
+      expect_true(cmd.onTryCapture(ops, kNoChildProcess));
+
+      // mimic shell echoing back the command
+      cmd.output(cmd.getFullCommand());
+      cmd.output(cmd.getBOM());
+      cmd.output("\n");
+      cmd.output(results);
+
+      // verify we can't get results until EOM is seen
+      expect_true(cmd.getPrivateOutput().empty());
+
+      // close off the output
+      cmd.output(cmd.getEOM());
+      cmd.output("\n");
+
+      // capture should now be done
+      expect_false(cmd.hasCaptured());
+
+      // trying to capture again should fail (not enough time has gone by)
+      expect_false(cmd.onTryCapture(ops, kNoChildProcess));
+
+      // verify the captured output
+      std::string captureResult = cmd.getPrivateOutput();
+      expect_true(captureResult == results);
+
+      // can only extract output one time per command
+      expect_true(cmd.getPrivateOutput().empty());
+   }
+
+   test_that("basic assumptions are true")
+   {
+      PrivateCommand cmd1(kCommand, kPrivate, kUser, kTimeout, kOncePerUserEnter);
+
+      expect_false(cmd1.hasCaptured());
+      expect_true(cmd1.getPrivateOutput().empty());
+      expect_false(cmd1.output("some output\n"));
+      expect_true(cmd1.getPrivateOutput().empty());
+      expect_false(cmd1.hasCaptured());
+
+      PrivateCommand cmd2(kCommand, kPrivate, kUser, kTimeout, kNotOncePerUserEnter);
+
+      expect_false(cmd2.hasCaptured());
+      expect_true(cmd2.getPrivateOutput().empty());
+      expect_false(cmd2.output("some output\n"));
+      expect_true(cmd2.getPrivateOutput().empty());
+      expect_false(cmd2.hasCaptured());
+   }
 
    test_that("no capture if terminal has child process")
    {
-      PrivateCommand cmd(kCommand);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kOncePerUserEnter);
 
-      expect_false(cmd.hasCaptured());
       expect_false(cmd.onTryCapture(ops, kHasChildProcess));
       expect_false(cmd.hasCaptured());
       expect_true(cmd.getPrivateOutput().empty());
    }
 
-   test_that("no capture if user is in the middle of typing but hasn't hit <enter>")
+   test_that("(NotEnter) no capture if terminal has child process")
    {
-      PrivateCommand cmd(kCommand);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kNotOncePerUserEnter);
 
+      expect_false(cmd.onTryCapture(ops, kHasChildProcess));
       expect_false(cmd.hasCaptured());
+      expect_true(cmd.getPrivateOutput().empty());
+   }
+
+   test_that("no capture if user hasn't hit <enter>")
+   {
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kOncePerUserEnter);
+
       cmd.userInput("partial user command");
       expect_false(cmd.onTryCapture(ops, kNoChildProcess));
-      expect_false(cmd.hasCaptured());
-      expect_true(cmd.getPrivateOutput().empty());
-   }
-
-   test_that("no capture if user is in the middle of typing but hasn't hit <enter> in child proc")
-   {
-      PrivateCommand cmd(kCommand);
-
-      expect_false(cmd.hasCaptured());
-      cmd.userInput("partial user command");
-      expect_false(cmd.onTryCapture(ops, kHasChildProcess));
-      expect_false(cmd.hasCaptured());
-      expect_true(cmd.getPrivateOutput().empty());
    }
 
    test_that("no capture if user has entered a command but there is a child process")
    {
       PrivateCommand cmd(kCommand);
 
-      expect_false(cmd.hasCaptured());
       cmd.userInput("user command\n");
       expect_false(cmd.onTryCapture(ops, kHasChildProcess));
-      expect_false(cmd.hasCaptured());
-      expect_true(cmd.getPrivateOutput().empty());
+   }
+
+   test_that("(NotEnter) no capture if user has entered a command but there is a child process")
+   {
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kNotOncePerUserEnter);
+
+      cmd.userInput("user command\n");
+      expect_false(cmd.onTryCapture(ops, kHasChildProcess));
    }
 
    test_that("no command issued if user has entered a command and no child process, but too soon")
    {
       PrivateCommand cmd(kCommand);
 
-      expect_false(cmd.hasCaptured());
       cmd.userInput("user command\n");
       expect_false(cmd.onTryCapture(ops, kNoChildProcess));
-      expect_false(cmd.hasCaptured());
-      expect_true(cmd.getPrivateOutput().empty());
+   }
+
+   test_that("(NotEnter) command not issued after user command, no child process, but too soon")
+   {
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kNotOncePerUserEnter);
+
+      cmd.userInput("user command\n");
+      expect_false(cmd.onTryCapture(ops, kNoChildProcess));
    }
 
    test_that("command issued if user has entered a command and post-user-command timeout expired")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kOncePerUserEnter);
 
-      expect_false(cmd.hasCaptured());
       cmd.userInput("user command\n");
       boost::this_thread::sleep(milliseconds(kUser * 2));
 
@@ -158,67 +220,120 @@ context("Private Terminal Command Tests")
       expect_true(ops.writesEof.size() == ops.writes.size());
       std::string sentCommand = ops.writes[0];
       expect_true(*sentCommand.rbegin() == '\r' || *sentCommand.rbegin() == '\n');
-      expect_true(cmd.getPrivateOutput().empty());
+   }
+
+   test_that("(NotEnter) command issued, user has entered a command, post-user-cmd timeout expired")
+   {
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kNotOncePerUserEnter);
+
+      cmd.userInput("user command\n");
+      boost::this_thread::sleep(milliseconds(kUser * 2));
+
+      expect_true(cmd.onTryCapture(ops, kNoChildProcess));
+      expect_true(ops.writes.size() == 1);
+      expect_true(ops.writesEof.size() == ops.writes.size());
+      std::string sentCommand = ops.writes[0];
+      expect_true(*sentCommand.rbegin() == '\r' || *sentCommand.rbegin() == '\n');
+   }
+
+   test_that("(NotEnter) command issued immediately w/o user command entered")
+   {
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kNotOncePerUserEnter);
+
+      expect_true(cmd.onTryCapture(ops, kNoChildProcess));
+      expect_true(ops.writes.size() == 1);
+      expect_true(ops.writesEof.size() == ops.writes.size());
    }
 
    test_that("command not issued if user hasn't entered a new command since last private comand")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kOncePerUserEnter);
 
-      expect_false(cmd.hasCaptured());
       cmd.userInput("user command one\n");
       boost::this_thread::sleep(milliseconds(kUser * 2));
 
       expect_true(cmd.onTryCapture(ops, kNoChildProcess));
-      expect_true(cmd.hasCaptured());
-      cmd.endCapture();
+      cmd.terminateCapture();
 
       // no new user command entered, and enough time has passed for the private command delay
       boost::this_thread::sleep(milliseconds(kPrivate * 2));
       expect_false(cmd.onTryCapture(ops, kNoChildProcess));
-      expect_false(cmd.hasCaptured());
+   }
+
+   test_that("(NotEnter) command reissued if private command delay has expired")
+   {
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kNotOncePerUserEnter);
+
+      expect_true(cmd.onTryCapture(ops, kNoChildProcess));
+      cmd.terminateCapture();
+
+      // no new user command entered, but enough time has passed for the private command delay
+      boost::this_thread::sleep(milliseconds(kPrivate * 2));
+      expect_true(cmd.onTryCapture(ops, kNoChildProcess));
    }
 
    test_that("command not issued if private command interval hasn't expired")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kOncePerUserEnter);
 
-      expect_false(cmd.hasCaptured());
       cmd.userInput("user command one\n");
       boost::this_thread::sleep(milliseconds(kUser * 2));
 
       expect_true(cmd.onTryCapture(ops, kNoChildProcess));
-      expect_true(cmd.hasCaptured());
-      cmd.endCapture();
+      cmd.terminateCapture();
 
       cmd.userInput("user command two\n");
       expect_false(cmd.onTryCapture(ops, kNoChildProcess));
-      expect_false(cmd.hasCaptured());
+   }
+
+   test_that("(NotEnter) command not issued if private command interval hasn't expired")
+   {
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kNotOncePerUserEnter);
+
+      cmd.userInput("user command one\n");
+      boost::this_thread::sleep(milliseconds(kUser * 2));
+
+      expect_true(cmd.onTryCapture(ops, kNoChildProcess));
+      cmd.terminateCapture();
+
+      cmd.userInput("user command two\n");
+      expect_false(cmd.onTryCapture(ops, kNoChildProcess));
    }
 
    test_that("command issued if private command interval has expired")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kOncePerUserEnter);
 
-      expect_false(cmd.hasCaptured());
       cmd.userInput("user command one\n");
       boost::this_thread::sleep(milliseconds(kUser * 2));
 
       expect_true(cmd.onTryCapture(ops, kNoChildProcess));
-      expect_true(cmd.hasCaptured());
-      cmd.endCapture();
+      cmd.terminateCapture();
 
       cmd.userInput("user command two\n");
       boost::this_thread::sleep(milliseconds(kPrivate * 2));
       expect_true(cmd.onTryCapture(ops, kNoChildProcess));
-      expect_true(cmd.hasCaptured());
+   }
+
+   test_that("(NotEnter) command issued if private command interval has expired")
+   {
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kNotOncePerUserEnter);
+
+      cmd.userInput("user command one\n");
+      boost::this_thread::sleep(milliseconds(kUser * 2));
+
+      expect_true(cmd.onTryCapture(ops, kNoChildProcess));
+      cmd.terminateCapture();
+
+      cmd.userInput("user command two\n");
+      boost::this_thread::sleep(milliseconds(kPrivate * 2));
+      expect_true(cmd.onTryCapture(ops, kNoChildProcess));
    }
 
    test_that("private command terminated if taking too long")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kOncePerUserEnter);
 
-      expect_false(cmd.hasCaptured());
       cmd.userInput("user command\n");
       boost::this_thread::sleep(milliseconds(kUser * 2));
 
@@ -229,6 +344,19 @@ context("Private Terminal Command Tests")
       expect_true(ops.ptyInterrupted);
       expect_false(cmd.hasCaptured());
    }
+
+   test_that("(NotEnter) private command terminated if taking too long")
+   {
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kNotOncePerUserEnter);
+
+      expect_true(cmd.onTryCapture(ops, kNoChildProcess));
+
+      boost::this_thread::sleep(milliseconds(kTimeout * 2));
+      expect_false(cmd.onTryCapture(ops, kNoChildProcess));
+      expect_true(ops.ptyInterrupted);
+      expect_false(cmd.hasCaptured());
+   }
+
 }
 
 } // end namespace tests

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -441,12 +441,9 @@ bool ConsoleProcess::onContinue(core::system::ProcessOperations& ops)
       // to deal with input built-up during a privateCommandLoop.
       processQueuedInput(ops);
 
-      if (procInfo_->getChannelMode() == Websocket)
-      {
-         // capture weak reference to the callbacks so websocket callback
-         // can use them
-         pOps_ = ops.weak_from_this();
-      }
+      // capture weak reference to the callbacks so websocket callback
+      // can use them
+      pOps_ = ops.weak_from_this();
    }
    END_LOCK_MUTEX
 
@@ -955,7 +952,6 @@ void ConsoleProcess::saveEnvironment(const std::string& env)
       size_t equalSign = line.find_first_of('=');
       if (equalSign == std::string::npos)
       {
-         LOG_ERROR_MESSAGE("Malformed terminal environment ignored");
          return;
       }
 
@@ -969,7 +965,6 @@ void ConsoleProcess::saveEnvironment(const std::string& env)
    }
    if (environment.empty())
    {
-      LOG_ERROR_MESSAGE("Ignoring empty environment");
       return;
    }
 

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -32,6 +32,17 @@ namespace {
 
 ConsoleProcessSocket s_terminalSocket;
 
+// minimum delay between private command executions
+const boost::posix_time::milliseconds kPrivateCommandDelay = boost::posix_time::milliseconds(3000);
+
+// how long after a command is started do we delay before considering running a private command
+const boost::posix_time::milliseconds kWaitForCommandDelay = boost::posix_time::milliseconds(1500);
+
+boost::posix_time::ptime now()
+{
+   return boost::posix_time::microsec_clock::universal_time();
+}
+
 bool useWebsockets()
 {
    return session::options().allowTerminalWebsockets() &&
@@ -115,7 +126,11 @@ core::system::ProcessOptions ConsoleProcess::createTerminalProcOptions(
 ConsoleProcess::ConsoleProcess(boost::shared_ptr<ConsoleProcessInfo> procInfo)
    : procInfo_(procInfo), interrupt_(false), interruptChild_(false),
      newCols_(-1), newRows_(-1), pid_(-1), childProcsSent_(false),
-     lastInputSequence_(kIgnoreSequence), started_(false)
+     lastInputSequence_(kIgnoreSequence), started_(false), haveProcOps_(false),
+     privateCommandLoop_(false),
+     lastPrivateCommand_(boost::posix_time::not_a_date_time),
+     lastEnterTime_(boost::posix_time::not_a_date_time),
+     pendingCommand_(true)
 {
    regexInit();
 
@@ -130,7 +145,11 @@ ConsoleProcess::ConsoleProcess(const std::string& command,
    : command_(command), options_(options), procInfo_(procInfo),
      interrupt_(false), interruptChild_(false), newCols_(-1), newRows_(-1),
      pid_(-1), childProcsSent_(false), lastInputSequence_(kIgnoreSequence),
-     started_(false)
+     started_(false), haveProcOps_(false), privateCommandLoop_(false),
+     lastPrivateCommand_(boost::posix_time::not_a_date_time),
+     lastEnterTime_(boost::posix_time::not_a_date_time),
+     pendingCommand_(true)
+
 {
    commonInit();
 }
@@ -142,7 +161,10 @@ ConsoleProcess::ConsoleProcess(const std::string& program,
    : program_(program), args_(args), options_(options), procInfo_(procInfo),
      interrupt_(false), interruptChild_(false), newCols_(-1), newRows_(-1),
      pid_(-1), childProcsSent_(false), lastInputSequence_(kIgnoreSequence),
-     started_(false)
+     started_(false), haveProcOps_(false), privateCommandLoop_(false),
+     lastPrivateCommand_(boost::posix_time::not_a_date_time),
+     lastEnterTime_(boost::posix_time::not_a_date_time),
+     pendingCommand_(true)
 {
    commonInit();
 }
@@ -157,6 +179,15 @@ void ConsoleProcess::commonInit()
 {
    regexInit();
    procInfo_->ensureHandle();
+
+   privateOutputBOM_ = core::system::generateUuid(false);
+   privateOutputEOM_ = core::system::generateUuid(true);
+
+   captureEnvironmentCommand_ =  "echo ";
+   captureEnvironmentCommand_ += privateOutputBOM_;
+   captureEnvironmentCommand_ += "\n/usr/bin/env && echo ";
+   captureEnvironmentCommand_ += privateOutputEOM_;
+   captureEnvironmentCommand_ += "\n";
 
    // always redirect stderr to stdout so output is interleaved
    options_.redirectStdErrToStdOut = true;
@@ -230,7 +261,6 @@ void ConsoleProcess::commonInit()
 #endif
    }
 
-
    // When we retrieve from outputBuffer, we only want complete lines. Add a
    // dummy \n so we can tell the first line is a complete line.
    if (!options_.smartTerminal)
@@ -279,40 +309,47 @@ Error ConsoleProcess::start()
 
 void ConsoleProcess::enqueInput(const Input& input)
 {
-   if (input.sequence == kIgnoreSequence)
+   LOCK_MUTEX(inputQueueMutex_)
    {
-      inputQueue_.push_back(input);
-      return;
-   }
+      if (input.sequence == kIgnoreSequence)
+      {
+         inputQueue_.push_back(input);
+         return;
+      }
 
-   if (input.sequence == kFlushSequence)
-   {
-      inputQueue_.push_back(input);
+      if (input.sequence == kFlushSequence)
+      {
+         inputQueue_.push_back(input);
 
-      // set everything in queue to "ignore" so it will be pulled from
-      // queue as-is, even with gaps
+         // set everything in queue to "ignore" so it will be pulled from
+         // queue as-is, even with gaps
+         for (std::deque<Input>::iterator it = inputQueue_.begin();
+              it != inputQueue_.end(); it++)
+         {
+            (*it).sequence = kIgnoreSequence;
+         }
+         lastInputSequence_ = kIgnoreSequence;
+         return;
+      }
+
+      // insert in order by sequence
       for (std::deque<Input>::iterator it = inputQueue_.begin();
            it != inputQueue_.end(); it++)
       {
-         (*it).sequence = kIgnoreSequence;
+         if (input.sequence < (*it).sequence)
+         {
+            inputQueue_.insert(it, input);
+            return;
+         }
       }
-      lastInputSequence_ = kIgnoreSequence;
-      return;
+      inputQueue_.push_back(input);
    }
-
-   // insert in order by sequence
-   for (std::deque<Input>::iterator it = inputQueue_.begin();
-        it != inputQueue_.end(); it++)
-   {
-      if (input.sequence < (*it).sequence)
-      {
-         inputQueue_.insert(it, input);
-         return;
-      }
-   }
-   inputQueue_.push_back(input);
+   END_LOCK_MUTEX
 }
 
+// Do not call directly, needs to be within the inputQueueMutex_ for safety in
+// presence of multithreaded calls (via websockets). This is handled by
+// processQueuedInput.
 ConsoleProcess::Input ConsoleProcess::dequeInput()
 {
    // Pull next available Input from queue; return an empty Input
@@ -389,6 +426,69 @@ void ConsoleProcess::resize(int cols, int rows)
    newRows_ = rows;
 }
 
+bool ConsoleProcess::privateCommandLoop(core::system::ProcessOperations& ops)
+{
+   if (!procInfo_->getTrackEnv() || procInfo_->getHasChildProcs())
+      return false;
+
+   boost::posix_time::ptime currentTime = now();
+   if (privateCommandLoop_.get())
+   {
+      // TODO (gary)
+      // safeguard timeout here to exit private command loop if parsing fails after
+      // a couple of seconds!
+
+      return true;
+   }
+   else
+   {
+      LOCK_MUTEX(inputQueueMutex_)
+      {
+         // We don't start a private command if something is being typed, or a command has never
+         // been run.
+         if (pendingCommand_ || lastEnterTime_.is_not_a_date_time())
+            return false;
+
+         if (currentTime - kWaitForCommandDelay <= lastEnterTime_)
+         {
+            // not enough time has elapsed since last command was submitted
+            return false;
+         }
+
+         if (!lastPrivateCommand_.is_not_a_date_time() &&
+             currentTime - kPrivateCommandDelay <= lastPrivateCommand_)
+         {
+            // not enough time has elapsed since last private command ran
+            return false;
+         }
+
+         if (!lastPrivateCommand_.is_not_a_date_time() &&
+             lastPrivateCommand_ > lastEnterTime_)
+         {
+            // Hasn't been a new command executed since our last private command, no need
+            // to run it.
+            return false;
+         }
+      }
+      END_LOCK_MUTEX
+
+      lastPrivateCommand_ = currentTime;
+      privateCommandLoop_.set(true);
+
+      // send the command
+      Error error = ops.writeToStdin(captureEnvironmentCommand_, false);
+      if (error)
+      {
+         LOG_ERROR(error);
+         privateCommandLoop_.set(false);
+         lastPrivateCommand_ = boost::posix_time::pos_infin; // disable private commands
+         return false;
+      }
+      return true;
+   }
+   return false;
+}
+
 bool ConsoleProcess::onContinue(core::system::ProcessOperations& ops)
 {
    // full stop interrupt if requested
@@ -404,19 +504,29 @@ bool ConsoleProcess::onContinue(core::system::ProcessOperations& ops)
       interruptChild_ = false;
    }
 
-   if (procInfo_->getChannelMode() == Rpc)
-   {
-      processQueuedInput(ops);
-   }
-   else
+   // opportunity to execute a private commmand (send a command-line to the shell and
+   // capture the output for special processing, but end-user doesn't see it)
+   if (privateCommandLoop(ops))
+      return true;
+
+   // For RPC-based communication, this is where input is always dispatched; for websocket
+   // communication, it is normally dispatched inside onReceivedInput, but this call is needed
+   // to deal with input built-up during a privateCommandLoop.
+   processQueuedInput(ops);
+
+   if (procInfo_->getChannelMode() == Websocket)
    {
       // capture weak reference to the callbacks so websocket callback
-      // can use them
-      LOCK_MUTEX(mutex_)
+      // can use them; only need to capture the first time
+      if (!haveProcOps_)
       {
-         pOps_ = ops.weak_from_this();
+         LOCK_MUTEX(procOpsMutex_)
+         {
+            pOps_ = ops.weak_from_this();
+            haveProcOps_ = true;
+         }
+         END_LOCK_MUTEX
       }
-      END_LOCK_MUTEX
    }
 
    if (newCols_ != -1 && newRows_ != -1)
@@ -437,46 +547,59 @@ bool ConsoleProcess::onContinue(core::system::ProcessOperations& ops)
 
 void ConsoleProcess::processQueuedInput(core::system::ProcessOperations& ops)
 {
-   // process input queue
-   Input input = dequeInput();
-   while (!input.empty())
+   LOCK_MUTEX(inputQueueMutex_)
    {
-      // pty interrupt
-      if (input.interrupt)
+      // process input queue
+      Input input = dequeInput();
+      while (!input.empty())
       {
-         Error error = ops.ptyInterrupt();
-         if (error)
-            LOG_ERROR(error);
+         pendingCommand_ = true;
 
-         if (input.echoInput)
-            procInfo_->appendToOutputBuffer("^C");
-      }
-
-      // text input
-      else
-      {
-         std::string inputText = input.text;
-#ifdef _WIN32
-         if (!options_.smartTerminal)
+         // pty interrupt
+         if (input.interrupt)
          {
-            string_utils::convertLineEndings(&inputText, string_utils::LineEndingWindows);
-         }
-#endif
-         Error error = ops.writeToStdin(inputText, false);
-         if (error)
-            LOG_ERROR(error);
+            Error error = ops.ptyInterrupt();
+            if (error)
+               LOG_ERROR(error);
 
-         if (!options_.smartTerminal) // smart terminal does echo via pty
-         {
             if (input.echoInput)
-               procInfo_->appendToOutputBuffer(inputText);
-            else
-               procInfo_->appendToOutputBuffer("\n");
+               procInfo_->appendToOutputBuffer("^C");
          }
-      }
 
-      input = dequeInput();
+         // text input
+         else
+         {
+            std::string inputText = input.text;
+
+            if (!inputText.empty() && *inputText.rbegin() == '\r')
+            {
+               lastEnterTime_ = now();
+               pendingCommand_ = false;
+            }
+
+#ifdef _WIN32
+            if (!options_.smartTerminal)
+            {
+               string_utils::convertLineEndings(&inputText, string_utils::LineEndingWindows);
+            }
+#endif
+            Error error = ops.writeToStdin(inputText, false);
+            if (error)
+               LOG_ERROR(error);
+
+            if (!options_.smartTerminal) // smart terminal does echo via pty
+            {
+               if (input.echoInput)
+                  procInfo_->appendToOutputBuffer(inputText);
+               else
+                  procInfo_->appendToOutputBuffer("\n");
+            }
+         }
+
+         input = dequeInput();
+      }
    }
+   END_LOCK_MUTEX
 }
 
 void ConsoleProcess::deleteLogFile(bool lastLineOnly) const
@@ -496,6 +619,15 @@ std::string ConsoleProcess::getBuffer() const
 
 void ConsoleProcess::enqueOutputEvent(const std::string &output)
 {
+   if (privateCommandLoop_.get())
+   {
+// TODO (gary)
+// capture results of a private command
+//      return;
+      privateCommandLoop_.set(false);
+   }
+
+   // normal output processing
    bool currentAltBufferStatus = procInfo_->getAltBufferActive();
 
    // copy to output buffer
@@ -867,13 +999,14 @@ ConsoleProcessSocketConnectionCallbacks ConsoleProcess::createConsoleProcessSock
 // rstudioapi, may be called on different thread
 void ConsoleProcess::onReceivedInput(const std::string& input)
 {
-   LOCK_MUTEX(mutex_)
+   enqueInput(Input(input));
+   LOCK_MUTEX(procOpsMutex_)
    {
-      enqueInput(Input(input));
       boost::shared_ptr<core::system::ProcessOperations> ops = pOps_.lock();
       if (ops)
       {
-         processQueuedInput(*ops);
+         if (!privateCommandLoop_.get())
+            processQueuedInput(*ops);
       }
    }
    END_LOCK_MUTEX

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -581,7 +581,7 @@ void ConsoleProcess::maybeConsolePrompt(core::system::ProcessOperations& ops,
 void ConsoleProcess::handleConsolePrompt(core::system::ProcessOperations& ops,
                                          const std::string& prompt)
 {
-   // if there is a custom prmopt handler then give it a chance to
+   // if there is a custom prompt handler then give it a chance to
    // handle the prompt first
    if (onPrompt_)
    {

--- a/src/cpp/session/SessionConsoleProcessApi.cpp
+++ b/src/cpp/session/SessionConsoleProcessApi.cpp
@@ -411,7 +411,7 @@ Error procWriteStdin(const json::JsonRpcRequest& request,
    ConsoleProcessPtr proc = findProcByHandle(handle);
    if (proc != NULL)
    {
-      proc->enqueInput(input);
+      proc->enqueInputInternalLock(input);
       return Success();
    }
    else

--- a/src/cpp/session/SessionConsoleProcessInfo.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfo.cpp
@@ -177,6 +177,11 @@ void ConsoleProcessInfo::deleteLogFile(bool lastLineOnly) const
    console_persist::deleteLogFile(handle_, lastLineOnly);
 }
 
+void ConsoleProcessInfo::deleteEnvFile() const
+{
+   console_persist::deleteEnvFile(handle_);
+}
+
 core::json::Object ConsoleProcessInfo::toJson() const
 {
    json::Object result;
@@ -285,6 +290,16 @@ void ConsoleProcessInfo::deleteOrphanedLogs(bool (*validHandle)(const std::strin
 void ConsoleProcessInfo::saveConsoleProcesses(const std::string& metadata)
 {
    console_persist::saveConsoleProcesses(metadata);
+}
+
+void ConsoleProcessInfo::saveConsoleEnvironment(const std::string& env)
+{
+   console_persist::saveConsoleEnvironment(handle_, env);
+}
+
+void ConsoleProcessInfo::loadConsoleEnvironment(const std::string& handle, core::system::Options* pEnv)
+{
+   console_persist::loadConsoleEnvironment(handle, pEnv);
 }
 
 } // namespace console_process_info

--- a/src/cpp/session/SessionConsoleProcessInfo.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfo.cpp
@@ -39,7 +39,7 @@ ConsoleProcessInfo::ConsoleProcessInfo()
      showOnOutput_(false), outputBuffer_(kOutputBufferSize), childProcs_(true),
      altBufferActive_(false), shellType_(TerminalShell::DefaultShell),
      channelMode_(Rpc), cols_(system::kDefaultCols), rows_(system::kDefaultRows),
-     restarted_(false), autoClose_(DefaultAutoClose), zombie_(false)
+     restarted_(false), autoClose_(DefaultAutoClose), zombie_(false), trackEnv_(false)
 {
    // When we retrieve from outputBuffer, we only want complete lines. Add a
    // dummy \n so we can tell the first line is a complete line.
@@ -54,14 +54,14 @@ ConsoleProcessInfo::ConsoleProcessInfo(
          TerminalShell::TerminalShellType shellType,
          bool altBufferActive,
          const core::FilePath& cwd,
-         int cols, int rows, bool zombie)
+         int cols, int rows, bool zombie, bool trackEnv)
    : caption_(caption), title_(title), handle_(handle),
      terminalSequence_(terminalSequence), allowRestart_(true),
      interactionMode_(InteractionAlways), maxOutputLines_(kDefaultTerminalMaxOutputLines),
      showOnOutput_(false), outputBuffer_(kOutputBufferSize), childProcs_(true),
      altBufferActive_(altBufferActive), shellType_(shellType),
      channelMode_(Rpc), cwd_(cwd), cols_(cols), rows_(rows), restarted_(false),
-     autoClose_(DefaultAutoClose), zombie_(zombie)
+     autoClose_(DefaultAutoClose), zombie_(zombie), trackEnv_(trackEnv)
 {
 }
 
@@ -74,7 +74,7 @@ ConsoleProcessInfo::ConsoleProcessInfo(
      showOnOutput_(false), outputBuffer_(kOutputBufferSize), childProcs_(true),
      altBufferActive_(false), shellType_(TerminalShell::DefaultShell),
      channelMode_(Rpc), cols_(system::kDefaultCols), rows_(system::kDefaultRows),
-     restarted_(false), autoClose_(DefaultAutoClose), zombie_(false)
+     restarted_(false), autoClose_(DefaultAutoClose), zombie_(false), trackEnv_(false)
 {
 }
 
@@ -206,6 +206,7 @@ core::json::Object ConsoleProcessInfo::toJson() const
    result["restarted"] = restarted_;
    result["autoclose"] = static_cast<int>(autoClose_);
    result["zombie"] = zombie_;
+   result["track_env"] = trackEnv_;
 
    return result;
 }
@@ -266,6 +267,7 @@ boost::shared_ptr<ConsoleProcessInfo> ConsoleProcessInfo::fromJson(core::json::O
    int autoCloseInt = obj["autoclose"].get_int();
    pProc->autoClose_ = static_cast<AutoCloseMode>(autoCloseInt);
    pProc->zombie_ = obj["zombie"].get_bool();
+   pProc->trackEnv_ = obj["track_env"].get_bool();
 
    return pProc;
 }

--- a/src/cpp/session/SessionConsoleProcessInfo.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfo.cpp
@@ -292,9 +292,9 @@ void ConsoleProcessInfo::saveConsoleProcesses(const std::string& metadata)
    console_persist::saveConsoleProcesses(metadata);
 }
 
-void ConsoleProcessInfo::saveConsoleEnvironment(const std::string& env)
+void ConsoleProcessInfo::saveConsoleEnvironment(const core::system::Options& environment)
 {
-   console_persist::saveConsoleEnvironment(handle_, env);
+   console_persist::saveConsoleEnvironment(handle_, environment);
 }
 
 void ConsoleProcessInfo::loadConsoleEnvironment(const std::string& handle, core::system::Options* pEnv)

--- a/src/cpp/session/SessionConsoleProcessInfoTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfoTests.cpp
@@ -46,6 +46,7 @@ const int cols = core::system::kDefaultCols;
 const int rows = core::system::kDefaultRows;
 const bool restarted = false;
 const bool zombie = false;
+const bool trackEnv = false;
 
 const size_t maxLines = kDefaultTerminalMaxOutputLines;
 
@@ -76,7 +77,8 @@ bool sameCpi(const ConsoleProcessInfo& first, const ConsoleProcessInfo& second)
            first.getRows() == second.getRows() &&
            first.getRestarted() == second.getRestarted() &&
            first.getAutoClose() == second.getAutoClose() &&
-           first.getZombie() == second.getZombie());
+           first.getZombie() == second.getZombie() &&
+           first.getTrackEnv() == second.getTrackEnv());
 }
 
 } // anonymous namespace
@@ -87,7 +89,7 @@ TEST_CASE("ConsoleProcessInfo")
    SECTION("Create ConsoleProcessInfo and read properties")
    {
       ConsoleProcessInfo cpi(caption, title, handle1, sequence,
-                             shellType, altActive, cwd, cols, rows, zombie);
+                             shellType, altActive, cwd, cols, rows, zombie, trackEnv);
 
       CHECK_FALSE(caption.compare(cpi.getCaption()));
       CHECK_FALSE(title.compare(cpi.getTitle()));
@@ -117,6 +119,7 @@ TEST_CASE("ConsoleProcessInfo")
       CHECK(cpi.getAutoClose() == NeverAutoClose);
 
       CHECK(cpi.getZombie() == zombie);
+      CHECK(cpi.getTrackEnv() == trackEnv);
    }
 
    SECTION("Generate a handle")
@@ -133,7 +136,7 @@ TEST_CASE("ConsoleProcessInfo")
    SECTION("Change properties")
    {
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             altActive, cwd, cols, rows, zombie);
+                             altActive, cwd, cols, rows, zombie, trackEnv);
 
       std::string altCaption("other caption");
       CHECK(altCaption.compare(caption));
@@ -184,12 +187,15 @@ TEST_CASE("ConsoleProcessInfo")
 
       cpi.setZombie(true);
       CHECK(cpi.getZombie());
+
+      cpi.setTrackEnv(true);
+      CHECK(cpi.getTrackEnv());
    }
 
    SECTION("Change exit code")
    {
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             altActive, cwd, cols, rows, zombie);
+                             altActive, cwd, cols, rows, zombie, trackEnv);
 
       const int exitCode = 14;
       cpi.setExitCode(exitCode);
@@ -212,9 +218,9 @@ TEST_CASE("ConsoleProcessInfo")
    SECTION("Compare ConsoleProcInfos with different exit codes")
    {
       ConsoleProcessInfo cpiFirst(caption, title, handle1, sequence, shellType,
-                                  altActive, cwd, cols, rows, zombie);
+                                  altActive, cwd, cols, rows, zombie, trackEnv);
       ConsoleProcessInfo cpiSecond(caption, title, handle1, sequence, shellType,
-                                   altActive, cwd, cols, rows, zombie);
+                                   altActive, cwd, cols, rows, zombie, trackEnv);
 
       cpiFirst.setExitCode(1);
       cpiSecond.setExitCode(12);
@@ -224,7 +230,7 @@ TEST_CASE("ConsoleProcessInfo")
    SECTION("Persist and restore")
    {
       ConsoleProcessInfo cpiOrig(caption, title, handle1, sequence, shellType,
-                                  altActive, cwd, cols, rows, zombie);
+                                  altActive, cwd, cols, rows, zombie, trackEnv);
 
       core::json::Object origJson = cpiOrig.toJson();
       boost::shared_ptr<ConsoleProcessInfo> pCpiRestored =
@@ -270,7 +276,7 @@ TEST_CASE("ConsoleProcessInfo")
       // in the JSON. Same comment on the leaky abstractions here as for
       // previous non-terminal test.
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             altActive, cwd, cols, rows, zombie);
+                             altActive, cwd, cols, rows, zombie, trackEnv);
 
       // blow away anything that might have been left over from a previous
       // failed run
@@ -306,7 +312,7 @@ TEST_CASE("ConsoleProcessInfo")
    SECTION("Persist and restore terminals with multiple chunks")
    {
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             altActive, cwd, cols, rows, zombie);
+                             altActive, cwd, cols, rows, zombie, trackEnv);
 
       // blow away anything that might have been left over from a previous
       // failed run
@@ -371,9 +377,9 @@ TEST_CASE("ConsoleProcessInfo")
    SECTION("Delete unknown log files")
    {
       ConsoleProcessInfo cpiGood(caption, title, handle1, sequence, shellType,
-                                 altActive, cwd, cols, rows, zombie);
+                                 altActive, cwd, cols, rows, zombie, trackEnv);
       ConsoleProcessInfo cpiBad(caption, title, bogusHandle1, sequence, shellType,
-                                altActive, cwd, cols, rows, zombie);
+                                altActive, cwd, cols, rows, zombie, trackEnv);
 
       std::string orig1("hello how are you?\nthat is good\nhave a nice day");
       CHECK(orig1.length() < kOutputBufferSize);
@@ -409,7 +415,7 @@ TEST_CASE("ConsoleProcessInfo")
    {
       const int smallMaxLines = 5;
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             altActive, cwd, cols, rows, zombie);
+                             altActive, cwd, cols, rows, zombie, trackEnv);
       cpi.setMaxOutputLines(smallMaxLines);
 
       // blow away anything that might have been left over from a previous
@@ -451,7 +457,7 @@ TEST_CASE("ConsoleProcessInfo")
    {
       const int smallMaxLines = 3;
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             altActive, cwd, cols, rows, zombie);
+                             altActive, cwd, cols, rows, zombie, trackEnv);
       cpi.setMaxOutputLines(smallMaxLines);
 
       // blow away anything that might have been left over from a previous
@@ -495,7 +501,7 @@ TEST_CASE("ConsoleProcessInfo")
    {
       const int lines = 10;
       ConsoleProcessInfo cpi(caption, title, handle1, sequence, shellType,
-                             altActive, cwd, cols, rows, zombie);
+                             altActive, cwd, cols, rows, zombie, trackEnv);
       cpi.setMaxOutputLines(lines * 2);
 
       // blow away anything that might have been left over from a previous

--- a/src/cpp/session/SessionConsoleProcessPersist.cpp
+++ b/src/cpp/session/SessionConsoleProcessPersist.cpp
@@ -47,7 +47,9 @@ namespace console_persist {
 //                Added current-working directory, alt-buffer, cols, rows
 // 2017/06/8  - console04 -> console05
 //                Added autoClose, zombie
-#define kConsoleDir "console05"
+// 2017/06/16 - console05 -> console06
+//                Added trackEnv
+#define kConsoleDir "console06"
 
 namespace {
 

--- a/src/cpp/session/SessionConsoleProcessPersist.cpp
+++ b/src/cpp/session/SessionConsoleProcessPersist.cpp
@@ -56,6 +56,7 @@ namespace {
 FilePath s_consoleProcPath;
 FilePath s_consoleProcIndexPath;
 bool s_inited = false;
+const std::string s_envFileExt = ".env";
 
 void initialize()
 {
@@ -87,6 +88,7 @@ const FilePath& getConsoleProcIndexPath()
 
 Error getLogFilePath(const std::string& handle, FilePath* pFile)
 {
+   initialize();
    Error error = getConsoleProcPath().ensureDirectory();
    if (error)
    {
@@ -94,6 +96,21 @@ Error getLogFilePath(const std::string& handle, FilePath* pFile)
    }
 
    *pFile = getConsoleProcPath().complete(handle);
+   return Success();
+}
+
+Error getEnvFilePath(const std::string& handle, FilePath* pFile)
+{
+   initialize();
+   Error error = getConsoleProcPath().ensureDirectory();
+   if (error)
+   {
+      return error;
+   }
+
+   std::string envHandle = handle;
+   envHandle.append(s_envFileExt);
+   *pFile = getConsoleProcPath().complete(envHandle);
    return Success();
 }
 
@@ -268,6 +285,48 @@ void deleteOrphanedLogs(bool (*validHandle)(const std::string&))
          if (error)
             LOG_ERROR(error);
       }
+   }
+}
+
+void saveConsoleEnvironment(const std::string& handle, const std::string& env)
+{
+   FilePath log;
+   Error error = getEnvFilePath(handle, &log);
+   if (error)
+   {
+      LOG_ERROR(error);
+      return;
+   }
+   error = rstudio::core::writeStringToFile(log, env);
+   if (error)
+   {
+      LOG_ERROR(error);
+   }
+}
+
+void loadConsoleEnvironment(const std::string& handle, core::system::Options* pEnv)
+{
+   // TODO (gary)
+}
+
+void deleteEnvFile(const std::string& handle)
+{
+   FilePath log;
+   Error error = getEnvFilePath(handle, &log);
+   if (error)
+   {
+      LOG_ERROR(error);
+      return;
+   }
+
+   if (!log.exists())
+      return;
+
+   error = log.removeIfExists();
+   if (error)
+   {
+      LOG_ERROR(error);
+      return;
    }
 }
 

--- a/src/cpp/session/SessionConsoleProcessTable.cpp
+++ b/src/cpp/session/SessionConsoleProcessTable.cpp
@@ -206,6 +206,7 @@ void addConsoleProcess(const ConsoleProcessPtr& proc)
 Error reapConsoleProcess(const ConsoleProcess& proc)
 {
    proc.deleteLogFile();
+   proc.deleteEnvFile();
    if (s_procs.erase(proc.handle()))
    {
       saveConsoleProcesses();

--- a/src/cpp/session/SessionConsoleProcessTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessTests.cpp
@@ -35,7 +35,7 @@ context("queue and fetch input")
             "test caption", "test title", "fakehandle", 9999 /*terminal*/,
             TerminalShell::DefaultShell, false /*altBuffer*/, cwd,
             core::system::kDefaultCols, core::system::kDefaultRows,
-            false /*zombie*/));
+            false /*zombie*/, false /*trackEnv*/));
 
    boost::shared_ptr<ConsoleProcess> pCP =
          ConsoleProcess::createTerminalProcess(procOptions, pCPI, false /*enableWebsockets*/);

--- a/src/cpp/session/SessionConsoleProcessTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessTests.cpp
@@ -150,7 +150,7 @@ context("queue and fetch input")
 
       // intentionally skipping item "0" to prevent pulling from queueA
       int lastAdded = kIgnoreSequence;
-      for (int i = 1; i < kAutoFlushLength + 5; i++)
+      for (size_t i = 1; i < kAutoFlushLength + 5; i++)
       {
          std::string item = boost::lexical_cast<std::string>(i);
          expected += item;

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -130,6 +130,8 @@ public:
          int cols, int rows,
          int termSequence,
          core::FilePath workingDir,
+         bool trackEnv,
+         const std::string& handle,
          TerminalShell::TerminalShellType *pSelectedShellType);
 
    virtual ~ConsoleProcess() {}
@@ -160,6 +162,7 @@ public:
    void setTitle(std::string& title) { procInfo_->setTitle(title); }
    std::string getTitle() const { return procInfo_->getTitle(); }
    void deleteLogFile(bool lastLineOnly = false) const;
+   void deleteEnvFile() const;
    void setNotBusy() { procInfo_->setHasChildProcs(false); }
    bool getIsBusy() const { return procInfo_->getHasChildProcs(); }
    bool getAllowRestart() const { return procInfo_->getAllowRestart(); }
@@ -218,6 +221,9 @@ private:
    ConsoleProcessSocketConnectionCallbacks createConsoleProcessSocketConnectionCallbacks();
    void onConnectionOpened();
    void onConnectionClosed();
+
+   void saveEnvironment(const std::string& env);
+   static void loadEnvironment(const std::string& handle, core::system::Options* pEnv);
 
 private:
    // Command and options that will be used when start() is called

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -264,7 +264,7 @@ private:
    bool haveProcOps_;
 
    // private command handler, used to capture environment variables during terminal idle time
-   core::terminal::PrivateCommand privateCmd_;
+   core::terminal::PrivateCommand envCaptureCmd_;
 };
 
 core::json::Array processesAsJson();

--- a/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
@@ -20,6 +20,7 @@
 
 #include <core/FilePath.hpp>
 #include <core/json/Json.hpp>
+#include <core/system/Types.hpp>
 
 #include <session/SessionTerminalShell.hpp>
 
@@ -129,6 +130,8 @@ public:
    std::string getFullSavedBuffer() const;
    int getBufferLineCount() const;
    void deleteLogFile(bool lastLineOnly = false) const;
+   void deleteEnvFile() const;
+   void saveConsoleEnvironment(const std::string& env);
 
    // Has the process exited, and what was the exit code?
    void setExitCode(int exitCode);
@@ -190,6 +193,7 @@ public:
    static std::string loadConsoleProcessMetadata();
    static void deleteOrphanedLogs(bool (*validHandle)(const std::string&));
    static void saveConsoleProcesses(const std::string& metadata);
+   static void loadConsoleEnvironment(const std::string& handle, core::system::Options* pEnv);
 
 private:
    std::string caption_;

--- a/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
@@ -79,7 +79,7 @@ public:
          TerminalShell::TerminalShellType shellType,
          bool altBufferActive,
          const core::FilePath& cwd,
-         int cols, int rows, bool zombie);
+         int cols, int rows, bool zombie, bool trackEnv);
 
    // constructor for non-terminals
    ConsoleProcessInfo(
@@ -180,6 +180,10 @@ public:
    void setZombie(bool zombie) { zombie_ = zombie; }
    bool getZombie() const { return zombie_; }
 
+   // Track terminal session's environment?
+   void setTrackEnv(bool trackEnv) { trackEnv_ = trackEnv; }
+   bool getTrackEnv() const { return trackEnv_; }
+
    core::json::Object toJson() const;
    static boost::shared_ptr<ConsoleProcessInfo> fromJson(core::json::Object& obj);
 
@@ -209,6 +213,7 @@ private:
    bool restarted_;
    AutoCloseMode autoClose_;
    bool zombie_;
+   bool trackEnv_;
 };
 
 } // namespace console_process

--- a/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
@@ -131,7 +131,7 @@ public:
    int getBufferLineCount() const;
    void deleteLogFile(bool lastLineOnly = false) const;
    void deleteEnvFile() const;
-   void saveConsoleEnvironment(const std::string& env);
+   void saveConsoleEnvironment(const core::system::Options& environment);
 
    // Has the process exited, and what was the exit code?
    void setExitCode(int exitCode);

--- a/src/cpp/session/include/session/SessionConsoleProcessPersist.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessPersist.hpp
@@ -17,6 +17,8 @@
 
 #include <string>
 
+#include <core/system/Types.hpp>
+
 namespace rstudio {
 namespace core {
    class Error;
@@ -54,6 +56,15 @@ void deleteLogFile(const std::string& handle, bool lastLineOnly = false);
 // Clean up ConsoleProcess buffer cache
 // Takes a function to see if a given handle represents a known process.
 void deleteOrphanedLogs(bool (*validHandle)(const std::string&));
+
+// Save the environment for a given terminal handle.
+void saveConsoleEnvironment(const std::string& handle, const std::string& env);
+
+// Load environment variables for a given terminal handle
+void loadConsoleEnvironment(const std::string& handle, core::system::Options* pEnv);
+
+// Delete the persisted environment for the given ConsoleProcess
+void deleteEnvFile(const std::string& handle);
 
 } // namespace console_persist
 } // namespace console_process

--- a/src/cpp/session/include/session/SessionConsoleProcessPersist.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessPersist.hpp
@@ -58,7 +58,7 @@ void deleteLogFile(const std::string& handle, bool lastLineOnly = false);
 void deleteOrphanedLogs(bool (*validHandle)(const std::string&));
 
 // Save the environment for a given terminal handle.
-void saveConsoleEnvironment(const std::string& handle, const std::string& env);
+void saveConsoleEnvironment(const std::string& handle, const core::system::Options& environment);
 
 // Load environment variables for a given terminal handle
 void loadConsoleEnvironment(const std::string& handle, core::system::Options* pEnv);

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -932,7 +932,7 @@ Error startTerminal(const json::JsonRpcRequest& request,
 
    TerminalShell::TerminalShellType actualShellType;
    core::system::ProcessOptions options = ConsoleProcess::createTerminalProcOptions(
-         shellType, cols, rows, termSequence, cwd, &actualShellType);
+         shellType, cols, rows, termSequence, cwd, trackEnv, termHandle, &actualShellType);
 
    boost::shared_ptr<ConsoleProcessInfo> ptrProcInfo =
          boost::shared_ptr<ConsoleProcessInfo>(new ConsoleProcessInfo(

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -887,7 +887,12 @@ Error startTerminal(const json::JsonRpcRequest& request,
    bool altBufferActive;
    std::string currentDir;
    bool zombie;
-   
+#if defined(_WIN32)
+   bool trackEnv = false;
+#else
+   bool trackEnv = true;
+#endif
+
    Error error = json::readParams(request.params,
                                   &shellTypeInt,
                                   &cols,
@@ -932,7 +937,7 @@ Error startTerminal(const json::JsonRpcRequest& request,
    boost::shared_ptr<ConsoleProcessInfo> ptrProcInfo =
          boost::shared_ptr<ConsoleProcessInfo>(new ConsoleProcessInfo(
             termCaption, termTitle, termHandle, termSequence, actualShellType,
-            altBufferActive, cwd, cols, rows, zombie));
+            altBufferActive, cwd, cols, rows, zombie, trackEnv));
 
    boost::shared_ptr<ConsoleProcess> ptrProc =
                ConsoleProcess::createTerminalProcess(options, ptrProcInfo);

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
@@ -65,7 +65,7 @@ public class ConsoleProcessInfo extends JavaScriptObject
       procInfo.cols = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::DEFAULT_COLS;
       procInfo.rows = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::DEFAULT_ROWS;
       procInfo.restarted = false;
-      procInfo.autoclose = AUTOCLOSE_DEFAULT;
+      procInfo.autoclose = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::AUTOCLOSE_DEFAULT;
       procInfo.zombie = false;
 
       return procInfo;

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
@@ -243,6 +243,10 @@ public class ConsoleProcessInfo extends JavaScriptObject
       return this.zombie;
    }-*/;
 
+   public final native boolean getTrackEnv() /*-{
+      return this.track_env;
+   }-*/;
+
    public final native boolean isTerminal() /*-{
       return this.terminal_sequence > 0;
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
@@ -58,6 +58,7 @@ public class TerminalInfoDialog extends ModalDialogBase
       diagnostics.append("Busy:        '" + session.getHasChildProcs() + "'\n");
       diagnostics.append("Alt-Buffer:  '" + session.altBufferActive() + "'\n");
       diagnostics.append("Zombie:      '" + session.getZombie() + "'\n");
+      diagnostics.append("Track Env    '" + session.getTrackEnv() + "'\n");
       diagnostics.append("Local-echo:  '" + localEchoEnabled + "'\n"); 
       diagnostics.append("Working Dir: '" + cwd + "'\n"); 
       diagnostics.append("WebSockets:  '" + uiPrefs_.terminalUseWebsockets().getValue() + "'\n");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -800,6 +800,15 @@ public class TerminalSession extends XTermWidget
       return zombie_;
    }
    
+   public boolean getTrackEnv()
+   {
+      if (consoleProcess_ == null)
+      {
+         return true;
+      }
+      return consoleProcess_.getProcessInfo().getTrackEnv();
+   }
+   
    private HandlerRegistrations registrations_ = new HandlerRegistrations();
    private TerminalSessionSocket socket_;
    private ConsoleProcess consoleProcess_;


### PR DESCRIPTION
Not ready for merge, I want to do more testing, but code is done.

Terminal now persists the environment variables, so they can be restored when a terminal has to be restarted (e.g. after a session suspend, restart, or closing and reopening a project).

This is only on Mac and Linux IDE, and Linux server. This feature is not enabled on Windows IDE; it requires plumbing that I don't have on Windows. Not planning to do it for Windows.

Short of debugging APIs, there is no clean way to get the current environment of a process (procfs, for example, can give you the initial environment, but not the current one). 

So I implemented something JJ had suggested. When terminal is idle, I put the terminal in a private command mode, trigger "/usr/bin/env", capture the output, and save it. The user doesn't see this happening. If user starts typing in the middle of this brief operation, it is queued and played back when private command mode ends.

I don't run the private command more often than the user hits the enter key, idea being if they haven't entered a command (e.g. export FOO=BAR), then the current environment hasn't changed. If they are running a program, either long-running regular program, or a full-screen program, the private command doesn't fire.

I've wired it up in a way that I could add a user preference to disable this feature, but haven't done the actual preference yet.