### PR TITLE
Fix contrast for light-on-dark color themes

### DIFF
--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -104,7 +104,7 @@ MainWindow::MainWindow(QUrl url) :
    desktop::enableFullscreenMode(this, true);
 
    //setContentsMargins(10000, 0, -10000, 0);
-   setStyleSheet(QString::fromUtf8("QMainWindow { background: #e1e2e5; }"));
+   setStyleSheet(QString::fromUtf8("QMainWindow { background: #e1e2e5; } QMenuBar { color: #000000; }"));
 }
 
 QString MainWindow::getSumatraPdfExePath()


### PR DESCRIPTION
When I use a Linux theme with light text color and dark background, the menu text is invisible.

This fixes it.

An alternative fix would be to just leave the background color for the QMainWindow alone. (Remove the line I changed here)