### PR TITLE
Make self-contained output compatible with Pandoc 2

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -2236,6 +2236,8 @@ Error createSelfContainedHtml(const FilePath& sourceFilePath,
 {
    r::exec::RFunction func(".rs.pandocSelfContainedHtml");
    func.addParam(string_utils::utf8ToSystem(sourceFilePath.absolutePath()));
+   func.addParam(string_utils::utf8ToSystem(
+            session::options().rResourcesPath().complete("pandoc_template.html").absolutePath()));
    func.addParam(string_utils::utf8ToSystem(targetFilePath.absolutePath()));
    return func.call();
 }

--- a/src/cpp/session/resources/pandoc_template.html
+++ b/src/cpp/session/resources/pandoc_template.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+$body$

--- a/src/cpp/session/resources/plot_publish.html
+++ b/src/cpp/session/resources/plot_publish.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 
 <head>


### PR DESCRIPTION
This change makes the minimal changes necessary to make `pandocSelfContainedHtml` work under Pandoc 2, in the case wherein `RSTUDIO_PANDOC` has been set to use Pandoc 2. In particular, it adapts to the following breaking changes in Pandoc 2:

1. The `<!DOCTYPE html>` header was treated as HTML and passed through, unmodified, in Pandoc 1. In Pandoc 2, it is treated as Markdown and escaped.

2. In Pandoc 2, the HTML converter warns loudly if no title is present in the metadata. 

To address these, respectively:

1. We now use an HTML template that includes the `DOCTYPE` header. If the `DOCTYPE` header is also present in the input HTML, it is removed. 

2. We pass a dummy title metadata field into the converter. It is not used in the template, so it isn't present in the output. 

These changes are also compatible with Pandoc 1, so RStudio can work with either version. 

Fixes #1756.