### PR TITLE
support reticulate engine in R Notebooks

### DIFF
--- a/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.R
+++ b/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.R
@@ -37,6 +37,11 @@
 
 .rs.addFunction("runUserDefinedEngine", function(engine, code, options)
 {
+   # if we're using the python engine, attempt to load reticulate (this
+   # will load the reticulate knitr engine and set it as the default engine)
+   if (identical(engine, "python") && !"reticulate" %in% loadedNamespaces())
+      requireNamespace("reticulate", quietly = TRUE)
+   
    # retrieve the engine
    knitrEngines <- knitr::knit_engines$get()
    if (!engine %in% names(knitrEngines))
@@ -52,14 +57,6 @@
    {
       fmt <- "engine '%s' is not a function"
       stop(sprintf(fmt, options))
-   }
-   
-   # if we're using the python engine, attempt to load reticulate (this
-   # will load the reticulate knitr engine and set it as the default engine)
-   if (identical(engine, "python") &&
-       !"reticulate" %in% loadedNamespaces())
-   {
-      requireNamespace("reticulate", quietly = TRUE)
    }
    
    # prepare the R environment for reticulate Python engine

--- a/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.R
+++ b/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.R
@@ -39,8 +39,14 @@
 {
    # if we're using the python engine, attempt to load reticulate (this
    # will load the reticulate knitr engine and set it as the default engine)
-   if (identical(engine, "python") && !"reticulate" %in% loadedNamespaces())
+   useReticulate <-
+      identical(engine, "python") &&
+      !identical(getOption("python.reticulate"), FALSE)
+   
+   if (useReticulate) {
+      # TODO: prompt user for installation of reticulate?
       requireNamespace("reticulate", quietly = TRUE)
+   }
    
    # retrieve the engine
    knitrEngines <- knitr::knit_engines$get()
@@ -60,35 +66,32 @@
    }
    
    # prepare the R environment for reticulate Python engine
-   if ("reticulate" %in% loadedNamespaces())
+   if (useReticulate)
    {
-      reticulate <- asNamespace("reticulate")
-      if (identical(knitrEngine, reticulate$eng_python))
-      {
-         # install our own matplotlib hook -- TODO here is to save the plot
-         # object itself so we can redraw the plot if needed on resize
-         show <- getOption("reticulate.engine.matplotlib.show")
-         on.exit(options(reticulate.engine.matplotlib.show = show), add = TRUE)
-         options(reticulate.engine.matplotlib.show = function(plt, options) {
-            path <- tempfile("reticulate-matplotlib-plot-", fileext = ".png")
-            plt$savefig(path, dpi = options$dpi)
-            structure(list(path = path), class = "reticulate_matplotlib_plot")
-         })
-         
-         # install our own wrap hook -- we want to avoid the post-processing
-         # typically done by knitr; we implement our own wrap behavior for
-         # notebooks
-         wrap <- getOption("reticulate.engine.wrap")
-         on.exit(options(reticulate.engine.wrap = wrap), add = TRUE)
-         options(reticulate.engine.wrap = function(outputs, options) {
-            outputs
-         })
-         
-         # use the global environment for rendering
-         environment <- getOption("reticulate.engine.environment")
-         on.exit(options(reticulate.engine.environment = environment), add = TRUE)
-         options(reticulate.engine.environment = globalenv())
-      }
+      # install our own matplotlib hook -- TODO here is to save the plot
+      # object itself so we can redraw the plot if needed on resize
+      show <- getOption("reticulate.engine.matplotlib.show")
+      on.exit(options(reticulate.engine.matplotlib.show = show), add = TRUE)
+      options(reticulate.engine.matplotlib.show = function(plt, options) {
+         browser()
+         path <- tempfile("reticulate-matplotlib-plot-", fileext = ".png")
+         plt$savefig(path, dpi = options$dpi)
+         structure(list(path = path), class = "reticulate_matplotlib_plot")
+      })
+      
+      # install our own wrap hook -- we want to avoid the post-processing
+      # typically done by knitr; we implement our own wrap behavior for
+      # notebooks
+      wrap <- getOption("reticulate.engine.wrap")
+      on.exit(options(reticulate.engine.wrap = wrap), add = TRUE)
+      options(reticulate.engine.wrap = function(outputs, options) {
+         outputs
+      })
+      
+      # use the global environment for rendering
+      environment <- getOption("reticulate.engine.environment")
+      on.exit(options(reticulate.engine.environment = environment), add = TRUE)
+      options(reticulate.engine.environment = globalenv())
    }
    
    # prepare chunk options

--- a/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.R
+++ b/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.R
@@ -54,6 +54,14 @@
       stop(sprintf(fmt, options))
    }
    
+   # if we're using the python engine, attempt to load reticulate (this
+   # will load the reticulate knitr engine and set it as the default engine)
+   if (identical(engine, "python") &&
+       !"reticulate" %in% loadedNamespaces())
+   {
+      requireNamespace("reticulate", quietly = TRUE)
+   }
+   
    # prepare the R environment for reticulate Python engine
    if ("reticulate" %in% loadedNamespaces())
    {

--- a/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.R
+++ b/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.R
@@ -73,7 +73,6 @@
       show <- getOption("reticulate.engine.matplotlib.show")
       on.exit(options(reticulate.engine.matplotlib.show = show), add = TRUE)
       options(reticulate.engine.matplotlib.show = function(plt, options) {
-         browser()
          path <- tempfile("reticulate-matplotlib-plot-", fileext = ".png")
          plt$savefig(path, dpi = options$dpi)
          structure(list(path = path), class = "reticulate_matplotlib_plot")

--- a/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.R
+++ b/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.R
@@ -35,7 +35,7 @@
    }
 })
 
-.rs.addFunction("runUserDefinedEngine", function(engine, options)
+.rs.addFunction("runUserDefinedEngine", function(engine, code, options)
 {
    # retrieve the engine
    knitrEngines <- knitr::knit_engines$get()
@@ -54,8 +54,47 @@
       stop(sprintf(fmt, options))
    }
    
-   # invoke engine
+   # prepare the R environment for reticulate Python engine
+   if ("reticulate" %in% loadedNamespaces())
+   {
+      reticulate <- asNamespace("reticulate")
+      if (identical(knitrEngine, reticulate$eng_python))
+      {
+         # install our own matplotlib hook -- TODO here is to save the plot
+         # object itself so we can redraw the plot if needed on resize
+         show <- getOption("reticulate.engine.matplotlib.show")
+         on.exit(options(reticulate.engine.matplotlib.show = show), add = TRUE)
+         options(reticulate.engine.matplotlib.show = function(plt, options) {
+            path <- tempfile("reticulate-matplotlib-plot-", fileext = ".png")
+            plt$savefig(path, dpi = options$dpi)
+            structure(list(path = path), class = "reticulate_matplotlib_plot")
+         })
+         
+         # install our own wrap hook -- we want to avoid the post-processing
+         # typically done by knitr; we implement our own wrap behavior for
+         # notebooks
+         wrap <- getOption("reticulate.engine.wrap")
+         on.exit(options(reticulate.engine.wrap = wrap), add = TRUE)
+         options(reticulate.engine.wrap = function(outputs, options) {
+            outputs
+         })
+         
+         # use the global environment for rendering
+         environment <- getOption("reticulate.engine.environment")
+         on.exit(options(reticulate.engine.environment = environment), add = TRUE)
+         options(reticulate.engine.environment = globalenv())
+      }
+   }
+   
+   # prepare chunk options
    mergedOptions <- knitr::opts_chunk$merge(options)
+   code <- strsplit(code, "\n", fixed = TRUE)[[1]]
+   mergedOptions$code <- code
+   
+   # when invoking engines, we don't want to echo user code
+   mergedOptions$echo <- FALSE
+   
+   # invoke engine
    knitrEngine(mergedOptions)
    
 })

--- a/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.cpp
@@ -469,9 +469,6 @@ Error runUserDefinedEngine(const std::string& docId,
    bool emitWarnings = true;
    core::json::readObject(options, "warning", &emitWarnings);
    
-   bool emitErrors = true;
-   core::json::readObject(options, "error", &emitErrors);
-   
    unsigned int ordinal = 1;
    
    // helper function for emitting console text
@@ -509,12 +506,15 @@ Error runUserDefinedEngine(const std::string& docId,
    };
    
    // output will be captured by engine, but evaluation errors may be
-   // emitted directly to console, so capture those
+   // emitted directly to console, so capture those. note that the reticulate
+   // engine will automatically capture errors when 'error=TRUE', so if we
+   // receive an error it implies we should emit it to the chunk and execution
+   // will automatically stop
    auto consoleHandler = [&](
          module_context::ConsoleOutputType type,
          const std::string& output)
    {
-      if (type == module_context::ConsoleOutputError && emitErrors)
+      if (type == module_context::ConsoleOutputError)
          emitText(output, kChunkConsoleError);
    };
    

--- a/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.cpp
@@ -447,7 +447,7 @@ Error runUserDefinedEngine(const std::string& docId,
                            const std::string& nbCtxId,
                            const std::string& engine,
                            const std::string& code,
-                           const json::Object& options)
+                           json::Object options)
 {
    using namespace r::sexp;
    using namespace r::exec;
@@ -464,6 +464,10 @@ Error runUserDefinedEngine(const std::string& docId,
    error = cachePath.resetDirectory();
    if (error)
       return error;
+   
+   // default to 'error=FALSE' when unset
+   if (!options.count("error"))
+      options["error"] = false;
    
    // determine whether we want to emit warnings, errors in this chunk
    bool emitWarnings = true;

--- a/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.cpp
@@ -465,9 +465,9 @@ Error runUserDefinedEngine(const std::string& docId,
    if (error)
       return error;
    
-   // helper function for emitting console text
    unsigned int ordinal = 1;
    
+   // helper function for emitting console text
    auto emitText = [&](const std::string& text) -> Error
    {
       Error error;

--- a/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.cpp
@@ -519,7 +519,19 @@ Error runUserDefinedEngine(const std::string& docId,
          const std::string& output)
    {
       if (type == module_context::ConsoleOutputError)
-         emitText(output, kChunkConsoleError);
+      {
+         std::string errorPrefix =
+                "Error in py_run_string_impl(code, local, convert) : ";
+               
+         if (boost::algorithm::starts_with(output, errorPrefix))
+         {
+            emitText(output.substr(errorPrefix.size()), kChunkConsoleError);
+         }
+         else
+         {
+            emitText(output, kChunkConsoleError);
+         }
+      }
    };
    
    boost::signals::scoped_connection handler =

--- a/src/cpp/session/modules/rmarkdown/NotebookOutput.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookOutput.cpp
@@ -564,9 +564,10 @@ core::Error cleanChunkOutput(const std::string& docId,
    return Success();
 }
 
-core::Error appendConsoleOutput(int chunkConsoleType,
-                                const std::string& output,
-                                const core::FilePath& targetPath)
+core::Error writeConsoleOutput(int chunkConsoleType,
+                               const std::string& output,
+                               const core::FilePath& targetPath,
+                               bool truncate)
 {
    Error error;
    
@@ -583,8 +584,19 @@ core::Error appendConsoleOutput(int chunkConsoleType,
             targetPath,
             encoded,
             string_utils::LineEndingPassthrough,
-            false);
+            truncate);
    return error;
+}
+
+core::Error appendConsoleOutput(int chunkConsoleOutputType,
+                                const std::string& output,
+                                const FilePath& filePath)
+{
+   return writeConsoleOutput(
+            chunkConsoleOutputType,
+            output,
+            filePath,
+            false);
 }
 
 Error initOutput()

--- a/src/cpp/session/modules/rmarkdown/NotebookOutput.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookOutput.hpp
@@ -118,6 +118,12 @@ core::Error appendConsoleOutput(int chunkConsoleOutputType,
                                 const std::string& output,
                                 const core::FilePath& filePath);
 
+core::Error writeConsoleOutput(int chunkConsoleOutputType,
+                               const std::string& output,
+                               const core::FilePath& filePath,
+                               bool truncate);
+
+
 // send chunk output to client
 void enqueueChunkOutput(const std::string& docId,
       const std::string& chunkId, const std::string& nbCtxId, 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkPlotPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkPlotPage.java
@@ -51,20 +51,16 @@ public class ChunkPlotPage extends ChunkOutputPage
             @Override
             public void execute()
             {
-               ImageElementEx plot = plot_.getElement().cast();
                ImageElementEx img = thumbnail.getElement().cast();
-               if (plot.naturalHeight() < plot.naturalWidth())
-               {
-                  img.getStyle().setProperty("width", "100%");
-                  img.getStyle().setProperty("height", "auto");
-               }
-               else
-               {
-                  img.getStyle().setProperty("height", "100%");
-                  img.getStyle().setProperty("width", "auto");
-               }
+               
+               img.getStyle().setProperty("width", "100%");
+               img.getStyle().setProperty("height", "100%");
+               img.getStyle().setProperty("objectFit", "contain");
+               
                thumbnail.setUrl(url);
-               onRenderComplete.execute();
+               
+               if (onRenderComplete != null)
+                  onRenderComplete.execute();
             }
          }, chunkOutputSize);
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkPlotWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkPlotWidget.java
@@ -20,6 +20,8 @@ import org.rstudio.studio.client.common.FilePathUtils;
 import org.rstudio.studio.client.rmarkdown.model.NotebookPlotMetadata;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkOutputUi;
 
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.DOM;
@@ -59,10 +61,23 @@ public class ChunkPlotWidget extends Composite
                   img.getStyle().setProperty("height", "auto");
                   img.getStyle().setProperty("maxWidth", "100%");
                }
-                  
+               
                plot_.setVisible(true);
                if (onRenderComplete != null)
-                  onRenderComplete.execute();
+               {
+                  // it seems that the 'onload' event can be fired after the
+                  // image has been loaded, but before the browser has actually
+                  // sized and rendered the image. defer the 'onRenderComplete()'
+                  // action just so the browser gets a chance to render the image
+                  Scheduler.get().scheduleDeferred(new ScheduledCommand()
+                  {
+                     @Override
+                     public void execute()
+                     {
+                        onRenderComplete.execute();
+                     }
+                  });
+               }
             }
          });
       


### PR DESCRIPTION
This PR (alongside https://github.com/rstudio/reticulate/pull/143) provides initial support for Python plot output within R Notebooks.

![screen shot 2018-01-03 at 3 26 08 pm](https://user-images.githubusercontent.com/1976582/34544312-73051b70-f09a-11e7-8aaa-8e886a812c43.png)

Requires https://github.com/rstudio/reticulate/pull/143.

There's still some more work to be done to take this over the finish line, e.g.

- Re-draw the plot when the editor surface is resized,
- Tweak the padding around images generated from Python,

but this is a good start.

