### PR TITLE
Remove obsolete ligature setting in Appearance

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -26,7 +26,7 @@
 @external gwt-TabLayoutPanel-Workbench;
 @external gwt-TabLayoutPanelTabs;
 @external gwt-DecoratedPopupPanel;
-@external editor_dark, editor_ligatures;
+@external editor_dark;
 
 @external windowframe, windowframe-maximized, windowframe-exclusive;
 
@@ -2036,10 +2036,6 @@ body.ubuntu_mono .searchBox {
    background-position: 2px center;
    background-image: ERRORDARK;
    background-size: 16px 14px;
-}
-
-.editor_ligatures .ace_editor {
-   text-rendering: optimizeLegibility;
 }
 
 .menuSubheader {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -347,11 +347,6 @@ public class UIPrefsAccessor extends Prefs
       return dbl("font_size_points", 10.0);
    }
    
-   public PrefValue<Boolean> useLigatures()
-   {
-      return bool("use_ligatures", false);
-   }
-
    public PrefValue<String> theme()
    {
       return string("theme", null);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AceEditorPreview.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AceEditorPreview.java
@@ -95,11 +95,6 @@ public class AceEditorPreview extends DynamicIFrame
                         setFont(ThemeFonts.getFixedWidthFont());
                         body.appendChild(style);
 
-                        ligatureStyle_ = doc.createStyleElement();
-                        ligatureStyle_.setAttribute("type", "text/css");
-                        body.appendChild(ligatureStyle_);
-                        setUseLigatures(useLigatures_);
-
                         DivElement div = doc.createDivElement();
                         div.setId("editor");
                         div.getStyle().setWidth(100, Unit.PCT);
@@ -198,22 +193,10 @@ public class AceEditorPreview extends DynamicIFrame
          setFontSize(fontSize_);
    }
    
-   public void setUseLigatures(boolean use)
-   {
-      useLigatures_ = use;
-      if (!isFrameLoaded_)
-         return;
-
-      ligatureStyle_.setInnerText(".ace_editor { text-rendering: " +
-               (use ? "optimizeLegibility" : "auto")  + "; }");
-   }
- 
    private LinkElement currentStyleLink_;
-   private StyleElement ligatureStyle_;
    private boolean isFrameLoaded_;
    private String themeUrl_;
    private Double fontSize_;
    private Double zoomLevel_;
-   private boolean useLigatures_ = false;
    private final String code_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -152,29 +152,6 @@ public class AppearancePreferencesPane extends PreferencesPane
          });
       }
 
-      // Ligatures are opt-in on desktop
-      if (Desktop.isDesktop())
-      {
-         // reduce padding on font face element to group with ligature check
-         fontFace_.getElement().getStyle().setMarginBottom(3, Unit.PX);
-         
-         // create checkbox for ligatures
-         useLigatures_ = new CheckBox("Use ligatures");
-         useLigatures_.setValue(uiPrefs.useLigatures().getValue());
-         leftPanel.add(useLigatures_);
-         useLigatures_.addValueChangeHandler(new ValueChangeHandler<Boolean>()
-         {
-            @Override
-            public void onValueChange(ValueChangeEvent<Boolean> event)
-            {
-               preview_.setUseLigatures(event.getValue());
-            }
-         });
-         
-         // add padding beneath 
-         useLigatures_.getElement().getStyle().setMarginBottom(12, Unit.PX);
-      }
-
       String[] labels = {"7", "8", "9", "10", "11", "12", "13", "14", "16", "18", "24", "36"};
       String[] values = new String[labels.length];
       for (int i = 0; i < labels.length; i++)
@@ -230,7 +207,6 @@ public class AppearancePreferencesPane extends PreferencesPane
       preview_.setWidth("278px");
       preview_.setTheme(themes.getThemeUrl(uiPrefs_.theme().getGlobalValue()));
       preview_.setFontSize(Double.parseDouble(fontSize_.getValue()));
-      preview_.setUseLigatures(uiPrefs.useLigatures().getValue());
       updatePreviewZoomLevel();
       previewPanel.add(preview_);
 
@@ -269,14 +245,6 @@ public class AppearancePreferencesPane extends PreferencesPane
    public boolean onApply(RPrefs rPrefs)
    {
       boolean restartRequired = super.onApply(rPrefs);
-
-      if (useLigatures_ != null)
-      {
-         // restart required to re-render with ligatures
-         restartRequired |= 
-               useLigatures_.getValue() != uiPrefs_.useLigatures().getValue();
-         uiPrefs_.useLigatures().setGlobalValue(useLigatures_.getValue());
-      }
 
       double fontSize = Double.parseDouble(fontSize_.getValue());
       uiPrefs_.fontSize().setGlobalValue(fontSize);
@@ -322,7 +290,6 @@ public class AppearancePreferencesPane extends PreferencesPane
    private String initialFontFace_;
    private SelectWidget zoomLevel_;
    private String initialZoomLevel_;
-   private CheckBox useLigatures_;
    private final SelectWidget flatTheme_;
    private EventBus eventBus_;
    private Boolean relaunchRequired_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
@@ -167,11 +167,6 @@ public class AceThemes
       
       addDarkClassIfNecessary(document, themeName);
       
-      if (prefs_.get().useLigatures().getValue())
-         document.getBody().addClassName("editor_ligatures");
-      else
-         document.getBody().removeClassName("editor_ligatures");
-      
       // Deferred so that the browser can render the styles.
       new Timer()
       {


### PR DESCRIPTION
In RStudio 1.1 on Windows and Linux, we had a Use Ligatures checkbox in the Appearances preference pane. This added a CSS class which was required to enable ligatures in QtWebKit.

In RStudio 1.2 this checkbox doesn't work because QtWebEngine uses ligatures by default.

It's technically possible make the option work again by having it forcibly *disable* ligatures in CSS using [font-variant-ligatures](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures), but little evidence anyone would actually find this useful, so I'm removing it entirely.