### PR TITLE
patch 'selectDirectory()' for rstudioapi 0.7

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -496,6 +496,7 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
       // R code
       (bind(sourceModuleRFile, "SessionCodeTools.R"))
       (bind(sourceModuleRFile, "SessionCompletionHooks.R"))
+      (bind(sourceModuleRFile, "SessionPatches.R"))
    
       // unsupported functions
       (bind(rstudio::r::function_hook::registerUnsupported, "bug.report", "utils"))

--- a/src/cpp/session/modules/SessionPatches.R
+++ b/src/cpp/session/modules/SessionPatches.R
@@ -1,0 +1,36 @@
+#
+# SessionPatches.R
+#
+# Copyright (C) 2009-17 by RStudio, Inc.
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+setHook(
+   packageEvent("rstudioapi", "onLoad"),
+   function(...) {
+
+      # bail if we're not version 0.7
+      if (packageVersion("rstudioapi") != "0.7")
+         return()
+
+      # re-assign the 'selectDirectory()' function
+      rstudioapi <- asNamespace("rstudioapi")
+      override <- function(caption = "Select Directory",
+                           label = "Select",
+                           path = rstudioapi::getActiveProject())
+      {
+         callFun("selectDirectory", caption, label, path)
+      }
+      environment(override) <- rstudioapi
+
+      .rs.replaceBinding("selectDirectory", "rstudioapi", override)
+   }
+)


### PR DESCRIPTION
This PR fixes an issue in rstudioapi 0.7 (which unfortunately just hit CRAN) wherein we accidentally delegated `selectDirectory()` to `selectFile()` instead.

This PR allows us to fix the issue on the RStudio side without necessitating a patch release of the `rstudioapi` package. (@jjallaire, let me know if you'd prefer if we just submit a patch release instead)