### PR TITLE
Fix inability to execute command until 20 characters have been typed

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -224,6 +224,7 @@ public class TerminalSession extends XTermWidget
    public void disconnect(boolean permanent)
    {
       inputQueue_.setLength(0);
+      inputSequence_ = ShellInput.IGNORE_SEQUENCE;
       socket_.disconnect(permanent);
       registrations_.removeHandler();
       consoleProcess_ = null;


### PR DESCRIPTION
Scenario: with a terminal open and using RPC (vs. Websockets) restart R. Then try to execute a command in the terminal and you can't until you've entered at least 20 characters.

I recently made some logic that was previously Windows-only apply on all platform desktop IDEs and Darby quickly found a bug. Problem was there all along on Windows.

Introduced by Change 3a955c7.
