### PR TITLE
fix terminal created via rstudioapi stuck at busy

### DIFF
--- a/src/cpp/session/SessionConsoleProcessApi.cpp
+++ b/src/cpp/session/SessionConsoleProcessApi.cpp
@@ -133,6 +133,8 @@ SEXP rs_terminalCreate(SEXP typeSEXP, SEXP showSEXP)
                false /*zombie*/,
                session::userSettings().terminalTrackEnv()));
 
+   pCpi->setHasChildProcs(false);
+
    std::string handle;
    Error error = createTerminalConsoleProc(pCpi, &handle);
    if (error)


### PR DESCRIPTION
Issue that Darby was hitting. He'd create a terminal with `rstudioapi::terminalCreate("My Terminal")`, and it would come up, but always show as (busy) even though at command prompt. Terminal worked otherwise.

I couldn't repro, but very consistent for Darby.

This fix is very tightly scoped, only touching the codepath used by `rstudioapi::terminalCreate`. Darby tried it on his system and it stopped the problem from happening.

**More details**

The terminalCreate API spins up the terminal process on the server, then queues client message to tell the UI to load up the elements to connect that terminal session with the IDE; that involves a chain of calls on the client that go back to the server and wait for the response to fire the next call.

The ConsoleProcessInfo constructor on the server creates them with busy=true, so a terminal shows as busy until the server determines the shell has no child processes and notifies the client (another client message).

My theory is that it is possible that in the server-initiated API scenario, the client message sent telling the IDE that this terminal is NOT busy was arriving before the client-UI had completed hooking up and thus was dropped on the floor. The server doesn't send another busy-state message unless the state changes.

Might be better to have all ConsoleProcessInfo's start out as "not busy", but I vaguely recall having a reason for starting them as "busy", and want to minimize scope of change at this point.