### PR TITLE
build with boost 1.65

### DIFF
--- a/src/cpp/core/Trace.cpp
+++ b/src/cpp/core/Trace.cpp
@@ -22,6 +22,8 @@
 
 #include <core/Thread.hpp>
 
+#include <iostream>
+
 namespace rstudio {
 namespace core {
 namespace trace {

--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -1190,7 +1190,7 @@ struct CommitInfo
    std::string author;
    std::string subject;
    std::string description;
-   boost::posix_time::time_duration::sec_type date;
+   boost::uint64_t date;
 };
 
 bool commitIsMatch(const std::vector<std::string>& patterns,


### PR DESCRIPTION
I have just successfully built rstudio with boost 1.65 rather than 1.63. Two necessary changes are needed,

1. the `include <iostream>` is needed for `std:cerr`. May be because `boost/utility.hpp` doesn't include `iostream` now!?

2. instead of `boost::posix_time::time_duration::sec_type`, use `boost::uint64_t` to avoid ambiguous conversion in boost 1.65.

