### PR TITLE
Fix code margin overlapping chunk under 'chaos' editor theme

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chaos.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/chaos.css
@@ -160,6 +160,9 @@
   border: 0 !important;
   background-color: rgba(128, 128, 128, 0.5);
 }
+.ace_print-margin {
+  width: 0px;
+}
 .ace_marker-layer .ace_foreign_line {
   position: absolute;
   z-index: -1;

--- a/src/gwt/tools/compile-themes.R
+++ b/src/gwt/tools/compile-themes.R
@@ -1015,7 +1015,18 @@ for (file in themeFiles) {
          replace = foreground
       )
    }
-      
+
+   ## Tweak chaos on dark -- we want the margin column to not overlap the chunk
+   if (identical(basename(file), "chaos.css"))
+   {
+      content <- add_content(
+         content,
+         ".ace_print-margin {",
+         "  width: 0px;",
+         "}",
+         replace = ""
+      )
+   }
    
    ## Generate a color used for chunks, e.g. in .Rmd documents.
    backgroundRgb <- parse_css_color(background)


### PR DESCRIPTION
THe chaos theme uses `border 1px` instead of `width 1px` like the other themes for their code margin, not entirely sure why this theme behaves in this way but seems safe enough to reduce the width to make it render similar to the other themes, with this change:

<img width="933" alt="screen shot 2017-09-11 at 11 45 45 am" src="https://user-images.githubusercontent.com/3478847/30291258-25f3ec42-96e7-11e7-8e1e-8f4e2aaa05e0.png">
