### PR TITLE
Fix extra prompts caused by environment capture

### DIFF
--- a/src/cpp/core/include/core/terminal/PrivateCommand.hpp
+++ b/src/cpp/core/include/core/terminal/PrivateCommand.hpp
@@ -47,15 +47,21 @@ namespace terminal {
  *
  * Once PrivateCommand::hasCaptured() returns false, the output of the private command is available
  * via getPrivateOutput().
+ *
+ * Capture mode stays enabled briefly after the expected output has been received so it can
+ * suppress the prompt that is displayed after the hidden command is executed. Sometimes
+ * this prompt arrives in the same output string as the end of the input, but sometimes it
+ * doesn't and user would see a mysterious extra prompt.
  */
 class PrivateCommand : boost::noncopyable
 {
 public:
    PrivateCommand(
          const std::string& command,
-         int privateCommandDelayMs = 2000, // min delay between private commands
-         int waitAfterCommandDelayMs = 1500, // min delay after user command
+         int privateCommandDelayMs = 3000, // min delay between private commands
+         int waitAfterCommandDelayMs = 2000, // min delay after user command
          int privateCommandTimeoutMs = 1200, // timeout for private command
+         int postCommandTimeoutMs = 120, // how long to suppress output after private command done
          bool oncePerUserCommand = true); // only run private command after user has hit <enter>
 
    // Give private command opportunity to capture terminal; returns true if it does (or already did).
@@ -102,6 +108,9 @@ private:
    // When did user last hit Enter at the end of a line of input?
    boost::posix_time::ptime lastEnterTime_;
 
+   // When did we successfully receive the expected private output?
+   boost::posix_time::ptime outputReceivedTime_;
+
    // Is there a partially-typed command?
    bool pendingCommand_;
 
@@ -126,9 +135,15 @@ private:
    // how long after a private command is started do we allow for the result to be delivered?
    boost::posix_time::milliseconds privateCommandTimeout_;
 
+   // How long after expected output received do we continue to suppress showing output?
+   // Keep very short but long enough for shells that send the prompt shown after the
+   // private command in a separate output event, otherwise user sees duplicate prompts
+   boost::posix_time::milliseconds postCommandTimeout_;
+
    // parse details
    size_t firstCRLF_; // end of command
    size_t outputStart_; // start of output
+   size_t outputEnd_; // end of output
 
    // did last private command timeout?
    bool timeout_;

--- a/src/cpp/core/terminal/PrivateCommand.cpp
+++ b/src/cpp/core/terminal/PrivateCommand.cpp
@@ -50,6 +50,7 @@ PrivateCommand::PrivateCommand(const std::string& command,
                                int privateCommandDelayMs,
                                int waitAfterCommandDelayMs,
                                int privateCommandTimeoutMs,
+                               int postCommandTimeoutMs,
                                bool oncePerUserCommand)
    :
      command_(command),
@@ -57,12 +58,15 @@ PrivateCommand::PrivateCommand(const std::string& command,
      privateCommandLoop_(false),
      lastPrivateCommand_(boost::posix_time::not_a_date_time),
      lastEnterTime_(boost::posix_time::not_a_date_time),
+     outputReceivedTime_(boost::posix_time::not_a_date_time),
      pendingCommand_(false),
      privateCommandDelay_(privateCommandDelayMs),
      waitForCommandDelay_(waitAfterCommandDelayMs),
      privateCommandTimeout_(privateCommandTimeoutMs),
+     postCommandTimeout_(postCommandTimeoutMs),
      firstCRLF_(std::string::npos),
      outputStart_(std::string::npos),
+     outputEnd_(std::string::npos),
      timeout_(false)
 {
    outputBOM_ = core::system::generateShortenedUuid();
@@ -83,8 +87,14 @@ bool PrivateCommand::onTryCapture(core::system::ProcessOperations& ops, bool has
    {
       if (!output_.empty())
       {
-         privateCommandLoop_ = false;
-         return false; // all done
+         if (currentTime - outputReceivedTime_ > postCommandTimeout_)
+         {
+            resetParse();
+
+            privateCommandLoop_ = false;
+            return false; // all done
+         }
+         return true; // still waiting for our post-capture timeout
       }
 
       if (currentTime - lastPrivateCommand_ > privateCommandTimeout_)
@@ -204,17 +214,24 @@ bool PrivateCommand::output(const std::string& output)
    }
 
    // find the end of output
-   std::string eomLine = outputEOM_ + kEol;
-   size_t outputEnd = privateCommandOutput_.find(eomLine, outputStart_);
-   if (outputEnd == std::string::npos)
+   if (outputEnd_ == std::string::npos)
    {
-      return true;
+      std::string eomLine = outputEOM_ + kEol;
+      outputEnd_ = privateCommandOutput_.find(eomLine, outputStart_);
+      if (outputEnd_ == std::string::npos)
+      {
+         return true;
+      }
    }
 
-   // extract the command output
-   output_ = privateCommandOutput_.substr(outputStart_, outputEnd - outputStart_);
+   if (output_.empty())
+   {
+      // extract the command output
+      output_ = privateCommandOutput_.substr(outputStart_, outputEnd_ - outputStart_);
+      outputReceivedTime_ = now();
+   }
 
-   resetParse();
+   // Until we turn off capture, continue to ignore additional output, such as the trailing prompt
    return true;
 }
 
@@ -230,8 +247,10 @@ std::string PrivateCommand::getPrivateOutput()
 
 void PrivateCommand::resetParse()
 {
+   outputReceivedTime_ = boost::posix_time::not_a_date_time;
    firstCRLF_ = std::string::npos;
    outputStart_ = std::string::npos;
+   outputEnd_ = std::string::npos;
    privateCommandOutput_.clear();
 }
 

--- a/src/cpp/core/terminal/PrivateCommandTests.cpp
+++ b/src/cpp/core/terminal/PrivateCommandTests.cpp
@@ -89,16 +89,18 @@ context("Private Terminal Command Tests")
    const std::string kPrompt = "fake-prompt someuser$ ";
    const bool kHasChildProcess = true;
    const bool kNoChildProcess = false;
-   const int kPrivate = 25;
-   const int kUser = 25;
-   const int kTimeout = 25;
+   const int kPrivate = 25; // min delay between private commands
+   const int kUser = 25; // min delay after user command
+   const int kTimeout = 25; // private command timeout
+   const int kPostTimeout = 25; // how long to suppress output after private command is done
+
    const bool kOncePerUserEnter = true;
    const bool kNotOncePerUserEnter = false;
 
    // this tests the overall functionality of the expected usage pattern
    test_that("command output successfully parsed and returned")
    {
-      PrivateCommand cmd(kCommand, kPrivate * 2, kUser, kTimeout, kNotOncePerUserEnter);
+      PrivateCommand cmd(kCommand, kPrivate * 2, kUser, kTimeout, kPostTimeout, kNotOncePerUserEnter);
 
       std::string results = "one=two\nthree=four\nfive=six\n";
 
@@ -117,6 +119,12 @@ context("Private Terminal Command Tests")
       // close off the output
       cmd.output(cmd.getEOM());
       cmd.output(kEol);
+      cmd.output(kPrompt);
+
+      // trying to capture now should return true because final timeout hasn't expired
+      expect_true(cmd.onTryCapture(ops, kNoChildProcess));
+
+      boost::this_thread::sleep(milliseconds(kPostTimeout));
 
       // trying to capture now should return false, meaning we can get the output
       expect_false(cmd.onTryCapture(ops, kNoChildProcess));
@@ -131,7 +139,7 @@ context("Private Terminal Command Tests")
 
    test_that("basic assumptions are true")
    {
-      PrivateCommand cmd1(kCommand, kPrivate, kUser, kTimeout, kOncePerUserEnter);
+      PrivateCommand cmd1(kCommand, kPrivate, kUser, kTimeout, kPostTimeout, kOncePerUserEnter);
 
       expect_false(cmd1.hasCaptured());
       expect_true(cmd1.getPrivateOutput().empty());
@@ -139,7 +147,7 @@ context("Private Terminal Command Tests")
       expect_true(cmd1.getPrivateOutput().empty());
       expect_false(cmd1.hasCaptured());
 
-      PrivateCommand cmd2(kCommand, kPrivate, kUser, kTimeout, kNotOncePerUserEnter);
+      PrivateCommand cmd2(kCommand, kPrivate, kUser, kTimeout, kPostTimeout, kNotOncePerUserEnter);
 
       expect_false(cmd2.hasCaptured());
       expect_true(cmd2.getPrivateOutput().empty());
@@ -150,7 +158,7 @@ context("Private Terminal Command Tests")
 
    test_that("no capture if terminal has child process")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kOncePerUserEnter);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kPostTimeout, kOncePerUserEnter);
 
       expect_false(cmd.onTryCapture(ops, kHasChildProcess));
       expect_false(cmd.hasCaptured());
@@ -159,7 +167,7 @@ context("Private Terminal Command Tests")
 
    test_that("(NotEnter) no capture if terminal has child process")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kNotOncePerUserEnter);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kPostTimeout, kNotOncePerUserEnter);
 
       expect_false(cmd.onTryCapture(ops, kHasChildProcess));
       expect_false(cmd.hasCaptured());
@@ -168,7 +176,7 @@ context("Private Terminal Command Tests")
 
    test_that("no capture if user hasn't hit <enter>")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kOncePerUserEnter);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kPostTimeout, kOncePerUserEnter);
 
       cmd.userInput("partial user command");
       expect_false(cmd.onTryCapture(ops, kNoChildProcess));
@@ -184,7 +192,7 @@ context("Private Terminal Command Tests")
 
    test_that("(NotEnter) no capture if user has entered a command but there is a child process")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kNotOncePerUserEnter);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kPostTimeout, kNotOncePerUserEnter);
 
       cmd.userInput("user command\n");
       expect_false(cmd.onTryCapture(ops, kHasChildProcess));
@@ -200,7 +208,7 @@ context("Private Terminal Command Tests")
 
    test_that("(NotEnter) command not issued after user command, no child process, but too soon")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kNotOncePerUserEnter);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kPostTimeout, kNotOncePerUserEnter);
 
       cmd.userInput("user command\n");
       expect_false(cmd.onTryCapture(ops, kNoChildProcess));
@@ -208,7 +216,7 @@ context("Private Terminal Command Tests")
 
    test_that("command issued if user has entered a command and post-user-command timeout expired")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kOncePerUserEnter);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kPostTimeout, kOncePerUserEnter);
 
       cmd.userInput("user command\n");
       boost::this_thread::sleep(milliseconds(kUser * 2));
@@ -223,7 +231,7 @@ context("Private Terminal Command Tests")
 
    test_that("(NotEnter) command issued, user has entered a command, post-user-cmd timeout expired")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kNotOncePerUserEnter);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kPostTimeout, kNotOncePerUserEnter);
 
       cmd.userInput("user command\n");
       boost::this_thread::sleep(milliseconds(kUser * 2));
@@ -237,7 +245,7 @@ context("Private Terminal Command Tests")
 
    test_that("(NotEnter) command issued immediately w/o user command entered")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kNotOncePerUserEnter);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kPostTimeout, kNotOncePerUserEnter);
 
       expect_true(cmd.onTryCapture(ops, kNoChildProcess));
       expect_true(ops.writes.size() == 1);
@@ -246,7 +254,7 @@ context("Private Terminal Command Tests")
 
    test_that("command not issued if user hasn't entered a new command since last private comand")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kOncePerUserEnter);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kPostTimeout, kOncePerUserEnter);
 
       cmd.userInput("user command one\n");
       boost::this_thread::sleep(milliseconds(kUser * 2));
@@ -261,7 +269,7 @@ context("Private Terminal Command Tests")
 
    test_that("(NotEnter) command reissued if private command delay has expired")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kNotOncePerUserEnter);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kPostTimeout, kNotOncePerUserEnter);
 
       expect_true(cmd.onTryCapture(ops, kNoChildProcess));
       cmd.terminateCapture();
@@ -273,7 +281,7 @@ context("Private Terminal Command Tests")
 
    test_that("command not issued if private command interval hasn't expired")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kOncePerUserEnter);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kPostTimeout, kOncePerUserEnter);
 
       cmd.userInput("user command one\n");
       boost::this_thread::sleep(milliseconds(kUser * 2));
@@ -287,7 +295,7 @@ context("Private Terminal Command Tests")
 
    test_that("(NotEnter) command not issued if private command interval hasn't expired")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kNotOncePerUserEnter);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kPostTimeout, kNotOncePerUserEnter);
 
       cmd.userInput("user command one\n");
       boost::this_thread::sleep(milliseconds(kUser * 2));
@@ -301,7 +309,7 @@ context("Private Terminal Command Tests")
 
    test_that("command issued if private command interval has expired")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kOncePerUserEnter);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kPostTimeout, kOncePerUserEnter);
 
       cmd.userInput("user command one\n");
       boost::this_thread::sleep(milliseconds(kUser * 2));
@@ -316,7 +324,7 @@ context("Private Terminal Command Tests")
 
    test_that("(NotEnter) command issued if private command interval has expired")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kNotOncePerUserEnter);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kPostTimeout, kNotOncePerUserEnter);
 
       cmd.userInput("user command one\n");
       boost::this_thread::sleep(milliseconds(kUser * 2));
@@ -331,7 +339,7 @@ context("Private Terminal Command Tests")
 
    test_that("private command terminated if taking too long")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kOncePerUserEnter);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kPostTimeout, kOncePerUserEnter);
 
       cmd.userInput("user command\n");
       boost::this_thread::sleep(milliseconds(kUser * 2));
@@ -346,7 +354,7 @@ context("Private Terminal Command Tests")
 
    test_that("(NotEnter) private command terminated if taking too long")
    {
-      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kNotOncePerUserEnter);
+      PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kPostTimeout, kNotOncePerUserEnter);
 
       expect_true(cmd.onTryCapture(ops, kNoChildProcess));
 


### PR DESCRIPTION
Typical repro is to hold down enter key a few seconds, then hit Ctrl+L, then a couple more enters. Wait a few seconds, then you'd get another prompt. Sometimes this would continue every few seconds, sometimes just once.

Easier to repro on Mac with newer bash (e.g. brew install bash) than the standard Mac one but I did repro with the stock bash as well.

Problem is that private command capture stops suppressing output when it gets its expected EOM marker, and if the new prompt triggered by the hidden command didn't arrive in same chunk of output as the EOM, then it's going to be displayed. Something about the way newer bash does its I/O seems to make this very common. If timing is just right, then that new prompt could trigger another round of environment capture, and so on.

Fixed by adding a small delay after seeing the EOM during which output is still suppressed. This catches the extra prompt in my testing. Also tweaked some of the other timeouts to make the environment capture command wait a bit longer after user input before running.

An alternative approach would be to start interpreting the PS1 string to try and recognize prompts, but that's not trivial especially with the dynamic nature of prompts.