### PR TITLE
Don't give terminal busy warning when not needed

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
@@ -344,41 +344,51 @@ public class BuildPresenter extends BasePresenter
    
    private void executeBuild(final String type, final String subType)
    {
-      // attempt to start a build (this will be a silent no-op if there
-      // is already a build running)
-      final String caption = "Build";
+      if (type != "build-all" && type != "rebuild-all")
+      {
+         executeBuildNoBusyCheck(type, subType);
+         return;
+      }
+      
       terminalHelper_.warnBusyTerminalBeforeCommand(new Command() {
          @Override
          public void execute()
          {
-            workbenchContext_.setBuildInProgress(true);
-            sourceBuildHelper_.withSaveFilesBeforeCommand(new Command() {
-               @Override
-               public void execute()
-               {
-                  server_.startBuild(type, subType, 
-                        new SimpleRequestCallback<Boolean>() {
-                     @Override
-                     public void onResponseReceived(Boolean response)
-                     {
-
-                     }
-
-                     @Override
-                     public void onError(ServerError error)
-                     {
-                        super.onError(error);
-                        workbenchContext_.setBuildInProgress(false);
-                     }
-
-                  });
-               }
-            }, caption);
+            executeBuildNoBusyCheck(type, subType);
          }
-      }, caption, "Terminal jobs will be terminated. Are you sure?", 
+      }, "Build", "Terminal jobs will be terminated. Are you sure?", 
             uiPrefs_.terminalBusyMode().getValue());
    }
-   
+
+   private void executeBuildNoBusyCheck(final String type, final String subType)
+   {
+      // attempt to start a build (this will be a silent no-op if there
+      // is already a build running)
+      workbenchContext_.setBuildInProgress(true);
+      sourceBuildHelper_.withSaveFilesBeforeCommand(new Command() {
+         @Override
+         public void execute()
+         {
+            server_.startBuild(type, subType, 
+                  new SimpleRequestCallback<Boolean>() {
+               @Override
+               public void onResponseReceived(Boolean response)
+               {
+
+               }
+
+               @Override
+               public void onError(ServerError error)
+               {
+                  super.onError(error);
+                  workbenchContext_.setBuildInProgress(false);
+               }
+
+            });
+         }
+      }, "Build");
+   }
+
    void onStopBuild()
    {
        server_.terminateBuild(new DelayedProgressRequestCallback<Boolean>(


### PR DESCRIPTION
Of various package build commands, only the build-all and rebuild-all commands restart the R session. Other build commands don't.