### PR TITLE
Change rstudioapi getthemeinfo to mark themes dark in classic mode

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -693,7 +693,6 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
     ),
     editor,
     ignore.case = TRUE)
-  dark <- !identical(global, "Classic") && dark
 
   list(
     editor = editor,


### PR DESCRIPTION
`rstudioapi::getThemeInfo()` returns `dark = FALSE` under classic mode but since Hadley is using this to match console colors, changing this to be enabled under classic themes.