### PR TITLE
ensure dialogs created by R shown on top

### DIFF
--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -34,12 +34,29 @@ using namespace rstudio::core;
 namespace rstudio {
 namespace desktop {
 
+namespace {
+
+#ifdef _WIN32
+
+void CALLBACK onDialogStart(HWINEVENTHOOK hook, DWORD event, HWND hwnd,
+                            LONG idObject, LONG idChild,
+                            DWORD dwEventThread, DWORD dwmsEventTime)
+{
+   ::BringWindowToTop(hwnd);
+   ::SetActiveWindow(hwnd);
+}
+
+#endif
+
+} // end anonymous namespace
+
 MainWindow::MainWindow(QUrl url) :
       GwtWindow(false, false, QString(), url, nullptr),
       menuCallback_(this),
       gwtCallback_(this, this),
       pSessionLauncher_(nullptr),
-      pCurrentSessionProcess_(nullptr)
+      pCurrentSessionProcess_(nullptr),
+      eventHook_(NULL)
 {
    pToolbar_->setVisible(false);
 
@@ -210,6 +227,11 @@ wnd.desktopHooks.invokeCommand('%1');
 
 void MainWindow::closeEvent(QCloseEvent* pEvent)
 {
+#ifdef _WIN32
+   if (eventHook_)
+      ::UnhookWinEvent(eventHook_);
+#endif
+
    if (!webPage())
    {
        pEvent->accept();
@@ -311,6 +333,24 @@ void MainWindow::setSessionLauncher(SessionLauncher* pSessionLauncher)
 void MainWindow::setSessionProcess(QProcess* pSessionProcess)
 {
    pCurrentSessionProcess_ = pSessionProcess;
+
+   // when R creates dialogs (e.g. through utils::askYesNo), their first
+   // invocation might show behind the RStudio window. this allows us
+   // to detect when those Windows are opened and focused, and raise them
+   // to the front.
+#ifdef _WIN32
+   if (eventHook_)
+      ::UnhookWinEvent(eventHook_);
+
+   eventHook_ = ::SetWinEventHook(
+            EVENT_SYSTEM_DIALOGSTART, EVENT_SYSTEM_DIALOGSTART,
+            NULL,
+            onDialogStart,
+            pSessionProcess->processId(),
+            0,
+            WINEVENT_OUTOFCONTEXT);
+#endif
+
 }
 
 void MainWindow::setAppLauncher(ApplicationLaunch *pAppLauncher)

--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -43,7 +43,6 @@ void CALLBACK onDialogStart(HWINEVENTHOOK hook, DWORD event, HWND hwnd,
                             DWORD dwEventThread, DWORD dwmsEventTime)
 {
    ::BringWindowToTop(hwnd);
-   ::SetActiveWindow(hwnd);
 }
 
 #endif
@@ -342,13 +341,16 @@ void MainWindow::setSessionProcess(QProcess* pSessionProcess)
    if (eventHook_)
       ::UnhookWinEvent(eventHook_);
 
-   eventHook_ = ::SetWinEventHook(
-            EVENT_SYSTEM_DIALOGSTART, EVENT_SYSTEM_DIALOGSTART,
-            NULL,
-            onDialogStart,
-            pSessionProcess->processId(),
-            0,
-            WINEVENT_OUTOFCONTEXT);
+   if (pSessionProcess)
+   {
+      eventHook_ = ::SetWinEventHook(
+               EVENT_SYSTEM_DIALOGSTART, EVENT_SYSTEM_DIALOGSTART,
+               NULL,
+               onDialogStart,
+               pSessionProcess->processId(),
+               0,
+               WINEVENT_OUTOFCONTEXT);
+   }
 #endif
 
 }

--- a/src/cpp/desktop/DesktopMainWindow.hpp
+++ b/src/cpp/desktop/DesktopMainWindow.hpp
@@ -100,6 +100,11 @@ private:
    SessionLauncher* pSessionLauncher_;
    ApplicationLaunch *pAppLauncher_;
    QProcess* pCurrentSessionProcess_;
+
+#ifdef _WIN32
+   HWINEVENTHOOK eventHook_;
+#endif
+
 };
 
 } // namespace desktop


### PR DESCRIPTION
This PR attaches a Windows event handler, listening for dialogs created by the `rsession` process. When such a dialog is created, we ensure that window is activated and brought to the front.

Fixes #2901. One thing worth discussing is whether we need to be more careful about which dialogs that R might create need to be brought to the front; I think it's okay to assume that all dialogs created from R are modal and require immediate user attention but perhaps I'm missing some cases where that might not be true (download dialogs?)