### PR TITLE
Implement iterative Powerpoint workflow

### DIFF
--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -188,6 +188,7 @@ configure_file (${CMAKE_CURRENT_SOURCE_DIR}/desktop-config.h.in
 set(DESKTOP_SOURCE_FILES
   DesktopActivationOverlay.cpp
   DesktopBrowserWindow.cpp
+  DesktopComUtils.cpp
   DesktopDownloadItemHelper.cpp
   DesktopGwtCallback.cpp
   DesktopGwtWindow.cpp

--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -154,7 +154,10 @@ list(REMOVE_ITEM MOC_DESKTOP_HEADER_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/DesktopNetworkProxyFactory.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/DesktopProgressActivator.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/DesktopUtils.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/DesktopComUtils.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/DesktopOfficeViewer.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/DesktopWordViewer.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/DesktopPowerpointViewer.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/desktop-config.h.in
   ${CMAKE_CURRENT_SOURCE_DIR}/DockTileView.hpp
 )
@@ -217,8 +220,11 @@ set(DESKTOP_SOURCE_FILES
 if(WIN32)
   set(DESKTOP_SOURCE_FILES ${DESKTOP_SOURCE_FILES}
     DesktopChooseRHome.cpp
-    DesktopWin32ApplicationLaunch.cpp
+    DesktopComUtils.cpp
+    DesktopOfficeViewer.cpp
+    DesktopPowerpointViewer.cpp
     DesktopRVersion.cpp
+    DesktopWin32ApplicationLaunch.cpp
     DesktopWin32DetectRHome.cpp
     DesktopWin32ProgressActivator.cpp
     DesktopWordViewer.cpp

--- a/src/cpp/desktop/DesktopComUtils.cpp
+++ b/src/cpp/desktop/DesktopComUtils.cpp
@@ -25,16 +25,6 @@
 namespace rstudio {
 namespace desktop {
 
-// Convenience to convert an HRSULT to our own error type and bail out on
-// failure.
-#define VERIFY_HRESULT(x) hr = (x); \
-      if (FAILED(hr)) { \
-         errorHR = Error( \
-            boost::system::error_code(hr, boost::system::generic_category()), \
-            ERROR_LOCATION); \
-         goto LErrExit; \
-      }
-
 // Invoke a method or property by name on the given IDispatch interface.
 // Adapted from the standard automation AutoWrap helper function
 // (see http://support.microsoft.com/kb/238393)

--- a/src/cpp/desktop/DesktopComUtils.cpp
+++ b/src/cpp/desktop/DesktopComUtils.cpp
@@ -50,7 +50,8 @@ HRESULT invokeDispatch (int dispatchType, VARIANT *pvResult,
    boost::scoped_array<VARIANT> spArgs(new VARIANT[cArgs + 1]);
    for (int i = 0; i < cArgs; i++)
    {
-      spArgs[i] = va_arg(marker, VARIANT);
+      VARIANT varArg = va_arg(marker, VARIANT);
+      spArgs[i] = varArg;
    }
 
    dp.cArgs = cArgs;
@@ -63,8 +64,9 @@ HRESULT invokeDispatch (int dispatchType, VARIANT *pvResult,
       dp.rgdispidNamedArgs = &dispidNamed;
    }
 
+   EXCEPINFO excep;
    hr = pDisp->Invoke(dispID, IID_NULL, LOCALE_SYSTEM_DEFAULT, dispatchType,
-                      &dp, pvResult, nullptr, nullptr);
+                      &dp, pvResult, &excep, nullptr);
    va_end(marker);
    return hr;
 }

--- a/src/cpp/desktop/DesktopComUtils.cpp
+++ b/src/cpp/desktop/DesktopComUtils.cpp
@@ -1,0 +1,111 @@
+/*
+ * DesktopComUtils.cpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <windows.h>
+#include <winuser.h>
+#include <oleauto.h>
+
+#include <boost/utility.hpp>
+#include <boost/scoped_array.hpp>
+
+#include "DesktopComUtils.hpp"
+
+namespace rstudio {
+namespace desktop {
+
+// Convenience to convert an HRSULT to our own error type and bail out on
+// failure.
+#define VERIFY_HRESULT(x) hr = (x); \
+      if (FAILED(hr)) { \
+         errorHR = Error( \
+            boost::system::error_code(hr, boost::system::generic_category()), \
+            ERROR_LOCATION); \
+         goto LErrExit; \
+      }
+
+// Invoke a method or property by name on the given IDispatch interface.
+// Adapted from the standard automation AutoWrap helper function
+// (see http://support.microsoft.com/kb/238393)
+HRESULT invokeDispatch (int dispatchType, VARIANT *pvResult,
+                        IDispatch *pDisp, const std::wstring& strName,
+                        int cArgs...)
+{
+   va_list marker;
+   va_start(marker, cArgs);
+
+   DISPPARAMS dp = { nullptr, nullptr, 0, 0 };
+   DISPID dispidNamed = DISPID_PROPERTYPUT;
+   DISPID dispID;
+   HRESULT hr;
+
+   LPOLESTR wstrName = const_cast<WCHAR*>(strName.c_str());
+   hr = pDisp->GetIDsOfNames(IID_NULL, &wstrName, 1, LOCALE_USER_DEFAULT,
+                             &dispID);
+   if (FAILED(hr))
+      return hr;
+
+   // Create the argument list
+   boost::scoped_array<VARIANT> spArgs(new VARIANT[cArgs + 1]);
+   for (int i = 0; i < cArgs; i++)
+   {
+      spArgs[i] = va_arg(marker, VARIANT);
+   }
+
+   dp.cArgs = cArgs;
+   dp.rgvarg = spArgs.get();
+
+   // Handle special case: for property put, we need to use named args
+   if (dispatchType & DISPATCH_PROPERTYPUT)
+   {
+      dp.cNamedArgs = 1;
+      dp.rgdispidNamedArgs = &dispidNamed;
+   }
+
+   hr = pDisp->Invoke(dispID, IID_NULL, LOCALE_SYSTEM_DEFAULT, dispatchType,
+                      &dp, pvResult, nullptr, nullptr);
+   va_end(marker);
+   return hr;
+}
+
+// Given an IDispatch pointer and a name, return an IDispatch pointer to the
+// object property with the given name
+HRESULT getIDispatchProp(IDispatch* idispIn, const std::wstring& strName,
+                         IDispatch** pidispOut)
+{
+   VARIANT result;
+   VariantInit(&result);
+   HRESULT hr = invokeDispatch(DISPATCH_PROPERTYGET, &result,
+                               idispIn, strName, 0);
+   if (FAILED(hr))
+      return hr;
+   *pidispOut = result.pdispVal;
+   return hr;
+}
+
+HRESULT getIntProp(IDispatch* idisp, const std::wstring& strName, int* pOut)
+{
+   VARIANT result;
+   VariantInit(&result);
+   HRESULT hr = invokeDispatch(DISPATCH_PROPERTYGET, &result,
+                               idisp, strName, 0);
+   if (FAILED(hr))
+      return hr;
+   *pOut = result.intVal;
+   return hr;
+}
+
+} // namespace desktop
+} // namespace rstudio
+

--- a/src/cpp/desktop/DesktopComUtils.hpp
+++ b/src/cpp/desktop/DesktopComUtils.hpp
@@ -1,0 +1,44 @@
+/*
+ * DesktopComUtils.hpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef DESKTOP_COMUTILS_HPP
+#define DESKTOP_COMUTILS_HPP
+
+// Convenience to convert an HRSULT to our own error type and bail out on
+// failure.
+#define VERIFY_HRESULT(x) hr = (x); \
+      if (FAILED(hr)) { \
+         errorHR = Error( \
+            boost::system::error_code(hr, boost::system::generic_category()), \
+            ERROR_LOCATION); \
+         goto LErrExit; \
+      }
+
+namespace rstudio {
+namespace desktop {
+
+HRESULT invokeDispatch (int dispatchType, VARIANT *pvResult,
+                        IDispatch *pDisp, const std::wstring& strName,
+                        int cArgs...);
+
+HRESULT getIDispatchProp(IDispatch* idispIn, const std::wstring& strName,
+                         IDispatch** pidispOut);
+
+HRESULT getIntProp(IDispatch* idisp, const std::wstring& strName, int* pOut);
+
+} // namespace desktop
+} // namespace rstudio
+
+#endif

--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -551,7 +551,7 @@ void GwtCallback::showWordDoc(QString path)
 #ifdef Q_OS_WIN32
 
    path = resolveAliasedPath(path);
-   Error error = wordViewer_.showDocument(path);
+   Error error = wordViewer_.showItem(path.toStdWString());
    if (error)
    {
       LOG_ERROR(error);
@@ -569,7 +569,7 @@ void GwtCallback::showPptPresentation(QString path)
 #ifdef Q_OS_WIN32
 
    path = resolveAliasedPath(path);
-   Error error = pptViewer_.showPresentation(path);
+   Error error = pptViewer_.showItem(path.toStdWString());
    if (error)
    {
       LOG_ERROR(error);
@@ -592,7 +592,7 @@ void GwtCallback::showPDF(QString path, int pdfPage)
 void GwtCallback::prepareShowWordDoc()
 {
 #ifdef Q_OS_WIN32
-   Error error = wordViewer_.closeLastViewedDocument();
+   Error error = wordViewer_.closeLastViewedItem();
    if (error)
    {
       LOG_ERROR(error);
@@ -603,7 +603,7 @@ void GwtCallback::prepareShowWordDoc()
 void GwtCallback::prepareShowPptPresentation()
 {
 #ifdef Q_OS_WIN32
-   Error error = pptViewer_.closeLastPresentation();
+   Error error = pptViewer_.closeLastViewedItem();
    if (error)
    {
       LOG_ERROR(error);

--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -564,13 +564,13 @@ void GwtCallback::showWordDoc(QString path)
 #endif
 }
 
-#endif
-
 void GwtCallback::showPptPresentation(QString path)
 {
    // TODO (jmcphers): as with Word, connect more robustly with the application
    showFile(path);
 }
+
+#endif
 
 void GwtCallback::showPDF(QString path, int pdfPage)
 {

--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -566,8 +566,19 @@ void GwtCallback::showWordDoc(QString path)
 
 void GwtCallback::showPptPresentation(QString path)
 {
-   // TODO (jmcphers): as with Word, connect more robustly with the application
+#ifdef Q_OS_WIN32
+
+   path = resolveAliasedPath(path);
+   Error error = pptViewer_.showPresentation(path);
+   if (error)
+   {
+      LOG_ERROR(error);
+      showFile(path);
+   }
+#else
+   // Invoke default viewer on other platforms
    showFile(path);
+#endif
 }
 
 #endif
@@ -591,7 +602,13 @@ void GwtCallback::prepareShowWordDoc()
 
 void GwtCallback::prepareShowPptPresentation()
 {
-   // TODO (jmcphers): as with Word, we will close the document if it's currently open on Windows.
+#ifdef Q_OS_WIN32
+   Error error = pptViewer_.closeLastPresentation();
+   if (error)
+   {
+      LOG_ERROR(error);
+   }
+#endif
 }
 
 QString GwtCallback::getRVersion()

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -25,6 +25,7 @@
 
 #ifdef Q_OS_WIN32
 #include "DesktopWordViewer.hpp"
+#include "DesktopPowerpointViewer.hpp"
 #endif
 
 namespace rstudio {
@@ -254,7 +255,9 @@ private:
    int pendingQuit_;
    QString printText_;
 #ifdef Q_OS_WIN32
+   // viewers for Office file formats
    WordViewer wordViewer_;
+   PowerpointViewer pptViewer_;
 #endif
 
 };

--- a/src/cpp/desktop/DesktopOfficeViewer.cpp
+++ b/src/cpp/desktop/DesktopOfficeViewer.cpp
@@ -1,0 +1,126 @@
+/*
+ * DesktopOfficeViewer.cpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <iostream>
+
+#include <windows.h>
+#include <winuser.h>
+#include <oleauto.h>
+
+#include <boost/utility.hpp>
+#include <boost/scoped_array.hpp>
+
+#include <core/Error.hpp>
+#include <core/system/System.hpp>
+#include <core/system/Environment.hpp>
+
+#include "DesktopComUtils.hpp"
+#include "DesktopOfficeViewer.hpp"
+
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace desktop {
+
+OfficeViewer::OfficeViewer(const std::wstring& progId):
+   idisp_(nullptr),
+   progId_(progId)
+{
+}
+
+OfficeViewer::~OfficeViewer()
+{
+   try
+   {
+      if (idisp_)
+         idisp_->Release();
+   }
+   catch (...)
+   {
+      // Ignore exceptions during teardown
+   }
+}
+
+Error OfficeViewer::ensureInterface()
+{
+   HRESULT hr = S_OK;
+   Error errorHR = Success();
+
+   // If we have an active IDispatch pointer, check to see whether it has been
+   // closed
+   if (idisp_ != nullptr)
+   {
+      // Test the interface by looking up a known DISPID
+      const WCHAR* wstrQuit = L"Quit";
+      DISPID dispid;
+      hr = idisp_->GetIDsOfNames(IID_NULL, const_cast<WCHAR**>(&wstrQuit),
+                                     1, LOCALE_USER_DEFAULT, &dispid);
+
+      // If the lookup fails, release this IDispatch pointer--it's stale.
+      // We'll CoCreate a new instance below.
+      if (FAILED(hr) &&
+          SCODE_CODE(hr) == RPC_S_SERVER_UNAVAILABLE)
+      {
+         idisp_->Release();
+         idisp_ = nullptr;
+      }
+   }
+
+   // Get an IDispatch for the Word Application root object
+   if (idisp_ == nullptr)
+   {
+      CLSID clsid;
+      CoInitialize(nullptr);
+      VERIFY_HRESULT(CLSIDFromProgID(progId_.c_str(), &clsid));
+      VERIFY_HRESULT(CoCreateInstance(clsid, nullptr, CLSCTX_LOCAL_SERVER,
+                                      IID_IDispatch,
+                                      reinterpret_cast<void**>(&idisp_)));
+      idisp_->AddRef();
+   }
+
+LErrExit:
+   return errorHR;
+}
+
+Error OfficeViewer::showApp()
+{
+   // Allow the application to become the foreground window.
+   // CoAllowSetForegroundWindow would be preferable here, since we'd be able
+   // to restrict activation to only the process we started, but it is not
+   // exposed by MinGW headers.  Note that AllowSetForegroundWindow already
+   // limits activation to processes initiated by the foreground process, and
+   // self-expires on user input.
+   AllowSetForegroundWindow(ASFW_ANY);
+
+   Error errorHR = Success();
+   HRESULT hr = S_OK;
+
+   VARIANT visible;
+   visible.vt = VT_BOOL;
+   visible.boolVal = true;
+   VERIFY_HRESULT(invokeDispatch(DISPATCH_PROPERTYPUT, nullptr, idisp_,
+                                 L"Visible", 1, visible));
+LErrExit:
+   return errorHR;
+}
+
+IDispatch* OfficeViewer::idispApp()
+{
+   return idisp_;
+}
+
+} // namespace rstudio
+} // namespace desktop
+

--- a/src/cpp/desktop/DesktopOfficeViewer.hpp
+++ b/src/cpp/desktop/DesktopOfficeViewer.hpp
@@ -1,0 +1,47 @@
+/*
+ * DesktopOfficeViewer.hpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef DESKTOP_OFFICE_VIEWER_HPP
+#define DESKTOP_OFFICE_VIEWER_HPP
+
+#include <QString>
+
+#include <boost/utility.hpp>
+#include <core/Error.hpp>
+
+struct IDispatch;
+
+namespace rstudio {
+namespace desktop {
+
+class OfficeViewer : boost::noncopyable
+{
+public:
+   OfficeViewer(const std::wstring& progId);
+   ~OfficeViewer();
+   core::Error ensureInterface();
+   core::Error showApp();
+   IDispatch* idispApp();
+
+private:
+   IDispatch* idisp_;
+   std::wstring progId_;
+};
+
+} // namespace desktop
+} // namespace rstudio
+
+#endif // DESKTOP_OFFICE_VIEWER_HPP
+

--- a/src/cpp/desktop/DesktopOfficeViewer.hpp
+++ b/src/cpp/desktop/DesktopOfficeViewer.hpp
@@ -32,7 +32,8 @@ namespace desktop {
 class OfficeViewer : boost::noncopyable
 {
 public:
-   OfficeViewer(const std::wstring& progId, const std::wstring& collection);
+   OfficeViewer(const std::wstring& progId, const std::wstring& collection,
+                int readOnlyPos);
    ~OfficeViewer();
 
    // Public interface
@@ -61,6 +62,7 @@ private:
    std::wstring progId_;      // ID of the viewer application
    std::wstring collection_;  // Name of collection to search for items
    std::wstring path_;        // Path of currently open item
+   int readOnlyPos_;          // Position of read-only flag in open call
 };
 
 } // namespace desktop

--- a/src/cpp/desktop/DesktopOfficeViewer.hpp
+++ b/src/cpp/desktop/DesktopOfficeViewer.hpp
@@ -26,18 +26,41 @@ struct IDispatch;
 namespace rstudio {
 namespace desktop {
 
+// OfficeViewer represents a viewer for Microsoft Office file formats. It is
+// used as the base class for the Word document viewer (WordViewer) and the
+// Powerpoint presentation viewer (PowerpointViewer).
 class OfficeViewer : boost::noncopyable
 {
 public:
-   OfficeViewer(const std::wstring& progId);
+   OfficeViewer(const std::wstring& progId, const std::wstring& collection);
    ~OfficeViewer();
+
+   // Public interface
+   core::Error showItem(const std::wstring& path);
+   core::Error closeLastViewedItem();
+
+   // Pure virtual functions for implementation by individual formats
+   virtual core::Error savePosition(IDispatch* source) = 0;
+   virtual core::Error restorePosition(IDispatch* target) const = 0;
+   virtual void resetPosition() = 0;
+   virtual bool hasPosition() const = 0;
+
+protected:
    core::Error ensureInterface();
    core::Error showApp();
    IDispatch* idispApp();
 
+   core::Error openFile(const std::wstring& path, IDispatch** pidispOut);
+   core::Error getItemFromPath(const std::wstring& path, IDispatch** pidispOut);
+
+   std::wstring path();
+   void setPath(const std::wstring& path);
+
 private:
-   IDispatch* idisp_;
-   std::wstring progId_;
+   IDispatch* idisp_;         // Pointer to running application
+   std::wstring progId_;      // ID of the viewer application
+   std::wstring collection_;  // Name of collection to search for items
+   std::wstring path_;        // Path of currently open item
 };
 
 } // namespace desktop

--- a/src/cpp/desktop/DesktopPowerpointViewer.cpp
+++ b/src/cpp/desktop/DesktopPowerpointViewer.cpp
@@ -1,0 +1,54 @@
+/*
+ * DesktopPowerpointViewer.cpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <iostream>
+
+#include <windows.h>
+#include <winuser.h>
+#include <oleauto.h>
+
+#include <boost/utility.hpp>
+#include <boost/scoped_array.hpp>
+
+#include <core/Error.hpp>
+#include <core/system/System.hpp>
+#include <core/system/Environment.hpp>
+
+#include "DesktopComUtils.hpp"
+#include "DesktopPowerpointViewer.hpp"
+
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace desktop {
+
+PowerpointViewer::PowerpointViewer():
+    OfficeViewer(L"Powerpoint.Application"),
+    slideIndex_(0)
+{
+}
+
+Error PowerpointViewer::showPresentation(QString& path)
+{
+   return Success();
+}
+
+Error PowerpointViewer::closeLastPresentation()
+{
+   return Success();
+}
+
+} // namespace desktop
+} // namespace rstudio

--- a/src/cpp/desktop/DesktopPowerpointViewer.cpp
+++ b/src/cpp/desktop/DesktopPowerpointViewer.cpp
@@ -31,7 +31,8 @@ namespace rstudio {
 namespace desktop {
 
 PowerpointViewer::PowerpointViewer():
-    OfficeViewer(L"Powerpoint.Application", L"Presentations"),
+    OfficeViewer(L"Powerpoint.Application", L"Presentations",
+                 1 /* position of read-only flag in Open method */),
     slideIndex_(0)
 {
 }
@@ -44,8 +45,11 @@ Error PowerpointViewer::getDocumentWindow(IDispatch* source, IDispatch** window)
    // Get the first document window for the presentation
    IDispatch* idispWindows = nullptr;
    VARIANT varResult;
+   VARIANT varItem;
+   varItem.vt = VT_INT;
+   varItem.intVal = 1;
    VERIFY_HRESULT(getIDispatchProp(source, L"Windows", &idispWindows));
-   VERIFY_HRESULT(invokeDispatch(DISPATCH_METHOD, &varResult, idispWindows, L"Item", 1, 1));
+   VERIFY_HRESULT(invokeDispatch(DISPATCH_METHOD, &varResult, idispWindows, L"Item", 1, varItem));
    *window = varResult.pdispVal;
 
 LErrExit:
@@ -94,8 +98,12 @@ Error PowerpointViewer::restorePosition(IDispatch* target) const
    VERIFY_HRESULT(getIDispatchProp(idispPres, L"View", &idispView));
 
    // Go to the slide in question
+   VARIANT varSlide;
+   varSlide.vt = VT_INT;
+   varSlide.intVal = slideIndex_;
    VERIFY_HRESULT(invokeDispatch(DISPATCH_METHOD, nullptr, idispView,
-                                 L"GotoSlide", 1, slideIndex_));
+                                 L"GotoSlide", 1, varSlide));
+
 LErrExit:
    return errorHR;
 }

--- a/src/cpp/desktop/DesktopPowerpointViewer.hpp
+++ b/src/cpp/desktop/DesktopPowerpointViewer.hpp
@@ -15,11 +15,6 @@
 #ifndef DESKTOP_PRESENTATION_VIEWER_HPP
 #define DESKTOP_PRESENTATION_VIEWER_HPP
 
-#include <QString>
-
-#include <boost/utility.hpp>
-#include <core/Error.hpp>
-
 #include "DesktopOfficeViewer.hpp"
 
 struct IDispatch;
@@ -31,12 +26,16 @@ class PowerpointViewer : public OfficeViewer
 {
 public:
    PowerpointViewer();
-   core::Error showPresentation(QString& path);
-   core::Error closeLastPresentation();
+
+   core::Error savePosition(IDispatch* source) override;
+   core::Error restorePosition(IDispatch* target) const override;
+   void resetPosition() override;
+   bool hasPosition() const override;
 
 private:
+   core::Error getDocumentWindow(IDispatch* source, IDispatch** window) const;
+
    int slideIndex_;
-   QString docPath_;
 };
 
 } // namespace desktop

--- a/src/cpp/desktop/DesktopPowerpointViewer.hpp
+++ b/src/cpp/desktop/DesktopPowerpointViewer.hpp
@@ -1,5 +1,5 @@
 /*
- * DesktopWordViewer.hpp
+ * DesktopPowerpointViewer.hpp
  *
  * Copyright (C) 2009-18 by RStudio, Inc.
  *
@@ -12,10 +12,13 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
-#ifndef DESKTOPWORDVIEWER_HPP
-#define DESKTOPWORDVIEWER_HPP
+#ifndef DESKTOP_PRESENTATION_VIEWER_HPP
+#define DESKTOP_PRESENTATION_VIEWER_HPP
 
 #include <QString>
+
+#include <boost/utility.hpp>
+#include <core/Error.hpp>
 
 #include "DesktopOfficeViewer.hpp"
 
@@ -24,26 +27,19 @@ struct IDispatch;
 namespace rstudio {
 namespace desktop {
 
-class WordViewer : public OfficeViewer
+class PowerpointViewer : public OfficeViewer
 {
 public:
-   WordViewer();
-   core::Error showDocument(QString& path);
-   core::Error closeLastViewedDocument();
+   PowerpointViewer();
+   core::Error showPresentation(QString& path);
+   core::Error closeLastPresentation();
 
 private:
-   core::Error openDocument(QString& path, IDispatch* idispDocs,
-                            IDispatch** pidispDoc);
-   core::Error showWord();
-   core::Error getDocumentPosition(IDispatch* idispPos, int* pxPos, int* pyPos);
-   core::Error setDocumentPosition(IDispatch* idispPos, int xPos, int yPos);
-   core::Error getDocumentByPath(QString& path, IDispatch** pidispDoc);
-   int docScrollX_;
-   int docScrollY_;
+   int slideIndex_;
    QString docPath_;
 };
 
 } // namespace desktop
 } // namespace rstudio
 
-#endif // DESKTOPWORDVIEWER_HPP
+#endif // DESKTOP_PRESENTATION_VIEWER_HPP

--- a/src/cpp/desktop/DesktopWordViewer.cpp
+++ b/src/cpp/desktop/DesktopWordViewer.cpp
@@ -35,134 +35,13 @@ namespace rstudio {
 namespace desktop {
 
 WordViewer::WordViewer():
-   OfficeViewer(L"Word.Application"),
+   OfficeViewer(L"Word.Application", L"Documents"),
    docScrollX_(0),
    docScrollY_(0)
 {
 }
 
-Error WordViewer::showDocument(QString& path)
-{
-   Error errorHR = Success();
-   HRESULT hr = S_OK;
-
-   errorHR = ensureInterface();
-   if (errorHR)
-       return errorHR;
-
-   // Make Word visible
-   errorHR = showApp();
-   if (errorHR)
-      return errorHR;
-
-   IDispatch* idispDocs;
-   IDispatch* idispDoc;
-   VERIFY_HRESULT(getIDispatchProp(idispApp(), L"Documents", &idispDocs));
-
-   // Open the documenet
-   path = path.replace(QChar(L'/'), QChar(L'\\'));
-   errorHR = openDocument(path, idispDocs, &idispDoc);
-   if (errorHR)
-      return errorHR;
-   if (docPath_ == path)
-   {
-      // Reopening the last-opened doc: apply the scroll position if we have
-      // one cached
-      if (docScrollX_ > 0 || docScrollY_ > 0)
-         setDocumentPosition(idispDoc, docScrollX_, docScrollY_);
-   }
-   else
-   {
-      // Opening a different doc: forget scroll position and save the doc name
-      docScrollX_ = 0;
-      docScrollY_ = 0;
-      docPath_ = path;
-   }
-
-   // Bring Word to the foreground
-   VERIFY_HRESULT(invokeDispatch(DISPATCH_METHOD, nullptr, idispApp(),
-                                 L"Activate", 0));
-
-LErrExit:
-   return errorHR;
-}
-
-Error WordViewer::openDocument(QString& path, IDispatch* idispDocs,
-                               IDispatch** pidispDoc)
-{
-   Error errorHR = Success();
-   HRESULT hr = S_OK;
-
-   const WCHAR *strOpen = L"Open";
-   DISPID dispidOpen;
-
-   BSTR bstrFileName =
-         SysAllocString(reinterpret_cast<const WCHAR*>(path.utf16()));
-
-   // COM requires that arguments are specified in reverse order
-   DISPID argPos[2] = { 2, 0 };
-   VARIANT args[2];
-   VARIANT result;
-   DISPPARAMS dparams;
-
-   // ReadOnly argument
-   args[0].vt = VT_BOOL;
-   args[0].boolVal = true;
-
-   // FileName argument
-   args[1].vt = VT_BSTR;
-   args[1].bstrVal = bstrFileName;
-
-   VariantInit(&result);
-   dparams.rgvarg = args;
-   dparams.rgdispidNamedArgs = argPos;
-   dparams.cArgs = 2;
-   dparams.cNamedArgs = 2;
-   VERIFY_HRESULT(idispDocs->GetIDsOfNames(
-                     IID_NULL, const_cast<WCHAR**>(&strOpen),  1,
-                     LOCALE_USER_DEFAULT, &dispidOpen));
-   VERIFY_HRESULT(idispDocs->Invoke(
-                     dispidOpen, IID_NULL, LOCALE_SYSTEM_DEFAULT,
-                     DISPATCH_METHOD, &dparams, &result, nullptr, nullptr));
-   if (pidispDoc)
-      *pidispDoc = result.pdispVal;
-
-LErrExit:
-
-   // Release resources
-   SysFreeString(bstrFileName);
-   return errorHR;
-}
-
-Error WordViewer::closeLastViewedDocument()
-{
-   Error errorHR = Success();
-   HRESULT hr = S_OK;
-
-   if (idispApp() == nullptr)
-      return Success();
-
-   // Find the open document corresponding to the one we last rendered. If we
-   // find it, close it; if we can't find it, do nothing.
-   IDispatch* idispDoc = nullptr;
-   errorHR = getDocumentByPath(docPath_, &idispDoc);
-   if (errorHR)
-      return errorHR;
-   if (idispDoc == nullptr)
-      return Success();
-
-   errorHR = getDocumentPosition(idispDoc, &docScrollX_, &docScrollY_);
-   if (errorHR)
-      LOG_ERROR(errorHR);
-
-   VERIFY_HRESULT(invokeDispatch(DISPATCH_METHOD, nullptr, idispDoc, L"Close", 0));
-
-LErrExit:
-   return errorHR;
-}
-
-Error WordViewer::getDocumentPosition(IDispatch* idispDoc, int* pxPos,
-                                      int* pyPos)
+Error WordViewer::savePosition(IDispatch* idispDoc)
 {
    Error errorHR = Success();
    HRESULT hr = S_OK;
@@ -170,14 +49,14 @@ Error WordViewer::getDocumentPosition(IDispatch* idispDoc, int* pxPos,
    IDispatch* idispWindow = nullptr;
 
    VERIFY_HRESULT(getIDispatchProp(idispDoc, L"ActiveWindow", &idispWindow));
-   VERIFY_HRESULT(getIntProp(idispWindow, L"HorizontalPercentScrolled", pxPos));
-   VERIFY_HRESULT(getIntProp(idispWindow, L"VerticalPercentScrolled", pyPos));
+   VERIFY_HRESULT(getIntProp(idispWindow, L"HorizontalPercentScrolled", &docScrollX_));
+   VERIFY_HRESULT(getIntProp(idispWindow, L"VerticalPercentScrolled", &docScrollY_));
 
 LErrExit:
    return errorHR;
 }
 
-Error WordViewer::setDocumentPosition(IDispatch* idispDoc, int xPos, int yPos)
+Error WordViewer::restorePosition(IDispatch* idispDoc) const
 {
    Error errorHR = Success();
    HRESULT hr = S_OK;
@@ -187,54 +66,25 @@ Error WordViewer::setDocumentPosition(IDispatch* idispDoc, int xPos, int yPos)
    varPos.vt = VT_INT;
 
    VERIFY_HRESULT(getIDispatchProp(idispDoc, L"ActiveWindow", &idispWindow));
-   varPos.intVal = xPos;
+   varPos.intVal = docScrollX_;
    VERIFY_HRESULT(invokeDispatch(DISPATCH_PROPERTYPUT, nullptr, idispWindow,
                                  L"HorizontalPercentScrolled", 1, varPos));
-   varPos.intVal = yPos;
+   varPos.intVal = docScrollY_;
    VERIFY_HRESULT(invokeDispatch(DISPATCH_PROPERTYPUT, nullptr, idispWindow,
                                  L"VerticalPercentScrolled", 1, varPos));
 LErrExit:
    return errorHR;
 }
 
-// Given a path, searches for the document in the Documents collection that
-// has the path given. The out parameter is set to that document's IDispatch
-// pointer, or NULL if no document with the path could be found.
-Error WordViewer::getDocumentByPath(QString& path, IDispatch** pidispDoc)
+bool WordViewer::hasPosition() const
 {
-   Error errorHR = Success();
-   HRESULT hr = S_OK;
+   return docScrollX_ > 0 && docScrollY_ > 0;
+}
 
-   IDispatch* idispDocs = nullptr;
-   IDispatch* idispDoc = nullptr;
-   VARIANT varDocIdx;
-   VARIANT varResult;
-   int docCount = 0;
-
-   *pidispDoc = nullptr;
-
-   VERIFY_HRESULT(getIDispatchProp(idispApp(), L"Documents", &idispDocs));
-   VERIFY_HRESULT(getIntProp(idispDocs, L"Count", &docCount));
-
-   varDocIdx.vt = VT_INT;
-   for (int i = 1; i <= docCount; i++)
-   {
-      VariantInit(&varResult);
-      varDocIdx.intVal = i;
-      VERIFY_HRESULT(invokeDispatch(DISPATCH_METHOD, &varResult, idispDocs,
-                                    L"Item", 1, varDocIdx));
-      idispDoc = varResult.pdispVal;
-      VERIFY_HRESULT(invokeDispatch(DISPATCH_PROPERTYGET, &varResult, idispDoc,
-                                    L"FullName", 0));
-      if (path.toStdWString() == varResult.bstrVal)
-      {
-         *pidispDoc = idispDoc;
-         break;
-      }
-   }
-
-LErrExit:
-   return errorHR;
+void WordViewer::resetPosition()
+{
+   docScrollX_ = 0;
+   docScrollY_ = 0;
 }
 
 } // namespace desktop

--- a/src/cpp/desktop/DesktopWordViewer.cpp
+++ b/src/cpp/desktop/DesktopWordViewer.cpp
@@ -19,12 +19,8 @@
 #include <winuser.h>
 #include <oleauto.h>
 
-#include <boost/utility.hpp>
-#include <boost/scoped_array.hpp>
-
 #include <core/Error.hpp>
 #include <core/system/System.hpp>
-#include <core/system/Environment.hpp>
 
 #include "DesktopComUtils.hpp"
 #include "DesktopWordViewer.hpp"
@@ -35,7 +31,8 @@ namespace rstudio {
 namespace desktop {
 
 WordViewer::WordViewer():
-   OfficeViewer(L"Word.Application", L"Documents"),
+   OfficeViewer(L"Word.Application", L"Documents",
+                2 /* position of read-only flag in Open method */),
    docScrollX_(0),
    docScrollY_(0)
 {
@@ -72,13 +69,14 @@ Error WordViewer::restorePosition(IDispatch* idispDoc) const
    varPos.intVal = docScrollY_;
    VERIFY_HRESULT(invokeDispatch(DISPATCH_PROPERTYPUT, nullptr, idispWindow,
                                  L"VerticalPercentScrolled", 1, varPos));
+
 LErrExit:
    return errorHR;
 }
 
 bool WordViewer::hasPosition() const
 {
-   return docScrollX_ > 0 && docScrollY_ > 0;
+   return docScrollX_ > 0 || docScrollY_ > 0;
 }
 
 void WordViewer::resetPosition()

--- a/src/cpp/desktop/DesktopWordViewer.hpp
+++ b/src/cpp/desktop/DesktopWordViewer.hpp
@@ -15,11 +15,7 @@
 #ifndef DESKTOPWORDVIEWER_HPP
 #define DESKTOPWORDVIEWER_HPP
 
-#include <QString>
-
 #include "DesktopOfficeViewer.hpp"
-
-struct IDispatch;
 
 namespace rstudio {
 namespace desktop {
@@ -28,19 +24,15 @@ class WordViewer : public OfficeViewer
 {
 public:
    WordViewer();
-   core::Error showDocument(QString& path);
-   core::Error closeLastViewedDocument();
+
+   core::Error savePosition(IDispatch* source) override;
+   core::Error restorePosition(IDispatch* target) const override;
+   void resetPosition() override;
+   bool hasPosition() const override;
 
 private:
-   core::Error openDocument(QString& path, IDispatch* idispDocs,
-                            IDispatch** pidispDoc);
-   core::Error showWord();
-   core::Error getDocumentPosition(IDispatch* idispPos, int* pxPos, int* pyPos);
-   core::Error setDocumentPosition(IDispatch* idispPos, int xPos, int yPos);
-   core::Error getDocumentByPath(QString& path, IDispatch** pidispDoc);
    int docScrollX_;
    int docScrollY_;
-   QString docPath_;
 };
 
 } // namespace desktop


### PR DESCRIPTION
This change makes it easier to use R Markdown to iterate on Powerpoint slide decks. When a Powerpoint document is re-rendered, the selected slide is saved, the deck is reopened, and the slide is selected again. It's thus possible to iterate on changes to a single slide, even one many slides into the deck, by re-rendering the document.

The change is not quite as large as it looks; most of the churn is caused by some refactoring of the Windows version of the change, as 80% of the code that syncs the Word scroll position is reusable for syncing the Powerpoint slide selection.