### PR TITLE
Stop Ctrl+L from sending focus to browser address when in Terminal

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
@@ -1,7 +1,7 @@
 /*
  * ShortcutManager.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -490,7 +490,7 @@ public class ShortcutManager implements NativePreviewHandler,
                   // clear the currently hidden console instead
                   event.stopPropagation();
                   commands_.clearTerminalScrollbackBuffer().execute();
-                  return false;
+                  return true;
                }
                else if (binding.getId() == "closeSourceDoc")
                {


### PR DESCRIPTION
On Chrome (Windows and Linux, not Mac) hitting Ctrl+L in the RStudio terminal clears the terminal (as it should), but then puts focus in the browser address bar. This is quite painful, especially if you are a fast typist, hit Ctrl+L in terminal, then type a command and hit enter; now the browser is going somewhere you don't want it to.

Resolves #1636.