### PR TITLE
Improve search highlight under dark theme to fix #1582

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -115,6 +115,10 @@ public class HelpPane extends WorkbenchPane
          ".rstudio-themes-flat.editor_dark table {\n" +
          "  background: none !important;\n" +
          "  color: white !important;\n" +
+         "}\n" +
+         "\n" +
+         ".rstudio-themes-flat.editor_dark ::selection {\n" +
+         "  background-color: #CCC;\n" +
          "}\n",
          null,
          false);


### PR DESCRIPTION
See https://github.com/rstudio/rstudio/issues/1582, improve help highlight contrast under dark theme, as in:

<img width="619" alt="screen shot 2017-10-11 at 1 32 11 pm" src="https://user-images.githubusercontent.com/3478847/31465448-de410b8c-ae88-11e7-838f-1f668f8126fc.png">
