### PR TITLE
git: improve handling of multibyte paths

### DIFF
--- a/src/cpp/core/include/core/system/ShellUtils.hpp
+++ b/src/cpp/core/include/core/system/ShellUtils.hpp
@@ -52,6 +52,12 @@ enum EscapeMode
    EscapeFilesOnly
 };
 
+enum EncodingMode
+{
+   SystemEncoding,
+   DefaultEncoding
+};
+
 class ShellCommand
 {
 public:
@@ -98,6 +104,8 @@ private:
 class ShellArgs
 {
 public:
+   ShellArgs() : encodingMode_(SystemEncoding) {}
+   ShellArgs& operator<<(EncodingMode mode);
    ShellArgs& operator<<(const std::string& arg);
    ShellArgs& operator<<(int arg);
    ShellArgs& operator<<(const FilePath& path);
@@ -116,6 +124,7 @@ public:
 
 private:
    std::vector<std::string> args_;
+   EncodingMode encodingMode_;
 };
 
 }

--- a/src/cpp/core/system/ShellUtils.cpp
+++ b/src/cpp/core/system/ShellUtils.cpp
@@ -85,6 +85,12 @@ ShellCommand& ShellCommand::operator<<(const std::vector<FilePath> args)
    return *this;
 }
 
+ShellArgs& ShellArgs::operator <<(EncodingMode mode)
+{
+   encodingMode_ = mode;
+   return *this;
+}
+
 ShellArgs& ShellArgs::operator<<(const std::string& arg)
 {
    args_.push_back(arg);
@@ -99,7 +105,11 @@ ShellArgs& ShellArgs::operator<<(int arg)
 
 ShellArgs& ShellArgs::operator<<(const FilePath& path)
 {
-   return *this << string_utils::utf8ToSystem(path.absolutePath());
+   if (encodingMode_ == SystemEncoding)
+      *this << string_utils::utf8ToSystem(path.absolutePath());
+   else
+      *this << path.absolutePath();
+   return *this;
 }
 
 ShellArgs& ShellArgs::operator<<(const std::vector<std::string> args)

--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -401,7 +401,7 @@ Error ChildProcess::run()
       return systemError(::GetLastError(), ERROR_LOCATION);
 
    // populate startup info
-   STARTUPINFO si = { sizeof(STARTUPINFO) };
+   STARTUPINFOW si = { sizeof(STARTUPINFOW) };
    si.dwFlags |= STARTF_USESTDHANDLES;
    si.hStdOutput = hStdOutWrite;
    si.hStdError = options_.redirectStdErrToStdOut ? hStdOutWrite
@@ -429,32 +429,37 @@ Error ChildProcess::run()
    CloseHandleOnExitScope closeStdErrFile(&hStdErrWriteFile, ERROR_LOCATION);
 
    // build command line
-   std::vector<TCHAR> cmdLine;
+   std::vector<WCHAR> cmdLine;
 
-   bool exeQuot = std::string::npos != exe_.find(' ')
-         && std::string::npos == exe_.find('"');
+   bool exeQuot =
+         std::string::npos != exe_.find(' ') &&
+         std::string::npos == exe_.find('"');
+
    if (exeQuot)
-      cmdLine.push_back('"');
-   std::copy(exe_.begin(), exe_.end(), std::back_inserter(cmdLine));
+      cmdLine.push_back(L'"');
+   std::wstring exeWide = string_utils::utf8ToWide(exe_);
+   std::copy(exeWide.begin(), exeWide.end(), std::back_inserter(cmdLine));
    if (exeQuot)
-      cmdLine.push_back('"');
+      cmdLine.push_back(L'"');
 
    BOOST_FOREACH(std::string& arg, args_)
    {
-      cmdLine.push_back(' ');
+      cmdLine.push_back(L' ');
 
       // This is kind of gross. Ideally we would be more deterministic
       // than this.
-      bool quot = std::string::npos != arg.find(' ')
-            && std::string::npos == arg.find('"');
+      bool quot =
+            std::string::npos != arg.find(' ') &&
+            std::string::npos == arg.find('"');
 
       if (quot)
-         cmdLine.push_back('"');
-      std::copy(arg.begin(), arg.end(), std::back_inserter(cmdLine));
+         cmdLine.push_back(L'"');
+      std::wstring argWide = string_utils::utf8ToWide(arg);
+      std::copy(argWide.begin(), argWide.end(), std::back_inserter(cmdLine));
       if (quot)
-         cmdLine.push_back('"');
+         cmdLine.push_back(L'"');
    }
-   cmdLine.push_back('\0');
+   cmdLine.push_back(L'\0');
 
    // specify custom environment if requested
    DWORD dwFlags = 0;
@@ -494,18 +499,18 @@ Error ChildProcess::run()
    if (options_.breakawayFromJob)
       dwFlags |= CREATE_BREAKAWAY_FROM_JOB;
 
-   std::string workingDir;
+   std::wstring workingDir;
    if (!options_.workingDir.empty())
    {
-      workingDir = string_utils::utf8ToSystem(
+      workingDir = string_utils::utf8ToWide(
             options_.workingDir.absolutePathNative());
    }
 
    // Start the child process.
    PROCESS_INFORMATION pi;
-   ::ZeroMemory( &pi, sizeof(PROCESS_INFORMATION));
-   BOOL success = ::CreateProcess(
-     exe_.c_str(),    // Process
+   ::ZeroMemory(&pi, sizeof(PROCESS_INFORMATION));
+   BOOL success = ::CreateProcessW(
+     exeWide.c_str(), // Process
      &(cmdLine[0]),   // Command line
      NULL,            // Process handle not inheritable
      NULL,            // Thread handle not inheritable
@@ -515,7 +520,7 @@ Error ChildProcess::run()
                       // Use parent's starting directory
      workingDir.empty() ? NULL : workingDir.c_str(),
      &si,             // Pointer to STARTUPINFO structure
-     &pi );   // Pointer to PROCESS_INFORMATION structure
+     &pi);            // Pointer to PROCESS_INFORMATION structure
 
    if (!success)
       return systemError(::GetLastError(), ERROR_LOCATION);


### PR DESCRIPTION
This PR fixes an issue where attempts to stage a path whose filename is not representable in the active system encoding could fail. We accomplish this by:

- Adding a switch, allowing the `ShellArgs` class to avoid conversion of file paths to the system encoding;
- Using the wide API for creating a system process, and ensuring all the bits passed in are 'wide' (UTF-16) strings.

This PR deserves extra scrutiny since it exercises a heavily used codepath (Windows process creation). Fortunately, the changes are relatively straightforward -- we use `utf8ToWide()` to construct wide strings, and pass those on to the wide Windows APIs as needed.