### PR TITLE
Improvements to GWT build & test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,6 +43,16 @@ def compile_package(type, flavor, variant) {
   }
 }
 
+def run_tests(type, flavor, variant) {
+  try {
+    // attempt to run ant (gwt) unit tests
+    sh "cd package/linux/build-${flavor.capitalize()}-${type}/rstudio-*.${type.toLowerCase()}/src/gwt && ./gwt-unit-tests.sh"
+  } catch(err) {
+    // mark build as unstable if it fails unit tests
+    currentBuild.result = "UNSTABLE"
+  }
+}
+
 def s3_upload(type, flavor, os, arch) {
   // get package name from filesystem
   def buildFolder = "package/linux/build-${flavor.capitalize()}-${type}"
@@ -187,6 +197,9 @@ try {
                         }
                         stage('compile package') {
                             compile_package(get_type_from_os(current_container.os), current_container.flavor, current_container.variant)
+                        }
+                        stage('run tests') {
+                            run_tests(get_type_from_os(current_container.os), current_container.flavor, current_container.variant)
                         }
                     }
                     stage('upload artifacts') {

--- a/dependencies/common/install-gwt
+++ b/dependencies/common/install-gwt
@@ -33,8 +33,12 @@ download()
   fi
 }
 
-# target directory for gwt
-GWT_DIR=$INSTALL_DIR/../../src/gwt
+# target directory for gwt; if there's an opt folder then use that, otherwise,
+# presume we're using the install dir
+GWT_DIR="/opt/rstudio-tools/gwt"
+if ! [ -d "$GWT_DIR" ]; then
+   GWT_DIR=$INSTALL_DIR/../../src/gwt
+fi
 
 # lib dir
 LIB_DIR=$GWT_DIR/lib

--- a/docker/jenkins/Dockerfile.centos6-x86_64
+++ b/docker/jenkins/Dockerfile.centos6-x86_64
@@ -44,6 +44,11 @@ RUN bash /tmp/install-dependencies
 RUN wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo
 RUN yum install -y devtoolset-2-gcc devtoolset-2-binutils devtoolset-2-gcc-c++
 
+# install GWT libs
+COPY dependencies/common/install-gwt /tmp/
+RUN mkdir -p /opt/rstudio-tools/gwt && \
+    /tmp/install-gwt
+
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
 ARG JENKINS_GID=999
 ARG JENKINS_UID=999

--- a/docker/jenkins/Dockerfile.centos7-x86_64
+++ b/docker/jenkins/Dockerfile.centos7-x86_64
@@ -50,6 +50,11 @@ RUN mkdir -p /opt/RStudio-QtSDK && \
     export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.4.0 && \
     /tmp/install-qt-sdk
 
+# install GWT libs
+COPY dependencies/common/install-gwt /tmp/
+RUN mkdir -p /opt/rstudio-tools/gwt && \
+    /tmp/install-gwt
+
 # remove any previous users with conflicting IDs
 ARG JENKINS_GID=999
 ARG JENKINS_UID=999

--- a/docker/jenkins/Dockerfile.debian9-x86_64
+++ b/docker/jenkins/Dockerfile.debian9-x86_64
@@ -55,6 +55,11 @@ RUN mkdir -p /opt/RStudio-QtSDK && \
     export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.4.2 && \
     /tmp/install-qt-sdk
 
+# install GWT libs
+COPY dependencies/common/install-gwt /tmp/
+RUN mkdir -p /opt/rstudio-tools/gwt && \
+    /tmp/install-gwt
+
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
 ARG JENKINS_GID=999
 ARG JENKINS_UID=999

--- a/docker/jenkins/Dockerfile.precise-amd64
+++ b/docker/jenkins/Dockerfile.precise-amd64
@@ -74,7 +74,7 @@ RUN mkdir -p /opt/RStudio-QtSDK && \
 
 # install GWT libs
 COPY dependencies/common/install-gwt /tmp/
-RUN mkdir -p /opt/rstudio-tools/gwt &&
+RUN mkdir -p /opt/rstudio-tools/gwt && \
     /tmp/install-gwt
 
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting

--- a/docker/jenkins/Dockerfile.precise-amd64
+++ b/docker/jenkins/Dockerfile.precise-amd64
@@ -72,6 +72,11 @@ RUN mkdir -p /opt/RStudio-QtSDK && \
     export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.4.0 && \
     /tmp/install-qt-sdk
 
+# install GWT libs
+COPY dependencies/common/install-gwt /tmp/
+RUN mkdir -p /opt/rstudio-tools/gwt &&
+    /tmp/install-gwt
+
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
 ARG JENKINS_GID=999
 ARG JENKINS_UID=999

--- a/src/gwt/CMakeLists.txt
+++ b/src/gwt/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # CMakeLists.txt
 #
-# Copyright (C) 2009-12 by RStudio, Inc.
+# Copyright (C) 2009-17 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -16,14 +16,28 @@
 cmake_minimum_required(VERSION 2.6)
 project (RSTUDIO_GWT)
 
+# check for externals
+SET(GWT_LIBS "/opt/rstudio-tools/gwt/lib")
+if(NOT EXISTS GWT_LIBS)
+   SET(GWT_LIBS "${CMAKE_CURRENT_SOURCE_DIR}/lib")
+endif()
+
+# define output dirs
+set(GWT_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/gwt")
+set(GWT_BIN_DIR "${GWT_OUTPUT_DIR}/bin")
+set(GWT_WWW_DIR "${GWT_OUTPUT_DIR}/www")
+set(GWT_EXTRAS "${GWT_OUTPUT_DIR}/extras")
+
 # invoke ant to build
 add_custom_target(gwt_build ALL)
 add_custom_command(
    TARGET gwt_build
    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-   COMMAND ant)
+   COMMAND ant -Dbuild.dir=${GWT_BIN_DIR}
+               -Dwww.dir=${GWT_WWW_DIR}
+               -Dextras.dir=${GWT_EXTRAS_DIR})
 
 # installation rules
-install(DIRECTORY www DESTINATION ${RSTUDIO_INSTALL_SUPPORTING})
-install(DIRECTORY extras/rstudio/symbolMaps/
+install(DIRECTORY "$GWT_WWW_DIR" DESTINATION ${RSTUDIO_INSTALL_SUPPORTING})
+install(DIRECTORY "$GWT_EXTRAS_DIR/rstudio/symbolMaps/"
         DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/www-symbolmaps)

--- a/src/gwt/CMakeLists.txt
+++ b/src/gwt/CMakeLists.txt
@@ -17,16 +17,16 @@ cmake_minimum_required(VERSION 2.6)
 project (RSTUDIO_GWT)
 
 # check for externals
-SET(GWT_LIBS "/opt/rstudio-tools/gwt/lib")
-if(NOT EXISTS GWT_LIBS)
-   SET(GWT_LIBS "${CMAKE_CURRENT_SOURCE_DIR}/lib")
+SET(GWT_LIB_DIR "/opt/rstudio-tools/gwt/lib")
+if(NOT EXISTS "${GWT_LIB_DIR}")
+   SET(GWT_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib")
 endif()
 
 # define output dirs
-set(GWT_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/gwt")
+set(GWT_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 set(GWT_BIN_DIR "${GWT_OUTPUT_DIR}/bin")
 set(GWT_WWW_DIR "${GWT_OUTPUT_DIR}/www")
-set(GWT_EXTRAS "${GWT_OUTPUT_DIR}/extras")
+set(GWT_EXTRAS_DIR "${GWT_OUTPUT_DIR}/extras")
 
 # invoke ant to build
 add_custom_target(gwt_build ALL)
@@ -35,9 +35,18 @@ add_custom_command(
    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
    COMMAND ant -Dbuild.dir=${GWT_BIN_DIR}
                -Dwww.dir=${GWT_WWW_DIR}
-               -Dextras.dir=${GWT_EXTRAS_DIR})
+               -Dextras.dir=${GWT_EXTRAS_DIR}
+               -Dlib.dir=${GWT_LIB_DIR})
+
+# create test script and copy to binary directory with executable permissions
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/gwt-unit-tests.sh.in
+               ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/gwt-unit-tests.sh)
+file(COPY ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/gwt-unit-tests.sh
+          DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+          FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ
+          GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 
 # installation rules
-install(DIRECTORY "$GWT_WWW_DIR" DESTINATION ${RSTUDIO_INSTALL_SUPPORTING})
-install(DIRECTORY "$GWT_EXTRAS_DIR/rstudio/symbolMaps/"
+install(DIRECTORY "${GWT_WWW_DIR}" DESTINATION ${RSTUDIO_INSTALL_SUPPORTING})
+install(DIRECTORY "${GWT_EXTRAS_DIR}/rstudio/symbolMaps/"
         DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/www-symbolmaps)

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -15,34 +15,44 @@
 
 <project name="client" default="build" basedir=".">
 
+   <!-- configure dirs -->
+   <property name="src.dir" value="./src"/>        <!-- main Java sources -->
+   <property name="test.dir" value="./test"/>      <!-- Java sources for tests -->
+   <property name="www.dir" value="./www"/>        <!-- output folder for www artifacts (HTML, etc.) -->
+   <property name="build.dir" value="./bin"/>      <!-- output folder for compiled classes -->
+   <property name="lib.dir" value="./lib"/>        <!-- libraries (GWT, GIN, etc. -->
+   <property name="tools.dir" value="./tools"/>    <!-- other tools -->
+   <property name="extras.dir" value="./extras"/>  <!-- extras: symbol maps, etc. -->
+
    <taskdef name="jscomp"
             classname="com.google.javascript.jscomp.ant.CompileTask"
-            classpath="./tools/compiler/compiler.jar"/>
+            classpath="${tools.dir}/compiler/compiler.jar"/>
+
    <!-- Configure path to GWT SDK -->
-   <property name="gwt.sdk" value="lib/gwt/2.8.1"/>
+   <property name="gwt.sdk" value="${lib.dir}/gwt/2.8.1"/>
 
    <property name="gwt.extra.args" value=""/>
    <property name="gwt.main.module" value="org.rstudio.studio.RStudio"/>
-   <property name="ace.bin" value="src/org/rstudio/studio/client/workbench/views/source/editors/text/ace"/>
+   <property name="ace.bin" value="${src.dir}/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace"/>
 
    <path id="project.class.path">
       <pathelement location="bin"/>
       <fileset dir="${gwt.sdk}" includes="*.jar"/>
-      <fileset dir="lib/gin/2.1.2" includes="*.jar"/>
+      <fileset dir="${lib.dir}/gin/2.1.2" includes="*.jar"/>
    </path>
 
    <path id="test.class.path">
       <pathelement location="bin"/>
-      <fileset dir="lib/selenium/2.37.0" includes="*.jar"/>
-      <fileset dir="lib/selenium/2.37.0/libs" includes="*.jar"/>
+      <fileset dir="${lib.dir}/selenium/2.37.0" includes="*.jar"/>
+      <fileset dir="${lib.dir}/selenium/2.37.0/libs" includes="*.jar"/>
    </path>
 
    <path id="unittest.class.path">
-      <fileset dir="lib/" includes="*.jar"/>
+       <fileset dir="${lib.dir}/" includes="*.jar"/>
    </path>
 
    <fileset id="acesupport.sources.fileset" dir="acesupport">
-      <include name="**/*.js"/>
+      <include name="${src.dir}/**/*.js"/>
       <exclude name="extern.js"/>
    </fileset>
 
@@ -71,19 +81,19 @@
    </target>
 
    <target name="javac" description="Compile java source">
-      <mkdir dir="bin"/>
+      <mkdir dir="${build.dir}"/>
       <!-- Compile com.google stuff separately from org.rstudio stuff since
          theirs have lots of deprecation warnings we can't do anything about -->
-      <javac srcdir="src" includes="com/google/**" encoding="utf-8"
-             destdir="bin"
+      <javac srcdir="${src.dir}" includes="com/google/**" encoding="utf-8"
+             destdir="${build.dir}"
              source="1.8" target="1.8" nowarn="true" deprecation="false"
              debug="true" debuglevel="lines,vars,source"
              includeantruntime="false">
          <classpath refid="project.class.path"/>
          <compilerarg value="-Xlint:-deprecation"/>
       </javac>
-      <javac srcdir="src" includes="org/rstudio/**" encoding="utf-8"
-             destdir="bin"
+      <javac srcdir="${src.dir}" includes="org/rstudio/**" encoding="utf-8"
+             destdir="${build.dir}"
              source="1.8" target="1.8" nowarn="true" deprecation="true"
              debug="true" debuglevel="lines,vars,source"
              includeantruntime="false"
@@ -94,20 +104,20 @@
          <compilerarg value="-J-Xmx512m"/>
       </javac>
       <copy todir="bin">
-         <fileset dir="src" excludes="**/*.java"/>
+         <fileset dir="${src.dir}" excludes="**/*.java"/>
       </copy>
    </target>
 
    <target name="gwtc" depends="ext,javac" description="GWT compile to JavaScript">
       <java failonerror="true" fork="true" classname="com.google.gwt.dev.Compiler">
          <classpath>
-            <pathelement location="src"/>
+            <pathelement location="${src.dir}"/>
             <path refid="project.class.path"/>
          </classpath>
          <!-- add jvmarg -Xss16M or similar if you see a StackOverflowError -->
          <jvmarg value="-Xmx1536M"/>
          <arg value="-war"/>
-         <arg value="www"/>
+         <arg value="${www.dir}"/>
          <arg value="-localWorkers"/>
          <arg value="2"/>
          <arg value="-XdisableClassMetadata"/>
@@ -115,7 +125,7 @@
          <arg line="-strict"/>
          <arg line="-gen gen"/>
          <!--<arg line="-style PRETTY"/>-->
-         <arg line="-extra extras"/>
+         <arg line="-extra ${extras.dir}"/>
          <arg line="${gwt.extra.args}"/>
          <!-- Additional arguments like -logLevel DEBUG -->
          <arg value="${gwt.main.module}"/>
@@ -128,7 +138,7 @@
          <param name="gwt.extra.args" value="${gwt.extra.args} -compileReport"/>
       </antcall>
       <exec executable="open" os="Mac OS X">
-         <arg file="extras/rstudio/soycReport/compile-report/index.html"/>
+         <arg file="${extras.dir}/rstudio/soycReport/compile-report/index.html"/>
       </exec>
    </target>
 
@@ -142,7 +152,7 @@
    <target name="desktop" depends="acesupport,javac" description="Run development mode">
       <java failonerror="true" fork="true" classname="com.google.gwt.dev.DevMode">
          <classpath>
-            <pathelement location="src"/>
+            <pathelement location="${src.dir}"/>
             <path refid="project.class.path"/>
          </classpath>
          <jvmarg value="-Xmx2048M"/>
@@ -151,7 +161,7 @@
          <arg value="-XmethodNameDisplayMode"/>
          <arg value="ABBREVIATED"/>
          <arg value="-war"/>
-         <arg value="www"/>
+         <arg value="${www.dir}"/>
          <arg value="-noserver"/>
          <arg value="-startupUrl"/>
          <arg value="http://localhost:8787"/>
@@ -172,7 +182,7 @@
          <arg value="-XmethodNameDisplayMode"/>
          <arg value="ABBREVIATED"/>
          <arg value="-war"/>
-         <arg value="www"/>
+         <arg value="${www.dir}"/>
          <arg value="-noserver"/>
          <arg value="-startupUrl"/>
          <arg value="http://localhost:8787"/>
@@ -194,32 +204,32 @@
          <jvmarg value="-Xmx2048M"/>
       	<arg value="-src"/>
       	<arg value = "src"/>
-         <arg value="org.rstudio.studio.RStudioSuperDevMode"/>
+        <arg value="org.rstudio.studio.RStudioSuperDevMode"/>
       </java>
    </target>
 
    <target name="build" depends="gwtc" description="Build this project" />
 
    <target name="clean" description="Cleans this project">
-      <delete dir="bin" failonerror="false" />
+      <delete dir="${build.dir}" failonerror="false" />
       <delete dir="gwt-unitCache" failonerror="false" />
-      <delete dir="www/rstudio" failonerror="false" />
+      <delete dir="${www.dir}/rstudio" failonerror="false" />
       <delete file="${ace.bin}/acesupport.js" failonerror="false" />
       <delete dir="gen" failonerror="false" />
-      <delete dir="extras" failonerror="false" />
+      <delete dir="${extras.dir}" failonerror="false" />
    </target>
 
    <target name="test" description="Runs Selenium tests" depends="build-tests">
       <parallel>
          <daemons>
-            <exec executable="lib/selenium/chromedriver/2.7/chromedriver-mac" os="Mac OS X" />
-            <exec executable="lib/selenium/chromedriver/2.7/chromedriver-win.exe" os="Windows NT" />
-            <exec executable="lib/selenium/chromedriver/2.7/chromedriver-linux" os="Linux" />
+            <exec executable="${lib.dir}/selenium/chromedriver/2.7/chromedriver-mac" os="Mac OS X" />
+            <exec executable="${lib.dir}/selenium/chromedriver/2.7/chromedriver-win.exe" os="Windows NT" />
+            <exec executable="${lib.dir}/selenium/chromedriver/2.7/chromedriver-linux" os="Linux" />
          </daemons>
          <sequential>
             <java failonerror="true" fork="true" classname="org.junit.runner.JUnitCore">
                <classpath>
-                  <pathelement location="src"/>
+                  <pathelement location="${src.dir}"/>
                   <path refid="test.class.path"/>
                </classpath>
                <arg value="org.rstudio.studio.selenium.RStudioTestSuite"/>
@@ -230,7 +240,7 @@
 
    <target name="build-tests" description="Builds Selenium tests">
       <javac srcdir="test" includes="org/rstudio/studio/selenium/**" encoding="utf-8"
-             destdir="bin"
+             destdir="${build.dir}"
              source="1.8" target="1.8" nowarn="true" deprecation="true"
              debug="true" debuglevel="lines,vars,source"
              includeantruntime="false">
@@ -252,8 +262,8 @@
    <target name="unittest" description="Runs JUnit unit tests" depends="build-unittests">
      <java failonerror="true" fork="true" classname="org.junit.runner.JUnitCore">
         <classpath>
-            <pathelement location="test"/>
-            <pathelement location="src"/>
+            <pathelement location="${test.dir}"/>
+            <pathelement location="${src.dir}"/>
         </classpath>
         <classpath refid="project.class.path"/>
         <classpath refid="unittest.class.path"/>

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -36,13 +36,13 @@
    <property name="ace.bin" value="${src.dir}/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace"/>
 
    <path id="project.class.path">
-      <pathelement location="bin"/>
+     <pathelement location="${build.dir}"/>
       <fileset dir="${gwt.sdk}" includes="*.jar"/>
       <fileset dir="${lib.dir}/gin/2.1.2" includes="*.jar"/>
    </path>
 
    <path id="test.class.path">
-      <pathelement location="bin"/>
+      <pathelement location="{build.dir}"/>
       <fileset dir="${lib.dir}/selenium/2.37.0" includes="*.jar"/>
       <fileset dir="${lib.dir}/selenium/2.37.0/libs" includes="*.jar"/>
    </path>
@@ -103,7 +103,7 @@
          <compilerarg value="-J-Xms256m"/>
          <compilerarg value="-J-Xmx512m"/>
       </javac>
-      <copy todir="bin">
+      <copy todir="${build.dir}">
          <fileset dir="${src.dir}" excludes="**/*.java"/>
       </copy>
    </target>
@@ -250,7 +250,7 @@
 
    <target name="build-unittests" description="Builds JUnit unit tests">
        <javac srcdir="test" includes="org/rstudio/studio/client/**" encoding="utf-8"
-             destdir="bin"
+             destdir="${build.dir}"
              source="1.8" target="1.8" nowarn="true" deprecation="true"
              debug="true" debuglevel="lines,vars,source"
              includeantruntime="false">

--- a/src/gwt/gwt-unit-tests.sh.in
+++ b/src/gwt/gwt-unit-tests.sh.in
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+cd ${CMAKE_CURRENT_SOURCE_DIR}
+
+echo "Running ant unittest target..."
+
+ant -Dbuild.dir=${GWT_BIN_DIR} \
+    -Dwww.dir=${GWT_WWW_DIR} \
+    -Dextras.dir=${GWT_EXTRAS_DIR} \
+    -Dlib.dir=${GWT_LIB_DIR} \
+    unittest
+
+


### PR DESCRIPTION
This change makes a number of improvements to the GWT build process.

- **GWT, GIN, and other libraries can now be stored outside the source tree**. Formerly, these libraries were presumed to exist at a hardcoded location inside the source tree. This change allows us to cache them in the Docker build containers, resulting in faster, less network-reliant builds.

- **Build output can now be placed in the binary directory**. Formerly, build output only went to the source directory. Using the binary directory prepares us for an upcoming change in which builds will happen outside the source tree.

- **Unit tests are run as part the build process**, using a unit test script generated at compile time with the appropriate folders.

None of these changes disturb the workflow we already use; the default directories are the same as they've always been, so local development workflow is unchanged. 