### PR TITLE
more intelligent preview for files in subdirectories of websites

### DIFF
--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -176,9 +176,30 @@ std::string assignOutputUrl(const std::string& outputFile)
 {
    std::string outputUrl(kRmdOutput "/");
    s_currentRenderOutput = (s_currentRenderOutput + 1) % kMaxRenderOutputs;
-   s_renderOutputs[s_currentRenderOutput] = outputFile;
+
+   // if this is a website project and the file is not at the root then we need
+   // to do some special handling to make sure that the HTML can refer to
+   // locations in parent directories (e.g. for navigation links)
+   std::string path = "/";
+   FilePath outputPath = module_context::resolveAliasedPath(outputFile);
+   if (module_context::isWebsiteProject() && !r_util::isWebsiteDirectory(outputPath.parent()))
+   {
+      // assign website build dir as output root
+      FilePath websiteDir = projects::projectContext().buildTargetPath();
+      FilePath indexPath = websiteDir.childPath("index.html");
+      s_renderOutputs[s_currentRenderOutput] = indexPath.absolutePath();
+
+      // compute relative path to target file and append it to the path
+      std::string relativePath = outputPath.relativePath(websiteDir);
+      path += relativePath;
+   }
+   else
+   {
+      s_renderOutputs[s_currentRenderOutput] = outputFile;
+   }
+
    outputUrl.append(boost::lexical_cast<std::string>(s_currentRenderOutput));
-   outputUrl.append("/");
+   outputUrl.append(path);
    return outputUrl;
 }
 


### PR DESCRIPTION
This change improves the behavior of R Markdown preview for files in subdirectories of websites.

It was of course already possible to preview Rmds that were in subfolders of websites, this change allows those Rmds to refer and navigate to locations in parent directories (e.g. image assets or navigational links). This is done by inserting the website build dir into `s_renderOutputs` and then appending the build dir relative path to the Rmd to the path of the output url.

cc @jmcphers 