### PR TITLE
Revert session storage behavior for desktop mode

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1517,6 +1517,19 @@ r_util::ActiveSession& activeSession()
       std::string id = options().sessionScope().id();
       if (!id.empty())
          pSession = activeSessions().get(id);
+      else if (options().programMode() == kSessionProgramModeDesktop)
+      {
+         // if no active session, create one and use the launcher token as a
+         // synthetic session ID
+         //
+         // we only do this in desktop mode to preserve backwards compatibility
+         // with some functionality that depends on session data
+         // persisting after rstudio has been closed
+         //
+         // this entire clause will likely need to be reverted in a future release
+         // once we ensure that all execution modes have this squared away
+         pSession = activeSessions().emptySession(options().launcherToken());
+      }
       else
       {
          // if no scope was specified, we are in singleton session mode


### PR DESCRIPTION
Revert part of the change in 04106703a0f9500d132a9d461273a649296478bf, but only for desktop mode. Concern is there may be unanticipated side effects, so we'll take a look at "unreverting" this in 1.2 when we have more time to evaluate.