### PR TITLE
Render ctrl+based shortcuts in menus correctly on macOS

### DIFF
--- a/src/cpp/desktop/DesktopMenuCallback.cpp
+++ b/src/cpp/desktop/DesktopMenuCallback.cpp
@@ -168,6 +168,13 @@ void MenuCallback::addCommand(QString commandId,
                               QString shortcut,
                               bool checkable)
 {
+
+#ifdef Q_OS_MAC
+   // on macOS, replace instances of 'Ctrl' with 'Meta'; QKeySequence renders "Ctrl" using the
+   // macOS command symbol, but we want the menu to show the literal Ctrl symbol (^)
+   shortcut.replace(QStringLiteral("Ctrl"), QStringLiteral("Meta"));
+#endif
+
    // replace instances of 'Cmd' with 'Ctrl' -- note that on macOS
    // Qt automatically maps that to the Command key
    shortcut.replace(QStringLiteral("Cmd"), QStringLiteral("Ctrl"));


### PR DESCRIPTION
`QKeySequence` renders Ctrl using the macOS "command" icon. However, we want menu shortcuts to show the literal Ctrl symbol (^); this change replaces Ctrl with Meta on macOS when populating menus.

http://doc.qt.io/qt-5/qkeysequence.html