### PR TITLE
Remove Quit Session from hosted UI mode

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -1022,6 +1022,7 @@ public class Application implements ApplicationEventHandlers
       commands_.closeProject().remove();
       commands_.openProjectInNewWindow().remove();
       commands_.clearRecentProjects().remove();
+      commands_.quitSession().remove();
       commands_.projectMru0().remove();
       commands_.projectMru1().remove();
       commands_.projectMru2().remove();


### PR DESCRIPTION
Another removal requested by cloud team; gets rid of `Quit Session` on File and Session menus.