### PR TITLE
Fixes to make Mac Desktop buildable with Qt

### DIFF
--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -368,7 +368,7 @@ else()
       ${DESKTOP_UI_SOURCES}
       ${ICNS_FILES})
 
-   qt5_use_modules(RStudio Core Widgets Gui Network WebKit WebKitWidgets)
+   qt5_use_modules(RStudio Core Widgets Gui Network WebKit WebKitWidgets PrintSupport)
 
    target_link_libraries(RStudio
       ${QT_LIBRARIES}

--- a/src/cpp/desktop/DesktopUtilsMac.mm
+++ b/src/cpp/desktop/DesktopUtilsMac.mm
@@ -71,6 +71,10 @@ bool isOSXMavericks()
    return boost::algorithm::starts_with(version, "10.9");
 }
 
+bool isCentOS()
+{
+   return false;
+}
 
 namespace {
 


### PR DESCRIPTION
Bare minimum fixes to make Mac once again buildable with Qt. This doesn't enable it, just makes it work if you enable by modifying `src/cpp/CMakeLists.txt` delete the special case where APPLE uses `desktop-mac` instead of `desktop`. Must also install `Qt 5.4.2` sdk.

This was the bare minimum; I confirmed it builds and launches. I almost immediately found an issue, where Ctrl+L doesn't clear the console; didn't investigate any further.