### PR TITLE
fix handling of Shift+Tab keypress

### DIFF
--- a/src/cpp/desktop/DesktopPosixApplicationLaunch.cpp
+++ b/src/cpp/desktop/DesktopPosixApplicationLaunch.cpp
@@ -52,6 +52,17 @@ protected:
          auto* pKeyEvent = static_cast<QKeyEvent*>(pEvent);
          auto modifiers = pKeyEvent->modifiers();
          
+         // translate backtab to regular tab
+         if (pKeyEvent->key() == Qt::Key_Backtab)
+         {
+            auto* pTabEvent = new QKeyEvent(
+                     pKeyEvent->type(),
+                     Qt::Key_Tab,
+                     pKeyEvent->modifiers() | Qt::ShiftModifier);
+            QCoreApplication::postEvent(pObject, pTabEvent);
+            return true;
+         }
+         
          // fix up modifiers
          if (modifiers.testFlag(Qt::MetaModifier) &&
              !modifiers.testFlag(Qt::ControlModifier))

--- a/src/gwt/src/org/rstudio/core/rebind/command/ShortcutsEmitter.java
+++ b/src/gwt/src/org/rstudio/core/rebind/command/ShortcutsEmitter.java
@@ -64,6 +64,7 @@ public class ShortcutsEmitter
          String shortcutValue = childEl.getAttribute("value");
          String title = childEl.getAttribute("title");
          String disableModes = childEl.getAttribute("disableModes");
+         String handlesEventPropagation = childEl.getAttribute("handlesEventPropagation");
 
          // Use null when we don't have a command associated with the shortcut,
          // otherwise refer to the function that returns the command 
@@ -79,7 +80,8 @@ public class ShortcutsEmitter
          for (String shortcut : shortcuts)
          {
             printShortcut(writer, condition, shortcut, 
-                  command, groupName_, title, disableModes);
+                  command, groupName_, title, disableModes,
+                  handlesEventPropagation);
          }
       }
    }
@@ -110,7 +112,8 @@ public class ShortcutsEmitter
                               String command,
                               String shortcutGroup,
                               String title,
-                              String disableModes) throws UnableToCompleteException
+                              String disableModes,
+                              String handlesEventPropagation) throws UnableToCompleteException
    {
       List<Pair<Integer, String>> keys = new ArrayList<Pair<Integer, String>>();
       for (String keyCombination : shortcut.split("\\s+"))
@@ -201,6 +204,11 @@ public class ShortcutsEmitter
                Type.ERROR,
                "Invalid key sequence: sequences must be of length 1 or 2");
          throw new UnableToCompleteException();
+      }
+      
+      if (handlesEventPropagation.equals("true"))
+      {
+         writer.println("ShortcutManager.INSTANCE.registerCommandHandlesEventPropagation(" + command + ");");
       }
 
       if (!condition.isEmpty())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -30,6 +30,10 @@ well as menu structures (for main menu and popup menus).
       "background": always operates on main window, but in the background
       "<satellite name>": operates on named satellite; sent to the main window
         for processing unless fired from the named satellite
+  @handlesEventPropagation: Whether the command itself handles event propagation.
+     This is primarily used by commands which may be active and dispatched to,
+     but opt not to handle the event, thereby allowing the browser default
+     behavior in response to the pressed key.
 -->
 <commands>
    <menu id="mainMenu" vertical="false">
@@ -570,7 +574,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="insertPipeOperator" value="Cmd+Shift+M" title="Insert Pipe Operator" />
          <shortcut refid="renameInScope" value="Cmd+Alt+Shift+M" />
          <shortcut refid="insertRoxygenSkeleton" value="Cmd+Shift+Alt+R" title="Insert Roxygen Skeleton" />
-         <shortcut refid="insertSnippet" value="Shift+Tab" title="Insert Snippet"/>
+         <shortcut refid="insertSnippet" value="Shift+Tab" title="Insert Snippet" handlesEventPropagation="true" />
       </shortcutgroup>
       <shortcutgroup name="Source Navigation">
          <shortcut refid="sourceNavigateBack" value="Cmd+F9"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -38,6 +38,7 @@ import com.google.gwt.event.shared.GwtEvent;
 import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.ScrollPanel;
@@ -3695,7 +3696,14 @@ public class AceEditor implements DocDisplay,
    @Override
    public boolean onInsertSnippet()
    {
-      return snippets_.onInsertSnippet();
+      boolean executed = snippets_.onInsertSnippet();
+      if (executed)
+      {
+         Event evt = Event.getCurrentEvent();
+         evt.stopPropagation();
+         evt.preventDefault();
+      }
+      return executed;
    }
    
    public void toggleTokenInfo()


### PR DESCRIPTION
This PR fixes an issue where attempts to use <kbd>Shift + Tab</kbd> to shift focus to the previous element could fail. This was because the `insertSnippet` command was being handled within `AceEditorCommandDispatcher`, and since the `ShortcutManager` saw that the keypress had been dispatched to a command, it stopped propagation of the event and prevented the browser default behavior.

This PR also works around a Qt bug whereby its attempts to dispatch `Qt::Key_Backtab` events to Chromium would fail; we accommodate this by manually translating these back to regular shift-tabs.

Closes #2991.