### PR TITLE
add 'purrr' cheat sheet

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -472,11 +472,14 @@ well as menu structures (for main menu and popup menus).
             <cmd refid="openRStudioIDECheatSheet"/>'
             <cmd refid="openDataTransformationCheatSheet"/>
             <cmd refid="openDataVisualizationCheatSheet"/>
+            <cmd refid="openPurrrCheatSheet"/>
             <cmd refid="openPackageDevelopmentCheatSheet"/>
             <cmd refid="openShinyCheatSheet"/>
             <cmd refid="openSparklyrCheatSheet"/>
             <cmd refid="openRMarkdownCheatSheet"/>
             <cmd refid="openRMarkdownReferenceGuide"/>
+            <separator/>
+            <cmd refid="browseCheatSheets"/>
          </menu>
          <separator/>
          <cmd refid="helpKeyboardShortcuts"/>
@@ -1747,6 +1750,11 @@ well as menu structures (for main menu and popup menus).
          menuLabel="Data Visualization with ggplot2"
          desc="Data visualization with ggplot2"
          context="help"/>
+         
+    <cmd id="openPurrrCheatSheet"
+         menuLabel="List manipulation with purrr"
+         desc="List manipulation with purrr"
+         context="help"/>
 
     <cmd id="openPackageDevelopmentCheatSheet"
          menuLabel="Package Development with devtools"
@@ -1786,6 +1794,11 @@ well as menu structures (for main menu and popup menus).
     <cmd id="openShinyCheatSheet"
          menuLabel="Web Applications with shiny"
          desc="Build web applications with Shiny"
+         context="help"/>
+         
+    <cmd id="browseCheatSheets"
+         menuLabel="Browse Cheatsheets..."
+         desc="Browse available cheatsheets in your web browser"
          context="help"/>
 
    <cmd id="knitDocument"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -98,6 +98,8 @@ public abstract class
    public abstract AppCommand openShinyCheatSheet();
    public abstract AppCommand openRoxygenQuickReference();
    public abstract AppCommand openSparklyrCheatSheet();
+   public abstract AppCommand openPurrrCheatSheet();
+   public abstract AppCommand browseCheatSheets();
    public abstract AppCommand knitDocument();
    public abstract AppCommand previewHTML();
    public abstract AppCommand publishHTML();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/Help.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/Help.java
@@ -274,6 +274,16 @@ public class Help extends BasePresenter implements ShowHelpHandler
       openCheatSheet("sparklyr_cheat_sheet");
    }
    
+   void onOpenPurrrCheatSheet()
+   {
+      openCheatSheet("purrr_cheat_sheet");
+   }
+   
+   void onBrowseCheatSheets()
+   {
+      globalDisplay_.openWindow("https://www.rstudio.com/resources/cheatsheets/");
+   }
+   
    private void openCheatSheet(String name)
    {
       globalDisplay_.openRStudioLink(name, false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpTab.java
@@ -49,7 +49,9 @@ public class HelpTab extends DelayLoadWorkbenchTab<Help>
       @Handler public abstract void onOpenRMarkdownReferenceGuide();
       @Handler public abstract void onOpenShinyCheatSheet();
       @Handler public abstract void onOpenSparklyrCheatSheet();
+      @Handler public abstract void onOpenPurrrCheatSheet();
       @Handler public abstract void onOpenRoxygenQuickReference();
+      @Handler public abstract void onBrowseCheatSheets();
       @Handler public abstract void onProfileHelp();
       
       public abstract void bringToFront();


### PR DESCRIPTION
See also: https://github.com/rstudio/rstudio-web/pull/11

This PR adds a link to the `purrr` cheat sheet, and also a general `Browse Cheatsheets...` link to open the set of cheat sheets available at https://www.rstudio.com/resources/cheatsheets/.