### PR TITLE
Add logging to environment capture failure case

### DIFF
--- a/src/cpp/core/terminal/PrivateCommand.cpp
+++ b/src/cpp/core/terminal/PrivateCommand.cpp
@@ -89,6 +89,7 @@ bool PrivateCommand::onTryCapture(core::system::ProcessOperations& ops, bool has
 
       if (currentTime - lastPrivateCommand_ > privateCommandTimeout_)
       {
+         LOG_WARNING_MESSAGE("PrivateCommand timeout");
          terminateCapture();
          ops.ptyInterrupt();
          timeout_ = true;


### PR DESCRIPTION
Intermittent reports of extra prompts showing up in terminals, often after a few seconds delay. This goes away when environment capture is turned off. 

Logging a message in the failure case I suspect is causing this.

When terminal is doing environment capture, it fires a hidden command (/usr/bin/env followed by a sentinel, essentially) then parses the result and saves it, but there is a timeout which will issue a ptyInterrupt if the private command hasn't completed. This is likely what triggers another prompt.

Could be a race condition (multithreading and a mutex is in the picture with WebSockets), or some other timing-related window. At least knowing if it's hitting this error would be useful data.