### PR TITLE
Hide context help control on Windows dialogs

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -816,6 +816,7 @@ int GwtCallback::showMessageBox(int type,
    msgBox.setIcon(safeMessageBoxIcon(static_cast<QMessageBox::Icon>(type)));
    msgBox.setWindowFlags(Qt::Dialog | Qt::Sheet);
    msgBox.setWindowModality(Qt::WindowModal);
+   msgBox.setWindowFlag(Qt::WindowContextHelpButtonHint, false);
    msgBox.setTextFormat(Qt::PlainText);
 
    QStringList buttonList = buttons.split(QChar::fromLatin1('|'));

--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -343,6 +343,7 @@ void SessionLauncher::onLaunchError(QString message)
       QMessageBox errorMsg(safeMessageBoxIcon(QMessageBox::Critical),
                            desktop::activation().editionName(), message);
       errorMsg.addButton(QMessageBox::Close);
+      errorMsg.setWindowFlag(Qt::WindowContextHelpButtonHint, false);
       errorMsg.exec();
    }
   qApp->exit(EXIT_FAILURE);

--- a/src/cpp/desktop/DesktopUtils.cpp
+++ b/src/cpp/desktop/DesktopUtils.cpp
@@ -178,6 +178,7 @@ bool showYesNoDialog(QMessageBox::Icon icon,
    if (informativeText.length() > 0)
       messageBox.setInformativeText(informativeText);
    messageBox.setWindowModality(Qt::WindowModal);
+   messageBox.setWindowFlag(Qt::WindowContextHelpButtonHint, false);
 
    // initialize buttons
    QPushButton* pYes = messageBox.addButton(QMessageBox::Yes);
@@ -207,6 +208,7 @@ void showMessageBox(QMessageBox::Icon icon,
    if (informativeText.length() > 0)
       messageBox.setInformativeText(informativeText);
    messageBox.setWindowModality(Qt::WindowModal);
+   messageBox.setWindowFlag(Qt::WindowContextHelpButtonHint, false);
    messageBox.addButton(new QPushButton(QString::fromUtf8("OK")), QMessageBox::AcceptRole);
    messageBox.exec();
 }


### PR DESCRIPTION
Fixes #2570 

I had removed these on the native Pro dialogs, but missed these open-source variants.