### PR TITLE
fix check for pending actions

### DIFF
--- a/src/cpp/session/modules/SessionPackrat.cpp
+++ b/src/cpp/session/modules/SessionPackrat.cpp
@@ -748,7 +748,7 @@ bool resolveStateAfterAction(PackratActionType action,
    if (hashChangedState)
       packages::enquePackageStateChanged();
 
-   return hashChangedState || !(hasPendingRestoreActions || 
+   return hashChangedState || !(hasPendingSnapshotActions ||
                                 hasPendingRestoreActions);
 }
 


### PR DESCRIPTION
Minor bug fix -- it looks like we accidentally used `hasPendingRestoreActions` twice in the check here. (bumped into this while playing with some static analysis tools, although I suppose this codepath is effectively unused now)