### PR TITLE
Fix odbc installer uninstall in linux due to case sensitivity

### DIFF
--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -802,7 +802,7 @@ options(connectionObserver = list(
 
 .rs.addJsonRpcHandler("uninstall_odbc_driver", function(driverName) {
    tryCatch({
-      defaultInstallPath <- file.path(.rs.connectionOdbcInstallPath(), driverName)
+      defaultInstallPath <- file.path(.rs.connectionOdbcInstallPath(), tolower(driverName))
       defaultInstallExists <- dir.exists(defaultInstallPath)
 
       # delete the driver


### PR DESCRIPTION
Fix for https://github.com/rstudio/rstudio-pro/issues/458, need to match case sensitivity in linux to uninstall odbc drivers correctly.