### PR TITLE
Fix terminal local-echo EOL breaking backspace

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -24,6 +24,7 @@ import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.ResultCallback;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.SessionSerializationEvent;
 import org.rstudio.studio.client.application.events.SessionSerializationHandler;
@@ -323,10 +324,10 @@ public class TerminalSession extends XTermWidget
          inputQueue_.setLength(0);
       }
 
-      // On Windows, rapid typing sometimes causes RPC messages for writeStandardInput
+      // On desktop, rapid typing sometimes causes RPC messages for writeStandardInput
       // to arrive out of sequence in the terminal; send a sequence number with each
       // message so server can put messages back in order
-      if (BrowseCap.isWindowsDesktop() && 
+      if (Desktop.isDesktop() && 
             consoleProcess_.getChannelMode() == ConsoleProcessInfo.CHANNEL_RPC)
       {
          if (inputSequence_ == ShellInput.IGNORE_SEQUENCE)


### PR DESCRIPTION
Two fixes here:

First, turn on code to ensure RPC-based keyboard messages are processed in order when typing in the terminal. I had only enabled it for Windows previously (where it was very obviously needed) but was able to repro on Mac desktop, too, so enabling for all desktop builds.

Secondly, fix a local-echo match issue that happens when terminal is line-wrapping. This would sometimes put terminal in a state where you couldn't backspace to the previous line. Mostly only encountered when mashing keyboard, but I've hit it with fast typing, too.

There is still an issue where keyboard mashing on a narrow terminal (thus lots of wrapping), causes some lines to draw over each other. Unclear yet if this is a xterm.js issue or ours. Rare in real usage.