### PR TITLE
Filter NA attributes from driver enumeration in the odbc connection pane

### DIFF
--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -400,7 +400,7 @@ options(connectionObserver = list(
          drivers <- listDrivers()
       }, error = function(e) warning(e$message))
 
-      uniqueDrivers <- drivers[drivers$attribute == "Driver", ]
+      uniqueDrivers <- drivers[!is.na(drivers$attribute) & drivers$attribute == "Driver", ]
 
       driversNoSnippet <- Filter(function(e) { !(e %in% names(snippets)) }, uniqueDrivers$name)
 


### PR DESCRIPTION
unixODBC has a bug that SQLDrivers does not properly return driver
information if it is specified in the user configuration file
`~/.odbcinst` rather than the system wide configuration file. This
behavior was reported upstream and should be fixed in the next unixODBC
release (2.3.5).

As a result of this bug drivers specified in `~/.odbcinst` will have
`NA` values when returned by `odbc::odbcListDrivers()`, causing a number
of Warnings and empty entries added to the connection Dialog. See
<https://www.dropbox.com/s/wx64d9e6frtvbk3/snippetsFile.gif?dl=0> for an
example of the current behavior.

To fix this we can simply filter out NA entries from the dialog,
avoiding the issue.

cc/ @javierluraschi, this fixes the behavior I mentioned to you on slack.