### PR TITLE
Centralize source of desktop product name string

### DIFF
--- a/src/cpp/desktop/DesktopActivationOverlay.cpp
+++ b/src/cpp/desktop/DesktopActivationOverlay.cpp
@@ -66,6 +66,11 @@ void DesktopActivation::releaseLicense()
 {
 }
 
+QString DesktopActivation::editionName() const
+{
+   return QString(tr("RStudio"));
+}
+
 void DesktopActivation::emitLicenseLostSignal()
 {
    emit licenseLost(QString::fromStdString(currentLicenseStateMessage()));

--- a/src/cpp/desktop/DesktopActivationOverlay.hpp
+++ b/src/cpp/desktop/DesktopActivationOverlay.hpp
@@ -57,6 +57,9 @@ public:
 
    void releaseLicense();
 
+   // Name of product edition, for use in UI
+   QString editionName() const;
+
 Q_SIGNALS:
    void licenseLost(QString licenseMessage);
    void launchFirstSession();

--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -29,6 +29,7 @@
 #include "DesktopSlotBinders.hpp"
 #include "DesktopSessionLauncher.hpp"
 #include "DockTileView.hpp"
+#include "DesktopActivationOverlay.hpp"
 
 using namespace rstudio::core;
 
@@ -129,7 +130,7 @@ MainWindow::MainWindow(QUrl url) :
 
    setWindowIcon(QIcon(QString::fromUtf8(":/icons/RStudio.ico")));
 
-   setWindowTitle(QString::fromUtf8("RStudio"));
+   setWindowTitle(desktop::activation().editionName());
 
 #ifdef Q_OS_MAC
    auto* pDefaultMenu = new QMenuBar(this);
@@ -153,7 +154,7 @@ void MainWindow::launchSession(bool reload)
 
       showMessageBox(QMessageBox::Critical,
                      this,
-                     QString::fromUtf8("RStudio"),
+                     desktop::activation().editionName(),
                      QString::fromUtf8("The R session failed to start."),
                      QString());
 
@@ -195,12 +196,12 @@ void MainWindow::onWorkbenchInitialized()
 
       if (projectDir.length() > 0)
       {
-         setWindowTitle(projectDir + QString::fromUtf8(" - RStudio"));
+         setWindowTitle(tr("%1 - %2").arg(projectDir).arg(desktop::activation().editionName()));
          DockTileView::setLabel(projectDir);
       }
       else
       {
-         setWindowTitle(QString::fromUtf8("RStudio"));
+         setWindowTitle(desktop::activation().editionName());
          DockTileView::setLabel(QString());
       }
 

--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -202,7 +202,7 @@ void SessionLauncher::onRSessionExited(int, QProcess::ExitStatus)
       {
          showMessageBox(QMessageBox::Critical,
                         pMainWindow_,
-                        QString::fromUtf8("RStudio"),
+                        desktop::activation().editionName(),
                         launchFailedErrorMessage(), QString());
       }
    }
@@ -226,7 +226,7 @@ void SessionLauncher::onRSessionExited(int, QProcess::ExitStatus)
          message += licenseMessage;
          showMessageBox(QMessageBox::Critical,
                         pMainWindow_,
-                        QString::fromUtf8("RStudio"),
+                        desktop::activation().editionName(),
                         QString::fromUtf8(message.c_str()), QString());
          closeAllSatellites();
          pMainWindow_->quit();
@@ -246,7 +246,7 @@ void SessionLauncher::onRSessionExited(int, QProcess::ExitStatus)
 
          showMessageBox(QMessageBox::Critical,
                         pMainWindow_,
-                        QString::fromUtf8("RStudio"),
+                        desktop::activation().editionName(),
                         launchFailedErrorMessage(), QString());
 
          pMainWindow_->quit();
@@ -341,7 +341,7 @@ void SessionLauncher::onLaunchError(QString message)
    if (!message.isEmpty())
    {
       QMessageBox errorMsg(safeMessageBoxIcon(QMessageBox::Critical),
-                           tr("RStudio"), message);
+                           desktop::activation().editionName(), message);
       errorMsg.addButton(QMessageBox::Close);
       errorMsg.exec();
    }


### PR DESCRIPTION
Add method to return name of product shown in title bar and error message titles. This will be overridden in Pro desktop.

There is already an "editionName" in the GWT code, available via `ProductEditionInfo.editionName`, but we needed a native desktop variant (we show UI needing this string before loading the GWT frame, so can't ask via Javascript).