### PR TITLE
Add colors to getThemeInfo api to support better visualizations

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -699,10 +699,47 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
      editor,
      ignore.case = TRUE)
 
-   list(
-      editor = editor,
-      global = global,
-      dark = dark
+   colors <- list(
+      "Ambiance"              = list(background = "#202020", color = "#E6E1DC"),
+      "Chaos"                 = list(background = "#161616", color = "#E6E1DC"),
+      "Chrome"                = list(background = "#FFFFFF", color = "black"),
+      "Clouds Midnight"       = list(background = "#191919", color = "#929292"),
+      "Clouds"                = list(background = "#FFFFFF", color = "#000000"),
+      "Cobalt"                = list(background = "#002240", color = "#FFFFFF"),
+      "Crimson Editor"        = list(background = "#FFFFFF", color = "rgb(64, 64, 64)"),
+      "Dawn"                  = list(background = "#F9F9F9", color = "#080808"),
+      "Dracula"               = list(background = "#282a36", color = "#f8f8f2"),
+      "Dreamwaver"            = list(background = "#FFFFFF", color = "black"),
+      "Eclipse"               = list(background = "#FFFFFF", color = "black"),
+      "Idle Fingers"          = list(background = "#323232", color = "#FFFFFF"),
+      "Katzenmilch"           = list(background = "#f3f2f3", color = "rgba(15, 0, 9, 1.0)"),
+      "Kr Theme"              = list(background = "#0B0A09", color = "#FCFFE0"),
+      "Material"              = list(background = "#263238", color = "#C5C8C6"),
+      "Merbivore Soft"        = list(background = "#1C1C1C", color = "#E6E1DC"),
+      "Merbivore"             = list(background = "#161616", color = "#E6E1DC"),
+      "Mono Industrial"       = list(background = "#222C28", color = "#FFFFFF"),
+      "Monokai"               = list(background = "#272822", color = "#F8F8F2"),
+      "Pastel On Dark"        = list(background = "#2C2828", color = "#8F938F"),
+      "Solarized Dark"        = list(background = "#002B36", color = "#93A1A1"),
+      "Solarized Light"       = list(background = "#FDF6E3", color = "#586E75"),
+      "TextMate"              = list(background = "#FFFFFF", color = "black"),
+      "Tomorrow Night Blue"   = list(background = "#002451", color = "#FFFFFF"),
+      "Tomorrow Night Bright" = list(background = "#000000", color = "#DEDEDE"),
+      "Tomorrow Night 80s"    = list(background = "#2D2D2D", color = "#CCCCCC"),
+      "Tomorrow Night"        = list(background = "#1D1F21", color = "#C5C8C6"),
+      "Tomorrow"              = list(background = "#FFFFFF", color = "#4D4D4C"),
+      "Twilight"              = list(background = "#141414", color = "#F8F8F8"),
+      "Vibrant Ink"           = list(background = "#0F0F0F", color = "#FFFFFF"),
+      "Xcode"                 = list(background = "#FFFFFF", color = "#000000")
+   )
+
+   c(
+      list(
+         editor = editor,
+         global = global,
+         dark = dark
+      ),
+      colors[[editor]]
    )
 })
 


### PR DESCRIPTION
While working with `D3`, would be nice to support rendering visualizations based on editor themes by using a header similar to:

```
// !preview r2d3 data=read.csv(system.file("samples/bubbles/flare.csv", package = "r2d3")), d3_version=4, options=rstudioapi::getThemeInfo(), sizing=htmlwidgets::sizingPolicy(padding=0)
```

<img width="1440" alt="screen shot 2018-04-16 at 11 38 54 am" src="https://user-images.githubusercontent.com/3478847/38828390-c4904d9a-416a-11e8-943f-b6f9bec8f840.png">