### PR TITLE
automatically deduce number of arguments when registering methods

### DIFF
--- a/src/cpp/r/include/r/RRoutines.hpp
+++ b/src/cpp/r/include/r/RRoutines.hpp
@@ -24,18 +24,33 @@ namespace rstudio {
 namespace r {
 namespace routines {
 
+namespace internal {
+
+template <typename ReturnType, typename... ArgumentTypes>
+int n_arguments(ReturnType(ArgumentTypes...)) {
+    return sizeof...(ArgumentTypes);
+}
+
+} // end namespace internal
+
 void addCallMethod(const R_CallMethodDef method);
 void registerCallMethod(const char* name, DL_FUNC fun, int numArgs);
 void registerAll();
 
-#define RS_REGISTER_CALL_METHOD(__NAME__, __NUM_ARGS__)                        \
-   do                                                                          \
-   {                                                                           \
-      R_CallMethodDef callMethodDef;                                           \
-      callMethodDef.name = #__NAME__;                                          \
-      callMethodDef.fun = (DL_FUNC) __NAME__;                                  \
-      callMethodDef.numArgs = __NUM_ARGS__;                                    \
-      ::rstudio::r::routines::addCallMethod(callMethodDef);                    \
+// NOTE: This macro accepts multiple arguments but only uses the first one.
+// This is just for backwards compatibility, so that existing calls that
+// attempt to declare the number of arguments can continue to do so, while new
+// usages can omit it and still do the right thing. (This is done primarily to
+// avoid noisy diffs across the codebase where this macro is used)
+#define RS_REGISTER_CALL_METHOD(__NAME__, ...)                         \
+   do                                                                  \
+   {                                                                   \
+      int n = ::rstudio::r::routines::internal::n_arguments(__NAME__); \
+      R_CallMethodDef callMethodDef;                                   \
+      callMethodDef.name = #__NAME__;                                  \
+      callMethodDef.fun = (DL_FUNC) __NAME__;                          \
+      callMethodDef.numArgs = n;                                       \
+      ::rstudio::r::routines::addCallMethod(callMethodDef);            \
    } while (false)
 
 } // namespace routines   


### PR DESCRIPTION
This PR uses C++11 features to automatically deduce the number of functions accepted by a function, for use with call method registration. This should allow us to avoid bugs that result when the number of arguments in the registered function changes but the associated registration change is missed.