### PR TITLE
Update minimum R version

### DIFF
--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -119,8 +119,8 @@ else()
 endif()
 
 # required R version
-set(RSTUDIO_R_MAJOR_VERSION_REQUIRED 2)
-set(RSTUDIO_R_MINOR_VERSION_REQUIRED 11)
+set(RSTUDIO_R_MAJOR_VERSION_REQUIRED 3)
+set(RSTUDIO_R_MINOR_VERSION_REQUIRED 0)
 set(RSTUDIO_R_PATCH_VERSION_REQUIRED 1)
 
 # allow opting out of version checking (for building on older distros)


### PR DESCRIPTION
CMake will let you compile RStudio against very old versions of R we no longer support; this ensures compilation is happening with at least R 3.0.1. 