### PR TITLE
Rephrase a dialog for better clarity to beginners

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -582,7 +582,7 @@ public class EnvironmentPresenter extends BasePresenter
               "Confirm Load RData",
 
               "Do you want to load the R data file \"" + dataFilePath + "\" " +
-              "into the global environment?",
+              "into your global environment?",
 
               new ProgressOperation() {
                  public void execute(ProgressIndicator indicator)


### PR DESCRIPTION
Upon opening a .RData file, my student (a beginner in R) was
presented with the question "Do you want to load the R data file
into the global environment?" and understood it to mean that the
data would be uploaded to a public data repository.

By changing "the global environment" to "your global environment",
such confusion can hopefully be avoided. Further, the change from
"the" to "your" is consistent with the previous phrase in the
dialog, which was "your workspace". I believe the main intent of
db72a278 was to change "workspace" to "environment".

Thanks to Riley Bailey for the report and suggestion.

An alternative phrasing could be "your session's global environment".