### PR TITLE
tweak rsc deploy dialog for desktop

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.css
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.css
@@ -15,6 +15,21 @@
  
 @external .gwt-CheckBox;
 
+@if rstudio.desktop true {
+@def appDetailsWidth 250px
+@def accountListWidth 262px
+@def deployIllustrationMarginLeft 12px
+} @else {
+@def appDetailsWidth 238px
+@def accountListWidth 250px
+@def deployIllustrationMarginLeft 0
+}
+
+.deployIllustration
+{
+   margin-left: deployIllustrationMarginLeft;
+}
+
 .sourceDestLabels
 {
    color: #808080;
@@ -128,7 +143,7 @@
 .accountList
 {
    height: 100px;
-   width: 250px;
+   width: accountListWidth;
 }
 
 .accountList.accountListCondensed
@@ -173,7 +188,7 @@
    padding: 5px;
    margin: 0px;
    overflow: hidden;
-   width: 238px;
+   width: appDetailsWidth;
 }
 
 .appDetailsPanel 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -97,6 +97,7 @@ public class RSConnectDeploy extends Composite
       String appErrorPanel();
       String appWarningIcon();
       String controlLabel();
+      String deployIllustration();
       String deployLabel();
       String descriptionPanel();
       String fileList();


### PR DESCRIPTION
This PR ensures that the dialog elements for the RStudio Connect dialog are nicely aligned.

Before:

![screen shot 2018-03-22 at 4 16 40 pm](https://user-images.githubusercontent.com/1976582/37803520-6e9f1e84-2dec-11e8-8e41-6bbf5dc8c44f.png)

After:

![screen shot 2018-03-22 at 4 14 58 pm](https://user-images.githubusercontent.com/1976582/37803501-5502dcc2-2dec-11e8-86ac-dee9a6219234.png)
