### PR TITLE
added softlinks for openssl libraries for Fedora 2

### DIFF
--- a/package/linux/rpm-script/postinst-desktop.sh.in
+++ b/package/linux/rpm-script/postinst-desktop.sh.in
@@ -6,6 +6,27 @@ set +e
 # create softlink to rstudio in /usr/bin
 ln -f -s ${CMAKE_INSTALL_PREFIX}/bin/rstudio /usr/bin/rstudio
 
+# create openssl softlinks based off Fedora version 
+if test -f /etc/fedora-release
+then
+  if test -d /usr/lib64 || test -d /lib64
+  then
+    architecture_dir='lib64'
+  else
+    architecture_dir='lib'
+  fi
+
+  compare_versions() { test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" != "$1"; }
+  version_number=$(cat /etc/fedora-release | sed 's/[^0-9,.]*//g')
+
+  # verify if release version number is greater than 25
+  if compare_versions $version_number 25
+  then
+    ln -s -f /$architecture_dir/libssl.so.10 ${CMAKE_INSTALL_PREFIX}/bin/libssl.so.1.0.0
+    ln -s -f /$architecture_dir/libcrypto.so.10 ${CMAKE_INSTALL_PREFIX}/bin/libcrypto.so.1.0.0
+  fi
+fi
+
 # update mime database
 update-mime-database /usr/share/mime
 

--- a/package/linux/rpm-script/postrm-desktop.sh.in
+++ b/package/linux/rpm-script/postrm-desktop.sh.in
@@ -8,6 +8,10 @@ if [ "$1" = 0 ]
 then
    # remove softlink to rstudio
    rm -f /usr/bin/rstudio
+
+   # remove openssl softlinks
+   rm -f ${CMAKE_INSTALL_PREFIX}/bin/libssl.so.1.0.0
+   rm -f ${CMAKE_INSTALL_PREFIX}/bin/libcrypto.so.1.0.0
 fi
 
 # clear error termination state


### PR DESCRIPTION
similar to what we do for open suse.

Still waiting for an update on https://github.com/rstudio/shiny/issues/1796 to see if this fixes the problem that's being seen in the wild.