### PR TITLE
now restricting http methods in server implementation to PUT, POST, and GET unless the handler is a proxy handler

### DIFF
--- a/src/cpp/core/include/core/http/AsyncServer.hpp
+++ b/src/cpp/core/include/core/http/AsyncServer.hpp
@@ -45,6 +45,9 @@ public:
    virtual void addHandler(const std::string& prefix,
                            const AsyncUriHandlerFunction& handler) = 0;
 
+   virtual void addProxyHandler(const std::string& prefix,
+                                const AsyncUriHandlerFunction& handler) = 0;
+
 
    virtual void addBlockingHandler(const std::string& prefix,
                                    const UriHandlerFunction& handler) = 0;

--- a/src/cpp/core/include/core/http/AsyncServerImpl.hpp
+++ b/src/cpp/core/include/core/http/AsyncServerImpl.hpp
@@ -80,6 +80,13 @@ public:
       BOOST_ASSERT(!running_);
       abortOnResourceError_ = abortOnResourceError;
    }
+
+   virtual void addProxyHandler(const std::string& prefix,
+                                const AsyncUriHandlerFunction& handler)
+   {
+      BOOST_ASSERT(!running_);
+      uriHandlers_.add(AsyncUriHandler(baseUri_ + prefix, handler, true));
+   }
    
    virtual void addHandler(const std::string& prefix,
                            const AsyncUriHandlerFunction& handler)
@@ -325,11 +332,30 @@ private:
 
          // call the appropriate handler to generate a response
          std::string uri = pRequest->uri();
-         AsyncUriHandlerFunction handler = uriHandlers_.handlerFor(uri);
-         if (handler)
+         AsyncUriHandler handler = uriHandlers_.handlerFor(uri);
+         AsyncUriHandlerFunction handlerFunc = handler.function();
+
+         if (handlerFunc)
          {
+            if (!handler.isProxyHandler())
+            {
+               // check to ensure the request is for a supported method
+               // proxy handlers do not perform this checking as we
+               // flow all traffic like a proxy
+               const std::string& method = pRequest->method();
+               if (method != "GET" &&
+                   method != "PUT" &&
+                   method != "POST")
+               {
+                  // invalid method - fail out
+                  LOG_ERROR_MESSAGE("Invalid method " + method + " requested for uri: " + pRequest->uri());
+                  pConnection->response().setStatusCode(http::status::MethodNotAllowed);
+                  return;
+               }
+            }
+
             // call the handler
-            handler(pAsyncConnection) ;
+            handlerFunc(pAsyncConnection) ;
          }
          else if (defaultHandler_)
          {

--- a/src/cpp/core/include/core/http/AsyncUriHandler.hpp
+++ b/src/cpp/core/include/core/http/AsyncUriHandler.hpp
@@ -40,11 +40,12 @@ typedef boost::function<void(
 class AsyncUriHandler
 {
 public:
+   AsyncUriHandler() : isProxyHandler_(false) {} // other members default initialized
 
-public:
    AsyncUriHandler(const std::string& prefix,
-                   AsyncUriHandlerFunction function)
-       : prefix_(prefix), function_(function)
+                   AsyncUriHandlerFunction function,
+                   bool isProxyHandler = false)
+       : prefix_(prefix), function_(function), isProxyHandler_(isProxyHandler)
    {
    }
 
@@ -67,9 +68,15 @@ public:
       function_(pConnection);
    }
 
+   bool isProxyHandler() const
+   {
+      return isProxyHandler_;
+   }
+
 private:
    std::string prefix_;
    AsyncUriHandlerFunction function_ ;
+   bool isProxyHandler_;
 
 };
 
@@ -83,7 +90,7 @@ public:
       uriHandlers_.push_back(handler);
    }
 
-   AsyncUriHandlerFunction handlerFor(const std::string& uri) const
+   AsyncUriHandler handlerFor(const std::string& uri) const
    {
       std::vector<AsyncUriHandler>::const_iterator handler =
             std::find_if(
@@ -92,11 +99,11 @@ public:
               boost::bind(&AsyncUriHandler::matches, _1, uri));
       if ( handler != uriHandlers_.end() )
       {
-         return handler->function();
+         return *handler;
       }
       else
       {
-         return AsyncUriHandlerFunction();
+         return AsyncUriHandler();
       }
    }
 

--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -193,7 +193,7 @@ void httpServerAddHandlers()
 
    // proxy localhost if requested
    if (server::options().wwwProxyLocalhost())
-      uri_handlers::add("/p/", secureAsyncHttpHandler(proxyLocalhostRequest, true));
+      uri_handlers::addProxyHandler("/p/", secureAsyncHttpHandler(proxyLocalhostRequest, true));
 
    // establish logging handler
    uri_handlers::addBlocking("/log", secureJsonRpcHandler(gwt::handleLogRequest));
@@ -322,6 +322,12 @@ void add(const std::string& prefix,
          const http::AsyncUriHandlerFunction& handler)
 {
    s_pHttpServer->addHandler(prefix, handler);
+}
+
+void addProxyHandler(const std::string& prefix,
+                     const http::AsyncUriHandlerFunction& handler)
+{
+   s_pHttpServer->addProxyHandler(prefix, handler);
 }
 
 void addBlocking(const std::string& prefix,

--- a/src/cpp/server/include/server/ServerUriHandlers.hpp
+++ b/src/cpp/server/include/server/ServerUriHandlers.hpp
@@ -29,6 +29,11 @@ namespace uri_handlers {
 void add(const std::string& prefix,
          const core::http::AsyncUriHandlerFunction& handler);
 
+// add proxy handler
+// proxy handlers have special behavior to allow them to route all traffic
+void addProxyHandler(const std::string& prefix,
+                     const core::http::AsyncUriHandlerFunction& handler);
+
 // add blocking uri handler
 void addBlocking(const std::string& prefix,
                  const core::http::UriHandlerFunction& handler);


### PR DESCRIPTION
proxy handlers will be unrestricted (since they should proxy all traffic)