### PR TITLE
Lambda-ify some terminal code to get a feel for it

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -557,7 +557,7 @@ public class TerminalPane extends WorkbenchPane
       suppressAutoFocus_ = !setFocus;
       activateTerminal(() -> {
          ensureTerminal(text);
-         Scheduler.get().scheduleDeferred(() -> { suppressAutoFocus_ = false; });
+         Scheduler.get().scheduleDeferred(() -> suppressAutoFocus_ = false);
       });
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -42,7 +42,6 @@ import org.rstudio.studio.client.workbench.model.WorkbenchServerOperations;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.ui.WorkbenchPane;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.NewWorkingCopyEvent;
-import org.rstudio.studio.client.workbench.views.terminal.TerminalTabPresenter.Display;
 import org.rstudio.studio.client.workbench.views.terminal.events.SwitchToTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStartedEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStoppedEvent;
@@ -50,7 +49,6 @@ import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSubproc
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalTitleEvent;
 
 import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -172,48 +170,42 @@ public class TerminalPane extends WorkbenchPane
    
    private void updateTerminalToolbar()
    {
-      Scheduler.get().scheduleDeferred(new ScheduledCommand()
-      {
-         @Override
-         public void execute()
-         {
-            boolean interruptable = false;
-            boolean closable = false;
-            boolean clearable = false;
+      Scheduler.get().scheduleDeferred(() -> {
+         boolean interruptable = false;
+         boolean closable = false;
+         boolean clearable = false;
 
-            final TerminalSession visibleTerminal = getSelectedTerminal();
-            if (visibleTerminal != null)
+         final TerminalSession visibleTerminal = getSelectedTerminal();
+         if (visibleTerminal != null)
+         {
+            clearable = true;
+            if (!visibleTerminal.getHasChildProcs())
             {
-               clearable = true;
-               if (!visibleTerminal.getHasChildProcs())
+               // nothing running in current terminal
+               closable = true;
+            }
+            else
+            {
+               if (!visibleTerminal.xtermAltBufferActive())
                {
-                  // nothing running in current terminal
-                  closable = true;
+                  // not running a full-screen program
+                  interruptable = true;
+                  closable = false;
                }
                else
                {
-                  if (!visibleTerminal.xtermAltBufferActive())
-                  {
-                     // not running a full-screen program
-                     interruptable = true;
-                     closable = false;
-                  }
-                  else
-                  {
-                     // running a full-screen program
-                     closable = true;
-                     interruptable = false;
-                     clearable = false;
-                  }
+                  // running a full-screen program
+                  closable = true;
+                  interruptable = false;
+                  clearable = false;
                }
             }
-            interruptButton_.setVisible(interruptable);
-            closeButton_.setVisible(closable);
-            clearButton_.setVisible(clearable);
          }
+         interruptButton_.setVisible(interruptable);
+         closeButton_.setVisible(closable);
+         clearButton_.setVisible(clearable);
       });
-
-    }
+   }
 
    @Override
    public void onSelected()
@@ -222,7 +214,7 @@ public class TerminalPane extends WorkbenchPane
       
       if (selectedCallback_ != null)
       {
-         // terminal tab was shown programatically
+         // terminal tab was shown programmatically
          selectedCallback_.displaySelected();
          selectedCallback_ = null;
       }
@@ -563,23 +555,10 @@ public class TerminalPane extends WorkbenchPane
          return;
 
       suppressAutoFocus_ = !setFocus;
-      activateTerminal(new Display.DisplaySelectedCallback()
-      {
-         @Override
-         public void displaySelected()
-         {
-            ensureTerminal(text);
-            Scheduler.get().scheduleDeferred(new ScheduledCommand()
-            {
-               @Override
-               public void execute()
-               {
-                  suppressAutoFocus_ = false;
-               }
-            });
-         }
+      activateTerminal(() -> {
+         ensureTerminal(text);
+         Scheduler.get().scheduleDeferred(() -> { suppressAutoFocus_ = false; });
       });
-      
    }
 
    @Override
@@ -995,20 +974,15 @@ public class TerminalPane extends WorkbenchPane
     */
    public void setFocusOnVisible()
    {
-      Scheduler.get().scheduleDeferred(new ScheduledCommand()
-      {
-         @Override
-         public void execute()
+      Scheduler.get().scheduleDeferred(() -> {
+         TerminalSession visibleTerminal = getSelectedTerminal();
+         if (visibleTerminal != null)
          {
-            TerminalSession visibleTerminal = getSelectedTerminal();
-            if (visibleTerminal != null)
-            {
-               if (!suppressAutoFocus_)
-                  visibleTerminal.setFocus(true);
-               activeTerminalToolbarButton_.setActiveTerminal(
-                     visibleTerminal.getCaption(), visibleTerminal.getHandle());
-               setTerminalTitle(visibleTerminal.getTitle());
-            }
+            if (!suppressAutoFocus_)
+               visibleTerminal.setFocus(true);
+            activeTerminalToolbarButton_.setActiveTerminal(
+                  visibleTerminal.getCaption(), visibleTerminal.getHandle());
+            setTerminalTitle(visibleTerminal.getTitle());
          }
       });
    }
@@ -1060,27 +1034,22 @@ public class TerminalPane extends WorkbenchPane
          return;
       }
 
-      Scheduler.get().scheduleDeferred(new ScheduledCommand()
-      {
-         @Override
-         public void execute()
+      Scheduler.get().scheduleDeferred(() -> {
+         terminal.connect(new ResultCallback<Boolean, String>()
          {
-            terminal.connect(new ResultCallback<Boolean, String>()
+            @Override
+            public void onSuccess(Boolean connected) 
             {
-               @Override
-               public void onSuccess(Boolean connected) 
-               {
-               }
+            }
 
-               @Override
-               public void onFailure(String msg)
-               {
-                  Debug.log(msg);
-               }
-            });
-         }
+            @Override
+            public void onFailure(String msg)
+            {
+               Debug.log(msg);
+            }
+         });
       });
-   }
+}
 
    @Override
    public void onTerminalSubprocs(TerminalSubprocEvent event)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -546,14 +546,7 @@ public class TerminalSession extends XTermWidget
                   // terminal sessions and there was a resize.
                   // A delay is needed to give the xterm.js implementation an
                   // opportunity to be ready for this.
-                  Scheduler.get().scheduleDeferred(new ScheduledCommand()
-                  {
-                     @Override
-                     public void execute()
-                     {
-                        onResize();
-                     }
-                  });
+                  Scheduler.get().scheduleDeferred(() -> onResize());
                }
             }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
@@ -208,14 +208,7 @@ public class TerminalTabPresenter extends BusyPresenter
    public void onCreateTerminal(final CreateTerminalEvent event)
    {
       // New Terminal command, always creates a new terminal
-      view_.activateTerminal(new Display.DisplaySelectedCallback()
-      {
-         @Override
-         public void displaySelected()
-         {
-            view_.createTerminal(event.getPostCreateText());
-         }
-      });
+      view_.activateTerminal(() -> view_.createTerminal(event.getPostCreateText()));
    }
 
    @Override
@@ -239,15 +232,9 @@ public class TerminalTabPresenter extends BusyPresenter
       if (event.getShow())
       {
          // And optionally bring tab forward and select the requested terminal
-         view_.activateTerminal(new Display.DisplaySelectedCallback()
-         {
-            @Override
-            public void displaySelected()
-            {
-               view_.activateNamedTerminal(event.getProcessInfo().getCaption(),
-                                           true /*createdByApi*/);
-            }
-         });
+         view_.activateTerminal(
+               () -> view_.activateNamedTerminal(event.getProcessInfo().getCaption(), 
+                                                 true /*createdByApi*/));
       }
    }
 
@@ -262,16 +249,11 @@ public class TerminalTabPresenter extends BusyPresenter
    {
       // Request to display the terminal tab and optionally select a specific terminal; if
       // no terminal is specified, then make sure there is an active terminal
-      view_.activateTerminal(new Display.DisplaySelectedCallback()
-      {
-         @Override
-         public void displaySelected()
-         {
-            if (StringUtil.isNullOrEmpty(event.getId()))
-               view_.ensureTerminal();
-            else
-               view_.activateNamedTerminal(event.getId(), false /*createdByApi*/);
-         }
+      view_.activateTerminal(() -> {
+         if (StringUtil.isNullOrEmpty(event.getId()))
+            view_.ensureTerminal();
+         else
+            view_.activateNamedTerminal(event.getId(), false /*createdByApi*/);
       });
    }
 


### PR DESCRIPTION
Converted some terminal anonymous classes to lambdas to get a feel for the syntax.

One thing I noticed, breakpoints in Chrome debugger get trickier with the more compact syntax. For example, put breakpoints on each of these lines in TerminalPane.java, inside `sendToTerminal` function:

```
   activateTerminal(() -> { // breakpoint one
      ensureTerminal(text); // breakpoint two
      Scheduler.get().scheduleDeferred(() -> suppressAutoFocus_ = false); // bp three
   });
```
The first will fire when the app is starting up (the containing function `sendToTerminal` **doesn't** execute during startup).

When you do the UI action to trigger a call to `sendToTerminal`, the second breakpoint fires as expected, when `activateTerminal` invokes the passed callback lambda. Note that the first breakpoint does not fire again, so you can't stop at the actual activateTerminal invocation.

Then the third breakpoint fires as the scheduleDeferred lambda is created, but there's no way to set a breakpoint on the callback that I can find (the `suppressAutoFocus_ = false;` part). That could be annoying in some situations. If you wrap the line, putting that code on a separate line, then you can set a breakpoint on it, but that definitely takes away from the compactness gains from using the lambda here.

Figure we'll get a feel for this as we go along, and come up with some best-practices to balance the nifty syntax with debug-ability and readability.
