### PR TITLE
scan RBuildTools folder for Rtools

### DIFF
--- a/src/cpp/core/include/core/r_util/RToolsInfo.hpp
+++ b/src/cpp/core/include/core/r_util/RToolsInfo.hpp
@@ -65,7 +65,7 @@ private:
 
 std::ostream& operator<<(std::ostream& os, const RToolsInfo& info);
 
-Error scanRegistryForRTools(bool usingMingwGcc49, std::vector<RToolsInfo>* pRTools);
+Error scanForRTools(bool usingMingwGcc49, std::vector<RToolsInfo>* pRTools);
 
 template <typename T>
 void prependToSystemPath(const RToolsInfo& toolsInfo, T* pTarget)

--- a/src/cpp/core/r_util/RToolsInfo.cpp
+++ b/src/cpp/core/r_util/RToolsInfo.cpp
@@ -13,6 +13,7 @@
  *
  */
 
+#include <core/Version.hpp>
 #include <core/r_util/RToolsInfo.hpp>
 
 #include <boost/foreach.hpp>
@@ -229,6 +230,8 @@ std::ostream& operator<<(std::ostream& os, const RToolsInfo& info)
    return os;
 }
 
+namespace {
+
 Error scanRegistryForRTools(HKEY key,
                             bool usingMingwGcc49,
                             std::vector<RToolsInfo>* pRTools)
@@ -294,6 +297,69 @@ Error scanRegistryForRTools(bool usingMingwGcc49,
                                    pRTools);
    else
       return Success();
+}
+
+Error scanFoldersForRTools(bool usingMingwGcc49, std::vector<RToolsInfo>* pRTools)
+{
+   // look for Rtools as installed by RStudio
+   std::string systemDrive = core::system::getenv("SYSTEMDRIVE");
+   FilePath buildDirRoot(systemDrive + "/RBuildTools");
+
+   // find sub-directories
+   std::vector<FilePath> buildDirs;
+   Error error = buildDirRoot.children(&buildDirs);
+   if (error)
+      LOG_ERROR(error);
+
+   // infer Rtools information from each directory
+   for (const FilePath& buildDir : buildDirs)
+   {
+      RToolsInfo toolsInfo(buildDir.filename(), buildDir, usingMingwGcc49);
+      if (toolsInfo.isRecognized())
+         pRTools->push_back(toolsInfo);
+      else
+         LOG_WARNING_MESSAGE("Unknown Rtools version: " + buildDir.filename());
+   }
+
+   return Success();
+}
+
+} // end anonymous namespace
+
+Error scanForRTools(bool usingMingwGcc49, std::vector<RToolsInfo>* pRTools)
+{
+   Error error;
+   std::vector<RToolsInfo> rtoolsInfo;
+
+   // scan for Rtools
+   error = scanRegistryForRTools(usingMingwGcc49, &rtoolsInfo);
+   if (error)
+      return error;
+
+   error = scanFoldersForRTools(usingMingwGcc49, &rtoolsInfo);
+   if (error)
+      return error;
+
+   // remove duplicates
+   std::set<FilePath> knownPaths;
+   for (const RToolsInfo& info : rtoolsInfo)
+   {
+      if (knownPaths.count(info.installPath()))
+         continue;
+      pRTools->push_back(info);
+   }
+
+   // ensure sorted by version
+   std::sort(
+            pRTools->begin(),
+            pRTools->end(),
+            [](const RToolsInfo& lhs, const RToolsInfo& rhs)
+   {
+      return Version(lhs.name()) < Version(rhs.name());
+   });
+
+   // we're done!
+   return Success();
 }
 
 } // namespace r_util

--- a/src/cpp/core/r_util/RToolsInfo.cpp
+++ b/src/cpp/core/r_util/RToolsInfo.cpp
@@ -305,6 +305,11 @@ Error scanFoldersForRTools(bool usingMingwGcc49, std::vector<RToolsInfo>* pRTool
    std::string systemDrive = core::system::getenv("SYSTEMDRIVE");
    FilePath buildDirRoot(systemDrive + "/RBuildTools");
 
+   // ensure it exists (may not exist if the user has not installed
+   // any copies of Rtools through RStudio yet)
+   if (!buildDirRoot.exists())
+      return Success();
+
    // find sub-directories
    std::vector<FilePath> buildDirs;
    Error error = buildDirRoot.children(&buildDirs);

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -1940,9 +1940,12 @@ SEXP rs_addRToolsToPath()
     s_previousPath = core::system::getenv("PATH");
     std::string newPath = s_previousPath;
     std::string warningMsg;
-    module_context::addRtoolsToPathIfNecessary(&newPath, &warningMsg);
+    bool result = module_context::addRtoolsToPathIfNecessary(&newPath, &warningMsg);
+    if (!warningMsg.empty())
+       REprintf("%s\n", warningMsg.c_str());
     core::system::setenv("PATH", newPath);
-
+    r::sexp::Protect protect;
+    return r::sexp::create(result, &protect);
 #endif
     return R_NilValue;
 }

--- a/src/cpp/session/modules/build/SessionBuildEnvironment.cpp
+++ b/src/cpp/session/modules/build/SessionBuildEnvironment.cpp
@@ -138,7 +138,7 @@ bool doAddRtoolsToPathIfNecessary(T* pTarget,
     // ok so scan for R tools
     bool usingGcc49 = module_context::usingMingwGcc49();
     std::vector<r_util::RToolsInfo> rTools;
-    error = core::r_util::scanRegistryForRTools(usingGcc49, &rTools);
+    error = core::r_util::scanForRTools(usingGcc49, &rTools);
     if (error)
     {
        LOG_ERROR(error);

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -910,7 +910,7 @@ std::vector<std::string> RCompilationDatabase::rToolsArgs() const
       // scan for Rtools
       bool usingMingwGcc49 = module_context::usingMingwGcc49();
       std::vector<core::r_util::RToolsInfo> rTools;
-      Error error = core::r_util::scanRegistryForRTools(usingMingwGcc49, &rTools);
+      Error error = core::r_util::scanForRTools(usingMingwGcc49, &rTools);
       if (error)
          LOG_ERROR(error);
 


### PR DESCRIPTION
If I understand correctly, RStudio currently only detects versions of Rtools based on the contents of the registry. However, when Rtools is installed one can select whether or not the registry is updated after install. If the registry is not updated, then RStudio will fail to detect that install.

To complicate things a bit, when RStudio installs Rtools automatically / programmatically, it seems that the last-used preference for an Rtools installer is used. If the user opted out of updating the registry with an interactive installer, that same preference will be re-used on further installation attempts -- hence necessitating our folder-based lookup.

Fixes https://github.com/rstudio/rstudio/issues/3016.