### PR TITLE
properly handle re-opening object explorer tabs

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/ObjectExplorerFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/ObjectExplorerFileType.java
@@ -22,7 +22,7 @@ public class ObjectExplorerFileType extends EditableFileType
 {
    public ObjectExplorerFileType()
    {
-      super("object_explorer",
+      super(ID,
             "Object Explorer",
             new ImageResource2x(FileIconResources.INSTANCE.iconObjectExplorer2x()));
    }
@@ -33,4 +33,6 @@ public class ObjectExplorerFileType extends EditableFileType
       assert false :
          "Object explorer doesn't operate on filesystem files";
    }
+   
+   public static final String ID = "object_explorer";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -71,7 +71,9 @@ import org.rstudio.studio.client.common.GlobalProgressDelayer;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.dependencies.DependencyManager;
 import org.rstudio.studio.client.common.filetypes.EditableFileType;
+import org.rstudio.studio.client.common.filetypes.FileType;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
+import org.rstudio.studio.client.common.filetypes.ObjectExplorerFileType;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.common.filetypes.events.OpenPresentationSourceFileEvent;
 import org.rstudio.studio.client.common.filetypes.events.OpenSourceFileEvent;
@@ -1005,8 +1007,15 @@ public class Source implements InsertSourceHandler,
       // attempt to open pre-existing tab
       for (int i = 0; i < editors_.size(); i++)
       {
-         String path = editors_.get(i).getPath();
-         if (path != null && path.equals(handle.getPath()))
+         EditingTarget target = editors_.get(i);
+         
+         // bail if this isn't an object explorer filetype
+         FileType fileType = target.getFileType();
+         if (!(fileType instanceof ObjectExplorerFileType))
+            continue;
+         
+         // check for identical titles
+         if (handle.getTitle().equals(target.getTitle()))
          {
             ((ObjectExplorerEditingTarget)editors_.get(i)).update(handle);
             ensureVisible(false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
@@ -54,6 +54,7 @@ public interface EditingTarget extends IsWidget,
    ImageResource getIcon();
    String getTabTooltip();
    
+   FileType getFileType();
    TextFileType getTextFileType();
 
    void adaptToExtendedFileType(String extendedType);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
@@ -412,6 +412,12 @@ public class CodeBrowserEditingTarget implements EditingTarget
    }
    
    @Override
+   public FileType getFileType()
+   {
+      return null;
+   }
+   
+   @Override
    public TextFileType getTextFileType()
    {
       return null;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/ObjectExplorerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/ObjectExplorerEditingTarget.java
@@ -23,6 +23,8 @@ import org.rstudio.core.client.widget.SimplePanelWithProgress;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.filetypes.FileIconResources;
+import org.rstudio.studio.client.common.filetypes.FileType;
+import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.source.editors.explorer.model.ObjectExplorerHandle;
 import org.rstudio.studio.client.workbench.views.source.editors.explorer.view.ObjectExplorerEditingTargetWidget;
@@ -40,6 +42,7 @@ public class ObjectExplorerEditingTarget
                                       EventBus events)
    {
       super(server, commands, globalDisplay, events);
+      fileType_ = FileTypeRegistry.OBJECT_EXPLORER;
       events_ = events;
       isActive_ = false;
    }
@@ -117,13 +120,19 @@ public class ObjectExplorerEditingTarget
       events_.fireEvent(new PopoutDocEvent(getId(), null));
    }
    
+   @Override
+   public FileType getFileType()
+   {
+      return fileType_;
+   }
+   
    // Public methods ----
    
    public void update(ObjectExplorerHandle handle)
    {
       if (isActive_)
       {
-         // TODO
+         reloadDisplay();
       }
    }
    
@@ -146,5 +155,6 @@ public class ObjectExplorerEditingTarget
    private SimplePanelWithProgress progressPanel_;
    private ObjectExplorerEditingTargetWidget view_;
    private final EventBus events_;
+   private final FileType fileType_;
    private boolean isActive_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -164,6 +164,12 @@ public class ProfilerEditingTarget implements EditingTarget,
    {
       return new ImageResource2x(FileIconResources.INSTANCE.iconProfiler2x());
    }
+   
+   @Override
+   public FileType getFileType()
+   {
+      return fileType_;
+   }
 
    @Override
    public TextFileType getTextFileType()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2697,6 +2697,11 @@ public class TextEditingTarget implements
       return getPath();
    }
    
+   @Override
+   public FileType getFileType()
+   {
+      return fileType_;
+   }
 
    @Override
    public TextFileType getTextFileType()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
@@ -124,6 +124,12 @@ public class UrlContentEditingTarget implements EditingTarget
    }
    
    @Override
+   public FileType getFileType()
+   {
+      return null;
+   }
+   
+   @Override
    public TextFileType getTextFileType()
    {
       return null;


### PR DESCRIPTION
This PR fixes an issue where attempts to invoke the viewer with the same object intended for the object explorer, e.g.

    View(as.list(mtcars))
    View(as.list(mtcars))

would open two separate tabs rather than re-activating an existing tab.