### PR TITLE
zoom without reloading RStudio UI

### DIFF
--- a/src/cpp/desktop/DesktopGwtWindow.cpp
+++ b/src/cpp/desktop/DesktopGwtWindow.cpp
@@ -39,6 +39,12 @@ GwtWindow::GwtWindow(bool showToolbar,
       zoomLevels_.push_back(level);
 }
 
+void GwtWindow::zoomActualSize()
+{
+   setZoomLevel(1);
+   webView()->setZoomFactor(1);
+}
+
 void GwtWindow::zoomIn()
 {
    // get next greatest value
@@ -47,7 +53,7 @@ void GwtWindow::zoomIn()
    if (it != zoomLevels_.end())
    {
       setZoomLevel(*it);
-      webView()->reload();
+      webView()->setZoomFactor(*it);
    }
 }
 
@@ -58,8 +64,8 @@ void GwtWindow::zoomOut()
             zoomLevels_.begin(), zoomLevels_.end(), getZoomLevel());
    if (it != zoomLevels_.begin() && it != zoomLevels_.end())
    {
-      setZoomLevel(*(it-1));
-      webView()->reload();
+      setZoomLevel(*(it - 1));
+      webView()->setZoomFactor(*(it - 1));
    }
 }
 

--- a/src/cpp/desktop/DesktopGwtWindow.hpp
+++ b/src/cpp/desktop/DesktopGwtWindow.hpp
@@ -34,6 +34,7 @@ public:
    const std::vector<double>& zoomLevels() const { return zoomLevels_; }
 
 public Q_SLOTS:
+   void zoomActualSize();
    void zoomIn();
    void zoomOut();
 

--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -111,6 +111,7 @@ MainWindow::MainWindow(QUrl url) :
    connect(&menuCallback_, SIGNAL(commandInvoked(QString)),
            this, SLOT(invokeCommand(QString)));
 
+   connect(&menuCallback_, SIGNAL(zoomActualSize()), this, SLOT(zoomActualSize()));
    connect(&menuCallback_, SIGNAL(zoomIn()), this, SLOT(zoomIn()));
    connect(&menuCallback_, SIGNAL(zoomOut()), this, SLOT(zoomOut()));
 

--- a/src/cpp/desktop/DesktopMenuCallback.cpp
+++ b/src/cpp/desktop/DesktopMenuCallback.cpp
@@ -89,6 +89,7 @@ QAction* MenuCallback::addCustomAction(QString commandId,
 
    if (commandId == QStringLiteral("zoomActualSize"))
    {
+      // NOTE: CTRL implies META on macOS
       pAction = menuStack_.top()->addAction(QIcon(),
                                             label,
                                             this,

--- a/src/cpp/desktop/DesktopMenuCallback.cpp
+++ b/src/cpp/desktop/DesktopMenuCallback.cpp
@@ -87,7 +87,15 @@ QAction* MenuCallback::addCustomAction(QString commandId,
 
 #endif // Q_OS_MAC
 
-   if (commandId == QString::fromUtf8("zoomIn"))
+   if (commandId == QStringLiteral("zoomActualSize"))
+   {
+      pAction = menuStack_.top()->addAction(QIcon(),
+                                            label,
+                                            this,
+                                            SIGNAL(zoomActualSize()),
+                                            QKeySequence(Qt::CTRL + Qt::Key_0));
+   }
+   else if (commandId == QStringLiteral("zoomIn"))
    {
       pAction = menuStack_.top()->addAction(QIcon(),
                                             label,
@@ -95,7 +103,7 @@ QAction* MenuCallback::addCustomAction(QString commandId,
                                             SIGNAL(zoomIn()),
                                             QKeySequence::ZoomIn);
    }
-   else if (commandId == QString::fromUtf8("zoomOut"))
+   else if (commandId == QStringLiteral("zoomOut"))
    {
       pAction = menuStack_.top()->addAction(QIcon(),
                                             label,
@@ -103,6 +111,7 @@ QAction* MenuCallback::addCustomAction(QString commandId,
                                             SIGNAL(zoomOut()),
                                             QKeySequence::ZoomOut);
    }
+   
 #ifdef Q_OS_MAC
    // NOTE: even though we seem to be using Meta as a modifier key here, Qt
    // will translate that to CTRL (but only for Ctrl+Tab and Ctrl+Shift+Tab)

--- a/src/cpp/desktop/DesktopMenuCallback.hpp
+++ b/src/cpp/desktop/DesktopMenuCallback.hpp
@@ -60,6 +60,7 @@ Q_SIGNALS:
     void manageCommandVisibility(QString commandId, QAction* action);
     void commandInvoked(QString commandId);
 
+    void zoomActualSize();
     void zoomIn();
     void zoomOut();
 

--- a/src/cpp/desktop/DesktopSatelliteWindow.cpp
+++ b/src/cpp/desktop/DesktopSatelliteWindow.cpp
@@ -37,6 +37,7 @@ SatelliteWindow::SatelliteWindow(MainWindow* pMainWindow, QString name) :
 
    // satellites don't have a menu, so connect zoom keyboard shortcuts
    // directly
+   // NOTE: CTRL implies META on macOS
    QShortcut* zoomActualSizeShortcut = new QShortcut(Qt::CTRL + Qt::Key_0, this);
    QShortcut* zoomInShortcut = new QShortcut(QKeySequence::ZoomIn, this);
    QShortcut* zoomOutShortcut = new QShortcut(QKeySequence::ZoomOut, this);

--- a/src/cpp/desktop/DesktopSatelliteWindow.cpp
+++ b/src/cpp/desktop/DesktopSatelliteWindow.cpp
@@ -37,8 +37,11 @@ SatelliteWindow::SatelliteWindow(MainWindow* pMainWindow, QString name) :
 
    // satellites don't have a menu, so connect zoom keyboard shortcuts
    // directly
+   QShortcut* zoomActualSizeShortcut = new QShortcut(Qt::CTRL + Qt::Key_0, this);
    QShortcut* zoomInShortcut = new QShortcut(QKeySequence::ZoomIn, this);
    QShortcut* zoomOutShortcut = new QShortcut(QKeySequence::ZoomOut, this);
+   
+   connect(zoomActualSizeShortcut, SIGNAL(activated()), this, SLOT(zoomActualSize()));
    connect(zoomInShortcut, SIGNAL(activated()), this, SLOT(zoomIn()));
    connect(zoomOutShortcut, SIGNAL(activated()), this, SLOT(zoomOut()));
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -883,6 +883,7 @@ public class Application implements ApplicationEventHandlers
       // hide zoom in and zoom out in web mode
       if (!Desktop.isDesktop())
       {
+         commands_.zoomActualSize().remove();
          commands_.zoomIn().remove();
          commands_.zoomOut().remove();
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -275,6 +275,7 @@ well as menu structures (for main menu and popup menus).
          
          <separator/>
          
+         <cmd refid="zoomActualSize"/>
          <cmd refid="zoomIn"/>
          <cmd refid="zoomOut"/>
          <separator/>
@@ -1077,6 +1078,9 @@ well as menu structures (for main menu and popup menus).
    <cmd id="toggleToolbar"
         label="Toggle Visibility of Toolbar"
         menuLabel="Toggle Toolbar"/>
+        
+   <cmd id="zoomActualSize"
+        menuLabel="Actual Size"/>
         
    <cmd id="zoomIn"
         menuLabel="_Zoom In"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -277,6 +277,7 @@ public abstract class
    public abstract AppCommand showToolbar();
    public abstract AppCommand hideToolbar();
    public abstract AppCommand toggleToolbar();
+   public abstract AppCommand zoomActualSize();
    public abstract AppCommand zoomIn();
    public abstract AppCommand zoomOut();
    public abstract AppCommand jumpTo();


### PR DESCRIPTION
Does what it says on the tin -- makes it possible to zoom / unzoom the IDE on all platforms, without needing a reload of the whole UI.