### PR TITLE
Fixes to launching native shells on Windows (1.1)

### DIFF
--- a/src/cpp/desktop-mac/GwtCallbacks.mm
+++ b/src/cpp/desktop-mac/GwtCallbacks.mm
@@ -885,6 +885,7 @@ private:
 - (void) openTerminal: (NSString*) terminalPath
          workingDirectory: (NSString*) workingDirectory
          extraPathEntries: (NSString*) extraPathEntries
+         shellType: (int) shellType
 {
    // append extra path entries to our path before launching
    if ([extraPathEntries length] > 0)

--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -986,7 +986,8 @@ void GwtCallback::openSessionInNewWindow(QString workingDirectoryPath)
 
 void GwtCallback::openTerminal(QString terminalPath,
                                QString workingDirectory,
-                               QString extraPathEntries)
+                               QString extraPathEntries,
+                               int shellType)
 {
    // append extra path entries to our path before launching
    std::string path = core::system::getenv("PATH");
@@ -1010,32 +1011,45 @@ void GwtCallback::openTerminal(QString terminalPath,
 
 #elif defined(Q_OS_WIN)
 
-   // git bash
-   if (terminalPath.length() > 0)
+   // TODO: (gary) make these shell type constants shared with
+   // SessionTerminalShell.hpp instead of duplicating them
+   const int GitBash = 1; // Win32: Bash from Windows Git
+   const int WSLBash = 2; // Win32: Windows Services for Linux
+   const int Cmd32 = 3; // Win32: Windows command shell (32-bit)
+   const int Cmd64 = 4; // Win32: Windows command shell (64-bit)
+   const int PS32 = 5; // Win32: PowerShell (32-bit)
+   const int PS64 = 6; // Win32: PowerShell (64-bit)
+
+   if (terminalPath.length() == 0)
    {
-      QStringList args;
+      terminalPath = QString::fromUtf8("cmd.exe");
+      shellType = Cmd32;
+   }
+
+   QStringList args;
+   std::string previousHome = core::system::getenv("HOME");
+
+   switch (shellType)
+   {
+   case GitBash:
+   case WSLBash:
       args.append(QString::fromUtf8("--login"));
       args.append(QString::fromUtf8("-i"));
-      QProcess::startDetached(terminalPath,
-                              args,
-                              resolveAliasedPath(workingDirectory));
-   }
-   else
-   {
+      break;
+
+   default:
       // set HOME to USERPROFILE so msys ssh can find our keys
-      std::string previousHome = core::system::getenv("HOME");
       std::string userProfile = core::system::getenv("USERPROFILE");
       core::system::setenv("HOME", userProfile);
-
-      // run the process
-      QProcess::startDetached(QString::fromUtf8("cmd.exe"),
-                              QStringList(),
-                              resolveAliasedPath(workingDirectory));
-
-      // revert to previous home
-      core::system::setenv("HOME", previousHome);
+      break;
    }
 
+   QProcess::startDetached(terminalPath,
+                           args,
+                           resolveAliasedPath(workingDirectory));
+
+   // revert to previous home
+   core::system::setenv("HOME", previousHome);
 
 #elif defined(Q_OS_LINUX)
 

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -156,7 +156,8 @@ public slots:
 
    void openTerminal(QString terminalPath,
                      QString workingDirectory,
-                     QString extraPathEntries);
+                     QString extraPathEntries,
+                     int shellType);
 
    QString getFixedWidthFontList();
    QString getFixedWidthFont();

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -636,6 +636,11 @@ Error getTerminalOptions(const json::JsonRpcRequest& request,
 
    FilePath terminalPath;
 
+   // Shell type is needed on Windows to make additional shell-type
+   // specific tweaks, see DesktopGwtCallback.cpp::openTerminal
+   console_process::TerminalShell::TerminalShellType shellType =
+         console_process::TerminalShell::DefaultShell;
+
 #if defined(_WIN32)
 
    // Use default terminal setting for shell
@@ -644,6 +649,7 @@ Error getTerminalOptions(const json::JsonRpcRequest& request,
 
    if (shells.getInfo(userSettings().defaultTerminalShellValue(), &shell))
    {
+      shellType = shell.type;
       terminalPath = shell.path;
    }
 
@@ -653,6 +659,7 @@ Error getTerminalOptions(const json::JsonRpcRequest& request,
       console_process::TerminalShell sysShell;
       if (console_process::AvailableTerminalShells::getSystemShell(&sysShell))
       {
+         shellType = shell.type;
          terminalPath = sysShell.path;
       }
    }
@@ -678,6 +685,7 @@ Error getTerminalOptions(const json::JsonRpcRequest& request,
    optionsJson["working_directory"] =
                   module_context::shellWorkingDirectory().absolutePath();
    optionsJson["extra_path_entries"] = extraPathEntries;
+   optionsJson["shell_type"] = shellType;
    pResponse->setResult(optionsJson);
 
    return Success();

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -134,7 +134,8 @@ public interface DesktopFrame extends JavaScriptPassthrough
    
    void openTerminal(String terminalPath,
                      String workingDirectory,
-                     String extraPathEntries);
+                     String extraPathEntries,
+                     int shellType);
 
    String getFixedWidthFontList();
    String getFixedWidthFont();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
@@ -399,7 +399,8 @@ public class Workbench implements BusyHandler,
             {
                Desktop.getFrame().openTerminal(options.getTerminalPath(),
                      options.getWorkingDirectory(),
-                     options.getExtraPathEntries());
+                     options.getExtraPathEntries(),
+                     options.getShellType());
             }
          });
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/TerminalOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/TerminalOptions.java
@@ -31,4 +31,8 @@ public class TerminalOptions extends JavaScriptObject
    public native final String getExtraPathEntries() /*-{
       return this.extra_path_entries;
    }-*/;
+
+   public native final int getShellType() /*-{
+      return this.shell_type;
+   }-*/;
 }


### PR DESCRIPTION
Regressions/issues from this change back in June to **Make Tools/Shell use default terminal on Windows**: https://github.com/rstudio/rstudio/pull/1326

* PowerShell wasn't launching successfully; window would appear then go away; caused by passing `--login` and `--i` command line arguments, which should only be passed to Posix-y shells
* Native Windows shells (cmd, and newly added PowerShell) weren't getting `HOME` set to `USERPROFILE`, as they had been in 1.0.

To fix, I now pass the shell-type constant up to the code that launches the system terminal, and based on that can decide which behaviors to perform.