### PR TITLE
Fix win32 warnings (64-bit build)

### DIFF
--- a/src/cpp/core/FileSerializer.cpp
+++ b/src/cpp/core/FileSerializer.cpp
@@ -1,7 +1,7 @@
 /*
  * FileSerializer.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -193,7 +193,7 @@ Error readStringFromFile(const FilePath& filePath,
                // compute the portion of the line to be read; if this is the
                // start or end of the region to be read, use the character
                // offsets supplied
-               int lineLength = line.length();
+               int lineLength = static_cast<int>(line.length());
                content += line.substr(
                         currentLine == startLine ?
                            std::min(

--- a/src/cpp/core/FileUtils.cpp
+++ b/src/cpp/core/FileUtils.cpp
@@ -1,7 +1,7 @@
 /*
  * FileUtils.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -89,7 +89,7 @@ std::string readFile(const FilePath& filePath)
    {
       stream.seekg(0, std::ios::end);
       std::streamsize size = stream.tellg();
-      content.resize(size);
+      content.resize(static_cast<size_t>(size));
       stream.seekg(0, std::ios::beg);
       stream.read(&content[0], size);
       stream.close();

--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -121,7 +121,7 @@ std::vector<int> subsequenceIndices(std::string const& sequence,
       if (index == std::string::npos)
          continue;
       
-      result.push_back(index);
+      result.push_back(static_cast<int>(index));
       prevMatchIndex = index;
    }
    
@@ -135,12 +135,12 @@ bool subsequenceIndices(std::string const& sequence,
    pIndices->clear();
    pIndices->reserve(query.length());
    
-   int query_n = query.length();
+   int query_n = static_cast<int>(query.length());
    int prevMatchIndex = -1;
    
    for (int i = 0; i < query_n; i++)
    {
-      int index = sequence.find(query[i], prevMatchIndex + 1);
+      int index = static_cast<int>(sequence.find(query[i], prevMatchIndex + 1));
       if (index == -1)
          return false;
       
@@ -247,7 +247,7 @@ std::string utf8ToSystem(const std::string& str,
 
 #ifdef _WIN32
    std::vector<wchar_t> wide(str.length() + 1);
-   int chars = ::MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, &wide[0], wide.size());
+   int chars = ::MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, &wide[0], static_cast<int>(wide.size()));
    if (chars < 0)
    {
       LOG_ERROR(LAST_SYSTEM_ERROR());
@@ -284,7 +284,8 @@ std::string systemToUtf8(const std::string& str, int codepage)
 
 #ifdef _WIN32
    std::vector<wchar_t> wide(str.length() + 1);
-   int chars = ::MultiByteToWideChar(codepage, 0, str.c_str(), str.length(), &wide[0], wide.size());
+   int chars = ::MultiByteToWideChar(codepage, 0, str.c_str(), static_cast<int>(str.length()),
+                                     &wide[0], static_cast<int>(wide.size()));
    if (chars < 0)
    {
       LOG_ERROR(LAST_SYSTEM_ERROR());
@@ -292,8 +293,8 @@ std::string systemToUtf8(const std::string& str, int codepage)
    }
 
    int bytesRequired = ::WideCharToMultiByte(CP_UTF8, 0, &wide[0], chars,
-                                             NULL, 0,
-                                             NULL, NULL);
+                                             nullptr, 0,
+                                             nullptr, nullptr);
    if (bytesRequired == 0)
    {
       LOG_ERROR(LAST_SYSTEM_ERROR());
@@ -301,8 +302,8 @@ std::string systemToUtf8(const std::string& str, int codepage)
    }
    std::vector<char> buf(bytesRequired, 0);
    int bytesWritten = ::WideCharToMultiByte(CP_UTF8, 0, &wide[0], chars,
-                                            &(buf[0]), buf.size(),
-                                            NULL, NULL);
+                                            &(buf[0]), static_cast<int>(buf.size()),
+                                            nullptr, nullptr);
    return std::string(buf.begin(), buf.end());
 #else
    return str;
@@ -575,7 +576,7 @@ void stripQuotes(std::string* pStr)
    if (pStr->length() > 0 && (pStr->at(0) == '\'' || pStr->at(0) == '"'))
       *pStr = pStr->substr(1);
 
-   int len = pStr->length();
+   auto len = pStr->length();
 
    if (len > 0 && (pStr->at(len-1) == '\'' || pStr->at(len-1) == '"'))
       *pStr = pStr->substr(0, len -1);

--- a/src/cpp/core/Win32StringUtils.cpp
+++ b/src/cpp/core/Win32StringUtils.cpp
@@ -32,7 +32,7 @@ std::string wideToUtf8(const std::wstring& value)
    const wchar_t * cstr = value.c_str();
    int chars = ::WideCharToMultiByte(CP_UTF8, 0,
                                      cstr, -1,
-                                     NULL, 0, NULL, NULL);
+                                     nullptr, 0, nullptr, nullptr);
    if (chars == 0)
    {
       LOG_ERROR(LAST_SYSTEM_ERROR());
@@ -42,8 +42,8 @@ std::string wideToUtf8(const std::wstring& value)
    std::vector<char> result(chars, 0);
    chars = ::WideCharToMultiByte(CP_UTF8, 0,
                                  cstr, -1,
-                                 &(result[0]), result.size(),
-                                 NULL, NULL);
+                                 &(result[0]), static_cast<int>(result.size()),
+                                 nullptr, nullptr);
 
    return std::string(&(result[0]));
 }
@@ -70,7 +70,7 @@ std::wstring utf8ToWide(const std::string& value,
    std::vector<wchar_t> result(chars, 0);
    chars = ::MultiByteToWideChar(CP_UTF8, 0,
                                  cstr, -1,
-                                 &(result[0]), result.size());
+                                 &(result[0]), static_cast<int>(result.size()));
 
    return std::wstring(&(result[0]));
 }

--- a/src/cpp/core/http/Request.cpp
+++ b/src/cpp/core/http/Request.cpp
@@ -1,7 +1,7 @@
 /*
  * Request.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -173,7 +173,7 @@ std::string Request::queryParamValue(const std::string& name) const
 void Request::setBody(const std::string& body)
 {
    body_ = body;
-   setContentLength(body_.length());
+   setContentLength(static_cast<int>(body_.length()));
 }
    
 void Request::debugPrintUri(const std::string& caption) const

--- a/src/cpp/core/http/Response.cpp
+++ b/src/cpp/core/http/Response.cpp
@@ -265,7 +265,7 @@ void Response::setBodyUnencoded(const std::string& body)
 {
    removeHeader("Content-Encoding");
    body_ = body;
-   setContentLength(body_.length());
+   setContentLength(static_cast<int>(body_.length()));
 }
    
    

--- a/src/cpp/core/http/Util.cpp
+++ b/src/cpp/core/http/Util.cpp
@@ -1,7 +1,7 @@
 /*
  * Util.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -220,8 +220,8 @@ std::string urlEncode(const std::string& in, bool queryStringSpaces)
 {
    std::string encodedURL ;
       
-   int inputLength = in.length();
-   for (int i=0; i<inputLength; i++)
+   size_t inputLength = in.length();
+   for (size_t i=0; i<inputLength; i++)
    {
       char ch = in[i];
       

--- a/src/cpp/core/include/core/http/Response.hpp
+++ b/src/cpp/core/include/core/http/Response.hpp
@@ -1,7 +1,7 @@
 /*
  * Response.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -211,7 +211,7 @@ public:
             body_ = body_ + std::string(1024 - body_.length(), ' ');
          }
 
-         setContentLength(body_.length());
+         setContentLength(static_cast<int>(body_.length()));
          
          // return success
          return Success();

--- a/src/cpp/core/include/core/libclang/UnsavedFiles.hpp
+++ b/src/cpp/core/include/core/libclang/UnsavedFiles.hpp
@@ -1,7 +1,7 @@
 /*
  * UnsavedFiles.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -41,7 +41,7 @@ public:
    void removeAll();
 
    CXUnsavedFile* unsavedFilesArray() { return &(files_[0]); }
-   unsigned numUnsavedFiles() { return files_.size(); }
+   unsigned numUnsavedFiles() { return static_cast<unsigned>(files_.size()); }
 
 private:
    // vector of unsaved files we pass to various clang functions

--- a/src/cpp/core/include/core/r_util/RSourceIndex.hpp
+++ b/src/cpp/core/include/core/r_util/RSourceIndex.hpp
@@ -1,7 +1,7 @@
 /*
  * RSourceIndex.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -128,8 +128,8 @@ public:
    const std::string& name() const { return name_; }
    const std::vector<RS4MethodParam>& signature() const { return signature_; }
    const int braceLevel() const { return braceLevel_; }
-   int line() const { return core::safe_convert::numberTo<int>(line_,0); }
-   int column() const { return core::safe_convert::numberTo<int>(column_,0); }
+   int line() const { return core::safe_convert::numberTo<std::size_t, int>(line_,0); }
+   int column() const { return core::safe_convert::numberTo<std::size_t, int>(column_,0); }
 
    // support for RSourceIndex::search
 

--- a/src/cpp/core/libclang/SourceIndex.cpp
+++ b/src/cpp/core/libclang/SourceIndex.cpp
@@ -1,7 +1,7 @@
 /*
  * SourceIndex.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -247,7 +247,7 @@ TranslationUnit SourceIndex::getTranslationUnit(const std::string& filename,
                          index_,
                          filename.c_str(),
                          argsArray.args(),
-                         argsArray.argCount(),
+                         static_cast<int>(argsArray.argCount()),
                          unsavedFiles().unsavedFilesArray(),
                          unsavedFiles().numUnsavedFiles(),
                          options);

--- a/src/cpp/core/libclang/UnsavedFiles.cpp
+++ b/src/cpp/core/libclang/UnsavedFiles.cpp
@@ -65,7 +65,7 @@ void UnsavedFiles::update(const std::string& filename,
                 contents.data() + contents.length(),
                 buffContents);
       unsavedFile.Contents = buffContents;
-      unsavedFile.Length = contents.length();
+      unsavedFile.Length = static_cast<unsigned long>(contents.length());
 
       // add it to the list
       files_.push_back(unsavedFile);

--- a/src/cpp/core/system/RegistryKey.cpp
+++ b/src/cpp/core/system/RegistryKey.cpp
@@ -1,7 +1,7 @@
 /*
  * RegistryKey.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -23,7 +23,7 @@ namespace core {
 namespace system {
 
 RegistryKey::RegistryKey()
-   : hKey_(NULL)
+   : hKey_(nullptr)
 {
 }
 
@@ -33,7 +33,7 @@ RegistryKey::~RegistryKey()
    {
       if (hKey_)
          ::RegCloseKey(hKey_);
-      hKey_ = NULL;
+      hKey_ = nullptr;
    }
    catch (...)
    {
@@ -44,12 +44,12 @@ Error RegistryKey::open(HKEY hKey, std::string subKey, REGSAM samDesired)
 {
    if (hKey_)
       ::RegCloseKey(hKey_);
-   hKey_ = NULL;
+   hKey_ = nullptr;
 
    LONG error = ::RegOpenKeyEx(hKey, subKey.c_str(), 0, samDesired, &hKey_);
    if (error != ERROR_SUCCESS)
    {
-      hKey_ = NULL;
+      hKey_ = nullptr;
       return systemError(error, ERROR_LOCATION);
    }
 
@@ -85,11 +85,11 @@ Error RegistryKey::getStringValue(std::string name, std::string *pValue)
    while (true)
    {
       DWORD type;
-      DWORD size = buffer.capacity();
+      DWORD size = static_cast<DWORD>(buffer.capacity());
 
       LONG result = ::RegQueryValueEx(hKey_,
                                       name.c_str(),
-                                      NULL,
+                                      nullptr,
                                       &type,
                                       (LPBYTE)(&buffer[0]),
                                       &size);
@@ -136,8 +136,8 @@ std::vector<std::string> RegistryKey::keyNames()
    LONG result;
 
    DWORD subKeys, maxLen;
-   result = ::RegQueryInfoKey(hKey_, NULL, NULL, NULL, &subKeys, &maxLen,
-                              NULL, NULL, NULL, NULL, NULL, NULL);
+   result = ::RegQueryInfoKey(hKey_, nullptr, nullptr, nullptr, &subKeys, &maxLen,
+                              nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 
 
    std::vector<char> nameBuffer(maxLen+2);
@@ -146,12 +146,12 @@ std::vector<std::string> RegistryKey::keyNames()
 
    for (DWORD i = 0; ; i++)
    {
-      DWORD size = nameBuffer.capacity();
+      DWORD size = static_cast<DWORD>(nameBuffer.capacity());
       LONG result = ::RegEnumKeyEx(hKey_,
                                    i,
                                    &nameBuffer[0],
                                    &size,
-                                   NULL, NULL, NULL, NULL);
+                                   nullptr, nullptr, nullptr, nullptr);
       switch (result)
       {
       case ERROR_SUCCESS:

--- a/src/cpp/core/tex/TexLogParser.cpp
+++ b/src/cpp/core/tex/TexLogParser.cpp
@@ -1,7 +1,7 @@
 /*
  * TexLogParser.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -353,7 +353,7 @@ Error parseLatexLog(const FilePath& logFilePath, LogEntries* pLogEntries)
         it++)
    {
       const std::string& line = *it;
-      int logLineNum = (it - lines.begin()) + 1;
+      auto logLineNum = (it - lines.begin()) + 1;
 
       // We slurp overfull/underfull messages with no further processing
       // (i.e. not manipulating the file stack)
@@ -383,8 +383,8 @@ Error parseLatexLog(const FilePath& logFilePath, LogEntries* pLogEntries)
          }
 
          pLogEntries->push_back(LogEntry(logFilePath,
-                                         calculateWrappedLine(linesUnwrapped,
-                                                              logLineNum),
+                                         static_cast<int>(calculateWrappedLine(linesUnwrapped,
+                                                                               logLineNum)),
                                          LogEntry::Box,
                                          fileStack.currentFile(),
                                          lineNum,
@@ -430,8 +430,8 @@ Error parseLatexLog(const FilePath& logFilePath, LogEntries* pLogEntries)
          }
 
          pLogEntries->push_back(LogEntry(logFilePath,
-                                         calculateWrappedLine(linesUnwrapped,
-                                                              logLineNum),
+                                         static_cast<int>(calculateWrappedLine(linesUnwrapped,
+                                                                               logLineNum)),
                                          LogEntry::Error,
                                          fileStack.currentFile(),
                                          lineNum,
@@ -470,8 +470,8 @@ Error parseLatexLog(const FilePath& logFilePath, LogEntries* pLogEntries)
          }
 
          pLogEntries->push_back(LogEntry(logFilePath,
-                                         calculateWrappedLine(linesUnwrapped,
-                                                              logLineNum),
+                                         static_cast<int>(calculateWrappedLine(linesUnwrapped,
+                                                                               logLineNum)),
                                          LogEntry::Warning,
                                          fileStack.currentFile(),
                                          lineNum,
@@ -495,8 +495,8 @@ Error parseLatexLog(const FilePath& logFilePath, LogEntries* pLogEntries)
          {
             int lineNum = safe_convert::stringTo<int>(cStyleErrorMatch[2], -1);
             pLogEntries->push_back(LogEntry(logFilePath,
-                                            calculateWrappedLine(linesUnwrapped,
-                                                                 logLineNum),
+                                            static_cast<int>(calculateWrappedLine(linesUnwrapped,
+                                                                                  logLineNum)),
                                             LogEntry::Error,
                                             cstyleFile,
                                             lineNum,
@@ -529,7 +529,7 @@ Error parseBibtexLog(const FilePath& logFilePath, LogEntries* pLogEntries)
          pLogEntries->push_back(
                LogEntry(
                      logFilePath,
-                     (it - lines.begin()) + 1,
+                     static_cast<int>((it - lines.begin()) + 1),
                      LogEntry::Error,
                      texFilePath(match[3], logFilePath.parent()),
                      boost::lexical_cast<int>(match[2]),

--- a/src/cpp/r/include/r/session/RConsoleHistory.hpp
+++ b/src/cpp/r/include/r/session/RConsoleHistory.hpp
@@ -1,7 +1,7 @@
 /*
  * RConsoleHistory.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -58,7 +58,7 @@ public:
 
    int capacity() const
    {
-      return historyBuffer_.capacity();
+      return static_cast<int>(historyBuffer_.capacity());
    }
 
    void setRemoveDuplicates(bool removeDuplicates);
@@ -70,7 +70,7 @@ public:
    
    int size() const
    {
-      return historyBuffer_.size();
+      return static_cast<int>(historyBuffer_.size());
    }
 
    void clear();

--- a/src/cpp/session/SessionConsoleProcessPersist.cpp
+++ b/src/cpp/session/SessionConsoleProcessPersist.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionConsoleProcessPersist.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -199,7 +199,7 @@ std::string getSavedBuffer(const std::string& handle, int maxLines)
 int getSavedBufferLineCount(const std::string& handle, int maxLines)
 {
    std::string buffer = getSavedBuffer(handle, maxLines);
-   return string_utils::countNewlines(buffer) + 1;
+   return static_cast<int>(string_utils::countNewlines(buffer) + 1);
 }
 
 void appendToOutputBuffer(const std::string& handle, const std::string& buffer)

--- a/src/cpp/session/SessionConsoleProcessSocket.cpp
+++ b/src/cpp/session/SessionConsoleProcessSocket.cpp
@@ -102,7 +102,7 @@ Error ConsoleProcessSocket::ensureServerRunning()
                      static_cast<TcpIpHttpConnectionListener&>(httpConnectionListener());
 
                boost::asio::ip::tcp::endpoint endpoint = listener.getLocalEndpoint();
-               pwsServer_->listen(endpoint.address(), port);
+               pwsServer_->listen(endpoint.address(), static_cast<uint16_t>(port));
             }
             else
             {
@@ -119,7 +119,7 @@ Error ConsoleProcessSocket::ensureServerRunning()
 #endif
                {
                   // no ipv6 support, fall back to ipv4
-                  pwsServer_->listen(boost::asio::ip::tcp::v4(), port);
+                  pwsServer_->listen(boost::asio::ip::tcp::v4(), static_cast<uint16_t>(port));
                }
             }
 

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionCodeSearch.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -704,7 +704,7 @@ public:
          const FileInfo& fileInfo = (*it).fileInfo;
          if (fileInfo.isDirectory())
          {
-            int lastSlashIndex = fileInfo.absolutePath().rfind('/');
+            int lastSlashIndex = static_cast<int>(fileInfo.absolutePath().rfind('/'));
 
             std::string fileName =
                   fileInfo.absolutePath().substr(lastSlashIndex + 1);
@@ -749,7 +749,7 @@ public:
          if (fileInfo.empty())
             continue;
 
-         int lastSlashIndex = fileInfo.absolutePath().rfind('/');
+         int lastSlashIndex = static_cast<int>(fileInfo.absolutePath().rfind('/'));
 
          std::string fileName =
                fileInfo.absolutePath().substr(lastSlashIndex + 1);
@@ -1295,7 +1295,7 @@ int scoreMatch(std::string const& suggestion,
    int totalPenalty = 0;
 
    // Loop over the matches and assign a score
-   for (int j = 0, n = matches.size(); j < n; j++)
+   for (int j = 0, n = static_cast<int>(matches.size()); j < n; j++)
    {
       int matchPos = matches[j];
       int penalty = matchPos;
@@ -1331,7 +1331,7 @@ int scoreMatch(std::string const& suggestion,
       ++totalPenalty;
    
    // Penalize unmatched characters
-   totalPenalty += (query.size() - matches.size()) * query.size();
+   totalPenalty += static_cast<int>((query.size() - matches.size()) * query.size());
 
    return totalPenalty;
 }
@@ -1349,8 +1349,8 @@ void filterScores(std::vector< std::pair<int, int> >* pScore1,
                   std::vector< std::pair<int, int> >* pScore2,
                   int maxAmount)
 {
-   int s1_n = pScore1->size();
-   int s2_n = pScore2->size();
+   int s1_n = static_cast<int>(pScore1->size());
+   int s2_n = static_cast<int>(pScore2->size());
 
    int s1Count = 0;
    int s2Count = 0;
@@ -1565,7 +1565,7 @@ Error searchCode(const json::JsonRpcRequest& request,
    Error error = json::readParams(request.params, &term, &maxResultsInt);
    if (error)
       return error;
-   std::size_t maxResults = safe_convert::numberTo<std::size_t>(maxResultsInt,
+   std::size_t maxResults = safe_convert::numberTo<int, std::size_t>(maxResultsInt,
                                                                 20);
 
    // object to return
@@ -1579,13 +1579,13 @@ Error searchCode(const json::JsonRpcRequest& request,
    // TODO: Refactor searchSourceFiles, searchSource to no longer take maximum number
    // of results (since we want to grab everything possible then filter before
    // sending over the wire). Simiarly with the 'more*Available' bools
-   searchFiles(term, 1E2, true, &names, &paths, &moreFilesAvailable);
+   searchFiles(term, 100, true, &names, &paths, &moreFilesAvailable);
 
    // search source and convert to source items
    std::vector<SourceItem> srcItems;
    std::vector<r_util::RSourceItem> rSrcItems;
    bool moreSourceItemsAvailable = false;
-   searchSource(term, 1E2, false, &rSrcItems, &moreSourceItemsAvailable);
+   searchSource(term, 100, false, &rSrcItems, &moreSourceItemsAvailable);
    std::transform(rSrcItems.begin(),
                   rSrcItems.end(),
                   std::back_inserter(srcItems),
@@ -1633,7 +1633,7 @@ Error searchCode(const json::JsonRpcRequest& request,
    std::size_t srcItemScoresSizeBefore = srcItemScores.size();
    std::size_t fileScoresSizeBefore = fileScores.size();
 
-   filterScores(&fileScores, &srcItemScores, maxResults);
+   filterScores(&fileScores, &srcItemScores, static_cast<int>(maxResults));
 
    moreFilesAvailable = fileScoresSizeBefore > fileScores.size();
    moreSourceItemsAvailable = srcItemScoresSizeBefore > srcItemScores.size();
@@ -2335,7 +2335,7 @@ SEXP rs_scoreMatches(SEXP suggestionsSEXP,
    if (!r::sexp::fillVectorString(suggestionsSEXP, &suggestions))
       return R_NilValue;
    
-   int n = suggestions.size();
+   int n = static_cast<int>(suggestions.size());
    std::vector<int> scores;
    scores.reserve(n);
    

--- a/src/cpp/session/modules/SessionRCompletions.cpp
+++ b/src/cpp/session/modules/SessionRCompletions.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionRCompletions.cpp
  *
- * Copyright (C) 2014 by RStudio, Inc.
+ * Copyright (C) 2009-2018 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -182,7 +182,7 @@ SourceIndexCompletions getSourceIndexCompletions(const std::string& token)
 
    // TODO: wire up 'moreAvailable'
    modules::code_search::searchSource(token,
-                                      1E3,
+                                      1000,
                                       true,
                                       &items,
                                       &moreAvailable);

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionSource.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -146,7 +146,7 @@ int numSourceDocuments()
 {
    std::vector<boost::shared_ptr<SourceDocument> > docs;
    source_database::list(&docs);
-   return docs.size();
+   return static_cast<int>(docs.size());
 }
 
 // wrap source_database::put for situations where there are new contents

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionBuild.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -1307,7 +1307,7 @@ private:
       boost::algorithm::split(lines, output,  boost::algorithm::is_any_of("\n"));
 
       // apply filter to each line
-      int size = lines.size();
+      int size = static_cast<int>(lines.size());
       for (int i=0; i<size; i++)
       {
          // apply filter

--- a/src/cpp/session/modules/rmarkdown/NotebookDocQueue.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookDocQueue.cpp
@@ -1,7 +1,7 @@
 /*
  * NotebookDocQueue.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -226,7 +226,7 @@ json::Object NotebookDocQueue::defaultChunkOptions() const
 
 int NotebookDocQueue::remainingUnits() const 
 {
-   return queue_.size();
+   return static_cast<int>(queue_.size());
 }
 
 int NotebookDocQueue::maxUnits() const

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -1337,7 +1337,7 @@ Error initialize()
          LOG_ERROR(error);
       else
       {
-         s_currentRenderOutput = s_renderOutputs.size();
+         s_currentRenderOutput = static_cast<int>(s_renderOutputs.size());
          s_renderOutputs.reserve(kMaxRenderOutputs);
       }
    }

--- a/src/cpp/session/modules/tex/SessionSynctex.cpp
+++ b/src/cpp/session/modules/tex/SessionSynctex.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionSynctex.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -255,11 +255,13 @@ Error synctexInverseSearch(const json::JsonRpcRequest& request,
          // top of the user-visible content (in case the page is
          // scrolled down from the top)
          core::tex::PdfLocation contLoc = synctex.topOfPageContent(page);
-         x = std::max((float)x, contLoc.x());
-         y = std::max((float)y, contLoc.y());
+         x = std::max(static_cast<float>(x), contLoc.x());
+         y = std::max(static_cast<float>(y), contLoc.y());
       }
 
-      core::tex::PdfLocation pdfLocation(page, x, y, width, height);
+      core::tex::PdfLocation pdfLocation(page,
+            static_cast<float>(x), static_cast<float>(y),
+            static_cast<float>(width), static_cast<float>(height));
 
       core::tex::SourceLocation srcLoc = synctex.inverseSearch(pdfLocation);
       applyInverseConcordance(&srcLoc);

--- a/src/cpp/session/modules/viewer/ViewerHistory.cpp
+++ b/src/cpp/session/modules/viewer/ViewerHistory.cpp
@@ -1,7 +1,7 @@
 /*
  * ViewerHistory.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -45,7 +45,7 @@ ViewerHistory::ViewerHistory()
 void ViewerHistory::add(const module_context::ViewerHistoryEntry& entry)
 {
    entries_.push_back(entry);
-   currentIndex_ = entries_.size() - 1;
+   currentIndex_ = static_cast<int>(entries_.size() - 1);
 }
 
 void ViewerHistory::clear()
@@ -77,7 +77,7 @@ void ViewerHistory::clearCurrent()
 
 bool ViewerHistory::hasNext() const
 {
-   int size = safe_convert::numberTo<int>(entries_.size() - 1, 0);
+   int size = safe_convert::numberTo<std::size_t, int>(entries_.size() - 1, 0);
    return currentIndex_ != -1 && currentIndex_ < size;
 }
 


### PR DESCRIPTION
64-bit MSVC rsession build was generating 2000+ warnings. This change gets it down to around 300-ish, largely due to fixes in headers.

As before, mainly static_casts to make implicit conversions explicit (conversions with theoretical data loss, typically size_t to int). Too much work to evaluate switching to size_t types vs ints, but also don't want to turn off the warning as it can catch real problems.