### PR TITLE
Stop javascript exception after restarting session

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsPane.java
@@ -701,6 +701,9 @@ public class ConnectionsPane extends WorkbenchPane
       
       sortConnections();
       
-      installConnectionExplorerToolbar(exploredConnection_);
+      if (exploredConnection_ != null)
+         installConnectionExplorerToolbar(exploredConnection_);
+      else
+         installConnectionsToolbar();
    }
 }


### PR DESCRIPTION
I kept seeing this in the javascript console when working on other issues and found an old bug on it (case 6681) that had been closed, but I can repro 100% so reopened.

To repro, open RStudio (Mac development server). No existing connections.

In Javascript debugger, open ConnectionsPane.java, put breakpoint in onActiveConnectionsChanged() at the call to installConnectionExplorerToolbar.

Do Session->Restart R, repeat.

Breakpoint is hit, and installConnectionExplorerToolbar is called with a null connection, which leads to exceptions.

Added a check to prevent exception. Someone familiar with the connections feature should check that this is a reasonable fix.