### PR TITLE
Pass RStudio version to rmarkdown child process

### DIFF
--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -13,6 +13,8 @@
  *
  */
 
+#include "session-config.h"
+
 #include "SessionRMarkdown.hpp"
 #include "SessionRmdNotebook.hpp"
 #include "../SessionHTMLPreview.hpp"
@@ -414,6 +416,9 @@ private:
          environment.push_back(std::make_pair("RMARKDOWN_PREVIEW_DIR", tempDir));
       else
          LOG_ERROR(error);
+
+      // pass along the RSTUDIO_VERSION
+      environment.push_back(std::make_pair("RSTUDIO_VERSION", RSTUDIO_VERSION));
 
       // set the not cran env var
       environment.push_back(std::make_pair("NOT_CRAN", "true"));


### PR DESCRIPTION
The motivation is for R Markdown formats that are going to render content that can't be displayed in the v1.1. RStudio Viewer (e.g. relying on ES6, web components, etc.)

We could/should probably make this a global environment variable so it's available from all child processes, however we'd probably need to think through a bit whether there are some processes that should be carved out (e.g. terminals that might host other R sessions). Scoping to R Markdown for now just to be conservative.