### PR TITLE
Fix odd row saturation in files under flat themes

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesListDataGridStyle.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesListDataGridStyle.css
@@ -25,7 +25,7 @@
   color: #606060;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .dataGridOddRowCell img {
+.rstudio-themes-flat .rstudio-themes-dark .dataGridCell img {
    filter: brightness(90%) saturate(90%);
 }
 


### PR DESCRIPTION
Missed to apply saturation in the file list to even rows.