### PR TITLE
Change root folder for terminal metadata

### DIFF
--- a/src/cpp/session/SessionConsoleProcessPersist.cpp
+++ b/src/cpp/session/SessionConsoleProcessPersist.cpp
@@ -60,7 +60,7 @@ void initialize()
    if (s_inited) return;
 
    // storage for session-scoped console/terminal metadata
-   s_consoleProcPath = module_context::sessionScratchPath().complete(kConsoleDir);
+   s_consoleProcPath = module_context::scopedScratchPath().complete(kConsoleDir);
    Error error = s_consoleProcPath.ensureDirectory();
    if (error)
    {


### PR DESCRIPTION
Change root of terminal metadata storage to `scopedScratchPath` instead of `sessionScratchPath`. Net result is to make terminal storage be in the same location it was before this change: 04106703a0f9500d132a9d461273a649296478bf

Additional terminal persistence changes will be needed due to discoveries made in conversations after that change: RSP with multiple sessions, and desktop IDE with multiple windows open on the same project. Those scenarios can result in real-time sharing of the terminal metadata (which the code doesn't support).