### PR TITLE
Add community forum link

### DIFF
--- a/src/cpp/session/resources/help_resources/index.htm
+++ b/src/cpp/session/resources/help_resources/index.htm
@@ -77,6 +77,7 @@
             </h3>
             <ul>
                <li><a href="https://www.rstudio.org/links/rstudio-support">RStudio IDE Support</a></li>
+               <li><a href="https://www.rstudio.org/links/community-forum">RStudio Community Forum</a></li>
                <li><a href="https://www.rstudio.org/links/cheat_sheets">RStudio Cheat Sheets</a></li>
                <li><a href="https://twitter.com/rstudiotips">RStudio Tip of the Day</a></li>
                <li><a href="https://www.rstudio.org/links/rstudio-r-packages">RStudio Packages</a></li>

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -56,6 +56,7 @@ import org.rstudio.core.client.widget.Operation;
 import org.rstudio.studio.client.application.ApplicationQuit.QuitContext;
 import org.rstudio.studio.client.application.events.*;
 import org.rstudio.studio.client.application.model.InvalidSessionInfo;
+import org.rstudio.studio.client.application.model.ProductEditionInfo;
 import org.rstudio.studio.client.application.model.ProductInfo;
 import org.rstudio.studio.client.application.model.SessionSerializationAction;
 import org.rstudio.studio.client.application.ui.AboutDialog;
@@ -107,7 +108,8 @@ public class Application implements ApplicationEventHandlers
                       Provider<ApplicationClientInit> pClientInit,
                       Provider<ApplicationQuit> pApplicationQuit,
                       Provider<ApplicationInterrupt> pApplicationInterrupt,
-                      Provider<AceThemes> pAceThemes)
+                      Provider<AceThemes> pAceThemes,
+                      Provider<ProductEditionInfo> pEdition)
    {
       // save references
       view_ = view ;
@@ -125,6 +127,7 @@ public class Application implements ApplicationEventHandlers
       pApplicationQuit_ = pApplicationQuit;
       pApplicationInterrupt_ = pApplicationInterrupt;
       pAceThemes_ = pAceThemes;
+      pEdition_ = pEdition;
 
       // bind to commands
       binder.bind(commands_, this);
@@ -298,11 +301,17 @@ public class Application implements ApplicationEventHandlers
    }
    
    @Handler
+   public void onRstudioCommunityForum()
+   {
+      globalDisplay_.openRStudioLink("community-forum");
+   }
+   
+   @Handler
    public void onRstudioSupport()
    {
       globalDisplay_.openRStudioLink("support");
    }
-   
+
    @Handler
    public void onRstudioAgreement()
    {
@@ -890,6 +899,13 @@ public class Application implements ApplicationEventHandlers
             commands_.newSession().remove();
       }
       
+      // show support link only in RStudio Pro
+      if (pEdition_.get() != null)
+      {
+         if (!pEdition_.get().proLicense())
+            commands_.rstudioSupport().remove();
+      }
+      
       // toolbar (must be after call to showWorkbenchView because
       // showing the toolbar repositions the workbench view widget)
       showToolbar( uiPrefs_.get().toolbarVisible().getValue());
@@ -1055,6 +1071,7 @@ public class Application implements ApplicationEventHandlers
    private final Provider<ApplicationQuit> pApplicationQuit_;
    private final Provider<ApplicationInterrupt> pApplicationInterrupt_;
    private final Provider<AceThemes> pAceThemes_;
+   private final Provider<ProductEditionInfo> pEdition_;
    
    private final String CSRF_TOKEN_FIELD = "csrf-token";
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -466,6 +466,7 @@ well as menu structures (for main menu and popup menus).
          <cmd refid="checkForUpdates"/>
          <separator/>
          <cmd refid="helpUsingRStudio"/>
+         <cmd refid="rstudioCommunityForum"/>
          <cmd refid="rstudioSupport"/>
          <separator/>
          <menu label="_Cheatsheets">
@@ -2723,6 +2724,11 @@ well as menu structures (for main menu and popup menus).
    <cmd id="updateCredentials"
         menuLabel="_Update Credentials"
         rebindable="false"/>
+
+   <cmd id="rstudioCommunityForum"
+        menuLabel="RStudio Community _Forum"
+        rebindable="false"
+        windowMode="main"/>
 
    <cmd id="rstudioSupport"
         menuLabel="RStudio _Support"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -448,6 +448,7 @@ public abstract class
    public abstract AppCommand diagnosticsReport();
    public abstract AppCommand showLogFiles();
    public abstract AppCommand rstudioSupport();
+   public abstract AppCommand rstudioCommunityForum();
    public abstract AppCommand rstudioAgreement();
 
    public abstract AppCommand showWarningBar();


### PR DESCRIPTION
This change adds a link to the [RStudio Community Forum](https://community.rstudio.com/c/rstudio-ide) to the IDE's help menu.

![image](https://user-images.githubusercontent.com/470418/31566502-c60f67f0-b01f-11e7-905b-6a7cb1dd9158.png)

In RStudio Open Source, this link replaces the link to RStudio Support; in Pro, both links are shown. 

Practically speaking, very little peer-to-peer support occurs on the "support forum"; most questions take a long time to appear (~1 day), and have no responses or only a single response from the IDE team. In contrast, the community forum (though new) is much more user-friendly and has more active peer support. The downside, of course, is that it doesn't have the long tail of searchable content, so there's undoubtedly a tradeoff here.