### PR TITLE
Helpful diagnostic method to see xterm buffer

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
@@ -138,7 +138,23 @@ public class XTermNative extends JavaScriptObject
       }
       return current;
    }-*/;
-   
+
+   public final native String getLocalBuffer() /*-{
+      buffer = "";
+      for (row = 0; row < this.rows; row++) {
+         lineBuf = this.lines.get(row);
+         if (!lineBuf) // resize may be in progress
+            return null;
+      
+         for (col = 0; col < this.cols; col++) {
+            if (!lineBuf[col])
+               return null;
+            buffer += lineBuf[col][1];
+         }
+      }
+      return buffer;
+   }-*/;
+    
    /**
     * Install a handler for user input (typing). Only one handler at a 
     * time may be installed. Previous handler will be overwritten.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -326,6 +326,14 @@ public class XTermWidget extends Widget implements RequiresResize,
    }
    
    /**
+    * @return Local terminal buffer
+    */
+   public String getLocalBuffer()
+   {
+      return terminal_.getLocalBuffer();
+   }
+   
+   /**
     * Is the terminal showing the alternate full-screen buffer?
     * @return true if full-screen buffer is active
     */


### PR DESCRIPTION
I've rewritten this method a couple of times; not currently used but provides dump of of local xterm.js buffer when debugging. Production code uses the server-side buffer cache (for things like send terminal to editor, getting buffer via API, and dumping buffer in the diagnostics dialog). Comparing the two is helpful on occasion.