### PR TITLE
copy page region when exporting plot to clipboard

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -754,21 +754,10 @@ void GwtCallback::activateSatelliteWindow(QString name)
    pOwner_->webPage()->activateWindow(name);
 }
 
-void GwtCallback::copyImageToClipboard(int left, int top, int width, int height)
-{
-   // TODO: 'updatePositionDependentActions()' is no longer available;
-   // we might only be able to copy the currently selected image?
-   pOwner_->triggerPageAction(QWebEnginePage::CopyImageToClipboard);
-}
-
 void GwtCallback::copyPageRegionToClipboard(int left, int top, int width, int height)
 {
-   QPixmap pixmap = QPixmap::grabWidget(pMainWindow_->webView(),
-                                        left,
-                                        top,
-                                        width,
-                                        height);
-
+   auto* view = pMainWindow_->webView();
+   QPixmap pixmap = view->grab(QRect(left, top, width, height));
    QApplication::clipboard()->setPixmap(pixmap);
 }
 

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -129,9 +129,6 @@ public Q_SLOTS:
                               bool showToolbar);
    void closeNamedWindow(QString name);
 
-   // Image coordinates are relative to the window contents
-   void copyImageToClipboard(int left, int top, int width, int height);
-
    // coordinates are relative to entire containing web page
    void copyPageRegionToClipboard(int left, int top, int width, int height);
    void exportPageRegionToFile(QString targetPath,

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -88,14 +88,8 @@ public interface DesktopFrame extends JavaScriptPassthrough
          boolean showDesktopToolbar, Command onPrepared);
    void closeNamedWindow(String name);
    
-   // interface for plot export where coordinates are specified relative to
-   // the iframe where the image is located within
-   void copyImageToClipboard(int clientLeft,
-                             int clientTop,
-                             int clientWidth,
-                             int clientHeight);
-   
-   void copyPageRegionToClipboard(int left, int top, int width, int height);
+   void copyPageRegionToClipboard(int left, int top, int width, int height,
+                                  Command onCopied);
    
    void exportPageRegionToFile(String targetPath, 
                                String format, 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/clipboard/CopyPlotToClipboardDesktopDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/clipboard/CopyPlotToClipboardDesktopDialog.java
@@ -65,13 +65,18 @@ public class CopyPlotToClipboardDesktopDialog
             {
                ElementEx img = images.getItem(0).cast();
                DesktopFrame frame = Desktop.getFrame();
-               frame.copyImageToClipboard(img.getClientLeft(),
-                                          img.getClientTop(),
-                                          img.getClientWidth(),
-                                          img.getClientHeight());
+               frame.copyPageRegionToClipboard(
+                     img.getClientLeft(),
+                     img.getClientTop(),
+                     img.getClientWidth(),
+                     img.getClientHeight(),
+                     onCompleted::execute);
             }
-            
-            onCompleted.execute();
+            else
+            {
+               // shouldn't happen but make sure we clean up after
+               onCompleted.execute();
+            }
          }
       });
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/export/CopyViewerPlotToClipboardDesktopDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/export/CopyViewerPlotToClipboardDesktopDialog.java
@@ -46,7 +46,8 @@ public class CopyViewerPlotToClipboardDesktopDialog
                      viewerRect.getLeft(),
                      viewerRect.getTop(),
                      viewerRect.getWidth(),
-                     viewerRect.getHeight());
+                     viewerRect.getHeight(),
+                     onCompleted::execute);
             }
          
          },


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/2831.

The implementation of `copyImageToClipboard()` had effectively been stubbed out, due to changes in the Qt APIs in the WebKit -> Chromium changes. I erroneously thought things were working because the Copy Plot functionality worked on macOS, but we actually have a separate implementation for that altogether.

Qt also documents the `CopyImageToClipboard` action as only working in response to clicks; that is, the documentation purports that it is used to copy the clicked image to the clipboard. Since we don't have an actual click event here (although I suppose we could synthesize one if we really needed to?) the event is not processed as we would normally expect.

Because `copyImageToClipboard()` is no longer reliable, I've just removed its implementation and we now rely on `copyPageRegionToClipboard()` here.