### PR TITLE
avoid double init of pdf.js window UI

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/pdfviewer/model/PdfJsWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/pdfviewer/model/PdfJsWindow.java
@@ -1,5 +1,5 @@
 /*
- * PDFJsWindow.java
+ * PdfJsWindow.java
  *
  * Copyright (C) 2009-14 by RStudio, Inc.
  *
@@ -48,6 +48,11 @@ public class PdfJsWindow extends WindowEx
       
       // runs when we detect that the document has fully loaded
       var initUi = function() {
+         
+         // bail if we're already initialized
+         if (win.initialized)
+            return;
+         
          // inject our own CSS
          var rstudioCss = win.document.createElement("link");
          rstudioCss.rel = "stylesheet";
@@ -125,6 +130,8 @@ public class PdfJsWindow extends WindowEx
          win.addEventListener("click", function(evt) {
             @org.rstudio.studio.client.pdfviewer.model.PdfJsWindow::firePageClickEvent(Lorg/rstudio/studio/client/pdfviewer/model/PdfJsWindow;Lcom/google/gwt/dom/client/NativeEvent;Lcom/google/gwt/dom/client/Element;)(win, evt, evt.target);
          });
+         
+         win.initialized = true;
       };
 
       // starts a timer that initializes the UI when the PDFView object appears


### PR DESCRIPTION
In the macOS dailies, I was seeing `pdf.js` windows initialized twice. This had the side-effect of unnecessarily drawing a synctex button, as the associated code that hides the button when disabled was getting overridden by the newly-created button on the second initialization attempt.

This PR just introduces a flag to ensure initialization only happens once. In theory, it might be preferable to reason through the various codepaths that request window initialization and ensure only one is called, but making this routine idempotent seems sensible.