### PR TITLE
toggle enabledness of cut/copy/paste according to context

### DIFF
--- a/src/cpp/desktop/DesktopWebView.cpp
+++ b/src/cpp/desktop/DesktopWebView.cpp
@@ -15,6 +15,8 @@
 
 #include "DesktopWebView.hpp"
 
+#include <QApplication>
+#include <QClipboard>
 #include <QMenu>
 #include <QNetworkReply>
 #include <QStyleFactory>
@@ -168,16 +170,23 @@ void WebView::contextMenuEvent(QContextMenuEvent* event)
    }
    else
    {
-      if (!data.selectedText().isEmpty())
-      {
-         if (data.isContentEditable())
-         {
-            menu->addAction(webPage()->action(QWebEnginePage::Cut));
-         }
-         menu->addAction(webPage()->action(QWebEnginePage::Copy));
-      }
-
-      menu->addAction(webPage()->action(QWebEnginePage::Paste));
+      // always show cut / copy / paste, but only enable cut / copy if there
+      // is some selected text, and only enable paste if there is something
+      // on the clipboard. note that this isn't perfect -- the highlighted
+      // text may not correspond to the context menu click target -- but
+      // in general users who want to copy text will right-click on the
+      // selection, rather than elsewhere on the screen.
+      auto* cut   = webPage()->action(QWebEnginePage::Cut);
+      auto* copy  = webPage()->action(QWebEnginePage::Copy);
+      auto* paste = webPage()->action(QWebEnginePage::Paste);
+      
+      cut->setEnabled(data.isContentEditable() && !data.selectedText().isEmpty());
+      copy->setEnabled(!data.selectedText().isEmpty());
+      paste->setEnabled(QApplication::clipboard()->mimeData()->hasText());
+      
+      menu->addAction(cut);
+      menu->addAction(copy);
+      menu->addAction(paste);
       menu->addSeparator();
       menu->addAction(webPage()->action(QWebEnginePage::SelectAll));
    }


### PR DESCRIPTION
This PR ensures that we always show Cut / Copy / Paste in the context menu, but toggle the command enabled-ness based on whether there is some selected text (and that text is writable), or whether there is anything paste-able on the clipboard.

I think this is better than simply hiding the commands as it keeps the size + structure of the context menu more consistent, and the Paste command looks rather lonely when it's the only entry in the context menu.

![screen shot 2018-03-21 at 9 16 27 am](https://user-images.githubusercontent.com/1976582/37722167-8dabfdf6-2ce8-11e8-9e36-6ef9a25f9c65.png)

Note that 'Reload' and 'Inspect Element' are still only shown in development configurations.