### PR TITLE
fix formation of completion vector (#2236)

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -904,10 +904,14 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("formCompletionVector", function(object, default, n)
 {
-   if (!length(object))
-      rep.int(default, n)
-   else
+   if (length(object) == 0)
+      rep(default, length.out = n)
+   else if (length(object) == 1)
       rep.int(object, n)
+   else if (length(object) == n)
+      object
+   else
+      rep(object, length.out = n)
 })
 
 .rs.addFunction("makeCompletions", function(token,


### PR DESCRIPTION
This PR fixes an issue where we erroneously duplicated the contents of a completion vector, when its length had already been appropriately extended.