### PR TITLE
Support signaling viewer pane for openfile message

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
@@ -171,7 +171,7 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
       {
          activeViewerPane_ = this;
          initializedMessageListeners_ = true;
-         initializeMessageListeners();
+         initializeMessageListeners(getDomain());
       }
    }
 
@@ -306,7 +306,7 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
       }
    }
 
-   private native static void initializeMessageListeners() /*-{
+   private native static void initializeMessageListeners(String domain) /*-{
       var handler = $entry(function(e) {
          if (typeof e.data != 'object')
             return;
@@ -324,7 +324,28 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
          );
       });
       $wnd.addEventListener("message", handler, true);
+
+      if (window.parent.postMessage) {
+         var destination = window.location.origin;
+         window.parent.postMessage({
+           message: "canopenfile",
+           source: "rstudio",
+           domain: window.location.origin
+         }, domain);
+      }
    }-*/;
+
+   private String getDomain()
+   {
+      RegExp reg = RegExp.compile("https?://[^/]+/");
+      MatchResult result = reg.exec(unmodifiedUrl_);
+      if (result != null)
+      {
+         return result.getGroup(0);
+      }
+
+      return "";
+   }
 
    private RStudioFrame frame_;
    private String unmodifiedUrl_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
@@ -177,7 +177,7 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
       {
          activeViewerPane_ = this;
          initializedMessageListeners_ = true;
-         initializeMessageListeners(domain);
+         initializeMessageListeners();
       }
    }
 
@@ -312,8 +312,16 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
       }
    }
 
-   private native static void initializeMessageListeners(String domain) /*-{
+   public static String getCurrentDomain()
+   {
+      if (activeViewerPane_ == null) return "";
+
+      return getDomainFromUrl(activeViewerPane_.unmodifiedUrl_);
+   }
+
+   private native static void initializeMessageListeners() /*-{
       var handler = $entry(function(e) {
+         var domain = @org.rstudio.studio.client.workbench.views.viewer.ViewerPane::getCurrentDomain()();
          if (typeof e.data != 'object')
             return;
          if (e.origin != $wnd.location.origin && e.origin != domain)


### PR DESCRIPTION
Follow up to https://github.com/rstudio/rstudio/pull/2653 to:
1) Support signaling viewers that the `openfile` message is available.
2) As part of signaling, give the origin domain to allow cross-site message from a different domain/port hosting the widget.