### PR TITLE
Fix opening project file in osx to fix #2203 and fix #2238

### DIFF
--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -298,7 +298,7 @@ int main(int argc, char* argv[])
          // get filename from command line arguments
          if (pApp->arguments().size() > 1)
          {
-            QString arg = pApp->arguments().last();
+            QString arg = pApp->arguments().at(1);
             if (arg != QString::fromUtf8(kRunDiagnosticsOption))
                filename = verifyAndNormalizeFilename(arg);
          }


### PR DESCRIPTION
Fixes for #2203 and #2205. Project code assumes the last argument is the project name; therefore, this fix avoids appending more arguments at the very end. Somewhat related to https://github.com/rstudio/rstudio/commit/4350d5ea81c64b9d3f35d6a1deb9f42ee1f5012b but hard to catch since the relationship to the position was non-trivial.