### PR TITLE
Add rstudioapi as a dependency for odbc connections

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -723,7 +723,8 @@ public class DependencyManager implements InstallShinyEvent.Handler,
         "Preparing " + name,
         "Using " + name, 
         new Dependency[] {
-           Dependency.cranPackage("odbc", "1.1.5")
+           Dependency.cranPackage("odbc", "1.1.5"),
+           Dependency.cranPackage("rstudioapi", "0.5")
         }, 
         true, // update odbc if needed
         new CommandWithArg<Boolean>()


### PR DESCRIPTION
While connecting with `odbc` we recommend using `rstudioapi::askForPassword()`; however, we don't really prompt users to install `rstudioapi` from the connection dialog. While we don't want to force a particular version of rstudioapi, we should at least recommend installing the same version we recommend for shiny addins and rsconnect which is version `0.5`.

`askForPassword()` was added back in version `0.4`, https://github.com/rstudio/rstudioapi/commit/e2c20ef8c3b810ff43c7bf86562f7f0294098334.

CC: @ronblum 