### PR TITLE
Use a switch instead of nested conditionals

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.cpp
+++ b/src/cpp/session/modules/SessionRCompletions.cpp
@@ -61,24 +61,27 @@ char ends(char begins) {
 
 bool isBinaryOp(char character)
 {
-   return character == '~' ||
-         character == '!' ||
-         character == '@' ||
-         character == '$' ||
-         character == '%' ||
-         character == '^' ||
-         character == '&' ||
-         character == '*' ||
-         character == '-' ||
-         character == '+' ||
-         character == '*' ||
-         character == '/' ||
-         character == '=' ||
-         character == '|' ||
-         character == '<' ||
-         character == '>' ||
-         character == '?';
-
+  switch(character) {
+    case '~':
+    case '!':
+    case '@':
+    case '$':
+    case '%':
+    case '^':
+    case '&':
+    case '-':
+    case '+':
+    case '*':
+    case '/':
+    case '=':
+    case '|':
+    case '<':
+    case '>':
+    case '?':
+    return true;
+    default:
+    return false;
+  }
 }
 
 } // end anonymous namespace


### PR DESCRIPTION
While the performance impact is likely minimal the switch is also a little safer.
In this case there were two '*' cases in the original code, which caused a compiler error when using the switch.

Interestingly with -O3 clang 5.0.0 does this same optimization automatically (https://godbolt.org/g/Eji22K)