### PR TITLE
mitigate issue with multiple 'tools:rstudio' on search path

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -842,36 +842,31 @@
 
 .rs.addFunction("assign", function(x, value)
 {
-   pos <- which(search() == "tools:rstudio")
-   if (length(pos))
-      assign(paste(".rs.cache.", x, sep = ""), value, pos = pos)
+   assign(paste(".rs.cache.", x, sep = ""), value, envir = .rs.toolsEnv())
 })
 
 .rs.addFunction("get", function(x)
 {
-   pos <- which(search() == "tools:rstudio")
-   if (length(pos))
-      tryCatch(
-         get(paste(".rs.cache.", x, sep = ""), pos = pos),
-         error = function(e) NULL
-      )
+   tryCatch(
+      get(paste(".rs.cache.", x, sep = ""), envir = .rs.toolsEnv()),
+      error = function(e) NULL
+   )
 })
 
 .rs.addFunction("mget", function(x = NULL)
 {
-   pos <- which(search() == "tools:rstudio")
-   if (length(pos))
-      tryCatch({
-         
+   tryCatch(
+      {
          objects <- if (is.null(x))
-            .rs.selectStartsWith(objects(pos = pos, all.names = TRUE), ".rs.cache")
+            .rs.selectStartsWith(objects(envir = .rs.toolsEnv(), all.names = TRUE), ".rs.cache")
          else
             paste(".rs.cache.", x, sep = "")
          
-         mget(objects, envir = as.environment(pos))
+         mget(objects, envir = .rs.toolsEnv())
       },
-         error = function(e) NULL
-      )
+      
+      error = function(e) NULL
+   )
 })
 
 .rs.addFunction("packageNameForSourceFile", function(filePath)

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -16,7 +16,7 @@
 # Put the autocompletion types in the .rs.Env environment so they're accessible
 # everywhere (sync with RCompletionManager.java)
 assign(x = ".rs.acContextTypes",
-       pos = which(search() == "tools:rstudio"),
+       envir = as.environment("tools:rstudio"),
        value = list(
           UNKNOWN            =  0,
           FUNCTION           =  1,
@@ -37,7 +37,7 @@ assign(x = ".rs.acContextTypes",
 
 # Sync with RCompletionTypes.java
 assign(x = ".rs.acCompletionTypes",
-       pos = which(search() == "tools:rstudio"),
+       envir = as.environment("tools:rstudio"),
        value = list(
           UNKNOWN     =  0,
           VECTOR      =  1,
@@ -2524,10 +2524,9 @@ assign(x = ".rs.acCompletionTypes",
    ## could be slow
    pkgCacheName <- ".completions.attachedPackagesCache"
    helpTopicsName <- ".completions.helpTopics"
-   rsEnvPos <- which(search() == "tools:rstudio")
    
    attachedPackagesCache <- tryCatch(
-      get(pkgCacheName, pos = rsEnvPos),
+      get(pkgCacheName, envir = .rs.toolsEnv()),
       error = function(e) character()
    )
    
@@ -2538,7 +2537,7 @@ assign(x = ".rs.acCompletionTypes",
    {
       assign(pkgCacheName,
              basename(paths),
-             pos = rsEnvPos)
+             envir = .rs.toolsEnv())
       
       # Get the set of help topics
       topics <- lapply(paths, .rs.readAliases)
@@ -2546,10 +2545,10 @@ assign(x = ".rs.acCompletionTypes",
       
       assign(helpTopicsName,
              topics,
-             pos = rsEnvPos)
+             envir = .rs.toolsEnv())
    }
    
-   aliases <- get(helpTopicsName, pos = rsEnvPos)
+   aliases <- get(helpTopicsName, envir = .rs.toolsEnv())
    
    ## If the token is of the form `<pkg>::<topic>`,
    ## then attempt to get the topic 'topic' for that
@@ -2576,7 +2575,7 @@ assign(x = ".rs.acCompletionTypes",
          if (!is.null(pkgPath))
          {
             aliases[[pkg]] <- .rs.readAliases(pkgPath)
-            assign(helpTopicsName, aliases, pos = rsEnvPos)
+            assign(helpTopicsName, aliases, envir = .rs.toolsEnv())
          }
       }
       


### PR DESCRIPTION
This PR attempts to mitigate issues that can occur if multiple copies of `tools:rstudio` end up on the search path.

Having multiple versions of `tools:rstudio` on the search path is almost certainly a bug in our initialization code somewhere; however, [users have run into this issue before](https://support.rstudio.com/hc/en-us/community/posts/115007560148-The-R-session-had-a-fatal-error-), and @MariaSemple has also bumped into this with some of the theme testing code.

The attempts to use `which(search() == "tools:rstudio")` were a bit misguided when `as.environment("tools:rstudio")` works fine and also succeeds when multiple copies of that environment end up on the search path.