### PR TITLE
Make r-cran-repos and user setting consistent

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1820,13 +1820,13 @@ int main (int argc, char * const argv[])
       rOptions.rSourcePath = options.coreRSourcePath();
       if (!desktopMode) // ignore r-libs-user in desktop mode
          rOptions.rLibsUser = options.rLibsUser();
-      // CRAN repos: repos file trumps global server option which trumps user setting
+      // CRAN repos: user setting then repos file then global server option
+      if (userSettings().cranMirror().url)
+         rOptions.rCRANRepos = userSettings().cranMirror().url;
       if (!options.rCRANMultipleRepos().empty())
          rOptions.rCRANRepos = options.rCRANMultipleRepos();
-      else if (!options.rCRANRepos().empty())
+      else (!options.rCRANRepos().empty())
          rOptions.rCRANRepos = options.rCRANRepos();
-      else
-         rOptions.rCRANRepos = userSettings().cranMirror().url;
       rOptions.useInternet2 = userSettings().useInternet2();
       rOptions.rCompatibleGraphicsEngineVersion =
                               options.rCompatibleGraphicsEngineVersion();

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1821,11 +1821,11 @@ int main (int argc, char * const argv[])
       if (!desktopMode) // ignore r-libs-user in desktop mode
          rOptions.rLibsUser = options.rLibsUser();
       // CRAN repos: user setting then repos file then global server option
-      if (userSettings().cranMirror().url)
+      if (!userSettings().cranMirror().url.empty())
          rOptions.rCRANRepos = userSettings().cranMirror().url;
-      if (!options.rCRANMultipleRepos().empty())
+      else if (!options.rCRANMultipleRepos().empty())
          rOptions.rCRANRepos = options.rCRANMultipleRepos();
-      else (!options.rCRANRepos().empty())
+      else if (!options.rCRANRepos().empty())
          rOptions.rCRANRepos = options.rCRANRepos();
       rOptions.useInternet2 = userSettings().useInternet2();
       rOptions.rCompatibleGraphicsEngineVersion =

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1820,13 +1820,21 @@ int main (int argc, char * const argv[])
       rOptions.rSourcePath = options.coreRSourcePath();
       if (!desktopMode) // ignore r-libs-user in desktop mode
          rOptions.rLibsUser = options.rLibsUser();
-      // CRAN repos: user setting then repos file then global server option
+
+      CRANMirror emptyMirror;
+
+      // When edit disabled, clear user setting to fix previous versions
+      if (!options.allowCRANReposEdit())
+        userSettings().setCRANMirror(emptyMirror);
+
+      // CRAN repos precedence: user setting then repos file then global server option
       if (!userSettings().cranMirror().url.empty())
          rOptions.rCRANRepos = userSettings().cranMirror().url;
       else if (!options.rCRANMultipleRepos().empty())
          rOptions.rCRANRepos = options.rCRANMultipleRepos();
       else if (!options.rCRANRepos().empty())
          rOptions.rCRANRepos = options.rCRANRepos();
+
       rOptions.useInternet2 = userSettings().useInternet2();
       rOptions.rCompatibleGraphicsEngineVersion =
                               options.rCompatibleGraphicsEngineVersion();

--- a/src/cpp/session/SessionUserSettings.cpp
+++ b/src/cpp/session/SessionUserSettings.cpp
@@ -693,10 +693,15 @@ CRANMirror UserSettings::cranMirror() const
    // a previous bug/regression
    if (mirror.url.empty() || (mirror.url == "/"))
    {
-      mirror.name = "Global (CDN)";
-      mirror.host = "RStudio";
-      mirror.url = "http://cran.rstudio.com/";
-      mirror.country = "us";
+      // But only if the default not changed in r-cran-repos and repos.conf
+      if (session::options().rCRANRepos().empty() &&
+          session::options().rCRANMultipleRepos().size() == 0)
+      {
+         mirror.name = "Global (CDN)";
+         mirror.host = "RStudio";
+         mirror.url = "http://cran.rstudio.com/";
+         mirror.country = "us";
+      }
    }
 
    // re-map cran.rstudio.org to cran.rstudio.com
@@ -704,7 +709,7 @@ CRANMirror UserSettings::cranMirror() const
       mirror.url = "http://cran.rstudio.com/";
 
    // remap url without trailing slash
-   if (!boost::algorithm::ends_with(mirror.url, "/"))
+   if (mirror.url.size() > 0 && !boost::algorithm::ends_with(mirror.url, "/"))
       mirror.url += "/";
 
    return mirror;


### PR DESCRIPTION
This is older issue that reproes in RStudio Server 1.1 see #2864 and https://github.com/rstudio/rstudio-pro/issues/434

When the `r-cran-repos` option is set, `SessionUserSettings.cpp` still defaults to RStudio's CRAN repo, this is harmless in many cases. However,  as shown in #2864 and https://github.com/rstudio/rstudio-pro/issues/434, whenever the user preferences get refreshed, say by OKing the Global Preferences dialog, opening a new terminal or changing R versions, etc, we change the CRAN repo to the user settings value. This yields inconsistent behavior since some r sessions might start with some CRAN repo and some with other depending on when the terminal gets created or which operation is triggered in the r session.

The fix in `SessionUserSettings.cpp` is to prevent setting the user settings default if `r-cran-repos` is set. This should fix most problems in clean systems.

However, for existing systems, most users will have their user setting set to RStudio's CRAN, and therefore, this problem of inconsistent CRAN repos will persist. The fix in `SessionMain.cpp` gives precedence to the user setting to, at least, avoid random changes in the CRAN repo. It appears to be the case that we intended to give precedence to global settings with [d348bda](https://github.com/rstudio/rstudio/commit/d348bdaa8b2d1c35fe5e24aa2c1924ba708422fd) but it's less clear why.

Also worth mentioning that from the admin guide [CRAN Repositories](http://docs.rstudio.com/ide/server-pro/r-sessions.html#cran-repositories):

> RStudio Server uses the RStudio CRAN mirror (https://cran.rstudio.com) by default. This mirror is globally distributed using Amazon S3 storage so should provide good performance for all locales. You may however wish to override the default CRAN mirror. This can be done with the r-cran-repos settings

Which makes me thing than a full override of `r-cran-repos` was not intended, but rather, the change proposed in this change (to only change RStudio's default provided CRAN mirror) seems correct since it still allows users able to manually override this default.

This PR could use some code review from @jmcphers and @jjallaire.