### PR TITLE
Fix New Folder button in File Pane (QtWebEngine)

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -1,7 +1,7 @@
 /*
  * DesktopGwtCallback.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -777,7 +777,8 @@ QString GwtCallback::promptForText(QString title,
                                    bool extraOptionByDefault,
                                    bool numbersOnly,
                                    int selectionStart,
-                                   int selectionLength)
+                                   int selectionLength,
+                                   QString okButtonCaption)
 {
    InputDialog dialog(pOwner_->asWidget());
    dialog.setWindowTitle(title);

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -1,7 +1,7 @@
 /*
  * DesktopGwtCallback.hpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -143,7 +143,8 @@ public slots:
                          bool rememberByDefault,
                          bool numbersOnly,
                          int selectionStart,
-                         int selectionLength);
+                         int selectionLength,
+                         QString okButtonCaption);
 
    void bringMainFrameToFront();
    void bringMainFrameBehindActive();

--- a/src/gwt/src/org/rstudio/studio/client/common/impl/DesktopTextInput.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/impl/DesktopTextInput.java
@@ -1,7 +1,7 @@
 /*
  * DesktopTextInput.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -36,16 +36,16 @@ public class DesktopTextInput implements TextInput
                              Operation cancelOperation)
    {
       Desktop.getFrame().promptForText(
-            title,
-            label,
-            initialValue,
+            StringUtil.notNull(title),
+            StringUtil.notNull(label),
+            StringUtil.notNull(initialValue),
             usePasswordMask,
-            "",
-            false,
+            "", // extraOptionPrompt
+            false, // rememberByDefault
             numbersOnly,
             selectionStart,
             selectionLength,
-            okButtonCaption,
+            StringUtil.notNull(okButtonCaption),
             result ->
             {
                if (StringUtil.isNullOrEmpty(result))
@@ -78,16 +78,16 @@ public class DesktopTextInput implements TextInput
                                  Operation cancelOperation)
    {
       Desktop.getFrame().promptForText(
-            title,
-            label,
-            initialValue,
+            StringUtil.notNull(title),
+            StringUtil.notNull(label),
+            StringUtil.notNull(initialValue),
             usePasswordMask,
-            extraOptionPrompt,
+            StringUtil.notNull(extraOptionPrompt),
             extraOptionDefault,
-            false,
+            false, // numbersOnly
             selectionStart,
             selectionLength,
-            okButtonCaption,
+            StringUtil.notNull(okButtonCaption),
             result ->
             {
                if (StringUtil.isNullOrEmpty(result))


### PR DESCRIPTION
Two issues:

1. Mismatch in the signature of promptForText: the Javascript was passing one more argument than the native side was taking (okButtonCaption).
2. The New Folder codepath, and probably others, were passing null strings, which the QWebEngine doesn't handle; make sure those are mapped to empty strings, instead, when calling.

I will look closer and see if there are other places we need to do this, or maybe come up with a more elegant general solution, but want to get this issue fixed.

resolves #1956