### PR TITLE
Send-to-terminal support for .sh files and other text files

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -994,6 +994,8 @@ public class Application implements ApplicationEventHandlers
       commands_.showTerminalInfo().remove();
       commands_.interruptTerminal().remove();
       commands_.sendTerminalToEditor().remove();
+      commands_.sendToTerminal().remove();
+      commands_.sendToTerminalWithoutFocus().remove();
    }
 
    private final ApplicationView view_ ;

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -995,7 +995,6 @@ public class Application implements ApplicationEventHandlers
       commands_.interruptTerminal().remove();
       commands_.sendTerminalToEditor().remove();
       commands_.sendToTerminal().remove();
-      commands_.sendToTerminalWithoutFocus().remove();
    }
 
    private final ApplicationView view_ ;

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
@@ -138,7 +138,7 @@ public class FileTypeRegistry
 
    public static final TextFileType PYTHON = new ScriptFileType(
      "python", "Python", EditorLanguage.LANG_PYTHON, ".py",new ImageResource2x(ICONS.iconPython2x()),
-     "python", true);
+     "python", false, true);
 
    public static final TextFileType SQL =
          new TextFileType("sql", "SQL", EditorLanguage.LANG_SQL, ".sql",
@@ -147,7 +147,7 @@ public class FileTypeRegistry
 
    public static final TextFileType SH = new ScriptFileType(
          "sh", "Shell", EditorLanguage.LANG_SH, ".sh", new ImageResource2x(ICONS.iconSh2x()),
-         null, false);
+         null, true, false);
    
    public static final TextFileType TOML =
          new TextFileType("toml", "TOML", EditorLanguage.LANG_TOML, ".toml",

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
@@ -1,7 +1,7 @@
 /*
  * FileTypeRegistry.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/ScriptFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/ScriptFileType.java
@@ -31,10 +31,11 @@ public class ScriptFileType extends TextFileType
                          String ext, 
                          ImageResource icon,
                          String interpreter,
+                         boolean canExecuteCode,
                          boolean windowsCompatible)
    {
       super(id, label, language, ext, icon,
-            false, false, false, false, false, false, 
+            false, false, canExecuteCode, false, false, false, 
             false, false, false, false, false, false, false);
       interpreter_ = interpreter;
       windowsCompatible_ = windowsCompatible;
@@ -78,6 +79,25 @@ public class ScriptFileType extends TextFileType
          result.add(commands.sourceActiveDocument());
          result.add(commands.sourceActiveDocumentWithEcho());
       }
+
+      if (canExecuteCode())
+      {
+         result.remove(commands.reindent());
+         result.remove(commands.showDiagnosticsActiveDocument());
+         result.remove(commands.executeCurrentFunction());
+         result.remove(commands.executeLastCode());
+         result.remove(commands.extractFunction());
+         result.remove(commands.extractLocalVariable());
+         result.remove(commands.commentUncomment());
+         result.remove(commands.reflowComment());
+         result.remove(commands.reformatCode());
+         result.remove(commands.renameInScope());
+         result.remove(commands.profileCode());
+         result.remove(commands.profileCodeWithoutFocus());
+         result.remove(commands.sendToTerminal());
+         result.remove(commands.sendToTerminalWithoutFocus());
+      }
+      
       return result;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/ScriptFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/ScriptFileType.java
@@ -1,7 +1,7 @@
 /*
  * ScriptFileType.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/ScriptFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/ScriptFileType.java
@@ -79,25 +79,6 @@ public class ScriptFileType extends TextFileType
          result.add(commands.sourceActiveDocument());
          result.add(commands.sourceActiveDocumentWithEcho());
       }
-
-      if (canExecuteCode())
-      {
-         result.remove(commands.reindent());
-         result.remove(commands.showDiagnosticsActiveDocument());
-         result.remove(commands.executeCurrentFunction());
-         result.remove(commands.executeLastCode());
-         result.remove(commands.extractFunction());
-         result.remove(commands.extractLocalVariable());
-         result.remove(commands.commentUncomment());
-         result.remove(commands.reflowComment());
-         result.remove(commands.reformatCode());
-         result.remove(commands.renameInScope());
-         result.remove(commands.profileCode());
-         result.remove(commands.profileCodeWithoutFocus());
-         result.remove(commands.sendToTerminal());
-         result.remove(commands.sendToTerminalWithoutFocus());
-      }
-      
       return result;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -1,7 +1,7 @@
 /*
  * TextFileType.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -403,6 +403,9 @@ public class TextFileType extends EditableFileType
       results.add(commands.popoutDoc());
       if (!SourceWindowManager.isMainSourceWindow())
          results.add(commands.returnDocToMain());
+      
+      results.add(commands.sendToTerminal());
+      results.add(commands.sendToTerminalWithoutFocus());
 
       return results;
    }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -409,7 +409,6 @@ public class TextFileType extends EditableFileType
          results.add(commands.returnDocToMain());
       
       results.add(commands.sendToTerminal());
-      results.add(commands.sendToTerminalWithoutFocus());
 
       return results;
    }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -300,13 +300,13 @@ public class TextFileType extends EditableFileType
       results.add(commands.expandSelection());
       results.add(commands.shrinkSelection());
       
-      if (canExecuteCode() || isC())
+      if ((canExecuteCode() && !isScript()) || isC())
       {
          results.add(commands.reindent());
          results.add(commands.showDiagnosticsActiveDocument());
       }
       
-      if (canExecuteCode() && !isC())
+      if (canExecuteCode() && !isC() && !isScript())
       {
          results.add(commands.executeCurrentFunction());
       }
@@ -315,15 +315,19 @@ public class TextFileType extends EditableFileType
       {
          results.add(commands.executeCode());
          results.add(commands.executeCodeWithoutFocus());
-         results.add(commands.executeLastCode());
-         results.add(commands.extractFunction());
-         results.add(commands.extractLocalVariable());
-         results.add(commands.commentUncomment());
-         results.add(commands.reflowComment());
-         results.add(commands.reformatCode());
-         results.add(commands.renameInScope());
-         results.add(commands.profileCode());
-         results.add(commands.profileCodeWithoutFocus());
+         
+         if (!isScript())
+         {
+            results.add(commands.executeLastCode());
+            results.add(commands.extractFunction());
+            results.add(commands.extractLocalVariable());
+            results.add(commands.commentUncomment());
+            results.add(commands.reflowComment());
+            results.add(commands.reformatCode());
+            results.add(commands.renameInScope());
+            results.add(commands.profileCode());
+            results.add(commands.profileCodeWithoutFocus());
+         }
       }
       
       if (canExecuteAllCode())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -233,6 +233,7 @@ well as menu structures (for main menu and popup menus).
             <separator/>
             <cmd refid="executeAllCode"/>
          </menu>
+         <cmd refid="sendToTerminal"/>
          <separator/>
          <cmd refid="sourceActiveDocument"/>
          <cmd refid="sourceActiveDocumentWithEcho"/>
@@ -2508,7 +2509,16 @@ well as menu structures (for main menu and popup menus).
         buttonLabel=""
         menuLabel="Copy Terminal to _Editor"
         desc="Copy current terminal's buffer to a new editor buffer"/>
- 
+
+   <cmd id="sendToTerminal"
+        label="Send Selection to Terminal"
+        buttonLabel=""
+        menuLabel="Send to Terminal"
+        desc="Send the current line or selection to terminal"/>
+
+   <cmd id="sendToTerminalWithoutFocus"
+        rebindable="false"/>
+  
    <cmd id="browseAddins"
         label="Browse Addins"
         menuLabel="_Browse Addins..."

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -2516,9 +2516,6 @@ well as menu structures (for main menu and popup menus).
         menuLabel="Send to Terminal"
         desc="Send the current line or selection to terminal"/>
 
-   <cmd id="sendToTerminalWithoutFocus"
-        rebindable="false"/>
-  
    <cmd id="browseAddins"
         label="Browse Addins"
         menuLabel="_Browse Addins..."

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -1,7 +1,7 @@
 /*
  * Commands.java
  *
- * Copyright (C) 2009-15 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -397,6 +397,8 @@ public abstract class
    public abstract AppCommand showTerminalInfo();
    public abstract AppCommand interruptTerminal();
    public abstract AppCommand sendTerminalToEditor();
+   public abstract AppCommand sendToTerminal();
+   public abstract AppCommand sendToTerminalWithoutFocus();
     
    // Help
    public abstract AppCommand helpBack();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -398,7 +398,6 @@ public abstract class
    public abstract AppCommand interruptTerminal();
    public abstract AppCommand sendTerminalToEditor();
    public abstract AppCommand sendToTerminal();
-   public abstract AppCommand sendToTerminalWithoutFocus();
     
    // Help
    public abstract AppCommand helpBack();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -377,6 +377,8 @@ public class Source implements InsertSourceHandler,
       dynamicCommands_.add(commands.notebookClearOutput());
       dynamicCommands_.add(commands.notebookClearAllOutput());
       dynamicCommands_.add(commands.notebookToggleExpansion());
+      dynamicCommands_.add(commands.sendToTerminal());
+      dynamicCommands_.add(commands.sendToTerminalWithoutFocus());
       for (AppCommand command : dynamicCommands_)
       {
          command.setVisible(false);
@@ -3592,6 +3594,8 @@ public class Source implements InsertSourceHandler,
       // manage multi-tab commands
       manageMultiTabCommands();
       
+      manageTerminalCommands();
+      
       activeCommands_ = newCommands;
       
       // give the active editor a chance to manage commands
@@ -3747,7 +3751,11 @@ public class Source implements InsertSourceHandler,
       commands_.saveAllSourceDocs().setEnabled(false);
    }
    
-  
+   private void manageTerminalCommands()
+   {
+      commands_.sendToTerminal().setVisible(session_.getSessionInfo().getAllowShell());
+   }
+   
    private boolean verifyNoUnsupportedCommands(HashSet<AppCommand> commands)
    {
       HashSet<AppCommand> temp = new HashSet<AppCommand>(commands);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -378,7 +378,6 @@ public class Source implements InsertSourceHandler,
       dynamicCommands_.add(commands.notebookClearAllOutput());
       dynamicCommands_.add(commands.notebookToggleExpansion());
       dynamicCommands_.add(commands.sendToTerminal());
-      dynamicCommands_.add(commands.sendToTerminalWithoutFocus());
       for (AppCommand command : dynamicCommands_)
       {
          command.setVisible(false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -3753,7 +3753,8 @@ public class Source implements InsertSourceHandler,
    
    private void manageTerminalCommands()
    {
-      commands_.sendToTerminal().setVisible(session_.getSessionInfo().getAllowShell());
+      if (!session_.getSessionInfo().getAllowShell())
+         commands_.sendToTerminal().setVisible(false);
    }
    
    private boolean verifyNoUnsupportedCommands(HashSet<AppCommand> commands)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
@@ -188,10 +188,6 @@ public class EditingTargetCodeExecution
          selectionRange = Range.fromPoints(
                Position.create(row, 0),
                Position.create(row, docDisplay_.getLength(row)));
-
-         // if we failed to discover a range, bail
-         if (selectionRange == null)
-            return;
       }
       String code = codeExtractor_.extractCode(docDisplay_, selectionRange);
       if (!code.isEmpty() && !(code.endsWith("\n") || code.endsWith("\r")))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
@@ -194,6 +194,8 @@ public class EditingTargetCodeExecution
             return;
       }
       String code = codeExtractor_.extractCode(docDisplay_, selectionRange);
+      if (!code.isEmpty() && !(code.endsWith("\n") || code.endsWith("\r")))
+         code = code + "\n";
       events_.fireEvent(new SendToTerminalEvent(code, null));
  }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
@@ -161,23 +161,8 @@ public class EditingTargetCodeExecution
       executeRange(range, null, false);
    }
    
-   public void sendSelectionToTerminal(boolean terminalExecuteWhenNotFocused)
+   public void sendSelectionToTerminal()
    {
-      if (terminalExecuteWhenNotFocused && !docDisplay_.isFocused())
-      {
-         // the current editor may be in another window; if one of our source
-         // windows was last focused, use that one instead
-         SourceWindowManager manager = 
-               RStudioGinjector.INSTANCE.getSourceWindowManager();
-         if (!StringUtil.isNullOrEmpty(manager.getLastFocusedSourceWindowId()))
-         {
-            RStudioGinjector.INSTANCE.getSatelliteManager().dispatchCommand(
-                  commands_.sendToTerminalWithoutFocus(), SourceSatellite.NAME_PREFIX + 
-                           manager.getLastFocusedSourceWindowId());
-            return;
-         }
-      }
-
       // send selection from this editor to the terminal
       Range selectionRange = docDisplay_.getSelectionRange();
       boolean noSelection = selectionRange.isEmpty();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
@@ -196,7 +196,7 @@ public class EditingTargetCodeExecution
       String code = codeExtractor_.extractCode(docDisplay_, selectionRange);
       if (!code.isEmpty() && !(code.endsWith("\n") || code.endsWith("\r")))
          code = code + "\n";
-      events_.fireEvent(new SendToTerminalEvent(code, null));
+      events_.fireEvent(new SendToTerminalEvent(code));
  }
    
    public void profileSelection()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
@@ -261,15 +261,9 @@ public class CodeBrowserEditingTarget implements EditingTarget
    @Handler 
    void onSendToTerminal() 
    { 
-      codeExecution_.sendSelectionToTerminal(true);
+      codeExecution_.sendSelectionToTerminal();
    } 
 
-   @Handler 
-   void onSendToTerminalWithoutFocus() 
-   { 
-      codeExecution_.sendSelectionToTerminal(false);
-   } 
-    
    @Handler
    void onPrintSourceDoc()
    {
@@ -449,7 +443,6 @@ public class CodeBrowserEditingTarget implements EditingTarget
       commands.add(commands_.executeCodeWithoutFocus());
       commands.add(commands_.executeLastCode());
       commands.add(commands_.sendToTerminal());
-      commands.add(commands_.sendToTerminalWithoutFocus());
 
       if (SourceWindowManager.isMainSourceWindow())
          commands.add(commands_.popoutDoc());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
@@ -1,7 +1,7 @@
 /*
  * CodeBrowserEditingTarget.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -258,7 +258,18 @@ public class CodeBrowserEditingTarget implements EditingTarget
       codeExecution_.executeLastCode();
    }
    
-   
+   @Handler 
+   void onSendToTerminal() 
+   { 
+      codeExecution_.sendSelectionToTerminal(true);
+   } 
+
+   @Handler 
+   void onSendToTerminalWithoutFocus() 
+   { 
+      codeExecution_.sendSelectionToTerminal(false);
+   } 
+    
    @Handler
    void onPrintSourceDoc()
    {
@@ -437,6 +448,9 @@ public class CodeBrowserEditingTarget implements EditingTarget
       commands.add(commands_.executeCode());
       commands.add(commands_.executeCodeWithoutFocus());
       commands.add(commands_.executeLastCode());
+      commands.add(commands_.sendToTerminal());
+      commands.add(commands_.sendToTerminalWithoutFocus());
+
       if (SourceWindowManager.isMainSourceWindow())
          commands.add(commands_.popoutDoc());
       else

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -4006,10 +4006,7 @@ public class TextEditingTarget implements
    @Handler
    void onExecuteCodeWithoutFocus()
    {
-      if (fileType_.isScript())
-         onSendToTerminalWithoutFocus();
-      else
-         codeExecution_.executeSelection(false);
+      codeExecution_.executeSelection(false);
    }
 
    @Handler
@@ -4064,15 +4061,9 @@ public class TextEditingTarget implements
    @Handler
    void onSendToTerminal()
    {
-      codeExecution_.sendSelectionToTerminal(true);
+      codeExecution_.sendSelectionToTerminal();
    }
-
-   @Handler 
-   void onSendToTerminalWithoutFocus() 
-   { 
-      codeExecution_.sendSelectionToTerminal(false);
-   } 
-  
+ 
    @Override
    public String extractCode(DocDisplay docDisplay, Range range)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -4006,7 +4006,10 @@ public class TextEditingTarget implements
    @Handler
    void onExecuteCodeWithoutFocus()
    {
-      codeExecution_.executeSelection(false);
+      if (fileType_.isScript())
+         onSendToTerminalWithoutFocus();
+      else
+         codeExecution_.executeSelection(false);
    }
 
    @Handler
@@ -4034,7 +4037,10 @@ public class TextEditingTarget implements
    @Handler
    void onExecuteCode()
    {
-      codeExecution_.executeSelection(true);
+      if (fileType_.isScript())
+         onSendToTerminal();
+      else
+         codeExecution_.executeSelection(true);
    }
    
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -4055,6 +4055,18 @@ public class TextEditingTarget implements
       codeExecution_.executeBehavior(UIPrefsAccessor.EXECUTE_PARAGRAPH);
    }
 
+   @Handler
+   void onSendToTerminal()
+   {
+      codeExecution_.sendSelectionToTerminal(true);
+   }
+
+   @Handler 
+   void onSendToTerminalWithoutFocus() 
+   { 
+      codeExecution_.sendSelectionToTerminal(false);
+   } 
+  
    @Override
    public String extractCode(DocDisplay docDisplay, Range range)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -556,10 +556,17 @@ public class TextEditingTargetWidget
       boolean isScript = fileType.isScript();
       boolean isRMarkdown2 = extendedType_.equals("rmarkdown");
       boolean canPreviewFromR = fileType.canPreviewFromR();
+      boolean terminalAllowed = session_.getSessionInfo().getAllowShell();
+      
+      if (isScript && !terminalAllowed)
+      {
+         commands_.executeCode().setEnabled(false);
+         commands_.executeCodeWithoutFocus().setEnabled(false);
+      }
       
       // don't show the run buttons for cpp files, or R files in Shiny
       runButton_.setVisible(canExecuteCode && !canExecuteChunks && !isCpp && 
-            !isShinyFile());
+            !isShinyFile() && !(isScript && !terminalAllowed));
       runLastButton_.setVisible(runButton_.isVisible() && !canExecuteChunks && !isScript);
       
       // show insertion options for various knitr engines in rmarkdown v2
@@ -578,7 +585,7 @@ public class TextEditingTargetWidget
       else
          srcOnSaveLabel_.setText("Source on Save");
       codeTransform_.setVisible(
-            (canExecuteCode && !fileType.canAuthorContent()) ||
+            (canExecuteCode && !isScript && !fileType.canAuthorContent()) ||
             fileType.isC() || fileType.isStan());   
      
       sourceButton_.setVisible(canSource && !isPlainMarkdown);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -560,7 +560,7 @@ public class TextEditingTargetWidget
       // don't show the run buttons for cpp files, or R files in Shiny
       runButton_.setVisible(canExecuteCode && !canExecuteChunks && !isCpp && 
             !isShinyFile());
-      runLastButton_.setVisible(runButton_.isVisible() && !canExecuteChunks);
+      runLastButton_.setVisible(runButton_.isVisible() && !canExecuteChunks && !isScript);
       
       // show insertion options for various knitr engines in rmarkdown v2
       insertChunkMenu_.setVisible(isRMarkdown2);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -223,7 +223,7 @@ public class TerminalPane extends WorkbenchPane
       // if terminal is not selected, and the tab "X" is clicked, the tab receives
       // onSelected but in this case we don't want to create a new terminal
       if (!closingAll_)
-         ensureTerminal(null, true);
+         ensureTerminal(null);
    }
 
    @Override
@@ -267,9 +267,8 @@ public class TerminalPane extends WorkbenchPane
    /**
     * Ensure there's a terminal available, and optionally send text to it when ready. 
     * @param postCreateText text to send, may be null
-    * @param setFocus set focus on the terminal
     */
-   private void ensureTerminal(String postCreateText, boolean setFocus)
+   private void ensureTerminal(String postCreateText)
    {
       if (terminals_.terminalCount() == 0)
       {
@@ -288,13 +287,12 @@ public class TerminalPane extends WorkbenchPane
             Debug.log("Unexpected null terminal handle");
             return;
          }
-         events_.fireEvent(new SwitchToTerminalEvent(handle, postCreateText, setFocus));
+         events_.fireEvent(new SwitchToTerminalEvent(handle, postCreateText));
          return;
       }
       else
       {
-         if (setFocus)
-            setFocusOnVisible();
+         setFocusOnVisible();
          terminal.receivedInput(postCreateText);
       }
    }
@@ -508,7 +506,7 @@ public class TerminalPane extends WorkbenchPane
       if (StringUtil.isNullOrEmpty(text))
          return;
 
-      ensureTerminal(text, uiPrefs_.focusConsoleAfterExec().getValue());
+      ensureTerminal(text);
       activateTerminal();
    }
 
@@ -718,7 +716,7 @@ public class TerminalPane extends WorkbenchPane
       String newTerminalHandle = terminalToShowWhenClosing(handle);
       if (newTerminalHandle != null)
       {
-         events_.fireEvent(new SwitchToTerminalEvent(newTerminalHandle, null, true));
+         events_.fireEvent(new SwitchToTerminalEvent(newTerminalHandle, null));
       }
       
       // Remove terminated terminal from dropdown
@@ -764,8 +762,7 @@ public class TerminalPane extends WorkbenchPane
       if (terminal != null)
       {
          showTerminalWidget(terminal);
-         if (event.setFocus())
-            setFocusOnVisible();
+         setFocusOnVisible();
          ensureConnected(terminal); // needed after session suspend/resume
          terminal.receivedInput(event.getInputText());
          return;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
@@ -84,7 +84,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
                @Override
                public void execute()
                {
-                  eventBus_.fireEvent(new SwitchToTerminalEvent(handle));
+                  eventBus_.fireEvent(new SwitchToTerminalEvent(handle, null, true));
                }
             };
 
@@ -179,7 +179,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
       String handle = terminals_.handleForCaption(caption);
       if (StringUtil.isNullOrEmpty(handle))
          return;
-      eventBus_.fireEvent(new SwitchToTerminalEvent(handle));
+      eventBus_.fireEvent(new SwitchToTerminalEvent(handle, null, true));
    }
 
    /**
@@ -224,7 +224,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
       String prevHandle = getPreviousTerminalHandle();
       if (prevHandle != null)
       {
-         eventBus_.fireEvent(new SwitchToTerminalEvent(prevHandle));
+         eventBus_.fireEvent(new SwitchToTerminalEvent(prevHandle, null, true));
       }
    }
 
@@ -236,7 +236,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
       String nextHandle = getNextTerminalHandle();
       if (nextHandle != null)
       {
-         eventBus_.fireEvent(new SwitchToTerminalEvent(nextHandle));
+         eventBus_.fireEvent(new SwitchToTerminalEvent(nextHandle, null, true));
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
@@ -84,7 +84,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
                @Override
                public void execute()
                {
-                  eventBus_.fireEvent(new SwitchToTerminalEvent(handle, null, true));
+                  eventBus_.fireEvent(new SwitchToTerminalEvent(handle, null));
                }
             };
 
@@ -179,7 +179,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
       String handle = terminals_.handleForCaption(caption);
       if (StringUtil.isNullOrEmpty(handle))
          return;
-      eventBus_.fireEvent(new SwitchToTerminalEvent(handle, null, true));
+      eventBus_.fireEvent(new SwitchToTerminalEvent(handle, null));
    }
 
    /**
@@ -224,7 +224,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
       String prevHandle = getPreviousTerminalHandle();
       if (prevHandle != null)
       {
-         eventBus_.fireEvent(new SwitchToTerminalEvent(prevHandle, null, true));
+         eventBus_.fireEvent(new SwitchToTerminalEvent(prevHandle, null));
       }
    }
 
@@ -236,7 +236,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
       String nextHandle = getNextTerminalHandle();
       if (nextHandle != null)
       {
-         eventBus_.fireEvent(new SwitchToTerminalEvent(nextHandle, null, true));
+         eventBus_.fireEvent(new SwitchToTerminalEvent(nextHandle, null));
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
@@ -53,9 +53,10 @@ public class TerminalTabPresenter extends BusyPresenter
       void activateTerminal();
 
       /**
-       * Create a new terminal session.
+       * Create a new terminal session
+       * @param postCreateText text to insert in terminal after created, may be null
        */
-      void createTerminal();
+      void createTerminal(String postCreateText);
 
       /**
        * Terminate current terminal.
@@ -195,7 +196,7 @@ public class TerminalTabPresenter extends BusyPresenter
    public void onCreateTerminal(CreateTerminalEvent event)
    {
       onActivateTerminal();
-      view_.createTerminal();
+      view_.createTerminal(event.getPostCreateText());
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
@@ -87,7 +87,7 @@ public class TerminalTabPresenter extends BusyPresenter
       void previousTerminal();
       void nextTerminal();
       void showTerminalInfo();
-      void sendToTerminal(String text, String caption);
+      void sendToTerminal(String text);
       
       /**
        * Send SIGINT to child process of the terminal shell.
@@ -202,7 +202,7 @@ public class TerminalTabPresenter extends BusyPresenter
    @Override
    public void onSendToTerminal(SendToTerminalEvent event)
    {
-      view_.sendToTerminal(event.getText(), event.getId());
+      view_.sendToTerminal(event.getText());
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/CreateTerminalEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/CreateTerminalEvent.java
@@ -21,7 +21,8 @@ import org.rstudio.studio.client.application.events.CrossWindowEvent;
 import com.google.gwt.event.shared.EventHandler;
 
 /**
- * Event to trigger creation of a terminal session.
+ * Event to trigger creation of a terminal session, with optional text to insert
+ * in terminal after creation.
  */
 public class CreateTerminalEvent extends CrossWindowEvent<CreateTerminalEvent.Handler>
 {  
@@ -36,8 +37,14 @@ public class CreateTerminalEvent extends CrossWindowEvent<CreateTerminalEvent.Ha
 
    public CreateTerminalEvent()
    {
+      postCreateText_ = null;
    }
-    
+
+   public CreateTerminalEvent(String postCreateText)
+   {
+      postCreateText_ = postCreateText;
+   }
+     
    @Override
    public Type<Handler> getAssociatedType()
    {
@@ -49,6 +56,16 @@ public class CreateTerminalEvent extends CrossWindowEvent<CreateTerminalEvent.Ha
    {
       handler.onCreateTerminal(this);
    }
+   
+   /**
+    * @return text to insert in terminal after creation, may be null
+    */
+   public String getPostCreateText()
+   {
+      return postCreateText_;
+   }
+   
+   private final String postCreateText_;
 
    public static final Type<Handler> TYPE = new Type<Handler>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/SendToTerminalEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/SendToTerminalEvent.java
@@ -27,10 +27,7 @@ public class SendToTerminalEvent extends CrossWindowEvent<Handler>
    public interface Handler extends EventHandler
    {
       /**
-       * Output text to a terminal, specified by terminal name. If given
-       * name does not exist, create it. If name is NULL or empty, output
-       * to currently active terminal (if any). If no terminal is active, then
-       * open one.
+       * Output text to a terminal.
        * @param event contains string data typed by the user
        */
       void onSendToTerminal(SendToTerminalEvent event);
@@ -41,7 +38,6 @@ public class SendToTerminalEvent extends CrossWindowEvent<Handler>
       protected Data() {}
       
       public final native String getText() /*-{ return this["text"]; }-*/;
-      public final native String getId() /*-{ return this["id"]; }-*/;
    }
   
    public SendToTerminalEvent()
@@ -50,14 +46,12 @@ public class SendToTerminalEvent extends CrossWindowEvent<Handler>
 
    public SendToTerminalEvent(Data data)
    {
-      this(data.getText(), data.getId());
+      this(data.getText());
    }
    
-   public SendToTerminalEvent(String text, 
-                              String id)
+   public SendToTerminalEvent(String text)
    {
       text_ = text;
-      id_ = id;
    }
 
    public String getText()
@@ -65,11 +59,6 @@ public class SendToTerminalEvent extends CrossWindowEvent<Handler>
       return text_;
    }
    
-   public String getId()
-   {
-      return id_;
-   }
-
    @Override
    public Type<Handler> getAssociatedType()
    {
@@ -83,7 +72,6 @@ public class SendToTerminalEvent extends CrossWindowEvent<Handler>
    }
 
    private String text_;
-   private String id_;
 
    public static final Type<Handler> TYPE = new Type<Handler>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/SwitchToTerminalEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/SwitchToTerminalEvent.java
@@ -37,9 +37,16 @@ public class SwitchToTerminalEvent extends CrossWindowEvent<Handler>
    {
    }
    
-   public SwitchToTerminalEvent(String handle)
+   /**
+    * @param handle terminal to switch to
+    * @param input text to send to terminal, may be null
+    * @param setFocus give terminal focus when switching to it
+    */
+   public SwitchToTerminalEvent(String handle, String input, boolean setFocus)
    {
       terminalHandle_ = handle;
+      inputText_ = input;
+      setFocus_ = setFocus;
    }
 
    @Override
@@ -58,8 +65,20 @@ public class SwitchToTerminalEvent extends CrossWindowEvent<Handler>
    {
       return terminalHandle_;
    }
-  
+   
+   public String getInputText()
+   {
+      return inputText_;
+   }
+
+   public boolean setFocus()
+   {
+      return setFocus_;
+   }
+   
    private String terminalHandle_;
+   private String inputText_;
+   private boolean setFocus_;
    
    public static final Type<Handler> TYPE = new Type<Handler>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/SwitchToTerminalEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/SwitchToTerminalEvent.java
@@ -40,13 +40,11 @@ public class SwitchToTerminalEvent extends CrossWindowEvent<Handler>
    /**
     * @param handle terminal to switch to
     * @param input text to send to terminal, may be null
-    * @param setFocus give terminal focus when switching to it
     */
-   public SwitchToTerminalEvent(String handle, String input, boolean setFocus)
+   public SwitchToTerminalEvent(String handle, String input)
    {
       terminalHandle_ = handle;
       inputText_ = input;
-      setFocus_ = setFocus;
    }
 
    @Override
@@ -71,14 +69,8 @@ public class SwitchToTerminalEvent extends CrossWindowEvent<Handler>
       return inputText_;
    }
 
-   public boolean setFocus()
-   {
-      return setFocus_;
-   }
-   
    private String terminalHandle_;
    private String inputText_;
-   private boolean setFocus_;
    
    public static final Type<Handler> TYPE = new Type<Handler>();
 }


### PR DESCRIPTION
When editing a script file (.sh), the **Run** button/command is enabled and sends the current selection/line to the current terminal (e.g. via Cmd+Enter on Mac). Focus always goes to the terminal after issuing the command; making focus optional like it is for sending to Console was too invasive and fragile. The terminal _likes_ to get focus when activated and I don't want to mess with it now.

Also added a new `Send to Terminal` command on Code menu for all text file types EXCEPT shell scripts. This enables sending the current editor selection to the terminal from all other text file types. **I didn't assign a keyboard shortcut; any suggestions?**

The latter allows you (for example) to manually open a terminal and start Python, then send stuff from a .py file to it. Not a full-fledged repl but better than nothing.

Example of a shell script where I've sent a selection to the terminal via Cmd+Enter:

![2017-08-03_11-42-06](https://user-images.githubusercontent.com/10569626/28937777-cb176a84-7840-11e7-9e15-6967853e02a6.png)

Menu addition when editing other text files:

![2017-08-03_11-30-26](https://user-images.githubusercontent.com/10569626/28937789-d9415110-7840-11e7-9cc0-5a6f98ea3c39.png)
