### PR TITLE
choose appropriate package URL based on installed package type

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -296,6 +296,13 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    # mark whether packages are loaded
    ip$Loaded <- ip$Package %in% loadedNamespaces()
    
+   # get the CRAN repository URL, and remove a trailing slash if required
+   repos <- getOption("repos")
+   cran <- if ("CRAN" %in% names(repos))
+      gsub("/*$", "", repos[["CRAN"]])
+   else
+      "https://cran.rstudio.com"
+   
    # helper function for extracting information from a package's
    # DESCRIPTION file
    readPackageInfo <- function(pkgPath) {
@@ -323,13 +330,13 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
          url <- sprintf("https://www.bioconductor.org/packages/release/bioc/html/%s.html", desc$Package)
       } else if (identical(desc$Repository, "CRAN")) {
          source <- "CRAN"
-         url <- sprintf("https://cran.r-project.org/package=%s", desc$Package)
+         url <- sprintf("%s/package=%s", cran, desc$Package)
       } else if (!is.null(desc$GithubRepo)) {
          source <- "GitHub"
          url <- sprintf("https://github.com/%s/%s", desc$GithubUsername, desc$GithubRepo)
       } else {
          source <- "Unknown"
-         url <- sprintf("https://cran.r-project.org/package=%s", desc$Package)
+         url <- sprintf("%s/package=%s", cran, desc$Package)
       }
       
       list(

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -286,9 +286,12 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    # get the CRAN repository URL, and remove a trailing slash if required
    repos <- getOption("repos")
    cran <- if ("CRAN" %in% names(repos))
-      gsub("/*$", "", repos[["CRAN"]])
+      repos[["CRAN"]]
    else
-      "https://cran.rstudio.com"
+      .Call("rs_rstudioCRANReposUrl", PACKAGE = "(embedding)")
+   
+   # trim trailing slashes if necessary
+   cran <- gsub("/*", "", cran)
    
    # helper function for extracting information from a package's
    # DESCRIPTION file

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -335,7 +335,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
          Version     = desc$Version,
          Title       = desc$Title,
          Source      = source,
-         BrowseUrl   = url
+         BrowseUrl   = utils::URLencode(url)
       )
    }
    

--- a/src/gwt/src/org/rstudio/core/client/cellview/ImageButtonColumn.java
+++ b/src/gwt/src/org/rstudio/core/client/cellview/ImageButtonColumn.java
@@ -14,52 +14,124 @@
  */
 package org.rstudio.core.client.cellview;
 
+import static com.google.gwt.dom.client.BrowserEvents.CLICK;
+import static com.google.gwt.dom.client.BrowserEvents.KEYDOWN;
+
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.OperationWithInput;
 
-import com.google.gwt.cell.client.ButtonCell;
+import com.google.gwt.cell.client.AbstractCell;
 import com.google.gwt.cell.client.FieldUpdater;
-import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.cell.client.ValueUpdater;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.EventTarget;
+import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.cellview.client.Column;
 
-public class ImageButtonColumn<T> extends Column<T, String>
+public class ImageButtonColumn<T> extends Column<T, T>
 {
+   public static interface TitleProvider<U>
+   {
+      public String get(U object);
+   }
+   
+   private static class ImageButtonCell<U> extends AbstractCell<U>
+   {
+      public ImageButtonCell(final ImageResource2x image,
+                             final TitleProvider<U> titleProvider)
+      {
+         super(CLICK, KEYDOWN);
+         
+         image_ = image;
+         titleProvider_ = titleProvider;
+      }
+      
+      @Override
+      public void render(Context context,
+                         U value,
+                         SafeHtmlBuilder sb)
+      {
+         if (value != null)
+         {
+            sb.appendHtmlConstant("<span title=\"" + titleProvider_.get(value) + "\" " +
+                  "style=\"cursor: pointer;\">");
+            sb.append(image_.getSafeHtml());
+            sb.appendHtmlConstant("</span>");
+         }
+      }
+      
+      @Override
+      public void onBrowserEvent(Context context,
+                                 Element parent,
+                                 U value,
+                                 NativeEvent event,
+                                 ValueUpdater<U> valueUpdater)
+      {
+         super.onBrowserEvent(context, parent, value, event, valueUpdater);
+         
+         if (CLICK.equals(event.getType()))
+         {
+            EventTarget eventTarget = event.getEventTarget();
+            if (!Element.is(eventTarget))
+               return;
+            
+            if (parent.getFirstChildElement().isOrHasChild(Element.as(eventTarget))) {
+               // Ignore clicks that occur outside of the main element.
+               onEnterKeyDown(context, parent, value, event, valueUpdater);
+            }
+         }
+      }
+      
+      @Override
+      protected void onEnterKeyDown(Context context,
+                                    Element Parent,
+                                    U value,
+                                    NativeEvent event,
+                                    ValueUpdater<U> valueUpdater)
+      {
+         if (valueUpdater != null)
+            valueUpdater.update(value);
+      }
+      
+      private final ImageResource2x image_;
+      private final TitleProvider<U> titleProvider_;
+   }
+   
    public ImageButtonColumn(final ImageResource2x image,
                             final OperationWithInput<T> onClick,
-                            final String title)
+                            final TitleProvider<T> titleProvider)
    {
-      super(new ButtonCell(){
-         @Override
-         public void render(Context context, 
-                            SafeHtml value, 
-                            SafeHtmlBuilder sb) 
-         {   
-            if (value != null)
-            {
-               sb.appendHtmlConstant("<span title=\"" + title + "\" " +
-                                     "style=\"cursor: pointer;\">");
-               sb.append(image.getSafeHtml());
-               sb.appendHtmlConstant("</span>");
-            }
-         }                                
-      });
+      super(new ImageButtonCell<T>(image, titleProvider));
 
-      setFieldUpdater(new FieldUpdater<T,String>() {
-         public void update(int index, T object, String value)
+      setFieldUpdater(new FieldUpdater<T, T>() {
+         public void update(int index, T object, T value)
          {
             if (value != null)
                onClick.execute(object);
          }
       });
    }
-
+   
+   public ImageButtonColumn(final ImageResource2x image,
+                            final OperationWithInput<T> onClick,
+                            final String title)
+   {
+      this(image, onClick, new TitleProvider<T>()
+      {
+         @Override
+         public String get(T object)
+         {
+            return title;
+         }
+      });
+   }
 
    @Override
-   public String getValue(T object)
+   public T getValue(T object)
    {
       if (showButton(object))
-         return new String();
+         return object;
       else
          return null;
    }

--- a/src/gwt/src/org/rstudio/core/client/cellview/ImageButtonColumn.java
+++ b/src/gwt/src/org/rstudio/core/client/cellview/ImageButtonColumn.java
@@ -23,9 +23,12 @@ import org.rstudio.core.client.widget.OperationWithInput;
 import com.google.gwt.cell.client.AbstractCell;
 import com.google.gwt.cell.client.FieldUpdater;
 import com.google.gwt.cell.client.ValueUpdater;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.EventTarget;
 import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.safehtml.client.SafeHtmlTemplates;
+import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.cellview.client.Column;
 
@@ -34,6 +37,12 @@ public class ImageButtonColumn<T> extends Column<T, T>
    public static interface TitleProvider<U>
    {
       public String get(U object);
+   }
+   
+   public static interface RenderTemplates extends SafeHtmlTemplates
+   {
+      @Template("<span title=\"{1}\" style=\"cursor: pointer;\">{0}</span>")
+      SafeHtml render(SafeHtml image, String title);
    }
    
    private static class ImageButtonCell<U> extends AbstractCell<U>
@@ -54,10 +63,7 @@ public class ImageButtonColumn<T> extends Column<T, T>
       {
          if (value != null)
          {
-            sb.appendHtmlConstant("<span title=\"" + titleProvider_.get(value) + "\" " +
-                  "style=\"cursor: pointer;\">");
-            sb.append(image_.getSafeHtml());
-            sb.appendHtmlConstant("</span>");
+            sb.append(TEMPLATES.render(image_.getSafeHtml(), titleProvider_.get(value)));
          }
       }
       
@@ -140,4 +146,6 @@ public class ImageButtonColumn<T> extends Column<T, T>
    {
       return true;
    }
+   
+   private static final RenderTemplates TEMPLATES = GWT.create(RenderTemplates.class);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -717,7 +717,7 @@ public class Packages
    
    public void showHelp(PackageInfo packageInfo)
    {
-      events_.fireEvent(new ShowHelpEvent(packageInfo.getUrl())) ;
+      events_.fireEvent(new ShowHelpEvent(packageInfo.getHelpUrl())) ;
    }
    
    public void onPackageStateChanged(PackageStateChangedEvent event)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageInfo.java
@@ -19,6 +19,11 @@ import com.google.gwt.core.client.JavaScriptObject;
 
 public class PackageInfo extends JavaScriptObject 
 {
+   public static enum Source
+   {
+      Unknown, Base, Custom, CRAN, Bioconductor, GitHub
+   }
+   
    protected PackageInfo()
    {
    }
@@ -40,12 +45,16 @@ public class PackageInfo extends JavaScriptObject
       return this.desc == null ? "" : this.desc;
    }-*/;
    
-   public final native String getUrl() /*-{
-      return this.url;
+   public final native String getHelpUrl() /*-{
+      return "help/library/" + this.name + "/html/00Index.html";
    }-*/;
 
    public final native String getBrowseUrl() /*-{
-      return this.browse;
+      return this.browse_url;
+   }-*/;
+   
+   public final native String getPackageSource() /*-{
+      return this.source;
    }-*/;
    
    public final native boolean isLoaded() /*-{
@@ -118,4 +127,5 @@ public class PackageInfo extends JavaScriptObject
       packageInfo.loaded = loaded;
       return packageInfo;
    }-*/;
+   
 }


### PR DESCRIPTION
This PR augments the Packages pane's browse button in a number of ways:

1. We use information from the package's DESCRIPTION file to better select a URL. This is necessary for packages that were installed from Bioconductor, and helpful for packages that have their own dedicated website (e.g. `ggplot2` has `http://ggplot2.tidyverse.org`). We also navigate to the GitHub repository associated with a package for packages installed directly from GitHub.

2. Because base R packages don't have an external URL, we no longer draw a browse icon for these packages. Similarly, one shouldn't ever attempt to uninstall a base R package, so we also omit the remove package icon in that case as well.

Note that because this PR involves a rewrite of `.rs.listInstalledPackages()` some extra scrutiny is warranted, but I believe the newly-written version to be overall quite a bit simpler.