### PR TITLE
Add support for expressions in alternate notebook engines

### DIFF
--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -13,7 +13,7 @@
 #
 #
 
-.rs.addFunction("scalarListFromList", function(l)
+.rs.addFunction("scalarListFromList", function(l, expressions = FALSE)
 {
    # hint that every non-list element of the hierarchical list l
    # is a scalar value if it is of length 1
@@ -29,6 +29,8 @@
             Encoding(ele) <- "UTF-8"
          .rs.scalar(ele)
       }
+      else if (identical(expressions, TRUE) && (is.expression(ele) || is.call(ele)))
+         .rs.scalarListFromList(list(expr = eval(ele)))$expr
       else
          ele
    })

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -638,7 +638,7 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
   },
   error = function(e) {})
 
-  .rs.scalarListFromList(opts)
+  .rs.scalarListFromList(opts, expressions = TRUE)
 })
 
 .rs.addFunction("extractChunkInnerCode", function(code)


### PR DESCRIPTION
We would like to support `data` expressions in alternate engines to match `knitr` behavior, as in:

``````
```{d3 data=c(10,20,30), options='orange'}
  svg.selectAll('rect')
    .data(data)
  .enter()
    .append('rect')
      .attr('width', function(d) { return d * 10; })
      .attr('height', '20px')
      .attr('y', function(d, i) { return i * 22; })
      .attr('fill', options);
```
``````

See also: https://github.com/rstudio/r2d3/issues/5