### PR TITLE
Add openssl support to Windows build environment

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -670,7 +670,7 @@ OpenSSL License
   LICENSE ISSUES
   ==============
 
-  The OpenSSL toolkit stays under a dual license, i.e. both the conditions of
+  The OpenSSL toolkit stays under a double license, i.e. both the conditions of
   the OpenSSL License and the original SSLeay license apply to the toolkit.
   See below for the actual license texts. Actually both licenses are BSD-style
   Open Source licenses. In case of any license issues related to OpenSSL
@@ -680,7 +680,7 @@ OpenSSL License
   ---------------
 
 /* ====================================================================
- * Copyright (c) 1998-2008 The OpenSSL Project.  All rights reserved.
+ * Copyright (c) 1998-2017 The OpenSSL Project.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/dependencies/windows/.gitignore
+++ b/dependencies/windows/.gitignore
@@ -10,3 +10,4 @@ sumatra/
 winutils/
 rtools*
 winpty*/
+openssl*/

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -21,6 +21,7 @@ set MSYS_SSH_FILE=msys-ssh-1000-18.zip
 set SUMATRA_PDF_FILE=SumatraPDF-3.1.1.zip
 set WINUTILS_FILE=winutils-1.0.zip
 set WINPTY_FILES=winpty-0.4.3-msys2-2.7.0.zip
+set OPENSSL_FILES=openssl-1.0.2l_win.zip
 
 set PANDOC_VERSION=1.19.2.1
 set PANDOC_NAME=pandoc-%PANDOC_VERSION%
@@ -97,6 +98,13 @@ if not exist winpty-0.4.3-msys2-2.7.0 (
   echo Unzipping %WINPTY_FILES%
   unzip %UNZIP_ARGS% "%WINPTY_FILES%"
   del %WINPTY_FILES%
+)
+
+if not exist openssl-1.0.2l_win (
+  wget %WGET_ARGS% "%BASEURL%%OPENSSL_FILES%"
+  echo Unzipping %OPENSSL_FILES%
+  unzip %UNZIP_ARGS% "%OPENSSL_FILES%"
+  del %OPENSSL_FILES%
 )
 
 if not exist ..\..\src\gwt\lib (
@@ -203,7 +211,3 @@ if not exist libclang\%LIBCLANG_HEADERS% (
 install-packages.cmd
 
 popd
-
-
-
-

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -211,3 +211,7 @@ if not exist libclang\%LIBCLANG_HEADERS% (
 install-packages.cmd
 
 popd
+
+
+
+

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -34,8 +34,8 @@ add_definitions(-DBOOST_ENABLE_ASSERT_HANDLER)
 add_definitions(-D_WEBSOCKETPP_NO_CPP11_MEMORY_=1)
 
 
-# the non-strict masking option was identified as a potentially crashing 
-# issue due to reliance on undefined C++ behavior, and was removed entirely in 
+# the non-strict masking option was identified as a potentially crashing
+# issue due to reliance on undefined C++ behavior, and was removed entirely in
 # websocketpp 0.7 (RStudio is using 0.5.1 at this time)
 add_definitions(-DWEBSOCKETPP_STRICT_MASKING)
 
@@ -71,10 +71,10 @@ if(UNIX)
          message(STATUS "Set CMAKE_OSX_DEPLOYMENT_TARGET to ${CMAKE_OSX_DEPLOYMENT_TARGET}")
       endif()
       # Mavericks and later default to libc++, which is not compatible with the
-      # older libstdc++. Figure out if we're on Mavericks, and if so, add 
+      # older libstdc++. Figure out if we're on Mavericks, and if so, add
       # flags to enforce usage of the older library.
 
-      # Figure out what version of Mac OS X this is. Unfortunately 
+      # Figure out what version of Mac OS X this is. Unfortunately
       # CMAKE_SYSTEM_VERSION does not match uname -r, so get the Mac OS
       # version number another way.
       EXECUTE_PROCESS(COMMAND /usr/bin/sw_vers -productVersion OUTPUT_VARIABLE MACOSX_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -212,8 +212,8 @@ endif()
 # add boost as system include directory
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
-# winpty - pseudoterminal support on Windows
 if(WIN32)
+     # winpty - pseudoterminal support on Windows
      if(RSTUDIO_SESSION_WIN64)
         set(WINPTY_ARCH "64")
      else()
@@ -227,8 +227,24 @@ if(WIN32)
 
      # add winpty as system include directory
      include_directories(SYSTEM ${WINPTY_INCLUDEDIR})
-endif()
 
+     # openssl for Windows
+     if(RSTUDIO_SESSLIBRARY)
+        set(OPENSSL_ARCH "/x64/")
+     else()
+        set(OPENSSL_ARCH "/")
+     endif()
+
+     set(OPENSSL_ROOT_DIR "${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/openssl-1.0.2l_win")
+     set(OPENSSL_INCLUDE_DIR "${OPENSSL_ROOT_DIR}/include")
+     set(OPENSSL_LIBRARY_DIR "${OPENSSL_ROOT_DIR}${OPENSSL_ARCH}lib")
+     set(OPENSSL_CRYPTO_LIBRARY "${OPENSSL_LIBRARY_DIR}/libcrypto.a")
+     set(OPENSSL_SSL_LIBRARY "${OPENSSL_LIBRARY_DIR}/libssl.a")
+     list(APPEND OPENSSL_LIBRARIES "${OPENSSL_CRYPTO_LIBRARY}")
+     list(APPEND OPENSSL_LIBRARIES "${OPENSSL_SSL_LIBRARY}")
+
+     include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR})
+endif()
 
 # automatically build addins found in the addins subdirectory
 # (if another path wasn't already specified)
@@ -326,4 +342,3 @@ else()
    endif()
 
 endif()
-

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -34,8 +34,8 @@ add_definitions(-DBOOST_ENABLE_ASSERT_HANDLER)
 add_definitions(-D_WEBSOCKETPP_NO_CPP11_MEMORY_=1)
 
 
-# the non-strict masking option was identified as a potentially crashing
-# issue due to reliance on undefined C++ behavior, and was removed entirely in
+# the non-strict masking option was identified as a potentially crashing 
+# issue due to reliance on undefined C++ behavior, and was removed entirely in 
 # websocketpp 0.7 (RStudio is using 0.5.1 at this time)
 add_definitions(-DWEBSOCKETPP_STRICT_MASKING)
 
@@ -71,10 +71,10 @@ if(UNIX)
          message(STATUS "Set CMAKE_OSX_DEPLOYMENT_TARGET to ${CMAKE_OSX_DEPLOYMENT_TARGET}")
       endif()
       # Mavericks and later default to libc++, which is not compatible with the
-      # older libstdc++. Figure out if we're on Mavericks, and if so, add
+      # older libstdc++. Figure out if we're on Mavericks, and if so, add 
       # flags to enforce usage of the older library.
 
-      # Figure out what version of Mac OS X this is. Unfortunately
+      # Figure out what version of Mac OS X this is. Unfortunately 
       # CMAKE_SYSTEM_VERSION does not match uname -r, so get the Mac OS
       # version number another way.
       EXECUTE_PROCESS(COMMAND /usr/bin/sw_vers -productVersion OUTPUT_VARIABLE MACOSX_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -342,3 +342,4 @@ else()
    endif()
 
 endif()
+

--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -30,9 +30,9 @@ set (CORE_SOURCE_FILES
    BrowserUtils.cpp
    ConfigUtils.cpp
    DateTime.cpp
-   Error.cpp 
+   Error.cpp
    Exec.cpp
-   FileInfo.cpp 
+   FileInfo.cpp
    FileLogWriter.cpp
    FilePath.cpp
    FileSerializer.cpp
@@ -110,6 +110,7 @@ set (CORE_SOURCE_FILES
    spelling/HunspellDictionaryManager.cpp
    spelling/HunspellSpellingEngine.cpp
    system/ChildProcessSubprocPoll.cpp
+   system/Crypto.cpp
    system/Environment.cpp
    system/Process.cpp
    system/ShellUtils.cpp
@@ -184,11 +185,11 @@ if (UNIX)
    if(APPLE)
       if(${MACOSX_VERSION} VERSION_GREATER "10.10"
             AND EXISTS "/usr/local/opt/openssl")
-   
+
          set(CORE_SYSTEM_LIBRARIES
             ${CORE_SYSTEM_LIBRARIES}
             -L/usr/local/opt/openssl/lib -lssl -lcrypto)
-   
+
          set(CORE_INCLUDE_DIRS
             ${CORE_INCLUDE_DIRS}
             /usr/local/opt/openssl/include)
@@ -244,7 +245,6 @@ if (UNIX)
          SecureKeyFile.cpp
          SocketRpc.cpp
          http/SecureCookie.cpp
-         system/PosixCrypto.cpp
          system/Pam.cpp
       )
    endif()
@@ -268,7 +268,13 @@ else()
    add_subdirectory(zlib)
 
    # system libraries
-   set (CORE_SYSTEM_LIBRARIES -lws2_32 -lmswsock -lrpcrt4 -lShlwapi)
+   set (CORE_SYSTEM_LIBRARIES
+      -lws2_32
+      -lmswsock
+      -lrpcrt4
+      -lShlwapi
+      ${OPENSSL_CRYPTO_LIBRARY}
+   )
 
    # source files
    set(CORE_SOURCE_FILES ${CORE_SOURCE_FILES}

--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -30,9 +30,9 @@ set (CORE_SOURCE_FILES
    BrowserUtils.cpp
    ConfigUtils.cpp
    DateTime.cpp
-   Error.cpp
+   Error.cpp 
    Exec.cpp
-   FileInfo.cpp
+   FileInfo.cpp 
    FileLogWriter.cpp
    FilePath.cpp
    FileSerializer.cpp
@@ -185,11 +185,11 @@ if (UNIX)
    if(APPLE)
       if(${MACOSX_VERSION} VERSION_GREATER "10.10"
             AND EXISTS "/usr/local/opt/openssl")
-
+   
          set(CORE_SYSTEM_LIBRARIES
             ${CORE_SYSTEM_LIBRARIES}
             -L/usr/local/opt/openssl/lib -lssl -lcrypto)
-
+   
          set(CORE_INCLUDE_DIRS
             ${CORE_INCLUDE_DIRS}
             /usr/local/opt/openssl/include)

--- a/src/cpp/core/system/Crypto.cpp
+++ b/src/cpp/core/system/Crypto.cpp
@@ -70,18 +70,18 @@ Error lastCryptoError(const ErrorLocation& location)
                          "lastCrytpoError called with no pending error",
                          location);
    }
-
+   
    // get the error message (docs say max len is 120)
-   const int ERR_BUFF_SIZE = 250;
+   const int ERR_BUFF_SIZE = 250; 
    char errorBuffer[ERR_BUFF_SIZE];
    ::ERR_error_string_n(ec, errorBuffer, ERR_BUFF_SIZE);
-
+   
    // return the error
    return systemError(boost::system::errc::bad_message,
                       errorBuffer,
                       location);
-}
-
+} 
+   
 class BIOFreeAllScope : boost::noncopyable
 {
 public:
@@ -89,7 +89,7 @@ public:
       : pMem_(pMem)
    {
    }
-
+   
    ~BIOFreeAllScope()
    {
       try
@@ -103,27 +103,27 @@ public:
 private:
    BIO* pMem_;
 };
-
+   
 } // anonymous namespace
-
+   
 void initialize()
 {
    // load global error string table
    ::ERR_load_crypto_strings();
 }
-
+   
 Error HMAC_SHA2(const std::string& data,
                 const std::string& key,
                 std::vector<unsigned char>* pHMAC)
 {
    // copy data into vector
    std::vector<unsigned char> keyVector;
-   std::copy(key.begin(), key.end(), std::back_inserter(keyVector));
-
+   std::copy(key.begin(), key.end(), std::back_inserter(keyVector));  
+   
    // call core
    return HMAC_SHA2(data, keyVector, pHMAC);
 }
-
+   
 Error HMAC_SHA2(const std::string& data,
                 const std::vector<unsigned char>& key,
                 std::vector<unsigned char>* pHMAC)
@@ -131,7 +131,7 @@ Error HMAC_SHA2(const std::string& data,
    // copy data into data vector
    std::vector<unsigned char> dataVector;
    std::copy(data.begin(), data.end(), std::back_inserter(dataVector));
-
+   
    // perform the hash
    unsigned int md_len = 0;
    pHMAC->resize(EVP_MAX_MD_SIZE);
@@ -153,45 +153,45 @@ Error HMAC_SHA2(const std::string& data,
    }
 }
 
-Error base64Encode(const std::vector<unsigned char>& data,
+Error base64Encode(const std::vector<unsigned char>& data, 
                    std::string* pEncoded)
 {
    return base64Encode(&(data[0]), data.size(), pEncoded);
 }
-
-Error base64Encode(const unsigned char* pData,
-                   int len,
+   
+Error base64Encode(const unsigned char* pData, 
+                   int len, 
                    std::string* pEncoded)
 {
    // allocate BIO
    BIO* pB64 = ::BIO_new(BIO_f_base64());
    if (pB64 == NULL)
       return lastCryptoError(ERROR_LOCATION);
-
+      
    // no newlines
    BIO_set_flags(pB64, BIO_FLAGS_BASE64_NO_NL);
-
+   
    // make sure it is freed prior to exit from the function
    BIOFreeAllScope freeB64Scope(pB64);
-
-   // allocate memory stream
+   
+   // allocate memory stream 
    BIO* pMem = ::BIO_new(BIO_s_mem());
    if (pMem == NULL)
       return lastCryptoError(ERROR_LOCATION);
-
+   
    // tie the stream to the b64 stream
    pB64 = ::BIO_push(pB64, pMem);
-
+   
    // perform the encoding
    int written = ::BIO_write(pB64, pData, len);
    if (written != len)
       return lastCryptoError(ERROR_LOCATION);
-
+      
    // flush all writes
    int result = BIO_flush(pB64);
    if (result <= 0)
       return lastCryptoError(ERROR_LOCATION);
-
+   
    // seek to beginning of memory stream
    result = BIO_seek(pMem, 0);
    if (result == -1)
@@ -210,45 +210,45 @@ Error base64Encode(const unsigned char* pData,
    // return success
    return Success();
 }
-
-
-Error base64Decode(const std::string& data,
+   
+   
+Error base64Decode(const std::string& data, 
                    std::vector<unsigned char>* pDecoded)
 {
    // allocate b64 BIO
    BIO* pB64 = ::BIO_new(BIO_f_base64());
    if (pB64 == NULL)
       return lastCryptoError(ERROR_LOCATION);
-
+   
    // no newlines
    BIO_set_flags(pB64, BIO_FLAGS_BASE64_NO_NL);
-
+   
    // make sure it is freed prior to exit from the function
    BIOFreeAllScope freeB64Scope(pB64);
-
-   // allocate buffer
+   
+   // allocate buffer 
    BIO* pMem = BIO_new_mem_buf((void*)data.data(), data.length());
    if (pMem == NULL)
       return lastCryptoError(ERROR_LOCATION);
-
+   
    // tie the stream to the b64 stream
    pB64 = ::BIO_push(pB64, pMem);
-
+   
    // reserve adequate memory in the decoded buffer and read into it
    pDecoded->clear();
    pDecoded->resize(data.length());
-   int bytesRead = ::BIO_read(pB64,
-                              &(pDecoded->operator[](0)),
+   int bytesRead = ::BIO_read(pB64, 
+                              &(pDecoded->operator[](0)), 
                               pDecoded->size());
    if (bytesRead < 0)
       return lastCryptoError(ERROR_LOCATION);
-
+   
    // resize the out buffer to the number of bytes actually read
    pDecoded->resize(bytesRead);
-
+   
    // return success
    return Success();
-
+   
 }
 
 Error aesEncrypt(const std::vector<unsigned char>& data,
@@ -377,7 +377,7 @@ core::Error rsaInit()
    #else
       BIGNUM *bn = BN_new();
       BN_set_word(bn, RSA_F4);
-
+ 
       s_pRSA = RSA_new();
       int rc = ::RSA_generate_key_ex(s_pRSA, KEY_SIZE, bn, NULL);
       BN_clear_free(bn);
@@ -385,7 +385,7 @@ core::Error rsaInit()
         RSA_free(s_pRSA);
         return lastCryptoError(ERROR_LOCATION);
       }
-
+   
       RSA_get0_key(s_pRSA, &bn_n, &bn_e, NULL);
    #endif
 
@@ -496,8 +496,9 @@ Error decryptBase64EncodedString(const std::string& input,
    return Success();
 }
 
-
+                     
 } // namespace crypto
 } // namespace system
 } // namespace core
 } // namespace rstudio
+

--- a/src/cpp/core/system/Crypto.cpp
+++ b/src/cpp/core/system/Crypto.cpp
@@ -1,5 +1,5 @@
 /*
- * PosixCrypto.cpp
+ * Crypto.cpp
  *
  * Copyright (C) 2009-12 by RStudio, Inc.
  *
@@ -70,18 +70,18 @@ Error lastCryptoError(const ErrorLocation& location)
                          "lastCrytpoError called with no pending error",
                          location);
    }
-   
+
    // get the error message (docs say max len is 120)
-   const int ERR_BUFF_SIZE = 250; 
+   const int ERR_BUFF_SIZE = 250;
    char errorBuffer[ERR_BUFF_SIZE];
    ::ERR_error_string_n(ec, errorBuffer, ERR_BUFF_SIZE);
-   
+
    // return the error
    return systemError(boost::system::errc::bad_message,
                       errorBuffer,
                       location);
-} 
-   
+}
+
 class BIOFreeAllScope : boost::noncopyable
 {
 public:
@@ -89,7 +89,7 @@ public:
       : pMem_(pMem)
    {
    }
-   
+
    ~BIOFreeAllScope()
    {
       try
@@ -103,27 +103,27 @@ public:
 private:
    BIO* pMem_;
 };
-   
+
 } // anonymous namespace
-   
+
 void initialize()
 {
    // load global error string table
    ::ERR_load_crypto_strings();
 }
-   
+
 Error HMAC_SHA2(const std::string& data,
                 const std::string& key,
                 std::vector<unsigned char>* pHMAC)
 {
    // copy data into vector
    std::vector<unsigned char> keyVector;
-   std::copy(key.begin(), key.end(), std::back_inserter(keyVector));  
-   
+   std::copy(key.begin(), key.end(), std::back_inserter(keyVector));
+
    // call core
    return HMAC_SHA2(data, keyVector, pHMAC);
 }
-   
+
 Error HMAC_SHA2(const std::string& data,
                 const std::vector<unsigned char>& key,
                 std::vector<unsigned char>* pHMAC)
@@ -131,7 +131,7 @@ Error HMAC_SHA2(const std::string& data,
    // copy data into data vector
    std::vector<unsigned char> dataVector;
    std::copy(data.begin(), data.end(), std::back_inserter(dataVector));
-   
+
    // perform the hash
    unsigned int md_len = 0;
    pHMAC->resize(EVP_MAX_MD_SIZE);
@@ -153,45 +153,45 @@ Error HMAC_SHA2(const std::string& data,
    }
 }
 
-Error base64Encode(const std::vector<unsigned char>& data, 
+Error base64Encode(const std::vector<unsigned char>& data,
                    std::string* pEncoded)
 {
    return base64Encode(&(data[0]), data.size(), pEncoded);
 }
-   
-Error base64Encode(const unsigned char* pData, 
-                   int len, 
+
+Error base64Encode(const unsigned char* pData,
+                   int len,
                    std::string* pEncoded)
 {
    // allocate BIO
    BIO* pB64 = ::BIO_new(BIO_f_base64());
    if (pB64 == NULL)
       return lastCryptoError(ERROR_LOCATION);
-      
+
    // no newlines
    BIO_set_flags(pB64, BIO_FLAGS_BASE64_NO_NL);
-   
+
    // make sure it is freed prior to exit from the function
    BIOFreeAllScope freeB64Scope(pB64);
-   
-   // allocate memory stream 
+
+   // allocate memory stream
    BIO* pMem = ::BIO_new(BIO_s_mem());
    if (pMem == NULL)
       return lastCryptoError(ERROR_LOCATION);
-   
+
    // tie the stream to the b64 stream
    pB64 = ::BIO_push(pB64, pMem);
-   
+
    // perform the encoding
-   int written = ::BIO_write(pB64, pData, len); 
+   int written = ::BIO_write(pB64, pData, len);
    if (written != len)
       return lastCryptoError(ERROR_LOCATION);
-      
+
    // flush all writes
    int result = BIO_flush(pB64);
    if (result <= 0)
       return lastCryptoError(ERROR_LOCATION);
-   
+
    // seek to beginning of memory stream
    result = BIO_seek(pMem, 0);
    if (result == -1)
@@ -210,45 +210,45 @@ Error base64Encode(const unsigned char* pData,
    // return success
    return Success();
 }
-   
-   
-Error base64Decode(const std::string& data, 
+
+
+Error base64Decode(const std::string& data,
                    std::vector<unsigned char>* pDecoded)
 {
    // allocate b64 BIO
    BIO* pB64 = ::BIO_new(BIO_f_base64());
    if (pB64 == NULL)
       return lastCryptoError(ERROR_LOCATION);
-   
+
    // no newlines
    BIO_set_flags(pB64, BIO_FLAGS_BASE64_NO_NL);
-   
+
    // make sure it is freed prior to exit from the function
    BIOFreeAllScope freeB64Scope(pB64);
-   
-   // allocate buffer 
+
+   // allocate buffer
    BIO* pMem = BIO_new_mem_buf((void*)data.data(), data.length());
    if (pMem == NULL)
       return lastCryptoError(ERROR_LOCATION);
-   
+
    // tie the stream to the b64 stream
    pB64 = ::BIO_push(pB64, pMem);
-   
+
    // reserve adequate memory in the decoded buffer and read into it
    pDecoded->clear();
    pDecoded->resize(data.length());
-   int bytesRead = ::BIO_read(pB64, 
-                              &(pDecoded->operator[](0)), 
+   int bytesRead = ::BIO_read(pB64,
+                              &(pDecoded->operator[](0)),
                               pDecoded->size());
    if (bytesRead < 0)
       return lastCryptoError(ERROR_LOCATION);
-   
+
    // resize the out buffer to the number of bytes actually read
    pDecoded->resize(bytesRead);
-   
+
    // return success
    return Success();
-     
+
 }
 
 Error aesEncrypt(const std::vector<unsigned char>& data,
@@ -377,7 +377,7 @@ core::Error rsaInit()
    #else
       BIGNUM *bn = BN_new();
       BN_set_word(bn, RSA_F4);
- 
+
       s_pRSA = RSA_new();
       int rc = ::RSA_generate_key_ex(s_pRSA, KEY_SIZE, bn, NULL);
       BN_clear_free(bn);
@@ -385,7 +385,7 @@ core::Error rsaInit()
         RSA_free(s_pRSA);
         return lastCryptoError(ERROR_LOCATION);
       }
-   
+
       RSA_get0_key(s_pRSA, &bn_n, &bn_e, NULL);
    #endif
 
@@ -496,9 +496,8 @@ Error decryptBase64EncodedString(const std::string& input,
    return Success();
 }
 
-                      
+
 } // namespace crypto
 } // namespace system
 } // namespace core
 } // namespace rstudio
-

--- a/src/cpp/core/system/Crypto.cpp
+++ b/src/cpp/core/system/Crypto.cpp
@@ -183,7 +183,7 @@ Error base64Encode(const unsigned char* pData,
    pB64 = ::BIO_push(pB64, pMem);
    
    // perform the encoding
-   int written = ::BIO_write(pB64, pData, len);
+   int written = ::BIO_write(pB64, pData, len); 
    if (written != len)
       return lastCryptoError(ERROR_LOCATION);
       
@@ -248,7 +248,7 @@ Error base64Decode(const std::string& data,
    
    // return success
    return Success();
-   
+     
 }
 
 Error aesEncrypt(const std::vector<unsigned char>& data,
@@ -496,7 +496,7 @@ Error decryptBase64EncodedString(const std::string& input,
    return Success();
 }
 
-                     
+                      
 } // namespace crypto
 } // namespace system
 } // namespace core


### PR DESCRIPTION
**Requires rerunning `install-dependencies` and `cmake`.**

This seeds openssl for Windows for other ongoing work not included in this PR, I have confirmed it is working as expected in that other branch.

The openssl package was built via cross-compilation using MinGW on Linux. See README inside the downloaded package for full details.