### PR TITLE
Fix testing a file after opening a project

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
@@ -313,7 +313,10 @@ public class BuildPresenter extends BasePresenter
 
    void onTestTestthatFile()
    {
-      startBuild("test-file");
+   }
+
+   void onTestShinytestFile()
+   {
    }
    
    void onRebuildAll()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildTab.java
@@ -58,6 +58,10 @@ public class BuildTab extends DelayLoadWorkbenchTab<BuildPresenter>
       public abstract void onCheckPackage();
       @Handler
       public abstract void onTestPackage();
+      @Handler
+      public abstract void onTestTestthatFile();
+      @Handler
+      public abstract void onTestShinytestFile();
       
       abstract void initialize(BuildState buildState);
    }


### PR DESCRIPTION
Found out that the first time running after opening a project and not clicking the build pane, testing a file did not work since the build pane is not loaded yet and the test data is discarded.

CC: @ronblum 