### PR TITLE
Avoid relative urls while downloading secondary repos file to fix #2776

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1014,3 +1014,9 @@ assign(envir = .rs.Env, ".rs.hasVar", function(name)
 .rs.addFunction("isDesktop", function() {
    identical(.Call("rs_rstudioProgramMode"), "desktop")
 })
+
+# complete url with path
+.rs.addFunction("completeUrl", function(url, path)
+{
+  .Call("rs_completeUrl", url, path)
+})

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -31,6 +31,7 @@
 #include <core/FileSerializer.hpp>
 #include <core/FileUtils.hpp>
 #include <core/http/Util.hpp>
+#include <core/http/URL.hpp>
 
 #include <r/RExec.hpp>
 #include <r/RUtil.hpp>
@@ -207,6 +208,16 @@ SEXP rs_saveHistory(SEXP sFile)
    return R_NilValue;
 }
 
+
+SEXP rs_completeUrl(SEXP url, SEXP path)
+{
+   std::string completed = rstudio::core::http::URL::complete(
+      r::sexp::asString(url), r::sexp::asString(path));
+
+   r::sexp::Protect rProtect;
+   return r::sexp::create(completed, &rProtect);
+}
+
 namespace {
 
 SEXP rs_GEcopyDisplayList(SEXP fromDeviceSEXP)
@@ -334,6 +345,13 @@ Error run(const ROptions& options, const RCallbacks& callbacks)
    saveHistoryMethodDef.fun = (DL_FUNC) rs_saveHistory ;
    saveHistoryMethodDef.numArgs = 1;
    r::routines::addCallMethod(saveHistoryMethodDef);
+
+   // complete url
+   R_CallMethodDef completeUrlDef ;
+   completeUrlDef.name = "rs_completeUrl" ;
+   completeUrlDef.fun = (DL_FUNC) rs_completeUrl ;
+   completeUrlDef.numArgs = 2;
+   r::routines::addCallMethod(completeUrlDef);
 
    // register graphics methods
    RS_REGISTER_CALL_METHOD(rs_GEcopyDisplayList, 1);

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -1250,7 +1250,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
 
    if (.rs.startsWith(rCranReposUrl, "..") ||
        .rs.startsWith(rCranReposUrl, "/..")) {
-      rCranReposUrl <- paste(cran, rCranReposUrl, sep = "")
+      rCranReposUrl <- .rs.completeUrl(cran, rCranReposUrl)
    }
 
    if (custom) {


### PR DESCRIPTION
Some systems might not resolve relative URLs correctly while downloading files, instead, use C++ URL helper class to clean up URLs before downloading the secondary repos file in R.