### PR TITLE
inherit indentation settings from parent project

### DIFF
--- a/src/cpp/core/include/core/r_util/RProjectFile.hpp
+++ b/src/cpp/core/include/core/r_util/RProjectFile.hpp
@@ -122,6 +122,11 @@ struct RProjectConfig
    std::string defaultOpenDocs;
 };
 
+Error findProjectFile(FilePath filePath,
+                      FilePath* pProjPath);
+
+Error findProjectConfig(FilePath filePath,
+                        RProjectConfig* pConfig);
 
 Error readProjectFile(const FilePath& projectFilePath,
                       RProjectConfig* pConfig,

--- a/src/cpp/core/include/core/r_util/RProjectFile.hpp
+++ b/src/cpp/core/include/core/r_util/RProjectFile.hpp
@@ -123,11 +123,9 @@ struct RProjectConfig
 };
 
 Error findProjectFile(FilePath filePath,
-                      const FilePath& anchorPath,
                       FilePath* pProjPath);
 
 Error findProjectConfig(FilePath filePath,
-                        const FilePath& anchorPath,
                         RProjectConfig* pConfig);
 
 Error readProjectFile(const FilePath& projectFilePath,

--- a/src/cpp/core/include/core/r_util/RProjectFile.hpp
+++ b/src/cpp/core/include/core/r_util/RProjectFile.hpp
@@ -123,9 +123,11 @@ struct RProjectConfig
 };
 
 Error findProjectFile(FilePath filePath,
+                      const FilePath& anchorPath,
                       FilePath* pProjPath);
 
 Error findProjectConfig(FilePath filePath,
+                        const FilePath& anchorPath,
                         RProjectConfig* pConfig);
 
 Error readProjectFile(const FilePath& projectFilePath,

--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -19,6 +19,7 @@
 #include <iomanip>
 #include <ostream>
 
+#include <boost/foreach.hpp>
 #include <boost/format.hpp>
 #include <boost/regex.hpp>
 
@@ -309,6 +310,54 @@ std::ostream& operator << (std::ostream& stream, const YesNoAskValue& val)
    }
 
    return stream ;
+}
+
+Error findProjectFile(FilePath filePath,
+                      FilePath* pProjPath)
+{
+   // check to see if we already have a .Rproj file
+   if (filePath.extension() == ".Rproj")
+   {
+      *pProjPath = filePath;
+      return Success();
+   }
+   
+   if (!filePath.isDirectory())
+      filePath = filePath.parent();
+   
+   // no .Rproj file found; scan parent directories
+   for (; filePath.exists(); filePath = filePath.parent())
+   {
+      FilePath projPath = projectFromDirectory(filePath);
+      if (projPath.exists())
+      {
+         *pProjPath = projPath;
+         return Success();
+      }
+   }
+   
+   return fileNotFoundError(ERROR_LOCATION);
+}
+
+Error findProjectConfig(FilePath filePath,
+                        RProjectConfig* pConfig)
+{
+   Error error;
+   
+   if (!filePath.isDirectory())
+      filePath = filePath.parent();
+   
+   FilePath projPath;
+   error = findProjectFile(filePath, &projPath);
+   if (error)
+      return error;
+   
+   std::string errorMessage;
+   error = readProjectFile(projPath, pConfig, &errorMessage);
+   if (error)
+      return error;
+   
+   return Success();
 }
 
 Error readProjectFile(const FilePath& projectFilePath,

--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -313,7 +313,6 @@ std::ostream& operator << (std::ostream& stream, const YesNoAskValue& val)
 }
 
 Error findProjectFile(FilePath filePath,
-                      const FilePath& anchorPath,
                       FilePath* pProjPath)
 {
    // check to see if we already have a .Rproj file
@@ -322,17 +321,13 @@ Error findProjectFile(FilePath filePath,
       *pProjPath = filePath;
       return Success();
    }
-   
+
    if (!filePath.isDirectory())
       filePath = filePath.parent();
-   
+
    // no .Rproj file found; scan parent directories
-   while (true)
+   for (; filePath.exists(); filePath = filePath.parent())
    {
-      // bail if we get an empty path
-      if (filePath.empty())
-         break;
-      
       // scan this directory for .Rproj files
       FilePath projPath = projectFromDirectory(filePath);
       if (!projPath.empty())
@@ -340,19 +335,12 @@ Error findProjectFile(FilePath filePath,
          *pProjPath = projPath;
          return Success();
       }
-      
-      // bail if we hit the anchored path
-      if (filePath == anchorPath)
-         break;
-      
-      filePath = filePath.parent();
    }
-   
+
    return fileNotFoundError(ERROR_LOCATION);
 }
 
 Error findProjectConfig(FilePath filePath,
-                        const FilePath& anchorPath,
                         RProjectConfig* pConfig)
 {
    Error error;
@@ -361,7 +349,7 @@ Error findProjectConfig(FilePath filePath,
       filePath = filePath.parent();
    
    FilePath projPath;
-   error = findProjectFile(filePath, anchorPath, &projPath);
+   error = findProjectFile(filePath, &projPath);
    if (error)
       return error;
    

--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -345,9 +345,6 @@ Error findProjectConfig(FilePath filePath,
 {
    Error error;
    
-   if (!filePath.isDirectory())
-      filePath = filePath.parent();
-   
    FilePath projPath;
    error = findProjectFile(filePath, &projPath);
    if (error)

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -90,11 +90,23 @@ void writeDocToJson(boost::shared_ptr<SourceDocument> pDoc,
    (*pDocJson)["notebook"] = notebook;
    
    // discover project-specific settings when available
-   FilePath docPath = module_context::resolveAliasedPath(pDoc->path());
-   
    r_util::RProjectConfig projConfig;
-   Error error = r_util::findProjectConfig(docPath, &projConfig);
-   if (!error)
+   FilePath docPath = module_context::resolveAliasedPath(pDoc->path());
+   FilePath projDir = projects::projectContext().directory();
+   bool hasConfig = false;
+   
+   if (docPath.isWithin(projDir))
+   {
+      projConfig = projects::projectContext().config();
+      hasConfig = true;
+   }
+   else
+   {
+      Error error = r_util::findProjectConfig(docPath, &projConfig);
+      hasConfig = !error;
+   }
+   
+   if (hasConfig)
    {
       json::Object projConfigJson;
       

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -97,8 +97,12 @@ void writeDocToJson(boost::shared_ptr<SourceDocument> pDoc,
    if (!error)
    {
       json::Object projConfigJson;
+      
       projConfigJson["tab_size"] = projConfig.numSpacesForTab;
       projConfigJson["use_soft_tabs"] = projConfig.useSpacesForTab;
+      projConfigJson["strip_trailing_whitespace"] = projConfig.stripTrailingWhitespace;
+      projConfigJson["ensure_trailing_newline"] = projConfig.autoAppendNewline;
+      
       (*pDocJson)["project_config"] = projConfigJson;
    }
 }

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -32,7 +32,6 @@
 #include <core/FileInfo.hpp>
 #include <core/FileSerializer.hpp>
 #include <core/StringUtils.hpp>
-#include <core/text/DcfParser.hpp>
 #include <core/text/TemplateFilter.hpp>
 #include <core/r_util/RProjectFile.hpp>
 #include <core/r_util/RPackageInfo.hpp>

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -91,9 +91,10 @@ void writeDocToJson(boost::shared_ptr<SourceDocument> pDoc,
    
    // discover project-specific settings when available
    FilePath docPath = module_context::resolveAliasedPath(pDoc->path());
+   FilePath anchorPath = module_context::userHomePath().parent();
    
    r_util::RProjectConfig projConfig;
-   Error error = r_util::findProjectConfig(docPath, &projConfig);
+   Error error = r_util::findProjectConfig(docPath, anchorPath, &projConfig);
    if (!error)
    {
       json::Object projConfigJson;

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -91,10 +91,9 @@ void writeDocToJson(boost::shared_ptr<SourceDocument> pDoc,
    
    // discover project-specific settings when available
    FilePath docPath = module_context::resolveAliasedPath(pDoc->path());
-   FilePath anchorPath = module_context::userHomePath().parent();
    
    r_util::RProjectConfig projConfig;
-   Error error = r_util::findProjectConfig(docPath, anchorPath, &projConfig);
+   Error error = r_util::findProjectConfig(docPath, &projConfig);
    if (!error)
    {
       json::Object projConfigJson;

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -32,7 +32,9 @@
 #include <core/FileInfo.hpp>
 #include <core/FileSerializer.hpp>
 #include <core/StringUtils.hpp>
+#include <core/text/DcfParser.hpp>
 #include <core/text/TemplateFilter.hpp>
+#include <core/r_util/RProjectFile.hpp>
 #include <core/r_util/RPackageInfo.hpp>
 
 #include <core/json/JsonRpc.hpp>
@@ -86,6 +88,19 @@ void writeDocToJson(boost::shared_ptr<SourceDocument> pDoc,
          LOG_ERROR(error);
    }
    (*pDocJson)["notebook"] = notebook;
+   
+   // discover a project-specific tab width if available
+   FilePath docPath = module_context::resolveAliasedPath(pDoc->path());
+   
+   r_util::RProjectConfig projConfig;
+   Error error = r_util::findProjectConfig(docPath, &projConfig);
+   if (!error)
+   {
+      json::Object projConfigJson;
+      projConfigJson["tab_size"] = projConfig.numSpacesForTab;
+      projConfigJson["use_soft_tabs"] = projConfig.useSpacesForTab;
+      (*pDocJson)["project_config"] = projConfigJson;
+   }
 }
 
 void detectExtendedType(boost::shared_ptr<SourceDocument> pDoc)

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -89,7 +89,7 @@ void writeDocToJson(boost::shared_ptr<SourceDocument> pDoc,
    }
    (*pDocJson)["notebook"] = notebook;
    
-   // discover a project-specific tab width if available
+   // discover project-specific settings when available
    FilePath docPath = module_context::resolveAliasedPath(pDoc->path());
    
    r_util::RProjectConfig projConfig;

--- a/src/gwt/src/org/rstudio/studio/client/common/viewfile/ViewFilePanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/viewfile/ViewFilePanel.java
@@ -97,7 +97,8 @@ public class ViewFilePanel extends Composite implements TextDisplay
       docDisplay_.setReadOnly(true);
       
       TextEditingTarget.registerPrefs(releaseOnDismiss_, 
-            uiPrefs, 
+            uiPrefs,
+            null,
             docDisplay_,
             new TextEditingTarget.PrefsContext()
             {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
@@ -168,6 +168,7 @@ public class CodeBrowserEditingTarget implements EditingTarget
       
       TextEditingTarget.registerPrefs(releaseOnDismiss_, 
                                       prefs_, 
+                                      null,
                                       docDisplay_,
                                       document);
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
@@ -168,7 +168,7 @@ public class CodeBrowserEditingTarget implements EditingTarget
       
       TextEditingTarget.registerPrefs(releaseOnDismiss_, 
                                       prefs_, 
-                                      null,
+                                      document.getProjectConfig(),
                                       docDisplay_,
                                       document);
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2519,8 +2519,11 @@ public class TextEditingTarget implements
          return;
       }
       
+      boolean stripTrailingWhitespace = (projConfig_ == null)
+            ? prefs_.stripTrailingWhitespace().getValue()
+            : projConfig_.stripTrailingWhitespace();
       
-      if (prefs_.stripTrailingWhitespace().getValue() &&
+      if (stripTrailingWhitespace &&
           !fileType_.isMarkdown() &&
           !name_.getValue().equals("DESCRIPTION"))
       {
@@ -2538,7 +2541,11 @@ public class TextEditingTarget implements
          }
       }
       
-      if (prefs_.autoAppendNewline().getValue() || fileType_.isPython())
+      boolean autoAppendNewline = (projConfig_ == null)
+            ? prefs_.autoAppendNewline().getValue()
+            : projConfig_.ensureTrailingNewline();
+            
+      if (autoAppendNewline || fileType_.isPython())
       {
          String lastLine = docDisplay_.getLine(lineCount - 1);
          if (lastLine.length() != 0)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1314,7 +1314,7 @@ public class TextEditingTarget implements
          }.schedule(100);
       }
 
-      registerPrefs(releaseOnDismiss_, prefs_, docDisplay_, document);
+      registerPrefs(releaseOnDismiss_, prefs_, projConfig_, docDisplay_, document);
       
       // Initialize sourceOnSave, and keep it in sync
       view_.getSourceOnSave().setValue(document.sourceOnSave(), false);
@@ -6127,11 +6127,13 @@ public class TextEditingTarget implements
    public static void registerPrefs(
                      ArrayList<HandlerRegistration> releaseOnDismiss,
                      UIPrefs prefs,
+                     ProjectConfig projectConfig,
                      DocDisplay docDisplay,
                      final SourceDocument sourceDoc)
    {
       registerPrefs(releaseOnDismiss,
                     prefs,
+                    projectConfig,
                     docDisplay,
                     new PrefsContext() {
                         @Override
@@ -6149,6 +6151,7 @@ public class TextEditingTarget implements
    public static void registerPrefs(
                      ArrayList<HandlerRegistration> releaseOnDismiss,
                      UIPrefs prefs,
+                     final ProjectConfig projectConfig,
                      final DocDisplay docDisplay,
                      final PrefsContext context)
    {
@@ -6181,13 +6184,15 @@ public class TextEditingTarget implements
                   }
                   else
                   {
-                     docDisplay.setUseSoftTabs(arg);
+                     if (projectConfig == null)
+                        docDisplay.setUseSoftTabs(arg);
                   }
                }}));
       releaseOnDismiss.add(prefs.numSpacesForTab().bind(
             new CommandWithArg<Integer>() {
                public void execute(Integer arg) {
-                  docDisplay.setTabSize(arg);
+                  if (projectConfig == null)
+                     docDisplay.setTabSize(arg);
                }}));
       releaseOnDismiss.add(prefs.showMargin().bind(
             new CommandWithArg<Boolean>() {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1255,6 +1255,14 @@ public class TextEditingTarget implements
             releaseOnDismiss_, dependencyManager_);
       view_.addResizeHandler(notebook_);
       
+      // apply project properties
+      projConfig_ = document.getProjectConfig();
+      if (projConfig_ != null)
+      {
+         docDisplay_.setUseSoftTabs(projConfig_.useSoftTabs());
+         docDisplay_.setTabSize(projConfig_.getTabSize());
+      }
+      
       // ensure that Makefile and Makevars always use tabs
       name_.addValueChangeHandler(new ValueChangeHandler<String>() {
          @Override
@@ -6543,6 +6551,7 @@ public class TextEditingTarget implements
    private CollabEditStartParams queuedCollabParams_;
    private MathJax mathjax_;
    private InlinePreviewer inlinePreviewer_;
+   private ProjectConfig projConfig_;
    
    // Allows external edit checks to supercede one another
    private final Invalidation externalEditCheckInvalidation_ =

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/ProjectConfig.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/ProjectConfig.java
@@ -22,6 +22,24 @@ public class ProjectConfig extends JavaScriptObject
    {
    }
    
-   public native final int getTabSize()      /*-{ return this.tab_size;      }-*/;
-   public native final boolean useSoftTabs() /*-{ return this.use_soft_tabs; }-*/;
+   public native final int getTabSize()
+   /*-{
+      return this["tab_size"];
+   }-*/;
+   
+   public native final boolean useSoftTabs()
+   /*-{
+      return this["use_soft_tabs"];
+   }-*/;
+   
+   public native final boolean stripTrailingWhitespace()
+   /*-{
+      return this["strip_trailing_whitespace"];
+   }-*/;
+   
+   public native final boolean ensureTrailingNewline()
+   /*-{
+      return this["ensure_trailing_newline"];
+   }-*/;
+
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/ProjectConfig.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/ProjectConfig.java
@@ -1,0 +1,27 @@
+/*
+ * ProjectConfig.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.model;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+public class ProjectConfig extends JavaScriptObject
+{
+   protected ProjectConfig()
+   {
+   }
+   
+   public native final int getTabSize()      /*-{ return this.tab_size;      }-*/;
+   public native final boolean useSoftTabs() /*-{ return this.use_soft_tabs; }-*/;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceDocument.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceDocument.java
@@ -131,6 +131,10 @@ public class SourceDocument extends JavaScriptObject
       return this.notebook || {};
    }-*/;
    
+   public native final ProjectConfig getProjectConfig() /*-{
+      return this.project_config || null;
+   }-*/;
+   
    public final String getSourceWindowId() 
    {
       if (getProperties().hasKey(SourceWindowManager.SOURCE_WINDOW_ID))


### PR DESCRIPTION
This PR ensures that files inherit indentation settings from their 'owning' project (when available), rather than the 'active' project. This should help in cases where one attempts to edit files from multiple projects within the same IDE session.

We also inherit save settings associated with a project (this should help ensure we don't e.g. trim trailing whitespace unintentionally and create noisy diffs)