### PR TITLE
Fix .rs.api.sendToConsole() and package connection that use Shiny

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -402,7 +402,8 @@
       code = .rs.scalar(code),
       echo = .rs.scalar(as.logical(echo)),
       execute = .rs.scalar(as.logical(execute)),
-      focus = .rs.scalar(as.logical(focus))
+      focus = .rs.scalar(as.logical(focus)),
+      language = "R"
    )
 
    .rs.enqueClientEvent("send_to_console", data)

--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -702,12 +702,7 @@ options(connectionObserver = list(
       sep = ""
    )
 
-   .rs.enqueClientEvent("send_to_console", list(
-      "code" = .rs.scalar(consoleCommand),
-      "execute" = .rs.scalar(TRUE),
-      "focus" = .rs.scalar(FALSE),
-      "animate" = .rs.scalar(FALSE)
-   ))
+   .rs.api.sendToConsole(consoleCommand, echo = FALSE, execute = TRUE, focus = FALSE)
 
    .rs.success()
 })


### PR DESCRIPTION
Fixes:

```
.rs.api.sendToConsole("1+1")
```

and 

The Spark connection in `sparklyr` which uses shiny apps and send to console internally.