### PR TITLE
additional enhancements to page viewer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -101,6 +101,7 @@
 * Upgrade to [pandoc](http://pandoc.org/) 1.19.2.1
 * Remove Packrat package sync notifications; replace with Check Library Status command
 * Add support for ligature coding fonts in RStudio Desktop for Windows and Linux
+* Added page viewer (accessible via getOption("page_viewer")) for viewing web content in an external window.
 * Server Pro: Add option to disable file uploads
 * Server Pro: Upgrade to TurboActivate 4.0; improves licensing
 * Server Pro: Add support for floating (lease-based) licenses

--- a/src/cpp/r/R/Options.R
+++ b/src/cpp/r/R/Options.R
@@ -43,12 +43,12 @@ if (is.null(getOption("viewer"))) {
 
 # default page_viewer option if not already set
 if (is.null(getOption("page_viewer"))) {
-   options(page_viewer = function(url, self_contained = FALSE)
+   options(page_viewer = function(url)
    {
       if (!is.character(url) || (length(url) != 1))
          stop("url must be a single element character vector.", call. = FALSE)
 
-      invisible(.Call("rs_showPageViewer", url, isTRUE(self_contained)))
+      invisible(.Call("rs_showPageViewer", url))
    })
 }
 

--- a/src/cpp/r/R/Options.R
+++ b/src/cpp/r/R/Options.R
@@ -43,12 +43,15 @@ if (is.null(getOption("viewer"))) {
 
 # default page_viewer option if not already set
 if (is.null(getOption("page_viewer"))) {
-   options(page_viewer = function(url)
+   options(page_viewer = function(url, title = "RStudio Viewer")
    {
       if (!is.character(url) || (length(url) != 1))
          stop("url must be a single element character vector.", call. = FALSE)
-
-      invisible(.Call("rs_showPageViewer", url))
+      
+      if (!is.character(title) || (length(title) != 1))
+         stop("title must be a single element character vector.", call. = FALSE)
+      
+      invisible(.Call("rs_showPageViewer", url, title))
    })
 }
 

--- a/src/cpp/r/R/Options.R
+++ b/src/cpp/r/R/Options.R
@@ -43,12 +43,12 @@ if (is.null(getOption("viewer"))) {
 
 # default page_viewer option if not already set
 if (is.null(getOption("page_viewer"))) {
-   options(page_viewer = function(file, self_contained = FALSE)
+   options(page_viewer = function(url, self_contained = FALSE)
    {
-      if (!is.character(file) || (length(file) != 1))
-         stop("file must be a single element character vector.", call. = FALSE)
+      if (!is.character(url) || (length(url) != 1))
+         stop("url must be a single element character vector.", call. = FALSE)
 
-      invisible(.Call("rs_showPageViewer", file, isTRUE(self_contained)))
+      invisible(.Call("rs_showPageViewer", url, isTRUE(self_contained)))
    })
 }
 

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -2205,7 +2205,7 @@ json::Object plotExportFormat(const std::string& name,
 Error createSelfContainedHtml(const FilePath& sourceFilePath,
                               const FilePath& targetFilePath)
 {
-   r::exec::RFunction func("rmarkdown:::pandoc_self_contained_html");
+   r::exec::RFunction func(".rs.pandocSelfContainedHtml");
    func.addParam(string_utils::utf8ToSystem(sourceFilePath.absolutePath()));
    func.addParam(string_utils::utf8ToSystem(targetFilePath.absolutePath()));
    return func.call();

--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -292,3 +292,56 @@
 .rs.addGlobalFunction("rstudioDiagnosticsReport", function() {
   invisible(.Call(getNativeSymbolInfo("rs_sourceDiagnostics", PACKAGE="")))
 })
+
+
+.rs.addFunction("pandocSelfContainedHtml", function(input, output) {
+   
+   # make input file path absolute
+   input <- normalizePath(input)
+   
+   # ensure output file exists and make it's path absolute
+   if (!file.exists(output))
+      file.create(output)
+   output <- normalizePath(output)
+   
+   # create a simple body-only template
+   template <- tempfile(fileext = ".html")
+   writeLines("$body$", template)
+   
+   # convert from markdown to html to get base64 encoding
+   # (note there is no markdown in the source document but
+   # we still need to do this "conversion" to get the
+   # base64 encoding)
+   args <- c(input)
+   args <- c(args, "--from", "markdown_strict")
+   args <- c(args, "--output", output)
+   
+   # set stack size
+   stack_size <- getOption("pandoc.stack.size", default = "512m")
+   args <- c(c("+RTS", paste0("-K", stack_size), "-RTS"), args)
+   
+   # additional options
+   args <- c(args, "--self-contained")
+   args <- c(args, "--template", template)
+   
+   # build the conversion command
+   pandoc <- file.path(Sys.getenv("RSTUDIO_PANDOC"), "pandoc")
+   command <- paste(c(pandoc, args), collapse = " ")
+   
+   # setwd temporarily
+   wd <- getwd()
+   on.exit(setwd(wd), add = TRUE)
+   setwd(dirname(input))
+   
+   # execute it
+   result <- system(command)
+   if (result != 0) {
+      stop("pandoc document conversion failed with error ", result,
+           call. = FALSE)
+   }
+   
+   # return output file
+   invisible(output)
+})
+
+

--- a/src/cpp/session/modules/SessionHTMLPreview.cpp
+++ b/src/cpp/session/modules/SessionHTMLPreview.cpp
@@ -64,6 +64,33 @@ namespace html_preview {
 
 namespace {
 
+void enqueHTMLPreviewSucceeded(const std::string& previewUrl,
+                               const FilePath& sourceFile,
+                               const FilePath& htmlFile,
+                               bool enableSaveAs,
+                               bool enableRefresh,
+                               bool viewerMode)
+{
+   using namespace module_context;
+   json::Object resultJson;
+   resultJson["succeeded"] = true;
+   if (!sourceFile.empty())
+      resultJson["source_file"] = module_context::createAliasedPath(sourceFile);
+   else
+      resultJson["source_file"] = json::Value();
+   if (!htmlFile.empty())
+      resultJson["html_file"] = module_context::createAliasedPath(htmlFile);
+   else
+      resultJson["html_file"] = json::Value();
+   resultJson["preview_url"] = previewUrl;
+   resultJson["enable_saveas"] = enableSaveAs;
+   resultJson["enable_refresh"] = enableRefresh;
+   resultJson["previously_published"] = !previousRpubsUploadId(htmlFile).empty();
+   resultJson["viewer_mode"] = viewerMode;
+   ClientEvent event(client_events::kHTMLPreviewCompletedEvent, resultJson);
+   module_context::enqueClientEvent(event);
+}
+
 class HTMLPreview : public async_r::AsyncRProcess
 {
 public:
@@ -71,18 +98,16 @@ public:
                                                 const std::string& encoding,
                                                 bool isMarkdown,
                                                 bool isNotebook,
-                                                bool knit,
-                                                bool viewerMode)
+                                                bool knit)
    {
-      boost::shared_ptr<HTMLPreview> pPreview(new HTMLPreview(targetFile, viewerMode));
+      boost::shared_ptr<HTMLPreview> pPreview(new HTMLPreview(targetFile));
       pPreview->start(encoding, isMarkdown, isNotebook, knit);
       return pPreview;
    }
 
 private:
-   HTMLPreview(const FilePath& targetFile, bool viewerMode)
+   HTMLPreview(const FilePath& targetFile)
       : targetFile_(targetFile),
-        viewerMode_(viewerMode),
         isMarkdown_(false),
         isInternalMarkdown_(false),
         isNotebook_(false),
@@ -392,14 +417,12 @@ private:
       markCompleted();
       outputFile_ = outputFile;
 
-      bool enableSaveAs = isMarkdown() || viewerMode_;
-
       enqueHTMLPreviewSucceeded(kHTMLPreview "/",
                                 targetFile(),
                                 htmlPreviewFile(),
-                                enableSaveAs,
+                                isMarkdown(),
                                 !isNotebook(),
-                                viewerMode_);
+                                false);
    }
 
    static void enqueHTMLPreviewStarted(const FilePath& targetFile)
@@ -424,27 +447,6 @@ private:
       module_context::enqueClientEvent(event);
    }
 
-   static void enqueHTMLPreviewSucceeded(const std::string& previewUrl,
-                                         const FilePath& sourceFile,
-                                         const FilePath& htmlFile,
-                                         bool enableSaveAs,
-                                         bool enableRefresh,
-                                         bool viewerMode)
-   {
-      using namespace module_context;
-      json::Object resultJson;
-      resultJson["succeeded"] = true;
-      resultJson["source_file"] = module_context::createAliasedPath(sourceFile);
-      resultJson["html_file"] = module_context::createAliasedPath(htmlFile);
-      resultJson["preview_url"] = previewUrl;
-      resultJson["enable_saveas"] = enableSaveAs;
-      resultJson["enable_refresh"] = enableRefresh;
-      resultJson["previously_published"] = !previousRpubsUploadId(htmlFile).empty();
-      resultJson["viewer_mode"] = viewerMode;
-      ClientEvent event(client_events::kHTMLPreviewCompletedEvent, resultJson);
-      module_context::enqueClientEvent(event);
-   }
-
    static FilePath createOutputFile()
    {
       return module_context::tempFile("html_preview", "htm");
@@ -452,7 +454,6 @@ private:
 
 private:
    FilePath targetFile_;
-   bool viewerMode_;
    FilePath outputPathTempFile_;
    bool isMarkdown_;
    bool isInternalMarkdown_;
@@ -479,6 +480,9 @@ std::string deriveNotebookPath(const std::string& path)
 // serve the web content back)
 boost::shared_ptr<HTMLPreview> s_pCurrentPreview_;
 
+// current page_viewer html file
+std::string s_currentPageViewerFile;
+
 bool isPreviewRunning()
 {
    return s_pCurrentPreview_ && s_pCurrentPreview_->isRunning();
@@ -489,14 +493,13 @@ Error previewHTML(const json::JsonRpcRequest& request,
 {
    // read params
    std::string file, encoding;
-   bool isMarkdown, knit, isNotebook, viewerMode;
+   bool isMarkdown, knit, isNotebook;
    Error error = json::readObjectParam(request.params, 0,
                                        "path", &file,
                                        "encoding", &encoding,
                                        "is_markdown", &isMarkdown,
                                        "requires_knit", &knit,
-                                       "is_notebook", &isNotebook,
-                                       "viewer_mode", &viewerMode);
+                                       "is_notebook", &isNotebook);
 
    if (error)
       return error;
@@ -517,8 +520,9 @@ Error previewHTML(const json::JsonRpcRequest& request,
                                                encoding,
                                                isMarkdown,
                                                isNotebook,
-                                               knit,
-                                               viewerMode);
+                                               knit);
+      s_currentPageViewerFile = std::string();
+
       pResponse->setResult(true);
    }
 
@@ -922,8 +926,8 @@ void handleInternalMarkdownPreviewRequest(
 void handlePreviewRequest(const http::Request& request,
                           http::Response* pResponse)
 {
-   // if there isn't a current preview this is an error
-   if (!s_pCurrentPreview_)
+   // if there isn't a current preview or page viewer file this is an error
+   if (!s_pCurrentPreview_ && s_currentPageViewerFile.empty())
    {
       pResponse->setNotFoundError(request.uri());
       return;
@@ -939,7 +943,11 @@ void handlePreviewRequest(const http::Request& request,
    // if it is empty then this is the main request
    if (path.empty())
    {
-      if (s_pCurrentPreview_->isMarkdown())
+      if (!s_currentPageViewerFile.empty())
+      {
+         pResponse->setFile(FilePath(s_currentPageViewerFile), request);
+      }
+      else if (s_pCurrentPreview_->isMarkdown())
       {
          if (s_pCurrentPreview_->isInternalMarkdown())
             handleInternalMarkdownPreviewRequest(request, pResponse);
@@ -969,7 +977,11 @@ void handlePreviewRequest(const http::Request& request,
    // request for dependent file
    else
    {
-      FilePath filePath = s_pCurrentPreview_->targetDirectory().childPath(path);
+      FilePath filePath;
+      if (!s_currentPageViewerFile.empty())
+         filePath = FilePath(s_currentPageViewerFile).parent().childPath(path);
+      else
+         filePath = s_pCurrentPreview_->targetDirectory().childPath(path);
       addFileSpecificHeaders(filePath, pResponse);
       pResponse->setFile(filePath, request);
    }
@@ -979,6 +991,10 @@ SEXP rs_showPageViewer(SEXP fileSEXP, SEXP selfContainedSEXP)
 {
    try
    {
+      // terminate any running preview
+      if (isPreviewRunning())
+         s_pCurrentPreview_->terminate();
+
       // get full path to file
       FilePath filePath = module_context::resolveAliasedPath(r::sexp::safeAsString(fileSEXP));
 
@@ -1018,9 +1034,27 @@ SEXP rs_showPageViewer(SEXP fileSEXP, SEXP selfContainedSEXP)
       data["is_markdown"] = false;
       data["requires_knit"] = false;
       data["is_notebook"] = false;
-      data["viewer_mode"] = true;
       ClientEvent event(client_events::kShowPageViewerEvent, data);
       module_context::enqueClientEvent(event);
+
+      // we need to give the first event time to be delivered so that
+      // the preview succeeded event handler is set up
+      using namespace boost::posix_time;
+      boost::this_thread::sleep(milliseconds(500));
+
+      // set the current viewer file path (required so we can
+      // serve back the file and it's dependencies
+      s_currentPageViewerFile = viewerFilePath.absolutePath();
+
+      // emit html preview completed event
+      enqueHTMLPreviewSucceeded(
+         kHTMLPreview "/",    // preview url
+         filePath,            // original source file
+         viewerFilePath,      // file to show as preview
+         true,                // enable save as
+         true,                // enable refresh
+         true                 // viewer mode
+       );
    }
    catch(r::exec::RErrorException e)
    {

--- a/src/cpp/session/modules/SessionHTMLPreview.cpp
+++ b/src/cpp/session/modules/SessionHTMLPreview.cpp
@@ -1009,7 +1009,7 @@ SEXP rs_showPageViewer(SEXP urlSEXP, SEXP titleSEXP)
       if (boost::algorithm::starts_with(url, "http"))
       {
          // verify local url only
-         boost::regex re("^http[s]?://(?:localhost|127\\.0\\.0\\.1):([0-9]+).*$");
+         boost::regex re("^http[s]?://(?:localhost|127\\.0\\.0\\.1).*$");
          boost::smatch match;
          if (!regex_utils::search(url, match, re))
          {

--- a/src/cpp/session/modules/SessionHTMLPreview.cpp
+++ b/src/cpp/session/modules/SessionHTMLPreview.cpp
@@ -1009,8 +1009,9 @@ SEXP rs_showPageViewer(SEXP urlSEXP, SEXP titleSEXP)
       if (boost::algorithm::starts_with(url, "http"))
       {
          // verify local url only
-         if (!boost::algorithm::starts_with(url, "http://localhost") &&
-             !boost::algorithm::starts_with(url, "http://127.0.0.1"))
+         boost::regex re("^http[s]?://(?:localhost|127\\.0\\.0\\.1):([0-9]+).*$");
+         boost::smatch match;
+         if (!regex_utils::search(url, match, re))
          {
             throw r::exec::RErrorException(
               "Only localhost URLs are allowed in the page viewer");

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/HTMLPreview.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/HTMLPreview.java
@@ -14,11 +14,15 @@
  */
 package org.rstudio.studio.client.htmlpreview;
 
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Size;
+import org.rstudio.core.client.dom.WindowEx;
+import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.satellite.SatelliteManager;
 import org.rstudio.studio.client.htmlpreview.events.ShowHTMLPreviewEvent;
 import org.rstudio.studio.client.htmlpreview.events.ShowHTMLPreviewHandler;
+import org.rstudio.studio.client.rmarkdown.RmdOutputSatellite;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -35,11 +39,20 @@ public class HTMLPreview
          @Override
          public void onShowHTMLPreview(ShowHTMLPreviewEvent event)
          {
-            // open the window 
-            satelliteManager.openSatellite(HTMLPreviewApplication.NAME,     
-                                            event.getParams(),
-                                            new Size(1100,1200));   
-            
+            WindowEx win = satelliteManager.getSatelliteWindowObject(HTMLPreviewApplication.NAME);
+            if (win != null && !Desktop.isDesktop() && BrowseCap.isChrome())
+            {
+               satelliteManager.forceReopenSatellite(HTMLPreviewApplication.NAME, 
+                                                     event.getParams(),
+                                                     true);
+            }
+            else
+            {
+               satelliteManager.openSatellite(HTMLPreviewApplication.NAME,     
+                                              event.getParams(),
+                                              new Size(1100,1200));
+                                              
+            } 
          }  
       });
    }

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/HTMLPreview.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/HTMLPreview.java
@@ -22,7 +22,6 @@ import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.satellite.SatelliteManager;
 import org.rstudio.studio.client.htmlpreview.events.ShowHTMLPreviewEvent;
 import org.rstudio.studio.client.htmlpreview.events.ShowHTMLPreviewHandler;
-import org.rstudio.studio.client.rmarkdown.RmdOutputSatellite;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/HTMLPreviewPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/HTMLPreviewPresenter.java
@@ -70,8 +70,9 @@ public class HTMLPreviewPresenter implements IsWidget
       
       void showPreview(String url,
                        HTMLPreviewResult result,
-                       boolean enableRefresh,
                        boolean enableShowLog);
+      
+      void reload(String url);
       
       void print();
       
@@ -184,10 +185,12 @@ public class HTMLPreviewPresenter implements IsWidget
             {
                lastSuccessfulPreview_ = result;
                view_.closeProgress();
+               String url = result.getPreviewURL();
+               if (!url.startsWith("http"))
+                  url = server_.getApplicationURL(url);
                view_.showPreview(
-                  server_.getApplicationURL(result.getPreviewURL()),
+                  url,
                   result,
-                  result.getEnableRefresh(),
                   lastPreviewOutput_.length() > 0);
             }
             else
@@ -235,7 +238,10 @@ public class HTMLPreviewPresenter implements IsWidget
       if (lastSuccessfulPreview_ != null)
       {
          String htmlFile = lastSuccessfulPreview_.getHtmlFile();
-         globalDisplay_.showHtmlFile(htmlFile);
+         if (htmlFile != null)
+            globalDisplay_.showHtmlFile(htmlFile);
+         else
+            globalDisplay_.openWindow(lastSuccessfulPreview_.getPreviewURL());
       }
    }
    
@@ -303,8 +309,15 @@ public class HTMLPreviewPresenter implements IsWidget
    @Handler
    public void onRefreshHtmlPreview()
    {
-      server_.previewHTML(lastPreviewParams_, 
-                          new SimpleRequestCallback<Boolean>());
+      if (lastSuccessfulPreview_.getEnableReexecute())
+      {
+         server_.previewHTML(lastPreviewParams_, 
+                             new SimpleRequestCallback<Boolean>());
+      }
+      else
+      {
+         view_.reload(lastSuccessfulPreview_.getPreviewURL());
+      }
    }
    
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/model/HTMLPreviewParams.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/model/HTMLPreviewParams.java
@@ -26,15 +26,13 @@ public class HTMLPreviewParams extends JavaScriptObject
                                                        String encoding,
                                                        boolean isMarkdown,
                                                        boolean requiresKnit,
-                                                       boolean isNotebook,
-                                                       boolean viewerMode) /*-{
+                                                       boolean isNotebook) /*-{
       var params = new Object();
       params.path = path;
       params.encoding = encoding;
       params.is_markdown = isMarkdown;
       params.requires_knit = requiresKnit;
       params.is_notebook = isNotebook;
-      params.viewer_mode = viewerMode;
       return params;
    }-*/; 
    
@@ -57,8 +55,4 @@ public class HTMLPreviewParams extends JavaScriptObject
    public final native boolean isNotebook() /*-{
       return this.is_notebook;
    }-*/;
-   
-   public final native boolean getViewerMode() /*-{
-      return this.viewer_mode;
-    }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/model/HTMLPreviewResult.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/model/HTMLPreviewResult.java
@@ -26,6 +26,10 @@ public class HTMLPreviewResult extends JavaScriptObject
       return this.succeeded;
    }-*/;
    
+   public final native String getTitle() /*-{
+      return this.title;
+   }-*/;
+   
    public final native String getPreviewURL() /*-{
       return this.preview_url;
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/model/HTMLPreviewResult.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/model/HTMLPreviewResult.java
@@ -38,20 +38,23 @@ public class HTMLPreviewResult extends JavaScriptObject
       return this.html_file;
    }-*/;
    
+   public final native boolean getEnableFileLabel() /*-{
+      return this.enable_file_label;
+   }-*/;
+   
    public final native boolean getEnableSaveAs() /*-{
       return this.enable_saveas;
    }-*/;
    
-   public final native boolean getEnableRefresh() /*-{
-      return this.enable_refresh;
+   public final native boolean getEnableReexecute() /*-{
+      return this.enable_reexecute;
+   }-*/;
+   
+   public final native boolean getEnablePublish() /*-{
+      return this.succeeded && (this.source_file !== null);
    }-*/;
 
    public final native boolean getPreviouslyPublished() /*-{
       return this.previously_published;
    }-*/;
-   
-   public final native boolean getViewerMode() /*-{
-      return this.viewer_mode;
-   }-*/;
-
 }

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewApplicationWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewApplicationWindow.java
@@ -51,7 +51,7 @@ public class HTMLPreviewApplicationWindow extends SatelliteWindow
    @Override
    protected void onInitialize(LayoutPanel mainPanel, JavaScriptObject params)
    {
-      Window.setTitle("RStudio Viewer");
+      Window.setTitle("RStudio");
       
       // create the presenter and activate it with the passed params
       HTMLPreviewParams htmlPreviewParams = params.<HTMLPreviewParams>cast();

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
@@ -21,6 +21,7 @@ import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.LayoutPanel;
 import com.google.gwt.user.client.ui.ResizeComposite;
 import com.google.gwt.user.client.ui.Widget;
@@ -239,6 +240,8 @@ public class HTMLPreviewPanel extends ResizeComposite
                            HTMLPreviewResult result,
                            boolean enableShowLog)
    {
+      Window.setTitle(result.getTitle());
+      
       if (result.getEnableFileLabel()) 
       {
          String shortFileName = StringUtil.shortPathName(

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
@@ -164,11 +164,11 @@ public class HTMLPreviewPanel extends ResizeComposite
          
       });
       
-      refreshButtonSeparator_ = toolbar.addRightSeparator();
+      toolbar.addRightSeparator();
 
       ToolbarButton refreshButton = commands.refreshHtmlPreview().createToolbarButton();
       refreshButton.addStyleName(ThemeStyles.INSTANCE.refreshToolbarButton());
-      refreshButton_ = toolbar.addRightWidget(refreshButton);
+      toolbar.addRightWidget(refreshButton);
       
       
       return toolbar;
@@ -237,29 +237,38 @@ public class HTMLPreviewPanel extends ResizeComposite
    @Override
    public void showPreview(String url, 
                            HTMLPreviewResult result,
-                           boolean enableRefresh,
                            boolean enableShowLog)
    {
-      String shortFileName = StringUtil.shortPathName(
-            FileSystemItem.createFile(result.getHtmlFile()), 
-            ThemeStyles.INSTANCE.subtitle(), 
-            300);
-      
+      if (result.getEnableFileLabel()) 
+      {
+         String shortFileName = StringUtil.shortPathName(
+                FileSystemItem.createFile(result.getHtmlFile()), 
+                ThemeStyles.INSTANCE.subtitle(), 
+                300);
+         fileLabel_.setText(shortFileName);
+      }
+      else
+      {
+         fileCaption_.setVisible(false);
+         fileLabel_.setVisible(false);
+         fileLabelSeparator_.setVisible(false);
+      }
      
-      boolean viewerMode = result.getViewerMode();
-      fileCaption_.setVisible(!viewerMode);
-      fileLabel_.setVisible(!viewerMode);
-      fileLabelSeparator_.setVisible(!viewerMode);
-      
-      fileLabel_.setText(shortFileName);
       showLogButtonSeparator_.setVisible(enableShowLog);
       showLogButton_.setVisible(enableShowLog);
       saveHtmlPreviewAsSeparator_.setVisible(result.getEnableSaveAs());
       saveHtmlPreviewAs_.setVisible(result.getEnableSaveAs());
-      publishButton_.setHtmlPreview(result);
+      if (result.getEnablePublish()) 
+         publishButton_.setHtmlPreview(result);
+      else
+         publishButton_.setVisible(false);
       publishButtonSeparator_.setVisible(publishButton_.isVisible());
-      refreshButtonSeparator_.setVisible(enableRefresh);
-      refreshButton_.setVisible(enableRefresh);
+      previewFrame_.navigate(url);
+   }
+   
+   @Override
+   public void reload(String url)
+   {
       previewFrame_.navigate(url);
    }
    
@@ -297,7 +306,5 @@ public class HTMLPreviewPanel extends ResizeComposite
    private RSConnectPublishButton publishButton_;
    private Widget showLogButtonSeparator_;
    private ToolbarButton showLogButton_;
-   private Widget refreshButtonSeparator_;
-   private ToolbarButton refreshButton_;
    private HTMLPreviewProgressDialog activeProgressDialog_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
@@ -603,8 +603,8 @@ public class Workbench implements BusyHandler,
    }
    
    @Override
-   public void onShowPageViewer(ShowPageViewerEvent event) {
-      
+   public void onShowPageViewer(ShowPageViewerEvent event) 
+   {   
       // show the page viewer window
       HTMLPreviewParams params = event.getParams();
       eventBus_.fireEvent(new ShowHTMLPreviewEvent(params)); 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
@@ -605,10 +605,11 @@ public class Workbench implements BusyHandler,
    @Override
    public void onShowPageViewer(ShowPageViewerEvent event) {
       
+      // show the page viewer window
       HTMLPreviewParams params = event.getParams();
-      eventBus_.fireEvent(new ShowHTMLPreviewEvent(params));
-      server_.previewHTML(params, new SimpleRequestCallback<Boolean>());
+      eventBus_.fireEvent(new ShowHTMLPreviewEvent(params)); 
       
+      // server will now take care of sending the html_preview_completed event
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -5186,7 +5186,6 @@ public class TextEditingTarget implements
                                             docUpdateSentinel_.getEncoding(),
                                             fileType_.isMarkdown(),
                                             fileType_.requiresKnit(),
-                                            false,
                                             false);
          }
       });
@@ -5367,8 +5366,7 @@ public class TextEditingTarget implements
                                                docUpdateSentinel_.getEncoding(),
                                                true,
                                                true,
-                                               true,
-                                               false);
+                                               true);
             }
          });
       }


### PR DESCRIPTION
Several additional enhancements:

1) Ability to specify a window title for the page viewer

2) Self-contained HTML is now created directly with pandoc rather than calling the rmarkdown package (this means that all static HTML files are savable and publishable).

3) Some refactoring to give the page viewer it's own server-side codepath (previously it was masquerading as an HTML preview which worked but was fragile and hard to reason about)

4) Support for localhost URLs. This combined with processx makes it possible for packages to create add-ons that extend the API with arbitrary web apps running in other processes (shiny or otherwise)

Not as straightforward a change as the first one, however I still think it's quite safe given that it only touches the codepath dedicated to R Markdown v1 and previewing of plain HTML files, neither of which is done with any regularity by users.
 