### PR TITLE
Cleanup argument passing for terminal metadata

### DIFF
--- a/src/cpp/session/SessionConsoleProcessInfo.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfo.cpp
@@ -47,6 +47,11 @@ ConsoleProcessInfo::ConsoleProcessInfo()
    outputBuffer_.push_back('\n');
 }
 
+// The constant values in the initializer list (i.e. those not supplied as arguments
+// to the constructor) should match the constants set in the client
+// ConsoleProcessInfo.createNewTerminalInfo constructor. A new terminal can be
+// created from the client side via the UI using the client-side constructor, or on
+// the server-side via the R API (e.g. terminalCreate) which uses this C++ constructor.
 ConsoleProcessInfo::ConsoleProcessInfo(
          const std::string& caption,
          const std::string& title,

--- a/src/cpp/session/SessionConsoleProcessInfo.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfo.cpp
@@ -220,8 +220,13 @@ core::json::Object ConsoleProcessInfo::toJson() const
 boost::shared_ptr<ConsoleProcessInfo> ConsoleProcessInfo::fromJson(core::json::Object& obj)
 {
    boost::shared_ptr<ConsoleProcessInfo> pProc(new ConsoleProcessInfo());
-   pProc->handle_ = obj["handle"].get_str();
-   pProc->caption_ = obj["caption"].get_str();
+
+   json::Value handle = obj["handle"];
+   if (!handle.is_null())
+      pProc->handle_ = handle.get_str();
+   json::Value caption = obj["caption"];
+   if (!caption.is_null())
+      pProc->caption_ = caption.get_str();
 
    json::Value showOnOutput = obj["show_on_output"];
    if (!showOnOutput.is_null())
@@ -241,9 +246,13 @@ boost::shared_ptr<ConsoleProcessInfo> ConsoleProcessInfo::fromJson(core::json::O
    else
       pProc->maxOutputLines_ = kDefaultMaxOutputLines;
 
-   std::string bufferedOutput = obj["buffered_output"].get_str();
-   std::copy(bufferedOutput.begin(), bufferedOutput.end(),
-             std::back_inserter(pProc->outputBuffer_));
+   json::Value bufferedOutputValue = obj["buffered_output"];
+   if (!bufferedOutputValue.is_null())
+   {
+      std::string bufferedOutput = bufferedOutputValue.get_str();
+      std::copy(bufferedOutput.begin(), bufferedOutput.end(),
+                std::back_inserter(pProc->outputBuffer_));
+   }
    json::Value exitCode = obj["exit_code"];
    if (exitCode.is_null())
       pProc->exitCode_.reset();
@@ -252,19 +261,31 @@ boost::shared_ptr<ConsoleProcessInfo> ConsoleProcessInfo::fromJson(core::json::O
 
    pProc->terminalSequence_ = obj["terminal_sequence"].get_int();
    pProc->allowRestart_ = obj["allow_restart"].get_bool();
-   pProc->title_ = obj["title"].get_str();
+
+   json::Value title = obj["title"];
+   if (!title.is_null())
+      pProc->title_ = title.get_str();
+
    pProc->childProcs_ = obj["child_procs"].get_bool();
    int shellTypeInt = obj["shell_type"].get_int();
    pProc->shellType_ =
       static_cast<TerminalShell::TerminalShellType>(shellTypeInt);
    int channelModeInt = obj["channel_mode"].get_int();
    pProc->channelMode_ = static_cast<ChannelMode>(channelModeInt);
-   pProc->channelId_ = obj["channel_id"].get_str();
+
+   json::Value channelId = obj["channel_id"];
+   if (!channelId.is_null())
+      pProc->channelId_ = channelId.get_str();
+
    pProc->altBufferActive_ = obj["alt_buffer"].get_bool();
 
-   std::string cwd = obj["cwd"].get_str();
-   if (!cwd.empty())
-      pProc->cwd_ = module_context::resolveAliasedPath(obj["cwd"].get_str());
+   json::Value cwdValue = obj["cwd"];
+   if (!cwdValue.is_null())
+   {
+      std::string cwd = cwdValue.get_str();
+      if (!cwd.empty())
+         pProc->cwd_ = module_context::resolveAliasedPath(obj["cwd"].get_str());
+   }
 
    pProc->cols_ = obj["cols"].get_int();
    pProc->rows_ = obj["rows"].get_int();

--- a/src/cpp/session/SessionConsoleProcessTable.cpp
+++ b/src/cpp/session/SessionConsoleProcessTable.cpp
@@ -283,8 +283,7 @@ Error createTerminalConsoleProc(boost::shared_ptr<ConsoleProcessInfo> cpi,
 
    TerminalShell::TerminalShellType actualShellType;
    core::system::ProcessOptions options = ConsoleProcess::createTerminalProcOptions(
-            cpi->getShellType(), cpi->getCols(), cpi->getRows(), cpi->getTerminalSequence(),
-            cpi->getCwd(), cpi->getTrackEnv(), cpi->getHandle(), &actualShellType);
+            *cpi, &actualShellType);
 
    cpi->setShellType(actualShellType);
 

--- a/src/cpp/session/SessionConsoleProcessTable.hpp
+++ b/src/cpp/session/SessionConsoleProcessTable.hpp
@@ -65,19 +65,8 @@ core::Error reapConsoleProcess(const ConsoleProcess& proc);
 core::Error internalInitialize();
 
 // Create a ConsoleProcess and add it to the table. Final parameter returns handle.
-core::Error createTerminalConsoleProc(
-      TerminalShell::TerminalShellType shellType,
-      int cols,
-      int rows,
-      const std::string& termHandle, // empty if starting a new terminal
-      const std::string& termCaption,
-      const std::string& termTitle,
-      int termSequence,
-      bool altBufferActive,
-      const std::string& currentDir,
-      bool zombie,
-      bool trackEnv,
-      std::string* pHandle);
+core::Error createTerminalConsoleProc(boost::shared_ptr<ConsoleProcessInfo> cpi,
+                                      std::string* pHandle);
 
 } // namespace console_process
 } // namespace session

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -133,12 +133,7 @@ public:
    // the output param pSelectedShellType to indicate which shell type
    // was actually configured (e.g. what did 'default' get mapped to?).
    static core::system::ProcessOptions createTerminalProcOptions(
-         TerminalShell::TerminalShellType desiredShellType,
-         int cols, int rows,
-         int termSequence,
-         core::FilePath workingDir,
-         bool trackEnv,
-         const std::string& handle,
+         const ConsoleProcessInfo& procInfo,
          TerminalShell::TerminalShellType *pSelectedShellType);
 
    virtual ~ConsoleProcess() {}

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
@@ -54,7 +54,7 @@ public class ConsoleProcessInfo extends JavaScriptObject
       procInfo.buffered_output = "";
       procInfo.exit_code = null;
       procInfo.terminal_sequence = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::SEQUENCE_NEW_TERMINAL;
-      procInfo.allow_restart = false;
+      procInfo.allow_restart = true;
       procInfo.title = "";
       procInfo.child_procs = true;
       procInfo.shell_type = @org.rstudio.studio.client.workbench.views.terminal.TerminalShellInfo::SHELL_DEFAULT,

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
@@ -46,8 +46,8 @@ public class ConsoleProcessInfo extends JavaScriptObject
          
       var procInfo = new Object();
 
-      procInfo.handle = null;
-      procInfo.caption = null;
+      procInfo.handle = "";
+      procInfo.caption = "";
       procInfo.show_on_output = false;
       procInfo.interaction_mode = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::INTERACTION_ALWAYS;
       procInfo.max_output_lines = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::DEFAULT_MAX_OUTPUT_LINES;
@@ -55,13 +55,13 @@ public class ConsoleProcessInfo extends JavaScriptObject
       procInfo.exit_code = null;
       procInfo.terminal_sequence = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::SEQUENCE_NEW_TERMINAL;
       procInfo.allow_restart = false;
-      procInfo.title = null;
+      procInfo.title = "";
       procInfo.child_procs = true;
       procInfo.shell_type = @org.rstudio.studio.client.workbench.views.terminal.TerminalShellInfo::SHELL_DEFAULT,
       procInfo.channel_mode = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::CHANNEL_RPC;
       procInfo.channel_id = "";
       procInfo.alt_buffer = false;
-      procInfo.cwd = null;
+      procInfo.cwd = "";
       procInfo.cols = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::DEFAULT_COLS;
       procInfo.rows = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::DEFAULT_ROWS;
       procInfo.restarted = false;
@@ -71,68 +71,7 @@ public class ConsoleProcessInfo extends JavaScriptObject
 
       return procInfo;
    }-*/;
-   
-   /**
-    * Creates an object with sufficient metadata to display UI to trigger
-    * recreation of a previous terminal.
-    * @param handle
-    * @param caption
-    * @param title
-    * @param sequence
-    * @param childProcs
-    * @param cols
-    * @param rows
-    * @param shellType
-    * @param altBufferActive
-    * @param cwd
-    * @param autoCloseMode
-    * @param zombie
-    * @param trackEnv
-    * @return
-    */
-   public static final native ConsoleProcessInfo createTerminalMetadata(
-         String handle,
-         String caption,
-         String title,
-         int sequence,
-         boolean childProcs,
-         int cols,
-         int rows,
-         int shellType,
-         boolean altBufferActive,
-         String cwd,
-         int autoCloseMode,
-         boolean zombie,
-         boolean trackEnv) /*-{
-
-      var procInfo = new Object();
-
-      procInfo.handle = handle;
-      procInfo.caption = caption;
-      procInfo.show_on_output = false;
-      procInfo.interaction_mode = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::INTERACTION_ALWAYS;
-      procInfo.max_output_lines = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::DEFAULT_MAX_OUTPUT_LINES;
-      procInfo.buffered_output = "";
-      procInfo.exit_code = null;
-      procInfo.terminal_sequence = sequence;
-      procInfo.allow_restart = false;
-      procInfo.title = title;
-      procInfo.child_procs = childProcs;
-      procInfo.shell_type = shellType;
-      procInfo.channel_mode = @org.rstudio.studio.client.common.console.ConsoleProcessInfo::CHANNEL_RPC;
-      procInfo.channel_id = "";
-      procInfo.alt_buffer = altBufferActive;
-      procInfo.cwd = cwd;
-      procInfo.cols = cols;
-      procInfo.rows = rows;
-      procInfo.restarted = false;
-      procInfo.autoclose = autoCloseMode;
-      procInfo.zombie = zombie;
-      procInfo.track_env = trackEnv;
-
-      return procInfo;
-   }-*/;
-   
+  
    public final native String getHandle() /*-{
       return this.handle;
    }-*/;
@@ -245,5 +184,14 @@ public class ConsoleProcessInfo extends JavaScriptObject
 
    public final native void setZombie(boolean zombie) /*-{
       this.zombie = zombie;
+   }-*/;
+
+   public final native void setCaption(String caption) /*-{
+      this.caption = caption;
+   }-*/;
+
+   public final native void setDimensions(int cols, int rows) /*-{
+      this.cols = cols;
+      this.rows = rows;
    }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
@@ -41,6 +41,8 @@ public class ConsoleProcessInfo extends JavaScriptObject
 
    protected ConsoleProcessInfo() {}
 
+   // See comment in C++ code about keeping this in sync with SessionConsoleProcessInfo 
+   // constructor for terminal scenario.
    public static final native ConsoleProcessInfo createNewTerminalInfo(
          boolean trackEnv) /*-{
          

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -497,35 +497,12 @@ public class RemoteServer implements Server
    }
 
    @Override
-   public void startTerminal(
-                     int shellType,
-                     int cols, int rows,
-                     String terminalHandle,
-                     String caption,
-                     String title,
-                     int sequence,
-                     boolean altBufferActive,
-                     String cwd,
-                     boolean zombie,
-                     boolean trackEnv,
-                     ServerRequestCallback<ConsoleProcess> requestCallback)
+   public void startTerminal(ConsoleProcessInfo cpi,
+                             ServerRequestCallback<ConsoleProcess> requestCallback)
    {
-      JSONArray params = new JSONArray();
-      params.set(0, new JSONNumber(shellType));
-      params.set(1, new JSONNumber(cols));
-      params.set(2, new JSONNumber(rows));
-      params.set(3, new JSONString(StringUtil.notNull(terminalHandle)));
-      params.set(4, new JSONString(StringUtil.notNull(caption)));
-      params.set(5, new JSONString(StringUtil.notNull(title)));
-      params.set(6, new JSONNumber(sequence));
-      params.set(7, JSONBoolean.getInstance(altBufferActive));
-      params.set(8, new JSONString(StringUtil.notNull(cwd)));
-      params.set(9, JSONBoolean.getInstance(zombie));
-      params.set(10, JSONBoolean.getInstance(trackEnv));
-
       sendRequest(RPC_SCOPE,
                   START_TERMINAL,
-                  params,
+                  cpi,
                   new ConsoleProcessCallbackAdapter(requestCallback));
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchServerOperations.java
@@ -16,6 +16,7 @@ package org.rstudio.studio.client.workbench.model;
 
 import org.rstudio.studio.client.common.compilepdf.model.CompilePdfServerOperations;
 import org.rstudio.studio.client.common.console.ConsoleProcess;
+import org.rstudio.studio.client.common.console.ConsoleProcessInfo;
 import org.rstudio.studio.client.common.crypto.CryptoServerOperations;
 import org.rstudio.studio.client.common.debugging.DebuggingServerOperations;
 import org.rstudio.studio.client.common.dependencies.model.DependencyServerOperations;
@@ -132,9 +133,6 @@ public interface WorkbenchServerOperations extends ConsoleServerOperations,
    /**
     * Start a terminal session
     * 
-    * <p> Supports both a "caption" and a "title", and both are persisted on the
-    * server.</p>
-    * 
     * <p>On the client, the "caption" is displayed in the terminal tab, and
     * defaults to something like "Terminal 1", and can be changed by the user.</p>
     * 
@@ -142,22 +140,10 @@ public interface WorkbenchServerOperations extends ConsoleServerOperations,
     * above the terminal pane (e.g. show current working directory via bash's
     * PROMPT_COMMAND feature.</p>
     * 
-    * @param shellType one of TerminalShellInfo SHELL_* enum values
-    * @param cols initial number of text columns for pseudoterminal
-    * @param rows initial number of text rows for pseudoterminal
-    * @param handle initial terminal handle (pass empty or null string for new terminal)
-    * @param caption caption associated with the terminal
-    * @param title title associated with the terminal
-    * @param sequence relative order of terminal creation (1-based)
-    * @param altBufferActive terminal showing alt-buffer (full-screen ncurses)
-    * @param cwd current working directory
-    * @param zombie if true, terminal buffer reloaded but no process created
-    * @param trackEnv if true, server runs a hidden command to capture environment variables
+    * @param cpi terminal metadata
     * @param requestCallback callback from server upon completion
     */
-   void startTerminal(int shellType, int cols, int rows, String handle, 
-                      String caption, String title, int sequence, 
-                      boolean altBufferActive, String cwd, boolean zombie, boolean trackEnv,
+   void startTerminal(ConsoleProcessInfo cpi,
                       ServerRequestCallback<ConsoleProcess> requestCallback);
    
    void executeCode(String code, ServerRequestCallback<Void> requestCallback);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
@@ -24,6 +24,7 @@ import org.rstudio.core.client.widget.ModalDialogBase;
 import org.rstudio.core.client.widget.ThemedButton;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.Desktop;
+import org.rstudio.studio.client.common.console.ConsoleProcessInfo;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -44,24 +45,26 @@ public class TerminalInfoDialog extends ModalDialogBase
       boolean localEchoEnabled = uiPrefs_.terminalLocalEcho().getValue() && 
             !BrowseCap.isWindowsDesktop();
       
-      String cwd = session.getCwd();
+      ConsoleProcessInfo cpi = session.getProcInfo();
+      
+      String cwd = cpi.getCwd();
       if (StringUtil.isNullOrEmpty(cwd))
          cwd = "Default";
       
       final StringBuilder diagnostics = new StringBuilder();
       diagnostics.append("Terminal Session Information\n----------------------------\n");
-      diagnostics.append("Caption:     '" + session.getCaption() + "'\n");
-      diagnostics.append("Title:       '" + session.getTitle() + "'\n");
-      diagnostics.append("Cols x Rows  '" + session.getCols() + " x " + session.getRows() + "'\n");
-      diagnostics.append("Shell:       '" + TerminalShellInfo.getShellName(session.getShellType()) + "'\n");
-      diagnostics.append("Handle:      '" + session.getHandle() + "'\n");
-      diagnostics.append("Sequence:    '" + session.getSequence() + "'\n");
-      diagnostics.append("Restarted:   '" + session.getRestarted() + "\n");
-      diagnostics.append("Busy:        '" + session.getHasChildProcs() + "'\n");
+      diagnostics.append("Caption:     '" + cpi.getCaption() + "'\n");
+      diagnostics.append("Title:       '" + cpi.getTitle() + "'\n");
+      diagnostics.append("Cols x Rows  '" + cpi.getCols() + " x " + cpi.getRows() + "'\n");
+      diagnostics.append("Shell:       '" + TerminalShellInfo.getShellName(cpi.getShellType()) + "'\n");
+      diagnostics.append("Handle:      '" + cpi.getHandle() + "'\n");
+      diagnostics.append("Sequence:    '" + cpi.getTerminalSequence() + "'\n");
+      diagnostics.append("Restarted:   '" + cpi.getRestarted() + "\n");
+      diagnostics.append("Busy:        '" + cpi.getHasChildProcs() + "'\n");
       diagnostics.append("Full screen: 'client=" + session.xtermAltBufferActive() +  
-            "/server=" + session.getAltBufferActive() + "'\n"); 
-      diagnostics.append("Zombie:      '" + session.getZombie() + "'\n");
-      diagnostics.append("Track Env    '" + session.getTrackEnv() + "'\n");
+            "/server=" + cpi.getAltBufferActive() + "'\n"); 
+      diagnostics.append("Zombie:      '" + cpi.getZombie() + "'\n");
+      diagnostics.append("Track Env    '" + cpi.getTrackEnv() + "'\n");
       diagnostics.append("Local-echo:  '" + localEchoEnabled + "'\n"); 
       diagnostics.append("Working Dir: '" + cwd + "'\n"); 
       diagnostics.append("WebSockets:  '" + uiPrefs_.terminalUseWebsockets().getValue() + "'\n");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
@@ -63,20 +63,7 @@ public class TerminalList implements Iterable<String>,
     */
    public void addTerminal(TerminalSession term)
    {
-      addTerminal(ConsoleProcessInfo.createTerminalMetadata(
-            term.getHandle(),
-            term.getCaption(),
-            term.getTitle(),
-            term.getSequence(),
-            term.getHasChildProcs(),
-            term.getCols(),
-            term.getRows(),
-            term.getShellType(),
-            term.getAltBufferActive(),
-            term.getCwd(),
-            term.getAutoCloseMode(),
-            term.getZombie(),
-            term.getTrackEnv()));
+      addTerminal(term.getProcInfo());
    }
 
    /**
@@ -162,6 +149,19 @@ public class TerminalList implements Iterable<String>,
       if (current == null)
          return;
       current.setZombie(zombie);
+   }
+
+   /**
+    * update caption
+    * @param handle terminal handle
+    * @param zombie new caption
+    */
+   public void setCaption(String handle, String caption)
+   {
+      ConsoleProcessInfo current = getMetadataForHandle(handle);
+      if (current == null)
+         return;
+      current.setCaption(caption);
    }
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -43,7 +43,6 @@ import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.ui.WorkbenchPane;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.NewWorkingCopyEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.SwitchToTerminalEvent;
-import org.rstudio.studio.client.workbench.views.terminal.events.TerminalCwdEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStartedEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStoppedEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSubprocEvent;
@@ -80,8 +79,7 @@ public class TerminalPane extends WorkbenchPane
                                      SwitchToTerminalEvent.Handler,
                                      TerminalTitleEvent.Handler,
                                      SessionSerializationHandler,
-                                     TerminalSubprocEvent.Handler,
-                                     TerminalCwdEvent.Handler
+                                     TerminalSubprocEvent.Handler
 {
    @Inject
    protected TerminalPane(EventBus events,
@@ -103,7 +101,6 @@ public class TerminalPane extends WorkbenchPane
       events_.addHandler(TerminalTitleEvent.TYPE, this);
       events_.addHandler(SessionSerializationEvent.TYPE, this);
       events_.addHandler(TerminalSubprocEvent.TYPE, this);
-      events_.addHandler(TerminalCwdEvent.TYPE, this);
 
       events.addHandler(RestartStatusEvent.TYPE, 
                           new RestartStatusEvent.Handler()
@@ -570,13 +567,11 @@ public class TerminalPane extends WorkbenchPane
       }
 
       // The caption lives in multiple places:
-      // (1) the TerminalSession for connected terminals
-      // (2) the dropdown menu label
-      // (3) the TerminalMetadata held in terminals_
-      visibleTerminal.setCaption(newCaption);
+      // (1) the dropdown menu label
+      // (2) the ConsoleProcessInfo held in terminals_
       activeTerminalToolbarButton_.setActiveTerminal(
             newCaption, visibleTerminal.getHandle());
-      terminals_.addTerminal(visibleTerminal);
+      terminals_.setCaption(visibleTerminal.getHandle(), newCaption);
    }
 
    @Override
@@ -937,16 +932,6 @@ public class TerminalPane extends WorkbenchPane
       if (terminal != null)
       {
          terminal.setHasChildProcs(event.hasSubprocs());
-      }
-   }
-
-   @Override
-   public void onTerminalCwd(TerminalCwdEvent event)
-   {
-      TerminalSession terminal = loadedTerminalWithHandle(event.getHandle());
-      if (terminal != null)
-      {
-         terminal.setCwd(event.getCwd());
       }
    }
 


### PR DESCRIPTION
Been wanting to do this for a while and it's getting late, but think it's worth it for maintainability.

## Client-side ##
The ConsoleProcessInfo (CPI) object contains metadata about terminals. For whatever reason, early on I started passing and storing subsets of this around in various locations in the client-code. Then it was passed to the server as a bunch of arguments to terminalStart RPC call. This resulted int a bunch of places where I needed to ensure I was building/un-building CPI objects consistently, and keeping things in sync, and lots of little consistency errors crept in which I'm still finding.

I had cleaned some of this up a while ago, but the part I didn't get to is the `TerminalSession` which is constructed with a CPI, yet immediately tears it apart and stores the fields in separate members. Even though the same info was kept as a CPI already in the TerminalList, which is the ultimate owner of this on the client.

Now TerminalSession just keeps the CPI itself and references it as necessary. This is the same CPI object stored by the `TerminalList` so no longer a problem keeping in sync.

## Server-side ##
The `startTerminal` RPC now just takes a ConsoleProcessInfo object as its parameter, instead of all the individual fields. This ripples down through several APIs, cleaning up the signatures. 