### PR TITLE
Fixed small typo in the text for a button in debug mode. From 'remain…

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -2997,7 +2997,7 @@ well as menu structures (for main menu and popup menus).
    <cmd id="debugFinish"
         menuLabel="_Finish Function/Loop"
         buttonLabel=""
-        desc="Execute the remainer of the current function or loop"
+        desc="Execute the remainder of the current function or loop"
         rebindable="false"/>
         
    <cmd id="debugHelp"


### PR DESCRIPTION
…er' to 'remainder'