### PR TITLE
Correctly set encoding in RStudio debugger

### DIFF
--- a/src/cpp/session/modules/SessionBreakpoints.R
+++ b/src/cpp/session/modules/SessionBreakpoints.R
@@ -440,7 +440,7 @@
 # when executed, has the same effect as sourcing the file.
 .rs.addFunction("makeSourceEquivFunction", function(filename, encoding, envir = globalenv())
 {
-   content <- suppressWarnings(parse(filename, encoding))
+   content <- suppressWarnings(parse(filename, encoding = encoding))
 
    # Create an empty function to host the expressions in the file
    fun <- function() 


### PR DESCRIPTION
This change should fix this bug https://support.rstudio.com/hc/en-us/community/posts/210535867-debugSource-doesn-t-work-with-utf-8-characters-with-umlauts-

It seems that RStudio debugger currently uses only system encoding ingoring `encoding` argument. This lead to problems on Windows debugging UTF-8 files.

For example, these lines with cyrillic characters
```r
print("якорь")
print("тест")
```
are currently looking like this using RStudio ver. 1.0.153 debugger:
```r
> debugSource('D:/R code/ts.test/utf8_test.R', encoding = 'UTF-8', echo=TRUE)
Called from: eval(expr, envir, enclos)
Browse[1]> n
debug at D:/R code/ts.test/utf8_test.R#1: print("СЏРєРѕСЂСЊ")
Browse[2]> n
[1] "СЏРєРѕСЂСЊ"
debug at D:/R code/ts.test/utf8_test.R#3: print("С‚РµСЃС‚")
```

Should I really sign your contributor agreement for this small fix?