### PR TITLE
Allow building macOS package outside build folder

### DIFF
--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -4,19 +4,26 @@ set -e
 
 PACKAGE_DIR=`pwd`
 
+BUILD_DIR=$(pwd)/build
+
+# find package source folder
+PKG_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 if [ "$1" == "clean" ]
 then
    # remove existing build dir
-   rm -rf build
+   rm -rf "$BUILD_DIR"
    
-   # clean out ant build
-   cd ../../src/gwt
-   ant clean
+   # clean out ant build if
+   if [ -d "../../src/gwt" ]; then
+      cd ../../src/gwt
+      ant clean
+   fi
    cd $PACKAGE_DIR
 fi
 
-mkdir -p build
-cd build
+mkdir -p $BUILD_DIR/gwt
+cd $BUILD_DIR
 rm -f CMakeCache.txt
 rm -rf build/_CPack_Packages
 
@@ -29,7 +36,10 @@ fi
 cmake -DRSTUDIO_TARGET=Desktop \
       -DCMAKE_BUILD_TYPE=Release \
       -DRSTUDIO_PACKAGE_BUILD=1 \
-      ../../..
+      -DGWT_BIN_DIR="$BUILD_DIR/gwt/bin" \
+      -DGWT_WWW_DIR="$BUILD_DIR/gwt/www" \
+      -DGWT_EXTRAS_DIR="$BUILD_DIR/gwt/extras" \
+      $PKG_DIR/../..
 
 MAKEFLAGS="$MAKEFLAGS -j$(sysctl -n hw.ncpu)"
 
@@ -38,4 +48,4 @@ make $MAKEFLAGS
 
 cpack -G DragNDrop
 
-cd ..
+cd $PACKAGE_DIR


### PR DESCRIPTION
This change makes two small improvements to building on macOS:

1. The GWT compiled sources are now stored in the build folder rather than the source folder. This means that it is possible to run a `make-package` build without stomping on an active `ant devmode`.

2. It is now possible to run `make-package` from any directory to produce a build in that directory; you can build outside the source tree (as is already possible on Linux). 
