### PR TITLE
resolve aliased vcs paths from client

### DIFF
--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -431,19 +431,19 @@ Error setPrefs(const json::JsonRpcRequest& request, json::JsonRpcResponse*)
    userSettings().beginUpdate();
    userSettings().setVcsEnabled(vcsEnabled);
 
-   FilePath gitExePath(gitExe);
+   FilePath gitExePath = module_context::resolveAliasedPath(gitExe);
    if (gitExePath == git::detectedGitExePath())
       userSettings().setGitExePath(FilePath());
    else
       userSettings().setGitExePath(gitExePath);
 
-   FilePath svnExePath(svnExe);
+   FilePath svnExePath = module_context::resolveAliasedPath(svnExe);
    if (svnExePath == svn::detectedSvnExePath())
       userSettings().setSvnExePath(FilePath());
    else
       userSettings().setSvnExePath(svnExePath);
 
-   FilePath terminalFilePath(terminalPath);
+   FilePath terminalFilePath = module_context::resolveAliasedPath(terminalPath);
    if (terminalFilePath == detectedTerminalPath())
       userSettings().setVcsTerminalPath(FilePath());
    else


### PR DESCRIPTION
This PR fixes an issue where users who have e.g. Git or SVN binaries installed into a sub-directory of home (which is somewhat common for portable Git installations on Windows) would find that their binaries were not properly detected / used. This would manifest as e.g. the Git tab not showing up, despite having pointed RStudio to an existing git executable.