### PR TITLE
compile with newer OpenSSL variants

### DIFF
--- a/src/cpp/core/http/SocketProxy.cpp
+++ b/src/cpp/core/http/SocketProxy.cpp
@@ -148,8 +148,14 @@ namespace {
 #ifndef _WIN32
 bool isSslShutdownError(const core::Error& error)
 {
+#ifdef SSL_R_SHORT_READ
+   // OpenSSL 1.0.0
    return error.code().category() == boost::asio::error::get_ssl_category() &&
           error.code().value() == ERR_PACK(ERR_LIB_SSL, 0, SSL_R_SHORT_READ);
+#else
+   // OpenSSL 1.1.0
+   return error.code() == boost::asio::ssl::stream_truncated;
+#endif
 }
 #else
 bool isSslShutdownError(const core::Error& error)


### PR DESCRIPTION
re: https://github.com/rstudio/rstudio/issues/1891

This should help ensure that RStudio can compile against both older and newer variants of OpenSSL / Boost. This is based on the upstream Boost change, https://github.com/chriskohlhoff/asio/commit/92bfc623e6a71353dd2c783f4c9fef5591ac550d.

cc: @Mailaender