### PR TITLE
Support opening errors from D3 from external window

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/CodeNavigationListener.java
+++ b/src/gwt/src/org/rstudio/core/client/CodeNavigationListener.java
@@ -1,0 +1,116 @@
+/*
+ * CodeNavigationListener.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client;
+
+import org.rstudio.core.client.files.FileSystemItem;
+import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
+
+import com.google.gwt.regexp.shared.MatchResult;
+import com.google.gwt.regexp.shared.RegExp;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+@Singleton
+public class CodeNavigationListener
+{
+   @Inject
+   public CodeNavigationListener(FileTypeRegistry fileTypeRegistry)
+   {
+      codeNavigationListener_ = this;
+      fileTypeRegistry_ = fileTypeRegistry;
+      
+      initializeMessageListeners();
+   }
+
+   private static String getDomainFromUrl(String url)
+   {
+      RegExp reg = RegExp.compile("https?://[^/]+");
+      MatchResult result = reg.exec(url);
+      if (result != null)
+      {
+         return result.getGroup(0);
+      }
+
+      return "";
+   }
+
+   private native static String getOrigin() /*-{
+     return $wnd.location.origin;
+   }-*/;
+   
+   public void setUrl(String url)
+   {
+      url_ = url;
+   }
+   
+   public static String getCurrentDomain()
+   {
+      if (codeNavigationListener_ == null) return "";
+
+      return getDomainFromUrl(codeNavigationListener_.url_);
+   }
+   
+   private void openFileFromMessage(final String file,
+                                    final int line,
+                                    final int column)
+   {
+
+      FilePosition filePosition = FilePosition.create(line, column);
+      CodeNavigationTarget navigationTarget = new CodeNavigationTarget(file, filePosition);
+
+      fileTypeRegistry_.editFile(
+         FileSystemItem.createFile(navigationTarget.getFile()),
+         filePosition);
+   }
+
+   public static void onOpenFileFromMessage(final String file, int line, int column)
+   {
+      if (codeNavigationListener_ != null)
+      {
+         codeNavigationListener_.openFileFromMessage(file, line, column);
+      }
+   }
+   
+   private native static void initializeMessageListeners() /*-{
+      var handler = $entry(function(e) {
+         var domain = @org.rstudio.core.client.CodeNavigationListener::getCurrentDomain()();
+         if (typeof e.data != 'object')
+            return;
+         if (e.origin != $wnd.location.origin && e.origin != domain)
+            return;
+         if (e.data.message != "openfile")
+            return;
+         if (e.data.source != "r2d3")
+            return;
+            
+         @org.rstudio.core.client.CodeNavigationListener::onOpenFileFromMessage(Ljava/lang/String;II)(
+            e.data.file,
+            parseInt(e.data.line),
+            parseInt(e.data.column)
+         );
+      });
+      $wnd.addEventListener("message", handler, true);
+   }-*/;
+   
+   public String getOriginDomain()
+   {
+      return getDomainFromUrl(getOrigin());
+   }
+   
+   private final FileTypeRegistry fileTypeRegistry_;
+   private static CodeNavigationListener codeNavigationListener_;
+   private String url_;
+}

--- a/src/gwt/src/org/rstudio/core/client/CodeNavigationListener.java
+++ b/src/gwt/src/org/rstudio/core/client/CodeNavigationListener.java
@@ -68,6 +68,7 @@ public class CodeNavigationListener
                                     final int column,
                                     final boolean highlight)
    {
+      if (highlight && !highlightAllowed_) return;
 
       FilePosition filePosition = FilePosition.create(line, column);
       CodeNavigationTarget navigationTarget = new CodeNavigationTarget(file, filePosition);
@@ -76,6 +77,8 @@ public class CodeNavigationListener
          FileSystemItem.createFile(navigationTarget.getFile()),
          filePosition,
          highlight);
+
+      highlightAllowed_ = false;
    }
 
    public static void onOpenFileFromMessage(final String file, int line, int column, boolean highlight)
@@ -113,7 +116,13 @@ public class CodeNavigationListener
       return getDomainFromUrl(getOrigin());
    }
    
+   public void allowOpenOnLoad()
+   {
+      highlightAllowed_ = true;
+   }
+   
    private final FileTypeRegistry fileTypeRegistry_;
    private static CodeNavigationListener codeNavigationListener_;
    private String url_;
+   private boolean highlightAllowed_;
 }

--- a/src/gwt/src/org/rstudio/core/client/CodeNavigationListener.java
+++ b/src/gwt/src/org/rstudio/core/client/CodeNavigationListener.java
@@ -65,7 +65,8 @@ public class CodeNavigationListener
    
    private void openFileFromMessage(final String file,
                                     final int line,
-                                    final int column)
+                                    final int column,
+                                    final boolean highlight)
    {
 
       FilePosition filePosition = FilePosition.create(line, column);
@@ -73,14 +74,15 @@ public class CodeNavigationListener
 
       fileTypeRegistry_.editFile(
          FileSystemItem.createFile(navigationTarget.getFile()),
-         filePosition);
+         filePosition,
+         highlight);
    }
 
-   public static void onOpenFileFromMessage(final String file, int line, int column)
+   public static void onOpenFileFromMessage(final String file, int line, int column, boolean highlight)
    {
       if (codeNavigationListener_ != null)
       {
-         codeNavigationListener_.openFileFromMessage(file, line, column);
+         codeNavigationListener_.openFileFromMessage(file, line, column, highlight);
       }
    }
    
@@ -96,10 +98,11 @@ public class CodeNavigationListener
          if (e.data.source != "r2d3")
             return;
             
-         @org.rstudio.core.client.CodeNavigationListener::onOpenFileFromMessage(Ljava/lang/String;II)(
+         @org.rstudio.core.client.CodeNavigationListener::onOpenFileFromMessage(Ljava/lang/String;IIZ)(
             e.data.file,
             parseInt(e.data.line),
-            parseInt(e.data.column)
+            parseInt(e.data.column),
+            e.data.highlight === true
          );
       });
       $wnd.addEventListener("message", handler, true);

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinModule.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinModule.java
@@ -20,6 +20,7 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Singleton;
 import com.google.inject.name.Names;
 
+import org.rstudio.core.client.CodeNavigationListener;
 import org.rstudio.core.client.command.ApplicationCommandManager;
 import org.rstudio.core.client.command.EditorCommandManager;
 import org.rstudio.core.client.command.ShortcutViewer;
@@ -286,6 +287,7 @@ public class RStudioGinModule extends AbstractGinModule
       bind(ProjectTemplateRegistryProvider.class).in(Singleton.class);
       bind(PackageProvidedExtensions.class).asEagerSingleton();
       bind(JavaScriptEventHistory.class).asEagerSingleton();
+      bind(CodeNavigationListener.class).asEagerSingleton();
 
       bind(ApplicationView.class).to(ApplicationWindow.class)
             .in(Singleton.class) ;

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -18,6 +18,7 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.inject.client.GinModules;
 import com.google.gwt.inject.client.Ginjector;
 
+import org.rstudio.core.client.CodeNavigationListener;
 import org.rstudio.core.client.VirtualConsole;
 import org.rstudio.core.client.command.AddinCommandBinding;
 import org.rstudio.core.client.command.ApplicationCommandManager;
@@ -284,4 +285,5 @@ public interface RStudioGinjector extends Ginjector
    AddinsCommandManager getAddinsCommandManager();
    DependencyManager getDependencyManager();
    ShinyTestPopupMenu getShinyTestPopupMenu();
+   CodeNavigationListener getCodeNavigationListener();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPresenter.java
@@ -233,8 +233,12 @@ public class ViewerPresenter extends BasePresenter
             zoomWindow_ = input;
          }
       });
+
+      String displayUrl = display_.getUrl().replaceAll(
+         "capabilities=[^&]+",
+         "no");
       
-      globalDisplay_.openMinimalWindow(display_.getUrl(),
+      globalDisplay_.openMinimalWindow(displayUrl,
             false,
             windowSize.width,
             windowSize.height,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPresenter.java
@@ -16,6 +16,7 @@ import com.google.gwt.user.client.Command;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
+import org.rstudio.core.client.CodeNavigationListener;
 import org.rstudio.core.client.Size;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppCommand;
@@ -93,7 +94,8 @@ public class ViewerPresenter extends BasePresenter
                           Binder binder,
                           ViewerServerOperations server,
                           SourceShim sourceShim,
-                          Provider<UIPrefs> pUIPrefs)
+                          Provider<UIPrefs> pUIPrefs,
+                          CodeNavigationListener codeNavigationListener)
    {
       super(display);
       display_ = display;
@@ -107,6 +109,7 @@ public class ViewerPresenter extends BasePresenter
       globalDisplay_ = globalDisplay;
       sourceShim_ = sourceShim;
       pUIPrefs_ = pUIPrefs;
+      codeNavigationListener_ = codeNavigationListener;
       
       binder.bind(commands, this);
       
@@ -146,8 +149,10 @@ public class ViewerPresenter extends BasePresenter
       {
          manageCommands(true, event);
          
-         if (event.getBringToFront())
+         if (event.getBringToFront()) {
             display_.bringToFront();
+            codeNavigationListener_.allowOpenOnLoad();
+         }
       
          // respect height request
          int ensureHeight = event.getHeight();
@@ -155,7 +160,7 @@ public class ViewerPresenter extends BasePresenter
             display_.maximize();
          else if (ensureHeight > 0)
             display_.ensureHeight(ensureHeight);
-         
+            
          navigate(event.getURL());
          
          if (event.isHTMLWidget())
@@ -564,4 +569,6 @@ public class ViewerPresenter extends BasePresenter
    
    private WindowEx zoomWindow_ = null;
    private Size zoomWindowDefaultSize_ = null;
+   
+   private CodeNavigationListener codeNavigationListener_;
 }


### PR DESCRIPTION
`htmlwidgets` just added support with [/htmlwidgets/pull/308](https://github.com/ramnathv/htmlwidgets/pull/308) to open widgets in their own window, which we would also like to support in D3. This PR refactores the open file message functionality from the Viewer Pane and makes it available in HTML preview windows as well.