### PR TITLE
Fix search results background under dar theme

### DIFF
--- a/src/cpp/session/resources/grid/gridstyles.css
+++ b/src/cpp/session/resources/grid/gridstyles.css
@@ -335,6 +335,10 @@ th:focus {
     background-color: #e8e8ff;
 }
 
+.rstudio-themes-flat.editor_dark .searchMatch {
+    background-color: #6d787f;
+}
+
 .naCell {
     color: #b0b0b0;
     font-style: italic;

--- a/src/gwt/src/org/rstudio/core/client/theme/ThemeColors.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ThemeColors.java
@@ -53,4 +53,5 @@ public class ThemeColors
    public static String darkRowSelected                            = "rgba(255, 255, 255, 0.15)";
    public static String darkRowFocused                             = "rgba(255, 255, 255, 0.20)";
    public static String darkRowHovered                             = "rgba(255, 255, 255, 0.05)";
+   public static String darkSearchResultBackground                 = "#6d787f";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/consoleStyles.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/consoleStyles.css
@@ -9,6 +9,8 @@
 
 @eval THEME_DARKGREY_MENU_SELECTED org.rstudio.core.client.theme.ThemeColors.darkGreyMenuSelected;
 
+@eval THEME_DARK_SEARCHRESULT_BACKGROUND org.rstudio.core.client.theme.ThemeColors.darkSearchResultBackground;
+
 .console {
    font-family: fixedWidthFont;
    padding-left: 6px;
@@ -96,6 +98,11 @@
 
 .searchMatch {
    background-color: rgb(190, 230, 255);
+}
+
+.rstudio-themes-flat.rstudio-themes-dark-menus .searchMatch
+{
+   background-color: THEME_DARK_SEARCHRESULT_BACKGROUND;
 }
 
 .functionInfo, .paramInfoName {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.css
@@ -12,6 +12,8 @@
 @eval THEME_DARKGREY_BACKGROUND org.rstudio.core.client.theme.ThemeColors.darkGreyBackground;
 @eval THEME_ALTERNATE_BACKGROUND org.rstudio.core.client.theme.ThemeColors.alternateBackground;
 
+@eval THEME_DARK_SEARCHRESULT_BACKGROUND org.rstudio.core.client.theme.ThemeColors.darkSearchResultBackground;
+
 @def headerRowHeight 20px;
 
 .environmentPane
@@ -154,6 +156,11 @@
 .filterMatch
 {
 	background-color: #e8e8ff;
+}
+
+.rstudio-themes-flat .rstudio-themes-dark .filterMatch
+{
+   background-color: THEME_DARK_SEARCHRESULT_BACKGROUND;
 }
 
 .rstudio-themes-flat .rstudio-themes-default .objectGrid td.nameCol,


### PR DESCRIPTION
A few dark-theme fixes for search results...

<img width="780" alt="screen shot 2017-07-07 at 2 45 27 pm" src="https://user-images.githubusercontent.com/3478847/27978204-0793738c-6323-11e7-9fd0-791a58549f77.png">

<img width="781" alt="screen shot 2017-07-07 at 2 45 31 pm" src="https://user-images.githubusercontent.com/3478847/27978205-079a3500-6323-11e7-9f1e-90cb57ade334.png">

<img width="658" alt="screen shot 2017-07-07 at 2 45 38 pm" src="https://user-images.githubusercontent.com/3478847/27978206-07a09a9e-6323-11e7-9b77-e36290f5bc7d.png">

