### PR TITLE
launch instances to handle ide build scale

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,6 +109,8 @@ try {
           [os: 'debian9',  arch: 'x86_64', flavor: 'server', variant: 'stretch']
         ]
         containers = limit_builds(containers)
+        // launch jenkins agents to support the container scale!
+        spotScaleSwarm layer_name: 'swarm-ide', instance_count: containers.size()
         def parallel_containers = [:]
         for (int i = 0; i < containers.size(); i++) {
             def index = i


### PR DESCRIPTION
needs to land after https://github.com/rstudio/jenkins-pipeline-libraries/pull/6

uses a new jenkins-pipeline-library that launches spot instances to our jenkins cluster to support the influx of ide builds. This should actually allow (potentially after a round of debugging) the jenkins agents to handle a full set of builds 24/7, rather than just the nightlies.