### PR TITLE
Ensure tables refreshed on connected state

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionExplorer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionExplorer.java
@@ -110,7 +110,12 @@ public class ConnectionExplorer extends Composite implements RequiresResize
    {
       activePanel_ = connected ? objectBrowser_ : disconnectedUI_;
       showActivePanel();
-      if (!connected)
+      if (connected)
+      {
+         if (connection_ != null)
+            updateObjectBrowser();
+      }
+      else
          objectBrowser_.clear();
    }
    


### PR DESCRIPTION
This change fixes a bug in which the list of tables in the Connections pane is sometimes not fetched when initially connected. The fix is in two parts:

1. If we have a connection and enter the connected state, refresh the list of objects.

2. Because of this change (and some other codepaths around connection state changes), it is possible in some circumstances that two or more requests will be made for the list of tables concurrently. This can be an expensive call for some large databases, so if a request for the object list is made while we are currently waiting for one to return, we now stack the requests and fulfill both with the single pending RPC.