### PR TITLE
resolve race condition in tokenizer on paste

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/EditSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/EditSession.java
@@ -154,7 +154,7 @@ public class EditSession extends JavaScriptObject
    public native final void reindent(Range range) /*-{
       
       // ensure document re-tokenized before indent
-      var tokenizer = session.bgTokenizer;
+      var tokenizer = this.bgTokenizer;
       if (tokenizer != null) {
          var n = range.end.row;
          for (var i = 0; i <= n; i++)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/EditSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/EditSession.java
@@ -152,6 +152,17 @@ public class EditSession extends JavaScriptObject
    }-*/;
 
    public native final void reindent(Range range) /*-{
+      
+      // ensure document re-tokenized before indent
+      var tokenizer = session.bgTokenizer;
+      if (tokenizer != null) {
+         var n = range.end.row;
+         for (var i = 0; i <= n; i++)
+           tokenizer.$tokenizeRow(i);
+         tokenizer.fireUpdateEvent(0, n);
+      }
+      
+      // now ready to re-indent
       this.reindent(range);
    }-*/;
 


### PR DESCRIPTION
This PR fixes an issue where attempts to paste could incorrectly re-indent string selections in rare instances.

The ultimate cause of this issue was a race condition in the tokenizer. To avoid latency, the document is tokenized on a background timer that normally runs eagerly for the current line changed, but lazily for lines that follow that may need to be re-tokenized.

In this particular case, the attempt to paste was being handled _before_ the tokenizer could run. The re-indent logic we have relies on the tokenizer to communicate some state (e.g. "am I within a string right now?") and if the tokenizer had not yet run on the pasted text, an incorrect state would be computed for the line to be indented.

Closes #3036.