### PR TITLE
Fix Help pane popout button on desktop

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -1,7 +1,7 @@
 /*
  * HelpPane.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -66,6 +66,7 @@ import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.AutoGlassPanel;
 import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.common.GlobalDisplay.NewWindowOptions;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.ui.WorkbenchPane;
 import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
@@ -699,7 +700,9 @@ public class HelpPane extends WorkbenchPane
    public void popout()
    {
       String href = getContentWindow().getLocationHref() ;     
-      globalDisplay_.openWindow(href);
+      NewWindowOptions options = new NewWindowOptions();
+      options.setName("helppanepopout_" + popoutCount_++);
+      globalDisplay_.openWebMinimalWindow(href, false, 0, 0, options);
    }
    
    @Override
@@ -782,4 +785,5 @@ public class HelpPane extends WorkbenchPane
    private boolean navigated_;
    private boolean initialized_;
    private String targetUrl_;
+   private static int popoutCount_ = 0;
 }


### PR DESCRIPTION
This makes the help pane's "Show in new window" button work like it did in 1.1 and open in a minimal Qt browser window. Each time you click it a new instance is created, hence the name+counter; otherwise it would just reactivate the same window on subsequent clicks.

Fixes #2117 
