### PR TITLE
failure to lock source database should not be fatal

### DIFF
--- a/src/cpp/session/SessionSourceDatabaseSupervisor.cpp
+++ b/src/cpp/session/SessionSourceDatabaseSupervisor.cpp
@@ -420,10 +420,21 @@ Error removeAndRecreate(const FilePath& dir)
 Error attachToSourceDatabase()
 {  
    // this session may already have a source database; if it does, re-acquire a
-   // lock and then use it
+   // lock and then use it. don't log warnings as this should only fail when
+   // e.g. the filesystem does not support the active locking scheme
    FilePath existingSdb = sessionDirPath();
    if (existingSdb.exists())
-      return sessionDirLock().acquire(sessionLockFilePath(existingSdb));
+   {
+      Error error = sessionDirLock().acquire(sessionLockFilePath(existingSdb));
+      if (error)
+      {
+         LOG_ERROR(error);
+      }
+      else
+      {
+         return Success();
+      }
+   }
    
    // migrate from 'sdb' to current folder layout if needed
    bool needsSdbMigration =


### PR DESCRIPTION
This should resolve https://github.com/rstudio/rstudio/issues/1690. Note that the comment above this routine seems to indicate that this is the expected behavior: if we fail to lock an older, orphaned source database, that should not be fatal.