### PR TITLE
Make common RStudio dependencies cacheable

### DIFF
--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -1,3 +1,5 @@
+# vi: set ft=cmake:
+
 #
 # CMakeGlobals.txt
 #
@@ -11,7 +13,7 @@
 # MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
 # AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
 #
-#
+
 
 # include guard
 if(RSTUDIO_CMAKE_GLOBALS_INCLUDED)
@@ -125,10 +127,21 @@ get_filename_component(ROOT_SRC_DIR ${CMAKE_CURRENT_LIST_FILE} PATH)
 set(CMAKE_MODULE_PATH "${ROOT_SRC_DIR}/cmake/modules/")
 
 # dependencies
-set(RSTUDIO_DEPENDENCIES_DIR "${ROOT_SRC_DIR}/dependencies")
 if(WIN32)
    set(RSTUDIO_WINDOWS_DEPENDENCIES_DIR "${RSTUDIO_DEPENDENCIES_DIR}/windows")
+else()
+   # look for system-wide (global) dependencies folder
+   if(EXISTS "/opt/rstudio-tools/dependencies")
+      set(RSTUDIO_DEPENDENCIES_DIR "/opt/rstudio-tools/dependencies")
+   endif()
 endif()
+
+# look for dependencies in the source folder if not installed globally
+if(NOT EXISTS "${RSTUDIO_DEPENDENCIES_DIR}")
+   set(RSTUDIO_DEPENDENCIES_DIR "${ROOT_SRC_DIR}/dependencies")
+endif()
+
+message("Dep dir is ${RSTUDIO_DEPENDENCIES_DIR}")
 
 # special install directories for apple desktop
 if (APPLE AND RSTUDIO_DESKTOP)

--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -141,8 +141,6 @@ if(NOT EXISTS "${RSTUDIO_DEPENDENCIES_DIR}")
    set(RSTUDIO_DEPENDENCIES_DIR "${ROOT_SRC_DIR}/dependencies")
 endif()
 
-message("Dep dir is ${RSTUDIO_DEPENDENCIES_DIR}")
-
 # special install directories for apple desktop
 if (APPLE AND RSTUDIO_DESKTOP)
    set(RSTUDIO_INSTALL_BIN RStudio.app/Contents/MacOS)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,17 +15,6 @@ properties([
                 ])
 ])
 
-def resolve_deps(type, arch, variant) {
-  def linux_bin = (arch == 'i386') ? 'linux32' : '' // only required in centos-land.
-  switch ( type ) {
-      case "DEB":
-        sh "cd dependencies/linux && ./install-dependencies-debian --exclude-qt-sdk && cd ../.."
-        break
-      case "RPM":
-        sh "cd dependencies/linux && ${linux_bin} ./install-dependencies-yum --exclude-qt-sdk && cd ../.."
-  }
-}
-
 def compile_package(type, flavor, variant) {
   // start with major, minor, and patch versions
   def env = "RSTUDIO_VERSION_MAJOR=${rstudioVersionMajor} RSTUDIO_VERSION_MINOR=${rstudioVersionMinor} RSTUDIO_VERSION_PATCH=${rstudioVersionPatch}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -194,9 +194,6 @@ try {
                       container = pullBuildPush(image_name: 'jenkins/ide', dockerfile: "docker/jenkins/Dockerfile.${current_container.os}-${current_container.arch}", image_tag: image_tag, build_args: jenkins_user_build_args())
                     }
                     container.inside() {
-                        stage('resolve deps'){
-                            resolve_deps(get_type_from_os(current_container.os), current_container.arch, current_container.variant)
-                        }
                         stage('compile package') {
                             compile_package(get_type_from_os(current_container.os), current_container.flavor, current_container.variant)
                         }

--- a/dependencies/common/install-gwt
+++ b/dependencies/common/install-gwt
@@ -3,7 +3,7 @@
 #
 # install-gwt
 #
-# Copyright (C) 2009-17 by RStudio, Inc.
+# Copyright (C) 2009-18 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -27,22 +27,24 @@ download()
 {
   if [ "$PLATFORM" == "Darwin" ]
   then
-    curl -L https://s3.amazonaws.com/rstudio-buildtools/$1 > $1
+    curl -L "https://s3.amazonaws.com/rstudio-buildtools/$1" > "$1"
   else
-    wget https://s3.amazonaws.com/rstudio-buildtools/$1 -O $1
+    wget "https://s3.amazonaws.com/rstudio-buildtools/$1" -O "$1"
   fi
 }
 
 # target directory for gwt; if there's an opt folder then use that, otherwise,
 # presume we're using the install dir
-GWT_DIR="/opt/rstudio-tools/gwt"
-if ! [ -d "$GWT_DIR" ]; then
+OPT_DEPENDENCIES="/opt/rstudio-tools/dependencies/common"
+if [ -d "$OPT_DEPENDENCIES" ]; then
+   GWT_DIR="$OPT_DEPENDENCIES/gwt"
+else
    GWT_DIR=$INSTALL_DIR/../../src/gwt
 fi
 
 # lib dir
 LIB_DIR=$GWT_DIR/lib
-mkdir -p $LIB_DIR
+mkdir -p "$LIB_DIR"
 
 # gin
 GIN_VER=2.1.2

--- a/dependencies/common/install-pandoc
+++ b/dependencies/common/install-pandoc
@@ -3,7 +3,7 @@
 #
 # install-pandoc
 #
-# Copyright (C) 2009-12 by RStudio, Inc.
+# Copyright (C) 2009-18 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -24,6 +24,12 @@ PANDOC_VERSION="1.19.2.1"
 PANDOC_CITEPROC_VERSION="0.10.4"
 PANDOC_SUBDIR="pandoc/${PANDOC_VERSION}"
 PANDOC_URL_BASE="https://s3.amazonaws.com/rstudio-buildtools/pandoc/${PANDOC_VERSION}"
+
+# see if we already have binaries
+if [ -d "${PANDOC_SUBDIR}" ]; then
+    echo "Pandoc ${PANDOC_VERSION} already installed"
+    exit 0
+fi
 
 # enter pandoc subdirectory
 mkdir -p "${PANDOC_SUBDIR}"

--- a/dependencies/common/rstudio-tools
+++ b/dependencies/common/rstudio-tools
@@ -233,7 +233,7 @@ os-version-patch () {
 	os-version-part 3
 }
 
-# Helper functions for quickly checking paltform types
+# Helper functions for quickly checking platform types
 is-mac () {
 	[ "$(uname)" = "Darwin" ]
 }

--- a/docker/docker-compile.sh
+++ b/docker/docker-compile.sh
@@ -98,5 +98,5 @@ elif hash sysctl 2>/dev/null; then
 fi
 
 # run compile step
-docker run --rm -v $(pwd):/src $REPO:$IMAGE bash -c "cd /src/dependencies/linux && ./install-dependencies-$INSTALLER --exclude-qt-sdk && cd /src/package/linux && $ENV ./make-$FLAVOR-package $PACKAGE clean $VARIANT"
+docker run --rm -v $(pwd):/src $REPO:$IMAGE bash -c "cd /src/dependencies/linux && cd /src/package/linux && $ENV ./make-$FLAVOR-package $PACKAGE clean $VARIANT"
 

--- a/docker/jenkins/Dockerfile.centos6-x86_64
+++ b/docker/jenkins/Dockerfile.centos6-x86_64
@@ -51,10 +51,10 @@ RUN bash /tmp/install-boost || bash /tmp/install-boost
 COPY package/linux/install-dependencies /tmp/
 RUN bash /tmp/install-dependencies
 
-# install GWT libs
-COPY dependencies/common/install-gwt /tmp/
-RUN mkdir -p /opt/rstudio-tools/gwt && \
-    /tmp/install-gwt
+# install common dependencies
+RUN mkdir -p /opt/rstudio-tools/dependencies/common
+COPY dependencies/common/* /opt/rstudio-tools/dependencies/common/
+RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
 ARG JENKINS_GID=999

--- a/docker/jenkins/Dockerfile.centos7-x86_64
+++ b/docker/jenkins/Dockerfile.centos7-x86_64
@@ -51,16 +51,16 @@ RUN bash /tmp/install-boost || bash /tmp/install-boost
 COPY package/linux/install-dependencies /tmp/
 RUN bash /tmp/install-dependencies
 
+# install common dependencies
+RUN mkdir -p /opt/rstudio-tools/dependencies/common
+COPY dependencies/common/* /opt/rstudio-tools/dependencies/common/
+RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
+
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
     export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.10.0 && \
     /tmp/install-qt-sdk
-
-# install GWT libs
-COPY dependencies/common/install-gwt /tmp/
-RUN mkdir -p /opt/rstudio-tools/gwt && \
-    /tmp/install-gwt
 
 # remove any previous users with conflicting IDs
 ARG JENKINS_GID=999

--- a/docker/jenkins/Dockerfile.debian9-x86_64
+++ b/docker/jenkins/Dockerfile.debian9-x86_64
@@ -51,16 +51,16 @@ RUN bash /tmp/install-boost || bash /tmp/install-boost
 COPY package/linux/install-dependencies /tmp/
 RUN bash /tmp/install-dependencies
 
+# install common dependencies
+RUN mkdir -p /opt/rstudio-tools/dependencies/common
+COPY dependencies/common/* /opt/rstudio-tools/dependencies/common/
+RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
+
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
     export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.10.0 && \
     /tmp/install-qt-sdk
-
-# install GWT libs
-COPY dependencies/common/install-gwt /tmp/
-RUN mkdir -p /opt/rstudio-tools/gwt && \
-    /tmp/install-gwt
 
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
 ARG JENKINS_GID=999

--- a/docker/jenkins/Dockerfile.precise-amd64
+++ b/docker/jenkins/Dockerfile.precise-amd64
@@ -98,16 +98,16 @@ RUN bash /tmp/install-boost || bash /tmp/install-boost
 COPY package/linux/install-dependencies /tmp/
 RUN bash /tmp/install-dependencies
 
+# install common dependencies
+RUN mkdir -p /opt/rstudio-tools/dependencies/common
+COPY dependencies/common/* /opt/rstudio-tools/dependencies/common/
+RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
+
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
     export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.10.0 && \
     /tmp/install-qt-sdk
-
-# install GWT libs
-COPY dependencies/common/install-gwt /tmp/
-RUN mkdir -p /opt/rstudio-tools/gwt && \
-    /tmp/install-gwt
 
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
 ARG JENKINS_GID=999

--- a/docker/jenkins/Dockerfile.trusty-amd64
+++ b/docker/jenkins/Dockerfile.trusty-amd64
@@ -66,6 +66,11 @@ RUN cd /tmp \
 COPY dependencies/common/install-boost /tmp/
 RUN bash /tmp/install-boost || bash /tmp/install-boost
 
+# install common dependencies
+RUN mkdir -p /opt/rstudio-tools/dependencies/common
+COPY dependencies/common/* /opt/rstudio-tools/dependencies/common/
+RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
+
 # install cmake
 COPY package/linux/install-dependencies /tmp/
 RUN /bin/bash /tmp/install-dependencies

--- a/src/gwt/CMakeLists.txt
+++ b/src/gwt/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # CMakeLists.txt
 #
-# Copyright (C) 2009-17 by RStudio, Inc.
+# Copyright (C) 2009-18 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 2.6)
 project (RSTUDIO_GWT)
 
 # check for externals
-set(GWT_LIB_DIR "/opt/rstudio-tools/gwt/lib")
+set(GWT_LIB_DIR "/opt/rstudio-tools/dependencies/common/gwt/lib")
 if(NOT EXISTS "${GWT_LIB_DIR}")
    set(GWT_LIB_DIR "lib")
 endif()


### PR DESCRIPTION
Currently, RStudio builds (in Docker containers) always begin with a clean `rstudio` source folder, into which common dependencies like Pandoc, clang, and mathjax are downloaded and installed to `rstudio/dependencies/common`. This uses up a lot of unnecessarily time and bandwidth. 

This change does the following for common dependencies:

- Installs dependencies to `/opt/rstudio-tools/dependencies` when building in containers.
- Reads dependencies from this folder when building, if it is present, rather than the source folder.
- Removes the code which re-installed dependencies on every build. 

Paths for local development are fully unaffected; this change only affects the paths used when building in dedicated containers.

Partially resolves #1614. 