### PR TITLE
Avoid dark scrollbars on non-osx systems under popups

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2441,8 +2441,9 @@ body.rstudio-themes-flat .rstudio-themes-default {
 }
 
 @if user.agent safari {
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar-thumb,
-.rstudio-themes-flat .rstudio-themes-scrollbars::-webkit-scrollbar-thumb {
+.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar-thumb,
+.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar-thumb,
+.rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar-thumb {
    background: THEME_DARKGREY_BACKGROUND;
 }
 }
@@ -2480,10 +2481,12 @@ body.rstudio-themes-flat .rstudio-themes-dark-grey {
 }
 
 @if user.agent safari {
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar-track,
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar-corner,
-.rstudio-themes-flat .rstudio-themes-scrollbars::-webkit-scrollbar-track,
-.rstudio-themes-flat .rstudio-themes-scrollbars::-webkit-scrollbar-corner { 
+.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar-track,
+.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar-corner,
+.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar-track,
+.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar-corner,
+.rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar-track,
+.rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar-corner {
    background: THEME_DARKGREY_MOST_INACTIVE;
 }
 }
@@ -2561,29 +2564,27 @@ body.rstudio-themes-flat .rstudio-themes-alternate {
 /* RSTUDIO THEMES END */
 
 @if user.agent safari {
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar,
-.rstudio-themes-flat .rstudio-themes-scrollbars::-webkit-scrollbar {
+.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar,
+.rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
    background: #FFF;
 }
 
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar-thumb,
-.rstudio-themes-flat .rstudio-themes-scrollbars::-webkit-scrollbar-thumb {
+.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar-thumb,
+.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar-thumb,
+.rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar-thumb {
    -webkit-border-radius: 10px;
 }
 
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar-thumb,
-.rstudio-themes-flat .rstudio-themes-scrollbars::-webkit-scrollbar-thumb {
+.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar-thumb,
+.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar-thumb,
+.rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar-thumb {
    border: solid 3px THEME_DARKGREY_MOST_INACTIVE;
 }
 
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar-track-piece {
-}
-
-.rstudio-themes-flat .rstudio-themes-scrollbars ::-webkit-scrollbar-track {
-}
-
 @external com-google-gwt-user-client-ui-CustomScrollPanel-Style-customScrollPanelCorner;
-.rstudio-themes-flat .rstudio-themes-scrollbars .com-google-gwt-user-client-ui-CustomScrollPanel-Style-customScrollPanelCorner {
+.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars .com-google-gwt-user-client-ui-CustomScrollPanel-Style-customScrollPanelCorner,
+.rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars .com-google-gwt-user-client-ui-CustomScrollPanel-Style-customScrollPanelCorner {
    display: none;
 }
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
@@ -88,25 +88,25 @@ public class RStudioThemedFrame extends RStudioFrame
          if (customStyle == null) customStyle = "";
          
          customStyle += "\n" +
-         ".rstudio-themes-flat.rstudio-themes-scrollbars::-webkit-scrollbar,\n" +
-         ".rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar {\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar,\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {\n" +
          "   background: #FFF;\n" +
          "}\n" +
          "\n" +
-         ".rstudio-themes-flat.rstudio-themes-scrollbars::-webkit-scrollbar-thumb,\n" +
-         ".rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar-thumb {\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar-thumb,\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar-thumb {\n" +
          "   -webkit-border-radius: 10px;\n" +
          "   background: " + ThemeColors.darkGreyBackground + ";\n" +
          "}\n" +
          "\n" +
-         ".rstudio-themes-flat.rstudio-themes-scrollbars::-webkit-scrollbar-track,\n" + 
-         ".rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar-track,\n" + 
-         ".rstudio-themes-flat.rstudio-themes-scrollbars::-webkit-scrollbar-corner,\n" +
-         ".rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar-corner {\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar-track,\n" + 
+         ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar-track,\n" + 
+         ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar-corner,\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar-corner {\n" +
          "   background: " + ThemeColors.darkGreyMostInactiveBackground + ";\n" +
          "}\n" + 
-         ".rstudio-themes-flat.rstudio-themes-scrollbars::-webkit-scrollbar-thumb,\n" +
-         ".rstudio-themes-flat.rstudio-themes-scrollbars ::-webkit-scrollbar-thumb{\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar-thumb,\n" +
+         ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar-thumb{\n" +
          "   border: solid 3px " + ThemeColors.darkGreyMostInactiveBackground + ";" +
          "}\n";
          

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
@@ -58,11 +58,12 @@ public class RStudioThemes
          if (themeName.contains("dark")) {
             document.getBody().addClassName("rstudio-themes-dark-menus");
             element.addClassName("rstudio-themes-dark");
-            
-            if (usesScrollbars()) {
-               element.addClassName("rstudio-themes-scrollbars");
-            }
          }
+
+         if (usesScrollbars()) {
+            element.addClassName("rstudio-themes-scrollbars");
+         }
+            
          element.addClassName("rstudio-themes-" + themeName);
       }
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.css
@@ -41,24 +41,24 @@
 }
 
 @if user.agent safari {
-.rstudio-themes-flat .rstudio-themes-scrollbars.helpPopup *::-webkit-scrollbar {
+.rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars.helpPopup *::-webkit-scrollbar {
    background: #FFF;
 }
 
-.rstudio-themes-flat .rstudio-themes-scrollbars.helpPopup *::-webkit-scrollbar-thumb {
+.rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars.helpPopup *::-webkit-scrollbar-thumb {
    border: solid 3px rgb(94, 94, 78);
    background: rgb(111, 111, 95);
    -webkit-border-radius: 10px;
 }
 
-.rstudio-themes-flat .rstudio-themes-scrollbars.helpPopup *::-webkit-scrollbar-track,
-.rstudio-themes-flat .rstudio-themes-scrollbars.helpPopup *::-webkit-scrollbar-corner { 
+.rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars.helpPopup *::-webkit-scrollbar-track,
+.rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars.helpPopup *::-webkit-scrollbar-corner { 
    background: rgb(94, 94, 78);
 }
 
-.rstudio-themes-flat .rstudio-themes-scrollbars.helpPopup *::-webkit-scrollbar-track-piece {
+.rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars.helpPopup *::-webkit-scrollbar-track-piece {
 }
 
-.rstudio-themes-flat .rstudio-themes-scrollbars.helpPopup *::-webkit-scrollbar-track {
+.rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars.helpPopup *::-webkit-scrollbar-track {
 }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -110,9 +110,11 @@ public class HelpPane extends WorkbenchPane
          ".rstudio-themes-flat.editor_dark h1,\n" +
          ".rstudio-themes-flat.editor_dark h2,\n" +
          ".rstudio-themes-flat.editor_dark h3,\n" +
-         ".rstudio-themes-flat.editor_dark h4 {\n" +
-         "  background: none;\n" +
-         "  color: white;\n" +
+         ".rstudio-themes-flat.editor_dark h4,\n" +
+         ".rstudio-themes-flat.editor_dark table,\n" +
+         ".rstudio-themes-flat.editor_dark pre {\n" +
+         "  background: none !important;\n" +
+         "  color: white !important;\n" +
          "}\n",
          null,
          false);


### PR DESCRIPTION
Two issues, 

1) On windows:

<img width="774" alt="screen shot 2017-07-28 at 11 15 25 am" src="https://user-images.githubusercontent.com/3478847/28731103-66e5b31c-7387-11e7-9eb5-77e46982e31c.png">

The problem here is that `useScrollbars()` was setting the scrollbars CSS when it was only intended for dark themes. However, since...

2) While changing between dark and light themes scrollbars don't change and require an rstudio restart.

The fix for (1) and (2) is to rather make scrollbars dynamic based on `rstudio-dark-theme` CSS property.

This works for the most part, except for a Safari bug (https://stackoverflow.com/questions/3485365/how-can-i-force-webkit-to-redraw-repaint-to-propagate-style-changes) which prevents scrollbars from changing colors based on CSS changes. The workaround is to set a parent div to `display: none` and then `display: auto`. However, I'm hesitant to implement this workaround since it could cause unintended consequences. Instead, whenswitching themes, you might have to tab to a different pane and then tab back for the effect to take change.