### PR TITLE
ensure commands are fired to associated window

### DIFF
--- a/src/cpp/desktop/DesktopBrowserWindow.cpp
+++ b/src/cpp/desktop/DesktopBrowserWindow.cpp
@@ -17,11 +17,65 @@
 
 #include <QApplication>
 #include <QToolBar>
+#include <QWebChannel>
+#include <QWebEngineScript>
+#include <QWebEngineScriptCollection>
 
+#include "DesktopInfo.hpp"
 #include "DesktopOptions.hpp"
 
 namespace rstudio {
 namespace desktop {
+
+namespace {
+
+void initializeWebchannel(BrowserWindow* pWindow)
+{
+   auto* page = pWindow->webView()->webPage();
+   
+   // create web channel
+   auto* channel = new QWebChannel(pWindow);
+   channel->registerObject(QStringLiteral("desktopInfo"), &desktopInfo());
+   page->setWebChannel(channel);
+   
+   // load qwebchannel.js
+   QFile webChannelJsFile(QStringLiteral(":/qtwebchannel/qwebchannel.js"));
+   if (!webChannelJsFile.open(QFile::ReadOnly))
+      qWarning() << "Failed to load qwebchannel.js";
+
+   QString webChannelJs = QString::fromUtf8(webChannelJsFile.readAll());
+   webChannelJsFile.close();
+
+   // append our WebChannel initialization code
+   const char* webChannelInit = 1 + R"EOF(
+new QWebChannel(qt.webChannelTransport, function(channel) {
+
+   // export channel objects to the main window
+   for (var key in channel.objects) {
+      window[key] = channel.objects[key];
+   }
+
+   // notify that we're finished initialization and load
+   // GWT sources if necessary
+   window.qt.webChannelReady = true;
+   if (typeof window.rstudioDelayLoadApplication == "function") {
+      window.rstudioDelayLoadApplication();
+      window.rstudioDelayLoadApplication = null;
+   }
+});
+   )EOF";
+
+   webChannelJs.append(QString::fromUtf8(webChannelInit));
+
+   QWebEngineScript script;
+   script.setName(QStringLiteral("qwebchannel"));
+   script.setInjectionPoint(QWebEngineScript::DocumentCreation);
+   script.setWorldId(QWebEngineScript::MainWorld);
+   script.setSourceCode(webChannelJs);
+   page->scripts().insert(script);
+}
+
+} // end anonymous namespace
 
 BrowserWindow::BrowserWindow(bool showToolbar,
                              bool adjustTitle,
@@ -41,7 +95,9 @@ BrowserWindow::BrowserWindow(bool showToolbar,
    connect(pView_, SIGNAL(titleChanged(QString)), SLOT(adjustTitle()));
    connect(pView_, SIGNAL(loadProgress(int)), SLOT(setProgress(int)));
    connect(pView_, SIGNAL(loadFinished(bool)), SLOT(finishLoading(bool)));
-
+   
+   initializeWebchannel(this);
+   
    // set zoom factor
    double zoomLevel = options().zoomLevel();
    pView_->setZoomFactor(zoomLevel);

--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -192,9 +192,14 @@ void MainWindow::invokeCommand(QString commandId)
 {
 #ifdef Q_OS_MAC
    QString fmt = QStringLiteral(R"EOF(
-      var wnd = window.$RStudio.last_focused_window || window;
-      wnd.desktopHooks.invokeCommand('%1')
-   )EOF");
+var wnd;
+try {
+   wnd = window.$RStudio.last_focused_window;
+} catch (e) {
+   wnd = window;
+}
+wnd.desktopHooks.invokeCommand('%1');
+)EOF");
 #else
    QString fmt = QStringLiteral("window.desktopHooks.invokeCommand('%1')");
 #endif

--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -17,8 +17,6 @@
 
 #include <QToolBar>
 #include <QWebChannel>
-#include <QWebEngineScript>
-#include <QWebEngineScriptCollection>
 
 #include <boost/bind.hpp>
 #include <boost/format.hpp>
@@ -45,48 +43,10 @@ MainWindow::MainWindow(QUrl url) :
 {
    pToolbar_->setVisible(false);
 
-   // create web channel and bind GWT callbacks
-   auto* channel = new QWebChannel(this);
+   // bind GWT callbacks
+   auto* channel = webPage()->webChannel();
    channel->registerObject(QStringLiteral("desktop"), &gwtCallback_);
-   channel->registerObject(QStringLiteral("desktopInfo"), &desktopInfo());
    channel->registerObject(QStringLiteral("desktopMenuCallback"), &menuCallback_);
-   webPage()->setWebChannel(channel);
-
-   // load qwebchannel.js
-   QFile webChannelJsFile(QStringLiteral(":/qtwebchannel/qwebchannel.js"));
-   if (!webChannelJsFile.open(QFile::ReadOnly))
-      qDebug() << "Failed to open qwebchannel.js!";
-
-   QString webChannelJs = QString::fromUtf8(webChannelJsFile.readAll());
-   webChannelJsFile.close();
-
-   // append our WebChannel initialization code
-   const char* webChannelInit = R"EOF(
-      new QWebChannel(qt.webChannelTransport, function(channel) {
-
-         // export channel objects to the main window
-         for (var key in channel.objects) {
-            window[key] = channel.objects[key];
-         }
-
-         // notify that we're finished initialization and load
-         // GWT sources if necessary
-         window.qt.webChannelReady = true;
-         if (typeof window.rstudioDelayLoadApplication == "function") {
-            window.rstudioDelayLoadApplication();
-            window.rstudioDelayLoadApplication = null;
-         }
-      });
-   )EOF";
-
-   webChannelJs.append(QString::fromUtf8(webChannelInit));
-
-   QWebEngineScript script;
-   script.setName(QStringLiteral("qwebchannel"));
-   script.setInjectionPoint(QWebEngineScript::DocumentCreation);
-   script.setWorldId(QWebEngineScript::MainWorld);
-   script.setSourceCode(webChannelJs);
-   webPage()->scripts().insert(script);
 
    // Dummy menu bar to deal with the fact that
    // the real menu bar isn't ready until well

--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -190,11 +190,16 @@ void MainWindow::quit()
 
 void MainWindow::invokeCommand(QString commandId)
 {
-   QString command =
-         QString::fromUtf8("window.desktopHooks.invokeCommand('") +
-         commandId +
-         QString::fromUtf8("');");
-
+#ifdef Q_OS_MAC
+   QString fmt = QStringLiteral(R"EOF(
+      var wnd = window.$RStudio.last_focused_window || window;
+      wnd.desktopHooks.invokeCommand('%1')
+   )EOF");
+#else
+   QString fmt = QStringLiteral("window.desktopHooks.invokeCommand('%1')");
+#endif
+   
+   QString command = fmt.arg(commandId);
    webPage()->runJavaScript(command);
 }
 

--- a/src/cpp/desktop/DesktopSatelliteWindow.cpp
+++ b/src/cpp/desktop/DesktopSatelliteWindow.cpp
@@ -16,6 +16,7 @@
 #include "DesktopSatelliteWindow.hpp"
 
 #include <QShortcut>
+#include <QWebChannel>
 
 namespace rstudio {
 namespace desktop {
@@ -31,6 +32,10 @@ SatelliteWindow::SatelliteWindow(MainWindow* pMainWindow, QString name) :
 
    setWindowIcon(QIcon(QString::fromUtf8(":/icons/RStudio.ico")));
 
+   // bind GWT callbacks
+   auto* channel = webPage()->webChannel();
+   channel->registerObject(QStringLiteral("desktop"), &gwtCallback_);
+   
    // satellites don't have a menu, so connect zoom keyboard shortcuts
    // directly
    // NOTE: CTRL implies META on macOS

--- a/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
@@ -184,9 +184,6 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
          enabled_ = enabled;
          handlers_.fireEvent(new EnabledChangedEvent(this));
       }
-    
-      if (Desktop.isDesktop())
-         DesktopMenuCallback.setCommandEnabled(id_, enabled_);
    }
 
    public boolean isVisible()
@@ -201,9 +198,6 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
          visible_ = visible;
          handlers_.fireEvent(new VisibleChangedEvent(this));
       }
-      
-      if (Desktop.isDesktop())
-         DesktopMenuCallback.setCommandVisible(id_, visible_);
    }
    
    /**

--- a/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
@@ -107,12 +107,10 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
    
    public AppCommand()
    {
-      if (Desktop.hasDesktopMenuCallbacks())
+      if (Desktop.isDesktop())
       {
-         addEnabledChangedHandler((command) ->
-            DesktopMenuCallback.setCommandEnabled(id_, enabled_));
-         addVisibleChangedHandler((command) ->
-            DesktopMenuCallback.setCommandVisible(id_, visible_));
+         addEnabledChangedHandler((command) -> DesktopMenuCallback.setCommandEnabled(id_, enabled_));
+         addVisibleChangedHandler((command) -> DesktopMenuCallback.setCommandVisible(id_, visible_));
       }
    }
 
@@ -186,6 +184,9 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
          enabled_ = enabled;
          handlers_.fireEvent(new EnabledChangedEvent(this));
       }
+    
+      if (Desktop.isDesktop())
+         DesktopMenuCallback.setCommandEnabled(id_, enabled_);
    }
 
    public boolean isVisible()
@@ -200,6 +201,9 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
          visible_ = visible;
          handlers_.fireEvent(new VisibleChangedEvent(this));
       }
+      
+      if (Desktop.isDesktop())
+         DesktopMenuCallback.setCommandVisible(id_, visible_);
    }
    
    /**
@@ -230,10 +234,9 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
    {
       if (!isCheckable())
          return;
+      
       checked_ = checked;
-
-      // sync desktop menus
-      if (Desktop.hasDesktopMenuCallbacks())
+      if (Desktop.isDesktop())
          DesktopMenuCallback.setCommandChecked(id_, checked_);
    }
 
@@ -384,9 +387,7 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
    public void setMenuLabel(String menuLabel)
    {
       menuLabel_ = menuLabel;
-
-      // sync with desktop frame
-      if (Desktop.hasDesktopMenuCallbacks())
+      if (Desktop.isDesktop())
          DesktopMenuCallback.setCommandLabel(id_, menuLabel_);
    }
 

--- a/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
@@ -107,7 +107,7 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
    
    public AppCommand()
    {
-      if (Desktop.isDesktopReady())
+      if (Desktop.hasDesktopMenuCallbacks())
       {
          addEnabledChangedHandler((command) ->
             DesktopMenuCallback.setCommandEnabled(id_, enabled_));
@@ -233,7 +233,7 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
       checked_ = checked;
 
       // sync desktop menus
-      if (Desktop.isDesktop())
+      if (Desktop.hasDesktopMenuCallbacks())
          DesktopMenuCallback.setCommandChecked(id_, checked_);
    }
 
@@ -386,7 +386,7 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
       menuLabel_ = menuLabel;
 
       // sync with desktop frame
-      if (Desktop.isDesktopReady())
+      if (Desktop.hasDesktopMenuCallbacks())
          DesktopMenuCallback.setCommandLabel(id_, menuLabel_);
    }
 

--- a/src/gwt/src/org/rstudio/core/client/command/impl/DesktopMenuCallback.java
+++ b/src/gwt/src/org/rstudio/core/client/command/impl/DesktopMenuCallback.java
@@ -18,6 +18,8 @@ import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.MenuCallback;
 
+import com.google.gwt.core.client.JavaScriptObject;
+
 public class DesktopMenuCallback implements MenuCallback
 {
    public native final void beginMainMenu() /*-{
@@ -60,20 +62,53 @@ public class DesktopMenuCallback implements MenuCallback
       $wnd.desktopMenuCallback.endMainMenu();
    }-*/;
    
-   public native static final void setCommandVisible(String commandId, boolean visible) /*-{
-      $wnd.desktopMenuCallback.setCommandVisible(commandId, visible);
+   public static final void setCommandVisible(String commandId, boolean visible)
+   {
+      setCommandVisibleImpl(commandId, visible, MENU_CALLBACKS);
+   }
+   
+   private native static final void setCommandVisibleImpl(String commandId, boolean visible, JavaScriptObject callbacks)
+   /*-{
+      callbacks.setCommandVisible(commandId, visible);
    }-*/;
 
-   public native static final void setCommandEnabled(String commandId, boolean enabled) /*-{
-      $wnd.desktopMenuCallback.setCommandEnabled(commandId, enabled);
+   public static final void setCommandEnabled(String commandId, boolean enabled)
+   {
+      setCommandEnabledImpl(commandId, enabled, MENU_CALLBACKS);
+   }
+   
+   private native static final void setCommandEnabledImpl(String commandId, boolean enabled, JavaScriptObject callbacks)
+   /*-{
+      callbacks.setCommandEnabled(commandId, enabled);
    }-*/;
 
-   public native static final void setCommandChecked(String commandId, boolean checked) /*-{
-      $wnd.desktopMenuCallback.setCommandChecked(commandId, checked);
+   public static final void setCommandChecked(String commandId, boolean checked)
+   {
+      setCommandCheckedImpl(commandId, checked, MENU_CALLBACKS);
+   }
+   
+   private native static final void setCommandCheckedImpl(String commandId, boolean checked, JavaScriptObject callbacks)
+   /*-{
+      callbacks.setCommandChecked(commandId, checked);
    }-*/;
 
-   public native static final void setCommandLabel(String commandId, String label) /*-{
+   public static final void setCommandLabel(String commandId, String label)
+   {
+      setCommandLabelImpl(commandId, label, MENU_CALLBACKS);
+   }
+   
+   private native static final void setCommandLabelImpl(String commandId, String label, JavaScriptObject callbacks)
+   /*-{
       label = @org.rstudio.core.client.command.AppMenuItem::replaceMnemonics(Ljava/lang/String;Ljava/lang/String;)(label, "&");
-      $wnd.desktopMenuCallback.setCommandLabel(commandId, label);
+      callbacks.setCommandLabel(commandId, label);
    }-*/;
+   
+   private static final native JavaScriptObject menuCallbacks()
+   /*-{
+      for (var window = $wnd; window != null; window = window.opener)
+         if (window.desktopMenuCallback)
+            return window.desktopMenuCallback;
+   }-*/;
+   
+   private static final JavaScriptObject MENU_CALLBACKS = menuCallbacks();
 }

--- a/src/gwt/src/org/rstudio/core/client/dom/WindowEx.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/WindowEx.java
@@ -26,11 +26,16 @@ import com.google.gwt.event.shared.GwtEvent;
 import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.event.shared.HasHandlers;
+import com.google.gwt.user.client.Window;
 
 import org.rstudio.core.client.Point;
 
 public class WindowEx extends JavaScriptObject
 {
+   public static native Window getNative() /*-{
+      return $wnd;
+   }-*/;
+   
    public static native WindowEx get() /*-{
       return $wnd;
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/application/Desktop.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Desktop.java
@@ -28,10 +28,6 @@ public class Desktop
       return !!$wnd.desktop;
    }-*/;
    
-   public static native boolean hasDesktopMenuCallbacks() /*-{
-      return !!$wnd.desktopMenuCallback;
-   }-*/;
-
    public static DesktopFrame getFrame()
    {
       return desktopFrame_;

--- a/src/gwt/src/org/rstudio/studio/client/application/Desktop.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Desktop.java
@@ -27,6 +27,10 @@ public class Desktop
    public static native boolean isDesktopReady() /*-{
       return !!$wnd.desktop;
    }-*/;
+   
+   public static native boolean hasDesktopMenuCallbacks() /*-{
+      return !!$wnd.desktopMenuCallback;
+   }-*/;
 
    public static DesktopFrame getFrame()
    {

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/Satellite.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/Satellite.java
@@ -192,11 +192,6 @@ public class Satellite implements HasCloseHandlers<Satellite>
             }),
             true);
       
-      // inherit desktop frame from opener
-      $wnd.desktop             = $wnd.opener.desktop;
-      $wnd.desktopInfo         = $wnd.opener.desktopInfo;
-      $wnd.desktopMenuCallback = $wnd.opener.desktopMenuCallback;
-
       // register (this will call the setSessionInfo back)
       $wnd.opener.registerAsRStudioSatellite(name, $wnd);
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/MainWindowObject.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/MainWindowObject.java
@@ -91,9 +91,21 @@ public class MainWindowObject<T>
    
    // Helper Classes ----
    
-   public static final MainWindowObject<String> lastFocusedEditor()
+   public static final MainWindowObject<Window> lastFocusedWindow()
    {
-      return new MainWindowObject<String>(LAST_FOCUSED_EDITOR, new DefaultProvider<String>()
+      return new MainWindowObject<Window>(LAST_FOCUSED_WINDOW, new DefaultProvider<Window>()
+      {
+         @Override
+         public Window defaultValue()
+         {
+            return null;
+         }
+      });
+   }
+   
+   public static final MainWindowObject<String> lastFocusedEditorId()
+   {
+      return new MainWindowObject<String>(LAST_FOCUSED_EDITOR_ID, new DefaultProvider<String>()
       {
          @Override
          public String defaultValue()
@@ -103,9 +115,9 @@ public class MainWindowObject<T>
       });
    }
    
-   public static final MainWindowObject<String> lastFocusedWindow()
+   public static final MainWindowObject<String> lastFocusedWindowId()
    {
-      return new MainWindowObject<String>(LAST_FOCUSED_WINDOW, new DefaultProvider<String>()
+      return new MainWindowObject<String>(LAST_FOCUSED_WINDOW_ID, new DefaultProvider<String>()
       {
          @Override
          public String defaultValue()
@@ -115,9 +127,9 @@ public class MainWindowObject<T>
       });
    }
    
-   public static final MainWindowObject<String> lastFocusedSourceWindow()
+   public static final MainWindowObject<String> lastFocusedSourceWindowId()
    {
-      return new MainWindowObject<String>(LAST_FOCUSED_SOURCE_WINDOW, new DefaultProvider<String>()
+      return new MainWindowObject<String>(LAST_FOCUSED_SOURCE_WINDOW_ID, new DefaultProvider<String>()
       {
          @Override
          public String defaultValue()
@@ -139,8 +151,11 @@ public class MainWindowObject<T>
       });
    }
    
-   private static final String LAST_FOCUSED_EDITOR        = "last_focused_editor";
-   private static final String LAST_FOCUSED_WINDOW        = "last_focused_window";
-   private static final String LAST_FOCUSED_SOURCE_WINDOW = "last_focused_source_window";
-   private static final String R_ADDINS                   = "r_addins";
+   // Private methods ----
+   
+   private static final String LAST_FOCUSED_WINDOW           = "last_focused_window";
+   private static final String LAST_FOCUSED_WINDOW_ID        = "last_focused_window_id";
+   private static final String LAST_FOCUSED_EDITOR_ID        = "last_focused_editor_id";
+   private static final String LAST_FOCUSED_SOURCE_WINDOW_ID = "last_focused_source_window_id";
+   private static final String R_ADDINS                      = "r_addins";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/MainWindowObject.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/MainWindowObject.java
@@ -98,7 +98,7 @@ public class MainWindowObject<T>
          @Override
          public Window defaultValue()
          {
-            return null;
+            return ownWindow();
          }
       });
    }
@@ -152,6 +152,8 @@ public class MainWindowObject<T>
    }
    
    // Private methods ----
+   
+   private static final native Window ownWindow() /*-{ return $wnd; }-*/;
    
    private static final String LAST_FOCUSED_WINDOW           = "last_focused_window";
    private static final String LAST_FOCUSED_WINDOW_ID        = "last_focused_window_id";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -2698,7 +2698,8 @@ well as menu structures (for main menu and popup menus).
         
    <cmd id="openDeveloperConsole"
         menuLabel="Open Developer Console"
-        rebindable="false"/>
+        rebindable="false"
+        windowMode="main"/>
         
    <cmd id="reloadUi"
         menuLabel="Reload UI"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -679,7 +679,7 @@ public class Source implements InsertSourceHandler,
    
    private boolean consoleEditorHadFocusLast()
    {
-      String id = MainWindowObject.lastFocusedEditor().get();
+      String id = MainWindowObject.lastFocusedEditorId().get();
       return "rstudio_console_input".equals(id);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -21,6 +21,7 @@ import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
+import com.google.gwt.event.dom.client.FocusEvent;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.CloseHandler;
@@ -50,6 +51,7 @@ import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.Handler;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.command.ShortcutManager;
+import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.events.*;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.js.JsObject;
@@ -610,6 +612,16 @@ public class Source implements InsertSourceHandler,
             }
          }
       });
+      
+      // on macOS, we need to aggressively re-sync commands when a new
+      // window is selected (since the main menu applies to both main
+      // window and satellites)
+      if (BrowseCap.isMacintoshDesktop())
+      {
+         WindowEx.addFocusHandler((FocusEvent event) -> {
+            manageCommands(true);
+         });
+      }
       
       restoreDocuments(session);
       
@@ -3556,6 +3568,11 @@ public class Source implements InsertSourceHandler,
 
    private void manageCommands()
    {
+      manageCommands(false);
+   }
+   
+   private void manageCommands(boolean forceSync)
+   {
       boolean hasDocs = editors_.size() > 0;
 
       commands_.closeSourceDoc().setEnabled(hasDocs);
@@ -3567,26 +3584,43 @@ public class Source implements InsertSourceHandler,
       commands_.switchToTab().setEnabled(hasDocs);
       commands_.setWorkingDirToActiveDoc().setEnabled(hasDocs);
 
-      HashSet<AppCommand> newCommands =
-            activeEditor_ != null ? activeEditor_.getSupportedCommands()
-                                  : new HashSet<AppCommand>();
-            
-      HashSet<AppCommand> commandsToEnable = new HashSet<AppCommand>(newCommands);
-      commandsToEnable.removeAll(activeCommands_);
-
-      HashSet<AppCommand> commandsToDisable = new HashSet<AppCommand>(activeCommands_);
-      commandsToDisable.removeAll(newCommands);
-
-      for (AppCommand command : commandsToEnable)
+      HashSet<AppCommand> newCommands = activeEditor_ != null
+            ? activeEditor_.getSupportedCommands()
+            : new HashSet<AppCommand>();
+      
+      if (forceSync)
       {
-         command.setEnabled(true);
-         command.setVisible(true);
+         for (AppCommand command : activeCommands_)
+         {
+            command.setEnabled(false);
+            command.setVisible(false);
+         }
+         
+         for (AppCommand command : newCommands)
+         {
+            command.setEnabled(true);
+            command.setVisible(true);
+         }
       }
-
-      for (AppCommand command : commandsToDisable)
+      else
       {
-         command.setEnabled(false);
-         command.setVisible(false);
+         HashSet<AppCommand> commandsToEnable = new HashSet<AppCommand>(newCommands);
+         commandsToEnable.removeAll(activeCommands_);
+
+         HashSet<AppCommand> commandsToDisable = new HashSet<AppCommand>(activeCommands_);
+         commandsToDisable.removeAll(newCommands);
+
+         for (AppCommand command : commandsToEnable)
+         {
+            command.setEnabled(true);
+            command.setVisible(true);
+         }
+
+         for (AppCommand command : commandsToDisable)
+         {
+            command.setEnabled(false);
+            command.setVisible(false);
+         }
       }
       
       // commands which should always be visible even when disabled

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
@@ -213,14 +213,18 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
       
       // signal that this window has focus
       if (WindowEx.get().getDocument().hasFocus())
-         MainWindowObject.lastFocusedWindow().set(getSourceWindowId());
+      {
+         MainWindowObject.lastFocusedWindow().set(WindowEx.getNative());
+         MainWindowObject.lastFocusedWindowId().set(getSourceWindowId());
+      }
       
       WindowEx.addFocusHandler(new FocusHandler()
       {
          @Override
          public void onFocus(FocusEvent event)
          {
-            MainWindowObject.lastFocusedWindow().set(getSourceWindowId());
+            MainWindowObject.lastFocusedWindow().set(WindowEx.getNative());
+            MainWindowObject.lastFocusedWindowId().set(getSourceWindowId());
          }
       });
    }
@@ -273,12 +277,12 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
    
    public String getLastFocusedSourceWindowId()
    {
-      return MainWindowObject.lastFocusedSourceWindow().get();
+      return MainWindowObject.lastFocusedSourceWindowId().get();
    }
    
    public String getLastFocusedWindowId()
    {
-      return MainWindowObject.lastFocusedWindow().get();
+      return MainWindowObject.lastFocusedWindowId().get();
    }
    
    public int getSourceWindowOrdinal()
@@ -788,7 +792,7 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
                   ? ""
                   : sourceWindowId(event.originWindowName());
 
-            MainWindowObject.lastFocusedSourceWindow().set(id);
+            MainWindowObject.lastFocusedSourceWindowId().set(id);
          }
       });
    }
@@ -1285,7 +1289,7 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
    private WindowEx getLastFocusedSourceWindow()
    {
       String lastFocusedSourceWindow =
-            MainWindowObject.lastFocusedSourceWindow().get();
+            MainWindowObject.lastFocusedSourceWindowId().get();
             
       // if the last window focused was the main one, or there's no longer an
       // addressable window, there's nothing to do

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -425,7 +425,7 @@ public class AceEditor implements DocDisplay,
          public void onFocus(FocusEvent event)
          {
             String id = AceEditor.this.getWidget().getElement().getId();
-            MainWindowObject.lastFocusedEditor().set(id);
+            MainWindowObject.lastFocusedEditorId().set(id);
          }
       });
       


### PR DESCRIPTION
This PR fixes a few issues:

1. Rather than having a single web channel on the main window that all windows share, each window now gets its own web channel that it can use to communicate with the Qt backend. This ensures that attempts to show dialogs (e.g. message boxes) can show with the window from which they were requested, thereby fixing https://github.com/rstudio/rstudio/issues/2516.

2. On macOS, when a command is invoked from the main menu, it is always invoked from the main window. However, we typically want to target the behavior to the last active (or currently active) window; e.g. for source editor commands that should operate on the current window. We hence also allow the main menu to request that satellites execute a command.

3. We also need to more aggressively manage commands on macOS, since an attempt to invoke a command from the main menu may actually be targeted at an active satellite window, and so the commands need to synchronize based on what is open in the popped-out source window.