### PR TITLE
don't attempt to de-register non-existent observer

### DIFF
--- a/src/cpp/desktop-mac/MainFrameController.mm
+++ b/src/cpp/desktop-mac/MainFrameController.mm
@@ -36,9 +36,6 @@ using namespace rstudio;
 
 static MainFrameController* instance_;
 
-// context for tracking all running applications
-const static NSString *kRunningApplicationsContext = @"RunningAppsContext";
-
 namespace
 {
 
@@ -137,11 +134,6 @@ bool setWindowGeometry(NSWindow* window, NSString* geometry)
 
 - (void) dealloc
 {
-   // unsubscribe to changes in the list of running applications
-   [[NSWorkspace sharedWorkspace] removeObserver:self
-                                      forKeyPath:@"runningApplications"
-                                         context:&kRunningApplicationsContext];
-   
    instance_ = nil;
    [dockTile_ release];
    [menu_ release];


### PR DESCRIPTION
This PR removes our old attempt to de-register an observer that we never actually register.

@jmcphers, do you think this meets the bar for a patch release? If we plan to publish another patch release, we might want to wait until the end of rstudio::conf just to shake out any other issues that users bring to us.