### PR TITLE
Assorted terminal fixes and cleanup

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
@@ -57,7 +57,8 @@ public class TerminalInfoDialog extends ModalDialogBase
       diagnostics.append("Sequence:    '" + session.getSequence() + "'\n");
       diagnostics.append("Restarted:   '" + session.getRestarted() + "\n");
       diagnostics.append("Busy:        '" + session.getHasChildProcs() + "'\n");
-      diagnostics.append("Alt-Buffer:  '" + session.altBufferActive() + "'\n");
+      diagnostics.append("Full screen: 'client=" + session.altBufferActive() +  
+            "/server=" + session.getAltBufferActive() + "'\n"); 
       diagnostics.append("Zombie:      '" + session.getZombie() + "'\n");
       diagnostics.append("Track Env    '" + session.getTrackEnv() + "'\n");
       diagnostics.append("Local-echo:  '" + localEchoEnabled + "'\n"); 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
@@ -57,7 +57,7 @@ public class TerminalInfoDialog extends ModalDialogBase
       diagnostics.append("Sequence:    '" + session.getSequence() + "'\n");
       diagnostics.append("Restarted:   '" + session.getRestarted() + "\n");
       diagnostics.append("Busy:        '" + session.getHasChildProcs() + "'\n");
-      diagnostics.append("Full screen: 'client=" + session.altBufferActive() +  
+      diagnostics.append("Full screen: 'client=" + session.xtermAltBufferActive() +  
             "/server=" + session.getAltBufferActive() + "'\n"); 
       diagnostics.append("Zombie:      '" + session.getZombie() + "'\n");
       diagnostics.append("Track Env    '" + session.getTrackEnv() + "'\n");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -191,7 +191,7 @@ public class TerminalPane extends WorkbenchPane
                }
                else
                {
-                  if (!visibleTerminal.altBufferActive())
+                  if (!visibleTerminal.xtermAltBufferActive())
                   {
                      // not running a full-screen program
                      interruptable = true;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -85,6 +85,7 @@ public class TerminalSession extends XTermWidget
       cwd_ = info.getCwd();
       autoCloseMode_ = info.getAutoCloseMode();
       zombie_ = info.getZombie();
+      restarted_ = info.getRestarted();
       trackEnv_ = info.getTrackEnv();
       
       setTitle(info.getTitle());
@@ -154,8 +155,11 @@ public class TerminalSession extends XTermWidget
                return;
             } 
             
+            // Extract properties so they are available even if the terminal goes offline, which
+            // causes consoleProcess_ to become null.
             cols_ = consoleProcess_.getProcessInfo().getCols();
             rows_ = consoleProcess_.getProcessInfo().getRows();
+            restarted_ = consoleProcess_.getProcessInfo().getRestarted();
             trackEnv_ = consoleProcess_.getProcessInfo().getTrackEnv();
 
             addHandlerRegistration(addResizeTerminalHandler(TerminalSession.this));
@@ -599,7 +603,7 @@ public class TerminalSession extends XTermWidget
     */
    public boolean getRestarted()
    {
-      return consoleProcess_.getProcessInfo().getRestarted();
+      return restarted_;
    }
 
    /**
@@ -911,6 +915,7 @@ public class TerminalSession extends XTermWidget
    private String cwd_; 
    private int autoCloseMode_;
    private boolean zombie_; // process closed but UI kept alive
+   private boolean restarted_;
    private boolean trackEnv_;
 
    // Injected ---- 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
@@ -120,7 +120,11 @@ public class XTermNative extends JavaScriptObject
       this.write("\x1b[?1047l"); // show primary buffer
       this.write("\x1b[m"); // reset all visual attributes
    }-*/;
-   
+
+   public final native void showAltBuffer() /*-{
+      this.write("\x1b[?1047h"); // show alt buffer
+   }-*/;
+    
    public final native String currentLine() /*-{
       lineBuf = this.lines.get(this.y + this.ybase);
       if (!lineBuf) // resize may be in progress

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -296,7 +296,7 @@ public class XTermWidget extends Widget implements RequiresResize,
     */
    public boolean cursorAtEOL()
    {
-      if (altBufferActive())
+      if (xtermAltBufferActive())
       {
          return false;
       }
@@ -329,7 +329,7 @@ public class XTermWidget extends Widget implements RequiresResize,
     * Is the terminal showing the alternate full-screen buffer?
     * @return true if full-screen buffer is active
     */
-   public boolean altBufferActive()
+   public boolean xtermAltBufferActive()
    {
       return terminal_.altBufferActive();
    }
@@ -341,7 +341,15 @@ public class XTermWidget extends Widget implements RequiresResize,
    {
       terminal_.showPrimaryBuffer();
    }
-   
+
+   /**
+    * Switch terminal to alt-buffer
+    */
+   public void showAltBuffer()
+   {
+      terminal_.showAltBuffer();
+   }
+    
    public static boolean isXTerm(Element el)
    {
       while (el != null)


### PR DESCRIPTION
Fix: when a full-screen program is running in a terminal, and you refresh the browser, that terminal started showing the full-screen program in the regular buffer. If you then exited the full-screen program, you didn't see what you expected. Fixed by detecting this and sending the sequence to switch back to alt-buffer after reloading the regular buffer.

Fix: when session suspended, trying to show the terminal diagnostics dialog was a no-op due to an exception. Fixed by making `TerminalSession` object more consistent in how it extracts and stores metadata for the suspended/disconnected case

Tweak: in Terminal Diagnostics dialog, show both the last-known server state for alt-buffer flag, as well as the current client-side alt-buffer flag

Tweak: rename `XTermWidget.altBufferActive` method to `xtermAltBufferActive` to make it more obvious it's different than the similar server-side accessor method