### PR TITLE
Avoid loading the 'yaml' package on boot

### DIFF
--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -143,9 +143,13 @@
    )
 })
 
+.rs.addFunction("getTemplateDetails", function(templateYaml) {
+   yaml::yaml.load_file(templateYaml)
+})
+
 # given a path to a folder on disk, return information about the R Markdown
 # template in that folder.
-.rs.addFunction("getTemplateDetails", function(path) {
+.rs.addFunction("getTemplateYamlFile", function(path) {
    # check for required files
    templateYaml <- file.path(path, "template.yaml")
    skeletonPath <- file.path(path, "skeleton")
@@ -158,14 +162,14 @@
    if (!file.exists(file.path(skeletonPath, "skeleton.Rmd")))
       return(NULL)
 
-   # load template details from YAML
-   templateDetails <- yaml::yaml.load_file(templateYaml)
+   # will need to enforce create_dir if there are multiple files in /skeleton/
+   multiFile = length(list.files(skeletonPath)) > 1 
 
-   # enforce create_dir if there are multiple files in /skeleton/
-   if (length(list.files(skeletonPath)) > 1) 
-      templateDetails$create_dir <- TRUE
-
-   templateDetails
+   # return metadata; we won't parse until the client requests template files
+   list(
+      template_yaml = .rs.scalar(templateYaml),
+      multi_file    = .rs.scalar(multiFile)
+   )
 })
 
 


### PR DESCRIPTION
This change fixes an issue wherein every session of RStudio has the `yaml` package loaded (even if the user has just restarted R and has done nothing related to R Markdown or yaml).

The `yaml` package is loaded to parse R Markdown template metadata in each installed package. We have a lazy indexer which looks for these files at startup, parses them, and adds them to a global cache. This is necessary because some pathological setups have thousands of packages installed, so without some prefetching it takes unacceptably long to retrieve the set of templates.

To avoid loading the `yaml` package on startup, this is now a two-phase step:

1. The indexer no longer parses YAML; its job is only to *locate* the YAML files. On pathological configurations this is the slow phase.

2. When R Markdown templates are requested, the second phase (YAML parsing) occurs.
