### PR TITLE
Reconnect terminal if websocket was closed

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -265,7 +265,13 @@ public class TerminalSession extends XTermWidget
       }
       socket_.dispatchOutput(output, doLocalEcho());
    }
-
+   
+   @Override
+   public void connectionDisconnected()
+   {
+      disconnect(false);
+   }
+   
    public void receivedSendToTerminal(String input)
    {
       // tweak line endings 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
@@ -60,6 +60,11 @@ public class TerminalSessionSocket
        * @param output output from server
        */
       void receivedOutput(String output);
+   
+      /**
+       * Called to disconnect the terminal
+       */
+      void connectionDisconnected();
    }
    
    public interface ConnectCallback
@@ -237,6 +242,7 @@ public class TerminalSessionSocket
             {
                diagnostic("WebSocket closed");
                socket_ = null;
+               session_.connectionDisconnected();
             }
 
             @Override


### PR DESCRIPTION
Fixes #1844

If the terminal websocket gets closed (seeing this happen in container scenarios), mark the terminal as disconnected so the reconnection logic kicks in. For example, terminal should reconnect if the user types in the disconnected terminal.

Prior to this fix, the terminal would remain inactive and ignore input in this scenario.