### PR TITLE
Enable close window shortcuts on secondary windows

### DIFF
--- a/src/cpp/desktop/DesktopSecondaryWindow.cpp
+++ b/src/cpp/desktop/DesktopSecondaryWindow.cpp
@@ -81,6 +81,23 @@ SecondaryWindow::SecondaryWindow(bool showToolbar, QString name, QUrl baseUrl,
       size.setHeight(size.height()-75);
       resize(size);
    }
+
+   connect(webView(), SIGNAL(onCloseWindowShortcut()),
+           this, SLOT(onCloseWindowShortcut()));
+}
+
+void SecondaryWindow::finishLoading(bool ok)
+{
+   BrowserWindow::finishLoading(ok);
+
+   if (ok)
+      connect(webView(), SIGNAL(onCloseWindowShortcut()), this,
+              SLOT(onCloseWindowShortcut()));
+}
+
+void SecondaryWindow::onCloseWindowShortcut()
+{
+   close();
 }
 
 void SecondaryWindow::manageCommandState()

--- a/src/cpp/desktop/DesktopSecondaryWindow.hpp
+++ b/src/cpp/desktop/DesktopSecondaryWindow.hpp
@@ -1,7 +1,7 @@
 /*
  * DesktopSecondaryWindow.hpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -24,20 +24,23 @@ namespace desktop {
 
 class SecondaryWindow : public BrowserWindow
 {
-    Q_OBJECT
+   Q_OBJECT
 public:
-    explicit SecondaryWindow(bool showToolbar, QString name, QUrl baseUrl,
-                             QWidget* pParent = nullptr, WebPage *pOpener = nullptr,
-                             bool allowExternalNavigate = false);
+   explicit SecondaryWindow(bool showToolbar, QString name, QUrl baseUrl,
+                            QWidget* pParent = nullptr, WebPage *pOpener = nullptr,
+                            bool allowExternalNavigate = false);
+public Q_SLOTS:
+   void onCloseWindowShortcut();
 
 protected Q_SLOTS:
-    virtual void manageCommandState();
+   void finishLoading(bool ok) override;
+   virtual void manageCommandState();
 
 private:
-    QAction* back_;
-    QAction* forward_;
-    QAction* reload_;
-    QAction* print_;
+   QAction* back_;
+   QAction* forward_;
+   QAction* reload_;
+   QAction* print_;
 };
 
 } // namespace desktop


### PR DESCRIPTION
<kbd>Cmd</kbd>+<kbd>W</kbd> should generally close our secondary windows (that is, non-GWT windows like the Help popout and the PDF viewer), but doesn't. This change fixes that by making them self-close when the window-close shortcut is emitted. 

Fixes #2799.