### PR TITLE
Adjust new connections dialog for empty fields

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetHost.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetHost.java
@@ -212,10 +212,15 @@ public class NewConnectionSnippetHost extends Composite
       final Grid connGrid = new Grid(visibleRows + 1, 4);
       connGrid.addStyleName(RES.styles().grid());
 
-      connGrid.getCellFormatter().setWidth(0, 0, "150px");
-      connGrid.getCellFormatter().setWidth(0, 1, "180px");
-      connGrid.getCellFormatter().setWidth(0, 2, "60px");
-      connGrid.getCellFormatter().setWidth(0, 3, "74px");
+      if (visibleRows > 0) {
+         connGrid.getCellFormatter().setWidth(0, 0, "150px");
+         connGrid.getCellFormatter().setWidth(0, 1, "180px");
+         connGrid.getCellFormatter().setWidth(0, 2, "60px");
+         connGrid.getCellFormatter().setWidth(0, 3, "74px");
+      }
+      else {
+         connGrid.getCellFormatter().setWidth(0, 0, "495px");
+      }
 
       for (int idxParams = 0, idxRow = 0; idxRow < visibleRows; idxParams++, idxRow++) {
          connGrid.getRowFormatter().setStyleName(idxRow, RES.styles().gridRow());
@@ -346,8 +351,13 @@ public class NewConnectionSnippetHost extends Composite
       }
 
       connGrid.getRowFormatter().setStyleName(visibleRows, RES.styles().lastRow());
-      connGrid.getCellFormatter().getElement(visibleRows, 1).setAttribute("colspan", "4");
-      connGrid.setWidget(visibleRows, 1, buttonsPanel);
+
+
+      connGrid.getCellFormatter().getElement(visibleRows, 0).setAttribute("colspan", "4");
+      connGrid.getCellFormatter().getElement(visibleRows, 1).removeFromParent();
+      connGrid.getCellFormatter().getElement(visibleRows, 1).removeFromParent();
+      connGrid.getCellFormatter().getElement(visibleRows, 1).removeFromParent();
+      connGrid.setWidget(visibleRows, 0, buttonsPanel);
 
       return connGrid;
    }


### PR DESCRIPTION
New connections dialog renders the "test" button in the middle of the row when no fields are available, before:

<img width="546" alt="screen shot 2017-07-21 at 11 26 48 pm" src="https://user-images.githubusercontent.com/3478847/28488984-168a0a1e-6e6c-11e7-9cf9-fb0a2986b49e.png">

After:

<img width="563" alt="basic-connection-interface" src="https://user-images.githubusercontent.com/3478847/28488971-d1fe53dc-6e6b-11e7-841c-280dccb691bc.png">
