### PR TITLE
fix warning when requesting completions in e.g. 'return()'

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -494,19 +494,17 @@
 
 .rs.addFunction("getFunctionArgumentNames", function(object)
 {
+   # for primitive objects, 'args()' can be used to extract
+   # a function object with compatible prototype -- although
+   # primitive functions that power control flow (e.g. `if()`,
+   # `return()` can return NULL)
    if (is.primitive(object))
-   {
-      ## Only closures have formals, not primitive functions.
-      result <- tryCatch({
-        names(formals(args(object)))
-      }, error = function(e) {
-         character()
-      })
-   }
-   else
-   {
+      object <- args(object)
+   
+   result <- character()
+   if (is.function(object))
       result <- names(formals(object))
-   }
+   
    result
 })
 


### PR DESCRIPTION
This PR fixes an issue where attempts to request completions within certain primitive functions (primarily those powering control flow) would emit a warning of the form

    Warning in formals(fun) : argument is not a function

One can reproduce by typing e.g. `return(<TAB>)`.