### PR TITLE
Fixed a bug where empty responses were not sending Content-Length: 0

### DIFF
--- a/src/cpp/core/include/core/http/AsyncConnectionImpl.hpp
+++ b/src/cpp/core/include/core/http/AsyncConnectionImpl.hpp
@@ -95,6 +95,11 @@ public:
       if (close)
          response_.setHeader("Connection", "close");
 
+      // make sure that if no content-length was specified, we send a 0-length one
+      // otherwise, this response will be invalid
+      if (response_.headerValue("Content-Length").empty())
+          response_.setContentLength(0);
+
       // call the response filter if we have one
       if (responseFilter_)
          responseFilter_(originalUri_, &response_);


### PR DESCRIPTION
Before, if an empty response was written, no content-length header would be written, causing an invalid http response. This makes sure that if no content-length header is present on the response, an empty one is sent.