### PR TITLE
Allow connection icons to partially match connection names

### DIFF
--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -240,6 +240,7 @@ options(connectionObserver = list(
       tryCatch({
          snippet <- snippets[[snippetName]]
 
+         iconName <- .rs.connectionDBSimilarIcon(snippetName)
          list(
             package = .rs.scalar(NULL),
             version = .rs.scalar(NULL),
@@ -247,7 +248,7 @@ options(connectionObserver = list(
             type = .rs.scalar("Snippet"),
             snippet = .rs.scalar(snippet),
             help = .rs.scalar(NULL),
-            iconData = .rs.scalar(.Call("rs_connectionIcon", snippetName)),
+            iconData = .rs.scalar(.Call("rs_connectionIcon", iconName)),
             licensed = .rs.scalar(FALSE)
          )
       }, error = function(e) {
@@ -270,6 +271,22 @@ options(connectionObserver = list(
          version = "0.5.6"
       )
    )
+})
+
+.rs.addFunction("connectionDBSimilarIcon", function(name) {
+   allIcons <- dir(.Call("rs_connectionIconsPath", "drivers"))
+   allIconNames <- sub("\\.png", "", allIcons)
+
+   similarIcon <- sapply(allIconNames, function(icon) {
+      grepl(icon, name, ignore.case = TRUE)
+   })
+
+   if (any(similarIcon)) {
+      allIconNames[which(similarIcon)]
+   }
+   else {
+      name
+   }
 })
 
 .rs.addFunction("connectionReadOdbc", function() {
@@ -422,7 +439,8 @@ options(connectionObserver = list(
                "}\")",
                sep = "")
 
-            iconData <- .Call("rs_connectionIcon", dataSource$name)
+            iconName <- .rs.connectionDBSimilarIcon(dataSource$name)
+            iconData <- .Call("rs_connectionIcon", iconName)
             if (nchar(iconData) == 0)
                iconData <- .Call("rs_connectionIcon", "ODBC")
 

--- a/src/cpp/session/modules/connections/SessionConnections.cpp
+++ b/src/cpp/session/modules/connections/SessionConnections.cpp
@@ -282,6 +282,19 @@ Error removeConnection(const json::JsonRpcRequest& request,
    return Success();
 }
 
+SEXP rs_connectionIconsPath(SEXP iconGroupSEXP)
+{
+   std::string iconGroup = r::sexp::safeAsString(iconGroupSEXP);
+
+   FilePath path = options()
+     .rResourcesPath()
+     .childPath("connections")
+     .childPath(iconGroup);
+
+   r::sexp::Protect rProtect;
+   return r::sexp::create(path.absolutePath(), &rProtect);
+}
+
 Error connectionDisconnect(const json::JsonRpcRequest& request,
                         json::JsonRpcResponse* pResponse)
 {
@@ -581,6 +594,7 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_availableConnections, 0);
    RS_REGISTER_CALL_METHOD(rs_connectionIcon, 1);
    RS_REGISTER_CALL_METHOD(rs_connectionAddPackage, 2);
+   RS_REGISTER_CALL_METHOD(rs_connectionIconsPath, 1);
 
    // initialize environment
    initEnvironment();


### PR DESCRIPTION
@nwstephens suggests we do partial name matching to increase the Icons we associate in the connections pane and new connections dialog, we don't need this for the preview release as long as we merge before final release.

<img width="567" alt="screen shot 2017-08-04 at 3 41 13 pm" src="https://user-images.githubusercontent.com/3478847/28989616-5eaf489e-792b-11e7-920a-dc577f627cf3.png">