### PR TITLE
explicitly ignore '.git' folder on Windows

### DIFF
--- a/src/cpp/core/system/file_monitor/Win32FileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/Win32FileMonitor.cpp
@@ -494,7 +494,7 @@ bool gitFilter(const FileInfo& fileInfo,
 {
    // screen out '.git' folder
    if (fileInfo.isDirectory() &&
-       boost::algorithm::ends_with(fileInfo.absolutePath(), ".git"))
+       boost::algorithm::ends_with(fileInfo.absolutePath(), "/.git"))
    {
       return false;
    }


### PR DESCRIPTION
This PR seeks to resolve an issue where attempts to launch the IDE could fail if the `.git` folder was not marked as hidden. Effectively, the IDE would get deadlocked between the file monitor scanning for changes to the `.git/index.lock` file, and attempts to call `git status` to populate the Git pane.

Resolves #2141.

@jjallaire, let me know if this feels like the right change or if there's a more appropriate place for this fix to live.

Do we want to be resilient against other hidden folders that may become unhidden (e.g. the `.Rproj.user` folder)?