### PR TITLE
Fix argument mismatches in prepareForQuit

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -1,7 +1,7 @@
 /*
  * Application.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -450,8 +450,7 @@ public class Application implements ApplicationEventHandlers
    public void onSwitchToRVersion(final SwitchToRVersionEvent event)
    {
       final ApplicationQuit applicationQuit = pApplicationQuit_.get();
-      applicationQuit.prepareForQuit("Switch R Version", true /*allowCancel*/,
-                                             new QuitContext() {
+      applicationQuit.prepareForQuit("Switch R Version", new QuitContext() {
          public void onReadyToQuit(boolean saveChanges)
          {
             // see if we have a project (otherwise switch to "None")
@@ -750,11 +749,11 @@ public class Application implements ApplicationEventHandlers
       pAceThemes_.get();
 
       // subscribe to ClientDisconnected event (wait to do this until here
-      // because there were spurious ClientDisconnected events occuring
+      // because there were spurious ClientDisconnected events occurring
       // after a session interrupt sequence. we couldn't figure out why,
       // and since this is a temporary hack why not add another temporary
       // hack to go with it here :-)
-      // TOOD: move this back tot he constructor after we revise the
+      // TODO: move this back to the constructor after we revise the
       // interrupt hack(s)
       events_.addHandler(ClientDisconnectedEvent.TYPE, this); 
       

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
@@ -1,7 +1,7 @@
 /*
  * ApplicationQuit.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -120,10 +120,9 @@ public class ApplicationQuit implements SaveActionChangedHandler,
    }
    
    public void prepareForQuit(final String caption,
-                              final boolean allowCancel,
                               final QuitContext quitContext)
    {
-      prepareForQuit(caption, allowCancel, false /*forceSaveAll*/, quitContext);
+      prepareForQuit(caption, true /*allowCancel*/, false /*forceSaveAll*/, quitContext);
    }
 
    public void prepareForQuit(final String caption,
@@ -620,14 +619,13 @@ public class ApplicationQuit implements SaveActionChangedHandler,
    @Handler
    public void onQuitSession()
    {
-      prepareForQuit("Quit R Session", true /*allowCancel*/, 
-            (boolean saveChanges) -> performQuit(saveChanges));
+      prepareForQuit("Quit R Session", (boolean saveChanges) -> performQuit(saveChanges));
    }
 
    @Handler
    public void onForceQuitSession()
    {
-      prepareForQuit("Quit R Session", false/*allowCancel*/,
+      prepareForQuit("Quit R Session", false /*allowCancel*/, false /*forceSaveChanges*/,
             (boolean saveChanges) -> performQuit(saveChanges));
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -1,7 +1,7 @@
 /*
  * DesktopApplicationHeader.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -327,7 +327,7 @@ public class DesktopApplicationHeader implements ApplicationHeader
             @Override
             public void execute()
             {
-               appQuit_.prepareForQuit("Update RStudio", true /*allowCancel*/, new QuitContext()
+               appQuit_.prepareForQuit("Update RStudio", new QuitContext()
                {
                   @Override
                   public void onReadyToQuit(boolean saveChanges)

--- a/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
@@ -1,7 +1,7 @@
 /*
  * Projects.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -215,7 +215,7 @@ public class Projects implements OpenProjectFileHandler,
    @Handler
    public void onClearRecentProjects()
    {  
-      // Clear the contents of the most rencently used list of projects
+      // Clear the contents of the most recently used list of projects
       pMRUList_.get().clear();
    }
    
@@ -231,6 +231,7 @@ public class Projects implements OpenProjectFileHandler,
       // first resolve the quit context (potentially saving edited documents   
       // and determining whether to save the R environment on exit)
       applicationQuit_.prepareForQuit("Save Current Workspace",
+         true /*allowCancel*/,
          forceSaveAll,
          new ApplicationQuit.QuitContext() {
            @Override
@@ -773,8 +774,7 @@ public class Projects implements OpenProjectFileHandler,
    {
       // first resolve the quit context (potentially saving edited documents
       // and determining whether to save the R environment on exit)
-      applicationQuit_.prepareForQuit("Close Project", true /*allowCancel*/,
-                                      new ApplicationQuit.QuitContext() {
+      applicationQuit_.prepareForQuit("Close Project", new ApplicationQuit.QuitContext() {
          public void onReadyToQuit(final boolean saveChanges)
          {
             applicationQuit_.performQuit(saveChanges, NONE);
@@ -961,6 +961,7 @@ public class Projects implements OpenProjectFileHandler,
             if (valid)
             {
                applicationQuit_.prepareForQuit("Switch Projects",
+                  true /*allowCancel*/,
                   forceSaveAll,
                   new ApplicationQuit.QuitContext() {
                   public void onReadyToQuit(final boolean saveChanges)
@@ -1047,6 +1048,7 @@ public class Projects implements OpenProjectFileHandler,
       // first resolve the quit context (potentially saving edited documents
       // and determining whether to save the R environment on exit)
       applicationQuit_.prepareForQuit("Switch Projects",
+                                      true /*allowCancel*/,
                                       forceSaveAll,
                                       new ApplicationQuit.QuitContext() {
          public void onReadyToQuit(final boolean saveChanges)


### PR DESCRIPTION
When I added `allowCancel` to `prepareForQuit`, I changed the meaning of the existing three-argument constructor, such that the bool parameter switched from `forceSaveAll` to `allowCancel`.

Failed to update some uses, so they started setting `allowCancel` to false, when they thought they were setting `forceSaveAll` to false. Thus the cancel button vanished in those cases,

Cleaned up by eliminating the three-argument constructor, going back to one with default behavior for both `forceSaveAll` and `allowCancel`, and another constructor where both must be supplied.

Resolves #1934