### PR TITLE
Support multiple statements in SQL preview

### DIFF
--- a/src/cpp/session/modules/SessionDataPreview.R
+++ b/src/cpp/session/modules/SessionDataPreview.R
@@ -45,12 +45,25 @@
    )
 
    .rs.enqueClientEvent("data_output_completed", preview)
+
+   invisible(NULL)
 })
 
 .rs.addFunction("previewSql", function(script, conn, ...)
 {
    code <- paste(readLines(script), collapse = "\n")
-   data <- DBI::dbGetQuery(conn, statement = code, ...)
 
-   .rs.previewDataFrame(data, script)
+   statements <- unlist(strsplit(code, ";(\n||\r)"))
+
+   result <- NULL
+   for (idx in seq_along(statements)) {
+      if (identical(idx, length(statements))) {
+         result <- DBI::dbGetQuery(conn, statement = statements[[idx]], ...)
+      }
+      else {
+         result <- DBI::dbExecute(conn, statement = statements[[idx]], ...)
+      }
+   } 
+
+   .rs.previewDataFrame(result, script)
 })

--- a/src/cpp/session/resources/templates/query.sql
+++ b/src/cpp/session/resources/templates/query.sql
@@ -1,3 +1,7 @@
 -- !preview dbGetQuery conn=DBI::dbConnect(RSQLite::SQLite())
 
-SELECT 1
+CREATE TABLE t(x INTEGER PRIMARY KEY ASC, y, z);
+
+INSERT INTO t(x, y, z) VALUES(1, 2, 3);
+
+SELECT * FROM t;


### PR DESCRIPTION
Dependent on https://github.com/rstudio/rstudio/pull/2720 to consider this independently.

DBI does not support executing multiple statements, see https://github.com/r-dbi/RPostgres/issues/138, but we can consider splitting them ourselves to enable more useful SQL script and modify also the default script that is created:

<img width="506" alt="screen shot 2018-05-01 at 10 57 28 am" src="https://user-images.githubusercontent.com/3478847/39485823-dea82e58-4d2e-11e8-9232-1f1b0c4f14c1.png">
