### PR TITLE
Include MSVC runtimes with RStudio

### DIFF
--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -476,7 +476,11 @@ if(RSTUDIO_BUNDLE_QT)
       if (NOT WINDEPLOYQT_COMMAND)
          message(FATAL_ERROR "Did not find windeployqt under ${QT_BIN_DIR}.")
       endif()
-      install(CODE "execute_process(COMMAND \"${WINDEPLOYQT_COMMAND}\" \"\${CMAKE_INSTALL_PREFIX}\\\\bin\\\\rstudio.exe\" -verbose 0)")
+      install(CODE "execute_process(COMMAND \"${WINDEPLOYQT_COMMAND}\" \"\${CMAKE_INSTALL_PREFIX}\\\\bin\\\\rstudio.exe\" --no-compiler-runtime --verbose 0)")
+
+      # MSVC runtime
+      include(InstallRequiredSystemLibraries)
+      install(FILES ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS} DESTINATION ${RSTUDIO_INSTALL_BIN} COMPONENT Libraries)
    elseif(APPLE)
       # fixup bundle on osx
       set(APPS "\${CMAKE_INSTALL_PREFIX}/RStudio.app")

--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -480,7 +480,7 @@ if(RSTUDIO_BUNDLE_QT)
 
       # MSVC runtime
       include(InstallRequiredSystemLibraries)
-      install(FILES ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS} DESTINATION ${RSTUDIO_INSTALL_BIN} COMPONENT Libraries)
+      install(FILES ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS} DESTINATION ${RSTUDIO_INSTALL_BIN})
    elseif(APPLE)
       # fixup bundle on osx
       set(APPS "\${CMAKE_INSTALL_PREFIX}/RStudio.app")

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -529,9 +529,6 @@ if (NOT RSTUDIO_SESSION_WIN64)
          install(PROGRAMS "${WINPTY_BINDIR_64}/winpty-agent.exe"
                  DESTINATION "${RSTUDIO_INSTALL_BIN}/x64")
 
-         # 64-bit MSVC runtime
-         include(InstallRequiredSystemLibraries)
-         install(FILES ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS} DESTINATION "${RSTUDIO_INSTALL_BIN}/x64" COMPONENT Libraries)
       endif()
    endif()
 
@@ -560,6 +557,12 @@ if (NOT RSTUDIO_SESSION_WIN64)
 
    endif()
 
+endif()
+
+# install 64-bit MSVC runtime for session win64
+if(RSTUDIO_SESSION_WIN64)
+   include(InstallRequiredSystemLibraries)
+   install(FILES ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS} DESTINATION ${RSTUDIO_INSTALL_BIN})
 endif()
 
 # add overlay if it exists

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -529,6 +529,9 @@ if (NOT RSTUDIO_SESSION_WIN64)
          install(PROGRAMS "${WINPTY_BINDIR_64}/winpty-agent.exe"
                  DESTINATION "${RSTUDIO_INSTALL_BIN}/x64")
 
+         # 64-bit MSVC runtime
+         include(InstallRequiredSystemLibraries)
+         install(FILES ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS} DESTINATION "${RSTUDIO_INSTALL_BIN}/x64" COMPONENT Libraries)
       endif()
    endif()
 
@@ -558,16 +561,6 @@ if (NOT RSTUDIO_SESSION_WIN64)
    endif()
 
 endif()
-
-# # install 64-bit gcc runtime for session win64
-# # not needed with static build / link of gcc
-# if(RSTUDIO_SESSION_WIN64)
-#    get_filename_component(GCC_PATH ${CMAKE_C_COMPILER} PATH CACHE)
-#    install(PROGRAMS ${GCC_PATH}/libgcc_s_sjlj-1.dll
-#                     ${GCC_PATH}/libstdc++-6.dll
-#                     ${GCC_PATH}/libwinpthread-1.dll
-#            DESTINATION ${RSTUDIO_INSTALL_BIN})
-# endif()
 
 # add overlay if it exists
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/CMakeOverlay.txt")


### PR DESCRIPTION
Fixes #2197

Use CMake `InstallRequiredSystemLibraries` to bundle 32-bit and 64-bit runtime DLLs with RStudio.

This embeds the DLLs right in the package, versus separately installing and running `vcredist_x64.exe` and `vcredist_x86.exe`. So, we know the versions being shipped are the ones we built with, but we don't get automatic updates of these DLL's via windows-update. Pros and cons to that.