### PR TITLE
Fix regression in allow-cran-repos-edit and user preferences

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1831,6 +1831,13 @@ int main (int argc, char * const argv[])
 
       bool customRepo = true;
 
+      // When edit disabled, clear user setting to fix previous versions
+      if (!options.allowCRANReposEdit()) {
+        CRANMirror userMirror = userSettings().cranMirror();
+        userMirror.changed = false;
+        userSettings().setCRANMirror(userMirror, false);
+      }
+
       // CRAN repos precedence: user setting then repos file then global server option
       if (userSettings().cranMirror().changed)
          rOptions.rCRANRepos = userSettings().cranMirror().url;


### PR DESCRIPTION
Fix regression spotted by @fereshtehRS in todays build regarding setting `allow-cran-repos-edit=0` but user CRAN preferences not overridden.