### PR TITLE
allow non-framework R installation

### DIFF
--- a/cmake/modules/FindLibR.cmake
+++ b/cmake/modules/FindLibR.cmake
@@ -21,11 +21,24 @@
 if(APPLE)
 
    find_library(LIBR_LIBRARIES R)
-   if(LIBR_LIBRARIES)
+
+   if(LIBR_LIBRARIES MATCHES ".*\\.framework")
       set(LIBR_HOME "${LIBR_LIBRARIES}/Resources" CACHE PATH "R home directory")
       set(LIBR_INCLUDE_DIRS "${LIBR_HOME}/include" CACHE PATH "R include directory")
       set(LIBR_DOC_DIR "${LIBR_HOME}/doc" CACHE PATH "R doc directory")
       set(LIBR_EXECUTABLE "${LIBR_HOME}/R" CACHE PATH "R executable")
+   else()
+      get_filename_component(_LIBR_LIBRARIES "${LIBR_LIBRARIES}" REALPATH)
+      get_filename_component(_LIBR_LIBRARIES_DIR "${_LIBR_LIBRARIES}" DIRECTORY)
+      set(LIBR_EXECUTABLE "${_LIBR_LIBRARIES_DIR}/../bin/R")
+      execute_process(
+         COMMAND ${LIBR_EXECUTABLE} "--slave" "--vanilla" "-e" "cat(R.home())"
+                   OUTPUT_VARIABLE LIBR_HOME
+      )
+      set(LIBR_HOME ${LIBR_HOME} CACHE PATH "R home directory")
+      set(LIBR_INCLUDE_DIRS "${LIBR_HOME}/include" CACHE PATH "R include directory")
+      set(LIBR_DOC_DIR "${LIBR_HOME}/doc" CACHE PATH "R doc directory")
+      set(LIBR_LIB_DIR "${LIBR_HOME}/lib" CACHE PATH "R lib directory")
    endif()
 
 # detection for UNIX & Win32


### PR DESCRIPTION
I am on macOS 10.12 and R was installed via homebrew. Since it was not installed as a framework, `LIBR_LIBRARIES` returns `/usr/local/lib/libR.dylib` instead of `/<path to framework>/R.framework`. 

This PR extends `FindLibR.cmake` to find such R installation.