### PR TITLE
fixed initctl errors on docker builds when installing rstudio server

### DIFF
--- a/package/linux/debian-control/postinst.in
+++ b/package/linux/debian-control/postinst.in
@@ -33,9 +33,22 @@ mkdir -p /var/lib/rstudio-server/proxy
 # suspend all sessions
 rstudio-server force-suspend-all
 
-# check lsb release and init system
+# check lsb release
 LSB_RELEASE=`lsb_release --id --short`
-INIT_SYSTEM=`cat /proc/1/comm 2>/dev/null`
+
+# determine which init system is in use
+# a variation on:
+# https://wiki.ubuntu.com/SystemdForUpstartUsers#How_to_identify_which_init_system_you_are_currently_booting_with
+INIT_SYSTEM="unknown"
+if ps -p1 | grep systemd > /dev/null 2>&1; then
+    # If pid 1 is systemd, this is systemd.
+    INIT_SYSTEM="systemd"
+elif ps -p1 | grep init > /dev/null 2>&1; then
+    # If pid 1 is init and init tells us it is upstart, this is upstart.
+    if /sbin/init --version | grep upstart > /dev/null 2>&1; then
+        INIT_SYSTEM="upstart"
+    fi
+fi
 
 # add apparmor profile (but don't for systemd as this borks up process management)
 if test $LSB_RELEASE = "Ubuntu" && test -d /etc/apparmor.d/ && ! test $INIT_SYSTEM = "systemd"
@@ -59,7 +72,7 @@ then
    systemctl start rstudio-server.service
    sleep 1
    systemctl --no-pager status rstudio-server.service
-elif test $LSB_RELEASE = "Ubuntu" && test -d /etc/init/
+elif test $LSB_RELEASE = "Ubuntu" && test "$INIT_SYSTEM" = "upstart"
 then
    cp ${CMAKE_INSTALL_PREFIX}/extras/upstart/rstudio-server.conf /etc/init/
    initctl reload-configuration

--- a/package/linux/debian-control/postrm.in
+++ b/package/linux/debian-control/postrm.in
@@ -10,8 +10,21 @@ rm -f /usr/sbin/rstudio-server
 rm -rf /tmp/rstudio-rsession
 rm -rf /tmp/rstudio-rserver
 
+# determine which init system is in use
+# a variation on:
+# https://wiki.ubuntu.com/SystemdForUpstartUsers#How_to_identify_which_init_system_you_are_currently_booting_with
+INIT_SYSTEM="unknown"
+if ps -p1 | grep systemd > /dev/null 2>&1; then
+    # If pid 1 is systemd, this is systemd.
+    INIT_SYSTEM="systemd"
+elif ps -p1 | grep init > /dev/null 2>&1; then
+    # If pid 1 is init and init tells us it is upstart, this is upstart.
+    if /sbin/init --version | grep upstart > /dev/null 2>&1; then
+        INIT_SYSTEM="upstart"
+    fi
+fi
+
 # stop and remove service under systemd
-INIT_SYSTEM=`cat /proc/1/comm 2>/dev/null`
 if test "$INIT_SYSTEM" = "systemd"
 then
    systemctl stop rstudio-server.service 2>/dev/null

--- a/package/linux/rpm-script/postinst.sh.in
+++ b/package/linux/rpm-script/postinst.sh.in
@@ -57,8 +57,21 @@ then
   fi
 fi
 
+# determine which init system is in use
+# a variation on:
+# https://wiki.ubuntu.com/SystemdForUpstartUsers#How_to_identify_which_init_system_you_are_currently_booting_with
+INIT_SYSTEM="unknown"
+if ps -p1 | grep systemd > /dev/null 2>&1; then
+    # If pid 1 is systemd, this is systemd.
+    INIT_SYSTEM="systemd"
+elif ps -p1 | grep init > /dev/null 2>&1; then
+    # If pid 1 is init and init tells us it is upstart, this is upstart.
+    if /sbin/init --version | grep upstart > /dev/null 2>&1; then
+        INIT_SYSTEM="upstart"
+    fi
+fi
+
 # add systemd, upstart, or init.d script and start the server
-INIT_SYSTEM=`cat /proc/1/comm 2>/dev/null`
 if test "$INIT_SYSTEM" = "systemd"
 then
    # remove any previously existing init.d based scheme
@@ -73,7 +86,7 @@ then
    systemctl start rstudio-server.service
    sleep 1
    systemctl --no-pager status rstudio-server.service
-elif test -d /etc/init/
+elif test "$INIT_SYSTEM" = "upstart"
 then
    # remove any previously existing init.d based scheme
    service rstudio-server stop 2>/dev/null

--- a/package/linux/rpm-script/postrm.sh.in
+++ b/package/linux/rpm-script/postrm.sh.in
@@ -3,6 +3,20 @@
 # errors shouldn't cause script to exit
 set +e 
 
+# determine which init system is in use
+# a variation on:
+# https://wiki.ubuntu.com/SystemdForUpstartUsers#How_to_identify_which_init_system_you_are_currently_booting_with
+INIT_SYSTEM="unknown"
+if ps -p1 | grep systemd > /dev/null 2>&1; then
+    # If pid 1 is systemd, this is systemd.
+    INIT_SYSTEM="systemd"
+elif ps -p1 | grep init > /dev/null 2>&1; then
+    # If pid 1 is init and init tells us it is upstart, this is upstart.
+    if /sbin/init --version | grep upstart > /dev/null 2>&1; then
+        INIT_SYSTEM="upstart"
+    fi
+fi
+
 # only remove things if this is an uninstall
 if [ "$1" = 0 ]
 then
@@ -14,7 +28,6 @@ then
    rm -rf /tmp/rstudio-rserver
 
    # stop and remove service under systemd
-   INIT_SYSTEM=`cat /proc/1/comm 2>/dev/null`
    if test "$INIT_SYSTEM" = "systemd"
    then
       systemctl stop rstudio-server.service 2>/dev/null


### PR DESCRIPTION
this includes better detection of which init system is in use (from Connect team), and therefore upstart is being properly NOT detected on docker platforms (and thus the regular service command is used, which is available on docker)