### PR TITLE
Minor mechanical C++11-isms on a handful of source files

### DIFF
--- a/src/cpp/core/GitGraph.cpp
+++ b/src/cpp/core/GitGraph.cpp
@@ -1,7 +1,7 @@
 /*
  * GitGraph.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,9 +17,6 @@
 #include <algorithm>
 
 #include <core/GitGraph.hpp>
-
-#include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/SafeConvert.hpp>
 
@@ -92,12 +89,12 @@ Line GitGraph::addCommit(const std::string& commit,
    // If this commit isn't the parent of a previously seen node, then we'll
    // definitely be adding one or more columns to the right of all the
    // existing columns.
-   Line::iterator insertNewColumnsAt = pendingLine_.end();
+   auto insertNewColumnsAt = pendingLine_.end();
 
    // Counts how many of the parents have been assigned to columns.
    size_t parentsUsed = 0;
 
-   for (Line::iterator it = pendingLine_.begin();
+   for (auto it = pendingLine_.begin();
         it != pendingLine_.end();
         it++)
    {
@@ -147,12 +144,12 @@ Line GitGraph::addCommit(const std::string& commit,
     */
 
    // First remove all columns that have empty postCommit--these terminated.
-   Line::iterator newEnd = std::remove_if(
+   auto newEnd = std::remove_if(
          pendingLine_.begin(), pendingLine_.end(), &isColumnTerminating);
    pendingLine_.erase(newEnd, pendingLine_.end());
 
    // Now copy all of the postCommits to preCommit.
-   BOOST_FOREACH(Column& column, pendingLine_)
+   for (auto& column : pendingLine_)
    {
       column.preCommit = column.postCommit;
    }

--- a/src/cpp/core/ProgramOptions.cpp
+++ b/src/cpp/core/ProgramOptions.cpp
@@ -1,7 +1,7 @@
 /*
  * ProgramOptions.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,15 +15,11 @@
 
 #include <core/ProgramOptions.hpp>
 
-#include <string>
 #include <iostream>
-
-#include <boost/foreach.hpp>
 
 #include <core/Error.hpp>
 #include <core/Log.hpp>
 #include <core/FilePath.hpp>
-#include <core/ProgramStatus.hpp>
 #include <core/system/System.hpp>
 
 using namespace boost::program_options ;
@@ -39,8 +35,7 @@ bool validateOptionsProvided(const variables_map& vm,
                              const options_description& optionsDescription,
                              const std::string& configFile = std::string())
 {
-   BOOST_FOREACH( const boost::shared_ptr<option_description>& pOptionsDesc, 
-                  optionsDescription.options() )
+   for (const auto& pOptionsDesc : optionsDescription.options())
    {
       std::string optionName = pOptionsDesc->long_name();
       if ( !(vm.count(optionName)) )
@@ -87,14 +82,14 @@ void parseCommandLine(variables_map& vm,
    command_line_parser parser(argc, const_cast<char**>(argv));
    parser.options(commandLineOptions);
    parser.positional(optionsDescription.positionalOptions);
-   if (pUnrecognized != NULL)
+   if (pUnrecognized != nullptr)
       parser.allow_unregistered();
    parsed_options parsed = parser.run();
    store(parsed, vm);
    notify(vm) ;
 
    // collect unrecognized if necessary
-   if (pUnrecognized != NULL)
+   if (pUnrecognized != nullptr)
    {
       *pUnrecognized = collect_unrecognized(parsed.options,
                                             include_positional);

--- a/src/cpp/core/include/core/GitGraph.hpp
+++ b/src/cpp/core/include/core/GitGraph.hpp
@@ -1,7 +1,7 @@
 /*
  * GitGraph.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -55,8 +55,6 @@ public:
    // Prints out a machine-parsable string representation of this row
    std::string string() const;
 };
-
-typedef std::vector<Line> Lines;
 
 // Encapsulates the state and logic used to build up a graph,
 // based on repeated calls with commit-and-parent info.

--- a/src/cpp/core/system/ChildProcessSubprocPoll.cpp
+++ b/src/cpp/core/system/ChildProcessSubprocPoll.cpp
@@ -1,7 +1,7 @@
 /*
  * ChildProcessSubprocPoll.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,8 +14,6 @@
  */
 
 #include "ChildProcessSubprocPoll.hpp"
-
-#include <boost/foreach.hpp>
 
 namespace rstudio {
 namespace core {
@@ -120,10 +118,10 @@ bool ChildProcessSubprocPoll::pollSubproc(boost::posix_time::ptime currentTime)
    hasSubprocess_ = false;
    hasWhitelistSubprocess_ = false;
    std::vector<SubprocInfo> children = subProcCheck_(pid_);
-   BOOST_FOREACH(SubprocInfo proc, children)
+   for (const SubprocInfo& proc : children)
    {
       bool isWhitelistItem = false;
-      BOOST_FOREACH(std::string whitelistItem, subProcWhitelist_)
+      for (const auto& whitelistItem : subProcWhitelist_)
       {
          if (proc.exe == whitelistItem)
          {

--- a/src/cpp/core/system/Environment.cpp
+++ b/src/cpp/core/system/Environment.cpp
@@ -1,7 +1,7 @@
 /*
  * Environment.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,10 +15,7 @@
 
 #include <core/system/Environment.hpp>
 
-#include <algorithm>
-
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 
 #ifdef _WIN32
 #define kPathSeparator ";"
@@ -54,7 +51,7 @@ std::string getenv(const Options& environment, const std::string& name)
 void getModifiedEnv(const Options& extraVars, Options* pEnv)
 {
    core::system::environment(pEnv);
-   BOOST_FOREACH(const Option& var, extraVars)
+   for (const auto& var : extraVars)
    {
       core::system::setenv(pEnv, var.first, var.second);
    }

--- a/src/cpp/session/modules/SessionTerminalShell.cpp
+++ b/src/cpp/session/modules/SessionTerminalShell.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionTerminalShell.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,12 +15,8 @@
 
 #include <session/SessionTerminalShell.hpp>
 
-#include <boost/foreach.hpp>
-
 #include <core/Algorithm.hpp>
 #include <core/system/System.hpp>
-#include <core/Log.hpp>
-#include <core/Error.hpp>
 
 #include <session/SessionUserSettings.hpp>
 #include "SessionGit.hpp"
@@ -199,7 +195,7 @@ AvailableTerminalShells::AvailableTerminalShells()
 
 void AvailableTerminalShells::toJson(core::json::Array* pArray) const
 {
-   BOOST_FOREACH(const TerminalShell& shell, shells_)
+   for (const auto& shell : shells_)
    {
       pArray->push_back(shell.toJson());
    }
@@ -220,7 +216,7 @@ bool AvailableTerminalShells::getInfo(TerminalShell::TerminalShellType type,
          }
       }
    }
-   BOOST_FOREACH(const TerminalShell& shell, shells_)
+   for (const auto& shell : shells_)
    {
       if (shell.type == type)
       {
@@ -265,8 +261,8 @@ bool AvailableTerminalShells::getSystemShell(TerminalShell* pShellInfo)
    pShellInfo->name = "Bash";
    pShellInfo->type = TerminalShell::PosixBash;
    pShellInfo->path = core::FilePath("/usr/bin/env");
-   pShellInfo->args.push_back("bash");
-   pShellInfo->args.push_back("-l"); // act like a login shell
+   pShellInfo->args.emplace_back("bash");
+   pShellInfo->args.emplace_back("-l"); // act like a login shell
 #endif
    return true;
 }


### PR DESCRIPTION
- replace BOOST_FOREACH's with range-based for (they burn my eyes but will wait for start of 1.3 for a global replacement of these)
- remove unnecessary #includes
- in ChildProcessSubprocPoll, use const& iterators in whitelist checking to reduce object copies in nested loop
- auto for some iterator variables
- raw string literal for a regex string
- NULL to nullptr
- emplace_back to construct strings in place when adding "..." to a vector<string>