### PR TITLE
Replaced get_system_category() with system_category()

### DIFF
--- a/src/cpp/core/BoostErrors.cpp
+++ b/src/cpp/core/BoostErrors.cpp
@@ -148,7 +148,7 @@ std::string interprocess_error_category::message(int ev) const
 boost::system::error_code ec_from_exception(const interprocess_exception& e) 
 {
    if (e.get_error_code() == system_error)
-      return error_code(e.get_native_error(), get_system_category()) ;
+      return error_code(e.get_native_error(), system_category()) ;
    else
       return error_code(e.get_error_code(), interprocess_category()) ;
 }

--- a/src/cpp/core/Error.cpp
+++ b/src/cpp/core/Error.cpp
@@ -165,7 +165,7 @@ Error::Impl& Error::impl() const
 Error systemError(int value, const ErrorLocation& location) 
 {
    using namespace boost::system ;
-   return Error(error_code(value, get_system_category()), location);
+   return Error(error_code(value, system_category()), location);
 }
 
 Error systemError(int value,
@@ -173,7 +173,7 @@ Error systemError(int value,
                   const ErrorLocation& location)
 {
    using namespace boost::system ;
-   return Error(error_code(value, get_system_category()), cause, location);
+   return Error(error_code(value, system_category()), cause, location);
 }
 
 Error systemError(int value,

--- a/src/cpp/core/FilePath.cpp
+++ b/src/cpp/core/FilePath.cpp
@@ -962,7 +962,7 @@ FilePath FilePath::childPath(const std::string& path) const
                            "absolute path not permitted",
                            boost::system::error_code(
                               boost::system::errc::no_such_file_or_directory,
-                              boost::system::get_system_category()));
+                              boost::system::system_category()));
          }
 
          return complete(path);

--- a/src/cpp/core/include/core/http/AsyncServerImpl.hpp
+++ b/src/cpp/core/include/core/http/AsyncServerImpl.hpp
@@ -488,7 +488,7 @@ private:
    void checkForResourceExhaustion(const boost::system::error_code& ec,
                                    const core::ErrorLocation& location)
    {
-      if ( ec.category() == boost::system::get_system_category() &&
+      if ( ec.category() == boost::system::system_category() &&
           (ec.value() == boost::system::errc::too_many_files_open ||
            ec.value() == boost::system::errc::not_enough_memory) )
       {

--- a/src/cpp/core/include/core/http/NamedPipeAsyncClient.hpp
+++ b/src/cpp/core/include/core/http/NamedPipeAsyncClient.hpp
@@ -103,7 +103,7 @@ private:
 
    virtual bool isShutdownError(const boost::system::error_code& ec)
    {
-      if (ec.category() == boost::system::get_system_category() &&
+      if (ec.category() == boost::system::system_category() &&
           (ec.value() == ERROR_PIPE_NOT_CONNECTED) )
       {
          return true;

--- a/src/cpp/core/include/core/http/SocketUtils.hpp
+++ b/src/cpp/core/include/core/http/SocketUtils.hpp
@@ -75,7 +75,7 @@ inline bool isConnectionTerminatedError(const core::Error& error)
 
 #ifdef _WIN32
    boost::system::error_code ec = error.code();
-   bool noData = (ec.category() == boost::system::get_system_category()) &&
+   bool noData = (ec.category() == boost::system::system_category()) &&
                  (ec.value() == ERROR_NO_DATA);
 #else
    bool noData = false;
@@ -102,7 +102,7 @@ inline bool isConnectionUnavailableError(const Error& error)
       || error.code() == boost::system::windows_error::broken_pipe
       || error.code() == boost::system::error_code(
                                        ERROR_PIPE_BUSY,
-                                       boost::system::get_system_category())
+                                       boost::system::system_category())
  #endif
    );
 }

--- a/src/cpp/core/system/Win32OutputCapture.cpp
+++ b/src/cpp/core/system/Win32OutputCapture.cpp
@@ -64,7 +64,7 @@ void standardStreamCaptureThread(
 Error ioError(const std::string& description, const ErrorLocation& location)
 {
    boost::system::error_code ec(boost::system::errc::io_error,
-                                boost::system::get_system_category());
+                                boost::system::system_category());
    Error error(ec, location);
    error.addProperty("description", description);
    return error;

--- a/src/cpp/server/ServerSessionProxy.cpp
+++ b/src/cpp/server/ServerSessionProxy.cpp
@@ -586,7 +586,7 @@ void proxyRequest(
          // so reject access since we cannot verify the identity of the user
          Error permissionError(boost::system::error_code(
                                   boost::system::errc::permission_denied,
-                                  boost::system::get_system_category()),
+                                  boost::system::system_category()),
                                error,
                                ERROR_LOCATION);
          errorHandler(permissionError);


### PR DESCRIPTION
as the function was deprecated: www.boost.org/doc/libs/1_54_0/libs/system/doc/reference.html

Fixes https://github.com/rstudio/rstudio/issues/1891.