### PR TITLE
Reduced ui-mode setting (cloud work)

### DIFF
--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -316,6 +316,7 @@ void handleClientInit(const boost::function<void()>& initFunction,
    sessionInfo["allow_file_download"] = options.allowFileDownloads();
    sessionInfo["allow_file_upload"] = options.allowFileUploads();
    sessionInfo["allow_remove_public_folder"] = options.allowRemovePublicFolder();
+   sessionInfo["allow_full_ui"] = options.allowFullUI();
 
    // publishing may be disabled globally or just for external services, and
    // via configuration options or environment variables

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionOptions.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -262,7 +262,10 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
         "allow publishing content")
       ("allow-presentation-commands",
          value<bool>(&allowPresentationCommands_)->default_value(false),
-       "allow presentation commands");
+       "allow presentation commands")
+      ("allow-full-ui",
+         value<bool>(&allowFullUI_)->default_value(true),
+       "allow full standalone ui mode");
 
    // r options
    bool rShellEscape; // no longer works but don't want to break any

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -379,6 +379,11 @@ public:
       return allowPresentationCommands_;
    }
 
+   bool allowFullUI() const
+   {
+      return allowOverlay() || allowFullUI_;
+   }
+
    // user info
    std::string userIdentity() const 
    { 
@@ -637,6 +642,7 @@ private:
    bool allowExternalPublish_;
    bool allowPublish_;
    bool allowPresentationCommands_;
+   bool allowFullUI_;
 
    // user info
    bool showUserIdentity_;

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -762,6 +762,11 @@ public class Application implements ApplicationEventHandlers
          commands_.showShellDialog().remove();
          removeTerminalCommands();
       }
+      
+      if (!sessionInfo.getAllowFullUI())
+      {
+         removeProjectCommands();
+      }
 
       if (!sessionInfo.getAllowPackageInstallation())
       {
@@ -1009,6 +1014,30 @@ public class Application implements ApplicationEventHandlers
       commands_.sendTerminalToEditor().remove();
       commands_.sendToTerminal().remove();
    }
+
+   private void removeProjectCommands()
+   {
+      commands_.openProject().remove();
+      commands_.newProject().remove();
+      commands_.closeProject().remove();
+      commands_.openProjectInNewWindow().remove();
+      commands_.clearRecentProjects().remove();
+      commands_.projectMru0().remove();
+      commands_.projectMru1().remove();
+      commands_.projectMru2().remove();
+      commands_.projectMru3().remove();
+      commands_.projectMru4().remove();
+      commands_.projectMru5().remove();
+      commands_.projectMru6().remove();
+      commands_.projectMru7().remove();
+      commands_.projectMru8().remove();
+      commands_.projectMru9().remove();
+      commands_.projectMru10().remove();
+      commands_.projectMru11().remove();
+      commands_.projectMru12().remove();
+      commands_.projectMru13().remove();
+      commands_.projectMru14().remove();
+    }
 
    private final ApplicationView view_ ;
    private final GlobalDisplay globalDisplay_ ;

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
@@ -233,9 +233,12 @@ public class GlobalToolbar extends Toolbar
       addLeftWidget(new AddinsToolbarButton());
       
       // project popup menu
-      ProjectPopupMenu projectMenu = new ProjectPopupMenu(sessionInfo,
+      if (sessionInfo.getAllowFullUI())
+      {
+         ProjectPopupMenu projectMenu = new ProjectPopupMenu(sessionInfo,
                                                           commands_);
-      addRightWidget(projectMenu.getToolbarButton());
+         addRightWidget(projectMenu.getToolbarButton());
+      }
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
@@ -1,7 +1,7 @@
 /*
  * WebApplicationHeader.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -174,6 +174,8 @@ public class WebApplicationHeader extends Composite
          {
             SessionInfo sessionInfo = session.getSessionInfo();
             
+            hostedMode_ = !sessionInfo.getAllowFullUI();
+            
             // complete toolbar initialization
             toolbar_.completeInitialization(sessionInfo);
              
@@ -230,6 +232,7 @@ public class WebApplicationHeader extends Composite
     
    public void showToolbar(boolean showToolbar)
    {
+      toolbarVisible_ = showToolbar;
       outerPanel_.clear();
       
       if (showToolbar)
@@ -259,7 +262,7 @@ public class WebApplicationHeader extends Composite
    
    public boolean isToolbarVisible()
    {
-      return !projectMenuButton_.isVisible();
+      return toolbarVisible_;
    }
    
    public void focusGoToFunction()
@@ -269,6 +272,10 @@ public class WebApplicationHeader extends Composite
    
    private void showProjectMenu(boolean show)
    {
+      if (hostedMode_)
+      {
+         show = false;
+      }
       projectMenuSeparator_.setVisible(show);
       projectMenuButton_.setVisible(show);
    }
@@ -384,7 +391,7 @@ public class WebApplicationHeader extends Composite
    private void initCommandsPanel(final SessionInfo sessionInfo)
    {  
       // add username 
-      if (sessionInfo.getShowIdentity())
+      if (sessionInfo.getShowIdentity() && sessionInfo.getAllowFullUI())
       {
          ToolbarLabel usernameLabel = new ToolbarLabel();
          usernameLabel.getElement().getStyle().setMarginRight(2, Unit.PX);
@@ -411,7 +418,8 @@ public class WebApplicationHeader extends Composite
       
       overlay_.addCommands(this);
       
-      headerBarCommandsPanel_.add(commands_.quitSession().createToolbarButton());
+      if (sessionInfo.getAllowFullUI())
+         headerBarCommandsPanel_.add(commands_.quitSession().createToolbarButton());
    }
 
    private Widget createCommandSeparator()
@@ -538,4 +546,6 @@ public class WebApplicationHeader extends Composite
    private GlobalDisplay globalDisplay_;
    private Commands commands_; 
    private WebApplicationHeaderOverlay overlay_;
+   private boolean hostedMode_;
+   private boolean toolbarVisible_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -1,7 +1,7 @@
 /*
  * SessionInfo.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -367,6 +367,10 @@ public class SessionInfo extends JavaScriptObject
       return this.allow_remove_public_folder;
    }-*/;
    
+   public final native boolean getAllowFullUI() /*-{
+      return this.allow_full_ui;
+   }-*/;
+  
    public final native boolean getAllowExternalPublish() /*-{
       return this.allow_external_publish;
    }-*/;


### PR DESCRIPTION
New overlay option, `allow-full-ui`, when set to 0, hides Project menu items and user-identity menu items. Will eventually also hide the logo, but there are existing bugs in logo display I'd like resolved before I mess with it.

File menu with default behavior:
![2017-08-22_17-51-46](https://user-images.githubusercontent.com/10569626/29594149-d7272aee-8763-11e7-95bf-52fe785784a6.png)
File menu with allow-full-ui=0:
![2017-08-22_17-52-57](https://user-images.githubusercontent.com/10569626/29594174-1d056198-8764-11e7-9afb-f29179df3b38.png)
Right-hand toolbar with default behavior:
![2017-08-22_17-52-14](https://user-images.githubusercontent.com/10569626/29594176-27a55b12-8764-11e7-95f2-614743233d5a.png)
Right-hand toolbar with allow-full-ui=0:
![2017-08-22_17-53-16](https://user-images.githubusercontent.com/10569626/29594187-307161d2-8764-11e7-94de-3b7dcb28f062.png)
