### PR TITLE
Fix terminalCreate R API to return a ready-to-use terminal

### DIFF
--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -171,7 +171,7 @@ const int kRStudioAPIShowDialogCompleted = 152;
 const int kObjectExplorerEvent = 153;
 const int kSendToTerminal = 154;
 const int kClearTerminal = 155;
-const int kCreateNamedTerminal = 156;
+const int kAddTerminal = 156;
 const int kActivateTerminal = 157;
 const int kTerminalCwd = 158;
 const int kAdminNotification = 159;
@@ -476,8 +476,8 @@ std::string ClientEvent::typeName() const
          return "send_to_terminal";
       case client_events::kClearTerminal:
          return "clear_terminal";
-      case client_events::kCreateNamedTerminal:
-         return "create_named_terminal";
+      case client_events::kAddTerminal:
+         return "add_terminal";
       case client_events::kActivateTerminal:
          return "activate_terminal";
       case client_events::kTerminalCwd:

--- a/src/cpp/session/SessionConsoleProcessApi.cpp
+++ b/src/cpp/session/SessionConsoleProcessApi.cpp
@@ -136,8 +136,8 @@ SEXP rs_terminalCreate(SEXP typeSEXP)
    // notify the client so it adds this new terminal to the UI list
    json::Object eventData;
    eventData["process_info"] = ptrProc->toJson();
-   ClientEvent createNamedTerminalEvent(client_events::kAddTerminal, eventData);
-   module_context::enqueClientEvent(createNamedTerminalEvent);
+   ClientEvent addTerminalEvent(client_events::kAddTerminal, eventData);
+   module_context::enqueClientEvent(addTerminalEvent);
 
    return r::sexp::create(terminalId, &protect);
 }

--- a/src/cpp/session/SessionConsoleProcessApi.cpp
+++ b/src/cpp/session/SessionConsoleProcessApi.cpp
@@ -89,6 +89,14 @@ SEXP rs_terminalCreate(SEXP typeSEXP)
    {
       terminalId = termSequence.second;
    }
+   else if (findProcByCaption(terminalId) != NULL)
+   {
+      std::string msg = "Terminal id already in use: '";
+      msg += terminalId;
+      msg += "'";
+      r::exec::error(msg);
+      return R_NilValue;
+   }
 
    std::string handle;
    Error error = createTerminalConsoleProc(
@@ -98,7 +106,7 @@ SEXP rs_terminalCreate(SEXP typeSEXP)
             std::string(), // handle
             terminalId,
             std::string(), // title
-            kNewTerminal,
+            termSequence.first,
             false, // altBufferActive
             std::string(), // cwd
             false, // zombie

--- a/src/cpp/session/SessionConsoleProcessInfo.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfo.cpp
@@ -31,6 +31,7 @@ namespace console_process {
 const int kDefaultMaxOutputLines = 500;
 const int kDefaultTerminalMaxOutputLines = 1000; // xterm.js scrollback constant
 const int kNoTerminal = 0; // terminal sequence number for a non-terminal
+const int kNewTerminal = -1; // new terminal, sequence number yet to be determined
 const size_t kOutputBufferSize = 8192;
 
 ConsoleProcessInfo::ConsoleProcessInfo()

--- a/src/cpp/session/SessionConsoleProcessTable.cpp
+++ b/src/cpp/session/SessionConsoleProcessTable.cpp
@@ -23,6 +23,7 @@
 #include <session/SessionModuleContext.hpp>
 
 #include "SessionConsoleProcessApi.hpp"
+#include "modules/SessionVCS.hpp"
 
 using namespace rstudio::core;
 
@@ -155,9 +156,8 @@ std::vector<std::string> getAllCaptions()
    return allCaptions;
 }
 
-// Determine next terminal sequence, used when creating terminal name
-// via rstudioapi: mimics what happens in client code.
-std::string nextTerminalName()
+// Determine next terminal sequence and name
+std::pair<int, std::string> nextTerminalName()
 {
    int maxNum = kNoTerminal;
    BOOST_FOREACH(ConsoleProcessPtr& proc, s_procs | boost::adaptors::map_values)
@@ -166,7 +166,9 @@ std::string nextTerminalName()
    }
    maxNum++;
 
-   return std::string("Terminal ") + core::safe_convert::numberToString(maxNum);
+   return std::pair<int, std::string>(
+            maxNum,
+            std::string("Terminal ") + core::safe_convert::numberToString(maxNum));
 }
 
 void saveConsoleProcesses()
@@ -241,6 +243,77 @@ Error internalInitialize()
    loadConsoleProcesses();
 
    return initializeApi();
+}
+
+Error createTerminalConsoleProc(
+      TerminalShell::TerminalShellType shellType,
+      int cols,
+      int rows,
+      const std::string& termHandle, // empty if starting a new terminal
+      const std::string& termCaption,
+      const std::string& termTitle,
+      int termSequence,
+      bool altBufferActive,
+      std::string currentDir,
+      bool zombie,
+      bool trackEnv,
+      std::string* pHandle)
+{
+   using namespace session::module_context;
+   using namespace session::console_process;
+
+#if defined(_WIN32)
+   trackEnv = false;
+#endif
+
+   std::string computedCaption = termCaption;
+
+   if (termSequence == kNewTerminal)
+   {
+      std::pair<int, std::string> sequenceInfo = nextTerminalName();
+      termSequence = sequenceInfo.first;
+      if (computedCaption.empty())
+         computedCaption = sequenceInfo.second;
+   }
+
+   if (termSequence == kNoTerminal)
+   {
+      return systemError(boost::system::errc::invalid_argument,
+                         "Unsupported terminal sequence",
+                         ERROR_LOCATION);
+   }
+
+   if (computedCaption.empty())
+   {
+      return systemError(boost::system::errc::invalid_argument,
+                         "Empty terminal caption not supported",
+                         ERROR_LOCATION);
+   }
+
+   FilePath cwd;
+   if (!currentDir.empty())
+   {
+      cwd = module_context::resolveAliasedPath(currentDir);
+   }
+
+   TerminalShell::TerminalShellType actualShellType;
+   core::system::ProcessOptions options = ConsoleProcess::createTerminalProcOptions(
+         shellType, cols, rows, termSequence, cwd, trackEnv, termHandle, &actualShellType);
+
+   boost::shared_ptr<ConsoleProcessInfo> ptrProcInfo =
+         boost::shared_ptr<ConsoleProcessInfo>(new ConsoleProcessInfo(
+            computedCaption, termTitle, termHandle, termSequence, actualShellType,
+            altBufferActive, cwd, cols, rows, zombie, trackEnv));
+
+   boost::shared_ptr<ConsoleProcess> ptrProc =
+               ConsoleProcess::createTerminalProcess(options, ptrProcInfo);
+
+   ptrProc->onExit().connect(boost::bind(
+                              &modules::source_control::enqueueRefreshEvent));
+
+   *pHandle = ptrProc->handle();
+
+   return Success();
 }
 
 } // namespace console_process

--- a/src/cpp/session/SessionConsoleProcessTable.hpp
+++ b/src/cpp/session/SessionConsoleProcessTable.hpp
@@ -45,9 +45,8 @@ void setVisibleProc(const std::string& handle);
 // the Terminal R API)
 std::vector<std::string> getAllCaptions();
 
-// Determine next terminal sequence, used when creating terminal name
-// via rstudioapi: mimics what happens in client code.
-std::string nextTerminalName();
+// Determine next terminal sequence number and default name
+std::pair<int, std::string> nextTerminalName();
 
 // Get list of all process metadata
 core::json::Array allProcessesAsJson();
@@ -64,6 +63,21 @@ core::Error reapConsoleProcess(const ConsoleProcess& proc);
 
 // Initialize ConsoleProcess list and APIs
 core::Error internalInitialize();
+
+// Create a ConsoleProcess and add it to the table. Final parameter returns handle.
+core::Error createTerminalConsoleProc(
+      TerminalShell::TerminalShellType shellType,
+      int cols,
+      int rows,
+      const std::string& termHandle, // empty if starting a new terminal
+      const std::string& termCaption,
+      const std::string& termTitle,
+      int termSequence,
+      bool altBufferActive,
+      std::string currentDir,
+      bool zombie,
+      bool trackEnv,
+      std::string* pHandle);
 
 } // namespace console_process
 } // namespace session

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -162,8 +162,8 @@ SEXP rs_enqueClientEvent(SEXP nameSEXP, SEXP dataSEXP)
          type = session::client_events::kSendToTerminal;
       else if (name == "clear_terminal")
          type = session::client_events::kClearTerminal;
-      else if (name == "create_named_terminal")
-         type = session::client_events::kCreateNamedTerminal;
+      else if (name == "add_terminal")
+         type = session::client_events::kAddTerminal;
       else if (name == "activate_terminal")
          type = session::client_events::kActivateTerminal;
       else if (name == "terminal_cwd")

--- a/src/cpp/session/SessionUserSettings.cpp
+++ b/src/cpp/session/SessionUserSettings.cpp
@@ -434,6 +434,9 @@ void UserSettings::updatePrefsCache(const json::Object& prefs) const
    bool terminalAutoclose = readPref<bool>(prefs, "terminal_autoclose", true);
    pTerminalAutoclose_.reset(new bool(terminalAutoclose));
 
+   bool terminalTrackEnv = readPref<bool>(prefs, "terminal_track_env", true);
+   pTerminalTrackEnv_.reset(new bool(terminalTrackEnv));
+
    syncConsoleColorEnv();
 }
 
@@ -650,6 +653,11 @@ bool UserSettings::terminalWebsockets() const
 bool UserSettings::terminalAutoclose() const
 {
    return readUiPref<bool>(pTerminalAutoclose_);
+}
+
+bool UserSettings::terminalTrackEnv() const
+{
+   return readUiPref<bool>(pTerminalTrackEnv_);
 }
 
 CRANMirror UserSettings::cranMirror() const

--- a/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
@@ -58,6 +58,7 @@ enum AutoCloseMode
 extern const int kDefaultMaxOutputLines;
 extern const int kDefaultTerminalMaxOutputLines;
 extern const int kNoTerminal;
+extern const int kNewTerminal;
 extern const size_t kOutputBufferSize;
 
 // ConsoleProcess metadata that is persisted, and sent to the client on

--- a/src/cpp/session/include/session/SessionUserSettings.hpp
+++ b/src/cpp/session/include/session/SessionUserSettings.hpp
@@ -106,6 +106,7 @@ public:
    core::text::AnsiCodeMode ansiConsoleMode() const;
    bool terminalWebsockets() const;
    bool terminalAutoclose() const;
+   bool terminalTrackEnv() const;
 
    bool rProfileOnResume() const;
    void setRprofileOnResume(bool rProfileOnResume);
@@ -263,6 +264,7 @@ private:
    mutable boost::scoped_ptr<int> pAnsiConsoleMode_;
    mutable boost::scoped_ptr<bool> pTerminalWebsockets_;
    mutable boost::scoped_ptr<bool> pTerminalAutoclose_;
+   mutable boost::scoped_ptr<bool> pTerminalTrackEnv_;
 
    // diagnostic-related prefs
    mutable boost::scoped_ptr<bool> pLintRFunctionCalls_;

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -172,7 +172,7 @@ extern const int kRStudioAPIShowDialogCompleted;
 extern const int kObjectExplorerEvent;
 extern const int kSendToTerminal;
 extern const int kClearTerminal;
-extern const int kCreateNamedTerminal;
+extern const int kAddTerminal;
 extern const int kActivateTerminal;
 extern const int kTerminalCwd;
 extern const int kAdminNotification;

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
@@ -37,44 +37,11 @@ public class ConsoleProcessInfo extends JavaScriptObject
    public static final int AUTOCLOSE_NEVER = 2;
 
    public static final int SEQUENCE_NO_TERMINAL = 0;
+   public static final int SEQUENCE_NEW_TERMINAL = -1;
 
    protected ConsoleProcessInfo() {}
 
-   public static final native ConsoleProcessInfo createNamedTerminalInfo(
-         int sequence,
-         String caption,
-         boolean trackEnv) /*-{
-
-      var procInfo = new Object();
-
-      procInfo.handle = null;
-      procInfo.caption = caption;
-      procInfo.show_on_output = false;
-      procInfo.interaction_mode = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::INTERACTION_ALWAYS;
-      procInfo.max_output_lines = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::DEFAULT_MAX_OUTPUT_LINES;
-      procInfo.buffered_output = "";
-      procInfo.exit_code = null;
-      procInfo.terminal_sequence = sequence;
-      procInfo.allow_restart = false;
-      procInfo.title = null;
-      procInfo.child_procs = true;
-      procInfo.shell_type = @org.rstudio.studio.client.workbench.views.terminal.TerminalShellInfo::SHELL_DEFAULT,
-      procInfo.channel_mode = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::CHANNEL_RPC;
-      procInfo.channel_id = "";
-      procInfo.alt_buffer = false;
-      procInfo.cwd = null;
-      procInfo.cols = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::DEFAULT_COLS;
-      procInfo.rows = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::DEFAULT_ROWS;
-      procInfo.restarted = false;
-      procInfo.autoclose = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::AUTOCLOSE_DEFAULT;
-      procInfo.zombie = false;
-      procInfo.track_env = trackEnv;
-
-      return procInfo;
-   }-*/;
-
    public static final native ConsoleProcessInfo createNewTerminalInfo(
-         int sequence,
          boolean trackEnv) /*-{
          
       var procInfo = new Object();
@@ -86,7 +53,7 @@ public class ConsoleProcessInfo extends JavaScriptObject
       procInfo.max_output_lines = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::DEFAULT_MAX_OUTPUT_LINES;
       procInfo.buffered_output = "";
       procInfo.exit_code = null;
-      procInfo.terminal_sequence = sequence;
+      procInfo.terminal_sequence = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::SEQUENCE_NEW_TERMINAL;
       procInfo.allow_restart = false;
       procInfo.title = null;
       procInfo.child_procs = true;

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -163,7 +163,7 @@ class ClientEvent extends JavaScriptObject
    public static final String ObjectExplorerEvent = "object_explorer_event";
    public static final String SendToTerminal = "send_to_terminal";
    public static final String ClearTerminal = "clear_terminal";
-   public static final String CreateNamedTerminal = "create_named_terminal";
+   public static final String AddTerminal = "add_terminal";
    public static final String ActivateTerminal = "activate_terminal";
    public static final String TerminalCwd = "terminal_cwd";
    public static final String AdminNotification = "admin_notification";

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -166,8 +166,8 @@ import org.rstudio.studio.client.workbench.views.source.events.SourceExtendedTyp
 import org.rstudio.studio.client.workbench.views.source.model.ContentItem;
 import org.rstudio.studio.client.workbench.views.source.model.DataItem;
 import org.rstudio.studio.client.workbench.views.terminal.events.ActivateNamedTerminalEvent;
+import org.rstudio.studio.client.workbench.views.terminal.events.AddTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.ClearTerminalEvent;
-import org.rstudio.studio.client.workbench.views.terminal.events.CreateNamedTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.SendToTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalCwdEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSubprocEvent;
@@ -895,10 +895,10 @@ public class ClientEventDispatcher
             ClearTerminalEvent.Data data = event.getData();
             eventBus_.fireEvent(new ClearTerminalEvent(data));
          }
-         else if (type.equals(ClientEvent.CreateNamedTerminal))
+         else if (type.equals(ClientEvent.AddTerminal))
          {
-            CreateNamedTerminalEvent.Data data = event.getData();
-            eventBus_.fireEvent(new CreateNamedTerminalEvent(data));
+            AddTerminalEvent.Data data = event.getData();
+            eventBus_.fireEvent(new AddTerminalEvent(data));
          }
          else if (type.equals(ClientEvent.ActivateTerminal))
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
@@ -20,7 +20,6 @@ import java.util.LinkedHashMap;
 
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ResultCallback;
-import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.console.ConsoleProcess.ConsoleProcessFactory;
@@ -289,33 +288,7 @@ public class TerminalList implements Iterable<String>,
    public void createNewTerminal(final ResultCallback<Boolean, String> callback)
    {
       ConsoleProcessInfo info = ConsoleProcessInfo.createNewTerminalInfo(
-            nextTerminalSequence(), uiPrefs_.terminalTrackEnvironment().getValue());
-      startTerminal(info, callback);
-   }
-
-   /**
-    * Initiate startup of a new terminal with specified caption.
-    * @param caption desired caption; if null or empty creates standard caption
-    * @param callback report success or failure of connection
-    */
-   public void createNamedTerminal(String caption, final ResultCallback<Boolean, String> callback)
-   {
-      if (StringUtil.isNullOrEmpty(caption))
-      {
-         createNewTerminal(callback);
-         return;
-      }
-      
-      // is this terminal name available?
-      if (!isCaptionAvailable(caption))
-      {
-         callback.onFailure("Terminal name '" + caption + "' already in use");
-         return;
-      }
-      
-      ConsoleProcessInfo info = ConsoleProcessInfo.createNamedTerminalInfo(
-            nextTerminalSequence(), caption, uiPrefs_.terminalTrackEnvironment().getValue());
-
+            uiPrefs_.terminalTrackEnvironment().getValue());
       startTerminal(info, callback);
    }
 
@@ -391,22 +364,6 @@ public class TerminalList implements Iterable<String>,
          }
       }
       return false;
-   }
-
-   /**
-    * Choose a 1-based sequence number one higher than the highest currently 
-    * known terminal number. We don't try to fill gaps if terminals are closed 
-    * in the middle of the opened tabs.
-    * @return Highest currently known terminal plus one
-    */
-   private int nextTerminalSequence()
-   {
-      int maxNum = ConsoleProcessInfo.SEQUENCE_NO_TERMINAL;
-      for (final java.util.Map.Entry<String, ConsoleProcessInfo> item : terminals_.entrySet())
-      {
-         maxNum = Math.max(maxNum, item.getValue().getTerminalSequence());
-      }
-      return maxNum + 1;
    }
 
    private void startTerminal(ConsoleProcessInfo info, 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -313,27 +313,9 @@ public class TerminalPane extends WorkbenchPane
    }
 
    @Override
-   public void createNamedTerminal(String caption)
+   public void addTerminal(ConsoleProcessInfo cpi)
    {
-      if (creatingTerminal_)
-         return;
-
-      creatingTerminal_ = true;
-      
-      terminals_.createNamedTerminal(caption, new ResultCallback<Boolean, String>()
-      {
-         @Override
-         public void onSuccess(Boolean connected)
-         {
-         }
-         
-         @Override
-         public void onFailure(String msg)
-         {
-            Debug.devlog(msg);
-            creatingTerminal_ = false;
-         }
-      });
+      terminals_.addTerminal(cpi);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTab.java
@@ -32,8 +32,8 @@ import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.ui.DelayLoadTabShim;
 import org.rstudio.studio.client.workbench.ui.DelayLoadWorkbenchTab;
 import org.rstudio.studio.client.workbench.views.terminal.events.ActivateNamedTerminalEvent;
+import org.rstudio.studio.client.workbench.views.terminal.events.AddTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.ClearTerminalEvent;
-import org.rstudio.studio.client.workbench.views.terminal.events.CreateNamedTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.CreateTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.SendToTerminalEvent;
 
@@ -53,7 +53,7 @@ public class TerminalTab extends DelayLoadWorkbenchTab<TerminalTabPresenter>
                  CreateTerminalEvent.Handler,
                  SendToTerminalEvent.Handler,
                  ClearTerminalEvent.Handler,
-                 CreateNamedTerminalEvent.Handler,
+                 AddTerminalEvent.Handler,
                  ActivateNamedTerminalEvent.Handler
    {
       @Handler
@@ -108,7 +108,7 @@ public class TerminalTab extends DelayLoadWorkbenchTab<TerminalTabPresenter>
       events.addHandler(CreateTerminalEvent.TYPE, shim_);
       events.addHandler(SendToTerminalEvent.TYPE, shim_);
       events.addHandler(ClearTerminalEvent.TYPE, shim_);
-      events.addHandler(CreateNamedTerminalEvent.TYPE, shim_);
+      events.addHandler(AddTerminalEvent.TYPE, shim_);
       events.addHandler(ActivateNamedTerminalEvent.TYPE, shim_);
 
       events.addHandler(SessionInitEvent.TYPE, new SessionInitHandler()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
@@ -27,8 +27,8 @@ import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.BusyPresenter;
 import org.rstudio.studio.client.workbench.views.terminal.events.ActivateNamedTerminalEvent;
+import org.rstudio.studio.client.workbench.views.terminal.events.AddTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.ClearTerminalEvent;
-import org.rstudio.studio.client.workbench.views.terminal.events.CreateNamedTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.CreateTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.SendToTerminalEvent;
 
@@ -39,7 +39,7 @@ public class TerminalTabPresenter extends BusyPresenter
                                   implements SendToTerminalEvent.Handler,
                                              ClearTerminalEvent.Handler,
                                              CreateTerminalEvent.Handler,
-                                             CreateNamedTerminalEvent.Handler,
+                                             AddTerminalEvent.Handler,
                                              ActivateNamedTerminalEvent.Handler
 
 {
@@ -94,11 +94,11 @@ public class TerminalTabPresenter extends BusyPresenter
       void interruptTerminal();
       
       /**
-       * Create a new terminal with given caption.
-       * @param caption requested terminal caption, or null to autogenerate
+       * Add a terminal to the list.
+       * @param cpi information on the terminal
        * caption
        */
-      void createNamedTerminal(String caption);
+      void addTerminal(ConsoleProcessInfo cpi);
       
       /**
        * Activate (display) terminal with given caption. If none specified,
@@ -203,9 +203,9 @@ public class TerminalTabPresenter extends BusyPresenter
    }
 
    @Override
-   public void onCreateNamedTerminal(CreateNamedTerminalEvent event)
+   public void onAddTerminal(AddTerminalEvent event)
    {
-      view_.createNamedTerminal(event.getId());
+      view_.addTerminal(event.getProcessInfo());
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/AddTerminalEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/AddTerminalEvent.java
@@ -1,5 +1,5 @@
 /*
- * CreateNamedTerminalEvent.java
+ * AddTerminalEvent.java
  *
  * Copyright (C) 2009-17 by RStudio, Inc.
  *
@@ -14,45 +14,37 @@
  */
 package org.rstudio.studio.client.workbench.views.terminal.events;
 
-import org.rstudio.core.client.js.JavaScriptSerializable;
-import org.rstudio.studio.client.application.events.CrossWindowEvent;
-import org.rstudio.studio.client.workbench.views.terminal.events.CreateNamedTerminalEvent.Handler;
-
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
 
-@JavaScriptSerializable
-public class CreateNamedTerminalEvent extends CrossWindowEvent<Handler>
+import org.rstudio.studio.client.common.console.ConsoleProcessInfo;
+import org.rstudio.studio.client.workbench.views.terminal.events.AddTerminalEvent.Handler;
+
+public class AddTerminalEvent extends GwtEvent<Handler>
 {
-   public interface Handler extends EventHandler
-   {
-      void onCreateNamedTerminal(CreateNamedTerminalEvent event);
-   }
-
    public static class Data extends JavaScriptObject
    {
       protected Data() {}
-      
-      public final native String getId() /*-{ return this["id"]; }-*/;
+
+      public native final ConsoleProcessInfo getProcessInfo() /*-{ 
+         return this.process_info; 
+      }-*/;
    }
    
-   public CreateNamedTerminalEvent()
+   public interface Handler extends EventHandler
    {
-   }
-   
-   public CreateNamedTerminalEvent(Data data)
-   {
-      this(data.getId());
+      void onAddTerminal(AddTerminalEvent event);
    }
 
-   public CreateNamedTerminalEvent(String id)
+   public AddTerminalEvent(Data data)
    {
-      id_ = id;
+      processInfo_ = data.getProcessInfo();
    }
 
-   public String getId()
+   public ConsoleProcessInfo getProcessInfo()
    {
-      return id_;
+      return processInfo_;
    }
    
    @Override
@@ -62,12 +54,12 @@ public class CreateNamedTerminalEvent extends CrossWindowEvent<Handler>
    }
 
    @Override
-   protected void dispatch(Handler createNamedTerminalHandler)
+   protected void dispatch(Handler handler)
    {
-      createNamedTerminalHandler.onCreateNamedTerminal(this);
+      handler.onAddTerminal(this);
    }
 
-   private String id_;
-   
+   private final ConsoleProcessInfo processInfo_;
+
    public static final Type<Handler> TYPE = new Type<Handler>();
 }


### PR DESCRIPTION
Make the R API `rs_terminalCreate` independent of the client when starting up a terminal. Prior to this there was a gap between this API returning and the terminal being available for the other APIs to call.

Now you can, for example, immediately send a command to a created terminal (this would have failed before these changes):

`terminalSend(terminalCreate(), "ls -l\n")`

Also fix a potential scenario where multiple terminals could be created with the same "unique" identifier due to duplicate logic on client and server; now server-only.

**Details:**

1. Moved `getTerminalShells` and `startTerminal` RPC API implementations from SessionWorkbench.cpp to SessionConsoleProcessApi.cpp.
2. Pulled out the non-RPC-specific logic of `startTerminal` into `createTerminalConsoleProc` function which is now used when creating a new terminal via R API `rs_terminalCreate` as well as when creating through the IDE menu via the RPC call.
3. `rs_terminalCreate` now directly starts the terminal process on the server instead of relying on a client event to do it (via a server-RPC call). So when the R API returns, the terminal is up and running and don't have to wait some undefined amount of time before communicating with it via other R terminal APIs.
4. Client event `create_named_terminal` is replaced by `add_terminal` which adds metadata for an already-created terminal (on the server) to the client's terminal dropdown but doesn't invoke the now unnecessary creation sequence. It will connect normally if and when the user selects the terminal in the UI.
5. Eliminate duplicate logic for determining next terminal sequence number and auto-generated caption. It existed on both client and server-side, now only done on server.