### PR TITLE
Add highlight rules for d3 chunks in notebooks

### DIFF
--- a/src/gwt/acesupport/acemode/markdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/markdown_highlight_rules.js
@@ -64,6 +64,7 @@ var ScalaHighlightRules = require("ace/mode/scala_highlight_rules").ScalaHighlig
 var ShHighlightRules = require("mode/sh_highlight_rules").ShHighlightRules;
 var StanHighlightRules = require("mode/stan_highlight_rules").StanHighlightRules;
 var SqlHighlightRules = require("mode/sql_highlight_rules").SqlHighlightRules;
+var JavaScriptHighlightRules = require("ace/mode/javascript_highlight_rules").JavaScriptHighlightRules;
 
 var escaped = function(ch) {
     return "(?:[^" + lang.escapeRegExp(ch) + "\\\\]|\\\\.)*";
@@ -188,6 +189,7 @@ var MarkdownHighlightRules = function() {
         github_embed("bash", "bashcode-"),
         github_embed("stan", "stancode-"),
         github_embed("sql", "sqlcode-"),
+        github_embed("d3", "jscode-"),
         
         { // Github style block
             token : "support.function",
@@ -499,6 +501,12 @@ var MarkdownHighlightRules = function() {
     }]);
 
     this.embedRules(SqlHighlightRules, "sqlcode-", [{
+        token : "support.function",
+        regex : "^\\s*```",
+        next  : "pop"
+    }]);
+
+    this.embedRules(JavaScriptHighlightRules, "jscode-", [{
         token : "support.function",
         regex : "^\\s*```",
         next  : "pop"

--- a/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
@@ -31,6 +31,7 @@ var YamlHighlightRules = require("mode/yaml_highlight_rules").YamlHighlightRules
 var ShHighlightRules = require("mode/sh_highlight_rules").ShHighlightRules;
 var StanHighlightRules = require("mode/stan_highlight_rules").StanHighlightRules;
 var SqlHighlightRules = require("mode/sql_highlight_rules").SqlHighlightRules;
+var JavaScriptHighlightRules = require("ace/mode/javascript_highlight_rules").JavaScriptHighlightRules;
 var Utils = require("mode/utils");
 
 function makeDateRegex()
@@ -152,6 +153,16 @@ var RMarkdownHighlightRules = function() {
       ["firstLine"]
    );
 
+   // Embed JavaScript highlighting rules
+   Utils.embedRules(
+       this,
+       JavaScriptHighlightRules,
+       "sql",
+       this.$reJavaScriptChunkStartString,
+       this.$reChunkEndString,
+       ["start", "listblock", "allowBlock"]
+   );
+
    this.$rules["yaml-start"].unshift({
       token: ["string"],
       regex: makeDateRegex()
@@ -178,15 +189,15 @@ oop.inherits(RMarkdownHighlightRules, TextHighlightRules);
    this.$reChunkEndString =
       "^(?:[ ]{4})?`{3,}\\s*$";
 
-   this.$reCppChunkStartString      = engineRegex("[Rr]cpp");
-   this.$reMarkdownChunkStartString = engineRegex("block");
-   this.$rePerlChunkStartString     = engineRegex("perl");
-   this.$rePythonChunkStartString   = engineRegex("python");
-   this.$reRubyChunkStartString     = engineRegex("ruby");
-   this.$reShChunkStartString       = engineRegex("(?:bash|sh)");
-   this.$reStanChunkStartString     = engineRegex("stan");
-   this.$reSqlChunkStartString      = engineRegex("sql");
-   
+   this.$reCppChunkStartString        = engineRegex("[Rr]cpp");
+   this.$reMarkdownChunkStartString   = engineRegex("block");
+   this.$rePerlChunkStartString       = engineRegex("perl");
+   this.$rePythonChunkStartString     = engineRegex("python");
+   this.$reRubyChunkStartString       = engineRegex("ruby");
+   this.$reShChunkStartString         = engineRegex("(?:bash|sh)");
+   this.$reStanChunkStartString       = engineRegex("stan");
+   this.$reSqlChunkStartString        = engineRegex("sql");
+   this.$reJavaScriptChunkStartString = engineRegex("d3");
    
 }).call(RMarkdownHighlightRules.prototype);
 


### PR DESCRIPTION
Add highlight rules for d3 chunks, see https://github.com/rstudio/r2d3/issues/7.

<img width="827" alt="screen shot 2018-04-11 at 1 49 41 pm" src="https://user-images.githubusercontent.com/3478847/38642548-38f4ddb6-3d8f-11e8-8ce5-b9f4e3978b10.png">
