### PR TITLE
full page html viewer

### DIFF
--- a/src/cpp/r/R/Options.R
+++ b/src/cpp/r/R/Options.R
@@ -41,6 +41,18 @@ if (is.null(getOption("viewer"))) {
    })
 }
 
+# default page_viewer option if not already set
+if (is.null(getOption("page_viewer"))) {
+   options(page_viewer = function(file)
+   {
+      if (!is.character(file) || (length(file) != 1))
+         stop("file must be a single element character vector.", call. = FALSE)
+
+      # show the preview window
+      invisible(.Call("rs_showPageViewer", file))
+   })
+}
+
 # default shinygadgets.showdialog if not already set
 if (is.null(getOption("shinygadgets.showdialog"))) {
    options(shinygadgets.showdialog = function(caption,

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -180,6 +180,7 @@ const int kRequestDocumentSaveCompleted = 161;
 const int kRequestOpenProject = 162;
 const int kOpenFileDialog = 163;
 const int kRemoveTerminal = 164;
+const int kShowPageViewerEvent = 165;
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -495,6 +496,8 @@ std::string ClientEvent::typeName() const
          return "open_file_dialog";
       case client_events::kRemoveTerminal:
          return "remove_terminal";
+      case client_events::kShowPageViewerEvent:
+         return "show_page_viewer";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -170,6 +170,8 @@ SEXP rs_enqueClientEvent(SEXP nameSEXP, SEXP dataSEXP)
          type = session::client_events::kTerminalCwd;
       else if (name == "remove_terminal")
          type = session::client_events::kRemoveTerminal;
+      else if (name == "show_page_viewer")
+         type = session::client_events::kShowPageViewerEvent;
 
       if (type != -1)
       {

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -181,6 +181,7 @@ extern const int kRequestDocumentSaveCompleted;
 extern const int kRequestOpenProject;
 extern const int kOpenFileDialog;
 extern const int kRemoveTerminal;
+extern const int kShowPageViewerEvent;
 }
    
 class ClientEvent

--- a/src/cpp/session/modules/SessionHTMLPreview.cpp
+++ b/src/cpp/session/modules/SessionHTMLPreview.cpp
@@ -392,10 +392,12 @@ private:
       markCompleted();
       outputFile_ = outputFile;
 
+      bool enableSaveAs = isMarkdown() || viewerMode_;
+
       enqueHTMLPreviewSucceeded(kHTMLPreview "/",
                                 targetFile(),
                                 htmlPreviewFile(),
-                                isMarkdown(),
+                                enableSaveAs,
                                 !isNotebook(),
                                 viewerMode_);
    }

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/HTMLPreview.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/HTMLPreview.java
@@ -38,7 +38,7 @@ public class HTMLPreview
             // open the window 
             satelliteManager.openSatellite(HTMLPreviewApplication.NAME,     
                                             event.getParams(),
-                                            new Size(850,1100));   
+                                            new Size(1100,1200));   
             
          }  
       });

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/events/ShowPageViewerEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/events/ShowPageViewerEvent.java
@@ -1,0 +1,49 @@
+/*
+ * ShowPageViewerEvent.java
+ *
+ * Copyright (C) 2017 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.htmlpreview.events;
+
+import org.rstudio.studio.client.htmlpreview.model.HTMLPreviewParams;
+
+import com.google.gwt.event.shared.GwtEvent;
+
+public class ShowPageViewerEvent extends GwtEvent<ShowPageViewerHandler>
+{ 
+   public static final GwtEvent.Type<ShowPageViewerHandler> TYPE =
+      new GwtEvent.Type<ShowPageViewerHandler>();
+   
+   public ShowPageViewerEvent(HTMLPreviewParams params)
+   {
+      params_ = params;
+   }
+   
+   public HTMLPreviewParams getParams()
+   {
+      return params_;
+   }
+   
+   @Override
+   protected void dispatch(ShowPageViewerHandler handler)
+   {
+      handler.onShowPageViewer(this);
+   }
+
+   @Override
+   public GwtEvent.Type<ShowPageViewerHandler> getAssociatedType()
+   {
+      return TYPE;
+   }
+   
+   private HTMLPreviewParams params_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/events/ShowPageViewerHandler.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/events/ShowPageViewerHandler.java
@@ -1,0 +1,22 @@
+/*
+ * ShowPageViewerHandler.java
+ *
+ * Copyright (C) 2017 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.htmlpreview.events;
+
+import com.google.gwt.event.shared.EventHandler;
+
+public interface ShowPageViewerHandler extends EventHandler
+{
+   void onShowPageViewer(ShowPageViewerEvent event);
+}

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/model/HTMLPreviewParams.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/model/HTMLPreviewParams.java
@@ -26,13 +26,15 @@ public class HTMLPreviewParams extends JavaScriptObject
                                                        String encoding,
                                                        boolean isMarkdown,
                                                        boolean requiresKnit,
-                                                       boolean isNotebook)/*-{
+                                                       boolean isNotebook,
+                                                       boolean viewerMode) /*-{
       var params = new Object();
       params.path = path;
       params.encoding = encoding;
       params.is_markdown = isMarkdown;
       params.requires_knit = requiresKnit;
       params.is_notebook = isNotebook;
+      params.viewer_mode = viewerMode;
       return params;
    }-*/; 
    
@@ -55,4 +57,8 @@ public class HTMLPreviewParams extends JavaScriptObject
    public final native boolean isNotebook() /*-{
       return this.is_notebook;
    }-*/;
+   
+   public final native boolean getViewerMode() /*-{
+      return this.viewer_mode;
+    }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/model/HTMLPreviewResult.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/model/HTMLPreviewResult.java
@@ -49,5 +49,9 @@ public class HTMLPreviewResult extends JavaScriptObject
    public final native boolean getPreviouslyPublished() /*-{
       return this.previously_published;
    }-*/;
+   
+   public final native boolean getViewerMode() /*-{
+      return this.viewer_mode;
+   }-*/;
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewApplicationWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewApplicationWindow.java
@@ -51,7 +51,7 @@ public class HTMLPreviewApplicationWindow extends SatelliteWindow
    @Override
    protected void onInitialize(LayoutPanel mainPanel, JavaScriptObject params)
    {
-      Window.setTitle("RStudio: Preview HTML");
+      Window.setTitle("RStudio Viewer");
       
       // create the presenter and activate it with the passed params
       HTMLPreviewParams htmlPreviewParams = params.<HTMLPreviewParams>cast();

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
@@ -65,7 +65,7 @@ public class HTMLPreviewPanel extends ResizeComposite
       layoutPanel_.add(previewFrame_);
       layoutPanel_.setWidgetLeftRight(previewFrame_,  0, Unit.PX, 0, Unit.PX);
       
-      setToolbarVisible(false);
+      setToolbarVisible(true);
      
       initWidget(layoutPanel_);
    }
@@ -81,13 +81,14 @@ public class HTMLPreviewPanel extends ResizeComposite
    {
       Toolbar toolbar = new Toolbar();
       
-      toolbar.addLeftWidget(new ToolbarLabel("Preview: "));
+      fileCaption_ = new ToolbarLabel("Preview: ");
+      toolbar.addLeftWidget(fileCaption_);
       fileLabel_ = new ToolbarLabel();
       fileLabel_.addStyleName(ThemeStyles.INSTANCE.subtitle());
       fileLabel_.getElement().getStyle().setMarginRight(7, Unit.PX);
       toolbar.addLeftWidget(fileLabel_);
       
-      toolbar.addLeftSeparator();
+      fileLabelSeparator_ = toolbar.addLeftSeparator();
       toolbar.addLeftWidget(commands.openHtmlExternal().createToolbarButton());
       
       showLogButtonSeparator_ = toolbar.addLeftSeparator();
@@ -245,7 +246,11 @@ public class HTMLPreviewPanel extends ResizeComposite
             300);
       
      
-      setToolbarVisible(!result.getViewerMode());
+      boolean viewerMode = result.getViewerMode();
+      fileCaption_.setVisible(!viewerMode);
+      fileLabel_.setVisible(!viewerMode);
+      fileLabelSeparator_.setVisible(!viewerMode);
+      
       fileLabel_.setText(shortFileName);
       showLogButtonSeparator_.setVisible(enableShowLog);
       showLogButton_.setVisible(enableShowLog);
@@ -282,7 +287,9 @@ public class HTMLPreviewPanel extends ResizeComposite
    private final AnchorableFrame previewFrame_;
    private final Toolbar toolbar_;
    private final int tbHeight_;
+   private ToolbarLabel fileCaption_;
    private ToolbarLabel fileLabel_;
+   private Widget fileLabelSeparator_;
    private FindTextBox findTextBox_;
    private Widget saveHtmlPreviewAsSeparator_;
    private Widget saveHtmlPreviewAs_;

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
@@ -52,21 +52,29 @@ public class HTMLPreviewPanel extends ResizeComposite
    @Inject
    public HTMLPreviewPanel(Commands commands)
    {
-      LayoutPanel panel = new LayoutPanel();
+      layoutPanel_ = new LayoutPanel();
       
-      Toolbar toolbar = createToolbar(commands);
-      int tbHeight = toolbar.getHeight();
-      panel.add(toolbar);
-      panel.setWidgetLeftRight(toolbar, 0, Unit.PX, 0, Unit.PX);
-      panel.setWidgetTopHeight(toolbar, 0, Unit.PX, tbHeight, Unit.PX);
+      toolbar_ = createToolbar(commands);
+      tbHeight_ = toolbar_.getHeight();
+      layoutPanel_.add(toolbar_);
+      layoutPanel_.setWidgetLeftRight(toolbar_, 0, Unit.PX, 0, Unit.PX);
+      layoutPanel_.setWidgetTopHeight(toolbar_, 0, Unit.PX, tbHeight_, Unit.PX);
       
       previewFrame_ = new AnchorableFrame();
       previewFrame_.setSize("100%", "100%");
-      panel.add(previewFrame_);
-      panel.setWidgetLeftRight(previewFrame_,  0, Unit.PX, 0, Unit.PX);
-      panel.setWidgetTopBottom(previewFrame_, tbHeight+1, Unit.PX, 0, Unit.PX);
+      layoutPanel_.add(previewFrame_);
+      layoutPanel_.setWidgetLeftRight(previewFrame_,  0, Unit.PX, 0, Unit.PX);
       
-      initWidget(panel);
+      setToolbarVisible(false);
+     
+      initWidget(layoutPanel_);
+   }
+   
+   private void setToolbarVisible(boolean visible)
+   {
+      toolbar_.setVisible(visible);
+      int frameTop = visible ? tbHeight_+1 : 0;
+      layoutPanel_.setWidgetTopBottom(previewFrame_, frameTop, Unit.PX, 0, Unit.PX);    
    }
    
    private Toolbar createToolbar(Commands commands)
@@ -235,6 +243,9 @@ public class HTMLPreviewPanel extends ResizeComposite
             FileSystemItem.createFile(result.getHtmlFile()), 
             ThemeStyles.INSTANCE.subtitle(), 
             300);
+      
+     
+      setToolbarVisible(!result.getViewerMode());
       fileLabel_.setText(shortFileName);
       showLogButtonSeparator_.setVisible(enableShowLog);
       showLogButton_.setVisible(enableShowLog);
@@ -267,7 +278,10 @@ public class HTMLPreviewPanel extends ResizeComposite
       findTextBox_.focus();
    }
 
+   private final LayoutPanel layoutPanel_;
    private final AnchorableFrame previewFrame_;
+   private final Toolbar toolbar_;
+   private final int tbHeight_;
    private ToolbarLabel fileLabel_;
    private FindTextBox findTextBox_;
    private Widget saveHtmlPreviewAsSeparator_;

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -171,6 +171,7 @@ class ClientEvent extends JavaScriptObject
    public static final String RequestDocumentSave = "request_document_save";
    public static final String RequestOpenProject = "request_open_project";
    public static final String OpenFileDialog = "open_file_dialog";
+   public static final String ShowPageViewer = "show_page_viewer";
    
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -56,6 +56,8 @@ import org.rstudio.studio.client.events.EditorCommandEvent;
 import org.rstudio.studio.client.htmlpreview.events.HTMLPreviewCompletedEvent;
 import org.rstudio.studio.client.htmlpreview.events.HTMLPreviewOutputEvent;
 import org.rstudio.studio.client.htmlpreview.events.HTMLPreviewStartedEvent;
+import org.rstudio.studio.client.htmlpreview.events.ShowPageViewerEvent;
+import org.rstudio.studio.client.htmlpreview.model.HTMLPreviewParams;
 import org.rstudio.studio.client.htmlpreview.model.HTMLPreviewResult;
 import org.rstudio.studio.client.packages.events.PackageExtensionIndexingCompletedEvent;
 import org.rstudio.studio.client.projects.events.FollowUserEvent;
@@ -935,6 +937,11 @@ public class ClientEventDispatcher
          {
             OpenFileDialogEvent.Data data = event.getData();
             eventBus_.fireEvent(new OpenFileDialogEvent(data));
+         }
+         else if (type.equals(ClientEvent.ShowPageViewer))
+         {
+            HTMLPreviewParams params = event.getData();
+            eventBus_.fireEvent(new ShowPageViewerEvent(params));
          }
          else
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
@@ -47,6 +47,10 @@ import org.rstudio.studio.client.common.vcs.AskPassManager;
 import org.rstudio.studio.client.common.vcs.ShowPublicKeyDialog;
 import org.rstudio.studio.client.common.vcs.VCSConstants;
 import org.rstudio.studio.client.htmlpreview.HTMLPreview;
+import org.rstudio.studio.client.htmlpreview.events.ShowHTMLPreviewEvent;
+import org.rstudio.studio.client.htmlpreview.events.ShowPageViewerEvent;
+import org.rstudio.studio.client.htmlpreview.events.ShowPageViewerHandler;
+import org.rstudio.studio.client.htmlpreview.model.HTMLPreviewParams;
 import org.rstudio.studio.client.pdfviewer.PDFViewer;
 import org.rstudio.studio.client.projects.ProjectOpener;
 import org.rstudio.studio.client.projects.model.ProjectTemplateRegistryProvider;
@@ -85,7 +89,8 @@ public class Workbench implements BusyHandler,
                                   ShinyGadgetDialogEvent.Handler,
                                   ExecuteUserCommandEvent.Handler,
                                   AdminNotificationHandler,
-                                  OpenFileDialogEvent.Handler
+                                  OpenFileDialogEvent.Handler,
+                                  ShowPageViewerHandler
 {
    interface Binder extends CommandBinder<Commands, Workbench> {}
    
@@ -148,6 +153,7 @@ public class Workbench implements BusyHandler,
       eventBus.addHandler(ExecuteUserCommandEvent.TYPE, this);
       eventBus.addHandler(AdminNotificationEvent.TYPE, this);
       eventBus.addHandler(OpenFileDialogEvent.TYPE, this);
+      eventBus.addHandler(ShowPageViewerEvent.TYPE, this);
 
       // We don't want to send setWorkbenchMetrics more than once per 1/2-second
       metricsChangedCommand_ = new TimeBufferedCommand(-1, -1, 500)
@@ -597,6 +603,15 @@ public class Workbench implements BusyHandler,
    }
    
    @Override
+   public void onShowPageViewer(ShowPageViewerEvent event) {
+      
+      HTMLPreviewParams params = event.getParams();
+      eventBus_.fireEvent(new ShowHTMLPreviewEvent(params));
+      server_.previewHTML(params, new SimpleRequestCallback<Boolean>());
+      
+   }
+   
+   @Override
    public void onExecuteUserCommand(ExecuteUserCommandEvent event)
    {
       server_.executeUserCommand(event.getCommandName(), new VoidServerRequestCallback());
@@ -619,6 +634,5 @@ public class Workbench implements BusyHandler,
    private final TimeBufferedCommand metricsChangedCommand_;
    private WorkbenchMetrics lastWorkbenchMetrics_;
    private WorkbenchNewSession newSession_;
-   private boolean nearQuotaWarningShown_ = false;
-   
+   private boolean nearQuotaWarningShown_ = false; 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -5186,6 +5186,7 @@ public class TextEditingTarget implements
                                             docUpdateSentinel_.getEncoding(),
                                             fileType_.isMarkdown(),
                                             fileType_.requiresKnit(),
+                                            false,
                                             false);
          }
       });
@@ -5366,7 +5367,8 @@ public class TextEditingTarget implements
                                                docUpdateSentinel_.getEncoding(),
                                                true,
                                                true,
-                                               true);
+                                               true,
+                                               false);
             }
          });
       }


### PR DESCRIPTION
This PR introduces a full page HTML viewer to compliment the existing RStudio Viewer which displays HTML in an embedded pane. It can be accessed as follows:

```r
page_viewer <- getOption("page_viewer")
page_viewer("document.html")
```

The implementation re-uses the HTMLPreviewPanel which is currently used only for previewing R Markdown v1 documents as well as straight HTML files within the IDE. This makes the implementation straightforward and low-risk, however does result in the limitation that only HTML files can be viewed (the embedded RStudio Viewer can also view localhost URLs).

The main motivation for this feature is to enable packages to display full-page HTML reports. This is currently possible using browseURL however has a couple of problems:

1) It can potentially result in a huge proliferation of browser tabs. In contrast, the page viewer re-uses a single IDE managed window for viewing reports.

2) No straightforward way to publish the report. With the page viewer we get standard publishing to RPubs + RSC for free.

3) No obvious way to save the report (browsers have "Save Page As..." however many users aren't aware of this). With the page viewer we get a prominent "Save As" toolbar button.

There is a also an "Open in New Window" button which enables browsing of the report in a standard browser window should that have advantages for some scenarios.
