### PR TITLE
Avoid auto-opening test results issues list

### DIFF
--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -249,7 +249,7 @@ public:
 private:
    Build()
       : isRunning_(false), terminationRequested_(false), restartR_(false),
-        usedDevtools_(false)
+        usedDevtools_(false), openErrorList_(true)
    {
    }
 
@@ -641,9 +641,11 @@ private:
 
       // add testthat and shinyteset result parsers
       if (type == kTestFile) {
+         openErrorList_ = false;
          parsers.add(testthatErrorParser(packagePath.parent()));
       }
       else if (type == kTestPackage) {
+         openErrorList_ = false;
          parsers.add(testthatErrorParser(packagePath.complete("tests/testthat")));
       }
 
@@ -1613,6 +1615,7 @@ private:
       json::Object jsonData;
       jsonData["base_dir"] = errorsBaseDir_;
       jsonData["errors"] = errors;
+      jsonData["open_error_list"] = openErrorList_;
 
       ClientEvent event(client_events::kBuildErrors, jsonData);
       module_context::enqueClientEvent(event);
@@ -1746,6 +1749,7 @@ private:
    boost::function<bool(const std::string&)> errorOutputFilterFunction_;
    bool restartR_;
    bool usedDevtools_;
+   bool openErrorList_;
 };
 
 boost::shared_ptr<Build> s_pBuild;

--- a/src/gwt/src/org/rstudio/studio/client/common/compile/CompilePanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/compile/CompilePanel.java
@@ -138,22 +138,24 @@ public class CompilePanel extends Composite
    
    public void showErrors(String basePath, 
                           JsArray<SourceMarker> errors,
-                          int autoSelect)
+                          int autoSelect,
+                          boolean openErrors)
    {
-      showErrors(basePath, errors, autoSelect, false);
+      showErrors(basePath, errors, autoSelect, false, openErrors);
    }
    
    public void showErrors(String basePath, 
                           JsArray<SourceMarker> errors,
                           int autoSelect,
-                          boolean alwaysShowList)
+                          boolean alwaysShowList,
+                          boolean openErrors)
    {
       errorList_.showMarkers(targetFileName_, 
                              basePath, 
                              errors,
                              autoSelect);
 
-      if (alwaysShowList || SourceMarker.showErrorList(errors))
+      if (openErrors && (alwaysShowList || SourceMarker.showErrorList(errors)))
       {
          panel_.setWidget(errorList_);
          showOutputButton_.setVisible(true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPane.java
@@ -242,9 +242,10 @@ public class BuildPane extends WorkbenchPane
    public void showErrors(String basePath,
                           JsArray<SourceMarker> errors, 
                           boolean ensureVisible,
-                          int autoSelect)
+                          int autoSelect,
+                          boolean openErrors)
    {
-      compilePanel_.showErrors(basePath, errors, autoSelect);
+      compilePanel_.showErrors(basePath, errors, autoSelect, openErrors);
       
       if (ensureVisible && SourceMarker.showErrorList(errors))
          ensureVisible();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
@@ -73,7 +73,8 @@ public class BuildPresenter extends BasePresenter
       void showErrors(String basePath,
                       JsArray<SourceMarker> errors, 
                       boolean ensureVisible,
-                      int autoSelect);
+                      int autoSelect,
+                      boolean openErrors);
       void buildCompleted();
       
       HasSelectionCommitHandlers<CodeNavigationTarget> errorList();
@@ -146,7 +147,8 @@ public class BuildPresenter extends BasePresenter
                              true,
                              uiPrefs_.navigateToBuildError().getValue() ?
                                  SourceMarkerList.AUTO_SELECT_FIRST_ERROR :
-                                 SourceMarkerList.AUTO_SELECT_NONE);
+                                 SourceMarkerList.AUTO_SELECT_NONE,
+                             event.openErrorList());
             
             if (uiPrefs_.navigateToBuildError().getValue())
             {
@@ -244,7 +246,8 @@ public class BuildPresenter extends BasePresenter
          view_.showErrors(buildState.getErrorsBaseDir(),
                           buildState.getErrors(), 
                           false,
-                          SourceMarkerList.AUTO_SELECT_NONE);
+                          SourceMarkerList.AUTO_SELECT_NONE,
+                          true);
       
       if (!buildState.isRunning())
          view_.buildCompleted();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/events/BuildErrorsEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/events/BuildErrorsEvent.java
@@ -36,6 +36,10 @@ public class BuildErrorsEvent extends GwtEvent<BuildErrorsEvent.Handler>
       public final native JsArray<SourceMarker> getErrors() /*-{
          return this.errors;
       }-*/;
+
+      public final native boolean openErrorList() /*-{
+         return this.open_error_list;
+      }-*/;
    }
 
    
@@ -52,6 +56,11 @@ public class BuildErrorsEvent extends GwtEvent<BuildErrorsEvent.Handler>
    public String getBaseDirectory()
    {
       return data_.getBaseDirectory();
+   }
+
+   public boolean openErrorList()
+   {
+      return data_.openErrorList();
    }
    
    public JsArray<SourceMarker> getErrors()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/common/CompileOutputPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/common/CompileOutputPane.java
@@ -116,7 +116,7 @@ public class CompileOutputPane extends WorkbenchPane
    @Override
    public void showErrors(JsArray<SourceMarker> errors)
    {
-      compilePanel_.showErrors(null, errors, SourceMarkerList.AUTO_SELECT_FIRST);
+      compilePanel_.showErrors(null, errors, SourceMarkerList.AUTO_SELECT_FIRST, true);
       
       if (SourceMarker.showErrorList(errors))
          ensureVisible(true);


### PR DESCRIPTION
Mitigation for https://github.com/rstudio/rstudio/issues/2592 until an expandable results list is implemented. This prevents `testthat` issues from being opened and keeps the output tab visible instead.