### PR TITLE
Fix: reloaded terminals not showing a prompt

### DIFF
--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -789,8 +789,9 @@ ConsoleProcessPtr ConsoleProcess::createTerminalProcess(
       bool enableWebsockets)
 {
    ConsoleProcessPtr cp;
-   procInfo->setRestarted(true); // only flip to false if we find an existing
-                                 // process for this terminal handle
+
+   // only true if we create a new process with a previously used handle
+   procInfo->setRestarted(false);
 
    // Use websocket as preferred communication channel; it can fail
    // here if unable to establish the server-side of things, in which case
@@ -839,6 +840,7 @@ ConsoleProcessPtr ConsoleProcess::createTerminalProcess(
       else
       {
          // Create new process with previously used handle
+         procInfo->setRestarted(true);
 
          // previous terminal session might have been killed while a full-screen
          // program was running

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
@@ -55,6 +55,7 @@ public class TerminalInfoDialog extends ModalDialogBase
       diagnostics.append("Shell:       '" + TerminalShellInfo.getShellName(session.getShellType()) + "'\n");
       diagnostics.append("Handle:      '" + session.getHandle() + "'\n");
       diagnostics.append("Sequence:    '" + session.getSequence() + "'\n");
+      diagnostics.append("Restarted:   '" + session.getRestarted() + "\n");
       diagnostics.append("Busy:        '" + session.getHasChildProcs() + "'\n");
       diagnostics.append("Alt-Buffer:  '" + session.altBufferActive() + "'\n");
       diagnostics.append("Zombie:      '" + session.getZombie() + "'\n");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -746,6 +746,7 @@ public class TerminalSession extends XTermWidget
                         {
                            write(outputStr);
                         }
+                        deferredOutput_.clear();
                      }
                   }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -679,14 +679,15 @@ public class TerminalSession extends XTermWidget
    @Override
    protected void terminalReady()
    {
+      deferredOutput_.clear();
       if (newTerminal_)
       {
+         reloading_ = false;
          setNewTerminal(false);
       }
       else
       {
          reloading_ = true;
-         deferredOutput_.clear();
          fetchNextChunk(0);
       }
    }
@@ -779,7 +780,7 @@ public class TerminalSession extends XTermWidget
       {
          // Move cursor to first column and clear to end-of-line
          final String sequence = AnsiCode.CSI + AnsiCode.CHA + AnsiCode.CSI + AnsiCode.EL;
-         
+
          // immediately clear line locally
          write(sequence);
          
@@ -848,10 +849,8 @@ public class TerminalSession extends XTermWidget
    private boolean connected_;
    private boolean connecting_;
    private boolean terminating_;
-
    private boolean reloading_;
    private ArrayList<String> deferredOutput_ = new ArrayList<String>();
-
    private boolean restartSequenceWritten_;
    private StringBuilder inputQueue_ = new StringBuilder();
    private int inputSequence_ = ShellInput.IGNORE_SEQUENCE;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -744,7 +744,7 @@ public class TerminalSession extends XTermWidget
                         reloading_ = false;
                         for (String outputStr : deferredOutput_)
                         {
-                           write(outputStr);
+                           socket_.dispatchOutput(outputStr, doLocalEcho());
                         }
                         deferredOutput_.clear();
                      }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -15,9 +15,7 @@
 
 package org.rstudio.studio.client.workbench.views.terminal.xterm;
 
-import org.rstudio.core.client.AnsiCode;
 import org.rstudio.core.client.CommandWithArg;
-import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ExternalJavaScriptLoader;
 import org.rstudio.core.client.ExternalJavaScriptLoader.Callback;
 import org.rstudio.core.client.StringSink;
@@ -133,8 +131,6 @@ public class XTermWidget extends Widget implements RequiresResize,
    {
       terminal_.scrollToBottom();
       terminal_.write(str);
-      
-      Debug.devlog(AnsiCode.prettyPrint(str));
    }
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -15,7 +15,9 @@
 
 package org.rstudio.studio.client.workbench.views.terminal.xterm;
 
+import org.rstudio.core.client.AnsiCode;
 import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ExternalJavaScriptLoader;
 import org.rstudio.core.client.ExternalJavaScriptLoader.Callback;
 import org.rstudio.core.client.StringSink;
@@ -131,6 +133,8 @@ public class XTermWidget extends Widget implements RequiresResize,
    {
       terminal_.scrollToBottom();
       terminal_.write(str);
+      
+      Debug.devlog(AnsiCode.prettyPrint(str));
    }
 
    /**


### PR DESCRIPTION
When terminals are restarting (especially when opening a project's previous terminal instances) they often display with no prompt. Hitting <enter> will generate a prompt, but still looks bad.

Caused by a previous fix to reduce duplicate prompts piling up when doing builds or R restarts (https://github.com/rstudio/rstudio/pull/1206). Fix is to accumulate terminal output when restoring the buffer, then play it back when reloading is completed. Otherwise the real prompt can be deleted by `writeRestartSequence` depending on timing.

While I was at it, noticed the `restarted` flag on ConsoleProcessInfo wasn't accurate; it was intended to only be `true` if this terminal instance was a reload of a previous terminal session that was killed, versus a brand new terminal session. Fixed, and also now show in Terminal Diagnostics on client-side.