### PR TITLE
default to source on save for d3 scripts

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -1253,12 +1253,13 @@ public class Source implements InsertSourceHandler,
          FileTypeRegistry.JS, 
          "", 
          "d3.js",
-         Position.create(0, 0),
+         Position.create(5, 0),
          new CommandWithArg<EditingTarget> () {
            @Override
            public void execute(EditingTarget target)
            {
               target.verifyD3Prerequisites(); 
+              target.setSourceOnSave(true);
            }
          }
       );

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
@@ -86,6 +86,8 @@ public interface EditingTarget extends IsWidget,
    
    void forceLineHighlighting();
    
+   void setSourceOnSave(boolean sourceOnSave);
+   
    void setCursorPosition(Position position);
    void ensureCursorVisible();
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
@@ -605,6 +605,11 @@ public class CodeBrowserEditingTarget implements EditingTarget
    }
    
    @Override
+   public void setSourceOnSave(boolean sourceOnSave)
+   {  
+   }
+   
+   @Override
    public boolean onBeforeDismiss()
    {
       return true;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -235,6 +235,11 @@ public class ProfilerEditingTarget implements EditingTarget,
    public void forceLineHighlighting()
    {
    }
+   
+   @Override
+   public void setSourceOnSave(boolean sourceOnSave)
+   {  
+   }
 
    public void focus()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1047,6 +1047,13 @@ public class TextEditingTarget implements
    }
    
    @Override
+   public void setSourceOnSave(boolean sourceOnSave)
+   {
+      view_.getSourceOnSave().setValue(sourceOnSave);
+      docUpdateSentinel_.setSourceOnSave(sourceOnSave, null);
+   }
+   
+   @Override
    public void highlightDebugLocation(
          SourcePosition startPos,
          SourcePosition endPos,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1049,8 +1049,7 @@ public class TextEditingTarget implements
    @Override
    public void setSourceOnSave(boolean sourceOnSave)
    {
-      view_.getSourceOnSave().setValue(sourceOnSave);
-      docUpdateSentinel_.setSourceOnSave(sourceOnSave, null);
+      view_.getSourceOnSave().setValue(sourceOnSave, true);
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
@@ -195,6 +195,11 @@ public class UrlContentEditingTarget implements EditingTarget
    public void forceLineHighlighting()
    {
    }
+   
+   @Override
+   public void setSourceOnSave(boolean sourceOnSave)
+   {  
+   }
 
    @Handler
    void onPrintSourceDoc()


### PR DESCRIPTION
In order to default to source on save for d3 scripts I added an EditingTarget method to set the property. For whatever reason in the editing target I had to set both the view and the model (perhaps b/c the view event listener that normally syncs to the model isn't yet active?).

This seems to work fine, but it mildly bugs me that I have to set both the model and view. I don't think it's worth a refactor to improve this, but I'm wondering if I missed something and there is a simpler solution. @jmcphers Let me know what you think.