### PR TITLE
Fixed Windows unit tests building

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -218,7 +218,7 @@ if(WIN32)
      include_directories(SYSTEM ${WINPTY_INCLUDEDIR})
 
      # openssl for Windows
-     if(RSTUDIO_SESSLIBRARY)
+     if(RSTUDIO_SESSION_WIN64 OR RSTUDIO_SESSLIBRARY)
         set(OPENSSL_ARCH "/x64/")
      else()
         set(OPENSSL_ARCH "/")

--- a/src/cpp/core/system/ChildProcessSubprocPollTests.cpp
+++ b/src/cpp/core/system/ChildProcessSubprocPollTests.cpp
@@ -16,7 +16,7 @@
 #include "ChildProcessSubprocPoll.hpp"
 
 #include <boost/bind.hpp>
-#include <boost/asio/deadline_timer.hpp>
+#include <boost/thread/thread.hpp>
 
 #include <tests/TestThat.hpp>
 
@@ -39,9 +39,7 @@ const milliseconds kCheckCwdDelayExpired = milliseconds(45);
 
 void blockingwait(milliseconds ms)
 {
-   boost::asio::io_service io;
-   boost::asio::deadline_timer timer(io, ms);
-   timer.wait();
+   boost::this_thread::sleep(ms);
 }
 
 class NoSubProcPollingFixture


### PR DESCRIPTION
The first issue prevented one of the unit tests from building due to include order due to inclusion of Boost Deadline Timer, but this was fixed by simply changing the wait method to a simple thread sleep. Second issue occurred because building a package build for Win64 was not linking the correct x64 OpenSSL lib.

Let me know if there was a reason the OPENSSL_ARCH was not being set by default for x64 - perhaps I am missing something.