### PR TITLE
New command sends entire terminal buffer to new editor buffer

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/AnsiCode.java
+++ b/src/gwt/src/org/rstudio/core/client/AnsiCode.java
@@ -632,6 +632,16 @@ public class AnsiCode
                   .replace("\t", "<TAB>");
    }
 
+   public static String prettyPrintNonCRLF(String input)
+   {
+      // not efficient but only intended for debug/unit testing
+      return input.replace("\u001b", "<ESC>")
+                  .replace("\7", "<BEL>")
+                  .replace("\177", "<DEL>")
+                  .replace("\b", "<BS>");
+   }
+
+
    // Control characters handled by R console, plus leading character of
    // ANSI escape sequences
    public static final String CONTROL_REGEX = "[\r\b\f\n\u001b\u009b]";

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -993,6 +993,7 @@ public class Application implements ApplicationEventHandlers
       commands_.nextTerminal().remove();
       commands_.showTerminalInfo().remove();
       commands_.interruptTerminal().remove();
+      commands_.sendTerminalToEditor().remove();
    }
 
    private final ApplicationView view_ ;

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcess.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcess.java
@@ -371,7 +371,12 @@ public class ConsoleProcess implements ConsoleOutputEvent.HasHandlers,
    {
       server_.processGetBufferChunk(procInfo_.getHandle(), chunk, requestCallback);
    }
-   
+
+   public void getTerminalBuffer(boolean stripAnsiCodes, ServerRequestCallback<ProcessBufferChunk> requestCallback)
+   {
+      server_.processGetBuffer(procInfo_.getHandle(), stripAnsiCodes, requestCallback);
+   }
+    
    public void useRpcMode(ServerRequestCallback<Void> requestCallback)
    {
       forceRpc_ = true;

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -714,6 +714,17 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, PROCESS_GET_BUFFER_CHUNK, params, requestCallback);
    }
 
+   @Override
+   public void processGetBuffer(String handle,
+                                boolean stripAnsiCodes,
+                                ServerRequestCallback<ProcessBufferChunk> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(StringUtil.notNull(handle)));
+      params.set(1,  JSONBoolean.getInstance(stripAnsiCodes));
+      sendRequest(RPC_SCOPE, PROCESS_GET_BUFFER, params, requestCallback);
+   }
+
    @Override 
    public void processUseRpc(String handle,
                              ServerRequestCallback<Void> requestCallback)
@@ -5280,6 +5291,7 @@ public class RemoteServer implements Server
    private static final String PROCESS_SET_TITLE = "process_set_title";
    private static final String PROCESS_ERASE_BUFFER = "process_erase_buffer";
    private static final String PROCESS_GET_BUFFER_CHUNK = "process_get_buffer_chunk";
+   private static final String PROCESS_GET_BUFFER = "process_get_buffer";
    private static final String PROCESS_USE_RPC = "process_use_rpc";
    private static final String PROCESS_TEST_EXISTS = "process_test_exists";
    private static final String PROCESS_NOTIFY_VISIBLE = "process_notify_visible";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -434,6 +434,7 @@ well as menu structures (for main menu and popup menus).
             <cmd refid="newTerminal"/>
             <separator/>
             <cmd refid="renameTerminal"/>
+            <cmd refid="sendTerminalToEditor"/>
             <cmd refid="showTerminalInfo"/>
             <separator/>
             <cmd refid="activateTerminal"/>
@@ -2462,20 +2463,20 @@ well as menu structures (for main menu and popup menus).
         windowMode="main"/>
         
    <cmd id="renameTerminal"
-        label="Rename Current Terminal"
-        menuLabel="_Rename Current Terminal"
+        label="Rename Terminal"
+        menuLabel="_Rename Terminal"
         desc="Change terminal session name"/>
 
    <cmd id="closeTerminal"
    	    buttonLabel=""
-        label="Close Current Terminal"
-        menuLabel="Cl_ose Current Terminal"
+        label="Close Terminal"
+        menuLabel="Cl_ose Terminal"
         desc="Close current terminal session"/>
 
    <cmd id="clearTerminalScrollbackBuffer"
         buttonLabel=""
-        label="Clear Current Terminal"
-        menuLabel="_Clear Current Terminal"
+        label="Clear Terminal Buffer"
+        menuLabel="_Clear Terminal Buffer"
         desc="Clear terminal"/>
 
    <cmd id="previousTerminal"
@@ -2487,20 +2488,26 @@ well as menu structures (for main menu and popup menus).
    <cmd id="nextTerminal"
         label="Next Terminal"
         buttonLabel=""
-        menuLabel="_Next Terminal"
+        menuLabel="Ne_xt Terminal"
         desc="Show next terminal"/>
 
    <cmd id="showTerminalInfo"
         label="Terminal Diagnostics..."
         buttonLabel=""
         menuLabel="Terminal _Diagnostics..."
-        desc="Show Info on Current Terminal"/>
+        desc="Show info on current terminal"/>
 
    <cmd id="interruptTerminal"
         buttonLabel=""
-        label="Interrupt Current Terminal"
+        label="Send Interrupt"
         menuLabel="_Interrupt Current Terminal"
         desc="Send Ctrl+C to Current Terminal"/>
+
+   <cmd id="sendTerminalToEditor"
+        label="Copy Terminal to Editor"
+        buttonLabel=""
+        menuLabel="Copy Terminal to New _Editor Tab"
+        desc="Copy current terminal's buffer to a new editor buffer"/>
  
    <cmd id="browseAddins"
         label="Browse Addins"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -394,6 +394,7 @@ public abstract class
    public abstract AppCommand nextTerminal();
    public abstract AppCommand showTerminalInfo();
    public abstract AppCommand interruptTerminal();
+   public abstract AppCommand sendTerminalToEditor();
     
    // Help
    public abstract AppCommand helpBack();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/model/ConsoleServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/model/ConsoleServerOperations.java
@@ -58,7 +58,11 @@ public interface ConsoleServerOperations extends CodeToolsServerOperations,
    void processGetBufferChunk(String handle,
                               int chunk,
                               ServerRequestCallback<ProcessBufferChunk> requestCallback);
-   
+
+   void processGetBuffer(String handle,
+                         boolean stripAnsiCodes,
+                         ServerRequestCallback<ProcessBufferChunk> requestCallback);
+    
    /**
     * Switch a server process to use Rpc mode after failing to connect to
     * non-rpc channel such as websocket.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
@@ -95,9 +95,10 @@ public class TerminalInfoDialog extends ModalDialogBase
          }
       }));
       
-      addLeftButton(new ThemedButton("Append Buffer", new ClickHandler() {
+      appendBufferButton_ = new ThemedButton("Append Buffer", new ClickHandler() {
          @Override
          public void onClick(ClickEvent event) {
+            appendBufferButton_.setEnabled(false);
             diagnostics.append("\n\nTerminal Buffer\n---------------\n");
             session.getBuffer(false /*stripAnsiCodes*/, new ResultCallback<String, String>()
             {
@@ -106,6 +107,8 @@ public class TerminalInfoDialog extends ModalDialogBase
                {
                   diagnostics.append(AnsiCode.prettyPrintNonCRLF(buffer));
                   textArea_.setText(diagnostics.toString());
+                  textArea_.setCursorPos(diagnostics.toString().length());
+                  textArea_.getElement().setScrollTop(textArea_.getElement().getScrollHeight());
                }
                
                @Override
@@ -116,7 +119,9 @@ public class TerminalInfoDialog extends ModalDialogBase
                }
             });
          }
-      }));
+      });
+      addLeftButton(appendBufferButton_);
+      
    }
 
    @Inject
@@ -133,6 +138,7 @@ public class TerminalInfoDialog extends ModalDialogBase
    }
    
    TextArea textArea_;
+   ThemedButton appendBufferButton_;
 
    // Injected ---- 
    private UIPrefs uiPrefs_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
@@ -108,6 +108,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
          }
          addSeparator();
          addItem(commands_.renameTerminal().createMenuItem(false));
+         addItem(commands_.sendTerminalToEditor().createMenuItem(false));
          addItem(commands_.showTerminalInfo().createMenuItem(false));
          addSeparator();
          addItem(commands_.previousTerminal().createMenuItem(false));
@@ -162,6 +163,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
       commands_.interruptTerminal().setEnabled(haveActiveTerminal);
       commands_.previousTerminal().setEnabled(getPreviousTerminalHandle() != null);
       commands_.nextTerminal().setEnabled(getNextTerminalHandle() != null);
+      commands_.sendTerminalToEditor().setEnabled(haveActiveTerminal);
       
       // inform server of the selection
       server_.processNotifyVisible(activeTerminalHandle_, new ServerRequestCallback<Void>() {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -894,6 +894,25 @@ public class TerminalSession extends XTermWidget
       return trackEnv_;
    }
    
+   public void getBuffer(final boolean stripAnsiCodes, final ResultCallback<String, String> callback)
+   {
+      consoleProcess_.getTerminalBuffer(stripAnsiCodes, new ServerRequestCallback<ProcessBufferChunk>()
+      {
+         @Override
+         public void onResponseReceived(final ProcessBufferChunk chunk)
+         {
+            String buffer = chunk.getChunk();
+            callback.onSuccess(buffer);
+         }
+
+         @Override
+         public void onError(ServerError error)
+         {
+            Debug.logError(error);
+         }
+      });
+   }
+   
    private HandlerRegistrations registrations_ = new HandlerRegistrations();
    private TerminalSessionSocket socket_;
    private ConsoleProcess consoleProcess_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTab.java
@@ -74,6 +74,9 @@ public class TerminalTab extends DelayLoadWorkbenchTab<TerminalTabPresenter>
       @Handler
       public abstract void onInterruptTerminal();
 
+      @Handler
+      public abstract void onSendTerminalToEditor();
+
       abstract void initialize();
       abstract void confirmClose(Command onConfirmed);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
@@ -112,6 +112,11 @@ public class TerminalTabPresenter extends BusyPresenter
        * @param caption
        */
       void activateNamedTerminal(String caption);
+      
+      /**
+       * Send current terminal's buffer to a new editor buffer.
+       */
+      void sendTerminalToEditor();
    }
 
    @Inject
@@ -180,6 +185,12 @@ public class TerminalTabPresenter extends BusyPresenter
    public void onInterruptTerminal()
    {
       view_.interruptTerminal();
+   }
+   
+   @Handler
+   public void onSendTerminalToEditor()
+   {
+      view_.sendTerminalToEditor();
    }
 
    public void initialize()


### PR DESCRIPTION
Terminal dropdown menu now has command "Copy Terminal to New Editor Tab" which sends entire content of current terminal's buffer to a new editor buffer.

This is mainly a workaround for xterm.js lack of scrolling mouse select (i.e. selecting more than will fit on visible display) and lack of Select All / Copy.

Ansi codes are stripped out of the resulting editor buffer. At the moment backspaces are not, so you'll see some red dots in the editor. I'll look at cleaning this up separately.

Also added button to Terminal Diagnostics dialog to append the buffer to the diagnostics text, with Ansi codes preserved (and some pretty-print done, such as <ESC> for raw esc characters).