### PR TITLE
Fix profiler menu under dark theme

### DIFF
--- a/src/cpp/session/resources/profiler/profiler.css
+++ b/src/cpp/session/resources/profiler/profiler.css
@@ -112,3 +112,8 @@
 .rstudio-themes-flat.rstudio-themes-dark .profvis-message div {
    color: #FFF;
 }
+
+.rstudio-themes-flat.rstudio-themes-dark .profvis-options-panel {
+   background: rgb(47, 57, 65);
+   border-color: rgb(78, 92, 104);
+}


### PR DESCRIPTION
Profiler menu was rendering with white backgorund, fixed:

<img width="269" alt="screen shot 2017-08-02 at 10 15 21 am" src="https://user-images.githubusercontent.com/3478847/28885712-ab0c7548-776b-11e7-9a73-cfb626090495.png">
