### PR TITLE
associate rstudio API dialog requests with active window

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -225,14 +225,16 @@ QString GwtCallback::getOpenFileName(const QString& caption,
                                      const QString& label,
                                      const QString& dir,
                                      const QString& filter,
-                                     bool canChooseDirectories)
+                                     bool canChooseDirectories,
+                                     bool focusOwner)
 {
    QString resolvedDir = resolveAliasedPath(dir);
 
+   QWidget* owner = focusOwner ? pOwner_->asWidget() : qApp->focusWidget();
    QFileDialog dialog(
-            pOwner_->asWidget(),
+            owner,
             caption,
-            resolveAliasedPath(dir),
+            resolvedDir,
             filter);
 
    QFileDialog::FileMode mode = (canChooseDirectories)
@@ -242,12 +244,13 @@ QString GwtCallback::getOpenFileName(const QString& caption,
    dialog.setFileMode(mode);
    dialog.setLabelText(QFileDialog::Accept, label);
    dialog.setResolveSymlinks(false);
+   dialog.setWindowModality(Qt::WindowModal);
 
    QString result;
    if (dialog.exec() == QDialog::Accepted)
       result = dialog.selectedFiles().value(0);
 
-   activateAndFocusOwner();
+   desktop::raiseAndActivateWindow(owner);
    return createAliasedPath(result);
 }
 
@@ -261,17 +264,18 @@ QString getSaveFileNameImpl(QWidget* pParent,
                             const QString& dir,
                             QFileDialog::Options options)
 {
-    // initialize dialog
-    QFileDialog dialog(pParent, caption, dir);
-    dialog.setOptions(options);
-    dialog.setLabelText(QFileDialog::Accept, label);
-    dialog.setAcceptMode(QFileDialog::AcceptSave);
+   // initialize dialog
+   QFileDialog dialog(pParent, caption, dir);
+   dialog.setOptions(options);
+   dialog.setLabelText(QFileDialog::Accept, label);
+   dialog.setAcceptMode(QFileDialog::AcceptSave);
+   dialog.setWindowModality(Qt::WindowModal);
 
-    // execute dialog and check for success
-    if (dialog.exec() == QDialog::Accepted)
-        return dialog.selectedFiles().value(0);
+   // execute dialog and check for success
+   if (dialog.exec() == QDialog::Accepted)
+      return dialog.selectedFiles().value(0);
 
-    return QString();
+   return QString();
 }
 
 } // end anonymous namespace
@@ -280,20 +284,22 @@ QString GwtCallback::getSaveFileName(const QString& caption,
                                      const QString& label,
                                      const QString& dir,
                                      const QString& defaultExtension,
-                                     bool forceDefaultExtension)
+                                     bool forceDefaultExtension,
+                                     bool focusOwner)
 {
    QString resolvedDir = resolveAliasedPath(dir);
 
    while (true)
    {
+      QWidget* owner = focusOwner ? pOwner_->asWidget() : qApp->focusWidget();
       QString result = getSaveFileNameImpl(
-                  pOwner_->asWidget(),
+                  owner,
                   caption,
                   label,
                   resolvedDir,
                   standardFileDialogOptions());
 
-      activateAndFocusOwner();
+      desktop::raiseAndActivateWindow(owner);
       if (result.isEmpty())
          return result;
 
@@ -330,47 +336,28 @@ QString GwtCallback::getSaveFileName(const QString& caption,
 
 QString GwtCallback::getExistingDirectory(const QString& caption,
                                           const QString& label,
-                                          const QString& dir)
+                                          const QString& dir,
+                                          bool focusOwner)
 {
-   QString result;
 
-   // TODO: can we remove this code below?
-#ifdef _WIN32
-   if (dir.isNull())
-   {
-      // Bug
-      wchar_t szDir[MAX_PATH];
-      BROWSEINFOW bi;
-      bi.hwndOwner = (HWND)(pOwner_->asWidget()->winId());
-      bi.pidlRoot = nullptr;
-      bi.pszDisplayName = szDir;
-      bi.lpszTitle = L"Select a folder:";
-      bi.ulFlags = BIF_RETURNONLYFSDIRS;
-      bi.lpfn = nullptr;
-      bi.lpfn = 0;
-      bi.iImage = -1;
-      LPITEMIDLIST pidl = SHBrowseForFolderW(&bi);
-      if (!pidl || !SHGetPathFromIDListW(pidl, szDir))
-         result = QString();
-      else
-         result = QString::fromWCharArray(szDir);
-      activateAndFocusOwner();
-      return createAliasedPath(result);
-   }
-#endif
 
+   QWidget* owner = focusOwner ? pOwner_->asWidget() : qApp->focusWidget();
    QFileDialog dialog(
-            pOwner_->asWidget(),
+            owner,
             caption,
             resolveAliasedPath(dir));
 
    dialog.setLabelText(QFileDialog::Accept, label);
    dialog.setFileMode(QFileDialog::Directory);
    dialog.setOption(QFileDialog::ShowDirsOnly, true);
+   dialog.setWindowModality(Qt::WindowModal);
+
+   QString result;
    if (dialog.exec() == QDialog::Accepted)
       result = dialog.selectedFiles().value(0);
 
-   activateAndFocusOwner();
+   desktop::raiseAndActivateWindow(owner);
+
    return createAliasedPath(result);
 }
 

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -70,17 +70,20 @@ public Q_SLOTS:
                            const QString& label,
                            const QString& dir,
                            const QString& filter,
-                           bool canChooseDirectories);
+                           bool canChooseDirectories,
+                           bool focusOwner);
 
    QString getSaveFileName(const QString& caption,
                            const QString& label,
                            const QString& dir,
                            const QString& defaultExtension,
-                           bool forceDefaultExtension);
+                           bool forceDefaultExtension,
+                           bool focusOwner);
 
    QString getExistingDirectory(const QString& caption,
                                 const QString& label,
-                                const QString& dir);
+                                const QString& dir,
+                                bool focusOwner);
 
    void onClipboardSelectionChanged();
 

--- a/src/cpp/desktop/DesktopGwtCallbackMac.mm
+++ b/src/cpp/desktop/DesktopGwtCallbackMac.mm
@@ -200,7 +200,8 @@ QString GwtCallback::getSaveFileName(const QString& qCaption,
                                      const QString& qLabel,
                                      const QString& qDir,
                                      const QString& qDefaultExtension,
-                                     bool forceDefaultExtension)
+                                     bool forceDefaultExtension,
+                                     bool focusOwner)
 {
    NSString* caption          = qCaption.toNSString();
    NSString* label            = qLabel.toNSString();
@@ -265,7 +266,8 @@ QString GwtCallback::getSaveFileName(const QString& qCaption,
 
 QString GwtCallback::getExistingDirectory(const QString& qCaption,
                                           const QString& qLabel,
-                                          const QString& qDir)
+                                          const QString& qDir,
+                                          bool focusOwner)
 {
    NSString* caption = qCaption.toNSString();
    NSString* label = qLabel.toNSString();

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -37,6 +37,7 @@ public interface DesktopFrame extends JavaScriptPassthrough
                         String dir,
                         String filter,
                         boolean canChooseDirectories,
+                        boolean focusOpener,
                         CommandWithArg<String> callback);
    
    void getSaveFileName(String caption,
@@ -44,11 +45,13 @@ public interface DesktopFrame extends JavaScriptPassthrough
                         String dir, 
                         String defaultExtension, 
                         boolean forceDefaultExtension,
+                        boolean focusOpener,
                         CommandWithArg<String> callback);
    
    void getExistingDirectory(String caption,
                              String label,
                              String dir,
+                             boolean focusOpener,
                              CommandWithArg<String> callback);
    
    void undo();

--- a/src/gwt/src/org/rstudio/studio/client/common/FileDialogs.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/FileDialogs.java
@@ -45,6 +45,15 @@ public interface FileDialogs
                  String filter,
                  boolean canChooseDirectories,
                  ProgressOperationWithInput<FileSystemItem> operation);
+   
+   void openFile(String caption,
+                 String label,
+                 FileSystemContext fsContext,
+                 FileSystemItem initialFilePath,
+                 String filter,
+                 boolean canChooseDirectories,
+                 boolean focusOwner,
+                 ProgressOperationWithInput<FileSystemItem> operation);
 
    void saveFile(String caption,
                  FileSystemContext fsContext,
@@ -61,6 +70,16 @@ public interface FileDialogs
                  boolean forceDefaultExtension,
                  ProgressOperationWithInput<FileSystemItem> operation);
    
+   void saveFile(String caption,
+                 String label,
+                 FileSystemContext fsContext,
+                 FileSystemItem initialFilePath,
+                 String defaultExtension,
+                 boolean forceDefaultExtension,
+                 boolean focusOwner,
+                 ProgressOperationWithInput<FileSystemItem> operation);
+   
+   
    void chooseFolder(String caption,
                      FileSystemContext fsContext,
                      FileSystemItem initialDir,
@@ -70,6 +89,13 @@ public interface FileDialogs
                      String label,
                      FileSystemContext fsContext,
                      FileSystemItem initialDir,
+                     ProgressOperationWithInput<FileSystemItem> operation);
+   
+   void chooseFolder(String caption,
+                     String label,
+                     FileSystemContext fsContext,
+                     FileSystemItem initialDir,
+                     boolean focusOwner,
                      ProgressOperationWithInput<FileSystemItem> operation);
    
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/impl/DesktopFileDialogs.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/impl/DesktopFileDialogs.java
@@ -157,6 +157,19 @@ public class DesktopFileDialogs implements FileDialogs
                         final boolean canChooseDirectories,
                         final ProgressOperationWithInput<FileSystemItem> operation)
    {
+      openFile(caption, label, fsContext, initialFilePath, filter, canChooseDirectories, true, operation);
+   }
+   
+   public void openFile(final String caption,
+                        final String label,
+                        final FileSystemContext fsContext,
+                        final FileSystemItem initialFilePath,
+                        final String filter,
+                        final boolean canChooseDirectories,
+                        final boolean focusOpener,
+                        final ProgressOperationWithInput<FileSystemItem> operation)
+   {
+   
       new FileDialogOperation()
       {
          @Override
@@ -176,6 +189,7 @@ public class DesktopFileDialogs implements FileDialogs
                   StringUtil.notNull(dir),
                   StringUtil.notNull(filter),
                   canChooseDirectories,
+                  focusOpener,
                   fileName -> 
                   {
                      if (fileName != null)
@@ -207,6 +221,18 @@ public class DesktopFileDialogs implements FileDialogs
                         final boolean forceDefaultExtension,
                         final ProgressOperationWithInput<FileSystemItem> operation)
    {
+      saveFile(caption, buttonLabel, fsContext, initialFilePath, defaultExtension, forceDefaultExtension, true, operation);
+   }
+   
+   public void saveFile(final String caption,
+                        final String buttonLabel,
+                        final FileSystemContext fsContext,
+                        final FileSystemItem initialFilePath,
+                        final String defaultExtension,
+                        final boolean forceDefaultExtension,
+                        final boolean focusOwner,
+                        final ProgressOperationWithInput<FileSystemItem> operation)
+   {
       new FileDialogOperation()
       {
          @Override
@@ -220,6 +246,7 @@ public class DesktopFileDialogs implements FileDialogs
                   StringUtil.notNull(dir),
                   StringUtil.notNull(defaultExtension),
                   forceDefaultExtension,
+                  focusOwner,
                   fileName ->
                   {
                      if (fileName != null)
@@ -249,6 +276,16 @@ public class DesktopFileDialogs implements FileDialogs
                             final FileSystemItem initialDir,
                             ProgressOperationWithInput<FileSystemItem> operation)
    {
+      chooseFolder(caption, label, fsContext, initialDir, true, operation);
+   }
+   
+   public void chooseFolder(final String caption,
+                            final String label,
+                            final FileSystemContext fsContext,
+                            final FileSystemItem initialDir,
+                            final boolean focusOwner,
+                            ProgressOperationWithInput<FileSystemItem> operation)
+   {
       new FileDialogOperation()
       {
          @Override
@@ -260,10 +297,11 @@ public class DesktopFileDialogs implements FileDialogs
                   StringUtil.notNull(caption),
                   StringUtil.notNull(label),
                   initialDir != null ? StringUtil.notNull(initialDir.getPath()) : "",
+                  focusOwner,
                   directory -> 
-                     {
-                        onCompleted.execute(directory);
-                     });
+                  {
+                     onCompleted.execute(directory);
+                  });
          }
       }.execute(caption, fsContext, null, operation);
    }

--- a/src/gwt/src/org/rstudio/studio/client/common/impl/WebFileDialogs.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/impl/WebFileDialogs.java
@@ -62,6 +62,18 @@ public class WebFileDialogs implements FileDialogs
                         boolean canChooseDirectories,
                         ProgressOperationWithInput<FileSystemItem> operation)
    {
+      openFile(caption, label, fsContext, initialFilePath, filter, canChooseDirectories, true, operation);
+   }
+      
+   public void openFile(String caption,
+                        String label,
+                        FileSystemContext fsContext,
+                        FileSystemItem initialFilePath,
+                        String filter,
+                        boolean canChooseDirectories,
+                        boolean focusOwner,
+                        ProgressOperationWithInput<FileSystemItem> operation)
+   {
       OpenFileDialog dialog = new OpenFileDialog(caption,
                                                  label,
                                                  fsContext,
@@ -106,6 +118,18 @@ public class WebFileDialogs implements FileDialogs
                         boolean forceDefaultExtension,
                         ProgressOperationWithInput<FileSystemItem> operation)
    {
+      saveFile(caption, buttonLabel, fsContext, initialFilePath, defaultExtension, forceDefaultExtension, true, operation);
+   }
+   
+   public void saveFile(String caption,
+                        String buttonLabel,
+                        FileSystemContext fsContext,
+                        FileSystemItem initialFilePath,
+                        String defaultExtension,
+                        boolean forceDefaultExtension,
+                        boolean focusOwner,
+                        ProgressOperationWithInput<FileSystemItem> operation)
+   {
       SaveFileDialog dialog = new SaveFileDialog(caption,
                                                  buttonLabel,
                                                  fsContext,
@@ -130,6 +154,16 @@ public class WebFileDialogs implements FileDialogs
                             String label,
                             FileSystemContext fsContext,
                             FileSystemItem initialDir,
+                            ProgressOperationWithInput<FileSystemItem> operation)
+   {
+      chooseFolder(caption, label, fsContext, initialDir, true, operation);
+   }
+   
+   public void chooseFolder(String caption,
+                            String label,
+                            FileSystemContext fsContext,
+                            FileSystemItem initialDir,
+                            boolean focusOwner,
                             ProgressOperationWithInput<FileSystemItem> operation)
    {
       ChooseFolderDialog2 dialog = new ChooseFolderDialog2(caption,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
@@ -568,6 +568,7 @@ public class Workbench implements BusyHandler,
                   initialFilePath,
                   filter,
                   false,
+                  false,
                   onSelected);
          }
          else
@@ -579,6 +580,7 @@ public class Workbench implements BusyHandler,
                   initialFilePath,
                   "",
                   false,
+                  false,
                   onSelected);
          }
       }
@@ -589,6 +591,7 @@ public class Workbench implements BusyHandler,
                label,
                fsContext_,
                initialFilePath,
+               false,
                onSelected);
       }
       else


### PR DESCRIPTION
This PR ensures that the file dialog APIs launched through `rstudioapi` are associated with the window that is currently focused, rather than the 'owner' of the GWT callbacks. This ensures that e.g. Shiny applications which open file dialogs will show the file dialog above the Shiny window, rather than the main window.