### PR TITLE
(1.2) Stop environment capture when wrong HISTCONTROL found

### DIFF
--- a/src/cpp/core/include/core/terminal/PrivateCommand.hpp
+++ b/src/cpp/core/include/core/terminal/PrivateCommand.hpp
@@ -32,6 +32,12 @@ namespace terminal {
  * without the user seeing the input or output. It only runs if the terminal has no child
  * processes and if the user doesn't seem to be in the middle of typing a command.
  *
+ * Relies on HISTCONTROL=ignorespace to prevent the "hidden" command from being added to
+ * shell history. RStudio sets this when launching terminal, but shell config can change it.
+ * If the command sees that HISTCONTROL is not set to ignorespace (or ignoreboth)
+ * it will stop firing any more commands for duration of this object, otherwise users will see a
+ * "weird" thing in history after virtually every command they type.
+ *
  * Host must frequently call onTryCapture() to possibly fire the command, userInput() so
  * PrivateCommand can analyze if user has entered a command or is potentially in the middle of
  * typing a command, and output() to let PrivateCommand analyze output from a private command
@@ -142,11 +148,15 @@ private:
 
    // parse details
    size_t firstCRLF_; // end of command
+   size_t histcontrol_; // value of $HISTCONTROL
    size_t outputStart_; // start of output
    size_t outputEnd_; // end of output
 
    // did last private command timeout?
    bool timeout_;
+
+   // wrong HISTCONTROL, further commands disabled
+   bool detectedWrongHistControl_;
 };
 
 } // namespace terminal


### PR DESCRIPTION
Terminal environment capture relies on **$HISTCONTROL** being **ignoreboth** or **ignorespace**, otherwise the "hidden" commands will show up in terminal history, essentially one after every user command.

RStudio does set **$HISTCONTROL=ignoreboth** when launching a terminal, but shell config can override it (often to ignoredups).

This PR detects this and disables further "hidden commands" for the duration of the session, leaving only a single weird command in the shell history. It also logs a warning.