### PR TITLE
Avoid flashing overlay scrollbars when showing/resizing DataGrids

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -34,6 +34,9 @@ import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.UIObject;
 import com.google.gwt.user.client.ui.Widget;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.Point;
@@ -623,28 +626,58 @@ public class DomUtils
                                boolean siblings, 
                                NodePredicate filter)
    {
+      List<Node> results = findNodes(start, 1, recursive, siblings, filter);
+      if (results.isEmpty())
+         return null;
+      return results.get(0);
+   }
+   
+   /**
+    * Finds all the nodes that match the predicate.
+    * 
+    * @param start The node from which to start.
+    * @param max The maximum number of nodes to find.
+    * @param recursive If true, recurses into child nodes.
+    * @param siblings If true, looks at the next sibling from "start".
+    * @param filter The predicate that determines a match.
+    * @return The first matching node encountered in documented order, or null.
+    */
+   public static List<Node> findNodes(Node start,
+                                      int max,
+                                      boolean recursive,
+                                      boolean siblings,
+                                      NodePredicate filter)
+   {
+      List<Node> results = new ArrayList<Node>();
+      int remaining = 0;
+      
       if (start == null)
-         return null ;
+         return results;
       
       if (filter.test(start))
-         return start ;
+      {
+         results.add(start);
+         if (results.size() >= max)
+            return results;
+      }
       
       if (recursive)
       {
-         Node result = findNode(start.getFirstChild(), true, true, filter) ;
-         if (result != null)
-            return result ;
+         remaining = max - results.size();
+         List<Node> matched = findNodes(start.getFirstChild(), remaining,
+               true, true, filter);
+         results.addAll(matched);
       }
       
-      if (siblings)
+      if (siblings && results.size() < max)
       {
-         Node result = findNode(start.getNextSibling(), recursive, true, 
-                                filter) ;
-         if (result != null)
-            return result ;
+         remaining = max - results.size();
+         List<Node> matched = findNodes(start.getNextSibling(), remaining,
+               recursive, true, filter);
+         results.addAll(matched);
       }
       
-      return null ;
+      return results;
    }
 
    /**

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioDataGrid.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioDataGrid.java
@@ -1,0 +1,86 @@
+/*
+ * RStudioDataGrid.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.widget;
+
+import java.util.List;
+
+import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.dom.DomUtils;
+
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Node;
+import com.google.gwt.dom.client.Style.Overflow;
+import com.google.gwt.user.cellview.client.DataGrid;
+import com.google.gwt.view.client.ProvidesKey;
+
+public class RStudioDataGrid<T> extends DataGrid<T>
+{
+   public RStudioDataGrid()
+   {
+      super();
+   }
+   
+   public RStudioDataGrid(int max, DataGrid.Resources res)
+   {
+      super(max, res);
+   }
+   
+   public RStudioDataGrid(int max, DataGrid.Resources res, ProvidesKey<T> keyProvider)
+   {
+      super(max, res, keyProvider);
+   }
+   
+   @Override
+   public void onAttach()
+   {
+      super.onAttach();
+      
+      // None of the below is necessary unless on MacOS since that's the only
+      // platform that uses overlay scrollbars.
+      if (!BrowseCap.isMacintosh())
+         return;
+      
+      // GWT's DataGrid implementation adds a handful of nodes with aggressive
+      // inline styles in the header and footer of the grid. They're designed to
+      // help with scrolling, but in newer versions of Chromium, they cause
+      // horizontal overlay scrollbars to appear when the grid is created and
+      // whenever it's resized. The below tweaks these elements so that they
+      // don't have a scrollbar.
+      //
+      // Typically we'd use CSS here but these elements are buried, have no
+      // assigned class, and have all their style attributes applied inline, so
+      // instead we scan the attached DOM subtree and change the inline styles.
+      Element parent = getElement().getParentElement().getParentElement();
+      List<Node> matches = DomUtils.findNodes(parent, 10, true, false, node -> 
+      {
+         // Ignore text nodes, etc.
+         if (node.getNodeType() != Node.ELEMENT_NODE)
+            return false;
+
+         com.google.gwt.dom.client.Style style = Element.as(node).getStyle();
+         
+         // The scroll helpers are hidden, and set to appear behind the grid.
+         return style.getZIndex() == "-1" && 
+                style.getOverflow() == "scroll" &&
+                style.getVisibility() == "hidden";
+      });
+      
+      for (Node match: matches)
+      {
+         // Don't show scrollbars on these elements
+         Element.as(match).getStyle().setOverflow(Overflow.HIDDEN);
+      }
+   }
+}

--- a/src/gwt/src/org/rstudio/core/client/widget/VirtualizedDataGrid.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/VirtualizedDataGrid.java
@@ -1,7 +1,7 @@
 /*
  * VirtualizedDataGrid.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -23,7 +23,6 @@ import com.google.gwt.event.dom.client.ScrollEvent;
 import com.google.gwt.event.dom.client.ScrollHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.cellview.client.AbstractCellTable;
-import com.google.gwt.user.cellview.client.DataGrid;
 import com.google.gwt.user.cellview.client.DefaultCellTableBuilder;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.HeaderPanel;
@@ -33,7 +32,7 @@ import com.google.gwt.user.client.ui.ScrollPanel;
 // allowing the class to render large tables without overloading the DOM.
 // The main requirement is that all rows within the drawn table have the
 // same height.
-public abstract class VirtualizedDataGrid<T> extends DataGrid<T>
+public abstract class VirtualizedDataGrid<T> extends RStudioDataGrid<T>
 {
    public class TableBuilder extends DefaultCellTableBuilder<T>
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.css
@@ -64,6 +64,7 @@ td.expandCol
 {
    border: 1px solid #f0f0f0;
    border-right: none;
+   border-left: none;
    width: 20px;
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesList.java
@@ -26,6 +26,7 @@ import org.rstudio.core.client.cellview.LinkColumn;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.core.client.widget.RStudioDataGrid;
 import org.rstudio.studio.client.ResizableHeader;
 import org.rstudio.studio.client.common.filetypes.FileIconResources;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
@@ -71,7 +72,7 @@ public class FilesList extends Composite
                                                       dataProvider_.getList());
       
       // create cell table
-      filesDataGrid_ = new DataGrid<FileSystemItem>(
+      filesDataGrid_ = new RStudioDataGrid<FileSystemItem>(
                                           15,
                                           FilesListDataGridResources.INSTANCE,
                                           KEY_PROVIDER);


### PR DESCRIPTION
On MacOS, horizontal overlay scrollbars often flash in unpredictable locations when DataGrids appear and when they're resized. Via @hadley: 

![image](https://user-images.githubusercontent.com/470418/41931907-56bbe67e-7934-11e8-9ae3-6b15a1068ab4.png)

The cause of the problem turns out to be some internal elements created in GWT's `DataGrid` implementation. For reasons which are wholly unclear, Chrome draws horizontal overlay scrollbars for these elements when their widths are increased, even though they are not visible (i.e. have `visibility: hidden`). 

In a shameless removal of [Chesterson's Fence](https://en.wikipedia.org/wiki/Wikipedia:Chesterton%27s_fence), this change keeps the scrollbars concealed on these elements by scanning the DOM for them once, when the DataGrid is attached, and  turning off scrolling for the elements' contents.

Fixes #2808.