### PR TITLE
work harder to infer desired remote

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/RemotesInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/RemotesInfo.java
@@ -23,4 +23,5 @@ public class RemotesInfo extends JavaScriptObject
    public final native String getRemote() /*-{ return this["remote"]; }-*/;
    public final native String getUrl()    /*-{ return this["url"]; }-*/;
    public final native String getType()   /*-{ return this["type"]; }-*/;
+   public final native boolean isActive() /*-{ return this["active"]; }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchDialog.java
@@ -192,9 +192,9 @@ public class CreateBranchDialog extends ModalDialog<CreateBranchDialog.Input>
       container_.add(cbPush_);
    }
    
-   public void setRemotes(JsArray<RemotesInfo> remotes)
+   public void setRemotes(JsArray<RemotesInfo> remotesInfo)
    {
-      setRemotes(null, remotes);
+      setRemotes(null, remotesInfo);
    }
    
    public void setRemotes(String activeRemote,
@@ -204,14 +204,38 @@ public class CreateBranchDialog extends ModalDialog<CreateBranchDialog.Input>
       
       List<String> remotes = new ArrayList<String>();
       for (RemotesInfo info : JsUtil.asIterable(remotesInfo))
+      {
          if (!remotes.contains(info.getRemote()))
+         {
+            String remote = info.getRemote();
             remotes.add(info.getRemote());
+            if (activeRemote == null && info.isActive())
+               activeRemote = remote;
+         }
+      }
       
       String[] choices = new String[remotes.size() + 1];
       for (int i = 0; i < remotes.size(); i++)
          choices[i] = remotes.get(i);
       choices[remotes.size()] = REMOTE_NONE;
       
+      // if we haven't set an active remote, try defaulting to the one called
+      // 'origin' (if it exists)
+      if (activeRemote == null)
+      {
+         for (int i = 0; i < choices.length; i++)
+         {
+            if (REMOTE_ORIGIN.equals(choices[i]))
+            {
+               activeRemote = REMOTE_ORIGIN;
+               break;
+            }
+         }
+      }
+      
+      // if we still haven't found anything, just default to the first entry
+      // (note that because we always add the (none) remote there will always
+      // be an entry available here)
       if (activeRemote == null)
          activeRemote = choices[0];
       
@@ -250,4 +274,5 @@ public class CreateBranchDialog extends ModalDialog<CreateBranchDialog.Input>
    private final CheckBox cbPush_;
    
    private static final String REMOTE_NONE = "(None)";
+   private static final String REMOTE_ORIGIN = "origin";
 }


### PR DESCRIPTION
This PR tries harder to select an appropriate remote in the 'Create Branch' dialog:

1. If the current branch has a tracking remote, then we'll select that as the remote to use in the create branch dialog.

2. If the active branch has no tracking remote, then we'll default to a remote called `origin` (if it exists).

3. All else fails, we'll just use the first remote in the list (the current behavior).