### PR TITLE
Remove build and runtime requirements for libgstreamer

### DIFF
--- a/dependencies/linux/install-dependencies-debian
+++ b/dependencies/linux/install-dependencies-debian
@@ -79,14 +79,6 @@ cd ../linux
 # desktop dependencies (qt)
 if [ "$1" != "--exclude-qt-sdk" ]
 then
-   # ubuntu server doesn't include gstreamer by default so ensure that these
-   # libs are always available for desktop builds (required by QtWebKit 2.2)
-   sudo apt-get -y install libgstreamer0.10-0
-   sudo apt-get -y install libgstreamer-plugins-base0.10-0
-
-   # Ubuntu 12.04 doesn't include libjpeg62 (and it's required by Qt 4.8)
-   sudo apt-get -y install libjpeg62
-
    # Need the OpenGL development libraries to build QtGui
    sudo apt-get -y install libgl1-mesa-dev
 

--- a/dependencies/linux/install-dependencies-yum
+++ b/dependencies/linux/install-dependencies-yum
@@ -32,10 +32,6 @@ sudo yum install -y bzip2-devel
 sudo yum install -y zlib-devel
 sudo yum install -y pam-devel
 
-# needed by Qt WebKit >= 5
-sudo yum install -y gstreamer-devel
-sudo yum install -y gstreamer-plugins-base-devel
-
 # pandoc depenencies
 sudo yum install -y libffi
 

--- a/docker/jenkins/Dockerfile.centos6-x86_64
+++ b/docker/jenkins/Dockerfile.centos6-x86_64
@@ -13,8 +13,6 @@ RUN yum install -y \
     gcc-c++ \
     git \
     gpg \
-    gstreamer-devel \
-    gstreamer-plugins-base-devel \
     java-1.8.0-openjdk  \
     java-1.8.0-openjdk-devel  \
     libacl-devel \ 

--- a/docker/jenkins/Dockerfile.debian9-x86_64
+++ b/docker/jenkins/Dockerfile.debian9-x86_64
@@ -22,7 +22,6 @@ RUN apt-get update -y && apt-get install -y \
     gcc \
     git \
     gnupg1 \
-    gstreamer1.0-plugins-base \
     openjdk-8-jdk  \
     libacl1-dev \
     libcap-dev \

--- a/docker/jenkins/Dockerfile.trusty-amd64
+++ b/docker/jenkins/Dockerfile.trusty-amd64
@@ -36,7 +36,6 @@ RUN apt-get update && \
     libgtk-3-0 \
     libgl1-mesa-dev \
     libegl1-mesa \
-    libjpeg62 \
     libpam-dev \
     libpango1.0-dev \
     libssl-dev \

--- a/package/linux/CMakeLists.txt
+++ b/package/linux/CMakeLists.txt
@@ -85,19 +85,8 @@ elseif(RSTUDIO_DESKTOP)
   set(RPM_POSTRM postrm-desktop.sh.in)
 
   # deb dependencies
-  set(RSTUDIO_DEBIAN_DEPENDS "libjpeg62, libedit2, libssl1.0.0 | libssl1.0.2, ")
+  set(RSTUDIO_DEBIAN_DEPENDS "libedit2, libssl1.0.0 | libssl1.0.2, ")
   
-  # look for the well known locations for Qt SDK to determine which version
-  # of libgstreamer we depend on
-  if(EXISTS "/opt/RStudio-QtSDK/Qt5.4.2" OR EXISTS "$ENV{HOME}/Qt5.4.2")
-    set(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}libgstreamer1.0-0, libgstreamer-plugins-base1.0-0, ")
-  else()
-    set(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS}libgstreamer0.10-0, libgstreamer-plugins-base0.10-0, ")
-  endif()
-
-  # rpm dependencies
-  set(RSTUDIO_RPM_DEPENDS "gstreamer, gstreamer-plugins-base, ")
-
 endif()
 
 # define package suffix


### PR DESCRIPTION
QtWebKit, our browser engine in RStudio 1.1, depended on `libgstreamer`. (This was very inconvenient and eventually required us to produce a custom Qt build against `libgstreamer-1.0` as newer Linux distributions didn't provide a package for `libgstreamer-0.10`, against which Qt had been built originally.) 

Thankfully, QtWebEngine does not depend on this library, so we no longer require it at build time or runtime. This change removes it from our setup scripts, Docker build containers, and package dependencies. 

Closes #2716.