### PR TITLE
work around change in 'file' output

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1020,9 +1020,19 @@ bool isTextFile(const FilePath& targetPath)
       return true;
 
 #ifndef _WIN32
+   
+   // the behavior of the 'file' command in the macOS High Sierra beta
+   // changed such that '--mime' no longer ensured that mime-type strings
+   // were actually emitted. using '-I' instead appears to work around this.
+#ifdef __APPLE__
+   const char * const kMimeTypeArg = "-I";
+#else
+   const char * const kMimeTypeArg = "--mime";
+#endif
+   
    core::shell_utils::ShellCommand cmd("file");
    cmd << "--dereference";
-   cmd << "--mime";
+   cmd << kMimeTypeArg;
    cmd << "--brief";
    cmd << targetPath;
    core::system::ProcessResult result;


### PR DESCRIPTION
The macOS High Sierra beta has changed the behavior of the `file` command when invoked with the `--mime` argument, such that it does not actually produce the understood mime-type of the file. (Instead, it seems to produce the 'human readable' output; e.g. `regular file` for `DESCRIPTION` files).

The result is that text files without a known mime-type encoded directly in RStudio cannot be opened under macOS High Sierra; e.g.

![ddqrbeaxgaau2to](https://user-images.githubusercontent.com/1976582/27549689-aaaac834-5a51-11e7-8f82-c8deafad67aa.jpg)

While it's possible that Apple will fix this bug before they ship macOS High Sierra, this PR should guard us in case that behavior leaks into Apple's next OS release.

(note: this PR would be a candidate for the patch release)

https://github.com/lionheart/openradar-mirror/issues/17559