### PR TITLE
don't reindent python code on paste

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/PythonFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/PythonFileType.java
@@ -40,7 +40,7 @@ public class PythonFileType extends TextFileType
             false, // knit to HTML
             false, // compile PDF
             false, // execute chunks
-            true,  // auto-indent
+            false,  // auto-indent
             false, // check spelling
             false, // scope tree
             false  // preview from R


### PR DESCRIPTION
In at least one instance this actually breaks the code by overindenting if statements (possibly a bug in the Ace Python autoindenter?): https://raw.githubusercontent.com/datalogue/keras-attention/master/models/tdd.py

Note that there are other code oriented commands that should probably also be disabled for Python files:

<img width="685" alt="screen shot 2018-03-19 at 8 41 06 am" src="https://user-images.githubusercontent.com/104391/37596122-86ff26e2-2b51-11e8-9777-22ec022dd53f.png">

@kevinushey 