### PR TITLE
Pass Ctrl+L through to full-screen terminal programs

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
@@ -471,11 +471,21 @@ public class ShortcutManager implements NativePreviewHandler,
          {
             keyBuffer_.clear();
 
-            if (XTermWidget.isXTerm(Element.as(event.getEventTarget())))
+            XTermWidget xterm = XTermWidget.tryGetXTerm(Element.as(event.getEventTarget()));
+            if (xterm != null)
             {
                if (binding.getId() == "consoleClear")
                {
-                  // special case; we expect users will try to use Ctrl+L to
+                  if (xterm.xtermAltBufferActive())
+                  {
+                     // If the terminal is running a full-screen program, pass the 
+                     // keystroke through, instead. Otherwise we're potentially
+                     // clearing the main buffer even though user is seeing the alt-
+                     // buffer.
+                     return false;
+                  }
+
+                  // Otherwise, we expect users will try to use Ctrl+L to
                   // clear the terminal, and don't want that to actually
                   // clear the currently hidden console instead
                   event.stopPropagation();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -16,6 +16,7 @@
 package org.rstudio.studio.client.workbench.views.terminal.xterm;
 
 import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ExternalJavaScriptLoader;
 import org.rstudio.core.client.ExternalJavaScriptLoader.Callback;
 import org.rstudio.core.client.StringSink;
@@ -41,6 +42,8 @@ import com.google.gwt.dom.client.LinkElement;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.EventListener;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.RequiresResize;
 import com.google.gwt.user.client.ui.Widget;
@@ -357,17 +360,36 @@ public class XTermWidget extends Widget implements RequiresResize,
       terminal_.showAltBuffer();
    }
     
-   public static boolean isXTerm(Element el)
+   /**
+    * @param el Element to test, may be null
+    * @return If element is part of an XTermWidget, return that widget, otherwise null.
+    */
+   public static XTermWidget tryGetXTerm(Element el)
    {
       while (el != null)
       {
          if (el.hasClassName(XTERM_CLASS))
-            return true;
+         {
+            EventListener listener = DOM.getEventListener(el);
+            if (listener == null)
+            {
+               Debug.log("Unexpected failure to get XTERM_CLASS listener");
+            }
+            else if (listener instanceof XTermWidget)
+            {
+               return (XTermWidget) listener;
+            }
+            else
+            {
+               Debug.log("Unexpected: XTERM_CLASS listener was not an XTermWidget");
+            }
+            return null;
+         }
          el = el.getParentElement();
       }
-      return false;
+      return null;
    }
-   
+
    private static final ExternalJavaScriptLoader getLoader(StaticDataResource release,
                                                            StaticDataResource debug)
    {


### PR DESCRIPTION
When running a full-screen program pass Ctrl+L keystroke to it instead of interpreting that as "clear terminal buffer" command. Among other things, this lets Ctrl+L clear the current tmux pane, instead of messing up the entire display.