### PR TITLE
Add StringUtil.equals method for null-safe string comparison

### DIFF
--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -249,7 +249,7 @@
    </target>
 
    <target name="build-unittests" description="Builds JUnit unit tests">
-       <javac srcdir="test" includes="org/rstudio/studio/client/**" encoding="utf-8"
+       <javac srcdir="test" includes="org/rstudio/**/client/**" encoding="utf-8"
              destdir="${build.dir}"
              source="1.8" target="1.8" nowarn="true" deprecation="true"
              debug="true" debuglevel="lines,vars,source"

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -1,7 +1,7 @@
 /*
  * StringUtil.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class StringUtil
 {
@@ -122,7 +123,7 @@ public class StringUtil
       return FORMAT.format((double)size / divisor) + " " + LABELS[i];
    }
    
-   // Peform an integer division and return the result. GWT's division operator
+   // Perform an integer division and return the result. GWT's division operator
    // truncates the result to Int32 range. 
    public static native int nativeDivide(int num, int denom) 
    /*-{
@@ -1165,10 +1166,20 @@ public class StringUtil
       return (str.match(/\n/g)||[]).length;
    }-*/;
    
+   /**
+    * Compare two strings, works if one or both strings are null.
+    * @param str1
+    * @param str2
+    * @return true if non-null strings are equal, or both are null
+    */
+   public static final boolean equals(String str1, String str2)
+   {
+      return Objects.equals(str1, str2);
+   }
+   
    private static final NumberFormat FORMAT = NumberFormat.getFormat("0.#");
    private static final NumberFormat PRETTY_NUMBER_FORMAT = NumberFormat.getFormat("#,##0.#####");
    private static final DateTimeFormat DATE_FORMAT
                           = DateTimeFormat.getFormat("MMM d, yyyy, h:mm a");
    private static final Pattern RE_INDENT = Pattern.create("^\\s*", "");
-
 }

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -1172,10 +1172,9 @@ public class StringUtil
     * @param str2
     * @return true if non-null strings are equal, or both are null
     */
-   public static final boolean equals(String str1, String str2)
-   {
-      return Objects.equals(str1, str2);
-   }
+   public static native boolean equals(String str1, String str2) /*-{
+      return str1 == str2;
+   }-*/;
    
    private static final NumberFormat FORMAT = NumberFormat.getFormat("0.#");
    private static final NumberFormat PRETTY_NUMBER_FORMAT = NumberFormat.getFormat("#,##0.#####");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.Objects;
 
 import org.rstudio.core.client.ResultCallback;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.console.ConsoleProcess.ConsoleProcessFactory;
@@ -117,7 +118,7 @@ public class TerminalList implements Iterable<String>,
          return false;
       }
 
-      if (!Objects.equals(current.getTitle(), title))
+      if (!StringUtil.equals(current.getTitle(), title))
       {
          current.setTitle(title);
          return true;
@@ -158,7 +159,7 @@ public class TerminalList implements Iterable<String>,
       if (current == null)
          return;
 
-      if (!Objects.equals(current.getCwd(), cwd))
+      if (!StringUtil.equals(current.getCwd(), cwd))
       {
          current.setCwd(cwd);
       }
@@ -241,7 +242,7 @@ public class TerminalList implements Iterable<String>,
       int i = 0;
       for (final java.util.Map.Entry<String, TerminalListData> item : terminals_.entrySet())
       {
-         if (Objects.equals(item.getValue().getCPI().getHandle(), handle))
+         if (StringUtil.equals(item.getValue().getCPI().getHandle(), handle))
          {
             return i;
          }
@@ -279,7 +280,7 @@ public class TerminalList implements Iterable<String>,
    {
       for (final java.util.Map.Entry<String, TerminalListData> item : terminals_.entrySet())
       {
-         if (Objects.equals(item.getValue().getCPI().getCaption(), caption))
+         if (StringUtil.equals(item.getValue().getCPI().getCaption(), caption))
          {
             return false;
          }
@@ -297,7 +298,7 @@ public class TerminalList implements Iterable<String>,
    {
       for (final java.util.Map.Entry<String, TerminalListData> item : terminals_.entrySet())
       {
-         if (Objects.equals(item.getValue().getCPI().getCaption(), caption))
+         if (StringUtil.equals(item.getValue().getCPI().getCaption(), caption))
          {
             return item.getValue().getCPI().getHandle();
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalLocalEcho.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalLocalEcho.java
@@ -92,7 +92,7 @@ public class TerminalLocalEcho
          }
 
          String matchedValue = match.getValue();
-         if (Objects.equals(matchedValue, "\b")  && !localEcho_.isEmpty())
+         if (StringUtil.equals(matchedValue, "\b")  && !localEcho_.isEmpty())
          {
             // If the backspace was typed by the user, it will be in the
             // localecho buffer, and already echoed to the screen. If it isn't
@@ -101,7 +101,7 @@ public class TerminalLocalEcho
             // remove the backspace from the localEcho buffer so matching
             // doesn't break at this point.
             String popped = localEcho_.pop();
-            if (!Objects.equals(popped, "\b"))
+            if (!StringUtil.equals(popped, "\b"))
             {
                // Anything in localEcho at this point represents text written to
                // the local screen that the server doesn't know was written, so a

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -813,7 +813,7 @@ public class TerminalPane extends WorkbenchPane
       // Notification from a TerminalSession that it changed its title
       TerminalSession visibleTerm = getSelectedTerminal();
       TerminalSession retitledTerm = event.getTerminalSession();
-      if (visibleTerm != null && Objects.equals(visibleTerm.getHandle(), retitledTerm.getHandle()))
+      if (visibleTerm != null && StringUtil.equals(visibleTerm.getHandle(), retitledTerm.getHandle()))
       {
          // update the toolbar label if currently displayed terminal has changed
          // its title
@@ -876,7 +876,7 @@ public class TerminalPane extends WorkbenchPane
       for (int i = 0; i < total; i++)
       {
          TerminalSession t = getLoadedTerminalAtIndex(i);
-         if (t != null && Objects.equals(t.getHandle(), handle))
+         if (t != null && StringUtil.equals(t.getHandle(), handle))
          {
             return t;
          }
@@ -895,7 +895,7 @@ public class TerminalPane extends WorkbenchPane
       for (int i = 0; i < total; i++)
       {
          TerminalSession t = getLoadedTerminalAtIndex(i);
-         if (t != null && Objects.equals(t.getCaption(), caption))
+         if (t != null && StringUtil.equals(t.getCaption(), caption))
          {
             return t;
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
@@ -264,7 +264,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
          String prevHandle = null;
          for (final String handle : terminals_)
          {
-            if (Objects.equals(activeTerminalHandle_, handle))
+            if (StringUtil.equals(activeTerminalHandle_, handle))
             {
                if (prevHandle == null)
                {
@@ -295,7 +295,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
             {
                return handle;
             }
-            if (Objects.equals(activeTerminalHandle_, handle))
+            if (StringUtil.equals(activeTerminalHandle_, handle))
             {
                foundCurrent = true;
             }

--- a/src/gwt/test/org/rstudio/core/client/StringUtilTests.java
+++ b/src/gwt/test/org/rstudio/core/client/StringUtilTests.java
@@ -1,7 +1,7 @@
 /*
  * StringUtilTests.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -165,7 +165,53 @@ public class StringUtilTests extends GWTTestCase
       url = "8.8.8.8:443/notfound.html";
       assertEquals("8.8.8.8:443", StringUtil.getHostFromUrl(url));
    }
-
+   
+   public void testStringEquals()
+   {
+      String one_1 = "one";
+      String two_1 = "two";
+      String one_2 = "one";
+      String two_2 = "two";
+      String null_1 = null;
+      String null_2 = null;
+      
+      assertTrue(StringUtil.equals(one_1, one_2));
+      assertTrue(StringUtil.equals(one_2, one_1)); 
+      assertTrue(StringUtil.equals(two_1, two_2));
+      assertTrue(StringUtil.equals(two_2, two_1));
+      
+      assertTrue(StringUtil.equals(null_1, null_2));
+      assertTrue(StringUtil.equals(null_2, null_1));
+      
+      assertTrue(StringUtil.equals(one_1, one_1));
+      assertTrue(StringUtil.equals(one_2, one_2));
+      assertTrue(StringUtil.equals(two_1, two_1));
+      assertTrue(StringUtil.equals(two_2, two_2));
+      
+      assertTrue(StringUtil.equals(null_1, null_1));
+      assertTrue(StringUtil.equals(null_2, null_2));
+      
+      assertFalse(StringUtil.equals(one_1, two_1));
+      assertFalse(StringUtil.equals(two_1, one_1));
+      assertFalse(StringUtil.equals(one_2, two_2));
+      assertFalse(StringUtil.equals(two_2, one_2));
+      
+      assertFalse(StringUtil.equals(one_1, null_1));
+      assertFalse(StringUtil.equals(two_1, null_1));
+      assertFalse(StringUtil.equals(one_1, null_1));
+      assertFalse(StringUtil.equals(two_1, null_1));
+      
+      assertFalse(StringUtil.equals(one_2, null_1));
+      assertFalse(StringUtil.equals(two_2, null_1));
+      assertFalse(StringUtil.equals(one_2, null_1));
+      assertFalse(StringUtil.equals(two_2, null_1));
+      
+      assertFalse(StringUtil.equals(null_2, one_1));
+      assertFalse(StringUtil.equals(null_2, two_1));
+      assertFalse(StringUtil.equals(null_2, one_2));
+      assertFalse(StringUtil.equals(null_2, two_2));
+   } 
+   
    // -----------------------------------------------------------------------
 
    // TODO: Tests for remaining public StringUtil methods
@@ -421,5 +467,8 @@ public class StringUtilTests extends GWTTestCase
    // public static final native String crc32(String str)
 
    // -----------------------------------------------------------------------
+   
+   // public static native int newlineCount(String str)
 
+   // -----------------------------------------------------------------------
 }


### PR DESCRIPTION
Per a recent conversation, we decided to steer in the direction of using Java-compatible string comparision conventions, even though GWT output makes str1 == str2 an ok way to compare contents of strings (unlike Java).

For cases where null is a factor, added `StringUtil.equals(str1, str2)`. This defers to the newer Java `Objects.compare(str1, str2)`` method, but has the added benefit of compile-type type-safety (and gives a place to change our approach, should we need to).

For comparisions where we know the strings are not-null, then continued use of `str1.compare(str2)`` is the way to go, avoiding the slight performance penalty of the null checks inside Objects.compare.

Also discovered that the core/client unit tests (such as for StringUtil) were not being run. Modified build.xml to include them.

Changed the Objects.equals I had previously added when IntelliJ complained about it. Did not do a sweep looking for `==` usages.