### PR TITLE
provide better defaults for API-created dialogs

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -424,14 +424,19 @@
 })
 
 .rs.addApiFunction("showDialog", function(title, message, url = "") {
+   
+   # ensure URL is a string
+   if (is.null(url) || is.na(url))
+      url <- ""
+   
    .Call("rs_showDialog",
       title = title,
       message = message,
       dialogIcon = .rs.dialogIcon()$info,
       prompt = FALSE,
-      promptDefault = NULL,
-      ok = NULL,
-      cancel = NULL,
+      promptDefault = "",
+      ok = "OK",
+      cancel = "Cancel",
       url = url)
 })
 
@@ -444,18 +449,31 @@
 })
 
 .rs.addApiFunction("showPrompt", function(title, message, default = "") {
+   
+   # ensure default is a string
+   if (is.null(default) || is.na(default))
+      default <- ""
+   
    .Call("rs_showDialog",
       title = title,
       message = message,
       dialogIcon = .rs.dialogIcon()$info,
       prompt = TRUE,
       promptDefault = default,
-      ok = NULL,
-      cancel = NULL,
-      url = NULL)
+      ok = "OK",
+      cancel = "Cancel",
+      url = "")
 })
 
-.rs.addApiFunction("showQuestion", function(title, message, ok = "", cancel = "") {
+.rs.addApiFunction("showQuestion", function(title, message, ok = "OK", cancel = "Cancel") {
+   
+   # fix up ok, cancel
+   if (is.null(ok) || is.na(ok))
+      ok <- "OK"
+   
+   if (is.null(cancel) || is.na(cancel))
+      cancel <- "Cancel"
+   
    .Call("rs_showDialog",
       title = title,
       message = message,


### PR DESCRIPTION
This fixes an issue where attempts to generate RStudio dialogs using the default values for e.g. url, ok, cancel could introduce `NA` values into the generated UI, e.g.

---

![screen shot 2018-07-02 at 3 23 21 pm](https://user-images.githubusercontent.com/1976582/42189165-efb61f6c-7e0b-11e8-94c7-84b065a6cadb.png)
![screen shot 2018-07-02 at 3 23 05 pm](https://user-images.githubusercontent.com/1976582/42189166-efcd9282-7e0b-11e8-9be1-5b02a5301d77.png)
![screen shot 2018-07-02 at 3 22 48 pm](https://user-images.githubusercontent.com/1976582/42189168-efe437e4-7e0b-11e8-8d04-90b53f86741f.png)

The ultimate cause here is an impedance mismatch between RStudio and rstudioapi: the defaults for these arguments in `rstudioapi` are `NULL`, but the default conversion of `NULL` objects by RStudio when converting to strings is (surprisingly) the string "NA" rather than an empty string.