### PR TITLE
ensure zoom factor synchronized after zoom

### DIFF
--- a/src/cpp/desktop/DesktopBrowserWindow.cpp
+++ b/src/cpp/desktop/DesktopBrowserWindow.cpp
@@ -44,8 +44,7 @@ BrowserWindow::BrowserWindow(bool showToolbar,
 
    // set zoom factor
    double zoomLevel = options().zoomLevel();
-   if (zoomLevel != pView_->dpiAwareZoomFactor())
-      pView_->setDpiAwareZoomFactor(options().zoomLevel());
+   pView_->setZoomFactor(zoomLevel);
 
    // Kind of a hack to new up a toolbar and not attach it to anything.
    // Once it is clear what secondary browser windows look like we can

--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -1215,12 +1215,13 @@ QString GwtCallback::getZoomLevels()
 
 double GwtCallback::getZoomLevel()
 {
-   return options().zoomLevel();
+   return desktopInfo().getZoomLevel();
 }
 
 void GwtCallback::setZoomLevel(double zoomLevel)
 {
    options().setZoomLevel(zoomLevel);
+   desktopInfo().setZoomLevel(zoomLevel);
 }
 
 void GwtCallback::showLicenseDialog()

--- a/src/cpp/desktop/DesktopGwtWindow.cpp
+++ b/src/cpp/desktop/DesktopGwtWindow.cpp
@@ -35,8 +35,7 @@ GwtWindow::GwtWindow(bool showToolbar,
                      QString name,
                      QUrl baseUrl,
                      QWidget* pParent) :
-   BrowserWindow(showToolbar, adjustTitle, name, baseUrl, pParent),
-   zoomLevel_(options().zoomLevel())
+   BrowserWindow(showToolbar, adjustTitle, name, baseUrl, pParent)
 {
    // initialize zoom levels (synchronize with AppearancePreferencesPane.java)
    double levels[] = {
@@ -55,7 +54,8 @@ void GwtWindow::zoomActualSize()
 {
    if (isDuplicateZoomRequest(&lastZoomTimer_))
       return;
-   setZoomLevel(1);
+   
+   options().setZoomLevel(1);
    webView()->setZoomFactor(1);
 }
 
@@ -65,11 +65,11 @@ void GwtWindow::zoomIn()
       return;
    
    // get next greatest value
-   std::vector<double>::const_iterator it = std::upper_bound(
-            zoomLevels_.begin(), zoomLevels_.end(), getZoomLevel());
+   double zoomLevel = options().zoomLevel();
+   auto it = std::upper_bound(zoomLevels_.begin(), zoomLevels_.end(), zoomLevel);
    if (it != zoomLevels_.end())
    {
-      setZoomLevel(*it);
+      options().setZoomLevel(*it);
       webView()->setZoomFactor(*it);
    }
 }
@@ -80,11 +80,11 @@ void GwtWindow::zoomOut()
       return;
    
    // get next smallest value
-   std::vector<double>::const_iterator it = std::lower_bound(
-            zoomLevels_.begin(), zoomLevels_.end(), getZoomLevel());
+   double zoomLevel = options().zoomLevel();
+   auto it = std::lower_bound(zoomLevels_.begin(), zoomLevels_.end(), zoomLevel);
    if (it != zoomLevels_.begin() && it != zoomLevels_.end())
    {
-      setZoomLevel(*(it - 1));
+      options().setZoomLevel(*(it - 1));
       webView()->setZoomFactor(*(it - 1));
    }
 }
@@ -92,22 +92,6 @@ void GwtWindow::zoomOut()
 void GwtWindow::finishLoading(bool succeeded)
 {
    BrowserWindow::finishLoading(succeeded);
-
-   if (!succeeded)
-       return;
-
-   if (getZoomLevel() != webView()->dpiAwareZoomFactor())
-      webView()->setDpiAwareZoomFactor(getZoomLevel());
-}
-
-double GwtWindow::getZoomLevel()
-{
-   return zoomLevel_;
-}
-
-void GwtWindow::setZoomLevel(double zoomLevel)
-{
-   zoomLevel_ = zoomLevel;
 }
 
 bool GwtWindow::event(QEvent* pEvent)

--- a/src/cpp/desktop/DesktopGwtWindow.hpp
+++ b/src/cpp/desktop/DesktopGwtWindow.hpp
@@ -44,8 +44,6 @@ protected Q_SLOTS:
 
 protected:
    bool event(QEvent* pEvent) override;
-   virtual double getZoomLevel();
-   virtual void setZoomLevel(double zoomLevel);
 
 private:
    virtual void onActivated()

--- a/src/cpp/desktop/DesktopInfo.cpp
+++ b/src/cpp/desktop/DesktopInfo.cpp
@@ -36,10 +36,11 @@ namespace desktop {
 
 namespace {
 
-QString s_platform           = kUnknown;
-QString s_version            = kUnknown;
-QString s_sumatraPdfExePath  = kUnknown;
-double  s_zoomLevel          = 1.0;
+QString s_platform             = kUnknown;
+QString s_version              = kUnknown;
+QString s_sumatraPdfExePath    = kUnknown;
+int     s_chromiumDevtoolsPort = -1;
+double  s_zoomLevel            = 1.0;
 
 QString getFixedWidthFontList()
 {
@@ -197,7 +198,11 @@ QString DesktopInfo::getFixedWidthFontList()
 
 void DesktopInfo::setFixedWidthFontList(QString list)
 {
-   fixedWidthFontList() = list;
+   if (fixedWidthFontList() != list)
+   {
+      fixedWidthFontList() = list;
+      emit fixedWidthFontListChanged(list);
+   }
 }
 
 QString DesktopInfo::getFixedWidthFont()
@@ -228,7 +233,11 @@ QString DesktopInfo::getSumatraPdfExePath()
 
 void DesktopInfo::setSumatraPdfExePath(QString path)
 {
-   s_sumatraPdfExePath = path;
+   if (s_sumatraPdfExePath != path)
+   {
+      s_sumatraPdfExePath = path;
+      emit sumatraPdfExePathChanged(path);
+   }
 }
 
 double DesktopInfo::getZoomLevel()
@@ -238,18 +247,26 @@ double DesktopInfo::getZoomLevel()
 
 void DesktopInfo::setZoomLevel(double zoomLevel)
 {
-   s_zoomLevel = zoomLevel;
+   if (zoomLevel != s_zoomLevel)
+   {
+      s_zoomLevel = zoomLevel;
+      emit zoomLevelChanged(zoomLevel);
+   }
 }
 
 int DesktopInfo::getChromiumDevtoolsPort()
 {
-   std::string port = core::system::getenv("QTWEBENGINE_REMOTE_DEBUGGING");
-   return safe_convert::stringTo<int>(port, 0);
+   return s_chromiumDevtoolsPort;
 }
 
 void DesktopInfo::setChromiumDevtoolsPort(int port)
 {
-   core::system::setenv("QT_WEBENGINE_REMOTE_DEBUGGING", safe_convert::numberToString(port));
+   if (s_chromiumDevtoolsPort != port)
+   {
+      s_chromiumDevtoolsPort = port;
+      core::system::setenv("QT_WEBENGINE_REMOTE_DEBUGGING", safe_convert::numberToString(port));
+      emit chromiumDevtoolsPortChanged(port);
+   }
 }
 
 } // end namespace desktop

--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -283,16 +283,6 @@ void MainWindow::closeEvent(QCloseEvent* pEvent)
    });
 }
 
-double MainWindow::getZoomLevel()
-{
-   return options().zoomLevel();
-}
-
-void MainWindow::setZoomLevel(double zoomLevel)
-{
-   options().setZoomLevel(zoomLevel);
-}
-
 void MainWindow::setMenuBar(QMenuBar *pMenubar)
 {
    delete menuBar();

--- a/src/cpp/desktop/DesktopMainWindow.hpp
+++ b/src/cpp/desktop/DesktopMainWindow.hpp
@@ -66,8 +66,6 @@ protected Q_SLOTS:
 
 protected:
    void closeEvent(QCloseEvent*) override;
-   double getZoomLevel() override;
-   void setZoomLevel(double zoomLevel) override;
 
 // private interface for SessionLauncher
 private:

--- a/src/cpp/desktop/DesktopWebView.cpp
+++ b/src/cpp/desktop/DesktopWebView.cpp
@@ -36,8 +36,7 @@ namespace desktop {
 
 WebView::WebView(QUrl baseUrl, QWidget *parent, bool allowExternalNavigate) :
     QWebEngineView(parent),
-    baseUrl_(baseUrl),
-    dpiZoomScaling_(getDpiZoomScaling())
+    baseUrl_(baseUrl)
 {
 #ifdef Q_OS_LINUX
    if (!core::system::getenv("KDE_FULL_SESSION").empty())
@@ -130,20 +129,6 @@ void WebView::openFile(QString fileName)
 #endif
 
    QDesktopServices::openUrl(QUrl::fromLocalFile(fileName));
-}
-
-// QWebEngineView doesn't respect the system DPI and always renders as though
-// it were at 96dpi. To work around this, we take the user-specified zoom level
-// and scale it by a DPI-determined constant before applying it to the view.
-// See: https://bugreports.qt-project.org/browse/QTBUG-29571
-void WebView::setDpiAwareZoomFactor(qreal factor)
-{
-   setZoomFactor(factor * dpiZoomScaling_);
-}
-
-qreal WebView::dpiAwareZoomFactor()
-{
-   return zoomFactor() / dpiZoomScaling_;
 }
 
 bool WebView::event(QEvent* event)

--- a/src/cpp/desktop/DesktopWebView.hpp
+++ b/src/cpp/desktop/DesktopWebView.hpp
@@ -39,8 +39,6 @@ public:
 
    void activateSatelliteWindow(QString name);
    void prepareForWindow(const PendingWindow& pendingWnd);
-   void setDpiAwareZoomFactor(qreal factor);
-   qreal dpiAwareZoomFactor();
 
    bool event(QEvent* event) override;
 
@@ -65,7 +63,6 @@ protected Q_SLOTS:
 private:
    QUrl baseUrl_;
    WebPage* pWebPage_;
-   double dpiZoomScaling_;
 };
 
 } // namespace desktop


### PR DESCRIPTION
Fixes #2523.

Note that I removed some of the 'DPI-aware zoom factor' bits as this should no longer be necessary with QtWebengine (this was a workaround for DPI-related behaviors in Webkit)