### PR TITLE
Upgrade embedded Pandoc to 2.2

### DIFF
--- a/dependencies/common/install-pandoc
+++ b/dependencies/common/install-pandoc
@@ -20,8 +20,7 @@ set -e
 source rstudio-tools
 
 # variables that control download + installation process
-PANDOC_VERSION="2.1.3"
-PANDOC_CITEPROC_VERSION="0.14.2"
+PANDOC_VERSION="2.2"
 PANDOC_SUBDIR="pandoc/${PANDOC_VERSION}"
 PANDOC_URL_BASE="https://s3.amazonaws.com/rstudio-buildtools/pandoc/${PANDOC_VERSION}"
 
@@ -42,16 +41,14 @@ case "${PLATFORM}" in
 "Darwin-64")
   SUBDIR="macos"
   FILES=(
-    "pandoc-${PANDOC_VERSION}.zip"
-    "pandoc-citeproc-${PANDOC_CITEPROC_VERSION}.zip"
+    "pandoc-${PANDOC_VERSION}-macOS.zip"
   )
   ;;
 
 "Linux-64")
-  SUBDIR="linux-64"
+  SUBDIR="linux"
   FILES=(
-    "pandoc.gz"
-    "pandoc-citeproc.gz"
+    "pandoc-${PANDOC_VERSION}-linux.tar.gz"
   )
   ;;
 
@@ -62,24 +59,25 @@ case "${PLATFORM}" in
 
 esac
 
-# enter sub-directory
-mkdir -p "${SUBDIR}"
-pushd "${SUBDIR}"
-
 # download and extract files
 for FILE in "${FILES[@]}"; do
-  echo "Downloading ${FILE} from ${PANDOC_URL_BASE}/${SUBDIR}/${FILE}"
-  download "${PANDOC_URL_BASE}/${SUBDIR}/${FILE}" "${FILE}"
+  echo "Downloading ${FILE} from ${PANDOC_URL_BASE}/${FILE}"
+  download "${PANDOC_URL_BASE}/${FILE}" "${FILE}"
   extract "${FILE}"
   rm -f "${FILE}"
 done
 
+# enter binaries dir
+pushd "pandoc-${PANDOC_VERSION}/bin"
+
 # copy pandoc binaries to parent folder
-cp pandoc* ..
+cp pandoc* ../..
+
+# leave binaries dir
 popd
 
 # remove transient download folder
-rm -rf "${SUBDIR}"
+rm -rf "pandoc-${PANDOC_VERSION}"
 
 # make pandoc executable
 chmod 755 pandoc*

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -20,9 +20,9 @@ set WINPTY_FILES=winpty-0.4.3-msys2-2.7.0.zip
 set OPENSSL_FILES=openssl-1.0.2m.zip
 set BOOST_FILES=boost-1.65.1-win-msvc14.zip
 
-set PANDOC_VERSION=2.1.3
+set PANDOC_VERSION=2.2
 set PANDOC_NAME=pandoc-%PANDOC_VERSION%
-set PANDOC_FILE=%PANDOC_NAME%.zip
+set PANDOC_FILE=%PANDOC_NAME%-windows-x86_64.zip
 
 set LIBCLANG_VERSION=3.4
 set LIBCLANG_NAME=libclang-%LIBCLANG_VERSION%
@@ -159,11 +159,11 @@ if not exist "mathjax-26" (
 )
 
 if not exist pandoc\%PANDOC_VERSION% (
-  wget %WGET_ARGS% "%BASEURL%%PANDOC_FILE%"
+  wget %WGET_ARGS% "%BASEURL%/pandoc/%PANDOC_VERSION%/%PANDOC_FILE%"
   echo Unzipping %PANDOC_FILE%
   unzip %UNZIP_ARGS% "%PANDOC_FILE%"
   mkdir pandoc\%PANDOC_VERSION%
-  copy "%PANDOC_NAME%\windows\pandoc*" "pandoc\%PANDOC_VERSION%""
+  copy "%PANDOC_NAME%\pandoc*" "pandoc\%PANDOC_VERSION%""
   del %PANDOC_FILE%
   rmdir /s /q %PANDOC_NAME%
 )

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -159,7 +159,7 @@ if not exist "mathjax-26" (
 )
 
 if not exist pandoc\%PANDOC_VERSION% (
-  wget %WGET_ARGS% "%BASEURL%/pandoc/%PANDOC_VERSION%/%PANDOC_FILE%"
+  wget %WGET_ARGS% "%BASEURL%pandoc/%PANDOC_VERSION%/%PANDOC_FILE%"
   echo Unzipping %PANDOC_FILE%
   unzip %UNZIP_ARGS% "%PANDOC_FILE%"
   mkdir pandoc\%PANDOC_VERSION%


### PR DESCRIPTION
This change picks up Pandoc 2.2, which contains a number of important fixes to PowerPoint conversion.

It also updates our Pandoc installation scripts to use the folder layout from the official Pandoc releases, so that it's easier to upgrade to new releases (now that Pandoc is shipping static binaries we no longer need to rebuild or repackage). 

Closes #2714.