### PR TITLE
record error location for failed RPCs

### DIFF
--- a/src/cpp/core/json/JsonRpc.cpp
+++ b/src/cpp/core/json/JsonRpc.cpp
@@ -207,10 +207,19 @@ void JsonRpcResponse::setError(const Error& error, const json::Value& clientInfo
       // populate sub-error field with error details
       json::Object executionError;
       executionError["code"] = ec.value();
+      
       std::string errorCategoryName = ec.category().name();
       executionError["category"] = errorCategoryName;
+      
       std::string errorMessage = ec.message();
       executionError["message"] = errorMessage;
+      
+      if (error.location().hasLocation())
+      {
+         std::string errorLocation = error.location().asString();
+         executionError["location"] = errorLocation;
+      }
+      
       jsonError["error"] = executionError;
       if (!clientInfo.is_null())
       {


### PR DESCRIPTION
This PR tags the JSON return value passed back to the client with the error location, when available. This should help when attempting to debug errors that aren't logged session-side but do show up in the client-side logs.