### PR TITLE
pass continuation by value, rather than reference

### DIFF
--- a/src/cpp/session/modules/SessionProjectTemplate.cpp
+++ b/src/cpp/session/modules/SessionProjectTemplate.cpp
@@ -640,7 +640,7 @@ boost::shared_ptr<ProjectTemplateWorker>& projectTemplateWorker()
    return instance;
 }
 
-void respondWithProjectTemplateRegistry(const json::JsonRpcFunctionContinuation& continuation)
+void respondWithProjectTemplateRegistry(json::JsonRpcFunctionContinuation continuation)
 {
    json::JsonRpcResponse response;
    response.setResult(projectTemplateRegistry()->toJson());
@@ -659,7 +659,7 @@ void getProjectTemplateRegistry(const json::JsonRpcRequest& request,
                                 const json::JsonRpcFunctionContinuation& continuation)
 {
    withProjectTemplateRegistry(
-            boost::bind(respondWithProjectTemplateRegistry, boost::cref(continuation)));
+            boost::bind(respondWithProjectTemplateRegistry, continuation));
 }
 
 SEXP rs_getProjectTemplateRegistry()


### PR DESCRIPTION
This PR should fix an issue where crashes were seen when the project template indexer was running on R libraries containing a large number of R packages.

The crash was occurring because we were trying to construct a `boost::cref()` based on an object on the stack, and that object would already be out of scope by the time the continuation was to be executed. The fix is to simply pass in the continuation by value, since it (as it's just a `boost::function`) is copyable already.