### PR TITLE
fix error handling on Win32 debug builds

### DIFF
--- a/src/cpp/core/FilePath.cpp
+++ b/src/cpp/core/FilePath.cpp
@@ -1076,8 +1076,7 @@ Error FilePath::open_r(boost::shared_ptr<std::istream>* pStream) const
                                    NULL);
       if (hFile == INVALID_HANDLE_VALUE)
       {
-         auto lastErr = ::GetLastError();
-         Error error = systemError(lastErr, ERROR_LOCATION);
+         Error error = LAST_SYSTEM_ERROR();
          error.addProperty("path", absolutePath());
          return error;
       }
@@ -1129,8 +1128,7 @@ Error FilePath::open_w(boost::shared_ptr<std::ostream>* pStream, bool truncate) 
                                    NULL);
       if (hFile == INVALID_HANDLE_VALUE)
       {
-         auto lastErr = ::GetLastError();
-         Error error = systemError(lastErr, ERROR_LOCATION);
+         Error error = LAST_SYSTEM_ERROR();
          error.addProperty("path", absolutePath());
          return error;
       }

--- a/src/cpp/core/FilePath.cpp
+++ b/src/cpp/core/FilePath.cpp
@@ -1,7 +1,7 @@
 /*
  * FilePath.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -1076,7 +1076,8 @@ Error FilePath::open_r(boost::shared_ptr<std::istream>* pStream) const
                                    NULL);
       if (hFile == INVALID_HANDLE_VALUE)
       {
-         Error error = systemError(::GetLastError(), ERROR_LOCATION);
+         auto lastErr = ::GetLastError();
+         Error error = systemError(lastErr, ERROR_LOCATION);
          error.addProperty("path", absolutePath());
          return error;
       }
@@ -1128,7 +1129,8 @@ Error FilePath::open_w(boost::shared_ptr<std::ostream>* pStream, bool truncate) 
                                    NULL);
       if (hFile == INVALID_HANDLE_VALUE)
       {
-         Error error = systemError(::GetLastError(), ERROR_LOCATION);
+         auto lastErr = ::GetLastError();
+         Error error = systemError(lastErr, ERROR_LOCATION);
          error.addProperty("path", absolutePath());
          return error;
       }

--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -1,7 +1,7 @@
 /*
  * StringUtils.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -250,7 +250,8 @@ std::string utf8ToSystem(const std::string& str,
    int chars = ::MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, &wide[0], wide.size());
    if (chars < 0)
    {
-      LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+      auto lastErr = ::GetLastError();
+      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
       return str;
    }
 
@@ -287,7 +288,8 @@ std::string systemToUtf8(const std::string& str, int codepage)
    int chars = ::MultiByteToWideChar(codepage, 0, str.c_str(), str.length(), &wide[0], wide.size());
    if (chars < 0)
    {
-      LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+      auto lastErr = ::GetLastError();
+      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
       return str;
    }
 
@@ -296,7 +298,8 @@ std::string systemToUtf8(const std::string& str, int codepage)
                                              NULL, NULL);
    if (bytesRequired == 0)
    {
-      LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+      auto lastErr = ::GetLastError();
+      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
       return str;
    }
    std::vector<char> buf(bytesRequired, 0);

--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -250,8 +250,7 @@ std::string utf8ToSystem(const std::string& str,
    int chars = ::MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, &wide[0], wide.size());
    if (chars < 0)
    {
-      auto lastErr = ::GetLastError();
-      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+      LOG_ERROR(LAST_SYSTEM_ERROR());
       return str;
    }
 
@@ -288,8 +287,7 @@ std::string systemToUtf8(const std::string& str, int codepage)
    int chars = ::MultiByteToWideChar(codepage, 0, str.c_str(), str.length(), &wide[0], wide.size());
    if (chars < 0)
    {
-      auto lastErr = ::GetLastError();
-      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+      LOG_ERROR(LAST_SYSTEM_ERROR());
       return str;
    }
 
@@ -298,8 +296,7 @@ std::string systemToUtf8(const std::string& str, int codepage)
                                              NULL, NULL);
    if (bytesRequired == 0)
    {
-      auto lastErr = ::GetLastError();
-      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+      LOG_ERROR(LAST_SYSTEM_ERROR());
       return str;
    }
    std::vector<char> buf(bytesRequired, 0);

--- a/src/cpp/core/Win32StringUtils.cpp
+++ b/src/cpp/core/Win32StringUtils.cpp
@@ -1,7 +1,7 @@
 /*
  * Win32StringUtils.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -35,7 +35,8 @@ std::string wideToUtf8(const std::wstring& value)
                                      NULL, 0, NULL, NULL);
    if (chars == 0)
    {
-      LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+      auto lastErr = ::GetLastError();
+      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
       return std::string();
    }
 
@@ -60,7 +61,8 @@ std::wstring utf8ToWide(const std::string& value,
                                      NULL, 0);
    if (chars == 0)
    {
-      Error error = systemError(::GetLastError(), ERROR_LOCATION);
+      auto lastErr = ::GetLastError();
+      Error error = systemError(lastErr, ERROR_LOCATION);
       if (!context.empty())
          error.addProperty("context", context);
       LOG_ERROR(error);

--- a/src/cpp/core/Win32StringUtils.cpp
+++ b/src/cpp/core/Win32StringUtils.cpp
@@ -35,8 +35,7 @@ std::string wideToUtf8(const std::wstring& value)
                                      NULL, 0, NULL, NULL);
    if (chars == 0)
    {
-      auto lastErr = ::GetLastError();
-      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+      LOG_ERROR(LAST_SYSTEM_ERROR());
       return std::string();
    }
 
@@ -61,8 +60,7 @@ std::wstring utf8ToWide(const std::string& value,
                                      NULL, 0);
    if (chars == 0)
    {
-      auto lastErr = ::GetLastError();
-      Error error = systemError(lastErr, ERROR_LOCATION);
+      Error error = LAST_SYSTEM_ERROR();
       if (!context.empty())
          error.addProperty("context", context);
       LOG_ERROR(error);

--- a/src/cpp/core/include/core/Error.hpp
+++ b/src/cpp/core/include/core/Error.hpp
@@ -122,6 +122,13 @@ public:
    Success() : Error() {}
 };
 
+// On Windows, don't use ::GetLastError() as the first argument (value).
+//
+// On certain build configurations it is possible the ErrorLocation
+// argument is evaluated before the "value" argument and resets the
+// Win32 last-error to "no error". Always capture the GetLastError value
+// separately and pass that to systemError. Didn't wrap this in a function
+// or macro to avoid obfuscating the location of the call in error output.
 
 Error systemError(int value, const ErrorLocation& location) ; 
 Error systemError(int value,

--- a/src/cpp/core/include/core/Error.hpp
+++ b/src/cpp/core/include/core/Error.hpp
@@ -1,7 +1,7 @@
 /*
  * Error.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -113,7 +113,7 @@ private:
 };
 
 // 
-// No error subclass created for syntactic conveneince:
+// No error subclass created for syntactic convenience:
 //   return Success();
 //
 class Success : public Error
@@ -122,13 +122,15 @@ public:
    Success() : Error() {}
 };
 
-// On Windows, don't use ::GetLastError() as the first argument (value).
-//
-// On certain build configurations it is possible the ErrorLocation
-// argument is evaluated before the "value" argument and resets the
-// Win32 last-error to "no error". Always capture the GetLastError value
-// separately and pass that to systemError. Didn't wrap this in a function
-// or macro to avoid obfuscating the location of the call in error output.
+#ifdef _WIN32
+
+// Use this macro instead of systemError(::GetLastError(), ERROR_LOCATION) otherwise
+// the ERROR_LOCATION macro may evaluate first and reset the Win32 error code to
+// zero (no error), causing the wrong value to be passed to systemError. This is currently
+// the case on debug builds using MSVC.
+#define LAST_SYSTEM_ERROR() []() {auto lastErr = ::GetLastError(); return systemError(lastErr, ERROR_LOCATION);}()
+
+#endif // _WIN32
 
 Error systemError(int value, const ErrorLocation& location) ; 
 Error systemError(int value,

--- a/src/cpp/core/include/core/http/NamedPipeAsyncClient.hpp
+++ b/src/cpp/core/include/core/http/NamedPipeAsyncClient.hpp
@@ -81,8 +81,7 @@ private:
          // handle connection error if necessary)
          if (hPipe == INVALID_HANDLE_VALUE)
          {
-            auto lastErr = ::GetLastError();
-            handleConnectionError(systemError(lastErr, ERROR_LOCATION));
+            handleConnectionError(LAST_SYSTEM_ERROR());
             return;
          }
 

--- a/src/cpp/core/include/core/http/NamedPipeAsyncClient.hpp
+++ b/src/cpp/core/include/core/http/NamedPipeAsyncClient.hpp
@@ -1,7 +1,7 @@
 /*
  * NamedPipeAsyncClient.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -81,7 +81,8 @@ private:
          // handle connection error if necessary)
          if (hPipe == INVALID_HANDLE_VALUE)
          {
-            handleConnectionError(systemError(::GetLastError(),ERROR_LOCATION));
+            auto lastErr = ::GetLastError();
+            handleConnectionError(systemError(lastErr, ERROR_LOCATION));
             return;
          }
 

--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -245,8 +245,7 @@ Error ChildProcess::writeToStdin(const std::string& input, bool eof)
                                      NULL);
          if (!bSuccess)
          {
-            auto lastErr = ::GetLastError();
-            return systemError(lastErr, ERROR_LOCATION);
+            return LAST_SYSTEM_ERROR();
          }
       }
    }
@@ -286,8 +285,7 @@ Error ChildProcess::terminate()
    // terminate with exit code 15 (15 is SIGTERM on posix)
    if (!::TerminateProcess(pImpl_->hProcess, 15))
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
    else
       return Success();
@@ -330,8 +328,7 @@ Error openFile(const FilePath& file, bool inheritable, HANDLE* phFile)
                                 NULL);
    if (hFile == INVALID_HANDLE_VALUE)
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
 
    if (inheritable)
@@ -340,8 +337,7 @@ Error openFile(const FilePath& file, bool inheritable, HANDLE* phFile)
                                   HANDLE_FLAG_INHERIT,
                                   HANDLE_FLAG_INHERIT))
       {
-         auto lastErr = ::GetLastError();
-         Error err = systemError(lastErr, ERROR_LOCATION);
+         Error err = LAST_SYSTEM_ERROR();
          ::CloseHandle(hFile);
          return err;
       }
@@ -385,48 +381,42 @@ Error ChildProcess::run()
    HANDLE hStdInRead;
    if (!::CreatePipe(&hStdInRead, &pImpl_->hStdInWrite, NULL, 0))
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
    CloseHandleOnExitScope closeStdIn(&hStdInRead, ERROR_LOCATION);
    if (!::SetHandleInformation(hStdInRead,
                                HANDLE_FLAG_INHERIT,
                                HANDLE_FLAG_INHERIT))
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
 
    // Standard output pipe
    HANDLE hStdOutWrite;
    if (!::CreatePipe(&pImpl_->hStdOutRead, &hStdOutWrite, NULL, 0))
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
    CloseHandleOnExitScope closeStdOut(&hStdOutWrite, ERROR_LOCATION);
    if (!::SetHandleInformation(hStdOutWrite,
                                HANDLE_FLAG_INHERIT,
                                HANDLE_FLAG_INHERIT) )
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
 
    // Standard error pipe
    HANDLE hStdErrWrite;
    if (!::CreatePipe(&pImpl_->hStdErrRead, &hStdErrWrite, NULL, 0))
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
    CloseHandleOnExitScope closeStdErr(&hStdErrWrite, ERROR_LOCATION);
    if (!::SetHandleInformation(hStdErrWrite,
                                HANDLE_FLAG_INHERIT,
                                HANDLE_FLAG_INHERIT) )
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
 
    // populate startup info
@@ -553,8 +543,7 @@ Error ChildProcess::run()
 
    if (!success)
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
 
    // close thread handle on exit
@@ -589,8 +578,7 @@ Error SyncChildProcess::waitForExit(int* pExitStatus)
    {
       if (result == WAIT_FAILED)
       {
-         auto lastErr = ::GetLastError();
-         return systemError(lastErr, ERROR_LOCATION);
+         return LAST_SYSTEM_ERROR();
       }
       else
       {
@@ -606,8 +594,7 @@ Error SyncChildProcess::waitForExit(int* pExitStatus)
       DWORD dwStatus;
       if (!::GetExitCodeProcess(pImpl_->hProcess, &dwStatus))
       {
-         auto lastErr = ::GetLastError();
-         return systemError(lastErr, ERROR_LOCATION);
+         return LAST_SYSTEM_ERROR();
       }
 
       *pExitStatus = dwStatus;
@@ -763,8 +750,7 @@ void AsyncChildProcess::poll()
          DWORD dwStatus;
          if (!::GetExitCodeProcess(pImpl_->hProcess, &dwStatus))
          {
-            auto lastErr = ::GetLastError();
-            LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+            LOG_ERROR(LAST_SYSTEM_ERROR());
          }
          exitStatus = dwStatus;
       }
@@ -775,8 +761,7 @@ void AsyncChildProcess::poll()
          Error error;
          if (result == WAIT_FAILED)
          {
-            auto lastErr = ::GetLastError();
-            error = systemError(lastErr, ERROR_LOCATION);
+            error = LAST_SYSTEM_ERROR();
          }
          else
          {

--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -1,7 +1,7 @@
 /*
  * Win32ChildProcess.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -122,18 +122,19 @@ Error readPipeUntilDone(HANDLE hPipe, std::string* pOutput)
    {
       // read from pipe
       BOOL result = ::ReadFile(hPipe, buff, sizeof(buff), &nBytesRead, NULL);
+      auto lastErr = ::GetLastError();
 
       // end of file
       if (nBytesRead == 0)
          break;
 
       // pipe broken
-      else if (!result && (::GetLastError() == ERROR_BROKEN_PIPE))
+      else if (!result && (lastErr == ERROR_BROKEN_PIPE))
          break;
 
       // unexpected error
       else if (!result)
-         return systemError(::GetLastError(), ERROR_LOCATION);
+         return systemError(lastErr, ERROR_LOCATION);
 
       // got input, append it
       else
@@ -243,7 +244,10 @@ Error ChildProcess::writeToStdin(const std::string& input, bool eof)
                                      &dwWritten,
                                      NULL);
          if (!bSuccess)
-            return systemError(::GetLastError(), ERROR_LOCATION);
+         {
+            auto lastErr = ::GetLastError();
+            return systemError(lastErr, ERROR_LOCATION);
+         }
       }
    }
 
@@ -281,7 +285,10 @@ Error ChildProcess::terminate()
 {
    // terminate with exit code 15 (15 is SIGTERM on posix)
    if (!::TerminateProcess(pImpl_->hProcess, 15))
-      return systemError(::GetLastError(), ERROR_LOCATION);
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
    else
       return Success();
 }
@@ -322,7 +329,10 @@ Error openFile(const FilePath& file, bool inheritable, HANDLE* phFile)
                                 FILE_ATTRIBUTE_NORMAL,
                                 NULL);
    if (hFile == INVALID_HANDLE_VALUE)
-      return systemError(::GetLastError(), ERROR_LOCATION);
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
 
    if (inheritable)
    {
@@ -330,7 +340,8 @@ Error openFile(const FilePath& file, bool inheritable, HANDLE* phFile)
                                   HANDLE_FLAG_INHERIT,
                                   HANDLE_FLAG_INHERIT))
       {
-         Error err = systemError(::GetLastError(), ERROR_LOCATION);
+         auto lastErr = ::GetLastError();
+         Error err = systemError(lastErr, ERROR_LOCATION);
          ::CloseHandle(hFile);
          return err;
       }
@@ -373,32 +384,50 @@ Error ChildProcess::run()
    // Standard input pipe
    HANDLE hStdInRead;
    if (!::CreatePipe(&hStdInRead, &pImpl_->hStdInWrite, NULL, 0))
-      return systemError(::GetLastError(), ERROR_LOCATION);
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
    CloseHandleOnExitScope closeStdIn(&hStdInRead, ERROR_LOCATION);
    if (!::SetHandleInformation(hStdInRead,
                                HANDLE_FLAG_INHERIT,
                                HANDLE_FLAG_INHERIT))
-      return systemError(::GetLastError(), ERROR_LOCATION);
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
 
    // Standard output pipe
    HANDLE hStdOutWrite;
    if (!::CreatePipe(&pImpl_->hStdOutRead, &hStdOutWrite, NULL, 0))
-      return systemError(::GetLastError(), ERROR_LOCATION);
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
    CloseHandleOnExitScope closeStdOut(&hStdOutWrite, ERROR_LOCATION);
    if (!::SetHandleInformation(hStdOutWrite,
                                HANDLE_FLAG_INHERIT,
                                HANDLE_FLAG_INHERIT) )
-      return systemError(::GetLastError(), ERROR_LOCATION);
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
 
    // Standard error pipe
    HANDLE hStdErrWrite;
    if (!::CreatePipe(&pImpl_->hStdErrRead, &hStdErrWrite, NULL, 0))
-      return systemError(::GetLastError(), ERROR_LOCATION);
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
    CloseHandleOnExitScope closeStdErr(&hStdErrWrite, ERROR_LOCATION);
    if (!::SetHandleInformation(hStdErrWrite,
                                HANDLE_FLAG_INHERIT,
                                HANDLE_FLAG_INHERIT) )
-      return systemError(::GetLastError(), ERROR_LOCATION);
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
 
    // populate startup info
    STARTUPINFOW si = { sizeof(STARTUPINFOW) };
@@ -523,7 +552,10 @@ Error ChildProcess::run()
      &pi);            // Pointer to PROCESS_INFORMATION structure
 
    if (!success)
-      return systemError(::GetLastError(), ERROR_LOCATION);
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
 
    // close thread handle on exit
    CloseHandleOnExitScope closeThread(&pi.hThread, ERROR_LOCATION);
@@ -557,7 +589,8 @@ Error SyncChildProcess::waitForExit(int* pExitStatus)
    {
       if (result == WAIT_FAILED)
       {
-         return systemError(::GetLastError(), ERROR_LOCATION);
+         auto lastErr = ::GetLastError();
+         return systemError(lastErr, ERROR_LOCATION);
       }
       else
       {
@@ -572,7 +605,10 @@ Error SyncChildProcess::waitForExit(int* pExitStatus)
       // get exit code
       DWORD dwStatus;
       if (!::GetExitCodeProcess(pImpl_->hProcess, &dwStatus))
-         return systemError(::GetLastError(), ERROR_LOCATION);
+      {
+         auto lastErr = ::GetLastError();
+         return systemError(lastErr, ERROR_LOCATION);
+      }
 
       *pExitStatus = dwStatus;
       return Success();
@@ -726,7 +762,10 @@ void AsyncChildProcess::poll()
          // get the exit status
          DWORD dwStatus;
          if (!::GetExitCodeProcess(pImpl_->hProcess, &dwStatus))
-            LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+         {
+            auto lastErr = ::GetLastError();
+            LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+         }
          exitStatus = dwStatus;
       }
 
@@ -736,7 +775,8 @@ void AsyncChildProcess::poll()
          Error error;
          if (result == WAIT_FAILED)
          {
-            error = systemError(::GetLastError(), ERROR_LOCATION);
+            auto lastErr = ::GetLastError();
+            error = systemError(lastErr, ERROR_LOCATION);
          }
          else
          {

--- a/src/cpp/core/system/Win32Environment.cpp
+++ b/src/cpp/core/system/Win32Environment.cpp
@@ -1,7 +1,7 @@
 /*
  * Win32Environment.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -44,7 +44,8 @@ void environment(Options* pEnvironment)
    LPWSTR lpEnv = ::GetEnvironmentStringsW();
    if (lpEnv == NULL)
    {
-      LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+      auto lastErr = ::GetLastError();
+      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
       return;
    }
 
@@ -70,7 +71,10 @@ void environment(Options* pEnvironment)
 
    // free environment strings
    if (!::FreeEnvironmentStringsW(lpEnv))
-      LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+   {
+      auto lastErr = ::GetLastError();
+      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+   }
 }
 
 // Value returned is UTF-8 encoded

--- a/src/cpp/core/system/Win32Environment.cpp
+++ b/src/cpp/core/system/Win32Environment.cpp
@@ -44,8 +44,7 @@ void environment(Options* pEnvironment)
    LPWSTR lpEnv = ::GetEnvironmentStringsW();
    if (lpEnv == NULL)
    {
-      auto lastErr = ::GetLastError();
-      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+      LOG_ERROR(LAST_SYSTEM_ERROR());
       return;
    }
 
@@ -72,8 +71,7 @@ void environment(Options* pEnvironment)
    // free environment strings
    if (!::FreeEnvironmentStringsW(lpEnv))
    {
-      auto lastErr = ::GetLastError();
-      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+      LOG_ERROR(LAST_SYSTEM_ERROR());
    }
 }
 

--- a/src/cpp/core/system/Win32LibraryLoader.cpp
+++ b/src/cpp/core/system/Win32LibraryLoader.cpp
@@ -1,7 +1,7 @@
 /*
  * Win32LibraryLoader.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -28,14 +28,14 @@ namespace {
 std::string getLastErrorMessage()
 {
    LPVOID lpMsgBuf;
-   DWORD dw = ::GetLastError();
+   auto lastErr = ::GetLastError();
 
    DWORD length = ::FormatMessage(
        FORMAT_MESSAGE_ALLOCATE_BUFFER |
        FORMAT_MESSAGE_FROM_SYSTEM |
        FORMAT_MESSAGE_IGNORE_INSERTS,
        NULL,
-       dw,
+       lastErr,
        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
        (LPTSTR) &lpMsgBuf,
        0, NULL );
@@ -61,7 +61,8 @@ Error loadLibrary(const std::string& libPath, void** ppLib)
    *ppLib = (void*)::LoadLibraryEx(libPath.c_str(), NULL, 0);
    if (*ppLib == NULL)
    {
-      Error error = systemError(::GetLastError(), ERROR_LOCATION);
+      auto lastErr = ::GetLastError();
+      Error error = systemError(lastErr, ERROR_LOCATION);
       error.addProperty("dlerror", libPath + " - " + getLastErrorMessage());
       return error;
    }
@@ -77,7 +78,8 @@ Error loadSymbol(void* pLib, const std::string& name, void** ppSymbol)
    *ppSymbol = (void*)::GetProcAddress((HINSTANCE)pLib, name.c_str());
    if (*ppSymbol == NULL)
    {
-      Error error = systemError(::GetLastError(), ERROR_LOCATION);
+      auto lastErr = ::GetLastError();
+      Error error = systemError(lastErr, ERROR_LOCATION);
       error.addProperty("dlerror", name + " - " + getLastErrorMessage());
       return error;
    }
@@ -91,7 +93,8 @@ Error closeLibrary(void* pLib)
 {
    if (!::FreeLibrary((HMODULE)pLib))
    {
-      Error error = systemError(::GetLastError(), ERROR_LOCATION);
+      auto lastErr = ::GetLastError();
+      Error error = systemError(lastErr, ERROR_LOCATION);
       error.addProperty("dlerror", getLastErrorMessage());
       return error;
    }

--- a/src/cpp/core/system/Win32LibraryLoader.cpp
+++ b/src/cpp/core/system/Win32LibraryLoader.cpp
@@ -61,8 +61,7 @@ Error loadLibrary(const std::string& libPath, void** ppLib)
    *ppLib = (void*)::LoadLibraryEx(libPath.c_str(), NULL, 0);
    if (*ppLib == NULL)
    {
-      auto lastErr = ::GetLastError();
-      Error error = systemError(lastErr, ERROR_LOCATION);
+      Error error = LAST_SYSTEM_ERROR();
       error.addProperty("dlerror", libPath + " - " + getLastErrorMessage());
       return error;
    }
@@ -78,8 +77,7 @@ Error loadSymbol(void* pLib, const std::string& name, void** ppSymbol)
    *ppSymbol = (void*)::GetProcAddress((HINSTANCE)pLib, name.c_str());
    if (*ppSymbol == NULL)
    {
-      auto lastErr = ::GetLastError();
-      Error error = systemError(lastErr, ERROR_LOCATION);
+      Error error = LAST_SYSTEM_ERROR();
       error.addProperty("dlerror", name + " - " + getLastErrorMessage());
       return error;
    }
@@ -93,8 +91,7 @@ Error closeLibrary(void* pLib)
 {
    if (!::FreeLibrary((HMODULE)pLib))
    {
-      auto lastErr = ::GetLastError();
-      Error error = systemError(lastErr, ERROR_LOCATION);
+      Error error = LAST_SYSTEM_ERROR();
       error.addProperty("dlerror", getLastErrorMessage());
       return error;
    }

--- a/src/cpp/core/system/Win32OutputCapture.cpp
+++ b/src/cpp/core/system/Win32OutputCapture.cpp
@@ -1,7 +1,7 @@
 /*
  * Win32OutputCapture.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -61,7 +61,8 @@ void standardStreamCaptureThread(
          {
             // we don't expect errors to ever occur (since the standard
             // streams are never closed) so log any that do and continue
-            LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+            auto lastErr = ::GetLastError();
+            LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
          }
       }
    }
@@ -85,11 +86,17 @@ Error redirectToPipe(DWORD stdHandle,
    // create pipe
    HANDLE hWritePipe;
    if (!::CreatePipe(phReadPipe, &hWritePipe, NULL, 0))
-      return systemError(::GetLastError(), ERROR_LOCATION);
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
 
    // reset win32 standard handle
    if (!::SetStdHandle(stdHandle, hWritePipe))
-      return systemError(::GetLastError(), ERROR_LOCATION);
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
 
    // reset c runtime library handle
    int fd = ::_open_osfhandle((intptr_t)hWritePipe, _O_TEXT);

--- a/src/cpp/core/system/Win32OutputCapture.cpp
+++ b/src/cpp/core/system/Win32OutputCapture.cpp
@@ -61,8 +61,7 @@ void standardStreamCaptureThread(
          {
             // we don't expect errors to ever occur (since the standard
             // streams are never closed) so log any that do and continue
-            auto lastErr = ::GetLastError();
-            LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+            LOG_ERROR(LAST_SYSTEM_ERROR());
          }
       }
    }
@@ -87,15 +86,13 @@ Error redirectToPipe(DWORD stdHandle,
    HANDLE hWritePipe;
    if (!::CreatePipe(phReadPipe, &hWritePipe, NULL, 0))
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
 
    // reset win32 standard handle
    if (!::SetStdHandle(stdHandle, hWritePipe))
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
 
    // reset c runtime library handle

--- a/src/cpp/core/system/Win32System.cpp
+++ b/src/cpp/core/system/Win32System.cpp
@@ -1,7 +1,7 @@
 /*
  * Win32System.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -86,7 +86,10 @@ Error initJobObject(bool* detachFromJob)
 
    HANDLE hJob = ::CreateJobObject(NULL, NULL);
    if (!hJob)
-      return systemError(::GetLastError(), ERROR_LOCATION);
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
 
    JOBOBJECT_EXTENDED_LIMIT_INFORMATION jeli = { 0 };
    jeli.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE |
@@ -98,8 +101,8 @@ Error initJobObject(bool* detachFromJob)
 
    if (::AssignProcessToJobObject(hJob, ::GetCurrentProcess()))
    {
-      DWORD error = ::GetLastError();
-      if (error == ERROR_ACCESS_DENIED)
+      auto lastErr = ::GetLastError();
+      if (lastErr == ERROR_ACCESS_DENIED)
       {
          // Use an environment variable to prevent us from somehow
          // getting into an infinite loop of detaching (which would
@@ -113,7 +116,7 @@ Error initJobObject(bool* detachFromJob)
             *detachFromJob = true;
          }
       }
-      return systemError(error, ERROR_LOCATION);
+      return systemError(lastErr, ERROR_LOCATION);
    }
 
    return Success();
@@ -243,7 +246,8 @@ bool isVistaOrLater()
    }
    else
    {
-      LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+      auto lastErr = ::GetLastError();
+      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
       return false;
    }
 }
@@ -262,7 +266,8 @@ bool isWin7OrLater()
    }
    else
    {
-      LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+      auto lastErr = ::GetLastError();
+      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
       return false;
    }
 }
@@ -500,7 +505,8 @@ Error realPath(const FilePath& filePath, FilePath* pRealPath)
                                   NULL);
    if (res == 0)
    {
-      Error error = systemError(::GetLastError(), ERROR_LOCATION);
+      auto lastErr = ::GetLastError();
+      Error error = systemError(lastErr, ERROR_LOCATION);
       error.addProperty("path", filePath);
       return error;
    }
@@ -512,7 +518,10 @@ Error realPath(const FilePath& filePath, FilePath* pRealPath)
                                &(buffer[0]),
                                NULL);
       if (res == 0)
-         return systemError(::GetLastError(), ERROR_LOCATION);
+      {
+         auto lastErr = ::GetLastError();
+         return systemError(lastErr, ERROR_LOCATION);
+      }
       else if (res > buffer.size())
          return systemError(boost::system::windows_error::bad_length,
                             ERROR_LOCATION);
@@ -551,10 +560,16 @@ Error makeFileHidden(const FilePath& path)
 
    DWORD attribs = ::GetFileAttributesW(lpszPath);
    if (attribs == INVALID_FILE_ATTRIBUTES)
-      return systemError(GetLastError(), ERROR_LOCATION);
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
 
    if (!::SetFileAttributesW(lpszPath, attribs | FILE_ATTRIBUTE_HIDDEN))
-      return systemError(GetLastError(), ERROR_LOCATION);
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
 
    return Success();
 }
@@ -721,7 +736,8 @@ public:
    {
       if (!::OpenClipboard(NULL))
       {
-         return systemError(::GetLastError(), ERROR_LOCATION);
+         auto lastErr = ::GetLastError();
+         return systemError(lastErr, ERROR_LOCATION);
       }
       else
       {
@@ -737,7 +753,10 @@ public:
          if (opened_)
          {
             if (!::CloseClipboard())
-               LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+            {
+               auto lastErr = ::GetLastError();
+               LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+            }
          }
       }
       catch(...)
@@ -758,7 +777,10 @@ public:
    {
       hMF_ = ::GetEnhMetaFileW(path.absolutePathW().c_str());
       if (hMF_ == NULL)
-         return systemError(::GetLastError(), ERROR_LOCATION);
+      {
+         auto lastErr = ::GetLastError();
+         return systemError(lastErr, ERROR_LOCATION);
+      }
       else
          return Success();
    }
@@ -770,7 +792,10 @@ public:
          if (hMF_ != NULL)
          {
             if (!::DeleteEnhMetaFile(hMF_))
-               LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+            {
+               auto lastErr = ::GetLastError();
+               LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+            }
          }
       }
       catch(...)
@@ -806,11 +831,17 @@ Error copyMetafileToClipboard(const FilePath& path)
 
    // emtpy the clipboard
    if (!::EmptyClipboard())
-      return systemError(::GetLastError(), ERROR_LOCATION);
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
 
    // set the clipboard data
    if (!::SetClipboardData(CF_ENHMETAFILE, enhMetaFile.handle()))
-      return systemError(::GetLastError(), ERROR_LOCATION);
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
 
    // release the handle (because the clipboard now owns it)
    enhMetaFile.release();
@@ -841,7 +872,10 @@ Error expandEnvironmentVariables(std::string value, std::string* pResult)
 
    DWORD sizeRequired = ::ExpandEnvironmentStrings(value.c_str(), NULL, 0);
    if (!sizeRequired)
-      return systemError(::GetLastError(), ERROR_LOCATION);
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
 
    std::vector<char> buffer(sizeRequired);
    int result = ::ExpandEnvironmentStrings(value.c_str(),
@@ -849,7 +883,10 @@ Error expandEnvironmentVariables(std::string value, std::string* pResult)
                                            buffer.capacity());
 
    if (!result)
-      return systemError(GetLastError(), ERROR_LOCATION);
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
    else if (result > buffer.capacity())
       return systemError(ERROR_MORE_DATA, ERROR_LOCATION); // not expected
 
@@ -870,9 +907,15 @@ Error terminateProcess(PidType pid)
 {
    HANDLE hProc = ::OpenProcess(PROCESS_TERMINATE, false, pid);
    if (!hProc)
-      return systemError(::GetLastError(), ERROR_LOCATION);
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
    if (!::TerminateProcess(hProc, 1))
-      return systemError(::GetLastError(), ERROR_LOCATION);
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
    return Success();
 }
 
@@ -888,7 +931,8 @@ std::vector<SubprocInfo> getSubprocesses(PidType pid)
    {
       // err on the side of assuming child processes, so we don't kill
       // a job unintentionally
-      LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+      auto lastErr = ::GetLastError();
+      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
       return subprocs;
    }
 
@@ -896,7 +940,8 @@ std::vector<SubprocInfo> getSubprocesses(PidType pid)
    pe32.dwSize = sizeof(pe32);
    if (!Process32First(hSnapShot, &pe32))
    {
-      LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+      auto lastErr = ::GetLastError();
+      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
       return subprocs;
    }
 
@@ -933,7 +978,10 @@ Error closeHandle(HANDLE* pHandle, const ErrorLocation& location)
       *pHandle = NULL;
 
       if (!result)
-         return systemError(::GetLastError(), location);
+      {
+         auto lastErr = ::GetLastError();
+         return systemError(lastErr, location);
+      }
       else
          return Success();
    }
@@ -1032,7 +1080,8 @@ Error getProcesses(std::vector<ProcessInfo> *pOutProcesses)
    HANDLE hSnap = ::CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
    if (hSnap == INVALID_HANDLE_VALUE)
    {
-      return systemError(::GetLastError(), ERROR_LOCATION);
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
    }
 
    if (Process32First(hSnap, &processEntry))
@@ -1092,17 +1141,20 @@ Error terminateChildProcesses()
       {
          if (!::TerminateProcess(hChildProc, 1))
          {
-            LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+            auto lastErr = ::GetLastError();
+            LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
          }
 
          if (!::CloseHandle(hChildProc))
          {
-            LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+            auto lastErr = ::GetLastError();
+            LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
          }
       }
       else
       {
-         LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+            auto lastErr = ::GetLastError();
+         LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
       }
    }
 

--- a/src/cpp/core/system/Win32System.cpp
+++ b/src/cpp/core/system/Win32System.cpp
@@ -87,8 +87,7 @@ Error initJobObject(bool* detachFromJob)
    HANDLE hJob = ::CreateJobObject(NULL, NULL);
    if (!hJob)
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
 
    JOBOBJECT_EXTENDED_LIMIT_INFORMATION jeli = { 0 };
@@ -246,8 +245,7 @@ bool isVistaOrLater()
    }
    else
    {
-      auto lastErr = ::GetLastError();
-      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+      LOG_ERROR(LAST_SYSTEM_ERROR());
       return false;
    }
 }
@@ -266,8 +264,7 @@ bool isWin7OrLater()
    }
    else
    {
-      auto lastErr = ::GetLastError();
-      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+      LOG_ERROR(LAST_SYSTEM_ERROR());
       return false;
    }
 }
@@ -505,8 +502,7 @@ Error realPath(const FilePath& filePath, FilePath* pRealPath)
                                   NULL);
    if (res == 0)
    {
-      auto lastErr = ::GetLastError();
-      Error error = systemError(lastErr, ERROR_LOCATION);
+      Error error = LAST_SYSTEM_ERROR();
       error.addProperty("path", filePath);
       return error;
    }
@@ -519,8 +515,7 @@ Error realPath(const FilePath& filePath, FilePath* pRealPath)
                                NULL);
       if (res == 0)
       {
-         auto lastErr = ::GetLastError();
-         return systemError(lastErr, ERROR_LOCATION);
+         return LAST_SYSTEM_ERROR();
       }
       else if (res > buffer.size())
          return systemError(boost::system::windows_error::bad_length,
@@ -561,14 +556,12 @@ Error makeFileHidden(const FilePath& path)
    DWORD attribs = ::GetFileAttributesW(lpszPath);
    if (attribs == INVALID_FILE_ATTRIBUTES)
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
 
    if (!::SetFileAttributesW(lpszPath, attribs | FILE_ATTRIBUTE_HIDDEN))
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
 
    return Success();
@@ -736,8 +729,7 @@ public:
    {
       if (!::OpenClipboard(NULL))
       {
-         auto lastErr = ::GetLastError();
-         return systemError(lastErr, ERROR_LOCATION);
+         return LAST_SYSTEM_ERROR();
       }
       else
       {
@@ -754,8 +746,7 @@ public:
          {
             if (!::CloseClipboard())
             {
-               auto lastErr = ::GetLastError();
-               LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+               LOG_ERROR(LAST_SYSTEM_ERROR());
             }
          }
       }
@@ -778,8 +769,7 @@ public:
       hMF_ = ::GetEnhMetaFileW(path.absolutePathW().c_str());
       if (hMF_ == NULL)
       {
-         auto lastErr = ::GetLastError();
-         return systemError(lastErr, ERROR_LOCATION);
+         return LAST_SYSTEM_ERROR();
       }
       else
          return Success();
@@ -793,8 +783,7 @@ public:
          {
             if (!::DeleteEnhMetaFile(hMF_))
             {
-               auto lastErr = ::GetLastError();
-               LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+               LOG_ERROR(LAST_SYSTEM_ERROR());
             }
          }
       }
@@ -832,15 +821,13 @@ Error copyMetafileToClipboard(const FilePath& path)
    // emtpy the clipboard
    if (!::EmptyClipboard())
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
 
    // set the clipboard data
    if (!::SetClipboardData(CF_ENHMETAFILE, enhMetaFile.handle()))
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
 
    // release the handle (because the clipboard now owns it)
@@ -873,8 +860,7 @@ Error expandEnvironmentVariables(std::string value, std::string* pResult)
    DWORD sizeRequired = ::ExpandEnvironmentStrings(value.c_str(), NULL, 0);
    if (!sizeRequired)
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
 
    std::vector<char> buffer(sizeRequired);
@@ -884,8 +870,7 @@ Error expandEnvironmentVariables(std::string value, std::string* pResult)
 
    if (!result)
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
    else if (result > buffer.capacity())
       return systemError(ERROR_MORE_DATA, ERROR_LOCATION); // not expected
@@ -908,13 +893,11 @@ Error terminateProcess(PidType pid)
    HANDLE hProc = ::OpenProcess(PROCESS_TERMINATE, false, pid);
    if (!hProc)
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
    if (!::TerminateProcess(hProc, 1))
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
    return Success();
 }
@@ -931,8 +914,7 @@ std::vector<SubprocInfo> getSubprocesses(PidType pid)
    {
       // err on the side of assuming child processes, so we don't kill
       // a job unintentionally
-      auto lastErr = ::GetLastError();
-      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+      LOG_ERROR(LAST_SYSTEM_ERROR());
       return subprocs;
    }
 
@@ -940,8 +922,7 @@ std::vector<SubprocInfo> getSubprocesses(PidType pid)
    pe32.dwSize = sizeof(pe32);
    if (!Process32First(hSnapShot, &pe32))
    {
-      auto lastErr = ::GetLastError();
-      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+      LOG_ERROR(LAST_SYSTEM_ERROR());
       return subprocs;
    }
 
@@ -979,8 +960,7 @@ Error closeHandle(HANDLE* pHandle, const ErrorLocation& location)
 
       if (!result)
       {
-         auto lastErr = ::GetLastError();
-         return systemError(lastErr, location);
+         return LAST_SYSTEM_ERROR();
       }
       else
          return Success();
@@ -1080,8 +1060,7 @@ Error getProcesses(std::vector<ProcessInfo> *pOutProcesses)
    HANDLE hSnap = ::CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
    if (hSnap == INVALID_HANDLE_VALUE)
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
 
    if (Process32First(hSnap, &processEntry))
@@ -1141,20 +1120,17 @@ Error terminateChildProcesses()
       {
          if (!::TerminateProcess(hChildProc, 1))
          {
-            auto lastErr = ::GetLastError();
-            LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+            LOG_ERROR(LAST_SYSTEM_ERROR());
          }
 
          if (!::CloseHandle(hChildProc))
          {
-            auto lastErr = ::GetLastError();
-            LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+            LOG_ERROR(LAST_SYSTEM_ERROR());
          }
       }
       else
       {
-            auto lastErr = ::GetLastError();
-         LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+         LOG_ERROR(LAST_SYSTEM_ERROR());
       }
    }
 

--- a/src/cpp/core/system/file_monitor/Win32FileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/Win32FileMonitor.cpp
@@ -91,8 +91,7 @@ void safeCloseHandle(HANDLE hObject, const ErrorLocation& location)
    {
       if (!::CloseHandle(hObject))
       {
-         auto lastErr = ::GetLastError();
-         LOG_ERROR(systemError(lastErr, location));
+         LOG_ERROR(LAST_SYSTEM_ERROR());
       }
    }
 }
@@ -103,8 +102,7 @@ void cleanupContext(FileEventContext* pContext)
    {
       if (!::CancelIo(pContext->hDirectory))
       {
-         auto lastErr = ::GetLastError();
-         LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+         LOG_ERROR(LAST_SYSTEM_ERROR());
       }
 
       safeCloseHandle(pContext->hDirectory, ERROR_LOCATION);
@@ -117,8 +115,7 @@ void cleanupContext(FileEventContext* pContext)
       // make sure timer APC is never called after a cleanupContext
       if (!::CancelWaitableTimer(pContext->hRestartTimer))
       {
-         auto lastErr = ::GetLastError();
-         LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+         LOG_ERROR(LAST_SYSTEM_ERROR());
       }
 
       safeCloseHandle(pContext->hRestartTimer, ERROR_LOCATION);
@@ -369,8 +366,7 @@ void enqueRestartMonitoring(FileEventContext* pContext)
    pContext->hRestartTimer = ::CreateWaitableTimer(NULL, true, NULL);
    if (pContext->hRestartTimer == NULL)
    {
-      auto lastErr = ::GetLastError();
-      Error error = systemError(lastErr, ERROR_LOCATION);
+      Error error = LAST_SYSTEM_ERROR();
       terminateWithMonitoringError(pContext, error);
       return;
    }
@@ -392,8 +388,7 @@ void enqueRestartMonitoring(FileEventContext* pContext)
 
    if (!success)
    {
-      auto lastErr = ::GetLastError();
-      Error error = systemError(lastErr, ERROR_LOCATION);
+      Error error = LAST_SYSTEM_ERROR();
       terminateWithMonitoringError(pContext, error);
    }
 }
@@ -491,8 +486,7 @@ Error readDirectoryChanges(FileEventContext* pContext)
                                &(pContext->overlapped),
                                &FileChangeCompletionRoutine))
    {
-      auto lastErr = ::GetLastError();
-      return systemError(lastErr, ERROR_LOCATION);
+      return LAST_SYSTEM_ERROR();
    }
    else
    {
@@ -548,9 +542,7 @@ Handle registerMonitor(const core::FilePath& filePath,
                      NULL);
    if (pContext->hDirectory == INVALID_HANDLE_VALUE)
    {
-      auto lastErr = ::GetLastError();
-      callbacks.onRegistrationError(
-                     systemError(lastErr, ERROR_LOCATION));
+      callbacks.onRegistrationError(LAST_SYSTEM_ERROR());
       return Handle();
    }
 

--- a/src/cpp/desktop/DesktopWin32DetectRHome.cpp
+++ b/src/cpp/desktop/DesktopWin32DetectRHome.cpp
@@ -56,8 +56,7 @@ bool prepareEnvironment(Options &options)
    }
    else
    {
-      auto lastErr = ::GetLastError();
-      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+      LOG_ERROR(LAST_SYSTEM_ERROR());
    }
 
 

--- a/src/cpp/desktop/DesktopWin32DetectRHome.cpp
+++ b/src/cpp/desktop/DesktopWin32DetectRHome.cpp
@@ -1,7 +1,7 @@
 /*
  * DesktopWin32DetectRHome.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -56,7 +56,8 @@ bool prepareEnvironment(Options &options)
    }
    else
    {
-      LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+      auto lastErr = ::GetLastError();
+      LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
    }
 
 

--- a/src/cpp/desktop/DesktopWin32ProgressActivator.cpp
+++ b/src/cpp/desktop/DesktopWin32ProgressActivator.cpp
@@ -68,8 +68,7 @@ ProgressActivator::ProgressActivator()
 
   if (pImpl_->hWinEventHook == 0)
   {
-     auto lastErr = ::GetLastError();
-     Error error = systemError(lastErr, ERROR_LOCATION);
+     Error error = LAST_SYSTEM_ERROR();
      LOG_ERROR(error);
   }
 }

--- a/src/cpp/desktop/DesktopWin32ProgressActivator.cpp
+++ b/src/cpp/desktop/DesktopWin32ProgressActivator.cpp
@@ -1,7 +1,7 @@
 /*
  * DesktopWin32ProgressActivator.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -68,7 +68,8 @@ ProgressActivator::ProgressActivator()
 
   if (pImpl_->hWinEventHook == 0)
   {
-     Error error = systemError(::GetLastError(), ERROR_LOCATION);
+     auto lastErr = ::GetLastError();
+     Error error = systemError(lastErr, ERROR_LOCATION);
      LOG_ERROR(error);
   }
 }

--- a/src/cpp/session/http/SessionNamedPipeHttpConnectionListener.hpp
+++ b/src/cpp/session/http/SessionNamedPipeHttpConnectionListener.hpp
@@ -91,8 +91,7 @@ public:
          // check for error
          if (!result)
          {
-            auto lastErr = ::GetLastError();
-            Error error = systemError(lastErr, ERROR_LOCATION);
+            Error error = LAST_SYSTEM_ERROR();
             if (!core::http::isConnectionTerminatedError(error))
                LOG_ERROR(error);
 
@@ -175,8 +174,7 @@ public:
          if (!success || (bytesWritten != bytesToWrite))
          {
             // establish error
-            auto lastErr = ::GetLastError();
-            Error error = systemError(lastErr, ERROR_LOCATION);
+            Error error = LAST_SYSTEM_ERROR();
             error.addProperty("request-uri", request_.uri());
 
             // log the error if it wasn't connection terminated
@@ -198,20 +196,17 @@ public:
       {
          if (!::FlushFileBuffers(hPipe_))
          {
-            auto lastErr = ::GetLastError();
-            LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+            LOG_ERROR(LAST_SYSTEM_ERROR());
          }
 
          if (!::DisconnectNamedPipe(hPipe_))
          {
-            auto lastErr = ::GetLastError();
-            LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+            LOG_ERROR(LAST_SYSTEM_ERROR());
          }
 
          if (!::CloseHandle(hPipe_))
          {
-            auto lastErr = ::GetLastError();
-            LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+            LOG_ERROR(LAST_SYSTEM_ERROR());
          }
 
          hPipe_ = INVALID_HANDLE_VALUE;
@@ -336,7 +331,6 @@ private:
             }
             else
             {
-
                LOG_ERROR(systemError(lastError, ERROR_LOCATION));
             }
          }
@@ -424,8 +418,7 @@ private:
       }
       else
       {
-         auto lastErr = ::GetLastError();
-         LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+         LOG_ERROR(LAST_SYSTEM_ERROR());
          return NULL;
       }
    }
@@ -436,8 +429,7 @@ private:
       HANDLE hToken = NULL;
       if (!OpenProcessToken(::GetCurrentProcess(), TOKEN_QUERY, &hToken))
       {
-         auto lastErr = ::GetLastError();
-         return systemError(lastErr, ERROR_LOCATION);
+         return LAST_SYSTEM_ERROR();
       }
       core::system::CloseHandleOnExitScope tokenScope(&hToken, ERROR_LOCATION);
 
@@ -459,8 +451,7 @@ private:
       TOKEN_GROUPS* pTG = reinterpret_cast<TOKEN_GROUPS*>(&tg[0]);
       if (!::GetTokenInformation(hToken, TokenGroups, pTG, tgSize, &tgSize))
       {
-         auto lastErr = ::GetLastError();
-         return systemError(lastErr, ERROR_LOCATION);
+         return LAST_SYSTEM_ERROR();
       }
 
       // find login sid
@@ -487,8 +478,7 @@ private:
       char* pSidString = NULL;
       if (!::ConvertSidToStringSid(pSid, &pSidString))
       {
-         auto lastErr = ::GetLastError();
-         return systemError(lastErr, ERROR_LOCATION);
+         return LAST_SYSTEM_ERROR();
       }
 
       // format string for caller

--- a/src/cpp/session/http/SessionNamedPipeHttpConnectionListener.hpp
+++ b/src/cpp/session/http/SessionNamedPipeHttpConnectionListener.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionNamedPipeHttpConnectionListener.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -91,7 +91,8 @@ public:
          // check for error
          if (!result)
          {
-            Error error = systemError(::GetLastError(), ERROR_LOCATION);
+            auto lastErr = ::GetLastError();
+            Error error = systemError(lastErr, ERROR_LOCATION);
             if (!core::http::isConnectionTerminatedError(error))
                LOG_ERROR(error);
 
@@ -174,7 +175,8 @@ public:
          if (!success || (bytesWritten != bytesToWrite))
          {
             // establish error
-            Error error = systemError(::GetLastError(), ERROR_LOCATION);
+            auto lastErr = ::GetLastError();
+            Error error = systemError(lastErr, ERROR_LOCATION);
             error.addProperty("request-uri", request_.uri());
 
             // log the error if it wasn't connection terminated
@@ -195,13 +197,22 @@ public:
       if (hPipe_ != INVALID_HANDLE_VALUE)
       {
          if (!::FlushFileBuffers(hPipe_))
-            LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+         {
+            auto lastErr = ::GetLastError();
+            LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+         }
 
          if (!::DisconnectNamedPipe(hPipe_))
-            LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+         {
+            auto lastErr = ::GetLastError();
+            LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+         }
 
          if (!::CloseHandle(hPipe_))
-            LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+         {
+            auto lastErr = ::GetLastError();
+            LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
+         }
 
          hPipe_ = INVALID_HANDLE_VALUE;
      }
@@ -293,7 +304,7 @@ private:
                                               kReadBufferSize,
                                               0,
                                               pSA);
-            DWORD lastError = ::GetLastError(); // capture err before LocalFree
+            auto lastError = ::GetLastError(); // capture err before LocalFree
 
             // free security descriptor if we used one
             if (pSA)
@@ -307,9 +318,12 @@ private:
             }
 
             // attempt to connect
-            BOOL connected = ::ConnectNamedPipe(hPipe, NULL) ?
-                   TRUE : (::GetLastError() == ERROR_PIPE_CONNECTED);
-
+            BOOL connected = ::ConnectNamedPipe(hPipe, NULL);
+            lastError = ::GetLastError();
+            if (!connected)
+            {
+               connected = (lastError == ERROR_PIPE_CONNECTED);
+            }
             if (connected)
             {
                // create connection
@@ -322,7 +336,8 @@ private:
             }
             else
             {
-               LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+
+               LOG_ERROR(systemError(lastError, ERROR_LOCATION));
             }
          }
       }
@@ -409,7 +424,8 @@ private:
       }
       else
       {
-         LOG_ERROR(systemError(::GetLastError(), ERROR_LOCATION));
+         auto lastErr = ::GetLastError();
+         LOG_ERROR(systemError(lastErr, ERROR_LOCATION));
          return NULL;
       }
    }
@@ -419,21 +435,33 @@ private:
       // token for current process
       HANDLE hToken = NULL;
       if (!OpenProcessToken(::GetCurrentProcess(), TOKEN_QUERY, &hToken))
-         return systemError(::GetLastError(), ERROR_LOCATION);
+      {
+         auto lastErr = ::GetLastError();
+         return systemError(lastErr, ERROR_LOCATION);
+      }
       core::system::CloseHandleOnExitScope tokenScope(&hToken, ERROR_LOCATION);
 
       // size of token groups structure (note that we expect the error
       // since we pass NULL for the token information buffer)
       DWORD tgSize = 0;
       BOOL res = ::GetTokenInformation(hToken, TokenGroups, NULL, 0, &tgSize);
-      if (res != FALSE && ::GetLastError() != ERROR_INSUFFICIENT_BUFFER)
-         return systemError(::GetLastError(), ERROR_LOCATION);
+      if (res != FALSE)
+      {
+         auto lastErr = ::GetLastError();
+         if (lastErr != ERROR_INSUFFICIENT_BUFFER)
+         {
+            return systemError(lastErr, ERROR_LOCATION);
+         }
+      }
 
       // get the token groups structure
       std::vector<char> tg(tgSize);
       TOKEN_GROUPS* pTG = reinterpret_cast<TOKEN_GROUPS*>(&tg[0]);
       if (!::GetTokenInformation(hToken, TokenGroups, pTG, tgSize, &tgSize))
-         return systemError(::GetLastError(), ERROR_LOCATION);
+      {
+         auto lastErr = ::GetLastError();
+         return systemError(lastErr, ERROR_LOCATION);
+      }
 
       // find login sid
       SID* pSid = NULL;
@@ -458,7 +486,10 @@ private:
       // convert to a string
       char* pSidString = NULL;
       if (!::ConvertSidToStringSid(pSid, &pSidString))
-         return systemError(::GetLastError(), ERROR_LOCATION);
+      {
+         auto lastErr = ::GetLastError();
+         return systemError(lastErr, ERROR_LOCATION);
+      }
 
       // format string for caller
       boost::format fmt("D:(A;OICI;GA;;;%1%)");


### PR DESCRIPTION
On Win32 debug, the following pattern doesn't work:
```
Win32 call that sets an error (SetLastError)
Error error = systemError(::GetLastError(), ERROR_LOCATION);
```
The order of argument evaluation is not defined in C++ and on Win32 debug, at least, by the time ::GetLastError is called, the Win32 error code has been reset to zero, so the resulting `error` is set to an error code of zero (no-error). This leads to a variety of problems at runtime, including crashing failure of the rsession unit tests.

I opted to just manually change the calls to first store ::GetLastError in a variable which is then passed to systemError.

Doing it inside a new utility function would lose useful diagnostic information (ERROR_LOCATION would resolve to that function instead of the calling site), and a preprocessor macro that can evaluate to a return value of core:Error while capturing the original Win32 error and call-site location is tough without using non-portable behavior such as gcc "statement expressions". There may be a way, but it was faster to just do this manual search and replace.