### PR TITLE
Convert refclasses to environments before finding nulls

### DIFF
--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -1,7 +1,7 @@
 /*
  * RSexp.hpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -50,6 +50,7 @@ class Protect;
    
 // environments and namespaces
 SEXP asEnvironment(std::string name);
+core::Error asPrimitiveEnvironment(SEXP envirSEXP, SEXP* pTargetSEXP, Protect* pProtect);
 std::vector<std::string> getLoadedNamespaces();
 SEXP findNamespace(const std::string& name);
 SEXP asNamespace(const std::string& name);

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionEnvironment.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -114,7 +114,26 @@ bool hasExternalPtr(SEXP env,      // environment to search for external pointer
    // list the contents of this environment
    std::vector<r::sexp::Variable> vars;
    r::sexp::Protect rProtect;
-   r::sexp::listEnvironment(env, 
+
+   SEXP envir = R_NilValue;
+   if (TYPEOF(env) == ENVSXP)
+   {
+      // we were given a primitive environment (ENVSXP)
+      envir = env;
+   }
+   else
+   {
+      // convert the passed environment into a primitive environment; this is required so that e.g.
+      // reference objects that subclass 'environment' can be introspected below
+      Error error = r::sexp::asPrimitiveEnvironment(env, &envir, &rProtect);
+      if (error)
+      {
+         // can't search in here
+         return false;
+      }
+   }
+
+   r::sexp::listEnvironment(envir, 
                             true,  // include all values
                             false, // don't include last dot
                             &rProtect, &vars);


### PR DESCRIPTION
This change fixes a regression from https://github.com/rstudio/rstudio/commit/645a63cc072444a36da0783b4054225b24576a21, in which environment pane introspection can cause errors to be emitted at the console when reference objects are present. 

The problem is that reference objects subclass environments (`isEnvironment`), but they cannot be listed using `listEnvironment` because they are not primitive environments. The fix here is to convert the reference object into a primitive environment for introspection. 