### PR TITLE
Hide R logo in reduced UI mode

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
@@ -203,4 +203,6 @@ public interface ThemeStyles extends CssResource
    String tabIcon();
    
    String menuCheckable();
+   
+   String noLogo();
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -652,6 +652,10 @@ pre {
    margin-left: 58px;
 }
 
+.rstudio-themes-flat .mainMenu.noLogo {
+   margin-left: 6px;
+}
+
 .mainMenu .gwt-MenuItem {
    padding: 5px 9px 5px 9px;
    height: 15px;
@@ -1486,6 +1490,15 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
  @else { .webGlobalToolbar {
       margin-left: 55px;
       padding-right: 51px;
+   }
+ }
+
+ @if user.agent gecko1_8 { .webGlobalToolbar.noLogo {
+      margin-left: 2px;
+   }
+ }
+ @else { .webGlobalToolbar.noLogo {
+      margin-left: 4px;
    }
  }
 

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
@@ -78,7 +78,7 @@ public class WebApplicationHeader extends Composite
                   final Commands commands,
                   EventBus eventBus,
                   GlobalDisplay globalDisplay,
-                  ThemeResources themeResources,
+                  final ThemeResources themeResources,
                   final Session session,
                   Provider<CodeSearch> pCodeSearch)
    {
@@ -176,6 +176,12 @@ public class WebApplicationHeader extends Composite
             
             hostedMode_ = !sessionInfo.getAllowFullUI();
             
+            if (hostedMode_)
+            {
+               mainMenu_.addStyleName(themeResources.themeStyles().noLogo());
+               toolbar_.addStyleName(themeResources.themeStyles().noLogo());
+            }
+            
             // complete toolbar initialization
             toolbar_.completeInitialization(sessionInfo);
              
@@ -237,9 +243,12 @@ public class WebApplicationHeader extends Composite
       
       if (showToolbar)
       {
-         logoAnchor_.getElement().removeAllChildren();
-         logoAnchor_.getElement().appendChild(logoLarge_.getElement());
-         outerPanel_.add(logoAnchor_);
+         if (!hostedMode_)
+         {
+            logoAnchor_.getElement().removeAllChildren();
+            logoAnchor_.getElement().appendChild(logoLarge_.getElement());
+            outerPanel_.add(logoAnchor_);
+         }
          HeaderPanel headerPanel = new HeaderPanel(headerBarPanel_, toolbar_);
          outerPanel_.add(headerPanel);
          preferredHeight_ = 65;
@@ -247,9 +256,12 @@ public class WebApplicationHeader extends Composite
       }
       else
       {
-         logoAnchor_.getElement().removeAllChildren();
-         logoAnchor_.getElement().appendChild(logoSmall_.getElement());
-         outerPanel_.add(logoAnchor_);
+         if (!hostedMode_)
+         {
+            logoAnchor_.getElement().removeAllChildren();
+            logoAnchor_.getElement().appendChild(logoSmall_.getElement());
+            outerPanel_.add(logoAnchor_);
+         }
          MenubarPanel menubarPanel = new MenubarPanel(headerBarPanel_);
          outerPanel_.add(menubarPanel);
          preferredHeight_ = 45;


### PR DESCRIPTION
With reduced UI mode (allow-full-ui=0), hide the R logo in menu/toobar area, with or without toolbar showing.

**Regular mode (unchanged by this PR):**
![2017-08-23_16-50-59](https://user-images.githubusercontent.com/10569626/29643470-312cb624-8824-11e7-85c0-7aa5ceaadf3c.png)

![2017-08-23_16-51-22](https://user-images.githubusercontent.com/10569626/29643477-37246522-8824-11e7-8c13-e07cdae44fd5.png)

**No logo**
![2017-08-23_16-53-00](https://user-images.githubusercontent.com/10569626/29643487-3dd83e66-8824-11e7-8512-f471d9650a9e.png)

![2017-08-23_16-53-43](https://user-images.githubusercontent.com/10569626/29643489-401f676c-8824-11e7-9379-e2f986991b75.png)

![2017-08-23_16-54-14](https://user-images.githubusercontent.com/10569626/29643490-42636280-8824-11e7-8030-4a9aba726ccd.png)
