### PR TITLE
Tweaks to terminal environment capture

### DIFF
--- a/src/cpp/core/terminal/PrivateCommand.cpp
+++ b/src/cpp/core/terminal/PrivateCommand.cpp
@@ -40,6 +40,10 @@ const std::string kEol = "\r\n";
  *
  * where BOM and EOM would be actual uuids. This assumes our shell supports && for
  * issuing sequential commands.
+ *
+ * Command is prefixed with a space, to take advantage of
+ * HISTCONTROL=ignorespace (or ignoreboth) as a way to prevent command from
+ * showing up in shell history.
  */
 
 PrivateCommand::PrivateCommand(const std::string& command,
@@ -64,7 +68,7 @@ PrivateCommand::PrivateCommand(const std::string& command,
    outputBOM_ = core::system::generateShortenedUuid();
    outputEOM_ = core::system::generateShortenedUuid();
 
-   std::string commandBefore_ = "echo ";
+   std::string commandBefore_ = " echo ";
    commandBefore_ += outputBOM_;
    std::string commandAfter_ = "echo ";
    commandAfter_ += outputEOM_;

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -77,6 +77,12 @@ core::system::ProcessOptions ConsoleProcess::createTerminalProcOptions(
       core::system::setenv(&shellEnv, "GIT_EDITOR", editorCommand);
       core::system::setenv(&shellEnv, "SVN_EDITOR", editorCommand);
    }
+
+   // don't add commands starting with a space to shell history
+   if (trackEnv)
+   {
+      core::system::setenv(&shellEnv, "HISTCONTROL", "ignoreboth");
+   }
 #endif
 
    if (termSequence != kNoTerminal)

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -895,11 +895,7 @@ Error startTerminal(const json::JsonRpcRequest& request,
    bool altBufferActive;
    std::string currentDir;
    bool zombie;
-#if defined(_WIN32)
-   bool trackEnv = false;
-#else
-   bool trackEnv = true;
-#endif
+   bool trackEnv;
 
    Error error = json::readParams(request.params,
                                   &shellTypeInt,
@@ -911,9 +907,14 @@ Error startTerminal(const json::JsonRpcRequest& request,
                                   &termSequence,
                                   &altBufferActive,
                                   &currentDir,
-                                  &zombie);
+                                  &zombie,
+                                  &trackEnv);
    if (error)
       return error;
+
+#if defined(_WIN32)
+   bool trackEnv = false;
+#endif
 
    TerminalShell::TerminalShellType shellType =
          TerminalShell::safeShellTypeFromInt(shellTypeInt);

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -506,6 +506,7 @@ public class RemoteServer implements Server
                      boolean altBufferActive,
                      String cwd,
                      boolean zombie,
+                     boolean trackEnv,
                      ServerRequestCallback<ConsoleProcess> requestCallback)
    {
       JSONArray params = new JSONArray();
@@ -519,6 +520,7 @@ public class RemoteServer implements Server
       params.set(7, JSONBoolean.getInstance(altBufferActive));
       params.set(8, new JSONString(StringUtil.notNull(cwd)));
       params.set(9, JSONBoolean.getInstance(zombie));
+      params.set(10, JSONBoolean.getInstance(trackEnv));
 
       sendRequest(RPC_SCOPE,
                   START_TERMINAL,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchServerOperations.java
@@ -152,11 +152,12 @@ public interface WorkbenchServerOperations extends ConsoleServerOperations,
     * @param altBufferActive terminal showing alt-buffer (full-screen ncurses)
     * @param cwd current working directory
     * @param zombie if true, terminal buffer reloaded but no process created
+    * @param trackEnv if true, server runs a hidden command to capture environment variables
     * @param requestCallback callback from server upon completion
     */
    void startTerminal(int shellType, int cols, int rows, String handle, 
                       String caption, String title, int sequence, 
-                      boolean altBufferActive, String cwd, boolean zombie,
+                      boolean altBufferActive, String cwd, boolean zombie, boolean trackEnv,
                       ServerRequestCallback<ConsoleProcess> requestCallback);
    
    void executeCode(String code, ServerRequestCallback<Void> requestCallback);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -615,6 +615,11 @@ public class UIPrefsAccessor extends Prefs
       return bool("terminal_autoclose", true);
    }
 
+   public PrefValue<Boolean> terminalTrackEnvironment()
+   {
+      return bool("terminal_track_env", true);
+   }
+
    public static final String KNIT_DIR_DEFAULT = "default";
    public static final String KNIT_DIR_CURRENT = "current";
    public static final String KNIT_DIR_PROJECT = "project";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/TerminalPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/TerminalPreferencesPane.java
@@ -126,6 +126,14 @@ public class TerminalPreferencesPane extends PreferencesPane
             "Deselect this option to keep terminal pane open after shell exits.");
       add(chkTerminalAutoClose);
 
+      if (haveCaptureEnvPref())
+      {
+         CheckBox chkCaptureEnv = checkboxPref("Save and Restore Environment Variables",
+               prefs_.terminalTrackEnvironment(),
+               "Terminal occasionally runs a hidden command to capture state of environment variables.");
+         add(chkCaptureEnv);
+      }
+      
       HelpLink helpLink = new HelpLink("Using the RStudio terminal", "rstudio_terminal", false);
       nudgeRight(helpLink); 
       helpLink.addStyleName(res_.styles().newSection()); 
@@ -222,6 +230,11 @@ public class TerminalPreferencesPane extends PreferencesPane
    private boolean haveWebsocketPref()
    {
       return session_.getSessionInfo().getAllowTerminalWebsockets();
+   }
+
+   private boolean haveCaptureEnvPref()
+   {
+      return !BrowseCap.isWindowsDesktop();
    }
 
    private int selectedShellType()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -128,7 +128,7 @@ public class TerminalSession extends XTermWidget
       server_.startTerminal(getShellType(),
             getCols(), getRows(), getHandle(), getCaption(), 
             getTitle(), getSequence(), getAltBufferActive(), getCwd(), 
-            getZombie(),
+            getZombie(), uiPrefs_.terminalTrackEnvironment().getValue(),
             new ServerRequestCallback<ConsoleProcess>()
       {
          @Override


### PR DESCRIPTION
JJ noticed that the "hidden" command for environment capture shows up in shell history. Very irritating in that they run after each user-entered command.

Fixed that by setting HISTCONTROL=ignoreboth to not add commands starting with a space to shell history (and to not add duplicate commands to history); then added a space to start of the "hidden" command.

Added a user preference to terminal options to enable/disable the environment capture feature altogether. This feature is sensitive to the shell being used, so with the custom shell capability, you can get into scenarios where you'd want to disable it (csh, for example, is unhappy with environment capture feature; does anybody still use csh as an interactive terminal?).