### PR TITLE
Use odbc package version with SQL preview support

### DIFF
--- a/src/cpp/session/modules/SessionDataPreview.R
+++ b/src/cpp/session/modules/SessionDataPreview.R
@@ -44,6 +44,9 @@
    # remove comments since some drivers might not support them
    statement <- gsub("--[^\n]*\n+", "", statement)
 
+   # force the connection to let DBI and others initialize S3
+   conn <- force(conn)
+
    # fetch at most 100 records as a preview
    rs <- DBI::dbSendQuery(conn, statement = statement, ...)
    data <- DBI::dbFetch(rs, n = 1000)

--- a/src/cpp/session/resources/templates/query.sql
+++ b/src/cpp/session/resources/templates/query.sql
@@ -1,3 +1,3 @@
--- !preview conn=force(DBI::dbConnect(RSQLite::SQLite()))
+-- !preview conn=DBI::dbConnect(RSQLite::SQLite())
 
 SELECT 1

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -772,7 +772,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
         "Preparing " + name,
         "Using " + name, 
         new Dependency[] {
-           Dependency.cranPackage("odbc", "1.1.5"),
+           Dependency.cranPackage("odbc", "1.1.6"),
            Dependency.cranPackage("rstudioapi", "0.5")
         }, 
         true, // update odbc if needed


### PR DESCRIPTION
Fix for https://github.com/rstudio/rstudio/issues/2956 to support SQL preview in ODBC connections and avoid using `force()` in sample SQL code but rather implement this in the `previewSql` API.