### PR TITLE
Support package manager admins setting preferences

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1827,19 +1827,27 @@ int main (int argc, char * const argv[])
       if (!desktopMode) // ignore r-libs-user in desktop mode
          rOptions.rLibsUser = options.rLibsUser();
 
-      CRANMirror emptyMirror;
-
-      // When edit disabled, clear user setting to fix previous versions
-      if (!options.allowCRANReposEdit())
-        userSettings().setCRANMirror(emptyMirror);
+      bool customRepo = true;
 
       // CRAN repos precedence: user setting then repos file then global server option
-      if (!userSettings().cranMirror().url.empty())
+      if (userSettings().cranMirror().changed)
          rOptions.rCRANRepos = userSettings().cranMirror().url;
       else if (!options.rCRANMultipleRepos().empty())
          rOptions.rCRANRepos = options.rCRANMultipleRepos();
       else if (!options.rCRANRepos().empty())
          rOptions.rCRANRepos = options.rCRANRepos();
+      else {
+         rOptions.rCRANRepos = "https://cran.rstudio.com/";
+         customRepo = false;
+      }
+
+      if (!userSettings().cranMirror().changed) {
+         CRANMirror defaultMirror;
+         defaultMirror.name = customRepo ? "Custom" : "Global (CDN)";
+         defaultMirror.host = customRepo ? "Custom" : "RStudio";
+         defaultMirror.url = rOptions.rCRANRepos;
+         userSettings().setCRANMirror(defaultMirror, false);
+      }
 
       rOptions.useInternet2 = userSettings().useInternet2();
       rOptions.rCompatibleGraphicsEngineVersion =

--- a/src/cpp/session/include/session/SessionUserSettings.hpp
+++ b/src/cpp/session/include/session/SessionUserSettings.hpp
@@ -47,6 +47,7 @@ struct CRANMirror
    std::string host;
    std::string url;
    std::string country;
+   bool changed;
 };
 
 struct BioconductorMirror
@@ -155,6 +156,7 @@ public:
 
    CRANMirror cranMirror() const;
    void setCRANMirror(const CRANMirror& cranMirror);
+   void setCRANMirror(const CRANMirror& cranMirror, bool update);
 
    BioconductorMirror bioconductorMirror() const;
    void setBioconductorMirror(const BioconductorMirror& bioconductorMirror);

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -210,7 +210,8 @@ CRANMirror toCRANMirror(const json::Object& cranMirrorJson)
                     "name", &cranMirror.name,
                     "host", &cranMirror.host,
                     "url", &cranMirror.url,
-                    "country", &cranMirror.country);
+                    "country", &cranMirror.country,
+                    "changed", &cranMirror.changed);
    return cranMirror;
 }
 
@@ -512,6 +513,7 @@ json::Object toCRANMirrorJson(const CRANMirror& cranMirror)
    cranMirrorJson["host"] = cranMirror.host;
    cranMirrorJson["url"] = cranMirror.url;
    cranMirrorJson["country"] = cranMirror.country;
+   cranMirrorJson["changed"] = cranMirror.changed;
    return cranMirrorJson;
 }
 
@@ -944,6 +946,7 @@ Error setCRANMirror(const json::JsonRpcRequest& request,
    if (error)
       return error;
    CRANMirror cranMirror = toCRANMirror(cranMirrorJson);
+   cranMirror.changed = true;
 
    userSettings().beginUpdate();
    userSettings().setCRANMirror(cranMirror);

--- a/src/gwt/src/org/rstudio/studio/client/common/mirrors/model/CRANMirror.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mirrors/model/CRANMirror.java
@@ -33,6 +33,8 @@ public class CRANMirror extends JavaScriptObject
       cranMirror.host = "";
       cranMirror.url = "";
       cranMirror.country = "";
+      cranMirror.changed = false;
+
       return cranMirror;
    }-*/;
    
@@ -66,7 +68,15 @@ public class CRANMirror extends JavaScriptObject
    }-*/;
 
    private final native String getError() /*-{
-      this.error = error;
+      return this.error;
+   }-*/;
+
+   public final native boolean getChanged() /*-{
+      return this.changed;
+   }-*/;
+
+   public final native void setChanged(boolean changed) /*-{
+      this.changed = changed;
    }-*/;
 
    public final String getURL()

--- a/src/gwt/src/org/rstudio/studio/client/common/repos/SecondaryReposWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/repos/SecondaryReposWidget.java
@@ -122,6 +122,11 @@ public class SecondaryReposWidget extends Composite
       cranRepoUrl_ = cranUrl;
       cranIsCustom_ = cranIsCustom;
    }
+
+   public void setUpdateHandler(Operation updateHandler)
+   {
+      updateHandler_ = updateHandler;
+   }
    
    private ClickHandler addButtonClicked_ = new ClickHandler() {
       @Override
@@ -137,6 +142,8 @@ public class SecondaryReposWidget extends Composite
             {
                repos_.add(input);
                updateRepos();
+
+               updateHandler_.execute();
             }
          }, excluded, cranRepoUrl_, cranIsCustom_);
          
@@ -167,6 +174,7 @@ public class SecondaryReposWidget extends Composite
                },
                false);
             
+            updateHandler_.execute();  
          }
       }
    };
@@ -183,6 +191,8 @@ public class SecondaryReposWidget extends Composite
             repos_.set(index, swap);
             updateRepos();
             listBox_.setSelectedIndex(index - 1);
+
+            updateHandler_.execute();
          }
       }
    };
@@ -199,6 +209,8 @@ public class SecondaryReposWidget extends Composite
             repos_.set(index + 1, swap);
             updateRepos();
             listBox_.setSelectedIndex(index + 1);
+
+            updateHandler_.execute();
          }
       }
    };
@@ -222,6 +234,8 @@ public class SecondaryReposWidget extends Composite
    private SmallButton buttonRemove_;
    private SmallButton buttonUp_;
    private SmallButton buttonDown_;
+
+   private Operation updateHandler_;
    
    static interface Styles extends CssResource
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
@@ -104,8 +104,6 @@ public class PackagesPreferencesPane extends PreferencesPane
                         );
                      }     
                   });
-                 
-                  useDefaultsStyles(false);
                }
             },
             true);
@@ -274,16 +272,6 @@ public class PackagesPreferencesPane extends PreferencesPane
          secondaryReposWidget_.setRepos(cranMirror_.getSecondaryRepos());
       }
       
-      useDefaultsStyles(!cranMirror_.getChanged());
-
-      secondaryReposWidget_.setUpdateHandler(new Operation() {
-         @Override
-         public void execute()
-         {
-            useDefaultsStyles(false);
-         }
-      });
-      
       useInternet2_.setEnabled(true);
       useInternet2_.setValue(packagesPrefs.getUseInternet2());
       useInternet2_.addValueChangeHandler(new ValueChangeHandler<Boolean>() {
@@ -315,20 +303,6 @@ public class PackagesPreferencesPane extends PreferencesPane
       
       useNewlineInMakefiles_.setEnabled(true);
       useNewlineInMakefiles_.setValue(packagesPrefs.getUseNewlineInMakefiles());
-   }
-   
-   private void useDefaultsStyles(boolean use)
-   {
-      if (use)
-      {
-         cranMirrorTextBox_.getTextBox().addStyleName(res_.styles().settingDefault());
-         secondaryReposWidget_.addStyleName(res_.styles().settingDefault());
-      }
-      else
-      {
-         cranMirrorTextBox_.getTextBox().removeStyleName(res_.styles().settingDefault());
-         secondaryReposWidget_.removeStyleName(res_.styles().settingDefault());
-      }
    }
 
    private boolean secondaryReposHasChanged()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.css
@@ -63,3 +63,8 @@
 .themeInfobarShowing {
    display: block;
 }
+
+.settingDefault,
+.settingDefault option {
+   color: #909090;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.css
@@ -63,8 +63,3 @@
 .themeInfobarShowing {
    display: block;
 }
-
-.settingDefault,
-.settingDefault option {
-   color: #909090;
-}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialogResources.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialogResources.java
@@ -31,6 +31,7 @@ public interface PreferencesDialogResources extends ClientBundle
       String alwaysCompletePanel();
       String themeInfobar();
       String themeInfobarShowing();
+      String settingDefault();
    }
 
    @Source("PreferencesDialog.css")


### PR DESCRIPTION
While https://github.com/rstudio/rstudio/pull/2754 added support to set CRAN settings from the preferences pane or with admin settings like `r-cran-repos` and `repos.conf`, it was lacking support for use cases where admin settings are applied and also preferences need to be changed.

The behavior of this PR was to show inconsistent settings in the UI when the admin settings where set, usually, displaying the default CRAN repo or the user selection (which was made consistent with https://github.com/rstudio/rstudio/pull/2891 but was not showing what the final CRAN setting was).

This PR makes the system defaults visible by showing them in the preferences pane.
This PR also fixes one regression:
- Ability to change order in secondary CRAN repos from the UI

and a bug fix:
- Allow admins to change CRAN defaults after user logs in for the first time by setting `repos.conf`, etc. The problem here was that there are more places that use the user settings to set the CRAN repos, rather to chase all the places that might change this setting, we are adding a new `changed` user setting that is set only when an operation triggers from the UI.
