### PR TITLE
Attempt to parse package from testthat file

### DIFF
--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -361,7 +361,18 @@ private:
                             const core::system::ProcessOptions& options,
                             const core::system::ProcessCallbacks& cb)
    {
-      if (type != kTestFile)
+      if (type == kTestFile)
+      {
+          // try to read package from /tests/testthat/filename.R,
+          // but ignore errors if not within a package
+          FilePath maybePackage = FilePath::resolveAliasedPath(
+             packagePath.parent().parent().parent().absolutePath(),
+             core::system::userHomePath()
+          );
+
+          pkgInfo_.read(maybePackage);
+      }
+      else
       {
          // validate that this is a package
          if (!packagePath.childPath("DESCRIPTION").exists())
@@ -390,14 +401,6 @@ private:
                terminateWithError("reading package DESCRIPTION", error);
             }
             
-            return;
-         }
-
-         // get package info
-         error = pkgInfo_.read(packagePath);
-         if (error)
-         {
-            terminateWithError("Reading package DESCRIPTION", error);
             return;
          }
 


### PR DESCRIPTION
While testing a single `testthat` file under a project, `testthat::test_file()` works but the UI entry in the file does not. Previous testing of this feature was performed outside a project where one is expected to manually include the library, this fix parses the project only for `testthat` files and fixes an old merge conflict.