### PR TITLE
eliminate eclipse warnings

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/shiny/ui/ShinyTestPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ui/ShinyTestPopupMenu.java
@@ -15,10 +15,6 @@
 package org.rstudio.studio.client.shiny.ui;
 
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
-import org.rstudio.studio.client.common.shiny.model.ShinyServerOperations;
-import org.rstudio.studio.client.server.ServerError;
-import org.rstudio.studio.client.server.ServerRequestCallback;
-import org.rstudio.studio.client.shiny.model.ShinyViewerType;
 import org.rstudio.studio.client.workbench.commands.Commands;
 
 import com.google.inject.Inject;
@@ -28,10 +24,7 @@ public class ShinyTestPopupMenu extends ToolbarPopupMenu
    @Inject
    public ShinyTestPopupMenu(Commands commands)
    {
-      commands_ = commands;
       addItem(commands.shinyRecordTest().createMenuItem(false));
       addItem(commands.shinyRunAllTests().createMenuItem(false));
    }
-
-   private final Commands commands_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildTab.java
@@ -20,10 +20,7 @@ import com.google.inject.Inject;
 
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
-import org.rstudio.core.client.events.UpdateTabPanelsEvent;
-import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
-import org.rstudio.studio.client.application.events.ReloadWithLastChanceSaveEvent;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.events.SessionInitEvent;
 import org.rstudio.studio.client.workbench.events.SessionInitHandler;
@@ -75,7 +72,6 @@ public class BuildTab extends DelayLoadWorkbenchTab<BuildPresenter>
    {
       super("Build", shim);
       session_ = session;
-      eventBus_ = eventBus;
       binder.bind(commands, shim);
       
       // stop build always starts out disabled
@@ -113,5 +109,4 @@ public class BuildTab extends DelayLoadWorkbenchTab<BuildPresenter>
    }
 
    private Session session_;
-   private EventBus eventBus_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -122,7 +122,6 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       historyManager_ = new CommandLineHistory(input_);
       browseHistoryManager_ = new CommandLineHistory(input_);
       prefs_ = uiPrefs;
-      editorProvider_ = editorProvider;
       languageTracker_ = languageTracker;
       
       editorProvider.setConsoleEditor(input_);
@@ -767,7 +766,6 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    private String lastPromptText_ ;
    private final UIPrefs prefs_;
    
-   private final ConsoleEditorProvider editorProvider_;
    private final ConsoleLanguageTracker languageTracker_;
    
    private final CommandLineHistory historyManager_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/tests/TestsOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/tests/TestsOutputPresenter.java
@@ -24,17 +24,11 @@ import org.rstudio.core.client.CodeNavigationTarget;
 import org.rstudio.core.client.events.SelectionCommitEvent;
 import org.rstudio.core.client.events.SelectionCommitHandler;
 import org.rstudio.core.client.files.FileSystemItem;
-import org.rstudio.core.client.widget.Operation;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.RestartStatusEvent;
 import org.rstudio.studio.client.common.DelayedProgressRequestCallback;
 import org.rstudio.studio.client.common.GlobalDisplay;
-import org.rstudio.studio.client.common.sourcemarkers.SourceMarker;
-import org.rstudio.studio.client.server.ServerError;
-import org.rstudio.studio.client.server.ServerRequestCallback;
-import org.rstudio.studio.client.server.Void;
-import org.rstudio.studio.client.workbench.WorkbenchContext;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.ui.PaneManager;
 import org.rstudio.studio.client.workbench.ui.PaneManager.Tab;
@@ -44,7 +38,6 @@ import org.rstudio.studio.client.workbench.views.buildtools.events.BuildErrorsEv
 import org.rstudio.studio.client.workbench.views.buildtools.events.BuildOutputEvent;
 import org.rstudio.studio.client.workbench.views.buildtools.events.BuildStartedEvent;
 import org.rstudio.studio.client.workbench.views.buildtools.model.BuildServerOperations;
-import org.rstudio.studio.client.workbench.views.console.events.ConsoleActivateEvent;
 import org.rstudio.studio.client.workbench.views.output.common.CompileOutputPaneDisplay;
 import org.rstudio.studio.client.workbench.views.output.common.CompileOutputPaneFactory;
 
@@ -69,8 +62,6 @@ public class TestsOutputPresenter extends BusyPresenter
       view_.setHasLogs(false);
       server_ = server;
       paneManager_ = paneManager;
-      commands_ = commands;
-      events_ = events;
 
       view_.stopButton().addClickHandler(new ClickHandler() {
          @Override
@@ -185,6 +176,4 @@ public class TestsOutputPresenter extends BusyPresenter
    private final CompileOutputPaneDisplay view_;
    private final GlobalDisplay globalDisplay_;
    private final PaneManager paneManager_;
-   private final Commands commands_;
-   private final EventBus events_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -54,7 +54,6 @@ import org.rstudio.core.client.widget.*;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.ImageMenuItem;
-import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.common.icons.StandardIcons;
@@ -63,7 +62,6 @@ import org.rstudio.studio.client.rmarkdown.events.RenderRmdEvent;
 import org.rstudio.studio.client.rmarkdown.events.RmdOutputFormatChangedEvent;
 import org.rstudio.studio.client.rsconnect.RSConnect;
 import org.rstudio.studio.client.rsconnect.ui.RSConnectPublishButton;
-import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.shiny.model.ShinyApplicationParams;
 import org.rstudio.studio.client.shiny.ui.ShinyTestPopupMenu;
 import org.rstudio.studio.client.shiny.ui.ShinyViewerTypePopupMenu;
@@ -116,8 +114,7 @@ public class TextEditingTargetWidget
       shinyViewerMenu_ = RStudioGinjector.INSTANCE.getShinyViewerTypePopupMenu();
       shinyTestMenu_ = RStudioGinjector.INSTANCE.getShinyTestPopupMenu();
       handlerManager_ = new HandlerManager(this);
-      server_ = server;
-      
+
       findReplace_ = new TextEditingTargetFindReplace(
          new TextEditingTargetFindReplace.Container()
          {  
@@ -1374,7 +1371,6 @@ public class TextEditingTargetWidget
    private final DocDisplay editor_;
    private final ShinyViewerTypePopupMenu shinyViewerMenu_;
    private final ShinyTestPopupMenu shinyTestMenu_;
-   private final SourceServerOperations server_;
    private String extendedType_;
    private String publishPath_;
    private CheckBox sourceOnSave_;


### PR DESCRIPTION
Noticed there were a couple dozen eclipse warnings. I remediated them in some cases by removing code (e.g. member variable that is assigned to and never read). Probably worth a look to ensure that there isn't a side effect of one of these assignments not being considered (e.g. perhaps it's there for the initialization yielded by `@Inject` 