### PR TITLE
only allow single attempt to reload session

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/appended/ApplicationEndedPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/appended/ApplicationEndedPopupPanel.java
@@ -216,6 +216,10 @@ public class ApplicationEndedPopupPanel extends PopupPanel
    
    private void reloadApplication()
    {
+      if (reloading_)
+         return;
+      reloading_ = true;
+      
       if (Desktop.isDesktop())
       {
          Desktop.getFrame().launchSession(true);
@@ -289,4 +293,6 @@ public class ApplicationEndedPopupPanel extends PopupPanel
 
    @UiField
    SimplePanel content_;
+   
+   private boolean reloading_ = false;
 }


### PR DESCRIPTION
This PR resolves an issue where attempting to re-launch a session after a crash (by mashing on the 'Start New Session' button) could launch multiple new R sessions, and lead to a 'No locks available' error due to the multiple competing `rsession`s attempting to acquire a source database lock.