### PR TITLE
Mark TextMate theme as the default un UI

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -209,8 +209,16 @@ public class AppearancePreferencesPane extends PreferencesPane
          }
       });
 
+      
+      String[] themeOptions = themes.getThemeNames();
+      for (int idxTheme = 0; idxTheme < themeOptions.length; idxTheme++) {
+         if (themeOptions[idxTheme] == "TextMate") {
+            themeOptions[idxTheme] = "TextMate (default)";
+         }
+      }
+      
       theme_ = new SelectWidget("Editor theme:",
-                                themes.getThemeNames(),
+                                themeOptions,
                                 themes.getThemeNames(),
                                 false);
       theme_.getListBox().addChangeHandler(new ChangeHandler()


### PR DESCRIPTION
From [dark theme blog post](https://blog.rstudio.com/2017/08/30/rstudio-dark-theme/), suggestion to mark what the default theme is. I remember wondering also how to revert to the default myself.

<img width="619" alt="screen shot 2017-09-05 at 10 21 17 am" src="https://user-images.githubusercontent.com/3478847/30074005-b1339cc0-9224-11e7-9a16-b5edc4098497.png">
