### PR TITLE
remove specialized scrollbars from Packages pane

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -1093,5 +1093,27 @@ public class DomUtils
       disableAutoBehavior(w.getElement());
    }
    
+   public static final native int getScrollbarWidth()
+   /*-{
+      
+      // create our scroller
+      var div = $doc.createElement("div");
+      
+      // style to place offscreen
+      div.style.width    = "100px";
+      div.style.height   = "100px";
+      div.style.overflow = "scroll";
+      div.style.position = "absolute";
+      div.style.top      = "-10000px";
+      
+      // compute scrollbar width after attaching to DOM
+      $doc.body.appendChild(div);
+      var width = div.offsetWidth - div.clientWidth;
+      $doc.body.removeChild(div);
+      
+      return width;
+      
+   }-*/;
+   
    public static final int ESTIMATED_SCROLLBAR_WIDTH = 19;
 }

--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -1093,7 +1093,15 @@ public class DomUtils
       disableAutoBehavior(w.getElement());
    }
    
-   public static final native int getScrollbarWidth()
+   public static final int getScrollbarWidth()
+   {
+      if (SCROLLBAR_WIDTH == -1)
+         SCROLLBAR_WIDTH = getScrollbarWidthImpl();
+      
+      return SCROLLBAR_WIDTH;
+   }
+   
+   private static final native int getScrollbarWidthImpl()
    /*-{
       
       // create our scroller
@@ -1116,4 +1124,5 @@ public class DomUtils
    }-*/;
    
    public static final int ESTIMATED_SCROLLBAR_WIDTH = 19;
+   private static int SCROLLBAR_WIDTH = -1;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.cellview.ImageButtonColumn;
 import org.rstudio.core.client.cellview.LinkColumn;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.theme.res.ThemeStyles;
@@ -461,9 +462,13 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
       packagesTable_.setColumnWidth(browseColumn, 20, Unit.PX);
 
       // remove column is common (note that we allocate extra column
-      // width to provide space for a scrollbar)
+      // width to provide space for a scrollbar if needed)
+      int scrollWidth = DomUtils.getScrollbarWidth();
+      if (scrollWidth > 0)
+         scrollWidth += 3;
+      
       packagesTable_.addColumn(removeColumn, new TextHeader(""));
-      packagesTable_.setColumnWidth(removeColumn, 38, Unit.PX);
+      packagesTable_.setColumnWidth(removeColumn, 20 + scrollWidth, Unit.PX);
 
       packagesTable_.setTableBuilder(new 
             PackageTableBuilder(packagesTable_));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
@@ -460,9 +460,10 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
       packagesTable_.addColumn(browseColumn, new TextHeader(""));
       packagesTable_.setColumnWidth(browseColumn, 20, Unit.PX);
 
-      // remove column is common
+      // remove column is common (note that we allocate extra column
+      // width to provide space for a scrollbar)
       packagesTable_.addColumn(removeColumn, new TextHeader(""));
-      packagesTable_.setColumnWidth(removeColumn, 20, Unit.PX);
+      packagesTable_.setColumnWidth(removeColumn, 38, Unit.PX);
 
       packagesTable_.setTableBuilder(new 
             PackageTableBuilder(packagesTable_));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerDataGrid.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerDataGrid.java
@@ -876,7 +876,7 @@ public class ObjectExplorerDataGrid
          buttonWidth = 48;
 
       // add a bit of extra padding for the scroll bar
-      buttonWidth += 12;
+      buttonWidth += DomUtils.getScrollbarWidth();
       
       int totalWidth = getOffsetWidth();
       int remainingWidth = totalWidth - otherWidth - buttonWidth - 20;


### PR DESCRIPTION
GWT's DataGrid class attempts to draw its own specialized scrollbars, by placing an absolutely-positioned div of appropriate height with a slight blur to make the scrollbar transparent. Unfortunately, as a side effect of how GWT draws the scrollbar, it's possible to obscure the actual content in the associated table. This is especially an issue as in #3085 the scrollbar can effectively obscure buttons that we attempt to draw in the table.

The fix here is to delete the specialized GWT scrollbar element, and allow the browser to draw the scrollbar as appropriate. This also allows the browser to resize the table according to whether an overlay scrollbar is drawn, versus a regular space-occupying scrollbar.

Closes #3085.