### PR TITLE
Fix for Qt 5.10.1 bug where RStudio crashes on startup on Linux

### DIFF
--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -266,7 +266,15 @@ int main(int argc, char* argv[])
          static char disableRendererAccessibility[] = "--disable-renderer-accessibility";
          arguments.push_back(disableRendererAccessibility);
       }
-      
+
+#ifdef Q_OS_LINUX
+      // workaround for Qt 5.10.1 bug "Could not find QtWebEngineProcess"
+      // https://bugreports.qt.io/browse/QTBUG-67023
+      // https://bugreports.qt.io/browse/QTBUG-66346
+      static char noSandbox[] = "--no-sandbox";
+      arguments.push_back(noSandbox);
+#endif
+
       // re-assign command line arguments
       argc = (int) arguments.size();
       argv = &arguments[0];


### PR DESCRIPTION
This is a regression in Qt 5.10.1. The temporary workaround is to include --no-sandbox argument.

Fixes #2378 

Fix checked in to Qt 5.11 and 5.9.5, but no word yet if it will be fixed for 5.10.1. See this bug to track that:

https://bugreports.qt.io/browse/QTBUG-66346
