### PR TITLE
allow UTF-8 R literals

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -176,7 +176,7 @@ public class StringUtil
 
    public static String textToRLiteral(String value)
    {
-      String escaped = value.replaceAll("([\"\\\n\\r\\t\\b\\f\\\\])", "\\\\$1");
+      String escaped = value.replaceAll("([\"\\n\\r\\t\\b\\f\\\\])", "\\\\$1");
       return '"' + escaped + '"';
    }
 

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -174,49 +174,10 @@ public class StringUtil
       return val == null || val.length() == 0;
    }
 
-   // WARNING: I'm pretty sure this will fail for UTF-8
    public static String textToRLiteral(String value)
    {
-      StringBuffer sb = new StringBuffer();
-      sb.append('"');
-
-      for (char c : value.toCharArray())
-      {
-         switch (c)
-         {
-            case '"':
-               sb.append("\\\"");
-               break;
-            case '\n':
-               sb.append("\\n");
-               break;
-            case '\r':
-               sb.append("\\r");
-               break;
-            case '\t':
-               sb.append("\\t");
-               break;
-            case '\b':
-               sb.append("\\b");
-               break;
-            case '\f':
-               sb.append("\\f");
-               break;
-            case '\\':
-               sb.append("\\\\");
-               break;
-            default:
-               if (c < 32 || c > 126)
-                  sb.append("\\x").append(toHex(c));
-               else
-                  sb.append(c);
-               break;
-         }
-      }
-
-      sb.append('"');
-      
-      return sb.toString();
+      String escaped = value.replaceAll("([\"\\\n\\r\\t\\b\\f\\\\])", "\\\\$1");
+      return '"' + escaped + '"';
    }
 
    private static String toHex(char c)


### PR DESCRIPTION
Fixes #1910. Rather than hex-escaping character literals, we just allow plain old UTF-8 literals as those work as expected with R >= 3.0.0 (which we now require for newer versions of RStudio)