### PR TITLE
Discard old data import assemble responses

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -90,6 +90,8 @@ public class DataImport extends Composite
    private final DataImportModes dataImportMode_;
    
    private JavaScriptObject localFiles_;
+
+   private int assembleCount_ = 0;
    
    interface DataImportUiBinder extends UiBinder<Widget, DataImport>
    {
@@ -650,12 +652,17 @@ public class DataImport extends Composite
    
    private void assembleDataImport(final Operation onComplete)
    {
+      int assembleIndex = assembleCount_;
+
       server_.assembleDataImport(getOptions(),
             new ServerRequestCallback<DataImportAssembleResponse>()
       {
          @Override
          public void onResponseReceived(DataImportAssembleResponse response)
          {
+            if (assembleIndex < assembleCount_) return;
+            assembleCount_++;
+
             if (response.getErrorMessage() != null)
             {
                progressIndicator_.onError(response.getErrorMessage());
@@ -681,6 +688,8 @@ public class DataImport extends Composite
          @Override
          public void onError(ServerError error)
          {
+            assembleCount_++;
+
             Debug.logError(error);
             globalDisplay_.showErrorMessage(codePreviewErrorMessage_, error.getMessage());
          }


### PR DESCRIPTION
It is possible that a response will come out of order in the data import dialog while assembling preview, for instance, as report by @jennybc:

<img width="1208" alt="screen shot 2017-10-17 at 9 01 24 am" src="https://user-images.githubusercontent.com/3478847/31686671-a803dc9a-b33b-11e7-9a71-16712bd8a236.png">

and a request log showing:

<img width="192" alt="screen shot 2017-10-17 at 12 28 26 pm" src="https://user-images.githubusercontent.com/3478847/31686592-6963f47a-b33b-11e7-9452-02892010a62f.png">

Fix is to discard old assemble responses coming into this dialog.