### PR TITLE
Option to control warnings when killing terminal processes

### DIFF
--- a/src/cpp/core/include/core/system/PosixSystem.hpp
+++ b/src/cpp/core/include/core/system/PosixSystem.hpp
@@ -218,19 +218,16 @@ core::Error restorePriv();
 
 #ifdef __APPLE__
 // Detect subprocesses via Mac-only BSD-ish APIs
-bool hasSubprocessesMac(PidType pid);
 std::vector<SubprocInfo> getSubprocessesMac(PidType pid);
 #endif // __APPLE__
 
 // Detect subprocesses via shelling out to pgrep, kinda expensive but used
 // as last-resort on non-Mac Posix system without procfs.
-bool hasSubprocessesViaPgrep(PidType pid);
 std::vector<SubprocInfo> getSubprocessesViaPgrep(PidType pid);
 
 // Detect subprocesses via procfs; returns false no subprocesses, true if
 // subprocesses or unable to determine if there are subprocesses
 #ifndef __APPLE__
-bool hasSubprocessesViaProcFs(PidType pid);
 std::vector<SubprocInfo> getSubprocessesViaProcFs(PidType pid);
 #endif // !__APPLE__
 

--- a/src/cpp/core/include/core/system/PosixSystem.hpp
+++ b/src/cpp/core/include/core/system/PosixSystem.hpp
@@ -229,10 +229,10 @@ std::vector<SubprocInfo> getSubprocessesViaPgrep(PidType pid);
 
 // Detect subprocesses via procfs; returns false no subprocesses, true if
 // subprocesses or unable to determine if there are subprocesses
-#ifdef HAVE_PROCSELF
+#ifndef __APPLE__
 bool hasSubprocessesViaProcFs(PidType pid);
 std::vector<SubprocInfo> getSubprocessesViaProcFs(PidType pid);
-#endif // HAVE_PROCSELF
+#endif // !__APPLE__
 
 // Determine current working directory of a given process by shelling out
 // to lsof; used on systems without procfs.
@@ -240,9 +240,9 @@ FilePath currentWorkingDirViaLsof(PidType pid);
 
 // Determine current working directory of a given process via procfs; returns
 // empty FilePath if unable to determine.
-#ifdef HAVE_PROCSELF
+#ifndef __APPLE__
 FilePath currentWorkingDirViaProcFs(PidType pid);
-#endif // HAVE_PROCSELF
+#endif // !__APPLE__
 
 } // namespace system
 } // namespace core

--- a/src/cpp/core/include/core/system/PosixSystem.hpp
+++ b/src/cpp/core/include/core/system/PosixSystem.hpp
@@ -219,16 +219,19 @@ core::Error restorePriv();
 #ifdef __APPLE__
 // Detect subprocesses via Mac-only BSD-ish APIs
 bool hasSubprocessesMac(PidType pid);
+std::vector<SubprocInfo> getSubprocessesMac(PidType pid);
 #endif // __APPLE__
 
 // Detect subprocesses via shelling out to pgrep, kinda expensive but used
 // as last-resort on non-Mac Posix system without procfs.
 bool hasSubprocessesViaPgrep(PidType pid);
+std::vector<SubprocInfo> getSubprocessesViaPgrep(PidType pid);
 
 // Detect subprocesses via procfs; returns false no subprocesses, true if
 // subprocesses or unable to determine if there are subprocesses
 #ifdef HAVE_PROCSELF
 bool hasSubprocessesViaProcFs(PidType pid);
+std::vector<SubprocInfo> getSubprocessesViaProcFs(PidType pid);
 #endif // HAVE_PROCSELF
 
 // Determine current working directory of a given process by shelling out

--- a/src/cpp/core/include/core/system/Process.hpp
+++ b/src/cpp/core/include/core/system/Process.hpp
@@ -42,6 +42,18 @@ extern const char* const kDumbTerm;
 extern const int kDefaultCols;
 extern const int kDefaultRows;
 
+namespace busy_detection {
+
+enum Mode
+{
+   Always = 0,
+   Never = 1,
+   Whitelist = 2,
+};
+
+} // BusyDetectionMode
+
+
 ////////////////////////////////////////////////////////////////////////////////
 //
 // Run child process synchronously

--- a/src/cpp/core/include/core/system/Process.hpp
+++ b/src/cpp/core/include/core/system/Process.hpp
@@ -317,8 +317,8 @@ struct ProcessCallbacks
    // comment above for potential values)
    boost::function<void(int)> onExit;
 
-   // Called periodically to report if this process has subprocesses
-   boost::function<void(bool)> onHasSubprocs;
+   // Called periodically to report if this process has subprocesses (non-whitelist, whitelist)
+   boost::function<void(bool, bool)> onHasSubprocs;
 
    // Called periodically to report current working directory of process
    boost::function<void(const core::FilePath&)> reportCwd;

--- a/src/cpp/core/include/core/system/Process.hpp
+++ b/src/cpp/core/include/core/system/Process.hpp
@@ -169,6 +169,9 @@ struct ProcessOptions
    // Periodically report if process has any child processes
    bool reportHasSubprocs;
 
+   // Ignore these subprocesses when reporting
+   std::vector<std::string> subprocWhitelist;
+
    // Periodically track process' current working directory
    bool trackCwd;
 

--- a/src/cpp/core/include/core/system/System.hpp
+++ b/src/cpp/core/include/core/system/System.hpp
@@ -276,9 +276,6 @@ void abort();
 
 Error terminateProcess(PidType pid);
 
-// Returns true if pid has one or more subprocesses
-bool hasSubprocesses(PidType pid);
-
 struct SubprocInfo
 {
    PidType pid;

--- a/src/cpp/core/include/core/system/System.hpp
+++ b/src/cpp/core/include/core/system/System.hpp
@@ -279,6 +279,15 @@ Error terminateProcess(PidType pid);
 // Returns true if pid has one or more subprocesses
 bool hasSubprocesses(PidType pid);
 
+struct SubprocInfo
+{
+   PidType pid;
+   std::string exe;
+};
+
+// Return list of child processes, by executable filename and pid
+std::vector<SubprocInfo> getSubprocesses(PidType pid);
+
 // Get current-working directory of a process; returns empty FilePath
 // if unable to determine cwd
 FilePath currentWorkingDir(PidType pid);

--- a/src/cpp/core/system/ChildProcess.hpp
+++ b/src/cpp/core/system/ChildProcess.hpp
@@ -70,7 +70,10 @@ public:
    // Does this process have any subprocesses? True if there are
    // subprocesses, if it hasn't been checked yet, or if the process
    // isn't configured to check for subprocesses.
-   virtual bool hasSubprocess() const;
+   virtual bool hasNonWhitelistSubprocess() const;
+
+   // Does this process have any subprocesses that match the whitelist?
+   virtual bool hasWhitelistSubprocess() const;
 
    // What is current working directory of this process? Empty if unknown
    // or not configured to track cwd.
@@ -218,7 +221,8 @@ public:
    // override of terminate (allow special handling for unix pty termination)
    virtual Error terminate();
 
-   virtual bool hasSubprocess() const;
+   virtual bool hasNonWhitelistSubprocess() const;
+   virtual bool hasWhitelistSubprocess() const;
    virtual core::FilePath getCwd() const;
    virtual bool hasRecentOutput() const;
 

--- a/src/cpp/core/system/ChildProcessSubprocPoll.cpp
+++ b/src/cpp/core/system/ChildProcessSubprocPoll.cpp
@@ -15,6 +15,8 @@
 
 #include "ChildProcessSubprocPoll.hpp"
 
+#include <boost/foreach.hpp>
+
 namespace rstudio {
 namespace core {
 namespace system {
@@ -35,7 +37,8 @@ ChildProcessSubprocPoll::ChildProcessSubprocPoll(
       boost::posix_time::milliseconds resetRecentDelay,
       boost::posix_time::milliseconds checkSubprocDelay,
       boost::posix_time::milliseconds checkCwdDelay,
-      boost::function<bool (PidType pid)> subProcCheck,
+      boost::function<std::vector<SubprocInfo> (PidType pid)> subProcCheck,
+      const std::vector<std::string>& subProcWhitelist,
       boost::function<core::FilePath (PidType pid)> cwdCheck)
    :
      pid_(pid),
@@ -50,6 +53,7 @@ ChildProcessSubprocPoll::ChildProcessSubprocPoll(
      checkSubprocDelay_(checkSubprocDelay),
      checkCwdDelay_(checkCwdDelay),
      subProcCheck_(subProcCheck),
+     subProcWhitelist_(subProcWhitelist),
      cwdCheck_(cwdCheck)
 {
 }
@@ -112,7 +116,27 @@ bool ChildProcessSubprocPoll::pollSubproc(boost::posix_time::ptime currentTime)
 
    // Enough time has passed, update whether "pid" has subprocesses
    // and restart the timer.
-   hasSubprocess_ = subProcCheck_(pid_);
+   bool foundSubprocess = false;
+   std::vector<SubprocInfo> children = subProcCheck_(pid_);
+   BOOST_FOREACH(SubprocInfo proc, children)
+   {
+      bool isWhitelistItem = false;
+      BOOST_FOREACH(std::string whitelistItem, subProcWhitelist_)
+      {
+         if (proc.exe == whitelistItem)
+         {
+            isWhitelistItem = true;
+            break;
+         }
+      }
+      if (!isWhitelistItem)
+      {
+         foundSubprocess = true;
+         break;
+      }
+   }
+
+   hasSubprocess_ = foundSubprocess;
    checkSubProcAfter_ = currentTime + checkSubprocDelay_;
    didThrottleSubprocCheck_ = false;
    return true;

--- a/src/cpp/core/system/ChildProcessSubprocPoll.hpp
+++ b/src/cpp/core/system/ChildProcessSubprocPoll.hpp
@@ -58,7 +58,8 @@ public:
          boost::posix_time::milliseconds resetRecentDelay,
          boost::posix_time::milliseconds checkSubprocDelay,
          boost::posix_time::milliseconds checkCwdDelay,
-         boost::function<bool (PidType pid)> subProcCheck,
+         boost::function<std::vector<SubprocInfo> (PidType pid)> subProcCheck,
+         const std::vector<std::string>& subProcWhitelist,
          boost::function<core::FilePath (PidType pid)> cwdCheck);
 
    virtual ~ChildProcessSubprocPoll() {}
@@ -108,7 +109,10 @@ private:
 
    // function used to check for subprocesses; if NULL then subprocess
    // checking will not be done
-   boost::function<bool (PidType pid)> subProcCheck_;
+   boost::function<std::vector<SubprocInfo> (PidType pid)> subProcCheck_;
+
+   // list of processes that aren't reported when checking for subprocesses
+   std::vector<std::string> subProcWhitelist_;
 
    // function used to update current working directory; if NULL then cwd
    // updating will not be done

--- a/src/cpp/core/system/ChildProcessSubprocPoll.hpp
+++ b/src/cpp/core/system/ChildProcessSubprocPoll.hpp
@@ -69,7 +69,8 @@ public:
 
    void stop();
 
-   bool hasSubprocess() const;
+   bool hasNonWhitelistSubprocess() const;
+   bool hasWhitelistSubprocess() const;
    bool hasRecentOutput() const;
    core::FilePath getCwd() const;
 
@@ -91,6 +92,7 @@ private:
 
    // results of most recent checks
    bool hasSubprocess_;
+   bool hasWhitelistSubprocess_;
    bool hasRecentOutput_;
    core::FilePath cwd_;
 

--- a/src/cpp/core/system/ChildProcessSubprocPollTests.cpp
+++ b/src/cpp/core/system/ChildProcessSubprocPollTests.cpp
@@ -50,7 +50,7 @@ public:
    NoSubProcPollingFixture(PidType pid)
       :
         poller_(pid, kResetRecentDelay, kCheckSubprocDelay, kCheckCwdDelay,
-                NULL, NULL)
+                NULL, std::vector<std::string>(), NULL)
    {}
 
    ChildProcessSubprocPoll poller_;
@@ -63,17 +63,26 @@ public:
       :
         poller_(pid, kResetRecentDelay, kCheckSubprocDelay, kCheckCwdDelay,
                 boost::bind(&SubProcPollingFixture::checkSubproc, this, _1),
+                std::vector<std::string>(),
                 NULL),
         checkReturns_(false),
         callerPid_(0),
         checkCalled_(false)
    {}
 
-   bool checkSubproc(PidType pid)
+   std::vector<SubprocInfo> checkSubproc(PidType pid)
    {
       callerPid_ = pid;
       checkCalled_ = true;
-      return checkReturns_;
+      std::vector<SubprocInfo> result;
+      if (checkReturns_)
+      {
+         SubprocInfo info;
+         info.exe = "some_exe";
+         info.pid = 123;
+         result.push_back(info);
+      }
+      return result;
    }
 
    void clearFlags()
@@ -95,7 +104,7 @@ public:
    CwdPollingFixture(PidType pid)
       :
         poller_(pid, kResetRecentDelay, kCheckSubprocDelay, kCheckCwdDelay,
-                NULL,
+                NULL, std::vector<std::string>(),
                 boost::bind(&CwdPollingFixture::checkCwd, this, _1)),
         callerPid_(0),
         checkCalled_(false)

--- a/src/cpp/core/system/ChildProcessSubprocPollTests.cpp
+++ b/src/cpp/core/system/ChildProcessSubprocPollTests.cpp
@@ -139,9 +139,9 @@ context("ChildProcess polling support class")
       PidType pid = 12345;
       NoSubProcPollingFixture test(pid);
 
-      // we start with the flags set to true
       expect_true(test.poller_.hasRecentOutput());
-      expect_true(test.poller_.hasSubprocess());
+      expect_true(test.poller_.hasNonWhitelistSubprocess());
+      expect_false(test.poller_.hasWhitelistSubprocess());
    }
 
    test_that("recent input state without subproc polling doesn't change immediately")
@@ -174,9 +174,9 @@ context("ChildProcess polling support class")
       PidType pid = 12345;
       SubProcPollingFixture test(pid);
 
-      // we start with the flags set to true
       expect_true(test.poller_.hasRecentOutput());
-      expect_true(test.poller_.hasSubprocess());
+      expect_true(test.poller_.hasNonWhitelistSubprocess());
+      expect_false(test.poller_.hasWhitelistSubprocess());
    }
 
    test_that("childproc checked when recent output and timeout expires")
@@ -190,7 +190,7 @@ context("ChildProcess polling support class")
       blockingwait(kCheckSubprocDelayExpired); // longer than the subproc timeout
       expect_true(test.poller_.poll(false)); // not longer than the recent output timeout!
       expect_true(test.checkCalled_);
-      expect_true(test.poller_.hasSubprocess() == test.checkReturns_);
+      expect_true(test.poller_.hasNonWhitelistSubprocess() == test.checkReturns_);
       expect_true(test.poller_.hasRecentOutput());
       expect_true(test.callerPid_ == pid);
    }
@@ -206,7 +206,7 @@ context("ChildProcess polling support class")
       blockingwait(kCheckSubprocDelayExpired); // long enough for childproc polling
       test.poller_.poll(false); // not longer than the output timeout
       expect_true(test.checkCalled_);
-      expect_true(test.poller_.hasSubprocess() == test.checkReturns_);
+      expect_true(test.poller_.hasNonWhitelistSubprocess() == test.checkReturns_);
       expect_true(test.poller_.hasRecentOutput());
       expect_true(test.callerPid_ == pid);
 
@@ -216,7 +216,7 @@ context("ChildProcess polling support class")
       test.poller_.poll(false);
       expect_false(test.checkCalled_); // because of no recent output
       expect_false(test.poller_.hasRecentOutput());
-      expect_true(test.poller_.hasSubprocess() == test.checkReturns_);
+      expect_true(test.poller_.hasNonWhitelistSubprocess() == test.checkReturns_);
    }
 
    test_that("initial state for cwd polling matches expectations")

--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -819,7 +819,8 @@ void AsyncChildProcess::poll()
       pAsyncImpl_->pSubprocPoll_.reset(new ChildProcessSubprocPoll(
          pImpl_->pid,
          kResetRecentDelay, kCheckSubprocDelay, kCheckCwdDelay,
-         options().reportHasSubprocs ? core::system::hasSubprocesses : NULL,
+         options().reportHasSubprocs ? core::system::getSubprocesses : NULL,
+         options().subprocWhitelist,
          options().trackCwd ? core::system::currentWorkingDir : NULL));
 
       if (callbacks_.onStarted)

--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -389,10 +389,16 @@ Error ChildProcess::terminate()
    }
 }
 
-bool ChildProcess::hasSubprocess() const
+bool ChildProcess::hasNonWhitelistSubprocess() const
 {
    // base class doesn't support subprocess-checking; override to implement
    return true;
+}
+
+bool ChildProcess::hasWhitelistSubprocess() const
+{
+   // base class doesn't support subprocess-checking; override to implement
+   return false;
 }
 
 core::FilePath ChildProcess::getCwd() const
@@ -776,12 +782,20 @@ Error AsyncChildProcess::terminate()
    return ChildProcess::terminate();
 }
 
-bool AsyncChildProcess::hasSubprocess() const
+bool AsyncChildProcess::hasNonWhitelistSubprocess() const
 {
    if (pAsyncImpl_->pSubprocPoll_)
-      return pAsyncImpl_->pSubprocPoll_->hasSubprocess();
+      return pAsyncImpl_->pSubprocPoll_->hasNonWhitelistSubprocess();
    else
       return true;
+}
+
+bool AsyncChildProcess::hasWhitelistSubprocess() const
+{
+   if (pAsyncImpl_->pSubprocPoll_)
+      return pAsyncImpl_->pSubprocPoll_->hasWhitelistSubprocess();
+   else
+      return false;
 }
 
 core::FilePath AsyncChildProcess::getCwd() const
@@ -934,7 +948,8 @@ void AsyncChildProcess::poll()
    {
       if (callbacks_.onHasSubprocs)
       {
-         callbacks_.onHasSubprocs(hasSubprocess());
+         callbacks_.onHasSubprocs(hasNonWhitelistSubprocess(),
+                                  hasWhitelistSubprocess());
       }
       if (callbacks_.reportCwd)
       {

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -932,7 +932,7 @@ std::vector<SubprocInfo> getSubprocessesViaProcFs(PidType pid)
       }
 
       SubprocInfo info;
-      info.exe = contents.substr(openParen + 1, closingParen - openParen);
+      info.exe = contents.substr(openParen + 1, closingParen - openParen - 1);
       info.pid = safe_convert::stringTo<PidType>(contents.substr(0, openParen - 1), -1);
       if (info.pid == -1)
       {

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -725,26 +725,8 @@ Error terminateProcess(PidType pid)
 
 bool hasSubprocessesViaPgrep(PidType pid)
 {
-   // pgrep -P ppid returns 0 if there are matches, non-zero
-   // otherwise
-   shell_utils::ShellCommand cmd("pgrep");
-   cmd << "-P" << pid;
-
-   core::system::ProcessOptions options;
-   options.detachSession = true;
-
-   core::system::ProcessResult result;
-   Error error = runCommand(shell_utils::sendStdErrToStdOut(cmd),
-                            options,
-                            &result);
-   if (error)
-   {
-      // err on the side of assuming child processes, so we don't kill
-      // a job unintentionally
-      LOG_ERROR(error);
-      return true;
-   }
-   return result.exitStatus == 0;
+   std::vector<SubprocInfo> subprocs = getSubprocessesViaPgrep(pid);
+   return !subprocs.empty();
 }
 
 std::vector<SubprocInfo> getSubprocessesViaPgrep(PidType pid)
@@ -810,15 +792,8 @@ std::vector<SubprocInfo> getSubprocessesViaPgrep(PidType pid)
 #ifdef __APPLE__ // Mac-specific subprocess detection
 bool hasSubprocessesMac(PidType pid)
 {
-   int result = proc_listchildpids(pid, NULL, 0);
-   if (result > 0)
-   {
-      // have to fetch details to get accurate result
-      std::vector<int> buffer;
-      buffer.reserve(result);
-      result = proc_listchildpids(pid, &buffer[0], buffer.capacity() * sizeof(int));
-   }
-   return result > 0;
+   std::vector<SubprocInfo> subprocs = getSubprocessesMac(pid);
+   return !subprocs.empty();
 }
 
 std::vector<SubprocInfo> getSubprocessesMac(PidType pid)
@@ -854,15 +829,21 @@ std::vector<SubprocInfo> getSubprocessesMac(PidType pid)
    return subprocs;
 }
 
-#endif
-
-#ifdef HAVE_PROCSELF
+#else
 bool hasSubprocessesViaProcFs(PidType pid)
 {
+   std::vector<SubprocInfo> subprocs = getSubprocessesViaProcFs(pid);
+   return !subprocs.empty();
+}
+
+std::vector<SubprocInfo> getSubprocessesViaProcFs(PidType pid)
+{
+   std::vector<SubprocInfo> subprocs;
+
    core::FilePath procFsPath("/proc");
    if (!procFsPath.exists())
    {
-      return true; // err on the side of assuming child processes exist
+      return getSubprocessesViaPgrep(pid);
    }
 
    // We iterate all /proc/###/stat files, where ### is a process id.
@@ -887,7 +868,7 @@ bool hasSubprocessesViaProcFs(PidType pid)
    if (error)
    {
       LOG_ERROR(error);
-      return true; // err on the side of assuming child processes exist
+      return subprocs;
    }
 
    BOOST_FOREACH(const FilePath& child, children)
@@ -916,14 +897,14 @@ bool hasSubprocessesViaProcFs(PidType pid)
          continue;
       }
 
-      size_t i = contents.find_last_of(')');
-      if (i == std::string::npos)
+      size_t closingParen = contents.find_last_of(')');
+      if (closingParen == std::string::npos)
       {
          LOG_ERROR_MESSAGE("no closing parenthesis");
          continue;
       }
 
-      i = contents.find_first_of("0123456789", i);
+      size_t i = contents.find_first_of("0123456789", closingParen);
       if (i == std::string::npos)
       {
          LOG_ERROR_MESSAGE("no integer after closing parenthesis");
@@ -937,41 +918,56 @@ bool hasSubprocessesViaProcFs(PidType pid)
          continue;
       }
 
-      // extremely unexpected/unlikely, but make sure we don't have some funky
-      // super-large integer here that could cause lexical_cast to throw
       size_t ppidLen = j - i;
-      if (ppidLen > 9)
+      PidType ppid = safe_convert::stringTo<PidType>(contents.substr(i, ppidLen), -1);
+      if (ppid == -1)
       {
-         LOG_ERROR_MESSAGE("stat file ppid too large");
+         LOG_ERROR_MESSAGE("unrecognized parent process id");
          continue;
       }
-      int ppid = boost::lexical_cast<int>(contents.substr(i, ppidLen));
-      if (ppid == pid)
-         return true;
-   }
-   return false;
-}
+      if (ppid != pid)
+      {
+         continue;
+      }
 
-std::vector<SubprocInfo> getSubprocessesViaProcFs(PidType pid)
-{
-   // TODO (gary)
-   std::vector<SubprocInfo> subprocs;
+      size_t openParen = contents.find_first_of('(');
+      if (openParen == std::string::npos)
+      {
+         LOG_ERROR_MESSAGE("no opening parenthesis");
+         continue;
+      }
+      if (openParen < 2) // at a minimum, "# (foo)"
+      {
+         LOG_ERROR_MESSAGE("no pid before exe name");
+         continue;
+      }
+      if (closingParen < openParen)
+      {
+         LOG_ERROR_MESSAGE("closing paren before open paren");
+         continue;
+      }
+
+      SubprocInfo info;
+      info.exe = contents.substr(openParen + 1, closingParen - openParen);
+      info.pid = safe_convert::stringTo<PidType>(contents.substr(0, openParen - 1), -1);
+      if (info.pid == -1)
+      {
+         LOG_ERROR_MESSAGE("unrecognized child process id");
+         continue;
+      }
+      subprocs.push_back(info);
+   }
+
    return subprocs;
 }
-#endif // HAVE_PROCSELF
+#endif // !__APPLE__
 
 bool hasSubprocesses(PidType pid)
 {
 #ifdef __APPLE__
    return hasSubprocessesMac(pid);
 #else // Linux
-
-#ifdef HAVE_PROCSELF
    return hasSubprocessesViaProcFs(pid);
-#else
-   return hasSubprocessesViaPgrep(pid);
-#endif
-
 #endif
 }
 
@@ -980,13 +976,7 @@ std::vector<SubprocInfo> getSubprocesses(PidType pid)
 #ifdef __APPLE__
    return getSubprocessesMac(pid);
 #else // Linux
-
-#ifdef HAVE_PROCSELF
    return getSubprocessesViaProcFs(pid);
-#else
-   return getSubprocessesViaPgrep(pid);
-#endif
-
 #endif
 }
 
@@ -1035,13 +1025,13 @@ FilePath currentWorkingDirViaLsof(PidType pid)
    return FilePath();
 }
 
-#ifdef HAVE_PROCSELF
+#ifndef __APPLE__
 FilePath currentWorkingDirViaProcFs(PidType pid)
 {
    core::FilePath procFsPath("/proc");
    if (!procFsPath.exists())
    {
-      return FilePath();
+      return currentWorkingDirViaLsof(pid);
    }
 
    std::string procId = safe_convert::numberToString(pid);
@@ -1055,14 +1045,14 @@ FilePath currentWorkingDirViaProcFs(PidType pid)
    else
       return FilePath();
 }
-#endif // HAVE_PROCSELF
+#endif // !__APPLE__
 
 FilePath currentWorkingDir(PidType pid)
 {
-#ifdef HAVE_PROCSELF
-   return currentWorkingDirViaProcFs(pid);
-#else
+#ifdef __APPLE__
    return currentWorkingDirViaLsof(pid);
+#else
+   return currentWorkingDirViaProcFs(pid);
 #endif
 }
 

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -723,12 +723,6 @@ Error terminateProcess(PidType pid)
       return Success();
 }
 
-bool hasSubprocessesViaPgrep(PidType pid)
-{
-   std::vector<SubprocInfo> subprocs = getSubprocessesViaPgrep(pid);
-   return !subprocs.empty();
-}
-
 std::vector<SubprocInfo> getSubprocessesViaPgrep(PidType pid)
 {
    std::vector<SubprocInfo> subprocs;
@@ -790,11 +784,6 @@ std::vector<SubprocInfo> getSubprocessesViaPgrep(PidType pid)
 }
 
 #ifdef __APPLE__ // Mac-specific subprocess detection
-bool hasSubprocessesMac(PidType pid)
-{
-   std::vector<SubprocInfo> subprocs = getSubprocessesMac(pid);
-   return !subprocs.empty();
-}
 
 std::vector<SubprocInfo> getSubprocessesMac(PidType pid)
 {
@@ -830,11 +819,6 @@ std::vector<SubprocInfo> getSubprocessesMac(PidType pid)
 }
 
 #else
-bool hasSubprocessesViaProcFs(PidType pid)
-{
-   std::vector<SubprocInfo> subprocs = getSubprocessesViaProcFs(pid);
-   return !subprocs.empty();
-}
 
 std::vector<SubprocInfo> getSubprocessesViaProcFs(PidType pid)
 {
@@ -961,15 +945,6 @@ std::vector<SubprocInfo> getSubprocessesViaProcFs(PidType pid)
    return subprocs;
 }
 #endif // !__APPLE__
-
-bool hasSubprocesses(PidType pid)
-{
-#ifdef __APPLE__
-   return hasSubprocessesMac(pid);
-#else // Linux
-   return hasSubprocessesViaProcFs(pid);
-#endif
-}
 
 std::vector<SubprocInfo> getSubprocesses(PidType pid)
 {

--- a/src/cpp/core/system/PosixSystemTests.cpp
+++ b/src/cpp/core/system/PosixSystemTests.cpp
@@ -17,6 +17,7 @@
 
 #include <core/system/PosixSystem.hpp>
 #include <signal.h>
+#include <sys/wait.h>
 
 #include <tests/TestThat.hpp>
 

--- a/src/cpp/core/system/PosixSystemTests.cpp
+++ b/src/cpp/core/system/PosixSystemTests.cpp
@@ -175,7 +175,7 @@ context("PosixSystemTests")
       else
       {
          // process we started doesn't have a subprocess
-         std::vector<SubprocInfo> children = getSubprocessesViaPgrep(pid);
+         std::vector<SubprocInfo> children = getSubprocessesViaProcFs(pid);
          expect_true(children.empty());
 
          ::kill(pid, SIGKILL);
@@ -197,7 +197,7 @@ context("PosixSystemTests")
       else
       {
          // we now have a subprocess
-         std::vector<SubprocInfo> children = getSubprocessesViaPgrep(getpid());
+         std::vector<SubprocInfo> children = getSubprocessesViaProcFs(getpid());
          expect_true(children.size() >= 1);
          if (children.size() >= 1)
          {

--- a/src/cpp/core/system/PosixSystemTests.cpp
+++ b/src/cpp/core/system/PosixSystemTests.cpp
@@ -30,87 +30,6 @@ namespace tests {
 
 context("PosixSystemTests")
 {
-
-   test_that("No subprocess detected correctly with generic method")
-   {
-      pid_t pid = fork();
-      expect_false(pid == -1);
-
-      if (pid == 0)
-      {
-         ::sleep(1);
-         _exit(0);
-      }
-      else
-      {
-         // process we started doesn't have a subprocess
-         expect_false(hasSubprocesses(pid));
-
-         expect_true(::kill(pid, SIGKILL) == 0);
-         ::waitpid(pid, NULL, 0);
-      }
-   }
-
-   test_that("Subprocess detected correctly with generic method")
-   {
-      pid_t pid = fork();
-      expect_false(pid == -1);
-
-      if (pid == 0)
-      {
-         ::sleep(1);
-         _exit(0);
-      }
-      else
-      {
-         // we now have a subprocess
-         expect_true(hasSubprocesses(getpid()));
-
-         ::kill(pid, SIGKILL);
-         ::waitpid(pid, NULL, 0);
-      }
-   }
-
-   test_that("No subprocess detected correctly with pgrep method")
-   {
-      pid_t pid = fork();
-      expect_false(pid == -1);
-
-      if (pid == 0)
-      {
-         ::sleep(1);
-         _exit(0);
-      }
-      else
-      {
-         // process we started doesn't have a subprocess
-         expect_false(hasSubprocessesViaPgrep(pid));
-
-         ::kill(pid, SIGKILL);
-         ::waitpid(pid, NULL, 0);
-      }
-   }
-
-   test_that("Subprocess detected correctly with pgrep method")
-   {
-      pid_t pid = fork();
-      expect_false(pid == -1);
-
-      if (pid == 0)
-      {
-         ::sleep(1);
-         _exit(0);
-      }
-      else
-      {
-         // we now have a subprocess
-         expect_true(hasSubprocessesViaPgrep(getpid()));
-
-         ::kill(pid, SIGKILL);
-         ::waitpid(pid, NULL, 0);
-      }
-   }
-
    test_that("Empty subprocess list returned correctly with pgrep method")
    {
       pid_t pid = fork();
@@ -169,46 +88,6 @@ context("PosixSystemTests")
    }
 
 #ifdef __APPLE__ // Mac-specific subprocess detection
-
-   test_that("No subprocess detected correctly with Mac method")
-   {
-      pid_t pid = fork();
-      expect_false(pid == -1);
-
-      if (pid == 0)
-      {
-         ::sleep(1);
-         _exit(0);
-      }
-      else
-      {
-         // process we started doesn't have a subprocess
-         expect_false(hasSubprocessesMac(pid));
-
-         ::kill(pid, SIGKILL);
-         ::waitpid(pid, NULL, 0);
-      }
-   }
-
-   test_that("Subprocess detected correctly with Mac method")
-   {
-      pid_t pid = fork();
-      expect_false(pid == -1);
-
-      if (pid == 0)
-      {
-         ::sleep(1);
-         _exit(0);
-      }
-      else
-      {
-         // we now have a subprocess
-         expect_true(hasSubprocessesMac(getpid()));
-
-         ::kill(pid, SIGKILL);
-         ::waitpid(pid, NULL, 0);
-      }
-   }
 
    test_that("Subprocess list correctly empty with Mac method")
    {
@@ -282,46 +161,6 @@ context("PosixSystemTests")
 
 
 #else
-
-   test_that("No subprocess detected correctly with procfs method")
-   {
-      pid_t pid = fork();
-      expect_false(pid == -1);
-
-      if (pid == 0)
-      {
-         ::sleep(1);
-         _exit(0);
-      }
-      else
-      {
-         // process we started doesn't have a subprocess
-         expect_false(hasSubprocessesViaProcFs(pid));
-
-         ::kill(pid, SIGKILL);
-         ::waitpid(pid, NULL, 0);
-      }
-   }
-
-   test_that("Subprocess detected correctly with procfs method")
-   {
-      pid_t pid = fork();
-      expect_false(pid == -1);
-
-      if (pid == 0)
-      {
-         ::sleep(1);
-         _exit(0);
-      }
-      else
-      {
-         // we now have a subprocess
-         expect_true(hasSubprocessesViaProcFs(getpid()));
-
-         ::kill(pid, SIGKILL);
-         ::waitpid(pid, NULL, 0);
-      }
-   }
 
    test_that("No subprocesses detected correctly with procfs method")
    {

--- a/src/cpp/core/system/PosixSystemTests.cpp
+++ b/src/cpp/core/system/PosixSystemTests.cpp
@@ -15,6 +15,8 @@
 
 #ifndef _WIN32
 
+#include <boost/foreach.hpp>
+
 #include <core/system/PosixSystem.hpp>
 #include <signal.h>
 #include <sys/wait.h>
@@ -146,9 +148,20 @@ context("PosixSystemTests")
       {
          // we now have a subprocess
          std::vector<SubprocInfo> children = getSubprocessesViaPgrep(getpid());
-         expect_true(children.size() == 1);
-         if (children.size() == 1)
-            expect_true(children[0].exe.compare(exe) == 0);
+         expect_true(children.size() >= 1);
+         if (children.size() >= 1)
+         {
+            bool found = false;
+            BOOST_FOREACH(SubprocInfo info, children)
+            {
+               if (info.exe.compare(exe) == 0)
+               {
+                  found = true;
+                  break;
+               }
+            }
+            expect_true(found);
+         }
 
          ::kill(pid, SIGKILL);
          ::waitpid(pid, NULL, 0);

--- a/src/cpp/core/system/Process.cpp
+++ b/src/cpp/core/system/Process.cpp
@@ -291,7 +291,8 @@ namespace {
 
 bool has_activity(const boost::shared_ptr<AsyncChildProcess>& childProc)
 {
-   return childProc->hasSubprocess() || childProc->hasRecentOutput();
+   return childProc->hasNonWhitelistSubprocess() || childProc->hasWhitelistSubprocess()||
+         childProc->hasRecentOutput();
 }
 
 } // anonymous namespace

--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -657,7 +657,7 @@ void AsyncChildProcess::poll()
       pAsyncImpl_->pSubprocPoll_.reset(new ChildProcessSubprocPoll(
          pImpl_->pid,
          kResetRecentDelay, kCheckSubprocDelay, kCheckCwdDelay,
-         options().reportHasSubprocs ? core::system::hasSubprocesses : NULL,
+         options().reportHasSubprocs ? core::system::getSubprocesses : NULL,
          options().subprocWhitelist,
          options().trackCwd ? core::system::currentWorkingDir : NULL));
 

--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -644,6 +644,7 @@ void AsyncChildProcess::poll()
          pImpl_->pid,
          kResetRecentDelay, kCheckSubprocDelay, kCheckCwdDelay,
          options().reportHasSubprocs ? core::system::hasSubprocesses : NULL,
+         options().subprocWhitelist,
          options().trackCwd ? core::system::currentWorkingDir : NULL));
 
       if (callbacks_.onStarted)

--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -284,10 +284,16 @@ Error ChildProcess::terminate()
       return Success();
 }
 
-bool ChildProcess::hasSubprocess() const
+bool ChildProcess::hasNonWhitelistSubprocess() const
 {
    // base class doesn't support subprocess-checking; override to implement
    return true;
+}
+
+bool ChildProcess::hasWhitelistSubprocess() const
+{
+   // base class doesn't support subprocess-checking; override to implement
+   return false;
 }
 
 core::FilePath ChildProcess::getCwd() const
@@ -610,12 +616,20 @@ Error AsyncChildProcess::terminate()
    return ChildProcess::terminate();
 }
 
-bool AsyncChildProcess::hasSubprocess() const
+bool AsyncChildProcess::hasNonWhitelistSubprocess() const
 {
    if (pAsyncImpl_->pSubprocPoll_)
-      return pAsyncImpl_->pSubprocPoll_->hasSubprocess();
+      return pAsyncImpl_->pSubprocPoll_->hasNonWhitelistSubprocess();
    else
       return true;
+}
+
+bool AsyncChildProcess::hasWhitelistSubprocess() const
+{
+   if (pAsyncImpl_->pSubprocPoll_)
+      return pAsyncImpl_->pSubprocPoll_->hasWhitelistSubprocess();
+   else
+      return false;
 }
 
 core::FilePath AsyncChildProcess::getCwd() const
@@ -745,7 +759,8 @@ void AsyncChildProcess::poll()
    {
       if (callbacks_.onHasSubprocs)
       {
-         callbacks_.onHasSubprocs(hasSubprocess());
+         callbacks_.onHasSubprocs(hasNonWhitelistSubprocess(),
+                                  hasWhitelistSubprocess());
       }
       if (callbacks_.reportCwd)
       {

--- a/src/cpp/core/system/Win32System.cpp
+++ b/src/cpp/core/system/Win32System.cpp
@@ -912,6 +912,13 @@ bool hasSubprocesses(PidType pid)
    return false;
 }
 
+std::vector<SubprocInfo> getSubprocesses(PidType pid)
+{
+   // NYI for Win32
+   std::vector<SubprocInfo> subprocs;
+   return subprocs;
+}
+
 FilePath currentWorkingDir(PidType pid)
 {
    // NYI for Win32; commonly accepted technique for this is to use

--- a/src/cpp/core/system/Win32System.cpp
+++ b/src/cpp/core/system/Win32System.cpp
@@ -877,8 +877,10 @@ Error terminateProcess(PidType pid)
    return Success();
 }
 
-bool hasSubprocesses(PidType pid)
+std::vector<SubprocInfo> getSubprocesses(PidType pid)
 {
+   std::vector<SubprocInfo> subprocs;
+
    HANDLE hSnapShot;
    CloseHandleOnExitScope closeSnapShot(&hSnapShot, ERROR_LOCATION);
 
@@ -888,7 +890,7 @@ bool hasSubprocesses(PidType pid)
       // err on the side of assuming child processes, so we don't kill
       // a job unintentionally
       LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
-      return true;
+      return subprocs;
    }
 
    PROCESSENTRY32 pe32;
@@ -896,7 +898,7 @@ bool hasSubprocesses(PidType pid)
    if (!Process32First(hSnapShot, &pe32))
    {
       LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
-      return true;
+      return subprocs;
    }
 
    do
@@ -904,18 +906,14 @@ bool hasSubprocesses(PidType pid)
       if (pe32.th32ParentProcessID == pid)
       {
          // Found a child process
-         return true;
+         SubprocInfo info;
+         info.pid = pe32.th32ProcessID;
+         info.exe = pe32.szExeFile;
+
+         subprocs.push_back(info);
       }
    } while (Process32Next(hSnapShot, &pe32));
 
-   // Didn't find a child process
-   return false;
-}
-
-std::vector<SubprocInfo> getSubprocesses(PidType pid)
-{
-   // NYI for Win32
-   std::vector<SubprocInfo> subprocs;
    return subprocs;
 }
 

--- a/src/cpp/core/system/Win32SystemTests.cpp
+++ b/src/cpp/core/system/Win32SystemTests.cpp
@@ -224,6 +224,42 @@ TEST_CASE("Win32SystemTests")
       CloseHandle(pi.hProcess);
       CloseHandle(pi.hThread);
    }
+
+   SECTION("Empty subproc list when no child processes")
+   {
+      STARTUPINFO si;
+      PROCESS_INFORMATION pi;
+
+      ZeroMemory(&si, sizeof(si));
+      si.cb = sizeof(si);
+      ZeroMemory(&pi, sizeof(pi));
+
+      std::string cmd = "ping -n 8 www.rstudio.com";
+      std::vector<char> cmdBuf(cmd.size() + 1, '\0');
+      cmd.copy(&(cmdBuf[0]), cmd.size());
+
+      // Start the child process.
+      CHECK(CreateProcess(
+               NULL,          // No module name (use command line)
+               &(cmdBuf[0]),  // Command
+               NULL,          // Process handle not inheritable
+               NULL,          // Thread handle not inheritable
+               FALSE,         // Set handle inheritance to FALSE
+               0,             // No creation flags
+               NULL,          // Use parent's environment block
+               NULL,          // Use parent's starting directory
+               &si,           // Pointer to STARTUPINFO structure
+               &pi));         // Pointer to PROCESS_INFORMATION structure
+
+      std::vector<SubprocInfo> children = getSubprocesses(pi.dwProcessId);
+      expect_true(children.empty());
+
+      CHECK(TerminateProcess(pi.hProcess, 1));
+
+      WaitForSingleObject(pi.hProcess, INFINITE);
+      CloseHandle(pi.hProcess);
+      CloseHandle(pi.hThread);
+   }
 }
 
 } // end namespace tests

--- a/src/cpp/core/system/Win32SystemTests.cpp
+++ b/src/cpp/core/system/Win32SystemTests.cpp
@@ -252,7 +252,7 @@ TEST_CASE("Win32SystemTests")
                &pi));         // Pointer to PROCESS_INFORMATION structure
 
       std::vector<SubprocInfo> children = getSubprocesses(pi.dwProcessId);
-      expect_true(children.empty());
+      CHECK(children.empty());
 
       CHECK(TerminateProcess(pi.hProcess, 1));
 

--- a/src/cpp/core/system/Win32SystemTests.cpp
+++ b/src/cpp/core/system/Win32SystemTests.cpp
@@ -176,7 +176,7 @@ TEST_CASE("Win32SystemTests")
 
       ::Sleep(100); // give child time to start
 
-      std::string exe = "ping.exe";
+      std::string exe = "PING.EXE";
       std::vector<SubprocInfo> children = getSubprocesses(pi.dwProcessId);
       CHECK(children.size() >= 1);
       if (children.size() >= 1)

--- a/src/cpp/core/system/Win32SystemTests.cpp
+++ b/src/cpp/core/system/Win32SystemTests.cpp
@@ -18,6 +18,7 @@
 #include <core/system/System.hpp>
 #include <core/FilePath.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/foreach.hpp>
 
 #define RSTUDIO_NO_TESTTHAT_ALIASES
 #include <tests/TestThat.hpp>
@@ -137,7 +138,8 @@ TEST_CASE("Win32SystemTests")
                &si,           // Pointer to STARTUPINFO structure
                &pi));         // Pointer to PROCESS_INFORMATION structure
 
-      CHECK_FALSE(hasSubprocesses(pi.dwProcessId));
+      std::vector<SubprocInfo> children = getSubprocesses(pi.dwProcessId);
+      CHECK(children.empty());
 
       CHECK(TerminateProcess(pi.hProcess, 1));
 
@@ -173,7 +175,23 @@ TEST_CASE("Win32SystemTests")
                &pi));         // Pointer to PROCESS_INFORMATION structure
 
       ::Sleep(100); // give child time to start
-      CHECK(hasSubprocesses(pi.dwProcessId));
+
+      std::string exe = "ping.exe";
+      std::vector<SubprocInfo> children = getSubprocesses(pi.dwProcessId);
+      CHECK(children.size() >= 1);
+      if (children.size() >= 1)
+      {
+         bool found = false;
+         BOOST_FOREACH(SubprocInfo info, children)
+         {
+            if (info.exe.compare(exe) == 0)
+            {
+               found = true;
+               break;
+            }
+         }
+         CHECK(found);
+      }
 
       CHECK(TerminateProcess(pi.hProcess, 1));
 

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -120,7 +120,7 @@ core::system::ProcessOptions ConsoleProcess::createTerminalProcOptions(
 
 ConsoleProcess::ConsoleProcess(boost::shared_ptr<ConsoleProcessInfo> procInfo)
    : procInfo_(procInfo), interrupt_(false), interruptChild_(false),
-     newCols_(-1), newRows_(-1), pid_(-1), childProcsSent_(false),
+     newCols_(-1), newRows_(-1), pid_(-1), childProcsSent_(false), whitelistChildProc_(false),
      lastInputSequence_(kIgnoreSequence), started_(false), envCaptureCmd_(kEnvCommand)
 {
    regexInit();
@@ -135,7 +135,7 @@ ConsoleProcess::ConsoleProcess(const std::string& command,
                                boost::shared_ptr<ConsoleProcessInfo> procInfo)
    : command_(command), options_(options), procInfo_(procInfo),
      interrupt_(false), interruptChild_(false), newCols_(-1), newRows_(-1),
-     pid_(-1), childProcsSent_(false), lastInputSequence_(kIgnoreSequence),
+     pid_(-1), childProcsSent_(false), whitelistChildProc_(false), lastInputSequence_(kIgnoreSequence),
      started_(false), envCaptureCmd_(kEnvCommand)
 {
    commonInit();
@@ -147,7 +147,7 @@ ConsoleProcess::ConsoleProcess(const std::string& program,
                                boost::shared_ptr<ConsoleProcessInfo> procInfo)
    : program_(program), args_(args), options_(options), procInfo_(procInfo),
      interrupt_(false), interruptChild_(false), newCols_(-1), newRows_(-1),
-     pid_(-1), childProcsSent_(false), lastInputSequence_(kIgnoreSequence),
+     pid_(-1), childProcsSent_(false), whitelistChildProc_(false), lastInputSequence_(kIgnoreSequence),
      started_(false), envCaptureCmd_(kEnvCommand)
 {
    commonInit();
@@ -426,7 +426,7 @@ bool ConsoleProcess::onContinue(core::system::ProcessOperations& ops)
       if (procInfo_->getTrackEnv())
       {
          // try to capture and persist the environment
-         if (envCaptureCmd_.onTryCapture(ops, procInfo_->getHasChildProcs()))
+         if (envCaptureCmd_.onTryCapture(ops, getIsBusy()))
             return true;
 
          saveEnvironment(envCaptureCmd_.getPrivateOutput());
@@ -680,11 +680,12 @@ void ConsoleProcess::onExit(int exitCode)
    onExit_(exitCode);
 }
 
-void ConsoleProcess::onHasSubprocs(bool hasSubprocs)
+void ConsoleProcess::onHasSubprocs(bool hasNonWhitelistSubprocs, bool hasWhitelistSubprocs)
 {
-   if (hasSubprocs != procInfo_->getHasChildProcs() || !childProcsSent_)
+   whitelistChildProc_ = hasWhitelistSubprocs;
+   if (hasNonWhitelistSubprocs != procInfo_->getHasChildProcs() || !childProcsSent_)
    {
-      procInfo_->setHasChildProcs(hasSubprocs);
+      procInfo_->setHasChildProcs(hasNonWhitelistSubprocs);
 
       json::Object subProcs;
       subProcs["handle"] = handle();
@@ -759,7 +760,7 @@ core::system::ProcessCallbacks ConsoleProcess::createProcessCallbacks()
    cb.onExit = boost::bind(&ConsoleProcess::onExit, ConsoleProcess::shared_from_this(), _1);
    if (options_.reportHasSubprocs)
    {
-      cb.onHasSubprocs = boost::bind(&ConsoleProcess::onHasSubprocs, ConsoleProcess::shared_from_this(), _1);
+      cb.onHasSubprocs = boost::bind(&ConsoleProcess::onHasSubprocs, ConsoleProcess::shared_from_this(), _1, _2);
    }
    if (options_.trackCwd)
    {

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -89,6 +89,9 @@ core::system::ProcessOptions ConsoleProcess::createTerminalProcOptions(
    options.cols = procInfo.getCols();
    options.rows = procInfo.getRows();
 
+   if (session::userSettings().terminalBusyMode() == core::system::busy_detection::Whitelist)
+      options.subprocWhitelist = session::userSettings().terminalBusyWhitelist();
+
    // set path to shell
    AvailableTerminalShells shells;
    TerminalShell shell;

--- a/src/cpp/session/SessionConsoleProcessInfoTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfoTests.cpp
@@ -55,7 +55,7 @@ const bool restarted = false;
 const bool zombie = false;
 const bool trackEnv = false;
 
-const size_t maxLines = kDefaultTerminalMaxOutputLines;
+const int maxLines = kDefaultTerminalMaxOutputLines;
 
 bool testHandle(const std::string& handle)
 {

--- a/src/cpp/session/SessionConsoleProcessInfoTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfoTests.cpp
@@ -101,32 +101,32 @@ TEST_CASE("ConsoleProcessInfo")
       CHECK_FALSE(caption.compare(cpi.getCaption()));
       CHECK_FALSE(title.compare(cpi.getTitle()));
       CHECK_FALSE(handle1.compare(cpi.getHandle()));
-      CHECK(cpi.getTerminalSequence() == sequence);
-      CHECK(cpi.getAllowRestart() == true);
-      CHECK(cpi.getInteractionMode() == InteractionAlways);
-      CHECK(cpi.getMaxOutputLines() == maxLines);
+      CHECK((cpi.getTerminalSequence() == sequence));
+      CHECK((cpi.getAllowRestart() == true));
+      CHECK((cpi.getInteractionMode() == InteractionAlways));
+      CHECK((cpi.getMaxOutputLines() == maxLines));
 
       CHECK_FALSE(cpi.getShowOnOutput());
       CHECK_FALSE(cpi.getExitCode());
       CHECK(cpi.getHasChildProcs());
-      CHECK(cpi.getShellType() == shellType);
-      CHECK(cpi.getChannelMode() == Rpc);
+      CHECK((cpi.getShellType() == shellType));
+      CHECK((cpi.getChannelMode() == Rpc));
       CHECK(cpi.getChannelId().empty());
-      CHECK(cpi.getAltBufferActive() == altActive);
-      CHECK(cpi.getCwd() == cwd);
-      CHECK(cpi.getCols() == cols);
-      CHECK(cpi.getRows() == rows);
+      CHECK((cpi.getAltBufferActive() == altActive));
+      CHECK((cpi.getCwd() == cwd));
+      CHECK((cpi.getCols() == cols));
+      CHECK((cpi.getRows() == rows));
 
       CHECK_FALSE(cpi.getRestarted());
       cpi.setRestarted(true);
       CHECK(cpi.getRestarted());
 
-      CHECK(cpi.getAutoClose() == DefaultAutoClose);
+      CHECK((cpi.getAutoClose() == DefaultAutoClose));
       cpi.setAutoClose(NeverAutoClose);
-      CHECK(cpi.getAutoClose() == NeverAutoClose);
+      CHECK((cpi.getAutoClose() == NeverAutoClose));
 
-      CHECK(cpi.getZombie() == zombie);
-      CHECK(cpi.getTrackEnv() == trackEnv);
+      CHECK((cpi.getZombie() == zombie));
+      CHECK((cpi.getTrackEnv() == trackEnv));
    }
 
    SECTION("Generate a handle")
@@ -157,40 +157,40 @@ TEST_CASE("ConsoleProcessInfo")
 
       int altSequence = sequence + 1;
       cpi.setTerminalSequence(altSequence);
-      CHECK(altSequence == cpi.getTerminalSequence());
+      CHECK((altSequence == cpi.getTerminalSequence()));
 
       bool altAllowRestart = false;
       cpi.setAllowRestart(altAllowRestart);
-      CHECK(altAllowRestart == cpi.getAllowRestart());
+      CHECK((altAllowRestart == cpi.getAllowRestart()));
 
       InteractionMode altMode = InteractionNever;
-      CHECK_FALSE(altMode == mode);
+      CHECK_FALSE((altMode == mode));
       cpi.setInteractionMode(altMode);
-      CHECK(altMode == cpi.getInteractionMode());
+      CHECK((altMode == cpi.getInteractionMode()));
 
       int altMax = maxLines + 1;
       cpi.setMaxOutputLines(altMax);
-      CHECK(altMax == cpi.getMaxOutputLines());
+      CHECK((altMax == cpi.getMaxOutputLines()));
 
       bool altShowOnOutput = !cpi.getShowOnOutput();
       cpi.setShowOnOutput(altShowOnOutput);
-      CHECK(altShowOnOutput == cpi.getShowOnOutput());
+      CHECK((altShowOnOutput == cpi.getShowOnOutput()));
 
       bool altHasChildProcs = !cpi.getHasChildProcs();
       cpi.setHasChildProcs(altHasChildProcs);
-      CHECK(altHasChildProcs == cpi.getHasChildProcs());
+      CHECK((altHasChildProcs == cpi.getHasChildProcs()));
 
       ChannelMode altChannelMode = Websocket;
       std::string altChannelModeId = "Some other id";
       cpi.setChannelMode(altChannelMode, altChannelModeId);
-      CHECK(altChannelMode == cpi.getChannelMode());
+      CHECK((altChannelMode == cpi.getChannelMode()));
       CHECK(!altChannelModeId.compare(cpi.getChannelId()));
 
       cpi.setCwd(altCwd);
-      CHECK(altCwd == cpi.getCwd());
+      CHECK((altCwd == cpi.getCwd()));
 
       cpi.setAutoClose(AlwaysAutoClose);
-      CHECK(cpi.getAutoClose() == AlwaysAutoClose);
+      CHECK((cpi.getAutoClose() == AlwaysAutoClose));
 
       cpi.setZombie(true);
       CHECK(cpi.getZombie());
@@ -207,7 +207,7 @@ TEST_CASE("ConsoleProcessInfo")
       const int exitCode = 14;
       cpi.setExitCode(exitCode);
       CHECK(cpi.getExitCode());
-      CHECK(exitCode == *cpi.getExitCode());
+      CHECK((exitCode == *cpi.getExitCode()));
    }
 
    SECTION("Save and load console proc metadata")
@@ -340,7 +340,7 @@ TEST_CASE("ConsoleProcessInfo")
 
       // pad to exactly one chunk
       firstChunk += 'a';
-      CHECK(firstChunk.length() == kOutputBufferSize);
+      CHECK((firstChunk.length() == kOutputBufferSize));
       cpi.appendToOutputBuffer("a");
       loaded = cpi.getSavedBufferChunk(0, &moreAvailable);
       CHECK_FALSE(moreAvailable);
@@ -359,13 +359,13 @@ TEST_CASE("ConsoleProcessInfo")
 
       // finish second chunk and add a single character as third chunk
       std::string finishSecond(kOutputBufferSize - secondChunk.length(), 'b');
-      CHECK(finishSecond.length() + secondChunk.length() == kOutputBufferSize);
+      CHECK((finishSecond.length() + secondChunk.length() == kOutputBufferSize));
       cpi.appendToOutputBuffer(finishSecond);
 
       // try to read non-existent third chunk
       std::string thirdChunk = cpi.getSavedBufferChunk(3, &moreAvailable);
       CHECK_FALSE(moreAvailable);
-      CHECK(thirdChunk.length() == 0);
+      CHECK((thirdChunk.length() == 0));
 
       // add a single character third chunk and read it
       thirdChunk = "c";
@@ -528,7 +528,7 @@ TEST_CASE("ConsoleProcessInfo")
 
       // line count includes any partial lines at the end (even a zero-
       // length line after a final \n)
-      CHECK(cpi.getBufferLineCount() == lines + 1);
+      CHECK((cpi.getBufferLineCount() == lines + 1));
 
       // cleanup
       cpi.deleteLogFile();

--- a/src/cpp/session/SessionConsoleProcessPersistTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessPersistTests.cpp
@@ -198,6 +198,8 @@ TEST_CASE("ConsoleProcess Persistence")
       CHECK((loaded.compare(orig2) == 0));
    }
 
+#ifndef _WIN32
+
    SECTION("Save and restore environment")
    {
       core::system::Options env;
@@ -231,6 +233,9 @@ TEST_CASE("ConsoleProcess Persistence")
 
       console_persist::deleteEnvFile(handle1);
    }
+
+#endif // !_WIN32
+
 }
 
 } // end namespace tests

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -167,8 +167,8 @@ public:
    std::string getTitle() const { return procInfo_->getTitle(); }
    void deleteLogFile(bool lastLineOnly = false) const;
    void deleteEnvFile() const;
-   void setNotBusy() { procInfo_->setHasChildProcs(false); }
-   bool getIsBusy() const { return procInfo_->getHasChildProcs(); }
+   void setNotBusy() { procInfo_->setHasChildProcs(false); whitelistChildProc_ = false; }
+   bool getIsBusy() const { return procInfo_->getHasChildProcs() || whitelistChildProc_; }
    bool getAllowRestart() const { return procInfo_->getAllowRestart(); }
    std::string getChannelMode() const;
    int getTerminalSequence() const { return procInfo_->getTerminalSequence(); }
@@ -212,7 +212,7 @@ private:
    void onStdout(core::system::ProcessOperations& ops,
                  const std::string& output);
    void onExit(int exitCode);
-   void onHasSubprocs(bool hasSubProcs);
+   void onHasSubprocs(bool hasNonWhitelistSubProcs, bool hasWhitelistSubprocs);
    void reportCwd(const core::FilePath& cwd);
    void processQueuedInput(core::system::ProcessOperations& ops);
 
@@ -254,6 +254,9 @@ private:
 
    // Has client been notified of state of childProcs_ at least once?
    bool childProcsSent_;
+
+   // Is there a child process matching the whitelist?
+   bool whitelistChildProc_;
 
    // Pending input (writes or ptyInterrupts)
    std::deque<Input> inputQueue_;

--- a/src/cpp/session/include/session/SessionUserSettings.hpp
+++ b/src/cpp/session/include/session/SessionUserSettings.hpp
@@ -30,6 +30,7 @@
 #include <core/json/Json.hpp>
 
 #include <core/system/FileChangeEvent.hpp>
+#include <core/system/Process.hpp>
 
 #include <session/SessionTerminalShell.hpp>
 
@@ -107,6 +108,8 @@ public:
    bool terminalWebsockets() const;
    bool terminalAutoclose() const;
    bool terminalTrackEnv() const;
+   core::system::busy_detection::Mode terminalBusyMode() const;
+   std::vector<std::string> terminalBusyWhitelist() const;
 
    bool rProfileOnResume() const;
    void setRprofileOnResume(bool rProfileOnResume);
@@ -265,6 +268,8 @@ private:
    mutable boost::scoped_ptr<bool> pTerminalWebsockets_;
    mutable boost::scoped_ptr<bool> pTerminalAutoclose_;
    mutable boost::scoped_ptr<bool> pTerminalTrackEnv_;
+   mutable boost::scoped_ptr<int> pTerminalBusyMode_;
+   mutable boost::scoped_ptr<core::json::Array> pTerminalBusyWhitelist_;
 
    // diagnostic-related prefs
    mutable boost::scoped_ptr<bool> pLintRFunctionCalls_;

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
@@ -129,13 +129,15 @@ public class ApplicationQuit implements SaveActionChangedHandler,
                               final boolean forceSaveAll,
                               final QuitContext quitContext)
    {
-      boolean busy = workbenchContext_.isServerBusy() || terminalHelper_.isTerminalBusy();
+      int busyMode = pUiPrefs_.get().terminalBusyMode().getValue();
+
+      boolean busy = workbenchContext_.isServerBusy() || terminalHelper_.warnBeforeClosing(busyMode);
       String msg = null;
       if (busy)
       {
-         if (workbenchContext_.isServerBusy() && !terminalHelper_.isTerminalBusy())
+         if (workbenchContext_.isServerBusy() && !terminalHelper_.warnBeforeClosing(busyMode))
             msg = "The R session is currently busy.";
-         else if (workbenchContext_.isServerBusy() && terminalHelper_.isTerminalBusy())
+         else if (workbenchContext_.isServerBusy() && terminalHelper_.warnBeforeClosing(busyMode))
             msg = "The R session and the terminal are currently busy.";
          else 
             msg = "The terminal is currently busy.";
@@ -473,7 +475,8 @@ public class ApplicationQuit implements SaveActionChangedHandler,
                   SuspendOptions.createSaveMinimal(saveChanges),
                   null));  
          }
-      }, "Restart R", "Terminal jobs will be terminated. Are you sure?");
+      }, "Restart R", "Terminal jobs will be terminated. Are you sure?",
+         pUiPrefs_.get().terminalBusyMode().getValue());
    }
    
    @Handler
@@ -811,6 +814,6 @@ public class ApplicationQuit implements SaveActionChangedHandler,
    private final SourceShim sourceShim_;
    private final TerminalHelper terminalHelper_;
    private SaveAction saveAction_ = SaveAction.saveAsk();
-
+   
    private boolean suspendingAndRestarting_ = false;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -14,6 +14,10 @@
  */
 package org.rstudio.studio.client.workbench.prefs.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.VirtualConsole;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.studio.client.application.Desktop;
@@ -615,6 +619,25 @@ public class UIPrefsAccessor extends Prefs
       return bool("terminal_track_env", true);
    }
 
+   public static final int BUSY_DETECT_ALWAYS = 0;
+   public static final int BUSY_DETECT_NEVER = 1;
+   public static final int BUSY_DETECT_WHITELIST = 2;
+
+   public PrefValue<Integer> terminalBusyMode()
+   {
+      return integer("busy_detection", BUSY_DETECT_ALWAYS);
+   }
+
+   public PrefValue<JsArrayString> terminalBusyWhitelist()
+   {
+      List<String> defArray = new ArrayList<String>();
+      defArray.add("tmux");
+      defArray.add("screen");
+      JsArrayString defJsArray = JsArrayUtil.toJsArrayString(defArray);
+
+      return object("busy_whitelist", defJsArray);
+   }
+ 
    public static final String KNIT_DIR_DEFAULT = "default";
    public static final String KNIT_DIR_CURRENT = "current";
    public static final String KNIT_DIR_PROJECT = "project";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/TerminalPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/TerminalPreferencesPane.java
@@ -14,7 +14,10 @@
  */
 package org.rstudio.studio.client.workbench.prefs.views;
 
+import java.util.List;
+
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.SelectWidget;
@@ -27,6 +30,7 @@ import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.prefs.model.RPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.TerminalPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
+import org.rstudio.studio.client.workbench.prefs.model.UIPrefsAccessor;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalShellInfo;
 
 import com.google.gwt.core.client.JsArray;
@@ -56,8 +60,6 @@ public class TerminalPreferencesPane extends PreferencesPane
       session_ = session;
       server_ = server;
 
-      add(spaced(new Label("Use the terminal to run system commands, execute data-processing jobs, and more.")));
-
       Label shellLabel = headerLabel("Shell");
       shellLabel.getElement().getStyle().setMarginTop(8, Unit.PX);
       add(shellLabel);
@@ -70,10 +72,9 @@ public class TerminalPreferencesPane extends PreferencesPane
          @Override
          public void onChange(ChangeEvent event)
          {
-            manageControlVisibility();
+            manageCustomShellControlVisibility();
          }
       });
-
 
       String textboxWidth = "250px";
       customShellPathLabel_ = new Label("Custom shell binary (fully qualified path):");
@@ -132,6 +133,33 @@ public class TerminalPreferencesPane extends PreferencesPane
                prefs_.terminalTrackEnvironment(),
                "Terminal occasionally runs a hidden command to capture state of environment variables.");
          add(chkCaptureEnv);
+      }
+
+      if (haveBusyDetectionPref())
+      {
+         Label shutdownLabel = headerLabel("Process Termination");
+         shutdownLabel.getElement().getStyle().setMarginTop(8, Unit.PX);
+         add(shutdownLabel);
+         shutdownLabel.setVisible(true);
+
+         busyMode_ = new SelectWidget("Ask before killing processes:");
+         spaced(busyMode_);
+         add(busyMode_);
+         busyMode_.setEnabled(false);
+         busyMode_.addChangeHandler(new ChangeHandler() {
+            @Override
+            public void onChange(ChangeEvent event)
+            {
+               manageBusyModeControlVisibility();
+            }
+         });
+         busyWhitelistLabel_ = new Label("Don't ask before killing:");
+         add(busyWhitelistLabel_);
+         busyWhitelist_ = new TextBox();
+         busyWhitelist_.getElement().setAttribute("spellcheck", "false");
+         busyWhitelist_.setWidth(textboxWidth);
+         add(busyWhitelist_);
+         busyWhitelist_.setEnabled(false);
       }
       
       HelpLink helpLink = new HelpLink("Using the RStudio terminal", "rstudio_terminal", false);
@@ -199,7 +227,7 @@ public class TerminalPreferencesPane extends PreferencesPane
                      customShellOptions_.setText(terminalPrefs.getCustomTerminalShellOptions());
                      customShellOptions_.setEnabled(true);
                   }
-                  manageControlVisibility();
+                  manageCustomShellControlVisibility();
                }
 
                @Override
@@ -207,13 +235,54 @@ public class TerminalPreferencesPane extends PreferencesPane
             });
          }
       });
+
+      if (busyMode_ != null)
+      {
+         busyMode_.getListBox().clear();
+         busyMode_.addChoice("Always", Integer.toString(UIPrefsAccessor.BUSY_DETECT_ALWAYS));
+         busyMode_.addChoice("Never", Integer.toString(UIPrefsAccessor.BUSY_DETECT_NEVER));
+         busyMode_.addChoice("Always except for whitelist", Integer.toString(UIPrefsAccessor.BUSY_DETECT_WHITELIST));
+         busyMode_.setEnabled(true);
+         
+         int selection = prefs_.terminalBusyMode().getValue();
+         if (selection < UIPrefsAccessor.BUSY_DETECT_ALWAYS ||
+               selection > UIPrefsAccessor.BUSY_DETECT_WHITELIST)
+            selection = UIPrefsAccessor.BUSY_DETECT_ALWAYS;
+         
+         busyMode_.getListBox().setSelectedIndex(selection);
+         
+         List<String> whitelistArray = JsArrayUtil.fromJsArrayString(
+               prefs_.terminalBusyWhitelist().getValue());
+         
+         StringBuilder whitelist = new StringBuilder();
+         for (String entry: whitelistArray)
+         {
+            if (entry.trim().isEmpty())
+            {
+               continue;
+            }
+            if (whitelist.length() > 0)
+            {
+               whitelist.append(" ");
+            }
+            whitelist.append(entry.trim());
+         }
+
+         busyWhitelist_.setText(whitelist.toString());
+         busyWhitelist_.setEnabled(true);
+
+         manageBusyModeControlVisibility();
+      }
    }
 
    @Override
    public boolean onApply(RPrefs rPrefs)
    {
       boolean restartRequired = super.onApply(rPrefs);
-
+     
+      prefs_.terminalBusyWhitelist().setGlobalValue(StringUtil.split(busyWhitelist_.getText(), " "));
+      prefs_.terminalBusyMode().setGlobalValue(selectedBusyMode());
+      
       TerminalPrefs terminalPrefs = TerminalPrefs.create(selectedShellType(),
             customShellPath_.getText(),
             customShellOptions_.getText());
@@ -223,6 +292,11 @@ public class TerminalPreferencesPane extends PreferencesPane
    }
 
    private boolean haveLocalEchoPref()
+   {
+      return !BrowseCap.isWindowsDesktop();
+   }
+
+   private boolean haveBusyDetectionPref()
    {
       return !BrowseCap.isWindowsDesktop();
    }
@@ -244,7 +318,7 @@ public class TerminalPreferencesPane extends PreferencesPane
       return StringUtil.parseInt(valStr, TerminalShellInfo.SHELL_DEFAULT);
    }
 
-   private void manageControlVisibility()
+   private void manageCustomShellControlVisibility()
    {
       boolean customEnabled = (selectedShellType() == TerminalShellInfo.SHELL_CUSTOM);
       customShellPathLabel_.setVisible(customEnabled);
@@ -252,13 +326,31 @@ public class TerminalPreferencesPane extends PreferencesPane
       customShellOptionsLabel_.setVisible(customEnabled);
       customShellOptions_.setVisible(customEnabled);
    }
- 
+
+   private int selectedBusyMode()
+   {
+      int idx = busyMode_.getListBox().getSelectedIndex();
+      String valStr = busyMode_.getListBox().getValue(idx);
+      return StringUtil.parseInt(valStr, UIPrefsAccessor.BUSY_DETECT_ALWAYS);
+   }
+
+   private void manageBusyModeControlVisibility()
+   {
+      boolean whitelistEnabled = selectedBusyMode() == UIPrefsAccessor.BUSY_DETECT_WHITELIST;
+      busyWhitelistLabel_.setVisible(whitelistEnabled);
+      busyWhitelist_.setVisible(whitelistEnabled);
+   }
+  
    private SelectWidget terminalShell_;
    private Label customShellPathLabel_;
    private TextBox customShellPath_;
    private Label customShellOptionsLabel_;
    private TextBox customShellOptions_;
 
+   private SelectWidget busyMode_;
+   private Label busyWhitelistLabel_;
+   private TextBox busyWhitelist_;
+   
    // Injected ----  
    private final UIPrefs prefs_;
    private final PreferencesDialogResources res_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/TerminalPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/TerminalPreferencesPane.java
@@ -280,9 +280,11 @@ public class TerminalPreferencesPane extends PreferencesPane
    {
       boolean restartRequired = super.onApply(rPrefs);
      
-      prefs_.terminalBusyWhitelist().setGlobalValue(StringUtil.split(busyWhitelist_.getText(), " "));
-      prefs_.terminalBusyMode().setGlobalValue(selectedBusyMode());
-      
+      if (haveBusyDetectionPref())
+      {
+         prefs_.terminalBusyWhitelist().setGlobalValue(StringUtil.split(busyWhitelist_.getText(), " "));
+         prefs_.terminalBusyMode().setGlobalValue(selectedBusyMode());
+      } 
       TerminalPrefs terminalPrefs = TerminalPrefs.create(selectedShellType(),
             customShellPath_.getText(),
             customShellOptions_.getText());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
@@ -375,7 +375,8 @@ public class BuildPresenter extends BasePresenter
                }
             }, caption);
          }
-      }, caption, "Terminal jobs will be terminated. Are you sure?");
+      }, caption, "Terminal jobs will be terminated. Are you sure?", 
+            uiPrefs_.terminalBusyMode().getValue());
    }
    
    void onStopBuild()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalHelper.java
@@ -19,6 +19,7 @@ import org.rstudio.core.client.widget.MessageDialog;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.workbench.prefs.model.UIPrefsAccessor;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalBusyEvent;
 
 import com.google.gwt.user.client.Command;
@@ -42,24 +43,25 @@ public class TerminalHelper
          @Override
          public void onTerminalBusy(TerminalBusyEvent event)
          {
-            isTerminalBusy_ = event.isBusy();
+            warnBeforeClosing_ = event.isBusy();
          }
       });
    }
    
-   /**
-    * @return true if one or more terminals have child processes
-    */
-   public boolean isTerminalBusy()
+   public boolean warnBeforeClosing(int busyMode)
    {
-      return isTerminalBusy_;
+      if (busyMode == UIPrefsAccessor.BUSY_DETECT_NEVER)
+         warnBeforeClosing_ = false;
+      
+      return warnBeforeClosing_;
    }
 
    public void warnBusyTerminalBeforeCommand(final Command command, 
                                              String caption,
-                                             String question)
+                                             String question,
+                                             int busyMode)
    {
-      if (!isTerminalBusy())
+      if (!warnBeforeClosing(busyMode))
       {
          command.execute();
          return;
@@ -78,7 +80,7 @@ public class TerminalHelper
             true);
    }
    
-   private boolean isTerminalBusy_;
+   private boolean warnBeforeClosing_;
 
    // Injected ----  
    private GlobalDisplay globalDisplay_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
@@ -19,8 +19,6 @@ import java.util.ArrayList;
 
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
-import org.rstudio.core.client.widget.Operation;
-import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.console.ConsoleProcessInfo;
 import org.rstudio.studio.client.workbench.WorkbenchView;
 import org.rstudio.studio.client.workbench.commands.Commands;
@@ -125,12 +123,12 @@ public class TerminalTabPresenter extends BusyPresenter
 
    @Inject
    public TerminalTabPresenter(final Display view,
-                               GlobalDisplay globalDisplay,
+                               TerminalHelper terminalHelper,
                                UIPrefs uiPrefs)
    {
       super(view);
       view_ = view;
-      globalDisplay_ = globalDisplay;
+      terminalHelper_ = terminalHelper;
       uiPrefs_ = uiPrefs;
    }
 
@@ -244,27 +242,17 @@ public class TerminalTabPresenter extends BusyPresenter
 
    public void confirmClose(final Command onConfirmed)
    {
-      if (view_.activeTerminals())
-      {
-         globalDisplay_.showYesNoMessage(GlobalDisplay.MSG_QUESTION, 
-               "Close Terminal(s) ", 
-               "Are you sure you want to close all terminals? Any running jobs " +
-                     "will be stopped.", false, 
-                     new Operation()
+      final String caption = "Close Terminal(s) ";
+      terminalHelper_.warnBusyTerminalBeforeCommand(new Command() {
+         @Override
+         public void execute()
          {
-            @Override
-            public void execute()
-            {
-               shutDownTerminals();
-               onConfirmed.execute();
-            }
-         }, null, null, "Close Terminals", "Cancel", true);
-      }
-      else
-      {
-         shutDownTerminals();
-         onConfirmed.execute(); 
-      }
+            shutDownTerminals();
+            onConfirmed.execute();
+         }
+      }, caption, "Are you sure you want to close all terminals? Any running jobs " +
+            "will be stopped",
+            uiPrefs_.terminalBusyMode().getValue());
    }
 
    private void shutDownTerminals()
@@ -279,6 +267,6 @@ public class TerminalTabPresenter extends BusyPresenter
 
    // Injected ---- 
    private final Display view_;
-   private final GlobalDisplay globalDisplay_;
+   private final TerminalHelper terminalHelper_;
    private final UIPrefs uiPrefs_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
@@ -119,6 +119,7 @@ public class XTermNative extends JavaScriptObject
    public final native void showPrimaryBuffer() /*-{
       this.write("\x1b[?1047l"); // show primary buffer
       this.write("\x1b[m"); // reset all visual attributes
+      this.write("\x1b[?9l"); // reset mouse mode
    }-*/;
 
    public final native void showAltBuffer() /*-{


### PR DESCRIPTION
When you do something that kills the rsession (such as Restart R, or Build and Reload), any running terminal processes will be killed, so there are warnings about this. This change adds a user preference to control this behavior (Mac and Linux only, though I modified the underlying Win32 system code signatures to match the Mac/Linux code): Three choices:

**Always** (default) - current behavior; if shell has any subprocesses, you will be warned when doing something that will kill those processes.

**Never** - no warnings when killing terminal processes

**Always except for whitelist** - same as always' except it will not warn if the child processes match the user-editable whitelist (which contains `tmux` and `screen` by default)

![2017-07-20_10-48-58](https://user-images.githubusercontent.com/10569626/28431705-1ad02000-6d3a-11e7-869c-7f56fb637eda.png)

![2017-07-20_10-49-35](https://user-images.githubusercontent.com/10569626/28431709-1c959532-6d3a-11e7-9bb3-ab12e8fa6de6.png)

**Separate bug-fix included in this PR**: XtermNative.java tweak to turn off mouse support when setting terminal back to primary buffer, this prevents mouse clicks from sending escape sequences to the terminal after a full-screen which supports mouse, such as tmux, has been killed) 
