### PR TITLE
improve handling of NEWS navigation

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -29,19 +29,13 @@
    )
 })
 
-.rs.addFunction("withTimeLimit", function(time,
+.rs.addFunction("withTimeLimit", function(seconds,
                                           expr,
-                                          envir = parent.frame(),
                                           fail = NULL)
 {
-   setTimeLimit(elapsed = time, transient = TRUE)
+   setTimeLimit(elapsed = seconds, transient = TRUE)
    on.exit(setTimeLimit(), add = TRUE)
-   tryCatch(
-      eval(expr, envir = envir),
-      error = function(e) {
-         fail
-      }
-   )
+   tryCatch(expr, error = function(e) fail)
 })
 
 .rs.addFunction("startsWith", function(strings, string)

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2056,3 +2056,18 @@
 {
    .Call("rs_resolveAliasedPath", path, PACKAGE = "(embedding)")
 })
+
+.rs.addFunction("readPackageDescription", function(packagePath)
+{
+   # if this is an installed package with a package metafile,
+   # read from that location
+   metapath <- file.path(packagePath, "Meta/package.rds")
+   if (file.exists(metapath)) {
+      metadata <- readRDS(metapath)
+      return(as.list(metadata$DESCRIPTION))
+   }
+   
+   # otherwise, attempt to read DESCRIPTION directly
+   descPath <- file.path(packagePath, "DESCRIPTION")
+   read.dcf(descPath, all = TRUE)
+})

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -543,13 +543,6 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
       if (!hasSilent)
          addons <- c(addons, "-s")
       
-      # redirect stderr
-      hasStderrRedirect <-
-         grepl("\b--stderr -\b", extra)
-      
-      if (!hasStderrRedirect)
-         addons <- c(addons, "--stderr -")
-      
       if (nzchar(extra))
          extra <- paste(extra, paste(addons, collapse = " "))
       else

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -586,6 +586,10 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    
    # we failed to figure out the NEWS url; provide our first candidate
    # as the best guess
+   fmt <- "Failed to infer appropriate NEWS URL: using '%s' as best-guess candidate"
+   warning(sprintf(fmt, candidates[[1]]))
+   
+   # return that URL
    .rs.scalar(candidates[[1]])
 })
 

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -475,7 +475,8 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    else if (length(repos))
       repos[[1]]
    else
-      "https://cran.rstudio.com"
+      .Call("rs_rstudioCRANReposUrl", PACKAGE = "(embedding)")
+   cran <- gsub("/*$", "", cran)
    
    # check to see if this package was from Bioconductor. if so, we'll need
    # to construct a more appropriate url

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -485,10 +485,16 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    }
    
    for (candidate in candidates) {
+      
       url <- sprintf("%s/web/packages/%s/%s", cran, packageName, candidate)
-      status <- .rs.tryCatch(download.file(url, destfile = tempfile(), quiet = TRUE, mode = "wb"))
-      if (inherits(status, "error"))
+      
+      status <- .rs.withTimeLimit(5, {
+         .rs.tryCatch(download.file(url, destfile = tempfile(), quiet = TRUE, mode = "wb"))
+      })
+      
+      if (is.null(status) || inherits(status, "error"))
          next
+      
       
       if (identical(status, 0L))
          return(.rs.scalar(url))

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -468,6 +468,14 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    else
       "https://cran.rstudio.com"
    
+   # check to see if this package was from Bioconductor. if so, we'll need
+   # to construct a more appropriate url
+   desc <- .rs.tryCatch(.rs.readPackageDescription(file.path(libraryPath, packageName)))
+   prefix <- if (inherits(desc, "error") || !"biocViews" %in% names(desc))
+      file.path(cran, "web/packages")
+   else
+      "https://bioconductor.org/packages/release/bioc/news"
+   
    # the set of candidate URLs -- we use the presence of a NEWS or NEWS.md
    # to help us prioritize the order of checking.
    #
@@ -486,7 +494,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    
    for (candidate in candidates) {
       
-      url <- sprintf("%s/web/packages/%s/%s", cran, packageName, candidate)
+      url <- file.path(prefix, packageName, candidate)
       
       status <- .rs.withTimeLimit(5, {
          .rs.tryCatch(download.file(url, destfile = tempfile(), quiet = TRUE, mode = "wb"))

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -109,6 +109,7 @@ import org.rstudio.studio.client.workbench.views.console.shell.assist.HelpStrate
 import org.rstudio.studio.client.workbench.views.console.shell.assist.PythonCompletionManager;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.RCompletionManager;
 import org.rstudio.studio.client.workbench.views.output.lint.LintManager;
+import org.rstudio.studio.client.workbench.views.packages.ui.CheckForUpdatesDialog;
 import org.rstudio.studio.client.workbench.views.source.DocsMenu;
 import org.rstudio.studio.client.workbench.views.source.DocumentOutlineWidget;
 import org.rstudio.studio.client.workbench.views.source.NewPlumberAPI;
@@ -260,6 +261,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(NewConnectionPreInstallOdbcHost NewConnectionPreInstallOdbcHost);
    void injectMembers(SecondaryReposWidget widget);
    void injectMembers(SecondaryReposDialog widget);
+   void injectMembers(CheckForUpdatesDialog dialog);
    
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);
 

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1190,6 +1190,18 @@ public class RemoteServer implements Server
    {
       sendRequest(RPC_SCOPE, IGNORE_NEXT_LOADED_PACKAGE_CHECK, requestCallback);
    }
+   
+   public void getPackageNewsUrl(String packageName,
+                                 String libraryPath,
+                                 ServerRequestCallback<String> requestCallback)
+   {
+      JSONArray params = new JSONArrayBuilder()
+            .add(packageName)
+            .add(libraryPath)
+            .get();
+      
+      sendRequest(RPC_SCOPE, GET_PACKAGE_NEWS_URL, params, requestCallback);
+   }
 
    public void setCRANMirror(CRANMirror mirror,
                              ServerRequestCallback<Void> requestCallback)
@@ -5594,6 +5606,7 @@ public class RemoteServer implements Server
    private static final String INIT_DEFAULT_USER_LIBRARY = "init_default_user_library";
    private static final String LOADED_PACKAGE_UPDATES_REQUIRED = "loaded_package_updates_required";
    private static final String IGNORE_NEXT_LOADED_PACKAGE_CHECK = "ignore_next_loaded_package_check";
+   private static final String GET_PACKAGE_NEWS_URL = "get_package_news_url";
    private static final String GET_PACKAGE_INSTALL_CONTEXT = "get_package_install_context";
    private static final String IS_PACKAGE_LOADED = "is_package_loaded";
    private static final String SET_CRAN_MIRROR = "set_cran_mirror";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -409,7 +409,6 @@ public class Packages
    private void doUpdatePackages(final PackageInstallContext installContext)
    {
       new CheckForUpdatesDialog(
-         globalDisplay_,
          new ServerDataSource<JsArray<PackageUpdate>>() {
             public void requestData(
                ServerRequestCallback<JsArray<PackageUpdate>> requestCallback)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageUpdate.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageUpdate.java
@@ -37,10 +37,4 @@ public class PackageUpdate extends JavaScriptObject
    public final native String getAvailable() /*-{
       return this.available;
    }-*/;
-   
-  
-   
-   public final native String getNewsUrl() /*-{
-      return this.newsUrl;
-   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackagesServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackagesServerOperations.java
@@ -51,4 +51,9 @@ public interface PackagesServerOperations extends PackratServerOperations
    
    void ignoreNextLoadedPackageCheck(
                         ServerRequestCallback<Void> requestCallback);
+   
+   void getPackageNewsUrl(
+                        String packageName,
+                        String libraryPath,
+                        ServerRequestCallback<String> requestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/CheckForUpdatesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/CheckForUpdatesDialog.java
@@ -16,97 +16,139 @@ package org.rstudio.studio.client.workbench.views.packages.ui;
 
 import java.util.ArrayList;
 
-import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.cellview.ImageButtonColumn;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.widget.MessageDialog;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.core.client.widget.ProgressIndicator;
+import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.server.ServerDataSource;
+import org.rstudio.studio.client.server.ServerError;
+import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageUpdate;
+import org.rstudio.studio.client.workbench.views.packages.model.PackagesServerOperations;
 
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.cellview.client.TextColumn;
+import com.google.inject.Inject;
 
 public class CheckForUpdatesDialog extends PackageActionConfirmationDialog<PackageUpdate>
 {
-   public CheckForUpdatesDialog(
-         GlobalDisplay globalDisplay,
-         ServerDataSource<JsArray<PackageUpdate>> updatesDS,
-         OperationWithInput<ArrayList<PackageUpdate>> checkOperation,
-         Operation cancelOperation)
+   public CheckForUpdatesDialog(ServerDataSource<JsArray<PackageUpdate>> updatesDS,
+                                OperationWithInput<ArrayList<PackageUpdate>> checkOperation,
+                                Operation cancelOperation)
    {
       super("Update Packages", "Install Updates", updatesDS, checkOperation, cancelOperation);
+      RStudioGinjector.INSTANCE.injectMembers(this);
+      
+      indicator_ = addProgressIndicator();
+   }
+
+   @Inject
+   private void initialize(GlobalDisplay globalDisplay,
+                           PackagesServerOperations server)
+   {
       globalDisplay_ = globalDisplay;
+      server_ = server;
    }
 
    protected void showNoActionsRequired()
    {
       globalDisplay_.showMessage(
-                    MessageDialog.INFO, 
-                    "Check for Updates", 
-                    "All packages are up to date.");
-    
+            MessageDialog.INFO, 
+            "Check for Updates", 
+            "All packages are up to date.");
    }
-  
-  protected void addTableColumns(CellTable<PendingAction> table)
-  {
-    TextColumn<PendingAction> nameColumn = new TextColumn<PendingAction>() {
-        public String getValue(PendingAction action)
-        {
-           return action.getActionInfo().getPackageName();
-        } 
-     };  
-     table.addColumn(nameColumn, "Package");
-     table.setColumnWidth(nameColumn, 28, Unit.PCT);
-     
-     TextColumn<PendingAction> installedColumn = new TextColumn<PendingAction>() {
-        public String getValue(PendingAction action)
-        {
-           return action.getActionInfo().getInstalled();
-        } 
-     };  
-     table.addColumn(installedColumn, "Installed");
-     table.setColumnWidth(installedColumn, 28, Unit.PCT);
-     
-     TextColumn<PendingAction> availableColumn = new TextColumn<PendingAction>() {
-        public String getValue(PendingAction action)
-        {
-           return action.getActionInfo().getAvailable();
-        } 
-     };  
-     table.addColumn(availableColumn, "Available");
-     table.setColumnWidth(availableColumn, 28, Unit.PCT);
-     
-     ImageButtonColumn<PendingAction> newsColumn = 
-        new ImageButtonColumn<PendingAction>(
-          new ImageResource2x(ThemeResources.INSTANCE.newsButton2x()),
-          new OperationWithInput<PendingAction>() {
-            public void execute(PendingAction action)
-            {
-               GlobalDisplay.NewWindowOptions options = 
-                                 new GlobalDisplay.NewWindowOptions();
-               options.setName("_rstudio_package_news");
-               globalDisplay_.openWindow(action.getActionInfo().getNewsUrl(),
-                                         options);
-            }  
-          },
-          "Show package NEWS") 
-          {
-              @Override
-              protected boolean showButton(PendingAction action)
-              {
-                 return !StringUtil.isNullOrEmpty(
-                                         action.getActionInfo().getNewsUrl());
-              }
-          };
-     table.addColumn(newsColumn, "NEWS");
-     table.setColumnWidth(newsColumn, 16, Unit.PCT);
-  }
-  
-   private final GlobalDisplay globalDisplay_;
+
+   protected void addTableColumns(CellTable<PendingAction> table)
+   {
+      TextColumn<PendingAction> nameColumn = new TextColumn<PendingAction>() {
+         public String getValue(PendingAction action)
+         {
+            return action.getActionInfo().getPackageName();
+         } 
+      };  
+      table.addColumn(nameColumn, "Package");
+      table.setColumnWidth(nameColumn, 28, Unit.PCT);
+
+      TextColumn<PendingAction> installedColumn = new TextColumn<PendingAction>() {
+         public String getValue(PendingAction action)
+         {
+            return action.getActionInfo().getInstalled();
+         } 
+      };  
+      table.addColumn(installedColumn, "Installed");
+      table.setColumnWidth(installedColumn, 28, Unit.PCT);
+
+      TextColumn<PendingAction> availableColumn = new TextColumn<PendingAction>() {
+         public String getValue(PendingAction action)
+         {
+            return action.getActionInfo().getAvailable();
+         } 
+      };  
+      table.addColumn(availableColumn, "Available");
+      table.setColumnWidth(availableColumn, 28, Unit.PCT);
+
+      ImageButtonColumn<PendingAction> newsColumn = 
+            new ImageButtonColumn<PendingAction>(
+                  new ImageResource2x(ThemeResources.INSTANCE.newsButton2x()),
+                  new OperationWithInput<PendingAction>() {
+                     
+                     public void execute(PendingAction action)
+                     {
+                        indicator_.onProgress("Opening NEWS...");
+                        server_.getPackageNewsUrl(
+                              action.getActionInfo().getPackageName(),
+                              action.getActionInfo().getLibPath(),
+                              new ServerRequestCallback<String>()
+                              {
+                                 @Override
+                                 public void onResponseReceived(String response)
+                                 {
+                                    indicator_.clearProgress();
+                                    navigateToUrl(response);
+                                 }
+
+                                 @Override
+                                 public void onError(ServerError error)
+                                 {
+                                    indicator_.clearProgress();
+                                    Debug.logError(error);
+                                 }
+                              });
+
+                     }
+                  },
+                  "Show package NEWS");
+      table.addColumn(newsColumn, "NEWS");
+      table.setColumnWidth(newsColumn, 16, Unit.PCT);
+   }
+
+   private void navigateToUrl(String url)
+   {
+      if (url == null || url.length() == 0)
+      {
+         globalDisplay_.showErrorMessage(
+               "Error Opening NEWS",
+               "This package does not have a NEWS file or RStudio was unable to determine " +
+               "an appropriate NEWS URL for this package.");
+         return;
+      }
+      
+      GlobalDisplay.NewWindowOptions options = new GlobalDisplay.NewWindowOptions();
+      options.setName("_rstudio_package_news");
+      globalDisplay_.openWindow(url, options);
+   }
+   
+   private final ProgressIndicator indicator_;
+
+   // Injected ----
+   private GlobalDisplay globalDisplay_;
+   private PackagesServerOperations server_;
 }


### PR DESCRIPTION
This PR improves our ability to navigate to the CRAN NEWS file associated with a currently installed package.

Effectively, RStudio now tries multiple sets of links until it discovers one that does not 404; after discovering such a link it opens that link in the browser.

Note that with this change, we always show a NEWS link icon, but provide an error message to the user if we failed to figure out what the correct NEWS link is.

Closes #3082.