### PR TITLE
fix 'Export to Image' for macOS desktop

### DIFF
--- a/src/cpp/desktop-mac/GwtCallbacks.mm
+++ b/src/cpp/desktop-mac/GwtCallbacks.mm
@@ -711,13 +711,21 @@ private:
    }
    
    // write to file
-   NSBitmapImageRep *imageRep = (NSBitmapImageRep*) [[image representations] objectAtIndex: 0];
-   NSData *data = [imageRep representationUsingType: imageFileType properties: properties];
-   if (![data writeToFile: targetPath atomically: NO])
+   for (NSImageRep* imageRep in [image representations])
    {
-      Error error = systemError(boost::system::errc::io_error, ERROR_LOCATION);
-      error.addProperty("target-file", [targetPath UTF8String]);
-      LOG_ERROR(error);
+      if (![imageRep isKindOfClass: [NSBitmapImageRep class]])
+         continue;
+      
+      NSBitmapImageRep* bitmapImageRep = (NSBitmapImageRep*) imageRep;
+      NSData *data = [bitmapImageRep representationUsingType: imageFileType properties: properties];
+      if (![data writeToFile: targetPath atomically: NO])
+      {
+         Error error = systemError(boost::system::errc::io_error, ERROR_LOCATION);
+         error.addProperty("target-file", [targetPath UTF8String]);
+         LOG_ERROR(error);
+      }
+      
+      break;
    }
 }
 


### PR DESCRIPTION
This PR fixes an issue where `Export -> Save as Image...` failed for content shown in the Viewer pane (ie, htmlwidgets). One can test with e.g.

```R
library(dygraphs)
lungDeaths <- cbind(mdeaths, fdeaths)
dygraph(lungDeaths)
```

It looks like there is no guarantee that the first representation used for the image returned by `nsImageForPageRegion` is a bitmap image -- on my machine, I was seeing with a debug build:

> 2017-07-31 11:59:08.133 RStudio[11654:2941171] -[NSCGImageSnapshotRep representationUsingType:properties:]: unrecognized selector sent to instance 0x7faef2b9f3d0

indicating that the first representation was actually an instance of the `NSCGImageSnapshotRep` class.

I presume this was a change in WebKit, since this same issue also exists with old versions of the IDE (e.g. I can reproduce in v0.99.903). 