### PR TITLE
show key as appropriate for current keyboard layout

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
@@ -28,7 +28,6 @@ import com.google.gwt.user.client.ui.MenuItem;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.SafeHtmlUtil;
 import org.rstudio.core.client.StringUtil;
-import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
 import org.rstudio.core.client.command.impl.DesktopMenuCallback;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.resources.ImageResource2x;

--- a/src/gwt/src/org/rstudio/core/client/command/ApplicationCommandManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ApplicationCommandManager.java
@@ -18,7 +18,6 @@ import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Pair;
 import org.rstudio.core.client.command.EditorCommandManager.EditorKeyBindings;
 import org.rstudio.core.client.command.KeyMap.KeyMapType;
-import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
 import org.rstudio.core.client.files.FileBacked;
 import org.rstudio.core.client.events.ExecuteAppCommandEvent;
 import org.rstudio.core.client.events.RStudioKeybindingsChangedEvent;

--- a/src/gwt/src/org/rstudio/core/client/command/EditorCommandManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/EditorCommandManager.java
@@ -21,7 +21,6 @@ import java.util.Set;
 
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.StringUtil;
-import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
 import org.rstudio.core.client.files.FileBacked;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.js.JsUtil;

--- a/src/gwt/src/org/rstudio/core/client/command/KeyCombination.java
+++ b/src/gwt/src/org/rstudio/core/client/command/KeyCombination.java
@@ -1,0 +1,153 @@
+/*
+ * KeyCombination.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.command;
+
+import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.dom.EventProperty;
+
+import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.event.dom.client.KeyCodes;
+
+public class KeyCombination
+{
+   public KeyCombination(NativeEvent event)
+   {
+      key_ = EventProperty.key(event);
+      keyCode_ = event.getKeyCode();
+      modifiers_ = KeyboardShortcut.getModifierValue(event);
+   }
+
+   public KeyCombination(String key,
+                         int keyCode,
+                         int modifiers)
+   {
+      key_ = key;
+      keyCode_ = keyCode;
+      modifiers_ = modifiers;
+   }
+
+   public String key()
+   {
+      return key_;
+   }
+
+   public int getKeyCode()
+   {
+      return keyCode_;
+   }
+
+   public int getModifier()
+   {
+      return modifiers_;
+   }
+
+   public boolean isCtrlPressed()
+   {
+      return (modifiers_ & KeyboardShortcut.CTRL) == KeyboardShortcut.CTRL;
+   }
+
+   public boolean isAltPressed()
+   {
+      return (modifiers_ & KeyboardShortcut.ALT) == KeyboardShortcut.ALT;
+   }
+
+   public boolean isShiftPressed()
+   {
+      return (modifiers_ & KeyboardShortcut.SHIFT) == KeyboardShortcut.SHIFT;
+   }
+
+   public boolean isMetaPressed()
+   {
+      return (modifiers_ & KeyboardShortcut.META) == KeyboardShortcut.META;
+   }
+
+   @Override
+   public String toString()
+   {
+      return toString(false);
+   }
+
+   public String toString(boolean pretty)
+   {
+      if (BrowseCap.hasMetaKey() && pretty)
+      {
+         return ((modifiers_ & KeyboardShortcut.CTRL) == KeyboardShortcut.CTRL ? "&#8963;" : "")
+               + ((modifiers_ & KeyboardShortcut.ALT) == KeyboardShortcut.ALT ? "&#8997;" : "")
+               + ((modifiers_ & KeyboardShortcut.SHIFT) == KeyboardShortcut.SHIFT ? "&#8679;" : "")
+               + ((modifiers_ & KeyboardShortcut.META) == KeyboardShortcut.META ? "&#8984;" : "")
+               + getKeyName(true);
+      }
+      else
+      {
+         return ((modifiers_ & KeyboardShortcut.CTRL) == KeyboardShortcut.CTRL ? "Ctrl+" : "")
+               + ((modifiers_ & KeyboardShortcut.ALT) == KeyboardShortcut.ALT ? "Alt+" : "")
+               + ((modifiers_ & KeyboardShortcut.SHIFT) == KeyboardShortcut.SHIFT ? "Shift+" : "")
+               + ((modifiers_ & KeyboardShortcut.META) == KeyboardShortcut.META ? "Cmd+" : "")
+               + getKeyName(pretty);
+      }
+   }
+
+   private String getKeyName(boolean pretty)
+   {
+      boolean macStyle = BrowseCap.hasMetaKey() && pretty;
+
+      if (keyCode_ == KeyCodes.KEY_ENTER)
+         return macStyle ? "&#8617;" : "Enter";
+      else if (keyCode_ == KeyCodes.KEY_LEFT)
+         return macStyle ? "&#8592;" : "Left";
+      else if (keyCode_ == KeyCodes.KEY_RIGHT)
+         return macStyle ? "&#8594;" : "Right";
+      else if (keyCode_ == KeyCodes.KEY_UP)
+         return macStyle ? "&#8593;" : "Up";
+      else if (keyCode_ == KeyCodes.KEY_DOWN)
+         return macStyle ? "&#8595;" : "Down";
+      else if (keyCode_ == KeyCodes.KEY_TAB)
+         return macStyle ? "&#8677;" : "Tab";
+      else if (keyCode_ == KeyCodes.KEY_PAGEUP)
+         return pretty ? "PgUp" : "PageUp";
+      else if (keyCode_ == KeyCodes.KEY_PAGEDOWN)
+         return pretty ? "PgDn" : "PageDown";
+      else if (keyCode_ == 8)
+         return macStyle ? "&#9003;" : "Backspace";
+
+      if (key_ != null)
+         return key_;
+
+      return KeyboardHelper.keyNameFromKeyCode(keyCode_);
+   }
+
+   @Override
+   public int hashCode()
+   {
+      int result = modifiers_;
+      result = (result << 8) + keyCode_;
+      return result;
+   }
+
+   @Override
+   public boolean equals(Object object)
+   {
+      if (object == null || !(object instanceof KeyCombination))
+         return false;
+
+      KeyCombination other = (KeyCombination) object;
+      return keyCode_ == other.keyCode_ &&
+            modifiers_ == other.modifiers_;
+   }
+
+   private final String key_;
+   private final int keyCode_;
+   private final int modifiers_;
+}

--- a/src/gwt/src/org/rstudio/core/client/command/KeyMap.java
+++ b/src/gwt/src/org/rstudio/core/client/command/KeyMap.java
@@ -25,8 +25,6 @@ import org.rstudio.core.client.DirectedGraph;
 import org.rstudio.core.client.Mutable;
 import org.rstudio.core.client.DirectedGraph.DefaultConstructor;
 import org.rstudio.core.client.DirectedGraph.ForEachNodeCommand;
-import org.rstudio.core.client.command.KeyboardShortcut.KeyCombination;
-import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
 import org.rstudio.core.client.container.SafeMap;
 
 public class KeyMap

--- a/src/gwt/src/org/rstudio/core/client/command/KeySequence.java
+++ b/src/gwt/src/org/rstudio/core/client/command/KeySequence.java
@@ -1,0 +1,203 @@
+/*
+ * KeySequence.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.command;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.rstudio.core.client.StringUtil;
+
+import com.google.gwt.dom.client.NativeEvent;
+
+public class KeySequence
+{
+   public KeySequence()
+   {
+      keyCombinations_ = new ArrayList<KeyCombination>();
+   }
+
+   public KeySequence(List<KeyCombination> keyList)
+   {
+      keyCombinations_ = new ArrayList<KeyCombination>(keyList);
+   }
+
+   public static KeySequence fromShortcutString(String shortcut)
+   {
+      KeySequence sequence = new KeySequence();
+      if (StringUtil.isNullOrEmpty(shortcut))
+         return sequence;
+
+      String[] splat = shortcut.split("\\s+");
+      for (int i = 0; i < splat.length; i++)
+      {
+         String sc = splat[i].toLowerCase();
+
+         int modifiers = KeyboardShortcut.NONE;
+         if (sc.indexOf("ctrl") != -1)
+            modifiers |= KeyboardShortcut.CTRL;
+         if (sc.indexOf("alt") != -1 || sc.indexOf("option") != -1)
+            modifiers |= KeyboardShortcut.ALT;
+         if (sc.indexOf("shift") != -1)
+            modifiers |= KeyboardShortcut.SHIFT;
+         if (sc.indexOf("meta") != -1 || sc.indexOf("cmd") != -1 || sc.indexOf("command") != -1)
+            modifiers |= KeyboardShortcut.META;
+
+         KeyCombination keyCombination;
+
+         if (sc.endsWith("-"))
+         {
+            keyCombination = new KeyCombination("-", KeyboardHelper.KEY_HYPHEN, modifiers);
+         }
+         else if (sc.endsWith("+"))
+         {
+            keyCombination = new KeyCombination("+", 187, modifiers);
+         }
+         else
+         {
+            String[] keySplit = sc.split("[-+]");
+            String key = keySplit[keySplit.length - 1];
+            int keyCode = KeyboardHelper.keyCodeFromKeyName(key);
+            keyCombination = new KeyCombination(key, keyCode, modifiers);
+         }
+
+         sequence.add(keyCombination);
+      }
+
+      return sequence;
+   }
+
+   public void set(KeySequence others)
+   {
+      keyCombinations_.clear();
+      keyCombinations_.addAll(others.keyCombinations_);
+   }
+
+   public void clear()
+   {
+      keyCombinations_.clear();
+   }
+
+   public KeySequence clone()
+   {
+      KeySequence clone = new KeySequence();
+      clone.keyCombinations_.addAll(keyCombinations_);
+      return clone;
+   }
+
+   public boolean isEmpty()
+   {
+      return keyCombinations_.isEmpty();
+   }
+
+   public int size()
+   {
+      return keyCombinations_.size();
+   }
+
+   public KeyCombination get(int index)
+   {
+      return keyCombinations_.get(index);
+   }
+
+   public void pop()
+   {
+      if (keyCombinations_ != null && keyCombinations_.size() > 0)
+         keyCombinations_.remove(keyCombinations_.size() - 1);
+   }
+   
+   public void add(NativeEvent event)
+   {
+      keyCombinations_.add(new KeyCombination(event));
+   }
+
+   public void add(KeyCombination combination)
+   {
+      keyCombinations_.add(combination);
+   }
+
+   public boolean startsWith(KeySequence other, boolean strict)
+   {
+      if (other.keyCombinations_.size() > keyCombinations_.size())
+         return false;
+
+      if (strict && other.keyCombinations_.size() == keyCombinations_.size())
+         return false;
+
+      for (int i = 0; i < other.keyCombinations_.size(); i++)
+         if (keyCombinations_.get(i) != other.keyCombinations_.get(i))
+            return false;
+
+      return true;
+   }
+
+   @Override
+   public String toString()
+   {
+      return toString(false);
+   }
+
+   public String toString(boolean pretty)
+   {
+      if (keyCombinations_.isEmpty())
+         return "";
+
+      StringBuilder builder = new StringBuilder();
+      builder.append(keyCombinations_.get(0).toString(pretty));
+      for (int i = 1; i < keyCombinations_.size(); i++)
+      {
+         builder.append(" ");
+         builder.append(keyCombinations_.get(i).toString(pretty));
+      }
+      return builder.toString();
+   }
+
+   @Override
+   public int hashCode()
+   {
+      int code = 1;
+      for (int i = 0; i < keyCombinations_.size(); i++)
+         code += (1 << (10 + i)) + keyCombinations_.get(i).hashCode();
+      return code;
+   }
+
+   @Override
+   public boolean equals(Object object)
+   {
+      if (object == null || !(object instanceof KeySequence))
+         return false;
+
+      KeySequence other = (KeySequence) object;
+      if (keyCombinations_ == null || other.keyCombinations_ == null)
+         return false;
+
+      if (keyCombinations_.size() != other.keyCombinations_.size())
+         return false;
+
+      for (int i = 0; i < keyCombinations_.size(); i++)
+         if (keyCombinations_.get(i) != other.keyCombinations_.get(i))
+            return false;
+
+      return true;
+   }
+
+   public List<KeyCombination> getData()
+   {
+      return keyCombinations_;
+   }
+
+   private final List<KeyCombination> keyCombinations_;
+}
+
+

--- a/src/gwt/src/org/rstudio/core/client/command/KeySequence.java
+++ b/src/gwt/src/org/rstudio/core/client/command/KeySequence.java
@@ -67,7 +67,7 @@ public class KeySequence
          else
          {
             String[] keySplit = sc.split("[-+]");
-            String key = keySplit[keySplit.length - 1];
+            String key = StringUtil.capitalize(keySplit[keySplit.length - 1]);
             int keyCode = KeyboardHelper.keyCodeFromKeyName(key);
             keyCombination = new KeyCombination(key, keyCode, modifiers);
          }

--- a/src/gwt/src/org/rstudio/core/client/command/KeyboardShortcut.java
+++ b/src/gwt/src/org/rstudio/core/client/command/KeyboardShortcut.java
@@ -15,351 +15,13 @@
 package org.rstudio.core.client.command;
 
 import com.google.gwt.dom.client.NativeEvent;
-import com.google.gwt.event.dom.client.KeyCodes;
-
-import org.rstudio.core.client.BrowseCap;
-import org.rstudio.core.client.StringUtil;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class KeyboardShortcut
 {
-   public static class KeyCombination
-   {
-      public KeyCombination(NativeEvent event)
-      {
-         keyCode_ = event.getKeyCode();
-         modifiers_ = getModifierValue(event);
-      }
-      
-      public KeyCombination(int keyCode, int modifiers)
-      {
-         keyCode_ = keyCode;
-         modifiers_ = modifiers;
-      }
-      
-      public int getKeyCode()
-      {
-         return keyCode_;
-      }
-      
-      public int getModifier()
-      {
-         return modifiers_;
-      }
-      
-      public boolean isCtrlPressed()
-      {
-         return (modifiers_ & CTRL) == CTRL;
-      }
-      
-      public boolean isAltPressed()
-      {
-         return (modifiers_ & ALT) == ALT;
-      }
-      
-      public boolean isShiftPressed()
-      {
-         return (modifiers_ & SHIFT) == SHIFT;
-      }
-      
-      public boolean isMetaPressed()
-      {
-         return (modifiers_ & META) == META;
-      }
-      
-      @Override
-      public String toString()
-      {
-         return toString(false);
-      }
-      
-      public String toString(boolean pretty)
-      {
-         if (BrowseCap.hasMetaKey() && pretty)
-         {
-            return ((modifiers_ & CTRL) == CTRL ? "&#8963;" : "")
-                  + ((modifiers_ & SHIFT) == SHIFT ? "&#8679;" : "")
-                  + ((modifiers_ & ALT) == ALT ? "&#8997;" : "")
-                  + ((modifiers_ & META) == META ? "&#8984;" : "")
-                  + getKeyName(true);
-         }
-         else
-         {
-            return ((modifiers_ & CTRL) == CTRL ? "Ctrl+" : "")
-                  + ((modifiers_ & SHIFT) == SHIFT ? "Shift+" : "")
-                  + ((modifiers_ & ALT) == ALT ? "Alt+" : "")
-                  + ((modifiers_ & META) == META ? "Cmd+" : "")
-                  + getKeyName(pretty);
-         }
-      }
-      
-      private String getKeyName(boolean pretty)
-      {
-         boolean macStyle = BrowseCap.hasMetaKey() && pretty;
-
-         if (keyCode_ == KeyCodes.KEY_ENTER)
-            return macStyle ? "&#8617;" : "Enter";
-         else if (keyCode_ == KeyCodes.KEY_LEFT)
-            return macStyle ? "&#8592;" : "Left";
-         else if (keyCode_ == KeyCodes.KEY_RIGHT)
-            return macStyle ? "&#8594;" : "Right";
-         else if (keyCode_ == KeyCodes.KEY_UP)
-            return macStyle ? "&#8593;" : "Up";
-         else if (keyCode_ == KeyCodes.KEY_DOWN)
-            return macStyle ? "&#8595;" : "Down";
-         else if (keyCode_ == KeyCodes.KEY_TAB)
-            return macStyle ? "&#8677;" : "Tab";
-         else if (keyCode_ == KeyCodes.KEY_PAGEUP)
-            return pretty ? "PgUp" : "PageUp";
-         else if (keyCode_ == KeyCodes.KEY_PAGEDOWN)
-            return pretty ? "PgDn" : "PageDown";
-         else if (keyCode_ == 8)
-            return macStyle ? "&#9003;" : "Backspace";
-
-         return KeyboardHelper.keyNameFromKeyCode(keyCode_);
-      }
-      
-      @Override
-      public int hashCode()
-      {
-         int result = modifiers_;
-         result = (result << 8) + keyCode_;
-         return result;
-      }
-      
-      @Override
-      public boolean equals(Object object)
-      {
-         if (object == null || !(object instanceof KeyCombination))
-            return false;
-         
-         KeyCombination other = (KeyCombination) object;
-         return keyCode_ == other.keyCode_ &&
-                modifiers_ == other.modifiers_;
-      }
-      
-      private final int keyCode_;
-      private final int modifiers_;
-   }
-   
-   public static class KeySequence
-   {
-      public KeySequence()
-      {
-         keyCombinations_ = new ArrayList<KeyCombination>();
-      }
-      
-      public KeySequence(int keyCode, int modifiers)
-      {
-         this();
-         keyCombinations_.add(new KeyCombination(keyCode, modifiers));
-      }
-      
-      public KeySequence(List<KeyCombination> keyList)
-      {
-         keyCombinations_ = new ArrayList<KeyCombination>(keyList);
-      }
-      
-      public static KeySequence fromShortcutString(String shortcut)
-      {
-         KeySequence sequence = new KeySequence();
-         if (StringUtil.isNullOrEmpty(shortcut))
-            return sequence;
-         
-         String[] splat = shortcut.split("\\s+");
-         for (int i = 0; i < splat.length; i++)
-         {
-            String sc = splat[i].toLowerCase();
-
-            int modifiers = KeyboardShortcut.NONE;
-            if (sc.indexOf("ctrl") != -1)
-               modifiers |= KeyboardShortcut.CTRL;
-            if (sc.indexOf("alt") != -1 || sc.indexOf("option") != -1)
-               modifiers |= KeyboardShortcut.ALT;
-            if (sc.indexOf("shift") != -1)
-               modifiers |= KeyboardShortcut.SHIFT;
-            if (sc.indexOf("meta") != -1 || sc.indexOf("cmd") != -1 || sc.indexOf("command") != -1)
-               modifiers |= KeyboardShortcut.META;
-
-            int keyCode = 0;
-            if (sc.endsWith("-"))
-            {
-               keyCode = KeyboardHelper.KEY_HYPHEN;
-            }
-            else if (sc.endsWith("+"))
-            {
-               keyCode = 187;
-            }
-            else
-            {
-               String[] keySplit = sc.split("[-+]");
-               String keyName = keySplit[keySplit.length - 1];
-
-               keyCode = KeyboardHelper.keyCodeFromKeyName(keyName);
-            }
-            sequence.add(keyCode, modifiers);
-         }
-         
-         return sequence;
-      }
-      
-      public void set(KeySequence others)
-      {
-         keyCombinations_.clear();
-         keyCombinations_.addAll(others.keyCombinations_);
-      }
-      
-      public void clear()
-      {
-         keyCombinations_.clear();
-      }
-      
-      public KeySequence clone()
-      {
-         KeySequence clone = new KeySequence();
-         clone.keyCombinations_.addAll(keyCombinations_);
-         return clone;
-      }
-      
-      public boolean isEmpty()
-      {
-         return keyCombinations_.isEmpty();
-      }
-      
-      public int size()
-      {
-         return keyCombinations_.size();
-      }
-      
-      public KeyCombination get(int index)
-      {
-         return keyCombinations_.get(index);
-      }
-      
-      public void add(NativeEvent event)
-      {
-         add(new KeyCombination(event.getKeyCode(), getModifierValue(event)));
-      }
-      
-      public void pop()
-      {
-         if (keyCombinations_ != null && keyCombinations_.size() > 0)
-            keyCombinations_.remove(keyCombinations_.size() - 1);
-      }
-      
-      public void add(int keyCode, int modifiers)
-      {
-         add(new KeyCombination(keyCode, modifiers));
-      }
-      
-      public void add(KeyCombination combination)
-      {
-         keyCombinations_.add(combination);
-      }
-      
-      public boolean startsWith(KeySequence other, boolean strict)
-      {
-         if (other.keyCombinations_.size() > keyCombinations_.size())
-            return false;
-         
-         if (strict && other.keyCombinations_.size() == keyCombinations_.size())
-            return false;
-         
-         for (int i = 0; i < other.keyCombinations_.size(); i++)
-            if (keyCombinations_.get(i) != other.keyCombinations_.get(i))
-               return false;
-         
-         return true;
-      }
-      
-      @Override
-      public String toString()
-      {
-         return toString(false);
-      }
-      
-      public String toString(boolean pretty)
-      {
-         if (keyCombinations_.isEmpty())
-            return "";
-         
-         StringBuilder builder = new StringBuilder();
-         builder.append(keyCombinations_.get(0).toString(pretty));
-         for (int i = 1; i < keyCombinations_.size(); i++)
-         {
-            builder.append(" ");
-            builder.append(keyCombinations_.get(i).toString(pretty));
-         }
-         return builder.toString();
-      }
-      
-      @Override
-      public int hashCode()
-      {
-         int code = 1;
-         for (int i = 0; i < keyCombinations_.size(); i++)
-            code += (1 << (10 + i)) + keyCombinations_.get(i).hashCode();
-         return code;
-      }
-      
-      @Override
-      public boolean equals(Object object)
-      {
-         if (object == null || !(object instanceof KeySequence))
-            return false;
-         
-         KeySequence other = (KeySequence) object;
-         if (keyCombinations_ == null || other.keyCombinations_ == null)
-            return false;
-         
-         if (keyCombinations_.size() != other.keyCombinations_.size())
-            return false;
-         
-         for (int i = 0; i < keyCombinations_.size(); i++)
-            if (keyCombinations_.get(i) != other.keyCombinations_.get(i))
-               return false;
-         
-         return true;
-      }
-      
-      public List<KeyCombination> getData()
-      {
-         return keyCombinations_;
-      }
-      
-      private final List<KeyCombination> keyCombinations_;
-   }
-   
-   public KeyboardShortcut(int keyCode)
-   {
-      this(keyCode, "");
-   }
-
-   public KeyboardShortcut(int keyCode, String groupName)
-   {
-      this(KeyboardShortcut.NONE, keyCode, groupName, "", "");
-   }
-   
-   public KeyboardShortcut(int modifiers, int keyCode)
-   {
-      this(modifiers, keyCode, "", "", "");
-   }
-   
-   public KeyboardShortcut(int modifiers, int keyCode, 
-                           String groupName, String title, String disableModes)
-   {
-      this(new KeySequence(keyCode, modifiers), groupName, title, disableModes);
-   }
-   
-   public KeyboardShortcut(KeySequence keySequence)
-   {
-      this(keySequence, "", "", "");
-   }
-   
    public KeyboardShortcut(KeySequence keySequence,
-                           String groupName, String title, String disableModes)
+                           String groupName,
+                           String title,
+                           String disableModes)
    {
       keySequence_ = keySequence;
       groupName_ = groupName;
@@ -367,6 +29,17 @@ public class KeyboardShortcut
       title_ = title;
       disableModes_ = ShortcutManager.parseDisableModes(disableModes);
    }
+   
+   public KeyboardShortcut(KeySequence keySequence)
+   {
+      this(keySequence, "", "", "");
+   }
+   
+   public KeyboardShortcut(String key, int keyCode, int modifiers)
+   {
+      this(keySequence(key, keyCode, modifiers));
+   }
+   
    
    public int getDisableModes()
    {
@@ -452,6 +125,15 @@ public class KeyboardShortcut
       if (e.getShiftKey())
          modifiers += SHIFT;
       return modifiers;
+   }
+   
+   private static KeySequence keySequence(String key,
+                                          int keyCode,
+                                          int modifiers)
+   {
+      KeySequence sequence = new KeySequence();
+      sequence.add(new KeyCombination(key, keyCode, modifiers));
+      return sequence;
    }
    
    private final KeySequence keySequence_;

--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
@@ -30,8 +30,6 @@ import org.rstudio.core.client.Pair;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.KeyMap.CommandBinding;
 import org.rstudio.core.client.command.KeyMap.KeyMapType;
-import org.rstudio.core.client.command.KeyboardShortcut.KeyCombination;
-import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.events.NativeKeyDownEvent;
 import org.rstudio.core.client.events.NativeKeyDownHandler;
@@ -182,8 +180,9 @@ public class ShortcutManager implements NativePreviewHandler,
       };
    }
    
-   public void register(int modifiers, 
-                        int keyCode, 
+   public void register(String key,
+                        int keyCode,
+                        int modifiers, 
                         AppCommand command, 
                         String groupName, 
                         String title,
@@ -192,26 +191,27 @@ public class ShortcutManager implements NativePreviewHandler,
       if (!BrowseCap.hasMetaKey() && (modifiers & KeyboardShortcut.META) != 0)
          return;
       
+      KeySequence keySequence = new KeySequence();
+      keySequence.add(new KeyCombination(key, keyCode, modifiers));
+      
       register(
-            new KeySequence(keyCode, modifiers),
+            keySequence,
             command,
             groupName,
             title,
             disableModes);
    }
    
-   public void register(int m1,
-                        int k1,
-                        int m2,
-                        int k2,
+   public void register(String k1, int c1, int m1,
+                        String k2, int c2, int m2,
                         AppCommand command,
                         String groupName,
                         String title,
                         String disableModes)
    {
       KeySequence sequence = new KeySequence();
-      sequence.add(k1, m1);
-      sequence.add(k2, m2);
+      sequence.add(new KeyCombination(k1, c1, m1));
+      sequence.add(new KeyCombination(k2, c2, m2));
       register(sequence, command, groupName, title, disableModes);
    }
    
@@ -430,16 +430,7 @@ public class ShortcutManager implements NativePreviewHandler,
          return false;
       }
       
-      int keyCode = event.getKeyCode();
-      int modifier = KeyboardShortcut.getModifierValue(event);
-      
-      // Convert Firefox hyphen key code and NumPad hyphen key code
-      // to 'normal' hyphen keycode since we have code wired to that
-      // expectation
-      if (keyCode == 109 || keyCode == 173)
-         keyCode = 189;
-      
-      KeyCombination keyCombination = new KeyCombination(keyCode, modifier);
+      KeyCombination keyCombination = new KeyCombination(event);
       
       // Disable 'Ctrl+F' keybinding when Ace editor in Vim mode
       // is focused.

--- a/src/gwt/src/org/rstudio/core/client/command/UserCommandManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/UserCommandManager.java
@@ -7,7 +7,6 @@ import com.google.gwt.user.client.Command;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
-import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.server.remote.ExecuteUserCommandEvent;

--- a/src/gwt/src/org/rstudio/core/client/dom/EventProperty.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/EventProperty.java
@@ -1,7 +1,7 @@
 /*
- * Bool.java
+ * EventProperty.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,14 +16,8 @@ package org.rstudio.core.client.dom;
 
 import com.google.gwt.dom.client.NativeEvent;
 
-public class Bool extends JavaScriptObject
+public class EventProperty
 {
-   protected Bool()
-   {
-   }
-   
-   public final native boolean getValue() /*-{
-      return this.value;
-   }-*/;
+   public static final native String key(NativeEvent event) /*-{ return event.key; }-*/;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
@@ -68,7 +68,6 @@ import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.*;
 import org.rstudio.core.client.command.EditorCommandManager.EditorKeyBinding;
 import org.rstudio.core.client.command.EditorCommandManager.EditorKeyBindings;
-import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
 import org.rstudio.core.client.command.ShortcutManager.Handle;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.DomUtils.ElementPredicate;

--- a/src/gwt/src/org/rstudio/studio/client/application/events/SetEditorCommandBindingsEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/SetEditorCommandBindingsEvent.java
@@ -16,7 +16,7 @@ package org.rstudio.studio.client.application.events;
 
 import java.util.List;
 
-import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
+import org.rstudio.core.client.command.KeySequence;
 
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
@@ -131,19 +131,6 @@ public class WebApplicationHeader extends Composite
       if (BrowseCap.INSTANCE.suppressBrowserForwardBack())
          suppressBrowserForwardBack();
 
-      // override Cmd+W keybaord shortcut for Chrome
-      if (BrowseCap.isChrome())
-      {
-         int modifiers = (BrowseCap.hasMetaKey() ? KeyboardShortcut.META : 
-                                                   KeyboardShortcut.CTRL) |
-                         KeyboardShortcut.ALT;
-             
-         AppCommand closeSourceDoc = commands.closeSourceDoc();
-         closeSourceDoc.setShortcut(new KeyboardShortcut(modifiers, 'W'));
-         ShortcutManager.INSTANCE.register(
-               modifiers, 'W', closeSourceDoc, "", "", "");
-      }
-      
       // main menu
       advertiseEditingShortcuts(globalDisplay, commands);
       WebMenuCallback menuCallback = new WebMenuCallback();
@@ -311,18 +298,27 @@ public class WebApplicationHeader extends Composite
       } catch(err) {}
    }-*/;
 
+   private static final void setCommandShortcut(AppCommand command,
+                                                String key,
+                                                int keyCode,
+                                                int modifiers)
+   {
+      KeySequence sequence = new KeySequence();
+      sequence.add(new KeyCombination(key, keyCode, modifiers));
+      command.setShortcut(new KeyboardShortcut(sequence));
+   }
    private void advertiseEditingShortcuts(final GlobalDisplay display,
                                           final Commands commands)
    {
-      int mod = BrowseCap.hasMetaKey() ? KeyboardShortcut.META : KeyboardShortcut.CTRL;
+      int modifiers = BrowseCap.hasMetaKey() ? KeyboardShortcut.META : KeyboardShortcut.CTRL;
 
-      commands.undoDummy().setShortcut(new KeyboardShortcut(mod, 'Z'));
-      commands.redoDummy().setShortcut(new KeyboardShortcut(mod| KeyboardShortcut.SHIFT, 'Z'));
+      setCommandShortcut(commands.undoDummy(),  "z", 'Z', modifiers);
+      setCommandShortcut(commands.redoDummy(),  "Z", 'Z', modifiers | KeyboardShortcut.SHIFT);
 
-      commands.cutDummy().setShortcut(new KeyboardShortcut(mod, 'X'));
-      commands.copyDummy().setShortcut(new KeyboardShortcut(mod, 'C'));
-      commands.pasteDummy().setShortcut(new KeyboardShortcut(mod, 'V'));
-
+      setCommandShortcut(commands.cutDummy(),   "x", 'X', modifiers);
+      setCommandShortcut(commands.copyDummy(),  "c", 'C', modifiers);
+      setCommandShortcut(commands.pasteDummy(), "v", 'V', modifiers);
+      
       CommandHandler useKeyboardNotification = new CommandHandler()
       {
          public void onCommand(AppCommand command)

--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/ShowPublicKeyDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/ShowPublicKeyDialog.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.common.vcs;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.command.KeyCombination;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.widget.FocusHelper;
 import org.rstudio.core.client.widget.FontSizer;
@@ -59,7 +60,7 @@ public class ShowPublicKeyDialog extends ModalDialogBase
       
       int mod = BrowseCap.hasMetaKey() ? KeyboardShortcut.META : 
                                          KeyboardShortcut.CTRL;
-      String cmdText = new KeyboardShortcut(mod, 'C').toString(true);
+      String cmdText = new KeyCombination("c", 'C', mod).toString(true);
       HTML label = new HTML("Press " + cmdText + 
                             " to copy the key to the clipboard");
       label.addStyleName(RES.styles().viewPublicKeyLabel());

--- a/src/gwt/src/org/rstudio/studio/client/server/Bool.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/Bool.java
@@ -12,9 +12,9 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
-package org.rstudio.core.client.dom;
+package org.rstudio.studio.client.server;
 
-import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.core.client.JavaScriptObject;
 
 public class Bool extends JavaScriptObject
 {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/addins/AddinsCommandManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/addins/AddinsCommandManager.java
@@ -11,7 +11,7 @@ import org.rstudio.core.client.command.EditorCommandManager.EditorKeyBindings;
 import org.rstudio.core.client.command.KeyMap;
 import org.rstudio.core.client.command.KeyMap.CommandBinding;
 import org.rstudio.core.client.command.KeyMap.KeyMapType;
-import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
+import org.rstudio.core.client.command.KeySequence;
 import org.rstudio.core.client.command.ShortcutManager;
 import org.rstudio.core.client.files.FileBacked;
 import org.rstudio.studio.client.application.events.EventBus;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
@@ -37,8 +37,8 @@ import com.google.gwt.user.client.ui.VerticalPanel;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.Rectangle;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.command.KeyCombination;
 import org.rstudio.core.client.command.KeyboardShortcut;
-import org.rstudio.core.client.command.KeyboardShortcut.KeyCombination;
 import org.rstudio.core.client.command.ShortcutManager;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.events.SelectionCommitEvent;
@@ -449,8 +449,8 @@ public class CompletionPopupPanel extends ThemedPopupPanel
    {
       resetIgnoredKeysHandle();
       Set<KeyCombination> keySet = new HashSet<KeyCombination>();
-      keySet.add(new KeyCombination(KeyCodes.KEY_N, KeyboardShortcut.CTRL));
-      keySet.add(new KeyCombination(KeyCodes.KEY_P, KeyboardShortcut.CTRL));
+      keySet.add(new KeyCombination("n", KeyCodes.KEY_N, KeyboardShortcut.CTRL));
+      keySet.add(new KeyCombination("p", KeyCodes.KEY_P, KeyboardShortcut.CTRL));
       handle_ = ShortcutManager.INSTANCE.addIgnoredKeys(keySet);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -392,23 +392,10 @@ public class Source implements InsertSourceHandler,
       }
 
       // fake shortcuts for commands which we handle at a lower level
-      commands.goToHelp().setShortcut(new KeyboardShortcut(112));
-      commands.goToDefinition().setShortcut(new KeyboardShortcut(113));
-      commands.codeCompletion().setShortcut(
-                                    new KeyboardShortcut(KeyCodes.KEY_TAB));
+      commands.goToHelp().setShortcut(new KeyboardShortcut("F1", KeyCodes.KEY_F1, KeyboardShortcut.NONE));
+      commands.goToDefinition().setShortcut(new KeyboardShortcut("F2", KeyCodes.KEY_F2, KeyboardShortcut.NONE));
+      commands.codeCompletion().setShortcut(new KeyboardShortcut("Tab", KeyCodes.KEY_TAB, KeyboardShortcut.NONE));
       
-      // See bug 3673 and https://bugs.webkit.org/show_bug.cgi?id=41016
-      if (BrowseCap.isMacintosh())
-      {
-         ShortcutManager.INSTANCE.register(
-               KeyboardShortcut.META | KeyboardShortcut.ALT,
-               192,
-               commands.executeNextChunk(), 
-               "Execute",
-               commands.executeNextChunk().getMenuLabel(false), 
-               "");
-      }
-
       events.addHandler(ShowContentEvent.TYPE, this);
       events.addHandler(ShowDataEvent.TYPE, this);
       events.addHandler(OpenObjectExplorerEvent.TYPE, this);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -58,7 +58,7 @@ import org.rstudio.core.client.ExternalJavaScriptLoader;
 import org.rstudio.core.client.ExternalJavaScriptLoader.Callback;
 import org.rstudio.core.client.Rectangle;
 import org.rstudio.core.client.StringUtil;
-import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
+import org.rstudio.core.client.command.KeySequence;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.js.JsMap;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.workbench.views.source.editors.text;
 
 import org.rstudio.core.client.Rectangle;
+import org.rstudio.core.client.command.KeySequence;
 
 import java.util.List;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -19,7 +19,6 @@ import org.rstudio.core.client.command.KeySequence;
 
 import java.util.List;
 
-import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
 import org.rstudio.core.client.events.HasContextMenuHandlers;
 import org.rstudio.core.client.js.JsMap;
 import org.rstudio.studio.client.common.debugging.model.Breakpoint;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -40,6 +40,7 @@ import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.MathUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppCommand;
+import org.rstudio.core.client.command.KeyCombination;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.events.EnsureHeightEvent;
@@ -320,7 +321,7 @@ public class TextEditingTargetWidget
       int mod = BrowseCap.hasMetaKey() ? KeyboardShortcut.META : 
          KeyboardShortcut.CTRL;
       String cmdText = 
-        new KeyboardShortcut(mod + KeyboardShortcut.SHIFT, 'K').toString(true);
+        new KeyCombination("K", 'K', mod + KeyboardShortcut.SHIFT).toString(true);
       cmdText = DomUtils.htmlToText(cmdText);
       notebookToolbarButton_.setTitle("Compile Report (" + cmdText + ")");
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceCommandManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceCommandManager.java
@@ -7,9 +7,9 @@ import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.JsArrayString;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.command.KeyCombination;
+import org.rstudio.core.client.command.KeySequence;
 import org.rstudio.core.client.command.KeyboardHelper;
-import org.rstudio.core.client.command.KeyboardShortcut.KeyCombination;
-import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.js.JsUtil;
 


### PR DESCRIPTION
**NOTE: do not merge**; this PR unfortunately runs afoul of a Qt bug (https://bugreports.qt.io/browse/QTBUG-69442) and so cannot be merged until that issue is fixed upstream.

---

This PR intends to fix https://github.com/rstudio/rstudio/issues/2712.

For background: RStudio maintains its own key maps, attempting to map key codes to key names (and vice versa). Unfortunately, this mapping is not unique. As an example, German keyboards (QWERTZ) contain keys for insertion of both <kbd>,</kbd> and <kbd><</kbd>, and they both map to the same key code (`188`). (This is perhaps an artifact of <kbd>,</kbd> and <kbd><</kbd> sharing the same physical key on a QWERTY keyboard, with the <kbd>Shift</kbd> modifier controlling which of the two keys is actually inserted.)

Because of this, we erroneously infer that a <kbd><</kbd> key press on a German user's keyboard to be a <kbd>,</kbd>, and display the wrong key in the keyboard shortcuts dialog.

The fix, as in this PR, is to use the `key` attribute to determine the actual key pressed by the user, but until it's reliable in Qt we can't merge this PR.