### PR TITLE
Avoid incorrect connections in new connections list

### DIFF
--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -495,7 +495,12 @@ options(connectionObserver = list(
    }
 
    connectionContext <- .rs.rpc.get_new_connection_context()$connectionsList
-   connectionInfo <- Filter(function(e) e$package == package & e$name == name, connectionContext)
+   connectionInfo <- Filter(
+      function(e)
+        identical(as.character(e$package), as.character(package)) &
+        identical(as.character(e$name), as.character(name)),
+      connectionContext
+   )
 
    if (length(connectionInfo) != 1) {
       return(.rs.error(


### PR DESCRIPTION
When a custom `script.R` connection is added, other connections using shiny connections get the incorrect packages, for instance, `sparklyr` connections stop rendering.

The issue is with the compares while filtering...

```
Filter(
  function(e) e$package == "sparklyr" & e$name == "Spark",
  list(
    list(package = NULL, name = "Test"),
    list(package = "sparklyr", name = "Livy"),
    list(package = "sparklyr", name = "Spark")))
```

returns "Livy" while "Spark" would be expected.

This is caused by a package beding NULL, which mekes `package = NULL` becomes `logical(0)`, since Filter is implemented as:

```
ind <- as.logical(unlist(lapply(x, f)))
  x[which(ind)]
```

The `logical(0)` is omitted from `unlist` and the incorrect filter is returned.