### PR TITLE
Tolerate other tokens in Connection header when upgrading to a websocket

### DIFF
--- a/src/cpp/core/http/Util.cpp
+++ b/src/cpp/core/http/Util.cpp
@@ -519,6 +519,14 @@ bool isNetworkAddress(const std::string& str)
    return (!ec && iter != boost::asio::ip::tcp::resolver::iterator());
 }
 
+bool isWSUpgradeRequest(const Request& request)
+{
+   // look for the Upgrade token in the Connection request header; in most cases it will be the
+   // exact value of the the header, but some browsers (Firefox) include other tokens. (RFC 6455)
+   boost::regex upgrade("\\<Upgrade\\>", boost::regex::icase);
+   std::string connection = request.headerValue("Connection");
+   return boost::regex_search(connection, upgrade);
+}
 
 } // namespace util
 

--- a/src/cpp/core/include/core/http/AsyncClient.hpp
+++ b/src/cpp/core/include/core/http/AsyncClient.hpp
@@ -206,8 +206,7 @@ protected:
       // specify closing of the connection after the request unless this is
       // an attempt to upgrade to websockets
       Header overrideHeader;
-      if (!boost::algorithm::iequals(request_.headerValue("Connection"),
-                                     "Upgrade"))
+      if (!util::isWSUpgradeRequest(request_))
       {
          overrideHeader = Header::connectionClose();
       }

--- a/src/cpp/core/include/core/http/Util.hpp
+++ b/src/cpp/core/include/core/http/Util.hpp
@@ -173,6 +173,9 @@ bool isIpAddress(const std::string& addr);
 // querying the DNS system
 bool isNetworkAddress(const std::string& str);
 
+// determins if the given request is request to upgrade the connection to a websocket
+bool isWSUpgradeRequest(const Request& request);
+
 } // namespace util
 
 } // namespace http

--- a/src/cpp/server/ServerSessionProxy.cpp
+++ b/src/cpp/server/ServerSessionProxy.cpp
@@ -802,8 +802,10 @@ void proxyLocalhostRequest(
 
    // specify closing of the connection after the request unless this is
    // an attempt to upgrade to websockets
-   if (!boost::algorithm::iequals(request.headerValue("Connection"), "Upgrade"))
+   if (!http::util::isWSUpgradeRequest(request))
+   {
       request.setHeader("Connection", "close");
+   }
 
    LocalhostResponseHandler onResponse =
          boost::bind(handleLocalhostResponse, ptrConnection, _3, port, _2, ipv6, _1);


### PR DESCRIPTION
There were several places where we expected the websocket connection upgrade header `Connection` to have the exact value `Upgrade`. 

The standard, however, requires only that the header *include* the token `Upgrade`, and Firefox includes other values in the header (see #2940 for @jcheng5 's explanation of why this is a problem). 

This change brings the implementation in line with the standard.

Fixes #2940.