### PR TITLE
Prevent redundant Qt install on Mac / Linux

### DIFF
--- a/dependencies/linux/install-qt-sdk
+++ b/dependencies/linux/install-qt-sdk
@@ -15,8 +15,8 @@
 #
 #
 
-# This archive includes the files required to build against Qt 5.4.0. It
-# was created by installing Qt 5.4.0 via an interactive installer, and 
+# This archive includes the files required to build against Qt. It
+# was created by installing Qt via an interactive installer, and 
 # manually removing components not needed by RStudio.
 
 # define QT archive to download
@@ -35,9 +35,11 @@ QT_SDK_URL=https://s3.amazonaws.com/rstudio-buildtools/$QT_SDK_BINARY
 # set Qt SDK dir if not already defined
 if [ -z "$QT_SDK_DIR" ]; then
   QT_SDK_DIR=~/Qt${QT_VERSION}
+  QT_SDK_DIR2=~/Qt/Qt${QT_VERSION}
+  QT_SDK_DIR3=~/Qt/${QT_VERSION}
 fi
 
-if ! test -e $QT_SDK_DIR
+if [ ! -e "$QT_SDK_DIR" ] && [ ! -e "$QT_SDK_DIR2" ] && [ ! -e "$QT_SDK_DIR3" ]
 then
    # download and install
    wget $QT_SDK_URL -O /tmp/$QT_SDK_BINARY

--- a/dependencies/osx/install-qt-sdk-osx
+++ b/dependencies/osx/install-qt-sdk-osx
@@ -26,9 +26,11 @@ QT_SDK_URL=https://s3.amazonaws.com/rstudio-buildtools/$QT_SDK_BINARY
 # set Qt SDK dir if not already defined
 if [ -z "$QT_SDK_DIR" ]; then
   QT_SDK_DIR=~/Qt${QT_VERSION}
+  QT_SDK_DIR2=~/Qt/Qt${QT_VERSION}
+  QT_SDK_DIR3=~/Qt/${QT_VERSION}
 fi
 
-if ! test -e $QT_SDK_DIR
+if [ ! -e "$QT_SDK_DIR" ] && [ ! -e "$QT_SDK_DIR2" ] && [ ! -e "$QT_SDK_DIR3" ]
 then
    # download and install
    curl -L $QT_SDK_URL > /tmp/$QT_SDK_BINARY


### PR DESCRIPTION
The online Qt installer puts Qt under `~/Qt/5.10.1`, but the dependency scripts for Mac and Linux were only checking for the offline installer location (`~/Qt5.10.1`). Fix to check for the same variations that the Windows dependency script already supports.