### PR TITLE
Warn before killing active terminals

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
@@ -1,7 +1,7 @@
 /*
  * ApplicationQuit.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -62,6 +62,7 @@ import org.rstudio.studio.client.workbench.views.console.events.ConsoleRestartRC
 import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
 import org.rstudio.studio.client.workbench.views.source.Source;
 import org.rstudio.studio.client.workbench.views.source.SourceShim;
+import org.rstudio.studio.client.workbench.views.terminal.TerminalHelper;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
@@ -87,7 +88,8 @@ public class ApplicationQuit implements SaveActionChangedHandler,
                           SourceShim sourceShim,
                           Provider<UIPrefs> pUiPrefs,
                           Commands commands,
-                          Binder binder)
+                          Binder binder,
+                          TerminalHelper terminalHelper)
    {
       // save references
       server_ = server;
@@ -96,6 +98,7 @@ public class ApplicationQuit implements SaveActionChangedHandler,
       workbenchContext_ = workbenchContext;
       sourceShim_ = sourceShim;
       pUiPrefs_ = pUiPrefs;
+      terminalHelper_ = terminalHelper;
       
       // bind to commands
       binder.bind(commands, this);
@@ -126,13 +129,13 @@ public class ApplicationQuit implements SaveActionChangedHandler,
                               final boolean forceSaveAll,
                               final QuitContext quitContext)
    {
-      boolean busy = workbenchContext_.isServerBusy() || workbenchContext_.isTerminalBusy();
+      boolean busy = workbenchContext_.isServerBusy() || terminalHelper_.isTerminalBusy();
       String msg = null;
       if (busy)
       {
-         if (workbenchContext_.isServerBusy() && !workbenchContext_.isTerminalBusy())
+         if (workbenchContext_.isServerBusy() && !terminalHelper_.isTerminalBusy())
             msg = "The R session is currently busy.";
-         else if (workbenchContext_.isServerBusy() && workbenchContext_.isTerminalBusy())
+         else if (workbenchContext_.isServerBusy() && terminalHelper_.isTerminalBusy())
             msg = "The R session and the terminal are currently busy.";
          else 
             msg = "The terminal is currently busy.";
@@ -460,11 +463,17 @@ public class ApplicationQuit implements SaveActionChangedHandler,
    @Handler
    public void onRestartR()
    {   
-      boolean saveChanges = saveAction_.getAction() != SaveAction.NOSAVE;
-      eventBus_.fireEvent(new SuspendAndRestartEvent(
-                                 SuspendOptions.createSaveMinimal(saveChanges),
-                                 null));  
-
+      terminalHelper_.warnBusyTerminalBeforeCommand(new Command() 
+      {
+         @Override
+         public void execute()
+         {
+            boolean saveChanges = saveAction_.getAction() != SaveAction.NOSAVE;
+            eventBus_.fireEvent(new SuspendAndRestartEvent(
+                  SuspendOptions.createSaveMinimal(saveChanges),
+                  null));  
+         }
+      }, "Restart R", "Terminal jobs will be terminated. Are you sure?");
    }
    
    @Handler
@@ -800,7 +809,7 @@ public class ApplicationQuit implements SaveActionChangedHandler,
    private final EventBus eventBus_;
    private final WorkbenchContext workbenchContext_;
    private final SourceShim sourceShim_;
-   
+   private final TerminalHelper terminalHelper_;
    private SaveAction saveAction_ = SaveAction.saveAsk();
 
    private boolean suspendingAndRestarting_ = false;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/WorkbenchContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/WorkbenchContext.java
@@ -1,7 +1,7 @@
 /*
  * WorkbenchContext.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -27,7 +27,6 @@ import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.SessionInfo;
 import org.rstudio.studio.client.workbench.views.console.events.WorkingDirChangedEvent;
 import org.rstudio.studio.client.workbench.views.console.events.WorkingDirChangedHandler;
-import org.rstudio.studio.client.workbench.views.terminal.events.TerminalBusyEvent;
 import org.rstudio.studio.client.workbench.views.vcs.git.model.GitState;
 
 import com.google.gwt.user.client.Timer;
@@ -110,20 +109,7 @@ public class WorkbenchContext
             rVersionsInfo_ = event.getRVersionsInfo();
          }
       });
-      
-      // track busy terminals
-      eventBus.addHandler(TerminalBusyEvent.TYPE,
-                          new TerminalBusyEvent.Handler()
-      {
-         @Override
-         public void onTerminalBusy(TerminalBusyEvent event)
-         {
-            isTerminalBusy_ = event.isBusy();
-         }
-      });
    }
-   
-  
   
    public FileSystemItem getCurrentWorkingDir()
    {
@@ -223,11 +209,6 @@ public class WorkbenchContext
       return isServerBusy_;
    }
    
-   public boolean isTerminalBusy()
-   {
-      return isTerminalBusy_;
-   }
-   
    public boolean isRestartInProgress()
    {
       return isRestartInProgress_;
@@ -262,7 +243,6 @@ public class WorkbenchContext
    }
    
    private boolean isServerBusy_ = false;
-   private boolean isTerminalBusy_ = false;
    private boolean isRestartInProgress_ = false;
    private boolean isBuildInProgress_ = false;
    private FileSystemItem currentWorkingDir_ = FileSystemItem.home();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
@@ -347,11 +347,11 @@ public class BuildPresenter extends BasePresenter
       // attempt to start a build (this will be a silent no-op if there
       // is already a build running)
       final String caption = "Build";
-      workbenchContext_.setBuildInProgress(true);
       terminalHelper_.warnBusyTerminalBeforeCommand(new Command() {
          @Override
          public void execute()
          {
+            workbenchContext_.setBuildInProgress(true);
             sourceBuildHelper_.withSaveFilesBeforeCommand(new Command() {
                @Override
                public void execute()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalHelper.java
@@ -1,0 +1,86 @@
+/*
+ * TerminalHelper.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.terminal;
+
+import org.rstudio.core.client.widget.MessageDialog;
+import org.rstudio.core.client.widget.Operation;
+import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.workbench.views.terminal.events.TerminalBusyEvent;
+
+import com.google.gwt.user.client.Command;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+@Singleton
+public class TerminalHelper
+{
+   @Inject
+   TerminalHelper(EventBus events,
+                  GlobalDisplay globalDisplay)
+   {
+      events_ = events;
+      globalDisplay_ = globalDisplay;
+      
+      // track busy terminals
+      events_.addHandler(TerminalBusyEvent.TYPE,
+                          new TerminalBusyEvent.Handler()
+      {
+         @Override
+         public void onTerminalBusy(TerminalBusyEvent event)
+         {
+            isTerminalBusy_ = event.isBusy();
+         }
+      });
+   }
+   
+   /**
+    * @return true if one or more terminals have child processes
+    */
+   public boolean isTerminalBusy()
+   {
+      return isTerminalBusy_;
+   }
+
+   public void warnBusyTerminalBeforeCommand(final Command command, 
+                                             String caption,
+                                             String question)
+   {
+      if (!isTerminalBusy())
+      {
+         command.execute();
+         return;
+      }
+      
+      globalDisplay_.showYesNoMessage(
+            MessageDialog.QUESTION,
+            caption, 
+            "The terminal is currently busy. " + question,
+            new Operation() {
+               @Override
+               public void execute()
+               {
+                  command.execute();
+               }}, 
+            true);
+   }
+   
+   private boolean isTerminalBusy_;
+
+   // Injected ----  
+   private GlobalDisplay globalDisplay_;
+   private EventBus events_;
+ }


### PR DESCRIPTION
There was no warning before killing busy terminals via "Restart R", "Build and Reload", or "Clean and  Rebuild".

Received enough feedback to suggest users are quite surprised that these operations kill the terminal processes, and I'm worried they could lose work in the form of long-running jobs, so added warnings.