### PR TITLE
Fix issue with console carriage-return processing mixed with ANSI codes

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -260,7 +260,7 @@ public class VirtualConsole
                   parent_.insertAfter(range.element, overlap.element);
             }
          }
-         else if (start <= l && end <= r && end >= l)
+         else if (start <= l && end <= r && end > l)
          {
             // overlapping on the right side of the new range
             int delta = end - l;

--- a/src/gwt/test/org/rstudio/core/client/VirtualConsoleTests.java
+++ b/src/gwt/test/org/rstudio/core/client/VirtualConsoleTests.java
@@ -755,4 +755,50 @@ public class VirtualConsoleTests extends GWTTestCase
       Assert.assertEquals("<span>We are building sites \342\200\246</span>", ele.getInnerHTML());
       Assert.assertEquals("We are building sites \342\200\246", vc.toString());       
    }
+
+   public void testMultiCarriageReturnsWithoutColorsMultiSubmits()
+   {
+      PreElement ele = Document.get().createPreElement();
+      VirtualConsole vc = new VirtualConsole(ele);
+      vc.submit("123");
+      vc.submit("x \r");
+      vc.submit("456");
+      vc.submit("x \r");
+      vc.submit("789");
+      Assert.assertEquals("<span>789x </span>", ele.getInnerHTML());
+      Assert.assertEquals("789x ", vc.toString());
+   }
+   
+   public void testMultiCarriageReturnWithoutColors()
+   {
+      PreElement ele = Document.get().createPreElement();
+      VirtualConsole vc = new VirtualConsole(ele);
+      vc.submit("123" + "x \r" + "456" + "x \r" + "789");
+      Assert.assertEquals("<span>789x </span>", ele.getInnerHTML());
+      Assert.assertEquals("789x ", vc.toString());
+   }
+
+   public void testMultiCarriageReturnWithColors()
+   {
+      // https://github.com/rstudio/rstudio/issues/2387
+      // cat(c(crayon::red("123"), "x \r", crayon::red("456"), "x \r", crayon::red("789\n")), sep = "")
+      String red = AnsiCode.CSI + AnsiCode.ForeColorNum.RED + AnsiCode.SGR;
+      String reset = AnsiCode.CSI + AnsiCode.RESET_FOREGROUND + AnsiCode.SGR;
+      
+      PreElement ele = Document.get().createPreElement();
+      VirtualConsole vc = new VirtualConsole(ele);
+      vc.submit(red + "123" + reset + "x \r" +
+                red + "456" + reset + "x \r" +
+                red + "789");
+      
+      Debug.logToConsole("InnerHtml=[" + ele.getInnerHTML() + "]");
+      Debug.logToConsole("String=[" + vc.toString() + "]");
+      
+      String expected = 
+            "<span class=\"" + AnsiCode.clazzForColor(AnsiCode.ForeColorNum.RED) +
+            "\">789</span><span>x </span>"; 
+      
+      Assert.assertEquals(expected, ele.getInnerHTML());
+      Assert.assertEquals("789x ", vc.toString());
+   }
 }


### PR DESCRIPTION
Fixes #2387

Off-by-one boundary issue with VirtualConsole will create empty spans in this situation, which prevents proper handling of \r.

This is finicky code, but lots of unit-test coverage, and I added more for this scenario.

FYI @gaborcsardi
