### PR TITLE
Use class member init on ConsoleProcessInfo class

### DIFF
--- a/src/cpp/session/SessionConsoleProcessInfo.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfo.cpp
@@ -15,7 +15,6 @@
 
 #include <session/SessionConsoleProcessInfo.hpp>
 
-#include <core/system/Process.hpp>
 #include <core/system/System.hpp>
 #include <core/text/TermBufferParser.hpp>
 
@@ -35,12 +34,6 @@ const int kNewTerminal = -1; // new terminal, sequence number yet to be determin
 const size_t kOutputBufferSize = 8192;
 
 ConsoleProcessInfo::ConsoleProcessInfo()
-   : terminalSequence_(kNoTerminal), allowRestart_(false),
-     interactionMode_(InteractionNever), maxOutputLines_(kDefaultMaxOutputLines),
-     showOnOutput_(false), outputBuffer_(kOutputBufferSize), childProcs_(true),
-     altBufferActive_(false), shellType_(TerminalShell::DefaultShell),
-     channelMode_(Rpc), cols_(system::kDefaultCols), rows_(system::kDefaultRows),
-     restarted_(false), autoClose_(DefaultAutoClose), zombie_(false), trackEnv_(false)
 {
    // When we retrieve from outputBuffer, we only want complete lines. Add a
    // dummy \n so we can tell the first line is a complete line.
@@ -64,10 +57,9 @@ ConsoleProcessInfo::ConsoleProcessInfo(
    : caption_(caption), title_(title), handle_(handle),
      terminalSequence_(terminalSequence), allowRestart_(true),
      interactionMode_(InteractionAlways), maxOutputLines_(kDefaultTerminalMaxOutputLines),
-     showOnOutput_(false), outputBuffer_(kOutputBufferSize), childProcs_(true),
      altBufferActive_(altBufferActive), shellType_(shellType),
-     channelMode_(Rpc), cwd_(cwd), cols_(cols), rows_(rows), restarted_(false),
-     autoClose_(DefaultAutoClose), zombie_(zombie), trackEnv_(trackEnv)
+     cwd_(cwd), cols_(cols), rows_(rows),
+     zombie_(zombie), trackEnv_(trackEnv)
 {
 }
 
@@ -75,12 +67,7 @@ ConsoleProcessInfo::ConsoleProcessInfo(
          const std::string& caption,
          InteractionMode mode,
          int maxOutputLines)
-   : caption_(caption), terminalSequence_(kNoTerminal), allowRestart_(false),
-     interactionMode_(mode), maxOutputLines_(maxOutputLines),
-     showOnOutput_(false), outputBuffer_(kOutputBufferSize), childProcs_(true),
-     altBufferActive_(false), shellType_(TerminalShell::DefaultShell),
-     channelMode_(Rpc), cols_(system::kDefaultCols), rows_(system::kDefaultRows),
-     restarted_(false), autoClose_(DefaultAutoClose), zombie_(false), trackEnv_(false)
+   : caption_(caption), interactionMode_(mode), maxOutputLines_(maxOutputLines)
 {
 }
 

--- a/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
@@ -20,6 +20,7 @@
 
 #include <core/FilePath.hpp>
 #include <core/json/Json.hpp>
+#include <core/system/Process.hpp>
 #include <core/system/Types.hpp>
 
 #include <session/SessionTerminalShell.hpp>
@@ -201,25 +202,25 @@ private:
    std::string caption_;
    std::string title_;
    std::string handle_;
-   int terminalSequence_;
-   bool allowRestart_;
-   InteractionMode interactionMode_;
-   int maxOutputLines_;
-   bool showOnOutput_;
-   boost::circular_buffer<char> outputBuffer_;
+   int terminalSequence_ = kNoTerminal;
+   bool allowRestart_ = false;
+   InteractionMode interactionMode_ = InteractionNever;
+   int maxOutputLines_ = kDefaultMaxOutputLines;
+   bool showOnOutput_ = false;
+   boost::circular_buffer<char> outputBuffer_ {kOutputBufferSize};
    boost::optional<int> exitCode_;
-   bool childProcs_;
-   bool altBufferActive_;
-   TerminalShell::TerminalShellType shellType_;
-   ChannelMode channelMode_;
+   bool childProcs_ = true;
+   bool altBufferActive_ = false;
+   TerminalShell::TerminalShellType shellType_ = TerminalShell::DefaultShell;
+   ChannelMode channelMode_ = Rpc;
    std::string channelId_;
    core::FilePath cwd_;
-   int cols_;
-   int rows_;
-   bool restarted_;
-   AutoCloseMode autoClose_;
-   bool zombie_;
-   bool trackEnv_;
+   int cols_ = core::system::kDefaultCols;
+   int rows_ = core::system::kDefaultRows;
+   bool restarted_ = false;
+   AutoCloseMode autoClose_ = DefaultAutoClose;
+   bool zombie_ = false;
+   bool trackEnv_ = false;
 };
 
 } // namespace console_process


### PR DESCRIPTION
Use default member initialization to make the `ConsoleProcessInfo` constructors somewhat less repetitive, hideous, and error-prone.