### PR TITLE
Terminal API: Fixes to rstudioapi::terminalKill

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
@@ -103,7 +103,7 @@ public class TerminalTabPresenter extends BusyPresenter
       void addTerminal(ConsoleProcessInfo cpi, boolean hasSession);
       
       /**
-       * Remove a terminal from the list.
+       * Remove a terminal that was killed via rstudioapi::terminalKill.
        * @param handle terminal to remove
        * caption
        */

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/RemoveTerminalEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/RemoveTerminalEvent.java
@@ -20,6 +20,9 @@ import com.google.gwt.event.shared.GwtEvent;
 
 import org.rstudio.studio.client.workbench.views.terminal.events.RemoveTerminalEvent.Handler;
 
+/**
+ * Eliminate a terminal that was killed via rstudioapi::terminalKill.
+ */
 public class RemoveTerminalEvent extends GwtEvent<Handler>
 {
    public static class Data extends JavaScriptObject


### PR DESCRIPTION
The modified code is only hit when using rstudioapi::terminalKill / .Options$terminal.manager$terminalKill.

The client wasn't fully cleaning up. It needed to switch to a different terminal iff the killed terminal was the current selection, and to remove the TerminalSession (the actual widget) from the TerminalPane iff it had been loaded.