### PR TITLE
Make Tools/Shell use default terminal on Windows

### DIFF
--- a/src/cpp/session/SessionUserSettings.cpp
+++ b/src/cpp/session/SessionUserSettings.cpp
@@ -789,16 +789,6 @@ void UserSettings::setVcsTerminalPath(const FilePath& terminalPath)
    settings_.set("vcsTerminalPath", terminalPath.absolutePath());
 }
 
-bool UserSettings::vcsUseGitBash() const
-{
-   return settings_.getBool("vcsUseGitBash", true);
-}
-
-void UserSettings::setVcsUseGitBash(bool useGitBash)
-{
-   settings_.set("vcsUseGitBash", useGitBash);
-}
-
 bool UserSettings::cleanTexi2DviOutput() const
 {
    return settings_.getBool("cleanTexi2DviOutput", true);

--- a/src/cpp/session/include/session/SessionUserSettings.hpp
+++ b/src/cpp/session/include/session/SessionUserSettings.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionUserSettings.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -167,9 +167,6 @@ public:
 
    core::FilePath vcsTerminalPath() const;
    void setVcsTerminalPath(const core::FilePath& terminalPath);
-
-   bool vcsUseGitBash() const;
-   void setVcsUseGitBash(bool useGitBash);
 
    bool cleanTexi2DviOutput() const;
    void setCleanTexi2DviOutput(bool cleanTexi2DviOutput);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
@@ -20,6 +20,7 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.Size;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.TimeBufferedCommand;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/SourceControlPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/SourceControlPrefs.java
@@ -1,7 +1,7 @@
 /*
  * SourceControlPrefs.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -26,15 +26,13 @@ public class SourceControlPrefs extends JavaScriptObject
    public static final native SourceControlPrefs create(boolean vcsEnabled,
                                                         String gitExePath,
                                                         String svnExePath,
-                                                        String terminalPath,
-                                                        boolean useGitBash) 
+                                                        String terminalPath)
                                                                            /*-{
       var prefs = new Object();
       prefs.vcs_enabled = vcsEnabled;
       prefs.git_exe_path = gitExePath;
       prefs.svn_exe_path = svnExePath;
       prefs.terminal_path = terminalPath;
-      prefs.use_git_bash = useGitBash;
       return prefs ;
    }-*/;
 
@@ -52,10 +50,6 @@ public class SourceControlPrefs extends JavaScriptObject
    
    public native final String getTerminalPath() /*-{
       return this.terminal_path;
-   }-*/;
-   
-   public native final boolean getUseGitBash() /*-{
-      return this.use_git_bash;
    }-*/;
    
    public native final String getRsaKeyPath() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/SourceControlPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/SourceControlPreferencesPane.java
@@ -1,7 +1,7 @@
 /*
  * SourceControlPreferencesPane.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -110,15 +110,6 @@ public class SourceControlPreferencesPane extends PreferencesPane
       if (sessionInfo.getAllowVcsExeEdit())
          addTextBoxChooser(gitExePathLabel_, null, null, gitExePathChooser_);
  
-      // use git bash
-      chkUseGitBash_ = new CheckBox("Use Git Bash as shell for Git projects");
-      if (haveGitBashPref())
-      {
-         extraSpaced(chkUseGitBash_);
-         add(chkUseGitBash_);
-      }
-      
-        
       // svn exe path chooser
       svnExePathLabel_ = new Label("SVN executable:");
       svnExePathChooser_ = new FileChooserTextBox("",
@@ -152,7 +143,6 @@ public class SourceControlPreferencesPane extends PreferencesPane
       gitExePathChooser_.setEnabled(false);
       svnExePathChooser_.setEnabled(false);
       terminalPathChooser_.setEnabled(false);
-      chkUseGitBash_.setEnabled(false);
    }
 
    @Override
@@ -165,13 +155,11 @@ public class SourceControlPreferencesPane extends PreferencesPane
       gitExePathChooser_.setEnabled(true);
       svnExePathChooser_.setEnabled(true);
       terminalPathChooser_.setEnabled(true);
-      chkUseGitBash_.setEnabled(true);
 
       chkVcsEnabled_.setValue(prefs.getVcsEnabled());
       gitExePathChooser_.setText(prefs.getGitExePath());
       svnExePathChooser_.setText(prefs.getSvnExePath());
       terminalPathChooser_.setText(prefs.getTerminalPath());
-      chkUseGitBash_.setValue(prefs.getUseGitBash());
       
       sshKeyWidget_.setRsaSshKeyPath(prefs.getRsaKeyPath(),
                                      prefs.getHaveRsaKey());
@@ -205,8 +193,7 @@ public class SourceControlPreferencesPane extends PreferencesPane
 
       SourceControlPrefs prefs = SourceControlPrefs.create(
             chkVcsEnabled_.getValue(), gitExePathChooser_.getText(),
-            svnExePathChooser_.getText(), terminalPathChooser_.getText(),
-            chkUseGitBash_.getValue());
+            svnExePathChooser_.getText(), terminalPathChooser_.getText());
 
       rPrefs.setSourceControlPrefs(prefs);
 
@@ -218,11 +205,6 @@ public class SourceControlPreferencesPane extends PreferencesPane
       return Desktop.isDesktop() && BrowseCap.isLinux();
    }
    
-   private boolean haveGitBashPref()
-   {
-      return Desktop.isDesktop() && BrowseCap.isWindows();
-   }
-
    private void addTextBoxChooser(Label captionLabel, HyperlinkLabel link,
          String captionPanelStyle, TextBoxWithButton chooser)
    {
@@ -265,7 +247,6 @@ public class SourceControlPreferencesPane extends PreferencesPane
       svnExePathChooser_.setVisible(vcsEnabled);
       terminalPathLabel_.setVisible(vcsEnabled);
       terminalPathChooser_.setVisible(vcsEnabled && haveTerminalPathPref());
-      chkUseGitBash_.setVisible(vcsEnabled && haveGitBashPref());
       sshKeyWidget_.setVisible(vcsEnabled);
    }
    
@@ -279,6 +260,5 @@ public class SourceControlPreferencesPane extends PreferencesPane
    private TextBoxWithButton svnExePathChooser_;
    private Label terminalPathLabel_;
    private TextBoxWithButton terminalPathChooser_;
-   private CheckBox chkUseGitBash_;
    private SshKeyWidget sshKeyWidget_;
 }


### PR DESCRIPTION
Removed the Windows-only "Use Git-bash as shell for Git project" preferences checkbox. Now the shell will launch the default terminal as set on the Terminal Pane.

Doesn't change if a Git project is currently open or not, which was called out as a source of confusion.