### PR TITLE
match background color to theme (closes #2572)

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -1272,6 +1272,16 @@ void GwtCallback::zoomActualSize()
    pOwner_->zoomActualSize();
 }
 
+void GwtCallback::setBackgroundColor(QJsonArray rgbColor)
+{
+   int red   = rgbColor.at(0).toInt();
+   int green = rgbColor.at(1).toInt();
+   int blue  = rgbColor.at(2).toInt();
+   
+   QColor color = QColor::fromRgb(red, green, blue);
+   pOwner_->webPage()->setBackgroundColor(color);
+}
+
 void GwtCallback::showLicenseDialog()
 {
    activation().showLicenseDialog(false /*showQuitButton*/);

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -19,6 +19,7 @@
 #include <QObject>
 #include <QClipboard>
 #include <QKeySequence>
+#include <QJsonArray>
 #include <QJsonObject>
 #include <QPrinter>
 
@@ -187,6 +188,8 @@ public Q_SLOTS:
    void zoomIn();
    void zoomOut();
    void zoomActualSize();
+   
+   void setBackgroundColor(QJsonArray rgbColor);
 
    void showLicenseDialog();
    QString getInitMessages();

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -19,6 +19,7 @@ import org.rstudio.core.client.Point;
 import org.rstudio.core.client.js.BaseExpression;
 import org.rstudio.core.client.js.JavaScriptPassthrough;
 
+import com.google.gwt.core.client.JsArrayInteger;
 import com.google.gwt.user.client.Command;
 
 /**
@@ -157,6 +158,8 @@ public interface DesktopFrame extends JavaScriptPassthrough
    void zoomIn();
    void zoomOut();
    void zoomActualSize();
+   
+   void setBackgroundColor(JsArrayInteger rgbColor);
    
    void showLicenseDialog();
    void getInitMessages(CommandWithArg<String> callback);

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RStudioThemes.java
@@ -65,6 +65,7 @@ public class RStudioThemes
          }
             
          element.addClassName("rstudio-themes-" + themeName);
+         element.setId("rstudio_container");
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
@@ -14,16 +14,21 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.text.themes;
 
+import com.google.gwt.core.client.JsArrayInteger;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.LinkElement;
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.client.Timer;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
 
+import org.rstudio.core.client.ColorUtil.RGBColor;
 import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.resources.StaticDataResource;
+import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorThemeChangedEvent;
@@ -174,6 +179,21 @@ public class AceThemes
          public void run()
          {
             events_.fireEvent(new EditorThemeChangedEvent(themeName));
+            
+            // synchronize the effective background color with the desktop
+            if (Desktop.isDesktop())
+            {
+               Element el = Document.get().getElementById("rstudio_container");
+               Style style = DomUtils.getComputedStyles(el);
+               String color = style.getBackgroundColor();
+               RGBColor parsed = RGBColor.fromCss(color);
+               
+               JsArrayInteger colors = JsArrayInteger.createArray(3).cast();
+               colors.set(0, parsed.red());
+               colors.set(1, parsed.green());
+               colors.set(2, parsed.blue());
+               Desktop.getFrame().setBackgroundColor(colors);
+            }
          }
       }.schedule(100);
    }


### PR DESCRIPTION
This PR alleviates the issue described in https://github.com/rstudio/rstudio/issues/2150, so that the default background color is set during resize.

![resize](https://user-images.githubusercontent.com/1976582/38271014-04e991fc-373a-11e8-9247-a502e3e59f9a.gif)
