### PR TITLE
(linux) Terminal processes not being killed when closing terminals

### DIFF
--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -344,12 +344,10 @@ Error ChildProcess::terminate()
    // special code path for pseudoterminal
    if (options_.pseudoterminal)
    {
-      // on OSX you need to close all of the terminal handles to get
+      // you need to close all of the terminal handles to get
       // bash to quit, however some other processes (like svn+ssh
       // require the signal)
-#ifdef __APPLE__
       pImpl_->closeAll(false, ERROR_LOCATION);
-#endif
 
       if (::killpg(::getpgid(pImpl_->pid), SIGTERM) == -1)
       {
@@ -771,13 +769,11 @@ AsyncChildProcess::~AsyncChildProcess()
 
 Error AsyncChildProcess::terminate()
 {
-#ifdef __APPLE__
    if (options().pseudoterminal)
    {
       pAsyncImpl_->finishedStderr_ = true;
       pAsyncImpl_->finishedStdout_ = true;
    }
-#endif
 
    return ChildProcess::terminate();
 }

--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -344,10 +344,21 @@ Error ChildProcess::terminate()
    // special code path for pseudoterminal
    if (options_.pseudoterminal)
    {
-      // you need to close all of the terminal handles to get
-      // bash to quit, however some other processes (like svn+ssh
-      // require the signal)
-      pImpl_->closeAll(false, ERROR_LOCATION);
+#ifndef __APPLE__
+      // On Linux only do this if dealing with a Terminal-pane process.
+      // This is to reduce scope of this change for 1.1
+      // TODO: review post 1.1
+      if (options().smartTerminal)
+      {
+#endif
+         // you need to close all of the terminal handles to get
+         // bash to quit, however some other processes (like svn+ssh
+         // require the signal)
+         pImpl_->closeAll(false, ERROR_LOCATION);
+
+#ifndef __APPLE__
+      }
+#endif
 
       if (::killpg(::getpgid(pImpl_->pid), SIGTERM) == -1)
       {
@@ -769,12 +780,21 @@ AsyncChildProcess::~AsyncChildProcess()
 
 Error AsyncChildProcess::terminate()
 {
-   if (options().pseudoterminal)
+#ifndef __APPLE__
+   // On Linux only do this if dealing with a Terminal-pane process.
+   // This is to reduce scope of this change for 1.1
+   // TODO: review post 1.1
+   if (options().smartTerminal)
    {
-      pAsyncImpl_->finishedStderr_ = true;
-      pAsyncImpl_->finishedStdout_ = true;
+#endif
+      if (options().pseudoterminal)
+      {
+         pAsyncImpl_->finishedStderr_ = true;
+         pAsyncImpl_->finishedStdout_ = true;
+      }
+#ifndef __APPLE__
    }
-
+#endif
    return ChildProcess::terminate();
 }
 


### PR DESCRIPTION
When closing a terminal with running processes (e.g. sleep, vim, so on), on Linux, the processes weren't going away (but the UI was, so little hint that there's a problem).

Fixed by making some existing code not be OSX-specific. This isn't code I wrote or modified for terminal, just used as I found it. This will impact killing all PosixChildProcesses, not just the Terminal scenario. If this is a concern, I could scope this to only the terminal scenario.