### PR TITLE
Don't skip blank lines when sending non-.sh to terminal

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
@@ -159,7 +159,7 @@ public class EditingTargetCodeExecution
       executeRange(range, null, false);
    }
    
-   public void sendSelectionToTerminal()
+   public void sendSelectionToTerminal(boolean skipBlankLines)
    {
       // send selection from this editor to the terminal
       Range selectionRange = docDisplay_.getSelectionRange();
@@ -179,7 +179,7 @@ public class EditingTargetCodeExecution
 
       if (noSelection)
       {
-         moveCursorAfterExecution(selectionRange, false);
+         moveCursorAfterExecution(selectionRange, skipBlankLines);
       }
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
@@ -173,7 +173,7 @@ public class EditingTargetCodeExecution
                Position.create(row, docDisplay_.getLength(row)));
       }
       String code = codeExtractor_.extractCode(docDisplay_, selectionRange);
-      if (!code.isEmpty() && !(code.endsWith("\n") || code.endsWith("\r")))
+      if (!(code.endsWith("\n") || code.endsWith("\r")))
          code = code + "\n";
       events_.fireEvent(new SendToTerminalEvent(code, prefs_.focusConsoleAfterExec().getValue()));
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
@@ -142,7 +142,7 @@ public class EditingTargetCodeExecution
       // advance if there is no current selection
       if (noSelection && moveCursorAfter)
       {
-         moveCursorAfterExecution(selectionRange);
+         moveCursorAfterExecution(selectionRange, true);
       }
    }
    
@@ -179,7 +179,7 @@ public class EditingTargetCodeExecution
 
       if (noSelection)
       {
-         moveCursorAfterExecution(selectionRange);
+         moveCursorAfterExecution(selectionRange, false);
       }
    }
    
@@ -258,7 +258,7 @@ public class EditingTargetCodeExecution
    {
       Range range = getRangeFromBehavior(executionBehavior);
       executeRange(range, null, false);
-      moveCursorAfterExecution(range);
+      moveCursorAfterExecution(range, true);
    }
    
    private Range getRangeFromBehavior(String executionBehavior)
@@ -435,11 +435,11 @@ public class EditingTargetCodeExecution
       return true;
    }
    
-   private void moveCursorAfterExecution(Range selectionRange)
+   private void moveCursorAfterExecution(Range selectionRange, boolean skipBlankLines)
    {
       docDisplay_.setCursorPosition(Position.create(
             selectionRange.getEnd().getRow(), 0));
-      if (!docDisplay_.moveSelectionToNextLine(true))
+      if (!docDisplay_.moveSelectionToNextLine(skipBlankLines))
          docDisplay_.moveSelectionToBlankLine();
       docDisplay_.scrollCursorIntoViewIfNecessary(3);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
@@ -261,7 +261,7 @@ public class CodeBrowserEditingTarget implements EditingTarget
    @Handler 
    void onSendToTerminal() 
    { 
-      codeExecution_.sendSelectionToTerminal();
+      codeExecution_.sendSelectionToTerminal(false);
    } 
 
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -4035,7 +4035,7 @@ public class TextEditingTarget implements
    void onExecuteCode()
    {
       if (fileType_.isScript())
-         onSendToTerminal();
+         codeExecution_.sendSelectionToTerminal(true);
       else
          codeExecution_.executeSelection(true);
    }
@@ -4061,7 +4061,7 @@ public class TextEditingTarget implements
    @Handler
    void onSendToTerminal()
    {
-      codeExecution_.sendSelectionToTerminal();
+      codeExecution_.sendSelectionToTerminal(false);
    }
  
    @Override


### PR DESCRIPTION
When single-stepping a .sh via Cmd+Enter, we advance cursor to next non-blank line. This is fine in .sh files, but when doing the same in (for example) Python via Cmd+Alt+Enter, skipping blank lines is a problem due to the blank-line rule in the Python command-line REPL, which needs those blank lines to terminate scopes.

So I've changed to only skip blanks in the .sh (Cmd+Enter) case, the Cmd+Alt+Enter command will not skip blank lines when advancing the cursor.