### PR TITLE
tweak trimming of executed code

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
@@ -220,7 +220,7 @@ public class EditingTargetCodeExecution
       setLastExecuted(range.getStart(), range.getEnd());
       
       // trim intelligently
-      code = code.trim();
+      code = StringUtil.trimBlankLines(code);
       if (code.length() == 0)
          code = "\n";
       


### PR DESCRIPTION
This PR tweaks how we trim executed code -- in particular, we no longer trim leading whitespace from the first line, which should improve the display of executed code. See e.g.

![screen shot 2017-10-06 at 1 44 27 pm](https://user-images.githubusercontent.com/1976582/31297931-b9cad02a-aa9c-11e7-8b66-02af12df1509.png)
