### PR TITLE
Allow Run Selected Lines shortcut to work when terminal has focus

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
@@ -489,8 +489,9 @@ public class ShortcutManager implements NativePreviewHandler,
                   // the word behind the cursor; so we'll ignore this command 
                   // when focus is in the terminal and let terminal see keys
                   return false;
-               } 
-               if (binding.getContext() != AppCommand.Context.Workbench &&
+               }
+               if (binding.getId() != "executeCode" &&
+                     binding.getContext() != AppCommand.Context.Workbench &&
                      binding.getContext() != AppCommand.Context.Addin &&
                      binding.getContext() != AppCommand.Context.PackageDevelopment)
                {


### PR DESCRIPTION
If focus is in terminal, pressing shortcut for `Run Selected Lines` command (Cmd+Enter on Mac) does a regular enter within the terminal.

This change causes the command to run, instead, which will bring the console to the front and execute selected lines from the editor, if any, making it consistent with focus being on other locations in the IDE.