### PR TITLE
Change shortcut for moving focus to terminal

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -602,7 +602,7 @@ well as menu structures (for main menu and popup menus).
          
          <shortcut refid="activateSource" value="Ctrl+1"/>
          <shortcut refid="activateConsole" value="Ctrl+2"/>
-         <shortcut refid="activateTerminal" value="Ctrl+Shift+T"/>
+         <shortcut refid="activateTerminal" value="Ctrl+Alt+2"/>
          <shortcut refid="activateHelp" value="Ctrl+3"/>
          <shortcut refid="activateHistory" value="Ctrl+4"/>
          <shortcut refid="activateFiles" value="Ctrl+5"/>


### PR DESCRIPTION
@kevinushey discovered the previous shortcut clashed with Test Package (on client IDEs) so changing to Ctrl+Alt+2, which makes it nicely symmetric with the Ctrl+2 for sending focus to the Console.