### PR TITLE
Avoid terminating installation script

### DIFF
--- a/dependencies/linux/install-dependencies-debian
+++ b/dependencies/linux/install-dependencies-debian
@@ -28,10 +28,8 @@ sudo apt-get -y install uuid-dev
 
 # for libssl, we want to make sure we get 1.0.2
 # version 1.1.0+ is not compatible with our source code
-which apt-cache > /dev/null
-if [ $? == 0 ]; then
-  apt-cache show libssl1.0-dev > /dev/null
-  if [ $? == 0 ]; then
+if which apt-cache > /dev/null ; then
+  if apt-cache show libssl1.0-dev > /dev/null ; then
     sudo apt-get -y install libssl1.0-dev
   else
     sudo apt-get -y install libssl-dev


### PR DESCRIPTION
When errexit is set, a bash script will halt as soon as any command has
a non-zero exit status. So the checks here were just halting the script.