### PR TITLE
Fix rendering of connections with exactly 4 params and header field

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetHost.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetHost.java
@@ -206,6 +206,7 @@ public class NewConnectionSnippetHost extends Composite
       boolean showAdvancedButton = visibleRows > maxRows_;
       visibleRows = Math.min(visibleRows, maxRows_);
 
+      visibleParams = Math.min(visibleParams, snippetParts.size());
       final ArrayList<NewConnectionSnippetParts> secondarySnippetParts = 
             new ArrayList<NewConnectionSnippetParts>(snippetParts.subList(visibleParams, snippetParts.size()));
 


### PR DESCRIPTION
There is on snippet file case that must have exactly the following fields which should work but doesn't:

```r
library(DBI)
con <- dbConnect(odbc::odbc(),
  Driver="{hive}",
  Host = "${1:Host}",
  Port = "${1:Port=234234}", 
  UID = "${2:User}",
  PWD = rstudioapi::askForPassword("Password"),
  SchemaM = "${3:Schema}")
```

The problem is that with exactly 4 fields and a header, we try to create an array for the advanced fields that is off by one and throws an exception.

The fix is to get the `min()` to ensure we are within of the acceptable range while creating this array.

<img width="564" alt="screen shot 2017-08-04 at 2 51 36 pm" src="https://user-images.githubusercontent.com/3478847/28988387-75083c60-7924-11e7-8355-9738d0b16bdd.png">