### PR TITLE
Fix stuck console scrolling on high-dpi Windows

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/BottomScrollPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/BottomScrollPanel.java
@@ -1,7 +1,7 @@
 /*
  * BottomScrollPanel.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,6 +19,7 @@ import com.google.gwt.event.dom.client.ScrollHandler;
 import com.google.gwt.user.client.ui.ScrollPanel;
 import com.google.gwt.user.client.ui.Widget;
 
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.dom.DomUtils;
 
@@ -32,6 +33,13 @@ public class BottomScrollPanel extends ScrollPanel
    public BottomScrollPanel()
    {
       scrolling_ = false;
+      
+      // on high-dpi Windows, with a zoom factor, there
+      // was a frequent off-by-one (internal rounding error?)
+      // causing failure to set scrolledToBottom_
+      vDelta_ = 0;
+      if (BrowseCap.isWindowsDesktop())
+         vDelta_ = 1;
       addScrollHandler(new ScrollHandler()
       {
          public void onScroll(ScrollEvent event)
@@ -42,11 +50,11 @@ public class BottomScrollPanel extends ScrollPanel
             
             scrolledToBottom_ = 
              
-             (getVerticalScrollPosition() == 
-              getMaximumVerticalScrollPosition() || 
+             (Math.abs(getVerticalScrollPosition() - 
+                       getMaximumVerticalScrollPosition()) <= vDelta_) || 
               
-             ((getVerticalScrollPosition() + getOffsetHeight()) ==
-              getElement().getScrollHeight()));
+             (Math.abs((getVerticalScrollPosition() + getOffsetHeight()) - 
+                        getElement().getScrollHeight()) <= vDelta_);
          }
       });
    }
@@ -124,4 +132,5 @@ public class BottomScrollPanel extends ScrollPanel
    private boolean scrolling_;
    private Integer vScroll_;
    private int hScroll_;
+   private int vDelta_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/BottomScrollPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/BottomScrollPanel.java
@@ -19,7 +19,6 @@ import com.google.gwt.event.dom.client.ScrollHandler;
 import com.google.gwt.user.client.ui.ScrollPanel;
 import com.google.gwt.user.client.ui.Widget;
 
-import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.dom.DomUtils;
 
@@ -34,12 +33,10 @@ public class BottomScrollPanel extends ScrollPanel
    {
       scrolling_ = false;
       
-      // on high-dpi Windows, with a zoom factor, there
-      // was a frequent off-by-one (internal rounding error?)
-      // causing failure to set scrolledToBottom_
-      vDelta_ = 0;
-      if (BrowseCap.isWindowsDesktop())
-         vDelta_ = 1;
+      // Provide a close-enough zone for determining if scrolled
+      // to the bottom; allows for small rounding errors that have
+      // been seen on zoomed high-DPI displays.
+      final int vFudge = 4;
       addScrollHandler(new ScrollHandler()
       {
          public void onScroll(ScrollEvent event)
@@ -51,10 +48,10 @@ public class BottomScrollPanel extends ScrollPanel
             scrolledToBottom_ = 
              
              (Math.abs(getVerticalScrollPosition() - 
-                       getMaximumVerticalScrollPosition()) <= vDelta_) || 
+                       getMaximumVerticalScrollPosition()) <= vFudge) || 
               
              (Math.abs((getVerticalScrollPosition() + getOffsetHeight()) - 
-                        getElement().getScrollHeight()) <= vDelta_);
+                        getElement().getScrollHeight()) <= vFudge);
          }
       });
    }
@@ -132,5 +129,4 @@ public class BottomScrollPanel extends ScrollPanel
    private boolean scrolling_;
    private Integer vScroll_;
    private int hScroll_;
-   private int vDelta_;
 }


### PR DESCRIPTION
With Windows display zooming at a variety of settings (> 100% - 225%) I observed a frequent off-by-one in the values returned by `ScrollPanel` used to determine if it is scrolled to the bottom.

So for Windows, I allow a fudge-factor of 1 pixel to prevent auto-scrolling from getting stuck.