### PR TITLE
Enable connection extensions to create SQL documents

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -496,6 +496,13 @@
    .Call("rs_requestDocumentSave", NULL, PACKAGE = "(embedding)")
 })
 
+.rs.addApiFunction("documentNew", function(type, code) {
+   .rs.enqueClientEvent("new_document_with_code", list(
+      type = .rs.scalar(type),
+      code = .rs.scalar(code)
+   ))
+})
+
 .rs.addApiFunction("getConsoleHasColor", function(name) {
    value <- .rs.readUiPref("ansi_console_mode")
    if (is.null(value) || value != 1) FALSE else TRUE

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -504,6 +504,8 @@
       column = .rs.scalar(column),
       execute = .rs.scalar(execute)
    ))
+
+   invisible(NULL)
 })
 
 .rs.addApiFunction("getConsoleHasColor", function(name) {

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -496,10 +496,13 @@
    .Call("rs_requestDocumentSave", NULL, PACKAGE = "(embedding)")
 })
 
-.rs.addApiFunction("documentNew", function(type, code) {
+.rs.addApiFunction("documentNew", function(type, code, row = 0, column= 0, execute = FALSE) {
    .rs.enqueClientEvent("new_document_with_code", list(
       type = .rs.scalar(type),
-      code = .rs.scalar(code)
+      code = .rs.scalar(code),
+      row = .rs.scalar(row),
+      column = .rs.scalar(column),
+      execute = .rs.scalar(execute)
    ))
 })
 

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -497,6 +497,13 @@
 })
 
 .rs.addApiFunction("documentNew", function(type, code, row = 0, column= 0, execute = FALSE) {
+   type <- switch(
+      type,
+      rmarkdown = "r_markdown",
+      sql = "sql",
+      "r_script"
+   )
+
    .rs.enqueClientEvent("new_document_with_code", list(
       type = .rs.scalar(type),
       code = .rs.scalar(code),

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -189,6 +189,7 @@ const int kJobUpdated = 170;
 const int kJobRefresh = 171;
 const int kJobOutput = 172;
 const int kDataOutputCompleted = 173;
+const int kNewDocumentWithCode = 174;
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -522,6 +523,8 @@ std::string ClientEvent::typeName() const
          return "job_output";
       case client_events::kDataOutputCompleted:
          return "data_output_completed";
+      case client_events::kNewDocumentWithCode:
+         return "new_document_with_code";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -236,6 +236,8 @@ SEXP rs_enqueClientEvent(SEXP nameSEXP, SEXP dataSEXP)
          type = session::client_events::kShowPageViewerEvent;
       else if (name == "data_output_completed")
          type = session::client_events::kDataOutputCompleted;
+      else if (name == "new_document_with_code")
+         type = session::client_events::kNewDocumentWithCode;
 
       if (type != -1)
       {

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -190,6 +190,7 @@ extern const int kJobUpdated;
 extern const int kJobRefresh;
 extern const int kJobOutput;
 extern const int kDataOutputCompleted;
+extern const int kNewDocumentWithCode;
 }
    
 class ClientEvent

--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -678,8 +678,10 @@
       size <- nrow(data)
    }
 
-   for(i in seq_along(data)) {
-      data[[i]] <- .rs.formatDataColumn(data[[i]], 1, size)
+   if (nrow(data) > 0) {
+      for(i in seq_along(data)) {
+         data[[i]] <- .rs.formatDataColumn(data[[i]], 1, size)
+      }
    }
 
    list(

--- a/src/cpp/session/modules/SessionDataPreview.R
+++ b/src/cpp/session/modules/SessionDataPreview.R
@@ -29,6 +29,8 @@
    )
 
    .rs.enqueClientEvent("data_output_completed", preview)
+
+   invisible(NULL)
 })
 
 .rs.addFunction("previewSql", function(conn, statement, ...)

--- a/src/cpp/session/modules/SessionDataPreview.R
+++ b/src/cpp/session/modules/SessionDataPreview.R
@@ -41,6 +41,9 @@
       statement <- paste(readLines(script), collapse = "\n")
    }
 
+   # remove comments since some drivers might not support them
+   statement <- gsub("--[^\n]*\n+", "", statement)
+
    data <- DBI::dbGetQuery(conn, statement = statement, ...)
 
    .rs.previewDataFrame(data, script)

--- a/src/cpp/session/modules/SessionDataPreview.R
+++ b/src/cpp/session/modules/SessionDataPreview.R
@@ -44,7 +44,10 @@
    # remove comments since some drivers might not support them
    statement <- gsub("--[^\n]*\n+", "", statement)
 
-   data <- DBI::dbGetQuery(conn, statement = statement, ...)
+   # fetch at most 100 records as a preview
+   rs <- DBI::dbSendQuery(conn, statement = statement, ...)
+   data <- DBI::dbFetch(rs, n = 100)
+   DBI::dbClearResult(rs)
 
    .rs.previewDataFrame(data, script)
 })

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -180,6 +180,7 @@ class ClientEvent extends JavaScriptObject
    public static final String JobRefresh = "job_refresh";
    public static final String JobOutput = "job_output";
    public static final String DataOutputCompleted = "data_output_completed";
+   public static final String NewDocumentWithCode = "new_document_with_code";
 
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -174,6 +174,7 @@ import org.rstudio.studio.client.workbench.views.source.events.CollabEditStartPa
 import org.rstudio.studio.client.workbench.views.source.events.CollabEditStartedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.DataViewChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.FileEditEvent;
+import org.rstudio.studio.client.workbench.views.source.events.NewDocumentWithCodeEvent;
 import org.rstudio.studio.client.workbench.views.source.events.ShowContentEvent;
 import org.rstudio.studio.client.workbench.views.source.events.ShowDataEvent;
 import org.rstudio.studio.client.workbench.views.source.events.SourceExtendedTypeDetectedEvent;
@@ -995,6 +996,11 @@ public class ClientEventDispatcher
          {
             DataOutputResult result = event.getData();
             eventBus_.fireEvent(new DataOutputCompletedEvent(result));
+         }
+         else if (type == ClientEvent.NewDocumentWithCode)
+         {
+            NewDocumentWithCodeEvent.Data result = event.getData();
+            eventBus_.fireEvent(new NewDocumentWithCodeEvent(result));
          }
          else
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -2577,6 +2577,8 @@ public class Source implements InsertSourceHandler,
       final EditableFileType docType;
       if (event.getType() == NewDocumentWithCodeEvent.R_SCRIPT)
          docType = FileTypeRegistry.R;
+      else if (event.getType() == NewDocumentWithCodeEvent.SQL)
+         docType = FileTypeRegistry.SQL;
       else
          docType = FileTypeRegistry.RMARKDOWN;
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -2607,6 +2607,10 @@ public class Source implements InsertSourceHandler,
                         commands_.executeToCurrentLine().execute();
                         commands_.activateSource().execute();
                      }
+                     else if (docType.equals(FileTypeRegistry.SQL))
+                     {
+                        commands_.previewSql().execute();
+                     }
                      else
                      {
                         commands_.executePreviousChunks().execute();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -2587,12 +2587,12 @@ public class Source implements InsertSourceHandler,
          @Override
          public void execute()
          {
-            newDoc(docType,  
-                  new ResultCallback<EditingTarget, ServerError>() {
+            newDoc(docType,
+                   event.getCode(),
+                   new ResultCallback<EditingTarget, ServerError>() {
                public void onSuccess(EditingTarget arg)
                {
                   TextEditingTarget editingTarget = (TextEditingTarget)arg;
-                  editingTarget.insertCode(event.getCode(), false);
                   
                   if (event.getCursorPosition() != null)
                   {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -5368,13 +5368,7 @@ public class TextEditingTarget implements
          @Override
          public void execute()
          {
-            saveThenExecute(null, new Command() {
-               @Override
-               public void execute()
-               {
-                  sqlHelper_.previewSql(TextEditingTarget.this);
-               }
-            });
+            sqlHelper_.previewSql(TextEditingTarget.this);
          }
       }); 
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetSqlHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetSqlHelper.java
@@ -47,7 +47,19 @@ public class TextEditingTargetSqlHelper
       SqlPreview sqlPreview = parseSqlPreview();
       if (sqlPreview != null)
       {
-         String command = "previewSql(statement = \"" + editingTarget.getPath() + "\"," +
+         String statement = "";
+         
+         if (editingTarget.dirtyState().getValue() || editingTarget.getPath() == null)
+         {
+            statement = docDisplay_.getCode();
+         }
+         else
+         {
+            statement = editingTarget.getPath();
+         }
+
+         String statementEscaped = statement.replaceAll("\\\"", "\\\\\"");
+         String command = "previewSql(statement = \"" + statementEscaped + "\"," +
             sqlPreview.args +
             ")";
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/NewDocumentWithCodeEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/NewDocumentWithCodeEvent.java
@@ -2,7 +2,7 @@
 /*
  * NewDocumentWithCodeEvent.java
  *
- * Copyright (C) 2009-15 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,18 +17,43 @@ package org.rstudio.studio.client.workbench.views.source.events;
 
 import org.rstudio.studio.client.workbench.views.source.model.SourcePosition;
 
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 
 public class NewDocumentWithCodeEvent 
    extends GwtEvent<NewDocumentWithCodeEvent.Handler>
 {
+   public final static String SQL = "sql";
    public final static String R_SCRIPT = "r_script";
    public final static String R_NOTEBOOK = "r_notebook";
    
    public interface Handler extends EventHandler
    {
       void onNewDocumentWithCode(NewDocumentWithCodeEvent e);
+   }
+
+   public static class Data extends JavaScriptObject
+   {
+      protected Data() 
+      {
+      }
+      
+      public final native String type() /*-{
+         return this.type;
+      }-*/;
+
+      public final native String code() /*-{
+         return this.code;
+      }-*/;
+   }
+
+   public NewDocumentWithCodeEvent(Data data)
+   {
+      type_ = data.type();
+      code_ = data.code();
+      cursorPosition_ = SourcePosition.create(0, 0);
+      execute_ = false;
    }
    
    public NewDocumentWithCodeEvent(String type,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/NewDocumentWithCodeEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/NewDocumentWithCodeEvent.java
@@ -46,14 +46,26 @@ public class NewDocumentWithCodeEvent
       public final native String code() /*-{
          return this.code;
       }-*/;
+
+      public final native int row() /*-{
+         return this.row;
+      }-*/;
+
+      public final native int column() /*-{
+         return this.column;
+      }-*/;
+
+      public final native boolean execute() /*-{
+         return this.execute;
+      }-*/;
    }
 
    public NewDocumentWithCodeEvent(Data data)
    {
       type_ = data.type();
       code_ = data.code();
-      cursorPosition_ = SourcePosition.create(0, 0);
-      execute_ = false;
+      cursorPosition_ = SourcePosition.create(data.row(), data.column());
+      execute_ = data.execute();
    }
    
    public NewDocumentWithCodeEvent(String type,


### PR DESCRIPTION
This PR adds support for packages providing connection extensions to provide a custom action that creates and previews a SQL statement. For instance, one can use the `documentNew()` API to create a package with a new `SQL` action:

<img width="473" alt="screen shot 2018-05-15 at 8 32 31 pm" src="https://user-images.githubusercontent.com/3478847/40095105-1e8406f4-587f-11e8-9b51-0ff0ca05f3bd.png">

Which, when the action is triggered opens a SQL script document with the cursor on a given table for easy editing:

<img width="644" alt="screen shot 2018-05-15 at 8 29 14 pm" src="https://user-images.githubusercontent.com/3478847/40095120-2e08ba8e-587f-11e8-9ed2-3099ee2330d6.png">

and automatically opens the SQL Results on the console pane:

<img width="646" alt="screen shot 2018-05-15 at 8 29 23 pm" src="https://user-images.githubusercontent.com/3478847/40095140-409d9bce-587f-11e8-801d-271d4cefe4f2.png">
