### PR TITLE
Fix issue with persistent scrollbars on macOS

### DIFF
--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -275,6 +275,15 @@ int main(int argc, char* argv[])
       arguments.push_back(noSandbox);
 #endif
 
+#ifdef Q_OS_MAC
+      // don't prefer compositing to LCD text rendering. when enabled, this causes the compositor to
+      // be used too aggressively on Retina displays on macOS, with the side effect that the
+      // scrollbar doesn't auto-hide because a compositor layer is present.
+      // https://github.com/rstudio/rstudio/issues/1953
+      static char disableCompositorPref[] = "--disable-prefer-compositing-to-lcd-text";
+      arguments.push_back(disableCompositorPref);
+#endif
+
       // re-assign command line arguments
       argc = (int) arguments.size();
       argv = &arguments[0];

--- a/src/cpp/desktop/DesktopWebPage.cpp
+++ b/src/cpp/desktop/DesktopWebPage.cpp
@@ -52,12 +52,6 @@ WebPage::WebPage(QUrl baseUrl, QWidget *parent, bool allowExternalNavigate) :
    settings()->setAttribute(QWebEngineSettings::JavascriptCanAccessClipboard, true);
    settings()->setAttribute(QWebEngineSettings::LocalStorageEnabled, true);
    
-#ifdef Q_OS_MAC
-   // disable scrollbars entirely for now as otherwise they persist indefinitely
-   // and look terribly ugly (pending a better fix / workaround)
-   settings()->setAttribute(QWebEngineSettings::ShowScrollBars, false);
-#endif
-
    defaultSaveDir_ = QDir::home();
    connect(this, SIGNAL(windowCloseRequested()), SLOT(closeRequested()));
 }


### PR DESCRIPTION
This change fixes #1953, in which auto-hide scrollbars don't actually auto-hide on macOS (they are always visible).

The actual issue is fairly deep inside Chromium. Overlay scrollbars are painted on a second painting pass so that they're painted on top of other UI. However, this second pass does not occur when using the compositor, because the compositor defines a separate layer for scrollbar painting. Unfortunately the alpha animation that shows and hides the scrollbar is only painted during this 2nd pass, so using the compositor causes the animation to run but not paint, with the result that the scrollbar gets stuck in the fully opaque state.

The fix here is more of a workaround. Chromium has a preference which allows you to choose whether you'd prefer better text rendering (LCD text subpixel rendering/antialiasing) or using the compositor, which can be faster. The default is to use the faster but less accurate compositor. Switching the default to prefer better text rendering has the side effect of keeping us out of the problematic compositor codepath. 