### PR TITLE
avoid resolving symlinks in 'relativePath'

### DIFF
--- a/src/cpp/core/FileLockTests.cpp
+++ b/src/cpp/core/FileLockTests.cpp
@@ -122,7 +122,7 @@ TEST_CASE("File Locking")
       boost::posix_time::seconds timeout = FileLock::getTimeoutInterval();
       FileLock::setTimeoutInterval(boost::posix_time::seconds(600)); // 10 minutes
 
-      for (std::size_t i = 0; i < 1000; ++i)
+      for (std::size_t i = 0; i < 100; ++i)
          s_threads.create_thread(boost::bind(acquireLock, i));
       
       s_threads.join_all();

--- a/src/cpp/core/FilePath.cpp
+++ b/src/cpp/core/FilePath.cpp
@@ -604,26 +604,11 @@ std::time_t FilePath::lastWriteTime() const
 
 std::string FilePath::relativePath(const FilePath& parentPath) const
 {
-   // NOTE: we don't use boost::filesystem::relative here as this API
-   // also normalizes paths + resolves symlinks, which is undesired in
-   // our usages of this function. note that our usages of this API
-   // assume this path is a descendant of the parent path; we don't try
-   // to construct e.g. sibling paths using this API
-   std::string selfPath = absolutePath();
-   std::string scopePath = parentPath.absolutePath();
+   path_t relativePath =
+         pImpl_->path.lexically_normal().lexically_relative(
+            parentPath.pImpl_->path.lexically_normal());
    
-   if (selfPath == scopePath)
-   {
-      return selfPath;
-   }
-   else if (boost::algorithm::starts_with(selfPath, scopePath))
-   {
-      return selfPath.substr(scopePath.size() + 1);
-   }
-   else
-   {
-      return selfPath;
-   }
+   return BOOST_FS_PATH2STR(relativePath);
 }
 
 bool FilePath::isWithin(const FilePath& scopePath) const

--- a/src/cpp/core/FilePath.cpp
+++ b/src/cpp/core/FilePath.cpp
@@ -606,7 +606,9 @@ std::string FilePath::relativePath(const FilePath& parentPath) const
 {
    // NOTE: we don't use boost::filesystem::relative here as this API
    // also normalizes paths + resolves symlinks, which is undesired in
-   // our usages of this function
+   // our usages of this function. note that our usages of this API
+   // assume this path is a descendant of the parent path; we don't try
+   // to construct e.g. sibling paths using this API
    std::string selfPath = absolutePath();
    std::string scopePath = parentPath.absolutePath();
    

--- a/src/cpp/core/FilePathTests.cpp
+++ b/src/cpp/core/FilePathTests.cpp
@@ -37,7 +37,6 @@ TEST_CASE("file paths")
       CHECK(!aPath.isWithin(bPath));
 
       CHECK(aPath.relativePath(pPath) == "a");
-      CHECK(aPath.relativePath(bPath) == "../a");
    }
 }
 


### PR DESCRIPTION
This PR resolves an issue wherein, within the Files pane, the symlink target was shown rather than the symlink name itself.

This was a v1.2 regression caused by the Boost upgrade, wherein I switched our previous implementation of `relativePath()` to use the new `boost::filesystem::relative()` API. This was primarily prompted by our old implementation failing with gcc-5 and above. Unfortunately, `boost::filesystem::relative()` does a bit too much -- it also normalizes paths and resolves symlinks -- which is undesired in our usages of this function.

Resolves https://github.com/rstudio/rstudio/issues/2147.