### PR TITLE
ensure minimal windows closed when parent window closes

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -633,10 +633,9 @@ void GwtCallback::openMinimalWindow(QString name,
           (name == QString::fromUtf8("_rstudio_viewer_zoom"));
 
       browser = new BrowserWindow(false, !isViewerZoomWindow, name);
-      browser->setAttribute(Qt::WA_DeleteOnClose);
-      browser->setAttribute(Qt::WA_QuitOnClose, false);
-      browser->connect(browser->webView(), SIGNAL(onCloseWindowShortcut()),
-                       browser, SLOT(onCloseRequested()));
+      browser->setAttribute(Qt::WA_DeleteOnClose, true);
+      browser->setAttribute(Qt::WA_QuitOnClose, true);
+      connect(this, &GwtCallback::destroyed, browser, &BrowserWindow::close);
       if (named)
          s_windowTracker.addWindow(name, browser);
 


### PR DESCRIPTION
Closes #2137.

With Qt Webkit, we were able to rely on the `onCloseRequested()` slot for web views (or so it seems? I can't actually find that documented anywhere, now...).

Fortunately, we can still signal the request for the window to close by just hooking up the parent window's `destroyed()` signal to a close call.