### PR TITLE
Emoji completion :tada: 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,7 +110,7 @@ try {
         def parallel_containers = [:]
         for (int i = 0; i < containers.size(); i++) {
             def index = i
-            parallel_containers["${containers[i].os}-${containers[i].arch}-${containers[i].flavor}"] = {
+            parallel_containers["${containers[i].os}-${containers[i].arch}-${containers[i].flavor}-${containers[i].variant}"] = {
                 def current_container = containers[index]
                 node('ide') {
                     stage('prepare ws/container'){

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -576,7 +576,7 @@ assign(x = ".rs.acCompletionTypes",
       # the 'initialize()' method instead.
       if (.rs.isR6NewMethod(object))
          object <- .rs.getR6ClassGeneratorMethod(object, "initialize")
-      
+
       matchedCall <- .rs.matchCall(object, functionCall)
 
       # Try to figure out what function arguments are
@@ -1792,6 +1792,7 @@ assign(x = ".rs.acCompletionTypes",
                                                   documentId,
                                                   line)
 {
+
    # Ensure UTF-8 encoding, as that's the encoding set when passed down from
    # the client
    token <- .rs.setEncodingUnknownToUTF8(token)
@@ -1907,6 +1908,10 @@ assign(x = ".rs.acCompletionTypes",
          }
       }
    }
+
+   # emoji
+   if (.rs.acContextTypes$EMOJI %in% type)
+      return(.rs.getCompletionsEmoji(token))
 
    # help
    if (.rs.acContextTypes$HELP %in% type)
@@ -2317,7 +2322,7 @@ assign(x = ".rs.acCompletionTypes",
                                                                     string,
                                                                     cursorPos)
 {
-   result <- tryCatch(
+  result <- tryCatch(
 
       expr = {
          parsed <- parse(text = string)[[1]]
@@ -2481,7 +2486,13 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("getCompletionsEmoji", function(token)
 {
-    emo::ji_completion(token)
+  completions <- .rs.makeCompletions(
+     token = token,
+     results = emo::ji_completion(token),
+     quote = FALSE,
+     type = .rs.acCompletionTypes$STRING,
+     overrideInsertParens = TRUE
+  )
 })
 
 ## NOTE: This is a modified version of 'matchAvailableTopics'

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -65,6 +65,7 @@ assign(x = ".rs.acCompletionTypes",
           KEYWORD     = 22,
           OPTION      = 23,
           DATASET     = 24,
+          EMOJI       = 25,
           CONTEXT     = 99
        )
 )
@@ -2486,12 +2487,16 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("getCompletionsEmoji", function(token)
 {
+  results <- emo::ji_completion(token)
+
   completions <- .rs.makeCompletions(
      token = token,
-     results = emo::ji_completion(token),
+     results = unname(results),
+     packages = names(results),
      quote = FALSE,
-     type = .rs.acCompletionTypes$STRING,
-     overrideInsertParens = TRUE
+     type = .rs.acCompletionTypes$EMOJI,
+     overrideInsertParens = TRUE,
+     excludeOtherCompletions = TRUE
   )
 })
 

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -113,6 +113,11 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("attemptRoxygenTagCompletion", function(token, line)
 {
+    # short circuit if this looks like emoji completion
+    if( grepl( "[:][a-zA-Z0-9_]+$", token ) ){
+        return(.rs.getCompletionsEmoji(token))
+    }
+
    emptyCompletions <- .rs.emptyCompletions(excludeOtherCompletions = TRUE)
 
    # fix up tokenization

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2487,7 +2487,7 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("getCompletionsEmoji", function(token)
 {
-  results <- emo::ji_completion(token)
+  results <- emo::ji_completion(sub("^[:]","", token))
 
   completions <- .rs.makeCompletions(
      token = token,

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2487,17 +2487,19 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("getCompletionsEmoji", function(token)
 {
-  results <- emo::ji_completion(sub("^[:]","", token))
+  tryCatch( {
+      results <- emo::ji_completion(sub("^[:]","", token))
+      .rs.makeCompletions(
+         token = token,
+         results = unname(results),
+         packages = names(results),
+         quote = FALSE,
+         type = .rs.acCompletionTypes$EMOJI,
+         overrideInsertParens = TRUE,
+         excludeOtherCompletions = TRUE
+      )
+  }, error = .rs.emptyCompletions() )
 
-  completions <- .rs.makeCompletions(
-     token = token,
-     results = unname(results),
-     packages = names(results),
-     quote = FALSE,
-     type = .rs.acCompletionTypes$EMOJI,
-     overrideInsertParens = TRUE,
-     excludeOtherCompletions = TRUE
-  )
 })
 
 ## NOTE: This is a modified version of 'matchAvailableTopics'

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -31,7 +31,8 @@ assign(x = ".rs.acContextTypes",
           ROXYGEN            = 10,
           HELP               = 11,
           ARGUMENT           = 12,
-          PACKAGE            = 13
+          PACKAGE            = 13,
+          EMOJI              = 14
        )
 )
 
@@ -77,7 +78,7 @@ assign(x = ".rs.acCompletionTypes",
       .rs.acCompletionTypes$R5_CLASS
    else if (inherits(object, "refClass"))
       .rs.acCompletionTypes$R5_OBJECT
-   
+
    # S4
    else if (isS4(object))
    {
@@ -89,7 +90,7 @@ assign(x = ".rs.acCompletionTypes",
       else
          .rs.acCompletionTypes$S4_OBJECT
    }
-   
+
    # Base
    else if (is.function(object))
       .rs.acCompletionTypes$FUNCTION
@@ -112,27 +113,27 @@ assign(x = ".rs.acCompletionTypes",
 .rs.addFunction("attemptRoxygenTagCompletion", function(token, line)
 {
    emptyCompletions <- .rs.emptyCompletions(excludeOtherCompletions = TRUE)
-   
+
    # fix up tokenization
    if (grepl("^\\s*#+'\\s*$", line) && token == "'")
       token <- ""
-   
+
    # draw from 'man-roxygen' folder for '@template' completions
    if (grepl("^\\s*#+'\\s*@template\\s+", line))
    {
       projDir <- .rs.getProjectDirectory()
       if (is.null(projDir))
          return(emptyCompletions)
-      
+
       manRoxygen <- file.path(projDir, "man-roxygen")
       if (!utils::file_test("-d", manRoxygen))
          return(emptyCompletions)
-      
+
       completions <- .rs.getCompletionsFile(token, path = manRoxygen, quote = FALSE)
       completions$results <- sub("[.][rR]$", "", completions$results)
       return(completions)
    }
-   
+
    # allow the token to be empty only if we're attempting completions
    # at the start of the line
    if (token == "")
@@ -147,9 +148,9 @@ assign(x = ".rs.acCompletionTypes",
       if (!match)
          return(emptyCompletions)
    }
-   
+
    tag <- sub(".*(?=@)", '', token, perl = TRUE)
-   
+
    # All known Roxygen2 tags, in alphabetical order
    tags <- c(
       "@aliases ",
@@ -200,9 +201,9 @@ assign(x = ".rs.acCompletionTypes",
       "@usage ",
       "@useDynLib "
    )
-   
+
    matchingTags <- grep(paste("^", tag, sep = ""), tags, value = TRUE)
-   
+
    .rs.makeCompletions(tag,
                        matchingTags,
                        type = .rs.acCompletionTypes$ROXYGEN,
@@ -220,10 +221,10 @@ assign(x = ".rs.acCompletionTypes",
                           type = .rs.acCompletionTypes$VIGNETTE,
                           excludeOtherCompletions = TRUE)
    }
-   
+
    if (!is.null(vignettes <- .rs.get("vignettes")))
       return(doGetCompletionsVignettes(token, vignettes$results[, "Item"]))
-   
+
    vignettes <- vignette()
    .rs.assign("vignettes", vignettes)
    doGetCompletionsVignettes(token, vignettes$results[, "Item"])
@@ -235,13 +236,13 @@ assign(x = ".rs.acCompletionTypes",
                                                directoriesOnly = FALSE)
 {
    path <- suppressWarnings(.rs.normalizePath(path, winslash = "/"))
-   
+
    ## Separate the token into a 'directory' prefix, and a 'name' prefix. We need
    ## to prefix the prefix as we will need to prepend it onto completions for
    ## non-relative completions.
    tokenPrefix <- ""
    tokenName <- token
-   
+
    tokenSlashIndices <- c(gregexpr("[/\\\\]", token, perl = TRUE)[[1]])
    if (!identical(tokenSlashIndices, -1L))
    {
@@ -249,9 +250,9 @@ assign(x = ".rs.acCompletionTypes",
       tokenPrefix <- substring(token, 1, maxIndex)
       tokenName <- substring(token, maxIndex + 1)
    }
-   
+
    ## Figure out the directory to list files in.
-   
+
    # The token itself might dictate the directory we want to search in, e.g.
    # if we see `~`, `/`, `[a-zA-Z]:`. In those cases, override the path argument.
    regex <- "^[~/\\\\]|^[a-zA-Z]:[/\\\\]"
@@ -260,7 +261,7 @@ assign(x = ".rs.acCompletionTypes",
       directory <- path <-
          suppressWarnings(normalizePath(dirname(paste(token, ".", sep = ""))))
    }
-   
+
    # Check to see if there are delimiters in the token. If there are, but it's
    # a relative path, we need to further qualify the directory.
    else
@@ -276,29 +277,29 @@ assign(x = ".rs.acCompletionTypes",
          directory <- path
       }
    }
-   
+
    # If we're trying to get completions from a directory that doesn't
    # exist, give up
    if (!file.exists(directory))
       return(.rs.emptyCompletions(excludeOtherCompletions = TRUE))
-   
+
    # When checking if the path lies within the project directory,
    # we just do a substring check -- so make sure that the path
    # is actually within the project directory (append a trailing
    # slash to the directory we check)
    projDirEndsWithSlash <-
       paste(gsub("/*$", "", .rs.getProjectDirectory()), "/", sep = "")
-   
+
    directory <-
       paste(gsub("/*$", "", directory), "/", sep = "")
-   
+
    # If the directory lies within a folder that we're monitoring
    # for indexing, use that.
    cacheable <- TRUE
    usingFileMonitor <-
       .rs.hasFileMonitor() &&
       .rs.startsWith(directory, projDirEndsWithSlash)
-   
+
    absolutePaths <- character()
    if (usingFileMonitor)
    {
@@ -306,11 +307,11 @@ assign(x = ".rs.acCompletionTypes",
          index <- .rs.getIndexedFolders(tokenName, directory)
       else
          index <- .rs.getIndexedFilesAndFolders(tokenName, directory)
-      
+
       cacheable <- !index$more_available
       absolutePaths <- index$paths
    }
-   
+
    # Merge in completions from the current directory.
    dirPaths <- .rs.listFilesFuzzy(directory, tokenName)
    if (directoriesOnly)
@@ -319,11 +320,11 @@ assign(x = ".rs.acCompletionTypes",
       dirPaths <- dirPaths[dirInfo$isdir]
    }
    absolutePaths <- sort(union(absolutePaths, dirPaths))
-   
+
    ## Bail out early if we didn't get any completions.
    if (!length(absolutePaths))
       return(.rs.emptyCompletions(excludeOtherCompletions = TRUE))
-   
+
    ## Because the completions returned will replace the whole token,
    ## we need to be careful in how we construct the return result. In particular,
    ## we need to preserve the way the directory has been specified.
@@ -337,9 +338,9 @@ assign(x = ".rs.acCompletionTypes",
       nchar(directory) + 1L
    else
       nchar(directory) + 2L
-   
+
    relativePaths <- substring(absolutePaths, offset)
-   
+
    ## Order completions starting with alpha-numeric entries first if the
    ## token name is blank
    if (!nzchar(tokenName))
@@ -349,20 +350,20 @@ assign(x = ".rs.acCompletionTypes",
          which(startsWithAlnum),
          which(!startsWithAlnum)
       )
-      
+
       relativePaths <- relativePaths[order]
       absolutePaths <- absolutePaths[order]
    }
-   
+
    paths <- paste(tokenPrefix, relativePaths, sep = "")
-   
+
    # If we were able to use the file index and only wanted directories, we know that
    # all completions must be directories
    if (usingFileMonitor && directoriesOnly)
    {
       type <- rep.int(.rs.acCompletionTypes$DIRECTORY, length(absolutePaths))
    }
-   
+
    # Otherwise, query the file info for the set of completions we're using
    else
    {
@@ -370,14 +371,14 @@ assign(x = ".rs.acCompletionTypes",
       type <- ifelse(isDir,
                      .rs.acCompletionTypes$DIRECTORY,
                      .rs.acCompletionTypes$FILE)
-      
+
       if (directoriesOnly)
       {
          paths <- paths[isDir]
          type <- type[isDir]
       }
    }
-   
+
    # Order completions by depth
    matches <- gregexpr("/", paths, fixed = TRUE)
    depth <- vapply(matches, function(match) {
@@ -386,11 +387,11 @@ assign(x = ".rs.acCompletionTypes",
       else
          length(match)
    }, numeric(1))
-   
+
    idx <- order(depth)
    paths <- paths[idx]
    type <- type[idx]
-   
+
    .rs.makeCompletions(token = token,
                        results = paths,
                        type = type,
@@ -407,7 +408,7 @@ assign(x = ".rs.acCompletionTypes",
                                            envir)
 {
    tryCatch({
-      
+
       if (length(functionCall) > 1 && .rs.isS3Generic(object))
       {
          objectForDispatch <- .rs.getAnywhere(matchedCall[[2]], envir)
@@ -422,12 +423,12 @@ assign(x = ".rs.acCompletionTypes",
                list(functionName = functionName,
                     class = class)
             )
-            
+
             method <- tryCatch(
                eval(call, envir = envir),
                error = function(e) NULL
             )
-            
+
             if (!is.null(method))
             {
                formals <- .rs.getFunctionArgumentNames(method)
@@ -444,15 +445,15 @@ assign(x = ".rs.acCompletionTypes",
          formals <- .rs.getFunctionArgumentNames(object)
          methods <- rep.int(functionName, length(formals))
       }
-      
+
       keep <- .rs.fuzzyMatches(formals, token) &
          !(formals %in% names(functionCall)) ## leave out formals already in call
-      
+
       return(list(
          formals = formals[keep],
          methods = methods[keep]
       ))
-      
+
    }, error = function(e) NULL
    )
 })
@@ -467,42 +468,42 @@ assign(x = ".rs.acCompletionTypes",
    {
       if (i > length(call))
          break
-      
+
       if (length(call[[i]]) == 1 && is.symbol(call[[i]]) && as.character(call[[i]]) == "...")
          call <- call[-i]
       else
          i <- i + 1
    }
-   
+
    tryCatch(match.call(func, call), error = function(e) call)
 })
 
 .rs.addFunction("getCompletionsInstallPackages", function(token)
 {
    contrib.url <- contrib.url(getOption("repos"), getOption("pkgType"))
-   
+
    packages <- Reduce(union, lapply(contrib.url, function(url) {
-      
+
       # Try to get a package list from the cache
       result <- .rs.getCachedAvailablePackages(url)
-      
+
       # If it's null, there were no packages available
       if (is.null(result))
          .rs.downloadAvailablePackages(url)
-      
+
       # Try again
       result <- .rs.getCachedAvailablePackages(url)
-      
+
       # And return
       result
    }))
-   
+
    .rs.makeCompletions(token = token,
                        results = .rs.selectFuzzyMatches(packages, token),
                        quote = TRUE,
                        type = .rs.acCompletionTypes$PACKAGE,
                        excludeOtherCompletions = TRUE)
-   
+
 })
 
 .rs.addFunction("resolveObjectFromFunctionCall", function(functionCall,
@@ -519,7 +520,7 @@ assign(x = ".rs.acCompletionTypes",
    {
       namespaceString <- .rs.stripSurrounding(splat[[1]])
       functionString <- string <- .rs.stripSurrounding(splat[[2]])
-      
+
       if (namespaceString %in% loadedNamespaces())
       {
          object <- tryCatch(
@@ -529,7 +530,7 @@ assign(x = ".rs.acCompletionTypes",
          )
       }
    }
-   
+
    # Special casing for variants of read.table which hide additional
    # arguments in ...
    if ("utils" %in% loadedNamespaces())
@@ -540,22 +541,22 @@ assign(x = ".rs.acCompletionTypes",
          utils::read.delim,
          utils::read.delim2
       )
-      
+
       if (any(sapply(readers, identical, object)))
          object <- utils::read.table
-      
+
       # Similarily for write.csv
       writers <- list(
          utils::write.csv,
          utils::write.csv2
       )
-      
+
       if (any(sapply(writers, identical, object)))
          object <- utils::write.table
    }
-   
+
    object
-   
+
 })
 
 .rs.addFunction("getCompletionsFunction", function(token,
@@ -567,7 +568,7 @@ assign(x = ".rs.acCompletionTypes",
 {
    result <- .rs.emptyCompletions()
    object <- .rs.resolveObjectFromFunctionCall(functionCall, envir)
-   
+
    if (!is.null(object) && is.function(object))
    {
       # If we're attempting to get completions for an R6 'new()' function,
@@ -577,13 +578,13 @@ assign(x = ".rs.acCompletionTypes",
          object <- .rs.getR6ClassGeneratorMethod(object, "initialize")
       
       matchedCall <- .rs.matchCall(object, functionCall)
-      
+
       # Try to figure out what function arguments are
       # eligible for completion. Note that, on success,
       # this should be an R list with character fields
       # 'formals' and (optionally) 'methods'.
       formals <- NULL
-      
+
       ## Special cases
       # We handle special cases for function argument
       # completions first.
@@ -593,19 +594,19 @@ assign(x = ".rs.acCompletionTypes",
       if (.rs.isKnitrObject(object))
       {
          ns <- asNamespace("knitr")
-         
+
          # Get the knitr getters and setters for various
          # options
          tryGetKnitrGetter <- function(name, ns = asNamespace("knitr"))
             tryCatch(get(name, envir = ns)$get, error = function(e) NULL)
-         
+
          tryGetKnitrSetter <- function(name, ns = asNamespace("knitr"))
             tryCatch(get(name, envir = ns)$set, error = function(e) NULL)
-         
+
          tryGet <- function(name, ns = asNamespace("knitr"))
             list(getter = tryGetKnitrGetter(name, ns),
                  setter = tryGetKnitrSetter(name, ns))
-         
+
          knitrOpts <- list(
             tryGet("opts_chunk", ns),
             tryGet("opts_knit", ns),
@@ -614,7 +615,7 @@ assign(x = ".rs.acCompletionTypes",
             tryGet("knit_hooks", ns),
             tryGet("knit_theme", ns)
          )
-         
+
          for (opt in knitrOpts)
          {
             # If we're identical to the getter, short-circuit
@@ -625,13 +626,13 @@ assign(x = ".rs.acCompletionTypes",
                   names(opt$getter()),
                   token
                )
-               
+
                return(.rs.makeCompletions(token = token,
                                           results = results,
                                           type = .rs.acCompletionTypes$STRING,
                                           quote = TRUE))
             }
-            
+
             # If we're identical to the setter, get the
             # names from the getter as named arguments to use
             if (identical(object, opt$setter))
@@ -640,9 +641,9 @@ assign(x = ".rs.acCompletionTypes",
                break
             }
          }
-         
+
       }
-      
+
       # Resolve formals from a classGeneratorFunction based
       # on its slots
       if (is.null(formals) &&
@@ -658,7 +659,7 @@ assign(x = ".rs.acCompletionTypes",
             )
          })
       }
-      
+
       # Resolve formals from the function itself
       if (is.null(formals))
       {
@@ -669,10 +670,10 @@ assign(x = ".rs.acCompletionTypes",
                                        matchedCall,
                                        envir)
       }
-      
+
       if (length(formals$formals))
          formals$formals <- paste(formals$formals, "= ")
-      
+
       # If we're getting completions for the `base::c` function, just discard
       # the argument completions, since other context completions are more
       # likely and more useful
@@ -682,7 +683,7 @@ assign(x = ".rs.acCompletionTypes",
          formals <- list(formals = character(),
                          methods = character())
       }
-      
+
       # Get the current argument -- we can resolve this based on
       # 'numCommas' and the number of named formals. The idea is, e.g.
       # in a function call
@@ -693,10 +694,10 @@ assign(x = ".rs.acCompletionTypes",
       # by looking at which arguments have yet to be matched, and using the
       # first argument in that list.
       activeArg <- .rs.getActiveArgument(object, matchedCall)
-      
+
       if (!length(activeArg) || is.na(activeArg))
          activeArg <- ""
-      
+
       # Special casing for 'group_by' from dplyr
       # TODO: Should we just allow for any function named 'group_by', ie,
       # enable this even if 'dplyr' isn't loaded?
@@ -710,14 +711,14 @@ assign(x = ".rs.acCompletionTypes",
             .names <- .rs.getNames(.data)
             if (length(matchedCall) >= 3)
                .names <- setdiff(.names, as.character(matchedCall)[3:length(matchedCall)])
-            
+
             return(.rs.makeCompletions(token = token,
                                        results = .names,
                                        quote = FALSE,
                                        type = .rs.acCompletionTypes$CONTEXT))
          }
       }
-      
+
       # Get completions for the current active argument
       argCompletions <- .rs.getCompletionsArgument(
          token = token,
@@ -725,7 +726,7 @@ assign(x = ".rs.acCompletionTypes",
          functionCall = functionCall,
          envir = envir
       )
-      
+
       # If the active argument was 'formula' and we were able
       # to retrieve completions, it is unlikely that we also
       # want search path completions or otherwise -- just return
@@ -736,12 +737,12 @@ assign(x = ".rs.acCompletionTypes",
       {
          return(argCompletions)
       }
-      
+
       fguess <- if (length(formals$methods))
          formals$methods[[1]]
       else
          ""
-      
+
       result <- .rs.appendCompletions(
          argCompletions,
          .rs.makeCompletions(
@@ -754,7 +755,7 @@ assign(x = ".rs.acCompletionTypes",
          )
       )
    }
-   
+
    if (discardFirst)
    {
       result$results <- tail(result$results, length(result$results) - 1)
@@ -762,9 +763,9 @@ assign(x = ".rs.acCompletionTypes",
       result$quote <- tail(result$quote, length(result$quote) - 1)
       result$type <- tail(result$type, length(result$type) - 1)
    }
-   
+
    result
-   
+
 })
 
 .rs.addFunction("getSourceIndexCompletions", function(token)
@@ -775,7 +776,7 @@ assign(x = ".rs.acCompletionTypes",
 .rs.addFunction("getCompletionsNamespace", function(token, string, exportsOnly, envir)
 {
    result <- .rs.emptyCompletions(excludeOtherCompletions = TRUE)
-   
+
    if (!(string %in% loadedNamespaces()))
    {
       tryCatch(
@@ -783,7 +784,7 @@ assign(x = ".rs.acCompletionTypes",
          error = function(e) NULL
       )
    }
-   
+
    if (string %in% loadedNamespaces())
    {
       namespace <- asNamespace(string)
@@ -799,10 +800,10 @@ assign(x = ".rs.acCompletionTypes",
          arguments[["all.names"]] <- TRUE
          if ("sorted" %in% names(formals(objects)))
             arguments[["sorted"]] <- FALSE
-         
+
          do.call(objects, arguments)
       }
-      
+
       # For `::`, we also want to grab items in the 'lazydata' environment
       # within the namespace.
       lazydata <- new.env(parent = emptyenv())
@@ -816,11 +817,11 @@ assign(x = ".rs.acCompletionTypes",
             dataNames <- objects(lazydata, all.names = TRUE)
          }
       }
-      
+
       # Filter our results
       objectNames <- .rs.selectFuzzyMatches(objectNames, token)
       dataNames   <- .rs.selectFuzzyMatches(dataNames, token)
-      
+
       # Collect the object types
       objectTypes <- vapply(
          mget(objectNames, envir = namespace, inherits = TRUE),
@@ -828,10 +829,10 @@ assign(x = ".rs.acCompletionTypes",
          USE.NAMES = FALSE,
          .rs.getCompletionType
       )
-      
+
       # Let 'lazydata' be lazy -- don't force evaluation.
       dataTypes <- rep(.rs.acCompletionTypes$DATAFRAME, length(dataNames))
-      
+
       # Construct a data.frame to hold our results (because we'll
       # need to re-sort our items)
       df <- data.frame(
@@ -839,14 +840,14 @@ assign(x = ".rs.acCompletionTypes",
          types = c(objectTypes, dataTypes),
          stringsAsFactors = FALSE
       )
-      
+
       # Sort by 'names'
       df <- df[order(df$names), ]
-      
+
       # Construct the completion result
       completions <- df$names
       type <- df$types
-      
+
       result <- .rs.makeCompletions(
          token = token,
          results = completions,
@@ -856,9 +857,9 @@ assign(x = ".rs.acCompletionTypes",
          excludeOtherCompletions = TRUE
       )
    }
-   
+
    result
-   
+
 })
 
 
@@ -924,41 +925,41 @@ assign(x = ".rs.acCompletionTypes",
 {
    if (is.null(results))
       results <- character()
-   
+
    # Ensure other 'vector' completions are of the same length as 'results'
    n        <- length(results)
    packages <- .rs.formCompletionVector(packages, "", n)
    quote    <- .rs.formCompletionVector(quote, FALSE, n)
    type     <- .rs.formCompletionVector(type, .rs.acCompletionTypes$UNKNOWN, n)
-   
+
    # Favor completions starting with a letter
    if (orderStartsWithAlnumFirst)
    {
       startsWithLetter <- grepl("^[a-zA-Z0-9]", results, perl = TRUE)
-      
+
       first <- which(startsWithLetter)
       last  <- which(!startsWithLetter)
       order <- c(first, last)
-      
+
       results  <- results[order]
       packages <- packages[order]
       quote    <- quote[order]
       type     <- type[order]
    }
-   
+
    # Avoid generating too many completions
    limit <- 2000
    if (length(results) > limit)
    {
       cacheable <- FALSE
       idx <- seq_len(limit)
-      
+
       results  <- results[idx]
       packages <- packages[idx]
       quote    <- quote[idx]
       type     <- type[idx]
    }
-   
+
    list(token = token,
         results = results,
         packages = packages,
@@ -975,7 +976,7 @@ assign(x = ".rs.acCompletionTypes",
 {
    for (name in c("results", "packages", "quote", "type"))
       completions[[name]] <- completions[[name]][indices]
-   
+
    completions
 })
 
@@ -983,36 +984,36 @@ assign(x = ".rs.acCompletionTypes",
 {
    for (name in c("results", "packages", "quote", "type"))
       old[[name]] <- c(old[[name]], new[[name]])
-   
+
    # resolve duplicates -- a completion is duplicated if its result
    # and package are identical (if 'type' or 'quote' differs, it's probably a bug?)
    drop <- intersect(
       which(duplicated(old$results)),
       which(duplicated(old$packages))
    )
-   
+
    if (length(drop))
    {
       for (name in c("results", "packages", "quote", "type"))
          old[[name]] <- old[[name]][-c(drop)]
    }
-   
+
    if (length(new$fguess) && new$fguess != "")
       old$fguess <- new$fguess
-   
+
    if (length(new$excludeOtherCompletions) && new$excludeOtherCompletions)
       old$excludeOtherCompletions <- new$excludeOtherCompletions
-   
+
    if (length(new$overrideInsertParens) && new$overrideInsertParens)
       old$overrideInsertParens <- new$overrideInsertParens
-   
+
    # If one completion states we are not cacheable, that setting is 'sticky'
    if (length(new$cacheable) && !new$cacheable)
       old$cacheable <- new$cacheable
-   
+
    if (length(new$helpHandler))
       old$helpHandler <- new$helpHandler
-   
+
    old
 })
 
@@ -1021,11 +1022,11 @@ assign(x = ".rs.acCompletionTypes",
                                             shortestFirst = FALSE)
 {
    scores <- .rs.scoreMatches(completions$results, token)
-   
+
    # Put package completions at the end
    idx <- completions$type == .rs.acCompletionTypes$PACKAGE
    scores[idx] <- scores[idx] + 10
-   
+
    # Protect against NULL / otherwise invalid scores.
    # TODO: figure out what, upstream, might cause this
    if (length(scores))
@@ -1036,7 +1037,7 @@ assign(x = ".rs.acCompletionTypes",
          order(scores)
       completions <- .rs.subsetCompletions(completions, order)
    }
-   
+
    completions
 })
 
@@ -1051,7 +1052,7 @@ assign(x = ".rs.acCompletionTypes",
          string
       else
          substring(string, 1L, bracketIdx - 1L)
-      
+
       object <- .rs.getAnywhere(objectName, envir = envir)
       if (inherits(object, "data.table"))
       {
@@ -1067,39 +1068,39 @@ assign(x = ".rs.acCompletionTypes",
       }
    }, error = function(e) NULL
    )
-   
+
 })
 
 .rs.addFunction("blackListEvaluation", function(token, string, functionCall, envir)
 {
    if (!is.null(result <- .rs.blackListEvaluationDataTable(token, string, functionCall, envir)))
       return(result)
-   
+
    NULL
-   
+
 })
 
 ## NOTE: for '@' as well (set in the 'isAt' parameter)
 .rs.addFunction("getCompletionsDollar", function(token, string, functionCall, envir, isAt)
 {
    result <- .rs.emptyCompletions(excludeOtherCompletions = TRUE)
-   
+
    ## Blacklist certain evaluations
    if (!is.null(blacklist <- .rs.blackListEvaluation(token, string, functionCall, envir)))
    {
       blacklist$excludeOtherCompletions <- .rs.scalar(TRUE)
       return(blacklist)
    }
-   
+
    object <- .rs.getAnywhere(string, envir)
-   
+
    if (!is.null(object))
    {
       allNames <- character()
       names <- character()
       type <- numeric()
       helpHandler <- NULL
-      
+
       if (isAt)
       {
          if (isS4(object))
@@ -1107,7 +1108,7 @@ assign(x = ".rs.acCompletionTypes",
             tryCatch({
                allNames <- .slotNames(object)
                names <- .rs.selectFuzzyMatches(allNames, token)
-               
+
                # NOTE: Getting the types forces evaluation; we avoid that if
                # there are too many names to evaluate.
                if (length(names) > 2E2)
@@ -1135,7 +1136,7 @@ assign(x = ".rs.acCompletionTypes",
          if (is.function(dollarNamesMethod))
          {
             allNames <- dollarNamesMethod(object)
-            
+
             # rJava will include closing parentheses as part of the
             # completion list -- clean those up and use them to infer
             # symbol types
@@ -1150,11 +1151,11 @@ assign(x = ".rs.acCompletionTypes",
                allNames <- gsub("[()]*$", "", allNames)
                attr(allNames, "types") <- types
             }
-            
+
             # check for custom helpHandler
             helpHandler <- attr(allNames, "helpHandler", exact = TRUE)
          }
-         
+
          # Reference class generators / objects
          else if (inherits(object, "refObjectGenerator"))
          {
@@ -1164,7 +1165,7 @@ assign(x = ".rs.acCompletionTypes",
                c("new", "help", "methods", "fields", "lock", "accessors")
             ))
          }
-         
+
          # Reference class objects
          else if (inherits(object, "refClass"))
          {
@@ -1174,19 +1175,19 @@ assign(x = ".rs.acCompletionTypes",
                   ls(refClassDef@fieldPrototypes, all.names = TRUE),
                   ls(refClassDef@refMethods, all.names = TRUE)
                )
-               
+
                # Place the 'less interesting' methods lower
                baseMethods <- c("callSuper", "copy", "export", "field",
                                 "getClass", "getRefClass", "import", "initFields",
                                 "show", "trace", "untrace", "usingMethods")
-               
+
                allNames <- c(
                   setdiff(allNames, baseMethods),
                   baseMethods
                )
             }, error = function(e) NULL))
          }
-         
+
          # Objects for which 'names' returns non-NULL. This branch is used
          # to provide completions for S4 objects, essentially adhering to
          # the `.DollarNames.default` behaviour. (It looks like if an S4
@@ -1196,21 +1197,21 @@ assign(x = ".rs.acCompletionTypes",
          {
             allNames <- .rs.getNames(object)
          }
-         
+
          # Environments (note that some S4 objects 'are' environments;
          # e.g. 'hash' objects from the 'hash' package)
          else if (is.environment(object))
          {
             allNames <- .rs.getNames(object)
          }
-         
+
          # Other objects
          else
          {
             # '$' operator is invalid for atomic vectors
             if (is.atomic(object))
                return(.rs.emptyCompletions(excludeOtherCompletions = TRUE))
-            
+
             # Don't allow S4 objects for dollar name resolution
             # They will need to have defined a .DollarNames method, which
             # should have been resolved previously
@@ -1219,14 +1220,14 @@ assign(x = ".rs.acCompletionTypes",
                allNames <- .rs.getNames(object)
             }
          }
-         
+
          names <- .rs.selectFuzzyMatches(allNames, token)
 
          # See if types were provided
          types <- attr(names, "types")
          if (is.integer(types) && length(types) == length(names))
             type <- types
-         
+
          # NOTE: Getting the types forces evaluation; we avoid that if
          # there are too many names to evaluate.
          else if (length(names) > 2E2)
@@ -1246,7 +1247,7 @@ assign(x = ".rs.acCompletionTypes",
             }
          }
       }
-      
+
       result <- .rs.makeCompletions(
          token = token,
          results = names,
@@ -1257,9 +1258,9 @@ assign(x = ".rs.acCompletionTypes",
          helpHandler = helpHandler
       )
    }
-   
+
    result
-   
+
 })
 
 .rs.addFunction("getCompletionsSingleBracket", function(token,
@@ -1269,23 +1270,23 @@ assign(x = ".rs.acCompletionTypes",
                                                         envir)
 {
    result <- .rs.emptyCompletions()
-   
+
    ## Blacklist certain evaluations
    if (!is.null(result <- .rs.blackListEvaluation(token, string, functionCall, envir)))
       return(result)
-   
+
    object <- .rs.getAnywhere(string, envir)
    if (is.null(object))
       return(result)
-   
+
    completions <- character()
-   
+
    # Get completions from dimension names for arrays
    if (is.array(object) && !is.null(dn <- dimnames(object)))
    {
       if (numCommas + 1 <= length(dn))
          completions <- dimnames(object)[[numCommas + 1]]
-      
+
       string <- if (numCommas == 0)
          paste("rownames(", string, ")", sep = "")
       else if (numCommas == 1)
@@ -1293,7 +1294,7 @@ assign(x = ".rs.acCompletionTypes",
       else
          paste("dimnames(", string, ")[", numCommas + 1, "]", sep = "")
    }
-   
+
    # Get completions from rownames for data.frames if we have no commas, e.g.
    # `mtcars[|`
    else if (inherits(object, "data.frame") &&
@@ -1301,15 +1302,15 @@ assign(x = ".rs.acCompletionTypes",
    {
       completions <- rownames(object)
    }
-   
+
    # Just get the names of the object
    else
    {
       completions <- .rs.getNames(object)
    }
-   
+
    completions <- .rs.selectFuzzyMatches(completions, token)
-   
+
    if (length(completions))
    {
       result <- .rs.makeCompletions(
@@ -1320,9 +1321,9 @@ assign(x = ".rs.acCompletionTypes",
          type = .rs.acCompletionTypes$STRING
       )
    }
-   
+
    result
-   
+
 })
 
 .rs.addFunction("getCompletionsDoubleBracket", function(token,
@@ -1331,18 +1332,18 @@ assign(x = ".rs.acCompletionTypes",
                                                         envir = parent.frame())
 {
    result <- .rs.emptyCompletions()
-   
+
    ## Blacklist certain evaluations
    if (!is.null(result <- .rs.blackListEvaluation(token, string, functionCall, envir)))
       return(result)
-   
+
    object <- .rs.getAnywhere(string, envir)
    if (is.null(object))
       return(result)
-   
+
    completions <- .rs.getNames(object)
    completions <- .rs.selectFuzzyMatches(completions, token)
-   
+
    if (length(completions))
    {
       result <- .rs.makeCompletions(
@@ -1354,9 +1355,9 @@ assign(x = ".rs.acCompletionTypes",
          overrideInsertParens = TRUE
       )
    }
-   
+
    result
-   
+
 })
 
 .rs.addFunction("listIndexedPackages", function()
@@ -1370,13 +1371,13 @@ assign(x = ".rs.acCompletionTypes",
                                                    quote = !appendColons)
 {
    allPackages <- basename(.rs.listIndexedPackages())
-   
+
    # In case indexing is disabled, include any loaded namespaces by default
    allPackages <- union(allPackages, loadedNamespaces())
-   
+
    # Not sure why 'DESCRIPTION' might show up here, but let's take it out
    allPackages <- setdiff(allPackages, "DESCRIPTION")
-   
+
    # Also remove any '00LOCK' directories -- these might be leftovers
    # from earlier failed package installations
    if (length(allPackages))
@@ -1384,7 +1385,7 @@ assign(x = ".rs.acCompletionTypes",
       isLockDir <- substring(allPackages, 1, 6) == "00LOCK"
       allPackages <- allPackages[!isLockDir]
    }
-   
+
    # Construct our completions, and we're done
    completions <- .rs.selectFuzzyMatches(allPackages, token)
    .rs.makeCompletions(token = token,
@@ -1409,16 +1410,16 @@ assign(x = ".rs.acCompletionTypes",
    #       datasets have been moved from package 'stats' to package 'datasets'
    #
    availableData <- suppressWarnings(data()$results)
-   
+
    # Don't include aliases
    indices <- intersect(
       which(.rs.fuzzyMatches(availableData[, "Item"], token)),
       grep(" ", availableData[, "Item"], fixed = TRUE, invert = TRUE)
    )
-   
+
    results <- availableData[indices, "Item"]
    packages <- availableData[indices, "Package"]
-   
+
    .rs.makeCompletions(token,
                        results,
                        packages,
@@ -1442,7 +1443,7 @@ assign(x = ".rs.acCompletionTypes",
    completions <- .rs.selectFuzzyMatches(allOptions, token)
    if (length(completions))
       completions <- paste(completions, "= ")
-   
+
    .rs.makeCompletions(token,
                        completions,
                        type = .rs.acCompletionTypes$OPTION)
@@ -1453,10 +1454,10 @@ assign(x = ".rs.acCompletionTypes",
 {
    currentEnv <- envir
    encounteredEnvs <- list()
-   
+
    completions <- character()
    types <- numeric()
-   
+
    empty <- emptyenv()
    while (!(identical(currentEnv, empty) ||
             identical(currentEnv, .GlobalEnv) ||
@@ -1467,9 +1468,9 @@ assign(x = ".rs.acCompletionTypes",
          if (identical(currentEnv, encounteredEnvs[[i]]))
             return(.rs.emptyCompletions())
       }
-      
+
       objects <- objects(currentEnv, all.names = TRUE)
-      
+
       completions <- c(completions, objects)
       types <- c(
          types,
@@ -1480,11 +1481,11 @@ assign(x = ".rs.acCompletionTypes",
             )
          })
       )
-      
+
       encounteredEnvs <- c(encounteredEnvs, currentEnv)
       currentEnv <- parent.env(currentEnv)
    }
-   
+
    keep <- .rs.fuzzyMatches(completions, token)
    .rs.makeCompletions(token = token,
                        results = completions[keep],
@@ -1499,20 +1500,20 @@ assign(x = ".rs.acCompletionTypes",
 .rs.addFunction("getCompletionsNAMESPACE", function(token, documentId)
 {
    symbols <- .rs.getNAMESPACEImportedSymbols(documentId)
-   
+
    if (!length(symbols))
       return(.rs.emptyCompletions())
-   
+
    n <- vapply(symbols, function(x) length(x[[1]]), USE.NAMES = FALSE, FUN.VALUE = numeric(1))
-   
+
    output <- list(
       exports = unlist(lapply(symbols, `[[`, "exports"), use.names = FALSE),
       types = unlist(lapply(symbols, `[[`, "types"), use.names = FALSE),
       packages = rep.int(names(symbols), times = n)
    )
-   
+
    keep <- .rs.fuzzyMatches(output$exports, token)
-   
+
    .rs.makeCompletions(token = token,
                        results = output$exports[keep],
                        packages = output$packages[keep],
@@ -1527,50 +1528,50 @@ assign(x = ".rs.acCompletionTypes",
       .rs.objectsOnSearchPath(".")
    else
       .rs.objectsOnSearchPath()
-   
+
    objects[["keywords"]] <- c(
       "NULL", "NA", "TRUE", "FALSE", "T", "F", "Inf", "NaN",
       "NA_integer_", "NA_real_", "NA_character_", "NA_complex_"
    )
-   
+
    names <- names(objects)
    results <- unlist(objects, use.names = FALSE)
    packages <- unlist(lapply(1:length(objects), function(i) {
       rep.int(names[i], length(objects[[i]]))
    }))
-   
+
    # Keywords are really from the base package
    packages[packages == "keywords"] <- "base"
-   
+
    # discover completion matches for this token
    keep <- .rs.fuzzyMatches(results, token)
    results <- results[keep]
    packages <- packages[keep]
-   
+
    # remove duplicates (assume first element masks next)
    dupes    <- duplicated(results)
    results  <- results[!dupes]
    packages <- packages[!dupes]
-   
+
    # re-order the completion results (lexically)
    order <- order(results)
-   
+
    # If the token is 'T' or 'F', prefer 'TRUE' and 'FALSE' completions
    if (token == "T")
    {
       TRUEpos <- which(results == "TRUE")
       order <- c(TRUEpos, order[-c(TRUEpos)])
    }
-   
+
    if (token == "F")
    {
       FALSEpos <- which(results == "FALSE")
       order <- c(FALSEpos, order[-c(FALSEpos)])
    }
-   
+
    results <- results[order]
    packages <- packages[order]
-   
+
    type <- vapply(seq_along(results), function(i) {
       if (packages[[i]] == "keywords")
          .rs.acCompletionTypes$KEYWORD
@@ -1583,14 +1584,14 @@ assign(x = ".rs.acCompletionTypes",
             error = function(e) .rs.acCompletionTypes$UNKNOWN
          )
    }, FUN.VALUE = numeric(1), USE.NAMES = FALSE)
-   
+
    .rs.makeCompletions(token = token,
                        results = results,
                        packages = packages,
                        quote = FALSE,
                        type = type,
                        overrideInsertParens = overrideInsertParens)
-   
+
 })
 
 .rs.addFunction("finishExpression", function(string)
@@ -1610,12 +1611,12 @@ assign(x = ".rs.acCompletionTypes",
       objectExpr <- matched[["x"]]
       objectName <- capture.output(print(objectExpr))
       object <- eval(objectExpr, envir = envir)
-      
+
       completions <- .rs.selectFuzzyMatches(
          names(attributes(object)),
          token
       )
-      
+
       result <- .rs.makeCompletions(
          token,
          completions,
@@ -1623,7 +1624,7 @@ assign(x = ".rs.acCompletionTypes",
          quote = TRUE,
          type = .rs.acCompletionTypes$STRING
       )
-      
+
    }, error = function(e) .rs.emptyCompletions())
    result
 })
@@ -1656,30 +1657,30 @@ assign(x = ".rs.acCompletionTypes",
    # For other packages, search the namespace for the symbol.
    loadedDLLs <- getLoadedDLLs()
    routines <- lapply(loadedDLLs, getDLLRegisteredRoutines)
-   
+
    isDynamic <- unlist(lapply(loadedDLLs, `[[`, "dynamicLookup"))
-   
+
    dynRoutines <- c(
       routines[isDynamic],
       routines["(embedding)"]
    )
-   
+
    dynRoutineNames <- lapply(dynRoutines, function(x) {
       names(x[[interface]])
    })
-   
+
    if (is.null(names(dynRoutineNames)))
       return(.rs.emptyCompletions())
-   
+
    dynResults <- .rs.namedVectorAsList(dynRoutineNames)
    dynIndices <- .rs.fuzzyMatches(dynResults$values, token)
-   
+
    .rs.makeCompletions(token = token,
                        results = dynResults$values[dynIndices],
                        packages = dynResults$names[dynIndices],
                        quote = TRUE,
                        type = .rs.acCompletionTypes$STRING)
-   
+
 })
 
 .rs.addFunction("mightBeShinyFunction", function(string)
@@ -1694,13 +1695,13 @@ assign(x = ".rs.acCompletionTypes",
       if (any(c("inputId", "outputId") %in% formalNames))
          return(TRUE)
    }
-      
+
    # Try seeing if there's a function of this name
    # in the 'shiny' completion database.
    shinyFunctions <- .rs.getInferredCompletions("shiny")$functions
    if (string %in% names(shinyFunctions))
       return(TRUE)
-   
+
    return(FALSE)
 })
 
@@ -1714,10 +1715,10 @@ assign(x = ".rs.acCompletionTypes",
    if (!("knitr" %in% loadedNamespaces()))
       if (!requireNamespace("knitr", quietly = TRUE))
          return(NULL)
-   
+
    if (!("knit_params" %in% getNamespaceExports(asNamespace("knitr"))))
       return(NULL)
-   
+
    knitr::knit_params(content)
 })
 
@@ -1726,15 +1727,15 @@ assign(x = ".rs.acCompletionTypes",
    # TODO: Bail if 'params' is already defined?
    if (exists("params", envir = .GlobalEnv))
       return(NULL)
-   
+
    params <- .rs.getKnitParamsForDocument(documentId)
    if (!length(params))
       return(.rs.emptyCompletions())
-   
+
    names <- vapply(params, FUN.VALUE = character(1), USE.NAMES = FALSE, function(x) {
       x$name
    })
-   
+
    completions <- .rs.selectFuzzyMatches(names, token)
    .rs.makeCompletions(token = token,
                        results = completions)
@@ -1744,16 +1745,16 @@ assign(x = ".rs.acCompletionTypes",
 {
    if (exists("params", envir = .GlobalEnv))
       return(FALSE)
-   
+
    params <- .rs.getKnitParamsForDocument(documentId)
    if (!length(params))
       return(FALSE)
-   
+
    mockedObject <- lapply(params, `[[`, "value")
    names(mockedObject) <- unlist(lapply(params, `[[`, "name"))
    class(mockedObject) <- "rstudio_mock"
    assign("params", mockedObject, envir = .GlobalEnv)
-   
+
    return(TRUE)
 })
 
@@ -1763,7 +1764,7 @@ assign(x = ".rs.acCompletionTypes",
    {
       params <- get("params", envir = .GlobalEnv)
       if (inherits(params, "rstudio_mock"))
-         remove(params, envir = .GlobalEnv) 
+         remove(params, envir = .GlobalEnv)
    }
 })
 
@@ -1771,7 +1772,7 @@ assign(x = ".rs.acCompletionTypes",
 {
    candidates <- names(Sys.getenv())
    results <- .rs.selectFuzzyMatches(candidates, token)
-   
+
    .rs.makeCompletions(token = token,
                        results = results,
                        quote = TRUE,
@@ -1801,7 +1802,7 @@ assign(x = ".rs.acCompletionTypes",
    excludeArgs <- .rs.setEncodingUnknownToUTF8(excludeArgs)
    excludeArgsFromObject <- .rs.setEncodingUnknownToUTF8(excludeArgsFromObject)
    filePath <- .rs.setEncodingUnknownToUTF8(filePath)
-   
+
    # Inject 'params' into the global env to provide for completions in
    # parameterized R Markdown documents
    if (.rs.injectKnitrParamsObject(documentId))
@@ -1811,25 +1812,25 @@ assign(x = ".rs.acCompletionTypes",
    # 'rc.options("custom.completions")',
    # then use the internal R completions instead.
    if (.rs.isCustomCompletionsEnabled()) {
-      
+
       completions <- tryCatch(
          .rs.getCustomRCompletions(line),
          error = identity
       )
-      
+
       if (!inherits(completions, "error"))
          return(completions)
    }
-   
+
    # Get the currently active frame
    envir <- .rs.getActiveFrame()
-   
+
    filePath <- suppressWarnings(.rs.normalizePath(filePath))
-   
+
    ## NOTE: these are passed in as lists of strings; convert to character
    additionalArgs <- as.character(additionalArgs)
    excludeArgs <- as.character(excludeArgs)
-   
+
    ## For magrittr completions, we may see a pipe thrown in as part of the 'string'
    ## and 'functionCallString'. In such a case, we need to strip off everything before
    ## a '%>%' and signal to drop the first argument for that function.
@@ -1838,18 +1839,18 @@ assign(x = ".rs.acCompletionTypes",
    {
       pipes <- c("%>%", "%<>%", "%T>%", "%>>%")
       pattern <- paste(pipes, collapse = "|")
-      
+
       stringPipeMatches <- gregexpr(
          pattern, string[[1]], perl = TRUE
       )[[1]]
-      
+
       if (!identical(c(stringPipeMatches), -1L))
       {
          n <- length(stringPipeMatches)
          idx <- stringPipeMatches[n] + attr(stringPipeMatches, "match.length")[n]
          dropFirstArgument <- TRUE
          string[[1]] <- gsub("^[\\s\\n]*", "", substring(string[[1]], idx), perl = TRUE)
-         
+
          ## Figure out the 'parent object' of the call. We munge the
          ## function call and place that back in, so S3 dispatch and such
          ## can work.
@@ -1857,14 +1858,14 @@ assign(x = ".rs.acCompletionTypes",
          parentObject <- .rs.trimWhitespace(
             substring(functionCallString, 1, firstPipeIdx - 1L)
          )
-         
+
          functionCallString <- gsub(
             "^\\s*",
             "",
             substring(functionCallString, idx),
             perl = TRUE
          )
-         
+
          # Add the argument back in
          functionCallString <- sub(
             "(",
@@ -1874,16 +1875,16 @@ assign(x = ".rs.acCompletionTypes",
          )
       }
    }
-   
+
    ## Try to parse the function call string
    functionCall <- tryCatch({
       parse(text = .rs.finishExpression(functionCallString))[[1]]
    }, error = function(e)
       NULL
    )
-   
+
    ## Handle some special cases early
-   
+
    # custom help handler for arguments
    if (.rs.acContextTypes$FUNCTION %in% type) {
       scope <- string[[1]]
@@ -1906,19 +1907,19 @@ assign(x = ".rs.acCompletionTypes",
          }
       }
    }
-   
+
    # help
    if (.rs.acContextTypes$HELP %in% type)
       return(.rs.getCompletionsHelp(token))
-   
+
    # Roxygen
    if (.rs.acContextTypes$ROXYGEN %in% type)
       return(.rs.attemptRoxygenTagCompletion(token, line))
-   
+
    # install.packages
    if (length(string) && string[[1]] == "install.packages" && numCommas[[1]] == 0)
       return(.rs.getCompletionsInstallPackages(token))
-   
+
    # example / help
    if (nzchar(token) &&
        length(string) &&
@@ -1927,13 +1928,13 @@ assign(x = ".rs.acCompletionTypes",
    {
       return(.rs.getCompletionsHelp(token, quote = TRUE))
    }
-   
+
    # vignettes
    if (length(string) && string[[1]] == "vignette" && numCommas[[1]] == 0)
       return(.rs.getCompletionsVignettes(token))
-   
+
    # .Call, .C, .Fortran, .External
-   if (length(string) && 
+   if (length(string) &&
        string[[1]] %in% c(".Call", ".C", ".Fortran", ".External") &&
        numCommas[[1]] == 0)
    {
@@ -1942,7 +1943,7 @@ assign(x = ".rs.acCompletionTypes",
          .rs.getCompletionsSearchPath(token))
       return(completions)
    }
-   
+
    # data
    if (length(type) &&
        type[[1]] == .rs.acContextTypes$FUNCTION &&
@@ -1951,26 +1952,26 @@ assign(x = ".rs.acCompletionTypes",
    {
       return(.rs.getCompletionsData(token))
    }
-   
+
    # package name
    if (.rs.acContextTypes$PACKAGE %in% type)
       return(.rs.getCompletionsPackages(token = token,
                                         appendColons = TRUE,
                                         excludeOtherCompletions = TRUE))
-   
+
    # environment variables
    if (length(string) &&
        string[[1]] %in% c("Sys.getenv", "Sys.setenv") &&
        numCommas[[1]] == 0)
       return(.rs.getCompletionsEnvironmentVariables(token))
-   
+
    # No information on completions other than token
    if (!length(string))
    {
       # If there was no token, give up
       if (token == "")
          return(.rs.emptyCompletions(excludeOtherCompletions = TRUE))
-      
+
       # Otherwise, complete from the seach path + available packages
       completions <- Reduce(.rs.appendCompletions, list(
          .rs.getCompletionsSearchPath(token),
@@ -1986,7 +1987,7 @@ assign(x = ".rs.acCompletionTypes",
                                           documentId,
                                           envir)
       ))
-      
+
       # remove all queries that start with a '.' unless the
       # token itself starts with a dot
       if (!.rs.startsWith(token, "."))
@@ -1994,7 +1995,7 @@ assign(x = ".rs.acCompletionTypes",
          startsWithDot <- .rs.startsWith(completions$results, ".")
          completions <- .rs.subsetCompletions(completions, which(!startsWithDot))
       }
-      
+
       # try completing from the source index if this is an
       # R file within a package
       if (.rs.isRScriptInPackageBuildTarget(filePath))
@@ -2006,11 +2007,11 @@ assign(x = ".rs.acCompletionTypes",
             .rs.getCompletionsActivePackage(token, pkgName)
          )
       }
-      
+
       # Ensure case-sensitive matches come first.
       return(.rs.sortCompletions(completions, token))
    }
-   
+
    # transform 'install.packages' to 'utils::install.packages' to avoid
    # getting arguments from the RStudio hook
    if ("install.packages" %in% string[[1]])
@@ -2021,24 +2022,24 @@ assign(x = ".rs.acCompletionTypes",
          string[[1]] <- "utils::install.packages"
       }
    }
-   
+
    # library, require, requireNamespace, loadNamespace
    if (string[[1]] %in% c("library", "require", "requireNamespace") &&
        numCommas[[1]] == 0)
    {
       quote <- !(string[[1]] %in% c("library", "require"))
-      return(.rs.getCompletionsPackages(token, 
+      return(.rs.getCompletionsPackages(token,
                                         excludeOtherCompletions = TRUE,
                                         quote = quote))
    }
-   
+
    ## File-based completions
    if (.rs.acContextTypes$FILE %in% type)
    {
       whichIndex <- which(type == .rs.acContextTypes$FILE)
-      
+
       tokenToUse <- string[[whichIndex]]
-      
+
       directoriesOnly <- FALSE
       if (length(string) > whichIndex)
       {
@@ -2050,23 +2051,23 @@ assign(x = ".rs.acCompletionTypes",
             directoriesOnly <- TRUE
          }
       }
-      
+
       # NOTE: For Markdown link completions, we overload the meaning of the
       # function call string here, and use it as a signal to generate paths
       # relative to the R markdown path.
       isMarkdownLink <- identical(functionCallString, "useFile")
       isRmd <- .rs.endsWith(tolower(filePath), ".rmd")
-      
+
       path <- NULL
-      
-      if (!isMarkdownLink && isRmd) 
+
+      if (!isMarkdownLink && isRmd)
       {
          # if in an Rmd file, ask it for its desired working dir (can be changed
          # with the knitr root.dir option)
          path <- .Call("rs_getRmdWorkingDir", filePath, documentId)
       }
 
-      if (is.null(path) && (isMarkdownLink || isRmd)) 
+      if (is.null(path) && (isMarkdownLink || isRmd))
       {
          # for links, or R Markdown without an explicit working dir, use the
          # base directory of the file
@@ -2079,15 +2080,15 @@ assign(x = ".rs.acCompletionTypes",
          # completions
          path <- getwd()
       }
-      
+
       return(.rs.getCompletionsFile(token = tokenToUse,
                                     path = path,
                                     quote = FALSE,
                                     directoriesOnly = directoriesOnly))
    }
-   
+
    # Shiny completions
-   
+
    ## Completions for server.r (from ui.r)
    if (type[[1]] %in% c(.rs.acContextTypes$DOLLAR,
                         .rs.acContextTypes$DOUBLE_BRACKET) &&
@@ -2098,7 +2099,7 @@ assign(x = ".rs.acCompletionTypes",
       if (!is.null(completions))
          return(completions)
    }
-   
+
    ## Completions for server.r, on session
    if (type[[1]] == .rs.acContextTypes$DOLLAR &&
        tolower(basename(filePath)) == "server.r" &&
@@ -2108,7 +2109,7 @@ assign(x = ".rs.acCompletionTypes",
       if (!is.null(completions))
          return(completions)
    }
-   
+
    ## Completions for ui.r (from server.r)
    if (type[[1]] == .rs.acContextTypes$FUNCTION &&
        tolower(basename(filePath)) == "ui.r" &&
@@ -2119,34 +2120,34 @@ assign(x = ".rs.acCompletionTypes",
       if (!is.null(completions))
          return(completions)
    }
-   
+
    ## Other special cases (but we may still want completions from
    ## other contexts)
-   
+
    # attr
    completions <- if (string[[1]] == "attr")
    {
       .rs.getCompletionsAttr(token, functionCall, envir)
    }
-   
+
    # getOption
    else if (string[[1]] == "getOption" && numCommas[[1]] == 0)
    {
       .rs.getCompletionsGetOption(token)
    }
-   
+
    # options
    else if (string[[1]] == "options" && type == .rs.acContextTypes$FUNCTION)
    {
       .rs.getCompletionsOptions(token)
    }
-   
+
    # no special case (start with empty completions)
    else
    {
       .rs.emptyCompletions()
    }
-   
+
    ## If we are getting completions from a '$', '@', '::' or ':::' then we do not
    ## want to look for completions in other contexts
    # dollar context
@@ -2155,7 +2156,7 @@ assign(x = ".rs.acCompletionTypes",
       .rs.acContextTypes$NAMESPACE_EXPORTED,
       .rs.acContextTypes$NAMESPACE_ALL
    )
-   
+
    if (dontLookBack)
    {
       # dollar context
@@ -2169,7 +2170,7 @@ assign(x = ".rs.acCompletionTypes",
             type[[1]] == .rs.acContextTypes$AT
          )
       }
-      
+
       # namespace context
       else if (type[[1]] %in% c(.rs.acContextTypes$NAMESPACE_EXPORTED,
                                 .rs.acContextTypes$NAMESPACE_ALL))
@@ -2182,7 +2183,7 @@ assign(x = ".rs.acCompletionTypes",
          )
       }
    }
-   
+
    # otherwise, look through the contexts and pick up completions
    else
    {
@@ -2201,7 +2202,7 @@ assign(x = ".rs.acCompletionTypes",
          )
       }
    }
-   
+
    # get completions from the search path for the 'generic' contexts
    if (token != "" &&
        type[[1]] %in% c(.rs.acContextTypes$UNKNOWN,
@@ -2213,7 +2214,7 @@ assign(x = ".rs.acCompletionTypes",
       discardFirst <-
          (dropFirstArgument) ||
          (type[[1]] == .rs.acContextTypes$FUNCTION && chainObjectName != "")
-      
+
       completions <- Reduce(.rs.appendCompletions, list(
          completions,
          .rs.getCompletionsSearchPath(token),
@@ -2228,7 +2229,7 @@ assign(x = ".rs.acCompletionTypes",
                                           documentId,
                                           envir)
       ))
-      
+
       if (.rs.isRScriptInPackageBuildTarget(filePath))
       {
          pkgName <- .rs.packageNameForSourceFile(filePath)
@@ -2238,14 +2239,14 @@ assign(x = ".rs.acCompletionTypes",
          )
       }
    }
-   
+
    ## Package completions (e.g. `stats::`)
    if (token != "" && .rs.acContextTypes$UNKNOWN %in% type)
       completions <- .rs.appendCompletions(
          completions,
          .rs.getCompletionsPackages(token, TRUE)
       )
-   
+
    ## If the caller has supplied information about chain completions (e.g.
    ## for completions from
    ##
@@ -2262,7 +2263,7 @@ assign(x = ".rs.acCompletionTypes",
                                discardFirst,
                                envir)
    )
-   
+
    ## Override param insertion if the function was 'debug' or 'trace'
    for (i in seq_along(type))
    {
@@ -2286,13 +2287,13 @@ assign(x = ".rs.acCompletionTypes",
          }
       }
    }
-   
+
    if (nzchar(token))
       completions <- .rs.sortCompletions(completions, token)
-   
+
    completions$token <- token
    completions
-   
+
 })
 
 .rs.addJsonRpcHandler("get_dplyr_join_completions", function(token,
@@ -2309,7 +2310,7 @@ assign(x = ".rs.acCompletionTypes",
       cursorPos,
       .rs.getActiveFrame()
    )
-   
+
 })
 
 .rs.addJsonRpcHandler("get_dplyr_join_completions_string", function(token,
@@ -2317,7 +2318,7 @@ assign(x = ".rs.acCompletionTypes",
                                                                     cursorPos)
 {
    result <- tryCatch(
-      
+
       expr = {
          parsed <- parse(text = string)[[1]]
          verb <- as.character(parsed[[1]])
@@ -2334,12 +2335,12 @@ assign(x = ".rs.acCompletionTypes",
             parent.frame()
          )
       },
-      
+
       error = function(e) {
          .rs.emptyCompletions()
       }
    )
-   
+
    result
 })
 
@@ -2351,10 +2352,10 @@ assign(x = ".rs.acCompletionTypes",
                                                     envir)
 {
    result <- .rs.emptyCompletions()
-   
+
    leftData <- .rs.getAnywhere(leftDataName, envir)
    rightData <- .rs.getAnywhere(rightDataName, envir)
-   
+
    if (cursorPos == "left" && !is.null(leftData))
    {
       completions <- .rs.selectFuzzyMatches(
@@ -2385,9 +2386,9 @@ assign(x = ".rs.acCompletionTypes",
          excludeOtherCompletions = TRUE
       )
    }
-   
+
    result
-   
+
 })
 
 .rs.addFunction("getRChainCompletions", function(token,
@@ -2402,13 +2403,13 @@ assign(x = ".rs.acCompletionTypes",
    ## that we were performing completions within an e.g.
    ## `%>%` chain -- use completions from the associated data object.
    result <- .rs.emptyCompletions()
-   
+
    if (!is.null(chainObjectName) && !excludeArgsFromObject)
    {
       object <- .rs.getAnywhere(chainObjectName, envir = envir)
       if (inherits(object, "python.builtin.object"))
          return(.rs.emptyCompletions())
-      
+
       if (length(object))
       {
          objectNames <- .rs.getNames(object)
@@ -2418,7 +2419,7 @@ assign(x = ".rs.acCompletionTypes",
             type <- vapply(completions, FUN.VALUE = numeric(1), USE.NAMES = FALSE, function(i) {
                .rs.getCompletionType(object[[i]])
             })
-            
+
             result <- .rs.makeCompletions(
                token = token,
                results = completions,
@@ -2429,7 +2430,7 @@ assign(x = ".rs.acCompletionTypes",
          }
       }
    }
-   
+
    if (length(additionalArgs))
    {
       argsToAdd <- .rs.selectFuzzyMatches(additionalArgs, token)
@@ -2443,15 +2444,15 @@ assign(x = ".rs.acCompletionTypes",
          )
       )
    }
-   
+
    if (length(excludeArgs))
    {
       indices <- which(!(result$results %in% excludeArgs))
       result <- .rs.subsetCompletions(result, indices)
    }
-   
+
    result
-   
+
 })
 
 .rs.addFunction("getRCompletions", function(token,
@@ -2478,6 +2479,11 @@ assign(x = ".rs.acCompletionTypes",
    )
 })
 
+.rs.addFunction("getCompletionsEmoji", function(token)
+{
+    emo::ji_completion(token)
+})
+
 ## NOTE: This is a modified version of 'matchAvailableTopics'
 ## in 'completions.R' of the R sources.
 .rs.addFunction("getCompletionsHelp", function(token,
@@ -2489,12 +2495,12 @@ assign(x = ".rs.acCompletionTypes",
    pkgCacheName <- ".completions.attachedPackagesCache"
    helpTopicsName <- ".completions.helpTopics"
    rsEnvPos <- which(search() == "tools:rstudio")
-   
+
    attachedPackagesCache <- tryCatch(
       get(pkgCacheName, pos = rsEnvPos),
       error = function(e) character()
    )
-   
+
    ## If the the current search paths have changed, invalidate
    ## the cache and update our aliases
    paths <- searchpaths()[substring(search(), 1, 8) == "package:"]
@@ -2503,18 +2509,18 @@ assign(x = ".rs.acCompletionTypes",
       assign(pkgCacheName,
              basename(paths),
              pos = rsEnvPos)
-      
+
       # Get the set of help topics
       topics <- lapply(paths, .rs.readAliases)
       names(topics) <- basename(paths)
-      
+
       assign(helpTopicsName,
              topics,
              pos = rsEnvPos)
    }
-   
+
    aliases <- get(helpTopicsName, pos = rsEnvPos)
-   
+
    ## If the token is of the form `<pkg>::<topic>`,
    ## then attempt to get the topic 'topic' for that
    ## package.
@@ -2522,12 +2528,12 @@ assign(x = ".rs.acCompletionTypes",
    {
       splat <- strsplit(token, ":{2,3}", perl = TRUE)[[1]]
       pkg <- splat[[1]]
-      
+
       token <- if (length(splat) > 1)
          splat[[2]]
       else
          ""
-      
+
       ## If the help topics for this package have not been loaded,
       ## explicitly load and save them now.
       if (!(pkg %in% names(aliases)))
@@ -2536,23 +2542,23 @@ assign(x = ".rs.acCompletionTypes",
             find.package(pkg, quiet = TRUE),
             error = function(e) NULL
          )
-         
+
          if (!is.null(pkgPath))
          {
             aliases[[pkg]] <- .rs.readAliases(pkgPath)
             assign(helpTopicsName, aliases, pos = rsEnvPos)
          }
       }
-      
+
       aliases <- tryCatch(
          aliases[[pkg]],
          error = function(e) character()
       )
    }
-   
+
    aliases <- unlist(aliases)
    results <- .rs.selectFuzzyMatches(aliases, token)
-   
+
    completions <- .rs.makeCompletions(
       token = token,
       results = results,
@@ -2560,7 +2566,7 @@ assign(x = ".rs.acCompletionTypes",
       type = .rs.acCompletionTypes$HELP,
       overrideInsertParens = TRUE
    )
-   
+
    .rs.sortCompletions(completions, token)
 
 })
@@ -2580,7 +2586,7 @@ assign(x = ".rs.acCompletionTypes",
 {
    # Get completions from the source index
    sourceIndexCompletions <- .rs.getSourceIndexCompletions(token)
-   
+
    # format completions for return to R
    if (!length(sourceIndexCompletions$completions))
    {
@@ -2589,25 +2595,25 @@ assign(x = ".rs.acCompletionTypes",
    else
    {
       results <- sourceIndexCompletions$completions
-      
+
       # TODO: more granular lookup on the object type for source index completions
       type <- ifelse(sourceIndexCompletions$isFunction,
                      .rs.acCompletionTypes$FUNCTION,
                      .rs.acCompletionTypes$UNKNOWN)
-      
+
       completions <- .rs.makeCompletions(token = token,
                                          results = results,
                                          packages = pkgName,
                                          quote = FALSE,
                                          type = type)
    }
-   
+
    # get completions from the imports of the package
    importCompletions <- tryCatch(
       getNamespaceImports(asNamespace(pkgName)),
       error = function(e) NULL
    )
-   
+
    # workaround for devtools::load_all() clobbering the
    # namespace imports
    if (length(importCompletions) && is.null(names(importCompletions))) {
@@ -2618,7 +2624,7 @@ assign(x = ".rs.acCompletionTypes",
             if (length(el) == 1) {
                env[[el]] <- c(env[[el]], getNamespaceExports(asNamespace(el)))
             }
-            
+
             # Length >1 element: 'importFrom()'.
             else if (length(el) > 1) {
                env[[el]] <- c(env[[el]], tail(el, n = -1))
@@ -2627,36 +2633,36 @@ assign(x = ".rs.acCompletionTypes",
          importCompletions <- as.list(env)
       }, silent = TRUE)
    }
-   
+
    # remove 'base' element if it's just TRUE
    if (length(importCompletions))
    {
       if (isTRUE(importCompletions[["base"]]))
          importCompletions$base <- NULL
    }
-   
+
    # if we have import completions, use them
    if (length(importCompletions) && !is.null(names(importCompletions)))
    {
       importCompletionsList <- .rs.namedVectorAsList(importCompletions)
-      
+
       # filter completions
       indices <- .rs.fuzzyMatches(importCompletionsList$values, token)
       importCompletionsList <- lapply(importCompletionsList, function(x) {
          x[indices]
       })
-      
+
       objects <- lapply(seq_along(importCompletionsList$values), function(i) {
-         
+
          tryCatch(
             expr = get(importCompletionsList$values[[i]],
                        envir = asNamespace(importCompletionsList$names[[i]])),
             error = function(e) NULL
          )
       })
-      
+
       type <- vapply(objects, FUN.VALUE = numeric(1), USE.NAMES = FALSE, .rs.getCompletionType)
-      
+
       completions <- .rs.appendCompletions(
          completions,
          .rs.makeCompletions(token = token,
@@ -2665,9 +2671,9 @@ assign(x = ".rs.acCompletionTypes",
                              type = type)
       )
    }
-   
+
    completions
-   
+
 })
 
 .rs.addFunction("getCompletionsFromShinyServer", function(token, filePath, string, type)
@@ -2676,16 +2682,16 @@ assign(x = ".rs.acCompletionTypes",
    serverPath <- file.path(dir, "server.R")
    uiPath <- file.path(dir, "ui.R")
    name <- tolower(basename(filePath))
-   
+
    if (!file.exists(serverPath))
       return(NULL)
-   
+
    completions <- .rs.shinyServerCompletions(serverPath)
    results <- if (.rs.endsWith(string, "Input"))
       .rs.selectFuzzyMatches(completions$input, token)
    else
       .rs.selectFuzzyMatches(completions$output, token)
-   
+
    return(.rs.makeCompletions(token = token,
                               results = results,
                               packages = serverPath,
@@ -2700,16 +2706,16 @@ assign(x = ".rs.acCompletionTypes",
    serverPath <- file.path(dir, "server.R")
    uiPath <- file.path(dir, "ui.R")
    name <- tolower(basename(filePath))
-   
+
    if (!file.exists(uiPath))
       return(NULL)
-   
+
    completions <- .rs.shinyUICompletions(uiPath)
    results <- if (string == "input")
       .rs.selectFuzzyMatches(completions$input, token)
    else
       .rs.selectFuzzyMatches(completions$output, token)
-   
+
    return(.rs.makeCompletions(token = token,
                               results = results,
                               packages = uiPath,
@@ -2723,7 +2729,7 @@ assign(x = ".rs.acCompletionTypes",
    # Check to see if we can re-use cached completions
    fileCacheName <- paste(file, "shinyUILastModifiedTime", sep = "-")
    completionsCacheName <- paste(file, "shinyUICompletions", sep = "-")
-   
+
    info <- file.info(file)
    mtime <- info[1, "mtime"]
    if (identical(mtime, .rs.get(fileCacheName)) &&
@@ -2731,46 +2737,46 @@ assign(x = ".rs.acCompletionTypes",
    {
       return(.rs.get(completionsCacheName))
    }
-   
+
    # Otherwise, get the completions
    parsed <- tryCatch(
       suppressWarnings(parse(file)),
       error = function(e) NULL
    )
-   
+
    if (is.null(parsed))
       return(NULL)
-   
+
    # We fill environments (since these can grow efficiently / by reference)
    inputEnv <- new.env(parent = emptyenv())
    outputEnv <- new.env(parent = emptyenv())
-   
+
    inputCount <- new.env(parent = emptyenv())
    inputCount$count <- 1
-   
+
    outputCount <- new.env(parent = emptyenv())
    outputCount$count <- 1
-   
+
    shinyFunctions <- .rs.getInferredCompletions("shiny")$functions
    lapply(parsed, function(object) {
       .rs.doShinyUICompletions(object, inputEnv, outputEnv, inputCount, outputCount, shinyFunctions)
    })
-   
+
    completions <- list(input = unlist(mget(objects(inputEnv), envir = inputEnv), use.names = FALSE),
                        output = unlist(mget(objects(outputEnv), envir = outputEnv), use.names = FALSE))
-   
+
    .rs.assign(fileCacheName, mtime)
    .rs.assign(completionsCacheName, completions)
-   
+
    completions
-   
+
 })
 
 .rs.addFunction("extractFunctionNameFromCall", function(object)
 {
    if (!is.call(object))
       return("")
-   
+
    if (.rs.isSymbolCalled(object[[1]], "::") ||
        .rs.isSymbolCalled(object[[1]], ":::") ||
        (is.character(object[[1]]) && object[[1]] %in% c("::", ":::")))
@@ -2780,15 +2786,15 @@ assign(x = ".rs.acCompletionTypes",
       else
          return("")
    }
-   
+
    if (is.character(object[[1]]) || is.symbol(object[[1]]))
       return(as.character(object[[1]]))
-   
+
    if (is.call(object[[1]]))
       return(.rs.extractFunctionNameFromCall(object[[1]]))
-   
+
    return("")
-   
+
 })
 
 .rs.addFunction("doShinyUICompletions", function(object,
@@ -2805,7 +2811,7 @@ assign(x = ".rs.acCompletionTypes",
          object[[2]]
       else
          ""
-      
+
       if (nzchar(firstArgName))
       {
          functionArgs <- shinyFunctions[[functionName]]
@@ -2814,14 +2820,14 @@ assign(x = ".rs.acCompletionTypes",
             outputCount$count <- outputCount$count + 1
             outputs[[as.character(outputCount$count)]] <- firstArgName
          }
-         
+
          else if ("inputId" %in% functionArgs || .rs.endsWith(functionName, "Input"))
          {
             inputCount$count <- inputCount$count + 1
             inputs[[as.character(inputCount$count)]] <- firstArgName
          }
       }
-      
+
       for (j in 2:length(object))
       {
          if (is.call(object[[j]]))
@@ -2835,7 +2841,7 @@ assign(x = ".rs.acCompletionTypes",
          }
       }
    }
-   
+
 })
 
 .rs.addFunction("shinyServerCompletions", function(file)
@@ -2843,7 +2849,7 @@ assign(x = ".rs.acCompletionTypes",
    # Check to see if we can re-use cached completions
    fileCacheName <- paste(file, "shinyServerLastModifiedTime", sep = "-")
    completionsCacheName <- paste(file, "shinyServerCompletions", sep = "-")
-   
+
    info <- file.info(file)
    mtime <- info[1, "mtime"]
    if (identical(mtime, .rs.get(fileCacheName)) &&
@@ -2851,38 +2857,38 @@ assign(x = ".rs.acCompletionTypes",
    {
       return(.rs.get(completionsCacheName))
    }
-   
+
    # Otherwise, get the completions
    parsed <- tryCatch(
       suppressWarnings(parse(file)),
       error = function(e) NULL
    )
-   
+
    if (is.null(parsed))
       return(NULL)
-   
+
    # We fill environments (since these can grow efficiently / by reference)
    inputEnv <- new.env(parent = emptyenv())
    outputEnv <- new.env(parent = emptyenv())
-   
+
    inputCount <- new.env(parent = emptyenv())
    inputCount$count <- 1
-   
+
    outputCount <- new.env(parent = emptyenv())
    outputCount$count <- 1
-   
+
    lapply(parsed, function(object) {
       .rs.doShinyServerCompletions(object, inputEnv, outputEnv, inputCount, outputCount)
    })
-   
+
    completions <- list(input = unlist(mget(objects(inputEnv), envir = inputEnv), use.names = FALSE),
                        output = unlist(mget(objects(outputEnv), envir = outputEnv), use.names = FALSE))
-   
+
    .rs.assign(fileCacheName, mtime)
    .rs.assign(completionsCacheName, completions)
-   
+
    completions
-   
+
 })
 
 .rs.addFunction("doShinyServerCompletions", function(object,
@@ -2902,21 +2908,21 @@ assign(x = ".rs.acCompletionTypes",
             object[[2]]
          else
             ""
-         
+
          value <- as.character(object[[3]])
          if (name == "output")
          {
             outputCount$count <- outputCount$count + 1
             outputs[[as.character(outputCount$count)]] <- .rs.stripSurrounding(value)
          }
-         
+
          if (name == "input")
          {
             inputCount$count <- inputCount$count + 1
             inputs[[as.character(inputCount$count)]] <- .rs.stripSurrounding(value)
          }
       }
-      
+
       if (length(object) > 1)
          for (j in 2:length(object))
          {
@@ -2930,7 +2936,7 @@ assign(x = ".rs.acCompletionTypes",
             }
          }
    }
-   
+
 })
 
 .rs.addFunction("getCompletionsShinySession", function(token)
@@ -2938,46 +2944,46 @@ assign(x = ".rs.acCompletionTypes",
    # Use cached completions if possible
    if (!is.null(results <- .rs.get("shinySessionCompletions")))
       return(results)
-   
+
    # Get completions from shiny if available
    if (!("shiny" %in% loadedNamespaces()))
       return(NULL)
-   
+
    # Check to see if this version of Shiny has a completions
    # function we can use
    completionGetter <- tryCatch(
       eval(call(":::", "shiny", "session_completions")),
       error = function(e) NULL
    )
-   
+
    if (is.null(completionGetter))
       return(NULL)
-   
+
    # Get the completions from Shiny
    completions <- tryCatch(
       completionGetter(),
       error = function(e) NULL
    )
-   
+
    if (is.null(completions))
       return(NULL)
-   
+
    # Ensure that this is a character vector
    if (!is.character(completions))
       return(NULL)
-   
+
    # Return completions
    results <- .rs.selectFuzzyMatches(completions, token)
    output <- .rs.makeCompletions(token = token,
                                  results = results,
                                  type = .rs.acCompletionTypes$CONTEXT,
                                  excludeOtherCompletions = TRUE)
-   
+
    # Cache for later use
    .rs.assign("shinySessionCompletions", output)
-   
+
    output
-   
+
 })
 
 .rs.addFunction("getCompletionsArgument", function(token,
@@ -2986,13 +2992,13 @@ assign(x = ".rs.acCompletionTypes",
                                                    envir = NULL)
 {
    completions <- .rs.emptyCompletions()
-   
+
    object <- if (!is.null(functionCall))
       .rs.resolveObjectFromFunctionCall(functionCall, envir)
-   
+
    matchedCall <- if (!is.null(object))
       .rs.matchCall(object, functionCall)
-   
+
    # Get completions from a data object name if the active argument is 'formula'.
    # Useful for formula incantations in e.g.
    #
@@ -3014,14 +3020,14 @@ assign(x = ".rs.acCompletionTypes",
          ))
       }
    }
-      
+
    # Check for knitr chunk completions, if possible
    if ("knitr" %in% loadedNamespaces())
    {
       ns <- asNamespace("knitr")
       tryGet <- function(name, ns)
          tryCatch(get(name, envir = ns)$set, error = function(e) NULL)
-      
+
       setter <- tryGet("opts_chunk", ns)
       if (identical(object, setter))
       {
@@ -3032,7 +3038,7 @@ assign(x = ".rs.acCompletionTypes",
             foundCompletions <- FALSE
             results <- character()
             quote <- TRUE
-            
+
             if (is.list(opts[[activeArg]]))
             {
                foundCompletions <- TRUE
@@ -3040,7 +3046,7 @@ assign(x = ".rs.acCompletionTypes",
                results <- .rs.selectFuzzyMatches(potentials, token)
                quote <- TRUE
             }
-            
+
             if (identical(opts[[activeArg]], "logical"))
             {
                foundCompletions <- TRUE
@@ -3048,7 +3054,7 @@ assign(x = ".rs.acCompletionTypes",
                results <- .rs.selectFuzzyMatches(potentials, token)
                quote <- FALSE
             }
-            
+
             if (foundCompletions)
                return(.rs.makeCompletions(token = token,
                                           type = .rs.acCompletionTypes$ARGUMENT,
@@ -3057,7 +3063,7 @@ assign(x = ".rs.acCompletionTypes",
          }
       }
    }
-   
+
    # Get 'help', 'example' completions
    if (activeArg %in% "topic" &&
        (identical(object, utils::example) ||
@@ -3068,7 +3074,7 @@ assign(x = ".rs.acCompletionTypes",
          .rs.getCompletionsHelp(token, quote = TRUE)
       )
    }
-   
+
    # Get package names for completions
    if (activeArg %in% c("pkg", "package"))
       completions <- .rs.appendCompletions(
@@ -3077,7 +3083,7 @@ assign(x = ".rs.acCompletionTypes",
                                     appendColons = FALSE,
                                     excludeOtherCompletions = FALSE)
       )
-   
+
    completions
 })
 
@@ -3113,11 +3119,11 @@ assign(x = ".rs.acCompletionTypes",
          break
       }
    }
-   
+
    # Bail if we couldn't find anything
    if (is.null(pkg))
       return(.rs.emptyCompletions())
-   
+
    ## Make a dummy function to match a call against
    argsText <- paste(args, collapse = ", ")
    dummyFunction <- tryCatch(
@@ -3127,29 +3133,29 @@ assign(x = ".rs.acCompletionTypes",
    )
    if (is.null(dummyFunction))
       return(.rs.emptyCompletions())
-   
+
    matchedCall <- .rs.matchCall(dummyFunction, functionCall)
    if (is.null(matchedCall))
       return(.rs.emptyCompletions())
-   
+
    formals <- .rs.resolveFormals(token,
                                  dummyFunction,
                                  string[[1]],
                                  functionCall,
                                  matchedCall,
                                  envir)
-   
+
    # Protect against failure
    if (is.null(formals))
       return(.rs.emptyCompletions())
-   
+
    results <- .rs.selectFuzzyMatches(formals$formals, token)
    if (length(results))
       results <- paste(results, "= ")
-   
+
    if (discardFirst && length(results))
       results <- results[-1]
-   
+
    .rs.makeCompletions(token = token,
                        results = results,
                        packages = paste(pkg, string[[1]], sep = "|||"),
@@ -3169,7 +3175,7 @@ assign(x = ".rs.acCompletionTypes",
    # Bail on null / empty documentId (necessary for e.g. the console)
    if (is.null(documentId) || !nzchar(documentId))
       return(.rs.emptyCompletions())
-   
+
    ## If we detect that particular 'library' calls are in the source document,
    ## and those packages are actually available (but the package is not currently loaded),
    ## then we get an asynchronously-updated set of completions. We enocde them as 'context'
@@ -3178,17 +3184,17 @@ assign(x = ".rs.acCompletionTypes",
    packages <- .rs.listInferredPackages(documentId)
    if (!length(packages))
       return(.rs.emptyCompletions())
-   
+
    # Remove any packages that are on the search path
    searchNames <- paste("package", packages, sep = ":")
    packages <- packages[!(searchNames %in% search())]
-   
+
    if (!length(packages))
       return(.rs.emptyCompletions())
-   
+
    completions <- .rs.getInferredCompletions(packages, simplify = FALSE)
    results <- .rs.emptyCompletions()
-   
+
    # If we're getting completions for a particular function's arguments,
    # use those
    if (length(type) && type[[1]] == .rs.acContextTypes$FUNCTION)
@@ -3202,15 +3208,15 @@ assign(x = ".rs.acCompletionTypes",
                                                        completions)
       )
    }
-   
+
    # Add completions for exported items.
    results <- .rs.appendCompletions(
-      results, 
+      results,
       Reduce(.rs.appendCompletions, lapply(seq_along(completions), function(i) {
-         
+
          completion <- completions[[i]]
          package <- names(completions)[[i]]
-         
+
          keep <- .rs.fuzzyMatches(completion$exports, token)
          .rs.makeCompletions(token = token,
                              results = completion$exports[keep],
@@ -3218,26 +3224,26 @@ assign(x = ".rs.acCompletionTypes",
                              type = completion$types[keep])
       }))
    )
-   
+
 })
 
 .rs.addFunction("isKnitrObject", function(object)
 {
    if (!("knitr" %in% loadedNamespaces()))
       return(FALSE)
-   
+
    ns <- asNamespace("knitr")
    if (identical(environment(object), ns))
       return(TRUE)
-   
+
    parent <- tryCatch(
       parent.env(environment(object)),
       error = function(e) NULL
    )
-   
+
    if (identical(parent, ns))
       return(TRUE)
-   
+
    return(FALSE)
 })
 
@@ -3248,15 +3254,15 @@ assign(x = ".rs.acCompletionTypes",
    matches <- gregexpr(reRCode, snippet, perl = TRUE)[[1]]
    if (matches == -1)
       return(snippet)
-   
+
    match.length <- attr(matches, "match.length")
    if (is.null(match.length))
       return(snippet)
-   
+
    ranges <- lapply(seq_along(matches), function(i) {
       c(matches[[i]], matches[[i]] + match.length[[i]])
    })
-   
+
    extracted <- lapply(ranges, function(range) {
       substring(
          snippet,
@@ -3264,7 +3270,7 @@ assign(x = ".rs.acCompletionTypes",
          range[[2]] - 2 # leave out trailing "`"
       )
    })
-   
+
    frame <- parent.frame()
    evaluated <- lapply(extracted, function(code) {
       tryCatch({
@@ -3273,16 +3279,16 @@ assign(x = ".rs.acCompletionTypes",
                eval(parse(text = code), envir = frame)
             )))
          )
-         
+
          if (!length(result) && length(captured))
             paste(captured, collapse = " ")
          else
             result
-         
+
       }, error = function(e) ""
       )
    })
-   
+
    newSnippet <- snippet
    for (i in seq_along(evaluated))
    {
@@ -3291,7 +3297,7 @@ assign(x = ".rs.acCompletionTypes",
       replacement <- evaluated[[i]]
       newSnippet <- gsub(text, replacement, newSnippet, fixed = TRUE)
    }
-   
+
    .rs.scalar(newSnippet)
 })
 
@@ -3308,18 +3314,18 @@ assign(x = ".rs.acCompletionTypes",
    token <- utils:::.guessTokenFromLine()
    utils:::.completeToken()
    results <- utils:::.retrieveCompletions()
-   
+
    packages <- sub('^package:', '', .rs.which(results))
-   
+
    # ensure spaces around =
    results <- sub("=$", " = ", results)
-   
+
    choose = packages == '.GlobalEnv'
    results.sorted = c(results[choose], results[!choose])
    packages.sorted = c(packages[choose], packages[!choose])
-   
+
    packages.sorted = sub('^\\.GlobalEnv$', '', packages.sorted)
-   
+
    .rs.makeCompletions(
       token = token,
       results = results.sorted,

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/RCompletionType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/RCompletionType.java
@@ -41,10 +41,11 @@ public class RCompletionType
    public static final int KEYWORD     = 22;
    public static final int OPTION      = 23;
    public static final int DATASET     = 24;
-   
+   public static final int EMOJI       = 25;
+
    public static final int SNIPPET     = 98;
    public static final int CONTEXT     = 99;
-   
+
    public static boolean isFunctionType(int type)
    {
       return type == FUNCTION ||
@@ -52,7 +53,7 @@ public class RCompletionType
              type == S4_METHOD ||
              type == R5_METHOD;
    }
-   
+
    public static boolean isFileType(int type)
    {
       return type == FILE ||

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -94,21 +94,21 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       void onBeforeSelected();
       void onSelected();
    }
-   
+
    @Inject
-   public Shell(ConsoleServerOperations server, 
+   public Shell(ConsoleServerOperations server,
                 EventBus eventBus,
                 Display display,
                 Session session,
                 Commands commands,
-                UIPrefs uiPrefs, 
+                UIPrefs uiPrefs,
                 ErrorManager errorManager,
                 ConsoleEditorProvider tracker)
    {
       super() ;
 
       ((Binder)GWT.create(Binder.class)).bind(commands, this);
-      
+
       server_ = server ;
       eventBus_ = eventBus ;
       view_ = display ;
@@ -119,7 +119,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       browseHistoryManager_ = new CommandLineHistory(input_);
       prefs_ = uiPrefs;
       tracker.setConsoleEditor(input_);
-      
+
       prefs_.surroundSelection().bind(new CommandWithArg<String>()
       {
          @Override
@@ -130,7 +130,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       });
 
       inputAnimator_ = new ShellInputAnimator(view_.getInputEditorDisplay());
-      
+
       view_.setMaxOutputLines(session.getSessionInfo().getConsoleActionsLimit());
 
       keyDownPreviewHandlers_ = new ArrayList<KeyDownPreviewHandler>() ;
@@ -143,9 +143,9 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       view_.addCapturingKeyDownHandler(handler);
       view_.addKeyPressHandler(handler);
       view_.addCapturingKeyUpHandler(handler);
-      
+
       eventBus.addHandler(ConsoleHistoryAddedEvent.TYPE, this);
-      eventBus.addHandler(ConsoleInputEvent.TYPE, this); 
+      eventBus.addHandler(ConsoleInputEvent.TYPE, this);
       eventBus.addHandler(ConsoleWriteOutputEvent.TYPE, this);
       eventBus.addHandler(ConsoleWriteErrorEvent.TYPE, this);
       eventBus.addHandler(ConsoleWritePromptEvent.TYPE, this);
@@ -158,12 +158,12 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       eventBus.addHandler(DebugModeChangedEvent.TYPE, this);
       eventBus.addHandler(RunCommandWithDebugEvent.TYPE, this);
       eventBus.addHandler(UnhandledErrorEvent.TYPE, this);
-      
+
       final CompletionManager completionManager
                   = new RCompletionManager(view_.getInputEditorDisplay(),
                                           null,
-                                          new CompletionPopupPanel(), 
-                                          server, 
+                                          new CompletionPopupPanel(),
+                                          server,
                                           null,
                                           null,
                                           null,
@@ -171,11 +171,11 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
                                           true);
       addKeyDownPreviewHandler(completionManager) ;
       addKeyPressPreviewHandler(completionManager) ;
-      
+
       historyCompletion_ = new HistoryCompletionManager(
             view_.getInputEditorDisplay(), server);
       addKeyDownPreviewHandler(historyCompletion_);
-      
+
       // we need to explicitly connect a paste handler on Desktop
       // to ensure the completion popup is dismissed in shell on paste
       if (Desktop.isDesktop())
@@ -189,12 +189,12 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
             }
          });
       }
-      
+
       AceEditorNative.syncUiPrefs(uiPrefs);
 
       sessionInit(session);
    }
-   
+
    private void sessionInit(Session session)
    {
       SessionInfo sessionInfo = session.getSessionInfo();
@@ -226,7 +226,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       if (sessionInfo.getResumed())
       {
          // no special UI for this (resuming session with all console
-         // history and other UI state preserved deemed adequate feedback) 
+         // history and other UI state preserved deemed adequate feedback)
       }
    }
 
@@ -240,10 +240,10 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    {
       // clear output
       view_.clearOutput();
-      
+
       // notify server
       server_.resetConsoleActions(new VoidServerRequestCallback());
-      
+
       // if we don't bounce setFocus the menu retains focus
       Scheduler.get().scheduleDeferred(new ScheduledCommand() {
          public void execute()
@@ -258,19 +258,19 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    {
       keyDownPreviewHandlers_.add(handler) ;
    }
-   
+
    public void addKeyPressPreviewHandler(KeyPressPreviewHandler handler)
    {
       keyPressPreviewHandlers_.add(handler) ;
    }
-   
+
    public void onConsoleInput(final ConsoleInputEvent event)
    {
-      server_.consoleInput(event.getInput(), 
+      server_.consoleInput(event.getInput(),
                            event.getConsole(),
                            new ServerRequestCallback<Void>() {
          @Override
-         public void onError(ServerError error) 
+         public void onError(ServerError error)
          {
             // show the error in the console then re-prompt
             view_.consoleWriteError("Error: " + error.getUserMessage() + "\n");
@@ -289,19 +289,19 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    {
       view_.consoleWriteError(event.getError());
    }
-   
+
    public void onUnhandledError(UnhandledErrorEvent event)
    {
       if (!debugging_)
       {
          view_.consoleWriteExtendedError(
                event.getError().getErrorMessage(),
-               event.getError(), 
+               event.getError(),
                prefs_.autoExpandErrorTracebacks().getValue(),
                getHistoryEntry(0));
       }
    }
-   
+
    public void onConsoleWriteInput(ConsoleWriteInputEvent event)
    {
       view_.consoleWriteInput(event.getInput(), event.getConsole());
@@ -316,7 +316,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    {
       String prompt = event.getPrompt().getPromptText() ;
       boolean addToHistory = event.getPrompt().getAddToHistory() ;
-      
+
       consolePrompt(prompt, addToHistory) ;
    }
 
@@ -342,38 +342,38 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
          view_.getInputEditorDisplay().setFocus(true);
       }
    }
-   
+
    public void onConsoleResetHistory(ConsoleResetHistoryEvent event)
    {
       setHistory(event.getHistory());
    }
-   
+
    @Override
    public void onRestartRCompleted(ConsoleRestartRCompletedEvent event)
    {
       if (view_.isPromptEmpty())
          eventBus_.fireEvent(new SendToConsoleEvent("", true));
-         
+
       focus();
    }
-   
+
    private void processCommandEntry()
    {
       String commandText = view_.processCommandEntry() ;
       if (addToHistory_ && (commandText.length() > 0))
          eventBus_.fireEvent(new ConsoleHistoryAddedEvent(commandText));
 
-      // fire event 
+      // fire event
       eventBus_.fireEvent(new ConsoleInputEvent(commandText, ""));
    }
 
    public void onSendToConsole(final SendToConsoleEvent event)
-   {  
+   {
       final InputEditorDisplay display = view_.getInputEditorDisplay();
-      
+
       // get anything already at the console
       final String previousInput = StringUtil.notNull(display.getText());
-      
+
       // define code block we execute at finish
       Command finishSendToConsole = new Command() {
          @Override
@@ -385,20 +385,20 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
                if (previousInput.length() > 0)
                   display.setText(previousInput);
             }
-            
+
             if (!event.shouldExecute() || event.shouldFocus())
             {
                display.setFocus(true);
                display.collapseSelection(false);
-            }  
+            }
          }
       };
-      
+
       // do standrd finish if we aren't animating
       if (!event.shouldAnimate())
       {
          display.clear();
-         display.setText(event.getCode()); 
+         display.setText(event.getCode());
          finishSendToConsole.execute();
       }
       else
@@ -406,7 +406,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
          inputAnimator_.enque(event.getCode(), finishSendToConsole);
       }
    }
-   
+
    @Override
    public void onExecutePendingInput(ConsoleExecutePendingInputEvent event)
    {
@@ -415,25 +415,25 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       if (view_.getInputEditorDisplay().isFocused() &&
          (view_.getInputEditorDisplay().getText().length() > 0))
       {
-         processCommandEntry();  
+         processCommandEntry();
       }
       // otherwise delegate back to the source view. we do this via
       // executing a command which is a bit of hack but it's a clean
       // way to call code within the "current editor" (an event would
-      // go to all editors). another alternative would be to 
+      // go to all editors). another alternative would be to
       // call a method on the SourceShim
       else
       {
          AppCommand command = commands_.getCommandById(event.getCommandId());
-         
+
          // the current editor may be in another window; if one of our source
          // windows was last focused, use that one instead
-         SourceWindowManager manager = 
+         SourceWindowManager manager =
                RStudioGinjector.INSTANCE.getSourceWindowManager();
          if (!StringUtil.isNullOrEmpty(manager.getLastFocusedSourceWindowId()))
          {
             RStudioGinjector.INSTANCE.getSatelliteManager().dispatchCommand(
-                  command, SourceSatellite.NAME_PREFIX + 
+                  command, SourceSatellite.NAME_PREFIX +
                            manager.getLastFocusedSourceWindowId());
          }
          else
@@ -442,7 +442,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
          }
       }
    }
-   
+
    @Override
    public void onDebugModeChanged(DebugModeChangedEvent event)
    {
@@ -452,7 +452,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       }
       debugging_ = event.debugging();
    }
-   
+
    @Override
    public void onRunCommandWithDebug(final RunCommandWithDebugEvent event)
    {
@@ -467,13 +467,13 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
                   eventBus_.fireEvent(new SendToConsoleEvent(
                         event.getCommand(), true));
                }
-               
+
                @Override
                public void onError(ServerError error)
                {
                   // if we failed to set debug mode, don't rerun the command
                }
-            }); 
+            });
    }
 
    @Override
@@ -497,7 +497,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
          // this behavior is suppressed when we're incrementally searching the
          // history so we don't stack two kinds of completion popups
          ArrayList<KeyDownPreviewHandler> handlers = keyDownPreviewHandlers_;
-         if (historyCompletion_.getMode() == 
+         if (historyCompletion_.getMode() ==
                HistoryCompletionManager.PopupMode.PopupIncremental)
          {
             handlers = new ArrayList<KeyDownPreviewHandler>();
@@ -513,7 +513,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
                return;
             }
          }
-         
+
          if (event.getNativeKeyCode() == KeyCodes.KEY_TAB)
             event.preventDefault();
 
@@ -575,7 +575,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
                   eventBus_.fireEvent(new ConsoleInputEvent(null, ""));
                }
             }
-             
+
             input_.clear();
          }
          else
@@ -601,9 +601,9 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
                }
             }
             else if (
-                  (BrowseCap.hasMetaKey() && 
+                  (BrowseCap.hasMetaKey() &&
                    (mod == (KeyboardShortcut.META + KeyboardShortcut.SHIFT))) ||
-                  (!BrowseCap.hasMetaKey() && 
+                  (!BrowseCap.hasMetaKey() &&
                    (mod == (KeyboardShortcut.CTRL + KeyboardShortcut.SHIFT))))
             {
                switch (keyCode)
@@ -624,7 +624,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
          // this behavior is suppressed when we're incrementally searching the
          // history so we don't stack two kinds of completion popups
          ArrayList<KeyPressPreviewHandler> handlers = keyPressPreviewHandlers_;
-         if (historyCompletion_.getMode() == 
+         if (historyCompletion_.getMode() ==
                HistoryCompletionManager.PopupMode.PopupIncremental)
          {
             handlers = new ArrayList<KeyPressPreviewHandler>();
@@ -649,7 +649,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
             return;
          if (KeyCodeEvent.isArrow(event.getNativeKeyCode()))
             return;
-         if (historyCompletion_.getMode() == 
+         if (historyCompletion_.getMode() ==
                HistoryCompletionManager.PopupMode.PopupIncremental)
          {
             historyCompletion_.beginSearch();
@@ -659,18 +659,18 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       @SuppressWarnings("unused")
       private boolean lastKeyCodeWasZero_;
    }
-   
+
    private boolean isBrowsePrompt()
    {
       return lastPromptText_ != null && (lastPromptText_.startsWith("Browse"));
    }
-   
+
    private void resetHistoryPosition()
    {
       historyManager_.resetPosition();
       browseHistoryManager_.resetPosition();
    }
-   
+
    private String getHistoryEntry(int offset)
    {
       if (isBrowsePrompt())
@@ -685,7 +685,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
          browseHistoryManager_.navigateHistory(offset);
       else
          historyManager_.navigateHistory(offset);
-      
+
       view_.ensureInputVisible();
    }
 
@@ -693,7 +693,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    {
       input_.setFocus(true);
    }
-   
+
    private void setHistory(JsArrayString history)
    {
       ArrayList<String> historyList = new ArrayList<String>(history.length());
@@ -728,15 +728,15 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    private final ArrayList<KeyDownPreviewHandler> keyDownPreviewHandlers_ ;
    private final ArrayList<KeyPressPreviewHandler> keyPressPreviewHandlers_ ;
    private final HistoryCompletionManager historyCompletion_;
-   
+
    // indicates whether the next command should be added to history
    private boolean addToHistory_ ;
    private String lastPromptText_ ;
    private final UIPrefs prefs_;
- 
+
    private final CommandLineHistory historyManager_;
    private final CommandLineHistory browseHistoryManager_;
-   
+
    private final ShellInputAnimator inputAnimator_;
 
    private String initialInput_ ;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -865,6 +865,14 @@ public class CompletionRequester
                RES.styles().completion(),
                name);
 
+         // emoji aliases
+         if( type == RCompletionType.EMOJI ){
+           SafeHtmlUtil.appendSpan(
+                 sb,
+                 RES.styles().packageName(),
+                 ":" + source + ":");
+         }
+
          // Display the source for functions and snippets (unless there
          // is a custom helpHandler provided, indicating that the "source"
          // isn't a package but rather some custom DollarNames scope)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -164,6 +164,7 @@ public class CompletionRequester
 
       // Transform the token once beforehand for completions.
       final String tokenSub   = token.substring(token.lastIndexOf('/') + 1);
+      final String tokenEmoji = token.substring(token.lastIndexOf(':') + 1);
       final String tokenFuzzy = fuzzy(tokenSub);
 
       for (QualifiedName qname : cachedResult.completions)
@@ -173,6 +174,13 @@ public class CompletionRequester
          {
             if (StringUtil.isSubsequence(basename(qname.name), tokenFuzzy, true))
                newCompletions.add(qname);
+         }
+         else if( qname.type == RCompletionType.EMOJI)
+         {
+            // narrowing based on the .source
+            if( qname.source.contains(tokenEmoji) ){
+                newCompletions.add(qname);
+            }
          }
          else
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -70,7 +70,7 @@ public class CompletionRequester
    private HashMap<String, CompletionResult> cachedCompletions_ =
          new HashMap<String, CompletionResult>();
    private RnwCompletionContext rnwContext_ ;
-   
+
    public CompletionRequester(RnwCompletionContext rnwContext,
                               DocDisplay docDisplay,
                               SnippetHelper snippets)
@@ -80,21 +80,21 @@ public class CompletionRequester
       snippets_ = snippets;
       RStudioGinjector.INSTANCE.injectMembers(this);
    }
-   
+
    @Inject
    void initialize(CodeToolsServerOperations server, UIPrefs uiPrefs)
    {
       server_ = server;
       uiPrefs_ = uiPrefs;
    }
-   
+
    private boolean usingCache(
          String token,
          final ServerRequestCallback<CompletionResult> callback)
    {
       return usingCache(token, false, callback);
    }
-   
+
    private boolean usingCache(
          String token,
          boolean isHelpCompletion,
@@ -102,14 +102,14 @@ public class CompletionRequester
    {
       if (isHelpCompletion)
          token = token.substring(token.lastIndexOf(':') + 1);
-      
+
       if (cachedLinePrefix_ == null)
          return false;
-      
+
       CompletionResult cachedResult = cachedCompletions_.get("");
       if (cachedResult == null)
          return false;
-      
+
       if (token.toLowerCase().startsWith(cachedLinePrefix_.toLowerCase()))
       {
          String diff = token.substring(cachedLinePrefix_.length(), token.length());
@@ -129,43 +129,43 @@ public class CompletionRequester
             return true;
          }
       }
-      
+
       return false;
-      
+
    }
-   
+
    private String basename(String absolutePath)
    {
       return absolutePath.substring(absolutePath.lastIndexOf('/') + 1);
    }
-   
+
    private boolean filterStartsWithDot(String item,
                                        String token)
    {
       return !(!token.startsWith(".") && item.startsWith("."));
    }
-   
+
    private static final native String fuzzy(String string) /*-{
       return string.replace(/(?!^)[._]/g, "");
    }-*/;
-   
+
    private CompletionResult narrow(final String token,
                                    final String diff,
                                    CompletionResult cachedResult)
    {
       ArrayList<QualifiedName> newCompletions = new ArrayList<QualifiedName>();
       newCompletions.ensureCapacity(cachedResult.completions.size());
-      
+
       // For completions that are files or directories, we need to post-process
       // the token and the qualified name to strip out just the basename (filename).
       // Note that we normalize the paths such that files will have no trailing slash,
       // while directories will have one trailing slash (but we defend against multiple
       // trailing slashes)
-      
+
       // Transform the token once beforehand for completions.
       final String tokenSub   = token.substring(token.lastIndexOf('/') + 1);
       final String tokenFuzzy = fuzzy(tokenSub);
-      
+
       for (QualifiedName qname : cachedResult.completions)
       {
          // File types are narrowed only by the file name
@@ -181,42 +181,42 @@ public class CompletionRequester
                newCompletions.add(qname) ;
          }
       }
-      
+
       java.util.Collections.sort(newCompletions, new Comparator<QualifiedName>() {
-         
+
          @Override
          public int compare(QualifiedName lhs, QualifiedName rhs)
          {
             int lhsScore = RCompletionType.isFileType(lhs.type)
                   ? CodeSearchOracle.scoreMatch(basename(lhs.name), tokenSub, true)
                   : CodeSearchOracle.scoreMatch(lhs.name, token, false);
-            
+
             int rhsScore = RCompletionType.isFileType(rhs.type)
                ? CodeSearchOracle.scoreMatch(basename(rhs.name), tokenSub, true)
                : CodeSearchOracle.scoreMatch(rhs.name, token, false);
-            
+
             // Place arguments higher (give less penalty)
             if (lhs.type == RCompletionType.ARGUMENT) lhsScore -= 3;
             if (rhs.type == RCompletionType.ARGUMENT) rhsScore -= 3;
-            
+
             if (lhsScore == rhsScore)
                return lhs.compareTo(rhs);
-            
+
             return lhsScore < rhsScore ? -1 : 1;
          }
       });
-      
+
       CompletionResult result = new CompletionResult(
             token,
             newCompletions,
             cachedResult.guessedFunctionName,
             cachedResult.suggestOnAccept,
             cachedResult.dontInsertParens) ;
-      
+
       cachedCompletions_.put(diff, result);
       return result;
    }
-   
+
    public void getDplyrJoinCompletionsString(
          final String token,
          final String string,
@@ -226,13 +226,13 @@ public class CompletionRequester
    {
       if (usingCache(token, callback))
          return;
-      
+
       server_.getDplyrJoinCompletionsString(
             token,
             string,
             cursorPos,
             new ServerRequestCallback<Completions>() {
-               
+
                @Override
                public void onResponseReceived(Completions response)
                {
@@ -247,10 +247,10 @@ public class CompletionRequester
                }
 
             });
-      
-      
+
+
    }
-   
+
    public void getDplyrJoinCompletions(
          final DplyrJoinContext joinContext,
          final boolean implicit,
@@ -259,7 +259,7 @@ public class CompletionRequester
       final String token = joinContext.getToken();
       if (usingCache(token, callback))
          return;
-      
+
       server_.getDplyrJoinCompletions(
             joinContext.getToken(),
             joinContext.getLeftData(),
@@ -273,17 +273,17 @@ public class CompletionRequester
                {
                   callback.onError(error);
                }
-               
+
                @Override
                public void onResponseReceived(Completions response)
                {
                   cachedLinePrefix_ = token;
                   fillCompletionResult(response, implicit, callback);
                }
-               
+
             });
    }
-   
+
    private void fillCompletionResult(
          Completions response,
          boolean implicit,
@@ -315,14 +315,14 @@ public class CompletionRequester
          callback.onResponseReceived(result);
 
    }
-   
+
    private static final Pattern RE_EXTRACTION = Pattern.create("[$@:]", "");
    private boolean isTopLevelCompletionRequest()
    {
       String line = docDisplay_.getCurrentLineUpToCursor();
       return !RE_EXTRACTION.test(line);
    }
-   
+
    public void getCompletions(
          final String token,
          final List<String> assocData,
@@ -341,10 +341,10 @@ public class CompletionRequester
    {
       boolean isHelp = dataType.size() > 0 &&
             dataType.get(0) == AutocompletionContext.TYPE_HELP;
-      
+
       if (usingCache(token, isHelp, callback))
          return;
-      
+
       doGetCompletions(
             token,
             assocData,
@@ -377,40 +377,40 @@ public class CompletionRequester
             JsArrayBoolean quote = response.getQuote();
             JsArrayInteger type = response.getType();
             ArrayList<QualifiedName> newComp = new ArrayList<QualifiedName>();
-            
+
             // Get function completions from the server
             for (int i = 0; i < comp.length(); i++)
                if (comp.get(i).endsWith(" = "))
                   newComp.add(new QualifiedName(comp.get(i), pkgs.get(i), quote.get(i), type.get(i), response.getHelpHandler()));
-            
+
             // Try getting our own function argument completions
             if (!response.getExcludeOtherCompletions())
             {
                addFunctionArgumentCompletions(token, newComp);
                addScopedArgumentCompletions(token, newComp);
             }
-            
+
             // Get variable completions from the current scope
             if (!response.getExcludeOtherCompletions())
             {
                addScopedCompletions(token, newComp, "variable");
                addScopedCompletions(token, newComp, "function");
             }
-            
+
             // Get other server completions
             for (int i = 0; i < comp.length(); i++)
                if (!comp.get(i).endsWith(" = "))
                   newComp.add(new QualifiedName(comp.get(i), pkgs.get(i), quote.get(i), type.get(i), response.getHelpHandler()));
-            
+
             // Get snippet completions. Bail if this isn't a top-level
             // completion -- TODO is to add some more context that allows us
             // to properly ascertain this.
             if (isTopLevelCompletionRequest())
                addSnippetCompletions(token, newComp);
-            
+
             // Remove duplicates
             newComp = resolveDuplicates(newComp);
-            
+
             CompletionResult result = new CompletionResult(
                   response.getToken(),
                   newComp,
@@ -427,14 +427,14 @@ public class CompletionRequester
          }
       }) ;
    }
-   
+
    private ArrayList<QualifiedName>
    resolveDuplicates(ArrayList<QualifiedName> completions)
    {
       ArrayList<QualifiedName> result =
             new ArrayList<QualifiedName>();
       result.addAll(completions);
-      
+
       // sort the results by name and type for efficient processing
       Collections.sort(completions, new Comparator<QualifiedName>()
       {
@@ -447,24 +447,24 @@ public class CompletionRequester
             return o1.type - o2.type;
          }
       });
-      
-      // walk backwards through the list and remove elements which have the 
+
+      // walk backwards through the list and remove elements which have the
       // same name and type
       for (int i = completions.size() - 1; i > 0; i--)
       {
          QualifiedName o1 = completions.get(i);
          QualifiedName o2 = completions.get(i - 1);
-         
+
          // remove qualified names which have the same name and type (allow
          // shadowing of contextual results to reduce confusion)
-         if (o1.name == o2.name && 
+         if (o1.name == o2.name &&
              (o1.type == o2.type || o1.type == RCompletionType.CONTEXT))
             result.remove(o1);
       }
-      
+
       return result;
    }
-   
+
    private void addScopedArgumentCompletions(
          String token,
          ArrayList<QualifiedName> completions)
@@ -479,12 +479,12 @@ public class CompletionRequester
          CodeModel codeModel = editor.getSession().getMode().getRCodeModel();
          JsArray<RFunction> scopedFunctions =
                codeModel.getFunctionsInScope(cursorPosition);
-         
+
          if (scopedFunctions.length() == 0)
             return;
-         
+
          String tokenLower = token.toLowerCase();
-         
+
          for (int i = 0; i < scopedFunctions.length(); i++)
          {
             RFunction scopedFunction = scopedFunctions.get(i);
@@ -516,10 +516,10 @@ public class CompletionRequester
                   }
                }
             }
-         } 
+         }
       }
    }
-      
+
    private void addScopedCompletions(
          String token,
          ArrayList<QualifiedName> completions,
@@ -533,10 +533,10 @@ public class CompletionRequester
          Position cursorPosition =
                editor.getSession().getSelection().getCursor();
          CodeModel codeModel = editor.getSession().getMode().getRCodeModel();
-      
+
          JsArray<RScopeObject> scopeVariables =
                codeModel.getVariablesInScope(cursorPosition);
-         
+
          String tokenLower = token.toLowerCase();
          for (int i = 0; i < scopeVariables.length(); i++)
          {
@@ -552,7 +552,7 @@ public class CompletionRequester
          }
       }
    }
-   
+
    private void addFunctionArgumentCompletions(
          String token,
          ArrayList<QualifiedName> completions)
@@ -564,14 +564,14 @@ public class CompletionRequester
          Position cursorPosition =
                editor.getSession().getSelection().getCursor();
          CodeModel codeModel = editor.getSession().getMode().getRCodeModel();
-         
+
          // Try to see if we can find a function name
          TokenCursor cursor = codeModel.getTokenCursor();
-         
+
          // NOTE: This can fail if the document is empty
          if (!cursor.moveToPosition(cursorPosition))
             return;
-         
+
          String tokenLower = token.toLowerCase();
          if (cursor.currentValue() == "(" || cursor.findOpeningBracket("(", false))
          {
@@ -580,7 +580,7 @@ public class CompletionRequester
                // Check to see if this really is the name of a function
                JsArray<ScopeFunction> functionsInScope =
                      codeModel.getAllFunctionScopes();
-               
+
                String tokenName = cursor.currentValue();
                for (int i = 0; i < functionsInScope.length(); i++)
                {
@@ -606,14 +606,14 @@ public class CompletionRequester
          }
       }
    }
-   
+
    private void addSnippetCompletions(
          String token,
          ArrayList<QualifiedName> completions)
    {
       if (StringUtil.isNullOrEmpty(token))
          return;
-      
+
       if (uiPrefs_.enableSnippets().getValue())
       {
          ArrayList<String> snippets = snippets_.getAvailableSnippets();
@@ -680,7 +680,7 @@ public class CompletionRequester
                   optionsStartOffset,
                   cursorPos,
                   rnwContext_ == null ? null : rnwContext_.getActiveRnwWeave());
-            
+
             String[] pkgNames = new String[result.completions.length()];
             Arrays.fill(pkgNames, "`chunk-option`");
 
@@ -695,7 +695,7 @@ public class CompletionRequester
                   false,
                   true,
                   null);
-            
+
             // Unlike other completion types, Sweave completions are not
             // guaranteed to narrow the candidate list (in particular
             // true/false).
@@ -705,7 +705,7 @@ public class CompletionRequester
             {
                response.setSuggestOnAccept(true);
             }
-            
+
             requestCallback.onResponseReceived(response);
          }
 
@@ -722,7 +722,7 @@ public class CompletionRequester
       cachedLinePrefix_ = null ;
       cachedCompletions_.clear();
    }
-   
+
    public static class CompletionResult
    {
       public CompletionResult(String token,
@@ -737,14 +737,14 @@ public class CompletionRequester
          this.suggestOnAccept = suggestOnAccept ;
          this.dontInsertParens = dontInsertParens ;
       }
-      
+
       public final String token ;
       public final ArrayList<QualifiedName> completions ;
       public final String guessedFunctionName ;
       public final boolean suggestOnAccept ;
       public final boolean dontInsertParens ;
    }
-   
+
    public static class QualifiedName implements Comparable<QualifiedName>
    {
       public QualifiedName(
@@ -752,7 +752,7 @@ public class CompletionRequester
       {
          this(name, source, shouldQuote, type, null);
       }
-      
+
       public QualifiedName(
             String name, String source, boolean shouldQuote, int type, String helpHandler)
       {
@@ -761,9 +761,9 @@ public class CompletionRequester
          this.shouldQuote = shouldQuote;
          this.type = type;
          this.helpHandler = helpHandler;
-         
+
       }
-      
+
       public QualifiedName(String name, String source)
       {
          this.name = name;
@@ -772,7 +772,7 @@ public class CompletionRequester
          this.type = RCompletionType.UNKNOWN;
          this.helpHandler = null;
       }
-      
+
       public static QualifiedName createSnippet(String name)
       {
          return new QualifiedName(
@@ -782,31 +782,31 @@ public class CompletionRequester
                RCompletionType.SNIPPET,
                null);
       }
-      
+
       @Override
       public String toString()
       {
          SafeHtmlBuilder sb = new SafeHtmlBuilder();
-         
+
          // Get an icon for the completion
          // We use separate styles for file icons, so we can nudge them
          // a bit differently
          String style = RES.styles().completionIcon();
          if (RCompletionType.isFileType(type))
             style = RES.styles().fileIcon();
-            
+
          SafeHtmlUtil.appendImage(
                sb,
                style,
                getIcon());
-         
+
          // Get the display name. Note that for file completions this requires
          // some munging of the 'name' and 'package' fields.
          addDisplayName(sb);
-         
+
          return sb.toSafeHtml().asString();
       }
-      
+
       private void addDisplayName(SafeHtmlBuilder sb)
       {
          // Handle files specially
@@ -815,7 +815,7 @@ public class CompletionRequester
          else
             doAddDisplayNameGeneric(sb);
       }
-      
+
       private void doAddDisplayNameFile(SafeHtmlBuilder sb)
       {
          ArrayList<Integer> slashIndices =
@@ -856,7 +856,7 @@ public class CompletionRequester
          }
 
       }
-      
+
       private void doAddDisplayNameGeneric(SafeHtmlBuilder sb)
       {
          // Get the name for the completion
@@ -878,12 +878,12 @@ public class CompletionRequester
                   "{" + source.replaceAll("package:", "") + "}");
          }
       }
-      
+
       private ImageResource getIcon()
       {
          if (RCompletionType.isFunctionType(type))
             return new ImageResource2x(ICONS.function2x());
-         
+
          switch(type)
          {
          case RCompletionType.UNKNOWN:
@@ -927,7 +927,7 @@ public class CompletionRequester
             return new ImageResource2x(ICONS.variable2x());
          }
       }
-      
+
       private ImageResource getIconForFilename(String name)
       {
          return FILE_TYPE_REGISTRY.getIconForFilename(name);
@@ -946,7 +946,7 @@ public class CompletionRequester
             name = val.substring(0, idx).trim() ;
             pkgName = val.substring(idx + 1, val.length() - 1) ;
          }
-         
+
          return new QualifiedName(name, pkgName) ;
       }
 
@@ -954,27 +954,27 @@ public class CompletionRequester
       {
          if (name.endsWith("=") ^ o.name.endsWith("="))
             return name.endsWith("=") ? -1 : 1 ;
-         
+
          int result = String.CASE_INSENSITIVE_ORDER.compare(name, o.name) ;
          if (result != 0)
             return result ;
-         
+
          String pkg = source == null ? "" : source ;
          String opkg = o.source == null ? "" : o.source ;
          return pkg.compareTo(opkg) ;
       }
-      
+
       @Override
       public boolean equals(Object object)
       {
          if (!(object instanceof QualifiedName))
             return false;
-         
+
          QualifiedName other = (QualifiedName) object;
          return name.equals(other.name) &&
                 type == other.type;
       }
-      
+
       @Override
       public int hashCode()
       {
@@ -992,14 +992,14 @@ public class CompletionRequester
       private static final FileTypeRegistry FILE_TYPE_REGISTRY =
             RStudioGinjector.INSTANCE.getFileTypeRegistry();
    }
-   
+
    private static final CompletionRequesterResources RES =
          CompletionRequesterResources.INSTANCE;
-   
+
    private static final CodeIcons ICONS = CodeIcons.INSTANCE;
-   
+
    static {
       RES.styles().ensureInjected();
    }
-   
+
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1154,7 +1154,7 @@ public class RCompletionManager implements CompletionManager
       // never autocomplete in (non-roxygen) comments, or at the start
       // of roxygen comments (e.g. at "#' |")
       // unless it's an emoji completion
-      if (isLineInComment(firstLine) && !isLineInRoxygenComment(firstLine) && !isEmojiCompletion(firstLine))
+      if (isLineInComment(firstLine) && !( isLineInRoxygenComment(firstLine) || isEmojiCompletion(firstLine)) )
          return false;
 
       // don't autocomplete if the cursor lies within the text of a
@@ -2096,11 +2096,8 @@ public class RCompletionManager implements CompletionManager
             value = value + "/";
 
          if (qualifiedName.type == RCompletionType.EMOJI){
-             // tokens are set to "" on comments
-             // so no need to replace in that case
-             if( value != ""){
-                value = completionToken.replaceAll( "[:][a-zA-Z0-9_]+$", value ) ;
-             }
+             // tokens are set to "" on comments, fix that
+             value = completionToken.replaceAll( "[:][a-zA-Z0-9_]+$", value ) ;
          } else if (!RCompletionType.isFileType(qualifiedName.type)) {
             if (value == ":=")
                value = quoteIfNotSyntacticNameCompletion(value);
@@ -2275,6 +2272,8 @@ public class RCompletionManager implements CompletionManager
          return "";
 
       String tokenValue = currentToken.getValue();
+      if( tokenValue.matches( "^\\s*#+'\\s+$" ))
+        return "" ;
 
       String subsetted = tokenValue.substring(0, cursorPos.getColumn() - currentToken.getColumn());
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -94,7 +94,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public class RCompletionManager implements CompletionManager
-{  
+{
    // globally suppress F1 and F2 so no default browser behavior takes those
    // keystrokes (e.g. Help in Chrome)
    static
@@ -116,12 +116,12 @@ public class RCompletionManager implements CompletionManager
          }
       });
    }
-   
+
    public void onPaste(PasteEvent event)
    {
       popup_.hide();
    }
-   
+
    public RCompletionManager(InputEditorDisplay input,
                              NavigableSourceEditor navigableSourceEditor,
                              CompletionPopupDisplay popup,
@@ -133,7 +133,7 @@ public class RCompletionManager implements CompletionManager
                              boolean isConsole)
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
-      
+
       input_ = input ;
       navigableSourceEditor_ = navigableSourceEditor;
       popup_ = popup ;
@@ -148,7 +148,7 @@ public class RCompletionManager implements CompletionManager
       snippets_ = new SnippetHelper((AceEditor) docDisplay, getSourceDocumentPath());
       requester_ = new CompletionRequester(rnwContext, docDisplay, snippets_);
       handlers_ = new HandlerRegistrations();
-      
+
       handlers_.add(input_.addBlurHandler(new BlurHandler() {
          public void onBlur(BlurEvent event)
          {
@@ -174,7 +174,7 @@ public class RCompletionManager implements CompletionManager
                context_.onSelection(event.getSelectedItem()) ;
          }
       }));
-      
+
       handlers_.add(popup_.addSelectionHandler(new SelectionHandler<QualifiedName>() {
          public void onSelection(SelectionEvent<QualifiedName> event)
          {
@@ -185,23 +185,23 @@ public class RCompletionManager implements CompletionManager
                showHelpDeferred(context_, lastSelectedItem_, 600);
          }
       }));
-      
+
       handlers_.add(popup_.addMouseDownHandler(new MouseDownHandler() {
          public void onMouseDown(MouseDownEvent event)
          {
             ignoreNextInputBlur_ = true ;
          }
       }));
-      
+
       handlers_.add(popup_.addSelectionHandler(new SelectionHandler<QualifiedName>() {
-         
+
          @Override
          public void onSelection(SelectionEvent<QualifiedName> event)
          {
             docDisplay_.setPopupVisible(true);
          }
       }));
-      
+
       handlers_.add(popup_.addCloseHandler(new CloseHandler<PopupPanel>()
       {
          @Override
@@ -217,16 +217,16 @@ public class RCompletionManager implements CompletionManager
             });
          }
       }));
-      
+
       handlers_.add(popup_.addAttachHandler(new AttachEvent.Handler()
       {
          private boolean wasSigtipShowing_ = false;
-         
+
          @Override
          public void onAttachOrDetach(AttachEvent event)
          {
             RCompletionToolTip toolTip = sigTipManager_.getToolTip();
-            
+
             if (event.isAttached())
             {
                if (toolTip != null && toolTip.isShowing())
@@ -246,9 +246,9 @@ public class RCompletionManager implements CompletionManager
             }
          }
       }));
-      
+
    }
-   
+
    @Inject
    public void initialize(GlobalDisplay globalDisplay,
                           FileTypeRegistry fileTypeRegistry,
@@ -262,7 +262,7 @@ public class RCompletionManager implements CompletionManager
       helpStrategy_ = helpStrategy;
       uiPrefs_ = uiPrefs;
    }
-   
+
    public void detach()
    {
       handlers_.removeHandler();
@@ -275,25 +275,25 @@ public class RCompletionManager implements CompletionManager
    {
       popup_.hide();
    }
-   
+
    public void codeCompletion()
    {
       if (initFilter_ == null || initFilter_.shouldComplete(null))
          beginSuggest(true, false, true);
    }
-   
+
    public void goToHelp()
    {
-      InputEditorLineWithCursorPosition linePos = 
+      InputEditorLineWithCursorPosition linePos =
             InputEditorUtil.getLineWithCursorPosition(input_);
 
       server_.getHelpAtCursor(
             linePos.getLine(), linePos.getPosition(),
             new SimpleRequestCallback<Void>("Help"));
    }
-   
+
    public void goToFunctionDefinition()
-   {   
+   {
       // check for a file-local definition (intra-file navigation -- using
       // the active scope tree)
       AceEditor editor = (AceEditor) docDisplay_;
@@ -306,29 +306,29 @@ public class RCompletionManager implements CompletionManager
             // token (obstensibly a funciton name)
             if (cursor.isLeftBracket())
                cursor.moveToPreviousToken();
-            
+
             // if the previous token is an extraction operator, we shouldn't
             // navigate (as this isn't the 'full' function name)
             if (cursor.moveToPreviousToken())
             {
                if (cursor.isExtractionOperator())
                   return;
-               
+
                cursor.moveToNextToken();
             }
-            
+
             // if this is a string, try resolving that string as a file name
             if (cursor.hasType("string"))
             {
                String tokenValue = cursor.currentValue();
                String path = tokenValue.substring(1, tokenValue.length() - 1);
                FileSystemItem filePath = FileSystemItem.createFile(path);
-               
+
                // This will show a dialog error if no such file exists; this
                // seems the most appropriate action in such a case.
                fileTypeRegistry_.editFile(filePath);
             }
-            
+
             String functionName = cursor.currentValue();
             JsArray<ScopeFunction> scopes =
                   editor.getAllFunctionScopes();
@@ -347,70 +347,70 @@ public class RCompletionManager implements CompletionManager
             }
          }
       }
-      
+
       // intra-file navigation failed -- hit the server and find a definition
       // in the project index
-      
+
       // determine current line and cursor position
-      InputEditorLineWithCursorPosition lineWithPos = 
+      InputEditorLineWithCursorPosition lineWithPos =
                       InputEditorUtil.getLineWithCursorPosition(input_);
-      
+
       // delayed progress indicator
       final GlobalProgressDelayer progress = new GlobalProgressDelayer(
             globalDisplay_, 1000, "Searching for function definition...");
-      
+
       server_.getObjectDefinition(
          lineWithPos.getLine(),
-         lineWithPos.getPosition(), 
+         lineWithPos.getPosition(),
          new ServerRequestCallback<ObjectDefinition>() {
             @Override
             public void onResponseReceived(ObjectDefinition def)
             {
                 // dismiss progress
                 progress.dismiss();
-                    
+
                 // if we got a hit
                 if (def.getObjectName() != null)
-                {   
+                {
                    // search locally if a function navigator was provided
                    if (navigableSourceEditor_ != null)
                    {
                       // try to search for the function locally
-                      SourcePosition position = 
+                      SourcePosition position =
                          navigableSourceEditor_.findFunctionPositionFromCursor(
                                                          def.getObjectName());
                       if (position != null)
                       {
-                         navigableSourceEditor_.navigateToPosition(position, 
+                         navigableSourceEditor_.navigateToPosition(position,
                                                                    true);
                          return; // we're done
                       }
 
                    }
-                   
+
                    // if we didn't satisfy the request using a function
                    // navigator and we got a file back from the server then
                    // navigate to the file/loc
-                   if (def.getObjectType() == 
+                   if (def.getObjectType() ==
                          FileFunctionDefinition.OBJECT_TYPE)
-                   {  
-                      FileFunctionDefinition fileDef = 
+                   {
+                      FileFunctionDefinition fileDef =
                             def.getObjectData().cast();
-                      fileTypeRegistry_.editFile(fileDef.getFile(), 
+                      fileTypeRegistry_.editFile(fileDef.getFile(),
                                                  fileDef.getPosition());
                    }
-                   
-                   // if we didn't get a file back see if we got a 
+
+                   // if we didn't get a file back see if we got a
                    // search path definition
                    else if (def.getObjectType() ==
                               SearchPathFunctionDefinition.OBJECT_TYPE)
                    {
-                      SearchPathFunctionDefinition searchDef = 
+                      SearchPathFunctionDefinition searchDef =
                             def.getObjectData().cast();
                       eventBus_.fireEvent(
                             new CodeBrowserNavigationEvent(searchDef));
                    }
-                   
+
                    // finally, check to see if it's a data frame
                    else if (def.getObjectType() == DataDefinition.OBJECT_TYPE)
                    {
@@ -424,29 +424,29 @@ public class RCompletionManager implements CompletionManager
             public void onError(ServerError error)
             {
                progress.dismiss();
-               
+
                globalDisplay_.showErrorMessage("Error Searching for Function",
                                                error.getUserMessage());
             }
          });
    }
-   
+
    public boolean previewKeyDown(NativeEvent event)
    {
       suggestTimer_.cancel();
-      
+
       if (sigTipManager_.previewKeyDown(event))
          return true;
-      
+
       if (isDisabled())
          return false;
-      
+
       /**
        * KEYS THAT MATTER
        *
        * When popup not showing:
        * Tab - attempt completion (handled in Console.java)
-       * 
+       *
        * When popup showing:
        * Esc - dismiss popup
        * Enter/Tab - accept current selection
@@ -454,7 +454,7 @@ public class RCompletionManager implements CompletionManager
        * [identifier] - narrow suggestions--or if we're lame, just dismiss
        * All others - dismiss popup
        */
-      
+
       nativeEvent_ = event;
 
       int keycode = event.getKeyCode();
@@ -465,7 +465,7 @@ public class RCompletionManager implements CompletionManager
          // don't allow ctrl + space for completions in Emacs mode
          if (docDisplay_.isEmacsModeOn() && event.getKeyCode() == KeyCodes.KEY_SPACE)
             return false;
-         
+
          if (CompletionUtils.isCompletionRequest(event, modifier))
          {
             if (initFilter_ == null || initFilter_.shouldComplete(event))
@@ -481,7 +481,7 @@ public class RCompletionManager implements CompletionManager
                             StringUtil.countMatches(currentLine, '`') % 2 == 1)))
                      return false;
                }
-               
+
                // If we're in tex mode, only provide completions in chunks
                if (DocumentMode.isCursorInTexMode(docDisplay_))
                {
@@ -515,7 +515,7 @@ public class RCompletionManager implements CompletionManager
          // bail on modifier keys
          if (KeyboardHelper.isModifierKey(keycode))
             return false;
-         
+
          // allow emacs-style navigation of popup entries
          if (modifier == KeyboardShortcut.CTRL)
          {
@@ -525,7 +525,7 @@ public class RCompletionManager implements CompletionManager
             case KeyCodes.KEY_N: return popup_.selectNext();
             }
          }
-         
+
          else if (modifier == KeyboardShortcut.NONE)
          {
             if (keycode == KeyCodes.KEY_ESCAPE)
@@ -533,7 +533,7 @@ public class RCompletionManager implements CompletionManager
                invalidatePendingRequests() ;
                return true ;
             }
-            
+
             // NOTE: It is possible for the popup to still be showing, but
             // showing offscreen with no values. We only grab these keys
             // when the popup is both showing, and has completions.
@@ -551,7 +551,7 @@ public class RCompletionManager implements CompletionManager
                      return true ;
                   }
                }
-               
+
                else if (keycode == KeyCodes.KEY_TAB)
                {
                   QualifiedName value = popup_.getSelectedValue() ;
@@ -559,12 +559,12 @@ public class RCompletionManager implements CompletionManager
                   {
                      if (value.type == RCompletionType.DIRECTORY)
                         context_.suggestOnAccept_ = true;
-                     
+
                      context_.onSelection(value);
                      return true;
                   }
                }
-               
+
                else if (keycode == KeyCodes.KEY_UP)
                   return popup_.selectPrev() ;
                else if (keycode == KeyCodes.KEY_DOWN)
@@ -577,7 +577,7 @@ public class RCompletionManager implements CompletionManager
                   return popup_.selectFirst();
                else if (keycode == KeyCodes.KEY_END)
                   return popup_.selectLast();
-               
+
                if (keycode == 112) // F1
                {
                   context_.showHelpTopic() ;
@@ -589,12 +589,12 @@ public class RCompletionManager implements CompletionManager
                   return true;
                }
             }
-            
+
          }
-         
+
          if (canContinueCompletions(event))
             return false;
-         
+
          // if we insert a '/', we're probably forming a directory --
          // pop up completions
          if (keycode == 191 && modifier == KeyboardShortcut.NONE)
@@ -602,27 +602,27 @@ public class RCompletionManager implements CompletionManager
             input_.insertCode("/");
             return beginSuggest(true, true, false);
          }
-         
+
          // continue showing completions on backspace
          if (keycode == KeyCodes.KEY_BACKSPACE && modifier == KeyboardShortcut.NONE &&
              !docDisplay_.inMultiSelectMode())
          {
             int cursorColumn = input_.getCursorPosition().getColumn();
             String currentLine = docDisplay_.getCurrentLine();
-            
+
             // only suggest if the character previous to the cursor is an R identifier
             // also halt suggestions if we're about to remove the only character on the line
             if (cursorColumn > 0)
             {
                char ch = currentLine.charAt(cursorColumn - 2);
                char prevCh = currentLine.charAt(cursorColumn - 3);
-               
+
                boolean isAcceptableCharSequence = isValidForRIdentifier(ch) ||
                      (ch == ':' && prevCh == ':') ||
                      ch == '$' ||
                      ch == '@' ||
                      ch == '/'; // for file completions
-               
+
                if (currentLine.length() > 0 &&
                      cursorColumn > 0 &&
                      isAcceptableCharSequence)
@@ -641,7 +641,7 @@ public class RCompletionManager implements CompletionManager
 
                   input_.setSelection(new InputEditorSelection(start, end));
                   input_.replaceSelection("", false);
-                  
+
                   return beginSuggest(false, false, false);
                }
             }
@@ -651,14 +651,14 @@ public class RCompletionManager implements CompletionManager
                return true;
             }
          }
-         
+
          invalidatePendingRequests();
          return false ;
       }
-      
+
       return false ;
    }
-   
+
    private boolean isValidForRIdentifier(char c) {
       return (c >= 'a' && c <= 'z') ||
              (c >= 'A' && c <= 'Z') ||
@@ -666,30 +666,30 @@ public class RCompletionManager implements CompletionManager
              (c == '.') ||
              (c == '_');
    }
-   
+
    private boolean checkCanAutoPopup(char c, int lookbackLimit)
    {
       if (docDisplay_.isVimModeOn() &&
             !docDisplay_.isVimInInsertMode())
          return false;
-      
+
       String currentLine = docDisplay_.getCurrentLine();
       Position cursorPos = input_.getCursorPosition();
       int cursorColumn = cursorPos.getColumn();
-      
+
       // Don't auto-popup when the cursor is within a string
       if (docDisplay_.isCursorInSingleLineString())
          return false;
-      
+
       // Don't auto-popup if there is a character following the cursor
       // (this implies an in-line edit and automatic popups are likely to
       // be annoying)
       if (isValidForRIdentifier(docDisplay_.getCharacterAtCursor()))
          return false;
-      
+
       boolean canAutoPopup =
             (currentLine.length() > lookbackLimit - 1 && isValidForRIdentifier(c));
-      
+
       if (isConsole_ && !uiPrefs_.alwaysCompleteInConsole().getValue())
          canAutoPopup = false;
 
@@ -706,16 +706,16 @@ public class RCompletionManager implements CompletionManager
       }
 
       return canAutoPopup;
-      
+
    }
-   
+
    public boolean previewKeyPress(char c)
    {
       suggestTimer_.cancel();
-      
+
       if (isDisabled())
          return false;
-      
+
       if (popup_.isShowing())
       {
          // If insertion of this character completes an available suggestion,
@@ -723,7 +723,7 @@ public class RCompletionManager implements CompletionManager
          // apply that.
          QualifiedName selectedItem =
                popup_.getSelectedValue();
-         
+
          // NOTE: We should strip off trailing colons so that in-line edits of
          // package completions, e.g.
          //
@@ -734,7 +734,7 @@ public class RCompletionManager implements CompletionManager
                selectedItem.name.replaceAll(":",  "").equals(token_ + c))
          {
             String fullToken = token_ + c;
-            
+
             // Find prefix matches -- there should only be one if we really
             // want this behaviour (ie the current selection)
             int prefixMatchCount = 0;
@@ -748,25 +748,25 @@ public class RCompletionManager implements CompletionManager
                      break;
                }
             }
-            
+
             if (prefixMatchCount == 1)
             {
                // We place the completion list offscreen to ensure that
-               // backspace events are handled later. 
+               // backspace events are handled later.
                popup_.placeOffscreen();
                return false;
             }
          }
-         
+
          if (c == ':')
          {
             suggestTimer_.schedule(false, true, false);
             return false;
          }
-         
+
          if (c == ' ')
             return false;
-         
+
          // Always update the current set of completions following
          // a key insertion. Defer execution so the key insertion can
          // enter the document.
@@ -779,27 +779,27 @@ public class RCompletionManager implements CompletionManager
             }
          });
          return false;
-         
+
       }
       else
       {
          // Bail if we're not in R mode
          if (!DocumentMode.isCursorInRMode(docDisplay_))
             return false;
-         
+
          // Bail if we're in a single-line string
          if (docDisplay_.isCursorInSingleLineString())
             return false;
-         
+
          // if there's a selection, bail
-         if (input_.hasSelection()) 
+         if (input_.hasSelection())
             return false;
-         
+
          // Bail if there is an alpha-numeric character
          // following the cursor
          if (isValidForRIdentifier(docDisplay_.getCharacterAtCursor()))
             return false;
-         
+
          // Perform an auto-popup if a set number of R identifier characters
          // have been inserted (but only if the user has allowed it in prefs)
          boolean autoPopupEnabled = uiPrefs_.codeComplete().getValue().equals(
@@ -807,7 +807,7 @@ public class RCompletionManager implements CompletionManager
 
          if (!autoPopupEnabled)
             return false;
-         
+
          // Immediately display completions after '$', '::', etc.
          char prevChar = docDisplay_.getCurrentLine().charAt(
                input_.getCursorPosition().getColumn() - 1);
@@ -823,7 +823,7 @@ public class RCompletionManager implements CompletionManager
             {
                return false;
             }
-            
+
             Scheduler.get().scheduleDeferred(new ScheduledCommand()
             {
                @Override
@@ -834,10 +834,10 @@ public class RCompletionManager implements CompletionManager
             });
             return false;
          }
-         
+
          // Check for a valid number of R identifier characters for autopopup
          boolean canAutoPopup = checkCanAutoPopup(c, uiPrefs_.alwaysCompleteCharacters().getValue() - 1);
-         
+
          // Attempt to pop up completions immediately after a function call.
          if (c == '(' && !isLineInComment(docDisplay_.getCurrentLine()))
          {
@@ -847,13 +847,13 @@ public class RCompletionManager implements CompletionManager
                   "[" + RegexUtil.wordCharacter() + "._]",
                   false,
                   true);
-            
+
             if (token.matches("^(library|require|requireNamespace|data)\\s*$"))
                canAutoPopup = true;
-            
+
             sigTipManager_.resolveActiveFunctionAndDisplayToolTip();
          }
-         
+
          if (
                (canAutoPopup) ||
                isSweaveCompletion(c))
@@ -864,7 +864,7 @@ public class RCompletionManager implements CompletionManager
       }
       return false ;
    }
-   
+
    @SuppressWarnings("unused")
    private boolean isRoxygenTagValidHere()
    {
@@ -906,9 +906,9 @@ public class RCompletionManager implements CompletionManager
       {
          return false ;
       }
-      
+
       int keyCode = event.getKeyCode() ;
-      
+
       if (keyCode >= 'a' && keyCode <= 'z')
          return true ;
       else if (keyCode >= 'A' && keyCode <= 'Z')
@@ -919,15 +919,15 @@ public class RCompletionManager implements CompletionManager
          return true ;
       else if (KeyboardHelper.isUnderscore(event))
          return true;
-      
+
       if (event.getShiftKey())
          return false ;
-      
+
       if (keyCode >= '0' && keyCode <= '9')
          return true ;
       if (keyCode == 190) // period
          return true ;
-      
+
       return false ;
    }
 
@@ -940,18 +940,18 @@ public class RCompletionManager implements CompletionManager
                                           boolean hidePopup)
    {
       invalidation_.invalidate();
-      
+
       if (hidePopup && popup_.isShowing())
       {
          popup_.hide();
          popup_.clearHelp(false);
       }
-      
+
       if (flushCache)
          requester_.flushCache() ;
    }
-   
-   
+
+
    // Things we need to form an appropriate autocompletion:
    //
    // 1. The token to the left of the cursor,
@@ -959,7 +959,7 @@ public class RCompletionManager implements CompletionManager
    // 3. The associated data for a `[` call (if any -- completions from data object),
    // 4. The associated data for a `[[` call (if any -- completions from data object)
    class AutocompletionContext {
-      
+
       // Be sure to sync these with 'SessionCodeTools.R'!
       public static final int TYPE_UNKNOWN = 0;
       public static final int TYPE_FUNCTION = 1;
@@ -975,7 +975,8 @@ public class RCompletionManager implements CompletionManager
       public static final int TYPE_HELP = 11;
       public static final int TYPE_ARGUMENT = 12;
       public static final int TYPE_PACKAGE = 13;
-      
+      public static final int TYPE_EMOJI = 14;
+
       public AutocompletionContext(
             String token,
             List<String> assocData,
@@ -989,7 +990,7 @@ public class RCompletionManager implements CompletionManager
          numCommas_ = numCommas;
          functionCallString_ = functionCallString;
       }
-      
+
       public AutocompletionContext(
             String token,
             ArrayList<String> assocData,
@@ -1001,7 +1002,7 @@ public class RCompletionManager implements CompletionManager
          numCommas_ = Arrays.asList(0);
          functionCallString_ = "";
       }
-      
+
       public AutocompletionContext(
             String token,
             String assocData,
@@ -1013,8 +1014,8 @@ public class RCompletionManager implements CompletionManager
          numCommas_ = Arrays.asList(0);
          functionCallString_ = "";
       }
-      
-      
+
+
       public AutocompletionContext(
             String token,
             int dataType)
@@ -1025,7 +1026,7 @@ public class RCompletionManager implements CompletionManager
          numCommas_ = Arrays.asList(0);
          functionCallString_ = "";
       }
-      
+
       public AutocompletionContext()
       {
          token_ = "";
@@ -1084,19 +1085,19 @@ public class RCompletionManager implements CompletionManager
       {
          this.functionCallString_ = functionCallString;
       }
-      
+
       public void add(String assocData, Integer dataType, Integer numCommas)
       {
          assocData_.add(assocData);
          dataType_.add(dataType);
          numCommas_.add(numCommas);
       }
-      
+
       public void add(String assocData, Integer dataType)
       {
          add(assocData, dataType, 0);
       }
-      
+
       public void add(String assocData)
       {
          add(assocData, AutocompletionContext.TYPE_UNKNOWN, 0);
@@ -1107,20 +1108,20 @@ public class RCompletionManager implements CompletionManager
       private List<Integer> dataType_;
       private List<Integer> numCommas_;
       private String functionCallString_;
-      
+
    }
-   
+
    private boolean isLineInRoxygenComment(String line)
    {
       Pattern pattern = Pattern.create("^\\s*#+'");
       return pattern.test(line);
    }
-   
+
    private boolean isLineInComment(String line)
    {
       return StringUtil.stripBalancedQuotes(line).contains("#");
    }
-   
+
    /**
     * If false, the suggest operation was aborted
     */
@@ -1129,24 +1130,24 @@ public class RCompletionManager implements CompletionManager
                                 boolean canAutoInsert)
    {
       suggestTimer_.cancel();
-      
+
       if (!input_.isSelectionCollapsed())
          return false ;
-      
+
       invalidatePendingRequests(flushCache, false);
-      
+
       InputEditorSelection selection = input_.getSelection();
       if (selection == null)
          return false;
-      
+
       int cursorCol = selection.getStart().getPosition();
       String firstLine = input_.getText().substring(0, cursorCol);
-      
+
       // never autocomplete in (non-roxygen) comments, or at the start
       // of roxygen comments (e.g. at "#' |")
       if (isLineInComment(firstLine) && !isLineInRoxygenComment(firstLine))
          return false;
-      
+
       // don't autocomplete if the cursor lies within the text of a
       // multi-line string. the logic here isn't perfect (ideally, we'd detect
       // whether we're in the 'qstring' or 'qqstring' state), but this will catch
@@ -1161,7 +1162,7 @@ public class RCompletionManager implements CompletionManager
          if (!isSingleLineString)
             return false;
       }
-      
+
       // don't auto-complete with tab on lines with only whitespace,
       // if the insertion character was a tab (unless the user has opted in)
       if (!uiPrefs_.allowTabMultilineCompletion().getValue())
@@ -1171,9 +1172,9 @@ public class RCompletionManager implements CompletionManager
             if (firstLine.matches("^\\s*$"))
                return false;
       }
-      
+
       AutocompletionContext context = getAutocompletionContext();
-      
+
       // Fix up the context token for non-file completions -- e.g. in
       //
       //    foo<-rn
@@ -1182,48 +1183,48 @@ public class RCompletionManager implements CompletionManager
       // but is effectively a bandaid until the autocompletion revamp.
       if (context.getToken().startsWith("-"))
          context.setToken(context.getToken().substring(1));
-      
+
       // fix up roxygen autocompletion for case where '@' is snug against
       // the comment marker
       if (context.getToken().equals("'@"))
          context.setToken(context.getToken().substring(1));
-      
+
       context_ = new CompletionRequestContext(invalidation_.getInvalidationToken(),
                                               selection,
                                               canAutoInsert);
-      
+
       RInfixData infixData = RInfixData.create();
       AceEditor editor = (AceEditor) docDisplay_;
       if (editor != null)
       {
          CodeModel codeModel = editor.getSession().getMode().getRCodeModel();
          TokenCursor cursor = codeModel.getTokenCursor();
-         
+
          if (cursor.moveToPosition(input_.getCursorPosition()))
          {
             String token = "";
             if (cursor.hasType("identifier"))
                token = cursor.currentValue();
-            
+
             String cursorPos = "left";
             if (cursor.currentValue() == "=")
                cursorPos = "right";
-            
+
             TokenCursor clone = cursor.cloneCursor();
             if (clone.moveToPreviousToken())
                if (clone.currentValue() == "=")
                   cursorPos = "right";
-            
+
             // Try to get a dplyr join completion
             DplyrJoinContext joinContext =
                   codeModel.getDplyrJoinContextFromInfixChain(cursor);
-            
+
             // If that failed, try a non-infix lookup
             if (joinContext == null)
             {
                String joinString =
                      getDplyrJoinString(editor, cursor);
-               
+
                if (!StringUtil.isNullOrEmpty(joinString))
                {
                   requester_.getDplyrJoinCompletionsString(
@@ -1243,22 +1244,22 @@ public class RCompletionManager implements CompletionManager
                      implicit,
                      context_);
                return true;
-               
+
             }
-            
+
             // Try to see if there's an object name we should use to supplement
             // completions
             if (cursor.moveToPosition(input_.getCursorPosition()))
                infixData = codeModel.getDataFromInfixChain(cursor);
          }
       }
-      
+
       String filePath = getSourceDocumentPath();
       String docId = getSourceDocumentId();
-      
+
       // Provide 'line' for R custom completers
       String line = docDisplay_.getCurrentLineUpToCursor();
-      
+
       requester_.getCompletions(
             context.getToken(),
             context.getAssocData(),
@@ -1277,7 +1278,7 @@ public class RCompletionManager implements CompletionManager
 
       return true ;
    }
-   
+
    private String getDplyrJoinString(
          AceEditor editor,
          TokenCursor cursor)
@@ -1287,13 +1288,13 @@ public class RCompletionManager implements CompletionManager
          int commaCount = cursor.findOpeningBracketCountCommas("(", true);
          if (commaCount == -1)
             break;
-         
+
          if (!cursor.moveToPreviousToken())
             return "";
 
          if (!cursor.currentValue().matches(".*join$"))
             continue;
-         
+
          if (commaCount < 2)
             return "";
 
@@ -1312,8 +1313,8 @@ public class RCompletionManager implements CompletionManager
       }
       return "";
    }
-   
-   
+
+
    private void addAutocompletionContextForFile(AutocompletionContext context,
                                                 String line)
    {
@@ -1322,35 +1323,49 @@ public class RCompletionManager implements CompletionManager
       context.add(token, AutocompletionContext.TYPE_FILE);
       context.setToken(token);
    }
-   
+
+   private AutocompletionContext getAutocompletionContextForEmoji(
+         String line)
+   {
+      int index = line.lastIndexOf(':');
+      String token = line.substring(index + 1);
+
+      AutocompletionContext result = new AutocompletionContext(
+            token,
+            token,
+            AutocompletionContext.TYPE_EMOJI);
+
+      return result;
+   }
+
    private AutocompletionContext getAutocompletionContextForFileMarkdownLink(
          String line)
    {
       int index = line.lastIndexOf('(');
       String token = line.substring(index + 1);
-      
+
       AutocompletionContext result = new AutocompletionContext(
             token,
             token,
             AutocompletionContext.TYPE_FILE);
-      
+
       // NOTE: we overload the meaning of the function call string for file
       // completions, to signal whether we should generate files relative to
       // the current working directory, or to the file being used for
       // completions
       result.setFunctionCallString("useFile");
       return result;
-      
+
    }
-   
-   
+
+
    private void addAutocompletionContextForNamespace(
          String token,
          AutocompletionContext context)
    {
          String[] splat = token.split(":{2,3}");
          String left = "";
-         
+
          if (splat.length <= 0)
          {
             left = "";
@@ -1359,42 +1374,42 @@ public class RCompletionManager implements CompletionManager
          {
             left = splat[0];
          }
-         
+
          int type = token.contains(":::") ?
                AutocompletionContext.TYPE_NAMESPACE_ALL :
                   AutocompletionContext.TYPE_NAMESPACE_EXPORTED;
-               
+
          context.add(left, type);
    }
-   
-   
+
+
    private boolean addAutocompletionContextForDollar(AutocompletionContext context)
    {
       // Establish an evaluation context by looking backwards
       AceEditor editor = (AceEditor) docDisplay_;
       if (editor == null)
          return false;
-      
+
       CodeModel codeModel = editor.getSession().getMode().getRCodeModel();
       codeModel.tokenizeUpToRow(input_.getCursorPosition().getRow());
-      
+
       TokenCursor cursor = codeModel.getTokenCursor();
-         
+
       if (!cursor.moveToPosition(input_.getCursorPosition()))
          return false;
-      
+
       // Move back to the '$'
       while (cursor.currentValue() != "$" && cursor.currentValue() != "@")
          if (!cursor.moveToPreviousToken())
             return false;
-      
+
       int type = cursor.currentValue() == "$" ?
             AutocompletionContext.TYPE_DOLLAR :
             AutocompletionContext.TYPE_AT;
-      
+
       // Put a cursor here
       TokenCursor contextEndCursor = cursor.cloneCursor();
-      
+
       // We allow for arbitrary elements previous, so we want to get e.g.
       //
       //     env::foo()$bar()[1]$baz
@@ -1405,104 +1420,109 @@ public class RCompletionManager implements CompletionManager
       // (the completion is still occurring in a '$' context, so we do want
       // to exclude completions from other scopes)
       String data = "";
-      
+
       if (cursor.moveToPreviousToken() && cursor.findStartOfEvaluationContext())
       {
          data = editor.getTextForRange(Range.fromPoints(
                cursor.currentPosition(),
                contextEndCursor.currentPosition()));
       }
-      
+
       context.add(data, type);
       return true;
    }
-   
-   
+
+
    private AutocompletionContext getAutocompletionContext()
    {
       AutocompletionContext context = new AutocompletionContext();
-      
+
       String firstLine = input_.getText();
       int row = input_.getCursorPosition().getRow();
-      
+
       // trim to cursor position
       firstLine = firstLine.substring(0, input_.getCursorPosition().getColumn());
-      
+
       // If we're in Markdown mode and have an appropriate string, try to get
       // file completions
       if (DocumentMode.isCursorInMarkdownMode(docDisplay_) &&
             firstLine.matches(".*\\[.*\\]\\(.*"))
          return getAutocompletionContextForFileMarkdownLink(firstLine);
-      
+
+      // Markdown mode + emoji completions
+      if (DocumentMode.isCursorInMarkdownMode(docDisplay_) &&
+            firstLine.matches(".*[:][a-zA-Z0-9_]*"))
+         return getAutocompletionContextForEmoji(firstLine);
+
       // Get the token at the cursor position.
       String tokenRegex = ".*[^" +
          RegexUtil.wordCharacter() +
          "._:$@'\"`-]";
       String token = firstLine.replaceAll(tokenRegex, "");
-      
+
       // If we're completing an object within a string, assume it's a
       // file-system completion. Note that we may need other contextual information
       // to decide if e.g. we only want directories.
       String firstLineStripped = StringUtil.stripBalancedQuotes(
             StringUtil.stripRComment(firstLine));
-      
+
       boolean isFileCompletion = false;
-      if (firstLineStripped.indexOf('\'') != -1 || 
+      if (firstLineStripped.indexOf('\'') != -1 ||
           firstLineStripped.indexOf('"') != -1)
       {
          isFileCompletion = true;
          addAutocompletionContextForFile(context, firstLine);
       }
-      
+
       // If this line starts with '```{', then we're completing chunk options
       // pass the whole line as a token
       if (firstLine.startsWith("```{") || firstLine.startsWith("<<"))
          return new AutocompletionContext(firstLine, AutocompletionContext.TYPE_CHUNK);
-      
+
       // If this line starts with a '?', assume it's a help query
       if (firstLine.matches("^\\s*[?].*"))
          return new AutocompletionContext(token, AutocompletionContext.TYPE_HELP);
-      
+
       // escape early for roxygen
       if (firstLine.matches("\\s*#+'.*"))
          return new AutocompletionContext(token, AutocompletionContext.TYPE_ROXYGEN);
-      
+
       // If the token has '$' or '@', add in the autocompletion context --
       // note that we still need parent contexts to give more information
       // about the appropriate completion
       if (token.contains("$") || token.contains("@"))
          addAutocompletionContextForDollar(context);
-      
+
       // If the token has '::' or ':::', add that context. Note that
       // we still need outer contexts (so that e.g., if we try
       // 'debug(stats::rnorm)' we know not to auto-insert parens)
       if (token.contains("::"))
          addAutocompletionContextForNamespace(token, context);
-      
+
       // If this is not a file completion, we need to further strip and
       // then set the token. Note that the token will have already been
       // set if this is a file completion.
       token = token.replaceAll(".*[$@:]", "");
       if (!isFileCompletion)
          context.setToken(token);
-      
+
       // access to the R Code model
       AceEditor editor = (AceEditor) docDisplay_;
       if (editor == null)
          return context;
-      
+
       CodeModel codeModel = editor.getSession().getMode().getRCodeModel();
-      
+
       // We might need to grab content from further up in the document than
       // the current cursor position -- so tokenize ahead.
       codeModel.tokenizeUpToRow(row + 100);
-      
+
       // Make a token cursor and place it at the first token previous
       // to the cursor.
       TokenCursor tokenCursor = codeModel.getTokenCursor();
       if (!tokenCursor.moveToPosition(input_.getCursorPosition()))
          return context;
-      
+
       // Check to see if the token following the cursor is a `::` or `:::`.
       // If that's the case, then we probably only want to complete package
       // names.
@@ -1518,9 +1538,9 @@ public class RCompletionManager implements CompletionManager
          }
          tokenCursor.moveToPreviousToken();
       }
-      
+
       TokenCursor startCursor = tokenCursor.cloneCursor();
-      
+
       // Find an opening '(' or '[' -- this provides the function or object
       // for completion.
       int initialNumCommas = 0;
@@ -1528,7 +1548,7 @@ public class RCompletionManager implements CompletionManager
       {
          int commaCount = tokenCursor.findOpeningBracketCountCommas(
                new String[]{ "[", "(" }, true);
-         
+
          // commaCount == -1 implies we failed to find an opening bracket
          if (commaCount == -1)
          {
@@ -1543,7 +1563,7 @@ public class RCompletionManager implements CompletionManager
             initialNumCommas = commaCount;
          }
       }
-      
+
       // Figure out whether we're looking at '(', '[', or '[[',
       // and place the token cursor on the first token preceding.
       TokenCursor endOfDecl = tokenCursor.cloneCursor();
@@ -1558,12 +1578,12 @@ public class RCompletionManager implements CompletionManager
       {
          if (!tokenCursor.moveToPreviousToken())
             return context;
-         
+
          if (tokenCursor.currentValue() == "[")
          {
             if (!endOfDecl.moveToPreviousToken())
                return context;
-            
+
             initialDataType = AutocompletionContext.TYPE_DOUBLE_BRACKET;
             if (!tokenCursor.moveToPreviousToken())
                return context;
@@ -1573,21 +1593,21 @@ public class RCompletionManager implements CompletionManager
             initialDataType = AutocompletionContext.TYPE_SINGLE_BRACKET;
          }
       }
-      
+
       // Get the string marking the function or data
       if (!tokenCursor.findStartOfEvaluationContext())
          return context;
-      
+
       // Try to get the function call string -- either there's
       // an associated closing paren we can use, or we should just go up
       // to the current cursor position.
-      
+
       // First, attempt to determine where the closing paren is located. If
       // this fails, we'll just use the start cursor's position (and later
       // attempt to finish the expression to make it parsable)
       Position endPos = startCursor.currentPosition();
       endPos.setColumn(endPos.getColumn() + startCursor.currentValue().length());
-      
+
       // try to look forward for closing paren
       if (endOfDecl.currentValue() == "(")
       {
@@ -1598,7 +1618,7 @@ public class RCompletionManager implements CompletionManager
             endPos.setColumn(endPos.getColumn() + 1);
          }
       }
-      
+
       // We can now set the function call string.
       //
       // We strip out the current statement under the cursor, so that
@@ -1611,23 +1631,23 @@ public class RCompletionManager implements CompletionManager
          String value = clone.currentValue();
          if (value.indexOf(",") != -1 || value.equals("("))
             break;
-         
+
          if (clone.bwdToMatchingToken())
             continue;
-         
+
       } while (clone.moveToPreviousToken());
       Position startPosition = clone.currentPosition();
-      
+
       // Include the opening paren if that's what we found
       if (clone.currentValue().equals("("))
          startPosition.setColumn(startPosition.getColumn() + 1);
-      
+
       String beforeText = editor.getTextForRange(Range.fromPoints(
             tokenCursor.currentPosition(),
             startPosition));
-      
+
       // Now, attempt to find the end of the current statement.
-      // Look for the ',' or ')' that ends the statement for the 
+      // Look for the ',' or ')' that ends the statement for the
       // currently active argument.
       boolean lookupSucceeded = false;
       while (clone.moveToNextToken())
@@ -1638,16 +1658,16 @@ public class RCompletionManager implements CompletionManager
             lookupSucceeded = true;
             break;
          }
-         
+
          // Bail if we find a closing paren (we should walk over matched
          // pairs properly, so finding one implies that we have a parse error).
          if (value.equals("]") || value.equals("}"))
             break;
-         
+
          if (clone.fwdToMatchingToken())
             continue;
       }
-      
+
       String afterText = "";
       if (lookupSucceeded)
       {
@@ -1655,10 +1675,10 @@ public class RCompletionManager implements CompletionManager
                clone.currentPosition(),
                endPos));
       }
-      
+
       context.setFunctionCallString(
             (beforeText + afterText).trim());
-      
+
       // Try to identify whether we're producing autocompletions for
       // a _named_ function argument; if so, produce completions tuned to
       // that argument.
@@ -1666,7 +1686,7 @@ public class RCompletionManager implements CompletionManager
       do
       {
          String argsValue = argsCursor.currentValue();
-         
+
          // Bail if we encounter tokens that we don't expect as part
          // of the current expression -- this implies we're not really
          // within a named argument, although this isn't perfect.
@@ -1682,28 +1702,28 @@ public class RCompletionManager implements CompletionManager
          {
             break;
          }
-         
+
          // If we encounter an '=', we assume that this is
          // a function argument.
          if (argsValue.equals("=") && argsCursor.moveToPreviousToken())
          {
             if (!isFileCompletion)
                context.setToken(token);
-            
+
             context.add(
                   argsCursor.currentValue(),
                   AutocompletionContext.TYPE_ARGUMENT,
                   0);
             return context;
          }
-         
+
       } while (argsCursor.moveToPreviousToken());
-      
+
       String initialData =
             docDisplay_.getTextForRange(Range.fromPoints(
                   tokenCursor.currentPosition(),
                   endOfDecl.currentPosition())).trim();
-      
+
       // And the first context
       context.add(initialData, initialDataType, initialNumCommas);
 
@@ -1716,18 +1736,18 @@ public class RCompletionManager implements CompletionManager
          int commaCount = tokenCursor.findOpeningBracketCountCommas("[", false);
          if (commaCount == -1)
             break;
-         
+
          numCommas = commaCount;
-         
+
          TokenCursor declEnd = tokenCursor.cloneCursor();
          if (!tokenCursor.moveToPreviousToken())
             return context;
-         
+
          if (tokenCursor.currentValue() == "[")
          {
             if (!declEnd.moveToPreviousToken())
                return context;
-            
+
             dataType = AutocompletionContext.TYPE_DOUBLE_BRACKET;
             if (!tokenCursor.moveToPreviousToken())
                return context;
@@ -1736,28 +1756,28 @@ public class RCompletionManager implements CompletionManager
          {
             dataType = AutocompletionContext.TYPE_SINGLE_BRACKET;
          }
-         
+
          tokenCursor.findStartOfEvaluationContext();
-         
+
          assocData =
             docDisplay_.getTextForRange(Range.fromPoints(
                   tokenCursor.currentPosition(),
                   declEnd.currentPosition())).trim();
-         
+
          context.add(assocData, dataType, numCommas);
       }
-      
+
       return context;
-      
+
    }
-   
+
    private void showSnippetHelp(QualifiedName item,
                                 CompletionPopupDisplay popup)
    {
       popup.displaySnippetHelp(
             snippets_.getSnippetContents(item.name));
    }
-   
+
    /**
     * It's important that we create a new instance of this each time.
     * It maintains state that is associated with a completion request.
@@ -1773,7 +1793,7 @@ public class RCompletionManager implements CompletionManager
          selection_ = selection ;
          canAutoAccept_ = canAutoAccept;
       }
-      
+
       public void showHelp(QualifiedName selectedItem)
       {
          if (selectedItem.type == RCompletionType.SNIPPET)
@@ -1781,14 +1801,14 @@ public class RCompletionManager implements CompletionManager
          else
             helpStrategy_.showHelp(selectedItem, popup_);
       }
-      
+
       public void showHelpTopic()
       {
          QualifiedName selectedItem = popup_.getSelectedValue();
          // TODO: Show help should navigate to snippet file?
          if (selectedItem.type != RCompletionType.SNIPPET)
             helpStrategy_.showHelpTopic(selectedItem);
-            
+
       }
 
       @Override
@@ -1796,9 +1816,9 @@ public class RCompletionManager implements CompletionManager
       {
          if (invalidationToken_.isInvalid())
             return ;
-         
+
          RCompletionManager.this.popup_.showErrorMessage(
-                  error.getUserMessage(), 
+                  error.getUserMessage(),
                   new PopupPositioner(input_.getCursorBounds(), popup_)) ;
       }
 
@@ -1807,29 +1827,29 @@ public class RCompletionManager implements CompletionManager
       {
          if (invalidationToken_.isInvalid())
             return ;
-         
+
          // Only display the top completions
          final QualifiedName[] results =
                completions.completions.toArray(new QualifiedName[0]);
-         
+
          if (results.length == 0)
          {
             popup_.clearCompletions();
             boolean lastInputWasTab =
                   (nativeEvent_ != null && nativeEvent_.getKeyCode() == KeyCodes.KEY_TAB);
-            
+
             boolean lineIsWhitespace = docDisplay_.getCurrentLine().matches("^\\s*$");
-            
+
             if (lastInputWasTab && lineIsWhitespace)
             {
                docDisplay_.insertCode("\t");
                return;
             }
-            
+
             if (canAutoAccept_)
             {
                popup_.showErrorMessage(
-                     "(No matches)", 
+                     "(No matches)",
                      new PopupPositioner(input_.getCursorBounds(), popup_));
             }
             else
@@ -1839,10 +1859,10 @@ public class RCompletionManager implements CompletionManager
                // failed completion, e.g. 'stats::rna' -> 'stats::rn'
                popup_.placeOffscreen();
             }
-            
+
             return ;
          }
-         
+
          // If there is only one result and the name is identical to the
          // current token, then implicitly accept that completion. we hide
          // the popup to ensure that backspace can re-load completions from
@@ -1856,7 +1876,7 @@ public class RCompletionManager implements CompletionManager
                snippets_.applySnippet(completions.token, results[0].name);
                return;
             }
-            
+
             popup_.placeOffscreen();
             return;
          }
@@ -1885,18 +1905,18 @@ public class RCompletionManager implements CompletionManager
                   false);
          }
       }
-      
+
       private void onSelection(QualifiedName qname)
       {
          suggestTimer_.cancel();
          final String value = qname.name ;
-         
+
          if (invalidationToken_.isInvalid())
             return;
-         
+
          requester_.flushCache() ;
          helpStrategy_.clearCache();
-         
+
          if (value == null)
          {
             assert false : "Selected comp value is null" ;
@@ -1904,9 +1924,9 @@ public class RCompletionManager implements CompletionManager
          }
 
          applyValue(qname);
-         
+
          // For in-line edits, we don't want to auto-popup after replacement
-         if (suggestOnAccept_ || 
+         if (suggestOnAccept_ ||
                (qname.name.endsWith(":") &&
                      docDisplay_.getCharacterAtCursor() != ':'))
          {
@@ -1926,9 +1946,9 @@ public class RCompletionManager implements CompletionManager
             popup_.setHelpVisible(false);
             docDisplay_.setFocus(true);
          }
-         
+
       }
-      
+
       // For input of the form 'something$foo' or 'something@bar', quote the
       // element following '@' if it's a non-syntactic R symbol; otherwise
       // return as is
@@ -1939,11 +1959,11 @@ public class RCompletionManager implements CompletionManager
          else
             return "`" + string + "`";
       }
-      
+
       private void applyValueRmdOption(final String value)
       {
          suggestTimer_.cancel();
-         
+
          // If there is no token but spaces have been inserted, then compensate
          // for that. This is necessary as we allow for spaces in the completion,
          // and completions auto-popup after ',' so e.g. on
@@ -1962,7 +1982,7 @@ public class RCompletionManager implements CompletionManager
             while (startPos < currentLine.length() &&
                   currentLine.charAt(startPos) == ' ')
                ++startPos;
-            
+
             input_.setSelection(new InputEditorSelection(
                   selection_.getStart().movePosition(startPos, false),
                   input_.getSelection().getEnd()));
@@ -1973,7 +1993,7 @@ public class RCompletionManager implements CompletionManager
                   selection_.getStart().movePosition(-token_.length(), true),
                   input_.getSelection().getEnd()));
          }
-         
+
          input_.replaceSelection(value, true);
          token_ = value;
          selection_ = input_.getSelection();
@@ -1982,27 +2002,27 @@ public class RCompletionManager implements CompletionManager
       private void applyValue(final QualifiedName qualifiedName)
       {
          String completionToken = getCurrentCompletionToken();
-         
+
          // Strip off the quotes for string completions.
          if (completionToken.startsWith("'") || completionToken.startsWith("\""))
             completionToken = completionToken.substring(1);
-         
+
          if (qualifiedName.source.equals("`chunk-option`"))
          {
             applyValueRmdOption(qualifiedName.name);
             return;
          }
-         
+
          if (qualifiedName.type == RCompletionType.SNIPPET)
          {
             snippets_.applySnippet(completionToken, qualifiedName.name);
             return;
          }
-         
+
          boolean insertParen =
                uiPrefs_.insertParensAfterFunctionCompletion().getValue() &&
                RCompletionType.isFunctionType(qualifiedName.type);
-         
+
          // Don't insert a paren if there is already a '(' following
          // the cursor
          AceEditor editor = (AceEditor) input_;
@@ -2025,27 +2045,27 @@ public class RCompletionManager implements CompletionManager
                      cursor.currentValue() == "::" ||
                      cursor.currentValue() == ":::";
             }
-            
+
          }
 
          String value = qualifiedName.name;
          String source = qualifiedName.source;
          boolean shouldQuote = qualifiedName.shouldQuote;
-         
-         
+
+
          // Don't insert the `::` following a package completion if there is
          // already a `:` following the cursor
          if (textFollowingCursorIsColon)
             value = value.replaceAll(":", "");
-         
+
          if (qualifiedName.type == RCompletionType.DIRECTORY)
             value = value + "/";
-         
+
          if (!RCompletionType.isFileType(qualifiedName.type))
          {
             if (value == ":=")
                value = quoteIfNotSyntacticNameCompletion(value);
-            else if (!value.matches(".*[=:]\\s*$") && 
+            else if (!value.matches(".*[=:]\\s*$") &&
                   !value.matches("^\\s*([`'\"]).*\\1\\s*$") &&
                   source != "<file>" &&
                   source != "<directory>" &&
@@ -2062,20 +2082,20 @@ public class RCompletionManager implements CompletionManager
           * logic works the second time, we need to reset the
           * selection.
           */
-         
+
          // There might be multiple cursors. Get the position of each cursor.
          Range[] ranges = editor.getNativeSelection().getAllRanges();
-         
+
          // Determine the replacement value.
          boolean shouldInsertParens = insertParen &&
                !overrideInsertParens_ &&
                !textFollowingCursorIsOpenParen;
-         
+
          boolean insertMatching = uiPrefs_.insertMatching().getValue();
          boolean needToMoveCursorInsideParens = false;
          if (shouldInsertParens)
          {
-            // Munge the value -- determine whether we want to append '()' 
+            // Munge the value -- determine whether we want to append '()'
             // for e.g. function completions, and so on.
             if (textFollowingCursorIsClosingParen || !insertMatching)
             {
@@ -2100,7 +2120,7 @@ public class RCompletionManager implements CompletionManager
                value = value.substring(0, value.length() - kSpaceEquals.length()) + "=";
             }
          }
-         
+
          // Loop over all of the active cursors, and replace.
          for (Range range : ranges)
          {
@@ -2111,35 +2131,35 @@ public class RCompletionManager implements CompletionManager
             Position replaceStart = Position.create(
                   replaceEnd.getRow(),
                   replaceEnd.getColumn() - completionToken.length());
-            
+
             editor.replaceRange(
                   Range.fromPoints(replaceStart, replaceEnd),
                   value);
-            
+
          }
-         
+
          // Set the active selection, and update the token.
          token_ = value;
          selection_ = input_.getSelection();
-         
+
          // Move the cursor(s) back inside parens if necessary.
          if (needToMoveCursorInsideParens)
             editor.moveCursorLeft();
-         
+
          if (RCompletionType.isFunctionType(qualifiedName.type))
-            sigTipManager_.displayToolTip(qualifiedName.name, 
+            sigTipManager_.displayToolTip(qualifiedName.name,
                                           qualifiedName.source,
                                           qualifiedName.helpHandler);
       }
-      
+
       private final Invalidation.Token invalidationToken_ ;
       private InputEditorSelection selection_ ;
       private final boolean canAutoAccept_;
       private boolean suggestOnAccept_;
       private boolean overrideInsertParens_;
-      
+
    }
-   
+
    private String getSourceDocumentPath()
    {
       if (rContext_ == null)
@@ -2147,7 +2167,7 @@ public class RCompletionManager implements CompletionManager
       else
          return StringUtil.notNull(rContext_.getPath());
    }
-   
+
    private String getSourceDocumentId()
    {
       if (rContext_ != null)
@@ -2155,14 +2175,14 @@ public class RCompletionManager implements CompletionManager
       else
          return "";
    }
-   
+
    public void showHelpDeferred(final CompletionRequestContext context,
                                 final QualifiedName item,
                                 int milliseconds)
    {
       if (helpRequest_ != null && helpRequest_.isRunning())
          helpRequest_.cancel();
-      
+
       helpRequest_ = new Timer() {
          @Override
          public void run()
@@ -2173,23 +2193,23 @@ public class RCompletionManager implements CompletionManager
       };
       helpRequest_.schedule(milliseconds);
    }
-   
+
    String getCurrentCompletionToken()
    {
       AceEditor editor = (AceEditor) docDisplay_;
       if (editor == null)
          return "";
-      
+
       // TODO: Better handling of completions within markdown mode, e.g.
       // `r foo`
       if (DocumentMode.isCursorInMarkdownMode(docDisplay_))
          return token_;
-      
+
       Position cursorPos = editor.getCursorPosition();
       Token currentToken = editor.getSession().getTokenAt(cursorPos);
       if (currentToken == null)
          return "";
-      
+
       // If the user has inserted some spaces, the cursor might now lie
       // on a 'text' token. In that case, find the previous token and
       // use that for completion.
@@ -2210,28 +2230,28 @@ public class RCompletionManager implements CompletionManager
                currentToken = token;
          }
       }
-      
+
       // Exclude non-string and non-identifier tokens.
       if (currentToken.hasType("operator", "comment", "text", "punctuation"))
          return "";
-      
+
       String tokenValue = currentToken.getValue();
-      
+
       String subsetted = tokenValue.substring(0, cursorPos.getColumn() - currentToken.getColumn());
-      
+
       return subsetted + suffix;
    }
-   
+
    private boolean isDisabled()
    {
       // Disable the completion manager while a snippet tabstop
       // manager is active
       if (docDisplay_.isSnippetsTabStopManagerActive())
          return true;
-      
+
       return false;
    }
-   
+
    private GlobalDisplay globalDisplay_;
    private FileTypeRegistry fileTypeRegistry_;
    private EventBus eventBus_;
@@ -2248,7 +2268,7 @@ public class RCompletionManager implements CompletionManager
    // click on it to scroll.
    private boolean ignoreNextInputBlur_ = false;
    private String token_ ;
-   
+
    private final DocDisplay docDisplay_;
    private final SnippetHelper snippets_;
    private final boolean isConsole_;
@@ -2257,15 +2277,15 @@ public class RCompletionManager implements CompletionManager
    private CompletionRequestContext context_ ;
    private final RCompletionContext rContext_;
    private final RnwCompletionContext rnwContext_;
-   
+
    private final SignatureToolTipManager sigTipManager_;
-   
+
    private NativeEvent nativeEvent_;
-   
+
    private QualifiedName lastSelectedItem_;
    private Timer helpRequest_;
    private final SuggestionTimer suggestTimer_;
-   
+
    private static class SuggestionTimer
    {
       SuggestionTimer(RCompletionManager manager, UIPrefs uiPrefs)
@@ -2284,7 +2304,7 @@ public class RCompletionManager implements CompletionManager
             }
          };
       }
-      
+
       public void schedule(boolean flushCache,
                            boolean implicit,
                            boolean canAutoInsert)
@@ -2294,21 +2314,21 @@ public class RCompletionManager implements CompletionManager
          canAutoInsert_ = canAutoInsert;
          timer_.schedule(uiPrefs_.alwaysCompleteDelayMs().getValue());
       }
-      
+
       public void cancel()
       {
          timer_.cancel();
       }
-      
+
       private final RCompletionManager manager_;
       private final UIPrefs uiPrefs_;
       private final Timer timer_;
-      
+
       private boolean flushCache_;
       private boolean implicit_;
       private boolean canAutoInsert_;
-      
+
    }
-   
+
    private final HandlerRegistrations handlers_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -89,6 +89,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.r.Signature
 import org.rstudio.studio.client.workbench.views.source.events.CodeBrowserNavigationEvent;
 import org.rstudio.studio.client.workbench.views.source.model.RnwCompletionContext;
 import org.rstudio.studio.client.workbench.views.source.model.SourcePosition;
+import org.rstudio.core.client.Debug ;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1337,7 +1338,7 @@ public class RCompletionManager implements CompletionManager
          String line)
    {
       int index = line.lastIndexOf(':');
-      String token = line.substring(index + 1);
+      String token = line.substring(index);
 
       AutocompletionContext result = new AutocompletionContext(
             token,
@@ -2080,7 +2081,6 @@ public class RCompletionManager implements CompletionManager
          String source = qualifiedName.source;
          boolean shouldQuote = qualifiedName.shouldQuote;
 
-
          // Don't insert the `::` following a package completion if there is
          // already a `:` following the cursor
          if (textFollowingCursorIsColon)
@@ -2090,7 +2090,7 @@ public class RCompletionManager implements CompletionManager
             value = value + "/";
 
          if (qualifiedName.type == RCompletionType.EMOJI){
-              value = completionToken.replaceAll( "[:][a-zA-Z0-9_]+$", value ) ;
+            value = completionToken.replaceAll( "[:][a-zA-Z0-9_]+$", value ) ;
          } else if (!RCompletionType.isFileType(qualifiedName.type)) {
             if (value == ":=")
                value = quoteIfNotSyntacticNameCompletion(value);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1475,10 +1475,10 @@ public class RCompletionManager implements CompletionManager
         // is this an emoji completions
         if( firstLine.matches(".*[:][a-zA-Z0-9_]+") ){
           return getAutocompletionContextForEmoji(firstLine);
-        } else {
-          isFileCompletion = true;
-          addAutocompletionContextForFile(context, firstLine);
         }
+
+        isFileCompletion = true;
+        addAutocompletionContextForFile(context, firstLine);
       }
 
       // If this line starts with '```{', then we're completing chunk options
@@ -2068,8 +2068,9 @@ public class RCompletionManager implements CompletionManager
          if (qualifiedName.type == RCompletionType.DIRECTORY)
             value = value + "/";
 
-         if (!RCompletionType.isFileType(qualifiedName.type))
-         {
+         if (qualifiedName.type == RCompletionType.EMOJI){
+              value = completionToken.replaceAll( "[:][a-zA-Z0-9_]+$", value ) ;
+         } else if (!RCompletionType.isFileType(qualifiedName.type)) {
             if (value == ":=")
                value = quoteIfNotSyntacticNameCompletion(value);
             else if (!value.matches(".*[=:]\\s*$") &&

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1475,17 +1475,10 @@ public class RCompletionManager implements CompletionManager
         // is this an emoji completions
         if( firstLine.matches(".*[:][a-zA-Z0-9_]+") ){
           return getAutocompletionContextForEmoji(firstLine);
-<<<<<<< HEAD
         }
 
         isFileCompletion = true;
         addAutocompletionContextForFile(context, firstLine);
-=======
-        } else {
-          isFileCompletion = true;
-          addAutocompletionContextForFile(context, firstLine);
-        }
->>>>>>> e558a36f24b7b19b50574fe0a20fcc613bcd1c65
       }
 
       // If this line starts with '```{', then we're completing chunk options

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -264,19 +264,19 @@ public class AceEditor implements DocDisplay,
          }
       });
    }
-   
+
    public static final native AceEditor getEditor(Element el)
    /*-{
       for (; el != null; el = el.parentElement)
          if (el.$RStudioAceEditor != null)
             return el.$RStudioAceEditor;
    }-*/;
-   
+
    private static final native void attachToWidget(Element el, AceEditor editor)
    /*-{
       el.$RStudioAceEditor = editor;
    }-*/;
-   
+
    private static final native void detachFromWidget(Element el)
    /*-{
       el.$RStudioAceEditor = null;
@@ -293,14 +293,14 @@ public class AceEditor implements DocDisplay,
 
       completionManager_ = new NullCompletionManager();
       diagnosticsBgPopup_ = new DiagnosticsBackgroundPopup(this);
-      
+
       RStudioGinjector.INSTANCE.injectMembers(this);
-      
+
       backgroundTokenizer_ = new BackgroundTokenizer(this);
       vim_ = new Vim(this);
       bgLinkHighlighter_ = new AceEditorBackgroundLinkHighlighter(this);
       bgChunkHighlighter_ = new AceBackgroundHighlighter(this);
-      
+
       widget_.addValueChangeHandler(new ValueChangeHandler<Void>()
       {
          public void onValueChange(ValueChangeEvent<Void> evt)
@@ -311,7 +311,7 @@ public class AceEditor implements DocDisplay,
             }
          }
       });
-      
+
       widget_.addFoldChangeHandler(new FoldChangeEvent.Handler()
       {
          @Override
@@ -330,7 +330,7 @@ public class AceEditor implements DocDisplay,
                completionManager_.onPaste(event);
 
             final Position start = getSelectionStart();
-            
+
             Scheduler.get().scheduleDeferred(new ScheduledCommand()
             {
                @Override
@@ -390,7 +390,7 @@ public class AceEditor implements DocDisplay,
             clearDebugLineHighlight();
          }
       });
-      
+
       widget_.addAttachHandler(new AttachEvent.Handler()
       {
          @Override
@@ -400,7 +400,7 @@ public class AceEditor implements DocDisplay,
                attachToWidget(widget_.getElement(), AceEditor.this);
             else
                detachFromWidget(widget_.getElement());
-            
+
             if (!event.isAttached())
             {
                for (HandlerRegistration handler : editorEventListeners_)
@@ -414,7 +414,7 @@ public class AceEditor implements DocDisplay,
             }
          }
       });
-      
+
       widget_.addFocusHandler(new FocusHandler()
       {
          @Override
@@ -424,7 +424,7 @@ public class AceEditor implements DocDisplay,
             MainWindowObject.lastFocusedEditor().set(id);
          }
       });
-      
+
       events_.addHandler(
             AceEditorCommandEvent.TYPE,
             new AceEditorCommandEvent.Handler()
@@ -438,7 +438,7 @@ public class AceEditor implements DocDisplay,
                   {
                      return;
                   }
-                  
+
                   switch (event.getCommand())
                   {
                   case AceEditorCommandEvent.YANK_REGION:                yankRegion();               break;
@@ -457,17 +457,17 @@ public class AceEditor implements DocDisplay,
                }
             });
    }
-   
+
    public void yankRegion()
    {
       if (isVimModeOn() && !isVimInInsertMode())
          return;
-      
+
       // no-op if there is no selection
       String selectionValue = getSelectionValue();
       if (StringUtil.isNullOrEmpty(selectionValue))
          return;
-      
+
       if (Desktop.isDesktop() && isEmacsModeOn())
       {
          Desktop.getFrame().clipboardCut();
@@ -479,17 +479,17 @@ public class AceEditor implements DocDisplay,
          replaceSelection("");
       }
    }
-   
+
    public void yankBeforeCursor()
    {
       if (isVimModeOn() && !isVimInInsertMode())
          return;
-      
+
       Position cursorPos = getCursorPosition();
       Range yankRange = Range.fromPoints(
             Position.create(cursorPos.getRow(), 0),
             cursorPos);
-      
+
       if (Desktop.isDesktop() && isEmacsModeOn())
       {
          String text = getTextForRange(yankRange);
@@ -504,17 +504,17 @@ public class AceEditor implements DocDisplay,
          replaceSelection("");
       }
    }
-   
+
    public void yankAfterCursor()
    {
       if (isVimModeOn() && !isVimInInsertMode())
          return;
-      
+
       Position cursorPos = getCursorPosition();
       Range yankRange = null;
       String line = getLine(cursorPos.getRow());
       int lineLength = line.length();
-      
+
       // if the cursor is already at the end of the line
       // (allowing for trailing whitespace), then eat the
       // newline as well; otherwise, just eat to end of line
@@ -531,7 +531,7 @@ public class AceEditor implements DocDisplay,
                cursorPos,
                Position.create(cursorPos.getRow(), lineLength));
       }
-      
+
       if (Desktop.isDesktop() && isEmacsModeOn())
       {
          String text = getTextForRange(yankRange);
@@ -546,12 +546,12 @@ public class AceEditor implements DocDisplay,
          replaceSelection("");
       }
    }
-   
+
    public void pasteLastYank()
    {
       if (isVimModeOn() && !isVimInInsertMode())
          return;
-      
+
       if (Desktop.isDesktop() && isEmacsModeOn())
       {
          Desktop.getFrame().clipboardPaste();
@@ -560,12 +560,12 @@ public class AceEditor implements DocDisplay,
       {
          if (yankedText_ == null)
             return;
-         
+
          replaceSelection(yankedText_);
          setCursorPosition(getSelectionEnd());
       }
    }
-   
+
    public void insertAssignmentOperator()
    {
       if (DocumentMode.isCursorInRMode(this))
@@ -573,28 +573,28 @@ public class AceEditor implements DocDisplay,
       else
          insertAssignmentOperatorImpl("=");
    }
-   
+
    @SuppressWarnings("deprecation")
    private void insertAssignmentOperatorImpl(String op)
    {
       boolean hasWhitespaceBefore =
             Character.isSpace(getCharacterBeforeCursor()) ||
             (!hasSelection() && getCursorPosition().getColumn() == 0);
-      
+
       String insertion = hasWhitespaceBefore
             ? op + " "
             : " " + op + " ";
-      
+
       insertCode(insertion, false);
    }
-   
+
    @SuppressWarnings("deprecation")
    public void insertPipeOperator()
    {
       boolean hasWhitespaceBefore =
             Character.isSpace(getCharacterBeforeCursor()) ||
             (!hasSelection() && getCursorPosition().getColumn() == 0);
-      
+
       if (hasWhitespaceBefore)
          insertCode("%>% ", false);
       else
@@ -625,17 +625,17 @@ public class AceEditor implements DocDisplay,
 
       getSession().reindent(range);
    }
-   
+
    public AceCommandManager getCommandManager()
    {
       return getWidget().getEditor().getCommandManager();
    }
-   
+
    public void setEditorCommandBinding(String id, List<KeySequence> keys)
    {
       getWidget().getEditor().getCommandManager().rebindCommand(id, keys);
    }
-   
+
    public void resetCommands()
    {
       AceCommandManager manager = AceCommandManager.create();
@@ -754,18 +754,18 @@ public class AceEditor implements DocDisplay,
          completionManager_.detach();
          completionManager_ = null;
       }
-      
+
       completionManager_ = completionManager;
 
       updateKeyboardHandlers();
       syncCompletionPrefs();
       syncDiagnosticsPrefs();
-      
+
       snippets_.ensureSnippetsLoaded();
       getSession().setEditorMode(
             fileType_.getEditorLanguage().getParserName(),
             false);
-      
+
       handlers_.fireEvent(new EditorModeChangedEvent(getModeId()));
 
       getSession().setUseWrapMode(fileType_.getWordWrap());
@@ -783,14 +783,14 @@ public class AceEditor implements DocDisplay,
                                        UIPrefsAccessor.COMPLETION_ALWAYS);
       int characterThreshold = uiPrefs_.alwaysCompleteCharacters().getValue();
       int delay = uiPrefs_.alwaysCompleteDelayMs().getValue();
-      
+
       widget_.getEditor().setCompletionOptions(
             enabled,
             uiPrefs_.enableSnippets().getValue(),
             live,
             characterThreshold,
             delay);
-      
+
    }
 
    @Override
@@ -858,7 +858,7 @@ public class AceEditor implements DocDisplay,
          if (handler != null)
             handler.removeHandler();
       editorEventListeners_.clear();
-         
+
       // save and restore Vim marks as they can be lost when refreshing
       // the keyboard handlers. this is necessary as keyboard handlers are
       // regenerated on each document save, and clearing the Vim handler will
@@ -866,7 +866,7 @@ public class AceEditor implements DocDisplay,
       JsMap<Position> marks = JsMap.create().cast();
       if (useVimMode_)
          marks = widget_.getEditor().getMarks();
-      
+
       // create a keyboard previewer for our special hooks
       AceKeyboardPreviewer previewer = new AceKeyboardPreviewer(completionManager_);
 
@@ -877,10 +877,10 @@ public class AceEditor implements DocDisplay,
          widget_.getEditor().setKeyboardHandler(KeyboardHandler.emacs());
       else
          widget_.getEditor().setKeyboardHandler(null);
-      
+
       // add the previewer
       widget_.getEditor().addKeyboardHandler(previewer.getKeyboardHandler());
-      
+
       // Listen for command execution
       editorEventListeners_.add(AceEditorNative.addEventListener(
             widget_.getEditor().getCommandManager(),
@@ -893,7 +893,7 @@ public class AceEditor implements DocDisplay,
                   events_.fireEvent(new AceAfterCommandExecutedEvent(event));
                }
             }));
-      
+
       // Listen for keyboard activity
       editorEventListeners_.add(AceEditorNative.addEventListener(
             widget_.getEditor(),
@@ -906,11 +906,11 @@ public class AceEditor implements DocDisplay,
                   events_.fireEvent(new AceKeyboardActivityEvent(event));
                }
             }));
-      
+
       if (useVimMode_)
          widget_.getEditor().setMarks(marks);
    }
-   
+
    public String getCode()
    {
       return getSession().getValue();
@@ -934,7 +934,7 @@ public class AceEditor implements DocDisplay,
       // bug in 0.95. We can choose to remove this when 0.95 ships, hopefully
       // any documents that would be affected by this will be gone by then.
       code = code.replaceAll("\u001B", "");
-      
+
       // Normalize newlines -- convert all of '\r', '\r\n', '\n\r' to '\n'.
       code = StringUtil.normalizeNewLines(code);
 
@@ -995,7 +995,7 @@ public class AceEditor implements DocDisplay,
       // cancel any existing scroll animation
       if (scrollAnimator_ != null)
          scrollAnimator_.complete();
-      
+
       if (animateMs == 0)
          widget_.getEditor().getRenderer().scrollToY(y);
       else
@@ -1046,7 +1046,7 @@ public class AceEditor implements DocDisplay,
          return null;
       }
    }
-   
+
    @Override
    public void quickAddNext()
    {
@@ -1055,7 +1055,7 @@ public class AceEditor implements DocDisplay,
          getNativeSelection().selectWord();
          return;
       }
-      
+
       String needle = getSelectionValue();
       Search search = Search.create(
             needle,
@@ -1066,11 +1066,11 @@ public class AceEditor implements DocDisplay,
             getCursorPosition(),
             null,
             false);
-      
+
       Range range = search.find(getSession());
       if (range == null)
          return;
-      
+
       getNativeSelection().addRange(range, false);
       centerSelection();
    }
@@ -1092,19 +1092,19 @@ public class AceEditor implements DocDisplay,
       return getCode(((AceInputEditorPosition)selection.getStart()).getValue(),
                      ((AceInputEditorPosition)selection.getEnd()).getValue());
    }
-   
+
    @Override
    public JsArrayString getLines()
    {
       return getLines(0, getSession().getLength());
    }
-   
+
    @Override
    public JsArrayString getLines(int startRow, int endRow)
    {
       return getSession().getLines(startRow, endRow);
    }
-   
+
    public void focus()
    {
       widget_.getEditor().focus();
@@ -1241,21 +1241,21 @@ public class AceEditor implements DocDisplay,
    {
       getSession().getSelection().setSelectionRange(range);
    }
-   
+
    public void setSelectionRanges(JsArray<Range> ranges)
    {
       int n = ranges.length();
       if (n == 0)
          return;
-      
+
       if (vim_.isActive())
          vim_.exitVisualMode();
-      
+
       setSelectionRange(ranges.get(0));
       for (int i = 1; i < n; i++)
          getNativeSelection().addRange(ranges.get(i), false);
    }
-   
+
    public int getLength(int row)
    {
       return getSession().getDocument().getLine(row).length();
@@ -1281,20 +1281,20 @@ public class AceEditor implements DocDisplay,
    {
       return getSession().getLine(row);
    }
-   
+
    @Override
    public Position getDocumentEnd()
    {
       int lastRow = getRowCount() - 1;
       return Position.create(lastRow, getLength(lastRow));
    }
-   
+
    @Override
    public void setInsertMatching(boolean value)
    {
       widget_.getEditor().setInsertMatching(value);
    }
-   
+
    @Override
    public void setSurroundSelectionPref(String value)
    {
@@ -1410,7 +1410,7 @@ public class AceEditor implements DocDisplay,
             renderer.screenToTextCoordinates(rectangle.getLeft(), rectangle.getTop()),
             renderer.screenToTextCoordinates(rectangle.getRight(), rectangle.getBottom()));
    }
-   
+
    @Override
    public Rectangle getPositionBounds(Position position)
    {
@@ -1423,32 +1423,32 @@ public class AceEditor implements DocDisplay,
                            (int) Math.round(renderer.getCharacterWidth()),
                            (int) (renderer.getLineHeight() * 0.8));
    }
-   
+
    @Override
    public Rectangle getRangeBounds(Range range)
    {
       range = Range.toOrientedRange(range);
-      
+
       Renderer renderer = widget_.getEditor().getRenderer();
       if (!range.isMultiLine())
       {
          ScreenCoordinates start = documentPositionToScreenCoordinates(range.getStart());
          ScreenCoordinates end   = documentPositionToScreenCoordinates(range.getEnd());
-         
+
          int width  = (end.getPageX() - start.getPageX()) + (int) renderer.getCharacterWidth();
          int height = (end.getPageY() - start.getPageY()) + (int) renderer.getLineHeight();
-         
+
          return new Rectangle(start.getPageX(), start.getPageY(), width, height);
       }
-      
+
       Position startPos = range.getStart();
       Position endPos   = range.getEnd();
       int startRow = startPos.getRow();
       int endRow   = endPos.getRow();
-      
+
       // figure out top left coordinates
       ScreenCoordinates topLeft = documentPositionToScreenCoordinates(Position.create(startRow, 0));
-      
+
       // figure out bottom right coordinates (need to walk rows to figure out longest line)
       ScreenCoordinates bottomRight = documentPositionToScreenCoordinates(Position.create(endPos));
       for (int row = startRow; row <= endRow; row++)
@@ -1458,13 +1458,13 @@ public class AceEditor implements DocDisplay,
          if (coords.getPageX() > bottomRight.getPageX())
             bottomRight = ScreenCoordinates.create(coords.getPageX(), bottomRight.getPageY());
       }
-      
+
       // construct resulting range
       int width  = (bottomRight.getPageX() - topLeft.getPageX()) + (int) renderer.getCharacterWidth();
       int height = (bottomRight.getPageY() - topLeft.getPageY()) + (int) renderer.getLineHeight();
       return new Rectangle(topLeft.getPageX(), topLeft.getPageY(), width, height);
    }
-   
+
    @Override
    public Rectangle getPositionBounds(InputEditorPosition position)
    {
@@ -1525,17 +1525,17 @@ public class AceEditor implements DocDisplay,
    {
       setCode("", false);
    }
-   
+
    public boolean inMultiSelectMode()
    {
       return widget_.getEditor().inMultiSelectMode();
    }
-   
+
    public void exitMultiSelectMode()
    {
       widget_.getEditor().exitMultiSelectMode();
    }
-   
+
    public void clearSelection()
    {
       widget_.getEditor().clearSelection();
@@ -1613,7 +1613,7 @@ public class AceEditor implements DocDisplay,
    {
       return getSession().getMode().getLanguageMode(position);
    }
-   
+
    @Override
    public String getModeId()
    {
@@ -1696,35 +1696,35 @@ public class AceEditor implements DocDisplay,
       }
       return false;
    }
-   
+
    @Override
    public void expandSelection()
    {
       widget_.getEditor().expandSelection();
    }
-   
+
    @Override
    public void shrinkSelection()
    {
       widget_.getEditor().shrinkSelection();
    }
-   
+
    @Override
    public void expandRaggedSelection()
    {
       if (!inMultiSelectMode())
          return;
-      
+
       // TODO: It looks like we need to use an alternative API when
       // using Vim mode.
       if (isVimModeOn())
          return;
-      
+
       boolean hasSelection = hasSelection();
-      
+
       Range[] ranges =
             widget_.getEditor().getSession().getSelection().getAllRanges();
-      
+
       // Get the maximum columns for the current selection.
       int colMin = Integer.MAX_VALUE;
       int colMax = 0;
@@ -1733,7 +1733,7 @@ public class AceEditor implements DocDisplay,
          colMin = Math.min(range.getStart().getColumn(), colMin);
          colMax = Math.max(range.getEnd().getColumn(), colMax);
       }
-      
+
       // For each range:
       //
       //    1. Set the left side of the selection to the minimum,
@@ -1743,7 +1743,7 @@ public class AceEditor implements DocDisplay,
       {
          range.getStart().setColumn(colMin);
          range.getEnd().setColumn(colMax);
-         
+
          String line = getLine(range.getStart().getRow());
          if (line.length() < colMax)
          {
@@ -1752,7 +1752,7 @@ public class AceEditor implements DocDisplay,
                   StringUtil.repeat(" ", colMax - line.length()));
          }
       }
-      
+
       clearSelection();
       Selection selection = getNativeSelection();
       for (Range range : ranges)
@@ -1770,7 +1770,7 @@ public class AceEditor implements DocDisplay,
          }
       }
    }
-   
+
    @Override
    public void clearSelectionHistory()
    {
@@ -1830,13 +1830,13 @@ public class AceEditor implements DocDisplay,
                if (!event.isAttached() && selection != null)
                   selection.detach();
             }
-            
+
          });
       }
-      
+
       return selection;
    }
-   
+
    public AnchoredSelection createAnchoredSelection(Position start, Position end)
    {
       return createAnchoredSelection(null, start, end);
@@ -1921,12 +1921,12 @@ public class AceEditor implements DocDisplay,
       if (visible)
          widget_.getEditor().getRenderer().updateFontSize();
    }
-   
+
    public void onResize()
    {
       widget_.onResize();
    }
-   
+
    public void setHighlightSelectedLine(boolean on)
    {
       widget_.getEditor().setHighlightActiveLine(on);
@@ -1946,45 +1946,45 @@ public class AceEditor implements DocDisplay,
    {
       getSession().setUseSoftTabs(on);
    }
-   
+
    public void setScrollPastEndOfDocument(boolean enable)
    {
       widget_.getEditor().getRenderer().setScrollPastEnd(enable);
    }
-   
+
    public void setHighlightRFunctionCalls(boolean highlight)
    {
       _setHighlightRFunctionCallsImpl(highlight);
       widget_.getEditor().retokenizeDocument();
    }
-   
+
    public void setScrollLeft(int x)
    {
       getSession().setScrollLeft(x);
    }
-   
+
    public void setScrollTop(int y)
    {
       getSession().setScrollTop(y);
    }
-   
+
    public void scrollTo(int x, int y)
    {
       getSession().setScrollLeft(x);
       getSession().setScrollTop(y);
    }
-   
+
    private native final void _setHighlightRFunctionCallsImpl(boolean highlight)
    /*-{
       var Mode = $wnd.require("mode/r_highlight_rules");
       Mode.setHighlightRFunctionCalls(highlight);
    }-*/;
-   
+
    public void enableSearchHighlight()
    {
       widget_.getEditor().enableSearchHighlight();
    }
-   
+
    public void disableSearchHighlight()
    {
       widget_.getEditor().disableSearchHighlight();
@@ -2033,19 +2033,19 @@ public class AceEditor implements DocDisplay,
       useEmacsKeybindings_ = use;
       updateKeyboardHandlers();
    }
-   
+
    @Override
    public boolean isEmacsModeOn()
    {
       return useEmacsKeybindings_;
    }
-   
+
    @Override
    public void clearEmacsMark()
    {
       widget_.getEditor().clearEmacsMark();
    }
-   
+
    @Override
    public void setUseVimMode(boolean use)
    {
@@ -2063,7 +2063,7 @@ public class AceEditor implements DocDisplay,
    {
       return useVimMode_;
    }
-   
+
    @Override
    public boolean isVimInInsertMode()
    {
@@ -2093,7 +2093,7 @@ public class AceEditor implements DocDisplay,
       AceFold fold = getSession().getFoldAt(row, 0);
       if (fold == null)
          return null;
-      
+
       Position foldPos = fold.getStart();
       return getSession().getState(foldPos.getRow());
    }
@@ -2146,12 +2146,12 @@ public class AceEditor implements DocDisplay,
    {
       return widget_.addCursorChangedHandler(handler);
    }
-   
+
    public HandlerRegistration addSaveCompletedHandler(SaveFileHandler handler)
    {
       return handlers_.addHandler(SaveFileEvent.TYPE, handler);
    }
-   
+
    public HandlerRegistration addAttachHandler(AttachEvent.Handler handler)
    {
       return widget_.addAttachHandler(handler);
@@ -2161,13 +2161,13 @@ public class AceEditor implements DocDisplay,
    {
       return widget_.addFocusHandler(handler);
    }
-   
+
    public Scope getCurrentScope()
    {
       return getSession().getMode().getCodeModel().getCurrentScope(
             getCursorPosition());
    }
-   
+
    public Scope getScopeAtPosition(Position position)
    {
       return getSession().getMode().getCodeModel().getCurrentScope(position);
@@ -2236,7 +2236,7 @@ public class AceEditor implements DocDisplay,
    {
       return getSession().getSelection().getCursor();
    }
-   
+
    public Position getCursorPositionScreen()
    {
       return widget_.getEditor().getCursorPositionScreen();
@@ -2247,12 +2247,12 @@ public class AceEditor implements DocDisplay,
       getSession().getSelection().setSelectionRange(
             Range.fromPoints(position, position));
    }
-   
+
    public void goToLineStart()
    {
       widget_.getEditor().getCommandManager().exec("gotolinestart", widget_.getEditor());
    }
-   
+
    public void goToLineEnd()
    {
       widget_.getEditor().getCommandManager().exec("gotolineend", widget_.getEditor());
@@ -2264,25 +2264,25 @@ public class AceEditor implements DocDisplay,
       int screenRow = getSession().documentToScreenRow(getCursorPosition());
       widget_.getEditor().scrollToRow(Math.max(0, screenRow - rowOffset));
    }
-   
+
    @Override
    public void moveCursorForward()
    {
       moveCursorForward(1);
    }
-   
+
    @Override
    public void moveCursorForward(int characters)
    {
       widget_.getEditor().moveCursorRight(characters);
    }
-   
+
    @Override
    public void moveCursorBackward()
    {
       moveCursorBackward(1);
    }
-   
+
    @Override
    public void moveCursorBackward(int characters)
    {
@@ -2308,13 +2308,13 @@ public class AceEditor implements DocDisplay,
       if (!widget_.getEditor().isRowFullyVisible(row))
          setCursorPosition(Position.create(row, 0));
    }
-   
+
    @Override
    public void scrollCursorIntoViewIfNecessary(int rowsAround)
    {
       Position cursorPos = getCursorPosition();
       int cursorRow = cursorPos.getRow();
-      
+
       if (cursorRow >= widget_.getEditor().getLastVisibleRow() - rowsAround)
       {
          Position alignPos = Position.create(cursorRow + rowsAround, 0);
@@ -2326,7 +2326,7 @@ public class AceEditor implements DocDisplay,
          widget_.getEditor().getRenderer().alignCursor(alignPos, 0);
       }
    }
-   
+
    @Override
    public void scrollCursorIntoViewIfNecessary()
    {
@@ -2338,12 +2338,12 @@ public class AceEditor implements DocDisplay,
    {
       return StringUtil.isEndOfLineInRStringState(getCurrentLineUpToCursor());
    }
-   
+
    public void gotoPageUp()
    {
       widget_.getEditor().gotoPageUp();
    }
-   
+
    public void gotoPageDown()
    {
       widget_.getEditor().gotoPageDown();
@@ -2359,12 +2359,12 @@ public class AceEditor implements DocDisplay,
    {
       widget_.getEditor().revealRange(range, animate);
    }
-   
+
    public CodeModel getCodeModel()
    {
       return getSession().getMode().getCodeModel();
    }
-   
+
    public boolean hasCodeModel()
    {
       return getSession().getMode().hasCodeModel();
@@ -2374,19 +2374,19 @@ public class AceEditor implements DocDisplay,
    {
       return hasCodeModel() && getCodeModel().hasScopes();
    }
-   
+
    public void buildScopeTree()
    {
       // Builds the scope tree as a side effect
       if (hasScopeTree())
          getScopeTree();
    }
-   
+
    public int buildScopeTreeUpToRow(int row)
    {
       if (!hasScopeTree())
          return 0;
-      
+
       return getSession().getMode().getRCodeModel().buildScopeTreeUpToRow(row);
    }
 
@@ -2418,19 +2418,19 @@ public class AceEditor implements DocDisplay,
    {
       getSession().toggleFold();
    }
-   
+
    @Override
    public void setFoldStyle(String style)
    {
       getSession().setFoldStyle(style);
    }
-   
+
    @Override
    public JsMap<Position> getMarks()
    {
       return widget_.getEditor().getMarks();
    }
-   
+
    @Override
    public void setMarks(JsMap<Position> marks)
    {
@@ -2454,13 +2454,13 @@ public class AceEditor implements DocDisplay,
    {
       widget_.getEditor().jumpToMatching(true, true);
    }
-   
+
    @Override
    public void addCursorAbove()
    {
       widget_.getEditor().execCommand("addCursorAbove");
    }
-   
+
    @Override
    public void addCursorBelow()
    {
@@ -2472,7 +2472,7 @@ public class AceEditor implements DocDisplay,
    {
       widget_.getEditor().splitIntoLines();
    }
-   
+
    @Override
    public int getFirstFullyVisibleRow()
    {
@@ -2621,7 +2621,7 @@ public class AceEditor implements DocDisplay,
    {
       return widget_.hasBreakpoints();
    }
-   
+
    public void setChunkLineExecState(int start, int end, int state)
    {
       widget_.setChunkLineExecState(start, end, state);
@@ -2722,18 +2722,18 @@ public class AceEditor implements DocDisplay,
    {
       return handlers_.addHandler(FoldChangeEvent.TYPE, handler);
    }
-   
+
    public HandlerRegistration addLineWidgetsChangedHandler(
                            LineWidgetsChangedEvent.Handler handler)
    {
       return handlers_.addHandler(LineWidgetsChangedEvent.TYPE, handler);
    }
-   
+
    public boolean isScopeTreeReady(int row)
    {
       return backgroundTokenizer_.isReady(row);
    }
-   
+
    public HandlerRegistration addScopeTreeReadyHandler(ScopeTreeReadyEvent.Handler handler)
    {
       return handlers_.addHandler(ScopeTreeReadyEvent.TYPE, handler);
@@ -2743,12 +2743,12 @@ public class AceEditor implements DocDisplay,
    {
       return widget_.addHandler(handler, RenderFinishedEvent.TYPE);
    }
-   
+
    public HandlerRegistration addDocumentChangedHandler(DocumentChangedEvent.Handler handler)
    {
       return widget_.addHandler(handler, DocumentChangedEvent.TYPE);
    }
-   
+
    public HandlerRegistration addCapturingKeyDownHandler(KeyDownHandler handler)
    {
       return widget_.addCapturingKeyDownHandler(handler);
@@ -2778,7 +2778,7 @@ public class AceEditor implements DocDisplay,
    {
       return widget_.addAceClickHandler(handler);
    }
-   
+
    public HandlerRegistration addEditorModeChangedHandler(
          EditorModeChangedEvent.Handler handler)
    {
@@ -2817,17 +2817,17 @@ public class AceEditor implements DocDisplay,
    {
       return widget_.addBlurHandler(handler);
    }
-   
+
    public HandlerRegistration addMouseDownHandler(MouseDownHandler handler)
    {
       return widget_.addMouseDownHandler(handler);
    }
-   
+
    public HandlerRegistration addMouseMoveHandler(MouseMoveHandler handler)
    {
       return widget_.addMouseMoveHandler(handler);
    }
-   
+
    public HandlerRegistration addMouseUpHandler(MouseUpHandler handler)
    {
       return widget_.addMouseUpHandler(handler);
@@ -2852,17 +2852,17 @@ public class AceEditor implements DocDisplay,
    {
       return widget_.addKeyDownHandler(handler);
    }
-   
+
    public HandlerRegistration addKeyPressHandler(KeyPressHandler handler)
    {
       return widget_.addKeyPressHandler(handler);
    }
-   
+
    public HandlerRegistration addKeyUpHandler(KeyUpHandler handler)
    {
       return widget_.addKeyUpHandler(handler);
    }
-   
+
    public HandlerRegistration addSelectionChangedHandler(AceSelectionChangedEvent.Handler handler)
    {
       return widget_.addSelectionChangedHandler(handler);
@@ -3004,7 +3004,7 @@ public class AceEditor implements DocDisplay,
          executionLine_ = null;
       }
    }
-   
+
    public void setPopupVisible(boolean visible)
    {
       popupVisible_ = visible;
@@ -3014,7 +3014,7 @@ public class AceEditor implements DocDisplay,
    {
       return popupVisible_;
    }
-   
+
    public void selectAll(String needle)
    {
       widget_.getEditor().findAll(needle);
@@ -3095,10 +3095,10 @@ public class AceEditor implements DocDisplay,
 
       return cursor.getRow();
    }
-   
+
    private boolean rowEndsInBinaryOp(int row)
    {
-      // move to the last interesting token on this line 
+      // move to the last interesting token on this line
       JsArray<Token> tokens = getSession().getTokens(row);
       for (int i = tokens.length() - 1; i >= 0; i--)
       {
@@ -3110,10 +3110,10 @@ public class AceEditor implements DocDisplay,
              t.getValue() == ",")
             return true;
          break;
-      } 
+      }
       return false;
    }
-   
+
    private boolean rowIsEmptyOrComment(int row)
    {
       JsArray<Token> tokens = getSession().getTokens(row);
@@ -3122,56 +3122,56 @@ public class AceEditor implements DocDisplay,
             return false;
       return true;
    }
-   
+
    private boolean rowStartsWithClosingBracket(int row)
    {
       JsArray<Token> tokens = getSession().getTokens(row);
-      
+
       int n = tokens.length();
       if (n == 0)
          return false;
-      
+
       for (int i = 0; i < n; i++)
       {
          Token token = tokens.get(i);
          if (token.hasType("text"))
             continue;
-         
+
          String tokenValue = token.getValue();
          return tokenValue.equals("}") ||
                 tokenValue.equals(")") ||
                 tokenValue.equals("]");
       }
-      
+
       return false;
    }
-   
+
    private boolean rowEndsWithOpenBracket(int row)
    {
       JsArray<Token> tokens = getSession().getTokens(row);
-      
+
       int n = tokens.length();
       if (n == 0)
          return false;
-      
+
       for (int i = 0; i < n; i++)
       {
          Token token = tokens.get(n - i - 1);
          if (token.hasType("text", "comment", "virtual-comment"))
             continue;
-         
+
          String tokenValue = token.getValue();
          return tokenValue.equals("{") ||
                 tokenValue.equals("(") ||
                 tokenValue.equals("[");
       }
-      
+
       return false;
    }
-   
+
    /**
     * Finds the last non-empty line starting at the given line.
-    * 
+    *
     * @param initial Row to start on
     * @param limit Row at which to stop searching
     * @return Index of last non-empty line, or limit line if no empty lines
@@ -3182,7 +3182,7 @@ public class AceEditor implements DocDisplay,
       // no work to do if already at limit
       if (initial == limit)
          return initial;
-      
+
       // walk towards limit
       int delta = limit > initial ? 1 : -1;
       for (int row = initial + delta; row != limit; row += delta)
@@ -3190,7 +3190,7 @@ public class AceEditor implements DocDisplay,
          if (getLine(row).trim().isEmpty())
             return row - delta;
       }
-      
+
       // didn't find boundary
       return limit;
    }
@@ -3212,32 +3212,32 @@ public class AceEditor implements DocDisplay,
 
       // create token cursor (will be used to walk tokens as needed)
       TokenCursor c = getSession().getMode().getCodeModel().getTokenCursor();
-      
+
       // assume start, end at current position
       int startRow = pos.getRow();
       int endRow   = pos.getRow();
-      
+
       // expand to enclosing '(' or '['
       do
       {
          c.setRow(pos.getRow());
-         
+
          // move forward over commented / empty lines
          int n = getSession().getLength();
          while (rowIsEmptyOrComment(c.getRow()))
          {
             if (c.getRow() == n - 1)
                break;
-            
+
             c.setRow(c.getRow() + 1);
          }
-         
+
          // move to last non-right-bracket token on line
          c.moveToEndOfRow(c.getRow());
          while (c.valueEquals(")") || c.valueEquals("]"))
             if (!c.moveToPreviousToken())
                break;
-         
+
          // find the top-most enclosing bracket
          // check for function scope
          String[] candidates = new String[] {"(", "["};
@@ -3254,14 +3254,14 @@ public class AceEditor implements DocDisplay,
                if (scope != null)
                   return Range.fromPoints(scope.getPreamble(), scope.getEnd());
             }
-            
+
             // move off of opening bracket and continue lookup
             savedRow = c.getRow();
             savedOffset = c.getOffset();
             if (!c.moveToPreviousToken())
                break;
          }
-         
+
          // if we found a row, use it
          if (savedRow != -1 && savedOffset != -1)
          {
@@ -3273,16 +3273,16 @@ public class AceEditor implements DocDisplay,
                endRow = c.getRow();
             }
          }
-         
+
       } while (false);
-      
+
       // discover start of current statement
       while (startRow >= startRowLimit)
       {
          // if we've hit the start of the document, bail
          if (startRow <= 0)
             break;
-         
+
          // if the row starts with an open bracket, expand to its match
          if (rowStartsWithClosingBracket(startRow))
          {
@@ -3293,14 +3293,14 @@ public class AceEditor implements DocDisplay,
                continue;
             }
          }
-         
+
          // keep going if the line is empty or previous ends w/binary op
          if (rowEndsInBinaryOp(startRow - 1) || rowIsEmptyOrComment(startRow - 1))
          {
             startRow--;
             continue;
          }
-         
+
          // keep going if we're in a multiline string
          String state = getSession().getState(startRow - 1);
          if (state.equals("qstring") || state.equals("qqstring"))
@@ -3308,15 +3308,15 @@ public class AceEditor implements DocDisplay,
             startRow--;
             continue;
          }
-         
+
          // bail out of the loop -- we've found the start of the statement
          break;
       }
-      
+
       // discover end of current statement -- we search from the inferred statement
       // start, so that we can perform counting of matching pairs of brackets
       endRow = startRow;
-      
+
       // NOTE: '[[' is not tokenized as a single token in our Ace tokenizer,
       // so it is not included here (this shouldn't cause issues in practice
       // since balanced pairs of '[' and '[[' would still imply a correct count
@@ -3324,7 +3324,7 @@ public class AceEditor implements DocDisplay,
       int parenCount = 0;   // '(', ')'
       int braceCount = 0;   // '{', '}'
       int bracketCount = 0; // '[', ']'
-      
+
       while (endRow <= endRowLimit)
       {
          // update bracket token counts
@@ -3332,31 +3332,31 @@ public class AceEditor implements DocDisplay,
          for (Token token : JsUtil.asIterable(tokens))
          {
             String value = token.getValue();
-            
+
             parenCount += value.equals("(") ? 1 : 0;
             parenCount -= value.equals(")") ? 1 : 0;
-            
+
             braceCount += value.equals("{") ? 1 : 0;
             braceCount -= value.equals("}") ? 1 : 0;
-            
+
             bracketCount += value.equals("[") ? 1 : 0;
             bracketCount -= value.equals("]") ? 1 : 0;
          }
-         
+
          // continue search if line ends with binary operator
          if (rowEndsInBinaryOp(endRow) || rowIsEmptyOrComment(endRow))
          {
             endRow++;
             continue;
          }
-         
+
          // continue search if we have unbalanced brackets
          if (parenCount > 0 || braceCount > 0 || bracketCount > 0)
          {
             endRow++;
             continue;
          }
-         
+
          // continue search if we're in a multi-line string
          String state = getSession().getState(endRow);
          if (state.equals("qstring") || state.equals("qqstring"))
@@ -3364,28 +3364,28 @@ public class AceEditor implements DocDisplay,
             endRow++;
             continue;
          }
-         
+
          // we had balanced brackets and no trailing binary operator; bail
          break;
       }
-      
+
       // if we're unbalanced at this point, that means we tried to
       // expand in an unclosed expression -- just execute the current
       // line rather than potentially executing unintended code
       if (parenCount + braceCount + bracketCount > 0)
          return Range.create(pos.getRow(), 0, pos.getRow() + 1, 0);
-      
+
       // shrink selection for empty lines at borders
       while (startRow < endRow && rowIsEmptyOrComment(startRow))
          startRow++;
-      
+
       while (endRow > startRow && rowIsEmptyOrComment(endRow))
          endRow--;
-      
+
       // fixup for single-line execution
       if (startRow > endRow)
          startRow = endRow;
-      
+
       // if we've captured the body of a function definition, expand
       // to include whole definition
       c.setRow(startRow);
@@ -3403,15 +3403,15 @@ public class AceEditor implements DocDisplay,
          if (fn != null)
             return Range.fromPoints(fn.getPreamble(), fn.getEnd());
       }
-      
+
       // construct range
       int endColumn = getSession().getLine(endRow).length();
       Range range = Range.create(startRow, 0, endRow, endColumn);
-      
+
       // return empty range if nothing to execute
       if (getTextForRange(range).trim().isEmpty())
          range = Range.fromPoints(pos, pos);
-      
+
       return range;
    }
 
@@ -3450,7 +3450,7 @@ public class AceEditor implements DocDisplay,
    {
       widget_.clearLint();
    }
-   
+
    @Override
    public void showInfoBar(String message)
    {
@@ -3467,7 +3467,7 @@ public class AceEditor implements DocDisplay,
             }
          });
       }
-         
+
       infoBar_.setText(message);
       infoBar_.show();
    }
@@ -3491,7 +3491,7 @@ public class AceEditor implements DocDisplay,
    {
       return lastCursorChangedTime_;
    }
-   
+
    public int getFirstVisibleRow()
    {
       return widget_.getEditor().getFirstVisibleRow();
@@ -3506,7 +3506,7 @@ public class AceEditor implements DocDisplay,
    {
       widget_.getEditor().blockOutdent();
    }
-   
+
    public ScreenCoordinates documentPositionToScreenCoordinates(Position position)
    {
       return widget_.getEditor().getRenderer().textToScreenCoordinates(position);
@@ -3521,43 +3521,43 @@ public class AceEditor implements DocDisplay,
    {
       return widget_.getEditor().isRowFullyVisible(position.getRow());
    }
-   
+
    @Override
    public void tokenizeDocument()
    {
       widget_.getEditor().tokenizeDocument();
    }
-   
+
    @Override
    public void retokenizeDocument()
    {
       widget_.getEditor().retokenizeDocument();
    }
-   
+
    @Override
    public Token getTokenAt(int row, int column)
    {
       return getSession().getTokenAt(row, column);
    }
-   
+
    @Override
    public Token getTokenAt(Position position)
    {
       return getSession().getTokenAt(position);
    }
-   
+
    @Override
    public JsArray<Token> getTokens(int row)
    {
       return getSession().getTokens(row);
    }
-   
+
    @Override
    public TokenIterator createTokenIterator()
    {
       return createTokenIterator(null);
    }
-   
+
    @Override
    public TokenIterator createTokenIterator(Position position)
    {
@@ -3568,7 +3568,7 @@ public class AceEditor implements DocDisplay,
    }
 
    @Override
-   public void beginCollabSession(CollabEditStartParams params, 
+   public void beginCollabSession(CollabEditStartParams params,
          DirtyState dirtyState)
    {
       // suppress external value change events while the editor's contents are
@@ -3586,59 +3586,59 @@ public class AceEditor implements DocDisplay,
          }
       });
    }
-   
+
    @Override
    public boolean hasActiveCollabSession()
    {
       return collab_.hasActiveCollabSession(this);
    }
-   
+
    @Override
    public boolean hasFollowingCollabSession()
    {
       return collab_.hasFollowingCollabSession(this);
    }
-   
+
    public void endCollabSession()
    {
       collab_.endCollabSession(this);
    }
-   
+
    @Override
    public void setDragEnabled(boolean enabled)
    {
       widget_.setDragEnabled(enabled);
    }
-   
+
    @Override
    public boolean isSnippetsTabStopManagerActive()
    {
       return isSnippetsTabStopManagerActiveImpl(widget_.getEditor());
    }
-   
+
    private static final native
    boolean isSnippetsTabStopManagerActiveImpl(AceEditorNative editor)
    /*-{
       return editor.tabstopManager != null;
    }-*/;
-   
+
    private void insertSnippet()
    {
       if (!snippets_.onInsertSnippet())
          blockOutdent();
    }
-   
+
    @Override
    public boolean onInsertSnippet()
    {
       return snippets_.onInsertSnippet();
    }
-   
+
    public void toggleTokenInfo()
    {
       toggleTokenInfo(widget_.getEditor());
    }
-   
+
    private static final native void toggleTokenInfo(AceEditorNative editor) /*-{
       if (editor.tokenTooltip && editor.tokenTooltip.destroy) {
          editor.tokenTooltip.destroy();
@@ -3657,33 +3657,33 @@ public class AceEditor implements DocDisplay,
       if (widget.getRow() < getFirstVisibleRow())
       {
          widget.getElement().getStyle().setTop(-10000, Unit.PX);
-         
+
          // set left/right values so that the widget consumes space; necessary
          // to get layout offsets inside the widget while rendering but before
          // it comes onscreen
          widget.getElement().getStyle().setLeft(48, Unit.PX);
          widget.getElement().getStyle().setRight(15, Unit.PX);
       }
-      
+
       widget_.getLineWidgetManager().addLineWidget(widget);
       adjustScrollForLineWidget(widget);
       fireLineWidgetsChanged();
    }
-   
+
    @Override
    public void removeLineWidget(LineWidget widget)
    {
       widget_.getLineWidgetManager().removeLineWidget(widget);
       fireLineWidgetsChanged();
    }
-   
+
    @Override
    public void removeAllLineWidgets()
    {
       widget_.getLineWidgetManager().removeAllLineWidgets();
       fireLineWidgetsChanged();
    }
-   
+
    @Override
    public void onLineWidgetChanged(LineWidget widget)
    {
@@ -3696,19 +3696,19 @@ public class AceEditor implements DocDisplay,
       adjustScrollForLineWidget(widget);
       fireLineWidgetsChanged();
    }
-   
+
    @Override
    public JsArray<LineWidget> getLineWidgets()
    {
       return widget_.getLineWidgetManager().getLineWidgets();
    }
-   
+
    @Override
    public LineWidget getLineWidgetForRow(int row)
    {
       return widget_.getLineWidgetManager().getLineWidgetForRow(row);
    }
-   
+
 
    @Override
    public boolean hasLineWidgets()
@@ -3719,26 +3719,26 @@ public class AceEditor implements DocDisplay,
    private void adjustScrollForLineWidget(LineWidget w)
    {
       // the cursor is above the line widget, so the line widget is going
-      // to change the cursor position; adjust the scroll position to hold 
+      // to change the cursor position; adjust the scroll position to hold
       // the cursor in place
       if (getCursorPosition().getRow() > w.getRow())
       {
          int delta = w.getElement().getOffsetHeight() - w.getRenderedHeight();
-         
+
          // skip if no change to report
          if (delta == 0)
             return;
 
          // we adjust the scrolltop on the session since it knows the
-         // currently queued scroll position; the renderer only knows the 
+         // currently queued scroll position; the renderer only knows the
          // actual scroll position, which may not reflect unrendered changes
          getSession().setScrollTop(getSession().getScrollTop() + delta);
       }
-      
+
       // mark the current height as rendered
       w.setRenderedHeight(w.getElement().getOffsetHeight());
    }
-   
+
    @Override
    public JsArray<ChunkDefinition> getChunkDefs()
    {
@@ -3746,7 +3746,7 @@ public class AceEditor implements DocDisplay,
       // if we haven't rendered yet
       if (!isRendered())
          return null;
-      
+
       JsArray<ChunkDefinition> chunks = JsArray.createArray().cast();
       JsArray<LineWidget> lineWidgets = getLineWidgets();
       ScopeList scopes = new ScopeList(this);
@@ -3756,45 +3756,45 @@ public class AceEditor implements DocDisplay,
          if (lineWidget.getType().equals(ChunkDefinition.LINE_WIDGET_TYPE))
          {
             ChunkDefinition chunk = lineWidget.getData();
-            chunks.push(chunk.with(lineWidget.getRow(), 
+            chunks.push(chunk.with(lineWidget.getRow(),
                   TextEditingTargetNotebook.getKnitrChunkLabel(
                         lineWidget.getRow(), this, scopes)));
          }
       }
-      
+
       return chunks;
    }
-   
+
 
    @Override
    public boolean isRendered()
    {
       return widget_.isRendered();
    }
-   
+
    @Override
    public boolean showChunkOutputInline()
    {
       return showChunkOutputInline_;
    }
-   
+
    @Override
    public void setShowChunkOutputInline(boolean show)
    {
       showChunkOutputInline_ = show;
    }
-   
+
    private void fireLineWidgetsChanged()
    {
       AceEditor.this.fireEvent(new LineWidgetsChangedEvent());
    }
-   
+
    private static class BackgroundTokenizer
    {
       public BackgroundTokenizer(final AceEditor editor)
       {
          editor_ = editor;
-         
+
          timer_ = new Timer()
          {
             @Override
@@ -3808,13 +3808,13 @@ public class AceEditor implements DocDisplay,
                         editor_.getCurrentScope()));
                   return;
                }
-               
+
                row_ += ROWS_TOKENIZED_PER_ITERATION;
                row_ = Math.max(row_, editor.buildScopeTreeUpToRow(row_));
                timer_.schedule(DELAY_MS);
             }
          };
-         
+
          editor_.addDocumentChangedHandler(new DocumentChangedEvent.Handler()
          {
             @Override
@@ -3825,22 +3825,22 @@ public class AceEditor implements DocDisplay,
             }
          });
       }
-      
+
       public boolean isReady(int row)
       {
          return row < row_;
       }
-      
+
       private final AceEditor editor_;
       private final Timer timer_;
-      
+
       private int row_ = 0;
-      
+
       private static final int DELAY_MS = 5;
       private static final int ROWS_TOKENIZED_PER_ITERATION = 200;
    }
 
-   private class ScrollAnimator 
+   private class ScrollAnimator
                  implements AnimationScheduler.AnimationCallback
    {
       public ScrollAnimator(int targetY, int ms)
@@ -3851,13 +3851,13 @@ public class AceEditor implements DocDisplay,
          ms_ = ms;
          handle_ = AnimationScheduler.get().requestAnimationFrame(this);
       }
-      
+
       public void complete()
       {
          handle_.cancel();
          scrollAnimator_ = null;
       }
-      
+
       @Override
       public void execute(double timestamp)
       {
@@ -3886,7 +3886,7 @@ public class AceEditor implements DocDisplay,
       private double startTime_ = -1;
       private AnimationScheduler.AnimationHandle handle_;
    }
-   
+
    private static final int DEBUG_CONTEXT_LINES = 2;
    private final HandlerManager handlers_ = new HandlerManager(this);
    private final AceEditorWidget widget_;
@@ -3918,12 +3918,12 @@ public class AceEditor implements DocDisplay,
    private int scrollTarget_ = 0;
    private HandlerRegistration scrollCompleteReg_;
    private final AceEditorMixins mixins_;
-   
+
    private static final ExternalJavaScriptLoader getLoader(StaticDataResource release)
    {
       return getLoader(release, null);
    }
-   
+
    private static final ExternalJavaScriptLoader getLoader(StaticDataResource release,
                                                            StaticDataResource debug)
    {
@@ -3932,27 +3932,27 @@ public class AceEditor implements DocDisplay,
       else
          return new ExternalJavaScriptLoader(debug.getSafeUri().asString());
    }
-                                                           
-    
+
+
    private static final ExternalJavaScriptLoader aceLoader_ =
          getLoader(AceResources.INSTANCE.acejs(), AceResources.INSTANCE.acejsUncompressed());
-   
-   
+
+
    private static final ExternalJavaScriptLoader aceSupportLoader_ =
          getLoader(AceResources.INSTANCE.acesupportjs());
-   
+
    private static final ExternalJavaScriptLoader vimLoader_ =
          getLoader(AceResources.INSTANCE.keybindingVimJs(),
                    AceResources.INSTANCE.keybindingVimUncompressedJs());
-   
+
    private static final ExternalJavaScriptLoader emacsLoader_ =
          getLoader(AceResources.INSTANCE.keybindingEmacsJs(),
                    AceResources.INSTANCE.keybindingEmacsUncompressedJs());
-   
+
    private static final ExternalJavaScriptLoader extLanguageToolsLoader_ =
          getLoader(AceResources.INSTANCE.extLanguageTools(),
                    AceResources.INSTANCE.extLanguageToolsUncompressed());
-   
+
    private boolean popupVisible_;
 
    private final DiagnosticsBackgroundPopup diagnosticsBgPopup_;
@@ -3960,7 +3960,7 @@ public class AceEditor implements DocDisplay,
    private long lastCursorChangedTime_;
    private long lastModifiedTime_;
    private String yankedText_ = null;
-   
-   
+
+
    private final List<HandlerRegistration> editorEventListeners_;
 }


### PR DESCRIPTION
This adds slack (or GitHub) like emoji completion (with narrowing) , i.e. when you type `:cat` in some context, the completion popup offers emoji completions: 

![](https://media.giphy.com/media/3o6vY2YBhwzwg399eg/giphy.gif)

This is based on the function `ji_completion` in the emo 📦, with a failsafe in case the package is not installed .... 

```
.rs.addFunction("getCompletionsEmoji", function(token)
{
  tryCatch( {
      results <- emo::ji_completion(sub("^[:]","", token))
      .rs.makeCompletions(
         token = token,
         results = unname(results),
         packages = names(results),
         quote = FALSE,
         type = .rs.acCompletionTypes$EMOJI,
         overrideInsertParens = TRUE,
         excludeOtherCompletions = TRUE
      )
  }, error = .rs.emptyCompletions() )

})
```

(but this could be reworked to eliminate the dependency on the package, by e.g. hosting some json file on the client side

emoji completions are triggered based on the regex `"[:][a-zA-Z0-9_]+"` in these contexts: 
- in a single line string (assuming that matching the regex means we are not in business for file completion) 
 - in a multi line string
 - in comments
 - in the text of a markdown doc. 

I've only tested it on my 💻 , idk what it looks like on e.g. windows. no idea if ace or chrome render the emojis correctly. 

I started this based on the master branch. Not sure I can easily rebase it on some other branch if needed, but I guess I could redo the edits if necessary. 