### PR TITLE
use shell command when checking for build tools

### DIFF
--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -1993,7 +1993,7 @@ bool canBuildCpp()
    options.environment = childEnv;
 
    core::system::ProcessResult result;
-   error = core::system::runCommand(rCmd.commandString(), options, &result);
+   error = core::system::runCommand(rCmd.shellCommand(), options, &result);
    if (error)
    {
       LOG_ERROR(error);

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -603,7 +603,7 @@ core::Error RCompilationDatabase::executeRCmdSHLIB(
    core::system::ProcessOptions options;
    options.workingDir = srcPath.parent();
    options.environment = env;
-   return core::system::runCommand(rCmd.commandString(), options, pResult);
+   return core::system::runCommand(rCmd.shellCommand(), options, pResult);
 }
 
 bool RCompilationDatabase::isProjectTranslationUnit(


### PR DESCRIPTION
This PR ensures that we use the actual path to the R binary when invoking `R CMD SHLIB`. This should fix issues detecting build tools when R is not on the PATH.