### PR TITLE
Bug where Windows terminal is blank or double-output shows (non-Windows)

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -22,6 +22,7 @@ import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.ResultCallback;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.SessionSerializationEvent;
@@ -111,7 +112,7 @@ public class TerminalSession extends XTermWidget
       }
 
       connecting_ = true;
-      setNewTerminal(getHandle() == null);
+      setNewTerminal(StringUtil.isNullOrEmpty(getHandle()));
       
       socket_.resetDiagnostics();
 
@@ -679,7 +680,10 @@ public class TerminalSession extends XTermWidget
    private void fetchNextChunk(final int chunkToFetch)
    {
       if (!shellSupportsReload())
+      {
+         reloading_ = false;
          return;
+      }
 
       Scheduler.get().scheduleDeferred(new ScheduledCommand()
       {


### PR DESCRIPTION
On Windows IDE, a new terminal was coming up blank, just a blinking cursor. The buffer was being populated (confirmed by looking in the server log), typing was working (could enter 'exit' and terminal stopped), but nothing ever displayed.

This bug also caused a case Javier saw where starting a terminal in RStudio Server provisioned in Amazon EMR displayed the initial output twice.

It was a regression where a terminal was not being set to "new terminal" mode. This used to be identified by handle being null, but some changes I made also required checking for empty string.

On Windows, it thought the new terminal was a restarted terminal and was waiting to reload the buffer (which doesn't happen on Win32), so it kept accumulating all the terminal output in a string which is sent when terminal finishes reloading buffer (which never happened on Win32).

On non-Windows, this would cause the terminal buffer from the server to be played into the xterm, along with the actual output coming from the pseudo-terminal. This isn't terribly noticeable (maybe a line or two of duplicate output) unless dealing with a lot of lag.