### PR TITLE
Fix help headers under dark theme

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -105,7 +105,17 @@ public class HelpPane extends WorkbenchPane
    @Override 
    protected Widget createMainWidget()
    {
-      frame_ = new RStudioThemedFrame();
+      frame_ = new RStudioThemedFrame(
+         null,
+         ".rstudio-themes-flat.editor_dark h1,\n" +
+         ".rstudio-themes-flat.editor_dark h2,\n" +
+         ".rstudio-themes-flat.editor_dark h3,\n" +
+         ".rstudio-themes-flat.editor_dark h4 {\n" +
+         "  background: none;\n" +
+         "  color: white;\n" +
+         "}\n",
+         null,
+         false);
       frame_.setSize("100%", "100%");
       frame_.setStylePrimaryName("rstudio-HelpFrame");
       frame_.addStyleName("ace_editor_theme");


### PR DESCRIPTION
Before...

<img width="617" alt="screen shot 2017-07-25 at 11 58 21 am" src="https://user-images.githubusercontent.com/3478847/28589230-19777d92-7132-11e7-8d7b-f042a6ef54a1.png">

After...

<img width="616" alt="screen shot 2017-07-25 at 11 59 03 am" src="https://user-images.githubusercontent.com/3478847/28589239-1d43a19e-7132-11e7-9b28-53f0dc49287d.png">