### PR TITLE
Use unicode-aware isLetter function in R tokenizer

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/MathUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/MathUtil.java
@@ -36,4 +36,15 @@ public class MathUtil
          return value;
    }
    
+   /**
+    * Checks if an int value is in a range.
+    * @param value value to check
+    * @param min min value
+    * @param max max value
+    * @return whether value is in the range, inclusively.
+    */
+   public static boolean inRange(int value, int min, int max) {
+       return (value <= max) & (value >= min);
+   }
+
 }

--- a/src/gwt/src/org/rstudio/core/client/MathUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/MathUtil.java
@@ -44,7 +44,7 @@ public class MathUtil
     * @return whether value is in the range, inclusively.
     */
    public static boolean inRange(int value, int min, int max) {
-       return (value <= max) & (value >= min);
+       return (value <= max) && (value >= min);
    }
 
 }

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -1081,6 +1081,26 @@ public class StringUtil
       return false;
    }
 
+   /**
+    * A better implementation of isLetter -- the default GWT version doesn't support non-English characters.
+    * Adapted from: https://github.com/gwtproject/gwt/issues/1989
+    * @param c the character to check
+    * @return whether the character represents an alphabetic symbol.
+    */
+   public static boolean isLetter(char c) 
+   {
+      int val = (int) c;
+
+      return MathUtil.inRange(val, 65, 90)     || 
+             MathUtil.inRange(val, 97, 122)    || 
+             MathUtil.inRange(val, 192, 687)   || 
+             MathUtil.inRange(val, 900, 1159)  || 
+             MathUtil.inRange(val, 1162, 1315) || 
+             MathUtil.inRange(val, 1329, 1366) || 
+             MathUtil.inRange(val, 1377, 1415) || 
+             MathUtil.inRange(val, 1425, 1610);
+   }
+
    public static final String makeRandomId(int length) 
    {
       String alphanum = "0123456789abcdefghijklmnopqrstuvwxyz";

--- a/src/gwt/src/org/rstudio/studio/client/common/r/RTokenizer.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/r/RTokenizer.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.common.r;
 
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.regex.Match;
 import org.rstudio.core.client.regex.Pattern;
 
@@ -86,7 +87,7 @@ public class RTokenizer
          assert false : "matchNumber() returned a zero-length token" ;
       }
       
-      if (Character.isLetter(c) || c == '.')
+      if (StringUtil.isLetter(c) || c == '.')
       {
          // From Section 10.3.2, identifiers must not start with
          // a period followed by a digit.

--- a/src/gwt/test/org/rstudio/studio/client/common/r/RTokenizerTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/common/r/RTokenizerTests.java
@@ -159,7 +159,11 @@ public class RTokenizerTests extends GWTTestCase
          {
             if (t.getOffset() == prefix.length())
             {
-               Assert.assertEquals(tokenType, t.getTokenType()) ;
+               if (tokenType != t.getTokenType())
+               {
+                  Assert.fail("Expected token type " + tokenType + ", but got type " + t.getTokenType() +
+                               " for token '" + value + "'");
+               }
                Assert.assertEquals(value.length(), t.getLength()) ;
                Assert.assertEquals(value, t.getContent()) ;
                return ;


### PR DESCRIPTION
This change fixes a unit test failure with GWT 2.8. In particular, the identifier which begins with a Unicode letter `\u00C1qc1` is no longer recognized as an identifier and instead causes an error in the tokenizer.

https://github.com/rstudio/rstudio/blob/master/src/gwt/test/org/rstudio/studio/client/common/r/RTokenizerTests.java#L109

It turns out that the `isLetter()` function in GWT does not support non-ASCII characters, even though Java is supposed to do so; see this GWT issue for details: https://github.com/gwtproject/gwt/issues/1989

Since `isLetter()` doesn't do the right thing here, the fix is to use our own `isLetter()` which is unicode-aware. 