### PR TITLE
ensure RStudio window activated on launch

### DIFF
--- a/src/cpp/desktop/DesktopWin32ApplicationLaunch.cpp
+++ b/src/cpp/desktop/DesktopWin32ApplicationLaunch.cpp
@@ -91,7 +91,10 @@ void ApplicationLaunch::setActivationWindow(QWidget* pWindow)
 
 void ApplicationLaunch::activateWindow()
 {
-   activate((HWND)winId());
+   if (pMainWindow_)
+      activate((HWND) pMainWindow_->winId());
+   else
+      activate((HWND) winId());
 }
 
 QString ApplicationLaunch::startupOpenFileRequest() const
@@ -151,12 +154,7 @@ bool ApplicationLaunch::sendMessage(QString filename)
                                                        0));
       if (::IsWindow(hwnd))
       {
-         HWND hwndPopup = ::GetLastActivePopup(hwnd);
-         if (::IsWindow(hwndPopup))
-            hwnd = hwndPopup;
-         ::SetForegroundWindow(hwnd);
-         if (::IsIconic(hwnd))
-            ::ShowWindow(hwnd, SW_RESTORE);
+         activate(hwnd);
 
          if (!filename.isEmpty())
          {


### PR DESCRIPTION
Fixes https://github.com/rstudio/rstudio/issues/2502.

I have to admit I don't quite understand the mechanics around application / window launching on Windows -- hopefully someone else would be able to explain the whole ApplicationLaunch mechanism used here?