### PR TITLE
correctly handing for files not in website projects

### DIFF
--- a/src/cpp/core/include/core/r_util/RProjectFile.hpp
+++ b/src/cpp/core/include/core/r_util/RProjectFile.hpp
@@ -156,6 +156,9 @@ bool updateSetPackageInstallArgsDefault(RProjectConfig* pConfig);
 // indicate whether the given directory is an R Markdown website
 bool isWebsiteDirectory(const FilePath& projectDir);
 
+// discover website root directory for a filePath
+FilePath websiteRootDirectory(const FilePath& filePath);
+
 } // namespace r_util
 } // namespace core 
 } // namespace rstudio

--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -1120,6 +1120,21 @@ bool isWebsiteDirectory(const FilePath& projectDir)
    }
 }
 
+// find the website root (if any) for the given filepath
+FilePath websiteRootDirectory(const FilePath& filePath)
+{
+   FilePath dir = filePath.parent();
+   while (!dir.empty())
+   {
+      if (r_util::isWebsiteDirectory(dir))
+         return dir;
+
+      dir = dir.parent();
+   }
+
+   return FilePath();
+}
+
 } // namespace r_util
 } // namespace core 
 } // namespace rstudio

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -182,10 +182,10 @@ std::string assignOutputUrl(const std::string& outputFile)
    // locations in parent directories (e.g. for navigation links)
    std::string path = "/";
    FilePath outputPath = module_context::resolveAliasedPath(outputFile);
-   if (module_context::isWebsiteProject() && !r_util::isWebsiteDirectory(outputPath.parent()))
+   FilePath websiteDir = r_util::websiteRootDirectory(outputPath);
+   if (!websiteDir.empty() && !r_util::isWebsiteDirectory(outputPath.parent()))
    {
       // assign website build dir as output root
-      FilePath websiteDir = projects::projectContext().buildTargetPath();
       FilePath indexPath = websiteDir.childPath("index.html");
       s_renderOutputs[s_currentRenderOutput] = indexPath.absolutePath();
 


### PR DESCRIPTION
The previous fix only handled files that were in website projects. However, it's possible (and even likely) that users will be authoring articles in subdirectories with their own projects which didn't work correctly prior to this fix.