### PR TITLE
remove unnecessary call to macOS 10.12 plus API

### DIFF
--- a/src/cpp/desktop/DesktopUtilsMac.mm
+++ b/src/cpp/desktop/DesktopUtilsMac.mm
@@ -49,10 +49,6 @@ void initializeSystemPrefs()
    [defaults setBool:YES forKey:@"NSDisabledDictationMenuItem"];
    [defaults setBool:YES forKey:@"NSDisabledCharacterPaletteMenuItem"];
 
-   // Remove (don't allow) the "Show Tab Bar" menu item from the "View" menu, if supported
-   if ([NSWindow respondsToSelector:@selector(allowsAutomaticWindowTabbing)])
-      NSWindow.allowsAutomaticWindowTabbing = NO;
-
    // Remove the "Enter Full Screen" menu item from the "View" menu
    [defaults setBool:NO forKey:@"NSFullScreenMenuItemEverywhere"];
 }


### PR DESCRIPTION
Early in the move back to Qt on the Mac, was getting View menu items
related to native Mac tab support; this call was hiding those. The
property, however, was added in 10.12, so prevented building on 10.11.

Looking now, it seems the newer version of Qt we're using has fixed this
for us, so removing the call altogether.

Fixes #2693