### PR TITLE
multi-line send-to-terminal not behaving correctly on Windows

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -1122,7 +1122,15 @@ public class StringUtil
    public static final native String normalizeNewLines(String string) /*-{
       return string.replace(/\r\n|\n\r|\r/g, "\n");
    }-*/;
-   
+
+   /**
+    * Convert string line endings to carriage returns to mimic keyboard entry
+    * of text on Windows.
+    */
+   public static final native String normalizeNewLinesToCR(String string) /*-{
+      return string.replace(/\r\n|\n\r|\n/g, "\r");
+   }-*/;
+    
    public static final native JsArrayString split(String string, String delimiter) /*-{
       return string.split(delimiter);
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.views.terminal;
 
 import java.util.ArrayList;
 
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ResultCallback;
 import org.rstudio.core.client.StringUtil;
@@ -548,6 +549,8 @@ public class TerminalPane extends WorkbenchPane
          return;
 
       suppressAutoFocus_ = !setFocus;
+      if (BrowseCap.isWindowsDesktop())
+         text = StringUtil.normalizeNewLinesToCR(text);
       ensureTerminal(text);
       activateTerminal();
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -17,7 +17,6 @@ package org.rstudio.studio.client.workbench.views.terminal;
 
 import java.util.ArrayList;
 
-import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ResultCallback;
 import org.rstudio.core.client.StringUtil;
@@ -302,7 +301,7 @@ public class TerminalPane extends WorkbenchPane
       else
       {
          setFocusOnVisible();
-         terminal.receivedInput(postCreateText);
+         terminal.receivedSendToTerminal(postCreateText);
       }
    }
 
@@ -549,8 +548,6 @@ public class TerminalPane extends WorkbenchPane
          return;
 
       suppressAutoFocus_ = !setFocus;
-      if (BrowseCap.isWindowsDesktop())
-         text = StringUtil.normalizeNewLinesToCR(text);
       ensureTerminal(text);
       activateTerminal();
    }
@@ -702,7 +699,7 @@ public class TerminalPane extends WorkbenchPane
       {
          terminal.writeRestartSequence();
       }
-      terminal.receivedInput(postCreateText_);
+      terminal.receivedSendToTerminal(postCreateText_);
       creatingTerminal_ = false;
       postCreateText_ = null;
       updateTerminalToolbar();
@@ -809,7 +806,7 @@ public class TerminalPane extends WorkbenchPane
          showTerminalWidget(terminal);
          setFocusOnVisible();
          ensureConnected(terminal); // needed after session suspend/resume
-         terminal.receivedInput(event.getInputText());
+         terminal.receivedSendToTerminal(event.getInputText());
          return;
       }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -263,6 +263,24 @@ public class TerminalSession extends XTermWidget
       socket_.dispatchOutput(output, doLocalEcho());
    }
 
+   public void receivedSendToTerminal(String input)
+   {
+      // tweak line endings 
+      String inputText = input;
+      if (inputText != null && BrowseCap.isWindowsDesktop())
+      {
+         int shellType = getProcInfo().getShellType();
+         if (shellType == TerminalShellInfo.SHELL_CMD32 ||
+               shellType == TerminalShellInfo.SHELL_CMD64 ||
+               shellType == TerminalShellInfo.SHELL_PS32 ||
+               shellType == TerminalShellInfo.SHELL_PS64)
+         {
+            inputText = StringUtil.normalizeNewLinesToCR(inputText);
+         }
+      }
+      receivedInput(inputText);
+   }
+   
    @Override
    public void receivedInput(String input)
    {


### PR DESCRIPTION
Send to terminal with multiple lines selected should act like typing each line and hitting Enter in the terminal. On Windows Desktop IDE, this wasn't working as expected in Command Prompt and PowerShell. Fixed by changing line endings to CR when sending to those shells on Windows. Verified that behavior of Git Bash and WSL are not changed.

With this selected in editor:
```
echo hello 001
echo hello 002
echo hello 003
echo hello 004
echo hello 005
echo hello 006
echo hello 007
echo hello 008
echo hello 009
```

**Before and after with Command Prompt**
![2017-08-21_11-41-15](https://user-images.githubusercontent.com/10569626/29539876-a971dbc8-8680-11e7-9f1a-a2c660c283d1.png)

![2017-08-21_15-01-07](https://user-images.githubusercontent.com/10569626/29540101-abc88858-8681-11e7-988b-896844707295.png)

**Before and after with PowerShell**
![2017-08-21_11-43-31](https://user-images.githubusercontent.com/10569626/29539902-c5d40b10-8680-11e7-8f17-bd926f47cc14.png)

![2017-08-21_14-59-07](https://user-images.githubusercontent.com/10569626/29540025-613091b4-8681-11e7-938d-8f879c10e961.png)
