### PR TITLE
implement download helper for webengine downloads

### DIFF
--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -188,6 +188,7 @@ configure_file (${CMAKE_CURRENT_SOURCE_DIR}/desktop-config.h.in
 set(DESKTOP_SOURCE_FILES
   DesktopActivationOverlay.cpp
   DesktopBrowserWindow.cpp
+  DesktopDownloadItemHelper.cpp
   DesktopGwtCallback.cpp
   DesktopGwtWindow.cpp
   DesktopInfo.cpp

--- a/src/cpp/desktop/DesktopDownloadItemHelper.cpp
+++ b/src/cpp/desktop/DesktopDownloadItemHelper.cpp
@@ -1,0 +1,66 @@
+/*
+ * DesktopDownloadItemHelper.cpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "DesktopDownloadItemHelper.hpp"
+
+#include <QDebug>
+
+namespace rstudio {
+namespace desktop {
+
+DownloadHelper* DownloadHelper::manageDownload(
+      QWebEngineDownloadItem* item,
+      const QString& path)
+{
+   DownloadHelper* helper = new DownloadHelper(item);
+   item->setPath(path);
+   item->accept();
+   return helper;
+}
+
+DownloadHelper::DownloadHelper(QWebEngineDownloadItem* item)
+{
+   connect(item, &QWebEngineDownloadItem::downloadProgress,
+           this,  &DownloadHelper::onDownloadProgress);
+   
+   connect(item, &QWebEngineDownloadItem::finished,
+           this, &DownloadHelper::onFinished);
+   
+   connect(item, &QWebEngineDownloadItem::isPausedChanged,
+           this, &DownloadHelper::onPausedChanged);
+   
+   connect(item, &QWebEngineDownloadItem::stateChanged,
+           this, &DownloadHelper::onStateChanged);
+}
+
+void DownloadHelper::onDownloadProgress(qint64 bytesReceived, qint64 bytesTotal)
+{
+}
+
+void DownloadHelper::onFinished()
+{
+   deleteLater();
+}
+
+void DownloadHelper::onPausedChanged(bool isPaused)
+{
+}
+
+void DownloadHelper::onStateChanged(QWebEngineDownloadItem::DownloadState state)
+{
+}
+
+} // namespace desktop
+} // namespace rstudio

--- a/src/cpp/desktop/DesktopDownloadItemHelper.hpp
+++ b/src/cpp/desktop/DesktopDownloadItemHelper.hpp
@@ -1,0 +1,51 @@
+/*
+ * DesktopDownloadItemHelper.hpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef DESKTOP_DOWNLOAD_ITEM_HELPER_HPP
+#define DESKTOP_DOWNLOAD_ITEM_HELPER_HPP
+
+#include <QObject>
+
+#include <QWebEngineDownloadItem>
+
+namespace rstudio {
+namespace desktop {
+
+class DownloadHelper : public QObject
+{
+   Q_OBJECT
+   
+public:
+   
+   // NOTE: DownloadHelper automatically frees itself after the download
+   // is finished, in response to &QWebEngineDownloadItem::finished() signal
+   static DownloadHelper* manageDownload(
+         QWebEngineDownloadItem* item,
+         const QString& path);
+   
+public Q_SLOTS:
+   void onDownloadProgress(qint64 bytesReceived, qint64 bytesTotal);
+   void onFinished();
+   void onPausedChanged(bool isPaused);
+   void onStateChanged(QWebEngineDownloadItem::DownloadState state);
+   
+private:
+   DownloadHelper(QWebEngineDownloadItem* item);
+};
+
+} // namespace desktop
+} // namespace rstudio
+
+#endif // DESKTOP_DOWNLOAD_ITEM_HELPER_HPP

--- a/src/cpp/desktop/DesktopWebPage.cpp
+++ b/src/cpp/desktop/DesktopWebPage.cpp
@@ -22,11 +22,12 @@
 #include <QFileDialog>
 #include <QWebEngineSettings>
 
-#include "DesktopWindowTracker.hpp"
+#include "DesktopDownloadItemHelper.hpp"
+#include "DesktopMainWindow.hpp"
 #include "DesktopSatelliteWindow.hpp"
 #include "DesktopSecondaryWindow.hpp"
-#include "DesktopMainWindow.hpp"
 #include "DesktopWebProfile.hpp"
+#include "DesktopWindowTracker.hpp"
 
 using namespace rstudio::core;
 
@@ -51,8 +52,7 @@ void onDownloadRequested(QWebEngineDownloadItem* downloadItem)
    if (downloadPath.isEmpty())
       return;
    
-   downloadItem->setPath(downloadPath);
-   downloadItem->accept();
+   DownloadHelper::manageDownload(downloadItem, downloadPath);
 }
 
 } // anonymous namespace


### PR DESCRIPTION
This PR brings back a download helper for QtWebEngine downloads. Currently it's mostly just a stub; the intention is that this could be used for reporting download progress, download failures, etc.

Not sure we want to implement our own 'download manager' in RStudio but at least this leaves the door open if we do?