### PR TITLE
tweaks for roxygen completion

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -117,6 +117,22 @@ assign(x = ".rs.acCompletionTypes",
    if (grepl("^\\s*#+'\\s*$", line) && token == "'")
       token <- ""
    
+   # draw from 'man-roxygen' folder for '@template' completions
+   if (grepl("^\\s*#+'\\s*@template\\s+", line))
+   {
+      projDir <- .rs.getProjectDirectory()
+      if (is.null(projDir))
+         return(emptyCompletions)
+      
+      manRoxygen <- file.path(projDir, "man-roxygen")
+      if (!utils::file_test("-d", manRoxygen))
+         return(emptyCompletions)
+      
+      completions <- .rs.getCompletionsFile(token, path = manRoxygen, quote = FALSE)
+      completions$results <- sub("[.][rR]$", "", completions$results)
+      return(completions)
+   }
+   
    # allow the token to be empty only if we're attempting completions
    # at the start of the line
    if (token == "")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -2201,7 +2201,14 @@ public class RCompletionManager implements CompletionManager
          it.moveToPosition(cursorPos);
          Token token = it.stepBackward();
          if (token != null)
-            currentToken = token;
+         {
+            // don't allow spaces after roxygen keywords
+            boolean isRoxygen =
+                  token.hasType("keyword") &&
+                  token.hasType("virtual-comment");
+            if (!isRoxygen)
+               currentToken = token;
+         }
       }
       
       // Exclude non-string and non-identifier tokens.


### PR DESCRIPTION
This PR fixes a couple small bugs in Roxygen completion:

---

Roxygen completion now works when the cursor is flush against the roxygen comment marker, e.g.:

    #'|

Pressing <TAB> with the cursor at the `|` position now successfully autocompletes.

---

We no longer noisily attempt completions when there is no token at the cursor position, except when the cursor lies immediately after the Roxygen comment (+ whitespace). This should resolve issues where the autocompletion dialog would somewhat annoyingly re-show itself while typing on a comment line.