### PR TITLE
Implement rename in File menu

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/MessageDisplay.java
+++ b/src/gwt/src/org/rstudio/core/client/MessageDisplay.java
@@ -55,6 +55,15 @@ public abstract class MessageDisplay
                                       String okButtonCaption,
                                       ProgressOperationWithInput<String> operation);
 
+   public abstract void promptForText(String title,
+                                      String label,
+                                      String initialValue,
+                                      int selectionStart,
+                                      int selectionLength,
+                                      String okButtonCaption,
+                                      ProgressOperationWithInput<String> operation,
+                                      Operation cancelOperation);
+
    public void promptForPassword(
          String title,
          String label,

--- a/src/gwt/src/org/rstudio/studio/client/common/DefaultGlobalDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/DefaultGlobalDisplay.java
@@ -108,6 +108,29 @@ public class DefaultGlobalDisplay extends GlobalDisplay
    }
 
    @Override
+   public void promptForText(String title,
+                             String label,
+                             String initialValue,
+                             int selectionOffset,
+                             int selectionLength,
+                             String okButtonCaption,
+                             ProgressOperationWithInput<String> operation,
+                             Operation cancelOperation)
+   {
+      ((TextInput)GWT.create(TextInput.class)).promptForText(
+            title,
+            label,
+            initialValue,
+            false,
+            false,
+            selectionOffset,
+            selectionLength,
+            okButtonCaption,
+            operation,
+            cancelOperation);
+   }
+
+   @Override
    public void promptForTextWithOption(
                                  String title,
                                  String label,

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/events/RenameSourceFileEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/events/RenameSourceFileEvent.java
@@ -1,0 +1,55 @@
+/*
+ * RenameFileEvent.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.common.filetypes.events;
+
+import org.rstudio.core.client.js.JavaScriptSerializable;
+import org.rstudio.studio.client.application.events.CrossWindowEvent;
+
+import com.google.gwt.event.shared.EventHandler;
+
+@JavaScriptSerializable
+public class RenameSourceFileEvent extends CrossWindowEvent<RenameSourceFileEvent.Handler>
+{
+   public interface Handler extends EventHandler
+   {
+      void onRenameSourceFile(RenameSourceFileEvent event);
+   }
+   
+   public RenameSourceFileEvent(String path)
+   {
+      path_ = path;
+   }
+   
+   public String getPath()
+   {
+      return path_;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onRenameSourceFile(this);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+   
+   private final String path_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -124,6 +124,7 @@ well as menu structures (for main menu and popup menus).
          <separator/>
          <cmd refid="saveSourceDoc"/>
          <cmd refid="saveSourceDocAs"/>
+         <cmd refid="renameSourceDoc"/>
          <cmd refid="saveSourceDocWithEncoding"/>
          <cmd refid="saveAllSourceDocs"/>
          <separator/>
@@ -892,6 +893,12 @@ well as menu structures (for main menu and popup menus).
         menuLabel="_Save"
         buttonLabel=""
         desc="Save current document"/>
+
+   <cmd id="renameSourceDoc"
+        label="Rename Current Document"
+        menuLabel="_Rename"
+        buttonLabel=""
+        desc="Rename current document"/>
         
    <cmd id="saveSourceDocAs"
         label="Save Current Document As..."

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -45,6 +45,7 @@ public abstract class
    public abstract AppCommand saveSourceDocAs();
    public abstract AppCommand saveSourceDocWithEncoding();
    public abstract AppCommand saveAllSourceDocs();
+   public abstract AppCommand renameSourceDoc();
    public abstract AppCommand closeSourceDoc();
    public abstract AppCommand closeOtherSourceDocs();
    public abstract AppCommand closeAllSourceDocs();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/FilesTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/FilesTab.java
@@ -20,6 +20,7 @@ import org.rstudio.core.client.command.Handler;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.filetypes.events.OpenFileInBrowserEvent;
 import org.rstudio.studio.client.common.filetypes.events.OpenFileInBrowserHandler;
+import org.rstudio.studio.client.common.filetypes.events.RenameSourceFileEvent;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.ui.DelayLoadTabShim;
 import org.rstudio.studio.client.workbench.ui.DelayLoadWorkbenchTab;
@@ -32,7 +33,7 @@ public class FilesTab extends DelayLoadWorkbenchTab<Files>
    
    public abstract static class Shim
          extends DelayLoadTabShim<Files, FilesTab>
-         implements OpenFileInBrowserHandler, DirectoryNavigateHandler
+         implements OpenFileInBrowserHandler, DirectoryNavigateHandler, RenameSourceFileEvent.Handler
    {
       @Handler
       public abstract void onUploadFile();
@@ -52,5 +53,6 @@ public class FilesTab extends DelayLoadWorkbenchTab<Files>
       binder.bind(commands, shim);
       events.addHandler(OpenFileInBrowserEvent.TYPE, shim);
       events.addHandler(DirectoryNavigateEvent.TYPE, shim);
+      events.addHandler(RenameSourceFileEvent.TYPE, shim);
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -77,6 +77,7 @@ import org.rstudio.studio.client.common.filetypes.FileTypeCommands;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.filetypes.SweaveFileType;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
+import org.rstudio.studio.client.common.filetypes.events.RenameSourceFileEvent;
 import org.rstudio.studio.client.common.mathjax.MathJax;
 import org.rstudio.studio.client.common.r.roxygen.RoxygenHelper;
 import org.rstudio.studio.client.common.rnw.RnwWeave;
@@ -2887,6 +2888,12 @@ public class TextEditingTarget implements
       saveNewFile(docUpdateSentinel_.getPath(),
                   null,
                   postSaveCommand());
+   }
+   
+   @Handler
+   void onRenameSourceDoc()
+   {
+      events_.fireEvent(new RenameSourceFileEvent(docUpdateSentinel_.getPath()));
    }
 
    @Handler


### PR DESCRIPTION
This small change makes it simple to rename the currently open file in the editor. The command for doing this is currently on the File menu, but could be moved to a document tab context menu if and when we implement one (see #1664). 

Closes #2199.