### PR TITLE
Minor improvements to async R jobs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,12 @@
 * Author D3 visualizations in RStudio and preview in the Viewer pane
 * Use [r2d3](https://rstudio.github.io/r2d3/) D3 visualizations in R Notebook chunks
 
+### Jobs
+
+* Run any R script as a background job in a clean R session
+* Monitor progress and see script output in real time
+* Optionally give jobs your global environment when started, and export values back when complete
+
 ### SQL
 
 * Author SQL queries in RStudio and preview in the SQL Results pane

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -428,6 +428,11 @@ public class TextFileType extends EditableFileType
       if (!SourceWindowManager.isMainSourceWindow())
          results.add(commands.returnDocToMain());
       
+      if (isR())
+      {
+         results.add(commands.sourceAsJob());
+      }
+
       results.add(commands.sendToTerminal());
 
       return results;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobManager.java
@@ -305,6 +305,14 @@ public class JobManager implements JobRefreshEvent.Handler,
       );
    }
    
+   public List<Job> getJobs()
+   {
+      List<Job> jobs = new ArrayList<Job>();
+      for (String id: state_.iterableKeys())
+         jobs.add(state_.getJob(id));
+      return jobs;
+   }
+   
    public void promptForTermination(CommandWithArg<Boolean> onConfirmed)
    {
       // compute list of jobs that are running

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobLauncherControls.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobLauncherControls.java
@@ -42,9 +42,9 @@ public class JobLauncherControls extends Composite
 
       initWidget(uiBinder.createAndBindUi(this));
       
-      exportEnv_.addItem("Do nothing", "");
-      exportEnv_.addItem("Copy objects to global environment", "R_GlobalEnv");
-      exportEnv_.addItem("Copy objects to new environment", "local");
+      exportEnv_.addItem("(Don't copy)", "");
+      exportEnv_.addItem("To global environment", "R_GlobalEnv");
+      exportEnv_.addItem("To results object in global environment", "local");
    }
    
    public void setScriptPath(String path)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobLauncherControls.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobLauncherControls.ui.xml
@@ -28,7 +28,7 @@
 		            text="Run job with copy of global environment" 
 		            ui:field="importEnv_"></g:CheckBox>
 		<g:HorizontalPanel>
-			<g:InlineLabel text="After job:"></g:InlineLabel>
+			<g:InlineLabel text="Copy job results: "></g:InlineLabel>
 			<g:ListBox styleName="{style.check} {style.spaced}" ui:field="exportEnv_"></g:ListBox>
 		</g:HorizontalPanel>
 	</g:VerticalPanel>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobQuitControls.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobQuitControls.java
@@ -1,0 +1,49 @@
+/*
+ * JobQuitControls.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.jobs.view;
+
+import java.util.List;
+
+import org.rstudio.studio.client.workbench.views.jobs.model.Job;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.ListBox;
+import com.google.gwt.user.client.ui.Widget;
+
+public class JobQuitControls extends Composite
+{
+
+   private static JobQuitControlsUiBinder uiBinder = GWT.create(JobQuitControlsUiBinder.class);
+
+   interface JobQuitControlsUiBinder extends UiBinder<Widget, JobQuitControls>
+   {
+   }
+
+   public JobQuitControls(List<Job> runningJobs)
+   {
+      initWidget(uiBinder.createAndBindUi(this));
+      
+      // add running jobs to the list
+      for (Job job: runningJobs)
+      {
+         jobList_.addItem(job.name);
+      }
+   }
+
+   @UiField ListBox jobList_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobQuitControls.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobQuitControls.ui.xml
@@ -1,0 +1,26 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
+	xmlns:g="urn:import:com.google.gwt.user.client.ui">
+	<ui:style>
+		@eval fixedWidthFont org.rstudio.core.client.theme.ThemeFonts.getFixedWidthFont();
+		
+		.outer {
+			margin: 5px;
+		}
+		
+		.spaced {
+			margin-bottom: 5px;
+		}
+		
+		.list {
+			font-family: fixedWidthFont;
+			padding: 5px;
+			width: 100%;
+		}
+	</ui:style>
+	<g:VerticalPanel styleName="{style.outer}">
+		<g:Label styleName="{style.spaced}" text="The following jobs are still running."></g:Label>
+		<g:ListBox styleName="{style.spaced} {style.list}" visibleItemCount="5" ui:field="jobList_"></g:ListBox>
+		<g:Label styleName="{style.spaced}" text="Quitting the session will terminate these jobs."></g:Label>
+	</g:VerticalPanel>
+</ui:UiBinder> 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobQuitDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobQuitDialog.java
@@ -1,0 +1,50 @@
+/*
+ * JobQuitControls.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.jobs.view;
+
+import java.util.List;
+
+import org.rstudio.core.client.widget.ModalDialog;
+import org.rstudio.core.client.widget.Operation;
+import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.studio.client.workbench.views.jobs.model.Job;
+
+import com.google.gwt.user.client.ui.Widget;
+
+public class JobQuitDialog extends ModalDialog<Boolean>
+{
+   public JobQuitDialog(List<Job> runningJobs, 
+                        OperationWithInput<Boolean> onConfirmed,
+                        Operation cancelOperation)
+   {
+      super("Terminate Running Jobs", onConfirmed, cancelOperation);
+      running_ = runningJobs;
+      setOkButtonCaption("Terminate Jobs");
+   }
+
+   @Override
+   protected Widget createMainWidget()
+   {
+      return new JobQuitControls(running_);
+   }
+   
+   @Override
+   protected Boolean collectInput()
+   {
+      return true;
+   }
+
+   private List<Job> running_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -383,6 +383,7 @@ public class Source implements InsertSourceHandler,
       dynamicCommands_.add(commands.notebookToggleExpansion());
       dynamicCommands_.add(commands.sendToTerminal());
       dynamicCommands_.add(commands.renameSourceDoc());
+      dynamicCommands_.add(commands.sourceAsJob());
       for (AppCommand command : dynamicCommands_)
       {
          command.setVisible(false);


### PR DESCRIPTION
This change makes some minor improvements to the async R jobs:

- Attempting to quit while there are jobs running now shows a warning and requires confirmation.
- The jobs tab can no longer be closed while there are jobs running (there's no straightforward way to go back.)
- Only R Scripts get the Source as Job command (previously it leaked onto at least one non-R filetype).
- Some wording improvements have been made.