### PR TITLE
document \preformatted{} Rd markup

### DIFF
--- a/src/cpp/session/resources/roxygen_help.html
+++ b/src/cpp/session/resources/roxygen_help.html
@@ -295,10 +295,12 @@ NULL
    <tr>
       <td>
          <code>\code{}</code>
+         <br/>
+         <code>\preformatted{}</code>
       </td>
       <td>
-         For <code>code</code> or otherwise
-         <code>pre-formatted</code> text.
+         For code snippets. Use <code>\code{}</code> for single-line code snippets,
+         and <code>\preformatted{}</code> for blocks of code.
       </td>
    </tr>
    <tr>


### PR DESCRIPTION
Also document `\preformatted{}` alongside `\code{}` in the Roxygen quick help.