### PR TITLE
Fix client-side terminal alt-buffer detection

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
@@ -120,7 +120,7 @@ public class XTermNative extends JavaScriptObject
  
    // XTERM_IMP
    public final native boolean altBufferActive() /*-{
-      return this.normal != null;
+      return this.buffers.active == this.buffers.alt;
    }-*/;
    
    public final native void showPrimaryBuffer() /*-{


### PR DESCRIPTION
Broken by update to xterm.js 2.9.2 internals, which I took late in 1.1 cycle. So close to getting away with it relatively unscathed! :-(

Resolves #1725 

Regression caused Ctrl+L to clear entire terminal even when running a full-screen program such as tmux, which does its own handling of Ctrl+L to clear the current pane, instead. Essentially, Ctrl+L messes up full-screen programs and prevents them from doing what they want with Ctrl+L.

Also messed up which commands display in upper-right of Terminal toolbar (stop and clear should be hidden when running full-screen program, but they aren't).