### PR TITLE
include package providing help topic

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2547,18 +2547,20 @@ assign(x = ".rs.acCompletionTypes",
          }
       }
       
-      aliases <- tryCatch(
-         aliases[[pkg]],
-         error = function(e) character()
-      )
+      # filter the aliases list to just this package
+      aliases <- aliases[names(aliases) %in% pkg]
    }
    
-   aliases <- unlist(aliases)
-   results <- .rs.selectFuzzyMatches(aliases, token)
+   filtered <- lapply(aliases, function(alias) {
+      .rs.selectFuzzyMatches(alias, token)
+   })
+   
+   listed <- .rs.namedVectorAsList(filtered)
    
    completions <- .rs.makeCompletions(
       token = token,
-      results = results,
+      results = listed$values,
+      packages = listed$names,
       quote = quote,
       type = .rs.acCompletionTypes$HELP,
       overrideInsertParens = TRUE


### PR DESCRIPTION
When pressing `F1` to retrieve help for a topic, RStudio attempts to evaluate an R expression of the form:

    help(topic = <topic>, package = <package>)

However, because we were not pairing help topics with their package when retrieving help autocompletion results, we were effectively attempting to evaluate

    help(topic = <topic>, package = "")

Fixes https://github.com/rstudio/rstudio/issues/2261.

