### PR TITLE
Enforce input sequence on desktop terminals using RPC

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalLocalEcho.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalLocalEcho.java
@@ -129,13 +129,6 @@ public class TerminalLocalEcho
     */
    private int outputNonEchoed(String outputToMatch)
    {
-      // Server may output a space when wrapping a line, a space that wasn't sent to it,
-      // thus breaking local-match; so relax the rules on matching if output contains a 
-      // single space that wasn't local-echoed.
-      boolean trailingSpace = outputToMatch.endsWith(" ");
-      if (trailingSpace)
-         outputToMatch = outputToMatch.substring(0, outputToMatch.length() - 1);
-      
       String lastOutput = "";
       while (!localEcho_.isEmpty() && lastOutput.length() < outputToMatch.length())
       {
@@ -144,29 +137,11 @@ public class TerminalLocalEcho
 
       if (lastOutput.equals(outputToMatch))
       {
-         if (trailingSpace)
-         {
-            String nextLocalEcho = localEcho_.peek();
-            if (nextLocalEcho != null && nextLocalEcho == " ")
-            {
-               // also matched the trailing space so remove from local echo history
-               localEcho_.pop();
-            }
-            else
-            {
-               // we received an extra space, write it out
-               writer_.write(" ");
-            }
-         }
-
          // all matched, nothing to output
          return outputToMatch.length();
       }
 
-      if (trailingSpace)
-         outputToMatch += " ";
-      
-      if (outputToMatch.startsWith(lastOutput))
+      else if (outputToMatch.startsWith(lastOutput))
       {
          // output is superset of what was local-echoed; write out the
          // unmatched part

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -24,6 +24,7 @@ import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.ResultCallback;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.SessionSerializationEvent;
 import org.rstudio.studio.client.application.events.SessionSerializationHandler;
@@ -323,10 +324,10 @@ public class TerminalSession extends XTermWidget
          inputQueue_.setLength(0);
       }
 
-      // On Windows, rapid typing sometimes causes RPC messages for writeStandardInput
+      // On desktop, rapid typing sometimes causes RPC messages for writeStandardInput
       // to arrive out of sequence in the terminal; send a sequence number with each
       // message so server can put messages back in order
-      if (BrowseCap.isWindowsDesktop() && 
+      if (Desktop.isDesktop() && 
             consoleProcess_.getChannelMode() == ConsoleProcessInfo.CHANNEL_RPC)
       {
          if (inputSequence_ == ShellInput.IGNORE_SEQUENCE)


### PR DESCRIPTION
On Windows, the RPC messages for terminal keyboard input would often arrive out of sequence, so I had implemented a sequence number used to reassemble the order on the server and made it Windows desktop only.

I've found that although much less common, it can also happen on Mac desktop IDE. Haven't check on Linux IDE, but I'm turning on that handling for all desktop builds.