### PR TITLE
Cache and replay app launch environment

### DIFF
--- a/src/cpp/desktop/DesktopApplicationLaunch.hpp
+++ b/src/cpp/desktop/DesktopApplicationLaunch.hpp
@@ -19,6 +19,7 @@
 #include <QObject>
 #include <QWidget>
 #include <QApplication>
+#include <QProcess>
 #include <boost/scoped_ptr.hpp>
 
 namespace rstudio {
@@ -42,6 +43,9 @@ public:
 
    QString startupOpenFileRequest() const;
 
+   void launchRStudio(const std::vector<std::string>& args = std::vector<std::string>(),
+                      const std::string& initialWorkingDir = std::string());
+
 protected:
     explicit ApplicationLaunch();
 #ifdef _WIN32
@@ -58,6 +62,7 @@ public slots:
 
 private:
     QWidget* pMainWindow_;
+    QProcessEnvironment launchEnv_;
 };
 
 } // namespace desktop

--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -973,15 +973,14 @@ void GwtCallback::openProjectInNewWindow(QString projectFilePath)
 {
    std::vector<std::string> args;
    args.push_back(resolveAliasedPath(projectFilePath).toStdString());
-   launchRStudio(args);
+   pMainWindow_->launchRStudio(args);
 }
 
 void GwtCallback::openSessionInNewWindow(QString workingDirectoryPath)
 {
    workingDirectoryPath = resolveAliasedPath(workingDirectoryPath);
-   core::system::setenv(kRStudioInitialWorkingDir,
-                        workingDirectoryPath.toStdString());
-   launchRStudio();
+   pMainWindow_->launchRStudio(std::vector<std::string>(),
+                               workingDirectoryPath.toStdString());
 }
 
 void GwtCallback::openTerminal(QString terminalPath,

--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -131,6 +131,12 @@ void MainWindow::launchSession(bool reload)
    }
 }
 
+void MainWindow::launchRStudio(const std::vector<std::string> &args,
+                               const std::string& initialDir)
+{
+    pAppLauncher_->launchRStudio(args, initialDir);
+}
+
 void MainWindow::onCloseWindowShortcut()
 {
    QWebFrame* pMainFrame = webView()->page()->mainFrame();
@@ -327,6 +333,11 @@ void MainWindow::setSessionLauncher(SessionLauncher* pSessionLauncher)
 void MainWindow::setSessionProcess(QProcess* pSessionProcess)
 {
    pCurrentSessionProcess_ = pSessionProcess;
+}
+
+void MainWindow::setAppLauncher(ApplicationLaunch *pAppLauncher)
+{
+    pAppLauncher_ = pAppLauncher;
 }
 
 // allow SessionLauncher to collect restart requests from GwtCallback

--- a/src/cpp/desktop/DesktopMainWindow.hpp
+++ b/src/cpp/desktop/DesktopMainWindow.hpp
@@ -25,6 +25,7 @@
 #include "DesktopGwtCallback.hpp"
 #include "DesktopGwtWindow.hpp"
 #include "DesktopMenuCallback.hpp"
+#include "DesktopApplicationLaunch.hpp"
 
 namespace rstudio {
 namespace desktop {
@@ -42,6 +43,8 @@ public:
    QString getSumatraPdfExePath();
    void evaluateJavaScript(QString jsCode);
    void launchSession(bool reload);
+   void launchRStudio(const std::vector<std::string>& args = std::vector<std::string>(),
+                      const std::string& initialDir = std::string());
 
 public slots:
    void quit();
@@ -77,6 +80,9 @@ private:
    // call launchProcess back on it)
    void setSessionLauncher(SessionLauncher* pSessionLauncher);
 
+   // same for application launches
+   void setAppLauncher(ApplicationLaunch* pAppLauncher);
+
    // allow SessionLauncher to give us a reference to the currently
    // active rsession process so that we can use it in closeEvent handling
    void setSessionProcess(QProcess* pSessionProcess);
@@ -93,6 +99,7 @@ private:
    MenuCallback menuCallback_;
    GwtCallback gwtCallback_;
    SessionLauncher* pSessionLauncher_;
+   ApplicationLaunch *pAppLauncher_;
    QProcess* pCurrentSessionProcess_;
 };
 

--- a/src/cpp/desktop/DesktopPosixApplication.cpp
+++ b/src/cpp/desktop/DesktopPosixApplication.cpp
@@ -63,7 +63,7 @@ bool PosixApplication::event(QEvent* pEvent)
          {
             std::vector<std::string> args;
             args.push_back(filePath.absolutePath());
-            launchRStudio(args);
+            pAppLauncher_->launchRStudio(args);
          }
          else
          {

--- a/src/cpp/desktop/DesktopPosixApplication.hpp
+++ b/src/cpp/desktop/DesktopPosixApplication.hpp
@@ -18,6 +18,8 @@
 
 #include "3rdparty/qtsingleapplication/QtSingleApplication"
 
+#include "DesktopApplicationLaunch.hpp"
+
 namespace rstudio {
 namespace desktop {
 
@@ -27,14 +29,19 @@ class PosixApplication : public QtSingleApplication
 public:
 
    PosixApplication(QString appName, int& argc, char* argv[])
-    : QtSingleApplication(appName, argc, argv)
+    : QtSingleApplication(appName, argc, argv),
+      pAppLauncher_(NULL)
    {
-      setApplicationName(appName);
    }
 
    QString startupOpenFileRequest() const
    {
       return startupOpenFileRequest_;
+   }
+
+   void setAppLauncher(ApplicationLaunch* pAppLauncher)
+   {
+       pAppLauncher_ = pAppLauncher;
    }
 
 signals:
@@ -45,9 +52,8 @@ protected:
 
 private:
     QString startupOpenFileRequest_;
-
+    ApplicationLaunch* pAppLauncher_;
 };
-
 
 
 } // namespace desktop

--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -117,6 +117,7 @@ Error SessionLauncher::launchFirstSession(const QString& filename,
    pMainWindow_ = new MainWindow(url);
    pMainWindow_->setSessionLauncher(this);
    pMainWindow_->setSessionProcess(pRSessionProcess_);
+   pMainWindow_->setAppLauncher(pAppLaunch);
    pAppLaunch->setActivationWindow(pMainWindow_);
 
    desktop::options().restoreMainWindowBounds(pMainWindow_);

--- a/src/cpp/desktop/DesktopUtils.cpp
+++ b/src/cpp/desktop/DesktopUtils.cpp
@@ -229,32 +229,6 @@ void showFileError(const QString& action,
                   msg);
 }
 
-void launchRStudio(const std::vector<std::string>& args)
-{
-#ifdef _WIN32
-   core::system::ProcessOptions options;
-   options.breakawayFromJob = true;
-   options.detachProcess = true;
-   Error error = core::system::runProgram(
-      desktop::options().executablePath().absolutePath(),
-      args,
-      "",
-      options,
-      NULL);
-   if (error)
-      LOG_ERROR(error);
-#else
-   QStringList argList;
-   BOOST_FOREACH(const std::string& arg, args)
-   {
-      argList.append(QString::fromStdString(arg));
-   }
-   QString exePath = QString::fromUtf8(
-      desktop::options().executablePath().absolutePath().c_str());
-   QProcess::startDetached(exePath, argList);
-#endif
-}
-
 bool isFixedWidthFont(const QFont& font)
 {
    QFontMetrics metrics(font);

--- a/src/cpp/desktop/DesktopUtils.hpp
+++ b/src/cpp/desktop/DesktopUtils.hpp
@@ -67,8 +67,6 @@ void showFileError(const QString& action,
                    const QString& file,
                    const QString& error);
 
-void launchRStudio(const std::vector<std::string>& args = std::vector<std::string>());
-
 bool isFixedWidthFont(const QFont& font);
 
 void openUrl(const QUrl& url);

--- a/src/cpp/desktop/DesktopWin32ApplicationLaunch.cpp
+++ b/src/cpp/desktop/DesktopWin32ApplicationLaunch.cpp
@@ -18,6 +18,10 @@
 
 #include <QWidget>
 
+#include <core/system/Process.hpp>
+#include <core/system/Environment.hpp>
+#include <core/r_util/RUserData.hpp>
+
 #include "DesktopOptions.hpp"
 
 /*
@@ -203,6 +207,32 @@ bool ApplicationLaunch::nativeEvent(const QByteArray & eventType,
       return true;
    }
    return QWidget::nativeEvent(eventType, message, result);
+}
+
+void ApplicationLaunch::launchRStudio(const std::vector<std::string>& args,
+                                      const std::string& initialDir)
+{
+   core::system::ProcessOptions options;
+   options.breakawayFromJob = true;
+   options.detachProcess = true;
+
+   // supply initial dir to child process if specified
+   core::system::Options childEnv;
+   core::system::environment(&childEnv);
+   if (!initialDir.empty())
+   {
+      core::system::setenv(&childEnv, kRStudioInitialWorkingDir, initialDir);
+      options.environment = childEnv;
+   }
+
+   core::Error error = core::system::runProgram(
+      desktop::options().executablePath().absolutePath(),
+      args,
+      "",
+      options,
+      NULL);
+   if (error)
+      LOG_ERROR(error);
 }
 
 } // namespace desktop


### PR DESCRIPTION
This change fixes a problem in all RStudio Desktop releases on Ubuntu Xenial in which no commands that start a new session (open project in new session, etc.) work.

The underlying issue is that the desktop release of Xenial comes with its own version of Qt. When RStudio is first launched, this isn't a problem, as its `RPATH` causes the RStudio version of Qt to be used. However, during startup, RStudio invokes `prepareEnvironment`, which in turn sets `LD_LIBRARY_PATH` to include the system library folders. Now subsequent launches of RStudio don't work because they inherit this `LD_LIBRARY_PATH`, which overrides the `RPATH` and causes the nascent RStudio process to load the wrong Qt libraries and fail to start. 

The fix is to cache the `LD_LIBRARY_PATH` that's used when RStudio starts, and to temporarily restore it when new instances of RStudio are started. The `ApplicationLaunch` object encapsulates this new functionality. 

While this bug existed in 1.0, the fact that several commands simply don't work make it a 1.1 candidate.