### PR TITLE
Update EVP to work with OpenSSL1.1.0

### DIFF
--- a/src/cpp/core/system/Crypto.cpp
+++ b/src/cpp/core/system/Crypto.cpp
@@ -261,27 +261,26 @@ Error aesEncrypt(const std::vector<unsigned char>& data,
    int outlen = 0;
    int bytesEncrypted = 0;
 
-   EVP_CIPHER_CTX ctx;
-   EVP_CIPHER_CTX_init(&ctx);
-   EVP_CipherInit_ex(&ctx, EVP_aes_128_cbc(), NULL, &key[0], &iv[0], kEncrypt);
+   EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+   EVP_CipherInit_ex(ctx, EVP_aes_128_cbc(), NULL, &key[0], &iv[0], kEncrypt);
 
    // perform the encryption
-   if(!EVP_CipherUpdate(&ctx, &(pEncrypted->operator[](0)), &outlen, &data[0], data.size()))
+   if(!EVP_CipherUpdate(ctx, &(pEncrypted->operator[](0)), &outlen, &data[0], data.size()))
    {
-      EVP_CIPHER_CTX_cleanup(&ctx);
+      EVP_CIPHER_CTX_cleanup(ctx);
       return lastCryptoError(ERROR_LOCATION);
    }
    bytesEncrypted += outlen;
 
    // perform final flush including left-over padding
-   if(!EVP_CipherFinal_ex(&ctx, &(pEncrypted->operator[](outlen)), &outlen))
+   if(!EVP_CipherFinal_ex(ctx, &(pEncrypted->operator[](outlen)), &outlen))
    {
-      EVP_CIPHER_CTX_cleanup(&ctx);
+      EVP_CIPHER_CTX_cleanup(ctx);
       return lastCryptoError(ERROR_LOCATION);
    }
    bytesEncrypted += outlen;
 
-   EVP_CIPHER_CTX_cleanup(&ctx);
+   EVP_CIPHER_CTX_cleanup(ctx);
 
    // resize the container to the amount of actual bytes encrypted (including padding)
    pEncrypted->resize(bytesEncrypted);
@@ -298,27 +297,26 @@ Error aesDecrypt(const std::vector<unsigned char>& data,
    int outlen = 0;
    int bytesDecrypted = 0;
 
-   EVP_CIPHER_CTX ctx;
-   EVP_CIPHER_CTX_init(&ctx);
-   EVP_CipherInit_ex(&ctx, EVP_aes_128_cbc(), NULL, &key[0], &iv[0], kDecrypt);
+   EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+   EVP_CipherInit_ex(ctx, EVP_aes_128_cbc(), NULL, &key[0], &iv[0], kDecrypt);
 
    // perform the decryption
-   if(!EVP_CipherUpdate(&ctx, &(pDecrypted->operator[](0)), &outlen, &data[0], data.size()))
+   if(!EVP_CipherUpdate(ctx, &(pDecrypted->operator[](0)), &outlen, &data[0], data.size()))
    {
-      EVP_CIPHER_CTX_cleanup(&ctx);
+      EVP_CIPHER_CTX_cleanup(ctx);
       return lastCryptoError(ERROR_LOCATION);
    }
    bytesDecrypted += outlen;
 
    // perform final flush
-   if(!EVP_CipherFinal_ex(&ctx, &(pDecrypted->operator[](outlen)), &outlen))
+   if(!EVP_CipherFinal_ex(ctx, &(pDecrypted->operator[](outlen)), &outlen))
    {
-      EVP_CIPHER_CTX_cleanup(&ctx);
+      EVP_CIPHER_CTX_cleanup(ctx);
       return lastCryptoError(ERROR_LOCATION);
    }
    bytesDecrypted += outlen;
 
-   EVP_CIPHER_CTX_cleanup(&ctx);
+   EVP_CIPHER_CTX_cleanup(ctx);
 
    // resize the container to the amount of actual bytes decrypted (padding is removed)
    pDecrypted->resize(bytesDecrypted);

--- a/src/cpp/core/system/Crypto.cpp
+++ b/src/cpp/core/system/Crypto.cpp
@@ -261,13 +261,14 @@ Error aesEncrypt(const std::vector<unsigned char>& data,
    int outlen = 0;
    int bytesEncrypted = 0;
 
-   EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+   EVP_CIPHER_CTX *ctx;
+   ctx = EVP_CIPHER_CTX_new();
    EVP_CipherInit_ex(ctx, EVP_aes_128_cbc(), NULL, &key[0], &iv[0], kEncrypt);
 
    // perform the encryption
    if(!EVP_CipherUpdate(ctx, &(pEncrypted->operator[](0)), &outlen, &data[0], data.size()))
    {
-      EVP_CIPHER_CTX_cleanup(ctx);
+      EVP_CIPHER_CTX_free(ctx);
       return lastCryptoError(ERROR_LOCATION);
    }
    bytesEncrypted += outlen;
@@ -275,12 +276,12 @@ Error aesEncrypt(const std::vector<unsigned char>& data,
    // perform final flush including left-over padding
    if(!EVP_CipherFinal_ex(ctx, &(pEncrypted->operator[](outlen)), &outlen))
    {
-      EVP_CIPHER_CTX_cleanup(ctx);
+      EVP_CIPHER_CTX_free(ctx);
       return lastCryptoError(ERROR_LOCATION);
    }
    bytesEncrypted += outlen;
 
-   EVP_CIPHER_CTX_cleanup(ctx);
+   EVP_CIPHER_CTX_free(ctx);
 
    // resize the container to the amount of actual bytes encrypted (including padding)
    pEncrypted->resize(bytesEncrypted);
@@ -297,13 +298,14 @@ Error aesDecrypt(const std::vector<unsigned char>& data,
    int outlen = 0;
    int bytesDecrypted = 0;
 
-   EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+   EVP_CIPHER_CTX *ctx;
+   ctx = EVP_CIPHER_CTX_new();
    EVP_CipherInit_ex(ctx, EVP_aes_128_cbc(), NULL, &key[0], &iv[0], kDecrypt);
 
    // perform the decryption
    if(!EVP_CipherUpdate(ctx, &(pDecrypted->operator[](0)), &outlen, &data[0], data.size()))
    {
-      EVP_CIPHER_CTX_cleanup(ctx);
+      EVP_CIPHER_CTX_free(ctx);
       return lastCryptoError(ERROR_LOCATION);
    }
    bytesDecrypted += outlen;
@@ -311,12 +313,12 @@ Error aesDecrypt(const std::vector<unsigned char>& data,
    // perform final flush
    if(!EVP_CipherFinal_ex(ctx, &(pDecrypted->operator[](outlen)), &outlen))
    {
-      EVP_CIPHER_CTX_cleanup(ctx);
+      EVP_CIPHER_CTX_free(ctx);
       return lastCryptoError(ERROR_LOCATION);
    }
    bytesDecrypted += outlen;
 
-   EVP_CIPHER_CTX_cleanup(ctx);
+   EVP_CIPHER_CTX_free(ctx);
 
    // resize the container to the amount of actual bytes decrypted (padding is removed)
    pDecrypted->resize(bytesDecrypted);

--- a/src/cpp/core/system/CryptoTests.cpp
+++ b/src/cpp/core/system/CryptoTests.cpp
@@ -1,0 +1,62 @@
+/*
+ * CryptoTests.cpp
+ *
+ * Copyright (C) 2017 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <core/system/Crypto.hpp>
+
+#include <tests/TestThat.hpp>
+
+namespace rstudio {
+namespace core {
+namespace system {
+namespace tests {
+
+context("CryptoTests")
+{
+   test_that("Can AES encrypt/decrypt")
+   {
+      // generate a random 128-bit key and IV
+      std::vector<unsigned char> key;
+      std::vector<unsigned char> iv;
+      Error error = core::system::crypto::random(16, &key);
+      REQUIRE_FALSE(error);
+      error = core::system::crypto::random(8, &iv);
+      REQUIRE_FALSE(error);
+
+      // construct the data to encrypt
+      std::string payload = "Hello, world! This is a secret.";
+      std::vector<unsigned char> data;
+      std::copy(payload.begin(), payload.end(), std::back_inserter(data));
+
+      // encrypt the data
+      std::vector<unsigned char> encryptedData;
+      error = core::system::crypto::aesEncrypt(data, key, iv, &encryptedData);
+      REQUIRE_FALSE(error);
+
+      // decrypt the encrypted data
+      std::vector<unsigned char> decryptedData;
+      error = core::system::crypto::aesDecrypt(encryptedData, key, iv, &decryptedData);
+      REQUIRE_FALSE(error);
+
+      // verify that the decryption gives us back the original data
+      std::string decryptedPayload;
+      std::copy(decryptedData.begin(), decryptedData.end(), std::back_inserter(decryptedPayload));
+      REQUIRE(payload == decryptedPayload);
+   }
+}
+
+} // end namespace tests
+} // end namespace system
+} // end namespace core
+} // end namespace rstudio


### PR DESCRIPTION
In addition to a previous pull request of mine.

I assume this part of code was introduced after the release of 1.1. I use this to build locally for a while. Once this gets merged https://github.com/JanMarvin/rstudio-archlinuxpkg/blob/master/rstudio/openssl11.diff is the only pending change required to build with OpenSSL 1.1.0

Sincerely,
Marvin