### PR TITLE
fix font color in markdown quick reference

### DIFF
--- a/src/cpp/session/resources/markdown_help.html
+++ b/src/cpp/session/resources/markdown_help.html
@@ -41,6 +41,7 @@ h4 {
    margin-top: 3px;
    background-color: #f5f5f5;
    border: 1px solid #ccc;
+   color: #000;
    padding: 4px;
 }
 


### PR DESCRIPTION
Scoping this change to markdown quick reference since it changes the backgorund color without setting the color

Before,

<img width="659" alt="screen shot 2017-08-25 at 12 25 15 pm" src="https://user-images.githubusercontent.com/3478847/29729343-a2addff4-8990-11e7-973e-393772e029a4.png">

After,

<img width="659" alt="screen shot 2017-08-25 at 12 24 49 pm" src="https://user-images.githubusercontent.com/3478847/29729372-b2b66722-8990-11e7-9d5e-b144a56db8cd.png">

This is the classic mode version, which is also affected with this change but shouldn't cause a regression since the color was already implicitly black.

<img width="658" alt="screen shot 2017-08-25 at 12 24 37 pm" src="https://user-images.githubusercontent.com/3478847/29729371-b2b2a40c-8990-11e7-84b0-b09fe11f1909.png">