### PR TITLE
Fix span tag under help popup in dark themes

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.css
@@ -24,6 +24,10 @@
    color: #FFF;
 }
 
+.rstudio-themes-flat.rstudio-themes-dark-menus .helpBodyText span {
+   color: #bfbfbf !important;
+}
+
 .snippetText {
    font-family: fixedWidthFont;
    white-space: pre-wrap;


### PR DESCRIPTION
Before,

![image](https://user-images.githubusercontent.com/3478847/29226710-da74d33e-7e87-11e7-9e14-7625d7d8e406.png)

After,

<img width="711" alt="screen shot 2017-08-11 at 11 19 51 am" src="https://user-images.githubusercontent.com/3478847/29226696-cce206d8-7e87-11e7-80ba-47082ef267d0.png">
