### PR TITLE
APIs for getting, setting clipboard contents

### DIFF
--- a/src/cpp/desktop-mac/GwtCallbacks.mm
+++ b/src/cpp/desktop-mac/GwtCallbacks.mm
@@ -359,6 +359,19 @@ private:
    [self performClipboardAction: @selector(paste:)];
 }
 
+- (void) setClipboardText: (NSString*) text
+{
+   NSPasteboard* pasteboard = [NSPasteboard generalPasteboard];
+   [pasteboard declareTypes: [NSArray arrayWithObject: NSStringPboardType] owner: nil];
+   [pasteboard setString: text forType: NSStringPboardType];
+}
+
+- (NSString*) getClipboardText
+{
+   NSPasteboard* pasteboard = [NSPasteboard generalPasteboard];
+   return [pasteboard stringForType: NSStringPboardType];
+}
+
 - (NSString*) getUriForPath: (NSString*) path
 {
    NSURL* url = [NSURL fileURLWithPath: resolveAliasedPath(path)];

--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -372,6 +372,18 @@ void GwtCallback::clipboardPaste()
    doAction(QKeySequence::Paste);
 }
 
+void GwtCallback::setClipboardText(QString text)
+{
+   QClipboard* pClipboard = QApplication::clipboard();
+   pClipboard->setText(text, QClipboard::Clipboard);
+}
+
+QString GwtCallback::getClipboardText()
+{
+   QClipboard* pClipboard = QApplication::clipboard();
+   return pClipboard->text(QClipboard::Clipboard);
+}
+
 void GwtCallback::setGlobalMouseSelection(QString selection)
 {
     QClipboard* clipboard = QApplication::clipboard();

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -76,9 +76,13 @@ public slots:
 
    void undo(bool forAce);
    void redo(bool forAce);
+
    void clipboardCut();
    void clipboardCopy();
    void clipboardPaste();
+
+   void setClipboardText(QString text);
+   QString getClipboardText();
 
    void setGlobalMouseSelection(QString selection);
    QString getGlobalMouseSelection();

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -45,11 +45,17 @@ public interface DesktopFrame extends JavaScriptPassthrough
    
    void undo(boolean forAce);
    void redo(boolean forAce);
+   
    void clipboardCut();
    void clipboardCopy();
    void clipboardPaste();
+   
+   void setClipboardText(String text);
+   String getClipboardText();
+   
    void setGlobalMouseSelection(String selection);
    String getGlobalMouseSelection();
+   
    String getUriForPath(String path);
    void onWorkbenchInitialized(String scratchDir);
    void showFolder(String path);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -485,17 +485,20 @@ public class AceEditor implements DocDisplay,
          return;
       
       Position cursorPos = getCursorPosition();
-      setSelectionRange(Range.fromPoints(
+      Range yankRange = Range.fromPoints(
             Position.create(cursorPos.getRow(), 0),
-            cursorPos));
+            cursorPos);
       
       if (Desktop.isDesktop() && isEmacsModeOn())
       {
-         Desktop.getFrame().clipboardCut();
+         String text = getTextForRange(yankRange);
+         Desktop.getFrame().setClipboardText(text);
+         replaceRange(yankRange, "");
          clearEmacsMark();
       }
       else
       {
+         setSelectionRange(yankRange);
          yankedText_ = getSelectionValue();
          replaceSelection("");
       }
@@ -507,6 +510,7 @@ public class AceEditor implements DocDisplay,
          return;
       
       Position cursorPos = getCursorPosition();
+      Range yankRange = null;
       String line = getLine(cursorPos.getRow());
       int lineLength = line.length();
       
@@ -516,24 +520,27 @@ public class AceEditor implements DocDisplay,
       String rest = line.substring(cursorPos.getColumn());
       if (rest.trim().isEmpty())
       {
-         setSelectionRange(Range.fromPoints(
+         yankRange = Range.fromPoints(
                cursorPos,
-               Position.create(cursorPos.getRow() + 1, 0)));
+               Position.create(cursorPos.getRow() + 1, 0));
       }
       else
       {
-         setSelectionRange(Range.fromPoints(
+         yankRange = Range.fromPoints(
                cursorPos,
-               Position.create(cursorPos.getRow(), lineLength)));
+               Position.create(cursorPos.getRow(), lineLength));
       }
       
       if (Desktop.isDesktop() && isEmacsModeOn())
       {
-         Desktop.getFrame().clipboardCut();
+         String text = getTextForRange(yankRange);
+         Desktop.getFrame().setClipboardText(text);
+         replaceRange(yankRange, "");
          clearEmacsMark();
       }
       else
       {
+         setSelectionRange(yankRange);
          yankedText_ = getSelectionValue();
          replaceSelection("");
       }


### PR DESCRIPTION
This PR adds `getClipboardText()`, `setClipboardText()` APIs for interacting with the system clipboard.

This is added primarily to better handle the 'yank before' and 'yank after' commands -- currently, because yanks are implemented in this way:

1. Select a range,
2. Invoke the system cut command

there is the potential for a perceptible delay between steps 1. and 2. above, causing a brief selection 'flash' during the yank attempt. This PR removes that selection flash by sending the yanked text to the server, and only deleting text on the client side (rather than selecting and then later deleting)