### PR TITLE
WebSocket keep-alive pings for terminal

### DIFF
--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -71,6 +71,7 @@ set (SESSION_SOURCE_FILES
    SessionConsoleProcessInfo.cpp
    SessionConsoleProcessPersist.cpp
    SessionConsoleProcessSocket.cpp
+   SessionConsoleProcessSocketPacket.cpp
    SessionConsoleProcessTable.cpp
    SessionContentUrls.cpp
    SessionDirs.cpp

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionClientInit.hpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -320,6 +320,7 @@ void handleClientInit(const boost::function<void()>& initFunction,
    sessionInfo["allow_file_upload"] = options.allowFileUploads();
    sessionInfo["allow_remove_public_folder"] = options.allowRemovePublicFolder();
    sessionInfo["allow_full_ui"] = options.allowFullUI();
+   sessionInfo["websocket_ping_interval"] = options.webSocketPingInterval();
 
    // publishing may be disabled globally or just for external services, and
    // via configuration options or environment variables

--- a/src/cpp/session/SessionConsoleProcessSocketPacket.cpp
+++ b/src/cpp/session/SessionConsoleProcessSocketPacket.cpp
@@ -1,0 +1,58 @@
+/*
+ * SessionConsoleProcessSocketPacket.cpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <session/SessionConsoleProcessSocketPacket.hpp>
+
+namespace rstudio {
+namespace session {
+namespace console_process {
+
+const std::string ConsoleProcessSocketPacket::kKeepAlivePrefix = "b";
+const std::string ConsoleProcessSocketPacket::kTextPrefix = "a";
+
+/* static */
+std::string ConsoleProcessSocketPacket::textPacket(const std::string& text)
+{
+   return kTextPrefix + text;
+}
+
+/* static */
+std::string ConsoleProcessSocketPacket::keepAlivePacket()
+{
+   return kKeepAlivePrefix;
+}
+
+/* static */
+bool ConsoleProcessSocketPacket::isKeepAlive(const std::string& text)
+{
+   return text == kKeepAlivePrefix;
+}
+
+/* static */
+std::string ConsoleProcessSocketPacket::getMessage(const std::string& text)
+{
+   if (!text.compare(0, kTextPrefix.length(), kTextPrefix))
+   {
+      return text.substr(kTextPrefix.length());
+   }
+   else
+   {
+      return std::string();
+   }
+}
+
+} // namespace console_process
+} // namespace session
+} // namespace rstudio

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionOptions.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -229,7 +229,10 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
        "first project template path")
       ("default-rsconnect-server",
        value<std::string>(&defaultRSConnectServer_)->default_value(""),
-       "default RStudio Connect server URL");
+       "default RStudio Connect server URL")
+      (kWebSocketPingInterval,
+       value<int>(&webSocketPingSeconds_)->default_value(10),
+       "WebSocket keep-alive ping interval (seconds)");
 
    // allow options
    options_description allow("allow");

--- a/src/cpp/session/include/session/SessionConsoleProcessSocket.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessSocket.hpp
@@ -97,9 +97,18 @@ public:
    // stop listening to given terminal handle
    core::Error stopListening(const std::string& terminalHandle);
 
-   // send text to client
+   // send raw text to client
+   core::Error sendRawText(const std::string& terminalHandle,
+                           const std::string& message);
+
+   // send text packet to client
    core::Error sendText(const std::string& terminalHandle,
                         const std::string& message);
+
+   // send keepalive response to client; we're not using low-level WebSocket
+   // ping/pong as that isn't accessible from JavaScript apps; so we're just doing a
+   // simple message exchange to keep proxies from killing an idle terminal
+   core::Error sendPong(const std::string& terminalHandle);
 
    // network port for websocket listener; 0 means no port
    int port() const;

--- a/src/cpp/session/include/session/SessionConsoleProcessSocketPacket.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessSocketPacket.hpp
@@ -1,0 +1,61 @@
+/*
+ * SessionConsoleProcessSocketPacket.hpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+#ifndef SESSION_CONSOLE_PROCESS_SOCKET_PACKET_HPP
+#define SESSION_CONSOLE_PROCESS_SOCKET_PACKET_HPP
+
+#include <string>
+
+namespace rstudio {
+namespace session {
+namespace console_process {
+
+/**
+ * Super-simple packet format for Terminal Websocket payloads. Not using JSON to keep
+ * overhead to absolute minimum, and to make server-side parsing trivial on a worker
+ * thread.
+ *
+ * First character is a method indicator, as follows:
+ *    "a" = send text, e.g. "aHello"
+ *    "b" = ping/pong, e.g. "b"
+ *
+ * Only the "send text" method has a payload (everything after the "a").
+ *
+ * See TerminalSocketPacket in Java code for client-side of this.
+ */
+class ConsoleProcessSocketPacket
+{
+public:
+   // create packet for given text
+   static std::string textPacket(const std::string& text);
+
+   // create keepalive packet
+   static std::string keepAlivePacket();
+
+   // is this packet a keep-alive packet?
+   static bool isKeepAlive(const std::string& text);
+
+   // extract text from packet (empty string if unable to comply)
+   static std::string getMessage(const std::string& text);
+
+private:
+   static const std::string kKeepAlivePrefix;
+   static const std::string kTextPrefix;
+};
+
+} // namespace console_process
+} // namespace session
+} // namespace rstudio
+
+#endif // SESSION_CONSOLE_PROCESS_SOCKET_PACKET_HPP

--- a/src/cpp/session/include/session/SessionConstants.hpp
+++ b/src/cpp/session/include/session/SessionConstants.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionConstants.hpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -64,6 +64,8 @@
 #define kStandaloneSessionOption          "standalone"
 #define kWwwAddressSessionOption          "www-address"
 #define kWwwPortSessionOption             "www-port"
+
+#define kWebSocketPingInterval            "websocket-ping-seconds"
 
 // NOTE: literal versions of these are depended upon by the desktop/rsinverse
 // project so they should be updated there as well if they are changed

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionOptions.hpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -510,6 +510,11 @@ public:
       return defaultRSConnectServer_;
    }
 
+   int webSocketPingInterval() const
+   {
+      return webSocketPingSeconds_;
+   }
+
    std::string getOverlayOption(const std::string& name)
    {
       return overlayOptions_[name];
@@ -601,6 +606,7 @@ private:
    std::string firstProjectTemplatePath_;
    std::string signingKey_;
    bool verifySignatures_;
+   int webSocketPingSeconds_;
 
    // r
    std::string coreRSourcePath_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -1,7 +1,7 @@
 /*
  * SessionInfo.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -370,7 +370,11 @@ public class SessionInfo extends JavaScriptObject
    public final native boolean getAllowFullUI() /*-{
       return this.allow_full_ui;
    }-*/;
-  
+   
+   public final native int getWebSocketPingInterval() /*-{
+      return this.websocket_ping_interval;
+   }-*/;
+   
    public final native boolean getAllowExternalPublish() /*-{
       return this.allow_external_publish;
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -38,6 +38,8 @@ import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
+import org.rstudio.studio.client.workbench.model.Session;
+import org.rstudio.studio.client.workbench.model.SessionInfo;
 import org.rstudio.studio.client.workbench.model.WorkbenchServerOperations;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.console.model.ProcessBufferChunk;
@@ -82,7 +84,7 @@ public class TerminalSession extends XTermWidget
       hasChildProcs_ = new Value<>(info.getHasChildProcs());
       
       setTitle(info.getTitle());
-      socket_ = new TerminalSessionSocket(this, this);
+      socket_ = new TerminalSessionSocket(this, this, sessionInfo_.getWebSocketPingInterval());
 
       setHeight("100%");
    }
@@ -90,11 +92,13 @@ public class TerminalSession extends XTermWidget
    @Inject
    private void initialize(WorkbenchServerOperations server,
                            EventBus events,
+                           final Session session,
                            UIPrefs uiPrefs)
    {
       server_ = server;
       eventBus_ = events; 
       uiPrefs_ = uiPrefs;
+      sessionInfo_ = session.getSessionInfo();
    } 
 
    /**
@@ -855,4 +859,5 @@ public class TerminalSession extends XTermWidget
    private WorkbenchServerOperations server_; 
    private EventBus eventBus_;
    private UIPrefs uiPrefs_;
+   private SessionInfo sessionInfo_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSocketPacket.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSocketPacket.java
@@ -1,0 +1,61 @@
+/*
+ * TerminalSocketPacket.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.terminal;
+
+import org.rstudio.core.client.StringUtil;
+
+/**
+ * Super-simple packet format for Terminal Websocket payloads. Not using JSON to keep
+ * overhead to absolute minimum, and to make server-side parsing trivial on a worker
+ * thread.
+ * 
+ * First character is a method indicator, as follows:
+ *    "a" = send text, e.g. "aHello"
+ *    "b" = ping/pong, e.g. "b"
+ *    
+ * Only the "send text" method has a payload (everything after the "a").
+ * 
+ * See SessionConsoleProcessSocketPacket in session code for C++ side of this sophisticated
+ * wire format.
+ */
+public class TerminalSocketPacket
+{
+   public static String textPacket(String text)
+   {
+      return textPrefix + text;
+   }
+   
+   public static String keepAlivePacket() {
+      return keepAlivePrefix;
+   }
+   
+   public static boolean isKeepAlive(String text)
+   {
+      return StringUtil.equals(text, keepAlivePrefix);
+   }
+   
+   public static String getMessage(String text)
+   {
+      if (text.startsWith(textPrefix))
+      {
+         return text.substring(1); 
+      }
+      return "";
+   }
+
+   private static final String keepAlivePrefix = "b";
+   private static final String textPrefix = "a";
+}


### PR DESCRIPTION
Proxies can be configured to close inactivate websocket connections. This can lead to error messages showing in the console (in the case of .cloud), and possibly other issues.

Now Terminal websockets will send a 1 character "ping" followed by the server sending back a 1 character "pong", to reassure proxies that the websocket is still in use. Both directions, as proxies can be configured to pay attention to one or both directions.

Default interval is 10 seconds (per each terminal connection). Can be changed or disabled with `websocket-ping-seconds=n`. Only done for Terminal websockets, but concept (and the setting) could be extended to other uses of WebSockets in the product.

Using a super-sophisticated packet format, to keep overhead minimal. If the first character of a terminal websocket message is "a", then what follows is text. If it's "b", then it's a ping/pong message. Patent-pending.

Fixes: #1860 

FYI @ssinnott @kippandrew
