### PR TITLE
show invisibles, use tabs as appropriate in .csv, .tsv

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -6339,16 +6339,17 @@ public class TextEditingTarget implements
       releaseOnDismiss.add(prefs.useSpacesForTab().bind(
             new CommandWithArg<Boolean>() {
                public void execute(Boolean arg) {
-                  // Makefile always uses tabs
+                  // Makefile and tsv always uses tabs
                   FileSystemItem file = context.getActiveFile();
                   if ((file != null) && 
                      ("Makefile".equals(file.getName()) ||
                       "Makevars".equals(file.getName()) ||
-                      "Makevars.win".equals(file.getName())))
+                      "Makevars.win".equals(file.getName()) ||
+                      ".tsv".equals(file.getExtension())))
                   {
                      docDisplay.setUseSoftTabs(false);
                   }
-                  else
+                  else 
                   {
                      if (projectConfig == null)
                         docDisplay.setUseSoftTabs(arg);
@@ -6384,7 +6385,18 @@ public class TextEditingTarget implements
       releaseOnDismiss.add(prefs.showInvisibles().bind(
             new CommandWithArg<Boolean>() {
                public void execute(Boolean arg) {
-                  docDisplay.setShowInvisibles(arg);
+                  // show whitespace characters in '.csv', '.tsv' files
+                  boolean showInvisibles = arg;
+                  FileSystemItem file = context.getActiveFile();
+                  if (file != null)
+                  {
+                     String ext = file.getExtension();
+                     if (".tsv".contentEquals(ext) || ".csv".contentEquals(ext))
+                     {
+                        showInvisibles = true;
+                     }
+                  }
+                  docDisplay.setShowInvisibles(showInvisibles);
                }}));
       releaseOnDismiss.add(prefs.showIndentGuides().bind(
             new CommandWithArg<Boolean>() {


### PR DESCRIPTION
This PR:

- Shows invisible characters in `.csv` and `.tsv` files, so one can see what kind of whitespace actually lives in the file;

- Ensures the Tab key inserts a literal Tab in `.tsv` files.

I also wonder if it would be worth overriding the tab width in `.tsv` files -- I often edit with a small tab width (e.g. 2 characters) but that feels insufficient when editing a `.tsv`, where 4 or 8 might feel more natural.