### PR TITLE
Support running sample sql query immediately after session restart

### DIFF
--- a/src/cpp/session/resources/templates/query.sql
+++ b/src/cpp/session/resources/templates/query.sql
@@ -1,3 +1,3 @@
--- !preview conn=DBI::dbConnect(RSQLite::SQLite())
+-- !preview conn=force(DBI::dbConnect(RSQLite::SQLite()))
 
 SELECT 1


### PR DESCRIPTION
After a session restart, first time a sample SQL script is run, it fails with error:

<img width="981" alt="screen shot 2018-05-24 at 11 44 45 am" src="https://user-images.githubusercontent.com/3478847/40505025-e082c1fe-5f47-11e8-97e5-25048c451da3.png">

Problem is that `DBI` expect most connections to look like:

```r
conn <- DBI::dbConnect(RSQLite::SQLite())
DBI::dbSendQuery(conn = conn, "SELECT 1")
```

For the S3 methods to register properly, instead, this changes avoids lazy initialization in the connection using `force()`.