### PR TITLE
Don't set GIT_EDITOR or SVN_EDITOR in terminal environment

### DIFF
--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -62,13 +62,6 @@ core::system::ProcessOptions ConsoleProcess::createTerminalProcOptions(
    core::system::setenv(&shellEnv, "PROMPT_COMMAND",
                         "echo -ne \"\\033]0;${PWD/#${HOME}/~}\\007\"");
 
-   std::string editorCommand = session::modules::workbench::editFileCommand();
-   if (!editorCommand.empty())
-   {
-      core::system::setenv(&shellEnv, "GIT_EDITOR", editorCommand);
-      core::system::setenv(&shellEnv, "SVN_EDITOR", editorCommand);
-   }
-
    // don't add commands starting with a space to shell history
    if (procInfo.getTrackEnv())
    {


### PR DESCRIPTION
In 1.0 we set GIT_EDITOR and SVN_EDITOR to rpostback-editfile on Server, so the shell dialog could be used for source-control operations.

Now that terminal supports full-screen programs like vim, we won't set these environment variables.