### PR TITLE
mark encoding before parsing YAML

### DIFF
--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -61,13 +61,20 @@
 })
 
 .rs.addFunction("getCustomRenderFunction", function(file) {
+  # read the contents of the file
   lines <- readLines(file, warn = FALSE)
-
+  
+  # mark the encoding if it's available
+  properties <- .rs.getSourceDocumentProperties(file)
+  if (identical(properties$encoding, "UTF-8"))
+    Encoding(lines) <- "UTF-8"
+  
   yamlFrontMatter <- tryCatch(
     rmarkdown:::parse_yaml_front_matter(lines),
-    error=function(e) {
-       list()
-    })
+    error = function(e) {
+      list()
+    }
+  )
 
   if (is.character(yamlFrontMatter[["knit"]]))
     yamlFrontMatter[["knit"]][[1]]
@@ -111,21 +118,29 @@
 # whether it's up to date (e.g. for input.Rmd producing input.html, see whether
 # input.html exists and has been written since input.Rmd)
 .rs.addFunction("getRmdOutputInfo", function(target) {
-  # compute the name of the output file
-  lines <- readLines(target, warn = FALSE)
-  outputFormat <- rmarkdown:::output_format_from_yaml_front_matter(lines)
-  outputFormat <- rmarkdown:::create_output_format(
-                                    outputFormat$name, outputFormat$options)
-  outputFile <- rmarkdown:::pandoc_output_file(target, outputFormat$pandoc)
-  outputPath <- file.path(dirname(target), outputFile) 
-
-  # ensure output file exists
-  current <- file.exists(outputPath) && 
-             file.info(outputPath)$mtime >= file.info(target)$mtime
   
-  return(list(
-    output_file = .rs.scalar(outputPath),
-    is_current  = .rs.scalar(current)))
+   # read the contents of the file
+   lines <- readLines(target, warn = FALSE)
+   
+   # mark the encoding if it's available
+   properties <- .rs.getSourceDocumentProperties(target)
+   if (identical(properties$encoding, "UTF-8"))
+      Encoding(lines) <- "UTF-8"
+   
+   # compute the name of the output file
+   outputFormat <- rmarkdown:::output_format_from_yaml_front_matter(lines)
+   outputFormat <- rmarkdown:::create_output_format(outputFormat$name, outputFormat$options)
+   outputFile <- rmarkdown:::pandoc_output_file(target, outputFormat$pandoc)
+   outputPath <- file.path(dirname(target), outputFile) 
+   
+   # ensure output file exists
+   current <- file.exists(outputPath) && 
+      file.info(outputPath)$mtime >= file.info(target)$mtime
+   
+   list(
+      output_file = .rs.scalar(outputPath),
+      is_current  = .rs.scalar(current)
+   )
 })
 
 # given a path to a folder on disk, return information about the R Markdown


### PR DESCRIPTION
This PR should resolve an issue reported at https://github.com/rstudio/packrat/issues/382, where attempts to publish R Markdown documents containing multibyte characters within the YAML header to RStudio Connect would fail. Note that this issue primarily affects Windows users.

The issue here: users were saving documents with UTF-8 encoding; however, when reading that document back in, we were not re-marking the encoding as UTF-8 and so ended up with a UTF-8 document that we believed to be in the system encoding. Unfortunately, this causes the `yaml` package to barf when parsing the document.