### PR TITLE
ensure startup files have trailing newline (closes #3029)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -74,6 +74,7 @@
 * Add support for viewing external web URLs in the Viewer pane (#2252)
 * Add option to disable drag-and-drop for text in the editor (#2428)
 * Add option to disable cursor save/load; improves performance on some Windows machines (#2778)
+* R startup files (e.g. .Rprofile) are now always saved with trailing newlines (#3029)
 * Update embedded libclang to 5.0.2 (Windows only)
 * RStudio now a 64-bit application on Windows (Linux and Mac are already 64-bit)
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2652,7 +2652,15 @@ public class TextEditingTarget implements
             ? prefs_.autoAppendNewline().getValue()
             : projConfig_.ensureTrailingNewline();
             
-      if (autoAppendNewline || fileType_.isPython())
+      // auto-append newlines for commonly-used R startup files
+      String path = StringUtil.notNull(docUpdateSentinel_.getPath());
+      boolean isStartupFile =
+            path.endsWith("/.Rprofile") ||
+            path.endsWith("/.Rprofile.site") ||
+            path.endsWith("/.Renviron") ||
+            path.endsWith("/.Renviron.site");
+      
+      if (autoAppendNewline || isStartupFile || fileType_.isPython())
       {
          String lastLine = docDisplay_.getLine(lineCount - 1);
          if (lastLine.length() != 0)


### PR DESCRIPTION
Small enhancement that helps avoid the somewhat surprising behavior wherein a missing trailing newline in an R startup file can cause the final R expression in that file to be lost.