### PR TITLE
Avoid suggesting the primary repo in secondary repos list to fix #2775

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/repos/SecondaryReposDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/repos/SecondaryReposDialog.java
@@ -186,9 +186,16 @@ public class SecondaryReposDialog extends ModalDialog<CRANMirror>
                for(int i=0; i<repos.length(); i++)
                {
                   CRANMirror repo = repos.get(i);
+                  
+                  String mainRepoUrl = repo.getURL();
+                  if (mainRepoUrl.length() > 0 &&
+                     repo.getURL().charAt(mainRepoUrl.length() - 1) != '/') {
+                     mainRepoUrl = mainRepoUrl + "/";
+                  }
 
                   if (!StringUtil.isNullOrEmpty(repo.getName()) &&
-                      !repo.getName().toLowerCase().equals("cran"))
+                      !repo.getName().toLowerCase().equals("cran") &&
+                      !mainRepoUrl.equals(cranRepoUrl_))
                   {
                      repos_.add(repo);
                      listBox_.addItem(repo.getName(), repo.getURL());


### PR DESCRIPTION
Minor fix for #2775 to avoid suggesting the primary repo in the secondary repos list.