### PR TITLE
Add support for themes under hidden header

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
@@ -252,7 +252,6 @@ public class WebApplicationHeader extends Composite
          outerPanel_.add(logoAnchor_);
          MenubarPanel menubarPanel = new MenubarPanel(headerBarPanel_);
          outerPanel_.add(menubarPanel);
-         mainMenu_.getElement().getStyle().setMarginLeft(0, Unit.PX);
          preferredHeight_ = 45;
          showProjectMenu(true);
       }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/header/MenubarPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/header/MenubarPanel.css
@@ -1,8 +1,24 @@
+@external rstudio-themes-flat;
+
+@external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
+
+@eval THEME_DEFAULT_BACKGROUND org.rstudio.core.client.theme.ThemeColors.defaultBackground;
+@eval THEME_DARKGREY_BACKGROUND org.rstudio.core.client.theme.ThemeColors.darkGreyBackground;
+@eval THEME_ALTERNATE_BACKGROUND org.rstudio.core.client.theme.ThemeColors.alternateBackground;
+
+@eval THEME_DEFAULT_BORDER org.rstudio.core.client.theme.ThemeColors.defaultBorder;
+@eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.darkGreyBorder;
+@eval THEME_ALTERNATE_BORDER org.rstudio.core.client.theme.ThemeColors.alternateBorder;
+
 .panel {
    width: 100%;
    padding: 0 7px 0 7px;
    margin-top: 10px;
    overflow: visible;
+}
+
+.rstudio-themes-flat .panel {
+   padding: 0 8px 0 8px;
 }
 
 @sprite .left {
@@ -15,4 +31,44 @@
 
 @sprite .right {
    gwt-image: 'menubarRight';
+}
+
+.rstudio-themes-flat .center > table > tbody > tr > td {
+   border-bottom: none;
+}
+
+.rstudio-themes-flat .left {
+   display: none;
+}
+
+.rstudio-themes-flat .right {
+   display: none;
+}
+
+.rstudio-themes-flat .center {
+   color: #FFF;
+   border-radius: 3px;
+   border: solid 1px #000;
+   height: 28px;
+   padding: 0px;
+}
+
+.rstudio-themes-flat .center > table {
+   padding: 0px;
+   height: 27px;
+}
+
+.rstudio-themes-flat .rstudio-themes-default .center {
+   background: THEME_DEFAULT_BACKGROUND;
+   border-color: THEME_DEFAULT_BORDER;
+}
+
+.rstudio-themes-flat .rstudio-themes-dark-grey .center {
+   background: THEME_DARKGREY_BACKGROUND;
+   border-color: THEME_DARKGREY_BORDER;
+}
+
+.rstudio-themes-flat .rstudio-themes-alternate .center {
+   background: THEME_ALTERNATE_BACKGROUND;
+   border-color: THEME_ALTERNATE_BORDER;
 }


### PR DESCRIPTION
The feature was NYI for flat themes, before:

<img width="1086" alt="screen shot 2017-08-23 at 2 04 11 pm" src="https://user-images.githubusercontent.com/3478847/29640482-fff4d29a-8813-11e7-9f73-d921125e2443.png">

after:

<img width="1085" alt="screen shot 2017-08-23 at 2 59 49 pm" src="https://user-images.githubusercontent.com/3478847/29640481-fff34466-8813-11e7-9d0e-093adef51b51.png">