### PR TITLE
Fix terminal metadata storage on multi-session

### DIFF
--- a/src/cpp/session/SessionConsoleProcessPersist.cpp
+++ b/src/cpp/session/SessionConsoleProcessPersist.cpp
@@ -20,6 +20,7 @@
 #include <core/FileSerializer.hpp>
 
 #include <session/SessionModuleContext.hpp>
+#include <session/SessionOptions.hpp>
 
 using namespace rstudio::core;
 
@@ -62,8 +63,16 @@ void initialize()
 {
    if (s_inited) return;
 
-   // storage for session-scoped console/terminal metadata
-   s_consoleProcPath = module_context::scopedScratchPath().complete(kConsoleDir);
+   if (session::options().multiSession() &&
+       session::options().programMode() == kSessionProgramModeServer)
+   {
+      s_consoleProcPath = module_context::sessionScratchPath().complete(kConsoleDir);
+   }
+   else
+   {
+      s_consoleProcPath = module_context::scopedScratchPath().complete(kConsoleDir);
+   }
+
    Error error = s_consoleProcPath.ensureDirectory();
    if (error)
    {


### PR DESCRIPTION
On multi-session server, the terminal metadata should be strictly per-session. Previously it was per project meaning it was stomping over itself if opening multiple sessions on one project.

Now it uses the session scratch path for multi-session, meaning each new session will start clean (no existing terminals). So, unlike single-session server, if you close a project and reopen, you will not get back the previous set of terminals.