### PR TITLE
change Dockerfile.windows build context dir to match Jenkins assumption

### DIFF
--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -54,7 +54,7 @@ RUN Invoke-WebRequest https://s3.amazonaws.com/rstudio-buildtools/test-qt-window
   Remove-Item c:\nsis-2.50-setup.exe
 
 # install qt (note that we are using the current directory's context)
-COPY dependencies\windows\qt-noninteractive-install-win.qs c:\qt-noninteractive-install-win.qs
+COPY windows\qt-noninteractive-install-win.qs c:\qt-noninteractive-install-win.qs
 RUN $ErrorActionPreference = 'Stop'; ``
    $ProgressPreference = 'SilentlyContinue' ;`
    Invoke-WebRequest https://s3.amazonaws.com/rstudio-buildtools/qt-unified-windows-x86-3.0.5-online.exe -OutFile c:\qt.exe ;`

--- a/docker/jenkins/windows/qt-noninteractive-install-win.qs
+++ b/docker/jenkins/windows/qt-noninteractive-install-win.qs
@@ -1,0 +1,61 @@
+
+function Controller() {
+    installer.autoRejectMessageBoxes();
+    installer.installationFinished.connect(function() {
+        gui.clickButton(buttons.NextButton);
+    })
+    installer.setMessageBoxAutomaticAnswer("cancelInstallation", QMessageBox.Yes);
+}
+
+Controller.prototype.WelcomePageCallback = function() {
+    gui.clickButton(buttons.NextButton, 3000);
+}
+
+Controller.prototype.CredentialsPageCallback = function() {
+    var widget = gui.currentPageWidget();
+    widget.loginWidget.EmailLineEdit.setText("");
+    widget.loginWidget.PasswordLineEdit.setText("");
+    gui.clickButton(buttons.NextButton, 500);
+}
+
+Controller.prototype.IntroductionPageCallback = function() {
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.TargetDirectoryPageCallback = function()
+{
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.ComponentSelectionPageCallback = function() {
+    var widget = gui.currentPageWidget();
+
+    widget.selectComponent("qt.qt5.5111.win64_msvc2017_64");
+    widget.selectComponent("qt.qt5.5111.qtwebengine");
+    widget.selectComponent("qt.qt5.5111.qtwebengine.win64_msvc2017_64");
+    widget.deselectComponent("qt.qt5.5111.src");
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.LicenseAgreementPageCallback = function() {
+    gui.currentPageWidget().AcceptLicenseRadioButton.setChecked(true);
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.StartMenuDirectoryPageCallback = function() {
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.ReadyForInstallationPageCallback = function()
+{
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.FinishedPageCallback = function() {
+    var checkBoxForm = gui.currentPageWidget().LaunchQtCreatorCheckBoxForm
+    if (checkBoxForm && checkBoxForm.launchQtCreatorCheckBox) {
+        checkBoxForm.launchQtCreatorCheckBox.checked = false;
+    }
+    gui.clickButton(buttons.FinishButton);
+}
+

--- a/docker/win-docker-compile.cmd
+++ b/docker/win-docker-compile.cmd
@@ -60,7 +60,7 @@ if defined DOCKER_GITHUB_LOGIN (
 )
 
 REM rebuild the image if necessary
-docker build --tag %REPO%:%IMAGE% --file docker\jenkins\Dockerfile.%IMAGE% %BUILD_ARGS% -m 2GB .
+docker build --tag %REPO%:%IMAGE% --file docker\jenkins\Dockerfile.%IMAGE% %BUILD_ARGS% -m 2GB .\docker\jenkins
 
 echo Produced image.
 exit /b 0


### PR DESCRIPTION
During Qt 5.11 work I changed `Dockerfile.windows` to assume docker build context is root of rstudio repo, but [Jenkins  build script](https://github.com/rstudio/aws/blob/master/ElasticComputeCloud/launch-scripts/jenkins-swarm-windows.ps1) assumes root is docker/jenkins.

Changed dockerfile to match Jenkins assumption in finding the Qt installation script, and duplicate the script from dependencies\windows.

Haven't tested this directly, going to let the build pipeline test it.