### PR TITLE
Various fixes for package management feature

### DIFF
--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -316,9 +316,12 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
       ("r-cran-repos",
          value<std::string>(&rCRANRepos_)->default_value(""),
          "Default CRAN repository")
+      ("r-cran-repos-file",
+         value<std::string>(&rCRANReposFile_)->default_value("/etc/rstudio/repos.conf"),
+         "Path to configuration file with default CRAN repositories")
       ("r-cran-repos-url",
          value<std::string>(&rCRANReposUrl_)->default_value(""),
-         "Default CRAN repository")
+         "URL to configuration file with optional CRAN repositories")
       ("r-auto-reload-source",
          value<bool>(&autoReloadSource_)->default_value(false),
          "Reload R source if it changes during the session")
@@ -694,7 +697,7 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
    signingKey_ = core::system::getenv(kRStudioSigningKey);
 
    // load cran options from repos.conf
-   FilePath reposFile("/etc/rstudio/repos.conf");
+   FilePath reposFile(rCRANReposFile());
    rCRANMultipleRepos_ = parseReposConfig(reposFile);
 
    // return status

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -216,6 +216,11 @@ public:
       return std::string(rCRANReposUrl_.c_str());
    }
 
+   std::string rCRANReposFile() const
+   {
+      return std::string(rCRANReposFile_.c_str());
+   }
+
    int rCompatibleGraphicsEngineVersion() const
    {
       return rCompatibleGraphicsEngineVersion_;
@@ -644,6 +649,7 @@ private:
    std::string rCRANRepos_;
    std::string rCRANMultipleRepos_;
    std::string rCRANReposUrl_;
+   std::string rCRANReposFile_;
    bool autoReloadSource_ ;
    int rCompatibleGraphicsEngineVersion_;
    std::string rResourcesPath_;

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -1226,13 +1226,20 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    repos
 })
 
-.rs.addFunction("getSecondaryRepos", function(cran = getOption("repos")[[1]]) {
-   result <- list()
+.rs.addFunction("getSecondaryRepos", function(cran = getOption("repos")[[1]], custom = TRUE) {
+   result <- list(
+      repos = list()
+   )
    
    rCranReposUrl <- .Call("rs_getCranReposUrl")
-   if (identical(rCranReposUrl, NULL) || nchar(.Call("rs_getCranReposUrl")) == 0) {
+   isDefault <- identical(rCranReposUrl, NULL) || nchar(rCranReposUrl) == 0
+
+   if (isDefault) {
       slash <- if (.rs.lastCharacterIs(cran, "/")) "" else "/"
       rCranReposUrl <- paste(slash, "../../__api__/repos", sep = "")
+   }
+   else {
+      custom <- TRUE
    }
 
    if (.rs.startsWith(rCranReposUrl, "..") ||
@@ -1240,7 +1247,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
       rCranReposUrl <- paste(cran, rCranReposUrl, sep = "")
    }
 
-   if (nchar(rCranReposUrl) > 0) {
+   if (custom) {
       conf <- tempfile(fileext = ".conf")
       
       result <- tryCatch({
@@ -1266,6 +1273,6 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    result
 })
 
-.rs.addJsonRpcHandler("get_secondary_repos", function(cran) {
+.rs.addJsonRpcHandler("get_secondary_repos", function(cran, custom) {
    .rs.getSecondaryRepos(cran)
 })

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -1281,5 +1281,5 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
 })
 
 .rs.addJsonRpcHandler("get_secondary_repos", function(cran, custom) {
-   .rs.getSecondaryRepos(cran)
+   .rs.getSecondaryRepos(cran, custom)
 })

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -1251,7 +1251,14 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
       conf <- tempfile(fileext = ".conf")
       
       result <- tryCatch({
-         download.file(rCranReposUrl, conf, method = "curl", extra = "-H 'Accept: text/ini'")
+         download.file(
+            rCranReposUrl,
+            conf,
+            method = "curl",
+            extra = "-H 'Accept: text/ini'",
+            quiet = TRUE
+         )
+         
          result$repos <- .rs.parseSecondaryReposIni(conf)
          if (length(result$repos) == 0) {
             result$repos <- .rs.parseSecondaryReposJson(conf)

--- a/src/gwt/src/org/rstudio/studio/client/common/repos/SecondaryReposDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/repos/SecondaryReposDialog.java
@@ -53,12 +53,14 @@ public class SecondaryReposDialog extends ModalDialog<CRANMirror>
 {
    public SecondaryReposDialog(OperationWithInput<CRANMirror> operation,
                                ArrayList<String> excluded,
-                               String cranRepoUrl)
+                               String cranRepoUrl,
+                               boolean cranIsCustom)
    {
       super("Retrieving list of secondary repos...", operation);
       
       excluded_ = excluded;
       cranRepoUrl_ = cranRepoUrl;
+      cranIsCustom_ = cranIsCustom;
 
       RStudioGinjector.INSTANCE.injectMembers(this);
    }
@@ -222,7 +224,7 @@ public class SecondaryReposDialog extends ModalDialog<CRANMirror>
             closeDialog();
             super.onError(error);
          }
-      }, cranRepoUrl_);
+      }, cranRepoUrl_, cranIsCustom_);
       
       return root;
    }
@@ -261,6 +263,7 @@ public class SecondaryReposDialog extends ModalDialog<CRANMirror>
    private TextBox urlTextBox_ = null;
    private ArrayList<String> excluded_;
    private String cranRepoUrl_;
+   private boolean cranIsCustom_;
 
    private Label reposLabel_;
    private SimplePanelWithProgress panel_;

--- a/src/gwt/src/org/rstudio/studio/client/common/repos/SecondaryReposWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/repos/SecondaryReposWidget.java
@@ -65,6 +65,7 @@ public class SecondaryReposWidget extends Composite
       listBox_.setMultipleSelect(false);
       listBox_.addStyleName(RES.styles().listBox());
       listBox_.getElement().<SelectElement>cast().setSize(6);
+      listBox_.setHeight("90px");
       horizontal.add(listBox_);
       
       VerticalPanel buttonPanel = new VerticalPanel();

--- a/src/gwt/src/org/rstudio/studio/client/common/repos/SecondaryReposWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/repos/SecondaryReposWidget.java
@@ -118,9 +118,10 @@ public class SecondaryReposWidget extends Composite
       updateRepos();
    }
 
-   public void setCranRepoUrl(String cranUrl)
+   public void setCranRepoUrl(String cranUrl, boolean cranIsCustom)
    {
       cranRepoUrl_ = cranUrl;
+      cranIsCustom_ = cranIsCustom;
    }
    
    private ClickHandler addButtonClicked_ = new ClickHandler() {
@@ -138,7 +139,7 @@ public class SecondaryReposWidget extends Composite
                repos_.add(input);
                updateRepos();
             }
-         }, excluded, cranRepoUrl_);
+         }, excluded, cranRepoUrl_, cranIsCustom_);
          
          secondaryReposDialog.showModal();
       }
@@ -214,7 +215,9 @@ public class SecondaryReposWidget extends Composite
    private final ListBox listBox_;
    private GlobalDisplay globalDisplay_;
    private ArrayList<CRANMirror> repos_;
+   
    private String cranRepoUrl_;
+   private boolean cranIsCustom_;
 
    private SmallButton buttonAdd_;
    private SmallButton buttonRemove_;

--- a/src/gwt/src/org/rstudio/studio/client/common/repos/model/SecondaryReposServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/repos/model/SecondaryReposServerOperations.java
@@ -23,5 +23,6 @@ public interface SecondaryReposServerOperations
 {
    void getSecondaryRepos(
          ServerRequestCallback<SecondaryReposResult> requestCallback,
-         String cranRepoUrl);
+         String cranRepoUrl,
+         boolean cranIsCustom);
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -5397,10 +5397,12 @@ public class RemoteServer implements Server
 
    @Override
    public void getSecondaryRepos(ServerRequestCallback<SecondaryReposResult> callback,
-                                 String cranRepoUrl)
+                                 String cranRepoUrl,
+                                 boolean cranIsCustom)
    {
       JSONArray params = new JSONArray();
       params.set(0, new JSONString(cranRepoUrl));
+      params.set(1, JSONBoolean.getInstance(cranIsCustom));
 
       sendRequest(RPC_SCOPE,
                   GET_SECONDARY_REPOS,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
@@ -99,7 +99,10 @@ public class PackagesPreferencesPane extends PreferencesPane
 
                         cranMirrorStored_ = cranMirrorTextBox_.getTextBox().getText();
 
-                        secondaryReposWidget_.setCranRepoUrl(cranMirror_.getURL());
+                        secondaryReposWidget_.setCranRepoUrl(
+                           cranMirror_.getURL(),
+                           cranMirror_.getHost().equals("Custom")
+                        );
                      }     
                   });
                  
@@ -114,7 +117,7 @@ public class PackagesPreferencesPane extends PreferencesPane
          {
             if (!event.getValue().equals(cranMirror_.getDisplay()))
             {
-               secondaryReposWidget_.setCranRepoUrl(event.getValue());
+               secondaryReposWidget_.setCranRepoUrl(event.getValue(), true);
             }
          }
       });
@@ -252,7 +255,10 @@ public class PackagesPreferencesPane extends PreferencesPane
       if (!packagesPrefs.getCRANMirror().isEmpty())
       {
          cranMirror_ = packagesPrefs.getCRANMirror();
-         secondaryReposWidget_.setCranRepoUrl(cranMirror_.getURL());
+         secondaryReposWidget_.setCranRepoUrl(
+            cranMirror_.getURL(),
+            cranMirror_.getHost().equals("Custom")
+         );
 
          if (cranMirror_.getHost().equals("Custom"))
          {


### PR DESCRIPTION
- [x] Avoid secondary widget buttons to grow past the list height in desktop builds.
- [x] Secondary repos list download should be silent.
- [x] Secondary repos list should not be triggered for CRAN mirrors to avoid sending 404 to their systems.
- [x] Support changing location for `/etc/rstudio/repos.conf` with `r-repos-cran-file` option in `rsession.conf`.
- [x] Document `repos.conf`, `r-cran-repos-url` and `r-cran-repos-file` in server admin guide.
- [x] Write support article for "Managing Packages" link, see https://support.rstudio.com/hc/en-us/articles/360004067074?version=99.9.9&mode=server

Notes:

- Some CRAN mirrors do not support `/package=name` URL. I found out the major mirrors do support this URL. As a CRAN mirror, you probably want to support this path anyways since it's recommended by CRAN, but not all mirrors do. I was considering a workaround for this, but seems this behavior it's fine.