### PR TITLE
fix opening of files on desktop

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -504,11 +504,6 @@ QString GwtCallback::fixedWidthFont()
    return options().fixedWidthFont();
 }
 
-QString GwtCallback::getUriForPath(QString path)
-{
-   return QUrl::fromLocalFile(resolveAliasedPath(path)).toString();
-}
-
 void GwtCallback::onWorkbenchInitialized(QString scratchPath)
 {
    workbenchInitialized();

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -100,7 +100,6 @@ public Q_SLOTS:
    QJsonObject getCursorPosition();
    bool doesWindowExistAtCursorPosition();
 
-   QString getUriForPath(QString path);
    void onWorkbenchInitialized(QString scratchPath);
    void showFolder(QString path);
    void showFile(QString path);

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -129,6 +129,9 @@ void handleClientInit(const boost::function<void()>& initFunction,
    // R_LIBS_USER
    sessionInfo["r_libs_user"] = module_context::rLibsUser();
    
+   // user home path
+   sessionInfo["user_home_path"] = session::options().userHomePath().absolutePath();
+   
    // installed client version
    sessionInfo["client_version"] = http_methods::clientVersion();
    

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -67,7 +67,6 @@ public interface DesktopFrame extends JavaScriptPassthrough
    void doesWindowExistAtCursorPosition(CommandWithArg<Boolean> callback);
    void getCursorPosition(CommandWithArg<Point> callback);
    
-   String getUriForPath(String path);
    void onWorkbenchInitialized(String scratchDir);
    void showFolder(String path);
    void showFile(String path);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -56,6 +56,10 @@ public class SessionInfo extends JavaScriptObject
    public final native String getUserIdentity() /*-{
       return this.userIdentity;
    }-*/;
+   
+   public final native String getUserHomePath() /*-{
+      return this.user_home_path;
+   }-*/;
 
    public final native String getSessionId() /*-{
       return this.session_id;
@@ -550,4 +554,5 @@ public class SessionInfo extends JavaScriptObject
    public final native String getRLibsUser() /*-{
       return this.r_libs_user;
    }-*/;
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -57,10 +57,6 @@ public class SessionInfo extends JavaScriptObject
       return this.userIdentity;
    }-*/;
    
-   public final native String getUserHomePath() /*-{
-      return this.user_home_path;
-   }-*/;
-
    public final native String getSessionId() /*-{
       return this.session_id;
    }-*/;


### PR DESCRIPTION
This PR commits one of the cardinal sins: it teaches the client-side what the user's home path is. In this case, it's necessary to do so as otherwise we're stuck threading through a lot of asynchronous code into codepaths that are otherwise synchronous, or we take on the task of figuring out a way to thread client-side aliased paths into window opening APIs (which feels rather dicey).

Teaching the client-side the user's home directory for this particular usage seemed like the lowest-friction way of resolving.

Fixes https://github.com/rstudio/rstudio/issues/2440, https://github.com/rstudio/rstudio/issues/2156.