### PR TITLE
(1.1) Fix mouse-wheel scrolling on Windows/Linux desktop

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
@@ -216,12 +216,19 @@ public class XTermNative extends JavaScriptObject
 
             // create a normalized 'wheel' event object
             var event = {
+               // keep a ref to the original event object
+               ev: ev,
                target: ev.target || ev.srcElement,
                type: "wheel",
                deltaMode: ev.type == "MozMousePixelScroll" ? 0 : 1,
                deltaX: 0,
                deltaY: 0,
-               deltaZ: 0
+               deltaZ: 0,
+               preventDefault: function() {
+                  ev.preventDefault ?
+                  ev.preventDefault() :
+                  ev.returnValue = false;
+               }
             };
 
             // calculate deltaY (and deltaX) according to the event

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
@@ -23,10 +23,9 @@ import com.google.gwt.dom.client.Element;
 /**
  * <code>JavaScriptObject</code> wrapper for xterm.js
  * 
- * Code in this class that depends on implementation details of xterm.js
- * is marked with XTERM_IMP. Be careful of these when updating to a 
- * newer xterm.js build. The rest is using documented APIs found on
- * https://xtermjs.org/docs/api/terminal/
+ * Reliance on xterm.js implementation details is marked with XTERM_IMP.
+ * Be careful of these when updating to a newer xterm.js build.
+ * The rest uses documented APIs: https://xtermjs.org/docs/api/terminal/
  */
 public class XTermNative extends JavaScriptObject
 {
@@ -194,11 +193,14 @@ public class XTermNative extends JavaScriptObject
     * @param container HTML element to attach to
     * @param blink <code>true</code> for a blinking cursor, otherwise solid cursor
     * @param focus <code>true</code> to give terminal focus by default
-    * @param supportMousewheel <code> true to handle legacy mousewheel event
+    * @param supportMousewheel <code>true</code> to handle legacy mousewheel event
     * 
     * @return Native Javascript Terminal object wrapped in a <code>JavaScriptObject</code>.
     */
-   public static native XTermNative createTerminal(Element container, boolean blink, boolean focus, boolean supportMousewheel) /*-{
+   public static native XTermNative createTerminal(Element container, 
+                                                   boolean blink,
+                                                   boolean focus,
+                                                   boolean supportMousewheel) /*-{
       var nativeTerm_ = new $wnd.Terminal({cursorBlink: blink});
       nativeTerm_.open(container, focus);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
@@ -1,7 +1,7 @@
 /*
  * XTermNative.java
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-17 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -22,6 +22,11 @@ import com.google.gwt.dom.client.Element;
 
 /**
  * <code>JavaScriptObject</code> wrapper for xterm.js
+ * 
+ * Code in this class that depends on implementation details of xterm.js
+ * is marked with XTERM_IMP. Be careful of these when updating to a 
+ * newer xterm.js build. The rest is using documented APIs found on
+ * https://xtermjs.org/docs/api/terminal/
  */
 public class XTermNative extends JavaScriptObject
 {
@@ -104,14 +109,17 @@ public class XTermNative extends JavaScriptObject
       this.element.classList.add(classStr);
    }-*/;
    
+   // XTERM_IMP
    public final native int cursorX() /*-{
       return this.buffer.x;
    }-*/;
    
+   // XTERM_IMP
    public final native int cursorY() /*-{
       return this.buffer.y;
    }-*/;
  
+   // XTERM_IMP
    public final native boolean altBufferActive() /*-{
       return this.normal != null;
    }-*/;
@@ -126,6 +134,7 @@ public class XTermNative extends JavaScriptObject
       this.write("\x1b[?1047h"); // show alt buffer
    }-*/;
     
+   // XTERM_IMP
    public final native String currentLine() /*-{
       lineBuf = this.buffer.lines.get(this.y + this.ybase);
       if (!lineBuf) // resize may be in progress
@@ -139,6 +148,7 @@ public class XTermNative extends JavaScriptObject
       return current;
    }-*/;
 
+   // XTERM_IMP
    public final native String getLocalBuffer() /*-{
       buffer = "";
       for (row = 0; row < this.rows; row++) {
@@ -184,12 +194,44 @@ public class XTermNative extends JavaScriptObject
     * @param container HTML element to attach to
     * @param blink <code>true</code> for a blinking cursor, otherwise solid cursor
     * @param focus <code>true</code> to give terminal focus by default
+    * @param supportMousewheel <code> true to handle legacy mousewheel event
     * 
     * @return Native Javascript Terminal object wrapped in a <code>JavaScriptObject</code>.
     */
-   public static native XTermNative createTerminal(Element container, boolean blink, boolean focus) /*-{
+   public static native XTermNative createTerminal(Element container, boolean blink, boolean focus, boolean supportMousewheel) /*-{
       var nativeTerm_ = new $wnd.Terminal({cursorBlink: blink});
       nativeTerm_.open(container, focus);
+
+      // XTERM_IMP
+      if (supportMousewheel) {
+         // older browsers sent 'mousewheel' but xterm only handles 'wheel'
+         // logic to translate from mousewheel event to wheel event taken from:
+         // https://developer.mozilla.org/en-US/docs/Web/Events/wheel#Listening_to_this_event_across_browser
+         self = nativeTerm_;
+         nativeTerm_.element.addEventListener('mousewheel', function (ev) {
+         if (self.mouseEvents)
+            return;
+
+            // create a normalized 'wheel' event object
+            var event = {
+               target: ev.target || ev.srcElement,
+               type: "wheel",
+               deltaMode: ev.type == "MozMousePixelScroll" ? 0 : 1,
+               deltaX: 0,
+               deltaY: 0,
+               deltaZ: 0
+            };
+
+            // calculate deltaY (and deltaX) according to the event
+            event.deltaY = - 1/40 * ev.wheelDelta;
+
+            // Webkit also support wheelDeltaX
+            ev.wheelDeltaX && ( event.deltaX = - 1/40 * ev.wheelDeltaX );
+
+            self.viewport.onWheel(event);
+            return self.cancel(ev);
+         });
+      }
       return nativeTerm_;
    }-*/;
 } 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
@@ -211,8 +211,8 @@ public class XTermNative extends JavaScriptObject
          // https://developer.mozilla.org/en-US/docs/Web/Events/wheel#Listening_to_this_event_across_browser
          self = nativeTerm_;
          nativeTerm_.element.addEventListener('mousewheel', function (ev) {
-         if (self.mouseEvents)
-            return;
+            if (self.mouseEvents)
+               return;
 
             // create a normalized 'wheel' event object
             var event = {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client.workbench.views.terminal.xterm;
 
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ExternalJavaScriptLoader;
@@ -83,9 +84,11 @@ public class XTermWidget extends Widget implements RequiresResize,
       getElement().addClassName(XTERM_CLASS);
       getElement().addClassName("ace_editor");
 
+      boolean legacyMouseWheel = BrowseCap.isWindowsDesktop() || BrowseCap.isLinuxDesktop();
+
       // Create and attach the native terminal object to this Widget
       attachTheme(XTermThemeResources.INSTANCE.xtermcss());
-      terminal_ = XTermNative.createTerminal(getElement(), cursorBlink, focus);
+      terminal_ = XTermNative.createTerminal(getElement(), cursorBlink, focus, legacyMouseWheel);
       terminal_.addClass("ace_editor");
       terminal_.addClass(FontSizer.getNormalFontSizeClass());
 


### PR DESCRIPTION
Translate the older `mousewheel` events sent by Qt into the standard `wheel` events expected by xterm.js.

Also added additional comments calling out where code relies on xterm.js internals.