### PR TITLE
Set $RSTUDIO_TERM to handle, not sequence number

### DIFF
--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -75,11 +75,8 @@ core::system::ProcessOptions ConsoleProcess::createTerminalProcOptions(
    }
 #endif
 
-   if (procInfo.getTerminalSequence()!= kNoTerminal)
-   {
-      core::system::setenv(&shellEnv, "RSTUDIO_TERM",
-                           boost::lexical_cast<std::string>(procInfo.getTerminalSequence()));
-   }
+   core::system::setenv(&shellEnv, "RSTUDIO_TERM",
+                        boost::lexical_cast<std::string>(procInfo.getHandle()));
 
    // ammend shell paths as appropriate
    session::modules::workbench::ammendShellPaths(&shellEnv);

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -75,9 +75,6 @@ core::system::ProcessOptions ConsoleProcess::createTerminalProcOptions(
    }
 #endif
 
-   core::system::setenv(&shellEnv, "RSTUDIO_TERM",
-                        boost::lexical_cast<std::string>(procInfo.getHandle()));
-
    // ammend shell paths as appropriate
    session::modules::workbench::ammendShellPaths(&shellEnv);
 
@@ -233,6 +230,8 @@ void ConsoleProcess::commonInit()
       core::system::setenv(&(options_.environment.get()), "TERM",
                            options_.smartTerminal ? core::system::kSmartTerm :
                                                     core::system::kDumbTerm);
+
+      core::system::setenv(&(options_.environment.get()), "RSTUDIO_TERM", procInfo_->getHandle());
 #endif
    }
 


### PR DESCRIPTION
When a terminal is created, it is identified internally by a handle (8-char uuid). There is also a sequence number used to generate unique default captions e.g. "4" for Terminal 4. The handle is unique, the sequence number could be reused if you've closed some terminals and created new ones within the same session.

Set the RSTUDIO_TERM environment variable to the handle, instead of the integer sequence number. This could be used, for example, to give a tmux session a terminal-session-specific name when launching/creating via a custom terminal startup script.