### PR TITLE
Avoid Javascript exception due to null websocket

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
@@ -313,7 +313,11 @@ public class TerminalSessionSocket
                requestCallback);
          break;
       case ConsoleProcessInfo.CHANNEL_WEBSOCKET:
-         socket_.send(input);
+         if (socket_ != null)
+            socket_.send(input);
+         else
+            diagnostic("Tried to send user input over null websocket");
+            
          requestCallback.onResponseReceived(null);
          break;
       case ConsoleProcessInfo.CHANNEL_PIPE:

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.views.terminal;
 
 import java.util.LinkedList;
 
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.Stopwatch;
 import org.rstudio.core.client.StringUtil;
@@ -254,7 +255,7 @@ public class TerminalSessionSocket
             @Override
             public void onError()
             {
-               diagnostic("WebSocket connect error, switching to RPC");
+               diagnosticError("WebSocket connect error, switching to RPC");
                socket_ = null;
                
                // Unable to connect client to server via websocket; let server
@@ -316,7 +317,7 @@ public class TerminalSessionSocket
          if (socket_ != null)
             socket_.send(input);
          else
-            diagnostic("Tried to send user input over null websocket");
+            diagnosticError("Tried to send user input over null websocket");
             
          requestCallback.onResponseReceived(null);
          break;
@@ -413,6 +414,12 @@ public class TerminalSessionSocket
    public String getLocalEchoDiagnostics()
    {
       return localEcho_.getDiagnostics();
+   }
+   
+   private void diagnosticError(String msg)
+   {
+      Debug.log(msg);
+      diagnostic(msg);
    }
    
    private void diagnostic(String msg)


### PR DESCRIPTION
During some unrelated debugging, got into a state where terminal websocket was disconnected and the null socket was being referenced, leading to an exception. Add a check, and log a message to the terminal diagnostics and the console.

Not sure how or if this can happen in normal usage, but best to avoid the exception and log the fact this happened.