### PR TITLE
Send-to-terminal startup fixes

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
@@ -18,7 +18,6 @@ package org.rstudio.studio.client.workbench.views.terminal;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 
-import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ResultCallback;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
@@ -355,32 +354,21 @@ public class TerminalList implements Iterable<String>,
    /**
     * Reconnect to a known terminal.
     * @param handle
+    * @param callback result of reconnect attempt
     * @return true if terminal was known and reconnect initiated
     */
-   public boolean reconnectTerminal(String handle)
+   public void reconnectTerminal(String handle,
+                                 final ResultCallback<Boolean, String> callback) 
    {
       ConsoleProcessInfo existing = getMetadataForHandle(handle);
       if (existing == null)
       {
-         return false;
+         callback.onFailure("Tried to switch to unknown terminal handle"); 
+         return;
       }
 
       existing.setHandle(handle);
-      startTerminal(existing, new ResultCallback<Boolean, String>()
-      {
-         @Override
-         public void onSuccess(Boolean connected) 
-         {
-         }
-
-         @Override
-         public void onFailure(String msg)
-         {
-            Debug.log(msg);
-         }
-      });
-
-      return true;
+      startTerminal(existing, callback); 
    }
 
    /**


### PR DESCRIPTION
I had done this work a few weeks ago then stashed it. Bringing back to get feedback:

When sending text to terminal, and there is no "running" terminal (either due to previous session suspend, or no terminals currently open at all), the text isn't sent after creating/activating a terminal. After that the send-to's will work (but if doing line-by-line, the cursor has already advanced).

Also, focus is given to the terminal when it is created; this change does not address that (I tried, but xterm.js has an issue where it takes focus when created, even if you set its flag telling it not to, and I'm not cracking open xterm for 1.1).

With this fix, the text is sent after the terminal is shown/activated/created (but then the terminal has focus).

**Not sure this is much of an improvement (or worth it for 1.1); maybe instead should give a message saying "Please start and select a terminal before sending text" or something like that when these commands are invoked. Opinions?**

**Scenario 1**

1. On RStudio server, open a terminal, and then suspend the session
2. Start the session.
3. Don't open the terminal tab; select some text and sent-to-terminal

Switches to terminal tab, spins up the terminal, gives it focus, but it doesn't send the text. Subsequent "sent text" will work.

**Scenario 2**

1. Close the terminal tab altogether (or, at least, exit all terminals)
2. Send some text to terminal

Starts up a new terminal, gives it focus, but doesn't send the text.
Subsequent "sent text" will work