### PR TITLE
Fix rsession websocket crashes

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -33,6 +33,12 @@ add_definitions(-DBOOST_ENABLE_ASSERT_HANDLER)
 # they currently do not work with our source
 add_definitions(-D_WEBSOCKETPP_NO_CPP11_MEMORY_=1)
 
+
+# the non-strict masking option was identified as a potentially crashing 
+# issue due to reliance on undefined C++ behavior, and was removed entirely in 
+# websocketpp 0.7 (RStudio is using 0.5.1 at this time)
+add_definitions(-DWEBSOCKETPP_STRICT_MASKING)
+
 # test directory
 set(TESTS_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/tests/cpp" CACHE STRING "Test includes")
 


### PR DESCRIPTION
Rsession crashes in certain paste/sent-to-terminal situations were caused by the websocketpp library relying on undefined, platform-specific C++ behavior.

Discussion of the issue, and the ultimate resolution: https://github.com/zaphoyd/websocketpp/issues/395

Confirmed the crash was happening in the code described in that issue, and that our version of websocketpp was earlier than 0.7, where the fix was made by removing the troublesome code altogether.

This could be a crashing issue on all platforms, even though so far we've only heard about it on Windows, so making the change to the safer code for all platforms.
