### PR TITLE
helper for package builds on Windows

### DIFF
--- a/package/win32/make-install-win64.bat
+++ b/package/win32/make-install-win64.bat
@@ -16,6 +16,13 @@ REM perform 64-bit build
 mkdir %WIN64_BUILD_PATH%
 cd %WIN64_BUILD_PATH%
 if exist CMakeCache.txt del CMakeCache.txt
+
+REM Ensure Windows toolkit is on the PATH (for rc.exe)
+set "WINDOWS_TOOLKIT=C:\Program Files (x86)\Windows Kits\8.1\bin\x64"
+set "OLDPATH=%PATH%"
+set "PATH=%PATH%;%WINDOWS_TOOLKIT%"
+
+REM Build the project
 cmake -G"Visual Studio 14 2015 Win64" ^
       -DCMAKE_INSTALL_PREFIX:String=%INSTALL_PATH% ^
       -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% ^
@@ -24,6 +31,9 @@ cmake -G"Visual Studio 14 2015 Win64" ^
       ..\..\.. || goto :error
 cmake --build . --config %CMAKE_BUILD_TYPE% --target install || goto :error
 cd ..
+
+set "PATH=%OLDPATH%"
+
 endlocal
 
 goto :EOF

--- a/package/win32/make-package.bat
+++ b/package/win32/make-package.bat
@@ -37,6 +37,11 @@ if not exist "%BUILD_DIR%" mkdir "%BUILD_DIR%"
 cd "%BUILD_DIR%"
 if exist "%BUILD_DIR%/_CPack_Packages" rmdir /s /q "%BUILD_DIR%\_CPack_Packages"
 
+REM Ensure Windows toolkit is on the PATH (for rc.exe)
+set "WINDOWS_TOOLKIT=C:\Program Files (x86)\Windows Kits\8.1\bin\x86"
+set "OLDPATH=%PATH%"
+set "PATH=%PATH%;%WINDOWS_TOOLKIT%"
+
 REM Configure and build the project. (Note that Windows / MSVC builds require
 REM that we specify the build type both at configure time and at build time)
 cmake -G"Visual Studio 14 2015" ^
@@ -46,6 +51,8 @@ cmake -G"Visual Studio 14 2015" ^
       ..\..\.. || goto :error
 cmake --build . --config %CMAKE_BUILD_TYPE% || goto :error
 cd ..
+
+set "PATH=%OLDPATH%"
 
 REM perform 64-bit build and install it into the 32-bit tree
 REM (but only do this if we are on win64)


### PR DESCRIPTION
This PR places a Windows toolkit on the PATH for package builds, so that `rc.exe` can be easily discovered and things otherwise work as expected.