### PR TITLE
improve themeing for vignettes in dark themes

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
@@ -107,7 +107,8 @@ public class RStudioThemedFrame extends RStudioFrame
       {
          Document document = getWindow().getDocument();
          
-         if (customStyle == null) customStyle = "";
+         if (customStyle == null)
+            customStyle = "";
          
          customStyle += "\n" +
          ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar,\n" +

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -107,19 +107,7 @@ public class HelpPane extends WorkbenchPane
 
       frame_ = new RStudioThemedFrame(
          null,
-         ".rstudio-themes-flat.editor_dark div#TOC,\n" +
-         ".rstudio-themes-flat.editor_dark h1,\n" +
-         ".rstudio-themes-flat.editor_dark h2,\n" +
-         ".rstudio-themes-flat.editor_dark h3,\n" +
-         ".rstudio-themes-flat.editor_dark h4,\n" +
-         ".rstudio-themes-flat.editor_dark table {\n" +
-         "  background: none !important;\n" +
-         "  color: white !important;\n" +
-         "}\n" +
-         "\n" +
-         ".rstudio-themes-flat.editor_dark ::selection {\n" +
-         "  background-color: #CCC;\n" +
-         "}\n",
+         RES.editorStyles().getText(),
          null,
          false,
          RStudioThemes.isFlat());
@@ -771,10 +759,17 @@ public class HelpPane extends WorkbenchPane
       String topicTitle();
    }
    
+   public interface EditorStyles extends CssResource
+   {
+   }
+   
    public interface Resources extends ClientBundle
    {
       @Source("HelpPane.css")
       Styles styles();
+      
+      @Source("HelpPaneEditorStyles.css")
+      EditorStyles editorStyles();
    }
 
    private static final Resources RES = GWT.create(Resources.class);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPaneEditorStyles.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPaneEditorStyles.css
@@ -1,0 +1,70 @@
+@charset "UTF-8";
+
+@external rstudio-themes-flat;
+@external rstudio-themes-dark;
+@external rstudio-themes-scrollbars;
+@external editor_dark;
+@external ace_editor_theme;
+@external sourceLine
+@external odd
+@external even
+
+.rstudio-themes-flat.editor_dark div#TOC,
+.rstudio-themes-flat.editor_dark h1,
+.rstudio-themes-flat.editor_dark h2,
+.rstudio-themes-flat.editor_dark h3,
+.rstudio-themes-flat.editor_dark h4,
+.rstudio-themes-flat.editor_dark table {
+   background: none !important;
+}
+
+.rstudio-themes-flat.editor_dark h1,
+.rstudio-themes-flat.editor_dark h2,
+.rstudio-themes-flat.editor_dark h3,
+.rstudio-themes-flat.editor_dark h4 {
+   border-color: #6A6A6A !important;
+}
+
+.rstudio-themes-flat.editor_dark ::selection {
+   background-color: #CCC;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar,
+.rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {
+   background: #FFF;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark.editor_dark.ace_editor_theme a.sourceLine {
+   color: #A3A3A3 !important;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark.editor_dark.ace_editor_theme pre,
+.rstudio-themes-flat.rstudio-themes-dark.editor_dark.ace_editor_theme pre code {
+   background-color: #333;
+   color: #F7F7F7;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark.editor_dark.ace_editor_theme p code {
+   color: white !important;
+   background: none;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark.editor_dark.ace_editor_theme table thead,
+.rstudio-themes-flat.rstudio-themes-dark.editor_dark.ace_editor_theme table tr.even {
+   background-color: #333 !important;
+   border-color: #999 !important;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark.editor_dark.ace_editor_theme table tr.odd {
+   border-color: #999 !important;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark.editor_dark.ace_editor_theme table th,
+.rstudio-themes-flat.rstudio-themes-dark.editor_dark.ace_editor_theme table td {
+   border-color: #666 !important;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark.editor_dark.ace_editor_theme blockquote {
+   background-color: #333 !important;
+   border-radius: 3px;
+}


### PR DESCRIPTION
This PR improves the theming for vignettes as rendered in the help pane when a dark theme is active. Examples of before and after with a sample vignette:

Before:

<img width="379" alt="screen shot 2018-06-26 at 5 28 12 pm" src="https://user-images.githubusercontent.com/1976582/41946266-56b6b47e-7966-11e8-986d-49294cafa82f.png">


After:

<img width="375" alt="screen shot 2018-06-26 at 5 25 03 pm" src="https://user-images.githubusercontent.com/1976582/41946233-30c9724c-7966-11e8-9946-bd60163a543c.png">

Closes #2551.