### PR TITLE
Remove dead code in client-side repository/sql paths

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/mirrors/ChooseMirrorDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mirrors/ChooseMirrorDialog.java
@@ -186,7 +186,6 @@ public class ChooseMirrorDialog extends ModalDialog<CRANMirror>
          public void onResponseReceived(JsArray<CRANMirror> mirrors)
          {   
             // keep internal list of mirrors 
-            boolean haveInsecureMirror = false;
             mirrors_ = new ArrayList<CRANMirror>(mirrors.length());
             
             // create list box and select default item
@@ -204,8 +203,6 @@ public class ChooseMirrorDialog extends ModalDialog<CRANMirror>
                   mirrors_.add(mirror);
                   String item = mirrorSource_.getLabel(mirror);
                   String value = mirrorSource_.getURL(mirror);
-                  if (!value.startsWith("https"))
-                     haveInsecureMirror = true;
 
                   listBox_.addItem(item, value);
                }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
@@ -250,7 +250,6 @@ public class PackagesPreferencesPane extends PreferencesPane
       cranMirrorTextBox_.setEnabled(true);
       if (!packagesPrefs.getCRANMirror().isEmpty())
       {
-         cranMirrorOriginal_ = cranMirror_ = packagesPrefs.getCRANMirror();
          secondaryReposWidget_.setCranRepoUrl(
             cranMirror_.getURL(),
             cranMirror_.getHost().equals("Custom")
@@ -301,22 +300,6 @@ public class PackagesPreferencesPane extends PreferencesPane
       
       useNewlineInMakefiles_.setEnabled(true);
       useNewlineInMakefiles_.setValue(packagesPrefs.getUseNewlineInMakefiles());
-   }
-
-   private boolean secondaryReposHasChanged()
-   {
-      ArrayList<CRANMirror> secondaryRepos = secondaryReposWidget_.getRepos();
-
-      if (secondaryRepos.size() != cranMirrorOriginal_.getSecondaryRepos().size())
-         return true;
-
-      for (int i = 0; i < secondaryRepos.size(); i++)
-      {
-         if (secondaryRepos.get(i) != cranMirrorOriginal_.getSecondaryRepos().get(i))
-            return true;
-      }
-
-      return false;
    }
 
    @Override
@@ -376,7 +359,6 @@ public class PackagesPreferencesPane extends PreferencesPane
    private final MirrorsServerOperations server_;
    
    private CRANMirror cranMirror_ = CRANMirror.empty();
-   private CRANMirror cranMirrorOriginal_ = CRANMirror.empty();
    private CheckBox useInternet2_;
    private TextBoxWithButton cranMirrorTextBox_;
    private CheckBox cleanupAfterCheckSuccess_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetSqlHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetSqlHelper.java
@@ -66,7 +66,6 @@ public class TextEditingTargetSqlHelper
    
    private SqlPreview parseSqlPreview()
    {
-      String code = "";
       String args = "";
       Boolean hasPreview = false;
 
@@ -90,14 +89,10 @@ public class TextEditingTargetSqlHelper
                }
             }
          }   
-         else
-         {
-            code += line + " ";
-         }
       }
       
       if (hasPreview) {
-         return new SqlPreview(args, code);
+         return new SqlPreview(args);
       } else {
          return null;
       }
@@ -106,14 +101,12 @@ public class TextEditingTargetSqlHelper
    
    private class SqlPreview 
    {
-      public SqlPreview(String args, String code)
+      public SqlPreview(String args)
       {
          this.args = args;
-         this.code = code;
       }
       
       public final String args;
-      public final String code;
    }
    
    private static final Pattern sqlPreviewPattern_ = 


### PR DESCRIPTION
This change resolves some Java warnings about unused variable values (i.e. values that are written but never read) and functions.

@javierluraschi This should be very safe to merge since the code is demonstrably unable to affect runtime, but wanted a second set of eyes on it in case one or more of these paths was intended to be used.