### PR TITLE
re-focus source window if zoomed after render

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinModule.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinModule.java
@@ -112,6 +112,7 @@ import org.rstudio.studio.client.workbench.model.WorkbenchListsServerOperations;
 import org.rstudio.studio.client.workbench.model.WorkbenchServerOperations;
 import org.rstudio.studio.client.workbench.prefs.model.PrefsServerOperations;
 import org.rstudio.studio.client.workbench.snippets.SnippetServerOperations;
+import org.rstudio.studio.client.workbench.ui.PaneManager;
 import org.rstudio.studio.client.workbench.ui.WorkbenchScreen;
 import org.rstudio.studio.client.workbench.ui.WorkbenchTab;
 import org.rstudio.studio.client.workbench.views.buildtools.BuildPresenter;
@@ -243,6 +244,7 @@ public class RStudioGinModule extends AbstractGinModule
       bind(ProfilerPresenter.class).in(Singleton.class);
       bind(ObjectExplorerPresenter.class).asEagerSingleton();
       bind(WorkbenchContext.class).asEagerSingleton();
+      bind(PaneManager.class).in(Singleton.class);
       bind(DependencyManager.class).asEagerSingleton();
       bind(WorkbenchListManager.class).asEagerSingleton();
       bind(ApplicationQuit.class).asEagerSingleton();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -29,6 +29,7 @@ import com.google.gwt.user.client.ui.SplitterResizedEvent;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 
 import org.rstudio.core.client.Debug;
@@ -77,6 +78,7 @@ import java.util.List;
  * TODO: Push client state when selected tab or layout changes
  */
 
+@Singleton
 public class PaneManager
 {
    public interface Binder extends CommandBinder<Commands, PaneManager> {}
@@ -887,6 +889,11 @@ public class PaneManager
          return;
       
       toggleWindowZoom(parentWindow, tab);
+   }
+   
+   public LogicalWindow getZoomedWindow()
+   {
+      return maximizedWindow_;
    }
 
    public ConsolePane getConsole()


### PR DESCRIPTION
This PR re-zooms the Source window after a successful document knit.

The mechanism by which I provide access to the `PaneManager` feels 'wrong', but I don't see a simpler way forward without effectively duplicating a whole bunch of code in a separate class. (Let me know if I'm missing something obvious!)