### PR TITLE
Fix profiler colors under desktop and dark-themes

### DIFF
--- a/src/cpp/session/resources/profiler/profiler.css
+++ b/src/cpp/session/resources/profiler/profiler.css
@@ -58,7 +58,7 @@
 }
 
 .rstudio-themes-flat .profvis-treetable {
-   color: inherit;
+   color: inherit !important;
 }
 
 .rstudio-themes-flat .profvis-treetable table tr {


### PR DESCRIPTION
Profiler colors are broken under dark-themes for desktop builds...

<img width="714" alt="screen shot 2017-07-06 at 2 43 29 pm" src="https://user-images.githubusercontent.com/3478847/27934232-b13132b4-6259-11e7-87f0-f8e7bd0eb287.png">

fixed...

<img width="674" alt="screen shot 2017-07-06 at 2 43 39 pm" src="https://user-images.githubusercontent.com/3478847/27934233-b5be6478-6259-11e7-9416-d534c2c83207.png">
