### PR TITLE
Add .rs.api.getThemeInfo for rstudioapi pr

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -635,3 +635,47 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
          PACKAGE = "(embedding)")
 })
 
+.rs.addApiFunction("getThemeInfo", function() {
+   editor <- .Call("rs_readUiPref", "theme")
+   global <- .Call("rs_readUiPref", "flat_theme")
+
+   global <- switch(
+    if (is.null(global)) "" else global,
+    alternate = "Sky",
+    default = "Modern",
+    "Classic"
+  )
+
+  dark <- grepl(
+    paste(
+      "ambiance",
+      "chaos",
+      "clouds midnight",
+      "cobalt",
+      "idle fingers",
+      "kr theme",
+      "material",
+      "merbivore soft",
+      "merbivore",
+      "mono industrial",
+      "monokai",
+      "pastel on dark",
+      "solarized dark",
+      "tomorrow night blue",
+      "tomorrow night bright",
+      "tomorrow night 80s",
+      "tomorrow night",
+      "twilight",
+      "vibrant ink",
+      sep = "|"
+    ),
+    editor,
+    ignore.case = TRUE)
+  dark <- !identical(global, "Classic") && dark
+
+  list(
+    editor = editor,
+    global = global,
+    dark = dark
+  )
+})


### PR DESCRIPTION
This PR completes work from https://github.com/rstudio/rstudioapi/pull/47 by moving logic to RStudio to support a new `rstudioapi::getThemeInfo()` call that will provide users with information on the theme.