### PR TITLE
set build_number as patch version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,14 +7,17 @@ properties([
                               daysToKeepStr: '',
                               numToKeepStr: '100')),
     parameters([string(name: 'RSTUDIO_VERSION_MAJOR', defaultValue: '1', description: 'RStudio Major Version'),
-                string(name: 'RSTUDIO_VERSION_MINOR', defaultValue: '1', description: 'RStudio Minor Version'),
-                string(name: 'RSTUDIO_VERSION_PATCH', defaultValue: '0', description: 'RStudio Patch Version'),
+                string(name: 'RSTUDIO_VERSION_MINOR', defaultValue: '2', description: 'RStudio Minor Version'),
+                //string(name: 'RSTUDIO_VERSION_PATCH', defaultValue: '0', description: 'RStudio Patch Version'),
                 string(name: 'SLACK_CHANNEL', defaultValue: '#ide-builds', description: 'Slack channel to publish build message.'),
                 string(name: 'OS_FILTER', defaultValue: '', description: 'Pattern to limit builds by matching OS'),
                 string(name: 'ARCH_FILTER', defaultValue: '', description: 'Pattern to limit builds by matching ARCH'),
                 string(name: 'FLAVOR_FILTER', defaultValue: '', description: 'Pattern to limit builds by matching FLAVOR')
                 ])
 ])
+
+// inject the build number as patch version temporarily
+def RSTUDIO_VERSION_PATCH = env.BUILD_NUMBER
 
 def resolve_deps(type, arch, variant) {
   def linux_bin = (arch == 'i386') ? 'linux32' : '' // only required in centos-land.


### PR DESCRIPTION
this should allow multibranch pipelining (currently restricted to just the `v1.2` branch) to produce different build numbers