### PR TITLE
Fix menu search boxes as regression from recent 1px up search box change

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2262,10 +2262,8 @@ body.ubuntu_mono .searchBox {
    background: THEME_LIGHT_CONTROL_BACKGROUND;
 }
 
-@if rstudio.desktop true {
-.linux.rstudio-themes-flat .search {
-   top: 0px;
-}
+.rstudio-themes-flat .gwt-MenuBar .search {
+   margin-top: 1px;
 }
 
 .rstudio-themes-flat .tallerToolbarWrapper .search {


### PR DESCRIPTION
Regression from https://github.com/rstudio/rstudio/pull/1371, before...

<img width="369" alt="screen shot 2017-07-24 at 9 34 40 am" src="https://user-images.githubusercontent.com/3478847/28585480-2ca0f978-7125-11e7-86eb-aa8137a71e1d.png">

After...

<img width="289" alt="screen shot 2017-07-25 at 10 36 58 am" src="https://user-images.githubusercontent.com/3478847/28585561-6ed074a4-7125-11e7-8062-de103b6cdb52.png">
<img width="329" alt="screen shot 2017-07-25 at 10 37 02 am" src="https://user-images.githubusercontent.com/3478847/28585559-6ed06306-7125-11e7-9b27-baba255dd46f.png">