### PR TITLE
Add type if the custom results contain the attribute

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -3323,6 +3323,7 @@ assign(x = ".rs.acCompletionTypes",
    .rs.makeCompletions(
       token = token,
       results = results.sorted,
-      packages = packages.sorted
+      packages = packages.sorted,
+      type = attr(results, "type")
    )
 })

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -3309,21 +3309,26 @@ assign(x = ".rs.acCompletionTypes",
    utils:::.completeToken()
    results <- utils:::.retrieveCompletions()
    
+   packages <- NULL
+   type <- .rs.formCompletionVector(attr(results, "type"), .rs.acCompletionTypes$UNKNOWN, length(results))
+   if (type[[1]] %in% c(.rs.acCompletionTypes$UNKNOWN, .rs.acCompletionTypes$FUNCTION)) {
    packages <- sub('^package:', '', .rs.which(results))
    
    # ensure spaces around =
    results <- sub("=$", " = ", results)
    
-   choose = packages == '.GlobalEnv'
-   results.sorted = c(results[choose], results[!choose])
-   packages.sorted = c(packages[choose], packages[!choose])
+     choose <- packages == '.GlobalEnv'
+     results <- c(results[choose], results[!choose])
+     packages <- c(packages[choose], packages[!choose])
+     type <- c(type[choose], type[!choose])
    
-   packages.sorted = sub('^\\.GlobalEnv$', '', packages.sorted)
+     packages <- sub('^\\.GlobalEnv$', '', packages)
+   }
    
    .rs.makeCompletions(
       token = token,
-      results = results.sorted,
-      packages = packages.sorted,
-      type = attr(results, "type")
+      results = results,
+      packages = packages,
+      type = type
    )
 })


### PR DESCRIPTION
Without this change the type is assumed to be `.rs.acCompletionTypes$UNKNOWN`, which the IDE will use backticks to quote if it contains non-syntastic characters. This allows custom completions to pass a type along to the IDE if desired and along with https://github.com/jimhester/completeme/commit/60a46e9786ab4e39ef3399cd96927366b3079183 makes custom completions work well in the IDE for (https://github.com/hadley/emo/pull/32, https://github.com/hadley/devtools/pull/1595).

It would be nice to have this change in the 1.1 release, but understandable if it is not possible.