### PR TITLE
Fix to package repos and support parsing inis with headers

### DIFF
--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -1111,6 +1111,28 @@ SEXP create(const std::map<std::string, std::vector<std::string> > &value,
    
    return listSEXP;
 }
+
+SEXP create(const std::map<std::string, SEXP> &value,
+            Protect *pProtect)
+{
+   SEXP listSEXP, namesSEXP;
+   std::size_t n = value.size();
+   pProtect->add(listSEXP = Rf_allocVector(VECSXP, n));
+   pProtect->add(namesSEXP = Rf_allocVector(STRSXP, n));
+   
+   int index = 0;
+   typedef std::map<std::string, SEXP>::const_iterator iterator;
+   for (iterator it = value.begin(); it != value.end(); ++it)
+   {
+      SET_STRING_ELT(namesSEXP, index, Rf_mkChar(it->first.c_str()));
+      SET_VECTOR_ELT(listSEXP, index, it->second);
+      ++index;
+   }
+   
+   Rf_setAttrib(listSEXP, R_NamesSymbol, namesSEXP);
+   
+   return listSEXP;
+}
    
 SEXP create(const std::vector<std::pair<std::string,std::string> >& value, 
             Protect* pProtect)

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -159,6 +159,8 @@ SEXP create(const core::json::Array& value, Protect* pProtect);
 SEXP create(const core::json::Object& value, Protect* pProtect);
 SEXP create(const ListBuilder& builder, Protect* pProtect);
 SEXP create(const std::map<std::string, std::string>& value, Protect* pProtect);
+SEXP create(const std::map<std::string, SEXP> &value,
+            Protect *pProtect);
 
 // Create a raw vector (binary data)
 SEXP createRawVector(const std::string& data, Protect* pProtect);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
@@ -252,7 +252,7 @@ public class PackagesPreferencesPane extends PreferencesPane
       cranMirrorTextBox_.setEnabled(true);
       if (!packagesPrefs.getCRANMirror().isEmpty())
       {
-         cranMirror_ = packagesPrefs.getCRANMirror();
+         cranMirrorOriginal_ = cranMirror_ = packagesPrefs.getCRANMirror();
          secondaryReposWidget_.setCranRepoUrl(
             cranMirror_.getURL(),
             cranMirror_.getHost().equals("Custom")
@@ -309,12 +309,12 @@ public class PackagesPreferencesPane extends PreferencesPane
    {
       ArrayList<CRANMirror> secondaryRepos = secondaryReposWidget_.getRepos();
 
-      if (secondaryRepos.size() != cranMirror_.getSecondaryRepos().size())
+      if (secondaryRepos.size() != cranMirrorOriginal_.getSecondaryRepos().size())
          return true;
 
       for (int i = 0; i < secondaryRepos.size(); i++)
       {
-         if (secondaryRepos.get(i) != cranMirror_.getSecondaryRepos().get(i))
+         if (secondaryRepos.get(i) != cranMirrorOriginal_.getSecondaryRepos().get(i))
             return true;
       }
 
@@ -383,6 +383,7 @@ public class PackagesPreferencesPane extends PreferencesPane
    private final MirrorsServerOperations server_;
    
    private CRANMirror cranMirror_ = CRANMirror.empty();
+   private CRANMirror cranMirrorOriginal_ = CRANMirror.empty();
    private CheckBox useInternet2_;
    private TextBoxWithButton cranMirrorTextBox_;
    private CheckBox cleanupAfterCheckSuccess_;


### PR DESCRIPTION
`.rs.readIniFile()` was missing to support nested structures to be properly called an `ini` file parser; while this feature is not required by the package management feature, better add support for this now that this is being heavily tested in case `.rs.readIniFile()` gets reused in the future.

Also fixing a repos preferences issue with reprex:
- Set `repos.conf`
- Clear user settings
- Restart session
- From preferences UI, remove secondary repos and revert to RStudio CDN
- Apply changes

Actual: Changes don't take effect until next session restart.
Expected: Changes to take effect.
