### PR TITLE
Tweak terminal shortcuts

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -602,7 +602,7 @@ well as menu structures (for main menu and popup menus).
          
          <shortcut refid="activateSource" value="Ctrl+1"/>
          <shortcut refid="activateConsole" value="Ctrl+2"/>
-         <shortcut refid="activateTerminal" value="Ctrl+Alt+2"/>
+         <shortcut refid="activateTerminal" value="Alt+Shift+T"/>
          <shortcut refid="activateHelp" value="Ctrl+3"/>
          <shortcut refid="activateHistory" value="Ctrl+4"/>
          <shortcut refid="activateFiles" value="Ctrl+5"/>
@@ -736,8 +736,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut value="Cmd+Up" title="Popup Command History"/>
       </shortcutgroup>
       <shortcutgroup name="Terminal">
-         <shortcut refid="newTerminal" value="Alt+Shift+T"/>
-         <shortcut refid="renameTerminal" value="Alt+Shift+R"/>
+         <shortcut refid="newTerminal" value="Alt+Shift+R"/>
          <shortcut refid="clearTerminalScrollbackBuffer" value="Ctrl+Shift+L"/>
          <shortcut refid="previousTerminal" value="Ctrl+Alt+F11"/>
          <shortcut refid="nextTerminal" value="Ctrl+Alt+F12"/>


### PR DESCRIPTION
The shortcut `Ctrl+Alt+2` for `View/Move focus to terminal` prevented users from entering the "@" character on Italian keyboards.

Changed `Move focus to terminal` to use `Alt+Shift+T`, formerly the shortcut for `New Terminal`. 

Guessing `Move focus to terminal` is the most commonly desired operation given it shows the terminal pane, creates a terminal if there isn't one, and gives it focus.

`New Terminal` now uses `Alt+Shift+R`, which was the shortcut for `Rename Terminal`, which now doesn't have a shortcut. Assuming `Alt+Shift+T` is the most memorable terminal shortcut, better it doesn't cause users to create a bunch of terminals when they just want to keep using the same one.

At least this gives some symmetry to shortcuts for New Terminal / Move Focus to terminal, and Rename Terminal seems like a rarely used command.
