### PR TITLE
Hide odbc installer registry output but support odbc.installer.verbose option

### DIFF
--- a/src/cpp/session/modules/SessionConnectionsInstaller.R
+++ b/src/cpp/session/modules/SessionConnectionsInstaller.R
@@ -138,7 +138,8 @@
            "/f",
            paste("/reg:", bitness, sep = "")
         ),
-        stderr = FALSE
+        stdout = getOption("odbc.installer.verbose", FALSE),
+        stderr = getOption("odbc.installer.verbose", FALSE)
      )
 
      if (!validateEntry(entry)) {


### PR DESCRIPTION
Fix for https://github.com/rstudio/rstudio-pro/issues/444, to disable verbose output while setting registry keys in windows for odbc installers but also add support for a `odbc.installer.verbose` option in case users need to troubleshoot.