### PR TITLE
Use r2d3 from CRAN

### DIFF
--- a/dependencies/common/.gitignore
+++ b/dependencies/common/.gitignore
@@ -17,7 +17,5 @@ profvis/
 profvis*.tar.gz
 *.tar.bz
 *.tar.bz2
-r2d3/
-r2d3*.tar.gz
 plumber/
 plumber*.tar.gz

--- a/dependencies/common/install-packages
+++ b/dependencies/common/install-packages
@@ -80,7 +80,6 @@ mv $PACKAGE_ARCHIVE $PACKAGE_ARCHIVE_SHA1
 # we often embed these packages but are not currently
 # install rsconnect master rstudio
 # install rmarkdown master rstudio
-install r2d3 master rstudio 
 install plumber master trestletech
 
 # back to install-dir

--- a/dependencies/common/install-packages.cmd
+++ b/dependencies/common/install-packages.cmd
@@ -11,7 +11,6 @@ set PATH=%PATH%;%CD%\tools
 
 REM call:install rsconnect master rstudio --no-build-vignettes
 REM call:install rmarkdown master rstudio --no-build-vignettes
-call:install r2d3 master rstudio --no-build-vignettes
 call:install plumber master trestletech --no-build-vignettes
 GOTO:EOF
 

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -37,9 +37,6 @@ endif()
 # if(NOT EXISTS "${RSTUDIO_DEPENDENCIES_DIR}/common/rsconnect")
 #   message(FATAL_ERROR "rsconnect package not found (re-run install-dependencies script to install)")
 # endif()
-if(NOT EXISTS "${RSTUDIO_DEPENDENCIES_DIR}/common/r2d3")
-  message(FATAL_ERROR "r2d3 package not found (re-run install-dependencies script to install)")
-endif()
 if(NOT EXISTS "${RSTUDIO_DEPENDENCIES_DIR}/common/plumber")
   message(FATAL_ERROR "plumber package not found (re-run install-dependencies script to install)")
 endif()
@@ -494,11 +491,6 @@ if (NOT RSTUDIO_SESSION_WIN64)
    #file(GLOB RSCONNECT_PACKAGE "${RSTUDIO_DEPENDENCIES_DIR}/common/rsconnect*.tar.gz")
    #install(FILES ${RSCONNECT_PACKAGE}
    #        DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/R/packages)
-           
-   # install r2d3 package
-   file(GLOB R2D3_PACKAGE "${RSTUDIO_DEPENDENCIES_DIR}/common/r2d3*.tar.gz")
-   install(FILES ${R2D3_PACKAGE}
-           DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/R/packages)
 
    # install plumber package
    file(GLOB PLUMBER_PACKAGE "${RSTUDIO_DEPENDENCIES_DIR}/common/plumber*.tar.gz")

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -135,7 +135,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
          new Dependency[] {
             Dependency.cranPackage("htmltools", "0.3.6"),
             Dependency.cranPackage("htmlwidgets", "1.2", true),
-            Dependency.embeddedPackage("r2d3")
+            Dependency.cranPackage("r2d3", "0.2.0")
          },
          true,
          new CommandWithArg<Boolean>()


### PR DESCRIPTION
Remove r2d3 as embedded package, use CRAN package instead. Need to wait for r2d3 to be available in CRAN:

![](https://www.r-pkg.org/badges/version/r2d3)