### PR TITLE
select random port for chromium devtools server

### DIFF
--- a/src/cpp/desktop/DesktopInfo.hpp
+++ b/src/cpp/desktop/DesktopInfo.hpp
@@ -32,6 +32,7 @@ Q_SIGNALS:
    void sumatraPdfExePathChanged(QString value);
    void fixedWidthFontListChanged(QString value);
    void zoomLevelChanged(double value);
+   void chromiumDevtoolsPortChanged(quint16 value);
 
 public:
    explicit DesktopInfo(QObject* parent = nullptr);
@@ -77,6 +78,13 @@ public:
               READ getZoomLevel
               WRITE setZoomLevel
               NOTIFY zoomLevelChanged)
+   
+   Q_INVOKABLE int getChromiumDevtoolsPort();
+   Q_INVOKABLE void setChromiumDevtoolsPort(int port);
+   Q_PROPERTY(int chromiumDevtoolsPort
+              READ getChromiumDevtoolsPort
+              WRITE setChromiumDevtoolsPort
+              NOTIFY chromiumDevtoolsPortChanged)
 };
 
 inline DesktopInfo& desktopInfo()

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopInfo.java
@@ -101,5 +101,9 @@ public class DesktopInfo
       $wnd.desktopInfo.zoomLevel = zoomLevel;
    }-*/;
    
+   public static final native int getChromiumDevtoolsPort()
+   /*-{
+      return $wnd.desktopInfo.chromiumDevtoolsPort;
+   }-*/;
    
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -31,6 +31,7 @@ import org.rstudio.studio.client.application.ApplicationQuit;
 import org.rstudio.studio.client.application.ApplicationQuit.QuitContext;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.DesktopHooks;
+import org.rstudio.studio.client.application.DesktopInfo;
 import org.rstudio.studio.client.application.IgnoredUpdates;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.model.ApplicationServerOperations;
@@ -267,11 +268,20 @@ public class DesktopApplicationHeader implements ApplicationHeader
    @Handler
    void onOpenDeveloperConsole()
    {
-      // TODO: Request this port as part of the startup session info?
-      globalDisplay_.openMinimalWindow(
-            "http://127.0.0.1:59009",
-            Window.getClientWidth() - 20,
-            Window.getClientHeight() - 20);
+      int port = DesktopInfo.getChromiumDevtoolsPort();
+      if (port == 0)
+      {
+         globalDisplay_.showErrorMessage(
+               "Error Opening Devtools",
+               "The Chromium devtools server could not be activated.");
+      }
+      else
+      {
+         globalDisplay_.openMinimalWindow(
+               ("http://127.0.0.1:" + DesktopInfo.getChromiumDevtoolsPort()),
+               Window.getClientWidth() - 20,
+               Window.getClientHeight() - 20);
+      }
    }
    
    @Handler


### PR DESCRIPTION
This PR allows us to select a random port for the Chromium Devtools server -- ensuring that multiple instances of RStudio can each launch their own Devtools server as required (and also selecting an open port in the case that 59009 is occupied)