### PR TITLE
Enable publish workflows that depend on self-signed SSL certs

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSettings.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSettings.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 
 import com.google.gwt.core.client.JavaScriptObject;
 
@@ -64,6 +65,7 @@ public class RSConnectPublishSettings
    
    public JavaScriptObject toJso()
    {
+      UIPrefs prefs = RStudioGinjector.INSTANCE.getUIPrefs();
       JsObject obj = JsObject.createJsObject();
       obj.setJsArrayString("deploy_files", 
             JsArrayUtil.toJsArrayString(getDeployFiles()));
@@ -73,9 +75,9 @@ public class RSConnectPublishSettings
             JsArrayUtil.toJsArrayString(getIgnoredFiles()));
       obj.setBoolean("as_multiple", getAsMultiple());
       obj.setBoolean("as_static", getAsStatic());
-      obj.setBoolean("show_diagnostics", 
-            RStudioGinjector.INSTANCE.getUIPrefs()
-                            .showPublishDiagnostics().getValue());
+      obj.setBoolean("show_diagnostics", prefs.showPublishDiagnostics().getValue());
+      obj.setBoolean("check_ssl_certs", prefs.publishCheckCertificates().getValue());
+      obj.setString("ca_bundle_path", prefs.publishCABundle().getValue());
       return obj.cast();
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSettings.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSettings.java
@@ -75,9 +75,13 @@ public class RSConnectPublishSettings
             JsArrayUtil.toJsArrayString(getIgnoredFiles()));
       obj.setBoolean("as_multiple", getAsMultiple());
       obj.setBoolean("as_static", getAsStatic());
-      obj.setBoolean("show_diagnostics", prefs.showPublishDiagnostics().getValue());
-      obj.setBoolean("check_ssl_certs", prefs.publishCheckCertificates().getValue());
-      obj.setString("ca_bundle_path", prefs.publishCABundle().getValue());
+      obj.setBoolean("show_diagnostics", 
+            prefs.showPublishDiagnostics().getValue());
+      obj.setBoolean("check_ssl_certs", 
+            prefs.publishCheckCertificates().getValue());
+      obj.setString("ca_bundle_path", 
+            prefs.usePublishCABundle().getValue() ? 
+               prefs.publishCABundle().getValue() : "");
       return obj.cast();
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/NewRSConnectAuthPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/NewRSConnectAuthPage.java
@@ -125,17 +125,9 @@ public class NewRSConnectAuthPage
       });
    }
 
-
    @Override
    public void onWindowClosed(WindowClosedEvent event)
    {
-      if (event.getName() == AUTH_WINDOW_NAME)
-      {
-         waitingForAuth_.setValue(false, true);
-         
-         // check to see if the user successfully authenticated
-         onAuthCompleted();
-      }
    }
    
    @Override
@@ -220,13 +212,6 @@ public class NewRSConnectAuthPage
                         result_.setAuthUser(user);
                         waitingForAuth_.setValue(false, true);
                         
-                        if (Desktop.isDesktop())
-                        {
-                           // on the desktop, we can close the window by name
-                           Desktop.getFrame().closeNamedWindow(
-                                 AUTH_WINDOW_NAME);
-                        }
-                       
                         onUserAuthVerified();
                      }
 
@@ -326,20 +311,19 @@ public class NewRSConnectAuthPage
                   contents_.showWaiting();
                   
                   // prepare a new window with the auth URL loaded
-                  if (canSpawnAuthenticationWindow())
+                  if (Desktop.isDesktop())
+                  {
+                     Desktop.getFrame().browseUrl(StringUtil.notNull(result_.getPreAuthToken().getClaimUrl()));
+                  }
+                  else
                   {
                      NewWindowOptions options = new NewWindowOptions();
-                     options.setName(AUTH_WINDOW_NAME);
                      options.setAllowExternalNavigation(true);
                      options.setShowDesktopToolbar(false);
                      display_.openWebMinimalWindow(
                            result_.getPreAuthToken().getClaimUrl(),
                            false, 
                            700, 800, options);
-                  }
-                  else
-                  {
-                     Desktop.getFrame().browseUrl(StringUtil.notNull(result_.getPreAuthToken().getClaimUrl()));
                   }
                   
                   // close the window automatically when authentication finishes
@@ -382,18 +366,6 @@ public class NewRSConnectAuthPage
       });
    }
    
-   private boolean canSpawnAuthenticationWindow()
-   {
-      if (!Desktop.isDesktop())
-         return true;
-      
-      String platform = DesktopInfo.getPlatform();
-      if (platform.contentEquals("centos") || platform.contentEquals("rhel"))
-         return false;
-      
-      return true;
-   }
-   
    private OperationWithInput<Boolean> setOkButtonVisible_;
    
    private NewRSConnectAccountResult result_;
@@ -403,6 +375,4 @@ public class NewRSConnectAuthPage
    private Value<Boolean> waitingForAuth_ = new Value<Boolean>(false);
    private boolean runningAuthCompleteCheck_ = false;
    private ProgressIndicator wizardIndicator_;
-
-   public final static String AUTH_WINDOW_NAME = "rstudio_rsconnect_auth";
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSAccountConnector.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSAccountConnector.java
@@ -139,7 +139,6 @@ public class RSAccountConnector implements
                   });
                   wizard.showModal();
                   found = true;
-                  closeAuthWindowWhenFinished(wizard);
                   break;
                }
             }
@@ -246,8 +245,6 @@ public class RSAccountConnector implements
             showingWizard_ = false;
          }
       });
-
-      closeAuthWindowWhenFinished(wizard);
    }
    
    private void processDialogResult(final NewRSConnectAccountResult input, 
@@ -388,23 +385,6 @@ public class RSAccountConnector implements
    }-*/;
    
    
-   private void closeAuthWindowWhenFinished(PopupPanel panel)
-   {
-      if (Desktop.isDesktop())
-      {
-         panel.addCloseHandler(new CloseHandler<PopupPanel>()
-         {
-            @Override
-            public void onClose(CloseEvent<PopupPanel> arg0)
-            {
-               // take down the auth window if it's still showing
-               Desktop.getFrame().closeNamedWindow(
-                     NewRSConnectAuthPage.AUTH_WINDOW_NAME);
-            }
-         });
-      }
-   }
-
    private final GlobalDisplay display_;
    private final RSConnectServerOperations server_;
    private final OptionsLoader.Shim optionsLoader_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -587,6 +587,11 @@ public class UIPrefsAccessor extends Prefs
       return bool("publish_check_certificates", true);
    }
    
+   public PrefValue<Boolean> usePublishCABundle()
+   {
+      return bool("use_publish_ca_bundle", false);
+   }
+   
    public PrefValue<String> publishCABundle()
    {
       return string("publish_ca_bundle", "");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -581,7 +581,17 @@ public class UIPrefsAccessor extends Prefs
    {
       return bool("show_publish_diagnostics", false);
    }
-     
+   
+   public PrefValue<Boolean> publishCheckCertificates()
+   {
+      return bool("publish_check_certificates", true);
+   }
+   
+   public PrefValue<String> publishCABundle()
+   {
+      return string("publish_ca_bundle", "");
+   }
+   
    public PrefValue<Boolean> showRmdChunkOutputInline()
    {
       return bool("rmd_chunk_output_inline", true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PublishingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PublishingPreferencesPane.java
@@ -218,9 +218,15 @@ public class PublishingPreferencesPane extends PreferencesPane
       add(checkboxPref("Check SSL certificates when publishing",
             uiPrefs_.publishCheckCertificates()));
       
-      caBundlePath_ = new FileChooserTextBox("Use custom CA bundle:",
-            "(none)", null, null);
+      CheckBox useCaBundle = checkboxPref("Use custom CA bundle",
+            uiPrefs_.usePublishCABundle());
+      useCaBundle.addValueChangeHandler(
+            val -> caBundlePath_.setVisible(val.getValue()));
+      add(useCaBundle);
+
+      caBundlePath_ = new FileChooserTextBox("", "(none)", null, null);
       caBundlePath_.setText(uiPrefs_.publishCABundle().getValue());
+      caBundlePath_.setVisible(uiPrefs_.usePublishCABundle().getValue());
       add(caBundlePath_);
 
       server_.hasOrphanedAccounts(new ServerRequestCallback<Int>()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PublishingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PublishingPreferencesPane.java
@@ -33,6 +33,7 @@ import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.prefs.PreferencesDialogBaseResources;
 import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.core.client.widget.FileChooserTextBox;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ThemedButton;
@@ -212,6 +213,16 @@ public class PublishingPreferencesPane extends PreferencesPane
       add(checkboxPref("Show diagnostic information when publishing",
             uiPrefs_.showPublishDiagnostics()));
       
+      add(spacedBefore(headerLabel("SSL Certificates")));
+
+      add(checkboxPref("Check SSL certificates when publishing",
+            uiPrefs_.publishCheckCertificates()));
+      
+      caBundlePath_ = new FileChooserTextBox("Use custom CA bundle:",
+            "(none)", null, null);
+      caBundlePath_.setText(uiPrefs_.publishCABundle().getValue());
+      add(caBundlePath_);
+
       server_.hasOrphanedAccounts(new ServerRequestCallback<Int>()
       {
          @Override
@@ -240,6 +251,8 @@ public class PublishingPreferencesPane extends PreferencesPane
    public boolean onApply(RPrefs rPrefs)
    {
       boolean reload = super.onApply(rPrefs);
+      
+      uiPrefs_.publishCABundle().setGlobalValue(caBundlePath_.getText());
 
       return reload || reloadRequired_;
    }
@@ -390,6 +403,7 @@ public class PublishingPreferencesPane extends PreferencesPane
    private ThemedButton connectButton_;
    private ThemedButton disconnectButton_;
    private ThemedButton reconnectButton_;
+   private FileChooserTextBox caBundlePath_;
    private boolean reloadRequired_;
 }
 


### PR DESCRIPTION
This change contains three smaller changes which make it possible to publish to RStudio Connect servers that use custom or self-signed SSL certificates using only the RStudio IDE (it was formerly necessary to use a series of `rsconnect` commands to make this work). 

They are as follows:

1. **Allow specifying a path to a custom CA bundle**. This path can also be set in an environment variable, or an R option; setting it in RStudio is a convenience for setting the R option in the child precess that performs the deploy.
2. **Always use the system browser to authenticate**. We formerly used a window hosted by RStudio itself on the desktop; this improves window management but has caused a number of problems in edge cases, which range from difficult to insurmountable (see #1541 and #3035).  
3. **Make it possible to skip the SSL certificate check**. This is of course not advisable, but can at a minimum be used to see if SSL certificates are the problem.

![image](https://user-images.githubusercontent.com/470418/41682063-82c868ee-748b-11e8-8ced-1997ab47f5fc.png)
