### PR TITLE
allow insertion of Bash chunks on Windows (closes #2727)

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -351,10 +351,7 @@ public class TextEditingTargetWidget
       insertChunksMenu.addItem(commands_.insertChunkR().createMenuItem(false));
       insertChunksMenu.addSeparator();
 
-      if (!BrowseCap.isWindowsDesktop()) {
-         insertChunksMenu.addItem(commands_.insertChunkBash().createMenuItem(false));
-      }
-
+      insertChunksMenu.addItem(commands_.insertChunkBash().createMenuItem(false));
       insertChunksMenu.addItem(commands_.insertChunkD3().createMenuItem(false));
       insertChunksMenu.addItem(commands_.insertChunkPython().createMenuItem(false));
       insertChunksMenu.addItem(commands_.insertChunkRCPP().createMenuItem(false));


### PR DESCRIPTION
I'm guessing we screened out this option for Windows just because `bash` isn't available by default, but I think it makes sense to enable it.

I think most Windows users who will want to run `bash` chunks will do so with Git for Windows installed + its associated tools on the PATH.