### PR TITLE
Fix focus and auto-advance for send-to-terminal from .sh

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
@@ -25,8 +25,6 @@ import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefsAccessor;
 import org.rstudio.studio.client.workbench.views.console.events.ConsoleExecutePendingInputEvent;
 import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
-import org.rstudio.studio.client.workbench.views.source.SourceSatellite;
-import org.rstudio.studio.client.workbench.views.source.SourceWindowManager;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay.AnchoredSelection;
 import org.rstudio.studio.client.workbench.views.source.editors.text.Scope;
@@ -177,8 +175,8 @@ public class EditingTargetCodeExecution
       String code = codeExtractor_.extractCode(docDisplay_, selectionRange);
       if (!code.isEmpty() && !(code.endsWith("\n") || code.endsWith("\r")))
          code = code + "\n";
-      events_.fireEvent(new SendToTerminalEvent(code));
- }
+      events_.fireEvent(new SendToTerminalEvent(code, prefs_.focusConsoleAfterExec().getValue()));
+   }
    
    public void profileSelection()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
@@ -176,6 +176,11 @@ public class EditingTargetCodeExecution
       if (!code.isEmpty() && !(code.endsWith("\n") || code.endsWith("\r")))
          code = code + "\n";
       events_.fireEvent(new SendToTerminalEvent(code, prefs_.focusConsoleAfterExec().getValue()));
+
+      if (noSelection)
+      {
+         moveCursorAfterExecution(selectionRange);
+      }
    }
    
    public void profileSelection()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -224,6 +224,15 @@ public class TerminalPane extends WorkbenchPane
       // onSelected but in this case we don't want to create a new terminal
       if (!closingAll_)
          ensureTerminal(null);
+
+      Scheduler.get().scheduleDeferred(new ScheduledCommand()
+      {
+         @Override
+         public void execute()
+         {
+            suppressAutoFocus_ = false;
+         }
+      });
    }
 
    @Override
@@ -260,7 +269,6 @@ public class TerminalPane extends WorkbenchPane
    public void activateTerminal()
    {
       closingAll_ = false;
-      ensureVisible();
       bringToFront();
    }
 
@@ -501,11 +509,12 @@ public class TerminalPane extends WorkbenchPane
    }
 
    @Override
-   public void sendToTerminal(String text)
+   public void sendToTerminal(String text, boolean setFocus)
    {
       if (StringUtil.isNullOrEmpty(text))
          return;
 
+      suppressAutoFocus_ = !setFocus;
       ensureTerminal(text);
       activateTerminal();
    }
@@ -921,7 +930,8 @@ public class TerminalPane extends WorkbenchPane
             TerminalSession visibleTerminal = getSelectedTerminal();
             if (visibleTerminal != null)
             {
-               visibleTerminal.setFocus(true);
+               if (!suppressAutoFocus_)
+                  visibleTerminal.setFocus(true);
                activeTerminalToolbarButton_.setActiveTerminal(
                      visibleTerminal.getCaption(), visibleTerminal.getHandle());
                setTerminalTitle(visibleTerminal.getTitle());
@@ -1068,6 +1078,7 @@ public class TerminalPane extends WorkbenchPane
    private HandlerRegistration terminalHasChildProcsHandler_;
    private boolean isRestartInProgress_;
    private boolean closingAll_;
+   private boolean suppressAutoFocus_;
    
    // Injected ----  
    private GlobalDisplay globalDisplay_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
@@ -87,7 +87,7 @@ public class TerminalTabPresenter extends BusyPresenter
       void previousTerminal();
       void nextTerminal();
       void showTerminalInfo();
-      void sendToTerminal(String text);
+      void sendToTerminal(String text, boolean setFocus);
       
       /**
        * Send SIGINT to child process of the terminal shell.
@@ -202,7 +202,7 @@ public class TerminalTabPresenter extends BusyPresenter
    @Override
    public void onSendToTerminal(SendToTerminalEvent event)
    {
-      view_.sendToTerminal(event.getText());
+      view_.sendToTerminal(event.getText(), event.getSetFocus());
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/SendToTerminalEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/SendToTerminalEvent.java
@@ -38,6 +38,7 @@ public class SendToTerminalEvent extends CrossWindowEvent<Handler>
       protected Data() {}
       
       public final native String getText() /*-{ return this["text"]; }-*/;
+      public final native boolean getSetFocus() /*-{ return this["set_focus"]; }-*/;
    }
   
    public SendToTerminalEvent()
@@ -46,17 +47,23 @@ public class SendToTerminalEvent extends CrossWindowEvent<Handler>
 
    public SendToTerminalEvent(Data data)
    {
-      this(data.getText());
+      this(data.getText(), data.getSetFocus());
    }
    
-   public SendToTerminalEvent(String text)
+   public SendToTerminalEvent(String text, boolean setFocus)
    {
       text_ = text;
+      setFocus_ = setFocus;
    }
 
    public String getText()
    {
       return text_;
+   }
+   
+   public boolean getSetFocus()
+   {
+      return setFocus_;
    }
    
    @Override
@@ -72,6 +79,7 @@ public class SendToTerminalEvent extends CrossWindowEvent<Handler>
    }
 
    private String text_;
+   private boolean setFocus_;
 
    public static final Type<Handler> TYPE = new Type<Handler>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -139,7 +139,6 @@ public class XTermWidget extends Widget implements RequiresResize,
    public void clear()
    {
       terminal_.clear();
-      setFocus(true);
    }
 
    /**


### PR DESCRIPTION
For .sh files executing in terminal, focus now stays in editor if the "Focus console after executing from source" option is false.

Also the cursor advances to next non-blank line (unless text was selected, same behavior as console).

One known issue, if sending text via Cmd+Enter requires the terminal to be created or re-attached, the terminal will take focus that one time. After that it is fine. I'll open a separate issue on that.