### PR TITLE
use correct path for boost SSL error

### DIFF
--- a/src/cpp/core/http/SocketProxy.cpp
+++ b/src/cpp/core/http/SocketProxy.cpp
@@ -154,7 +154,7 @@ bool isSslShutdownError(const core::Error& error)
           error.code().value() == ERR_PACK(ERR_LIB_SSL, 0, SSL_R_SHORT_READ);
 #else
    // OpenSSL 1.1.0
-   return error.code() == boost::asio::ssl::stream_truncated;
+   return error.code() == boost::asio::ssl::error::stream_truncated;
 #endif
 }
 #else


### PR DESCRIPTION
see https://github.com/rstudio/rstudio/pull/1894#commitcomment-26605603