### PR TITLE
discard duplicated zoom requests

### DIFF
--- a/src/cpp/desktop/DesktopGwtWindow.cpp
+++ b/src/cpp/desktop/DesktopGwtWindow.cpp
@@ -20,6 +20,16 @@
 namespace rstudio {
 namespace desktop {
 
+namespace {
+
+bool isDuplicateZoomRequest(QElapsedTimer* pTimer)
+{
+   qint64 elapsed = pTimer->restart();
+   return elapsed < 10;
+}
+
+} // end anonymous namespace
+
 GwtWindow::GwtWindow(bool showToolbar,
                      bool adjustTitle,
                      QString name,
@@ -37,16 +47,23 @@ GwtWindow::GwtWindow(bool showToolbar,
    
    for (double level : levels)
       zoomLevels_.push_back(level);
+   
+   lastZoomTimer_.start();
 }
 
 void GwtWindow::zoomActualSize()
 {
+   if (isDuplicateZoomRequest(&lastZoomTimer_))
+      return;
    setZoomLevel(1);
    webView()->setZoomFactor(1);
 }
 
 void GwtWindow::zoomIn()
 {
+   if (isDuplicateZoomRequest(&lastZoomTimer_))
+      return;
+   
    // get next greatest value
    std::vector<double>::const_iterator it = std::upper_bound(
             zoomLevels_.begin(), zoomLevels_.end(), getZoomLevel());
@@ -59,6 +76,9 @@ void GwtWindow::zoomIn()
 
 void GwtWindow::zoomOut()
 {
+   if (isDuplicateZoomRequest(&lastZoomTimer_))
+      return;
+   
    // get next smallest value
    std::vector<double>::const_iterator it = std::lower_bound(
             zoomLevels_.begin(), zoomLevels_.end(), getZoomLevel());

--- a/src/cpp/desktop/DesktopGwtWindow.hpp
+++ b/src/cpp/desktop/DesktopGwtWindow.hpp
@@ -53,6 +53,7 @@ private:
 
    std::vector<double> zoomLevels_;
    double zoomLevel_;
+   QElapsedTimer lastZoomTimer_;
 };
 
 } // namespace desktop

--- a/src/cpp/desktop/DesktopMenuCallback.cpp
+++ b/src/cpp/desktop/DesktopMenuCallback.cpp
@@ -90,27 +90,30 @@ QAction* MenuCallback::addCustomAction(QString commandId,
    if (commandId == QStringLiteral("zoomActualSize"))
    {
       // NOTE: CTRL implies META on macOS
-      pAction = menuStack_.top()->addAction(QIcon(),
-                                            label,
-                                            this,
-                                            SIGNAL(zoomActualSize()),
-                                            QKeySequence(Qt::CTRL + Qt::Key_0));
+      pAction = menuStack_.top()->addAction(
+               QIcon(),
+               label,
+               this,
+               SIGNAL(zoomActualSize()),
+               QKeySequence(Qt::CTRL + Qt::Key_0));
    }
    else if (commandId == QStringLiteral("zoomIn"))
    {
-      pAction = menuStack_.top()->addAction(QIcon(),
-                                            label,
-                                            this,
-                                            SIGNAL(zoomIn()),
-                                            QKeySequence::ZoomIn);
+      pAction = menuStack_.top()->addAction(
+               QIcon(),
+               label,
+               this,
+               SIGNAL(zoomIn()),
+               QKeySequence::ZoomIn);
    }
    else if (commandId == QStringLiteral("zoomOut"))
    {
-      pAction = menuStack_.top()->addAction(QIcon(),
-                                            label,
-                                            this,
-                                            SIGNAL(zoomOut()),
-                                            QKeySequence::ZoomOut);
+      pAction = menuStack_.top()->addAction(
+               QIcon(),
+               label,
+               this,
+               SIGNAL(zoomOut()),
+               QKeySequence::ZoomOut);
    }
    
 #ifdef Q_OS_MAC


### PR DESCRIPTION
This PR works around what appears to be a Qt bug by discarding duplicated zoom requests.

Closes https://github.com/rstudio/rstudio/issues/2126.

Reported upstream at https://bugreports.qt.io/browse/QTBUG-66207 (was able to reproduce using the Qt 'minimal' example)