### PR TITLE
Bugfix/websocket timeout tweak

### DIFF
--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -234,7 +234,7 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
        value<int>(&webSocketPingSeconds_)->default_value(10),
        "WebSocket keep-alive ping interval (seconds)")
       (kWebSocketConnectTimeout,
-       value<int>(&webSocketConnectTimeout_)->default_value(5),
+       value<int>(&webSocketConnectTimeout_)->default_value(3),
        "WebSocket initial connection timeout (seconds)");
 
    // allow options

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -186,7 +186,7 @@ public class TerminalSession extends XTermWidget
             socket_.connect(consoleProcess_, new TerminalSessionSocket.ConnectCallback()
             {
                @Override
-               public void onConnected(String message)
+               public void onConnected()
                {
                   consoleProcess_.start(new ServerRequestCallback<Void>()
                   {
@@ -198,12 +198,6 @@ public class TerminalSession extends XTermWidget
                         sendUserInput();
                         eventBus_.fireEvent(new TerminalSessionStartedEvent(TerminalSession.this));
                         callback.onSuccess(true /*connected*/);
-                        
-                        if (!StringUtil.isNullOrEmpty(message))
-                        {
-                           globalDisplay_.showMessage(GlobalDisplay.MSG_INFO,
-                                                      "Terminal Connected", message);
-                        }
                      }
 
                      @Override
@@ -211,14 +205,8 @@ public class TerminalSession extends XTermWidget
                      {
                         disconnect(false);
                         callback.onFailure(error.getUserMessage());
-                        if (!StringUtil.isNullOrEmpty(message))
-                        {
-                           globalDisplay_.showMessage(GlobalDisplay.MSG_ERROR,
-                                                      "Terminal Failed to Connect", message);
-                        }
                      }
                   });
-
                }
 
                @Override
@@ -226,6 +214,11 @@ public class TerminalSession extends XTermWidget
                {
                   disconnect(false);
                   callback.onFailure(errorMsg);
+                  if (!StringUtil.isNullOrEmpty(errorMsg))
+                  {
+                     globalDisplay_.showMessage(GlobalDisplay.MSG_ERROR,
+                           "Terminal Failed to Connect", errorMsg);
+                  }
                }
             });
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSessionSocket.java
@@ -72,9 +72,8 @@ public class TerminalSessionSocket
    {
       /**
        * Callback when connection has been made.
-       * @param message additional info about the connection, may be null
        */
-      void onConnected(String message);
+      void onConnected();
    
    
       /**
@@ -234,7 +233,7 @@ public class TerminalSessionSocket
       if (consoleProcess.getProcessInfo().getZombie())
       {
          diagnostic("Zombie, not reconnecting");
-         callback.onConnected(null /*message*/);
+         callback.onConnected();
          return;
       }
 
@@ -249,7 +248,7 @@ public class TerminalSessionSocket
       {
       case ConsoleProcessInfo.CHANNEL_RPC:
          diagnostic("Connected with RPC");
-         callback.onConnected(null /*message*/);
+         callback.onConnected();
          break;
          
       case ConsoleProcessInfo.CHANNEL_WEBSOCKET:
@@ -318,7 +317,7 @@ public class TerminalSessionSocket
             {
                connectWebSocketTimer_.cancel();
                diagnostic("WebSocket connected");
-               callback.onConnected(null);
+               callback.onConnected();
                if (webSocketPingInterval_ > 0)
                {
                   keepAliveTimer_.scheduleRepeating(webSocketPingInterval_ * 1000);
@@ -362,18 +361,14 @@ public class TerminalSessionSocket
          public void onResponseReceived(Void response)
          {
             diagnostic("Switched to RPC");
-            connectCallback_.onConnected("Unable to connect with WebSockets so terminal " +
-                  "performance will be reduced. If WebSockets cannot be enabled in your environment, " +
-                  "disable them in Tools / Global Options / Terminal preferences. This will avoid terminal " +
-                  "startup delay and suppress this message.");
+            connectCallback_.onConnected();
          }
       
          @Override
          public void onError(ServerError error)
          {
-            connectCallback_.onError("Terminal unable to use WebSockets and failed to " +
-                  "switch to HTTP mode. Turn off WebSockets via Tools / " +
-                  "Global Options / Terminal preferences and try to start the terminal again.");
+            diagnostic("Failed to switch to RPC: " + error.getMessage());
+            connectCallback_.onError("Terminal failed to connect. Please try again.");
          }
       });
    }      


### PR DESCRIPTION
Fixes #2207 

Tweak previous fix to shorten timeout from 5 seconds to 3; that is, if WebSockets fails to connect after 3 seconds, switch to RPC (for this terminal only).

Also remove the worst-error-message of the year shown when WebSocket timed out and fallback to RPC was successful.

Finally, simplify message shown if RPC fallback also fails (should be quite rare, but still want to show something instead of failing silently).