### PR TITLE
Require rsconnect 0.8.8; add unit test

### DIFF
--- a/src/cpp/session/SessionUserSettings.cpp
+++ b/src/cpp/session/SessionUserSettings.cpp
@@ -187,6 +187,9 @@ SEXP rs_writeUiPref(SEXP prefName, SEXP value)
    uiPrefs[pref] = prefValue;
    userSettings().setUiPrefs(uiPrefs);
 
+   // fire preferences saved event
+   module_context::events().onPreferencesSaved();
+
    return R_NilValue;
 }
 

--- a/src/cpp/session/SessionUserSettings.cpp
+++ b/src/cpp/session/SessionUserSettings.cpp
@@ -187,7 +187,7 @@ SEXP rs_writeUiPref(SEXP prefName, SEXP value)
    uiPrefs[pref] = prefValue;
    userSettings().setUiPrefs(uiPrefs);
 
-   // fire preferences saved event
+   // let other modules know we've updated the prefs
    module_context::events().onPreferencesSaved();
 
    return R_NilValue;

--- a/src/cpp/tests/testthat/test-rsconnect.R
+++ b/src/cpp/tests/testthat/test-rsconnect.R
@@ -1,5 +1,5 @@
 #
-# test-rssconnect.R
+# test-rsconnect.R
 #
 # Copyright (C) 2009-18 by RStudio, Inc.
 #

--- a/src/cpp/tests/testthat/test-rsconnect.R
+++ b/src/cpp/tests/testthat/test-rsconnect.R
@@ -1,0 +1,51 @@
+#
+# test-rssconnect.R
+#
+# Copyright (C) 2009-18 by RStudio, Inc.
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+context("rsconnect")
+
+test_that("setting UI prefs updates options", {
+   # save old preference values and restore on exit
+   checkCerts <- getOption("rsconnect.check.certificate")
+   caBundle <- getOption("rsconnect.ca.bundle")
+   on.exit({
+      options(rsconnect.check.certificate = checkCerts,
+              rsconnect.ca.bundle         = caBundle)
+   }, add = TRUE)
+
+   # save old UI prefs and restore on exit
+   publishCheckCertificates <- .rs.readUiPref("publish_check_certificates")
+   usePublishCaBundle <- .rs.readUiPref("use_publish_ca_bundle")
+   publishCaBundle <- .rs.readUiPref("publish_ca_bundle")
+   on.exit({
+      .rs.writeUiPref("publish_check_certificates", publishCheckCertificates)
+      .rs.writeUiPref("use_publish_ca_bundle", usePublishCaBundle)
+      .rs.writeUiPref("publish_ca_bundle", publishCaBundle)
+   }, add = TRUE)
+
+   # check toggle for certificates
+   .rs.writeUiPref("publish_check_certificates", TRUE)
+   expect_true(getOption("rsconnect.check.certificate"))
+   .rs.writeUiPref("publish_check_certificates", FALSE)
+   expect_false(getOption("rsconnect.check.certificate"))
+
+   # use a custom bundle
+   .rs.writeUiPref("publish_ca_bundle", "42")
+   .rs.writeUiPref("use_publish_ca_bundle", TRUE)
+   expect_equal(getOption("rsconnect.ca.bundle"), "42")
+
+   # don't use a bundle
+   .rs.writeUiPref("use_publish_ca_bundle", FALSE)
+   expect_null(getOption("rsconnect.ca.bundle"))
+})

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -212,7 +212,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       if (requiresRmarkdown)
          deps.addAll(rmarkdownDependencies());
       deps.add(Dependency.cranPackage("packrat", "0.4.8-1", true));
-      deps.add(Dependency.cranPackage("rsconnect", "0.8.5"));
+      deps.add(Dependency.cranPackage("rsconnect", "0.8.8"));
       
       withDependencies(
         "Publishing",


### PR DESCRIPTION
This change makes a few minor updates to the work done recently to support SSL options.

- rsconnect 0.8.8 (which is on CRAN) is now installed. Using an older version won't break publishing, but it won't respect the SSL options.
- A unit test has been added; it verifies that the R options track the UI options correctly. 