### PR TITLE
Prevent blank startup screen when exception thrown at startup

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/MessageDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/MessageDialog.java
@@ -18,6 +18,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.client.ui.*;
 
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.widget.images.MessageDialogImages;
@@ -136,7 +137,7 @@ public class MessageDialog extends ModalDialogBase
    
    public static Label labelForMessage(String message)
    {
-      Label label = new MultiLineLabel(message);
+      Label label = new MultiLineLabel(StringUtil.notNull(message));
       label.setStylePrimaryName(
                      ThemeResources.INSTANCE.themeStyles().dialogMessage());
       return label;


### PR DESCRIPTION
My devmode setup was throwing an exception at startup, and the resulting attempt to show error dialog was also throwing exception leaving a grey screen after the progress spinner dismissed.

Console had one of these from each attempt to reload.

`26 Sep 2017 18:34:47 [rserver] CLIENT EXCEPTION (rsession-gary): (TypeError) : Cannot read property 'replace' of undefined;`

There was an RPC parsing exception being thrown, with a null message in the exception, which led the DomUtils.textToHtml being called on a null string while building the error dialog.

This change prevents that null exception and allows the dialog to be shown, albeit without a message in it, versus a grey screen.

As soon as I fixed this the UI launched successfully, which seems rather odd, as I was expecting to see the error dialog and then investigate the underlying exception. Perhaps making the code change triggered recompilation of something problematic?

Still, seems worth handling receipt of a null exception message during startup.