### PR TITLE
Improve debugger traceback pane visuals

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -903,7 +903,6 @@ pre {
 
 
 .gwt-SplitLayoutPanel-HDragger, .gwt-SplitLayoutPanel-VDragger {
-   background-color: transparent !important;
    border: 0px;
    cursor: move;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/InfoBar.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/InfoBar.ui.xml
@@ -37,6 +37,13 @@
          width: 9px;
          height: 9px;
       }
+      .rstudio-themes-flat .rstudio-themes-dark-grey .dismiss {
+         -webkit-filter: invert(100%);
+            -moz-filter: invert(100%);
+             -ms-filter: invert(100%);
+              -o-filter: invert(100%);
+                 filter: invert(100%);
+      }
    </ui:style>
 
    <g:FlowPanel>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/CallFramePanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/CallFramePanel.css
@@ -36,3 +36,13 @@
 	font-weight: normal;
 	margin-right: 10px;
 }
+
+.showInternalsCheckbox
+{
+   margin-top: 1px;
+}
+
+.showInternalsCheckbox input
+{
+   margin-right: 5px !important;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/CallFramePanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/CallFramePanel.java
@@ -91,6 +91,7 @@ public class CallFramePanel extends ResizeComposite
       callFramePanelHeader.addStyleName(globalStyles.windowframe());
       callFramePanelHeader.add(tracebackTitle);
       CheckBox showInternals = new CheckBox("Show internals");
+      showInternals.addStyleName(style.showInternalsCheckbox());
       showInternals.setValue(panelHost_.getShowInternalFunctions());
       showInternals.addValueChangeHandler(
             new ValueChangeHandler<Boolean>()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/CallFramePanelStyle.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/CallFramePanelStyle.java
@@ -21,4 +21,5 @@ public interface CallFramePanelStyle extends CssResource
 {
    String tracebackHeader();
    String toggleHide();
+   String showInternalsCheckbox();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.css
@@ -17,12 +17,12 @@
 .rstudio-themes-flat .categoryHeaderRow
 {
    color: #000;
+   font-weight: normal;
 }
 
 .rstudio-themes-flat .rstudio-themes-dark .categoryHeaderRow
 {
    color: #FFF;
-   font-weight: inherit;
 }
 
 .expandIcon
@@ -95,6 +95,11 @@ td.valueCol
 .categoryHeaderText
 {
    padding-left: 5px;
+}
+
+.rstudio-themes-flat .categoryHeaderText
+{
+
 }
 
 .clickableCol

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.css
@@ -4,6 +4,8 @@
 @external rstudio-themes-flat, rstudio-themes-dark;
 @external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
 
+@external gwt-SplitLayoutPanel-VDragger;
+
 @eval THEME_DEFAULT_BORDER org.rstudio.core.client.theme.ThemeColors.defaultBorder;
 @eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.darkGreyBorder;
 @eval THEME_ALTERNATE_BORDER org.rstudio.core.client.theme.ThemeColors.alternateBorder;
@@ -18,6 +20,12 @@
 {
    font-family: fixedWidthFont;
    background-color: #e0e0e0;
+}
+
+.rstudio-themes-flat .environmentPane .gwt-SplitLayoutPanel-VDragger {
+   border-top: solid 1px #000;
+   border-bottom: solid 1px #000;
+   height: 6px !important;
 }
 
 .environmentPanel
@@ -160,7 +168,8 @@
 .rstudio-themes-flat .rstudio-themes-default .objectGrid td.expandCol,
 .rstudio-themes-flat .rstudio-themes-default .objectGrid td.valueCol,
 .rstudio-themes-flat .rstudio-themes-default .objectGrid .detailRow,
-.rstudio-themes-flat .rstudio-themes-default .categoryHeaderRow {
+.rstudio-themes-flat .rstudio-themes-default .categoryHeaderRow,
+.rstudio-themes-flat .rstudio-themes-default .environmentPane .gwt-SplitLayoutPanel-VDragger {
    border-color: THEME_DEFAULT_BORDER;
 }
 
@@ -168,7 +177,8 @@
 .rstudio-themes-flat .rstudio-themes-dark-grey .objectGrid td.expandCol,
 .rstudio-themes-flat .rstudio-themes-dark-grey .objectGrid td.valueCol,
 .rstudio-themes-flat .rstudio-themes-dark-grey .objectGrid .detailRow,
-.rstudio-themes-flat .rstudio-themes-dark-grey .categoryHeaderRow {
+.rstudio-themes-flat .rstudio-themes-dark-grey .categoryHeaderRow,
+.rstudio-themes-flat .rstudio-themes-dark-grey .environmentPane .gwt-SplitLayoutPanel-VDragger {
    border-color: THEME_DARKGREY_BORDER;
 }
 
@@ -176,7 +186,8 @@
 .rstudio-themes-flat .rstudio-themes-alternate .objectGrid td.expandCol,
 .rstudio-themes-flat .rstudio-themes-alternate .objectGrid td.valueCol,
 .rstudio-themes-flat .rstudio-themes-alternate .objectGrid .detailRow,
-.rstudio-themes-flat .rstudio-themes-alternate .categoryHeaderRow {
+.rstudio-themes-flat .rstudio-themes-alternate .categoryHeaderRow,
+.rstudio-themes-flat .rstudio-themes-alternate .environmentPane .gwt-SplitLayoutPanel-VDragger {
    border-color: THEME_ALTERNATE_BORDER;
 }
 


### PR DESCRIPTION
A few tweaks to the debugger traceback pane to improve its visuals...

<img width="613" alt="screen shot 2017-07-07 at 3 43 26 pm" src="https://user-images.githubusercontent.com/3478847/27979486-3e1e03f6-632b-11e7-85db-10de4d7c76b1.png">

<img width="612" alt="screen shot 2017-07-07 at 3 43 37 pm" src="https://user-images.githubusercontent.com/3478847/27979487-3e20aade-632b-11e7-9d45-4aa996a76caa.png">

<img width="611" alt="screen shot 2017-07-07 at 3 43 54 pm" src="https://user-images.githubusercontent.com/3478847/27979485-3e1d6cfc-632b-11e7-9056-770284728e04.png">

