### PR TITLE
allow case-only renames (closes #1886)

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
+++ b/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
@@ -45,10 +45,11 @@ public class FileSystemItem extends JavaScriptObject
       return create(path, false, -1, 0);
    }
 
-   private static final native FileSystemItem create(String path,
-                                                     boolean dir,
-                                                     double length,
-                                                     double lastModified) /*-{
+   public static final native FileSystemItem create(String path,
+                                                    boolean dir,
+                                                    double length,
+                                                    double lastModified)
+   /*-{
       // Boost "complete" function crashes rsession if it
       // sees e.g. "C:" as opposed to "C:/"
       if (path.match(/^[a-z]:$/im))

--- a/src/gwt/src/org/rstudio/studio/client/server/VoidServerRequestCallback.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/VoidServerRequestCallback.java
@@ -43,7 +43,10 @@ public class VoidServerRequestCallback extends ServerRequestCallback<Void>
       Debug.logError(error);
 
       if (progress_ != null)
+      {
          progress_.onError(error.getUserMessage());
+         progress_.onCompleted();
+      }
       
       onFailure();
       onCompleted();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
@@ -515,12 +515,12 @@ public class Files
             final FileSystemItem target =
                file.isDirectory() ?
                   FileSystemItem.createDir(path) :
-                  FileSystemItem.createFile(path);
+                  FileSystemItem.create(path, false, file.getLength(), file.getLastModifiedNative());
               
             // clear selection
             view_.selectNone();
             
-            // premptively rename in the UI then fallback to refreshing
+            // pre-emptively rename in the UI then fallback to refreshing
             // the view if there is an error
             view_.renameFile(file, target);
             


### PR DESCRIPTION
This PR ensures that case-only renamings, e.g.

    .rprofile -> .Rprofile

can succeed when executed through the `renameFile` command.