### PR TITLE
orchestrate initialization of QWebChannel + GWT

### DIFF
--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -60,12 +60,23 @@ MainWindow::MainWindow(QUrl url) :
    webChannelJsFile.close();
 
    // append our WebChannel initialization code
-   const char* webChannelInit =
-         "new QWebChannel(qt.webChannelTransport, function(channel) {"
-         "   for (var key in channel.objects) {"
-         "      window[key] = channel.objects[key];"
-         "   }"
-         "});";
+   const char* webChannelInit = R"EOF(
+      new QWebChannel(qt.webChannelTransport, function(channel) {
+
+         // export channel objects to the main window
+         for (var key in channel.objects) {
+            window[key] = channel.objects[key];
+         }
+
+         // notify that we're finished initialization and load
+         // GWT sources if necessary
+         window.qt.webChannelReady = true;
+         if (window.delayLoadApplication) {
+            window.delayLoadApplication();
+            window.delayLoadApplication = null;
+         }
+      });
+   )EOF";
 
    webChannelJs.append(QString::fromUtf8(webChannelInit));
 

--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -71,9 +71,9 @@ MainWindow::MainWindow(QUrl url) :
          // notify that we're finished initialization and load
          // GWT sources if necessary
          window.qt.webChannelReady = true;
-         if (window.delayLoadApplication) {
-            window.delayLoadApplication();
-            window.delayLoadApplication = null;
+         if (typeof window.rstudioDelayLoadApplication == "function") {
+            window.rstudioDelayLoadApplication();
+            window.rstudioDelayLoadApplication = null;
          }
       });
    )EOF";

--- a/src/gwt/src/org/rstudio/studio/client/RStudio.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudio.java
@@ -104,10 +104,10 @@ public class RStudio implements EntryPoint
    public void onModuleLoad() 
    {
       Debug.injectDebug();
-      dismissProgressAnimation_ = showProgress();
-      delayLoadApplication();
+      Debug.devlog("onModuleLoad()!");
+      maybeDelayLoadApplication(this);
    }
-
+   
    private Command showProgress()
    {
       final Label background = new Label();
@@ -155,8 +155,37 @@ public class RStudio implements EntryPoint
       };
    }
    
+   private static final native void maybeDelayLoadApplication(RStudio rstudio)
+   /*-{
+   	
+      if ($wnd.qt)
+      {
+         // on the desktop main window, we may need to wait for Qt to finish
+         // initialization before loading GWT
+         if ($wnd.qt.webChannelReady)
+         {
+            // Qt is ready; load the application now
+            rstudio.@org.rstudio.studio.client.RStudio::delayLoadApplication()();
+            return;
+         }
+         
+         // Qt not yet ready; set a hook and let the Qt WebChannel
+         // initialization script call it to finish initialization
+         $wnd.delayLoadApplication = $entry(function() {
+            rstudio.@org.rstudio.studio.client.RStudio::delayLoadApplication()();
+         });
+         
+         return;
+      }
+      
+      // server and satellites can load as usual
+      rstudio.@org.rstudio.studio.client.RStudio::delayLoadApplication()();
+      
+   }-*/;
+   
    private void delayLoadApplication()
    {
+      dismissProgressAnimation_ = showProgress();
       final SerializedCommandQueue queue = new SerializedCommandQueue();
       
       // TODO (gary) This early loading of XTermWidget dependencies needs to be

--- a/src/gwt/src/org/rstudio/studio/client/RStudio.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudio.java
@@ -175,6 +175,16 @@ public class RStudio implements EntryPoint
             rstudio.@org.rstudio.studio.client.RStudio::delayLoadApplication()();
          });
          
+         // set a timeout and attempt load just in case something goes wrong with
+         // Qt initialization (we don't want to just leave the user with a blank
+         // window)
+         setTimeout(function() {
+            if ($wnd.delayLoadApplication) {
+               $wnd.delayLoadApplication();
+               $wnd.delayLoadApplication = null;
+            }
+         }, 2000);
+         
          return;
       }
       

--- a/src/gwt/src/org/rstudio/studio/client/RStudio.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudio.java
@@ -178,7 +178,7 @@ public class RStudio implements EntryPoint
             // Qt initialization (we don't want to just leave the user with a blank
             // window)
             setTimeout(function() {
-               if ($wnd.rstudioDelayLoadApplication) {
+               if (typeof $wnd.rstudioDelayLoadApplication == "function") {
                   $wnd.rstudioDelayLoadApplication();
                   $wnd.rstudioDelayLoadApplication = null;
                }

--- a/src/gwt/src/org/rstudio/studio/client/RStudio.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudio.java
@@ -104,7 +104,6 @@ public class RStudio implements EntryPoint
    public void onModuleLoad() 
    {
       Debug.injectDebug();
-      Debug.devlog("onModuleLoad()!");
       maybeDelayLoadApplication(this);
    }
    
@@ -168,28 +167,30 @@ public class RStudio implements EntryPoint
             rstudio.@org.rstudio.studio.client.RStudio::delayLoadApplication()();
             return;
          }
-         
-         // Qt not yet ready; set a hook and let the Qt WebChannel
-         // initialization script call it to finish initialization
-         $wnd.delayLoadApplication = $entry(function() {
-            rstudio.@org.rstudio.studio.client.RStudio::delayLoadApplication()();
-         });
-         
-         // set a timeout and attempt load just in case something goes wrong with
-         // Qt initialization (we don't want to just leave the user with a blank
-         // window)
-         setTimeout(function() {
-            if ($wnd.delayLoadApplication) {
-               $wnd.delayLoadApplication();
-               $wnd.delayLoadApplication = null;
-            }
-         }, 2000);
-         
-         return;
+         else
+         {
+            // Qt not yet ready; set a hook and let the Qt WebChannel
+            // initialization script call it to finish initialization
+            $wnd.rstudioDelayLoadApplication = $entry(function() {
+               rstudio.@org.rstudio.studio.client.RStudio::delayLoadApplication()();
+            });
+            
+            // set a timeout and attempt load just in case something goes wrong with
+            // Qt initialization (we don't want to just leave the user with a blank
+            // window)
+            setTimeout(function() {
+               if ($wnd.rstudioDelayLoadApplication) {
+                  $wnd.rstudioDelayLoadApplication();
+                  $wnd.rstudioDelayLoadApplication = null;
+               }
+            }, 5000);
+         }
       }
-      
-      // server and satellites can load as usual
-      rstudio.@org.rstudio.studio.client.RStudio::delayLoadApplication()();
+      else
+      {
+         // server and satellites can load as usual
+         rstudio.@org.rstudio.studio.client.RStudio::delayLoadApplication()();
+      }
       
    }-*/;
    

--- a/src/gwt/src/org/rstudio/studio/client/RStudio.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudio.java
@@ -165,7 +165,6 @@ public class RStudio implements EntryPoint
          {
             // Qt is ready; load the application now
             rstudio.@org.rstudio.studio.client.RStudio::delayLoadApplication()();
-            return;
          }
          else
          {


### PR DESCRIPTION
This PR fixes an issue where an attempt to load GWT before QWebChannel had been initialized could cause the IDE to fail to load on startup.

Effectively, QWebChannel is loaded asynchronously -- we create the channel object, and we provide an initialization function that gets called with channel data when it is available. This implies a JSON-RPC roundtrip over the Qt WebChannel, which may not always finish before the request to load GWT is made.

This is now handled in the following way:

1. If QWebChannel loads first, it will set a flag letting our module code know that GWT can be initialized 'eagerly'.

2. If GWT tries to load first, but sees QWebChannel is not ready, it will expose a `delayLoadApplication()` hook on the `window` object, which our QWebChannel initialization code will call when ready.

Closes https://github.com/rstudio/rstudio/issues/2049. Since this PR plays with startup / initialization of GWT sources we should scrutinize this carefully!