### PR TITLE
fix 'Export to Image' for macOS desktop

### DIFF
--- a/src/cpp/desktop-mac/GwtCallbacks.mm
+++ b/src/cpp/desktop-mac/GwtCallbacks.mm
@@ -710,8 +710,12 @@ private:
       imageFileType = NSPNGFileType;
    }
    
+   
    // write to file
-   NSBitmapImageRep *imageRep = (NSBitmapImageRep*) [[image representations] objectAtIndex: 0];
+   CGImageRef cgRef = [image CGImageForProposedRect: NULL
+                                            context: nil
+                                              hints: nil];
+   NSBitmapImageRep *imageRep = [[NSBitmapImageRep alloc] initWithCGImage: cgRef];
    NSData *data = [imageRep representationUsingType: imageFileType properties: properties];
    if (![data writeToFile: targetPath atomically: NO])
    {


### PR DESCRIPTION
This PR fixes an issue where 'Export to Image' would fail on macOS when attempting to export Viewer content (e.g. HTML widgets).

It looks like newer versions of WebKit no longer return an `NSBitmapImageRep` as the first element of the possible image representations here -- rather, it returns an `NSCGImageSnapshotRep`, which AFAICS is not a publicly exported type. However, we can still get the bitmap image data through a separate set of APIs, which I believe should be backwards-compatible with older WebKit as well.

This may be a candidate for the patch release, since the current release of RStudio is affected by this as well.