### PR TITLE
handle classed external pointers

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1942,3 +1942,9 @@
       error = function(e) NULL
    )
 })
+
+.rs.addFunction("isExternalPointer", function(object)
+{
+   identical(typeof(object), "externalptr")
+})
+

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -316,9 +316,18 @@
         else
           return(paste("Oracle R frame:", sqlTable))
       }
-      else if (is(obj, "externalptr"))
+      else if (.rs.isExternalPointer(obj))
       {
-         return("External pointer")
+         class <- class(obj)
+         if (length(class) && !identical(class, "externalptr"))
+         {
+            fmt <- "External pointer of class '%s'"
+            return(sprintf(fmt, class[[1]]))
+         }
+         else
+         {
+            return("External pointer")
+         }
       }
       else if (is.data.frame(obj))
       {
@@ -657,7 +666,8 @@
    else
    {
       # check the object itself for a null pointer
-      inherits(obj, "externalptr") && capture.output(print(obj)) == "<pointer: 0x0>"
+      .rs.isExternalPointer(obj) &&
+         capture.output(base::print.default(obj)) == "<pointer: 0x0>"
    }
 })
 

--- a/src/cpp/session/modules/SessionObjectExplorer.R
+++ b/src/cpp/session/modules/SessionObjectExplorer.R
@@ -862,9 +862,9 @@
       output <- sprintf("S4 object of class %s", class(object))
       more <- FALSE
    }
-   else if (inherits(object, "externalptr"))
+   else if (.rs.isExternalPointer(object))
    {
-      output <- capture.output(print(unclass(object)))
+      output <- capture.output(base::print.default(object))
       more <- FALSE
    }
    


### PR DESCRIPTION
This PR fixes an issue where classed external pointers were not properly detected as external pointers by RStudio in some code paths. The main issue here is that:

    inherits(object, "externalptr")

returns `FALSE` for classed external pointers. The safest way to detect these is check `typeof()` directly.