### PR TITLE
(1.2) Fix rstudio-tests script for Mac IDE build

### DIFF
--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -7,11 +7,22 @@ else
 	VALGRIND="valgrind --dsymutil=yes $@"
 fi
 
+## On a Debug Mac IDE build via xcodebuild, the executables 
+## will be in a Debug folder
+if [ ! -e ${CMAKE_CURRENT_BINARY_DIR}/core/rstudio-core-tests ]
+then
+    RSTUDIO_CORETEST_BIN="Debug/rstudio-core-tests"
+    RSTUDIO_SESSION_BIN="Debug/rsession"
+else
+    RSTUDIO_CORETEST_BIN="rstudio-core-tests"
+    RSTUDIO_SESSION_BIN="rsession"
+fi
+
 echo Running 'core' tests...
-$VALGRIND ${CMAKE_CURRENT_BINARY_DIR}/core/rstudio-core-tests
+$VALGRIND ${CMAKE_CURRENT_BINARY_DIR}/core/$RSTUDIO_CORETEST_BIN
 
 echo Running 'rsession' tests...
-$VALGRIND ${CMAKE_CURRENT_BINARY_DIR}/session/rsession \
+$VALGRIND ${CMAKE_CURRENT_BINARY_DIR}/session/$RSTUDIO_SESSION_BIN \
     --run-tests \
     --config-file=${CMAKE_CURRENT_BINARY_DIR}/conf/rdesktop-dev.conf
 


### PR DESCRIPTION
After a Mac IDE desktop debug build, the `rstudio-tests` script wouldn't work without manual tweaks. Fix to handle both cases.