### PR TITLE
additional improvements to page viewer

### DIFF
--- a/src/cpp/desktop-mac/GwtCallbacks.mm
+++ b/src/cpp/desktop-mac/GwtCallbacks.mm
@@ -995,11 +995,6 @@ private:
 
 - (void) setViewerUrl: (NSString*) url
 {
-   // set it for myself (in case I am hosting the page_viewer)
-   WebViewController* webViewController = (WebViewController*)self;
-   [webViewController setViewerURL: url];
-
-   // set it for the main frame
    [[MainFrameController instance] setViewerURL: url];
 }
 

--- a/src/cpp/desktop-mac/GwtCallbacks.mm
+++ b/src/cpp/desktop-mac/GwtCallbacks.mm
@@ -995,6 +995,11 @@ private:
 
 - (void) setViewerUrl: (NSString*) url
 {
+   // set it for myself (in case I am hosting the page_viewer)
+   WebViewController* webViewController = (WebViewController*)self;
+   [webViewController setViewerURL: url];
+
+   // set it for the main frame
    [[MainFrameController instance] setViewerURL: url];
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
@@ -266,13 +266,13 @@ public class HTMLPreviewPanel extends ResizeComposite
       else
          publishButton_.setVisible(false);
       publishButtonSeparator_.setVisible(publishButton_.isVisible());
-      previewFrame_.navigate(url);
+      navigate(url);
    }
    
    @Override
    public void reload(String url)
    {
-      previewFrame_.navigate(url);
+      navigate(url);
    }
    
    @Override
@@ -295,6 +295,13 @@ public class HTMLPreviewPanel extends ResizeComposite
       findTextBox_.focus();
    }
 
+   private void navigate(String url)
+   {
+      if (Desktop.isDesktop())
+         Desktop.getFrame().setViewerUrl(url);
+      previewFrame_.navigate(url);
+   }
+   
    private final LayoutPanel layoutPanel_;
    private final AnchorableFrame previewFrame_;
    private final Toolbar toolbar_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPresenter.java
@@ -402,10 +402,12 @@ public class ViewerPresenter extends BasePresenter
    
    private void updateZoomWindow(String url)
    {
-      if (Desktop.isDesktop())
+      if (Desktop.isDesktop()) {
+         Desktop.getFrame().setViewerUrl(url);
          Desktop.getFrame().reloadViewerZoomWindow(url);
-      else if ((zoomWindow_ != null) && !zoomWindow_.isClosed())
+      } else if ((zoomWindow_ != null) && !zoomWindow_.isClosed()) {
          zoomWindow_.setLocationHref(url);
+      }
    }
    
    private void stop(boolean interruptR)


### PR DESCRIPTION
NOTE: not yet ready for merge -- Requires some additional testing on (3) as described below.

1) Go back to always creating a new temp file for html files (previously we used an existing html file in place so long as it was in the session temp dir). We do ths so that htmlwidgets that elect into the page_viewer can always be published (they write their html as non self-contained so rely on the viewer to make it self-contained.

2) Return the path to the viewer html file in the session temp directory from the page_viewer function. This accomplshes the same objective as the "in place" behavior we removed in this commit: allowing the calling R code to know the path to the html file displayed in the viewer (so that it can write e.g. JSON files along side it that are polled by the main html page).

3) Set the "viewerUrl_" attribute of the desktop HTML container. As things currently stand the page viewer on Windows and Ubuntu can't view localhost URLs that have a distinct port b/c their URL is not set as a whitelisted viewer URL. This *should* remedy that problem.

Note that (3) above has not been tested (since I am running out of battery life and full rebuilds on all platforms will take me all the way down). I added the setViewerURL logic on Mac OS (even though it appears to not be necessary) for consistency. We can back that out if we think it has too much risk (especially given that it sets the viewer url on the current page controller whereas previously it didn't do that -- no idea why).