### PR TITLE
re-implement document popup for QtWebEngine

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -28,6 +28,7 @@
 #include <QMessageBox>
 #include <QApplication>
 #include <QAbstractButton>
+#include <QJsonObject>
 
 #include <QtPrintSupport/QPrinter>
 #include <QtPrintSupport/QPrintPreviewDialog>
@@ -458,20 +459,19 @@ QString GwtCallback::getGlobalMouseSelection()
     return s_globalMouseSelection;
 }
 
-QString GwtCallback::getCursorPosition()
+QJsonObject GwtCallback::getCursorPosition()
 {
    QPoint cursorPosition = QCursor::pos();
-   return QString::asprintf(
-            "%i,%i",
-            cursorPosition.x(),
-            cursorPosition.y());
+   
+   return QJsonObject {
+      { QStringLiteral("x"), cursorPosition.x() },
+      { QStringLiteral("y"), cursorPosition.y() }
+   };
 }
 
-QString GwtCallback::doesWindowExistAtCursorPosition()
+bool GwtCallback::doesWindowExistAtCursorPosition()
 {
-   return (qApp->topLevelAt(QCursor::pos()) == nullptr)
-         ? QStringLiteral("false")
-         : QStringLiteral("true");
+   return qApp->topLevelAt(QCursor::pos()) != nullptr;
 }
 
 QString GwtCallback::proportionalFont()

--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -458,6 +458,22 @@ QString GwtCallback::getGlobalMouseSelection()
     return s_globalMouseSelection;
 }
 
+QString GwtCallback::getCursorPosition()
+{
+   QPoint cursorPosition = QCursor::pos();
+   return QString::asprintf(
+            "%i,%i",
+            cursorPosition.x(),
+            cursorPosition.y());
+}
+
+QString GwtCallback::doesWindowExistAtCursorPosition()
+{
+   return (qApp->topLevelAt(QCursor::pos()) == nullptr)
+         ? QStringLiteral("false")
+         : QStringLiteral("true");
+}
+
 QString GwtCallback::proportionalFont()
 {
    return options().proportionalFont();

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -83,9 +83,12 @@ public Q_SLOTS:
 
    void setClipboardText(QString text);
    QString getClipboardText();
-
+   
    void setGlobalMouseSelection(QString selection);
    QString getGlobalMouseSelection();
+
+   QString getCursorPosition();
+   QString doesWindowExistAtCursorPosition();
 
    QString getUriForPath(QString path);
    void onWorkbenchInitialized(QString scratchPath);

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -18,6 +18,7 @@
 
 #include <QObject>
 #include <QClipboard>
+#include <QJsonObject>
 
 #include "DesktopGwtCallbackOwner.hpp"
 
@@ -87,8 +88,8 @@ public Q_SLOTS:
    void setGlobalMouseSelection(QString selection);
    QString getGlobalMouseSelection();
 
-   QString getCursorPosition();
-   QString doesWindowExistAtCursorPosition();
+   QJsonObject getCursorPosition();
+   bool doesWindowExistAtCursorPosition();
 
    QString getUriForPath(QString path);
    void onWorkbenchInitialized(QString scratchPath);

--- a/src/gwt/src/org/rstudio/core/client/Point.java
+++ b/src/gwt/src/org/rstudio/core/client/Point.java
@@ -1,7 +1,7 @@
 /*
  * Point.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,57 +14,28 @@
  */
 package org.rstudio.core.client;
 
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
 public class Point
 {
-   public final int x;
-   public final int y;
+   public int x;
+   public int y;
    
-   public Point(int x, int y)
+   @JsOverlay public final int getX() { return x; }
+   @JsOverlay public final int getY() { return y; }
+   @JsOverlay public static final Point create(int x, int y)
    {
-      super() ;
-      this.x = x ;
-      this.y = y ;
-   }
-   
-   public int getX()
-   {
-      return x ;
+      Point point = new Point();
+      point.x = x;
+      point.y = y;
+      return point;
    }
    
-   public int getY()
-   {
-      return y ;
-   }
-
-   @Override
-   public int hashCode()
-   {
-      final int prime = 31 ;
-      int result = 1 ;
-      result = prime * result + x ;
-      result = prime * result + y ;
-      return result ;
-   }
-
-   @Override
-   public boolean equals(Object obj)
-   {
-      if (this == obj)
-         return true ;
-      if (obj == null)
-         return false ;
-      if (getClass() != obj.getClass())
-         return false ;
-      Point other = (Point) obj ;
-      if (x != other.x)
-         return false ;
-      if (y != other.y)
-         return false ;
-      return true ;
-   }
-   
-   @Override
-   public String toString()
+   @JsOverlay
+   public final String toString()
    {
       return x + ", " + y;
    }

--- a/src/gwt/src/org/rstudio/core/client/Rectangle.java
+++ b/src/gwt/src/org/rstudio/core/client/Rectangle.java
@@ -99,7 +99,7 @@ public class Rectangle
    
    public Point getLocation()
    {
-      return new Point(x, y) ;
+      return Point.create(x, y);
    }
    
    public Size getSize()
@@ -109,8 +109,9 @@ public class Rectangle
    
    public Point getCorner(boolean left, boolean top)
    {
-      return new Point(left ? getLeft() : getRight(),
-                       top ? getTop() : getBottom()) ;
+      return Point.create(
+            left ? getLeft() : getRight(),
+            top ? getTop() : getBottom());
    }
 
    public Rectangle move(int x, int y)
@@ -171,8 +172,9 @@ public class Rectangle
     */
    public Point center()
    {
-      return new Point((getLeft() + getRight()) / 2,
-                       (getTop() + getBottom()) / 2);
+      return Point.create(
+            (getLeft() + getRight()) / 2,
+            (getTop() + getBottom()) / 2);
    }
 
    /**

--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -509,7 +509,7 @@ public class DomUtils
          child = child.getOffsetParent();
       }
 
-      return new Point(left, top);
+      return Point.create(left, top);
    }
 
    public static int ensureVisibleHoriz(Element container,

--- a/src/gwt/src/org/rstudio/core/client/dom/WindowEx.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/WindowEx.java
@@ -101,7 +101,7 @@ public class WindowEx extends JavaScriptObject
    public final Point getScrollPosition()
    {
       JsArrayInteger pos = getScrollPositionInternal();
-      return new Point(pos.get(0), pos.get(1));
+      return Point.create(pos.get(0), pos.get(1));
    }
 
    public final void setScrollPosition(Point pos)

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/DirectoryContentsWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/DirectoryContentsWidget.java
@@ -442,8 +442,9 @@ public class DirectoryContentsWidget
 
    public Point getScrollPosition()
    {
-      return new Point(scrollPanel_.getHorizontalScrollPosition(),
-                       scrollPanel_.getVerticalScrollPosition());
+      return Point.create(
+            scrollPanel_.getHorizontalScrollPosition(),
+            scrollPanel_.getVerticalScrollPosition());
    }
 
    public void setScrollPosition(Point p)

--- a/src/gwt/src/org/rstudio/core/client/widget/DoubleClickState.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/DoubleClickState.java
@@ -37,7 +37,7 @@ public class DoubleClickState
 
       if (!isDoubleClick(event, now))
       {
-         lastClickPos_ = new Point(event.getClientX(), event.getClientY());
+         lastClickPos_ = Point.create(event.getClientX(), event.getClientY());
          lastClickTime_ = now;
          return false;
       }

--- a/src/gwt/src/org/rstudio/core/rebind/JavaScriptPassthroughGenerator.java
+++ b/src/gwt/src/org/rstudio/core/rebind/JavaScriptPassthroughGenerator.java
@@ -138,7 +138,7 @@ public class JavaScriptPassthroughGenerator extends Generator
                   }
                   else if (simpleName.equals("CommandWithArg"))
                   {
-                     w.print("(Ljava/lang/Object;)(result)");
+                     w.print("(*)(result)");
                   }
                   w.print(";");
                   w.print("}");

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -15,8 +15,10 @@
 package org.rstudio.studio.client.application;
 
 import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.Point;
 import org.rstudio.core.client.js.BaseExpression;
 import org.rstudio.core.client.js.JavaScriptPassthrough;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 
 import com.google.gwt.user.client.Command;
 
@@ -63,8 +65,8 @@ public interface DesktopFrame extends JavaScriptPassthrough
    void setGlobalMouseSelection(String selection);
    void getGlobalMouseSelection(CommandWithArg<String> callback);
    
-   void doesWindowExistAtCursorPosition(CommandWithArg<String> callback);
-   void getCursorPosition(CommandWithArg<String> callback);
+   void doesWindowExistAtCursorPosition(CommandWithArg<Boolean> callback);
+   void getCursorPosition(CommandWithArg<Point> callback);
    
    String getUriForPath(String path);
    void onWorkbenchInitialized(String scratchDir);

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -63,6 +63,9 @@ public interface DesktopFrame extends JavaScriptPassthrough
    void setGlobalMouseSelection(String selection);
    void getGlobalMouseSelection(CommandWithArg<String> callback);
    
+   void doesWindowExistAtCursorPosition(CommandWithArg<String> callback);
+   void getCursorPosition(CommandWithArg<String> callback);
+   
    String getUriForPath(String path);
    void onWorkbenchInitialized(String scratchDir);
    void showFolder(String path);

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/Satellite.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/Satellite.java
@@ -191,6 +191,10 @@ public class Satellite implements HasCloseHandlers<Satellite>
                $wnd.opener.notifyRStudioSatelliteClosed(name);
             }),
             true);
+      
+      // inherit desktop frame from opener
+      $wnd.desktop = $wnd.opener.desktop;
+      $wnd.desktopMenuCallback = $wnd.opener.desktopMenuCallback;
 
       // register (this will call the setSessionInfo back)
       $wnd.opener.registerAsRStudioSatellite(name, $wnd);

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteManager.java
@@ -235,7 +235,7 @@ public class SatelliteManager implements CloseHandler<Window>
             final WindowEx win = satellite.getWindow();
             Document doc = win.getDocument();
             preferredSize = new Size(doc.getClientWidth(), doc.getClientHeight());
-            preferredPos = new Point(win.getLeft(), win.getTop());
+            preferredPos = Point.create(win.getLeft(), win.getTop());
             callNotifyPendingReactivate(win);
             satellite.close();
             break;

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/model/SatelliteWindowGeometry.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/model/SatelliteWindowGeometry.java
@@ -65,7 +65,7 @@ public class SatelliteWindowGeometry extends JavaScriptObject
    
    public final Point getPosition() 
    {
-      return new Point(getX(), getY());
+      return Point.create(getX(), getY());
    }
    
    public final Size getSize()

--- a/src/gwt/src/org/rstudio/studio/client/pdfviewer/PDFViewer.java
+++ b/src/gwt/src/org/rstudio/studio/client/pdfviewer/PDFViewer.java
@@ -242,7 +242,7 @@ public class PDFViewer implements CompilePdfCompletedEvent.Handler,
       {
          width = pdfJsWindow_.getOuterWidth();
          height = pdfJsWindow_.getOuterHeight();
-         pos = new Point(pdfJsWindow_.getLeft(), pdfJsWindow_.getTop());
+         pos = Point.create(pdfJsWindow_.getLeft(), pdfJsWindow_.getTop());
          pdfJsWindow_.close();
          pdfJsWindow_ = null;
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionList.java
@@ -59,8 +59,7 @@ class CompletionList<TItem> extends Composite
                return;
             }
          }
-         lastMouseMoveCoordinates_ = new Point(event.getScreenX(),
-                                               event.getScreenY());
+         lastMouseMoveCoordinates_ = Point.create(event.getScreenX(), event.getScreenY());
 
          if (firstEvent_)
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -607,7 +607,7 @@ public class HelpPane extends WorkbenchPane
       ensureWidget();
       bringToFront();
       navStack_.navigate(url);
-      setLocation(url, new Point(0, 0));
+      setLocation(url, Point.create(0, 0));
       navigated_ = true;
    }
      
@@ -666,7 +666,7 @@ public class HelpPane extends WorkbenchPane
    {
       String url = getUrl();
       if (url != null)
-         setLocation(url, new Point(0, 0));
+         setLocation(url, Point.create(0, 0));
    }
 
    private WindowEx getContentWindow()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/VirtualHistory.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/VirtualHistory.java
@@ -30,7 +30,7 @@ public class VirtualHistory
       public Data(String url)
       {
          url_ = url;
-         scrollPos_ = new Point(0, 0);
+         scrollPos_ = Point.create(0, 0);
       }
       
       public String getUrl()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/LocatorPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/LocatorPanel.java
@@ -67,8 +67,9 @@ public class LocatorPanel extends LayoutPanel
             int x = event.getNativeEvent().getClientX();
             int y = event.getNativeEvent().getClientY();
 
-            Point p = new Point(
-                  x - el.getAbsoluteLeft(), y - el.getAbsoluteTop());
+            Point p = Point.create(
+                  x - el.getAbsoluteLeft(),
+                  y - el.getAbsoluteTop());
 
             showFeedbackAt(p);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
@@ -873,7 +873,7 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
                size = new Size(window.getInnerWidth(), 
                      window.getInnerHeight());
                if (position == null)
-                  position = new Point(
+                  position = Point.create(
                         window.getScreenX() + 50,
                         window.getScreenY() + 50);
             }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/WordWrapCursorTracker.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/WordWrapCursorTracker.java
@@ -57,8 +57,9 @@ public class WordWrapCursorTracker
       else if (currentInputRow_ == row_ && inputColumn <= column_)
       {
          // Cursor position is inside the current chunk--nice!
-         output_ = new Point(outputColumn + (column_ - inputColumn),
-                             outputRow);
+         output_ = Point.create(
+               outputColumn + (column_ - inputColumn),
+               outputRow);
 //         Debug.devlogf("exact: {0}, {1}", output_.getY(), output_.getX());
       }
       else
@@ -66,7 +67,7 @@ public class WordWrapCursorTracker
 //         Debug.devlog("slop");
          // We've gone past the cursor position; use the current insertion
          // point before we get any further away
-         output_ = new Point(outputColumn, outputRow);
+         output_ = Point.create(outputColumn, outputRow);
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/PopoutDocInitiatedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/PopoutDocInitiatedEvent.java
@@ -54,7 +54,7 @@ public class PopoutDocInitiatedEvent
    {
       if (posX_ == 0 && posY_ == 0)
          return null;
-      return new Point(posX_, posY_);
+      return Point.create(posX_, posY_);
    }
    
    @Override


### PR DESCRIPTION
This PR fixes document popup in the desktop products when using Qt WebEngine. Now, rather than requesting the cursor position from the browser (which cannot report the cursor position when it lies outside of the associated window), we simply ask the lower-level Qt application, which can.

This PR also exercises some of the other abilities of Qt's QWebChannel interop -- in particular, the JSON RPC. I translate our `Point` class into a native `@JsType`-annotated class so it can be used in this way, and transform usages of that class where appropriate.