### PR TITLE
Add support for ligatures in Qt-based desktop clients

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -26,7 +26,7 @@
 @external gwt-TabLayoutPanel-Workbench;
 @external gwt-TabLayoutPanelTabs;
 @external gwt-DecoratedPopupPanel;
-@external editor_dark;
+@external editor_dark, editor_ligatures;
 
 @external windowframe, windowframe-maximized, windowframe-exclusive;
 
@@ -1971,6 +1971,10 @@ body.ubuntu_mono .searchBox {
    background-position: 2px center;
    background-image: ERRORDARK;
    background-size: 16px 14px;
+}
+
+.editor_ligatures .ace_editor {
+   text-rendering: optimizeLegibility;
 }
 
 .menuSubheader {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -334,6 +334,11 @@ public class UIPrefsAccessor extends Prefs
    {
       return dbl("font_size_points", 10.0);
    }
+   
+   public PrefValue<Boolean> useLigatures()
+   {
+      return bool("use_ligatures", false);
+   }
 
    public PrefValue<String> theme()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AceEditorPreview.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AceEditorPreview.java
@@ -95,6 +95,11 @@ public class AceEditorPreview extends DynamicIFrame
                         setFont(ThemeFonts.getFixedWidthFont());
                         body.appendChild(style);
 
+                        ligatureStyle_ = doc.createStyleElement();
+                        ligatureStyle_.setAttribute("type", "text/css");
+                        body.appendChild(ligatureStyle_);
+                        setUseLigatures(useLigatures_);
+
                         DivElement div = doc.createDivElement();
                         div.setId("editor");
                         div.getStyle().setWidth(100, Unit.PCT);
@@ -192,11 +197,23 @@ public class AceEditorPreview extends DynamicIFrame
       if (fontSize_ != null)
          setFontSize(fontSize_);
    }
+   
+   public void setUseLigatures(boolean use)
+   {
+      useLigatures_ = use;
+      if (!isFrameLoaded_)
+         return;
+
+      ligatureStyle_.setInnerText(".ace_editor { text-rendering: " +
+               (use ? "optimizeLegibility" : "auto")  + "; }");
+   }
  
    private LinkElement currentStyleLink_;
+   private StyleElement ligatureStyle_;
    private boolean isFrameLoaded_;
    private String themeUrl_;
    private Double fontSize_;
    private Double zoomLevel_;
+   private boolean useLigatures_ = false;
    private final String code_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
@@ -160,6 +160,11 @@ public class AceThemes
       
       addDarkClassIfNecessary(document, themeName);
       
+      if (prefs_.get().useLigatures().getValue())
+         document.getBody().addClassName("editor_ligatures");
+      else
+         document.getBody().removeClassName("editor_ligatures");
+      
       // Deferred so that the browser can render the styles.
       new Timer()
       {


### PR DESCRIPTION
This small change adds support for ligature "coding fonts" such as [Fira Code](https://github.com/tonsky/FiraCode) in RStudio for Windows and Linux (they already work out of the box on MacOS). Checking the new *Use ligatures* box next to *Editor font* turns on ligatures if the font has them (notice e.g. the assignment arrow, ellipsis, and && operator):

![image](https://user-images.githubusercontent.com/470418/28485721-506aefb4-6e30-11e7-9594-b3c4fdf5a34b.png)

Inspired by motivated users who had taken to hacking in the relevant CSS class by [editing RStudio resources directly](https://stackoverflow.com/questions/34548194/rstudio-how-to-enable-font-ligatures-in-rstudio/34714296#34714296). :-)

Off by default to match existing behavior, and since the relevant CSS property may carry a [performance penalty](https://developer.mozilla.org/en-US/docs/Web/CSS/text-rendering).