### PR TITLE
Propagate uiprefs while changing theme

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -41,6 +41,7 @@ import com.google.inject.Singleton;
 
 import org.rstudio.core.client.Barrier;
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.Barrier.Token;
@@ -717,9 +718,19 @@ public class Application implements ApplicationEventHandlers
    
    private void initializeWorkbench()
    {
-      RStudioThemes.initializeThemes(uiPrefs_.get(),
-                                     Document.get(),
-                                     rootPanel_.getElement());
+      CommandWithArg<String> changedTheme = new CommandWithArg<String>()
+      {
+         public void execute(String theme)
+         {
+            RStudioThemes.initializeThemes(uiPrefs_.get(),
+                                           Document.get(),
+                                           rootPanel_.getElement());
+         }
+      };
+
+      uiPrefs_.get().getFlatTheme().bind(changedTheme);
+      uiPrefs_.get().theme().bind(changedTheme);
+      changedTheme.execute(uiPrefs_.get().getFlatTheme().getValue());
 
       pAceThemes_.get();
 

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -725,6 +725,8 @@ public class Application implements ApplicationEventHandlers
             RStudioThemes.initializeThemes(uiPrefs_.get(),
                                            Document.get(),
                                            rootPanel_.getElement());
+
+            events_.fireEventToAllSatellites(new ThemeChangedEvent(theme));
          }
       };
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
@@ -315,6 +315,9 @@ public class UIPrefs extends UIPrefsAccessor implements UiPrefsChangedHandler
       
          // theme
          theme().setGlobalValue(newUiPrefs.theme().getGlobalValue());
+
+         // flat theme
+         getFlatTheme().setGlobalValue(newUiPrefs.getFlatTheme().getGlobalValue());
       
          // default encoding
          defaultEncoding().setGlobalValue(


### PR DESCRIPTION
Changing preferences in one windows partially changes themes in the other one leaving us in this situation:

<img width="1269" alt="screen shot 2017-08-08 at 4 23 25 pm" src="https://user-images.githubusercontent.com/3478847/29099451-4fad56b0-7c5a-11e7-83a1-10c549730d35.png">
