### PR TITLE
Specify shell type via terminalCreate API

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -551,18 +551,8 @@
 
    validShellType = TRUE
    if (!is.null(shellType)) {
-      validShellType <- grepl(
-         paste(
-            "default",
-            "win-cmd",
-            "win-ps",
-            "win-git-bash",
-            "win-wsl-bash",
-            "custom",
-          sep = "|"
-        ),
-        shellType,
-        ignore.case = TRUE)
+      validShellType <- tolower(shellType) %in% c("default", "win-cmd", 
+            "win-ps", "win-git-bash", "win-wsl-bash", "custom")
    }      
    if (!validShellType)
       stop("'shellType' must be NULL, or one of 'default', 'win-cmd', 'win-ps', 'win-git-bash', 'win-wsl-bash', or 'custom'.") 

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -539,14 +539,35 @@
   invisible(NULL)
 })
 
-.rs.addApiFunction("terminalCreate", function(caption = NULL, show = TRUE) {
+.rs.addApiFunction("terminalCreate", function(caption = NULL, show = TRUE, shellType = NULL) {
    if (!is.null(caption) && (!is.character(caption) || (length(caption) != 1)))
       stop("'caption' must be NULL or a character vector of length one")
 
    if (is.null(show) || !is.logical(show))
       stop("'show' must be a logical vector")
 
-   .Call("rs_terminalCreate", caption, show)
+   if (!is.null(shellType) && (!is.character(shellType) || (length(shellType) != 1)))
+      stop("'shellType' must be NULL or a character vector of length one")
+
+   validShellType = TRUE
+   if (!is.null(shellType)) {
+      validShellType <- grepl(
+         paste(
+            "default",
+            "win-cmd",
+            "win-ps",
+            "win-git-bash",
+            "win-wsl-bash",
+            "custom",
+          sep = "|"
+        ),
+        shellType,
+        ignore.case = TRUE)
+   }      
+   if (!validShellType)
+      stop("'shellType' must be NULL, or one of 'default', 'win-cmd', 'win-ps', 'win-git-bash', 'win-wsl-bash', or 'custom'.") 
+
+   .Call("rs_terminalCreate", caption, show, shellType)
 })
 
 .rs.addApiFunction("terminalBusy", function(id) {

--- a/src/cpp/session/SessionConsoleProcessApi.cpp
+++ b/src/cpp/session/SessionConsoleProcessApi.cpp
@@ -94,8 +94,8 @@ SEXP rs_terminalList()
 }
 
 // Create a terminal with given caption. If null, create with automatically
-// generated name.
-SEXP rs_terminalCreate(SEXP captionSEXP, SEXP showSEXP)
+// generated name. Optionally specify shell type.
+SEXP rs_terminalCreate(SEXP captionSEXP, SEXP showSEXP, SEXP shellTypeSEXP)
 {
    r::sexp::Protect protect;
 
@@ -119,6 +119,14 @@ SEXP rs_terminalCreate(SEXP captionSEXP, SEXP showSEXP)
       return R_NilValue;
    }
 
+   TerminalShell::TerminalShellType shellType = TerminalShell::DefaultShell;
+   std::string terminalTypeStr;
+   if (!r::sexp::isNull(shellTypeSEXP))
+      terminalTypeStr = r::sexp::asString(shellTypeSEXP);
+   if (!terminalTypeStr.empty())
+   {
+      shellType = TerminalShell::shellTypeFromString(terminalTypeStr);
+   }
    bool show = r::sexp::asLogical(showSEXP);
 
    boost::shared_ptr<ConsoleProcessInfo> pCpi(
@@ -127,7 +135,7 @@ SEXP rs_terminalCreate(SEXP captionSEXP, SEXP showSEXP)
                std::string() /*title*/,
                std::string() /*handle*/,
                termSequence.first,
-               TerminalShell::DefaultShell,
+               shellType,
                false /*altBufferActive*/,
                core::FilePath() /*cwd*/,
                core::system::kDefaultCols, core::system::kDefaultRows,
@@ -939,7 +947,7 @@ Error initializeApi()
    using boost::bind;
 
    RS_REGISTER_CALL_METHOD(rs_terminalActivate, 2);
-   RS_REGISTER_CALL_METHOD(rs_terminalCreate, 2);
+   RS_REGISTER_CALL_METHOD(rs_terminalCreate, 3);
    RS_REGISTER_CALL_METHOD(rs_terminalClear, 1);
    RS_REGISTER_CALL_METHOD(rs_terminalList, 0);
    RS_REGISTER_CALL_METHOD(rs_terminalContext, 1);

--- a/src/cpp/session/include/session/SessionTerminalShell.hpp
+++ b/src/cpp/session/include/session/SessionTerminalShell.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionTerminalShell.hpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -85,6 +85,9 @@ struct TerminalShell
 
    // get a user-friendly name for the given shell type
    static std::string getShellName(TerminalShellType type);
+   
+   // map an rstudioapi terminalCreate shell type string to enum type
+   static TerminalShellType shellTypeFromString(const std::string& str);
 };
 
 class AvailableTerminalShells

--- a/src/cpp/session/modules/SessionTerminalShell.cpp
+++ b/src/cpp/session/modules/SessionTerminalShell.cpp
@@ -17,6 +17,7 @@
 
 #include <core/Algorithm.hpp>
 #include <core/system/System.hpp>
+#include <core/StringUtils.hpp>
 
 #include <session/SessionUserSettings.hpp>
 #include "SessionGit.hpp"
@@ -185,6 +186,37 @@ std::string TerminalShell::getShellName(TerminalShellType type)
       return "User command";
    default:
       return "Unknown";
+   }
+}
+
+// keep in sync with values supported by terminalCreate "shellType" argument in 
+// rstudioapi and rs_terminalCreate
+TerminalShell::TerminalShellType TerminalShell::shellTypeFromString(const std::string& str)
+{
+   std::string typeStr = core::string_utils::toLower(str);
+   if (typeStr == "win-cmd")
+   {
+      return TerminalShell::TerminalShellType::Cmd64;
+   }
+   else if (typeStr == "win-ps")
+   {
+      return TerminalShell::TerminalShellType::PS64;
+   }
+   else if (typeStr == "win-git-bash")
+   {
+      return TerminalShell::TerminalShellType::GitBash;
+   }
+   else if (typeStr == "win-wsl-bash")
+   {
+      return TerminalShell::TerminalShellType::WSLBash;
+   }
+   else if (typeStr == "custom")
+   {
+      return TerminalShell::TerminalShellType::CustomShell;
+   }
+   else // implicity includes "default"
+   {
+      return TerminalShell::TerminalShellType::DefaultShell;
    }
 }
 


### PR DESCRIPTION
Optional `shellType` argument to specify shell type via `terminalCreate`. The `rstudioapi` package will be updated to support this.

The shellType argument is a string and can be:

- **NULL** (default, uses shell type selected in Global Options, i.e. current behavior)
- **"default"**, same as NULL
- **"custom"**, Mac, Linux, Server: use "custom" shell specified in Global Options
- **"win-cmd"**, 64-bit Windows Command Prompt
- **"win-ps"**, 64-bit Windows PowerShell
- **"win-git-bash"** (Windows-only)
- **"win-wsl-bash"** (Windows-only)

Fixes #2903

If you request a shell type that isn't available, the default is used.

Example via rstudioapi and same thing using built-in RStudio syntax:

- `rstudioapi::terminalCreate(caption = "My Terminal", show = TRUE, shellType = "win-cmd")`
- `.Options$terminal.manager$terminalCreate("My Terminal", TRUE, "win-cmd")`