### PR TITLE
fix crash when executing certain malformed chunk headers

### DIFF
--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -627,6 +627,11 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
     opts <- .rs.mergeLists(opts,
                            eval(substitute(knitr:::parse_params(code)),
                                 envir = .GlobalEnv))
+
+    # convert language name objects to plain characters (these can occur in
+    # malformed expressions, and cause scalar conversion below to fail)
+    names <- vapply(opts, is.name, TRUE)
+    opts[names] <- as.character(opts[names])
   },
   error = function(e) {})
 


### PR DESCRIPTION
This change fixes a problem reported here, in which executing a chunk with a malformed header can lead to a crash:

https://community.rstudio.com/t/quick-way-to-crash-rstudio/1358

The actual problem is somewhat deep, and has to do with how error conditions affect notebook chunk execution. In this case, the ordering is such that the chunk's execution context is connected, but never disconnected, and so it keeps receiving console input events when no longer on the heap, leading (predictably) to a crash. This shouldn't be possible.

However, this warrants fixing for 1.1, so I'm proposing this more targeted fix to begin with, which simply eliminates the source of this specific error so that it can't set off the dominos. 