### PR TITLE
Expose R session to testthat

### DIFF
--- a/src/cpp/RScriptCallbacks.hpp
+++ b/src/cpp/RScriptCallbacks.hpp
@@ -1,0 +1,34 @@
+/*
+ * RStdCallbacks.hpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef R_SESSION_SCRIPT_CALLBACKS_HPP
+#define R_SESSION_SCRIPT_CALLBACKS_HPP
+
+namespace rstudio {
+namespace r {
+namespace session {
+
+void setRunScript(const std::string& runScript);
+
+int RReadScript (const char *pmt, CONSOLE_BUFFER_CHAR* buf, int buflen, int hist);
+
+void RWriteStdout (const char *buf, int buflen, int otype);
+
+
+} // namespace session
+} // namespace r
+} // namespace rstudio
+
+#endif // R_SESSION_SCRIPT_CALLBACKS_HPP 

--- a/src/cpp/RScriptCallbacks.hpp
+++ b/src/cpp/RScriptCallbacks.hpp
@@ -1,5 +1,5 @@
 /*
- * RStdCallbacks.hpp
+ * RScriptCallbacks.hpp
  *
  * Copyright (C) 2009-18 by RStudio, Inc.
  *

--- a/src/cpp/r/CMakeLists.txt
+++ b/src/cpp/r/CMakeLists.txt
@@ -40,6 +40,7 @@ set (R_SOURCE_FILES
    session/RInit.cpp
    session/RQuit.cpp
    session/RRestartContext.cpp
+   session/RScriptCallbacks.cpp
    session/RSearchPath.cpp
    session/RSessionState.cpp
    session/RSession.cpp

--- a/src/cpp/r/CMakeLists.txt
+++ b/src/cpp/r/CMakeLists.txt
@@ -37,12 +37,14 @@ set (R_SOURCE_FILES
    session/RConsoleActions.cpp
    session/RConsoleHistory.cpp
    session/RDiscovery.cpp
+   session/RInit.cpp
    session/RQuit.cpp
    session/RRestartContext.cpp
    session/RSearchPath.cpp
    session/RSessionState.cpp
    session/RSession.cpp
    session/RStdCallbacks.cpp
+   session/RSuspend.cpp
    session/graphics/RGraphicsDevice.cpp
    session/graphics/RGraphicsErrorCategory.cpp
    session/graphics/RGraphicsPlot.cpp

--- a/src/cpp/r/CMakeLists.txt
+++ b/src/cpp/r/CMakeLists.txt
@@ -37,10 +37,12 @@ set (R_SOURCE_FILES
    session/RConsoleActions.cpp
    session/RConsoleHistory.cpp
    session/RDiscovery.cpp
+   session/RQuit.cpp
    session/RRestartContext.cpp
    session/RSearchPath.cpp
    session/RSessionState.cpp
    session/RSession.cpp
+   session/RStdCallbacks.cpp
    session/graphics/RGraphicsDevice.cpp
    session/graphics/RGraphicsErrorCategory.cpp
    session/graphics/RGraphicsPlot.cpp

--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -32,7 +32,7 @@
 
 namespace rstudio {
 namespace core {
-	class Error;
+	class Error ;
    class Settings;
 } 
 }

--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -32,7 +32,7 @@
 
 namespace rstudio {
 namespace core {
-	class Error ;
+	class Error;
    class Settings;
 } 
 }

--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -82,6 +82,7 @@ struct ROptions
    core::FilePath rSourcePath;
    std::string rLibsUser;
    std::string rCRANRepos;
+   std::string runScript;
    bool useInternet2;
    int rCompatibleGraphicsEngineVersion;
    bool serverMode;

--- a/src/cpp/r/include/r/session/RSessionUtils.hpp
+++ b/src/cpp/r/include/r/session/RSessionUtils.hpp
@@ -57,7 +57,19 @@ core::FilePath tempDir();
 core::FilePath logPath();
 
 core::FilePath rSourcePath();
-     
+
+core::FilePath rHistoryDir();
+
+core::FilePath sessionScratchPath();
+
+core::FilePath clientStatePath();
+
+core::FilePath projectClientStatePath();
+
+core::FilePath startupEnvironmentFilePath();
+
+bool restoreWorkspace();
+
 // suppress output in scope
 class SuppressOutputInScope
 {

--- a/src/cpp/r/include/r/session/RSessionUtils.hpp
+++ b/src/cpp/r/include/r/session/RSessionUtils.hpp
@@ -68,6 +68,10 @@ core::FilePath projectClientStatePath();
 
 core::FilePath startupEnvironmentFilePath();
 
+std::string sessionPort();
+
+std::string rCRANRepos();
+
 bool restoreWorkspace();
 
 // suppress output in scope

--- a/src/cpp/r/include/r/session/RSessionUtils.hpp
+++ b/src/cpp/r/include/r/session/RSessionUtils.hpp
@@ -54,6 +54,9 @@ core::FilePath tempFile(const std::string& prefix,
 
 core::FilePath tempDir();
 
+core::FilePath logPath();
+
+core::FilePath rSourcePath();
      
 // suppress output in scope
 class SuppressOutputInScope

--- a/src/cpp/r/include/r/session/RSessionUtils.hpp
+++ b/src/cpp/r/include/r/session/RSessionUtils.hpp
@@ -60,7 +60,11 @@ core::FilePath rSourcePath();
 
 core::FilePath rHistoryDir();
 
+core::FilePath rEnvironmentDir();
+
 core::FilePath sessionScratchPath();
+
+core::FilePath scopedScratchPath();
 
 core::FilePath clientStatePath();
 
@@ -68,11 +72,17 @@ core::FilePath projectClientStatePath();
 
 core::FilePath startupEnvironmentFilePath();
 
+core::FilePath suspendedSessionPath();
+
 std::string sessionPort();
 
 std::string rCRANRepos();
 
 bool restoreWorkspace();
+
+bool useInternet2();
+
+bool alwaysSaveHistory();
 
 // suppress output in scope
 class SuppressOutputInScope

--- a/src/cpp/r/session/RInit.cpp
+++ b/src/cpp/r/session/RInit.cpp
@@ -13,6 +13,14 @@
  *
  */
 
+#include <r/RExec.hpp>
+#include <r/RSourceManager.hpp>
+#include <r/session/RConsoleHistory.hpp>
+#include <r/session/RSession.hpp>
+
+#include "RInit.hpp"
+#include "RSuspend.hpp"
+
 using namespace rstudio::core;
 
 namespace rstudio {
@@ -21,10 +29,10 @@ namespace session {
 
 namespace {
 
-// is this R 3.0 or greator
+// is this R 3.0 or greater
 bool s_isR3 = false;
 
-// is this R 3.3 or greator
+// is this R 3.3 or greater
 bool s_isR3_3 = false;
 
 }
@@ -60,13 +68,13 @@ Error initialize()
    r::session::consoleHistory().setCapacityFromRHistsize();
 
    // install R tools
-   FilePath toolsFilePath = s_options.rSourcePath.complete("Tools.R");
+   FilePath toolsFilePath = utils::rSourcePath().complete("Tools.R");
    Error error = r::sourceManager().sourceTools(toolsFilePath);
    if (error)
       return error ;
 
    // install RStudio API
-   FilePath apiFilePath = s_options.rSourcePath.complete("Api.R");
+   FilePath apiFilePath = utils::rSourcePath().complete("Api.R");
    error = r::sourceManager().sourceTools(apiFilePath);
    if (error)
       return error;
@@ -75,7 +83,7 @@ Error initialize()
    // and temp directory for desktop mode (so that we can support multiple
    // concurrent processes using the same project)
    FilePath graphicsPath;
-   if (s_options.serverMode)
+   if (utils::isServerMod())
    {
       std::string path = kGraphicsPath;
       if (utils::isR3())
@@ -114,11 +122,11 @@ Error initialize()
       // note we were resumed
       wasResumed = true;
    }
-   else if (s_suspendedSessionPath.exists())
+   else if (suspendedSessionPath().exists())
    {  
       // restore session
       std::string errorMessages ;
-      restoreSession(s_suspendedSessionPath, &errorMessages);
+      restoreSession(suspendedSessionPath(), &errorMessages);
       
       // show any error messages
       if (!errorMessages.empty())
@@ -175,7 +183,7 @@ Error initialize()
       return error;
 
    // set global R options
-   FilePath optionsFilePath = s_options.rSourcePath.complete("Options.R");
+   FilePath optionsFilePath = utils::rSourcePath().complete("Options.R");
    error = r::sourceManager().sourceLocal(optionsFilePath);
    if (error)
       return error;
@@ -184,7 +192,7 @@ Error initialize()
    if (s_options.serverMode)
    {
 #ifndef __APPLE__
-      FilePath serverOptionsFilePath =  s_options.rSourcePath.complete(
+      FilePath serverOptionsFilePath =  utils::rSourcePath().complete(
                                                          "ServerOptions.R");
       return r::sourceManager().sourceLocal(serverOptionsFilePath);
 #else

--- a/src/cpp/r/session/RInit.cpp
+++ b/src/cpp/r/session/RInit.cpp
@@ -1,0 +1,217 @@
+/*
+ * RInit.cpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace r {
+namespace session {
+
+namespace {
+
+// is this R 3.0 or greator
+bool s_isR3 = false;
+
+// is this R 3.3 or greator
+bool s_isR3_3 = false;
+
+}
+
+// one-time per session initialization
+Error initialize()
+{
+   // ensure that the utils package is loaded (it might not be loaded
+   // if R is attempting to recover from a library loading error which
+   // occurs during .Rprofile)
+   Error libError = r::exec::RFunction("library", "utils").call();
+   if (libError)
+      LOG_ERROR(libError);
+
+   // check whether this is R 3.3 or greater
+   Error r33Error = r::exec::evaluateString("getRversion() >= '3.3.0'", &s_isR3_3);
+   if (r33Error)
+      LOG_ERROR(r33Error);
+
+   if (s_isR3_3)
+   {
+      s_isR3 = true;
+   }
+   else
+   {
+      // check whether this is R 3.0 or greater
+      Error r3Error = r::exec::evaluateString("getRversion() >= '3.0.0'", &s_isR3);
+      if (r3Error)
+         LOG_ERROR(r3Error);
+   }
+
+   // initialize console history capacity
+   r::session::consoleHistory().setCapacityFromRHistsize();
+
+   // install R tools
+   FilePath toolsFilePath = s_options.rSourcePath.complete("Tools.R");
+   Error error = r::sourceManager().sourceTools(toolsFilePath);
+   if (error)
+      return error ;
+
+   // install RStudio API
+   FilePath apiFilePath = s_options.rSourcePath.complete("Api.R");
+   error = r::sourceManager().sourceTools(apiFilePath);
+   if (error)
+      return error;
+
+   // initialize graphics device -- use a stable directory for server mode
+   // and temp directory for desktop mode (so that we can support multiple
+   // concurrent processes using the same project)
+   FilePath graphicsPath;
+   if (s_options.serverMode)
+   {
+      std::string path = kGraphicsPath;
+      if (utils::isR3())
+         path += "-r3";
+      graphicsPath = s_options.sessionScratchPath.complete(path);
+   }
+   else
+   {
+      graphicsPath = r::session::utils::tempDir().complete(
+                              "rs-graphics-" + core::system::generateUuid());
+   }
+
+   error = graphics::device::initialize(graphicsPath,
+                                        s_callbacks.locator);
+   if (error) 
+      return error;
+   
+   // restore client state
+   session::clientState().restore(s_clientStatePath,
+                                  s_projectClientStatePath);
+      
+   // restore suspended session if we have one
+   bool wasResumed = false;
+   
+   // first check for a pending restart
+   if (restartContext().hasSessionState())
+   {
+      // restore session
+      std::string errorMessages ;
+      restoreSession(restartContext().sessionStatePath(), &errorMessages);
+
+      // show any error messages
+      if (!errorMessages.empty())
+         REprintf(errorMessages.c_str());
+
+      // note we were resumed
+      wasResumed = true;
+   }
+   else if (s_suspendedSessionPath.exists())
+   {  
+      // restore session
+      std::string errorMessages ;
+      restoreSession(s_suspendedSessionPath, &errorMessages);
+      
+      // show any error messages
+      if (!errorMessages.empty())
+         REprintf(errorMessages.c_str());
+
+      // note we were resumed
+      wasResumed = true;
+   }  
+   // new session
+   else
+   {  
+      // restore console history
+      FilePath historyPath = rHistoryFilePath();
+      error = consoleHistory().loadFromFile(historyPath, false);
+      if (error)
+         reportHistoryAccessError("read history from", historyPath, error);
+
+      // defer loading of global environment
+      s_deferredDeserializationAction = deferredRestoreNewSession;
+   }
+   
+   // initialize client
+   RInitInfo rInitInfo(wasResumed);
+   error = s_callbacks.init(rInitInfo);
+   if (error)
+      return error;
+
+   // call resume hook if we were resumed
+   if (wasResumed)
+      s_callbacks.resumed();
+   
+   // now that all initialization code has had a chance to run we 
+   // can register all external routines which were added to r::routines
+   // during the init sequence
+   r::routines::registerAll();
+   
+   // set default repository if requested
+   if (!s_options.rCRANRepos.empty())
+   {
+      error = r::exec::RFunction(".rs.setCRANReposAtStartup",
+                                 s_options.rCRANRepos).call();
+      if (error)
+         return error;
+   }
+
+   // initialize profile resources
+   error = r::exec::RFunction(".rs.profileResources").call();
+   if (error)
+      return error;
+
+   // complete embedded r initialization
+   error = r::session::completeEmbeddedRInitialization(s_options.useInternet2);
+   if (error)
+      return error;
+
+   // set global R options
+   FilePath optionsFilePath = s_options.rSourcePath.complete("Options.R");
+   error = r::sourceManager().sourceLocal(optionsFilePath);
+   if (error)
+      return error;
+
+   // server specific R options options
+   if (s_options.serverMode)
+   {
+#ifndef __APPLE__
+      FilePath serverOptionsFilePath =  s_options.rSourcePath.complete(
+                                                         "ServerOptions.R");
+      return r::sourceManager().sourceLocal(serverOptionsFilePath);
+#else
+      return Success();
+#endif
+   }
+   else
+   {
+      return Success();
+   }
+}
+
+namespace utils {
+
+bool isR3()
+{
+   return s_isR3;
+}
+
+bool isR3_3()
+{
+   return s_isR3_3;
+}
+
+}
+
+} // namespace session
+} // namespace r
+} // namespace rstudio
+

--- a/src/cpp/r/session/RInit.hpp
+++ b/src/cpp/r/session/RInit.hpp
@@ -18,6 +18,7 @@
 namespace rstudio {
 namespace core {
 	class Error;
+	class FilePath;
 } 
 }
 
@@ -27,6 +28,13 @@ namespace session {
 
 core::Error initialize();
 
+void reportHistoryAccessError(const std::string& context,
+                              const core::FilePath& historyFilePath,
+                              const core::Error& error);
+
+core::FilePath rHistoryFilePath();
+
+   
 } // namespace session
 } // namespace r
 } // namespace rstudio

--- a/src/cpp/r/session/RInit.hpp
+++ b/src/cpp/r/session/RInit.hpp
@@ -1,0 +1,34 @@
+/*
+ * RInit.hpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+#ifndef R_SESSION_INIT_HPP
+#define R_SESSION_INIT_HPP
+
+namespace rstudio {
+namespace core {
+	class Error;
+} 
+}
+
+namespace rstudio {
+namespace r {
+namespace session {
+
+core::Error initialize();
+
+} // namespace session
+} // namespace r
+} // namespace rstudio
+
+#endif // R_SESSION_INIT_HPP 

--- a/src/cpp/r/session/RQuit.cpp
+++ b/src/cpp/r/session/RQuit.cpp
@@ -1,0 +1,160 @@
+/*
+ * RQuit.cpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#define R_INTERNAL_FUNCTIONS
+#include <r/RErrorCategory.hpp>
+#include <r/RExec.hpp>
+
+#include "RQuit.hpp"
+
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace r {
+namespace session {
+
+// forward declare win32 quit handler and provide string based quit
+// handler that parses the quit command from the console
+#ifdef _WIN32
+bool win32Quit(const std::string& saveAction,
+               int status,
+               bool runLast,
+               std::string* pErrMsg);
+
+bool win32Quit(const std::string& command, std::string* pErrMsg)
+{
+   // default values
+   std::string saveAction = "default";
+   double status = 0;
+   bool runLast = true;
+
+   // parse quit arguments
+   SEXP argsSEXP;
+   r::sexp::Protect rProtect;
+   Error error = r::exec::RFunction(".rs.parseQuitArguments", command).call(
+                                                                     &argsSEXP,
+                                                                     &rProtect);
+   if (!error)
+   {
+      error = r::sexp::getNamedListElement(argsSEXP,
+                                           "save",
+                                           &saveAction,
+                                           saveAction);
+      if (error)
+         LOG_ERROR(error);
+
+      error = r::sexp::getNamedListElement(argsSEXP,
+                                           "status",
+                                           &status,
+                                           status);
+      if (error)
+         LOG_ERROR(error);
+
+      error = r::sexp::getNamedListElement(argsSEXP,
+                                           "runLast",
+                                           &runLast,
+                                           runLast);
+      if (error)
+         LOG_ERROR(error);
+   }
+   else
+   {
+      *pErrMsg = r::endUserErrorMessage(error);
+      return false;
+   }
+
+   return win32Quit(saveAction, static_cast<int>(status), runLast, pErrMsg);
+}
+
+#endif
+
+
+void quit(bool saveWorkspace, int status)
+{
+   // invoke quit
+   std::string save = saveWorkspace ? "yes" : "no";
+ #ifdef _WIN32
+   std::string quitErr;
+   bool didQuit = win32Quit(save, 0, true, &quitErr);
+   if (!didQuit)
+   {
+      REprintf((quitErr + "\n").c_str());
+      LOG_ERROR_MESSAGE(quitErr);
+   }
+ #else
+   Error error = r::exec::RFunction("base:::q", save, status, true).call();
+   if (error)
+   {
+      REprintf((r::endUserErrorMessage(error) + "\n").c_str());
+      LOG_ERROR(error);
+   }
+ #endif
+}
+   
+// Replace the quit function so we can call our R_CleanUp hook. Note
+// that we need to take special measures to code this safely visa-vi
+// Rf_error long jmps and C++ exceptions. Currently, the RCleanUp
+// function can still long jump if runLast encounters an error. We
+// should re-write the combination of this function and RCleanUp to
+// be fully "error-safe" (not doing this now due to regression risk)
+#ifdef _WIN32
+bool win32Quit(const std::string& saveAction,
+               int status,
+               bool runLast,
+               std::string* pErrMsg)
+{
+   if (r::session::browserContextActive())
+   {
+      *pErrMsg = "unable to quit when browser is active";
+      return false;
+   }
+
+   // determine save action
+   SA_TYPE action = SA_DEFAULT;
+   if (saveAction == "ask")
+      action = SA_SAVEASK;
+   else if (saveAction == "no")
+      action = SA_NOSAVE;
+   else if (saveAction == "yes")
+      action = SA_SAVE;
+   else if (saveAction == "default")
+      action = SA_DEFAULT;
+   else
+   {
+      *pErrMsg = "Unknown save action: " + saveAction;
+      return false;
+   }
+
+   // clean up
+   Error error = r::exec::executeSafely(
+                  boost::bind(&RCleanUp, action, status, runLast));
+   if (error)
+   {
+      *pErrMsg = r::endUserErrorMessage(error);
+      return false;
+   }
+
+   // failsafe in case we don't actually quit as a result of cleanup
+   ::exit(0);
+
+   // keep compiler happy
+   return true;
+}
+#endif
+
+
+} // namespace session
+} // namespace r
+} // namespace rstudio

--- a/src/cpp/r/session/RQuit.hpp
+++ b/src/cpp/r/session/RQuit.hpp
@@ -1,0 +1,33 @@
+/*
+ * RQuit.hpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef R_SESSION_QUIT_HPP
+#define R_SESSION_QUIT_HPP
+
+namespace rstudio {
+namespace r {
+namespace session {
+
+#ifdef _WIN32
+bool win32Quit(const std::string& command, std::string* pErrMsg);
+#endif
+
+void quit(bool saveWorkspace, int status);
+
+} // namespace session
+} // namespace r
+} // namespace rstudio
+
+#endif // R_SESSION_QUIT_HPP

--- a/src/cpp/r/session/RScriptCallbacks.cpp
+++ b/src/cpp/r/session/RScriptCallbacks.cpp
@@ -1,0 +1,46 @@
+
+// variant of RReadConsole which reads a script instead of using an interactive console
+int RReadScript (const char *pmt,
+                 CONSOLE_BUFFER_CHAR* buf,
+                 int buflen,
+                 int hist)
+{
+   if (s_runScript.empty())
+   {
+      // exit after we have consumed the script
+      return 0;
+   }
+
+   // ensure input fits in buffer; we need two extra bytes -- one for the terminating newline and
+   // one for the terminating null
+   if (s_runScript.length() > (buflen - 2))
+   {
+      std::string msg = "Script too long (" +
+         safe_convert::numberToString(s_runScript.length()) + "), max is " +
+         safe_convert::numberToString(buflen - 2) + " characters)";
+      LOG_ERROR_MESSAGE(msg);
+      rSuicide(msg);
+   }
+
+   // copy input into buffer
+   s_runScript.copy(buf, s_runScript.length(), 0);
+
+   // append newline and terminating null
+   buf[s_runScript.length()] = '\n';
+   buf[s_runScript.length() +1 ] = '\0';
+
+   // remove script
+   s_runScript.clear();
+
+   // success
+   return 0;
+}
+
+// variant of RWriteConsoleEx which writes to standard out
+void RWriteStdout (const char *buf, int buflen, int otype)
+{
+   std::cout << buf;
+}
+
+
+   

--- a/src/cpp/r/session/RScriptCallbacks.cpp
+++ b/src/cpp/r/session/RScriptCallbacks.cpp
@@ -16,7 +16,10 @@
 #include <core/Error.hpp>
 #include <core/SafeConvert.hpp>
 
+#include <r/RExec.hpp>
+
 #include "REmbedded.hpp"
+#include "RInit.hpp"
 #include "RScriptCallbacks.hpp"
 #include "RStdCallbacks.hpp"
 
@@ -56,6 +59,14 @@ int RReadScript (const char *pmt,
    {
       return 0;
    }
+
+   // attempt to initialize
+   Error initError;
+   Error error = r::exec::executeSafely<Error>(initialize, &initError);
+   if (error)
+      LOG_ERROR(error);
+   if (initError)
+      LOG_ERROR(initError);
 
    // ensure input fits in buffer; we need two extra bytes -- one for the terminating newline and
    // one for the terminating null

--- a/src/cpp/r/session/RScriptCallbacks.hpp
+++ b/src/cpp/r/session/RScriptCallbacks.hpp
@@ -1,0 +1,34 @@
+/*
+ * RStdCallbacks.hpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef R_SESSION_SCRIPT_CALLBACKS_HPP
+#define R_SESSION_SCRIPT_CALLBACKS_HPP
+
+namespace rstudio {
+namespace r {
+namespace session {
+
+void setRunScript(const std::string& runScript);
+
+int RReadScript (const char *pmt, CONSOLE_BUFFER_CHAR* buf, int buflen, int hist);
+
+void RWriteStdout (const char *buf, int buflen, int otype);
+
+
+} // namespace session
+} // namespace r
+} // namespace rstudio
+
+#endif // R_SESSION_SCRIPT_CALLBACKS_HPP 

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -51,6 +51,7 @@
 #include "RQuit.hpp"
 #include "RRestartContext.hpp"
 #include "RStdCallbacks.hpp"
+#include "RScriptCallbacks.hpp"
 #include "RSuspend.hpp"
 
 #include "graphics/RGraphicsDevDesc.hpp"
@@ -79,9 +80,6 @@ namespace {
 
 // options
 ROptions s_options;
-
-// script to run, if any
-std::string s_runScript;
 
 } // anonymous namespace
   
@@ -366,9 +364,21 @@ Error run(const ROptions& options, const RCallbacks& callbacks)
                 suspendedSessionPath().exists();
 
    r::session::Callbacks cb;
+   if (options.runScript.empty())
+   {
+      // normal session: read/write from browser
+      cb.readConsole = RReadConsole;
+      cb.writeConsoleEx = RWriteConsoleEx;
+   }
+   else
+   {
+      // headless script execution: read/write from script and output to stdout
+      setRunScript(options.runScript);
+      cb.readConsole = RReadScript;
+      cb.writeConsoleEx = RWriteStdout;
+   }
+
    cb.showMessage = RShowMessage;
-   cb.readConsole = RReadConsole;
-   cb.writeConsoleEx = RWriteConsoleEx;
    cb.editFile = REditFile;
    cb.busy = RBusy;
    cb.chooseFile = RChooseFile;

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -1,0 +1,604 @@
+/*
+ * RStdCallbacks.cpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#define R_INTERNAL_FUNCTIONS
+
+#include <boost/function.hpp>
+#include <boost/regex.hpp>
+
+#include <r/RExec.hpp>
+#include <r/ROptions.hpp>
+#include <r/RUtil.hpp>
+#include <r/session/RSession.hpp>
+#include <r/session/RConsoleActions.hpp>
+
+#include <core/FileSerializer.hpp>
+#include <core/RegexUtils.hpp>
+
+#include "RInit.hpp"
+#include "REmbedded.hpp"
+#include "RStdCallbacks.hpp"
+#include "RQuit.hpp"
+
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace r {
+namespace session {
+
+namespace {
+
+// have we completed our one-time initialization yet?
+bool s_initialized = false;
+
+// main callbacks; pointer to statically allocated memory
+RCallbacks* s_pCallbacks;
+
+// internal callbacks for delegation
+InternalCallbacks s_internalCallbacks;
+
+// temporarily suppress output
+bool s_suppressOutput = false;
+
+// server mode
+bool s_serverMode = false;
+
+void doHistoryFileOperation(SEXP args, 
+                            boost::function<Error(const FilePath&)> fileOp)
+{
+   // validate filename argument
+   SEXP file = CAR(args);
+   if (!sexp::isString(file) || sexp::length(file) < 1)
+      throw r::exec::RErrorException("invalid 'file' argument");
+   
+   // calculate full path to history file
+   FilePath historyFilePath(R_ExpandFileName(Rf_translateChar(STRING_ELT(file, 
+                                                                         0))));
+   // perform operation
+   Error error = fileOp(historyFilePath);
+   if (error)
+      throw r::exec::RErrorException(error.code().message());
+}
+   
+void rSuicide(const std::string& msg)
+{
+   // log abort message if we are in desktop mode
+   if (!utils::isServerMode())
+   {
+      FilePath abendLogPath = utils::logPath().complete(
+                                                 "rsession_abort_msg.log");
+      Error error = core::writeStringToFile(abendLogPath, msg);
+      if (error)
+         LOG_ERROR(error);
+   }
+
+   R_Suicide(msg.c_str());
+}
+
+void rSuicide(const Error& error)
+{
+   // provide error message if the error was unexpected
+   std::string msg;
+   if (!error.expected())
+      msg = core::log::errorAsLogEntry(error);
+
+   rSuicide(msg);
+}
+
+bool consoleInputHook(const std::string& prompt,
+                      const std::string& input)
+{
+   // only check for quit when we're at the default prompt
+   if (!r::session::utils::isDefaultPrompt(prompt))
+      return true;
+
+   // check for user quit invocation
+    boost::regex re("^\\s*(q|quit)\\s*\\(.*$");
+    boost::smatch match;
+    if (regex_utils::match(input, match, re))
+   {
+      if (!s_pCallbacks->handleUnsavedChanges())
+      {
+         REprintf("User cancelled quit operation\n");
+         return false;
+      }
+
+      // on win32 we will actually assume responsibility for the
+      // quit function entirely (so we can call our internal cleanup
+      // handler code)
+#ifdef _WIN32
+      std::string quitErr;
+      bool didQuit = win32Quit(input, &quitErr);
+      if (!didQuit)
+         REprintf((quitErr + "\n").c_str());
+
+      // always return false (since we take over the command fully)
+      return false;
+#else
+      return true;
+#endif
+   }
+   else
+   {
+      return true;
+   }
+}
+
+bool imageIsDirty()
+{
+   return R_DirtyImage != 0;
+}
+
+} // anonymous namespace
+
+void setStdCallbacks(RCallbacks* pCallbacks)
+{
+   s_pCallbacks = pCallbacks;
+}
+
+InternalCallbacks* stdInternalCallbacks()
+{
+   return &s_internalCallbacks;
+}
+
+int RReadConsole (const char *pmt,
+                  CONSOLE_BUFFER_CHAR* buf,
+                  int buflen,
+                  int hist)
+{
+   try
+   {
+      // capture the prompt for later manipulation
+      std::string prompt(pmt);
+
+      // invoke one time initialization
+      if (!s_initialized)
+      {
+         // ignore interrupts which occur during initialization. any
+         // interrupt will cause the initialization to fail which will
+         // then require the user to start over from the beginning. if the
+         // user has to wait in any case we might as well help them out by
+         // never having to start from scratch
+         r::exec::IgnoreInterruptsScope ignoreInterrupts;
+         
+         // attempt to initialize 
+         Error initError;
+         Error error = r::exec::executeSafely<Error>(initialize, &initError);
+         if (error || initError)
+         {
+            if (initError)
+               error = initError;
+
+            // log the error if it was unexpected
+            if (!error.expected())
+               LOG_ERROR(error);
+            
+            // terminate the session (use suicide so that no special
+            // termination code runs -- i.e. call to setAbnormalEnd(false)
+            // or call to client::quitSession)
+            rSuicide(error);
+         }
+         
+         // reset the prompt to whatever the default is after we've
+         // fully initialized (and restored suspended options)
+         prompt = r::options::getOption<std::string>("prompt");
+
+         // ensure only one initialization 
+         s_initialized = true;
+      }
+
+      std::string promptString(prompt);
+      promptString = util::rconsole2utf8(promptString);
+
+      // get the next input
+      bool addToHistory = (hist == 1);
+      RConsoleInput consoleInput("");
+      if (s_pCallbacks->consoleRead(promptString, addToHistory, &consoleInput) )
+      {
+         // add prompt to console actions (we do this after consoleRead
+         // completes so that we don't send both a console prompt event
+         // AND include the same prompt in the actions history)
+         consoleActions().add(kConsoleActionPrompt, prompt);
+
+         if (consoleInput.cancel)
+         {
+            // notify of interrupt
+            consoleActions().notifyInterrupt();
+
+            // escape out using exception so that we can allow normal
+            // c++ stack unwinding to occur before jumping
+            throw r::exec::InterruptException();
+         }
+         else
+         {
+            // determine the input to return to R
+            std::string rInput = consoleInput.text;
+
+            // refresh source if necessary (no-op in production)
+            r::sourceManager().reloadIfNecessary();
+            
+            // ensure that our input fits within the buffer
+            std::string::size_type maxLen = buflen - 2; // for \n\0
+            rInput = string_utils::utf8ToSystem(rInput, true);
+            if (rInput.length() > maxLen)
+               rInput.resize(maxLen);
+            std::string::size_type inputLen = rInput.length();
+            
+            // add to console actions and history (if requested). note that
+            // we add the user's input rather than any tranformed input we
+            // created as a result of a shell escape
+            consoleActions().add(kConsoleActionInput, consoleInput.text);
+            if (addToHistory && !isInjectedBrowserCommand(consoleInput.text))
+               consoleHistory().add(consoleInput.text);
+
+            // call console input hook and interrupt if the hook tells us to
+            if (!consoleInputHook(prompt, consoleInput.text))
+               throw r::exec::InterruptException();
+
+            // copy to buffer and add terminators
+            rInput.copy( (char*)buf, maxLen);
+            buf[inputLen] = '\n';
+            buf[inputLen+1] = '\0';
+         }
+
+         return 1 ;
+      }
+      else
+      {
+         return 0; // terminate
+      }
+   }
+   catch(r::exec::InterruptException&)
+   {
+      // set interrupts pending
+      r::exec::setInterruptsPending(true);
+
+      // only issue an interrupt when not on Windows -- let the regular
+      // event loop handle interrupts there. note that this will longjmp
+#ifndef _WIN32
+      r::exec::checkUserInterrupt();
+#endif
+
+      // return success
+      return 1;
+   }
+   catch(const std::exception& e)
+   {
+      std::string msg = std::string("Unexpected exception: ") + e.what();
+      LOG_ERROR_MESSAGE(msg);
+      rSuicide(msg);
+   }
+   catch(...)
+   {
+      std::string msg = "Unknown exception";
+      LOG_ERROR_MESSAGE(msg);
+      rSuicide(msg);
+   }
+      
+   return 0 ; // keep compiler happy
+}
+   
+void RShowMessage(const char* msg)
+{
+   try 
+   {
+      s_pCallbacks->showMessage(msg) ;
+   }
+   CATCH_UNEXPECTED_EXCEPTION
+}
+
+void RWriteConsoleEx (const char *buf, int buflen, int otype)
+{
+   try
+   {
+      if (!s_suppressOutput)
+      {
+         // get output
+         std::string output = std::string(buf,buflen);
+         output = util::rconsole2utf8(output);
+         
+         // add to console actions
+         int type = otype == 1 ? kConsoleActionOutputError :
+                                 kConsoleActionOutput;
+         consoleActions().add(type, output);
+         
+         // write
+         s_pCallbacks->consoleWrite(output, otype) ;
+      }
+   }
+   CATCH_UNEXPECTED_EXCEPTION
+}
+
+// NOTE: Win32 doesn't receive this callback
+int REditFile(const char* file)
+{
+   try 
+   {
+      return s_pCallbacks->editFile(r::util::fixPath(file));
+   }
+   CATCH_UNEXPECTED_EXCEPTION
+   
+   // error if we got this far
+   return 1 ;
+}
+
+void RBusy(int which)   
+{
+   try
+   {
+      s_pCallbacks->busy(which == 1) ;
+   }
+   CATCH_UNEXPECTED_EXCEPTION 
+}
+
+// NOTE: Win32 doesn't receive this callback
+int RChooseFile (int newFile, char *buf, int len) 
+{
+   try 
+   {
+      FilePath filePath = s_pCallbacks->chooseFile(newFile == TRUE);
+      if (!filePath.empty())
+      {
+         // get absolute path
+         std::string absolutePath = filePath.absolutePath();
+         
+         // trunate file if it is too long
+         std::string::size_type maxLen = len - 1; 
+         if (absolutePath.length() > maxLen)
+            absolutePath.resize(maxLen);
+         
+         // copy the file to the buffer
+         absolutePath.copy(buf, maxLen);
+         buf[absolutePath.length()] = '\0';
+         
+         // return the length of the filepath buffer
+         return absolutePath.length();
+      }
+      else
+      {
+         return 0;
+      }
+   }
+   CATCH_UNEXPECTED_EXCEPTION
+
+   // error if we got this far
+   return 0;
+}
+         
+// NOTE: Win32 doesn't receive this callback
+int RShowFiles (int nfile, 
+                const char **file, 
+                const char **headers, 
+                const char *wtitle, 
+                Rboolean del, 
+                const char *pager)
+{
+   try 
+   {
+      for (int i=0; i<nfile; i++)
+      {
+         // determine file path and title
+         std::string fixedPath = r::util::fixPath(file[i]);
+         FilePath filePath = utils::safeCurrentPath().complete(fixedPath);
+         if (filePath.exists())
+         {
+            std::string title(headers[i]);
+            if (title.empty())
+               title = wtitle;
+         
+            // show file
+            s_pCallbacks->showFile(title, filePath, del);
+         }
+         else
+         {
+            throw r::exec::RErrorException(
+                               "File " + fixedPath + " does not exist.");
+         }
+      }
+   }
+   catch(r::exec::RErrorException& e)
+   {
+      r::exec::error(e.message());
+   }
+
+   CATCH_UNEXPECTED_EXCEPTION
+   
+   // NOTE: the documentation doesn't indicate what to return and do_fileshow
+   // in platform.c doesn't check the return value s
+   return 0;
+}
+
+void Rloadhistory(SEXP call, SEXP op, SEXP args, SEXP env)
+{
+   try
+   {
+      doHistoryFileOperation(args, boost::bind(&ConsoleHistory::loadFromFile,
+                                               &consoleHistory(), _1, true));
+      
+      s_pCallbacks->consoleHistoryReset();
+   }
+   catch(r::exec::RErrorException& e)
+   {
+      r::exec::errorCall(call, e.message());
+   }
+}
+   
+void Rsavehistory(SEXP call, SEXP op, SEXP args, SEXP env)
+{
+   try
+   {
+      doHistoryFileOperation(args, boost::bind(&ConsoleHistory::saveToFile,
+                                               &consoleHistory(), _1));
+   }
+   catch(r::exec::RErrorException& e)
+   {
+      r::exec::errorCall(call, e.message());
+   }
+}
+   
+void Raddhistory(SEXP call, SEXP op, SEXP args, SEXP env)
+{
+   try
+   {
+      // get commands
+      std::vector<std::string> commands ;
+      Error error = sexp::extract(CAR(args), &commands);
+      if (error)
+         throw r::exec::RErrorException(error.code().message());
+      
+      // append them
+      ConsoleHistory& history = consoleHistory();
+      std::for_each(commands.begin(), 
+                    commands.end(),
+                    boost::bind(&ConsoleHistory::add, &history, _1));
+   }
+   catch(r::exec::RErrorException& e)
+   {
+      r::exec::errorCall(call, e.message());
+   }
+}
+
+
+// NOTE: Win32 doesn't receive this callback
+void RSuicide(const char* s)
+{
+   s_pCallbacks->suicide(s);
+   s_internalCallbacks.suicide(s);
+}
+
+// NOTE: Win32 doesn't receive this function. As a result we only use
+// it in server mode (where it is used to support suspending as well as
+// notifying the browser of quit). In desktop mode we allow standard
+// R_CleanUp processing to take place. There are two important implications
+// of this:
+//
+//   (1) In desktop mode we override do_quit and use it as an indicator
+//       that we should save history and persistent client state (an
+//       alternative would be to more eagerly persist this data)
+//
+//   (2) In desktop mode we don't receive termination oriented events such
+//       as quit, suicide, and cleanup. This means that the desktop process
+//       must simply detect that we have exited and terminate itself. It also
+//       means that cleanup of our http damons, file monitoring, etc. never
+//       occurs (not an issue b/c our process is going away but worth noting)
+//
+void RCleanUp(SA_TYPE saveact, int status, int runLast)
+{
+   // perform cleanup that is coupled to our internal history,
+   // environment-saving, client-state, and graphics implementations
+   // and then delegate to internal R_CleanUp for the remainder
+   // of processing
+   try
+   {
+      // set to default if requested
+      if (saveact == SA_DEFAULT)
+         saveact = SaveAction ;
+      
+      // prompt user to resolve SA_SAVEASK into SA_SAVE or SA_NOSAVE
+      if (saveact == SA_SAVEASK) 
+      {
+         if (imageIsDirty() || !s_options.alwaysSaveHistory())
+            saveact = saveAsk(); // can Rf_jump_to_toplevel()
+         else
+            saveact = SA_NOSAVE; // auto-resolve to no save when not dirty
+      }
+
+      // if the session was quit by the user then run our termination code
+      bool sessionQuitByUser = (saveact != SA_SUICIDE) && !s_suspended ;
+      if (sessionQuitByUser)
+      {
+         // run last if requested (can throw error)
+         if (runLast)
+            R_dot_Last();
+         
+         // save history if we either always save history or saveact == SA_SAVE
+         if (s_options.alwaysSaveHistory() || saveact == SA_SAVE)
+         {
+            FilePath historyPath = rHistoryFilePath();
+            Error error = consoleHistory().saveToFile(historyPath);
+            if (error)
+               reportHistoryAccessError("write history to", historyPath, error);
+         }
+
+         // save environment and history
+         if (saveact == SA_SAVE)
+         {
+            // attempt save if the image is dirty
+            if (imageIsDirty())
+            {
+               // attempt to save global environment. raise error (longjmp 
+               // back to REPL) if there was a problem saving
+               Error error = saveDefaultGlobalEnvironment();
+               if (error)
+                  r::exec::error(r::endUserErrorMessage(error));
+            }
+            
+            // update state
+            saveact = SA_NOSAVE;     // prevent R from saving
+         }
+         
+         // since we've successfully completed the session we can safely
+         // remove any serialized session remaining on disk. note that if 
+         // we do not successfully destroy the session then this would cause
+         // data loss when the previous session is read rather than the
+         // contents of .RData. therefore, we refuse to quit if we can't
+         // successfully destroy the suspended session
+         if (!r::session::state::destroy(s_suspendedSessionPath))
+         {
+            // this will cause us to jump back to the REPL loop
+            r::exec::error("Unable to quit (session cleanup failure)\n");
+         }
+
+         // commit client state
+         saveClientState(ClientStateCommitPersistentOnly);
+
+         // clear display
+         r::session::graphics::display().clear();
+                
+         // notify client that the session has been quit
+         s_pCallbacks->quit();
+      }
+
+      // allow client to cleanup
+      bool terminatedNormally = saveact != SA_SUICIDE;
+      s_pCallbacks->cleanup(terminatedNormally);
+      
+      // call internal cleanup (never .runLast because we do it above)
+      // NOTE: may want to replace RCleanUp entirely so that the client
+      // can see any errors which occur during cleanup in the console
+      // (they aren't seen now because the handling of quit obstructs them)
+      s_internalCallbacks.cleanUp(saveact, status, FALSE);
+   }
+   CATCH_UNEXPECTED_EXCEPTION 
+}
+
+namespace utils {
+
+SuppressOutputInScope::SuppressOutputInScope()
+{
+  s_suppressOutput = true;
+}
+
+SuppressOutputInScope::~SuppressOutputInScope()
+{
+   s_suppressOutput = false;
+}
+
+} // namespace utils
+
+} // namespace session
+} // namespace r
+} // namespace rstudio
+

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -20,9 +20,11 @@
 
 #include <r/RExec.hpp>
 #include <r/ROptions.hpp>
+#include <r/RSourceManager.hpp>
 #include <r/RUtil.hpp>
 #include <r/session/RSession.hpp>
 #include <r/session/RConsoleActions.hpp>
+#include <r/session/RConsoleHistory.hpp>
 
 #include <core/FileSerializer.hpp>
 #include <core/RegexUtils.hpp>
@@ -46,7 +48,7 @@ namespace {
 bool s_initialized = false;
 
 // main callbacks; pointer to statically allocated memory
-RCallbacks* s_pCallbacks;
+RCallbacks s_callbacks;
 
 // internal callbacks for delegation
 InternalCallbacks s_internalCallbacks;
@@ -143,11 +145,18 @@ bool imageIsDirty()
    return R_DirtyImage != 0;
 }
 
+bool isInjectedBrowserCommand(const std::string& cmd)
+{
+   return browserContextActive() &&
+          (cmd == "c" || cmd == "Q" || cmd == "n" || cmd == "s" || cmd == "f");
+}
+
+
 } // anonymous namespace
 
-void setStdCallbacks(RCallbacks* pCallbacks)
+void setRCallbacks(const RCallbacks& callbacks)
 {
-   s_pCallbacks = pCallbacks;
+   s_callbacks = callbacks;
 }
 
 InternalCallbacks* stdInternalCallbacks()

--- a/src/cpp/r/session/RStdCallbacks.hpp
+++ b/src/cpp/r/session/RStdCallbacks.hpp
@@ -20,10 +20,16 @@ namespace rstudio {
 namespace r {
 namespace session {
 
-void setStdCallbacks(RCallbacks* pCallbacks);
+struct RCallbacks;
+struct InternalCallbacks;
+
+// callback management
+void setRCallbacks(const RCallbacks& callbacks);
+RCallbacks& rCallbacks();
 InternalCallbacks* stdInternalCallbacks();
 
-int RReadConsole (const char *pmt, CONSOLE_BUFFER_CHAR* buf, int buflen, int hist);
+// individual callbacks from R
+int RReadConsole(const char *pmt, CONSOLE_BUFFER_CHAR* buf, int buflen, int hist);
 void RShowMessage(const char* msg);
 void RWriteConsoleEx (const char *buf, int buflen, int otype);
 int REditFile(const char* file);

--- a/src/cpp/r/session/RStdCallbacks.hpp
+++ b/src/cpp/r/session/RStdCallbacks.hpp
@@ -1,0 +1,48 @@
+/*
+ * RStdCallbacks.hpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef R_SESSION_STD_CALLBACKS_HPP
+#define R_SESSION_STD_CALLBACKS_HPP
+
+namespace rstudio {
+namespace r {
+namespace session {
+
+void setStdCallbacks(RCallbacks* pCallbacks);
+InternalCallbacks* stdInternalCallbacks();
+
+int RReadConsole (const char *pmt, CONSOLE_BUFFER_CHAR* buf, int buflen, int hist);
+void RShowMessage(const char* msg);
+void RWriteConsoleEx (const char *buf, int buflen, int otype);
+int REditFile(const char* file);
+void RBusy(int which);
+int RChooseFile (int newFile, char *buf, int len);
+int RShowFiles (int nfile, 
+                const char **file, 
+                const char **headers, 
+                const char *wtitle, 
+                Rboolean del, 
+                const char *pager);
+void Rloadhistory(SEXP call, SEXP op, SEXP args, SEXP env);
+void Rsavehistory(SEXP call, SEXP op, SEXP args, SEXP env);
+void Raddhistory(SEXP call, SEXP op, SEXP args, SEXP env);
+void RSuicide(const char* s);
+void RCleanUp(SA_TYPE saveact, int status, int runLast);
+
+} // namespace session
+} // namespace r
+} // namespace rstudio
+
+#endif // R_SESSION_STD_CALLBACKS_HPP 

--- a/src/cpp/r/session/RStdCallbacks.hpp
+++ b/src/cpp/r/session/RStdCallbacks.hpp
@@ -47,6 +47,9 @@ void Raddhistory(SEXP call, SEXP op, SEXP args, SEXP env);
 void RSuicide(const char* s);
 void RCleanUp(SA_TYPE saveact, int status, int runLast);
 
+// exported utilities
+void rSuicide(const std::string& msg);
+
 } // namespace session
 } // namespace r
 } // namespace rstudio

--- a/src/cpp/r/session/RSuspend.cpp
+++ b/src/cpp/r/session/RSuspend.cpp
@@ -171,8 +171,8 @@ bool suspend(bool force, int status)
 void suspendForRestart(const RSuspendOptions& options)
 {
    suspend(options,
-           RestartContext::createSessionStatePath(s_options.scopedScratchPath,
-                                                  s_options.sessionPort),
+           RestartContext::createSessionStatePath(utils::scopedScratchPath(),
+                                                  utils::sessionPort()),
            true,  // disable save compression
            true);  // force suspend
 }

--- a/src/cpp/r/session/RSuspend.cpp
+++ b/src/cpp/r/session/RSuspend.cpp
@@ -1,0 +1,196 @@
+/*
+ * RSuspend.cpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <core/FilePath.hpp>
+
+#include <Rembedded.h>
+
+#include <r/RExec.hpp>
+#include <r/session/RClientState.hpp>
+#include <r/session/RGraphics.hpp>
+#include <r/session/RSession.hpp>
+#include <r/session/RSessionState.hpp>
+
+#include "REmbedded.hpp"
+#include "RRestartContext.hpp"
+#include "RStdCallbacks.hpp"
+#include "RSuspend.hpp"
+
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace r {
+namespace session {
+
+namespace {
+
+// session state path
+FilePath s_suspendedSessionPath ; 
+
+// client-state paths
+FilePath s_clientStatePath;
+FilePath s_projectClientStatePath;
+   
+// are in the middle of servicing a suspend request?
+bool s_suspended = false;
+
+void saveClientState(ClientStateCommitType commitType)
+{
+   using namespace r::session;
+
+   // save client state (note we don't explicitly restore this
+   // in restoreWorkingState, rather it is restored during
+   // initialize() so that the client always has access to it when
+   // for client_init)
+   r::session::clientState().commit(commitType,
+                                    s_clientStatePath,
+                                    s_projectClientStatePath);
+}
+
+bool saveSessionState(const RSuspendOptions& options,
+                      const FilePath& suspendedSessionPath,
+                      bool disableSaveCompression)
+{
+   // notify client of serialization status
+   SerializationCallbackScope cb(kSerializationActionSuspendSession);
+   
+   // suppress interrupts which occur during saving
+   r::exec::IgnoreInterruptsScope ignoreInterrupts;
+   
+   // save 
+   if (options.saveMinimal)
+   {
+      // save minimal
+      return r::session::state::saveMinimal(suspendedSessionPath,
+                                            options.saveWorkspace);
+
+   }
+   else
+   {
+      return r::session::state::save(suspendedSessionPath,
+                                     utils::isServerMode(),
+                                     options.excludePackages,
+                                     disableSaveCompression);
+   }
+}
+   
+} // anonymous namespace
+
+void setSuspendPaths(const FilePath& suspendedSessionPath,
+                     const FilePath& clientStatePath,
+                     const FilePath& projectClientStatePath)
+{
+   s_suspendedSessionPath = suspendedSessionPath;
+   s_clientStatePath = clientStatePath;
+   s_projectClientStatePath = projectClientStatePath;
+   
+}
+
+FilePath suspendedSessionPath()
+{
+   return s_suspendedSessionPath;
+}
+   
+bool suspend(const RSuspendOptions& options,
+             const FilePath& suspendedSessionPath,
+             bool disableSaveCompression,
+             bool force)
+{
+   // validate that force == true if disableSaveCompression is specified
+   // this is because save compression is disabled and the previous options
+   // are not restored, so it is only suitable to use this when we know
+   // the process is going to go away completely
+   if (disableSaveCompression)
+      BOOST_ASSERT(force == true);
+
+   // commit all client state
+   saveClientState(ClientStateCommitAll);
+
+   // if we are saving minimal then clear the graphics device
+   if (options.saveMinimal)
+   {
+      r::session::graphics::display().clear();
+   }
+
+   // save the session state. errors are handled internally and reported
+   // directly to the end user and written to the server log.
+   bool suspend = saveSessionState(options,
+                                   suspendedSessionPath,
+                                   disableSaveCompression);
+      
+   // if we failed to save the data and are being forced then warn user
+   if (!suspend && force)
+   {
+      reportAndLogWarning("Forcing suspend of process in spite of all session "
+                          "data not being fully saved.");
+      suspend = true;
+   }
+   
+   // only continue with exiting the process if we actually succeed in saving
+   if(suspend)
+   {      
+      // set suspended flag so cleanup code can act accordingly
+      s_suspended = true;
+      
+      // call suspend hook
+      rCallbacks().suspended(options);
+   
+      // clean up but don't save workspace or runLast because we have
+      // been suspended
+      RCleanUp(SA_NOSAVE, options.status, FALSE);
+      
+      // keep compiler happy (this line will never execute)
+      return true;
+   }
+   else
+   {
+      return false;
+   }
+}
+
+bool suspend(bool force, int status)
+{
+   return suspend(RSuspendOptions(status),
+                  s_suspendedSessionPath,
+                  false,
+                  force);
+}
+
+void suspendForRestart(const RSuspendOptions& options)
+{
+   suspend(options,
+           RestartContext::createSessionStatePath(s_options.scopedScratchPath,
+                                                  s_options.sessionPort),
+           true,  // disable save compression
+           true);  // force suspend
+}
+
+SerializationCallbackScope::SerializationCallbackScope(int action,
+                           const FilePath& targetPath = FilePath())
+{
+   rCallbacks().serialization(action, targetPath);
+}
+
+SerializationCallbackScope::~SerializationCallbackScope()
+{
+   try {
+      rCallbacks().serialization(kSerializationActionCompleted,
+                                 FilePath());
+   } catch(...) {}
+}
+
+} // namespace session
+} // namespace r
+} // namespace rstudio

--- a/src/cpp/r/session/RSuspend.cpp
+++ b/src/cpp/r/session/RSuspend.cpp
@@ -191,6 +191,22 @@ SerializationCallbackScope::~SerializationCallbackScope()
    } catch(...) {}
 }
 
+
+namespace utils
+{
+
+core::FilePath clientStatePath()
+{
+   return s_clientStatePath;
+}
+
+core::FilePath projectClientStatePath()
+{
+   return s_projectClientStatePath;
+}
+
+} // namespace utils
+
 } // namespace session
 } // namespace r
 } // namespace rstudio

--- a/src/cpp/r/session/RSuspend.cpp
+++ b/src/cpp/r/session/RSuspend.cpp
@@ -46,19 +46,6 @@ FilePath s_projectClientStatePath;
 // are in the middle of servicing a suspend request?
 bool s_suspended = false;
 
-void saveClientState(ClientStateCommitType commitType)
-{
-   using namespace r::session;
-
-   // save client state (note we don't explicitly restore this
-   // in restoreWorkingState, rather it is restored during
-   // initialize() so that the client always has access to it when
-   // for client_init)
-   r::session::clientState().commit(commitType,
-                                    s_clientStatePath,
-                                    s_projectClientStatePath);
-}
-
 bool saveSessionState(const RSuspendOptions& options,
                       const FilePath& suspendedSessionPath,
                       bool disableSaveCompression)
@@ -178,7 +165,7 @@ void suspendForRestart(const RSuspendOptions& options)
 }
 
 SerializationCallbackScope::SerializationCallbackScope(int action,
-                           const FilePath& targetPath = FilePath())
+                           const FilePath& targetPath)
 {
    rCallbacks().serialization(action, targetPath);
 }
@@ -191,6 +178,23 @@ SerializationCallbackScope::~SerializationCallbackScope()
    } catch(...) {}
 }
 
+bool suspended()
+{
+   return s_suspended;
+}
+
+void saveClientState(ClientStateCommitType commitType)
+{
+   using namespace r::session;
+
+   // save client state (note we don't explicitly restore this
+   // in restoreWorkingState, rather it is restored during
+   // initialize() so that the client always has access to it when
+   // for client_init)
+   r::session::clientState().commit(commitType,
+                                    s_clientStatePath,
+                                    s_projectClientStatePath);
+}
 
 namespace utils
 {
@@ -203,6 +207,11 @@ core::FilePath clientStatePath()
 core::FilePath projectClientStatePath()
 {
    return s_projectClientStatePath;
+}
+
+core::FilePath suspendedSessionPath()
+{
+   return s_suspendedSessionPath;
 }
 
 } // namespace utils

--- a/src/cpp/r/session/RSuspend.hpp
+++ b/src/cpp/r/session/RSuspend.hpp
@@ -32,6 +32,9 @@ bool suspend(const RSuspendOptions& options,
              const core::FilePath& suspendedSessionPath,
              bool disableSaveCompression,
              bool force);
+bool suspended();
+
+void saveClientState(ClientStateCommitType commitType);
 
 class SerializationCallbackScope : boost::noncopyable
 {

--- a/src/cpp/r/session/RSuspend.hpp
+++ b/src/cpp/r/session/RSuspend.hpp
@@ -1,0 +1,45 @@
+/*
+ * RSuspend.hpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef R_SESSION_SUSPEND_HPP
+#define R_SESSION_SUSPEND_HPP
+
+#include <core/FilePath.hpp>
+
+namespace rstudio {
+namespace r {
+namespace session {
+
+struct RSuspendOptions;
+
+void setSuspendedSessionPath(const core::FilePath& path);
+core::FilePath suspendedSessionPath();
+bool suspend(const RSuspendOptions& options,
+             const core::FilePath& suspendedSessionPath,
+             bool disableSaveCompression,
+             bool force);
+
+class SerializationCallbackScope : boost::noncopyable
+{
+public:
+   SerializationCallbackScope(int action, const core::FilePath& targetPath = core::FilePath());
+   ~SerializationCallbackScope();
+};
+
+} // namespace session
+} // namespace r
+} // namespace rstudio
+
+#endif // R_SESSION_SUSPEND_HPP 

--- a/src/cpp/r/session/RSuspend.hpp
+++ b/src/cpp/r/session/RSuspend.hpp
@@ -24,7 +24,9 @@ namespace session {
 
 struct RSuspendOptions;
 
-void setSuspendedSessionPath(const core::FilePath& path);
+void setSuspendPaths(const core::FilePath& sessionPath, 
+      const core::FilePath& clientStatePath, 
+      const core::FilePath& projectClientStatePath);
 core::FilePath suspendedSessionPath();
 bool suspend(const RSuspendOptions& options,
              const core::FilePath& suspendedSessionPath,

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -8,7 +8,23 @@ checkUnitTestFailure() {
    fi
 }
 
-## Any arguments passed in are considered arguments to valgrind
+TEST_SCOPE=
+if [ "$1" == "--scope" ]; then 
+   # Remember test scope
+   TEST_SCOPE="$2"
+
+   # Remove the option and argument we just read
+   shift 2
+
+else if [ "$1" == "--help" ]; then 
+   printf "Runs RStudio unit tests. Available flags: \n\n"
+   printf "--help   Show this help\n"
+   printf "--scope  Run only tests with the given scope (core, rsession, or r)\n\n"
+   printf "Any other options are passed to Valgrind."
+   exit 0;
+fi
+
+## Any remaining arguments passed in are considered arguments to valgrind
 if [ "$#" -eq 0 ]; then
 	VALGRIND=
 else
@@ -26,14 +42,15 @@ else
     RSTUDIO_SESSION_BIN="rsession"
 fi
 
+# Run core tests
+if [ -z "$TEST_SCOPE" ] || [ "$TEST_SCOPE" == "core" ]; then
+    echo Running 'core' tests...
+    $VALGRIND ${CMAKE_CURRENT_BINARY_DIR}/core/$RSTUDIO_CORETEST_BIN -s
+    checkUnitTestFailure
+fi
 
-echo Running 'core' tests...
-$VALGRIND ${CMAKE_CURRENT_BINARY_DIR}/core/$RSTUDIO_CORETEST_BIN -s
-checkUnitTestFailure
-
-echo Running 'rsession' tests...
-if [ -e ${CMAKE_CURRENT_BINARY_DIR}/conf/rdesktop-dev.conf ]
-then
+# Setup for rsession tests
+if [ -e ${CMAKE_CURRENT_BINARY_DIR}/conf/rdesktop-dev.conf ]; then
    SESSION_CONF_FILE=${CMAKE_CURRENT_BINARY_DIR}/conf/rdesktop-dev.conf
 else
    # set R environment variables needed by rsession tests
@@ -42,11 +59,25 @@ else
 
    SESSION_CONF_FILE=${CMAKE_CURRENT_BINARY_DIR}/conf/rsession-dev.conf
 fi
+
+
+if [ -z "$TEST_SCOPE" ] || [ "$TEST_SCOPE" == "rsession" ]; then
+    echo Running 'rsession' tests...
+
+    $VALGRIND ${CMAKE_CURRENT_BINARY_DIR}/session/$RSTUDIO_SESSION_BIN \
+       --run-tests \
+       --config-file=$SESSION_CONF_FILE
+    checkUnitTestFailure
+fi
    
-$VALGRIND ${CMAKE_CURRENT_BINARY_DIR}/session/$RSTUDIO_SESSION_BIN \
-   --run-tests \
-   --config-file=$SESSION_CONF_FILE
-checkUnitTestFailure
+if [ -z "$TEST_SCOPE" ] || [ "$TEST_SCOPE" == "r" ]; then
+    echo Running 'r' tests...
+
+    ${CMAKE_CURRENT_BINARY_DIR}/session/$RSTUDIO_SESSION_BIN \
+       --run-script "print('Hello, world!')" \
+       --config-file=$SESSION_CONF_FILE
+    checkUnitTestFailure
+fi
 
 # return an error exit code if any unit tests failed
 if [ "$UNIT_TEST_FAILURE" = true ] ; then

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 checkUnitTestFailure() {
    RET_CODE=$?
@@ -10,18 +10,23 @@ checkUnitTestFailure() {
 
 TEST_SCOPE=
 if [ "$1" == "--scope" ]; then 
+   if [ "$#" == 1 ]; then 
+      printf "Specify scope (core, session, or r).\n"
+      exit 1
+   fi
+
    # Remember test scope
    TEST_SCOPE="$2"
 
    # Remove the option and argument we just read
    shift 2
 
-else if [ "$1" == "--help" ]; then 
+elif [ "$1" == "--help" ]; then 
    printf "Runs RStudio unit tests. Available flags: \n\n"
    printf "--help   Show this help\n"
    printf "--scope  Run only tests with the given scope (core, rsession, or r)\n\n"
    printf "Any other options are passed to Valgrind."
-   exit 0;
+   exit 0
 fi
 
 ## Any remaining arguments passed in are considered arguments to valgrind
@@ -74,13 +79,13 @@ if [ -z "$TEST_SCOPE" ] || [ "$TEST_SCOPE" == "r" ]; then
     echo Running 'r' tests...
 
     ${CMAKE_CURRENT_BINARY_DIR}/session/$RSTUDIO_SESSION_BIN \
-       --run-script "print('Hello, world!')" \
+       --run-script "print(153)" \
        --config-file=$SESSION_CONF_FILE
     checkUnitTestFailure
 fi
 
 # return an error exit code if any unit tests failed
-if [ "$UNIT_TEST_FAILURE" = true ] ; then
+if [ "$UNIT_TEST_FAILURE" = true ]; then
     exit 1
 fi
 

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -79,7 +79,7 @@ if [ -z "$TEST_SCOPE" ] || [ "$TEST_SCOPE" == "r" ]; then
     echo Running 'r' tests...
 
     ${CMAKE_CURRENT_BINARY_DIR}/session/$RSTUDIO_SESSION_BIN \
-        --run-script "print(153)" \
+        --run-script "testthat::test_dir('${CMAKE_CURRENT_SOURCE_DIR}/tests/testthat')" \
         --config-file=$SESSION_CONF_FILE
     checkUnitTestFailure
 fi

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -79,8 +79,8 @@ if [ -z "$TEST_SCOPE" ] || [ "$TEST_SCOPE" == "r" ]; then
     echo Running 'r' tests...
 
     ${CMAKE_CURRENT_BINARY_DIR}/session/$RSTUDIO_SESSION_BIN \
-       --run-script "print(153)" \
-       --config-file=$SESSION_CONF_FILE
+        --run-script "print(153)" \
+        --config-file=$SESSION_CONF_FILE
     checkUnitTestFailure
 fi
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1826,6 +1826,7 @@ int main (int argc, char * const argv[])
                                   userSettings().rProfileOnResume();
       rOptions.packratEnabled = persistentState().settings().getBool("packratEnabled");
       rOptions.sessionScope = options.sessionScope();
+      rOptions.runScript = options.runScript();
       
       // r callbacks
       rstudio::r::session::RCallbacks rCallbacks;

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -116,6 +116,13 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
           value<bool>(&runTests_)->default_value(false)->implicit_value(true),
           "run unit tests");
 
+   // run an R script
+   options_description runScript("script");
+   runScript.add_options()
+     (kRunScriptSessionOption,
+      value<std::string>(&runScript_)->default_value(""),
+      "run an R script");
+
    // verify installation flag
    options_description verify("verify");
    verify.add_options()
@@ -411,6 +418,7 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
 
    optionsDesc.commandLine.add(verify);
    optionsDesc.commandLine.add(runTests);
+   optionsDesc.commandLine.add(runScript);
    optionsDesc.commandLine.add(program);
    optionsDesc.commandLine.add(log);
    optionsDesc.commandLine.add(agreement);

--- a/src/cpp/session/include/session/SessionConstants.hpp
+++ b/src/cpp/session/include/session/SessionConstants.hpp
@@ -55,6 +55,7 @@
 #define kVerifyInstallationSessionOption  "verify-installation"
 
 #define kRunTestsSessionOption            "run-tests"
+#define kRunScriptSessionOption           "run-script"
 
 #define kTimeoutSessionOption             "session-timeout-minutes"
 #define kDisconnectedTimeoutSessionOption "session-disconnected-timeout-minutes"

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -65,6 +65,11 @@ public:
    {
       return runTests_;
    }
+
+   std::string runScript() const
+   {
+      return runScript_;
+   }
    
    bool verifyInstallation() const
    {
@@ -552,6 +557,7 @@ private:
 private:
    // tests
    bool runTests_;
+   std::string runScript_;
    
    // verify
    bool verifyInstallation_;

--- a/src/cpp/session/modules/SessionConsole.cpp
+++ b/src/cpp/session/modules/SessionConsole.cpp
@@ -153,7 +153,8 @@ SEXP rs_getPendingInput()
 Error initialize()
 {    
    if (!(session::options().verifyInstallation() ||
-         session::options().runTests()))
+         session::options().runTests() ||
+         !session::options().runScript().empty()))
    {
       // capture standard streams
       Error error = initializeOutputCapture();

--- a/src/cpp/tests/testthat/test-lists.R
+++ b/src/cpp/tests/testthat/test-lists.R
@@ -1,3 +1,18 @@
+#
+# test-lists.R
+#
+# Copyright (C) 2009-18 by RStudio, Inc.
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
 context("lists")
 
 test_that("lists converted to scalars", {

--- a/src/cpp/tests/testthat/test-lists.R
+++ b/src/cpp/tests/testthat/test-lists.R
@@ -1,0 +1,15 @@
+context("lists")
+
+test_that("lists converted to scalars", {
+   input <- list(1, 2, 3)
+   expect_equal(.rs.scalarListFromList(input), 
+                list(.rs.scalar(1), .rs.scalar(2), .rs.scalar(3)))
+})
+
+test_that("nested lists converted to scalars", {
+   input <- list(1, 2, list(3, 4))
+   expect_equal(.rs.scalarListFromList(input), 
+                list(.rs.scalar(1), .rs.scalar(2), 
+                     list(.rs.scalar(3), .rs.scalar(4))))
+})
+


### PR DESCRIPTION
This change was made in order to support testing on a new 1.2 feature. It makes it possible to run tests against the R session executable, `rsession`, using the R package testthat.

The new tests complement the existing C++ unit tests (written in Catch). They are most useful for the following:

- Testing the .R code which supports the various session modules.
- Testing the R session from outside, as a black box in real-world conditions.
- Writing test scripts in R.

To make this possible, the R session gains a new parameter, `--run-script`. This new parameter causes the R session to behave very much like R does with `-e`; that is, it starts up normally, runs the R code given, and exits. In this mode, it also outputs to stdout rather than emitting console events. 

After this change, the R unit tests are run as part of `rstudio-tests`. You can also run just the R unit tests as follows:

    ./rstudio-tests --scope r

Future improvements may include:

- The ability to test session RPCs directly (w/o going over http)
- Integration with the build system to run tests as part of the build

The change is much smaller than it looks; most of the delta here is just a refactor of a large file (`RSession.cpp`) that would have otherwise been pushed pass the 2K line mark with this change.