### PR TITLE
implement a simple status bar for explorer

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerEditingTargetStatusBar.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerEditingTargetStatusBar.css
@@ -1,0 +1,11 @@
+@CHARSET "UTF-8";
+
+.panel {
+	padding: 0 4px 0 4px;
+}
+
+.label {
+	user-select: text;
+	font-size: 11px;
+	margin-top: 1px;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerEditingTargetStatusBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerEditingTargetStatusBar.java
@@ -1,0 +1,105 @@
+/*
+ * ObjectExplorerEditingTargetStatusBar.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.explorer.view;
+
+import org.rstudio.core.client.widget.events.SelectionChangedEvent;
+import org.rstudio.core.client.widget.events.SelectionChangedHandler;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.resources.client.ClientBundle;
+import com.google.gwt.resources.client.CssResource;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.Label;
+
+public class ObjectExplorerEditingTargetStatusBar extends Composite
+{
+   public ObjectExplorerEditingTargetStatusBar(ObjectExplorerEditingTargetWidget widget,
+                                               ObjectExplorerDataGrid grid)
+   {
+      widget_ = widget;
+      grid_ = grid;
+      
+      panel_ = new FlowPanel();
+      label_ = new Label(NO_SELECTION);
+      
+      panel_.setSize("100%", "100%");
+      panel_.addStyleName("rstudio-themes-background");
+      panel_.addStyleName(RES.styles().panel());
+      panel_.add(label_);
+      
+      label_.addStyleName(RES.styles().label());
+      
+      initWidget(panel_);
+      
+      initializeHandlers();
+   }
+   
+   public void setText(String text)
+   {
+      label_.setText(text);
+   }
+   
+   private void initializeHandlers()
+   {
+      grid_.addSelectionChangedHandler(new SelectionChangedHandler()
+      {
+         @Override
+         public void onSelectionChanged(SelectionChangedEvent event)
+         {
+            ObjectExplorerDataGrid.Data data = grid_.getCurrentSelection();
+            if (data == null)
+            {
+               label_.setText(NO_SELECTION);
+               return;
+            }
+            
+            String accessor = ObjectExplorerDataGrid.generateExtractingRCode(
+                  data,
+                  widget_.getHandle().getTitle());
+            
+            label_.setText(accessor);
+         }
+      });
+   }
+   
+   private final ObjectExplorerEditingTargetWidget widget_;
+   private final ObjectExplorerDataGrid grid_;
+   private final FlowPanel panel_;
+   private final Label label_;
+   
+   private static final String NO_SELECTION = "(No selection)";
+   
+   // Boilerplate ----
+
+   public interface Styles extends CssResource
+   {
+      String panel();
+      String label();
+   }
+
+   public interface Resources extends ClientBundle
+   {
+      @Source("ObjectExplorerEditingTargetStatusBar.css")
+      Styles styles();
+   }
+
+   private static final Resources RES = GWT.create(Resources.class);
+   static
+   {
+      RES.styles().ensureInjected();
+   }
+
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerEditingTargetWidget.java
@@ -54,6 +54,8 @@ public class ObjectExplorerEditingTargetWidget extends Composite
       toolbar_ = new EditingTargetToolbar(commands_, true);
       grid_ = new ObjectExplorerDataGrid(handle, document);
       resizePanel_ = new ResizeLayoutPanel();
+      statusBar_ = new ObjectExplorerEditingTargetStatusBar(this, grid_);
+      handle_ = handle;
       
       cbAttributes_ = new CheckBox();
       
@@ -144,13 +146,21 @@ public class ObjectExplorerEditingTargetWidget extends Composite
       });
       
       mainWidget_.setSize("100%", "100%");
+      mainWidget_.addSouth(statusBar_, 16);
       mainWidget_.add(resizePanel_);
+   }
+   
+   public ObjectExplorerHandle getHandle()
+   {
+      return handle_;
    }
    
    private final DockLayoutPanel mainWidget_;
    private final Toolbar toolbar_;
    private final ResizeLayoutPanel resizePanel_;
    private final ObjectExplorerDataGrid grid_;
+   private final ObjectExplorerEditingTargetStatusBar statusBar_;
+   private final ObjectExplorerHandle handle_;
    
    private final ToolbarButton refreshButton_;
    private final CheckBox cbAttributes_;


### PR DESCRIPTION
This PR implements a simple status bar for the object explorer, showing the R code that can be used to extract the currently selected node. `user-select` is explicitly set so that users can copy + paste the text as desired (in case the button for running the active code is not discoverable).

![screen shot 2017-06-28 at 3 14 13 pm](https://user-images.githubusercontent.com/1976582/27662845-78e59ed6-5c14-11e7-9321-b30c28182816.png)

