### PR TITLE
set the default LANG to en_US.UTF-8

### DIFF
--- a/src/cpp/server/extras/launchd/com.rstudio.launchd.rserver.plist.in
+++ b/src/cpp/server/extras/launchd/com.rstudio.launchd.rserver.plist.in
@@ -5,6 +5,11 @@
 <dict>
         <key>Label</key>
         <string>com.rstudio.launchd.rserver</string>
+        <key>EnvironmentVariables</key>
+        <dict>
+               <key>LANG</key>
+               <string>en_US.UTF-8</string>
+        </dict>
         <key>ProgramArguments</key>
         <array>
                 <string>${CMAKE_INSTALL_PREFIX}/bin/rserver</string>


### PR DESCRIPTION
On macOS, the locale was only set for desktop GUI. For rstudio server, we need to hard code it in the launch script. 