### PR TITLE
Remove multiple instances of pagedtable.js

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkDataWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkDataWidget.java
@@ -67,8 +67,9 @@ public class ChunkDataWidget extends SimplePanel
 
    public static void injectPagedTableResources()
    {
-      injectStyleElement("rmd_data/pagedtable.css", "pagedtable-css");
-      ScriptInjector.fromUrl("rmd_data/pagedtable.js").inject();
+      if (injectStyleElement("rmd_data/pagedtable.css", "pagedtable-css")) {
+         ScriptInjector.fromUrl("rmd_data/pagedtable.js").inject();
+      }
    }
    
    @Override
@@ -106,7 +107,7 @@ public class ChunkDataWidget extends SimplePanel
       }
    }
 
-   private static final native void injectStyleElement(String url, String id) /*-{
+   private static final native boolean injectStyleElement(String url, String id) /*-{
       var linkElement = $doc.getElementById(id);
       if (linkElement === null) {
          linkElement = $doc.createElement("link");
@@ -115,7 +116,10 @@ public class ChunkDataWidget extends SimplePanel
          linkElement.setAttribute("rel", "stylesheet");
          
          $doc.getElementsByTagName("head")[0].appendChild(linkElement);
+         return true;
       }
+
+      return false;
    }-*/;
 
    private final native boolean pagedTableExists() /*-{


### PR DESCRIPTION
From http://www.gwtproject.org/javadoc/latest/com/google/gwt/core/client/ScriptInjector.FromUrl.html:

```
Warning: This class does not control whether or not a URL has already been injected into the document. The client of this class has the responsibility of keeping score of the injected JavaScript files.
```

![pasted image at 2017_10_04 01_43 pm](https://user-images.githubusercontent.com/3478847/31197236-590786ea-a905-11e7-9efa-2fffa0f03907.png)
