### PR TITLE
Enable connections pane and trigger immediate indexing in dialog

### DIFF
--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -555,3 +555,8 @@ options(connectionObserver = list(
 
    .rs.scalar(error)
 })
+
+.rs.addJsonRpcHandler("connection_add_package", function(package) {
+   extensionPath <- system.file("rstudio/connections.dcf", package = package)
+   invisible(.Call("rs_connectionAddPackage", package, extensionPath))
+})

--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -244,12 +244,12 @@ options(connectionObserver = list(
       list(
          name = "ODBC",
          package = "odbc",
-         version = "1.0.1.9000"
+         version = "1.1.1"
       ),
       list(
          name = "Spark",
          package = "sparklyr",
-         version = "0.5.5"
+         version = "0.5.6"
       )
    )
 })

--- a/src/cpp/session/modules/connections/ConnectionsIndexer.cpp
+++ b/src/cpp/session/modules/connections/ConnectionsIndexer.cpp
@@ -279,6 +279,12 @@ core::json::Value connectionsRegistryAsJson()
    return connectionsRegistry().toJson();
 }
 
+void registerConnectionsRegistryEntry(std::string packageName, std::string extensionPath)
+{
+   FilePath extensionFilePath(extensionPath);
+   connectionsRegistry().add(packageName, extensionFilePath);
+}
+
 void registerConnectionsWorker()
 {
    ppe::indexer().addWorker(connectionsWorker());

--- a/src/cpp/session/modules/connections/ConnectionsIndexer.hpp
+++ b/src/cpp/session/modules/connections/ConnectionsIndexer.hpp
@@ -25,6 +25,7 @@ namespace connections {
 
 core::json::Value connectionsRegistryAsJson();
 void registerConnectionsWorker();
+void registerConnectionsRegistryEntry(std::string packageName, std::string extensionPath);
                        
 } // namespace connections
 } // namespace modules

--- a/src/cpp/session/modules/connections/SessionConnections.cpp
+++ b/src/cpp/session/modules/connections/SessionConnections.cpp
@@ -485,79 +485,6 @@ void connectionPreviewObject(const json::JsonRpcRequest& request,
    sendResponse(error, sexpResult, continuation, ERROR_LOCATION);
 }
 
-
-Error installSpark(const json::JsonRpcRequest& request,
-                   json::JsonRpcResponse* pResponse)
-{
-   // get params
-   std::string sparkVersion, hadoopVersion;
-   Error error = json::readParams(request.params,
-                                  &sparkVersion,
-                                  &hadoopVersion);
-   if (error)
-      return error;
-
-   // R binary
-   FilePath rProgramPath;
-   error = module_context::rScriptPath(&rProgramPath);
-   if (error)
-      return error;
-
-   // options
-   core::system::ProcessOptions options;
-   options.terminateChildren = true;
-   options.redirectStdErrToStdOut = true;
-
-   // build install command
-   boost::format fmt("sparklyr::spark_install('%1%', hadoop_version = '%2%', "
-                     "verbose = TRUE)");
-   std::string cmd = boost::str(fmt %
-                                 sparkVersion %
-                                 hadoopVersion);
-
-   // build args
-   std::vector<std::string> args;
-   args.push_back("--slave");
-   args.push_back("--vanilla");
-
-   // propagate R_LIBS
-   core::system::Options childEnv;
-   core::system::environment(&childEnv);
-   std::string libPaths = module_context::libPathsString();
-   if (!libPaths.empty())
-      core::system::setenv(&childEnv, "R_LIBS", libPaths);
-   options.environment = childEnv;
-
-
-   // for windows we need to forward setInternet2
-#ifdef _WIN32
-   if (!r::session::utils::isR3_3() && userSettings().useInternet2())
-      args.push_back("--internet2");
-#endif
-
-   args.push_back("-e");
-   args.push_back(cmd);
-
-   boost::shared_ptr<console_process::ConsoleProcessInfo> pCPI =
-         boost::make_shared<console_process::ConsoleProcessInfo>(
-            "Installing Spark " + sparkVersion,
-            console_process::InteractionNever);
-
-   // create and execute console process
-   boost::shared_ptr<console_process::ConsoleProcess> pCP;
-   pCP = console_process::ConsoleProcess::create(
-            string_utils::utf8ToSystem(rProgramPath.absolutePath()),
-            args,
-            options,
-            pCPI);
-
-   // return console process
-   pResponse->setResult(pCP->toJson());
-   return Success();
-}
-
-
-
 // track whether connections were enabled at the start of this R session
 bool s_connectionsInitiallyEnabled = false;
 
@@ -609,6 +536,15 @@ Error handleConnectionsResourceRequest(const http::Request& request,
 
 } // anonymous namespace
 
+SEXP rs_connectionAddPackage(SEXP packageSEXP, SEXP extensionSEXP)
+{
+   std::string packageName = r::sexp::safeAsString(packageSEXP);
+   std::string extensionPath = r::sexp::safeAsString(extensionSEXP);
+
+   registerConnectionsRegistryEntry(packageName, extensionPath);
+
+   return R_NilValue;
+}
 
 bool connectionsEnabled()
 {
@@ -644,6 +580,7 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_availableRemoteServers, 0);
    RS_REGISTER_CALL_METHOD(rs_availableConnections, 0);
    RS_REGISTER_CALL_METHOD(rs_connectionIcon, 1);
+   RS_REGISTER_CALL_METHOD(rs_connectionAddPackage, 2);
 
    // initialize environment
    initEnvironment();
@@ -674,7 +611,6 @@ Error initialize()
       (bind(registerIdleOnlyAsyncRpcMethod, "connection_list_objects", connectionListObjects))
       (bind(registerIdleOnlyAsyncRpcMethod, "connection_list_fields", connectionListFields))
       (bind(registerIdleOnlyAsyncRpcMethod, "connection_preview_object", connectionPreviewObject))
-      (bind(registerRpcMethod, "install_spark", installSpark))
       (bind(module_context::registerUriHandler, "/" kConnectionsPath, 
             handleConnectionsResourceRequest))
       (bind(sourceModuleRFile, "SessionConnections.R"));

--- a/src/cpp/session/modules/connections/SessionConnections.cpp
+++ b/src/cpp/session/modules/connections/SessionConnections.cpp
@@ -612,8 +612,7 @@ Error handleConnectionsResourceRequest(const http::Request& request,
 
 bool connectionsEnabled()
 {
-   return module_context::isPackageVersionInstalled("sparklyr", "0.5.5") ||
-          module_context::isPackageVersionInstalled("odbc", "1.0.1.9000");
+   return true;
 }
 
 bool activateConnections()

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -5190,6 +5190,15 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, STOP_SHINY_APP, params, true, callback);
    }
 
+   @Override
+   public void connectionAddPackage(String packageName,
+                                    ServerRequestCallback<Void> callback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(packageName));
+      sendRequest(RPC_SCOPE, CONNECTION_ADD_PACKAGE, params, callback);
+   }
+
    private String clientId_;
    private String clientVersion_ = "";
    private boolean listeningForEvents_;
@@ -5599,4 +5608,7 @@ public class RemoteServer implements Server
    private static final String RSTUDIOAPI_SHOW_DIALOG_COMPLETED = "rstudioapi_show_dialog_completed";
 
    private static final String STOP_SHINY_APP = "stop_shiny_app";
+
+   private static final String CONNECTION_ADD_PACKAGE = "connection_add_package";
+
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/ConnectionsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/ConnectionsServerOperations.java
@@ -58,4 +58,7 @@ public interface ConnectionsServerOperations extends CryptoServerOperations
 
    void connectionTest(String code, 
                        ServerRequestCallback<String> callback);
+
+   void connectionAddPackage(String packageName, 
+                             ServerRequestCallback<Void> callback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionInstallPackagePage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionInstallPackagePage.java
@@ -94,6 +94,7 @@ public class NewConnectionInstallPackagePage
                      public void onError(ServerError error)
                      {
                         Debug.logError(error);
+                        wizard.closeDialog();
                      }
                   });
                }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionInstallPackagePage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionInstallPackagePage.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.connections.ui;
 
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.resources.ImageResourceUrl;
 import org.rstudio.core.client.widget.ModalDialogBase;
@@ -22,8 +23,12 @@ import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.WizardPage;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.dependencies.DependencyManager;
+import org.rstudio.studio.client.server.ServerError;
+import org.rstudio.studio.client.server.ServerRequestCallback;
+import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.views.connections.ConnectionsPresenter;
 import org.rstudio.studio.client.workbench.views.connections.model.ConnectionOptions;
+import org.rstudio.studio.client.workbench.views.connections.model.ConnectionsServerOperations;
 import org.rstudio.studio.client.workbench.views.connections.model.NewConnectionContext;
 import org.rstudio.studio.client.workbench.views.connections.model.NewConnectionContext.NewConnectionInfo;
 
@@ -56,10 +61,12 @@ public class NewConnectionInstallPackagePage
 
    @Inject
    private void initialize(DependencyManager dependencyManager,
-                           ConnectionsPresenter connectionsPresenter)
+                           ConnectionsPresenter connectionsPresenter,
+                           ConnectionsServerOperations server)
    {
       dependencyManager_ = dependencyManager;
       connectionsPresenter_ = connectionsPresenter;
+      server_ = server;
    }
 
    @Override
@@ -74,8 +81,21 @@ public class NewConnectionInstallPackagePage
                @Override
                public void execute()
                {
-                  wizard.closeDialog();
-                  connectionsPresenter_.onNewConnection();
+                  server_.connectionAddPackage(info_.getPackage(), new ServerRequestCallback<Void>()
+                  {
+                     @Override
+                     public void onResponseReceived(Void empty)
+                     {
+                        wizard.closeDialog();
+                        connectionsPresenter_.onNewConnection();
+                     }
+                     
+                     @Override
+                     public void onError(ServerError error)
+                     {
+                        Debug.logError(error);
+                     }
+                  });
                }
             }
       );
@@ -118,4 +138,5 @@ public class NewConnectionInstallPackagePage
    private NewConnectionInfo info_;
    private DependencyManager dependencyManager_;
    private ConnectionsPresenter connectionsPresenter_;
+   private ConnectionsServerOperations server_;
 }


### PR DESCRIPTION
- `ODBC` and `sparklyr` are both now on CRAN; therefore, we can enable the Connections pane.
- "Create Connection" followed by ODBC or sparklyr triggers the installation page; however, package indexing does not trigger fast enough and the dialog was not opening with the new connections, fixed.

