### PR TITLE
Enable auth and publish workflows with Connect servers requiring custom SSL settings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -77,6 +77,7 @@
 * R startup files (e.g. .Rprofile) are now always saved with trailing newlines (#3029)
 * Update embedded libclang to 5.0.2 (Windows only)
 * RStudio now a 64-bit application on Windows (Linux and Mac are already 64-bit)
+* New SSL options for authenticating and publishing to RStudio Connect servers using self-signed certs or internal CAs (#3040)
 
 ### Bug Fixes
 

--- a/src/cpp/session/SessionUserSettings.cpp
+++ b/src/cpp/session/SessionUserSettings.cpp
@@ -422,6 +422,18 @@ void UserSettings::updatePrefsCache(const json::Object& prefs) const
    bool showRmdRenderCommand = readPref<bool>(prefs, "show_rmd_render_command", false);
    pShowRmdRenderCommand_.reset(new bool(showRmdRenderCommand));
 
+   bool showPublishDiagnostics = readPref<bool>(prefs, "show_publish_diagnostics", false);
+   pShowPublishDiagnostics_.reset(new bool(showPublishDiagnostics));
+
+   bool publishCheckSslCerts = readPref<bool>(prefs, "publish_check_certificates", true);
+   pPublishCheckSslCerts_.reset(new bool(publishCheckSslCerts));
+
+   bool publishUseCABundle = readPref<bool>(prefs, "use_publish_ca_bundle", true);
+   pPublishUseCABundle_.reset(new bool(publishUseCABundle));
+
+   std::string publishCABundlePath = readPref<std::string>(prefs, "publish_ca_bundle", "");
+   pPublishCABundlePath_.reset(new std::string(publishCABundlePath));
+
    core::json::Array defWhitelist;
    defWhitelist.push_back("tmux");
    defWhitelist.push_back("screen");
@@ -670,6 +682,46 @@ bool UserSettings::terminalTrackEnv() const
 bool UserSettings::showRmdRenderCommand() const
 {
    return readUiPref<bool>(pShowRmdRenderCommand_);
+}
+
+bool UserSettings::showPublishDiagnostics() const
+{
+   return readUiPref<bool>(pShowPublishDiagnostics_);
+}
+
+void UserSettings::setShowPublishDiagnostics(bool show)
+{
+   settings_.set("show_publish_diagnostics", show);
+}
+
+bool UserSettings::publishCheckSslCerts() const
+{
+   return readUiPref<bool>(pPublishCheckSslCerts_);
+}
+
+void UserSettings::setPublishCheckSslCerts(bool check)
+{
+   settings_.set("publish_check_certificates", check);
+}
+
+bool UserSettings::usePublishCABundle() const
+{
+   return readUiPref<bool>(pPublishUseCABundle_);
+}
+
+void UserSettings::setUsePublishCABundle(bool use)
+{
+   settings_.set("use_publish_ca_bundle", use);
+}
+
+std::string UserSettings::publishCABundlePath() const
+{
+   return readUiPref<std::string>(pPublishCABundlePath_);
+}
+
+void UserSettings::setPublishCABundlePath(const std::string& path)
+{
+   settings_.set("publish_ca_bundle", path);
 }
 
 core::system::busy_detection::Mode UserSettings::terminalBusyMode() const
@@ -956,7 +1008,6 @@ void UserSettings::setUseNewlineInMakefiles(bool useNewline)
    settings_.set(kUseNewlineInMakefiles, useNewline);
 }
 
-
 void UserSettings::setInitialWorkingDirectory(const FilePath& filePath)
 {
    setWorkingDirectoryValue(kInitialWorkingDirectory, filePath);
@@ -967,7 +1018,6 @@ FilePath UserSettings::getWorkingDirectoryValue(const std::string& key) const
    return module_context::resolveAliasedPath(
             settings_.get(key, session::options().defaultWorkingDir()));
 }
-
 
 void UserSettings::setWorkingDirectoryValue(const std::string& key,
                                             const FilePath& filePath)

--- a/src/cpp/session/include/session/SessionUserSettings.hpp
+++ b/src/cpp/session/include/session/SessionUserSettings.hpp
@@ -231,6 +231,18 @@ public:
    bool reuseSessionsForProjectLinks() const;
    void setReuseSessionsForProjectLinks(bool reuse);
 
+   bool showPublishDiagnostics() const;
+   void setShowPublishDiagnostics(bool show);
+
+   bool publishCheckSslCerts() const;
+   void setPublishCheckSslCerts(bool check);
+
+   bool usePublishCABundle() const;
+   void setUsePublishCABundle(bool use);
+
+   std::string publishCABundlePath() const;
+   void setPublishCABundlePath(const std::string& path);
+
    void syncConsoleColorEnv() const;
 
 private:
@@ -279,6 +291,10 @@ private:
    mutable boost::scoped_ptr<int> pTerminalBusyMode_;
    mutable boost::scoped_ptr<core::json::Array> pTerminalBusyWhitelist_;
    mutable boost::scoped_ptr<bool> pShowRmdRenderCommand_;
+   mutable boost::scoped_ptr<bool> pShowPublishDiagnostics_;
+   mutable boost::scoped_ptr<bool> pPublishCheckSslCerts_;
+   mutable boost::scoped_ptr<bool> pPublishUseCABundle_;
+   mutable boost::scoped_ptr<std::string> pPublishCABundlePath_;
 
    // diagnostic-related prefs
    mutable boost::scoped_ptr<bool> pLintRFunctionCalls_;

--- a/src/cpp/session/modules/SessionRSConnect.cpp
+++ b/src/cpp/session/modules/SessionRSConnect.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionRSConnect.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -26,6 +26,7 @@
 #include <r/RSexp.hpp>
 #include <r/RExec.hpp>
 #include <r/RJson.hpp>
+#include <r/ROptions.hpp>
 
 #include <session/SessionModuleContext.hpp>
 #include <session/SessionAsyncRProcess.hpp>
@@ -90,13 +91,10 @@ public:
          const std::string& appTitle,
          const std::string& appId, 
          const std::string& contentCategory,
-         const std::string& caBundlePath,
          const json::Array& additionalFilesList,
          const json::Array& ignoredFilesList,
          bool asMultiple,
          bool asStatic,
-         bool diagnostics,
-         bool checkSslCerts,
          boost::shared_ptr<RSConnectPublish>* pDeployOut)
    {
       boost::shared_ptr<RSConnectPublish> pDeploy(new RSConnectPublish(file));
@@ -104,11 +102,13 @@ public:
       // lead command with download options and certificate check state
       std::string cmd("{ " + module_context::CRANDownloadOptions() + "; " 
                       "options(rsconnect.check.certificate = " +
-                      (checkSslCerts ? "TRUE" : "FALSE") + "); ");
+                      (userSettings().publishCheckSslCerts() ? "TRUE" : "FALSE") + "); ");
 
-      if (!caBundlePath.empty())
+      if (userSettings().usePublishCABundle() && 
+          !userSettings().publishCABundlePath().empty())
       {
-         FilePath caBundleFile = module_context::resolveAliasedPath(caBundlePath);
+         FilePath caBundleFile = module_context::resolveAliasedPath(
+               userSettings().publishCABundlePath());
          if (caBundleFile.exists())
          {
             // if a valid bundle path was specified, use it
@@ -188,7 +188,7 @@ public:
                  (ignoredFiles.empty() ? "" : ", ignoredFiles = '" + 
                     ignoredFiles + "'") + 
              ")" + 
-             (diagnostics ? ", logLevel = 'verbose'" : "") + 
+             (userSettings().showPublishDiagnostics() ? ", logLevel = 'verbose'" : "") + 
              ")}";
 
       pDeploy->start(cmd.c_str(), FilePath(), async_r::R_PROCESS_VANILLA);
@@ -290,17 +290,13 @@ Error rsconnectPublish(const json::JsonRpcRequest& request,
       return error;
 
    // read publish settings
-   bool asMultiple = false, asStatic = false, diagnostics = false, checkSslCerts = true;
+   bool asMultiple = false, asStatic = false;
    json::Array deployFiles, additionalFiles, ignoredFiles;
-   std::string caBundlePath;
    error = json::readObject(settings, "deploy_files",     &deployFiles,
                                       "additional_files", &additionalFiles,
                                       "ignored_files",    &ignoredFiles,
                                       "as_multiple",      &asMultiple, 
-                                      "as_static",        &asStatic,
-                                      "show_diagnostics", &diagnostics,
-                                      "check_ssl_certs",  &checkSslCerts,
-                                      "ca_bundle_path",   &caBundlePath);
+                                      "as_static",        &asStatic);
    if (error)
       return error;
 
@@ -314,10 +310,9 @@ Error rsconnectPublish(const json::JsonRpcRequest& request,
       error = RSConnectPublish::create(sourceDir, deployFiles, 
                                        sourceFile, sourceDoc, 
                                        account, server, appName, appTitle, appId, 
-                                       contentCategory, caBundlePath,
+                                       contentCategory,
                                        additionalFiles,
-                                       ignoredFiles, asMultiple,
-                                       asStatic, diagnostics, checkSslCerts,
+                                       ignoredFiles, asMultiple, asStatic,
                                        &s_pRSConnectPublish_);
       if (error)
          return error;
@@ -472,6 +467,55 @@ Error getRmdPublishDetails(const json::JsonRpcRequest& request,
    return Success();
 }
 
+void applyPreferences()
+{
+   // push preference changes into rsconnect package options immediately, so that it's possible to
+   // use them without restarting R
+   r::options::setOption("rsconnect.check.certificate", userSettings().publishCheckSslCerts());
+   if (userSettings().usePublishCABundle())
+      r::options::setOption("rsconnect.ca.bundle", userSettings().publishCABundlePath());
+   else
+      r::options::setOption("rsconnect.ca.bundle", R_NilValue);
+}
+
+Error initializeOptions()
+{
+   SEXP checkSEXP = r::options::getOption("rsconnect.check.certificate");
+   if (checkSEXP == R_NilValue)
+   {
+      // no user defined setting for certificate checks; disable if requested for the session
+      if (!userSettings().publishCheckSslCerts())
+         r::options::setOption("rsconnect.check.certificate", false);
+   }
+   else
+   {
+      // the user has a setting defined; mirror it if it differs. this allows us to reflect the
+      // the current value of the option in our preferences, but also means that if you've set the
+      // option in e.g. .Rprofile then it wins over RStudio's setting in the end.
+      bool check = r::sexp::asLogical(checkSEXP);
+      if (userSettings().publishCheckSslCerts() != check)
+      {
+         userSettings().setPublishCheckSslCerts(check);
+      }
+   }
+
+   std::string caBundle = r::sexp::safeAsString(r::options::getOption("rsconnect.ca.bundle"));
+   if (caBundle.empty() && userSettings().usePublishCABundle())
+   {
+      // no user defined setting for CA bundle; inject a bundle if the user asked for one
+      r::options::setOption("rsconnect.ca.bundle", userSettings().publishCABundlePath());
+   }
+   else if (!caBundle.empty())
+   {
+      // promote user setting as above
+      userSettings().beginUpdate();
+      userSettings().setUsePublishCABundle(true);
+      userSettings().setPublishCABundlePath(caBundle);
+      userSettings().endUpdate();
+   }
+   
+   return Success();
+}
 
 } // anonymous namespace
 
@@ -480,13 +524,16 @@ Error initialize()
    using boost::bind;
    using namespace module_context;
 
+   module_context::events().onPreferencesSaved.connect(applyPreferences);
+
    ExecBlock initBlock;
    initBlock.addFunctions()
       (bind(registerRpcMethod, "get_rsconnect_deployments", rsconnectDeployments))
       (bind(registerRpcMethod, "rsconnect_publish", rsconnectPublish))
       (bind(registerRpcMethod, "get_edit_published_docs", getEditPublishedDocs))
       (bind(registerRpcMethod, "get_rmd_publish_details", getRmdPublishDetails))
-      (bind(sourceModuleRFile, "SessionRSConnect.R"));
+      (bind(sourceModuleRFile, "SessionRSConnect.R"))
+      (bind(initializeOptions));
 
    return initBlock.execute();
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSettings.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSettings.java
@@ -65,7 +65,6 @@ public class RSConnectPublishSettings
    
    public JavaScriptObject toJso()
    {
-      UIPrefs prefs = RStudioGinjector.INSTANCE.getUIPrefs();
       JsObject obj = JsObject.createJsObject();
       obj.setJsArrayString("deploy_files", 
             JsArrayUtil.toJsArrayString(getDeployFiles()));
@@ -75,13 +74,6 @@ public class RSConnectPublishSettings
             JsArrayUtil.toJsArrayString(getIgnoredFiles()));
       obj.setBoolean("as_multiple", getAsMultiple());
       obj.setBoolean("as_static", getAsStatic());
-      obj.setBoolean("show_diagnostics", 
-            prefs.showPublishDiagnostics().getValue());
-      obj.setBoolean("check_ssl_certs", 
-            prefs.publishCheckCertificates().getValue());
-      obj.setString("ca_bundle_path", 
-            prefs.usePublishCABundle().getValue() ? 
-               prefs.publishCABundle().getValue() : "");
       return obj.cast();
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSettings.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSettings.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 
 import com.google.gwt.core.client.JavaScriptObject;
 
@@ -64,6 +65,7 @@ public class RSConnectPublishSettings
    
    public JavaScriptObject toJso()
    {
+      UIPrefs prefs = RStudioGinjector.INSTANCE.getUIPrefs();
       JsObject obj = JsObject.createJsObject();
       obj.setJsArrayString("deploy_files", 
             JsArrayUtil.toJsArrayString(getDeployFiles()));
@@ -73,9 +75,9 @@ public class RSConnectPublishSettings
             JsArrayUtil.toJsArrayString(getIgnoredFiles()));
       obj.setBoolean("as_multiple", getAsMultiple());
       obj.setBoolean("as_static", getAsStatic());
-      obj.setBoolean("show_diagnostics", 
-            RStudioGinjector.INSTANCE.getUIPrefs()
-                            .showPublishDiagnostics().getValue());
+      obj.setBoolean("show_diagnostics", prefs.showPublishDiagnostics().getValue());
+      obj.setBoolean("check_ssl_certs", prefs.publishCheckCertificates().getValue());
+      obj.setString("ca_bundle_path", prefs.publishCABundle().getValue());
       return obj.cast();
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSettings.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSettings.java
@@ -75,9 +75,13 @@ public class RSConnectPublishSettings
             JsArrayUtil.toJsArrayString(getIgnoredFiles()));
       obj.setBoolean("as_multiple", getAsMultiple());
       obj.setBoolean("as_static", getAsStatic());
-      obj.setBoolean("show_diagnostics", prefs.showPublishDiagnostics().getValue());
-      obj.setBoolean("check_ssl_certs", prefs.publishCheckCertificates().getValue());
-      obj.setString("ca_bundle_path", prefs.publishCABundle().getValue());
+      obj.setBoolean("show_diagnostics", 
+            prefs.showPublishDiagnostics().getValue());
+      obj.setBoolean("check_ssl_certs", 
+            prefs.publishCheckCertificates().getValue());
+      obj.setString("ca_bundle_path", 
+            prefs.usePublishCABundle().getValue() ? 
+               prefs.publishCABundle().getValue() : "");
       return obj.cast();
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/NewRSConnectAuthPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/NewRSConnectAuthPage.java
@@ -125,17 +125,9 @@ public class NewRSConnectAuthPage
       });
    }
 
-
    @Override
    public void onWindowClosed(WindowClosedEvent event)
    {
-      if (event.getName() == AUTH_WINDOW_NAME)
-      {
-         waitingForAuth_.setValue(false, true);
-         
-         // check to see if the user successfully authenticated
-         onAuthCompleted();
-      }
    }
    
    @Override
@@ -220,13 +212,6 @@ public class NewRSConnectAuthPage
                         result_.setAuthUser(user);
                         waitingForAuth_.setValue(false, true);
                         
-                        if (Desktop.isDesktop())
-                        {
-                           // on the desktop, we can close the window by name
-                           Desktop.getFrame().closeNamedWindow(
-                                 AUTH_WINDOW_NAME);
-                        }
-                       
                         onUserAuthVerified();
                      }
 
@@ -326,20 +311,19 @@ public class NewRSConnectAuthPage
                   contents_.showWaiting();
                   
                   // prepare a new window with the auth URL loaded
-                  if (canSpawnAuthenticationWindow())
+                  if (Desktop.isDesktop())
+                  {
+                     Desktop.getFrame().browseUrl(StringUtil.notNull(result_.getPreAuthToken().getClaimUrl()));
+                  }
+                  else
                   {
                      NewWindowOptions options = new NewWindowOptions();
-                     options.setName(AUTH_WINDOW_NAME);
                      options.setAllowExternalNavigation(true);
                      options.setShowDesktopToolbar(false);
                      display_.openWebMinimalWindow(
                            result_.getPreAuthToken().getClaimUrl(),
                            false, 
                            700, 800, options);
-                  }
-                  else
-                  {
-                     Desktop.getFrame().browseUrl(StringUtil.notNull(result_.getPreAuthToken().getClaimUrl()));
                   }
                   
                   // close the window automatically when authentication finishes
@@ -382,18 +366,6 @@ public class NewRSConnectAuthPage
       });
    }
    
-   private boolean canSpawnAuthenticationWindow()
-   {
-      if (!Desktop.isDesktop())
-         return true;
-      
-      String platform = DesktopInfo.getPlatform();
-      if (platform.contentEquals("centos") || platform.contentEquals("rhel"))
-         return false;
-      
-      return true;
-   }
-   
    private OperationWithInput<Boolean> setOkButtonVisible_;
    
    private NewRSConnectAccountResult result_;
@@ -403,6 +375,4 @@ public class NewRSConnectAuthPage
    private Value<Boolean> waitingForAuth_ = new Value<Boolean>(false);
    private boolean runningAuthCompleteCheck_ = false;
    private ProgressIndicator wizardIndicator_;
-
-   public final static String AUTH_WINDOW_NAME = "rstudio_rsconnect_auth";
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSAccountConnector.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSAccountConnector.java
@@ -139,7 +139,6 @@ public class RSAccountConnector implements
                   });
                   wizard.showModal();
                   found = true;
-                  closeAuthWindowWhenFinished(wizard);
                   break;
                }
             }
@@ -246,8 +245,6 @@ public class RSAccountConnector implements
             showingWizard_ = false;
          }
       });
-
-      closeAuthWindowWhenFinished(wizard);
    }
    
    private void processDialogResult(final NewRSConnectAccountResult input, 
@@ -388,23 +385,6 @@ public class RSAccountConnector implements
    }-*/;
    
    
-   private void closeAuthWindowWhenFinished(PopupPanel panel)
-   {
-      if (Desktop.isDesktop())
-      {
-         panel.addCloseHandler(new CloseHandler<PopupPanel>()
-         {
-            @Override
-            public void onClose(CloseEvent<PopupPanel> arg0)
-            {
-               // take down the auth window if it's still showing
-               Desktop.getFrame().closeNamedWindow(
-                     NewRSConnectAuthPage.AUTH_WINDOW_NAME);
-            }
-         });
-      }
-   }
-
    private final GlobalDisplay display_;
    private final RSConnectServerOperations server_;
    private final OptionsLoader.Shim optionsLoader_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -587,6 +587,11 @@ public class UIPrefsAccessor extends Prefs
       return bool("publish_check_certificates", true);
    }
    
+   public PrefValue<Boolean> usePublishCABundle()
+   {
+      return bool("use_publish_ca_bundle", false);
+   }
+   
    public PrefValue<String> publishCABundle()
    {
       return string("publish_ca_bundle", "");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -581,7 +581,17 @@ public class UIPrefsAccessor extends Prefs
    {
       return bool("show_publish_diagnostics", false);
    }
-     
+   
+   public PrefValue<Boolean> publishCheckCertificates()
+   {
+      return bool("publish_check_certificates", true);
+   }
+   
+   public PrefValue<String> publishCABundle()
+   {
+      return string("publish_ca_bundle", "");
+   }
+   
    public PrefValue<Boolean> showRmdChunkOutputInline()
    {
       return bool("rmd_chunk_output_inline", true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PublishingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PublishingPreferencesPane.java
@@ -218,9 +218,15 @@ public class PublishingPreferencesPane extends PreferencesPane
       add(checkboxPref("Check SSL certificates when publishing",
             uiPrefs_.publishCheckCertificates()));
       
-      caBundlePath_ = new FileChooserTextBox("Use custom CA bundle:",
-            "(none)", null, null);
+      CheckBox useCaBundle = checkboxPref("Use custom CA bundle",
+            uiPrefs_.usePublishCABundle());
+      useCaBundle.addValueChangeHandler(
+            val -> caBundlePath_.setVisible(val.getValue()));
+      add(useCaBundle);
+
+      caBundlePath_ = new FileChooserTextBox("", "(none)", null, null);
       caBundlePath_.setText(uiPrefs_.publishCABundle().getValue());
+      caBundlePath_.setVisible(uiPrefs_.usePublishCABundle().getValue());
       add(caBundlePath_);
 
       server_.hasOrphanedAccounts(new ServerRequestCallback<Int>()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PublishingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PublishingPreferencesPane.java
@@ -33,6 +33,7 @@ import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.prefs.PreferencesDialogBaseResources;
 import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.core.client.widget.FileChooserTextBox;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ThemedButton;
@@ -212,6 +213,16 @@ public class PublishingPreferencesPane extends PreferencesPane
       add(checkboxPref("Show diagnostic information when publishing",
             uiPrefs_.showPublishDiagnostics()));
       
+      add(spacedBefore(headerLabel("SSL Certificates")));
+
+      add(checkboxPref("Check SSL certificates when publishing",
+            uiPrefs_.publishCheckCertificates()));
+      
+      caBundlePath_ = new FileChooserTextBox("Use custom CA bundle:",
+            "(none)", null, null);
+      caBundlePath_.setText(uiPrefs_.publishCABundle().getValue());
+      add(caBundlePath_);
+
       server_.hasOrphanedAccounts(new ServerRequestCallback<Int>()
       {
          @Override
@@ -240,6 +251,8 @@ public class PublishingPreferencesPane extends PreferencesPane
    public boolean onApply(RPrefs rPrefs)
    {
       boolean reload = super.onApply(rPrefs);
+      
+      uiPrefs_.publishCABundle().setGlobalValue(caBundlePath_.getText());
 
       return reload || reloadRequired_;
    }
@@ -390,6 +403,7 @@ public class PublishingPreferencesPane extends PreferencesPane
    private ThemedButton connectButton_;
    private ThemedButton disconnectButton_;
    private ThemedButton reconnectButton_;
+   private FileChooserTextBox caBundlePath_;
    private boolean reloadRequired_;
 }
 


### PR DESCRIPTION
This change contains three smaller changes which make it possible to authenticate and publish to RStudio Connect servers that use custom or self-signed SSL certificates using only the RStudio IDE (it was formerly necessary to use a series of `rsconnect` commands to make this work). 

They are as follows:

1. **Allow specifying a path to a custom CA bundle**. This path can also be set in an environment variable, or an R option; setting it in RStudio is a convenience for setting the R option, which is also reflected in the child precess that performs the deploy.
2. **Always use the system browser to authenticate**. We formerly used a window hosted by RStudio itself on the desktop; this improves window management but has caused a number of problems in edge cases, which range from difficult to insurmountable (see #1541 and #3035).  
3. **Make it possible to skip the SSL certificate check**. This is of course not advisable, but can at a minimum be used to see if SSL certificates are the problem.

![image](https://user-images.githubusercontent.com/470418/41682063-82c868ee-748b-11e8-8ced-1997ab47f5fc.png)

Closes #1604. 