### PR TITLE
Don't pass null string to desktop frame functions

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -23,6 +23,8 @@ import com.google.gwt.user.client.Command;
 /**
  * This is an interface straight through to a C++ object that lives
  * in the Qt desktop frame.
+ * 
+ * String arguments must not be null.
  */
 @BaseExpression("$wnd.desktop")
 public interface DesktopFrame extends JavaScriptPassthrough

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -16,6 +16,7 @@ package org.rstudio.studio.client.application.ui.impl;
 
 import java.util.ArrayList;
 
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
 import org.rstudio.core.client.command.impl.DesktopMenuCallback;
@@ -154,7 +155,7 @@ public class DesktopApplicationHeader implements ApplicationHeader
                public void execute()
                {
                   Desktop.getFrame().onWorkbenchInitialized(
-                        sessionInfo.getScratchDir());
+                        StringUtil.notNull(sessionInfo.getScratchDir()));
                   
                   if (sessionInfo.getDisableCheckForUpdates())
                      commands.checkForUpdates().remove();
@@ -173,7 +174,7 @@ public class DesktopApplicationHeader implements ApplicationHeader
       {
          public void onShowFolder(ShowFolderEvent event)
          {
-            Desktop.getFrame().showFolder(event.getPath().getPath());
+            Desktop.getFrame().showFolder(StringUtil.notNull(event.getPath().getPath()));
          }
       });
       
@@ -243,7 +244,7 @@ public class DesktopApplicationHeader implements ApplicationHeader
    @Handler
    void onShowLogFiles()
    {
-      Desktop.getFrame().showFolder(session_.getSessionInfo().getLogDir());
+      Desktop.getFrame().showFolder(StringUtil.notNull(session_.getSessionInfo().getLogDir()));
    }
    
    @Handler
@@ -343,7 +344,7 @@ public class DesktopApplicationHeader implements ApplicationHeader
                   @Override
                   public void onReadyToQuit(boolean saveChanges)
                   {
-                     Desktop.getFrame().browseUrl(result.getUpdateUrl());
+                     Desktop.getFrame().browseUrl(StringUtil.notNull(result.getUpdateUrl()));
                      appQuit_.performQuit(null, saveChanges);
                   }
                }); 

--- a/src/gwt/src/org/rstudio/studio/client/common/DefaultGlobalDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/DefaultGlobalDisplay.java
@@ -1,7 +1,7 @@
 /*
  * DefaultGlobalDisplay.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -20,6 +20,7 @@ import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.RootLayoutPanel;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.CommandHandler;
 import org.rstudio.core.client.dom.WindowEx;
@@ -367,7 +368,7 @@ public class DefaultGlobalDisplay extends GlobalDisplay
    public void showHtmlFile(String path)
    {
       if (Desktop.isDesktop())
-         Desktop.getFrame().showFile(path);
+         Desktop.getFrame().showFile(StringUtil.notNull(path));
       else
          openWindow(server_.getFileUrl(FileSystemItem.createFile(path)));
    }
@@ -376,7 +377,7 @@ public class DefaultGlobalDisplay extends GlobalDisplay
    public void showWordDoc(String path)
    {
       if (Desktop.isDesktop())
-         Desktop.getFrame().showWordDoc(path);
+         Desktop.getFrame().showWordDoc(StringUtil.notNull(path));
       else
          openWindow(server_.getFileUrl(FileSystemItem.createFile(path)));
    }

--- a/src/gwt/src/org/rstudio/studio/client/common/dialog/DesktopDialogBuilderFactory.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dialog/DesktopDialogBuilderFactory.java
@@ -1,7 +1,7 @@
 /*
  * DesktopDialogBuilderFactory.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -51,9 +51,9 @@ public class DesktopDialogBuilderFactory implements DialogBuilderFactory
 
          Desktop.getFrame().showMessageBox(
                type,
-               caption,
-               message_,
-               buttons.toString(),
+               StringUtil.notNull(caption),
+               StringUtil.notNull(message_),
+               StringUtil.notNull(buttons.toString()),
                defaultButton_,
                buttons_.size() - 1,
                result ->

--- a/src/gwt/src/org/rstudio/studio/client/common/impl/DesktopFileDialogs.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/impl/DesktopFileDialogs.java
@@ -1,7 +1,7 @@
 /*
  * DesktopFileDialogs.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -171,10 +171,10 @@ public class DesktopFileDialogs implements FileDialogs
                         final CommandWithArg<String> onCompleted)
          {
             Desktop.getFrame().getOpenFileName(
-                  caption,
-                  label,
-                  dir,
-                  filter,
+                  StringUtil.notNull(caption),
+                  StringUtil.notNull(label),
+                  StringUtil.notNull(dir),
+                  StringUtil.notNull(filter),
                   canChooseDirectories,
                   fileName -> 
                   {
@@ -215,10 +215,10 @@ public class DesktopFileDialogs implements FileDialogs
                         final CommandWithArg<String> onCompleted)
          {
             Desktop.getFrame().getSaveFileName(
-                  caption,
-                  buttonLabel,
-                  dir,
-                  defaultExtension,
+                  StringUtil.notNull(caption),
+                  StringUtil.notNull(buttonLabel),
+                  StringUtil.notNull(dir),
+                  StringUtil.notNull(defaultExtension),
                   forceDefaultExtension,
                   fileName ->
                   {
@@ -257,9 +257,9 @@ public class DesktopFileDialogs implements FileDialogs
                         final CommandWithArg<String> onCompleted)
          {
             Desktop.getFrame().getExistingDirectory(
-                  caption,
-                  label,
-                  initialDir != null ? initialDir.getPath() : null,
+                  StringUtil.notNull(caption),
+                  StringUtil.notNull(label),
+                  initialDir != null ? StringUtil.notNull(initialDir.getPath()) : "",
                   directory -> 
                      {
                         onCompleted.execute(directory);

--- a/src/gwt/src/org/rstudio/studio/client/common/impl/DesktopWindowOpener.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/impl/DesktopWindowOpener.java
@@ -1,7 +1,7 @@
 /*
  * DesktopWindowOpener.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.common.impl;
 
 import org.rstudio.core.client.Point;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.GlobalDisplay.NewWindowOptions;
@@ -32,7 +33,7 @@ public class DesktopWindowOpener extends WebWindowOpener
       // open externally if we have a protocol and aren't an app url
       if (hasProtocol(url) && !isAppUrl(url))
       {
-         Desktop.getFrame().browseUrl(url);
+         Desktop.getFrame().browseUrl(StringUtil.notNull(url));
 
          assert options.getCallback() == null;
       }
@@ -61,7 +62,7 @@ public class DesktopWindowOpener extends WebWindowOpener
                                     int height,
                                     boolean showLocation)
    {
-      Desktop.getFrame().prepareForNamedWindow(options.getName(),
+      Desktop.getFrame().prepareForNamedWindow(StringUtil.notNull(options.getName()),
             options.allowExternalNavigation(),
             options.showDesktopToolbar(), () ->
                super.openWebMinimalWindow(globalDisplay, url, options, width, 
@@ -76,8 +77,8 @@ public class DesktopWindowOpener extends WebWindowOpener
                                  int height,
                                  boolean showLocation)
    {
-      Desktop.getFrame().openMinimalWindow(options.getName(),
-                                           url,
+      Desktop.getFrame().openMinimalWindow(StringUtil.notNull(options.getName()),
+                                           StringUtil.notNull(url),
                                            width,
                                            height);
    }
@@ -102,7 +103,8 @@ public class DesktopWindowOpener extends WebWindowOpener
          y = pos.getY();
       }
 
-      Desktop.getFrame().prepareForSatelliteWindow(windowName, x, y, width, height, ()-> 
+      Desktop.getFrame().prepareForSatelliteWindow(StringUtil.notNull(windowName), x, y, 
+            width, height, ()-> 
          super.openSatelliteWindow(globalDisplay, mode, width, height, options));
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteManager.java
@@ -1,7 +1,7 @@
 /*
  * SatelliteManager.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -175,7 +175,7 @@ public class SatelliteManager implements CloseHandler<Window>
                   if (activate) 
                   {
                      Desktop.getFrame().activateSatelliteWindow(
-                       SatelliteUtils.getSatelliteWindowName(satellite.getName()));
+                       StringUtil.notNull(SatelliteUtils.getSatelliteWindowName(satellite.getName())));
                   }
                   callNotifyReactivated(window, params);
                   return;
@@ -273,7 +273,7 @@ public class SatelliteManager implements CloseHandler<Window>
       if (Desktop.isDesktop())
       {
          Desktop.getFrame().activateSatelliteWindow(
-               SatelliteUtils.getSatelliteWindowName(name));
+               SatelliteUtils.getSatelliteWindowName(StringUtil.notNull(name)));
       }
       else
       {

--- a/src/gwt/src/org/rstudio/studio/client/common/synctex/Synctex.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/synctex/Synctex.java
@@ -1,7 +1,7 @@
 /*
  * Synctex.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -124,7 +124,7 @@ public class Synctex implements CompilePdfStartedEvent.Handler,
          if (event.getResult().isSynctexAvailable())
             page = event.getResult().getPdfLocation().getPage();
          Desktop.getFrame().externalSynctexPreview(
-                                 event.getResult().getPdfPath(), 
+                                 StringUtil.notNull(event.getResult().getPdfPath()), 
                                  page);
       }
    }
@@ -186,8 +186,8 @@ public class Synctex implements CompilePdfStartedEvent.Handler,
                if (sourceLocation != null)
                {
                   Desktop.getFrame().externalSynctexView(
-                                 pdfFile,
-                                 sourceLocation.getFile(),
+                                 StringUtil.notNull(pdfFile),
+                                 StringUtil.notNull(sourceLocation.getFile()),
                                  sourceLocation.getLine(),
                                  sourceLocation.getColumn());    
                }

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
@@ -1,7 +1,7 @@
 /*
  * HTMLPreviewPanel.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -298,7 +298,7 @@ public class HTMLPreviewPanel extends ResizeComposite
    private void navigate(String url)
    {
       if (Desktop.isDesktop())
-         Desktop.getFrame().setViewerUrl(url);
+         Desktop.getFrame().setViewerUrl(StringUtil.notNull(url));
       // use setUrl rather than navigate to deal with same origin policy
       previewFrame_.setUrl(url);
    }

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/RmdOutput.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/RmdOutput.java
@@ -1,7 +1,7 @@
 /*
  * RmdOutput.java
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.rmarkdown;
 import java.util.Map;
 import java.util.HashMap;
 
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.files.FileSystemItem;
@@ -565,7 +566,7 @@ public class RmdOutput implements RmdRenderStartedEvent.Handler,
          else if (previewer != UIPrefs.PDF_PREVIEW_NONE)
          {
             if (Desktop.isDesktop())
-               Desktop.getFrame().showPDF(result.getOutputFile(),
+               Desktop.getFrame().showPDF(StringUtil.notNull(result.getOutputFile()),
                                           result.getPreviewSlide());
             else 
                globalDisplay_.showHtmlFile(result.getOutputFile());
@@ -607,7 +608,7 @@ public class RmdOutput implements RmdRenderStartedEvent.Handler,
       else
       {
          if (Desktop.isDesktop())
-            Desktop.getFrame().showFile(result.getOutputFile());
+            Desktop.getFrame().showFile(StringUtil.notNull(result.getOutputFile()));
          else
          {
             showDownloadPreviewFileDialog(result, new Command() {

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/NewRSConnectAuthPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/NewRSConnectAuthPage.java
@@ -1,5 +1,20 @@
+/*
+ * NewRSConnectAuthPage.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
 package org.rstudio.studio.client.rsconnect.ui;
 
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ProgressIndicator;
@@ -324,7 +339,7 @@ public class NewRSConnectAuthPage
                   }
                   else
                   {
-                     Desktop.getFrame().browseUrl(result_.getPreAuthToken().getClaimUrl());
+                     Desktop.getFrame().browseUrl(StringUtil.notNull(result_.getPreAuthToken().getClaimUrl()));
                   }
                   
                   // close the window automatically when authentication finishes

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ui/ShinyGadgetDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ui/ShinyGadgetDialog.java
@@ -1,7 +1,7 @@
 /*
  * ShinyGadgetDialog.java
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,6 +16,7 @@
 package org.rstudio.studio.client.shiny.ui;
 
 import org.rstudio.core.client.Size;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomMetrics;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
@@ -92,7 +93,7 @@ public class ShinyGadgetDialog extends ModalDialogBase
       frame_.setSize(size.width + "px", size.height + "px");
       
       if (Desktop.isDesktop())
-         Desktop.getFrame().setShinyDialogUrl(url_);
+         Desktop.getFrame().setShinyDialogUrl(StringUtil.notNull(url_));
       
       frame_.setUrl(url_);
       return frame_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
@@ -1,7 +1,7 @@
 /*
  * Workbench.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -400,9 +400,10 @@ public class Workbench implements BusyHandler,
             @Override
             public void onResponseReceived(TerminalOptions options)
             {
-               Desktop.getFrame().openTerminal(options.getTerminalPath(),
-                     options.getWorkingDirectory(),
-                     options.getExtraPathEntries(),
+               Desktop.getFrame().openTerminal(
+                     StringUtil.notNull(options.getTerminalPath()),
+                     StringUtil.notNull(options.getWorkingDirectory()),
+                     StringUtil.notNull(options.getExtraPathEntries()),
                      options.getShellType());
             }
          });
@@ -610,8 +611,8 @@ public class Workbench implements BusyHandler,
    {
       if (BrowseCap.isWindowsDesktop())
       {
-         Desktop.getFrame().installRtools(event.getVersion(),
-                                          event.getInstallerPath());  
+         Desktop.getFrame().installRtools(StringUtil.notNull(event.getVersion()),
+                                          StringUtil.notNull(event.getInstallerPath())); 
       }
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/WorkbenchNewSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/WorkbenchNewSession.java
@@ -1,7 +1,7 @@
 /*
  * WorkbenchNewSession.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client.workbench;
 
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.model.ApplicationServerOperations;
 import org.rstudio.studio.client.common.GlobalDisplay;
@@ -37,7 +38,7 @@ public class WorkbenchNewSession
       else
       {
          Desktop.getFrame().openSessionInNewWindow(
-               workbenchContext.getCurrentWorkingDir().getPath());
+               StringUtil.notNull(workbenchContext.getCurrentWorkingDir().getPath()));
       }
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -1,7 +1,7 @@
 /*
  * AppearancePreferencesPane.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -291,7 +291,7 @@ public class AppearancePreferencesPane extends PreferencesPane
       {
          if (initialFontFace_ != fontFace_.getValue())
          {
-            Desktop.getFrame().setFixedWidthFont(fontFace_.getValue());
+            Desktop.getFrame().setFixedWidthFont(StringUtil.notNull(fontFace_.getValue()));
             restartRequired = true;
          }
          

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyHost.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyHost.java
@@ -1,7 +1,7 @@
 /*
  * NewConnectionShinyHost.java
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -181,7 +181,7 @@ public class NewConnectionShinyHost extends Composite
       String url = event.getURL();
       
       if (Desktop.isDesktop())
-         Desktop.getFrame().setShinyDialogUrl(url);
+         Desktop.getFrame().setShinyDialogUrl(StringUtil.notNull(url));
 
       frame_.setUrl(StringUtil.makeAbsoluteUrl(url));
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/presentation/Presentation.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/presentation/Presentation.java
@@ -2,7 +2,7 @@
  * Presentation.java
 
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -243,7 +243,7 @@ public class Presentation extends BasePresenter
                @Override
                public void onResponseReceived(String path)
                {
-                  Desktop.getFrame().showFile(path);
+                  Desktop.getFrame().showFile(StringUtil.notNull(path));
                }
             });
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -1,7 +1,7 @@
 /*
  * AceEditor.java
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -493,7 +493,7 @@ public class AceEditor implements DocDisplay,
       if (Desktop.isDesktop() && isEmacsModeOn())
       {
          String text = getTextForRange(yankRange);
-         Desktop.getFrame().setClipboardText(text);
+         Desktop.getFrame().setClipboardText(StringUtil.notNull(text));
          replaceRange(yankRange, "");
          clearEmacsMark();
       }
@@ -535,7 +535,7 @@ public class AceEditor implements DocDisplay,
       if (Desktop.isDesktop() && isEmacsModeOn())
       {
          String text = getTextForRange(yankRange);
-         Desktop.getFrame().setClipboardText(text);
+         Desktop.getFrame().setClipboardText(StringUtil.notNull(text));
          replaceRange(yankRange, "");
          clearEmacsMark();
       }
@@ -1181,7 +1181,7 @@ public class AceEditor implements DocDisplay,
       if (Desktop.isDesktop())
       {
          // the desktop frame prints the code directly
-         Desktop.getFrame().printText(getCode());
+         Desktop.getFrame().printText(StringUtil.notNull(getCode()));
       }
       else
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPresenter.java
@@ -1,7 +1,7 @@
 /*
  * ViewerPresenter.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * This program is licensed to you under the terms of version 3 of the
  * GNU Affero General Public License. This program is distributed WITHOUT
@@ -17,6 +17,7 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 
 import org.rstudio.core.client.Size;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.EnabledChangedHandler;
@@ -177,7 +178,7 @@ public class ViewerPresenter extends BasePresenter
          display_.maximize();
       rmdPreviewParams_ = event.getParams();
       if (Desktop.isDesktop())
-         Desktop.getFrame().setViewerUrl(event.getParams().getOutputUrl());
+         Desktop.getFrame().setViewerUrl(StringUtil.notNull(event.getParams().getOutputUrl()));
       display_.previewRmd(event.getParams());
    }
    
@@ -192,7 +193,7 @@ public class ViewerPresenter extends BasePresenter
          manageCommands(true);
          display_.bringToFront();
          if (Desktop.isDesktop())
-            Desktop.getFrame().setViewerUrl(event.getParams().getUrl());
+            Desktop.getFrame().setViewerUrl(StringUtil.notNull(event.getParams().getUrl()));
          display_.previewShiny(event.getParams());
          runningShinyAppParams_ = event.getParams();
       }
@@ -396,15 +397,15 @@ public class ViewerPresenter extends BasePresenter
    private void navigate(String url)
    {
       if (Desktop.isDesktop())
-         Desktop.getFrame().setViewerUrl(url);
+         Desktop.getFrame().setViewerUrl(StringUtil.notNull(url));
       display_.navigate(url);
    }
    
    private void updateZoomWindow(String url)
    {
       if (Desktop.isDesktop()) {
-         Desktop.getFrame().setViewerUrl(url);
-         Desktop.getFrame().reloadViewerZoomWindow(url);
+         Desktop.getFrame().setViewerUrl(StringUtil.notNull(url));
+         Desktop.getFrame().reloadViewerZoomWindow(StringUtil.notNull(url));
       } else if ((zoomWindow_ != null) && !zoomWindow_.isClosed()) {
          zoomWindow_.setLocationHref(url);
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/export/ViewerPaneSaveAsImageDesktopOperation.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/export/ViewerPaneSaveAsImageDesktopOperation.java
@@ -1,7 +1,7 @@
 /*
  * ViewerPaneSaveAsImageDesktopOperation.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,6 +16,7 @@
 package org.rstudio.studio.client.workbench.views.viewer.export;
 
 import org.rstudio.core.client.Rectangle;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
@@ -43,15 +44,15 @@ public class ViewerPaneSaveAsImageDesktopOperation implements SavePlotAsImageOpe
                {
                   // perform the export
                   Desktop.getFrame().exportPageRegionToFile(
-                        targetPath.getPath(), 
-                        format, 
+                        StringUtil.notNull(targetPath.getPath()), 
+                        StringUtil.notNull(format), 
                         viewerRect.getLeft(),
                         viewerRect.getTop(),
                         viewerRect.getWidth(),
                         viewerRect.getHeight());
                     
                   if (viewAfterSave) 
-                     Desktop.getFrame().showFile(targetPath.getPath());
+                     Desktop.getFrame().showFile(StringUtil.notNull(targetPath.getPath()));
                }
             },
             onCompleted


### PR DESCRIPTION
The qtwebchannel doesn't support passing null strings, so run them through StringUtil.notNull.

I had previously fixed a known problem in #1964; this change is just a blanket application to all desktop frame APIs.