### PR TITLE
Start producing RStudio builds for OpenSUSE 15

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,14 +137,16 @@ messagePrefix = "Jenkins ${env.JOB_NAME} build: <${env.BUILD_URL}display/redirec
 try {
     timestamps {
         def containers = [
-          [os: 'centos6',  arch: 'x86_64', flavor: 'server',  variant: ''],
-          [os: 'opensuse', arch: 'x86_64', flavor: 'server',  variant: ''],
-          [os: 'opensuse', arch: 'x86_64', flavor: 'desktop', variant: ''],
-          [os: 'centos7',  arch: 'x86_64', flavor: 'desktop', variant: ''],
-          [os: 'trusty',   arch: 'amd64',  flavor: 'server',  variant: ''],
-          [os: 'trusty',   arch: 'amd64',  flavor: 'desktop', variant: ''],
-          [os: 'debian9',  arch: 'x86_64', flavor: 'server',  variant: ''],
-          [os: 'debian9',  arch: 'x86_64', flavor: 'desktop', variant: '']
+          [os: 'centos6',    arch: 'x86_64', flavor: 'server',  variant: ''],
+          [os: 'opensuse',   arch: 'x86_64', flavor: 'server',  variant: ''],
+          [os: 'opensuse',   arch: 'x86_64', flavor: 'desktop', variant: ''],
+          [os: 'opensuse15', arch: 'x86_64', flavor: 'server',  variant: ''],
+          [os: 'opensuse15', arch: 'x86_64', flavor: 'desktop', variant: ''],
+          [os: 'centos7',    arch: 'x86_64', flavor: 'desktop', variant: ''],
+          [os: 'trusty',     arch: 'amd64',  flavor: 'server',  variant: ''],
+          [os: 'trusty',     arch: 'amd64',  flavor: 'desktop', variant: ''],
+          [os: 'debian9',    arch: 'x86_64', flavor: 'server',  variant: ''],
+          [os: 'debian9',    arch: 'x86_64', flavor: 'desktop', variant: '']
         ]
         containers = limit_builds(containers)
         // create the version we're about to build

--- a/docker/jenkins/Dockerfile.opensuse15-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse15-x86_64
@@ -1,0 +1,71 @@
+FROM opensuse/leap:15.0
+
+# needed to build RPMs
+RUN zypper --non-interactive addrepo http://download.opensuse.org/repositories/systemsmanagement:wbem:deps/openSUSE_Tumbleweed/systemsmanagement:wbem:deps.repo
+
+# refresh repos and install required packages
+RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
+    zypper --non-interactive install -y \
+    ant \
+    boost-devel \
+    expect \
+    fakeroot \
+    gcc \
+    gcc-c++ \
+    git \
+    java-1_8_0-openjdk-devel  \
+    libacl-devel \
+    libattr-devel \
+    libcap-devel \
+    libuser-devel \
+    libuuid-devel \
+    libXcursor-devel \
+    libXrandr-devel \
+    lsof \
+    make \
+    openssl-devel \
+    pam-devel \
+    pango-devel \
+    python \
+    R \
+    rpm-build \
+    sudo \
+    tar \
+    unzip \
+    wget \
+    xml-commons-apis \
+    zlib-devel
+
+## run install-boost twice - boost exits 1 even though it has installed good enough for our uses.
+## https://github.com/rstudio/rstudio/blob/master/vagrant/provision-primary-user.sh#L12-L15
+COPY dependencies/common/install-boost /tmp/
+RUN bash /tmp/install-boost || bash /tmp/install-boost
+
+# install cmake
+COPY package/linux/install-dependencies /tmp/
+RUN bash /tmp/install-dependencies
+
+# set github login from build argument if defined
+ARG GITHUB_LOGIN
+ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN
+
+# ensure we use the java 8 compiler
+RUN update-alternatives --set java /usr/lib64/jvm/jre-1.8.0-openjdk/bin/java
+
+# install common dependencies
+RUN mkdir -p /opt/rstudio-tools/dependencies/common
+COPY dependencies/common/* /opt/rstudio-tools/dependencies/common/
+RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
+
+# install Qt SDK
+COPY dependencies/linux/install-qt-sdk /tmp/
+RUN mkdir -p /opt/RStudio-QtSDK && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.10.1 && \
+    /tmp/install-qt-sdk
+
+# create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
+ARG JENKINS_GID=999
+ARG JENKINS_UID=999
+RUN groupadd -g $JENKINS_GID jenkins && \
+    useradd -m -d /var/lib/jenkins -u $JENKINS_UID -g jenkins jenkins && \
+    echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers


### PR DESCRIPTION
OpenSUSE 15 was [released a few weeks ago](https://itsfoss.com/opensuse-leap-15/). It's not currently possible to run RStudio on OpenSUSE 15 without compiling from sources, primarily due to OpenSSL locations and versions. 

We formerly had an RPATH-based system to symlink libssl on SuSE, but that system hadn't adapted to the way the version is declared in OpenSUSE 15. Even if it had, symlinking wouldn't work -- OpenSUSE 15 bundles only libssl 1.1, which is [very, very ABI incompatible](https://abi-laboratory.pro/tracker/timeline/openssl/) with libssl 1.0, which is what most of our builders use. 

This change adds an OpenSUSE 15-specific build to our matrix. 

Closes #2606.