### PR TITLE
FIx blank Windows terminal created with api

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
@@ -348,7 +348,7 @@ public class TerminalList implements Iterable<String>,
    {
       ConsoleProcessInfo info = ConsoleProcessInfo.createNewTerminalInfo(
             uiPrefs_.terminalTrackEnvironment().getValue());
-      startTerminal(info, callback);
+      startTerminal(info, false /*createdByApi*/, callback);
    }
 
    /**
@@ -358,6 +358,7 @@ public class TerminalList implements Iterable<String>,
     * @return true if terminal was known and reconnect initiated
     */
    public void reconnectTerminal(String handle,
+                                 boolean createdByApi,
                                  final ResultCallback<Boolean, String> callback) 
    {
       ConsoleProcessInfo existing = getMetadataForHandle(handle);
@@ -368,7 +369,7 @@ public class TerminalList implements Iterable<String>,
       }
 
       existing.setHandle(handle);
-      startTerminal(existing, callback); 
+      startTerminal(existing, createdByApi, callback); 
    }
 
    /**
@@ -415,6 +416,7 @@ public class TerminalList implements Iterable<String>,
    }
 
    private void startTerminal(ConsoleProcessInfo info, 
+                              boolean createdByApi,
                               final ResultCallback<Boolean, String> callback)
    {
       // When terminals are created via the R API, guard against creation of multiple
@@ -428,7 +430,7 @@ public class TerminalList implements Iterable<String>,
       }
 
       TerminalSession newSession = new TerminalSession(
-            info, uiPrefs_.blinkingCursor().getValue(), true /*focus*/);
+            info, uiPrefs_.blinkingCursor().getValue(), true /*focus*/, createdByApi);
 
       if (existing != null)
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -391,12 +391,12 @@ public class TerminalPane extends WorkbenchPane
    }
 
    @Override
-   public void activateNamedTerminal(String caption)
+   public void activateNamedTerminal(String caption, boolean createdByApi)
    {
       if (StringUtil.isNullOrEmpty(caption))
          return;
       
-      activeTerminalToolbarButton_.setActiveTerminalByCaption(caption);
+      activeTerminalToolbarButton_.setActiveTerminalByCaption(caption, createdByApi);
    }
 
    @Override
@@ -837,7 +837,8 @@ public class TerminalPane extends WorkbenchPane
       }
 
       // Reconnect to server?
-      terminals_.reconnectTerminal(event.getTerminalHandle(), new ResultCallback<Boolean, String>()
+      terminals_.reconnectTerminal(event.getTerminalHandle(), event.createdByApi(),
+            new ResultCallback<Boolean, String>()
       {
          @Override 
          public void onSuccess(Boolean connected)  

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
@@ -174,12 +174,12 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
       });
    }
    
-   public void setActiveTerminalByCaption(String caption)
+   public void setActiveTerminalByCaption(String caption, boolean createdByApi)
    {
       String handle = terminals_.handleForCaption(caption);
       if (StringUtil.isNullOrEmpty(handle))
          return;
-      eventBus_.fireEvent(new SwitchToTerminalEvent(handle, null));
+      eventBus_.fireEvent(new SwitchToTerminalEvent(handle, null, createdByApi));
    }
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -68,15 +68,18 @@ public class TerminalSession extends XTermWidget
     * @param info terminal metadata
     * @param cursorBlink should terminal cursor blink
     * @param focus should terminal automatically get focus
+    * @param createdbyApi was this terminal just created by the rstudioapi
     */
    public TerminalSession(ConsoleProcessInfo info, 
                           boolean cursorBlink, 
-                          boolean focus)
+                          boolean focus,
+                          boolean createdByApi)
    {
       super(cursorBlink, focus);
       
       RStudioGinjector.INSTANCE.injectMembers(this);
       procInfo_ = info;
+      createdByApi_ = createdByApi;
       hasChildProcs_ = new Value<Boolean>(info.getHasChildProcs());
       
       setTitle(info.getTitle());
@@ -690,7 +693,10 @@ public class TerminalSession extends XTermWidget
       case TerminalShellInfo.SHELL_CMD64:
       case TerminalShellInfo.SHELL_PS32:
       case TerminalShellInfo.SHELL_PS64:
-         return false;
+         // Do load the buffer if terminal was just created via API, as
+         // the initial message and prompt may have been sent before the
+         // client/server channel was opened.
+         return createdByApi_;
 
       default:
          return true;
@@ -853,6 +859,7 @@ public class TerminalSession extends XTermWidget
    private int inputSequence_ = ShellInput.IGNORE_SEQUENCE;
    private boolean newTerminal_ = true;
    private boolean showAltAfterReload_;
+   private boolean createdByApi_;
 
    // Injected ---- 
    private WorkbenchServerOperations server_; 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
@@ -122,8 +122,9 @@ public class TerminalTabPresenter extends BusyPresenter
        * Activate (display) terminal with given caption. If none specified,
        * do nothing.
        * @param caption
+       * @param createdByApi terminal just created via rstudioapi?
        */
-      void activateNamedTerminal(String caption);
+      void activateNamedTerminal(String caption, boolean createdByApi);
       
       /**
        * Send current terminal's buffer to a new editor buffer.
@@ -243,7 +244,8 @@ public class TerminalTabPresenter extends BusyPresenter
             @Override
             public void displaySelected()
             {
-               view_.activateNamedTerminal(event.getProcessInfo().getCaption());
+               view_.activateNamedTerminal(event.getProcessInfo().getCaption(),
+                                           true /*createdByApi*/);
             }
          });
       }
@@ -268,7 +270,7 @@ public class TerminalTabPresenter extends BusyPresenter
             if (StringUtil.isNullOrEmpty(event.getId()))
                view_.ensureTerminal();
             else
-               view_.activateNamedTerminal(event.getId());
+               view_.activateNamedTerminal(event.getId(), false /*createdByApi*/);
          }
       });
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/SwitchToTerminalEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/SwitchToTerminalEvent.java
@@ -45,6 +45,14 @@ public class SwitchToTerminalEvent extends CrossWindowEvent<Handler>
    {
       terminalHandle_ = handle;
       inputText_ = input;
+      createdByApi_ = false;
+   }
+
+   public SwitchToTerminalEvent(String handle, String input, boolean createdByApi)
+   {
+      terminalHandle_ = handle;
+      inputText_ = input;
+      createdByApi_ = createdByApi;
    }
 
    @Override
@@ -68,9 +76,15 @@ public class SwitchToTerminalEvent extends CrossWindowEvent<Handler>
    {
       return inputText_;
    }
+   
+   public boolean createdByApi()
+   {
+      return createdByApi_;
+   }
 
    private String terminalHandle_;
    private String inputText_;
+   private boolean createdByApi_;
    
    public static final Type<Handler> TYPE = new Type<Handler>();
 }


### PR DESCRIPTION
When a terminal is created via the API, it is started up on the server-side, then the client is told to connect to it. The client then loads the buffer from the server into the terminal.

For Command Prompt and PowerShell, buffers aren't loaded from the server due to issues with those shells and WinPty if text is injected directly into xterm.js.

So any output that was generated before the client/server connection was established is never shown, i.e. the initial shell message and prompt. Results vary based on timing of the different steps.

This change special cases it so the buffer is loaded when a Command-Prompt or PowerShell terminal is first being created and connected via the API. This prevents the blank screen, but can introduce some of the issues with WinPty.

Example would be a terminal that doesn't completely clear or lines that don't seem to scroll.  These issues are intermittent, as they involve many layers with multiple rounds of interprocess communication (rstudio.exe to rsession.exe to winpty's screen-scraping agent to the actual shell process). Unless very severe, this seems acceptable versus getting a completely blank screen, and the risk is contained to this API-only scenario, with those particular shell types.

We can also see issues with duplicate prompts at startup, where the prompt was slow to be sent and thus connection was already established, so it is displayed, the the buffer is loaded and duplicates it. These sorts of issues are not specific to this Command-Prompt/PowerShell scenario.