### PR TITLE
use queue for pending windows

### DIFF
--- a/src/cpp/desktop/DesktopWebPage.hpp
+++ b/src/cpp/desktop/DesktopWebPage.hpp
@@ -16,6 +16,8 @@
 #ifndef DESKTOP_WEB_PAGE_HPP
 #define DESKTOP_WEB_PAGE_HPP
 
+#include <queue>
+
 #include <QtGui>
 #include <QWebEnginePage>
 
@@ -109,7 +111,7 @@ private:
    QString shinyDialogUrl_;
    bool navigated_;
    bool allowExternalNav_;
-   PendingWindow pendingWindow_;
+   std::queue<PendingWindow> pendingWindows_;
    QDir defaultSaveDir_;
 };
 


### PR DESCRIPTION
This PR fixes an issue where, upon launch of RStudio, some satellite windows launched may be launched as 'secondary' windows rather than 'satellite' windows, hence inheriting a funky scrollbar.

On initialization, satellite windows from the previous session are prepared and launched asynchronously, at the same time. Because of this, it's possible that multiple windows could be prepared at once, and then later launched. Prior to this PR, we only had space for one pending window, so attempts to prepare more than one pending window would overwrite any pre-existing pending windows, leading to funkiness when the windows are later launched.