### PR TITLE
ensure we're in a project before trying to use project config

### DIFF
--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -91,10 +91,10 @@ void writeDocToJson(boost::shared_ptr<SourceDocument> pDoc,
    // discover project-specific settings when available
    r_util::RProjectConfig projConfig;
    FilePath docPath = module_context::resolveAliasedPath(pDoc->path());
-   FilePath projDir = projects::projectContext().directory();
    bool hasConfig = false;
    
-   if (docPath.isWithin(projDir))
+   if (projects::projectContext().hasProject() &&
+       docPath.isWithin(projects::projectContext().directory()))
    {
       projConfig = projects::projectContext().config();
       hasConfig = true;


### PR DESCRIPTION
This PR should fix an issue where attempts to set some editor settings (e.g. tab width) would not be respected when no project was open.

Because this code path did not properly verify that we were within a project, we ended up propagating the 'default' project configuration options, and using those to override whatever global settings that might've already been set by the user.

Should be a candidate for v1.1 backport.