### PR TITLE
Fix unable to use secure CRAN warning

### DIFF
--- a/src/cpp/session/SessionUserSettings.cpp
+++ b/src/cpp/session/SessionUserSettings.cpp
@@ -689,6 +689,14 @@ CRANMirror UserSettings::cranMirror() const
    mirror.country = settings_.get(kCRANMirrorCountry);
    mirror.changed = settings_.getBool(kCRANMirrorChanged);
 
+   // extract primary cran repo
+   std::vector<std::string> parts;
+   boost::split(parts, mirror.url, boost::is_any_of("|"));
+   if (parts.size() >= 2)
+      mirror.primary = parts.at(1);
+   else
+      mirror.primary = mirror.url;
+
    // if there is no URL then return the default RStudio mirror
    // (return the insecure version so we can rely on probing for
    // the secure version). also check for "/" to cleanup from

--- a/src/cpp/session/include/session/SessionUserSettings.hpp
+++ b/src/cpp/session/include/session/SessionUserSettings.hpp
@@ -48,6 +48,7 @@ struct CRANMirror
    std::string url;
    std::string country;
    bool changed = false;
+   std::string primary;
 };
 
 struct BioconductorMirror

--- a/src/cpp/session/modules/SessionPackages.cpp
+++ b/src/cpp/session/modules/SessionPackages.cpp
@@ -114,7 +114,7 @@ public:
    {
       // get the URL currently in settings. if it's https already then bail
       CRANMirror mirror = userSettings().cranMirror();
-      if (isSecure(mirror.url))
+      if (isSecure(mirror.primary))
          return;
 
       // modify to be secure
@@ -125,7 +125,7 @@ public:
       // build the command
       std::string cmd("{ " + module_context::CRANDownloadOptions() + "; ");
       cmd += "tmp <- tempfile(); ";
-      cmd += "download.file(paste(contrib.url('" + mirror.url +
+      cmd += "download.file(paste(contrib.url('" + mirror.primary +
               "'), '/PACKAGES.gz', sep = ''), destfile = tmp); ";
       cmd += "cat(readLines(tmp)); ";
       cmd += "} ";
@@ -149,9 +149,9 @@ public:
       }
       else
       {
-         std::string url = userSettings().cranMirror().url;
+         std::string url = userSettings().cranMirror().primary;
          if (isKnownSecureMirror(url))
-            unableToSecureConnectionWarning(secureMirror_.url);
+            unableToSecureConnectionWarning(secureMirror_.primary);
          else
             insecureReposURLWarning(url);
       }

--- a/src/cpp/session/modules/build/SessionInstallRtools.cpp
+++ b/src/cpp/session/modules/build/SessionInstallRtools.cpp
@@ -82,7 +82,7 @@ Error installRtools()
       {
          version = rTools.name();
 
-         std::string repos = userSettings().cranMirror().url;
+         std::string repos = userSettings().cranMirror().primary;
          if (repos.empty())
             repos = module_context::rstudioCRANReposURL();
          url = rTools.url(repos);


### PR DESCRIPTION
Git the package repo changes, I noticed that there are cases where we introduced a regression were a "not secure warning" got printed with the secondary URLs, as in `CRAN|https://cloud.rstudio.com` instead of just `https://cloud.rstudio.com`. Search for other instances where cpp code also expected single urls and fixed those as well.

CC: @ronblum 