### PR TITLE
allow multiple arguments to custom shell

### DIFF
--- a/src/cpp/session/modules/SessionTerminalShell.cpp
+++ b/src/cpp/session/modules/SessionTerminalShell.cpp
@@ -17,6 +17,7 @@
 
 #include <boost/foreach.hpp>
 
+#include <core/Algorithm.hpp>
 #include <core/system/System.hpp>
 #include <core/Log.hpp>
 #include <core/Error.hpp>
@@ -275,9 +276,13 @@ bool AvailableTerminalShells::getCustomShell(TerminalShell* pShellInfo)
    pShellInfo->name = "Custom";
    pShellInfo->type = TerminalShell::CustomShell;
    pShellInfo->path = userSettings().customShellCommand();
+
+   // arguments are space separated, currently no way to represent a literal space
    std::vector<std::string> args;
    if (!userSettings().customShellOptions().empty())
-      args.push_back(userSettings().customShellOptions());
+   {
+      args = core::algorithm::split(userSettings().customShellOptions(), " ");
+   }
    pShellInfo->args = args;
    return true;
 }


### PR DESCRIPTION
When specifying a custom terminal shell, the arguments are supplied as a single string in the UI but need to be split into separate arguments when passed to exec. Added simple space-separated split. With this fix in place, can do fun stuff like specify a custom script to run when starting a terminal to (for example) auto-launch/attach to tmux.