### PR TITLE
Checkboxes in windows are not properly adjusted under flat themes

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1791,6 +1791,12 @@ body.ubuntu_mono .searchBox {
   margin-bottom: 2px;
 }
 
+.windows.rstudio-themes-flat input[type="checkbox"] {
+  margin-right: 3px;
+  margin-top: 1px;
+  vertical-align: top;
+}
+
 .rstudio-themes-flat .rstudio-themes-dark input[type="checkbox"] {
    background: #d3d8dc;
    border-color: rgb(45,60,75);


### PR DESCRIPTION
Before:

<img width="587" alt="screen shot 2017-07-21 at 11 07 57 pm" src="https://user-images.githubusercontent.com/3478847/28488940-c8eb929c-6e6a-11e7-85c9-cc163940338e.png">

After:

<img width="586" alt="screen shot 2017-07-21 at 11 18 05 pm" src="https://user-images.githubusercontent.com/3478847/28488944-e20e3e96-6e6a-11e7-823e-f91fb6dc1142.png">
