### PR TITLE
Show terminal typing lag in diagnostics dialog

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/Stopwatch.java
+++ b/src/gwt/src/org/rstudio/core/client/Stopwatch.java
@@ -16,8 +16,13 @@ package org.rstudio.core.client;
 
 public class Stopwatch
 {
-   public Stopwatch()
+   /**
+    * Track how long something takes, you know, like a Stopwatch.
+    * @param debugLog Show timing via Debug.log
+    */
+   public Stopwatch(boolean debugLog)
    {
+      debugLog_ = debugLog;
       reset();
    }
 
@@ -29,9 +34,11 @@ public class Stopwatch
    public long mark(String label)
    {
       long stopTime = System.currentTimeMillis();
-      Debug.log("[Stopwatch] " + label + ": " + (stopTime - startTime_) + " ms");
+      if (debugLog_)
+         Debug.log("[Stopwatch] " + label + ": " + (stopTime - startTime_) + " ms");
       return stopTime - startTime_;
    }
 
    private long startTime_;
+   private boolean debugLog_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -1,7 +1,7 @@
 /*
  * RStudioGinjector.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -129,7 +129,6 @@ import org.rstudio.studio.client.workbench.views.terminal.TerminalInfoDialog;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalList;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalPopupMenu;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalSession;
-import org.rstudio.studio.client.workbench.views.terminal.TerminalSessionSocket;
 import org.rstudio.studio.client.workbench.views.source.editors.text.r.SignatureToolTipManager;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.TextEditingTargetNotebook;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.display.ChunkOptionsPopupPanel;
@@ -231,7 +230,6 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(NewConnectionSnippetHost newConnectionSnippetHost);
    void injectMembers(NewConnectionSnippetDialog newConnectionSnippetDialog);
    void injectMembers(NewPackagePage page);
-   void injectMembers(TerminalSessionSocket socket);
    void injectMembers(NewConnectionInstallPackagePage newConnectionInstallPackagePage);
    void injectMembers(ObjectExplorerEditingTargetWidget widget);
    void injectMembers(ObjectExplorerDataGrid widget);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -17,7 +17,6 @@ package org.rstudio.studio.client.workbench.prefs.model;
 import org.rstudio.core.client.VirtualConsole;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.studio.client.application.Desktop;
-import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.notebook.CompileNotebookPrefs;
 import org.rstudio.studio.client.notebookv2.CompileNotebookv2Prefs;
 import org.rstudio.studio.client.rmarkdown.RmdOutput;
@@ -599,11 +598,6 @@ public class UIPrefsAccessor extends Prefs
    public PrefValue<Boolean> showTerminalTab()
    {
       return bool("show_terminal_tab", true);
-   }
-   
-   public PrefValue<Boolean> enableReportTerminalLag()
-   {
-      return bool("enable_report_terminal_lag", false);
    }
    
    public PrefValue<Boolean> terminalLocalEcho()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -1,7 +1,7 @@
 /*
  * AppearancePreferencesPane.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -33,7 +33,6 @@ import org.rstudio.core.client.widget.SelectWidget;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.ThemeChangedEvent;
-import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.workbench.prefs.model.RPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
@@ -62,7 +62,7 @@ public class TerminalInfoDialog extends ModalDialogBase
       diagnostics.append("Local-echo:  '" + localEchoEnabled + "'\n"); 
       diagnostics.append("Working Dir: '" + cwd + "'\n"); 
       diagnostics.append("WebSockets:  '" + uiPrefs_.terminalUseWebsockets().getValue() + "'\n");
-      diagnostics.append("Report lag:  '" + uiPrefs_.enableReportTerminalLag().getValue() + "'\n");
+      diagnostics.append("Typing lag:  '" + socket.getTypingLagMsg() + "'\n");
 
       diagnostics.append("\nSystem Information\n------------------\n");
       diagnostics.append("Desktop:    '" + Desktop.isDesktop() + "'\n");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
@@ -21,7 +21,6 @@ import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.Stopwatch;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.regex.Pattern;
-import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.common.console.ConsoleOutputEvent;
 import org.rstudio.studio.client.common.console.ConsoleProcess;
@@ -31,13 +30,11 @@ import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
-import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalDataInputEvent;
 import org.rstudio.studio.client.workbench.views.terminal.xterm.XTermWidget;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.inject.Inject;
 import com.sksamuel.gwt.websockets.CloseEvent;
 import com.sksamuel.gwt.websockets.Websocket;
 import com.sksamuel.gwt.websockets.WebsocketListenerExt;
@@ -99,7 +96,7 @@ public class TerminalSessionSocket
          }
          
          private String input_;
-         private Stopwatch stopWatch_ = new Stopwatch();
+         private Stopwatch stopWatch_ = new Stopwatch(false);
          private long duration_;
       }
       
@@ -119,12 +116,7 @@ public class TerminalSessionSocket
          if (item == null)
             return;
          
-         long average = 0;
-         if (accumulatedPoints_ > 0)
-         {
-            average = accumulatedTime_ / accumulatedPoints_;
-         }
-         if (!item.matches(output, average))
+         if (!item.matches(output, average()))
          {
             // output not what we expected, reset the whole list
             pending_.clear();
@@ -134,6 +126,20 @@ public class TerminalSessionSocket
             accumulatedPoints_++;
             accumulatedTime_ += item.duration();
          }
+      }
+      
+      private long average()
+      {
+         if (accumulatedPoints_ > 0)
+         {
+            return accumulatedTime_ / accumulatedPoints_;
+         }
+         return 0;
+      }
+
+      public String averageTimeMsg()
+      {
+         return Long.toString(average()) + "ms";
       }
       
       private LinkedList<InputDatapoint> pending_;
@@ -149,29 +155,16 @@ public class TerminalSessionSocket
    public TerminalSessionSocket(Session session,
                                 XTermWidget xterm)
    {
-      RStudioGinjector.INSTANCE.injectMembers(this);
-
       session_ = session;
       xterm_ = xterm;
       localEcho_ = new TerminalLocalEcho(xterm_);
 
       // Show delay between receiving a keystroke and sending it to the 
-      // terminal emulator; for diagnostics on laggy typing. Intended for
-      // brief use from a command-prompt. Time between input/display shown
-      // in console.
-      reportTypingLag_ = uiPrefs_.enableReportTerminalLag().getValue();
-      if (reportTypingLag_)
-      {
-         inputEchoTiming_ = new InputEchoTimeMonitor();
-      }
+      // terminal emulator; for diagnostics on laggy typing.
+      // Time between input/display shown in terminal diagnostics dialog.
+      inputEchoTiming_ = new InputEchoTimeMonitor();
    }
 
-   @Inject
-   private void initialize(UIPrefs uiPrefs)
-   {
-      uiPrefs_ = uiPrefs;
-   }
-   
    /**
     * Connect the input/output channel to the server. This requires that
     * an rsession has already been started via RPC and the consoleProcess
@@ -360,16 +353,14 @@ public class TerminalSessionSocket
    @Override
    public void onTerminalDataInput(TerminalDataInputEvent event)
    {
-      if (reportTypingLag_)
-         inputEchoTiming_.inputReceived(event.getData());
+      inputEchoTiming_.inputReceived(event.getData());
       session_.receivedInput(event.getData());
    }
 
    @Override
    public void onConsoleOutput(ConsoleOutputEvent event)
    {
-      if (reportTypingLag_)
-         inputEchoTiming_.outputReceived(event.getOutput());
+      inputEchoTiming_.outputReceived(event.getOutput());
       session_.receivedOutput(event.getOutput());
    }
 
@@ -430,13 +421,17 @@ public class TerminalSessionSocket
       diagnostic_.append(msg);
       diagnostic_.append("\n");
    }
+   
+   public String getTypingLagMsg()
+   {
+      return inputEchoTiming_.averageTimeMsg();
+   }
  
    private HandlerRegistrations registrations_ = new HandlerRegistrations();
    private final Session session_;
    private final XTermWidget xterm_;
    private ConsoleProcess consoleProcess_;
    private HandlerRegistration terminalInputHandler_;
-   private boolean reportTypingLag_;
    private InputEchoTimeMonitor inputEchoTiming_;
    private Websocket socket_;
    private TerminalLocalEcho localEcho_;
@@ -448,7 +443,4 @@ public class TerminalSessionSocket
    
    public static final Pattern PASSWORD_PATTERN =
          Pattern.create(PASSWORD_REGEX, "im");
- 
-   // Injected ---- 
-   private UIPrefs uiPrefs_;
 }


### PR DESCRIPTION
I already had code to compute typing lag in terminal, hidden behind an undocumented user preference and reporting to Javascript console. Got rid of preference, and just show the value in Terminal Diagnostics.

Also removed some unused imports reported by Eclipse.