### PR TITLE
register '.ini' file type

### DIFF
--- a/src/cpp/core/FilePath.cpp
+++ b/src/cpp/core/FilePath.cpp
@@ -466,6 +466,7 @@ MimeType s_mimeTypes[] =
    { "tsv",   "text/tab-separated-values" },
    { "tab",   "text/tab-separated-values" },
    { "dcf",   "text/debian-control-file" },
+   { "ini",   "text/plain" },
    { "txt",   "text/plain" },
    { "mml",   "text/mathml" },
    { "log",   "text/plain" },

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -1138,8 +1138,11 @@ void enqueFileEditEvent(const std::string& file)
       }
    }
 
-   // fire event
+   // construct file system item (also tag with mime type)
    json::Object fileJson = module_context::createFileSystemItem(filePath);
+   fileJson["mime_type"] = filePath.mimeContentType();
+   
+   // fire event
    ClientEvent event(client_events::kFileEdit, fileJson);
    module_context::enqueClientEvent(event);
 }

--- a/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
+++ b/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
@@ -375,6 +375,7 @@ public class FileSystemItem extends JavaScriptObject
       MIME_TYPES.put( "tsv",   "text/tab-separated-values" );
       MIME_TYPES.put( "tab",   "text/tab-separated-values" );
       MIME_TYPES.put( "dcf",   "text/debian-control-file" );
+      MIME_TYPES.put( "ini",   "text/plain" );
       MIME_TYPES.put( "txt",   "text/plain" );
       MIME_TYPES.put( "mml",   "text/mathml" );
       MIME_TYPES.put( "log",   "text/plain");

--- a/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
+++ b/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
@@ -236,6 +236,10 @@ public class FileSystemItem extends JavaScriptObject
 
    public final String mimeType(String defaultType)
    {
+      String reportedMimeType = getMimeTypeInternal();
+      if (reportedMimeType != null)
+         return reportedMimeType;
+      
       String ext = getExtension().toLowerCase();
       if (ext.length() > 0)
       {
@@ -322,6 +326,10 @@ public class FileSystemItem extends JavaScriptObject
 
    public final native boolean exists() /*-{
       return this.exists;
+   }-*/;
+   
+   private final native String getMimeTypeInternal() /*-{
+      return this.mime_type;
    }-*/;
 
    // NOTE: should be synced with mime type database in FilePath.cpp

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
@@ -69,6 +69,12 @@ public class FileTypeRegistry
                           new ImageResource2x(ICONS.iconDCF2x()), false, false, false, false, false,
                           false, false, false, false, false, false, false, false);
    
+   public static final TextFileType INI =
+         new TextFileType("ini", "INI", EditorLanguage.LANG_INI, ".ini",
+                          new ImageResource2x(ICONS.iconDCF2x()), false, false, false, false, false,
+                          false, false, false, false, false, false, false, false);
+   
+   
    public static final TextFileType STAN = new StanFileType();
    
    public static final TextFileType MERMAID = new MermaidFileType();
@@ -377,6 +383,7 @@ public class FileTypeRegistry
       register("*.rds", RDS, new ImageResource2x(icons.iconRdata2x()));
       register("*.Rproj", RPROJECT, new ImageResource2x(icons.iconRproject2x()));
       register("*.dcf", DCF, new ImageResource2x(icons.iconDCF2x()));
+      register("*.ini", INI, new ImageResource2x(icons.iconDCF2x()));
       register("*.mmd", MERMAID, new ImageResource2x(icons.iconMermaid2x()));
       register("*.gv", GRAPHVIZ, new ImageResource2x(icons.iconGraphviz2x()));
       register("*.dot", GRAPHVIZ, new ImageResource2x(icons.iconGraphviz2x()));

--- a/src/gwt/src/org/rstudio/studio/client/common/reditor/EditorLanguage.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/reditor/EditorLanguage.java
@@ -84,6 +84,7 @@ public class EditorLanguage
    public static final EditorLanguage LANG_GROOVY = new EditorLanguage("ace/mode/groovy", false, true);
    public static final EditorLanguage LANG_HASKELL = new EditorLanguage("ace/mode/haskell", false, true);
    public static final EditorLanguage LANG_HAXE = new EditorLanguage("ace/mode/haxe", false, true);
+   public static final EditorLanguage LANG_INI = new EditorLanguage("ace/mode/ini", false, true);
    public static final EditorLanguage LANG_JAVA = new EditorLanguage("ace/mode/java", false, true);
    public static final EditorLanguage LANG_JULIA = new EditorLanguage("ace/mode/julia", false, true);
    public static final EditorLanguage LANG_LISP = new EditorLanguage("ace/mode/lisp", false, true);


### PR DESCRIPTION
This PR adds the `.ini` file type to RStudio (which Ace fortuitously provides a highlight mode that we already bundle).