### PR TITLE
omit library path when un-needed; use absolute library path otherwise

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -389,6 +389,8 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    packages <- data.frame(
       name             = info$Package,
       library          = .rs.createAliasedPath(info$LibPath),
+      library_absolute = info$LibPath,
+      library_index    = match(info$LibPath, .libPaths(), nomatch = 0L),
       version          = info$Version,
       desc             = info$Title,
       loaded           = info$Loaded,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -684,33 +684,41 @@ public class Packages
       server_.getPackageState(manualUpdate, new PackageStateUpdater());
    }
 
-   public void loadPackage(final String packageName, final String libName)
-   {  
+   public void loadPackage(PackageInfo info)
+   {
       // check status to make sure the package was unloaded
-      checkPackageStatusOnNextConsolePrompt(packageName, libName);
+      checkPackageStatusOnNextConsolePrompt(info.getName(), info.getLibrary());
       
       // send the command
       StringBuilder command = new StringBuilder();
-      command.append("library(\"");
-      command.append(packageName);
-      command.append("\"");
-      command.append(", lib.loc=\"");
-      command.append(libName.replaceAll("\\\\", "\\\\\\\\"));
-      command.append("\"");
-      command.append(")");
+      if (info.getLibraryIndex() == 1)
+      {
+         command.append("library(")
+                .append(info.getName())
+                .append(")");
+      }
+      else
+      {
+         command.append("library(")
+                .append(info.getName())
+                .append(", lib.loc = \"")
+                .append(info.getLibraryAbsolute().replaceAll("\\\\", "\\\\\\\\"))
+                .append("\")");
+      }
+      
       events_.fireEvent(new SendToConsoleEvent(command.toString(), true));
      
    }
 
-   public void unloadPackage(String packageName, String libName)
+   public void unloadPackage(PackageInfo info)
    { 
       // check status to make sure the package was unloaded
-      checkPackageStatusOnNextConsolePrompt(packageName, libName);
+      checkPackageStatusOnNextConsolePrompt(info.getName(), info.getLibrary());
       
       StringBuilder command = new StringBuilder();
       command.append("detach(\"package:");
-      command.append(packageName);
-      command.append("\", unload=TRUE)");
+      command.append(info.getName());
+      command.append("\", unload = TRUE)");
       events_.fireEvent(new SendToConsoleEvent(command.toString(), true));
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesDisplayObserver.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesDisplayObserver.java
@@ -19,8 +19,8 @@ import org.rstudio.studio.client.workbench.views.packages.model.PackageInfo;
 public interface PackagesDisplayObserver
 {
    void updatePackageState(boolean showProgress, boolean manualUpdate);
-   void loadPackage(String pkgName, String libName) ;
-   void unloadPackage(String pkgName, String libName) ;
+   void loadPackage(PackageInfo info) ;
+   void unloadPackage(PackageInfo info) ;
    void showHelp(PackageInfo packageInfo) ;
    void removePackage(PackageInfo packageInfo);
    void onPackageFilterChanged(String filter);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
@@ -547,11 +547,9 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
                else
                {
                   if (value.booleanValue())
-                     observer_.loadPackage(packageInfo.getName(),
-                                           packageInfo.getSourceLibrary()) ;
+                     observer_.loadPackage(packageInfo);
                   else
-                     observer_.unloadPackage(packageInfo.getName(),
-                                             packageInfo.getSourceLibrary()) ;
+                     observer_.unloadPackage(packageInfo);
                }
             }    
          });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageInfo.java
@@ -36,6 +36,14 @@ public class PackageInfo extends JavaScriptObject
    public final native String getLibrary() /*-{
       return this.library == null ? "" : this.library;
    }-*/;
+   
+   public final native String getLibraryAbsolute() /*-{
+      return this.library_absolute || "";
+   }-*/;
+   
+   public final native int getLibraryIndex() /*-{
+      return this.library_index || 0;
+   }-*/;
 
    public final native String getVersion() /*-{
       return this.version == null ? "" : this.version;


### PR DESCRIPTION
This PR tries to avoid generating R code that can run afoul of a strange R bug -- attempting to load `tidyverse` when using an aliased path for the library location can cause downstream errors when attempting to use sub-packages, e.g. `readr`. See https://github.com/tidyverse/tidyverse/issues/46 for more details.

Now, when attempting to load an R package from the default user library, RStudio omits `lib.loc` (as R will by default load the package from the first library in `.libPaths()`). If we do need to explicitly specify a library path, we use the absolute path to that library rather than an aliased path.

Closes #3130.