### PR TITLE
candidate fix for slowness on NFS

### DIFF
--- a/src/cpp/core/include/core/r_util/RProjectFile.hpp
+++ b/src/cpp/core/include/core/r_util/RProjectFile.hpp
@@ -125,9 +125,11 @@ struct RProjectConfig
 };
 
 Error findProjectFile(FilePath filePath,
+                      const FilePath& anchorPath,
                       FilePath* pProjPath);
 
 Error findProjectConfig(FilePath filePath,
+                        const FilePath& anchorPath,
                         RProjectConfig* pConfig);
 
 Error readProjectFile(const FilePath& projectFilePath,

--- a/src/cpp/core/include/core/r_util/RProjectFile.hpp
+++ b/src/cpp/core/include/core/r_util/RProjectFile.hpp
@@ -125,7 +125,7 @@ struct RProjectConfig
 };
 
 Error findProjectFile(FilePath filePath,
-                      const FilePath& anchorPath,
+                      FilePath anchorPath,
                       FilePath* pProjPath);
 
 Error findProjectConfig(FilePath filePath,

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -90,19 +90,26 @@ void writeDocToJson(boost::shared_ptr<SourceDocument> pDoc,
    
    // discover project-specific settings when available
    r_util::RProjectConfig projConfig;
-   FilePath docPath = module_context::resolveAliasedPath(pDoc->path());
    bool hasConfig = false;
    
-   if (projects::projectContext().hasProject() &&
-       docPath.isWithin(projects::projectContext().directory()))
+   if (!pDoc->path().empty())
    {
-      projConfig = projects::projectContext().config();
-      hasConfig = true;
-   }
-   else
-   {
-      Error error = r_util::findProjectConfig(docPath, &projConfig);
-      hasConfig = !error;
+      FilePath docPath = module_context::resolveAliasedPath(pDoc->path());
+
+      if (projects::projectContext().hasProject() &&
+          docPath.isWithin(projects::projectContext().directory()))
+      {
+         projConfig = projects::projectContext().config();
+         hasConfig = true;
+      }
+      else
+      {
+         Error error = r_util::findProjectConfig(
+                  docPath,
+                  module_context::userHomePath(),
+                  &projConfig);
+         hasConfig = !error;
+      }
    }
    
    if (hasConfig)


### PR DESCRIPTION
This is a candidate fix for the slowness observed by some Windows users running on networked filesystems, re: https://github.com/rstudio/rstudio/issues/1592.

In v1.1, we introduced a feature that attempts to respect a parent project configuration when opening a file located outside of the current project. We do this by looking up the filesystem for files with the extension `.Rproj`, which implies recursively listing the contents of directories until a directory is found.

Unfortunately, there were two problems:

1) Newly-created documents don't have a path; calling `resolveAliasedPath()` on those returns the home directory;

2) We never anchored the lookup to a suitable path (ie, the user's home directory, or the parent of that directory)

This meant that opening a new file would trigger a recursive listing of all files within the home directory (and parent directory where permissions allowed), and I suspect this may be a very slow operation on certain NFS configurations.

This PR attempts to alleviate both issues.

This is a candidate for the v1.1 patch release, if we can confirm it does alleviate the slowness observed.