### PR TITLE
improve NSE detection for dplyr

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -329,18 +329,14 @@
       class <- substring(method, nchar(generic) + 2)
       
       call <- substitute(
-         utils::getS3method(generic, class),
+         utils::getS3method(generic, class, optional = TRUE),
          list(generic = generic, class = class)
       )
       
-      tryCatch(
-         eval(call, envir = globalenv()),
-         error = function(e) NULL
-      )
-      
+      eval(call, envir = globalenv())
    })
-   names(defns) <- rownames(info)
    
+   names(defns) <- rownames(info)
    defns
 })
 

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -281,15 +281,25 @@
    generic <- NULL
    .rs.recursiveSearch(x, function(node) {
       
-      if (!is.call(node))
+      if (!is.call(node) || length(node) < 2 || length(node) > 3)
          return(FALSE)
       
       lhs <- node[[1]]
       if (!identical(lhs, UseMethod))
          return(FALSE)
       
-      generic <<- as.character(node[[2]])
-      TRUE
+      matched <- tryCatch(
+         match.call(function(generic, object) {}, node),
+         error = function(e) NULL
+      )
+      
+      if (is.character(matched[["generic"]]))
+      {
+         generic <<- matched[["generic"]]
+         return(TRUE)
+      }
+      
+      FALSE
    })
    
    generic


### PR DESCRIPTION
This PR updates the non-standard evaluation detection system to better understand S3 dispatch + `rlang` idioms for non-standard evaluation. This should fix spurious warnings seen with the latest versions of `dplyr` + other packages using `tidyselect` when diagnostics are all enabled.

In other words, we should no longer see false positives like the following:
![screen shot 2017-09-15 at 2 59 00 pm](https://user-images.githubusercontent.com/1976582/30504949-79269c06-9a26-11e7-95b2-125b31c76e98.png)
