### PR TITLE
improve Viewer performance w/large datasets

### DIFF
--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -178,8 +178,21 @@
 
 .rs.addFunction("formatRowNames", function(x, start, len) 
 {
-  rownames <- row.names(x)
-  rownames[start:min(length(rownames), start+len)]
+   # detect whether this is a data.frame that contains
+   # row names, or if the row names are stored compactly
+   if (is.data.frame(x))
+   {
+      info <- .row_names_info(x, type = 0L)
+      if (is.na(info)[[1]])
+      {
+         range <- seq(from = start, to = start + len)
+         return(as.character(range))
+      }
+   }
+   
+   # otherwise, extract row names and subset as usual
+   rownames <- row.names(x)
+   rownames[start:min(length(rownames), start + len)]
 })
 
 # wrappers for nrow/ncol which will report the class of object for which we


### PR DESCRIPTION
This PR should vastly improve the data viewer performance when attempting to view large datasets (>10M rows). We avoid accidentally synthesizing a character vector equal to the number of rows of the dataset, when the row names are stored in a so-called compact representation.

I believe this will close #1705. While this does fix one kind of data viewer slowness, I unfortunately don't think it'll fix the issue seen by users when attempting to View datasets when their home directory lives on a network drive (that is still a separate issue).