### PR TITLE
Make chunk icons visible under dark classic themes

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -44,6 +44,8 @@
 @external rstudio-themes-background, rstudio-themes-inverts, rstudio-themes-scrollbars, rstudio-themes-darkens;
 @external rstudio-themes-dark-menus;
 
+@external rstudio-classic-inverts;
+
 @external rstudio-animating;
 
 @external dataGridSortedHeaderAscending, dataGridSortedHeaderDescending;
@@ -2346,6 +2348,7 @@ body.ubuntu_mono .searchBox {
   margin-right: 3px;
 }
 
+.editor_dark img.rstudio-classic-inverts,
 .rstudio-themes-flat .rstudio-themes-dark .rstudio-themes-inverts img,
 .rstudio-themes-flat .rstudio-themes-dark img.rstudio-themes-inverts {
    -webkit-filter: invert(100%);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -129,7 +129,9 @@ public class ChunkOutputWidget extends Composite
       ChunkDataWidget.injectPagedTableResources();
 
       clear_.addStyleName("rstudio-themes-inverts");
+      clear_.addStyleName("rstudio-classic-inverts");
       expand_.addStyleName("rstudio-themes-inverts");
+      expand_.addStyleName("rstudio-classic-inverts");
       
       if (chunkOutputSize_ == ChunkOutputSize.Default)
       {


### PR DESCRIPTION
https://support.rstudio.com/hc/en-us/community/posts/115007238727-Icons-in-R-Markdown-Notebook-result-window-are-almost-invisible-RStudio-preview-release-1-1-329-

Fixed...

<img width="561" alt="screen shot 2017-08-08 at 2 16 52 pm" src="https://user-images.githubusercontent.com/3478847/29094998-4215bdfa-7c44-11e7-8890-f5a11e772346.png">
