### PR TITLE
allow users to toggle save/load of cursor pos (#2778)

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
@@ -268,6 +268,9 @@ public class UIPrefs extends UIPrefsAccessor implements UiPrefsChangedHandler
          
          stripTrailingWhitespace().setGlobalValue(
                        newUiPrefs.stripTrailingWhitespace().getGlobalValue());
+         
+         restoreSourceDocumentCursorPosition().setGlobalValue(
+                       newUiPrefs.restoreSourceDocumentCursorPosition().getGlobalValue());
       
          // soft wrap R files
          softWrapRFiles().setGlobalValue(

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -266,6 +266,11 @@ public class UIPrefsAccessor extends Prefs
       return bool("strip_trailing_whitespace", false);
    }
    
+   public PrefValue<Boolean> restoreSourceDocumentCursorPosition()
+   {
+      return bool("restore_source_document_cursor_position", true);
+   }
+   
    public PrefValue<Boolean> reindentOnPaste()
    {
       return bool("reindent_on_paste", true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -250,6 +250,7 @@ public class EditingPreferencesPane extends PreferencesPane
       savePanel.add(headerLabel("General"));
       savePanel.add(checkboxPref("Ensure that source files end with newline", prefs_.autoAppendNewline()));
       savePanel.add(checkboxPref("Strip trailing horizontal whitespace when saving", prefs_.stripTrailingWhitespace()));
+      savePanel.add(checkboxPref("Restore last cursor position when opening file", prefs_.restoreSourceDocumentCursorPosition()));
 
       Label serializationLabel = headerLabel("Serialization");
       serializationLabel.getElement().getStyle().setPaddingTop(14, Unit.PX);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1594,7 +1594,8 @@ public class TextEditingTarget implements
          @Override
          public void onCursorChanged(CursorChangedEvent event)
          {
-            timer_.schedule(1000);
+            if (prefs_.restoreSourceDocumentCursorPosition().getValue())
+               timer_.schedule(1000);
          }
       });
       
@@ -1603,6 +1604,9 @@ public class TextEditingTarget implements
          @Override
          public void execute()
          {
+            if (!prefs_.restoreSourceDocumentCursorPosition().getValue())
+               return;
+            
             String cursorPosition = docUpdateSentinel_.getProperty(
                   PROPERTY_CURSOR_POSITION,
                   "");


### PR DESCRIPTION
This PR allows users to enable / disable the restoration of the last known cursor position when source documents are opened.

<img width="617" alt="screen shot 2018-05-14 at 2 47 50 pm" src="https://user-images.githubusercontent.com/1976582/40025245-d2c3618c-5785-11e8-885a-2dfe6c786205.png">
