### PR TITLE
Fix send-to-terminal line endings on terminal startup

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -333,7 +333,7 @@ public class TerminalPane extends WorkbenchPane
                Debug.log("No selected terminal after creation"); 
                return; 
             } 
-            terminal.receivedInput(postCreateText);
+            terminal.receivedSendToTerminal(postCreateText);
          }
          
          @Override
@@ -849,7 +849,7 @@ public class TerminalPane extends WorkbenchPane
                Debug.log("Terminal not found after switching"); 
                return; 
             } 
-            terminal.receivedInput(event.getInputText()); 
+            terminal.receivedSendToTerminal(event.getInputText()); 
          } 
          @Override 
          public void onFailure(String msg) 


### PR DESCRIPTION
When sending multiple lines of text to terminal (Windows-specific, Command Prompt or PowerShell only) the wrong line endings were sent and the input was smushed together in one command instead of multiple commands.

This was partially fixed by https://github.com/rstudio/rstudio/pull/1463, but it didn't handle the case where (1) there was no existing terminal so one had to be created and started or (2) the first terminal had not yet been shown (i.e. after closing and restarting RStudio, but not clicking on the Terminal tab), so it had to be started before sending text. Good catch by @ronblum.

Simple change to use the helper I created for the mainline scenario (sending text to a "live" terminal instance).

`receivedSendToTerminal` just passes through to `receivedInput` unless running Windows desktop and the targeted terminal is using Command Prompt or PowerShell, so the scope of impact (risk) is pretty narrow.

FYI, at the time I fixed this mainline scenario, these sub-scenarios weren't working at all; that was fixed by https://github.com/rstudio/rstudio/pull/1477.
