### PR TITLE
don't refresh if running w/console proc

### DIFF
--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -1677,8 +1677,6 @@ Error vcsListBranches(const json::JsonRpcRequest& request,
 Error vcsCheckout(const json::JsonRpcRequest& request,
                   json::JsonRpcResponse* pResponse)
 {
-   RefreshOnExit refreshOnExit;
-
    std::string id;
    Error error = json::readParams(request.params, &id);
    if (error)
@@ -1697,8 +1695,6 @@ Error vcsCheckout(const json::JsonRpcRequest& request,
 Error vcsCheckoutRemote(const json::JsonRpcRequest& request,
                         json::JsonRpcResponse* pResponse)
 {
-   RefreshOnExit scope;
-   
    std::string branch, remote;
    Error error = json::readParams(request.params, &branch, &remote);
    if (error)
@@ -1773,8 +1769,6 @@ Error vcsAllStatus(const json::JsonRpcRequest& request,
 Error vcsCommit(const json::JsonRpcRequest& request,
                 json::JsonRpcResponse* pResponse)
 {
-   RefreshOnExit refreshOnExit;
-
    std::string commitMsg;
    bool amend, signOff;
    Error error = json::readParams(request.params, &commitMsg, &amend, &signOff);


### PR DESCRIPTION
This PR fixes an issue where attempts to commit from the RStudio UI could occasionally fail (especially when using NFS) with an error message like:

    fatal: Unable to create '<project>/.git/index.lock': File exists.

This was effectively caused by us creating a race condition between a `git status` call and a separate `git commit` call. (It's worth noting that some read-only operations, e.g `git status`, still require a lock on the index)

Because we used a `RefreshOnExitScope` in these routines where we created console processes, we ended up with the following sequence of events:

1. A `RefreshOnExitScope` object is created,

2. A console process that will attempt to call e.g. `git commit` is created,

3. The routine exits, and the destructor of the `RefreshOnExitScope` is called,

4. We now have two threads running and attempting to call `git` at the same time.

Fortunately, the fix here is simple. Git console processes already force a refresh when they finish, so these `RefreshOnExitScope` usages were spurious.

IMO this is safe to take for v1.1.