### PR TITLE
fixups for tooltip positioning + sizing

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/SignatureToolTipManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/SignatureToolTipManager.java
@@ -503,11 +503,7 @@ public class SignatureToolTipManager
    
    private void resolvePositionAndShow(String signature, Position position)
    {
-      // Default to displaying before cursor; however, display above
-      // if doing so would place the tooltip too close (or off) of
-      // the window.
-      toolTip_.setText(signature);
-      setTooltipPosition(position);
+      toolTip_.resolvePositionAndShow(signature, position);
    }
    
    private void setTooltipPosition(Position position)


### PR DESCRIPTION
This PR fixes an issue where the tooltip signature was not properly truncated when shown through a mouse idle, and also improves the general positioning behavior (better avoiding right-overflow when the browser width is small).