### PR TITLE
Avoid use of uninitialized 'diag' variable

### DIFF
--- a/src/cpp/r/R/Diagnostics.R
+++ b/src/cpp/r/R/Diagnostics.R
@@ -57,9 +57,10 @@ capture.output({
       cppDiag <- paste("../bin/diagnostics", ext, sep="")
   }
   
-  if (file.exists(cppDiag))
+  if (file.exists(cppDiag)) {
     diag <- system(cppDiag, intern=TRUE)
-  cat(diag, sep="\n")
+    cat(diag, sep="\n")
+  }
   
   
 }, file=diagnosticsFile)


### PR DESCRIPTION
This fixes an issue in which `--run-diagnostics` shows an error caused by attempting to `cat()` the uninitialized `diag` variable.