### PR TITLE
Add support for hyperlinks in job names

### DIFF
--- a/src/cpp/session/modules/SessionJobs.R
+++ b/src/cpp/session/modules/SessionJobs.R
@@ -15,7 +15,7 @@
 
 .rs.addApiFunction("addJob", function(name, status = "", progressUnits = 0L,
       actions = NULL, estimate = 0L, estimateRemaining = FALSE, running = FALSE, 
-      autoRemove = TRUE, group = "", show = TRUE) {
+      autoRemove = TRUE, group = "", show = TRUE, url = "") {
 
    # validate arguments
    if (missing(name))
@@ -27,7 +27,8 @@
 
    # begin tracking job
    .Call("rs_addJob", name, status, progressUnits,
-      actions, estimate, estimateRemaining, running, autoRemove, group, show, PACKAGE = "(embedding)")
+      actions, estimate, estimateRemaining, running,
+      autoRemove, group, show, url, PACKAGE = "(embedding)")
 })
 
 .rs.addApiFunction("removeJob", function(job) {

--- a/src/cpp/session/modules/jobs/Job.cpp
+++ b/src/cpp/session/modules/jobs/Job.cpp
@@ -33,6 +33,7 @@
 #define kJobCompleted   "completed"
 #define kJobElapsed     "elapsed"
 #define kJobShow        "show"
+#define kJobUrl         "url"
 
 #define kJobStateIdle      "idle"
 #define kJobStateRunning   "running"
@@ -55,7 +56,8 @@ Job::Job(const std::string& id,
          int max,
          JobState state,
          bool autoRemove,
-         bool show):
+         bool show,
+         const std::string& url):
    id_(id), 
    name_(name),
    status_(status),
@@ -68,7 +70,8 @@ Job::Job(const std::string& id,
    completed_(0),
    autoRemove_(autoRemove),
    listening_(false),
-   show_(show)
+   show_(show),
+   url_(url)
 {
    setState(state);
 }
@@ -82,7 +85,8 @@ Job::Job():
    completed_(0),
    autoRemove_(true),
    listening_(false),
-   show_(true)
+   show_(true),
+   url_("")
 {
 }
 
@@ -135,7 +139,8 @@ json::Object Job::toJson() const
    job[kJobRecorded]   = static_cast<int64_t>(recorded_);
    job[kJobStarted]    = static_cast<int64_t>(started_);
    job[kJobCompleted]  = static_cast<int64_t>(completed_);
-   job[kJobShow]  = static_cast<int64_t>(show_);
+   job[kJobShow]       = static_cast<int64_t>(show_);
+   job[kJobUrl]        = url_;
 
    // amend with computed elapsed time
    if (started_ >= recorded_ && started_ > completed_)
@@ -175,7 +180,8 @@ Error Job::fromJson(const json::Object& src, boost::shared_ptr<Job> *pJobOut)
       kJobStarted,   &started,
       kJobCompleted, &completed,
       kJobState,     &state,
-      kJobShow,      &pJob->show_);
+      kJobShow,      &pJob->show_,
+      kJobUrl,       &pJob->url_);
    if (error)
       return error;
 
@@ -265,6 +271,11 @@ time_t Job::completed() const
 bool Job::show() const
 {
    return show_;
+}
+
+std::string Job::url() const
+{
+   return url_;
 }
 
 FilePath Job::jobCacheFolder()

--- a/src/cpp/session/modules/jobs/Job.hpp
+++ b/src/cpp/session/modules/jobs/Job.hpp
@@ -54,7 +54,8 @@ public:
        int max,
        JobState state,
        bool autoRemove,
-       bool show);
+       bool show,
+       const std::string& url);
 
    // job ID (machine-generated)
    std::string id() const;
@@ -92,6 +93,9 @@ public:
 
    // whether the job pane should should be shown at start
    bool show() const;
+
+   // the job's details url (optional)
+   std::string url() const;
 
    // timing
    time_t recorded() const;
@@ -135,6 +139,7 @@ private:
    bool autoRemove_;
    bool listening_;
    bool show_;
+   std::string url_;
 };
 
 

--- a/src/cpp/session/modules/jobs/JobsApi.cpp
+++ b/src/cpp/session/modules/jobs/JobsApi.cpp
@@ -85,7 +85,8 @@ boost::shared_ptr<Job> addJob(
       int progress,
       JobState state,
       bool autoRemove,
-      bool show)
+      bool show,
+      const std::string& url)
 {
    // find an unused job id
    std::string id;
@@ -96,8 +97,16 @@ boost::shared_ptr<Job> addJob(
    while(s_jobs.find(id) != s_jobs.end());
 
    // create the job!
-   boost::shared_ptr<Job> pJob = boost::make_shared<Job>(
-         id, name, status, group, 0 /* completed units */, progress, state, autoRemove, show); 
+   boost::shared_ptr<Job> pJob = boost::make_shared<Job>(id,
+                                                         name,
+                                                         status,
+                                                         group,
+                                                         0 /* completed units */,
+                                                         progress,
+                                                         state,
+                                                         autoRemove,
+                                                         show,
+                                                         url); 
 
    // cache job and notify client
    s_jobs[id] = pJob;

--- a/src/cpp/session/modules/jobs/JobsApi.hpp
+++ b/src/cpp/session/modules/jobs/JobsApi.hpp
@@ -36,7 +36,8 @@ boost::shared_ptr<Job> addJob(
       int progress,
       JobState state,
       bool autoRemove,
-      bool show);
+      bool show,
+      const std::string& url);
 
 void removeJob(boost::shared_ptr<Job> pJob);
 

--- a/src/cpp/session/modules/jobs/ScriptJob.cpp
+++ b/src/cpp/session/modules/jobs/ScriptJob.cpp
@@ -72,7 +72,7 @@ private:
       Error error;
       
       // add the job -- currently idle until we get some content from it
-      job_ = addJob(spec_.path().filename(), "", "", 0, JobIdle, false, true);
+      job_ = addJob(spec_.path().filename(), "", "", 0, JobIdle, false, true, "");
 
       std::string importRdata = "NULL";
       std::string exportRdata = "NULL";

--- a/src/cpp/session/modules/jobs/SessionJobs.cpp
+++ b/src/cpp/session/modules/jobs/SessionJobs.cpp
@@ -57,7 +57,7 @@ bool lookupJob(SEXP jobSEXP, boost::shared_ptr<Job> *pJob)
 
 SEXP rs_addJob(SEXP nameSEXP, SEXP statusSEXP, SEXP progressUnitsSEXP, SEXP actionsSEXP,
       SEXP estimateSEXP, SEXP estimateRemainingSEXP, SEXP runningSEXP, SEXP autoRemoveSEXP,
-      SEXP groupSEXP, SEXP showSEXP) 
+      SEXP groupSEXP, SEXP showSEXP, SEXP urlSEXP) 
 {
    // convert to native types
    std::string name   = r::sexp::safeAsString(nameSEXP, "");
@@ -67,10 +67,11 @@ SEXP rs_addJob(SEXP nameSEXP, SEXP statusSEXP, SEXP progressUnitsSEXP, SEXP acti
    JobState state     = r::sexp::asLogical(runningSEXP) ? JobRunning : JobIdle;
    bool autoRemove    = r::sexp::asLogical(autoRemoveSEXP);
    bool show          = r::sexp::asLogical(showSEXP);
+   std::string url    = r::sexp::safeAsString(urlSEXP);
       
    // add the job
    boost::shared_ptr<Job> pJob =  
-      addJob(name, status, group, progress, state, autoRemove, show);
+      addJob(name, status, group, progress, state, autoRemove, show, url);
 
    // return job id
    r::sexp::Protect protect;

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -755,7 +755,7 @@ public class Application implements ApplicationEventHandlers
                                            Document.get(),
                                            rootPanel_.getElement());
 
-            events_.fireEventToAllSatellites(new ThemeChangedEvent(theme));
+            events_.fireEventToAllSatellites(new ThemeChangedEvent());
          }
       };
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/Job.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/Job.java
@@ -55,4 +55,7 @@ public class Job
 
    // whether the job pane should should be shown at start
    public boolean show;
+
+   // the job's details url (optional)
+   public String url;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.java
@@ -29,6 +29,7 @@ import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Anchor;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Label;
@@ -65,6 +66,7 @@ public class JobItem extends Composite
       initWidget(uiBinder.createAndBindUi(this));
       
       name_.setText(job.name);
+      name_.setHref("https://www.rstudio.com");
       select_.setResource(new ImageResource2x(RESOURCES.jobSelect()));
       select_.addClickHandler(evt -> 
       {
@@ -148,6 +150,6 @@ public class JobItem extends Composite
    @UiField Image select_;
    @UiField Image state_;
    @UiField Label elapsed_;
-   @UiField Label name_;
+   @UiField Anchor name_;
    @UiField Label status_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.java
@@ -66,7 +66,12 @@ public class JobItem extends Composite
       initWidget(uiBinder.createAndBindUi(this));
       
       name_.setText(job.name);
-      name_.setHref("https://www.rstudio.com");
+
+      if (!StringUtil.isNullOrEmpty(job.url))
+      {
+         name_.setHref(job.url);
+      }
+
       select_.setResource(new ImageResource2x(RESOURCES.jobSelect()));
       select_.addClickHandler(evt -> 
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.ui.xml
@@ -66,7 +66,11 @@
 				<g:VerticalPanel styleName="{style.item}">
 					<g:HorizontalPanel styleName="{style.metadata}">
 						<g:cell horizontalAlignment="ALIGN_LEFT" width="80%">
-							<g:Label ui:field="name_" styleName="{style.name}"></g:Label>
+							<g:Anchor
+								ui:field="name_"
+								target="_blank"
+								styleName="{style.name}">
+							</g:Anchor>
 						</g:cell>
 						<g:cell horizontalAlignment="ALIGN_RIGHT" width="20%">
 							<g:Label ui:field="status_" styleName="{style.status}"></g:Label>


### PR DESCRIPTION
In sparklyr, jobs have not text output, instead, there is a detailed job url that would be more helpful to navigate to; additionally, I don't think it would be uncommon to have an url with additional information associated to jobs for other clusters technologies.

This PR adds a `url` parameter in `.rs.api.addJob`; when not specified, the Jobs UI remains unchanged with no hyperlink treatment. However, when specified, the Job name becomes a Url.

For sparklyr, this could be used for:

<img width="1017" alt="screen shot 2018-06-20 at 3 57 50 am" src="https://user-images.githubusercontent.com/3478847/41633318-98f87a70-743e-11e8-9c56-c0b88265550e.png">

to navigate to...

<img width="1440" alt="screen shot 2018-06-20 at 4 01 28 am" src="https://user-images.githubusercontent.com/3478847/41633334-a648d6ca-743e-11e8-9cd1-f8d815f2a807.png">
