### PR TITLE
Added option to toggle whether .Rprofile is run when starting a session in a project

### DIFF
--- a/src/cpp/core/include/core/r_util/RProjectFile.hpp
+++ b/src/cpp/core/include/core/r_util/RProjectFile.hpp
@@ -87,6 +87,7 @@ struct RProjectConfig
         customScriptPath(),
         tutorialPath(),
         quitChildProcessesOnExit(DefaultValue),
+        executeRprofile(true),
         defaultOpenDocs()
    {
    }
@@ -119,6 +120,7 @@ struct RProjectConfig
    std::string customScriptPath;
    std::string tutorialPath;
    int quitChildProcessesOnExit;
+   bool executeRprofile;
    std::string defaultOpenDocs;
 };
 

--- a/src/cpp/core/include/core/r_util/RProjectFile.hpp
+++ b/src/cpp/core/include/core/r_util/RProjectFile.hpp
@@ -87,7 +87,7 @@ struct RProjectConfig
         customScriptPath(),
         tutorialPath(),
         quitChildProcessesOnExit(DefaultValue),
-        executeRprofile(true),
+        disableExecuteRprofile(false),
         defaultOpenDocs()
    {
    }
@@ -120,7 +120,7 @@ struct RProjectConfig
    std::string customScriptPath;
    std::string tutorialPath;
    int quitChildProcessesOnExit;
-   bool executeRprofile;
+   bool disableExecuteRprofile;
    std::string defaultOpenDocs;
 };
 

--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -759,15 +759,15 @@ Error readProjectFile(const FilePath& projectFilePath,
    }
 
    // extract execute rprofile
-   it = dcfFields.find("ExecuteRprofile");
+   it = dcfFields.find("DisableExecuteRprofile");
    if (it != dcfFields.end())
    {
-      if (!interpretBoolValue(it->second, &(pConfig->executeRprofile)))
-         return requiredFieldError("ExecuteRprofile", pUserErrMsg);
+      if (!interpretBoolValue(it->second, &(pConfig->disableExecuteRprofile)))
+         return requiredFieldError("DisableExecuteRprofile", pUserErrMsg);
    }
    else
    {
-      pConfig->executeRprofile = true;
+      pConfig->disableExecuteRprofile = false;
    }
 
    // extract default open docs
@@ -971,10 +971,10 @@ Error writeProjectFile(const FilePath& projectFilePath,
       contents.append(boost::str(quitChildProcFmt % yesNoAskValueToString(config.quitChildProcessesOnExit)));
    }
 
-   // add ExecuteRprofile if it's not the default
-   if (!config.executeRprofile)
+   // add DisableExecuteRprofile if it's not the default
+   if (config.disableExecuteRprofile)
    {
-      contents.append("ExecuteRprofile: No\n");
+      contents.append("DisableExecuteRprofile: Yes\n");
    }
 
    // add default open docs if it's present

--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -758,6 +758,18 @@ Error readProjectFile(const FilePath& projectFilePath,
       *pProvidedDefaults = true;
    }
 
+   // extract execute rprofile
+   it = dcfFields.find("ExecuteRprofile");
+   if (it != dcfFields.end())
+   {
+      if (!interpretBoolValue(it->second, &(pConfig->executeRprofile)))
+         return requiredFieldError("ExecuteRprofile", pUserErrMsg);
+   }
+   else
+   {
+      pConfig->executeRprofile = true;
+   }
+
    // extract default open docs
    it = dcfFields.find("DefaultOpenDocs");
    if (it != dcfFields.end())
@@ -957,6 +969,12 @@ Error writeProjectFile(const FilePath& projectFilePath,
    {
       boost::format quitChildProcFmt("\nQuitChildProcessesOnExit: %1%\n");
       contents.append(boost::str(quitChildProcFmt % yesNoAskValueToString(config.quitChildProcessesOnExit)));
+   }
+
+   // add ExecuteRprofile if it's not the default
+   if (!config.executeRprofile)
+   {
+      contents.append("ExecuteRprofile: No\n");
    }
 
    // add default open docs if it's present

--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -64,8 +64,9 @@ struct ROptions
          autoReloadSource(false),
          restoreWorkspace(true),
          saveWorkspace(SA_SAVEASK),
-         rProfileOnStart(true),
-         rProfileOnResume(false)
+         disableRProfileOnStart(false),
+         rProfileOnResume(false),
+         packratEnabled(false)
    {
    }
    core::FilePath userHomePath;
@@ -87,9 +88,10 @@ struct ROptions
    bool autoReloadSource ;
    bool restoreWorkspace;
    SA_TYPE saveWorkspace;
-   bool rProfileOnStart;
+   bool disableRProfileOnStart;
    bool rProfileOnResume;
    core::r_util::SessionScope sessionScope;
+   bool packratEnabled;
 };
       
 struct RInitInfo

--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -64,6 +64,7 @@ struct ROptions
          autoReloadSource(false),
          restoreWorkspace(true),
          saveWorkspace(SA_SAVEASK),
+         rProfileOnStart(true),
          rProfileOnResume(false)
    {
    }
@@ -86,6 +87,7 @@ struct ROptions
    bool autoReloadSource ;
    bool restoreWorkspace;
    SA_TYPE saveWorkspace;
+   bool rProfileOnStart;
    bool rProfileOnResume;
    core::r_util::SessionScope sessionScope;
 };

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -1494,16 +1494,17 @@ Error run(const ROptions& options, const RCallbacks& callbacks)
    bool loadInitFile = false;
    if (restartContext().hasSessionState())
    {
-      loadInitFile = restartContext().rProfileOnRestore() && options.rProfileOnStart;
+      loadInitFile = restartContext().rProfileOnRestore() && !options.disableRProfileOnStart;
    }
    else
    {
       // we run the .Rprofile if this is a brand new session and
-      // we are in a project and the ExecuteProfile setting is set, or we are not in a project
+      // we are in a project and the DisableExecuteProfile setting is not set, or we are not in a project
       // alternatively, if we are resuming a session and the option is set to possibly run the .Rprofile
-      // we will only run it if the ExecuteProfile project setting is set (or we are not in a project)
-      loadInitFile = (!s_suspendedSessionPath.exists() && options.rProfileOnStart)
-                     || (options.rProfileOnResume && options.rProfileOnStart)
+      // we will only run it if the DisableExecuteProfile project setting is not set (or we are not in a project)
+      // finally, if this is a packrat project, we always run the Rprofile as it is required for correct operation
+      loadInitFile = (!options.disableRProfileOnStart && (!s_suspendedSessionPath.exists() || options.rProfileOnResume))
+                     || options.packratEnabled
                      || r::session::state::packratModeEnabled(s_suspendedSessionPath);
    }
 

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -1494,7 +1494,7 @@ Error run(const ROptions& options, const RCallbacks& callbacks)
    bool loadInitFile = false;
    if (restartContext().hasSessionState())
    {
-      loadInitFile = restartContext().rProfileOnRestore();
+      loadInitFile = restartContext().rProfileOnRestore() && options.rProfileOnStart;
    }
    else
    {

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -1498,10 +1498,13 @@ Error run(const ROptions& options, const RCallbacks& callbacks)
    }
    else
    {
-      loadInitFile = !s_suspendedSessionPath.exists()
-                     || options.rProfileOnResume
-                     || r::session::state::packratModeEnabled(
-                                                s_suspendedSessionPath);
+      // we run the .Rprofile if this is a brand new session and
+      // we are in a project and the ExecuteProfile setting is set, or we are not in a project
+      // alternatively, if we are resuming a session and the option is set to possibly run the .Rprofile
+      // we will only run it if the ExecuteProfile project setting is set (or we are not in a project)
+      loadInitFile = (!s_suspendedSessionPath.exists() && options.rProfileOnStart)
+                     || (options.rProfileOnResume && options.rProfileOnStart)
+                     || r::session::state::packratModeEnabled(s_suspendedSessionPath);
    }
 
    // quiet for resume cases

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -198,17 +198,17 @@ using namespace rsession::client_events;
 namespace rstudio {
 namespace session {
 
-bool executeRprofile()
+bool disableExecuteRprofile()
 {
-   bool executeRprofile = true;
+   bool disableExecuteRprofile = false;
 
    const projects::ProjectContext& projContext = projects::projectContext();
    if (projContext.hasProject())
    {
-      executeRprofile = projContext.config().executeRprofile;
+      disableExecuteRprofile = projContext.config().disableExecuteRprofile;
    }
 
-   return executeRprofile;
+   return disableExecuteRprofile;
 }
 
 bool quitChildProcesses()
@@ -1811,9 +1811,10 @@ int main (int argc, char * const argv[])
       rOptions.autoReloadSource = options.autoReloadSource();
       rOptions.restoreWorkspace = restoreWorkspaceOption();
       rOptions.saveWorkspace = saveWorkspaceOption();
-      rOptions.rProfileOnStart = executeRprofile();
+      rOptions.disableRProfileOnStart = disableExecuteRprofile();
       rOptions.rProfileOnResume = serverMode &&
                                   userSettings().rProfileOnResume();
+      rOptions.packratEnabled = persistentState().settings().getBool("packratEnabled");
       rOptions.sessionScope = options.sessionScope();
       
       // r callbacks

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -198,6 +198,19 @@ using namespace rsession::client_events;
 namespace rstudio {
 namespace session {
 
+bool executeRprofile()
+{
+   bool executeRprofile = true;
+
+   const projects::ProjectContext& projContext = projects::projectContext();
+   if (projContext.hasProject())
+   {
+      executeRprofile = projContext.config().executeRprofile;
+   }
+
+   return executeRprofile;
+}
+
 bool quitChildProcesses()
 {
    // allow project override
@@ -1798,6 +1811,7 @@ int main (int argc, char * const argv[])
       rOptions.autoReloadSource = options.autoReloadSource();
       rOptions.restoreWorkspace = restoreWorkspaceOption();
       rOptions.saveWorkspace = saveWorkspaceOption();
+      rOptions.rProfileOnStart = executeRprofile();
       rOptions.rProfileOnResume = serverMode &&
                                   userSettings().rProfileOnResume();
       rOptions.sessionScope = options.sessionScope();

--- a/src/cpp/session/modules/SessionPackrat.cpp
+++ b/src/cpp/session/modules/SessionPackrat.cpp
@@ -1027,9 +1027,11 @@ PackratContext packratContext()
                   projectPath).call(&context.modeOn);
          if (error)
             LOG_ERROR(error);
+
+         // cache results in project directory to make packrat status information available on session start
+         persistentState().settings().set("packratEnabled", context.modeOn);
       }
    }
-
    return context;
 }
 

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -298,7 +298,7 @@ json::Object projectConfigJson(const r_util::RProjectConfig& config)
    configJson["custom_script_path"] = config.customScriptPath;
    configJson["tutorial_path"] = config.tutorialPath;
    configJson["quit_child_processes_on_exit"] = config.quitChildProcessesOnExit;
-   configJson["execute_rprofile"] = config.executeRprofile;
+   configJson["disable_execute_rprofile"] = config.disableExecuteRprofile;
 
    return configJson;
 }
@@ -531,7 +531,7 @@ Error writeProjectOptions(const json::JsonRpcRequest& request,
    if (error)
       return error;
 
-   error = json::readObject(configJson, "execute_rprofile", &(config.executeRprofile));
+   error = json::readObject(configJson, "disable_execute_rprofile", &(config.disableExecuteRprofile));
    if (error)
       return error;
 

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -298,6 +298,7 @@ json::Object projectConfigJson(const r_util::RProjectConfig& config)
    configJson["custom_script_path"] = config.customScriptPath;
    configJson["tutorial_path"] = config.tutorialPath;
    configJson["quit_child_processes_on_exit"] = config.quitChildProcessesOnExit;
+   configJson["execute_rprofile"] = config.executeRprofile;
 
    return configJson;
 }
@@ -527,6 +528,10 @@ Error writeProjectOptions(const json::JsonRpcRequest& request,
                     "website_path", &(config.websitePath),
                     "custom_script_path", &(config.customScriptPath),
                     "tutorial_path", &(config.tutorialPath));
+   if (error)
+      return error;
+
+   error = json::readObject(configJson, "execute_rprofile", &(config.executeRprofile));
    if (error)
       return error;
 

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
@@ -81,6 +81,14 @@ public class RProjectConfig extends JavaScriptObject
       this.quit_child_processes_on_exit = quitChildProcessesOnExit;
    }-*/;  
    
+   public native final boolean getExecuteRprofile() /*-{
+      return this.execute_rprofile;
+   }-*/;
+   
+   public native final void setExecuteRprofile(boolean executeRprofile) /*-{
+      this.execute_rprofile = executeRprofile;
+   }-*/;
+   
    public native final boolean getEnableCodeIndexing() /*-{
       return this.enable_code_indexing;
    }-*/;  

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
@@ -81,12 +81,12 @@ public class RProjectConfig extends JavaScriptObject
       this.quit_child_processes_on_exit = quitChildProcessesOnExit;
    }-*/;  
    
-   public native final boolean getExecuteRprofile() /*-{
-      return this.execute_rprofile;
+   public native final boolean getDisableExecuteRprofile() /*-{
+      return this.disable_execute_rprofile;
    }-*/;
    
-   public native final void setExecuteRprofile(boolean executeRprofile) /*-{
-      this.execute_rprofile = executeRprofile;
+   public native final void setDisableExecuteRprofile(boolean disableExecuteRprofile) /*-{
+      this.disable_execute_rprofile = disableExecuteRprofile;
    }-*/;
    
    public native final boolean getEnableCodeIndexing() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectGeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectGeneralPreferencesPane.java
@@ -16,6 +16,7 @@ package org.rstudio.studio.client.projects.ui.prefs;
 
 import org.rstudio.core.client.prefs.PreferencesDialogBaseResources;
 import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.studio.client.packrat.model.PackratContext;
 import org.rstudio.studio.client.projects.model.RProjectConfig;
 import org.rstudio.studio.client.projects.model.RProjectOptions;
 import org.rstudio.studio.client.projects.model.RProjectRVersion;
@@ -56,8 +57,8 @@ public class ProjectGeneralPreferencesPane extends ProjectPreferencesPane
       grid.setWidget(3, 0, new Label("Always save history (even if not saving .RData)"));
       grid.setWidget(3, 1, alwaysSaveHistory_ = new YesNoAskDefault(false));
 
-      // execute .Rprofile
-      grid.setWidget(4, 0, executeRprofile_ = new CheckBox("Execute .Rprofile on session start"));
+      // disable execute .Rprofile
+      grid.setWidget(4, 0, disableExecuteRprofile_ = new CheckBox("Disable .Rprofile execution on session start/resume"));
       
       // quit child processes
       grid.setWidget(5, 0, quitChildProcessesOnExit_ = new CheckBox("Quit child processes on exit"));
@@ -81,12 +82,22 @@ public class ProjectGeneralPreferencesPane extends ProjectPreferencesPane
    protected void initialize(RProjectOptions options)
    {
       RProjectConfig config = options.getConfig();
+      PackratContext context = options.getPackratContext();
       restoreWorkspace_.setSelectedIndex(config.getRestoreWorkspace());
       saveWorkspace_.setSelectedIndex(config.getSaveWorkspace());
       alwaysSaveHistory_.setSelectedIndex(config.getAlwaysSaveHistory());
       tutorialPath_ = config.getTutorialPath();
       rVersion_ = config.getRVersion();
-      executeRprofile_.setValue(config.getExecuteRprofile());
+      
+      // if we are in packrat mode, disable the ability to set the disable execute Rprofile setting
+      // the Rprofile always executes on session start in this case as it is required by packrat
+      if (context != null && context.isModeOn())
+      {
+         disableExecuteRprofile_.setEnabled(false);
+         disableExecuteRprofile_.setValue(false);
+      }
+      else
+         disableExecuteRprofile_.setValue(config.getDisableExecuteRprofile());
       
       // check or uncheck the checkbox for child processes based on the configuration value
       // if default is specified, we need to use the current session setting
@@ -117,7 +128,7 @@ public class ProjectGeneralPreferencesPane extends ProjectPreferencesPane
       config.setAlwaysSaveHistory(alwaysSaveHistory_.getSelectedIndex());
       config.setTutorialPath(tutorialPath_);
       config.setRVersion(rVersion_);
-      config.setExecuteRprofile(executeRprofile_.getValue());
+      config.setDisableExecuteRprofile(disableExecuteRprofile_.getValue());
       
       // turn the quit child processes checkbox from a boolean into the 
       // YesNoAsk value that it should be in the configuration
@@ -166,7 +177,7 @@ public class ProjectGeneralPreferencesPane extends ProjectPreferencesPane
    private YesNoAskDefault restoreWorkspace_;
    private YesNoAskDefault saveWorkspace_;
    private YesNoAskDefault alwaysSaveHistory_;
-   private CheckBox executeRprofile_;
+   private CheckBox disableExecuteRprofile_;
    private CheckBox quitChildProcessesOnExit_;
    private SessionInfo sessionInfo_;
    

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectGeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectGeneralPreferencesPane.java
@@ -36,7 +36,7 @@ public class ProjectGeneralPreferencesPane extends ProjectPreferencesPane
    {        
       sessionInfo_ = session.getSessionInfo();
 
-      Grid grid = new Grid(5, 2);
+      Grid grid = new Grid(6, 2);
       grid.addStyleName(RESOURCES.styles().workspaceGrid());
       grid.setCellSpacing(8);
 
@@ -56,8 +56,11 @@ public class ProjectGeneralPreferencesPane extends ProjectPreferencesPane
       grid.setWidget(3, 0, new Label("Always save history (even if not saving .RData)"));
       grid.setWidget(3, 1, alwaysSaveHistory_ = new YesNoAskDefault(false));
 
+      // execute .Rprofile
+      grid.setWidget(4, 0, executeRprofile_ = new CheckBox("Execute .Rprofile on session start"));
+      
       // quit child processes
-      grid.setWidget(4, 0, quitChildProcessesOnExit_ = new CheckBox("Quit child processes on exit"));
+      grid.setWidget(5, 0, quitChildProcessesOnExit_ = new CheckBox("Quit child processes on exit"));
 
       add(grid);
    }
@@ -83,6 +86,7 @@ public class ProjectGeneralPreferencesPane extends ProjectPreferencesPane
       alwaysSaveHistory_.setSelectedIndex(config.getAlwaysSaveHistory());
       tutorialPath_ = config.getTutorialPath();
       rVersion_ = config.getRVersion();
+      executeRprofile_.setValue(config.getExecuteRprofile());
       
       // check or uncheck the checkbox for child processes based on the configuration value
       // if default is specified, we need to use the current session setting
@@ -113,6 +117,7 @@ public class ProjectGeneralPreferencesPane extends ProjectPreferencesPane
       config.setAlwaysSaveHistory(alwaysSaveHistory_.getSelectedIndex());
       config.setTutorialPath(tutorialPath_);
       config.setRVersion(rVersion_);
+      config.setExecuteRprofile(executeRprofile_.getValue());
       
       // turn the quit child processes checkbox from a boolean into the 
       // YesNoAsk value that it should be in the configuration
@@ -161,6 +166,7 @@ public class ProjectGeneralPreferencesPane extends ProjectPreferencesPane
    private YesNoAskDefault restoreWorkspace_;
    private YesNoAskDefault saveWorkspace_;
    private YesNoAskDefault alwaysSaveHistory_;
+   private CheckBox executeRprofile_;
    private CheckBox quitChildProcessesOnExit_;
    private SessionInfo sessionInfo_;
    


### PR DESCRIPTION
This adds a new project option to toggle whether or not .Rprofile should be run when a new session is started in a project. It also interacts with the existing option to run the Rprofile on resume - if that is set, it will use the behavior specified in this new project option.