### PR TITLE
Connections Pane: Show status while fetching object list

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ProgressPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ProgressPanel.java
@@ -18,6 +18,7 @@ import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.DockPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
@@ -46,9 +47,12 @@ public class ProgressPanel extends Composite
       progressSpinner_.getElement().getStyle().setHeight(32, Unit.PX);
       
       progressLabel_ = new Label();
+      progressLabel_.getElement().getStyle().setOpacity(0.5);
 
       VerticalPanel panel = new VerticalPanel();
-      panel.add(progressSpinner_.isSupported() ? progressSpinner_ : progressImage_);
+      Widget spinner = progressSpinner_.isSupported() ? progressSpinner_ : progressImage_;
+      panel.add(spinner);
+      panel.setCellHorizontalAlignment(spinner, DockPanel.ALIGN_CENTER);
       panel.add(progressLabel_);
 
       HorizontalCenterPanel progressPanel = new HorizontalCenterPanel(panel, verticalOffset);
@@ -88,7 +92,7 @@ public class ProgressPanel extends Composite
             if (message != null)
             {
                progressLabel_.setText(message);
-               progressSpinner_.setVisible(true);
+               progressLabel_.setVisible(true);
             }
          }
       };

--- a/src/gwt/src/org/rstudio/core/client/widget/ProgressPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ProgressPanel.java
@@ -1,7 +1,7 @@
 /*
  * ProgressPanel.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -18,6 +18,8 @@ import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 
 import org.rstudio.core.client.theme.res.ThemeStyles;
@@ -42,13 +44,18 @@ public class ProgressPanel extends Composite
       progressSpinner_ = new ProgressSpinner(getSpinnerColor());
       progressSpinner_.getElement().getStyle().setWidth(32, Unit.PX);
       progressSpinner_.getElement().getStyle().setHeight(32, Unit.PX);
+      
+      progressLabel_ = new Label();
 
-      HorizontalCenterPanel progressPanel = new HorizontalCenterPanel(
-         progressSpinner_.isSupported() ? progressSpinner_ : progressImage_, 
-         verticalOffset);
+      VerticalPanel panel = new VerticalPanel();
+      panel.add(progressSpinner_.isSupported() ? progressSpinner_ : progressImage_);
+      panel.add(progressLabel_);
 
+      HorizontalCenterPanel progressPanel = new HorizontalCenterPanel(panel, verticalOffset);
+      
       progressImage_.setVisible(false);
       progressSpinner_.setVisible(false);
+      progressLabel_.setVisible(false);
 
       progressPanel.setSize("100%", "100%");
       progressPanel.addStyleName(ThemeStyles.INSTANCE.progressPanel());
@@ -56,14 +63,20 @@ public class ProgressPanel extends Composite
 
       initWidget(progressPanel);
    }
-   
+
    public void beginProgressOperation(int delayMs)
+   {
+      beginProgressOperation(delayMs, null);
+   }
+   
+   public void beginProgressOperation(int delayMs, final String message)
    {
       clearTimer();
 
       progressSpinner_.setColorType(getSpinnerColor());
       progressSpinner_.setVisible(false);
       progressImage_.setVisible(false);
+      progressLabel_.setVisible(false);
 
       timer_ = new Timer() {
          public void run() {
@@ -72,6 +85,11 @@ public class ProgressPanel extends Composite
 
             progressImage_.setVisible(true);
             progressSpinner_.setVisible(true);
+            if (message != null)
+            {
+               progressLabel_.setText(message);
+               progressSpinner_.setVisible(true);
+            }
          }
       };
       timer_.schedule(delayMs);
@@ -82,6 +100,7 @@ public class ProgressPanel extends Composite
       clearTimer();
       progressImage_.setVisible(false);
       progressSpinner_.setVisible(false);
+      progressLabel_.setVisible(false);
    }
 
    private int getSpinnerColor()
@@ -103,5 +122,6 @@ public class ProgressPanel extends Composite
 
    private final Widget progressImage_ ;
    private final ProgressSpinner progressSpinner_;
+   private final Label progressLabel_;
    private Timer timer_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/SimplePanelWithProgress.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SimplePanelWithProgress.java
@@ -46,8 +46,13 @@ public class SimplePanelWithProgress extends SimplePanel
       super.setWidget(widget);
       
    }
-   
+
    public void showProgress(int delayMs)
+   {
+      showProgress(delayMs, null);
+   }
+   
+   public void showProgress(int delayMs, String message)
    {
       if (!isProgressShowing())
       {

--- a/src/gwt/src/org/rstudio/core/client/widget/SimplePanelWithProgress.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SimplePanelWithProgress.java
@@ -1,7 +1,7 @@
 /*
  * SimplePanelWithProgress.java
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/core/client/widget/SimplePanelWithProgress.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SimplePanelWithProgress.java
@@ -57,7 +57,7 @@ public class SimplePanelWithProgress extends SimplePanel
       if (!isProgressShowing())
       {
          setWidget(loadProgressPanel_);
-         loadProgressPanel_.beginProgressOperation(delayMs);
+         loadProgressPanel_.beginProgressOperation(delayMs, message);
       }
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ConnectionsPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ConnectionsPresenter.java
@@ -99,7 +99,7 @@ public class ConnectionsPresenter extends BasePresenter
       String getConnectVia();
       String getConnectCode();
       
-      void showConnectionProgress();
+      void showConnectionProgress(String message);
    }
    
    public interface Binder extends CommandBinder<Commands, ConnectionsPresenter> {}
@@ -324,7 +324,7 @@ public class ConnectionsPresenter extends BasePresenter
          eventBus_.fireEvent(
                new SendToConsoleEvent(connectCode, true));
          
-         display_.showConnectionProgress();
+         display_.showConnectionProgress("Connecting in R Console");
       }
       else if (connectVia.equals(ConnectionOptions.CONNECT_NEW_R_SCRIPT) ||
                connectVia.equals(ConnectionOptions.CONNECT_NEW_R_NOTEBOOK))
@@ -359,7 +359,7 @@ public class ConnectionsPresenter extends BasePresenter
          eventBus_.fireEvent(
             new NewDocumentWithCodeEvent(type, code, cursorPosition, true));
          
-         display_.showConnectionProgress();
+         display_.showConnectionProgress("Connecting");
       }
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ConnectionsPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ConnectionsPresenter.java
@@ -324,7 +324,7 @@ public class ConnectionsPresenter extends BasePresenter
          eventBus_.fireEvent(
                new SendToConsoleEvent(connectCode, true));
          
-         display_.showConnectionProgress("Connecting in R Console");
+         display_.showConnectionProgress("Connecting");
       }
       else if (connectVia.equals(ConnectionOptions.CONNECT_NEW_R_SCRIPT) ||
                connectVia.equals(ConnectionOptions.CONNECT_NEW_R_NOTEBOOK))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionExplorer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionExplorer.java
@@ -94,9 +94,9 @@ public class ConnectionExplorer extends Composite implements RequiresResize
       eventBus_ = eventBus;
    }
    
-   public void showConnectionProgress()
+   public void showConnectionProgress(String message)
    {
-      containerPanel_.showProgress(50); 
+      containerPanel_.showProgress(50, message); 
    }
    
    public void setConnection(Connection connection, String connectVia)
@@ -139,7 +139,6 @@ public class ConnectionExplorer extends Composite implements RequiresResize
    {
       containerPanel_.onResize();
       codePanel_.onResize();
-      
    }
    
    private void showActivePanel()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsPane.java
@@ -345,9 +345,9 @@ public class ConnectionsPane extends WorkbenchPane
    }
    
    @Override
-   public void showConnectionProgress()
+   public void showConnectionProgress(String message)
    {
-      connectionExplorer_.showConnectionProgress();
+      connectionExplorer_.showConnectionProgress(message);
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ObjectBrowser.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ObjectBrowser.java
@@ -85,6 +85,8 @@ public class ObjectBrowser extends Composite implements RequiresResize
       // capture scroll position
       final int scrollPosition = scrollPanel_.getVerticalScrollPosition();
 
+      // TODO: this is where we should draw progress
+      
       // update the table then restore expanded nodes
       objectsModel_.update(
          connection,      // connection 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ObjectBrowser.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ObjectBrowser.java
@@ -18,6 +18,7 @@ package org.rstudio.studio.client.workbench.views.connections.ui;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.rstudio.core.client.widget.ProgressPanel;
 import org.rstudio.studio.client.workbench.views.connections.model.Connection;
 import org.rstudio.studio.client.workbench.views.connections.model.DatabaseObject;
 
@@ -40,7 +41,6 @@ public class ObjectBrowser extends Composite implements RequiresResize
 {
    public ObjectBrowser()
    {
-      // create scroll panel and set the vertical wrapper as it's widget
       scrollPanel_ = new ScrollPanel();
       scrollPanel_.setSize("100%", "100%");
       connection_ = null;
@@ -85,8 +85,11 @@ public class ObjectBrowser extends Composite implements RequiresResize
       // capture scroll position
       final int scrollPosition = scrollPanel_.getVerticalScrollPosition();
 
-      // TODO: this is where we should draw progress
-      
+      // show progress while updating the connection
+      final ProgressPanel progress = new ProgressPanel();
+      progress.beginProgressOperation(50, "Loading objects");
+      scrollPanel_.setWidget(progress);
+            
       // update the table then restore expanded nodes
       objectsModel_.update(
          connection,      // connection 
@@ -95,6 +98,11 @@ public class ObjectBrowser extends Composite implements RequiresResize
             @Override
             public void execute()
             {
+               // clear progress and show the object tree again
+               progress.endProgressOperation();
+               scrollPanel_.setWidget(objectsWrapper_);
+               
+               // restore expanded nodes
                TreeNode rootNode = objects_.getRootTreeNode();
                if (!rootNode.isDestroyed())
                {
@@ -138,11 +146,11 @@ public class ObjectBrowser extends Composite implements RequiresResize
       objects_.setWidth("100%");
       
       // wrap in vertical panel to get correct scrollbar behavior
-      VerticalPanel verticalWrapper = new VerticalPanel();
-      verticalWrapper.setWidth("100%");
-      verticalWrapper.add(objects_);
+      objectsWrapper_ = new VerticalPanel();
+      objectsWrapper_.setWidth("100%");
+      objectsWrapper_.add(objects_);
       
-      scrollPanel_.setWidget(verticalWrapper);
+      scrollPanel_.setWidget(objectsWrapper_);
       
       // cache connection
       connection_ = connection;
@@ -204,6 +212,7 @@ public class ObjectBrowser extends Composite implements RequiresResize
    
    private final ScrollPanel scrollPanel_;
    private CellTree objects_;
+   private VerticalPanel objectsWrapper_;
    private ObjectBrowserModel objectsModel_;
    private Connection connection_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ObjectBrowser.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ObjectBrowser.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.rstudio.core.client.widget.ProgressPanel;
+import org.rstudio.core.client.widget.SimplePanelWithProgress;
 import org.rstudio.studio.client.workbench.views.connections.model.Connection;
 import org.rstudio.studio.client.workbench.views.connections.model.DatabaseObject;
 
@@ -41,12 +42,14 @@ public class ObjectBrowser extends Composite implements RequiresResize
 {
    public ObjectBrowser()
    {
+      hostPanel_ = new SimplePanelWithProgress();
       scrollPanel_ = new ScrollPanel();
       scrollPanel_.setSize("100%", "100%");
+      hostPanel_.setWidget(scrollPanel_);
       connection_ = null;
        
       // init widget
-      initWidget(scrollPanel_);
+      initWidget(hostPanel_);
    }
   
    public void clear()
@@ -86,9 +89,7 @@ public class ObjectBrowser extends Composite implements RequiresResize
       final int scrollPosition = scrollPanel_.getVerticalScrollPosition();
 
       // show progress while updating the connection
-      final ProgressPanel progress = new ProgressPanel();
-      progress.beginProgressOperation(50, "Loading objects");
-      scrollPanel_.setWidget(progress);
+      hostPanel_.showProgress(50, "Loading objects");
             
       // update the table then restore expanded nodes
       objectsModel_.update(
@@ -99,8 +100,7 @@ public class ObjectBrowser extends Composite implements RequiresResize
             public void execute()
             {
                // clear progress and show the object tree again
-               progress.endProgressOperation();
-               scrollPanel_.setWidget(objectsWrapper_);
+               hostPanel_.setWidget(scrollPanel_);
                
                // restore expanded nodes
                TreeNode rootNode = objects_.getRootTreeNode();
@@ -210,6 +210,7 @@ public class ObjectBrowser extends Composite implements RequiresResize
    private static final TableBrowserMessages MESSAGES 
                               = GWT.create(TableBrowserMessages.class);
    
+   private final SimplePanelWithProgress hostPanel_;
    private final ScrollPanel scrollPanel_;
    private CellTree objects_;
    private VerticalPanel objectsWrapper_;


### PR DESCRIPTION
Prior to this change, the Connections Pane was blank while the list of objects was loaded. 

Consequently, if there are a lot of objects, or the server is slow, navigating to the connection goes to a blank page indefinitely, and you might be forgiven for thinking that there were no objects in your connection, or that something was broken.

This change adds a progress spinner while the pane is loading the object list, along with some descriptive text. 