### PR TITLE
Cure for macOS build using macports openssl 1.0.2n

### DIFF
--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -212,7 +212,7 @@ if (UNIX)
       )
    set(CORE_INCLUDE_DIRS
       ${CORE_INCLUDE_DIRS}
-      ${OPENSSL_INCLUDE_DIRS}
+      ${OPENSSL_INCLUDE_DIR}
    )
 
    if(RSTUDIO_SERVER)

--- a/src/cpp/server/CMakeLists.txt
+++ b/src/cpp/server/CMakeLists.txt
@@ -135,7 +135,7 @@ if(APPLE)
    )
    set(CORE_INCLUDE_DIRS
       ${CORE_INCLUDE_DIRS}
-      ${OPENSSL_INCLUDE_DIRS}
+      ${OPENSSL_INCLUDE_DIR}
    )
 endif()
 


### PR DESCRIPTION
A solution for #2558.

`-I/opt/local/include` gets passed correctly and results in a successful build.

```
[ 54%] Building CXX object src/cpp/core/CMakeFiles/rstudio-core.dir/http/SocketProxy.cpp.o
cd /Users/kiwiroy/code/rstudio/compilation-dir/src/cpp/core && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -DBOOST_ASIO_DISABLE_KQUEUE -DBOOST_ENABLE_ASSERT_HANDLER -DBOOST_SIGNALS_NO_DEPRECATION_WARNING -DRSTUDIO_BOOST_NAMESPACE=rstudio_boost -DWEBSOCKETPP_STRICT_MASKING -D_WEBSOCKETPP_NO_CPP11_MEMORY_=1 -isystem /opt/rstudio-tools/boost/boost_1_63_0/include -I/opt/local/include -I/Users/kiwiroy/code/rstudio/src/cpp/core/include -I/Users/kiwiroy/code/rstudio/compilation-dir/src/cpp/core -I/Users/kiwiroy/code/rstudio/src/cpp/tests/cpp  -std=c++0x -std=c++11 -O3 -DNDEBUG -fPIC   -Wall -pthread -Wno-unknown-warning-option -Wsign-compare -Wno-unused-local-typedefs -Wno-deprecated-declarations -o CMakeFiles/rstudio-core.dir/http/SocketProxy.cpp.o -c /Users/kiwiroy/code/rstudio/src/cpp/core/http/SocketProxy.cpp
[ 58%] Building CXX object src/cpp/core/CMakeFiles/rstudio-core.dir/http/URL.cpp.o
cd /Users/kiwiroy/code/rstudio/compilation-dir/src/cpp/core && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -DBOOST_ASIO_DISABLE_KQUEUE -DBOOST_ENABLE_ASSERT_HANDLER -DBOOST_SIGNALS_NO_DEPRECATION_WARNING -DRSTUDIO_BOOST_NAMESPACE=rstudio_boost -DWEBSOCKETPP_STRICT_MASKING -D_WEBSOCKETPP_NO_CPP11_MEMORY_=1 -isystem /opt/rstudio-tools/boost/boost_1_63_0/include -I/opt/local/include -I/Users/kiwiroy/code/rstudio/src/cpp/core/include -I/Users/kiwiroy/code/rstudio/compilation-dir/src/cpp/core -I/Users/kiwiroy/code/rstudio/src/cpp/tests/cpp  -std=c++0x -std=c++11 -O3 -DNDEBUG -fPIC   -Wall -pthread -Wno-unknown-warning-option -Wsign-compare -Wno-unused-local-typedefs -Wno-deprecated-declarations -o CMakeFiles/rstudio-core.dir/http/URL.cpp.o -c /Users/kiwiroy/code/rstudio/src/cpp/core/http/URL.cpp
```