### PR TITLE
Fix issue with RPC delivery when R is busy

### DIFF
--- a/src/cpp/r/session/REmbeddedPosix.cpp
+++ b/src/cpp/r/session/REmbeddedPosix.cpp
@@ -320,6 +320,10 @@ void initializePolledEventHandler(void (*newPolledEventHandler)(void))
    // preserve old handler and set new one
    s_oldPolledEventHandler = R_PolledEvents;
    R_PolledEvents = polledEventHandler;
+   
+   // set R_wait_usec
+   if (R_wait_usec > 10000 || R_wait_usec == 0)
+      R_wait_usec = 10000;
 }
 
 // NOTE: this call is used in child process after multicore forks


### PR DESCRIPTION
This resolves #1970, resolves #1957 and backs-out 2a131ea9.

We need to open issues for the fixes undone by this; these predate our move to GitHub issue so need to be created.