### PR TITLE
mark UTF-8 encoding when extracting params

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1743,7 +1743,8 @@ assign(x = ".rs.acCompletionTypes",
    
    if (!("knit_params" %in% getNamespaceExports(asNamespace("knitr"))))
       return(NULL)
-   
+
+   Encoding(content) <- "UTF-8"
    knitr::knit_params(content)
 })
 

--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -177,6 +177,8 @@
 
 .rs.addFunction("evaluateRmdParams", function(contents) {
 
+   Encoding(contents) <- "UTF-8"
+
    # extract the params using knitr::knit_params
    knitParams <- knitr::knit_params(contents)
 


### PR DESCRIPTION
This PR ensures that we re-mark the encoding of the document contents before passing it down to `knitr::knit_params()`. This fixes issues that occur when the document params cannot be represented in the current encoding.

(Some additional work is required in `knitr` to ensure arbitrary UTF-8 content can be handled on Windows)