### PR TITLE
Fix: terminal stuck in alt-buffer after forced restart

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -154,6 +154,14 @@ public class TerminalSession extends XTermWidget
             addHandlerRegistration(addXTermTitleHandler(TerminalSession.this));
             addHandlerRegistration(eventBus_.addHandler(SessionSerializationEvent.TYPE, TerminalSession.this));
             
+            if (!consoleProcess_.getProcessInfo().getAltBufferActive() && altBufferActive())
+            {
+               // If server reports the terminal is not showing alt-buffer, but local terminal
+               // emulator is showing alt-buffer, terminal was killed while running
+               // a full-screen program. Switch local terminal back to primary buffer.
+               showPrimaryBuffer();
+            }
+            
             socket_.connect(consoleProcess_, new TerminalSessionSocket.ConnectCallback()
             {
                @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
@@ -116,6 +116,11 @@ public class XTermNative extends JavaScriptObject
       return this.normal != null;
    }-*/;
    
+   public final native void showPrimaryBuffer() /*-{
+      this.write("\x1b[?1047l"); // show primary buffer
+      this.write("\x1b[m"); // reset all visual attributes
+   }-*/;
+   
    public final native String currentLine() /*-{
       lineBuf = this.lines.get(this.y + this.ybase);
       if (!lineBuf) // resize may be in progress

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -334,6 +334,14 @@ public class XTermWidget extends Widget implements RequiresResize,
       return terminal_.altBufferActive();
    }
    
+   /**
+    * Switch terminal to primary buffer.
+    */
+   public void showPrimaryBuffer()
+   {
+      terminal_.showPrimaryBuffer();
+   }
+   
    public static boolean isXTerm(Element el)
    {
       while (el != null)


### PR DESCRIPTION
If a full-screen program is running and the terminal is killed on the server (e.g. R restart), the client terminal emulator keeps showing the alt-buffer when it is restarted. Fixed by detecting this condition and forcing terminal back to primary buffer via esc sequences.