### PR TITLE
Fix some issues with running terminal on 64-bit rsession (Windows)

### DIFF
--- a/src/cpp/core/system/Win32Pty.cpp
+++ b/src/cpp/core/system/Win32Pty.cpp
@@ -111,7 +111,10 @@ Error tryLoad(const core::FilePath& libraryPath)
             libraryPath.absolutePath(),
             (void**)&hMod);
    if (error)
+   {
+      LOG_ERROR(error);
       return error;
+   }
 
    LOAD_WINPTY_SYMBOL(error_code);
    LOAD_WINPTY_SYMBOL(error_msg);

--- a/src/cpp/core/system/Win32System.cpp
+++ b/src/cpp/core/system/Win32System.cpp
@@ -672,10 +672,17 @@ PidType currentProcessId()
    return ::GetCurrentProcessId();
 }
 
-Error executablePath(const char * argv0,
+Error executablePath(const char *argv0,
                      FilePath* pExecutablePath)
 {
-   *pExecutablePath = FilePath(_pgmptr);
+   wchar_t exePath[MAX_PATH];
+   if (!GetModuleFileNameW(nullptr, exePath, MAX_PATH))
+   {
+      auto lastErr = ::GetLastError();
+      return systemError(lastErr, ERROR_LOCATION);
+   }
+   std::wstring wzPath(exePath);
+   *pExecutablePath = FilePath(wzPath);
    return Success();
 }
 

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -104,10 +104,8 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
 
    // detect running in x64 directory and tweak resource path
 #ifdef _WIN32
-   bool is64 = false;
    if (resourcePath_.complete("x64").exists())
    {
-      is64 = true;
       resourcePath_ = resourcePath_.parent();
    }
 #endif
@@ -579,17 +577,19 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
    std::string completion;
    if (pty.isWithin(resourcePath_))
    {
-      if (is64)
-         completion = "x64/winpty.dll";
-      else
-         completion = "winpty.dll";
+#ifdef _WIN64
+      completion = "x64/winpty.dll";
+#else
+      completion = "winpty.dll";
+#endif
    }
    else
    {
-      if (is64)
-         completion = "64/bin/winpty.dll";
-      else
-         completion = "32/bin/winpty.dll";
+#ifdef _WIN64
+      completion = "64/bin/winpty.dll";
+#else
+      completion = "32/bin/winpty.dll";
+#endif
    }
    winptyPath_ = pty.complete(completion).absolutePath();
 #endif


### PR DESCRIPTION
Fixes #2817

This has been somewhat non-deterministic. I'm seeing cases where Win32 `executablePath()` returns an empty string, leading to mistakes in locating the winpty.dll (and presumably other problems). Also problems running terminal with 64-bit rsession build in dev environment; hadn't tried that before, always used 32-bit.

Found some mention online that using `_pgmptr` for getting at full path of current executable can have issues if used early in startup, but it is safe to use `GetModuleFileName` early. So switched to that approach.

Added an error log if there is a failure to find winpty.dll.

Made the decision on using 32-bit or 64-bit winpty.dll a compile-time thing instead of runtime, since it's already known by virtue of which rsession.exe is being built.