### PR TITLE
Fix a handful of build warnings on Windows

### DIFF
--- a/src/cpp/core/FilePath.cpp
+++ b/src/cpp/core/FilePath.cpp
@@ -134,7 +134,7 @@ bool copySingleItem(const FilePath& from, const FilePath& to,
    return true;
 }
 
-bool addItemSize(const FilePath& item, boost::shared_ptr<int> pTotal)
+bool addItemSize(const FilePath& item, boost::shared_ptr<uintmax_t> pTotal)
 {
    if (!item.isDirectory())
       *pTotal = *pTotal + item.size();
@@ -852,7 +852,7 @@ uintmax_t FilePath::sizeRecursive() const
    if (!isDirectory())
       return size();
 
-   boost::shared_ptr<int> pTotal = boost::make_shared<int>(0);
+   boost::shared_ptr<uintmax_t> pTotal = boost::make_shared<uintmax_t>(0);
    Error error = childrenRecursive(boost::bind(addItemSize, _2, pTotal)); 
    if (error)
       LOG_ERROR(error);

--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -1,7 +1,7 @@
 /*
  * RProjectFile.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -195,7 +195,7 @@ bool interpretIntValue(const std::string& value, int* pValue)
       *pValue = boost::lexical_cast<int>(value);
       return true;
    }
-   catch(const boost::bad_lexical_cast& e)
+   catch(const boost::bad_lexical_cast&)
    {
       return false;
    }

--- a/src/cpp/core/r_util/RToolsInfo.cpp
+++ b/src/cpp/core/r_util/RToolsInfo.cpp
@@ -1,7 +1,7 @@
 /*
  * RToolsInfo.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -243,7 +243,7 @@ Error scanRegistryForRTools(HKEY key,
    }
 
    std::vector<std::string> keys = regKey.keyNames();
-   for (int i = 0; i < keys.size(); i++)
+   for (size_t i = 0; i < keys.size(); i++)
    {
       std::string name = keys.at(i);
       core::system::RegistryKey verKey;

--- a/src/cpp/core/system/Win32System.cpp
+++ b/src/cpp/core/system/Win32System.cpp
@@ -864,7 +864,7 @@ Error expandEnvironmentVariables(std::string value, std::string* pResult)
    }
 
    std::vector<char> buffer(sizeRequired);
-   int result = ::ExpandEnvironmentStrings(value.c_str(),
+   auto result = ::ExpandEnvironmentStrings(value.c_str(),
                                            &buffer[0],
                                            buffer.capacity());
 

--- a/src/cpp/core/system/file_monitor/FileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/FileMonitor.cpp
@@ -1,7 +1,7 @@
 /*
  * FileMonitor.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -545,7 +545,7 @@ void fileMonitorThreadMain()
       running = true;
       file_monitor::detail::run(boost::bind(checkForInput));   
    }
-   catch(const boost::thread_interrupted& e)
+   catch(const boost::thread_interrupted&)
    {
    }
    CATCH_UNEXPECTED_EXCEPTION

--- a/src/cpp/session/SessionClientEventService.cpp
+++ b/src/cpp/session/SessionClientEventService.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionClientEventService.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -103,7 +103,7 @@ void ClientEventService::stop()
          serviceThread_.detach();
       }
    }
-   catch(const boost::thread_interrupted& e)
+   catch(const boost::thread_interrupted&)
    {
       // the main thread is the one who calls stop() and it should 
       // NEVER be interrupted for any reason
@@ -304,7 +304,7 @@ void ClientEventService::run()
                }
            }
          }
-         catch(const boost::thread_interrupted& e)
+         catch(const boost::thread_interrupted&)
          {
             // set flag so we terminate on the next accept loop iteration
             stopServer = true ;

--- a/src/cpp/session/SessionConsoleProcessSocketTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessSocketTests.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionConsoleProcessSocketTests.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -268,7 +268,7 @@ public:
                   boost::bind(&SocketClient::watchSocket, this),
                   &clientSocketThread_);
       }
-      catch (websocketpp::exception const & e)
+      catch (websocketpp::exception const &)
       {
          return false;
       }

--- a/src/cpp/session/SessionUserSettings.cpp
+++ b/src/cpp/session/SessionUserSettings.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionUserSettings.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -401,7 +401,7 @@ void UserSettings::updatePrefsCache(const json::Object& prefs) const
    int ansiConsoleMode = readPref<int>(prefs, "ansi_console_mode", core::text::AnsiColorOn);
    pAnsiConsoleMode_.reset(new int(ansiConsoleMode));
 
-   int terminalWebsockets = readPref<bool>(prefs, "terminal_websockets", true);
+   bool terminalWebsockets = readPref<bool>(prefs, "terminal_websockets", true);
    pTerminalWebsockets_.reset(new bool(terminalWebsockets));
 
    bool terminalAutoclose = readPref<bool>(prefs, "terminal_autoclose", true);

--- a/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionConsoleProcessInfo.hpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -121,7 +121,7 @@ public:
    int getMaxOutputLines() const { return maxOutputLines_; }
 
    void setShowOnOutput(bool showOnOutput) { showOnOutput_ = showOnOutput; }
-   int getShowOnOutput() const { return showOnOutput_; }
+   bool getShowOnOutput() const { return showOnOutput_; }
 
    // Buffer output in case client disconnects/reconnects and needs
    // to recover some history.

--- a/src/cpp/session/modules/SessionAsyncPackageInformation.cpp
+++ b/src/cpp/session/modules/SessionAsyncPackageInformation.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionAsyncCompletions.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -92,9 +92,9 @@ void fillFormalInfo(const json::Array& formalNamesJson,
       
       const json::Array& formalInfoJson = formalInfoJsonArray[i].get_array();
       
-      int hasDefaultValue = formalInfoJson[0].get_int();
-      int isMissingnessHandled = formalInfoJson[1].get_int();
-      int isUsed = formalInfoJson[2].get_int();
+      bool hasDefaultValue = formalInfoJson[0].get_int() != 0;
+      bool isMissingnessHandled = formalInfoJson[1].get_int() != 0;
+      bool isUsed = formalInfoJson[2].get_int() != 0;
       
       info.setHasDefaultValue(hasDefaultValue);
       info.setMissingnessHandled(isMissingnessHandled);


### PR DESCRIPTION
MSVC build emits several hundred warnings. Fixing a few of them, just to start chipping away at the mountain. Mainly some type issues, and a few unused arguments in catches.