### PR TITLE
Fix 1.2 Mac build break

### DIFF
--- a/src/cpp/core/r_util/REnvironmentPosix.cpp
+++ b/src/cpp/core/r_util/REnvironmentPosix.cpp
@@ -146,7 +146,8 @@ bool getRHomeAndLibPath(const FilePath& rScriptPath,
                         const config_utils::Variables& scriptVars,
                         std::string* pRHome,
                         std::string* pRLibPath,
-                        std::string* pErrMsg)
+                        std::string* pErrMsg,
+                        const std::string& prelaunchScript = "")
 {
    config_utils::Variables::const_iterator it = scriptVars.find("R_HOME_DIR");
    if (it != scriptVars.end())


### PR DESCRIPTION
I don't think the `prelaunchScript` needs to be used for anything on Mac desktop or open-source dev server but @kfeinauer should confirm.