### PR TITLE
Include profiler resources in build file

### DIFF
--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -495,6 +495,10 @@ if (NOT RSTUDIO_SESSION_WIN64)
    install(DIRECTORY "resources/pagedtable"
            DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/resources)
 
+   # install profiler
+   install(DIRECTORY "resources/profiler"
+           DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/resources)
+
    # install libclang
    if(WIN32)
       file(GLOB LIBCLANG_32_FILES "${LIBCLANG_DIR}/x86/libclang.*")


### PR DESCRIPTION
The profiler resources are not being copied in builds. I haven't spotted this since I've been using dev builds for the most part which serve resources directly from the build directory.

Before:

<img width="938" alt="screen shot 2017-08-02 at 11 02 21 am" src="https://user-images.githubusercontent.com/3478847/28887484-32dbcefa-7772-11e7-944e-4216d6c45e1e.png">

After:

<img width="937" alt="screen shot 2017-08-02 at 11 02 30 am" src="https://user-images.githubusercontent.com/3478847/28887537-566f1fa2-7772-11e7-83b6-03b742b27ea3.png">
