### PR TITLE
make it possible to run bash chunks on Windows

### DIFF
--- a/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
@@ -77,8 +77,7 @@ std::string scriptPathForShellCommand(
 
 #ifndef _WIN32
    return defaultPath();
-#endif
-
+#else
    if (engine == "bash")
    {
       std::string bashPath = "bash.exe";
@@ -103,15 +102,17 @@ std::string scriptPathForShellCommand(
          return defaultPath();
       }
 
-      return
+      std::string path =
             string_utils::trimWhitespace(result.stdOut) +
             "/" +
             scriptPath.filename();
+      return string_utils::utf8ToSystem(path);
    }
    else
    {
       return defaultPath();
    }
+#endif
 }
 
 } // end anonymous namespace


### PR DESCRIPTION
This PR fixes an issue where attempting to run Bash chunks when using the Windows Subsystem for Linux could fail. This is effectively because WSL bash uses the prefix `/mnt/c/` for paths rather than `C:/`, and does not attempt to translate paths from `C:/` to the expected counterpart. (Note that Git Bash _does_ do this transformation)

We work around this by asking `bash.exe` what it believes the current path is from within the R temporary directory, and use that to construct a path that the particular flavor of `bash.exe` will understand.

Closes #2724.