### PR TITLE
save / restore help pane position

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -29,6 +29,8 @@ import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.event.dom.client.KeyUpEvent;
 import com.google.gwt.event.dom.client.KeyUpHandler;
+import com.google.gwt.event.dom.client.LoadEvent;
+import com.google.gwt.event.dom.client.LoadHandler;
 import com.google.gwt.event.logical.shared.ResizeEvent;
 import com.google.gwt.event.logical.shared.ResizeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -41,7 +43,9 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ElementIds;
+import org.rstudio.core.client.Point;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.command.ShortcutManager;
@@ -99,12 +103,6 @@ public class HelpPane extends WorkbenchPane
          }
       });
 
-      ensureWidget();
-   }
-
-   @Override 
-   protected Widget createMainWidget()
-   {
       frame_ = new RStudioThemedFrame(
          null,
          ".rstudio-themes-flat.editor_dark div#TOC,\n" +
@@ -126,7 +124,15 @@ public class HelpPane extends WorkbenchPane
       frame_.setStylePrimaryName("rstudio-HelpFrame");
       frame_.addStyleName("ace_editor_theme");
       ElementIds.assignElementId(frame_.getElement(), ElementIds.HELP_FRAME);
+      
+      navStack_ = new VirtualHistory(frame_);
+      
+      ensureWidget();
+   }
 
+   @Override 
+   protected Widget createMainWidget()
+   {
       return new AutoGlassPanel(frame_);
    }
    
@@ -600,12 +606,13 @@ public class HelpPane extends WorkbenchPane
    {
       ensureWidget();
       bringToFront();
-      navStack_.navigate(url) ;
-      setLocation(url);
+      navStack_.navigate(url);
+      setLocation(url, new Point(0, 0));
       navigated_ = true;
    }
      
-   private void setLocation(final String url)
+   private void setLocation(final String url,
+                            final Point scrollPos)
    {
       // allow subsequent calls to setLocation to override any previous 
       // call (necessary so two consecutive calls like we get during
@@ -614,40 +621,52 @@ public class HelpPane extends WorkbenchPane
       targetUrl_ = url;
       
       RepeatingCommand navigateCommand = new RepeatingCommand() {
+         
+         private HandlerRegistration handler_ = frame_.addLoadHandler(new LoadHandler()
+         {
+            @Override
+            public void onLoad(LoadEvent event)
+            {
+               getIFrameEx().getContentWindow().setScrollPosition(scrollPos);
+               handler_.removeHandler();
+               handler_ = null;
+            }
+         });
+         
          @Override
          public boolean execute()
          {
-            if (getIFrameEx() != null && 
-                  getIFrameEx().getContentWindow() != null)
+            if (getIFrameEx() == null)
+               return true;
+            
+            if (getIFrameEx().getContentWindow() == null)
+               return true;
+
+            if (targetUrl_ == getUrl())
             {
-               if (targetUrl_ == getUrl())
-               {
-                  getIFrameEx().getContentWindow().reload();
-               }
-               else
-               {
-                  frame_.setUrl(targetUrl_);
-                  replaceFrameUrl(frame_.getIFrame().cast(), targetUrl_);
-               }
-               
-               return false;
+               getIFrameEx().getContentWindow().reload();
             }
             else
             {
-               return true;
+               frame_.setUrl(targetUrl_);
+               replaceFrameUrl(frame_.getIFrame().cast(), targetUrl_);
             }
+
+            return false;
          }
       };
 
       if (navigateCommand.execute())
-         Scheduler.get().scheduleFixedDelay(navigateCommand, 100);      
+      {
+         Scheduler.get().scheduleFixedDelay(navigateCommand, 100);
+      }
    }
    
    public void refresh()
    {
       String url = getUrl();
       if (url != null)
-         setLocation(url);
+         setLocation(url, new Point(0, 0));
    }
 
    private WindowEx getContentWindow()
@@ -657,16 +676,16 @@ public class HelpPane extends WorkbenchPane
 
    public void back()
    {
-      String backUrl = navStack_.back() ;
-      if (backUrl != null)
-         setLocation(backUrl) ;
+      VirtualHistory.Data back = navStack_.back();
+      if (back != null)
+         setLocation(back.getUrl(), back.getScrollPosition());
    }
 
    public void forward()
    {
-      String fwdUrl = navStack_.forward() ;
-      if (fwdUrl != null)
-         setLocation(fwdUrl) ;
+      VirtualHistory.Data fwd = navStack_.forward();
+      if (fwd != null)
+         setLocation(fwd.getUrl(), fwd.getScrollPosition());
    }
 
    public void print()
@@ -748,7 +767,7 @@ public class HelpPane extends WorkbenchPane
    private static final Resources RES = GWT.create(Resources.class);
    static { RES.styles().ensureInjected(); }
 
-   private final VirtualHistory navStack_ = new VirtualHistory() ;
+   private final VirtualHistory navStack_ ;
    private final ToolbarLinkMenu history_ ;
  
    private Label title_ ;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/VirtualHistory.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/VirtualHistory.java
@@ -15,58 +15,94 @@
 package org.rstudio.studio.client.workbench.views.help.model;
 
 import java.util.ArrayList;
+import java.util.List;
+
+import org.rstudio.core.client.Point;
+import org.rstudio.core.client.dom.IFrameElementEx;
+import org.rstudio.core.client.dom.WindowEx;
+
+import com.google.gwt.user.client.ui.Frame;
 
 public class VirtualHistory
 {
+   public static class Data
+   {
+      public Data(String url)
+      {
+         url_ = url;
+         scrollPos_ = new Point(0, 0);
+      }
+      
+      public String getUrl()
+      {
+         return url_;
+      }
+      
+      public Point getScrollPosition()
+      {
+         return scrollPos_;
+      }
+      
+      public void setScrollPosition(Point scrollPos)
+      {
+         scrollPos_ = scrollPos;
+      }
+      
+      private final String url_;
+      private Point scrollPos_;
+   }
+   
+   public VirtualHistory(Frame frame)
+   {
+      frame_ = frame;
+   }
+   
    public void navigate(String url)
    {
       // truncate the stack to the current pos
       while (stack_.size() > pos_ + 1)
          stack_.remove(stack_.size() - 1) ;
       
-      stack_.add(url) ;
+      saveScrollPosition();
+      stack_.add(new Data(url)) ;
       pos_ = stack_.size() - 1;
-      
-      dump() ;
    }
 
-   public String back()
+   public Data back()
    {
       if (pos_ <= 0)
-         return null ;
-      pos_-- ;
+         return null;
+      
+      saveScrollPosition();
+      pos_--;
 
-      dump() ;
-
-      return stack_.get(pos_) ;
+      return stack_.get(pos_);
    }
    
-   public String forward()
+   public Data forward()
    {
       if (pos_ >= stack_.size() - 1)
-         return null ;
-      pos_++ ;
+         return null;
       
-      dump() ;
+      saveScrollPosition();
+      pos_++ ;
 
-      return stack_.get(pos_) ;
+      return stack_.get(pos_);
    }
    
-   private void dump()
+   private void saveScrollPosition()
    {
-      /*
-      StringBuffer out = new StringBuffer() ;
-      for (int i = stack_.size() - 1; i >= 0; i--)
-      {
-         if (i == pos_)
-            out.append('*') ;
-         out.append(stack_.get(i)) ;
-         out.append('\n') ;
-      }
-      Debug.log(out.toString()) ;
-      */
+      if (pos_ < 0 || pos_ >= stack_.size())
+         return;
+      
+      WindowEx contentWindow =
+            ((IFrameElementEx) frame_.getElement().cast()).getContentWindow();
+      
+      Data data = stack_.get(pos_);
+      data.setScrollPosition(contentWindow.getScrollPosition());
    }
    
-   private ArrayList<String> stack_ = new ArrayList<String>() ;
-   private int pos_ = -1 ;
+   private final Frame frame_;
+   private List<Data> stack_ = new ArrayList<Data>();
+   private int pos_ = -1;
 }


### PR DESCRIPTION
Save the scroll position as part of the virtual history used by the Help
pane.

Closes #1919.