### PR TITLE
clamp htmlwidget height; tweak propagation of wheel events

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -327,6 +327,9 @@ public class ChunkOutputWidget extends Composite
       {
          int contentHeight = root_.getElement().getOffsetHeight() + 19;
          height = Math.max(ChunkOutputUi.MIN_CHUNK_HEIGHT, contentHeight);
+         
+         // clamp height of widgets
+         height = Math.min(height, 650);
 
          // if we have renders pending, don't shrink until they're loaded 
          if (pendingRenders_ > 0 && height < renderedHeight_)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -329,7 +329,7 @@ public class ChunkOutputWidget extends Composite
          height = Math.max(ChunkOutputUi.MIN_CHUNK_HEIGHT, contentHeight);
          
          // clamp height of widgets
-         height = Math.min(height, 650);
+         height = Math.min(height, ChunkOutputUi.MAX_CHUNK_HEIGHT);
 
          // if we have renders pending, don't shrink until they're loaded 
          if (pendingRenders_ > 0 && height < renderedHeight_)


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/2174.

Note that this does tweak the scroll behavior for HTML widgets in Notebooks: widgets no longer unilaterally propagate wheel events; rather, they only propagate them when they have reached their scroll bounds and cannot be scrolled anymore.

(I initially wanted to test this by looking at e.g. the height of the iframe, but that was always reported as 0 -- or perhaps I'm misunderstanding some interplay between how an iframe's scroll position is reported)