### PR TITLE
Don't turn on log-stderr just because server-daemonize is off

### DIFF
--- a/src/cpp/conf/rserver-dev.conf
+++ b/src/cpp/conf/rserver-dev.conf
@@ -16,7 +16,7 @@
 # set which r from config
 rsession-which-r=${LIBR_EXECUTABLE}
 
-# don't daemonize so we can see errors in the console and easily abort
+# don't daemonize so we can easily abort
 server-daemonize=0
 
 # app-armor is not enabled in debug mode

--- a/src/cpp/conf/rsession-dev.conf
+++ b/src/cpp/conf/rsession-dev.conf
@@ -17,6 +17,9 @@
 # timeout frequently for build iteration and to test suspend
 session-timeout-minutes=1
 
+# see errors in the console
+log-stderr=1
+
 # reload changed R source files on the fly
 r-auto-reload-source=1
 

--- a/src/cpp/server/ServerSessionManager.cpp
+++ b/src/cpp/server/ServerSessionManager.cpp
@@ -114,10 +114,6 @@ core::system::ProcessConfig sessionProcessConfig(
                               context.scope.id()));
    }
 
-   // log to stderr if we aren't daemonized
-   if (!options.serverDaemonize())
-      args.push_back(std::make_pair("--log-stderr", "1"));
-
    // pass extra params
    std::copy(extraArgs.begin(), extraArgs.end(), std::back_inserter(args));
 

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -91,7 +91,7 @@ public:
 
    bool logStderr() const
    {
-      return allowFullUI() ? logStderr_ : false;
+      return logStderr_;
    }
    
    // agreement

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -91,7 +91,7 @@ public:
 
    bool logStderr() const
    {
-      return logStderr_;
+      return allowFullUI() ? logStderr_ : false;
    }
    
    // agreement


### PR DESCRIPTION
Normally running with `--server-daemonize=0` causes errors to be sent to stderr. If the `allow-full-ui` option is off (only available in RSP) override this behavior so the errors aren't showing up in the R Console in a containerized situation.