### PR TITLE
Strip unsupported ANSI codes from Console output

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/AnsiCode.java
+++ b/src/gwt/src/org/rstudio/core/client/AnsiCode.java
@@ -1,7 +1,7 @@
 /*
  * AnsiEscapeCode.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -467,12 +467,7 @@ public class AnsiCode
       }
       return getStyles();
    }
-   
-   public static boolean partialSequence(String code)
-   {
-      return (code.charAt(code.length() - 1) == 'm') ? false : true;
-   }
- 
+
    public static String clazzForColor(int color)
    {
       int index = ForeColorNum.WHITE;
@@ -656,6 +651,20 @@ public class AnsiCode
    // Match control characters and start of ANSI sequences
    public static final Pattern CONTROL_PATTERN = Pattern.create(CONTROL_REGEX);
    
+   // RegEx to match complete SGR codes (colors, fonts, appearance)
+   public static final String SGR_REGEX =
+         "[\u001b\u009b]\\[(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[m]";
+   
+   // Match ANSI SGR escape sequences
+   public static final Pattern SGR_ESCAPE_PATTERN = Pattern.create(SGR_REGEX);
+   
+   // RegEx to match partial SGR codes (don't have final "m" yet)
+   public static final String SGR_PARTIAL_REGEX =
+         "[\u001b\u009b]\\[(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9]";
+   
+   // Match partial potential ANSI SGR escape sequences
+   public static final Pattern SGR_PARTIAL_ESCAPE_PATTERN = Pattern.create(SGR_PARTIAL_REGEX);
+    
    private Color currentColor_ = new Color();
    private Color currentBgColor_ = new Color();
    private boolean inverted_ = false;

--- a/src/gwt/test/org/rstudio/core/client/VirtualConsoleTests.java
+++ b/src/gwt/test/org/rstudio/core/client/VirtualConsoleTests.java
@@ -1,7 +1,7 @@
 /*
  * VirtualConsoleTests.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -60,7 +60,7 @@ public class VirtualConsoleTests extends GWTTestCase
       Assert.assertEquals("jello", cr);
    }
    
-   public void testNewlineCarrigeReturn()
+   public void testNewlineCarriageReturn()
    {
       String cr = VirtualConsole.consolify("L1\nL2\rL3");
       Assert.assertEquals("L1\nL3", cr);
@@ -732,5 +732,27 @@ public class VirtualConsoleTests extends GWTTestCase
       vc.submit("hello world\b\b\b\b\b");
       Assert.assertEquals("<span>hello world</span>", ele.getInnerHTML());
       Assert.assertEquals("hello world", vc.toString());
+   }
+   
+   public void testSingleSupportedANSICodes()
+   {
+      // https://github.com/rstudio/rstudio/issues/2248
+      PreElement ele = Document.get().createPreElement();
+      VirtualConsole vc = new VirtualConsole(ele);
+      vc.submit(AnsiCode.CSI + "?25lBuilding sites \342\200\246 " +
+                AnsiCode.CSI + "?25h\r" + AnsiCode.CSI + "[K");
+      Assert.assertEquals("<span>Building sites \342\200\246 </span>", ele.getInnerHTML());
+      Assert.assertEquals("Building sites \342\200\246 ", vc.toString());       
+   }
+   
+   public void testMultipleUnknownANSICodes()
+   {
+      // https://github.com/rstudio/rstudio/issues/2248
+      PreElement ele = Document.get().createPreElement();
+      VirtualConsole vc = new VirtualConsole(ele);
+      vc.submit("We are " + AnsiCode.CSI + "?25lbuilding sites \342\200\246" +
+                AnsiCode.CSI + "?25h\r" + AnsiCode.CSI + "[K");
+      Assert.assertEquals("<span>We are building sites \342\200\246</span>", ele.getInnerHTML());
+      Assert.assertEquals("We are building sites \342\200\246", vc.toString());       
    }
 }


### PR DESCRIPTION
Fixes #2248

The RStudio console only supports color/font/appearance ANSI codes (SGR codes), and if other ANSI codes are sent to the console, it swallows all the output while waiting for those codes to somehow become SGR codes. Which they won't.

Fix by more specifically detecting SGR codes, and handling them, while discarding unsupported codes.

Added unit tests for this scenario.