### PR TITLE
Support for additional testthat file detection patterns

### DIFF
--- a/src/cpp/session/modules/SessionTests.cpp
+++ b/src/cpp/session/modules/SessionTests.cpp
@@ -47,11 +47,35 @@ namespace tests {
 
 namespace {
 
+bool isOnlySpaceBefore(const std::string& contents, size_t pos)
+{
+    while (pos > 0)
+    {
+        pos--;
+        if (!isspace(contents.at(pos)))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 TestsFileType getTestType(const std::string& contents)
 {
    size_t pos = contents.find("test_that(", 0);
    if (pos != std::string::npos && (pos == 0 || isspace(contents.at(pos - 1))))
       return TestsTestThat;
+
+   pos = contents.find("context(\"", 0);
+   if (pos != std::string::npos && (pos == 0 || isOnlySpaceBefore(contents, pos)))
+   {
+      pos = contents.find("test_", 0);
+      if (pos != std::string::npos && (pos == 0 || isspace(contents.at(pos - 1))))
+      {
+         return TestsTestThat;
+      }
+   }
 
    pos = contents.find("app <- ShinyDriver$new(", 0);
    if (pos == 0)


### PR DESCRIPTION
The following pattern not recognized by `testthat` files...

```r
context("render")

source("utils.R")

render_r2d3_barchart <- function(...) {
  r2d3(data=c(0.3, 0.6, 0.8, 0.95, 0.40, 0.20), script = "barchart.js", ...)
}

test_succeeds("r2d3 can render visualizations", {
  render_r2d3_barchart()
})
```

Mostly, since `test_that(` is used indirectly through a `test_succeeds` helper function. However, using `context("` at the very top and `test_` methods is a common pattern we can use to identify use cases like this one.