### PR TITLE
Reworked session default working directory logic to make it work properly across desktop, server, and server pro

### DIFF
--- a/src/cpp/core/include/core/r_util/RActiveSessions.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessions.hpp
@@ -103,7 +103,12 @@ public:
             return false;
       }
       else
-         return false;
+      {
+         // if empty, we are likely in desktop mode (as we have no specified scratch path)
+         // in this default case, we want initial to be true, since every time the session
+         // is started, we should start in the default working directory
+         return true;
+      }
    }
 
    void setInitial(bool initial)
@@ -357,7 +362,7 @@ public:
                       const std::string& working,
                       std::string* pId) const
    {
-      return create(project, working, false, pId);
+      return create(project, working, true, pId);
    }
 
    core::Error create(const std::string& project,

--- a/src/cpp/session/SessionDirs.cpp
+++ b/src/cpp/session/SessionDirs.cpp
@@ -44,6 +44,23 @@ FilePath getDefaultWorkingDirectory()
       return session::options().userHomePath();
 }
 
+FilePath getActiveSessionInitialWorkingDirectory()
+{
+   using namespace module_context;
+   if (activeSession().initial())
+   {
+      activeSession().setInitial(false);
+      return getDefaultWorkingDirectory();
+   }
+
+   FilePath workingDirPath = module_context::resolveAliasedPath(
+                   module_context::activeSession().workingDir());
+   if (workingDirPath.exists())
+      return workingDirPath;
+   else
+      return getDefaultWorkingDirectory();
+}
+
 FilePath getInitialWorkingDirectory()
 {
    // check for a project
@@ -55,21 +72,7 @@ FilePath getInitialWorkingDirectory()
    // check for working dir in project none
    else if (options().sessionScope().isProjectNone())
    {
-      // if this is the initial session then use the default working directory
-      // (reset initial to false so this is one shot thing)
-      using namespace module_context;
-      if (activeSession().initial())
-      {
-         activeSession().setInitial(false);
-         return getDefaultWorkingDirectory();
-      }
-
-      FilePath workingDirPath = module_context::resolveAliasedPath(
-                      module_context::activeSession().workingDir());
-      if (workingDirPath.exists())
-         return workingDirPath;
-      else
-         return getDefaultWorkingDirectory();
+      return getActiveSessionInitialWorkingDirectory();
    }
 
    // see if there is an override from the environment (perhaps based
@@ -81,8 +84,7 @@ FilePath getInitialWorkingDirectory()
    }
    else
    {
-      // if not then just return default working dir
-      return getDefaultWorkingDirectory();
+      return getActiveSessionInitialWorkingDirectory();
    }
 }
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1765,7 +1765,13 @@ int main (int argc, char * const argv[])
       error = workingDir.makeCurrentPath();
       if (error)
          return sessionExitFailure(error, ERROR_LOCATION);
-         
+
+      // override the active session's working directory
+      // it is created with the default value of ~, so if our session options
+      // have specified that a different directory should be used, we should
+      // persist the value to the session state as soon as possible
+      module_context::activeSession().setWorkingDir(workingDir.absolutePath());
+
       // start http connection listener
       error = waitWithTimeout(
             http_methods::startHttpConnectionListenerWithTimeout, 0, 100, 1);


### PR DESCRIPTION
The issue was occurring because by default, sessions are not created to respect the directory override (by not setting the initial flag), and because the initial flag is cleared before client_init (fixed by setting working dir in SessionMain). Fixes #2861.