### PR TITLE
Disable dark theme in viewer pane while rendering content

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
@@ -20,7 +20,7 @@ import org.rstudio.core.client.Size;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.URIUtils;
 import org.rstudio.core.client.resources.ImageResource2x;
-import org.rstudio.core.client.widget.RStudioThemedFrame;
+import org.rstudio.core.client.widget.RStudioFrame;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
@@ -141,7 +141,7 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
    @Override 
    protected Widget createMainWidget()
    {
-      frame_ = new RStudioThemedFrame();
+      frame_ = new RStudioFrame();
       frame_.setSize("100%", "100%");
       frame_.addStyleName("ace_editor_theme");
       navigate(ABOUT_BLANK, false);
@@ -263,10 +263,17 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
          frame_.setUrl(unmodifiedUrl_);
       }
       
+      if (unmodifiedUrl_ != null && !unmodifiedUrl_.equals(ABOUT_BLANK)) {
+         frame_.getElement().getStyle().setBackgroundColor("#FFF");
+      }
+      else {
+         frame_.getElement().getStyle().clearBackgroundColor();
+      }
+      
       events_.fireEvent(new ViewerNavigatedEvent(url, frame_));
    }
 
-   private RStudioThemedFrame frame_;
+   private RStudioFrame frame_;
    private String unmodifiedUrl_;
    private RmdPreviewParams rmdPreviewParams_;
    private final Commands commands_;


### PR DESCRIPTION
Most web content sets their `<body>` to the desired bg-color; however, `RMD` files did not and therefore, we attempted to change the colors to match the dark theme. This is hard to support for blog content (say the RStudio blog) and even a bit confusing while knitting files since one would expect to see the final output. This is the case also with the plot pane which will render white by default unless the content creator is aware of themes and implements support for this.

The pane will now render as:

<img width="1440" alt="screen shot 2017-08-15 at 5 59 32 pm" src="https://user-images.githubusercontent.com/3478847/29343061-8567ff4c-81e3-11e7-9afa-cd68085070f1.png">

<img width="1440" alt="screen shot 2017-08-15 at 4 59 48 pm" src="https://user-images.githubusercontent.com/3478847/29343022-41a6cdd8-81e3-11e7-8d75-42b0e1689778.png">

<img width="1440" alt="screen shot 2017-08-15 at 5 52 50 pm" src="https://user-images.githubusercontent.com/3478847/29343021-41a5bc68-81e3-11e7-89ba-1077164dfe66.png">
