### PR TITLE
don't set breakpoints in Plumber API source files

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1439,6 +1439,13 @@ public class TextEditingTarget implements
                if (event.isSet())
                {
                   Breakpoint breakpoint = null;
+                 
+                  // don't set breakpoints in Plumber documents
+                  if (SourceDocument.isPlumberFile(extendedType_))
+                  {
+                     view_.showWarningBar("Breakpoints not supported in Plumber API files.");
+                     return;
+                  }
                   
                   // don't try to set breakpoints in unsaved code
                   if (isNewDoc())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -757,7 +757,7 @@ public class TextEditingTargetWidget
 
    private boolean isPlumberFile()
    {
-      return extendedType_ != null && extendedType_ == SourceDocument.XT_PLUMBER_API;
+      return SourceDocument.isPlumberFile(extendedType_);
    }
 
    private boolean isTestFile()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceDocument.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceDocument.java
@@ -174,6 +174,11 @@ public class SourceDocument extends JavaScriptObject
       return this.read_only_alternatives;
    }-*/;
    
+   public static boolean isPlumberFile(String extendedType)
+   {
+      return extendedType != null && extendedType == SourceDocument.XT_PLUMBER_API;
+   }
+   
    public final static String XT_RMARKDOWN = "rmarkdown";
    public final static String XT_SHINY_PREFIX = "shiny-";
    public final static String XT_SHINY_DIR = "shiny-dir";


### PR DESCRIPTION
Due to the way Plumber APIs are executed, breakpoints set in the IDE will never be hit when calling the APIs. This change disallows setting breakpoints in R source files containing Plumber annotations. Attempting to do so shows a warning bar:

![2018-06-22_21-12-11](https://user-images.githubusercontent.com/10569626/41805548-91799aa2-7661-11e8-8aa1-d793de2a2c48.png)

- fixes #3059 