### PR TITLE
Store repos in repos setting to allow rstudio 1.1 to open cran settings to fix #2978

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -499,10 +499,6 @@ assign(envir = .rs.Env, ".rs.hasVar", function(name)
    .rs.registerReplaceHook(name, package, unsupported)
 })
 
-.rs.addFunction( "isCRANReposList", function(repos) {
-  .rs.startsWith(repos, "CRAN|")
-})
-
 .rs.addFunction( "parseCRANReposList", function(repos) {
   parts <- strsplit(repos, "\\|")[[1]]
   indexes <- seq_len(length(parts) / 2)
@@ -514,17 +510,20 @@ assign(envir = .rs.Env, ".rs.hasVar", function(name)
   r
 })
 
-.rs.addFunction( "setCRANRepos", function(repos)
+.rs.addFunction( "setCRANRepos", function(cran, secondary)
 {
   local({
-      if (.rs.isCRANReposList(repos))
+      if (nchar(secondary) > 0)
       {
-        r <- .rs.parseCRANReposList(repos)
+        r <- c(
+          list(CRAN = cran),
+          .rs.parseCRANReposList(secondary)
+        )
       }
       else
       {
         r <- getOption("repos");
-        r["CRAN"] <- repos;
+        r["CRAN"] <- cran;
       }
 
       # attribute indicating the repos was set from rstudio prefs
@@ -534,7 +533,7 @@ assign(envir = .rs.Env, ".rs.hasVar", function(name)
     })
 })
 
-.rs.addFunction( "setCRANReposAtStartup", function(reposUrl)
+.rs.addFunction( "setCRANReposAtStartup", function(cran, secondary)
 {
    # check whether the user has already set a CRAN repository
    # in their .Rprofile
@@ -542,7 +541,7 @@ assign(envir = .rs.Env, ".rs.hasVar", function(name)
    cranMirrorConfigured <- !is.null(repos) && repos != "@CRAN@"
 
    if (!cranMirrorConfigured)
-      .rs.setCRANRepos(reposUrl)
+      .rs.setCRANRepos(cran, secondary)
 })
 
 
@@ -552,13 +551,13 @@ assign(envir = .rs.Env, ".rs.hasVar", function(name)
 })
 
 
-.rs.addFunction( "setCRANReposFromSettings", function(reposUrl)
+.rs.addFunction( "setCRANReposFromSettings", function(cran, secondary)
 {
    # only set the repository if the repository was set by us
    # in the first place (it wouldn't be if the user defined a
    # repository in .Rprofile or called setRepositories directly)
    if (.rs.isCRANReposFromSettings())
-      .rs.setCRANRepos(reposUrl)
+      .rs.setCRANRepos(cran, secondary)
 })
 
 

--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -81,7 +81,8 @@ struct ROptions
    boost::function<bool()> alwaysSaveHistory;
    core::FilePath rSourcePath;
    std::string rLibsUser;
-   std::string rCRANRepos;
+   std::string rCRANUrl;
+   std::string rCRANSecondary;
    std::string runScript;
    bool useInternet2;
    int rCompatibleGraphicsEngineVersion;

--- a/src/cpp/r/include/r/session/RSessionUtils.hpp
+++ b/src/cpp/r/include/r/session/RSessionUtils.hpp
@@ -76,7 +76,9 @@ core::FilePath suspendedSessionPath();
 
 std::string sessionPort();
 
-std::string rCRANRepos();
+std::string rCRANUrl();
+
+std::string rCRANSecondary();
 
 bool restoreWorkspace();
 

--- a/src/cpp/r/session/RInit.cpp
+++ b/src/cpp/r/session/RInit.cpp
@@ -321,10 +321,11 @@ Error initialize()
    r::routines::registerAll();
    
    // set default repository if requested
-   if (!utils::rCRANRepos().empty())
+   if (!utils::rCRANUrl().empty() || !utils::rCRANSecondary().empty())
    {
       error = r::exec::RFunction(".rs.setCRANReposAtStartup",
-                                 utils::rCRANRepos()).call();
+                                 utils::rCRANUrl(),
+                                 utils::rCRANSecondary()).call();
       if (error)
          return error;
    }

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -557,9 +557,14 @@ std::string sessionPort()
    return s_options.sessionPort;
 }
 
-std::string rCRANRepos()
+std::string rCRANUrl()
 {
-   return s_options.rCRANRepos;
+   return s_options.rCRANUrl;
+}
+
+std::string rCRANSecondary()
+{
+   return s_options.rCRANSecondary;
 }
 
 bool useInternet2()

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -313,7 +313,7 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
          value<std::string>(&rLibsUser_)->default_value(""),
          "R user library path")
       ("r-cran-repos",
-         value<std::string>(&rCRANRepos_)->default_value(""),
+         value<std::string>(&rCRANUrl_)->default_value(""),
          "Default CRAN repository")
       ("r-cran-repos-file",
          value<std::string>(&rCRANReposFile_)->default_value("/etc/rstudio/repos.conf"),

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -201,9 +201,9 @@ public:
       return std::string(rLibsUser_.c_str());
    }
 
-   std::string rCRANRepos() const
+   std::string rCRANUrl() const
    {
-      return std::string(rCRANRepos_.c_str());
+      return std::string(rCRANUrl_.c_str());
    }
 
    std::string rCRANMultipleRepos() const
@@ -656,7 +656,7 @@ private:
    std::string sessionLibraryPath_;
    std::string sessionPackageArchivesPath_;
    std::string rLibsUser_;
-   std::string rCRANRepos_;
+   std::string rCRANUrl_;
    std::string rCRANMultipleRepos_;
    std::string rCRANReposUrl_;
    std::string rCRANReposFile_;

--- a/src/cpp/session/include/session/SessionUserSettings.hpp
+++ b/src/cpp/session/include/session/SessionUserSettings.hpp
@@ -48,7 +48,7 @@ struct CRANMirror
    std::string url;
    std::string country;
    bool changed = false;
-   std::string primary;
+   std::string secondary;
 };
 
 struct BioconductorMirror

--- a/src/cpp/session/modules/SessionPackages.cpp
+++ b/src/cpp/session/modules/SessionPackages.cpp
@@ -114,7 +114,7 @@ public:
    {
       // get the URL currently in settings. if it's https already then bail
       CRANMirror mirror = userSettings().cranMirror();
-      if (isSecure(mirror.primary))
+      if (isSecure(mirror.url))
          return;
 
       // modify to be secure
@@ -125,7 +125,7 @@ public:
       // build the command
       std::string cmd("{ " + module_context::CRANDownloadOptions() + "; ");
       cmd += "tmp <- tempfile(); ";
-      cmd += "download.file(paste(contrib.url('" + mirror.primary +
+      cmd += "download.file(paste(contrib.url('" + mirror.url +
               "'), '/PACKAGES.gz', sep = ''), destfile = tmp); ";
       cmd += "cat(readLines(tmp)); ";
       cmd += "} ";
@@ -149,9 +149,9 @@ public:
       }
       else
       {
-         std::string url = userSettings().cranMirror().primary;
+         std::string url = userSettings().cranMirror().url;
          if (isKnownSecureMirror(url))
-            unableToSecureConnectionWarning(secureMirror_.primary);
+            unableToSecureConnectionWarning(secureMirror_.url);
          else
             insecureReposURLWarning(url);
       }
@@ -218,7 +218,7 @@ void reconcileSecureDownloadConfiguration()
       // (in this case the global repository is always overriding the user
       // provided repository so it only makes sense to check/verify the
       // global repository)
-      std::string globalRepos = session::options().rCRANRepos();
+      std::string globalRepos = session::options().rCRANUrl();
       if (!globalRepos.empty() && !isSecure(globalRepos))
       {
          insecureReposURLWarning(globalRepos,

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -210,6 +210,7 @@ CRANMirror toCRANMirror(const json::Object& cranMirrorJson)
                     "name", &cranMirror.name,
                     "host", &cranMirror.host,
                     "url", &cranMirror.url,
+                    "secondary", &cranMirror.secondary,
                     "country", &cranMirror.country,
                     "changed", &cranMirror.changed);
    return cranMirror;
@@ -512,6 +513,7 @@ json::Object toCRANMirrorJson(const CRANMirror& cranMirror)
    cranMirrorJson["name"] = cranMirror.name;
    cranMirrorJson["host"] = cranMirror.host;
    cranMirrorJson["url"] = cranMirror.url;
+   cranMirrorJson["secondary"] = cranMirror.secondary;
    cranMirrorJson["country"] = cranMirror.country;
    cranMirrorJson["changed"] = cranMirror.changed;
    return cranMirrorJson;

--- a/src/cpp/session/modules/build/SessionInstallRtools.cpp
+++ b/src/cpp/session/modules/build/SessionInstallRtools.cpp
@@ -82,7 +82,7 @@ Error installRtools()
       {
          version = rTools.name();
 
-         std::string repos = userSettings().cranMirror().primary;
+         std::string repos = userSettings().cranMirror().url;
          if (repos.empty())
             repos = module_context::rstudioCRANReposURL();
          url = rTools.url(repos);

--- a/src/gwt/src/org/rstudio/studio/client/common/mirrors/model/CRANMirror.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mirrors/model/CRANMirror.java
@@ -32,6 +32,7 @@ public class CRANMirror extends JavaScriptObject
       cranMirror.name = "";
       cranMirror.host = "";
       cranMirror.url = "";
+      cranMirror.secondary = "";
       cranMirror.country = "";
       cranMirror.changed = false;
 
@@ -59,12 +60,20 @@ public class CRANMirror extends JavaScriptObject
       this.host = host;
    }-*/;
 
-   private final native String getRawURL() /*-{
+   public final native String getURL() /*-{
       return this.url;
    }-*/;
 
-   private final native void setRawURL(String url) /*-{
+   public final native void setURL(String url) /*-{
       this.url = url;
+   }-*/;
+
+   private final native String getSecondary() /*-{
+      return this.secondary;
+   }-*/;
+
+   private final native void setSecondary(String secondary) /*-{
+      this.secondary = secondary;
    }-*/;
 
    private final native String getError() /*-{
@@ -79,29 +88,11 @@ public class CRANMirror extends JavaScriptObject
       this.changed = changed;
    }-*/;
 
-   public final String getURL()
-   {
-      String rawUrl = getRawURL();
-
-      if (rawUrl.startsWith("CRAN|"))
-         return rawUrl.split("\\|")[1];
-      else
-         return rawUrl;
-   }
-
-   public final void setURL(String url)
-   {
-      if (getRawURL().startsWith("CRAN|"))
-         setSecondaryRepos(url, getSecondaryRepos());
-      else
-         setRawURL(url);
-   }
-
    private final void setSecondaryRepos(String cran, ArrayList<CRANMirror> repos)
    {
-      ArrayList<String> entries = new ArrayList<String>();
-      entries.add("CRAN|" + cran);
+      setURL(cran);
 
+      ArrayList<String> entries = new ArrayList<String>();
       for (CRANMirror repo : repos)
       {
          if (!repo.getName().toLowerCase().equals("cran"))
@@ -110,7 +101,7 @@ public class CRANMirror extends JavaScriptObject
          }
       }
       
-      setRawURL(StringUtil.join(entries, "|"));
+      setSecondary(StringUtil.join(entries, "|"));
    }
 
    public final void setSecondaryRepos(ArrayList<CRANMirror> repos)
@@ -122,23 +113,14 @@ public class CRANMirror extends JavaScriptObject
    {
       ArrayList<CRANMirror> repos = new ArrayList<CRANMirror>();
 
-      if (getRawURL().startsWith("CRAN|"))
+      String[] entries = getSecondary().split("\\|");
+      for (int i = 0; i < entries.length / 2; i++)
       {
-         String[] entries = getRawURL().split("\\|");
-         if (entries.length > 0)
-         {
-            for (int i = 1; i < entries.length / 2; i++)
-            {
-               CRANMirror repo = CRANMirror.empty();
-               repo.setName(entries[2 * i]);
-               repo.setURL(entries[2 * i + 1]);
+         CRANMirror repo = CRANMirror.empty();
+         repo.setName(entries[2 * i]);
+         repo.setURL(entries[2 * i + 1]);
 
-               if (!repo.getName().toLowerCase().equals("cran"))
-               {
-                  repos.add(repo);
-               }
-            }
-         }
+         repos.add(repo);
       }
       
       return repos;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
@@ -326,41 +326,36 @@ public class PackagesPreferencesPane extends PreferencesPane
    {
       boolean reload = super.onApply(rPrefs);
 
-      String mirrotTextValue = cranMirrorTextBox_.getTextBox().getText();
+      String mirrorTextValue = cranMirrorTextBox_.getTextBox().getText();
 
-      if (!mirrotTextValue.equals(cranMirrorStored_))
+      if (!mirrorTextValue.equals(cranMirrorStored_))
          cranMirror_.setChanged(true);
 
-      boolean cranRepoChangedToUrl = !mirrotTextValue.equals(cranMirrorStored_) && 
-                                      mirrotTextValue.startsWith("http");
-      
-      if (cranRepoChangedToUrl || secondaryReposHasChanged())
+      boolean cranRepoChangedToUrl = !mirrorTextValue.equals(cranMirrorStored_) && 
+                                      mirrorTextValue.startsWith("http");
+   
+      cranMirror_.setChanged(true);
+
+      if (cranRepoChangedToUrl)
       {
-         cranMirror_.setChanged(true);
+         cranMirror_.setURL(mirrorTextValue);
 
-         if (cranRepoChangedToUrl)
-         {
-            cranMirror_ = CRANMirror.empty();
-            cranMirror_.setURL(mirrotTextValue);
-
-            cranMirror_.setHost("Custom");
-            cranMirror_.setName("Custom");
-            cranMirror_.setChanged(true);
-         }
-         
-         ArrayList<CRANMirror> repos = secondaryReposWidget_.getRepos();
-         cranMirror_.setSecondaryRepos(repos);
-
-         server_.setCRANMirror(
-            cranMirror_,
-            new SimpleRequestCallback<Void>("Error Setting CRAN Mirror") {
-                @Override
-                public void onResponseReceived(Void response)
-                {
-                }
-            }
-         );
+         cranMirror_.setHost("Custom");
+         cranMirror_.setName("Custom");
       }
+      
+      ArrayList<CRANMirror> repos = secondaryReposWidget_.getRepos();
+      cranMirror_.setSecondaryRepos(repos);
+
+      server_.setCRANMirror(
+         cranMirror_,
+         new SimpleRequestCallback<Void>("Error Setting CRAN Mirror") {
+             @Override
+             public void onResponseReceived(Void response)
+             {
+             }
+         }
+      );
      
       // set packages prefs
       PackagesPrefs packagesPrefs = PackagesPrefs.create(


### PR DESCRIPTION
Fix for https://github.com/rstudio/rstudio/issues/2978.

Previously, we upgraded the `URL` user setting to store the CRAN repo and secondary repos. While this works fine in 1.2, RStudio 1.1 tries to read this `URL` which is not understandable. The fix is to leave the `cranMirrorUrl` field as it was, but introduce a new `cranMirrorRepos` user setting to store only the secondary repos.

There is also code to upgrade the RStudio 1.2 release bits that make use of the enhanced URL field.