### PR TITLE
tweaks for data viewer performance

### DIFF
--- a/src/cpp/session/resources/grid/dtstyles.css
+++ b/src/cpp/session/resources/grid/dtstyles.css
@@ -34,6 +34,10 @@ table.dataTable tbody td {
     border-bottom: 1px solid #cfd4d8;
     border-right: 1px solid #cfd4d8;
     font-size: 11px;
+
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .rstudio-themes-flat table.dataTable tbody td  {
@@ -309,13 +313,6 @@ th:focus {
     text-align: right;
 }
 
-.numberCell, .textCell, .listCell, .dataCell {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    position: relative;
-}
-
 .rstudio-themes-flat.rstudio-themes-dark-grey *::selection {
     background: rgba(255, 255, 255, 0.15);
     color: #FFF;
@@ -339,7 +336,7 @@ th:focus {
     display: table;
 }
 
-.cell, .headerCell {
+.headerCell {
     position: relative;
 }
 
@@ -441,10 +438,6 @@ table.dataTable thead th.columnClickable .columnTypeHeader {
     width: 5px;
     cursor: ew-resize;
     z-index: 5;
-}
-
-.cell .resizer {
-    right: -7px;
 }
 
 .headerCell .resizer {

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -208,12 +208,10 @@ var renderCellClass = function (data, type, row, meta, clazz) {
   var title = null;
   if (typeof(data) === "string") 
      title = data.replace(/\"/g, "&quot;");
-  return '<div class="cell">' + 
-         '<div class="' + clazz + '" ' + 
-         (title !== null ? 'title="' + title + '"' : '') +
-         '>' + 
-         renderCellContents(data, type, row, meta, clazz) + '</div>' +
-         '<div class="resizer" data-col="' + meta.col + '" /></div>';
+
+  return '<span title="' + title + '">' +
+    renderCellContents(data, type, row, meta, clazz) +
+    '</span>';
 };
 
 // render a number cell


### PR DESCRIPTION
This PR makes a number of changes intended at improving the performance of the Data Viewer:

1. Rather than attempting to draw a resizer for each cell in the table, we only draw it for the table header. This implies that now the table can only be resized by clicking and dragging from the header, but it is consistent with other tables with resizable columns (e.g. in the Files pane). (It was observed that drawing and positioning the resizer for each cell independently was very expensive)

2. Given that we're no longer drawing a resize element for each cell, it suffices to just use a simple `<span>` element without any class styling (used just so we can attach the `title` element).

In my tests with a 100x100 table of numbers, layout changes require ~70ms to redraw versus ~170ms in the current daily build.

Closes https://github.com/rstudio/rstudio/issues/2962.