### PR TITLE
allow interruption of subprocesses

### DIFF
--- a/src/cpp/session/http/SessionHttpConnectionListenerImpl.hpp
+++ b/src/cpp/session/http/SessionHttpConnectionListenerImpl.hpp
@@ -270,6 +270,9 @@ private:
       // to also initiate a suspend (e.g. an admin/supervisor process)
       if (connection::checkForSuspend(ptrHttpConnection))
          return;
+      
+      if (connection::checkForInterrupt(ptrHttpConnection))
+         return;
 
       // place the connection on the correct queue
       if (connection::isGetEvents(ptrHttpConnection))

--- a/src/cpp/session/http/SessionHttpConnectionUtils.hpp
+++ b/src/cpp/session/http/SessionHttpConnectionUtils.hpp
@@ -50,6 +50,8 @@ bool checkForAbort(boost::shared_ptr<HttpConnection> ptrConnection,
 
 bool checkForSuspend(boost::shared_ptr<HttpConnection> ptrConnection);
 
+bool checkForInterrupt(boost::shared_ptr<HttpConnection> ptrConnection);
+
 bool authenticate(boost::shared_ptr<HttpConnection> ptrConnection,
                   const std::string& secret);
 

--- a/src/cpp/session/http/SessionNamedPipeHttpConnectionListener.hpp
+++ b/src/cpp/session/http/SessionNamedPipeHttpConnectionListener.hpp
@@ -373,6 +373,9 @@ private:
       // to also initiate a suspend (e.g. an admin/supervisor process)
       if (connection::checkForSuspend(ptrHttpConnection))
          return;
+      
+      if (connection::checkForInterrupt(ptrHttpConnection))
+         return;
 
       // place the connection on the correct queue
       if (connection::isGetEvents(ptrHttpConnection))


### PR DESCRIPTION
NOTE: This PR is not fully baked but wanted to get it up just in case this seems like something worth taking over the finish line for v1.2 (otherwise we can leave for v1.3).

---

This PR allows us to forward interrupts (`SIGINT`) to child processes launched by the R session, thereby making it possible to interrupt system calls (as is possible when running R from a terminal).

The Windows bits are missing; I'm not sure if there's a similar mechanism for attaching to a process on Windows to send an interrupt (or the equivalent Windows analog).