### PR TITLE
Fix a batch of simple MSVC/Win32 warnings

### DIFF
--- a/src/cpp/core/DateTime.cpp
+++ b/src/cpp/core/DateTime.cpp
@@ -1,7 +1,7 @@
 /*
  * DateTime.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -51,7 +51,7 @@ double millisecondsSinceEpoch(const boost::posix_time::ptime& time)
    
    ptime time_t_epoch(date(1970,1,1));
    time_duration diff = time - time_t_epoch;
-   return diff.total_milliseconds();
+   return static_cast<double>(diff.total_milliseconds());
 }
    
 double millisecondsSinceEpoch(std::time_t time)
@@ -65,7 +65,7 @@ boost::posix_time::ptime timeFromSecondsSinceEpoch(double sec)
    using namespace boost::posix_time;
 
    ptime time_t_epoch(date(1970,1,1));
-   return time_t_epoch + seconds(sec);
+   return time_t_epoch + seconds(static_cast<long>(sec));
 }
 
 boost::posix_time::ptime timeFromMillisecondsSinceEpoch(int64_t ms)
@@ -96,7 +96,7 @@ std::string format(const boost::posix_time::ptime& datetime,
 std::string millisecondsSinceEpochAsString(double ms)
 {
    boost::posix_time::ptime time =
-                   date_time::timeFromMillisecondsSinceEpoch(ms);
+                   date_time::timeFromMillisecondsSinceEpoch(static_cast<int64_t>(ms));
 
    return date_time::format(time, "%d %b %Y %H:%M:%S");
 }

--- a/src/cpp/core/file_lock/FileLock.cpp
+++ b/src/cpp/core/file_lock/FileLock.cpp
@@ -1,7 +1,7 @@
 /*
  * FileLock.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -133,11 +133,11 @@ void FileLock::initialize(const Settings& settings)
 
    // timeout interval
    double timeoutInterval = getFieldPositive(settings, "timeout-interval", kDefaultTimeoutInterval);
-   FileLock::s_timeoutInterval = boost::posix_time::seconds(timeoutInterval);
+   FileLock::s_timeoutInterval = boost::posix_time::seconds(static_cast<long>(timeoutInterval));
    
    // refresh rate
    double refreshRate = getFieldPositive(settings, "refresh-rate", kDefaultRefreshRate);
-   FileLock::s_refreshRate = boost::posix_time::seconds(refreshRate);
+   FileLock::s_refreshRate = boost::posix_time::seconds(static_cast<long>(refreshRate));
    
    // logging
    bool loggingEnabled = settings.getBool("enable-logging", false);
@@ -212,8 +212,8 @@ void FileLock::log(const std::string& message)
 
 // default values for static members
 FileLock::LockType FileLock::s_defaultType(FileLock::LOCKTYPE_LINKBASED);
-boost::posix_time::seconds FileLock::s_timeoutInterval(kDefaultTimeoutInterval);
-boost::posix_time::seconds FileLock::s_refreshRate(kDefaultRefreshRate);
+boost::posix_time::seconds FileLock::s_timeoutInterval(static_cast<long>(kDefaultTimeoutInterval));
+boost::posix_time::seconds FileLock::s_refreshRate(static_cast<long>(kDefaultRefreshRate));
 bool FileLock::s_loggingEnabled(false);
 bool FileLock::s_isLoadBalanced(false);
 FilePath FileLock::s_logFile;

--- a/src/cpp/core/file_lock/LinkBasedFileLock.cpp
+++ b/src/cpp/core/file_lock/LinkBasedFileLock.cpp
@@ -166,7 +166,7 @@ bool LinkBasedFileLock::isLockFileStale(const FilePath& lockFilePath)
          return true;
    }
    
-   double seconds = s_timeoutInterval.total_seconds();
+   double seconds = static_cast<double>(s_timeoutInterval.total_seconds());
    double diff = ::difftime(::time(NULL), lockFilePath.lastWriteTime());
    return diff >= seconds;
 }

--- a/src/cpp/core/http/Response.cpp
+++ b/src/cpp/core/http/Response.cpp
@@ -77,7 +77,7 @@ void Response::setCacheForeverHeaders(bool publicAccessiblity)
    setHeader("Expires", http::util::httpDate(expireTime));
    
    // set Cache-Control header
-   int durationSeconds = yearDuration.total_seconds();
+   auto durationSeconds = yearDuration.total_seconds();
    std::string accessibility = publicAccessiblity ? "public" : "private";
    std::string cacheControl(accessibility + ", max-age=" + 
                             safe_convert::numberToString(durationSeconds));

--- a/src/cpp/core/system/Win32PtyTests.cpp
+++ b/src/cpp/core/system/Win32PtyTests.cpp
@@ -237,7 +237,7 @@ TEST_CASE("Win32PtyTests")
       err = pty.setSize(line1.length() * 4, kRows);
       CHECK(!err);
 
-      for (int i = 0; i < line1.length(); i++)
+      for (size_t i = 0; i < line1.length(); i++)
       {
          std::string typeThis;
          typeThis.push_back(line1[i]);

--- a/src/cpp/desktop/DesktopRVersion.cpp
+++ b/src/cpp/desktop/DesktopRVersion.cpp
@@ -1,7 +1,7 @@
 /*
  * DesktopRVersion.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -241,7 +241,7 @@ void enumRegistry(Architecture architecture, HKEY key, QList<RVersion>* pResults
    }
 
    std::vector<std::string> keys = regKey.keyNames();
-   for (int i = 0; i < keys.size(); i++)
+   for (size_t i = 0; i < keys.size(); i++)
    {
       RegistryKey verKey;
       error = verKey.open(regKey.handle(),

--- a/src/cpp/desktop/DesktopWordViewer.hpp
+++ b/src/cpp/desktop/DesktopWordViewer.hpp
@@ -1,7 +1,7 @@
 /*
  * DesktopWordViewer.hpp
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -20,7 +20,7 @@
 #include <boost/utility.hpp>
 #include <core/Error.hpp>
 
-class IDispatch;
+struct IDispatch;
 
 namespace rstudio {
 namespace desktop {

--- a/src/cpp/r/session/graphics/RGraphicsPlotManager.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsPlotManager.cpp
@@ -1,7 +1,7 @@
 /*
  * RGraphicsPlotManager.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -308,9 +308,9 @@ Error PlotManager::savePlotAsBitmapFile(const FilePath& targetPath,
    int res = 96;
 
    // adjust for device pixel ratio
-   width = width * pixelRatio;
-   height = height * pixelRatio;
-   res = res * pixelRatio;
+   width = static_cast<int>(width * pixelRatio);
+   height = static_cast<int>(height * pixelRatio);
+   res = static_cast<int>(res * pixelRatio);
 
    // optional format specific extra params
    std::string extraParams;

--- a/src/cpp/r/session/graphics/RShadowPngGraphicsHandler.cpp
+++ b/src/cpp/r/session/graphics/RShadowPngGraphicsHandler.cpp
@@ -1,7 +1,7 @@
 /*
  * RShadowPngGraphicsHandler.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -109,9 +109,9 @@ Error shadowDevDesc(DeviceContext* pDC, pDevDesc* pDev)
       PreserveCurrentDeviceScope preserveCurrentDeviceScope;
 
       // determine width, height, and res
-      int width = pDC->width * pDC->devicePixelRatio;
-      int height = pDC->height * pDC->devicePixelRatio;
-      int res = 96 * pDC->devicePixelRatio;
+      int width = static_cast<int>(pDC->width * pDC->devicePixelRatio);
+      int height = static_cast<int>(pDC->height * pDC->devicePixelRatio);
+      int res = static_cast<int>(96.0 * pDC->devicePixelRatio);
 
       // create PNG device (completely bail on error)
       boost::format fmt("grDevices:::png(\"%1%\", %2%, %3%, res = %4% %5%)");

--- a/src/cpp/session/SessionConsoleProcessSocket.cpp
+++ b/src/cpp/session/SessionConsoleProcessSocket.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionConsoleProcessSocket.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -66,7 +66,7 @@ Error ConsoleProcessSocket::ensureServerRunning()
    // initialize seed for random port selection
    if (!s_didSeedRand)
    {
-      srand(time(NULL));
+      srand(static_cast<unsigned int>(time(NULL)));
       s_didSeedRand = true;
    }
 

--- a/src/cpp/session/SessionSourceDatabase.cpp
+++ b/src/cpp/session/SessionSourceDatabase.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionSourceDatabase.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -303,7 +303,7 @@ SourceDocument::SourceDocument(const std::string& type)
    created_ = date_time::millisecondsSinceEpoch();
    sourceOnSave_ = false;
    relativeOrder_ = 0;
-   lastContentUpdate_ = date_time::millisecondsSinceEpoch();
+   lastContentUpdate_ = static_cast<std::time_t>(date_time::millisecondsSinceEpoch());
 }
    
 
@@ -334,7 +334,7 @@ void SourceDocument::setContents(const std::string& contents)
 {
    contents_ = contents;
    hash_ = hash::crc32Hash(contents_);
-   lastContentUpdate_ = date_time::millisecondsSinceEpoch();
+   lastContentUpdate_ = static_cast<std::time_t>(date_time::millisecondsSinceEpoch());
 }
 
 // set contents from file

--- a/src/cpp/session/modules/SessionMarkers.cpp
+++ b/src/cpp/session/modules/SessionMarkers.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionMarkers.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -382,8 +382,8 @@ SEXP rs_sourceMarkers(SEXP nameSEXP,
             SourceMarker marker(
                 sourceMarkerTypeFromString(type),
                 FilePath(path),
-                safe_convert::numberTo<int>(line, 1),
-                safe_convert::numberTo<int>(column, 1),
+                safe_convert::numberTo<double, int>(line, 1),
+                safe_convert::numberTo<double, int>(column, 1),
                 core::html_utils::HTML(message, messageHTML),
                 true);
 

--- a/src/cpp/session/modules/SessionPackrat.cpp
+++ b/src/cpp/session/modules/SessionPackrat.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionPackrat.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -767,8 +767,10 @@ void onPackratAction(const std::string& project,
    }
 
    if (running && (s_runningPackratAction != PACKRAT_ACTION_NONE))
+   {
       PACKRAT_TRACE("warning: '" << action << "' executed while action " << 
                     s_runningPackratAction << " was already running");
+   }
 
    PACKRAT_TRACE("packrat action '" << action << "' " <<
                  (running ? "started" : "finished"));

--- a/src/cpp/session/modules/clang/DefinitionIndex.cpp
+++ b/src/cpp/session/modules/clang/DefinitionIndex.cpp
@@ -1,7 +1,7 @@
 /*
  * DefinitionIndex.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -505,7 +505,7 @@ void loadDefinitionIndex()
          LOG_ERROR(error);
          continue;
       }
-      definitions.fileLastWrite = numberTo<std::time_t>(fileLastWrite, 0);
+      definitions.fileLastWrite = numberTo<double, std::time_t>(fileLastWrite, 0);
 
       // if the file doesn't exist then bail
       if (!FilePath::exists(definitions.file))
@@ -539,7 +539,7 @@ void saveDefinitionIndex()
       const CppDefinitions& definitions = defs.second;
       json::Object definitionsJson;
       definitionsJson["file"] = definitions.file;
-      definitionsJson["file_last_write"] = numberTo<double>(
+      definitionsJson["file_last_write"] = numberTo<std::time_t, double>(
                                                definitions.fileLastWrite, 0);
       json::Array defsArrayJson;
       std::transform(definitions.definitions.begin(),


### PR DESCRIPTION
Chipping away at Win32 build warnings from MSVC 2015. These are mainly ones where a silent cast was happening, "fixed" by replacing with the equivalent static_cast to make it explicit. This gets warnings down to ones that are increasingly interesting and have some potential to harbor actual issues.