### PR TITLE
Disable MSVC C4800 warning

### DIFF
--- a/CMakeCompiler.txt
+++ b/CMakeCompiler.txt
@@ -1,7 +1,7 @@
 #
 # CMakeCompiler.txt
 #
-# Copyright (C) 2009-16 by RStudio, Inc.
+# Copyright (C) 2009-18 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -40,6 +40,10 @@ if(MSVC)
 
   # use C++14 (MSVC doesn't support C++11)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++14")
+
+  # disable C4800 warning; this is very noisy, rarely useful, and was completely removed
+  # in Visual Studio 2017 (we're currently using VS 2015).
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4800")
 
   # ensure that we're using linker flags compatible with
   # the version of Boost that will be linked in


### PR DESCRIPTION
This warning complains about implicit casts to bool saying it has performance implications. It generated over 100 build warnings in our code, I previously fixed the handful that were genuine issues (barely), none of the rest are concerning. Microsoft removed this warning altogether in Visual C++ 2017, so I'm disabling it. This cuts about a third of our MSVC build warnings.