### PR TITLE
page viewer improvements

### DIFF
--- a/src/cpp/r/R/Options.R
+++ b/src/cpp/r/R/Options.R
@@ -43,7 +43,7 @@ if (is.null(getOption("viewer"))) {
 
 # default page_viewer option if not already set
 if (is.null(getOption("page_viewer"))) {
-   options(page_viewer = function(url, title = "RStudio Viewer")
+   options(page_viewer = function(url, title = "RStudio Viewer", self_contained = FALSE)
    {
       if (!is.character(url) || (length(url) != 1))
          stop("url must be a single element character vector.", call. = FALSE)
@@ -51,7 +51,10 @@ if (is.null(getOption("page_viewer"))) {
       if (!is.character(title) || (length(title) != 1))
          stop("title must be a single element character vector.", call. = FALSE)
       
-      invisible(.Call("rs_showPageViewer", url, title))
+      if (!is.logical(self_contained) || (length(self_contained) != 1))
+         stop("self_contained must be a single element logical vector.", call. = FALSE)
+      
+      invisible(.Call("rs_showPageViewer", url, title, self_contained))
    })
 }
 

--- a/src/cpp/session/modules/SessionHTMLPreview.cpp
+++ b/src/cpp/session/modules/SessionHTMLPreview.cpp
@@ -979,7 +979,7 @@ void handlePreviewRequest(const http::Request& request,
    }
 }
 
-SEXP rs_showPageViewer(SEXP urlSEXP, SEXP titleSEXP)
+SEXP rs_showPageViewer(SEXP urlSEXP, SEXP titleSEXP, SEXP selfContainedSEXP)
 {
    try
    {
@@ -987,9 +987,10 @@ SEXP rs_showPageViewer(SEXP urlSEXP, SEXP titleSEXP)
       if (isPreviewRunning())
          s_pCurrentPreview_->terminate();
 
-      // get url and title
+      // get parameters
       std::string url = r::sexp::safeAsString(urlSEXP);
       std::string title = r::sexp::safeAsString(titleSEXP);
+      bool selfContained = r::sexp::asLogical(selfContainedSEXP);
 
       // paths we will forward via event
       FilePath filePath, viewerFilePath;
@@ -1016,19 +1017,28 @@ SEXP rs_showPageViewer(SEXP urlSEXP, SEXP titleSEXP)
          // get full path to file
          filePath = module_context::resolveAliasedPath(url);
 
-         // create temp file to write standalone html to (place it within a temp dir
-         // so the default download file name is pretty)
-         FilePath viewerTempDir = module_context::tempFile("page-viewer", "dir");
-         Error error = viewerTempDir.ensureDirectory();
-         if (error)
-            throw r::exec::RErrorException(r::endUserErrorMessage(error));
-         viewerFilePath = viewerTempDir.childPath(filePath.filename());
+         // make it self_contained if it isn't already
+         if (!selfContained)
+         {
+            // create temp file to write standalone html to (place it within a temp dir
+            // so the default download file name is pretty)
+            FilePath viewerTempDir = module_context::tempFile("page-viewer", "dir");
+            Error error = viewerTempDir.ensureDirectory();
+            if (error)
+               throw r::exec::RErrorException(r::endUserErrorMessage(error));
+            viewerFilePath = viewerTempDir.childPath(filePath.filename());
 
-         // create base64 encoded version
-         error = module_context::createSelfContainedHtml(filePath, viewerFilePath);
-         if (error)
-            throw r::exec::RErrorException(r::endUserErrorMessage(error));
-
+            // create base64 encoded version
+            error = module_context::createSelfContainedHtml(filePath, viewerFilePath);
+            if (error)
+               throw r::exec::RErrorException(r::endUserErrorMessage(error));
+         }
+         // if it's already self contained then just set the viewerFilePath to filePath
+         else
+         {
+             viewerFilePath = filePath;
+         }
+          
          // set url to localhost previewer
          std::string tempPath = viewerFilePath.relativePath(module_context::tempDir());
          url = module_context::sessionTempDirUrl(tempPath);
@@ -1047,7 +1057,7 @@ SEXP rs_showPageViewer(SEXP urlSEXP, SEXP titleSEXP)
       // we need to give the first event time to be delivered so that
       // the preview succeeded event handler is set up
       using namespace boost::posix_time;
-      boost::this_thread::sleep(milliseconds(500));
+      boost::this_thread::sleep(milliseconds(200));
 
       // emit html preview completed event
       enqueHTMLPreviewSucceeded(
@@ -1131,7 +1141,7 @@ core::json::Object capabilitiesAsJson()
 
 Error initialize()
 {  
-   RS_REGISTER_CALL_METHOD(rs_showPageViewer, 2);
+   RS_REGISTER_CALL_METHOD(rs_showPageViewer, 3);
 
    using boost::bind;
    using namespace module_context;

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
@@ -299,7 +299,8 @@ public class HTMLPreviewPanel extends ResizeComposite
    {
       if (Desktop.isDesktop())
          Desktop.getFrame().setViewerUrl(url);
-      previewFrame_.navigate(url);
+      // use setUrl rather than navigate to deal with same origin policy
+      previewFrame_.setUrl(url);
    }
    
    private final LayoutPanel layoutPanel_;


### PR DESCRIPTION
- Allow callers to indicate that they've already created self_contained html (major performance boost for larger pages)
- Use 200ms rather than 500ms delay for event delivery
- Use setUrl rather than navigate when loading a new URL (deals with same origin policy restrictions)

Should carry zero risk for codepaths outside of page_viewer so very low risk (the use of setUrl rather than navigate is the only change that would affect other scenarios, however we also do this in several other previewers e.g. shiny app viewer so it should be safe).