### PR TITLE
use Q_SIGNALS / Q_SLOTS (avoid collisions with boost)

### DIFF
--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -92,7 +92,10 @@ get_filename_component(QT_BIN_DIR ${QT_QMAKE_EXECUTABLE} PATH)
 set(CMAKE_PREFIX_PATH "${QT_BIN_DIR}//..//lib//cmake")
 
 # find and include Qt
-add_definitions(-DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII)
+add_definitions(
+   -DQT_NO_CAST_FROM_ASCII
+   -DQT_NO_CAST_TO_ASCII
+   -DQT_NO_SIGNALS_SLOTS_KEYWORDS)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 find_package(Qt5Core REQUIRED)

--- a/src/cpp/desktop/DesktopActivationOverlay.hpp
+++ b/src/cpp/desktop/DesktopActivationOverlay.hpp
@@ -53,7 +53,7 @@ public:
 
    void showLicenseDialog();
 
-signals:
+Q_SIGNALS:
    void licenseLost(QString licenseMessage);
    void launchFirstSession();
    void launchError(QString message);

--- a/src/cpp/desktop/DesktopApplicationLaunch.hpp
+++ b/src/cpp/desktop/DesktopApplicationLaunch.hpp
@@ -54,10 +54,10 @@ protected:
                      long * result);
 #endif
 
-signals:
+Q_SIGNALS:
     void openFileRequest(QString filename);
 
-public slots:
+public Q_SLOTS:
     bool sendMessage(QString filename);
 
 private:

--- a/src/cpp/desktop/DesktopBrowserWindow.hpp
+++ b/src/cpp/desktop/DesktopBrowserWindow.hpp
@@ -39,7 +39,7 @@ public:
                            bool allowExternalNavigate = false);
     WebView* webView();
 
-protected slots:
+protected Q_SLOTS:
 
      void adjustTitle();
      void setProgress(int p);

--- a/src/cpp/desktop/DesktopChooseRHome.hpp
+++ b/src/cpp/desktop/DesktopChooseRHome.hpp
@@ -39,7 +39,7 @@ public:
    bool preferR64();
    void setValue(const rstudio::desktop::RVersion& value, bool preferR64);
 
-protected slots:
+protected Q_SLOTS:
    void chooseOther();
    void validateSelection();
    void onModeChanged();

--- a/src/cpp/desktop/DesktopDownloadHelper.hpp
+++ b/src/cpp/desktop/DesktopDownloadHelper.hpp
@@ -32,10 +32,10 @@ public:
 
     static void handleDownload(QNetworkReply* pReply, QString fileName);
 
-protected slots:
+protected Q_SLOTS:
     void onDownloadFinished();
 
-signals:
+Q_SIGNALS:
     void downloadFinished(QString fileName);
 
 private:

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -48,10 +48,10 @@ public:
 
    int collectPendingQuitRequest();
 
-signals:
+Q_SIGNALS:
    void workbenchInitialized();
 
-public slots:
+public Q_SLOTS:
    QString proportionalFont();
    QString fixedWidthFont();
    void browseUrl(QString url);

--- a/src/cpp/desktop/DesktopGwtWindow.hpp
+++ b/src/cpp/desktop/DesktopGwtWindow.hpp
@@ -33,11 +33,11 @@ public:
 
    const std::vector<double>& zoomLevels() const { return zoomLevels_; }
 
-public slots:
+public Q_SLOTS:
    void zoomIn();
    void zoomOut();
 
-protected slots:
+protected Q_SLOTS:
    void finishLoading(bool) override;
 
 protected:

--- a/src/cpp/desktop/DesktopMainWindow.hpp
+++ b/src/cpp/desktop/DesktopMainWindow.hpp
@@ -46,7 +46,7 @@ public:
    void launchRStudio(const std::vector<std::string>& args = std::vector<std::string>(),
                       const std::string& initialDir = std::string());
 
-public slots:
+public Q_SLOTS:
    void quit();
    void loadUrl(const QUrl& url);
    void setMenuBar(QMenuBar *pMenuBar);
@@ -56,10 +56,10 @@ public slots:
    void onPdfViewerSyncSource(QString srcFile, int line, int column);
    void onLicenseLost(QString licenseMessage);
 
-signals:
+Q_SIGNALS:
    void firstWorkbenchInitialized();
 
-protected slots:
+protected Q_SLOTS:
    void onCloseWindowShortcut();
    void onWorkbenchInitialized();
    void resetMargins();

--- a/src/cpp/desktop/DesktopMenuCallback.hpp
+++ b/src/cpp/desktop/DesktopMenuCallback.hpp
@@ -34,7 +34,7 @@ class MenuCallback : public QObject
 public:
     explicit MenuCallback(QObject *parent = nullptr);
 
-public slots:
+public Q_SLOTS:
     // menu-building commands
     void beginMainMenu();
     void beginMenu(QString label);
@@ -54,7 +54,7 @@ public slots:
     void setCommandLabel(QString commandId, QString label);
     void setCommandChecked(QString commandId, bool checked);
 
-signals:
+Q_SIGNALS:
     void menuBarCompleted(QMenuBar* menuBar);
     void manageCommand(QString commandId, QAction* action);
     void manageCommandVisibility(QString commandId, QAction* action);
@@ -99,11 +99,11 @@ class MenuActionBinder : public QObject
 public:
    MenuActionBinder(QMenu* pMenu, QAction* action);
 
-public slots:
+public Q_SLOTS:
    void onShowMenu();
    void onHideMenu();
 
-signals:
+Q_SIGNALS:
    void manageCommand(QString commandId, QAction* action);
 
 private:
@@ -117,7 +117,7 @@ class WindowMenu : public QMenu
 public:
    explicit WindowMenu(QWidget *parent = nullptr);
 
-protected slots:
+protected Q_SLOTS:
    void onMinimize();
    void onZoom();
    void onBringAllToFront();

--- a/src/cpp/desktop/DesktopPosixApplication.hpp
+++ b/src/cpp/desktop/DesktopPosixApplication.hpp
@@ -44,7 +44,7 @@ public:
        pAppLauncher_ = pAppLauncher;
    }
 
-signals:
+Q_SIGNALS:
     void openFileRequest(QString filename);
 
 protected:

--- a/src/cpp/desktop/DesktopSatelliteWindow.hpp
+++ b/src/cpp/desktop/DesktopSatelliteWindow.hpp
@@ -41,12 +41,12 @@ class SatelliteWindow : public GwtWindow
 public:
     SatelliteWindow(MainWindow* pMainWindow, QString name);
 
-signals:
+Q_SIGNALS:
 
-public slots:
+public Q_SLOTS:
 
 
-protected slots:
+protected Q_SLOTS:
    void onCloseWindowShortcut();
    void finishLoading(bool ok) override;
 

--- a/src/cpp/desktop/DesktopSecondaryWindow.hpp
+++ b/src/cpp/desktop/DesktopSecondaryWindow.hpp
@@ -30,7 +30,7 @@ public:
                              QWidget* pParent = nullptr, WebPage *pOpener = nullptr,
                              bool allowExternalNavigate = false);
 
-protected slots:
+protected Q_SLOTS:
     virtual void manageCommandState();
 
 private:

--- a/src/cpp/desktop/DesktopSessionLauncher.hpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.hpp
@@ -54,7 +54,7 @@ public:
 
    QString launchFailedErrorMessage() const;
 
-public slots:
+public Q_SLOTS:
    void onRSessionExited(int exitCode, QProcess::ExitStatus exitStatus);
    void onReloadFrameForNextSession();
    void onLaunchFirstSession();

--- a/src/cpp/desktop/DesktopSlotBinders.hpp
+++ b/src/cpp/desktop/DesktopSlotBinders.hpp
@@ -31,10 +31,10 @@ public:
    explicit StringSlotBinder(QString arg,
                              QObject *parent = nullptr);
 
-signals:
+Q_SIGNALS:
    void triggered(QString arg);
 
-public slots:
+public Q_SLOTS:
    void trigger();
 
 private:
@@ -53,7 +53,7 @@ public:
    {
    }
 
-public slots:
+public Q_SLOTS:
    void execute()
    {
       func_();

--- a/src/cpp/desktop/DesktopSubMenu.hpp
+++ b/src/cpp/desktop/DesktopSubMenu.hpp
@@ -31,7 +31,7 @@ class SubMenu : public QMenu
 public:
    explicit SubMenu(const QString& title, QWidget* parent = nullptr);
 
-protected slots:
+protected Q_SLOTS:
    void onAboutToShow();
 };
 

--- a/src/cpp/desktop/DesktopSynctex.hpp
+++ b/src/cpp/desktop/DesktopSynctex.hpp
@@ -88,7 +88,7 @@ protected:
    void onClosed(const QString& pdfFile);
    void onSyncSource(const QString& srcFile, const QPoint& sourceLoc);
 
-public slots:
+public Q_SLOTS:
    
 
 private:

--- a/src/cpp/desktop/DesktopURLDownloader.hpp
+++ b/src/cpp/desktop/DesktopURLDownloader.hpp
@@ -40,12 +40,12 @@ class URLDownloader : public QObject
 
     bool manuallyInvoked() { return manuallyInvoked_; }
 
- signals:
+ Q_SIGNALS:
     void downloadComplete(const QByteArray& data);
     void downloadError(const QString& message);
     void downloadTimeout();
 
- protected slots:
+ protected Q_SLOTS:
     void complete();
     void error(QNetworkReply::NetworkError);
     void timeout();

--- a/src/cpp/desktop/DesktopWebPage.hpp
+++ b/src/cpp/desktop/DesktopWebPage.hpp
@@ -89,7 +89,7 @@ public:
 
    void triggerAction(QWebEnginePage::WebAction action, bool checked = false) override;
 
-public slots:
+public Q_SLOTS:
    bool shouldInterruptJavaScript();
    void closeRequested();
 

--- a/src/cpp/desktop/DesktopWebView.hpp
+++ b/src/cpp/desktop/DesktopWebView.hpp
@@ -48,10 +48,10 @@ public:
 
    void contextMenuEvent(QContextMenuEvent* event) override;
 
-signals:
+Q_SIGNALS:
   void onCloseWindowShortcut();
 
-public slots:
+public Q_SLOTS:
 
 protected:
    QString promptForFilename(const QNetworkRequest& request,
@@ -59,7 +59,7 @@ protected:
    void keyPressEvent(QKeyEvent* pEvent) override;
    void closeEvent(QCloseEvent* pEv) override;
 
-protected slots:
+protected Q_SLOTS:
    void openFile(QString file);
 
 private:

--- a/src/cpp/desktop/DesktopWindowTracker.hpp
+++ b/src/cpp/desktop/DesktopWindowTracker.hpp
@@ -34,7 +34,7 @@ public:
     BrowserWindow* getWindow(QString key);
     void addWindow(QString key, BrowserWindow* window);
 
-protected slots:
+protected Q_SLOTS:
     void onWindowDestroyed(QString key);
 
 private:

--- a/src/cpp/desktop/synctex/evince/EvinceSynctex.hpp
+++ b/src/cpp/desktop/synctex/evince/EvinceSynctex.hpp
@@ -50,7 +50,7 @@ public:
 
    virtual void syncView(const QString& pdfFile, int pdfPage);
 
-private slots:
+private Q_SLOTS:
    void onFindWindowFinished(QDBusPendingCallWatcher *pCall);
    void onSyncViewFinished(QDBusPendingCallWatcher *pCall);
    void onClosed();


### PR DESCRIPTION
This is mainly to allow us to use `boost::signals` more easily within the desktop sources. (We don't use `boost::signals` there currently but they may still be useful for 'long-range' communication between objects)