### PR TITLE
Fix issues with terminal creation/selection via API

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -42,6 +42,7 @@ import org.rstudio.studio.client.workbench.model.WorkbenchServerOperations;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.ui.WorkbenchPane;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.NewWorkingCopyEvent;
+import org.rstudio.studio.client.workbench.views.terminal.TerminalTabPresenter.Display;
 import org.rstudio.studio.client.workbench.views.terminal.events.SwitchToTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStartedEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStoppedEvent;
@@ -217,22 +218,23 @@ public class TerminalPane extends WorkbenchPane
    @Override
    public void onSelected()
    {
-      // terminal tab was selected
       super.onSelected();
       
-      // if terminal is not selected, and the tab "X" is clicked, the tab receives
-      // onSelected but in this case we don't want to create a new terminal
-      if (!closingAll_)
-         ensureTerminal(null);
-
-      Scheduler.get().scheduleDeferred(new ScheduledCommand()
+      if (selectedCallback_ != null)
       {
-         @Override
-         public void execute()
-         {
-            suppressAutoFocus_ = false;
-         }
-      });
+         // terminal tab was shown programatically
+         selectedCallback_.displaySelected();
+         selectedCallback_ = null;
+      }
+      else
+      {
+         // user clicked the tab
+
+         // if terminal is not selected, and the tab "X" is clicked, the tab receives
+         // onSelected but in this case we don't want to create a new terminal
+         if (!closingAll_)
+            ensureTerminal(null);
+      }
    }
 
    @Override
@@ -266,12 +268,20 @@ public class TerminalPane extends WorkbenchPane
    }
 
    @Override
-   public void activateTerminal()
+   public void activateTerminal(DisplaySelectedCallback callback)
    {
+      selectedCallback_ = callback;
+      setShowTerminalPref(true);
       closingAll_ = false;
       bringToFront();
    }
 
+   @Override
+   public void ensureTerminal()
+   {
+      ensureTerminal(null);
+   }
+   
    /**
     * Ensure there's a terminal available, and optionally send text to it when ready. 
     * @param postCreateText text to send, may be null
@@ -466,6 +476,7 @@ public class TerminalPane extends WorkbenchPane
    @Override
    public void terminateAllTerminals()
    {
+      setShowTerminalPref(false);
       closingAll_ = true;
       
       // kill any terminal server processes, and remove them from the server-
@@ -546,14 +557,29 @@ public class TerminalPane extends WorkbenchPane
    }
 
    @Override
-   public void sendToTerminal(String text, boolean setFocus)
+   public void sendToTerminal(final String text, boolean setFocus)
    {
       if (StringUtil.isNullOrEmpty(text))
          return;
 
       suppressAutoFocus_ = !setFocus;
-      ensureTerminal(text);
-      activateTerminal();
+      activateTerminal(new Display.DisplaySelectedCallback()
+      {
+         @Override
+         public void displaySelected()
+         {
+            ensureTerminal(text);
+            Scheduler.get().scheduleDeferred(new ScheduledCommand()
+            {
+               @Override
+               public void execute()
+               {
+                  suppressAutoFocus_ = false;
+               }
+            });
+         }
+      });
+      
    }
 
    @Override
@@ -1112,6 +1138,15 @@ public class TerminalPane extends WorkbenchPane
       }
    }
 
+   private void setShowTerminalPref(boolean show)
+   {
+      if (uiPrefs_.showTerminalTab().getValue() != show)
+      {
+         uiPrefs_.showTerminalTab().setGlobalValue(show);
+         uiPrefs_.writeUIPrefs();
+      }
+   }
+
    private DeckLayoutPanel terminalSessionsPanel_;
    private TerminalPopupMenu activeTerminalToolbarButton_;
    private final TerminalList terminals_ = new TerminalList();
@@ -1124,6 +1159,7 @@ public class TerminalPane extends WorkbenchPane
    private boolean isRestartInProgress_;
    private boolean closingAll_;
    private boolean suppressAutoFocus_;
+   private DisplaySelectedCallback selectedCallback_;
    
    // Injected ----  
    private GlobalDisplay globalDisplay_;


### PR DESCRIPTION
This addresses two issues with the terminal API, both related to code relying on order-of-operation that isn't consistent at runtime.

I will definitely put this in 1.2, question is whether issues matter enough to take for 1.1.

**Issue 1**: When creating the first terminal with `rstudioapi::terminalCreate`, two terminals would be created (the one you wanted, plus an extra one).

**Issue 2**: When creating or selecting a terminal via the API, the wrong terminal would often be selected (i.e. not the one you just created, or not the one you told the API to select).

**WORKAROUNDS**: You can mostly mitigate these problems by making sure the terminal tab has been viewed during this rsession, and at least one terminal exists. It should be sufficient to do an `rstudioapi::terminalActivate()` call before doing any other terminal api calls sequences where you want the results shown in the terminal pane (vs. creating hidden terminals).

The downside is there will always be a visible terminal created that wasn't otherwise needed by the api scenarios.

**Cause**
The core issue was that when the terminal pane is displayed (via clicking the tab, or a command such as Move Focus to Terminal, or Send Text to Terminal, or via various rstudioapis), the `pane.onSelected()` override calls `ensureTerminal()`, which makes sure the pane has at least one running terminal.

This ensures that if the user exits all terminals, then comes back to the terminal tab, a new terminal is created. Similarly, if there are existing terminals, and user comes back to the tab after a browser refresh or session reload, code selects and load an existing terminal versus creating a new one.

When the rstudioapis need to activate/show the Terminal Tab programmatically, the `onSelected` call does not arrive immediately upon display of the pane, and thus can happen mixed in with the other events happening via the API. So, code may see no existing terminals and begin creating one (a multi-stage async-operation), woven in with the things the API wants to do (such as load and select a terminal that was created server-side versus via the UI). So, the wrong things can be selected, and an extra terminal created, depending on various states and orders-of-operations.

**Fix**
The fix was to supply a callback to `TerminalPane.ActivateTerminal`, which is then invoked by the pane's `onSelected` method, allowing a much more deterministic sequence of operations for the API scenarios (and some of the UI scenarios, too).