### PR TITLE
Prevent intermitent failure from interproc odbcinst.ini flush

### DIFF
--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -649,10 +649,15 @@ options(connectionObserver = list(
    context
 })
 
-.rs.addJsonRpcHandler("get_new_odbc_connection_context", function(name) {
-   connectionContext <- Filter(function(e) {
+.rs.addJsonRpcHandler("get_new_odbc_connection_context", function(name, retries = 1) {
+   singleEntryFilter <- function(e) {
       identical(as.character(e$name), name)
-   }, .rs.connectionReadOdbc())
+   }
+
+   connectionContext <- Filter(singleEntryFilter, .rs.connectionReadOdbc())
+
+   while (length(connectionContext) != 1 && (retries <- retries - 1) >= 0)
+      Sys.sleep(1)
 
    if (length(connectionContext) != 1)
       list(


### PR DESCRIPTION
Potential fix for https://github.com/rstudio/rstudio-pro/issues/442, I haven't been able to reproduce this and the original repro is intermittent. We do write the odbcinst.ini file form a separate process as the last step while installing a driver and we immediately query to verify the installation so it's possible that the flush has not completed, planning to try this fix to see if we can be able to avoid this issue.