### PR TITLE
Set terminal zombie flag directly on server, not via RPC

### DIFF
--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -605,7 +605,10 @@ Error ChildProcess::run()
       {
          if (::chdir(options_.workingDir.absolutePath().c_str()))
          {
-            LOG_ERROR(systemError(errno, "Error changing directory", ERROR_LOCATION));
+            std::string message = "Error changing directory: '";
+            message += options_.workingDir.absolutePath().c_str();
+            message += "'";
+            LOG_ERROR(systemError(errno, message.c_str(), ERROR_LOCATION));
          }
       }
 

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -661,6 +661,24 @@ void ConsoleProcess::onExit(int exitCode)
    procInfo_->setExitCode(exitCode);
    procInfo_->setHasChildProcs(false);
 
+   AutoCloseMode autoClose = procInfo_->getAutoClose();
+   if (procInfo_->getAutoClose() == DefaultAutoClose)
+   {
+      if (session::userSettings().terminalAutoclose())
+      {
+         autoClose = AlwaysAutoClose;
+      }
+      else
+      {
+         autoClose = NeverAutoClose;
+      }
+      procInfo_->setAutoClose(autoClose);
+   }
+
+   if (procInfo_->getAutoClose() == NeverAutoClose)
+   {
+      setZombie();
+   }
    saveConsoleProcesses();
 
    json::Object data;

--- a/src/cpp/session/SessionConsoleProcessApi.cpp
+++ b/src/cpp/session/SessionConsoleProcessApi.cpp
@@ -718,28 +718,6 @@ Error procNotifyVisible(const json::JsonRpcRequest& request,
    return Success();
 }
 
-Error procSetZombie(const json::JsonRpcRequest& request,
-                    json::JsonRpcResponse* pResponse)
-{
-   std::string handle;
-
-   Error error = json::readParams(request.params,
-                                  &handle);
-   if (error)
-      return error;
-
-   ConsoleProcessPtr proc = findProcByHandle(handle);
-   if (proc == NULL)
-      return systemError(boost::system::errc::invalid_argument,
-                         "Error setting process to zombie mode",
-                         ERROR_LOCATION);
-
-   // Set a process to zombie mode meaning we keep showing it and its buffer, but don't
-   // start its process
-   proc->setZombie();
-   return Success();
-}
-
 Error getTerminalShells(const json::JsonRpcRequest& request,
                         json::JsonRpcResponse* pResponse)
 {
@@ -847,7 +825,6 @@ Error initializeApi()
       (bind(registerRpcMethod, "process_test_exists", procTestExists))
       (bind(registerRpcMethod, "process_use_rpc", procUseRpc))
       (bind(registerRpcMethod, "process_notify_visible", procNotifyVisible))
-      (bind(registerRpcMethod, "process_set_zombie", procSetZombie))
       (bind(registerRpcMethod, "process_interrupt_child", procInterruptChild))
       (bind(registerRpcMethod, "process_get_buffer", procGetBuffer))
       (bind(registerRpcMethod, "get_terminal_shells", getTerminalShells))

--- a/src/cpp/session/SessionConsoleProcessTable.cpp
+++ b/src/cpp/session/SessionConsoleProcessTable.cpp
@@ -254,7 +254,7 @@ Error createTerminalConsoleProc(
       const std::string& termTitle,
       int termSequence,
       bool altBufferActive,
-      std::string currentDir,
+      const std::string& currentDir,
       bool zombie,
       bool trackEnv,
       std::string* pHandle)

--- a/src/cpp/session/SessionConsoleProcessTable.hpp
+++ b/src/cpp/session/SessionConsoleProcessTable.hpp
@@ -74,7 +74,7 @@ core::Error createTerminalConsoleProc(
       const std::string& termTitle,
       int termSequence,
       bool altBufferActive,
-      std::string currentDir,
+      const std::string& currentDir,
       bool zombie,
       bool trackEnv,
       std::string* pHandle);

--- a/src/cpp/session/include/session/SessionTerminalShell.hpp
+++ b/src/cpp/session/include/session/SessionTerminalShell.hpp
@@ -45,7 +45,7 @@ struct TerminalShell
       PosixBash    = 7, // Posix: Bash
       CustomShell  = 8, // User-specified shell command
 
-      Max          = PosixBash
+      Max          = CustomShell
    };
 
    TerminalShell()

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
@@ -242,4 +242,8 @@ public class ConsoleProcessInfo extends JavaScriptObject
    public final native void setHandle(String handle) /*-{
       this.handle = handle;
    }-*/;
+
+   public final native void setZombie(boolean zombie) /*-{
+      this.zombie = zombie;
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -761,15 +761,6 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, PROCESS_NOTIFY_VISIBLE, params, requestCallback);   
    }
 
-   @Override 
-   public void processSetZombie(String handle,
-                                ServerRequestCallback<Void> requestCallback)
-   {
-      JSONArray params = new JSONArray();
-      params.set(0, new JSONString(StringUtil.notNull(handle)));
-      sendRequest(RPC_SCOPE, PROCESS_SET_ZOMBIE, params, requestCallback);   
-   }
-
    public void interrupt(ServerRequestCallback<Void> requestCallback)
    {
       sendRequest(RPC_SCOPE, INTERRUPT, requestCallback);
@@ -5296,7 +5287,6 @@ public class RemoteServer implements Server
    private static final String PROCESS_TEST_EXISTS = "process_test_exists";
    private static final String PROCESS_NOTIFY_VISIBLE = "process_notify_visible";
    private static final String PROCESS_INTERRUPT_CHILD = "process_interrupt_child";
-   private static final String PROCESS_SET_ZOMBIE = "process_set_zombie";
 
    private static final String REMOVE_ALL_OBJECTS = "remove_all_objects";
    private static final String REMOVE_OBJECTS = "remove_objects";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/model/ConsoleServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/model/ConsoleServerOperations.java
@@ -117,13 +117,4 @@ public interface ConsoleServerOperations extends CodeToolsServerOperations,
     */
    void processInterruptChild(String handle,
                               ServerRequestCallback<Void> requestCallback);
-
-   /**
-    * Set zombie flag on a process. Server will keep this process's metadata and 
-    * buffer around, but won't restart the process.
-    * @param handle process handle
-    * @param requestCallback
-    */
-   void processSetZombie(String handle,
-                         ServerRequestCallback<Void> requestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
@@ -152,6 +152,19 @@ public class TerminalList implements Iterable<String>,
    }
 
    /**
+    * update zombie flag
+    * @param handle terminal handle
+    * @param zombie new zombie flag setting
+    */
+   public void setZombie(String handle, boolean zombie)
+   {
+      ConsoleProcessInfo current = getMetadataForHandle(handle);
+      if (current == null)
+         return;
+      current.setZombie(zombie);
+   }
+
+   /**
     * Remove given terminal from the list
     * @param handle terminal handle
     */

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -641,8 +641,8 @@ public class TerminalPane extends WorkbenchPane
             {
                terminal.showZombieMessage();
                terminal.disconnect(true /*permanent*/);
-               server_.processSetZombie(handle,  new VoidServerRequestCallback());
             }
+            terminals_.setZombie(handle, true);
             return;
          }
       }


### PR DESCRIPTION
Some minor refactoring made during other work. Doing it separately to make it clearer.

The `zombie` flag (a terminal exited but buffer stays visible) is set when a process exits on server, based on the ConsoleProc's settings and the user preference. Mainly intended for use by `terminalExecute` R API (the "other work") but can be enabled for all terminals via user preference.

Was catching this in client onExit handler, then sending the server an RPC to set the state, but this is unnecessary as the server already has the info to set this directly when a process exits. Eliminate the RPC and set it directly.

Also some other minor cleanup.