### PR TITLE
fix rstudio-tests script so --help works

### DIFF
--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -11,7 +11,7 @@ checkUnitTestFailure() {
 TEST_SCOPE=
 if [ "$1" == "--scope" ]; then 
    if [ "$#" == 1 ]; then 
-      printf "Specify scope (core, session, or r).\n"
+      printf "Specify scope (core, rsession, or r).\n"
       exit 1
    fi
 
@@ -28,11 +28,11 @@ elif [ "$1" == "--filter" ]; then
    shift 2
 
 elif [ "$1" == "--help" ]; then 
-   printf "Runs RStudio unit tests. Available flags: \n\n"
-   printf "--help    Show this help\n"
-   printf "--scope   Run only tests with the given scope (core, rsession, or r)\n\n"
-   printf "--filter  Used instead of --scope to run a subset of R tests\n\n"
-   printf "Any other options are passed to Valgrind."
+   printf "%s\n\n" "Runs RStudio unit tests. Available flags: "
+   printf "%s\n" "--help    Show this help"
+   printf "%s\n" "--scope   Run only tests with the given scope (core, rsession, or r)"
+   printf "%s\n\n" "--filter  Used instead of --scope to run a subset of R tests"
+   printf "%s\n" "Any other options are passed to Valgrind."
    exit 0
 fi
 


### PR DESCRIPTION
On my Mac, with stock bash (4.4.12), `rstudio-tests --help` gave this error:

```
gary@Garys-MacBook-Pro:~/rstudio/build$ ./rstudio-tests --help
Runs RStudio unit tests. Available flags:

./rstudio-tests: line 32: printf: --: invalid option
printf: usage: printf [-v var] format [arguments]
./rstudio-tests: line 33: printf: --: invalid option
printf: usage: printf [-v var] format [arguments]
./rstudio-tests: line 34: printf: --: invalid option
printf: usage: printf [-v var] format [arguments]
```