### PR TITLE
Bundle OpenSSL on MacOS

### DIFF
--- a/src/cpp/desktop-mac/CMakeLists.txt
+++ b/src/cpp/desktop-mac/CMakeLists.txt
@@ -129,3 +129,24 @@ endforeach()
 exec_program(defaults
              ARGS write org.rstudio.RStudio WebKitDeveloperExtras -bool true
              OUTPUT_VARIABLE DEV_EXTRAS)
+
+
+# we build against OpenSSL, but Apple no longer bundles OpenSSL, so copy it
+# into our install folder and fix the runtime path so that we can load from
+# there.
+
+add_custom_command (TARGET RStudio PRE_BUILD
+                    COMMAND mkdir -p ${RSTUDIO_INSTALL_BIN}/openssl)
+find_package(OpenSSL REQUIRED QUIET)
+
+# copy the libssl and libcrypto libraries 
+foreach(lib ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
+   get_filename_component(LIB_DIR ${lib} DIRECTORY)
+   execute_process(COMMAND readlink ${lib} OUTPUT_VARIABLE LIB_FILE OUTPUT_STRIP_TRAILING_WHITESPACE)
+   install(FILES ${LIB_DIR}/${LIB_FILE}
+           DESTINATION ${RSTUDIO_INSTALL_BIN}/openssl/)
+   add_custom_command (TARGET RStudio POST_BUILD
+      COMMAND install_name_tool -change ${LIB_DIR}/${LIB_FILE} @executable_path/openssl/${LIB_FILE} ${RSTUDIO_INSTALL_BIN}/RStudio
+      COMMENT "Fixing runtime path for ${lib}")
+endforeach()
+ 

--- a/src/cpp/desktop-mac/CMakeLists.txt
+++ b/src/cpp/desktop-mac/CMakeLists.txt
@@ -134,19 +134,54 @@ exec_program(defaults
 # we build against OpenSSL, but Apple no longer bundles OpenSSL, so copy it
 # into our install folder and fix the runtime path so that we can load from
 # there.
-
 add_custom_command (TARGET RStudio PRE_BUILD
                     COMMAND mkdir -p ${RSTUDIO_INSTALL_BIN}/openssl)
 find_package(OpenSSL REQUIRED QUIET)
 
-# copy the libssl and libcrypto libraries 
+# copy the libssl and libcrypto libraries to the install folder
 foreach(lib ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
+   # extract the parent directory and actual filename
    get_filename_component(LIB_DIR ${lib} DIRECTORY)
    execute_process(COMMAND readlink ${lib} OUTPUT_VARIABLE LIB_FILE OUTPUT_STRIP_TRAILING_WHITESPACE)
-   install(FILES ${LIB_DIR}/${LIB_FILE}
+
+   # create a writable copy of the libraries we will later modify
+   file(COPY ${LIB_DIR}/${LIB_FILE} 
+        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+        FILE_PERMISSIONS OWNER_WRITE OWNER_READ)
+
+   # install it read-only
+   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${LIB_FILE}
+           PERMISSIONS OWNER_READ GROUP_READ WORLD_READ
            DESTINATION ${RSTUDIO_INSTALL_BIN}/openssl/)
+
+   # save final destination filename
+   if(lib STREQUAL ${OPENSSL_CRYPTO_LIBRARY})
+      set(LIBCRYPTO ${CMAKE_CURRENT_BINARY_DIR}/${LIB_FILE})
+   else()
+      set(LIBSSL ${CMAKE_CURRENT_BINARY_DIR}/${LIB_FILE})
+   endif()
+
+   # modify the RStudio binaries to look for the installed copies instead of
+   # the system copies we linked against
    add_custom_command (TARGET RStudio POST_BUILD
       COMMAND install_name_tool -change ${LIB_DIR}/${LIB_FILE} @executable_path/openssl/${LIB_FILE} ${RSTUDIO_INSTALL_BIN}/RStudio
       COMMENT "Fixing runtime path for ${lib}")
 endforeach()
  
+
+# now we need to go back and fix up the dylibs themselves so that their
+# references to each other  point at the installed copies
+foreach(lib ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
+   # look up the installation path computed above
+   if(lib STREQUAL ${OPENSSL_CRYPTO_LIBRARY})
+      set(LIB_INSTALLED ${LIBCRYPTO})
+   else()
+      set(LIB_INSTALLED ${LIBSSL})
+   endif()
+
+   # figure out which libcrypto we're linking against
+   execute_process(COMMAND bash "-c" "otool -L ${lib} | grep libcrypto | grep version | cut -d ' ' -f 1" OUTPUT_VARIABLE LIBCRYPTO_DYLIB OUTPUT_STRIP_TRAILING_WHITESPACE)
+   get_filename_component(LIBCRYPTO_FILE ${LIBCRYPTO} NAME)
+   add_custom_command (TARGET RStudio POST_BUILD
+      COMMAND install_name_tool -change ${LIBCRYPTO_DYLIB} @executable_path/openssl/${LIBCRYPTO_FILE} ${LIB_INSTALLED})
+endforeach()

--- a/src/cpp/desktop-mac/CMakeLists.txt
+++ b/src/cpp/desktop-mac/CMakeLists.txt
@@ -131,57 +131,58 @@ exec_program(defaults
              OUTPUT_VARIABLE DEV_EXTRAS)
 
 
-# we build against OpenSSL, but Apple no longer bundles OpenSSL, so copy it
-# into our install folder and fix the runtime path so that we can load from
-# there.
-add_custom_command (TARGET RStudio PRE_BUILD
-                    COMMAND mkdir -p ${RSTUDIO_INSTALL_BIN}/openssl)
-find_package(OpenSSL REQUIRED QUIET)
+# we build against OpenSSL, but Apple no longer bundles OpenSSL, so, when doing
+# a package build, copy it into our install folder and fix the runtime path so
+# that we can load from there.
+if(RSTUDIO_PACKAGE_BUILD)
+   add_custom_command (TARGET RStudio PRE_BUILD
+                       COMMAND mkdir -p ${RSTUDIO_INSTALL_BIN}/openssl)
+   find_package(OpenSSL REQUIRED QUIET)
 
-# copy the libssl and libcrypto libraries to the install folder
-foreach(lib ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
-   # extract the parent directory and actual filename
-   get_filename_component(LIB_DIR ${lib} DIRECTORY)
-   execute_process(COMMAND readlink ${lib} OUTPUT_VARIABLE LIB_FILE OUTPUT_STRIP_TRAILING_WHITESPACE)
+   # copy the libssl and libcrypto libraries to the install folder
+   foreach(lib ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
+      # extract the parent directory and actual filename
+      get_filename_component(LIB_DIR ${lib} DIRECTORY)
+      execute_process(COMMAND readlink ${lib} OUTPUT_VARIABLE LIB_FILE OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-   # create a writable copy of the libraries we will later modify
-   file(COPY ${LIB_DIR}/${LIB_FILE} 
-        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
-        FILE_PERMISSIONS OWNER_WRITE OWNER_READ)
+      # create a writable copy of the libraries we will later modify
+      file(COPY ${LIB_DIR}/${LIB_FILE} 
+           DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+           FILE_PERMISSIONS OWNER_WRITE OWNER_READ)
 
-   # install it read-only
-   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${LIB_FILE}
-           PERMISSIONS OWNER_READ GROUP_READ WORLD_READ
-           DESTINATION ${RSTUDIO_INSTALL_BIN}/openssl/)
+      # install it read-only
+      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${LIB_FILE}
+              PERMISSIONS OWNER_READ GROUP_READ WORLD_READ
+              DESTINATION ${RSTUDIO_INSTALL_BIN}/openssl/)
 
-   # save final destination filename
-   if(lib STREQUAL ${OPENSSL_CRYPTO_LIBRARY})
-      set(LIBCRYPTO ${CMAKE_CURRENT_BINARY_DIR}/${LIB_FILE})
-   else()
-      set(LIBSSL ${CMAKE_CURRENT_BINARY_DIR}/${LIB_FILE})
-   endif()
+      # save final destination filename
+      if(lib STREQUAL ${OPENSSL_CRYPTO_LIBRARY})
+         set(LIBCRYPTO ${CMAKE_CURRENT_BINARY_DIR}/${LIB_FILE})
+      else()
+         set(LIBSSL ${CMAKE_CURRENT_BINARY_DIR}/${LIB_FILE})
+      endif()
 
-   # modify the RStudio binaries to look for the installed copies instead of
-   # the system copies we linked against
-   add_custom_command (TARGET RStudio POST_BUILD
-      COMMAND install_name_tool -change ${LIB_DIR}/${LIB_FILE} @executable_path/openssl/${LIB_FILE} ${RSTUDIO_INSTALL_BIN}/RStudio
-      COMMENT "Fixing runtime path for ${lib}")
-endforeach()
- 
+      # modify the RStudio binaries to look for the installed copies instead of
+      # the system copies we linked against
+      add_custom_command (TARGET RStudio POST_BUILD
+         COMMAND install_name_tool -change ${LIB_DIR}/${LIB_FILE} @executable_path/openssl/${LIB_FILE} ${RSTUDIO_INSTALL_BIN}/RStudio)
+   endforeach()
+    
 
-# now we need to go back and fix up the dylibs themselves so that their
-# references to each other  point at the installed copies
-foreach(lib ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
-   # look up the installation path computed above
-   if(lib STREQUAL ${OPENSSL_CRYPTO_LIBRARY})
-      set(LIB_INSTALLED ${LIBCRYPTO})
-   else()
-      set(LIB_INSTALLED ${LIBSSL})
-   endif()
+   # now we need to go back and fix up the OpenSSL dylibs themselves so that
+   # their references to each other point at the installed copies
+   foreach(lib ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
+      # look up the installation path computed above
+      if(lib STREQUAL ${OPENSSL_CRYPTO_LIBRARY})
+         set(LIB_INSTALLED ${LIBCRYPTO})
+      else()
+         set(LIB_INSTALLED ${LIBSSL})
+      endif()
 
-   # figure out which libcrypto we're linking against
-   execute_process(COMMAND bash "-c" "otool -L ${lib} | grep libcrypto | grep version | cut -d ' ' -f 1" OUTPUT_VARIABLE LIBCRYPTO_DYLIB OUTPUT_STRIP_TRAILING_WHITESPACE)
-   get_filename_component(LIBCRYPTO_FILE ${LIBCRYPTO} NAME)
-   add_custom_command (TARGET RStudio POST_BUILD
-      COMMAND install_name_tool -change ${LIBCRYPTO_DYLIB} @executable_path/openssl/${LIBCRYPTO_FILE} ${LIB_INSTALLED})
-endforeach()
+      # figure out which libcrypto we're linking against
+      execute_process(COMMAND bash "-c" "otool -L ${lib} | grep libcrypto | grep version | cut -d ' ' -f 1" OUTPUT_VARIABLE LIBCRYPTO_DYLIB OUTPUT_STRIP_TRAILING_WHITESPACE)
+      get_filename_component(LIBCRYPTO_FILE ${LIBCRYPTO} NAME)
+      add_custom_command (TARGET RStudio POST_BUILD
+         COMMAND install_name_tool -change ${LIBCRYPTO_DYLIB} @executable_path/openssl/${LIBCRYPTO_FILE} ${LIB_INSTALLED})
+   endforeach()
+endif()

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -584,3 +584,15 @@ endif()
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/CMakeOverlay.txt")
    include(CMakeOverlay.txt)
 endif()
+
+# if doing a package build on MacOS, reroute the OpenSSL libraries to our
+# bundled copies
+if(APPLE AND RSTUDIO_PACKAGE_BUILD)
+   find_package(OpenSSL REQUIRED QUIET)
+   foreach(lib ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
+      get_filename_component(LIB_DIR ${lib} DIRECTORY)
+      execute_process(COMMAND readlink ${lib} OUTPUT_VARIABLE LIB_FILE OUTPUT_STRIP_TRAILING_WHITESPACE)
+      add_custom_command (TARGET rsession POST_BUILD
+         COMMAND install_name_tool -change ${LIB_DIR}/${LIB_FILE} @executable_path/openssl/${LIB_FILE} ${CMAKE_CURRENT_BINARY_DIR}/rsession)
+   endforeach()
+endif()


### PR DESCRIPTION
Fixes #1600.

## Background

RStudio 1.1 was built on a Mac Mini running Mavericks. Apple included an (old) copy of OpenSSL with Mavericks, with the accompanying headers. It continues to ship that very old copy of OpenSSL today in MacOS, presumably for compatibility with apps built on older MacOS (like ours) but no longer includes headers.

When Apple formally removed all the OpenSSL development headers in El Capitan (in favor of the [LibreSSL](http://www.libressl.org/) fork), we kept RStudio building on our development machines by building and linking against a non-Apple OpenSSL. 

https://github.com/rstudio/rstudio/blob/34755a49383433202e758e1cd1f3a49ff0220e2d/src/cpp/core/CMakeLists.txt#L185-L203

## Missing OpenSSL

Now that we're building Mac releases on newer machines, we can no longer build our release against OpenSSL 0.9.8, at least not without doing some real gymnastics to keep and build against a copy of the headers (probably ill-advised anyway since this version of OpenSSL isn't receiving security or maintenance updates). 

The RStudio 1.2 build, since it's built against a non-Apple OpenSSL, now actually *requires* that non-Apple OpenSSL to be present at runtime -- so the 1.2 build actually has a hard dependency on Homebrew OpenSSL, and it won't launch on any machine that doesn't have it. 

## Bundling

This change resolves the problem by including OpenSSL as part of RStudio on MacOS. It does three things:

1. Copies the OpenSSL binaries into the RStudio app bundle, and installs them with RStudio.
2. Changes the runtime paths inside the binaries so that they can find each other. 
3. Changes the `RStudio` and `rsession` executables so that they locate the OpenSSL libraries relative to their own path via `@executable_path`. 

It isn't uncommon to bundle OpenSSL inside Mac apps; a quick scan of my own system found a bunch of OpenSSL copies installed in a similar manner:
    
    $ find . -iname libssl*.dylib
    ./TeX/TeXworks.app/Contents/MacOS/libssl.1.0.0.dylib
    ./VMware Fusion.app/Contents/Library/VMware OVF Tool/lib/libssl.1.0.1.dylib
    ./VMware Fusion.app/Contents/Frameworks/libssl.1.0.1.dylib
    ./Microsoft Remote Desktop.app/Contents/Frameworks/libssl.1.0.0.dylib
    ./zoom.us.app/Contents/Frameworks/libssl.1.0.0.dylib
    ./Last.fm.app/Contents/MacOS/libssl.1.0.0.dylib
    ./pgAdmin 4.app/Contents/Frameworks/libssl.1.0.0.dylib
    ./Processing.app/Contents/Java/modes/java/libraries/video/library/macosx64/libssl.dylib

We also already bundle OpenSSL on Windows, and as such it's already part of our NOTICE file.

https://github.com/rstudio/rstudio/blob/560aeb25f6634b3187082280e192d595ebc047be/NOTICE#L667-L794
