### PR TITLE
properly handle datasets in completions, diagnostics

### DIFF
--- a/src/cpp/core/include/core/Algorithm.hpp
+++ b/src/cpp/core/include/core/Algorithm.hpp
@@ -193,13 +193,31 @@ bool get(const AssociativeContainer& container,
    return true;
 }
 
-template <typename ContainerType>
-void append(ContainerType* pContainer, const ContainerType& other)
+namespace detail {
+
+template <typename Container, typename Iterator>
+typename boost::enable_if_c<type_traits::has_key_type<Container>::value, void>::type
+append(Container* pContainer, Iterator begin, Iterator end, boost::true_type)
 {
-   pContainer->insert(
-            pContainer->end(),
-            other.begin(),
-            other.end());
+   pContainer->insert(begin, end);
+}
+
+template <typename Container, typename Iterator>
+typename boost::disable_if_c<type_traits::has_key_type<Container>::value, void>::type
+append(Container* pContainer, Iterator begin, Iterator end, boost::false_type)
+{
+   pContainer->insert(pContainer->end(), begin, end);
+}
+
+} // namespace detail
+
+template <typename ContainerType, typename OtherType>
+void append(ContainerType* pContainer, const OtherType& other)
+{
+   detail::append(pContainer,
+                  other.begin(),
+                  other.end(),
+                  type_traits::has_key_type<ContainerType>());
 }
 
 inline std::vector<std::string> split(const std::string& string,

--- a/src/cpp/core/include/core/r_util/RFunctionInformation.hpp
+++ b/src/cpp/core/include/core/r_util/RFunctionInformation.hpp
@@ -198,6 +198,7 @@ struct PackageInformation
    std::string package;
    std::vector<std::string> exports;
    std::vector<int> types;
+   std::vector<std::string> datasets;
    FunctionInformationMap functionInfo;
 };
 

--- a/src/cpp/session/modules/SessionAsyncPackageInformation.cpp
+++ b/src/cpp/session/modules/SessionAsyncPackageInformation.cpp
@@ -173,13 +173,15 @@ void AsyncPackageInformationProcess::onCompleted(int exitStatus)
    //    "package": <single package name>
    //    "exports": <array of object names in the namespace>,
    //    "types": <array of types (see .rs.acCompletionTypes)>,
-   //    "function_info": {big ugly object with function info}
+   //    "function_info": {big ugly object with function info},
+   //    "data" <array of dataset names>
    // }
    for (std::size_t i = 0; i < n; ++i)
    {
       json::Array exportsJson;
       json::Array typesJson;
       json::Object functionInfoJson;
+      json::Array datasetsJson;
       
       core::r_util::PackageInformation pkgInfo;
 
@@ -215,7 +217,8 @@ void AsyncPackageInformationProcess::onCompleted(int exitStatus)
                                      "package", &pkgInfo.package,
                                      "exports", &exportsJson,
                                      "types", &typesJson,
-                                     "function_info", &functionInfoJson);
+                                     "function_info", &functionInfoJson,
+                                     "datasets", &datasetsJson);
 
       if (error)
       {
@@ -233,6 +236,9 @@ void AsyncPackageInformationProcess::onCompleted(int exitStatus)
 
       if (!fillFunctionInfo(functionInfoJson, pkgInfo.package, &(pkgInfo.functionInfo)))
          LOG_ERROR_MESSAGE("Failed to read JSON 'functions' object to map");
+      
+      if (!json::fillVectorString(datasetsJson, &(pkgInfo.datasets)))
+         LOG_ERROR_MESSAGE("Failed to read JSON 'data' array to vector");
       
       // Update the index
       core::r_util::RSourceIndex::addPackageInformation(pkgInfo.package, pkgInfo);

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1267,12 +1267,16 @@
       )
    })
    
+   # List data objects exported by this package
+   datasets <- .rs.listDatasetsProvidedByPackage(package)
+   
    # Generate the output
    output <- list(
       package = I(package),
       exports = exports,
       types = types,
-      function_info = functionInfo
+      function_info = functionInfo,
+      datasets = datasets
    )
    
    # Write the JSON to stdout; parent processes
@@ -1951,4 +1955,25 @@
 .rs.addFunction("fileInfo", function(..., extra_cols = TRUE)
 {
    suppressWarnings(file.info(..., extra_cols = extra_cols))
+})
+
+.rs.addFunction("listDatasetsProvidedByPackage", function(package)
+{
+   # verify we have a non-empty length-one string
+   if (!is.character(package) || length(package) != 1 || !nzchar(package))
+      return(character())
+   
+   # find the installed package location (returns empty vector on failure)
+   location <- find.package(package, quiet = TRUE)
+   if (!length(location) || !file.exists(location))
+      return(character())
+   
+   # construct path to datalist file
+   datalist <- file.path(location, "data/datalist")
+   if (!file.exists(datalist))
+      return(character())
+   
+   # read the names of the provided objects
+   readLines(datalist, warn = FALSE)
+   
 })

--- a/src/cpp/session/modules/SessionDiagnostics.cpp
+++ b/src/cpp/session/modules/SessionDiagnostics.cpp
@@ -157,8 +157,8 @@ void addInferredSymbols(const FilePath& filePath,
       const PackageInformation& completions =
             pIndex->getPackageInformation(package);
       
-      pSymbols->insert(completions.exports.begin(),
-                       completions.exports.end());
+      core::algorithm::append(pSymbols, completions.exports);
+      core::algorithm::append(pSymbols, completions.datasets);
    }
    
    // make 'shiny' implicitly available in shiny documents
@@ -200,9 +200,8 @@ void addNamespaceSymbols(std::set<std::string>* pSymbols)
             RSourceIndex::getPackageInformation(package);
       
       DEBUG("--- Adding " << pkgInfo.exports.size() << " symbols");
-      pSymbols->insert(
-               pkgInfo.exports.begin(),
-               pkgInfo.exports.end());
+      core::algorithm::append(pSymbols, pkgInfo.exports);
+      core::algorithm::append(pSymbols, pkgInfo.datasets);
    }
 }
 

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -3089,10 +3089,25 @@ assign(x = ".rs.acCompletionTypes",
 .rs.addFunction("getInferredCompletions", function(packages = character(),
                                                    simplify = TRUE)
 {
-   result <- .Call("rs_getInferredCompletions", as.character(packages))
-   if (simplify && length(result) == 1)
-      return(result[[1]])
-   result
+   # get completions from database
+   completionList <- .Call("rs_getInferredCompletions",
+                           as.character(packages),
+                           PACKAGE = "(embedding)")
+   
+   # append dataset completions on to export vector
+   completionList <- lapply(completionList, function(completion) {
+      datasetTypes <- rep.int(.rs.acCompletionTypes$DATASET, length(completion$datasets))
+      completion$exports  <- c(completion$exports, completion$datasets)
+      completion$types    <- c(completion$types, datasetTypes)
+      completion$datasets <- NULL
+      completion
+   })
+   
+   # simplify if requested
+   if (simplify && length(completionList) == 1)
+      return(completionList[[1]])
+   
+   completionList
 })
 
 .rs.addFunction("getCompletionsLibraryContextArgumentNames", function(token,

--- a/src/cpp/session/modules/SessionRCompletions.cpp
+++ b/src/cpp/session/modules/SessionRCompletions.cpp
@@ -412,6 +412,7 @@ SEXP rs_getInferredCompletions(SEXP packagesSEXP)
       builder.add("exports", pkgInfo.exports);
       builder.add("types", pkgInfo.types);
       builder.add("functions", core::r_util::infoToFormalMap(pkgInfo.functionInfo));
+      builder.add("datasets", pkgInfo.datasets);
       parent.add(*it, builder);
    }
    


### PR DESCRIPTION
This PR fixes a couple issues in the completion + diagnostic engines. In a document with the contents:

```R
library(nycflights13)
print(flights)
```

Firstly, RStudio would fail to detect that the `flights` object is made available by this package, e.g.

![screen shot 2017-08-31 at 1 29 24 pm](https://user-images.githubusercontent.com/1976582/29943982-702b4750-8e50-11e7-827f-a4718ea8d8a1.png)

Secondly, the dataset would not be reported as part of the completion list:

![screen shot 2017-08-31 at 1 30 20 pm](https://user-images.githubusercontent.com/1976582/29944014-9222ba32-8e50-11e7-8e15-c1ec9497e923.png)

Note that both of these issues are resolved by explicitly loading the `nycflights13` package (recall that RStudio has a system for asynchronously building a completion list for packages that are used, but not loaded, in the current session).