### PR TITLE
Ignore errors in first regedit attempt in windows since it's expected to fail

### DIFF
--- a/src/cpp/session/modules/SessionConnectionsInstaller.R
+++ b/src/cpp/session/modules/SessionConnectionsInstaller.R
@@ -137,7 +137,8 @@
            shQuote(entry$value),
            "/f",
            paste("/reg:", bitness, sep = "")
-        )
+        ),
+        stderr = FALSE
      )
 
      if (!validateEntry(entry)) {


### PR DESCRIPTION
Fix for https://github.com/rstudio/rstudio-pro/issues/443