### PR TITLE
disallow attempts to open external URLs in iframes (closes #2756)

### DIFF
--- a/src/cpp/desktop/DesktopWebPage.hpp
+++ b/src/cpp/desktop/DesktopWebPage.hpp
@@ -20,7 +20,9 @@
 
 #include <QtGui>
 #include <QWebEnginePage>
+#include <QWebEngineUrlRequestInfo>
 
+#include "DesktopWebProfile.hpp"
 #include "DesktopUtils.hpp"
 
 namespace rstudio {
@@ -94,6 +96,7 @@ public:
 public Q_SLOTS:
    bool shouldInterruptJavaScript();
    void closeRequested();
+   void onUrlIntercepted(QUrl url, int type);
 
 protected:
    QWebEnginePage* createWindow(QWebEnginePage::WebWindowType type) override;
@@ -102,6 +105,8 @@ protected:
    QString userAgentForUrl(const QUrl &url) const;
    bool acceptNavigationRequest(const QUrl &url, NavigationType, bool isMainFrame) override;
    QString viewerUrl();
+   
+   inline WebProfile* profile() { return static_cast<WebProfile*>(QWebEnginePage::profile()); }
 
 private:
    void handleBase64Download(QUrl url);
@@ -113,6 +118,9 @@ private:
    bool allowExternalNav_;
    std::queue<PendingWindow> pendingWindows_;
    QDir defaultSaveDir_;
+   
+   QUrl lastInterceptedRequestUrl_;
+   QWebEngineUrlRequestInfo::ResourceType lastInterceptedResourceType_;
 };
 
 } // namespace desktop

--- a/src/cpp/desktop/DesktopWebProfile.cpp
+++ b/src/cpp/desktop/DesktopWebProfile.cpp
@@ -28,10 +28,11 @@ class Interceptor : public QWebEngineUrlRequestInterceptor
 {
 public:
    explicit Interceptor(
-         QObject* parent,
+         WebProfile* parent,
          const QUrl& baseUrl,
          const std::string& sharedSecret)
       : QWebEngineUrlRequestInterceptor(parent),
+        parent_(parent),
         sharedSecret_(sharedSecret),
         baseUrl_(baseUrl)
    {
@@ -39,6 +40,8 @@ public:
 
    void interceptRequest(QWebEngineUrlRequestInfo& info) override
    {
+      parent_->onInterceptRequest(info);
+      
       if (info.requestUrl().authority() == baseUrl_.authority())
       {
          // The shared secret helps the session authenticate that the request actually came from the
@@ -53,6 +56,7 @@ public:
    }
 
 private:
+   WebProfile* parent_;
    std::string sharedSecret_;
    QUrl baseUrl_;
 };
@@ -70,6 +74,11 @@ void WebProfile::setBaseUrl(const QUrl& baseUrl)
 {
    interceptor_.reset(new Interceptor(this, baseUrl, sharedSecret_));
    setRequestInterceptor(interceptor_.data());
+}
+
+void WebProfile::onInterceptRequest(QWebEngineUrlRequestInfo& info)
+{
+   emit urlIntercepted(info.requestUrl(), info.resourceType());
 }
 
 } // end namespace desktop

--- a/src/cpp/desktop/DesktopWebProfile.cpp
+++ b/src/cpp/desktop/DesktopWebProfile.cpp
@@ -40,6 +40,9 @@ public:
 
    void interceptRequest(QWebEngineUrlRequestInfo& info) override
    {
+      // notify the parent of the intercept -- this is primarily done to
+      // communicate some extra information about the incoming request
+      // to WebPage, for use in acceptNavigationRequest()
       parent_->onInterceptRequest(info);
       
       if (info.requestUrl().authority() == baseUrl_.authority())

--- a/src/cpp/desktop/DesktopWebProfile.hpp
+++ b/src/cpp/desktop/DesktopWebProfile.hpp
@@ -18,6 +18,7 @@
 
 #include <QWebEngineProfile>
 #include <QWebEngineUrlRequestInterceptor>
+#include <QWebEngineUrlRequestInfo>
 
 namespace rstudio {
 namespace desktop {
@@ -29,6 +30,10 @@ class WebProfile : public QWebEngineProfile
 public:
    explicit WebProfile(const QUrl& baseUrl, QObject* parent = nullptr);
    void setBaseUrl(const QUrl& baseUrl);
+   void onInterceptRequest(QWebEngineUrlRequestInfo& info);
+   
+Q_SIGNALS:
+   void urlIntercepted(QUrl url, int type);
 
 private:
    QScopedPointer<QWebEngineUrlRequestInterceptor> interceptor_;


### PR DESCRIPTION
This is a second attempt at fixing #2756. The main difference here is that we're now careful to make sure the last intercepted URL is indeed associated with the attempted URL for navigation, and we deny attempts to load external URLs in iframes.