### PR TITLE
Terminal API fix, created terminal not always shown

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
@@ -31,6 +31,8 @@ import org.rstudio.studio.client.workbench.views.terminal.events.CreateTerminalE
 import org.rstudio.studio.client.workbench.views.terminal.events.RemoveTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.SendToTerminalEvent;
 
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.user.client.Command;
 import com.google.inject.Inject;
 
@@ -212,15 +214,23 @@ public class TerminalTabPresenter extends BusyPresenter
    }
 
    @Override
-   public void onAddTerminal(AddTerminalEvent event)
+   public void onAddTerminal(final AddTerminalEvent event)
    {
-      view_.addTerminal(event.getProcessInfo(), false /*hasSession*/);
-      
       if (event.getShow())
-      {
          onActivateTerminal();
-         view_.activateNamedTerminal(event.getProcessInfo().getCaption());
-      }
+
+      Scheduler.get().scheduleDeferred(new ScheduledCommand()
+      {
+         @Override
+         public void execute()
+         {
+            view_.addTerminal(event.getProcessInfo(), false /*hasSession*/);
+            if (event.getShow())
+            {
+               view_.activateNamedTerminal(event.getProcessInfo().getCaption());
+            }
+         }
+      });
    }
 
    @Override


### PR DESCRIPTION
Bug: When creating a new terminal via `rstudioapi::terminalCreate` or `rstudioapi::terminalExecute`, the created terminal isn't always switched-to in the UI (another terminal is shown).

Fix only touches code hit via `rstudioapi` for terminal.

To repro, there must be at least one terminal already created, the session must have been stopped or suspended, then reloaded, but the terminal tab has not yet been activated so the existing terminals are not loaded.

Problem happens because triggering display of terminal tab will asynchronously load and show the first terminal in the list (which won't be the one being created via the API if there are already terminals). This finishes after the call to select the newly created terminal.

Fix: trigger `onActivateTerminal()` first (thus selecting the tab), then do the actual selection of the desired terminal inside a `scheduleDeferred`.