### PR TITLE
Show connection source on hover

### DIFF
--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -248,7 +248,8 @@ options(connectionObserver = list(
             snippet = .rs.scalar(snippet),
             help = .rs.scalar(NULL),
             iconData = .rs.scalar(.Call("rs_connectionIcon", snippetName)),
-            licensed = .rs.scalar(FALSE)
+            licensed = .rs.scalar(FALSE),
+            source = .rs.scalar("Snippet")
          )
       }, error = function(e) {
          warning(e$message)
@@ -336,7 +337,8 @@ options(connectionObserver = list(
                snippet = .rs.scalar(snippet),
                help = .rs.scalar(NULL),
                iconData = .rs.scalar(iconData),
-               licensed = .rs.scalar(identical(file.exists(licenseFile), TRUE))
+               licensed = .rs.scalar(identical(file.exists(licenseFile), TRUE)),
+               source = .rs.scalar("ODBC")
             )
          }, error = function(e) {
             warning(e$message)
@@ -395,7 +397,8 @@ options(connectionObserver = list(
             snippet = .rs.scalar(snippet),
             help = .rs.scalar(con$help),
             iconData = .rs.scalar(iconData),
-            licensed = .rs.scalar(FALSE)
+            licensed = .rs.scalar(FALSE),
+            source = .rs.scalar("Package")
          )
       }, error = function(e) {
          warning(e$message)
@@ -445,7 +448,8 @@ options(connectionObserver = list(
                snippet = .rs.scalar(snippet),
                help = .rs.scalar(NULL),
                iconData = .rs.scalar(iconData),
-               licensed = .rs.scalar(FALSE)
+               licensed = .rs.scalar(FALSE),
+               source = .rs.scalar("DSN")
             )
          }, error = function(e) {
             warning(e$message)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/NewConnectionContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/NewConnectionContext.java
@@ -44,6 +44,10 @@ public class NewConnectionContext extends JavaScriptObject
          return this["name"];
       }-*/;
 
+      public final native String getSource() /*-{
+         return this["source"];
+      }-*/;
+
       public final native String getType() /*-{
          return this["type"];
       }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionNavigationPage.java
@@ -79,11 +79,13 @@ public class NewConnectionNavigationPage
          if (!connectionInfo.getLicensed() || 
              RStudioGinjector.INSTANCE.getSession().getSessionInfo().getSupportDriverLicensing()) {
 
+            String subTitle = connectionInfo.getName() + " via " + connectionInfo.getSource();
+
             if (connectionInfo.getType() == "Shiny") {
-               pages.add(new NewConnectionShinyPage(connectionInfo));
+               pages.add(new NewConnectionShinyPage(connectionInfo, subTitle));
             }
             else if (connectionInfo.getType() == "Snippet") {
-               pages.add(new NewConnectionSnippetPage(connectionInfo));
+               pages.add(new NewConnectionSnippetPage(connectionInfo, subTitle));
             }
             else if (connectionInfo.getType() == "Install") {
                pages.add(new NewConnectionInstallPackagePage(connectionInfo));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyPage.java
@@ -31,10 +31,10 @@ import com.google.gwt.user.client.ui.Widget;
 public class NewConnectionShinyPage 
    extends WizardPage<NewConnectionContext, ConnectionOptions>
 {
-   public NewConnectionShinyPage(final NewConnectionInfo info)
+   public NewConnectionShinyPage(final NewConnectionInfo info, String subTitle)
    {
       super(info.getName(),
-            "",
+            subTitle,
             info.getName() + " Connection",
             StringUtil.isNullOrEmpty(info.iconData()) ? null
                   : new ImageResourceUrl(new SafeUri()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetPage.java
@@ -31,11 +31,11 @@ import com.google.gwt.user.client.ui.Widget;
 public class NewConnectionSnippetPage 
    extends WizardPage<NewConnectionContext, ConnectionOptions>
 {
-   public NewConnectionSnippetPage(final NewConnectionInfo info)
+   public NewConnectionSnippetPage(final NewConnectionInfo info, String subTitle)
    {
       super(
          info.getName(),
-         "",
+         subTitle,
          info.getName() + " Connection",
          StringUtil.isNullOrEmpty(info.iconData()) ? null : new ImageResourceUrl(
             new SafeUri()


### PR DESCRIPTION
Help users understand where the connections come from by adding meaningful on-hover behavior:

<img width="563" alt="screen shot 2017-08-14 at 9 27 45 pm" src="https://user-images.githubusercontent.com/3478847/29302287-aebbe428-8137-11e7-8c84-71e614f4658d.png">
