### PR TITLE
use embedded devtools for Qt 5.11

### DIFF
--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -238,8 +238,13 @@ bool isNonProjectFilename(const QString &filename)
    return filePath.exists() && filePath.extensionLowerCase() != ".rproj";
 }
 
-bool useChromiumDevtools()
+bool useRemoteDevtoolsDebugging()
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+   // don't need remote debugging for newer Qt
+   return false;
+#else
+   
    // disable by default due to security concerns
    // https://bugreports.qt.io/browse/QTBUG-50725
    bool useDevtools = false;
@@ -256,6 +261,8 @@ bool useChromiumDevtools()
    }
 
    return useDevtools;
+   
+#endif
 }
 
 } // anonymous namespace
@@ -268,7 +275,7 @@ int main(int argc, char* argv[])
    {
       initializeLang();
       
-      if (useChromiumDevtools())
+      if (useRemoteDevtoolsDebugging())
       {
          // use QTcpSocket to find an open port. this is unfortunately a bit racey
          // but AFAICS there isn't a better solution for port selection

--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -317,11 +317,15 @@ int main(int argc, char* argv[])
       static char enableViewport[] = "--enable-viewport";
       arguments.push_back(enableViewport);
       
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
+      
 #ifndef NDEBUG
       // disable web security for development builds (so we can
       // get access to sourcemaps)
       static char disableWebSecurity[] = "--disable-web-security";
       arguments.push_back(disableWebSecurity);
+#endif
+      
 #endif
       
       // disable chromium renderer accessibility by default (it can cause

--- a/src/cpp/desktop/DesktopWebView.cpp
+++ b/src/cpp/desktop/DesktopWebView.cpp
@@ -300,9 +300,13 @@ void WebView::contextMenuEvent(QContextMenuEvent* event)
    
 #else
    
+# ifndef NDEBUG
+   
    menu->addSeparator();
    menu->addAction(tr("&Reload"), [&]() { triggerPageAction(QWebEnginePage::Reload); });
    menu->addAction(webPage()->action(QWebEnginePage::InspectElement));
+   
+# endif
    
 #endif
    

--- a/src/cpp/desktop/DesktopWebView.cpp
+++ b/src/cpp/desktop/DesktopWebView.cpp
@@ -27,6 +27,8 @@
 
 #include <core/system/Environment.hpp>
 
+#include "DesktopBrowserWindow.hpp"
+
 #ifdef _WIN32
 #include <windows.h>
 #include <wingdi.h>
@@ -34,6 +36,46 @@
 
 namespace rstudio {
 namespace desktop {
+
+namespace {
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+
+class DevToolsWindow : public QMainWindow
+{
+public:
+   
+   DevToolsWindow()
+      : webPage_(new QWebEnginePage(this)),
+        webView_(new QWebEngineView(this))
+   {
+      webView_->setPage(webPage_);
+      
+      QScreen* screen = QApplication::primaryScreen();
+      QRect geometry = screen->geometry();
+      resize(geometry.width() * 0.7, geometry.height() * 0.7);
+      
+      setWindowTitle(QStringLiteral("RStudio DevTools"));
+      setAttribute(Qt::WA_DeleteOnClose, false);
+      setAttribute(Qt::WA_QuitOnClose, true);
+      
+      setUnifiedTitleAndToolBarOnMac(true);
+      setCentralWidget(webView_);
+   }
+   
+   QWebEnginePage* webPage() { return webPage_; }
+   QWebEngineView* webView() { return webView_; }
+   
+private:
+   QWebEnginePage* webPage_;
+   QWebEngineView* webView_;
+};
+
+std::map<QWebEnginePage*, DevToolsWindow*> s_devToolsWindows;
+
+#endif
+
+} // end anonymous namespace
 
 WebView::WebView(QUrl baseUrl, QWidget *parent, bool allowExternalNavigate) :
     QWebEngineView(parent),
@@ -229,10 +271,39 @@ void WebView::contextMenuEvent(QContextMenuEvent* event)
       menu->addAction(webPage()->action(QWebEnginePage::SelectAll));
    }
    
-#ifndef NDEBUG
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+   
+   menu->addSeparator();
+   menu->addAction(tr("&Reload"), [&]() { triggerPageAction(QWebEnginePage::Reload); });
+   menu->addAction(tr("&Inspect Element"), [&]() {
+      
+      QWebEnginePage* devToolsPage = webPage()->devToolsPage();
+      if (devToolsPage == nullptr)
+      {
+         DevToolsWindow* devToolsWindow = new DevToolsWindow();
+         devToolsPage = devToolsWindow->webPage();
+         webPage()->setDevToolsPage(devToolsPage);
+         
+         s_devToolsWindows[webPage()] = devToolsWindow;
+      }
+      
+      // make sure the devtools window is showing and focused
+      DevToolsWindow* devToolsWindow = s_devToolsWindows[webPage()];
+      
+      devToolsWindow->show();
+      devToolsWindow->raise();
+      devToolsWindow->setFocus();
+      
+      // we have a window; invoke Inspect Element now
+      webPage()->triggerAction(QWebEnginePage::InspectElement);
+   });
+   
+#else
+   
    menu->addSeparator();
    menu->addAction(tr("&Reload"), [&]() { triggerPageAction(QWebEnginePage::Reload); });
    menu->addAction(webPage()->action(QWebEnginePage::InspectElement));
+   
 #endif
    
    menu->setAttribute(Qt::WA_DeleteOnClose, true);


### PR DESCRIPTION
This PR makes use of Qt 5.11's embedded Chromium DevTools, and also implements the `Inspect Element` behavior we know and love from RStudio v1.1 -- spawning and focusing a new DevTools window as required, and then focusing the active element within.