### PR TITLE
disable macOS-specific Cmd+Shift+/ handling (closes #2443)

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -74,6 +74,8 @@ GwtCallback::GwtCallback(MainWindow* pMainWindow, GwtWindow* pOwner)
      pSynctex_(nullptr),
      pendingQuit_(PendingQuitNone)
 {
+   initialize();
+   
 #ifdef Q_OS_LINUX
    // listen for clipboard selection change events (X11 only); allow override in options or 
    // via environment variable. clipboard monitoring enables us to support middle-click paste on
@@ -96,6 +98,17 @@ GwtCallback::GwtCallback(MainWindow* pMainWindow, GwtWindow* pOwner)
       }
    }
 #endif
+}
+
+#ifndef Q_OS_MAC
+void GwtCallback::initialize()
+{
+}
+#endif
+
+void GwtCallback::invokeReflowComment()
+{
+   pMainWindow_->invokeCommand(QStringLiteral("reflowComment"));
 }
 
 Synctex& GwtCallback::synctex()

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -57,7 +57,7 @@ class GwtCallback : public QObject
 
 public:
    GwtCallback(MainWindow* pMainWindow, GwtWindow* pOwner);
-
+   void initialize();
    int collectPendingQuitRequest();
 
 Q_SIGNALS:
@@ -242,8 +242,8 @@ public Q_SLOTS:
    QString getDisplayDpi();
 
 private:
+   void invokeReflowComment();
    Synctex& synctex();
-
    void activateAndFocusOwner();
 
 private:

--- a/src/cpp/desktop/DesktopGwtCallbackMac.mm
+++ b/src/cpp/desktop/DesktopGwtCallbackMac.mm
@@ -178,6 +178,29 @@ bool showOfficeDoc(NSString* path, NSString* appName, NSString* formatString)
 
 RS_END_NAMESPACE()
 
+void GwtCallback::initialize()
+{
+   [NSEvent addLocalMonitorForEventsMatchingMask: NSKeyDownMask
+                                         handler: ^(NSEvent* event)
+    {
+       // detect attempts to run Command + Shift + /, and let our own
+       // reflow comment code run instead
+       if (event.keyCode == 44 &&
+           (event.modifierFlags & NSEventModifierFlagShift) != 0 &&
+           (event.modifierFlags & NSEventModifierFlagCommand) != 0 &&
+           (event.modifierFlags & NSEventModifierFlagControl) == 0 &&
+           (event.modifierFlags & NSEventModifierFlagOption) == 0 &&
+           (event.modifierFlags & NSEventModifierFlagFunction) == 0)
+       {
+          invokeReflowComment();
+          return (NSEvent*) nil;
+       }
+       
+       return event;
+    }];
+
+}
+
 int GwtCallback::showMessageBox(int type,
                                 QString qCaption,
                                 QString qMessage,

--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -85,7 +85,7 @@ MainWindow::MainWindow(QUrl url) :
    pMainMenuStub->addMenu(QString::fromUtf8("Help"));
    setMenuBar(pMainMenuStub);
 #endif
-
+   
    connect(&menuCallback_, SIGNAL(menuBarCompleted(QMenuBar*)),
            this, SLOT(setMenuBar(QMenuBar*)));
    connect(&menuCallback_, SIGNAL(commandInvoked(QString)),


### PR DESCRIPTION
This PR is an attempt to resolve #2443. We attach our own Cocoa key handler, detect attempts to press <kbd>Command + Shift + /</kbd>, and then re-route that command to reflow comments explicitly.

TODO: I plan to investigate whether we can just route this to the ShortcutManager to execute whatever command is associated with this key combination (in case the user has rebound commands)