### PR TITLE
enable more warnings with new gcc

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -104,6 +104,17 @@ if(UNIX)
       set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie -Wl,-z,relro,-z,now")
    endif()
 
+   # other useful gcc diagnostics
+   if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      add_definitions(-Wlogical-op)
+      if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0.0)
+         add_definitions(-Wduplicated-cond)
+         add_definitions(-Wduplicated-branches)
+         add_definitions(-Wrestrict)
+         add_definitions(-Wnull-dereference)
+      endif()
+   endif()
+
 # Win32 specific global directives
 else()
 


### PR DESCRIPTION
Closes #2346. Will be useful when Ubuntu 18.04 is released and compilation is attempted there (e.g. for dev machines)