### PR TITLE
'Go to directory' starts from project directory

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/PathBreadcrumbWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/PathBreadcrumbWidget.java
@@ -253,10 +253,11 @@ public class PathBreadcrumbWidget
       {
          FileSystemContext tempContext =
                RStudioGinjector.INSTANCE.getRemoteFileSystemContext();
+         
          RStudioGinjector.INSTANCE.getFileDialogs().chooseFolder(
                "Go To Folder",
                tempContext,
-               null,
+               pSession_.get().getSessionInfo().getActiveProjectDir(),
                new ProgressOperationWithInput<FileSystemItem>()
                {
                   public void execute(FileSystemItem input,


### PR DESCRIPTION
I think this is overall preferred to always starting from the user home directory.