### PR TITLE
Avoid eager wait hang when htmlwidgets fail to load

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/DynamicIFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/DynamicIFrame.java
@@ -76,7 +76,8 @@ public abstract class DynamicIFrame extends Frame
          {
             if (loadFrame.execute()) 
             {
-               Scheduler.get().scheduleFixedDelay(loadFrame, 50);
+               if (retryInterval_ < 500) retryInterval_ += 50;
+               Scheduler.get().scheduleFixedDelay(loadFrame, retryInterval_);
             }
          }
       });
@@ -100,4 +101,5 @@ public abstract class DynamicIFrame extends Frame
    protected abstract void onFrameLoaded();
 
    private String url_;
+   private int retryInterval_ = 50;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/DynamicIFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/DynamicIFrame.java
@@ -40,6 +40,7 @@ public abstract class DynamicIFrame extends Frame
    @Override
    public void setUrl(String url)
    {
+      retryInterval_ = 0;
       url_ = url;
       super.setUrl(url);
       pollForLoad();
@@ -101,5 +102,5 @@ public abstract class DynamicIFrame extends Frame
    protected abstract void onFrameLoaded();
 
    private String url_;
-   private int retryInterval_ = 50;
+   private int retryInterval_ = 0;
 }


### PR DESCRIPTION
With `1.2.657` and heavy use of D3 chunks, satellite windows and a [chunk-piled bug now fixed](https://github.com/rstudio/rstudio/pull/2843), it was possible for the R2D3 widgets to hand the rsession; the UI was also hanging but not related to the rsession hand but rather for eagerly waiting for the htmlwidgets to load, this is probably worse with many D3 widgets but still, the `50ms` wait time was too fast. This change increases the wait time to `500ms` over the first couple seconds linearly to mitigate this hang.