### PR TITLE
use standalone script for installing Qt components

### DIFF
--- a/cmake/modules/RStudioCMakeUtils.cmake
+++ b/cmake/modules/RStudioCMakeUtils.cmake
@@ -23,6 +23,5 @@ function(download URL FILE)
 endfunction()
 
 function(install_process)
-   cmake_parse_arguments(install_process "" "" "COMMAND" ${ARGN})
-   install(CODE "execute_process(COMMAND ${install_process_COMMAND} WORKING_DIRECTORY \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}\")")
+   install(CODE "execute_process(COMMAND ${ARGV} WORKING_DIRECTORY \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}\")")
 endfunction()

--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -2,30 +2,6 @@
 
 set -e
 
-with-root () {
-
-  if [ "$(id -u)" = "0" ]; then
-    # if we're already root, just execute commands as-is
-    "$@"
-  elif sudo -nv &> /dev/null; then
-    # the current user can use sudo without extra auth
-    sudo "$@"
-  elif [ "$(whoami)" = "jenkins" ]; then
-    # we're running on Jenkins, attempt sudo access
-    sudo "$@"
-  else
-    # can't elevate to root; just use fakeroot
-    fakeroot "$@"
-  fi
-
-}
-
-if-jenkins () {
-  if [ "$(whoami)" = "jenkins" ]; then
-    "$@"
-  fi
-}
-
 # raise the limit on number of open files
 ulimit -n 2048
 
@@ -57,7 +33,7 @@ if [ "$3" == "clean" ]
 then
    # remove existing build dir
    rm -rf $BUILD_DIR
-   
+
    # clean out ant build
    cd ../../src/gwt
    ant clean
@@ -88,8 +64,7 @@ make ${MAKEFLAGS}
 
 if [ "$2" != "DEB" ]
 then
-  with-root cpack -G "$2"
-  if-jenkins sudo chown jenkins *.rpm
+  fakeroot cpack -G "$2"
 else
   cpack -G $2
   ../fix-debian-permissions `ls *.deb`

--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -119,9 +119,10 @@ if(UNIX AND NOT APPLE)
    find_package(Qt5DBus REQUIRED)
 endif()
 
-set(QT_BINARY_PATH "${QT_BIN_DIR}" CACHE INTERNAL "")
-set(QT_PLUGIN_PATH "${QT_BIN_DIR}/../plugins" CACHE INTERNAL "")
-set(QT_LIBRARY_PATH "${QT_BIN_DIR}/../lib" CACHE INTERNAL "")
+get_filename_component(QT_BINARY_PATH  "${QT_BIN_DIR}"            ABSOLUTE CACHE)
+get_filename_component(QT_PLUGIN_PATH  "${QT_BIN_DIR}/../plugins" ABSOLUTE CACHE)
+get_filename_component(QT_LIBRARY_PATH "${QT_BIN_DIR}/../lib"     ABSOLUTE CACHE)
+get_filename_component(QT_INSTALL_PATH "${QT_BIN_DIR}/.."         ABSOLUTE CACHE)
 
 # disable clang warnings for qt sources
 if(APPLE)
@@ -500,12 +501,6 @@ if(RSTUDIO_BUNDLE_QT)
       endforeach()
       target_link_libraries(rstudio ${ICU_LIBRARIES})
 
-      # download linuxdeployqt tool
-      set(LINUXDEPLOYQT_BIN "$ENV{HOME}/rstudio-tools/linuxdeployqt")
-      set(LINUXDEPLOYQT_URL "http://s3.amazonaws.com/rstudio-buildtools/linuxdeployqt")
-      download("${LINUXDEPLOYQT_URL}" "${LINUXDEPLOYQT_BIN}")
-      execute_process(COMMAND chmod 755 "${LINUXDEPLOYQT_BIN}")
-
       # configure and install qt
       configure_file(
          "${CMAKE_CURRENT_SOURCE_DIR}/install/LinuxInstallQt.sh.in"
@@ -513,10 +508,7 @@ if(RSTUDIO_BUNDLE_QT)
          @ONLY)
 
       install_process(
-         COMMAND
-         "${CMAKE_CURRENT_BINARY_DIR}/install/LinuxInstallQt.sh"
-         "${LINUXDEPLOYQT_BIN}"
-         "${QT_QMAKE_EXECUTABLE}")
+         "${CMAKE_CURRENT_BINARY_DIR}/install/LinuxInstallQt.sh")
 
    endif()
           

--- a/src/cpp/desktop/install/LinuxInstallQt.sh.in
+++ b/src/cpp/desktop/install/LinuxInstallQt.sh.in
@@ -1,22 +1,73 @@
 #!/usr/bin/env bash
 
 OWD="${PWD}"
-LINUXDEPLOYQT="$1"
-QMAKE="$2"
 
-# invoke linuxdeployqt (running it twice is necessary to
-# pick up certain dependencies; e.g. OpenGL)
-# https://github.com/probonopd/linuxdeployqt/issues/150
-#
-# also make sure we unset LD_PRELOAD as otherwise fakeroot (which is used when
-# cpack is invoked) can inject a library that interferes with the operation of
-# linuxdeployqt
-cd "$(dirname "${LINUXDEPLOYQT}")"
-[ -d squashfs-root ] || "${LINUXDEPLOYQT}" --appimage-extract
-cd squashfs-root
-LD_PRELOAD="" ./AppRun "${OWD}/bin/rstudio" -qmake="${QMAKE}"
-LD_PRELOAD="" ./AppRun "${OWD}/bin/rstudio" -qmake="${QMAKE}"
-cd "${OWD}"
+: ${QT_INSTALL_PATH="@QT_INSTALL_PATH@"}
+
+COMPONENTS=(
+
+	lib/libicudata.so.56
+	lib/libicui18n.so.56
+	lib/libicuuc.so.56
+	lib/libQt5Core.so.5
+	lib/libQt5DBus.so.5
+	lib/libQt5Gui.so.5
+	lib/libQt5Network.so.5
+	lib/libQt5OpenGL.so.5
+	lib/libQt5Positioning.so.5
+	lib/libQt5PrintSupport.so.5
+	lib/libQt5Qml.so.5
+	lib/libQt5Quick.so.5
+	lib/libQt5QuickWidgets.so.5
+	lib/libQt5WebChannel.so.5
+	lib/libQt5WebEngineCore.so.5
+	lib/libQt5WebEngineWidgets.so.5
+	lib/libQt5Widgets.so.5
+	lib/libQt5XcbQpa.so.5
+
+	libexec/QtWebEngineProcess
+
+	plugins/bearer
+	plugins/imageformats
+	plugins/platforminputcontexts
+	plugins/platforms
+	plugins/platformthemes
+	plugins/printsupport
+	plugins/xcbglintegrations
+
+	resources/icudtl.dat
+	resources/qtwebengine_devtools_resources.pak
+	resources/qtwebengine_resources_100p.pak
+	resources/qtwebengine_resources_200p.pak
+	resources/qtwebengine_resources.pak
+
+)
+
+# copy required Qt components into installation
+for COMPONENT in "${COMPONENTS[@]}"; do
+	src="${QT_INSTALL_PATH}/${COMPONENT}"
+	tgt="${COMPONENT}"
+
+	rm -rf tgt
+	mkdir -p "$(dirname "${tgt}")"
+	if [ -d "${src}" ]; then
+		cp -R "${src}" "${tgt}"
+	else
+		cp "${src}" "${tgt}"
+	fi
+
+done
+
+# write qt.conf
+read -r -d '' QTCONF <<- EOF
+[Paths]
+Prefix = ../
+EOF
+
+mkdir -p bin
+mkdir -p libexec
+printf "%s\n" "${QTCONF}" > bin/qt.conf
+printf "%s\n" "${QTCONF}" > libexec/qt.conf
 
 # now, force RPATHS (not RUNPATHS) so that LD_LIBRARY_PATH
 # shenanigans don't cause RStudio to load an incompatible

--- a/src/cpp/desktop/install/LinuxInstallQt.sh.in
+++ b/src/cpp/desktop/install/LinuxInstallQt.sh.in
@@ -41,6 +41,8 @@ COMPONENTS=(
 	resources/qtwebengine_resources_200p.pak
 	resources/qtwebengine_resources.pak
 
+	translations/qtwebengine_locales
+
 )
 
 # copy required Qt components into installation
@@ -56,6 +58,14 @@ for COMPONENT in "${COMPONENTS[@]}"; do
 		cp "${src}" "${tgt}"
 	fi
 
+done
+
+# copy qtbase translation files
+mkdir -p translations
+for FILE in "${QT_INSTALL_PATH}"/translations/qtbase_*; do
+	src="${FILE}"
+	tgt="translations/$(basename "${src/qtbase_/qt_}")"
+	cp "${src}" "${tgt}"
 done
 
 # write qt.conf

--- a/src/cpp/desktop/install/LinuxInstallQt.sh.in
+++ b/src/cpp/desktop/install/LinuxInstallQt.sh.in
@@ -48,7 +48,7 @@ for COMPONENT in "${COMPONENTS[@]}"; do
 	src="${QT_INSTALL_PATH}/${COMPONENT}"
 	tgt="${COMPONENT}"
 
-	rm -rf tgt
+	rm -rf "${tgt}"
 	mkdir -p "$(dirname "${tgt}")"
 	if [ -d "${src}" ]; then
 		cp -R "${src}" "${tgt}"


### PR DESCRIPTION
This PR introduces our own standalone Bash script for bundling Qt components as necessary with a Linux installation.

Don't merge quite yet; need to test on our Linux machines + Docker images.