### PR TITLE
Reimplement Mac Dock menu for opening new RStudio window

### DIFF
--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -1,7 +1,7 @@
 /*
  * DesktopSessionLauncher.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -164,6 +164,7 @@ Error SessionLauncher::launchFirstSession()
    // show the window (but don't if we are doing a --run-diagnostics)
    if (!options().runDiagnostics())
    {
+      finalPlatformInitialize(pMainWindow_);
       pMainWindow_->show();
       pAppLaunch_->activateWindow();
       pMainWindow_->loadUrl(url);

--- a/src/cpp/desktop/DesktopUtils.cpp
+++ b/src/cpp/desktop/DesktopUtils.cpp
@@ -35,6 +35,7 @@
 #include <core/system/Environment.hpp>
 
 #include "DesktopOptions.hpp"
+#include "DesktopMainWindow.hpp"
 
 #ifdef Q_OS_WIN
 #include <windows.h>
@@ -44,8 +45,6 @@ using namespace rstudio::core;
 
 namespace rstudio {
 namespace desktop {
-
-class DesktopMainWindow;
 
 #ifdef Q_OS_WIN
 

--- a/src/cpp/desktop/DesktopUtils.cpp
+++ b/src/cpp/desktop/DesktopUtils.cpp
@@ -1,7 +1,7 @@
 /*
  * DesktopUtils.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -44,6 +44,8 @@ using namespace rstudio::core;
 
 namespace rstudio {
 namespace desktop {
+
+class DesktopMainWindow;
 
 #ifdef Q_OS_WIN
 
@@ -122,6 +124,11 @@ bool supportsFullscreenMode(QMainWindow* pMainWindow)
 
 void initializeLang()
 {
+}
+
+void finalPlatformInitialize(MainWindow* pMainWindow)
+{
+
 }
 
 #endif

--- a/src/cpp/desktop/DesktopUtils.hpp
+++ b/src/cpp/desktop/DesktopUtils.hpp
@@ -1,7 +1,7 @@
 /*
  * DesktopUtils.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -32,6 +32,8 @@ namespace core {
 
 namespace rstudio {
 namespace desktop {
+
+class MainWindow;
 
 void reattachConsoleIfNecessary();
 
@@ -77,6 +79,9 @@ void toggleFullscreenMode(QMainWindow* pMainWindow);
 bool supportsFullscreenMode(QMainWindow* pMainWindow);
 
 void initializeLang();
+
+// Platform-specific initialization requiring main window object.
+void finalPlatformInitialize(MainWindow* pMainWindow);
 
 double getDpiZoomScaling();
 int getDpi();

--- a/src/cpp/desktop/Info.plist.in
+++ b/src/cpp/desktop/Info.plist.in
@@ -220,7 +220,7 @@
 	<key>CFBundleExecutable</key>
 	<string>RStudio</string>
 	<key>CFBundleGetInfoString</key>
-   <string>RStudio ${CPACK_PACKAGE_VERSION}, © 2009-2017 RStudio, Inc.</string>
+   <string>RStudio ${CPACK_PACKAGE_VERSION}, © 2009-2018 RStudio, Inc.</string>
 	<key>CFBundleIconFile</key>
 	<string>RStudio.icns</string>
 	<key>CFBundleIdentifier</key>
@@ -244,7 +244,7 @@
 	<key>LSRequiresCarbon</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-  <string>RStudio ${CPACK_PACKAGE_VERSION}, © 2009-2017 RStudio, Inc.</string>
+  <string>RStudio ${CPACK_PACKAGE_VERSION}, © 2009-2018 RStudio, Inc.</string>
   <key>NSHighResolutionCapable</key>
   <true/>
 </dict>

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -136,6 +136,8 @@ Error findProjectInFolder(const json::JsonRpcRequest& request,
       return error;
 
    boost::algorithm::trim(folder);
+   while ((folder.back() == '/'))
+      folder.erase(folder.size()-1); // remove trailing slash
    if (folder.empty())
    {
       pResponse->setResult("");


### PR DESCRIPTION
This was lost in the move back to Qt. Resolves #2004.