### PR TITLE
Add RStudio windows to Mac dock context menu

### DIFF
--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -172,6 +172,11 @@ if(NOT WIN32)
      ${CMAKE_CURRENT_SOURCE_DIR}/synctex/sumatra/SumatraSynctex.hpp
    )
 endif()
+if(NOT APPLE)
+   list(REMOVE_ITEM MOC_DESKTOP_HEADER_FILES
+      ${CMAKE_CURRENT_SOURCE_DIR}/DockMenu.hpp
+   )
+endif()
 
 configure_file (${CMAKE_CURRENT_SOURCE_DIR}/desktop-config.h.in
                 ${CMAKE_CURRENT_BINARY_DIR}/desktop-config.h)
@@ -239,6 +244,7 @@ endif(WIN32)
 if(APPLE)
   set(DESKTOP_SOURCE_FILES ${DESKTOP_SOURCE_FILES}
     DesktopUtilsMac.mm
+    DockMenu.cpp
     DockTileView.mm
   )
 else()

--- a/src/cpp/desktop/DesktopUtilsMac.mm
+++ b/src/cpp/desktop/DesktopUtilsMac.mm
@@ -17,18 +17,13 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 
-#include <QObject>
-#include <QWidget>
-#include <QMenu>
-#include <QString>
-
 #include <core/system/Environment.hpp>
 
 #import <Foundation/NSString.h>
 #import <AppKit/NSView.h>
 #import <AppKit/NSWindow.h>
 
-#include "DesktopMainWindow.hpp"
+#include "DockMenu.hpp"
 
 using namespace rstudio;
 
@@ -43,7 +38,7 @@ NSWindow* nsWindowForMainWindow(QMainWindow* pMainWindow)
    return [nsview window];
 }
 
-static QMenu* s_pDockMenu;
+static DockMenu* s_pDockMenu;
 
 void initializeSystemPrefs()
 {
@@ -211,18 +206,10 @@ void initializeLang()
 
 void finalPlatformInitialize(MainWindow* pMainWindow)
 {
-   // Add to dock menu
-   s_pDockMenu = new QMenu();
-   s_pDockMenu->setAsDockMenu();
-   s_pDockMenu->addAction(QObject::tr("New RStudio Window"));
-   
-   // Lambda holds a raw pointer to MainWindow. When the main window
-   // goes away, so does the dock icon, thus the menu and the possibility of the
-   // user clicking it, so this is safe (though unpleasant).
-   QObject::connect(s_pDockMenu, &QMenu::triggered, [pMainWindow] (QAction* action) { 
-      std::vector<std::string> args;
-      pMainWindow->launchRStudio(args);
-   });
+   if (!s_pDockMenu)
+   {
+      s_pDockMenu = new DockMenu(pMainWindow);
+   }
 }
 
 } // namespace desktop

--- a/src/cpp/desktop/DockMenu.cpp
+++ b/src/cpp/desktop/DockMenu.cpp
@@ -1,0 +1,89 @@
+/*
+ * DockMenu.cpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "DockMenu.hpp"
+
+#include "DesktopMainWindow.hpp"
+
+namespace rstudio {
+namespace desktop {
+
+DockMenu::DockMenu(MainWindow *pMainWindow)
+{
+   setAsDockMenu();
+   
+   pWindowPlaceholder_ = addSeparator();
+
+   QAction* pNewWindow = addAction(QObject::tr("New RStudio Window"));
+
+   // Lambda holds a raw pointer to MainWindow. When the main window
+   // goes away, so does the dock icon, thus the menu and the possibility of the
+   // user clicking it, so this is safe (though unpleasant).
+   QObject::connect(pNewWindow, &QAction::triggered, [pMainWindow] () { 
+      std::vector<std::string> args;
+      pMainWindow->launchRStudio(args);
+   });
+
+   connect(this, &QMenu::aboutToShow,
+           this, &DockMenu::onAboutToShow);
+}
+
+void DockMenu::onAboutToShow()
+{
+   // remove actions from last time the menu was shown
+   for (auto i = windows_.size() - 1; i >= 0; i--)
+   {
+      QAction* pAction = windows_[i];
+      removeAction(pAction);
+      windows_.removeAt(i);
+      pAction->deleteLater();
+   }
+   
+   // populate menu with windows
+   QWidgetList topLevels = QApplication::topLevelWidgets();
+   for (auto pWindow : topLevels)
+   {
+      if (!pWindow->isVisible())
+         continue;
+
+      QAction* pAction = new QAction(pWindow->windowTitle(), nullptr);
+      pAction->setData(QVariant::fromValue(pWindow));
+      pAction->setCheckable(true);
+      if (pWindow->isActiveWindow())
+         pAction->setChecked(true);
+      insertAction(pWindowPlaceholder_, pAction);
+      connect(pAction, SIGNAL(triggered()),
+              this, SLOT(showWindow()));
+
+      windows_.append(pAction);
+   }
+}
+
+void DockMenu::showWindow()
+{
+   auto* pAction = qobject_cast<QAction*>(sender());
+   if (!pAction)
+      return;
+   auto* pWidget = pAction->data().value<QWidget*>();
+   if (!pWidget)
+      return;
+   if (pWidget->isMinimized())
+      pWidget->setWindowState(pWidget->windowState() & ~Qt::WindowMinimized);
+   pWidget->activateWindow();
+   pWidget->raise();
+}
+
+} // namespace desktop
+} // namespace rstudio

--- a/src/cpp/desktop/DockMenu.hpp
+++ b/src/cpp/desktop/DockMenu.hpp
@@ -1,0 +1,46 @@
+/*
+ * DockMenu.hpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef DOCK_MENU_HPP
+#define DOCK_MENU_HPP
+
+#include <QObject>
+#include <QMenu>
+
+namespace rstudio {
+namespace desktop {
+
+class MainWindow;
+
+// Customize macOS dock menu
+class DockMenu: public QMenu
+{
+   Q_OBJECT
+public:
+   explicit DockMenu(MainWindow* pMainWindow);
+
+protected Q_SLOTS:
+   void onAboutToShow();
+   void showWindow();
+
+private:
+   QAction* pWindowPlaceholder_ = nullptr;
+   QList<QAction*> windows_;
+};
+
+} // namespace desktop
+} // namespace rstudio
+
+#endif // DOCK_MENU_HPP


### PR DESCRIPTION
This was lost when we switched back to Qt for Mac. Implemented using very similar code to how the Window menu's list of windows is populated.

So, the dock menu once again lists the RStudio windows, and clicking on one gives it focus and brings it forward.

![2018-01-21_12-00-24](https://user-images.githubusercontent.com/10569626/35198369-b846abde-fea2-11e7-8fc2-093cf3a98c05.png)

Did not implement the generic window icons seen on the original; some programs have it, some don't. XCode itself, for example, doesn't show icons for its open windows on the dock menu (surprisingly). Neither does Qt Creator.

Also RStudio dock menu doesn't show the diamond symbol next to minimized windows. Qt Creator is the same in this regard; this isn't something you get automatically from a Qt app on the Mac.

Resolves #2005