### PR TITLE
add self_contained option to page_viewer

### DIFF
--- a/src/cpp/r/R/Options.R
+++ b/src/cpp/r/R/Options.R
@@ -43,13 +43,12 @@ if (is.null(getOption("viewer"))) {
 
 # default page_viewer option if not already set
 if (is.null(getOption("page_viewer"))) {
-   options(page_viewer = function(file)
+   options(page_viewer = function(file, self_contained = FALSE)
    {
       if (!is.character(file) || (length(file) != 1))
          stop("file must be a single element character vector.", call. = FALSE)
 
-      # show the preview window
-      invisible(.Call("rs_showPageViewer", file))
+      invisible(.Call("rs_showPageViewer", file, isTRUE(self_contained)))
    })
 }
 


### PR DESCRIPTION
Since self_contained requires rmarkdown we default this to FALSE. If TRUE is specified and rmarkdown is not available then an error is thrown.