### PR TITLE
Enable shiny-connections to render in non-local servers by using proxy urls

### DIFF
--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -483,9 +483,7 @@ options(connectionObserver = list(
 
 .rs.addFunction("embeddedViewer", function(url)
 {
-   .rs.enqueClientEvent("navigate_shiny_frame", list(
-      "url" = .rs.scalar(url)
-   ))
+   .Call("rs_embeddedViewer", url)
 })
 
 .rs.addJsonRpcHandler("launch_embedded_shiny_connection_ui", function(package, name)

--- a/src/cpp/session/modules/connections/SessionConnections.cpp
+++ b/src/cpp/session/modules/connections/SessionConnections.cpp
@@ -54,7 +54,6 @@ namespace connections {
 
 namespace {
 
-
 SEXP rs_connectionOpened(SEXP connectionSEXP)
 {
    // read params -- note that these attributes are already guaranteed to
@@ -546,6 +545,21 @@ SEXP rs_connectionAddPackage(SEXP packageSEXP, SEXP extensionSEXP)
    return R_NilValue;
 }
 
+SEXP rs_embeddedViewer(SEXP urlSEXP)
+{
+   std::string url = r::sexp::safeAsString(urlSEXP);
+
+   std::string mappedUrl = module_context::mapUrlPorts(url);
+
+   json::Object dataJson;
+   dataJson["url"] = mappedUrl;
+
+   ClientEvent event(client_events::kNavigateShinyFrame, dataJson);
+   module_context::enqueClientEvent(event);
+
+   return R_NilValue;
+}
+
 bool connectionsEnabled()
 {
    return true;
@@ -581,6 +595,7 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_availableConnections, 0);
    RS_REGISTER_CALL_METHOD(rs_connectionIcon, 1);
    RS_REGISTER_CALL_METHOD(rs_connectionAddPackage, 2);
+   RS_REGISTER_CALL_METHOD(rs_embeddedViewer, 1);
 
    // initialize environment
    initEnvironment();


### PR DESCRIPTION
Need to map URLs using ports to get shiny-based connections to work in RStudio server, otherwise:

<img width="587" alt="screen shot 2017-08-08 at 2 00 44 pm" src="https://user-images.githubusercontent.com/3478847/29094405-15723e24-7c42-11e7-9228-4f1630b25883.png">