### PR TITLE
ensure RStudio exits after last window closed

### DIFF
--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -227,18 +227,23 @@ wnd.desktopHooks.invokeCommand('%1');
    webPage()->runJavaScript(command);
 }
 
+namespace {
+
+void closeAllSatellites(QWidget* mainWindow)
+{
+   for (auto window: QApplication::topLevelWidgets())
+      if (window != mainWindow)
+         window->close();
+}
+
+} // end anonymous namespace
+
 void MainWindow::closeEvent(QCloseEvent* pEvent)
 {
 #ifdef _WIN32
    if (eventHook_)
       ::UnhookWinEvent(eventHook_);
 #endif
-
-   if (!webPage())
-   {
-       pEvent->accept();
-       return;
-   }
 
    if (!geometrySaved_)
    {
@@ -250,6 +255,7 @@ void MainWindow::closeEvent(QCloseEvent* pEvent)
        pCurrentSessionProcess_ == nullptr ||
        pCurrentSessionProcess_->state() != QProcess::Running)
    {
+      closeAllSatellites(this);
       pEvent->accept();
       return;
    }
@@ -264,6 +270,7 @@ void MainWindow::closeEvent(QCloseEvent* pEvent)
          LOG_ERROR_MESSAGE("Main window closed unexpectedly");
 
          // exit to avoid user having to kill/force-close the application
+         closeAllSatellites(this);
          QApplication::quit();
       }
       else
@@ -272,6 +279,7 @@ void MainWindow::closeEvent(QCloseEvent* pEvent)
                   QStringLiteral("window.desktopHooks.quitR()"),
                   [&](QVariant ignored)
          {
+            closeAllSatellites(this);
          });
       }
    });

--- a/src/cpp/desktop/DesktopSatelliteWindow.cpp
+++ b/src/cpp/desktop/DesktopSatelliteWindow.cpp
@@ -27,7 +27,7 @@ SatelliteWindow::SatelliteWindow(MainWindow* pMainWindow, QString name, WebPage*
     gwtCallback_(pMainWindow, this),
     close_(CloseStageOpen)
 {
-   setAttribute(Qt::WA_QuitOnClose, false);
+   setAttribute(Qt::WA_QuitOnClose, true);
    setAttribute(Qt::WA_DeleteOnClose, true);
 
    setWindowIcon(QIcon(QString::fromUtf8(":/icons/RStudio.ico")));

--- a/src/cpp/desktop/DesktopSecondaryWindow.cpp
+++ b/src/cpp/desktop/DesktopSecondaryWindow.cpp
@@ -42,7 +42,7 @@ SecondaryWindow::SecondaryWindow(bool showToolbar, QString name, QUrl baseUrl,
     BrowserWindow(showToolbar, true, name, baseUrl, pParent, pOpener,
                   allowExternalNavigate)
 {
-   setAttribute(Qt::WA_QuitOnClose, false);
+   setAttribute(Qt::WA_QuitOnClose, true);
    setAttribute(Qt::WA_DeleteOnClose, true);
 
 #ifdef Q_OS_MAC


### PR DESCRIPTION
This PR ensures that a close of a secondary window, if it is the final RStudio window opened, also quits the application.