### PR TITLE
Added a sub category for the .desktop file

### DIFF
--- a/src/cpp/desktop/resources/freedesktop/rstudio.desktop.in
+++ b/src/cpp/desktop/resources/freedesktop/rstudio.desktop.in
@@ -4,5 +4,5 @@ Icon=rstudio
 Type=Application
 Terminal=false
 Name=RStudio
-Categories=Development;
+Categories=Development;IDE;
 MimeType=text/x-r-source;text/x-r;text/x-R;text/x-r-doc;text/x-r-sweave;text/x-r-markdown;text/x-r-html;text/x-r-presentation;application/x-r-data;application/x-r-project;text/x-r-history;text/x-r-profile;text/x-tex;text/x-markdown;text/html;text/css;text/javascript;text/x-chdr;text/x-csrc;text/x-c++hdr;text/x-c++src;


### PR DESCRIPTION
https://en.opensuse.org/openSUSE:Packaging_desktop_menu_categories#Development according to the FreeDesktop standards. Some Linux distributions are rather strict about it.