### PR TITLE
Don't add Win32-specific msys-ssh to subprocess paths

### DIFF
--- a/src/cpp/session/modules/SessionWorkbench.hpp
+++ b/src/cpp/session/modules/SessionWorkbench.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionWorkbench.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -53,9 +53,11 @@ void ammendShellPaths(T* pTarget)
    if (!svnBinDir.empty())
       core::system::addToPath(pTarget, svnBinDir);
 
+#ifdef _WIN32
    // msys_ssh path
    core::system::addToPath(pTarget,
                            session::options().msysSshPath().absolutePath());
+#endif
 }
 
 } // namespace workbench


### PR DESCRIPTION
All other uses of msysSshPath() were inside #ifdef _WIN32 except this one.

Fixes #2352