### PR TITLE
Stop createProject from making another .Rproj if one already exists

### DIFF
--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -1011,8 +1011,12 @@ Error writeProjectFile(const FilePath& projectFilePath,
                             string_utils::LineEndingNative);
 }
 
-FilePath projectFromDirectory(const FilePath& directoryPath)
+FilePath projectFromDirectory(const FilePath& path)
 {
+   // canonicalize the path; this handles the case (among others) where the incoming
+   // path ends with a "/"; without removing that, the matching logic below fails
+   FilePath directoryPath(path.canonicalPath());
+
    // first use simple heuristic of a case sentitive match between
    // directory name and project file name
    std::string dirName = directoryPath.filename();

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -133,19 +133,6 @@ Error findExistingProjFileInFolder(const std::string& inFolder, std::string* pRe
    
    std::string folder = inFolder;
    boost::algorithm::trim(folder);
-   
-   if (folder.length() > 1) // don't tamper with "/" or "\\"
-   {
-      // r_util::projectFromDirectory doesn't like a path with trailing slash(es),
-      // so strip them off
-      while (folder.back() == '/' || folder.back() == '\\')
-         folder.erase(folder.size()-1); // remove trailing slash
-      if (folder.empty())
-      {
-         return Success();
-      }
-   }
-   
    FilePath projectFilePath = module_context::resolveAliasedPath(folder);
    if (!projectFilePath.exists())
    {

--- a/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
@@ -531,11 +531,18 @@ public class Projects implements OpenProjectFileHandler,
                      newProject.getNewPackageOptions(),
                      newProject.getNewShinyAppOptions(),
                      newProject.getProjectTemplateOptions(),
-                     new VoidServerRequestCallback(indicator)
+                     new SimpleRequestCallback<String>()
                      {
                         @Override
-                        public void onSuccess()
+                        public void onResponseReceived(String foundProjectFile)
                         {
+                           if (!StringUtil.isNullOrEmpty(foundProjectFile))
+                           {
+                              // found an existing project file with different name than the
+                              // parent folder; have to update here so that's what we end up
+                              // opening
+                              newProject.setProjectFile(foundProjectFile);
+                           }
                            continuation.execute();
                         }
                      });

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/NewProjectResult.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/NewProjectResult.java
@@ -1,7 +1,7 @@
 /*
  * NewProjectResult.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -44,6 +44,11 @@ public class NewProjectResult
    public String getProjectFile()
    {
       return projectFile_;
+   }
+   
+   public void setProjectFile(String projectFile)
+   {
+      projectFile_ = projectFile;
    }
    
    public boolean getCreateGitRepo()
@@ -113,7 +118,7 @@ public class NewProjectResult
    private final boolean usePackrat_;
    private boolean openInNewWindow_;
    private RVersionSpec rVersion_;
-   private final String projectFile_;
+   private String projectFile_;
    private final String newDefaultProjectLocation_;
    private final VcsCloneOptions vcsCloneOptions_;
    private final NewPackageOptions newPackageOptions_;

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/ProjectsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/ProjectsServerOperations.java
@@ -1,7 +1,7 @@
 /*
  * ProjectsServerOperations.java
  *
- * Copyright (C) 2009-15 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -30,12 +30,19 @@ public interface ProjectsServerOperations extends PrefsServerOperations,
                             ServerRequestCallback<Boolean> callback);
    
    void getNewProjectContext(ServerRequestCallback<NewProjectContext> callback);
-     
+   
+   /**
+    * @param projectFile project file to create if none found
+    * @param newPackageOptions
+    * @param newShinyAppOptions
+    * @param projectTemplateOptions
+    * @param callback if an existing .Rproj is found, return it, otherwise null
+    */
    void createProject(String projectFile,
                       NewPackageOptions newPackageOptions,
                       NewShinyAppOptions newShinyAppOptions,
                       ProjectTemplateOptions projectTemplateOptions,
-                      ServerRequestCallback<Void> callback);
+                      ServerRequestCallback<String> callback);
    
    void createProjectFile(String projectFile,
                           ServerRequestCallback<Boolean> callback);

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1682,11 +1682,12 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, EXECUTE_R_CODE, params, requestCallback);
    }
    
+   @Override
    public void createProject(String projectFile,
                              NewPackageOptions newPackageOptions,
                              NewShinyAppOptions newShinyAppOptions,
                              ProjectTemplateOptions projectTemplateOptions,
-                             ServerRequestCallback<Void> requestCallback)
+                             ServerRequestCallback<String> requestCallback)
    {
       JSONArray params = new JSONArray();
       params.set(0, new JSONString(projectFile));


### PR DESCRIPTION
Resolves #1581 
# Problem
When creating a project in an existing directory (or cloning a repo), if there's an existing .Rproj with a different name than the folder, another .Rproj matching the folder name is created and opened.

E.g. Have /foo/bar.Rproj and try to create a project in /foo, RStudio creates /foo/foo.Rproj and opens it.

# New Behavior
Uses existing `r_util:: projectFromDirectory` to search the folder for an existing .Rproj. The logic is:

(1) matching parent folder, case sensitive (/foo/foo.Rproj)
(2) matching parent folder, case insensitive (/foo/Foo.Rproj)
(3) single .Rproj in folder
(4) most recently modified .Rproj

If found, use it, otherwise create the one matching the directory name.

# Implementation
In `SessionProjects.cpp` I broke out the guts of the RPC handler `findProjectInFolder` to a shared function `findExistingProjFileInFolder` that implements the logic (minus the json). That RPC was recently added by me and only used in Server Pro by the Tutorial API (namely, rstudio.cloud).

Modified RPC `createProject` to search target folder using logic described. If an .Rproj is found and it is different than the one passed in, then return the full path of the one found.

Fixed r_util::projectFromDirectory to handle incoming path with a slash on the end. This was an issue noticed in some Pro work for rstudio.cloud, and I had fixed it by stripping slashes before calling the function. Moved the fix to the function itself, to catch any other uses.