### PR TITLE
vim extension: open adjacent files on filesystem

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -2837,6 +2837,12 @@ well as menu structures (for main menu and popup menus).
         label="Insert Pipe Operator"
         context="editor"/>
         
+   <cmd id="openNextFileOnFilesystem"
+        label="Open Next File on Filesystem"/>
+        
+   <cmd id="openPreviousFileOnFilesystem"
+        label="Open Previous File on Filesystem"/>
+        
    <cmd id="maximizeConsole"
         menuLabel="Maximize Console"/>
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -167,6 +167,8 @@ public abstract class
    public abstract AppCommand pasteLastYank();
    public abstract AppCommand insertAssignmentOperator();
    public abstract AppCommand insertPipeOperator();
+   public abstract AppCommand openNextFileOnFilesystem();
+   public abstract AppCommand openPreviousFileOnFilesystem();
  
    // Projects
    public abstract AppCommand newProject();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -118,6 +118,7 @@ import org.rstudio.studio.client.workbench.views.console.shell.editor.InputEdito
 import org.rstudio.studio.client.workbench.views.data.events.ViewDataEvent;
 import org.rstudio.studio.client.workbench.views.data.events.ViewDataHandler;
 import org.rstudio.studio.client.workbench.views.environment.events.DebugModeChangedEvent;
+import org.rstudio.studio.client.workbench.views.files.model.DirectoryListing;
 import org.rstudio.studio.client.workbench.views.output.find.events.FindInFilesEvent;
 import org.rstudio.studio.client.workbench.views.source.NewShinyWebApplication.Result;
 import org.rstudio.studio.client.workbench.views.source.SourceWindowManager.NavigationResult;
@@ -750,6 +751,8 @@ public class Source implements InsertSourceHandler,
       vimCommands_.showHelpAtCursor(this);
       vimCommands_.reindent(this);
       vimCommands_.expandShrinkSelection(this);
+      vimCommands_.openNextFile(this);
+      vimCommands_.openPreviousFile(this);
       vimCommands_.addStarRegister();
    }
    
@@ -3878,6 +3881,79 @@ public class Source implements InsertSourceHandler,
       if (navigation != null)
          attemptSourceNavigation(navigation, commands_.sourceNavigateForward());
    }
+   
+   @Handler
+   public void onOpenNextFileOnFilesystem()
+   {
+      openAdjacentFile(true);
+   }
+   
+   @Handler
+   public void onOpenPreviousFileOnFilesystem()
+   {
+      openAdjacentFile(false);
+   }
+   
+   private void openAdjacentFile(final boolean forward)
+   {
+      // ensure we have an editor and a titled document is open
+      if (activeEditor_ == null || StringUtil.isNullOrEmpty(activeEditor_.getPath()))
+         return;
+      
+      final FileSystemItem activePath =
+            FileSystemItem.createFile(activeEditor_.getPath());
+      final FileSystemItem activeDir = activePath.getParentPath();
+      
+      server_.listFiles(
+            activeDir,
+            false,
+            new ServerRequestCallback<DirectoryListing>()
+            {
+               @Override
+               public void onResponseReceived(DirectoryListing listing)
+               {
+                  // read file listing (bail if there are no adjacent files)
+                  JsArray<FileSystemItem> files = listing.getFiles();
+                  int n = files.length();
+                  if (n < 2)
+                     return;
+                  
+                  // find the index of the currently open file
+                  int index = -1;
+                  for (int i = 0; i < n; i++)
+                  {
+                     FileSystemItem file = files.get(i);
+                     if (file.equalTo(activePath))
+                     {
+                        index = i;
+                        break;
+                     }
+                  }
+                  
+                  // if this failed for some reason, bail
+                  if (index == -1)
+                     return;
+                  
+                  // compute index of file to be opened (with wrap-around)
+                  int target = (forward ? index + 1 : index - 1);
+                  if (target < 0)
+                     target = n - 1;
+                  else if (target >= n)
+                     target = 0;
+                  
+                  // extract the file and attempt to open
+                  FileSystemItem targetItem = files.get(target);
+                  openFile(targetItem);
+               }
+
+               @Override
+               public void onError(ServerError error)
+               {
+                  Debug.logError(error);
+               }
+            });
+   }
+   
    
    private void attemptSourceNavigation(final SourceNavigation navigation,
                                         final AppCommand retryCommand)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceShim.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceShim.java
@@ -127,6 +127,10 @@ public class SourceShim extends Composite
       public abstract void onSourceNavigateBack();
       @Handler
       public abstract void onSourceNavigateForward();
+      @Handler
+      public abstract void onOpenNextFileOnFilesystem();
+      @Handler
+      public abstract void onOpenPreviousFileOnFilesystem();
      
       
       @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceVimCommands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceVimCommands.java
@@ -289,6 +289,54 @@ public class SourceVimCommands
    
    }-*/;
    
+   public native final void openNextFile(Source source) /*-{
+      
+      var Vim = $wnd.require("ace/keyboard/vim").CodeMirror.Vim;
+      var callback = $entry(function(cm, args, vim) {
+         source.@org.rstudio.studio.client.workbench.views.source.Source::onOpenNextFileOnFilesystem()();
+      });
+      
+      Vim.defineAction("openNextFile", callback);
+      Vim.mapCommand({
+         keys: "]f",
+         type: "action",
+         action: "openNextFile",
+         context: "normal"
+      });
+      
+      Vim.mapCommand({
+         keys: "]f",
+         type: "action",
+         action: "openNextFile",
+         context: "visual"
+      });
+      
+   }-*/;
+   
+   public native final void openPreviousFile(Source source) /*-{
+      
+      var Vim = $wnd.require("ace/keyboard/vim").CodeMirror.Vim;
+      var callback = $entry(function(cm, args, vim) {
+         source.@org.rstudio.studio.client.workbench.views.source.Source::onOpenPreviousFileOnFilesystem()();
+      });
+      
+      Vim.defineAction("openPreviousFile", callback);
+      Vim.mapCommand({
+         keys: "[f",
+         type: "action",
+         action: "openPreviousFile",
+         context: "normal"
+      });
+      
+      Vim.mapCommand({
+         keys: "[f",
+         type: "action",
+         action: "openPreviousFile",
+         context: "visual"
+      });
+      
+   }-*/;
+   
    public native final void addStarRegister() /*-{
       
       var SystemClipboardRegister = function(text, linewise, blockwise) {


### PR DESCRIPTION
This PR adds a small extension to our Vim integration that allows `]f` to open the next file on the filesystem, and `[f` to open the previous file on the filesystem (relative to the currently active open file). (Inspired by [vim-unimpaired](https://github.com/tpope/vim-unimpaired))

Users who want to use these commands outside of Vim mode can do so by rebinding them to separate shortcut keys.