### PR TITLE
explicitly allocate JSON methods map on heap

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -105,6 +105,7 @@
 #include "SessionHttpMethods.hpp"
 #include "SessionInit.hpp"
 #include "SessionMainProcess.hpp"
+#include "SessionRpc.hpp"
 #include "SessionSuspend.hpp"
 
 #include <session/SessionRUtil.hpp>
@@ -409,6 +410,9 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
    
       // client event service
       (startClientEventService)
+      
+      // rpc methods
+      (rpc::initialize)
 
       // json-rpc listeners
       (bind(registerRpcMethod, kConsoleInput, bufferConsoleInput))

--- a/src/cpp/session/SessionRpc.hpp
+++ b/src/cpp/session/SessionRpc.hpp
@@ -31,6 +31,8 @@ void handleRpcRequest(const core::json::JsonRpcRequest& request,
                       boost::shared_ptr<HttpConnection> ptrConnection,
                       http_methods::ConnectionType connectionType);
 
+core::Error initialize();
+
 } // namespace rpc
 } // namespace session
 } // namespace rstudio


### PR DESCRIPTION
This avoids issues where the destructor could be run during an abnormal
process termination, leaving the R session pegging the CPU at 100%.

Closes https://github.com/rstudio/rstudio/issues/1881.