### PR TITLE
provide fallback fonts

### DIFF
--- a/src/cpp/desktop/DesktopOptions.cpp
+++ b/src/cpp/desktop/DesktopOptions.cpp
@@ -204,11 +204,8 @@ QString Options::fixedWidthFont() const
 #endif
            ;
 
-   // The fallback font is Courier, not monospace, because QtWebKit doesn't
-   // actually provide a monospace font (appears to use Helvetica)
-
    return detectedFont = QString::fromUtf8("\"") +
-         findFirstMatchingFont(fontList, QString::fromUtf8("Courier"), true) +
+         findFirstMatchingFont(fontList, QString::fromUtf8("monospace"), true) +
          QString::fromUtf8("\"");
 }
 

--- a/src/gwt/src/org/rstudio/core/client/theme/ThemeFonts.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ThemeFonts.java
@@ -26,12 +26,12 @@ public class ThemeFonts
    
    public static String getProportionalFont()
    {
-      return fontLoader.getProportionalFont();
+      return fontLoader.getProportionalFont() + ", serif";
    }
 
    public static String getFixedWidthFont()
    {
-      return fontLoader.getFixedWidthFont();
+      return fontLoader.getFixedWidthFont() + ", monospace";
    }
 
    static interface ThemeFontLoader


### PR DESCRIPTION
This PR should fix https://github.com/rstudio/rstudio/issues/2266, and should also help ensure that, in the case where a user has specified a font that may no longer exist or is not loadable for another reason, we fall back to an appropriate font.