### PR TITLE
broadcast rstudioapi events to all windows

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
@@ -586,30 +586,12 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
       else if (type.equals(EditorCommandEvent.TYPE_REPLACE_RANGES))
       {
          ReplaceRangesEvent.Data data = event.getData();
-         ReplaceRangesEvent newEvent = new ReplaceRangesEvent(data);
-         if (StringUtil.isNullOrEmpty(data.getId()))
-         {
-            fireEventToLastFocusedWindow(newEvent);
-         }
-         else
-         {
-            events_.fireEventToMainWindow(newEvent);
-            events_.fireEventToAllSatellites(newEvent);
-         }
+         fireEventForDocument(data.getId(), new ReplaceRangesEvent(data));
       }
       else if (type.equals(EditorCommandEvent.TYPE_SET_SELECTION_RANGES))
       {
          SetSelectionRangesEvent.Data data = event.getData();
-         SetSelectionRangesEvent newEvent = new SetSelectionRangesEvent(data);
-         if (StringUtil.isNullOrEmpty(data.getId()))
-         {
-            fireEventToLastFocusedWindow(newEvent);
-         }
-         else
-         {
-            events_.fireEventToMainWindow(newEvent);
-            events_.fireEventToAllSatellites(newEvent);
-         }
+         fireEventForDocument(data.getId(), new SetSelectionRangesEvent(data));
       }
       else
          assert false: "Unrecognized editor event type '" + type + "'";
@@ -818,6 +800,21 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
    }
 
    // Private methods ---------------------------------------------------------
+   
+   private void fireEventForDocument(String docId, CrossWindowEvent<?> event)
+   {
+      if (StringUtil.isNullOrEmpty(docId))
+      {
+         fireEventToLastFocusedWindow(event);
+         return;
+      }
+      
+      String windowId = getWindowIdOfDocId(docId);
+      if (StringUtil.isNullOrEmpty(windowId))
+         events_.fireEventToMainWindow(event);
+      else
+         fireEventToSourceWindow(windowId, event, false);
+   }
    
    private void fireEventToSourceWindow(String windowId, 
          CrossWindowEvent<?> evt,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
@@ -586,12 +586,30 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
       else if (type.equals(EditorCommandEvent.TYPE_REPLACE_RANGES))
       {
          ReplaceRangesEvent.Data data = event.getData();
-         fireEventToLastFocusedWindow(new ReplaceRangesEvent(data));
+         ReplaceRangesEvent newEvent = new ReplaceRangesEvent(data);
+         if (StringUtil.isNullOrEmpty(data.getId()))
+         {
+            fireEventToLastFocusedWindow(newEvent);
+         }
+         else
+         {
+            events_.fireEventToMainWindow(newEvent);
+            events_.fireEventToAllSatellites(newEvent);
+         }
       }
       else if (type.equals(EditorCommandEvent.TYPE_SET_SELECTION_RANGES))
       {
          SetSelectionRangesEvent.Data data = event.getData();
-         fireEventToLastFocusedWindow(new SetSelectionRangesEvent(data));
+         SetSelectionRangesEvent newEvent = new SetSelectionRangesEvent(data);
+         if (StringUtil.isNullOrEmpty(data.getId()))
+         {
+            fireEventToLastFocusedWindow(newEvent);
+         }
+         else
+         {
+            events_.fireEventToMainWindow(newEvent);
+            events_.fireEventToAllSatellites(newEvent);
+         }
       }
       else
          assert false: "Unrecognized editor event type '" + type + "'";


### PR DESCRIPTION
This PR fixes an `rstudioapi` issue where attempting to call e.g.

```R
rstudioapi::insertText("text", id = "<id>")
```

where `<id>` is the id of a document belonging to a different source window would fail.

@jmcphers, there's likely a better way to ensure that an event is broadcasted to all windows (both main window + source window) -- let me know if you think there's a cleaner way to accomplish this.