### PR TITLE
Support installing odbc drivers with existing drivers with same name

### DIFF
--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -402,6 +402,71 @@ options(connectionObserver = list(
    do.call(rbind, lapply(registryEntriesValue, function(e) data.frame(e, stringsAsFactors = FALSE)))
 })
 
+.rs.addFunction("connectionReadOdbcEntry", function(drivers, uniqueDriverNames, driver) {
+   tryCatch({
+      currentDriver <- drivers[drivers$attribute == "Driver" & drivers$name == driver, ]
+      driverInstaller <- drivers[drivers$attribute == "Installer" & drivers$name == driver, ]
+      driverId <- gsub(" with RStudio", "", driver)
+
+      basePath <- sub(paste(tolower(driver), ".*$", sep = ""), "", currentDriver$value)
+      snippetsFile <- file.path(
+         basePath,
+         tolower(driver),
+         "snippets",
+         paste(tolower(driverId), ".R", sep = "")
+      )
+      
+      if (identical(file.exists(snippetsFile), TRUE)) {
+         snippet <- paste(readLines(snippetsFile), collapse = "\n")
+      }
+      else {
+         snippet <- paste(
+            "library(DBI)\n",
+            "con <- dbConnect(odbc::odbc(), .connection_string = \"", 
+            "Driver={", driver, "};${1:Parameters}\")",
+            sep = "")
+      }
+
+      licenseFile <- file.path(dirname(currentDriver$value), "license.lock")
+
+      iconData <- .Call("rs_connectionIcon", driverId)
+      if (nchar(iconData) == 0)
+         iconData <- .Call("rs_connectionIcon", "ODBC")
+
+      hasInstaller <- .rs.connectionHasInstaller(driverId)
+      warningMessage <- NULL
+
+      if (hasInstaller) {
+         installerVersion <- .rs.connectionInstallerInfo(driverId)$version
+
+         currentVersion <- drivers[drivers$attribute == "Version" & drivers$name == driver, ]
+         if (nrow(currentVersion) == 1) {
+            if (compareVersion(installerVersion, currentVersion$value) > 0) {
+               warningMessage <- "A new driver version is available, to upgrade, uninstall and then reinstall."
+            }
+         }
+      }
+
+      list(
+         package = .rs.scalar(NULL),
+         version = .rs.scalar(NULL),
+         name = .rs.scalar(driver),
+         type = .rs.scalar("Snippet"),
+         snippet = .rs.scalar(snippet),
+         help = .rs.scalar(NULL),
+         iconData = .rs.scalar(iconData),
+         licensed = .rs.scalar(identical(file.exists(licenseFile), TRUE)),
+         source = .rs.scalar("ODBC"),
+         hasInstaller = .rs.scalar(hasInstaller),
+         warning = .rs.scalar(warningMessage),
+         installer = .rs.scalar(driverInstaller$value)
+      )
+   }, error = function(e) {
+      warning(e$message)
+      NULL
+   })
+})
+
 .rs.addFunction("connectionReadOdbc", function() {
    if (.rs.isPackageInstalled("odbc")) {
       drivers <- data.frame()
@@ -417,65 +482,7 @@ options(connectionObserver = list(
       uniqueDriverNames <- unique(drivers$name)
 
       lapply(uniqueDriverNames, function(driver) {
-         tryCatch({
-            currentDriver <- drivers[drivers$attribute == "Driver" & drivers$name == driver, ]
-
-            basePath <- sub(paste(tolower(driver), ".*$", sep = ""), "", currentDriver$value)
-            snippetsFile <- file.path(
-               basePath,
-               tolower(driver),
-               "snippets",
-               paste(tolower(driver), ".R", sep = "")
-            )
-            
-            if (identical(file.exists(snippetsFile), TRUE)) {
-               snippet <- paste(readLines(snippetsFile), collapse = "\n")
-            }
-            else {
-               snippet <- paste(
-                  "library(DBI)\n",
-                  "con <- dbConnect(odbc::odbc(), .connection_string = \"", 
-                  "Driver={", driver, "};${1:Parameters}\")",
-                  sep = "")
-            }
-
-            licenseFile <- file.path(dirname(currentDriver$value), "license.lock")
-
-            iconData <- .Call("rs_connectionIcon", driver)
-            if (nchar(iconData) == 0)
-               iconData <- .Call("rs_connectionIcon", "ODBC")
-
-            hasInstaller <- .rs.connectionHasInstaller(driver)
-            warningMessage <- NULL
-
-            if (hasInstaller) {
-               installerVersion <- .rs.connectionInstallerInfo(driver)$version
-
-               currentVersion <- drivers[drivers$attribute == "Version" & drivers$name == driver, ]
-               if (nrow(currentVersion) == 1) {
-                  if (compareVersion(installerVersion, currentVersion$value) > 0) {
-                     warningMessage <- "A new driver version is available, to upgrade, uninstall and then reinstall."
-                  }
-               }
-            }
-
-            list(
-               package = .rs.scalar(NULL),
-               version = .rs.scalar(NULL),
-               name = .rs.scalar(driver),
-               type = .rs.scalar("Snippet"),
-               snippet = .rs.scalar(snippet),
-               help = .rs.scalar(NULL),
-               iconData = .rs.scalar(iconData),
-               licensed = .rs.scalar(identical(file.exists(licenseFile), TRUE)),
-               source = .rs.scalar("ODBC"),
-               hasInstaller = .rs.scalar(hasInstaller),
-               warning = .rs.scalar(warningMessage)
-            )
-         }, error = function(e) {
-            warning(e$message)
-            NULL
-         })
+         .rs.connectionReadOdbcEntry(drivers, uniqueDriverNames, driver)
       })
    }
 })
@@ -635,9 +642,22 @@ options(connectionObserver = list(
    for (i in seq_along(connectionList)) {
       entryName <- connectionList[[i]]$name
       if (!is.null(connectionNames[[entryName]])) {
-         connectionList[[i]]$remove <- TRUE
+         existingDriver <- connectionNames[[entryName]]
+         withRStudioName <- paste(entryName, "with RStudio")
+
+         if (identical(as.character(connectionList[[i]]$type), "Install") &&
+             !identical(existingDriver$installer, "RStudio") &&
+             is.null(connectionNames[[withRStudioName]])) {
+            connectionList[[i]]$name <- entryName <- .rs.scalar(withRStudioName)
+         }
+         else {
+            connectionList[[i]]$remove <- TRUE
+         }
       }
-      connectionNames[[entryName]] <- TRUE
+
+      if (is.null(connectionNames[[entryName]])) {
+         connectionNames[[entryName]] <- connectionList[[i]]
+      }
    }
    
    connectionList <- Filter(function(e) !identical(e$remove, TRUE), connectionList)
@@ -748,7 +768,10 @@ options(connectionObserver = list(
 
 .rs.addFunction("connectionInstallerCommand", function(driverName, installationPath) {
    connectionContext <- Filter(function(e) {
-      identical(as.character(e$name), driverName)
+      identical(
+         as.character(e$name),
+         gsub(" with RStudio", "", driverName)
+      )
    }, .rs.connectionReadInstallers())[[1]]
 
    placeholder <-  connectionContext$odbcFile

--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -433,7 +433,7 @@ options(connectionObserver = list(
       if (nchar(iconData) == 0)
          iconData <- .Call("rs_connectionIcon", "ODBC")
 
-      hasInstaller <- .rs.connectionHasInstaller(driverId)
+      hasInstaller <- identical(driverInstaller$value, "RStudio")
       warningMessage <- NULL
 
       if (hasInstaller) {

--- a/src/cpp/session/modules/SessionConnectionsInstaller.R
+++ b/src/cpp/session/modules/SessionConnectionsInstaller.R
@@ -378,7 +378,8 @@
    # Set odbcinst.ini entries
    odbcinst[[name]] <- list(
       paste("Driver", "=", driverPath),
-      paste("Version", "=", version)
+      paste("Version", "=", version),
+      paste("Installer", "=", "RStudio")
    )
    
    # Write odbcinst.ini
@@ -402,6 +403,11 @@
             path = file.path("SOFTWARE", "ODBC", "ODBCINST.INI", name, fsep = "\\"),
             key = "Version",
             value = version
+         ),
+         list(
+            path = file.path("SOFTWARE", "ODBC", "ODBCINST.INI", name, fsep = "\\"),
+            key = "Installer",
+            value = "RStudio"
          )
       )
    )
@@ -415,7 +421,7 @@
    )
    
    osExtension <- osExtensions[[.rs.odbcBundleOsName()]]
-   driverName <- gsub(" ", "", name)
+   driverName <- gsub(" |with RStudio", "", name)
    
    if (is.null(libraryPattern) || nchar(libraryPattern) == 0) {
       libraryPattern <- paste(


### PR DESCRIPTION
Fix for https://github.com/rstudio/rstudio-pro/issues/445, in some platforms, some drivers are already installed with the same name as potential drivers installed by RStudio. Only in these cases, a `with RStudio` is appended to the driver:

<img width="530" alt="screen shot 2018-06-07 at 3 40 52 pm" src="https://user-images.githubusercontent.com/3478847/41109239-6f3eb30e-6a6e-11e8-89b8-c38e4c224229.png">
