### PR TITLE
ensure errno loaded from msvcrt when checking iconv success

### DIFF
--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -300,6 +300,7 @@ else()
       system/Win32ParentProcessMonitor.cpp
       system/Win32Pty.cpp
       system/Win32OutputCapture.cpp
+      system/Win32RuntimeLibrary.cpp
       system/Win32ShellUtils.cpp
       system/Win32System.cpp
       system/Win32ChildProcess.cpp

--- a/src/cpp/core/include/core/system/Win32RuntimeLibrary.hpp
+++ b/src/cpp/core/include/core/system/Win32RuntimeLibrary.hpp
@@ -1,0 +1,31 @@
+/*
+ * Win32RuntimeLibrary.hpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef CORE_WIN32_RUNTIME_LIBRARY_HPP
+#define CORE_WIN32_RUNTIME_LIBRARY_HPP
+
+namespace rstudio {
+namespace core {
+namespace runtime {
+
+int errorNumber();
+
+} // end namespace runtime
+} // end namespace core
+} // end namespace rstudio
+
+#define MSVC_ERRNO (::rstudio::core::runtime::errorNumber())
+
+#endif /* CORE_WIN32_RUNTIME_LIBRARY_HPP */

--- a/src/cpp/core/system/Win32RuntimeLibrary.cpp
+++ b/src/cpp/core/system/Win32RuntimeLibrary.cpp
@@ -1,0 +1,99 @@
+/*
+ * Win32RuntimeLibrary.cpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <core/system/Win32RuntimeLibrary.hpp>
+
+#include <boost/noncopyable.hpp>
+
+#include <core/Error.hpp>
+#include <core/Log.hpp>
+
+#include <core/system/LibraryLoader.hpp>
+
+#define RS_LOAD_SYMBOL(__NAME__)                                              \
+   do                                                                         \
+   {                                                                          \
+      Error error = system::loadSymbol(pLib_, #__NAME__, (void**) &__NAME__); \
+      if (error)                                                              \
+         LOG_ERROR(error);                                                    \
+   } while (0)
+
+namespace rstudio {
+namespace core {
+namespace runtime {
+
+namespace {
+
+namespace defaults {
+int s_zero = 0;
+int* _errno() { return &s_zero; }
+} // namespace defaults
+
+// helper class for RAII lifetime of library handle
+class Library : boost::noncopyable
+{
+public:
+
+   Library()
+      : pLib_(NULL),
+        _errno(defaults::_errno)
+   {
+      Error error = core::system::loadLibrary("msvcrt.dll", &pLib_);
+      if (error)
+      {
+         LOG_ERROR(error);
+         return;
+      }
+
+      RS_LOAD_SYMBOL(_errno);
+   }
+
+   int* (*_errno)(void);
+
+   ~Library()
+   {
+      try
+      {
+         if (pLib_ != NULL)
+         {
+            Error error = core::system::closeLibrary(pLib_);
+            if (error)
+               LOG_ERROR(error);
+         }
+      }
+      CATCH_UNEXPECTED_EXCEPTION
+   }
+
+private:
+   void* pLib_;
+};
+
+Library& library()
+{
+   static Library instance;
+   return instance;
+}
+
+} // end anonymous namespace
+
+
+int errorNumber()
+{
+   return *(library()._errno());
+}
+
+} // end namespace runtime
+} // end namespace core
+} // end namespace rstudio

--- a/src/cpp/r/RUtil.cpp
+++ b/src/cpp/r/RUtil.cpp
@@ -127,7 +127,7 @@ core::Error iconvstr(const std::string& value,
 
    void* handle = ::Riconv_open(to.c_str(), from.c_str());
    if (handle == (void*)(-1))
-      return systemError(errno, ERROR_LOCATION);
+      return systemError(R_ERRNO, ERROR_LOCATION);
 
    const char* pIn = value.data();
    size_t inBytes = value.size();
@@ -145,20 +145,20 @@ core::Error iconvstr(const std::string& value,
 
       if (result == (size_t)(-1))
       {
-         if ((errno == EILSEQ || errno == EINVAL) && allowSubstitution)
+         if ((R_ERRNO == EILSEQ || R_ERRNO == EINVAL) && allowSubstitution)
          {
             output.push_back('?');
             pIn++;
             inBytes--;
          }
-         else if (errno == E2BIG && pInOrig != pIn)
+         else if (R_ERRNO == E2BIG && pInOrig != pIn)
          {
             continue;
          }
          else
          {
             ::Riconv_close(handle);
-            Error error = systemError(errno, ERROR_LOCATION);
+            Error error = systemError(R_ERRNO, ERROR_LOCATION);
             error.addProperty("str", value);
             error.addProperty("len", value.length());
             error.addProperty("from", from);

--- a/src/cpp/r/include/r/RUtil.hpp
+++ b/src/cpp/r/include/r/RUtil.hpp
@@ -18,6 +18,13 @@
 
 #include <string>
 
+#ifdef _WIN32
+# include <core/system/Win32RuntimeLibrary.hpp>
+# define R_ERRNO MSVC_ERRNO
+#else
+# define R_ERRNO errno
+#endif
+
 namespace rstudio {
 namespace core {
    class FilePath;
@@ -28,7 +35,7 @@ namespace core {
 namespace rstudio {
 namespace r {
 namespace util {
-   
+
 std::string expandFileName(const std::string& name);
    
 std::string fixPath(const std::string& path);

--- a/src/cpp/session/modules/SessionRUtil.cpp
+++ b/src/cpp/session/modules/SessionRUtil.cpp
@@ -141,7 +141,7 @@ Error initialize()
    
    using boost::bind;
    using namespace module_context;
-   
+
    ExecBlock initBlock;
    initBlock.addFunctions()
          (bind(sourceModuleRFile, "SessionRUtil.R"));

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -366,7 +366,7 @@ Error saveDocumentCore(const std::string& contents,
                           "Not all of the characters in " + path +
                           " could be encoded using " + pDoc->encoding() +
                           ". To save using a different encoding, choose \"File | "
-                          "Save with Encoding...\" from the main menu.");
+                          "Save with Encoding...\" from the main menu.\n");
       }
 
       // note whether the file existed prior to writing


### PR DESCRIPTION
This should fix #2315.

---

Some background: it looks like `Riconv.dll` imports `msvcrt.dll`, and uses `_errno` from there. On the other hand, `rsession` is getting it from a different runtime altogether: `api-ms-win-crt-runtime-l1-1-0.dll`, which I believe is required for applications built with MSVC 2015 + Qt.

One alternative way of approaching this would be to attempt to link directly with `msvcrt.dll`, but I'm not sure if this would work with MSVC + Qt (although this may be worth exploring if we're not a fan of this solution).

We might want to wrap this up into something cleaner, and make it clear that when calling R APIs that set `errno` we need to explicitly grab it from `msvcrt.dll`.