### PR TITLE
use help server for page viewer

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -2136,6 +2136,24 @@ core::Error recursiveCopyDirectory(const core::FilePath& fromDir,
    return fileCopy.call();
 }
 
+bool isSessionTempPath(FilePath filePath)
+{
+   // get the real path
+   Error error = core::system::realPath(filePath, &filePath);
+   if (error)
+      LOG_ERROR(error);
+
+   // get the session temp dir real path; needed since the file path above is
+   // also a real path--e.g. on OS X, it refers to /private/tmp rather than
+   // /tmp
+   FilePath tempDir;
+   error = core::system::realPath(module_context::tempDir(), &tempDir);
+   if (error)
+      LOG_ERROR(error);
+
+   return filePath.isWithin(tempDir);
+}
+
 std::string sessionTempDirUrl(const std::string& sessionTempPath)
 {
    if (session::options().programMode() == kSessionProgramModeDesktop)

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -746,6 +746,8 @@ void addViewerHistoryEntry(const ViewerHistoryEntry& entry);
 core::Error recursiveCopyDirectory(const core::FilePath& fromDir,
                                    const core::FilePath& toDir);
 
+bool isSessionTempPath(core::FilePath filePath);
+
 std::string sessionTempDirUrl(const std::string& sessionTempPath);
 
 core::Error uniqueSaveStem(const core::FilePath& directoryPath,

--- a/src/cpp/session/modules/SessionHTMLPreview.cpp
+++ b/src/cpp/session/modules/SessionHTMLPreview.cpp
@@ -484,7 +484,6 @@ std::string deriveNotebookPath(const std::string& path)
 boost::shared_ptr<HTMLPreview> s_pCurrentPreview_;
 
 // current page_viewer html file
-std::string s_currentPageViewerFile;
 
 bool isPreviewRunning()
 {
@@ -524,8 +523,6 @@ Error previewHTML(const json::JsonRpcRequest& request,
                                                isMarkdown,
                                                isNotebook,
                                                knit);
-      s_currentPageViewerFile = std::string();
-
       pResponse->setResult(true);
    }
 
@@ -929,8 +926,8 @@ void handleInternalMarkdownPreviewRequest(
 void handlePreviewRequest(const http::Request& request,
                           http::Response* pResponse)
 {
-   // if there isn't a current preview or page viewer file this is an error
-   if (!s_pCurrentPreview_ && s_currentPageViewerFile.empty())
+   // if there isn't a current preview this is an error
+   if (!s_pCurrentPreview_)
    {
       pResponse->setNotFoundError(request.uri());
       return;
@@ -946,11 +943,7 @@ void handlePreviewRequest(const http::Request& request,
    // if it is empty then this is the main request
    if (path.empty())
    {
-      if (!s_currentPageViewerFile.empty())
-      {
-         pResponse->setFile(FilePath(s_currentPageViewerFile), request);
-      }
-      else if (s_pCurrentPreview_->isMarkdown())
+      if (s_pCurrentPreview_->isMarkdown())
       {
          if (s_pCurrentPreview_->isInternalMarkdown())
             handleInternalMarkdownPreviewRequest(request, pResponse);
@@ -980,11 +973,7 @@ void handlePreviewRequest(const http::Request& request,
    // request for dependent file
    else
    {
-      FilePath filePath;
-      if (!s_currentPageViewerFile.empty())
-         filePath = FilePath(s_currentPageViewerFile).parent().childPath(path);
-      else
-         filePath = s_pCurrentPreview_->targetDirectory().childPath(path);
+      FilePath filePath = s_pCurrentPreview_->targetDirectory().childPath(path);
       addFileSpecificHeaders(filePath, pResponse);
       pResponse->setFile(filePath, request);
    }
@@ -1019,29 +1008,38 @@ SEXP rs_showPageViewer(SEXP urlSEXP, SEXP titleSEXP)
 
          // port mapping for RStudio Server
          url = module_context::mapUrlPorts(url);
-
       }
-      // otherwise it's a file
+
+      // otherwise it's a file in the filesystem
       else
       {
          // get full path to file
          filePath = module_context::resolveAliasedPath(url);
 
-         // create temp file to write standalone html to (place it within a temp dir
-         // so the default download file name is pretty)
-         FilePath viewerTempDir = module_context::tempFile("page-viewer", "dir");
-         Error error = viewerTempDir.ensureDirectory();
-         if (error)
-            throw r::exec::RErrorException(r::endUserErrorMessage(error));
-         viewerFilePath = viewerTempDir.childPath(filePath.filename());
+         // if it's already in the session temp dir then use the path directly
+         if (module_context::isSessionTempPath(filePath))
+         {
+            viewerFilePath = filePath;
+         }
+         else
+         {
+            // create temp file to write standalone html to (place it within a temp dir
+            // so the default download file name is pretty)
+            FilePath viewerTempDir = module_context::tempFile("page-viewer", "dir");
+            Error error = viewerTempDir.ensureDirectory();
+            if (error)
+               throw r::exec::RErrorException(r::endUserErrorMessage(error));
+            viewerFilePath = viewerTempDir.childPath(filePath.filename());
+         }
 
          // create base64 encoded version
-         error = module_context::createSelfContainedHtml(filePath, viewerFilePath);
+         Error error = module_context::createSelfContainedHtml(filePath, viewerFilePath);
          if (error)
             throw r::exec::RErrorException(r::endUserErrorMessage(error));
 
-         // set url to file previewer
-         url = kHTMLPreview "/";
+         // set url to localhost previewer
+         std::string tempPath = viewerFilePath.relativePath(module_context::tempDir());
+         url = module_context::sessionTempDirUrl(tempPath);
       }
 
       // emit show page viewer event
@@ -1058,10 +1056,6 @@ SEXP rs_showPageViewer(SEXP urlSEXP, SEXP titleSEXP)
       // the preview succeeded event handler is set up
       using namespace boost::posix_time;
       boost::this_thread::sleep(milliseconds(500));
-
-      // set the current viewer file path (required so we can
-      // serve back the file and it's dependencies
-      s_currentPageViewerFile = viewerFilePath.absolutePath();
 
       // emit html preview completed event
       enqueHTMLPreviewSucceeded(


### PR DESCRIPTION
This PR makes a couple of changes to the page_viewer:

1) It uses the R help server rather than the custom html viewer http handler to serve the page_viewer. As you'll see this ends up eliminating a new "state" that was introduced with the original PR (i.e. net reduction in risk/complexity).

2) If a file is provided to it that is already contained within the session temp dir it is served in place (previously it make another temp dir and created self contained html within it). This enables clients to provision their own temp directory and write files to it while the page_viewer is running (i.e. realtime updates based on polling).
