### PR TITLE
Support for dark themed iframes in url content tabs

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
@@ -37,9 +37,24 @@ public class RStudioThemedFrame extends RStudioFrame
       this(null, null, null, false);
    }
 
-   public RStudioThemedFrame(String url, String customStyle, String urlStyle, boolean removeBodyStyle)
+   public RStudioThemedFrame(
+      String url,
+      String customStyle,
+      String urlStyle,
+      boolean removeBodyStyle)
    {
-      super(url);
+      this(url, false, null, customStyle, urlStyle, removeBodyStyle);
+   }
+
+   public RStudioThemedFrame(
+      String url,
+      boolean sandbox,
+      String sandboxAllow,
+      String customStyle,
+      String urlStyle,
+      boolean removeBodyStyle)
+   {
+      super(url, sandbox, sandboxAllow);
       
       customStyle_ = customStyle;
       urlStyle_ = urlStyle;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTargetWidget.java
@@ -18,6 +18,7 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.dom.IFrameElementEx;
 import org.rstudio.core.client.widget.RStudioFrame;
+import org.rstudio.core.client.widget.RStudioThemedFrame;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.source.PanelWithToolbars;
@@ -30,7 +31,7 @@ public class UrlContentEditingTargetWidget extends Composite
    {
       commands_ = commands;
 
-      frame_ = new RStudioFrame(url, true, "");
+      frame_ = new RStudioThemedFrame(url, true, "allow-same-origin", null, null, false);
       frame_.setSize("100%", "100%");
 
       PanelWithToolbars panel = new PanelWithToolbars(createToolbar(),
@@ -58,5 +59,5 @@ public class UrlContentEditingTargetWidget extends Composite
    }
 
    private final Commands commands_;
-   private RStudioFrame frame_;
+   private RStudioThemedFrame frame_;
 }


### PR DESCRIPTION
Before...

<img width="821" alt="screen shot 2017-07-25 at 11 49 39 am" src="https://user-images.githubusercontent.com/3478847/28588423-5f78204c-712f-11e7-99bf-60bbb9ceaa98.png">

After...

<img width="823" alt="screen shot 2017-07-25 at 11 47 21 am" src="https://user-images.githubusercontent.com/3478847/28588384-3f2fe586-712f-11e7-9d0a-35ce20b73f3b.png">


@jmcphers can you think of other common uses of `UrlContentEditingTargetWidget`appart from `vignettes()`?
