### PR TITLE
Fix issues with Cmd+W on macOS

### DIFF
--- a/src/cpp/desktop/DesktopGwtWindow.cpp
+++ b/src/cpp/desktop/DesktopGwtWindow.cpp
@@ -118,6 +118,22 @@ bool GwtWindow::event(QEvent* pEvent)
    return BrowserWindow::event(pEvent);
 }
 
+void GwtWindow::onCloseWindowShortcut()
+{
+   // check to see if the window has desktop hooks (not all GWT windows do); if it does, check to
+   // see whether it has a closeSourceDoc() command we should be executing instead
+   webPage()->runJavaScript(
+            QStringLiteral(
+               "if (window.desktopHooks) "
+               " window.desktopHooks.isCommandEnabled('closeSourceDoc');"
+               "else false"),
+            [&](QVariant closeSourceDocEnabled)
+   {
+      if (!closeSourceDocEnabled.toBool())
+         close();
+   });
+}
+
 
 } // namespace desktop
 } // namespace rstudio

--- a/src/cpp/desktop/DesktopGwtWindow.hpp
+++ b/src/cpp/desktop/DesktopGwtWindow.hpp
@@ -1,7 +1,7 @@
 /*
  * DesktopGwtWindow.hpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -34,6 +34,7 @@ public:
    const std::vector<double>& zoomLevels() const { return zoomLevels_; }
 
 public Q_SLOTS:
+   void onCloseWindowShortcut();
    void zoomActualSize();
    void zoomIn();
    void zoomOut();

--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -168,17 +168,6 @@ void MainWindow::launchRStudio(const std::vector<std::string> &args,
     pAppLauncher_->launchRStudio(args, initialDir);
 }
 
-void MainWindow::onCloseWindowShortcut()
-{
-   webPage()->runJavaScript(
-            QStringLiteral("window.desktopHooks.isCommandEnabled('closeSourceDoc')"),
-            [&](QVariant closeSourceDocEnabled)
-   {
-      if (!closeSourceDocEnabled.toBool())
-         close();
-   });
-}
-
 void MainWindow::onWorkbenchInitialized()
 {
    //QTimer::singleShot(300, this, SLOT(resetMargins()));

--- a/src/cpp/desktop/DesktopMainWindow.hpp
+++ b/src/cpp/desktop/DesktopMainWindow.hpp
@@ -60,7 +60,6 @@ Q_SIGNALS:
    void firstWorkbenchInitialized();
 
 protected Q_SLOTS:
-   void onCloseWindowShortcut();
    void onWorkbenchInitialized();
    void resetMargins();
    void commitDataRequest(QSessionManager &manager);

--- a/src/cpp/desktop/DesktopSatelliteWindow.cpp
+++ b/src/cpp/desktop/DesktopSatelliteWindow.cpp
@@ -43,11 +43,6 @@ SatelliteWindow::SatelliteWindow(MainWindow* pMainWindow, QString name) :
    connect(zoomOutShortcut, SIGNAL(activated()), this, SLOT(zoomOut()));
 }
 
-void SatelliteWindow::onCloseWindowShortcut()
-{
-   close();
-}
-
 void SatelliteWindow::finishLoading(bool ok)
 {
    BrowserWindow::finishLoading(ok);

--- a/src/cpp/desktop/DesktopSatelliteWindow.hpp
+++ b/src/cpp/desktop/DesktopSatelliteWindow.hpp
@@ -47,7 +47,6 @@ public Q_SLOTS:
 
 
 protected Q_SLOTS:
-   void onCloseWindowShortcut();
    void finishLoading(bool ok) override;
 
 protected:

--- a/src/cpp/desktop/DesktopWebView.cpp
+++ b/src/cpp/desktop/DesktopWebView.cpp
@@ -95,7 +95,23 @@ QString WebView::promptForFilename(const QNetworkRequest& request,
 
 void WebView::keyPressEvent(QKeyEvent* pEvent)
 {
+#ifdef Q_OS_MAC
+   if (pEvent->key() == Qt::Key_W &&
+       pEvent->modifiers() == Qt::CTRL)
+   {
+      // on macOS, intercept Cmd+W and emit the window close signal
+      onCloseWindowShortcut();
+   }
+   else
+   {
+      // pass other key events through to WebEngine
+      QWebEngineView::keyPressEvent(pEvent);
+   }
+#else
+
    QWebEngineView::keyPressEvent(pEvent);
+   
+#endif
 }
 
 void WebView::openFile(QString fileName)
@@ -132,6 +148,14 @@ qreal WebView::dpiAwareZoomFactor()
 
 bool WebView::event(QEvent* event)
 {
+   if (event->type() == QEvent::ShortcutOverride)
+   {
+      // take a first crack at shortcuts
+      QKeyEvent *pKeyEvent = dynamic_cast<QKeyEvent*>(event);
+      if (pKeyEvent != nullptr)
+         keyPressEvent(pKeyEvent);
+      return true;
+   }
    return this->QWebEngineView::event(event);
 }
 

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -847,8 +847,12 @@ void registerGwtHandlers()
    // initialize gwt symbol maps
    gwt::initializeSymbolMaps(options.wwwSymbolMapsPath());
 
+   // declare program mode in JS init block (for GWT boot time access)
+   std::string initJs = "window.program_mode = \"" + options.programMode() + "\";\n";
+
    // set default handler
-   s_defaultUriHandler = gwt::fileHandlerFunction(options.wwwLocalPath(), "/");
+   s_defaultUriHandler = gwt::fileHandlerFunction(options.wwwLocalPath(), "/",
+         http::UriFilterFunction(), initJs);
 }
 
 std::string nextSessionUrl()

--- a/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
@@ -107,7 +107,7 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
    
    public AppCommand()
    {
-      if (Desktop.isDesktop())
+      if (Desktop.isDesktopReady())
       {
          addEnabledChangedHandler((command) ->
             DesktopMenuCallback.setCommandEnabled(id_, enabled_));
@@ -386,7 +386,7 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
       menuLabel_ = menuLabel;
 
       // sync with desktop frame
-      if (Desktop.isDesktop())
+      if (Desktop.isDesktopReady())
          DesktopMenuCallback.setCommandLabel(id_, menuLabel_);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/application/Desktop.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Desktop.java
@@ -1,7 +1,7 @@
 /*
  * Desktop.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,6 +19,12 @@ import com.google.gwt.core.client.GWT;
 public class Desktop
 {
    public static native boolean isDesktop() /*-{
+      // we're in desktop mode if the program mode is explicitly set that way;
+      // as a fallback, check for the desktop object injected by Qt
+      return $wnd.program_mode === "desktop" || !!$wnd.desktop;
+   }-*/;
+   
+   public static native boolean isDesktopReady() /*-{
       return !!$wnd.desktop;
    }-*/;
 


### PR DESCRIPTION
On macOS, Cmd+W is overloaded. In the main window and source windows, it closes source documents. In other windows, *and* in the main window/source window when no docs are open, it closes the whole window.

This has been broken since the QtWebEngine transition. Fixing it turned out to involve solving three problems.

### keyEvent handlers not called

Because our `WebView::event` override delegates directly to `QtWebEngineView`, our `keyEvent` handler never gets called. Now, we check for an override event, and on macOS we take the opportunity to implement our own Qt key handling.

### isDesktop is not reliable during GWT startup

We use `isDesktop()` all over the place, but it relies on `window.desktop` being present. In QtWebEngine, that object is now injected asynchronously and may not be available during GWT startup. Consequently, some code that runs on startup thinks that it's in server mode. 

In other words, `isDesktop` conflates two different questions: "am I in desktop mode?" and "can I talk to the WebChannel"? These are now two different functions: `isDesktop` checks for a new static variable that is available synchronously, and `isDesktopReady` checks for the asynchronously available WebChannel.

### Source window is closed on Cmd + W

Source Windows are satellites, and they closed without condition `onCloseWindowShortcut()`. This meant that you couldn't close individual documents in a source window with Cmd + W (it just closed the whole window). 

The code which checks `onCloseSourceDoc` has been moved back to `GwtWindow`, so it's shared among the source and main windows (and several others which don't need it, so it's been tweaked slightly so the window itself can tell us whether it needs the check). 

Fixes #2301. 