### PR TITLE
Compatibility with Rtools 3.5

### DIFF
--- a/src/cpp/core/r_util/RToolsInfo.cpp
+++ b/src/cpp/core/r_util/RToolsInfo.cpp
@@ -149,10 +149,10 @@ RToolsInfo::RToolsInfo(const std::string& name,
       versionMax = "3.2.99";
       gcc463Configuration(installPath, &relativePathEntries, &clangArgs);
    }
-   else if (name == "3.4")
+   else if (name == "3.4" || name == "3.5")
    {
       versionMin = "3.3.0";
-      versionMax = "3.4.99";
+      versionMax = "3.5.99";
 
       relativePathEntries.push_back("bin");
 

--- a/src/cpp/session/modules/build/SessionInstallRtools.cpp
+++ b/src/cpp/session/modules/build/SessionInstallRtools.cpp
@@ -65,6 +65,7 @@ Error installRtools()
    std::string version, url;
    FilePath installPath("C:\\Rtools");
    std::vector<r_util::RToolsInfo> availableRtools;
+   availableRtools.push_back(r_util::RToolsInfo("3.5", installPath, gcc49));
    availableRtools.push_back(r_util::RToolsInfo("3.4", installPath, gcc49));
    availableRtools.push_back(r_util::RToolsInfo("3.3", installPath, gcc49));
    availableRtools.push_back(r_util::RToolsInfo("3.2", installPath, gcc49));


### PR DESCRIPTION
NOTE: This PR should not be merged as it's just a starting point for testing. I don't currently have a working Windows dev setup for RStudio (my VM got borked a few weeks back) so hope that someone who does can validate that these changes are correct and complete).

RTools is doing a minor update to v3.5 as part of the upcoming R 3.5 release. According to Jeroen:

> The toolchain is unchanged, but I updated the build utilities (make,
sh, tar, etc) and refactored the installer. The scripts are now
available at: https://github.com/rwinlib/rtools35

RStudio needs to have knowledge of various versions of Rtools for 2 reasons:

1) When we scan the registry for installed versions of Rtools we need to know which versions of R they are compatible with as well as what directories to add to the PATH as well as what directories should be made available to libclang for code completion.

2) When we prompt for the installation of Rtools we need to know which version to suggest based on the current version of R as well as it's URL.

As you can see from this change based on Jeroen's description of Rtools 3.5 being just an update to embedded tools we basically treat Rtools 3.4 and 3.5 exactly the same. We should test to ensure that this is in fact the case.

Note that another part of this change is asserting that Rtools 3.4 will work for versions of R >= 3.5. Current installed versions of the IDE contain the assertion that Rtools 3.4 only works up to R 3.4, which means that anyone running R 3.5 pre-releases (or the final release later this month) will not be able to use Rtools with RStudio! This implies that we need this change to be backported to the public release as soon as we've validated it.

So the remaining work here is to validate that this change:

1) Successfully identifies and uses Rtools 3.5 when it's available (this applies to both package building and use of libclang autocomplete and diagnostics)

2) Allows the use of Rtools 3.4 for R version 3.5 (to test this you need to make sure that Rtools 3.5 is NOT installed)

3) Prompts for and successfully installs Rtools 3.5 when no version of Rtools is currently available.


