### PR TITLE
allow enable / disable of GWT build

### DIFF
--- a/src/gwt/CMakeLists.txt
+++ b/src/gwt/CMakeLists.txt
@@ -34,14 +34,21 @@ if("${GWT_EXTRAS_DIR}" STREQUAL "")
 endif()
 
 # invoke ant to build
-add_custom_target(gwt_build ALL)
-add_custom_command(
-   TARGET gwt_build
-   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-   COMMAND ant -Dbuild.dir="${GWT_BIN_DIR}"
-               -Dwww.dir="${GWT_WWW_DIR}"
-               -Dextras.dir="${GWT_EXTRAS_DIR}"
-               -Dlib.dir="${GWT_LIB_DIR}")
+set(GWT_BUILD Yes)
+if(DEFINED ENV{GWT_BUILD})
+   set(GWT_BUILD $ENV{GWT_BUILD})
+endif()
+
+if(GWT_BUILD)
+   add_custom_target(gwt_build ALL)
+   add_custom_command(
+      TARGET gwt_build
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+      COMMAND ant -Dbuild.dir="${GWT_BIN_DIR}"
+                  -Dwww.dir="${GWT_WWW_DIR}"
+                  -Dextras.dir="${GWT_EXTRAS_DIR}"
+                  -Dlib.dir="${GWT_LIB_DIR}")
+endif()
 
 # create test script and copy to binary directory with executable permissions
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/gwt-unit-tests.sh.in


### PR DESCRIPTION
This is primarily for use when attempting to more quickly produce package builds. One can explicitly invoke `ant build` as needed, and then use something like `GWT_BUILD=No ./make-package` to produce a package build while skipping a rebuild of our GWT sources.