### PR TITLE
Stop terminal from hijacking Ctrl+Shift+L shortcut

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -740,7 +740,6 @@ well as menu structures (for main menu and popup menus).
       </shortcutgroup>
       <shortcutgroup name="Terminal">
          <shortcut refid="newTerminal" value="Alt+Shift+R"/>
-         <shortcut refid="clearTerminalScrollbackBuffer" value="Ctrl+Shift+L"/>
          <shortcut refid="previousTerminal" value="Ctrl+Alt+F11"/>
          <shortcut refid="nextTerminal" value="Ctrl+Alt+F12"/>
       </shortcutgroup>


### PR DESCRIPTION
Resolves #1723 

Don't need a special "clear terminal" shortcut key, as we use Ctrl+L for that when terminal is showing, and Ctrl+Shift+L is used by Load All.