### PR TITLE
disable accessibility by default

### DIFF
--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -261,10 +261,10 @@ int main(int argc, char* argv[])
       arguments.push_back(disableWebSecurity);
 #endif
       
-      // disable chromium renderer accessibility if requested (it can cause
+      // disable chromium renderer accessibility by default (it can cause
       // slowdown when used in conjunction with some applications; see e.g.
       // https://github.com/rstudio/rstudio/issues/1990)
-      if (!core::system::getenv("RSTUDIO_NO_ACCESSIBILITY").empty())
+      if (core::system::getenv("RSTUDIO_ACCESSIBILITY").empty())
       {
          static char disableRendererAccessibility[] = "--disable-renderer-accessibility";
          arguments.push_back(disableRendererAccessibility);


### PR DESCRIPTION
As per https://github.com/rstudio/rstudio/issues/1539, it looks like the issue with accessibility-aware rendering in Chromium causing lagginess in the IDE affects a number of users. Because of this, we should consider disabling this by default, but allowing users who require this functionality to re-enable it (by setting the `RSTUDIO_ACCESSIBILITY` environment variable)