### PR TITLE
Prevent computations while spinner is not visible

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ProgressPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ProgressPanel.java
@@ -81,7 +81,7 @@ public class ProgressPanel extends Composite
    {
       clearTimer();
       progressImage_.setVisible(false);
-      progressSpinner_.setVisible(true);
+      progressSpinner_.setVisible(false);
    }
 
    private int getSpinnerColor()

--- a/src/gwt/src/org/rstudio/core/client/widget/ProgressSpinner.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ProgressSpinner.java
@@ -78,7 +78,7 @@ public class ProgressSpinner extends Composite
          public boolean execute()
          {
             frame_++;
-            redraw();
+            if (isVisible()) redraw();
             return !complete_;
          }
       }, FRAME_RATE_MS);


### PR DESCRIPTION
This https://github.com/rstudio/rstudio/pull/1178 switched progress panes to be rendered using the canvas to support better theming; however, while hidden, computations were still running causing CPU to be higher than usual while idle.