### PR TITLE
discover required dependencies and prompt user

### DIFF
--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -191,6 +191,7 @@ const int kJobOutput = 172;
 const int kDataOutputCompleted = 173;
 const int kNewDocumentWithCode = 174;
 const int kPlumberViewer = 175;
+const int kAvailablePackagesReady = 176;
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -526,6 +527,8 @@ std::string ClientEvent::typeName() const
          return "data_output_completed";
       case client_events::kNewDocumentWithCode:
          return "new_document_with_code";
+      case client_events::kAvailablePackagesReady:
+         return "available_packages_ready";
       case client_events::kPlumberViewer:
          return "plumber_viewer";
       default:

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -238,6 +238,8 @@ SEXP rs_enqueClientEvent(SEXP nameSEXP, SEXP dataSEXP)
          type = session::client_events::kDataOutputCompleted;
       else if (name == "new_document_with_code")
          type = session::client_events::kNewDocumentWithCode;
+      else if (name == "available_packages_ready")
+         type = session::client_events::kAvailablePackagesReady;
 
       if (type != -1)
       {

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -192,6 +192,7 @@ extern const int kJobOutput;
 extern const int kDataOutputCompleted;
 extern const int kNewDocumentWithCode;
 extern const int kPlumberViewer;
+extern const int kAvailablePackagesReady;
 }
    
 class ClientEvent

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2080,11 +2080,18 @@
 
 .rs.addFunction("readSourceDocument", function(id)
 {
-   .Call("rs_readSourceDocument", as.character(id), PACKAGE = "(embedding)")
+   contents <- .Call("rs_readSourceDocument", as.character(id), PACKAGE = "(embedding)")
+   Encoding(contents) <- "UTF-8"
+   contents
 })
 
 .rs.addFunction("discoverPackageDependencies", function(id, type)
 {
+   # check to see if we have available packages -- if none, bail
+   available <- .rs.availablePackages()
+   if (is.null(available$value))
+      return(character())
+   
    # attempt to read the file
    contents <- .rs.tryCatch(.rs.readSourceDocument(id))
    if (inherits(contents, "error"))
@@ -2201,6 +2208,9 @@
    })
    
    packages <- ls(envir = discoveries)
+   
+   # keep only packages that are available in an active repository
+   packages <- packages[packages %in% rownames(available$value)]
    
    # figure out which packages aren't actually installed
    info <- .rs.listInstalledPackages()

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2138,7 +2138,28 @@
          return(TRUE)
       }
       
-      return(FALSE)
+      FALSE
+      
+   }
+   
+   handleRequireNamespaceCall <- function(node) {
+      
+      if (!is.call(node))
+         return(FALSE)
+      
+      if (!identical(node[[1]], as.name("requireNamespace")))
+         return(FALSE)
+      
+      matched <- .rs.tryCatch(match.call(base::requireNamespace, node))
+      if (inherits(matched, "error"))
+         return(FALSE)
+      
+      if (is.character(matched$package) && length(matched$package == 1)) {
+         discoveries[[matched$package]] <<- TRUE
+         return(TRUE)
+      }
+      
+      FALSE
       
    }
    
@@ -2169,13 +2190,14 @@
       
       # all looks good; add the discovery
       discoveries[[package]] <<- TRUE
-      return(TRUE)
+      TRUE
       
    }
    
    .rs.recursiveWalk(parsed, function(node) {
       handleLibraryRequireCall(node) ||
-      handleColonCall(node)
+      handleColonCall(node) ||
+      handleRequireNamespaceCall(node)
    })
    
    packages <- ls(envir = discoveries)

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2086,7 +2086,8 @@
 .rs.addFunction("readSourceDocument", function(id)
 {
    contents <- .Call("rs_readSourceDocument", as.character(id), PACKAGE = "(embedding)")
-   Encoding(contents) <- "UTF-8"
+   if (is.character(contents))
+      Encoding(contents) <- "UTF-8"
    contents
 })
 

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2101,6 +2101,9 @@
    # read the associated source file
    contents <- .rs.readSourceDocument(id)
    
+   # NOTE: the following regular expressions were extracted from knitr;
+   # we pull these out here just to avoid potentially loading the knitr
+   # package without the user's consent
    code <- if (identical(extension, ".R"))
       contents
    else if (identical(extension, ".Rmd"))
@@ -2110,7 +2113,7 @@
    else if (identical(extension, ".Rnw"))
       .rs.extractRCode(contents,
                        "^\\s*<<(.*)>>=.*$",
-                       "^^\\s*@\\s*(%+.*|)$")
+                       "^\\s*@\\s*(%+.*|)$")
    
    if (is.null(code))
       return(character())

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -15,7 +15,10 @@
 
 .rs.addJsonRpcHandler("discover_package_dependencies", function(docId, fileType)
 {
-   .rs.discoverPackageDependencies(docId, fileType)
+   available <- .rs.availablePackages()
+   ready <- !is.null(available$value)
+   packages <- .rs.discoverPackageDependencies(docId, fileType)
+   list(ready = .rs.scalar(ready), packages = packages)
 })
 
 .rs.addFunction("error", function(...)

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1438,7 +1438,9 @@
    indents[indents == -1] <- Inf
    common <- min(indents)
    result <- paste(substring(splat, common, nchar(string)), collapse = "\n")
-   .rs.trimWhitespace(sprintf(result, ...))
+   dots <- list(...)
+   formatted <- if (length(dots)) sprintf(result, ...) else result
+   .rs.trimWhitespace(formatted)
 })
 
 .rs.addFunction("parseNamespaceImports", function(path)

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -1460,12 +1460,12 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    on.exit(setwd(owd), add = TRUE)
    
    # define our helper script that will download + save available.packages
-   template <- .rs.trimWhitespace('
-options(repos = %s, pkgType = %s)
-packages <- available.packages()
-attr(packages, "time") <- Sys.time()
-saveRDS(packages, file = "packages.rds")
-')
+   template <- .rs.trimCommonIndent('
+      options(repos = %s, pkgType = %s)
+      packages <- available.packages()
+      attr(packages, "time") <- Sys.time()
+      saveRDS(packages, file = "packages.rds")
+   ')
    
    script <- sprintf(
       template,

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -1429,6 +1429,27 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
 
 .rs.addFunction("onAvailablePackagesStale", function(reposString)
 {
+   # check and see if R has already queried available packages;
+   # if so we can ask R for available packages as it will use
+   # the cache
+   paths <- sprintf(
+      "%s/repos_%s.rds",
+      tempdir(),
+      URLencode(contrib.url(getOption("repos")), TRUE)
+   )
+   
+   if (all(file.exists(paths))) {
+      
+      # request available packages
+      packages <- available.packages(max_repo_cache_age = Inf)
+      
+      # add it to the cache
+      .rs.availablePackagesEnv[[reposString]] <- packages
+      
+      # we're done!
+      packages
+   }
+   
    # prepare directory for discovery of available packages
    dir <- tempfile("rstudio-available-packages-")
    dir.create(dir, showWarnings = FALSE)

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -1455,7 +1455,7 @@ saveRDS(packages, file = "packages.rds")
    # run the script
    R <- file.path(R.home("bin"), "R")
    args <- c("--vanilla", "--slave", "-f", "script.R")
-   system2(R, args, stdout = FALSE, stderr = FALSE, wait = FALSE)
+   system2(R, args, stdout = "stdout.txt", stderr = "stderr.txt", wait = FALSE)
    
    # NULL indicates we don't have available packages yet
    return(NULL)

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -161,7 +161,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
          .Call("rs_packageLibraryMutated")
          .rs.restorePreviousPath()
       })
-
+      
       # call original
       original(pkgs, lib, repos, ...)
    })

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -1397,7 +1397,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
       # verify the cache entry is not stale
       time <- attr(entry, "time", exact = TRUE)
       elapsed <- difftime(Sys.time(), time, units = "secs")
-      limit <- Sys.getenv("R_AVAILABLE_PACKAGES_CACHE_CONTROL_MAX_AGE", 3600)
+      limit <- as.numeric(Sys.getenv("R_AVAILABLE_PACKAGES_CACHE_CONTROL_MAX_AGE", 3600))
       
       if (elapsed > limit)
          return("STALE")

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -1477,8 +1477,9 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    .rs.runAsyncRProcess(
       script,
       onCompleted = function(exitStatus) {
-         # TODO: let source documents know we're ready
-         .rs.onAvailablePackagesReady(reposString)
+         available <- .rs.onAvailablePackagesReady(reposString)
+         data <- list(ready = .rs.scalar(TRUE), packages = rownames(available))
+         .rs.enqueClientEvent("available_packages_ready", data)
       }
    )
    

--- a/src/cpp/session/modules/SessionRUtil.R
+++ b/src/cpp/session/modules/SessionRUtil.R
@@ -22,3 +22,29 @@
 {
    as.list(.Call("rs_readIniFile", filePath))
 })
+
+.rs.addFunction("runAsyncRProcess", function(
+   code,
+   workingDir  = getwd(),
+   onStarted   = function() {},
+   onContinue  = function() {},
+   onStdout    = function(output) {},
+   onStderr    = function(output) {},
+   onCompleted = function(exitStatus) {})
+{
+   callbacks <- list(
+      started   = onStarted,
+      continue  = onContinue,
+      stdout    = onStdout,
+      stderr    = onStderr,
+      completed = onCompleted
+   )
+   
+   .Call(
+      "rs_runAsyncRProcess",
+      as.character(code),
+      normalizePath(workingDir, mustWork = TRUE),
+      as.list(callbacks),
+      PACKAGE = "(embedding)"
+   )
+})

--- a/src/cpp/session/modules/SessionRUtil.cpp
+++ b/src/cpp/session/modules/SessionRUtil.cpp
@@ -283,6 +283,7 @@ SEXP rs_runAsyncRProcess(SEXP codeSEXP,
    
    std::string code = r::sexp::asString(codeSEXP);
    std::string workingDir = r::sexp::asString(workingDirSEXP);
+   boost::algorithm::replace_all(code, "\n", "; ");
    launchProcess(code, module_context::resolveAliasedPath(workingDir), callbacksSEXP);
    
    r::sexp::Protect protect;

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -1241,6 +1241,18 @@ SEXP rs_requestDocumentSave(SEXP idsSEXP)
    return r::sexp::create(success, &protect);
 }
 
+SEXP rs_readSourceDocument(SEXP idSEXP)
+{
+   std::string id = r::sexp::asString(idSEXP);
+   boost::shared_ptr<SourceDocument> pDoc(new SourceDocument());
+   Error error = source_database::get(id, pDoc);
+   if (error)
+      return R_NilValue;
+   
+   r::sexp::Protect protect;
+   return r::sexp::create(pDoc->contents(), &protect);
+}
+
 } // anonymous namespace
 
 Error clientInitDocuments(core::json::Array* pJsonDocs)
@@ -1298,6 +1310,7 @@ Error initialize()
 
    RS_REGISTER_CALL_METHOD(rs_fileEdit, 1);
    RS_REGISTER_CALL_METHOD(rs_requestDocumentSave, 1);
+   RS_REGISTER_CALL_METHOD(rs_readSourceDocument, 1);
 
    // install rpc methods
    using boost::bind;

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -1247,7 +1247,10 @@ SEXP rs_readSourceDocument(SEXP idSEXP)
    boost::shared_ptr<SourceDocument> pDoc(new SourceDocument());
    Error error = source_database::get(id, pDoc);
    if (error)
+   {
+      LOG_ERROR(error);
       return R_NilValue;
+   }
    
    r::sexp::Protect protect;
    return r::sexp::create(pDoc->contents(), &protect);

--- a/src/gwt/src/org/rstudio/core/client/SingleShotTimer.java
+++ b/src/gwt/src/org/rstudio/core/client/SingleShotTimer.java
@@ -1,7 +1,7 @@
 /*
- * WarningBarDisplay.java
+ * SingleShotTimer.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -12,16 +12,22 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
-package org.rstudio.studio.client.workbench.views.source.editors.text;
+package org.rstudio.core.client;
 
-import java.util.List;
+import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Timer;
 
-import com.google.gwt.user.client.ui.IsWidget;
-
-public interface WarningBarDisplay extends IsWidget
+public class SingleShotTimer
 {
-   void showReadOnlyWarning(List<String> alternatives);
-   void showRequiredPackagesMissingWarning(List<String> packages);
-   void showWarningBar(String message);
-   void hideWarningBar();
+   public static void fire(final int delayMs, final Command command)
+   {
+      new Timer()
+      {
+         @Override
+         public void run()
+         {
+            command.execute();
+         }
+      }.schedule(delayMs);
+   }
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/InfoBar.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/InfoBar.java
@@ -32,6 +32,7 @@ import com.google.gwt.user.client.ui.Widget;
 
 import java.util.List;
 
+import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
@@ -91,6 +92,43 @@ public class InfoBar extends Composite
    public int getHeight()
    {
       return 19;
+   }
+   
+   public void showRequiredPackagesMissingWarning(List<String> packages,
+                                                  CommandWithArg<Boolean> onPackageInstallCompleted)
+   {
+      String message;
+      
+      int n = packages.size();
+      if (n == 1)
+      {
+         message = "Package " + packages.get(0) + " required but is not installed.";
+      }
+      else if (n == 2)
+      {
+         message = "Packages " + packages.get(0) + " and " + packages.get(1) + " required but are not installed.";
+      }
+      else if (n == 3)
+      {
+         message = "Packages " + packages.get(0) + ", " + packages.get(1) + ", and " + packages.get(2) + " required but are not installed.";
+      }
+      else
+      {
+         message = "Packages " + packages.get(0) + ", " + packages.get(1) + ", and " + (n - 2) + " others are required but not installed.";
+      }
+      
+      label_.setText(message);
+      
+      if (labelRight_.getWidgetCount() == 0)
+      {
+         Label anchor = new Label("Install");
+         anchor.getElement().getStyle().setTextDecoration(TextDecoration.UNDERLINE);
+         anchor.getElement().getStyle().setPaddingLeft(5, Unit.PX);
+         anchor.getElement().getStyle().setCursor(Cursor.POINTER);
+         anchor.getElement().getStyle().setWhiteSpace(WhiteSpace.NOWRAP);
+         anchor.addClickHandler((ClickEvent event) -> { RStudioGinjector.INSTANCE.getDependencyManager().installPackages(packages, onPackageInstallCompleted); });
+         labelRight_.add(anchor);
+      }
    }
    
    public void showReadOnlyWarning(List<String> alternatives)

--- a/src/gwt/src/org/rstudio/core/client/widget/InfoBar.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/InfoBar.java
@@ -115,7 +115,7 @@ public class InfoBar extends Composite
       }
       else
       {
-         message = "Packages " + packages.get(0) + ", " + packages.get(1) + ", and " + (n - 2) + " others are required but not installed.";
+         message = "Packages " + packages.get(0) + ", " + packages.get(1) + ", and " + (n - 2) + " others required but are not installed.";
       }
       
       label_.setText(message);

--- a/src/gwt/src/org/rstudio/core/client/widget/InfoBar.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/InfoBar.java
@@ -33,7 +33,6 @@ import com.google.gwt.user.client.ui.Widget;
 
 import java.util.List;
 
-import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
@@ -96,7 +95,7 @@ public class InfoBar extends Composite
    }
    
    public void showRequiredPackagesMissingWarning(List<String> packages,
-                                                  CommandWithArg<Boolean> onPackageInstallCompleted,
+                                                  Command onInstall,
                                                   Command onDismiss)
    {
       String message;
@@ -124,7 +123,7 @@ public class InfoBar extends Composite
       if (labelRight_.getWidgetCount() == 0)
       {
          labelRight_.add(label("Install", () -> {
-            RStudioGinjector.INSTANCE.getDependencyManager().installPackages(packages, onPackageInstallCompleted);
+            onInstall.execute();
          }));
          
          labelRight_.add(label("Don't Show Again", () -> {

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -126,6 +126,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditorId
 import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditorMixins;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetIdleMonitor;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetJSHelper;
+import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetPackageDependencyHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetSqlHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditorWidget;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ChunkSatellite;
@@ -189,6 +190,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(TextEditingTargetJSHelper jsHelper);
    void injectMembers(TextEditingTargetSqlHelper sqlHelper);
    void injectMembers(TextEditingTargetChunks chunks);
+   void injectMembers(TextEditingTargetPackageDependencyHelper packageDependencyHelper);
    void injectMembers(EditingTargetCodeExecution codeExecution);
    void injectMembers(LocalRepositoriesWidget localRepositoriesWidget);
    void injectMembers(CppCompletionRequest request);

--- a/src/gwt/src/org/rstudio/studio/client/application/events/EventBus.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/EventBus.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.application.events;
 
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.js.JavaScriptSerializer;
 import org.rstudio.studio.client.application.Desktop;
@@ -61,6 +62,8 @@ public class EventBus extends HandlerManager
    
    private void fireEvent(GwtEvent<?> event, boolean fromOtherWindow)
    {
+      Debug.logToRConsole(event.toDebugString());
+      
       // if this is a cross-window event that originated in this satellite 
       // window (and wasn't itself forwarded from somewhere else), pass it to
       // the main window

--- a/src/gwt/src/org/rstudio/studio/client/application/events/EventBus.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/EventBus.java
@@ -14,7 +14,6 @@
  */
 package org.rstudio.studio.client.application.events;
 
-import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.js.JavaScriptSerializer;
 import org.rstudio.studio.client.application.Desktop;
@@ -62,8 +61,6 @@ public class EventBus extends HandlerManager
    
    private void fireEvent(GwtEvent<?> event, boolean fromOtherWindow)
    {
-      Debug.logToRConsole(event.toDebugString());
-      
       // if this is a cross-window event that originated in this satellite 
       // window (and wasn't itself forwarded from somewhere else), pass it to
       // the main window

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -42,6 +42,7 @@ import org.rstudio.studio.client.workbench.views.packages.events.PackageStateCha
 import org.rstudio.studio.client.workbench.views.packages.events.PackageStateChangedHandler;
 import org.rstudio.studio.client.workbench.views.vcs.common.ConsoleProgressDialog;
 
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.user.client.Command;
 import com.google.inject.Inject;
@@ -840,6 +841,18 @@ public class DependencyManager implements InstallShinyEvent.Handler,
            }
         }
       );
+   }
+   
+   public void installPackages(List<String> packageNames,
+                               CommandWithArg<Boolean> onCompleted)
+   {
+      int n = packageNames.size();
+      JsArray<Dependency> dependencies = JavaScriptObject.createArray(n).cast();
+      for (int i = 0; i < n; i++)
+      {
+         dependencies.set(i, Dependency.cranPackage(packageNames.get(i)));
+      }
+      installDependencies(dependencies, false, onCompleted);
    }
 
    private Dependency[] connectionPackageDependenciesArray(String packageName,

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/model/Dependency.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/model/Dependency.java
@@ -27,6 +27,11 @@ public class Dependency extends JavaScriptObject
    {
    }
    
+   public static Dependency cranPackage(String name)
+   {
+      return cranPackage(name, "", false);
+   }
+   
    public static Dependency cranPackage(String name, 
                                         String version)
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -181,6 +181,7 @@ class ClientEvent extends JavaScriptObject
    public static final String JobOutput = "job_output";
    public static final String DataOutputCompleted = "data_output_completed";
    public static final String NewDocumentWithCode = "new_document_with_code";
+   public static final String AvailablePackagesReady = "available_packages_ready";
    public static final String PlumberViewer = "plumber_viewer";
 
    protected ClientEvent()

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -169,6 +169,7 @@ import org.rstudio.studio.client.workbench.views.presentation.events.ShowPresent
 import org.rstudio.studio.client.workbench.views.presentation.model.PresentationState;
 import org.rstudio.studio.client.workbench.views.source.editors.explorer.events.ObjectExplorerEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.profiler.RprofEvent;
+import org.rstudio.studio.client.workbench.views.source.events.AvailablePackagesReadyEvent;
 import org.rstudio.studio.client.workbench.views.source.events.CodeBrowserNavigationEvent;
 import org.rstudio.studio.client.workbench.views.source.events.CollabEditEndedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.CollabEditSavedEvent;
@@ -1003,6 +1004,11 @@ public class ClientEventDispatcher
          {
             NewDocumentWithCodeEvent.Data result = event.getData();
             eventBus_.dispatchEvent(new NewDocumentWithCodeEvent(result));
+         }
+         else if (type == ClientEvent.AvailablePackagesReady)
+         {
+            AvailablePackagesReadyEvent.Data data = event.getData();
+            eventBus_.dispatchEvent(new AvailablePackagesReadyEvent(data));
          }
          else if (type == ClientEvent.PlumberViewer)
          {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1706,6 +1706,19 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, CREATE_PLUMBER_API, params, requestCallback);
    }
    
+   public void discoverPackageDependencies(String docId,
+                                           String fileType,
+                                           ServerRequestCallback<JsArrayString> requestCallback)
+   {
+      JSONArray params = new JSONArrayBuilder()
+            .add(docId)
+            .add(fileType)
+            .get();
+      
+      sendRequest(RPC_SCOPE, DISCOVER_PACKAGE_DEPENDENCIES, params, requestCallback);
+            
+   }
+   
    public void getEditorContextCompleted(GetEditorContextEvent.SelectionData data,
                                          ServerRequestCallback<Void> requestCallback)
    {
@@ -5618,6 +5631,7 @@ public class RemoteServer implements Server
    private static final String SET_CRAN_MIRROR = "set_cran_mirror";
    private static final String GET_CRAN_MIRRORS = "get_cran_mirrors";
    private static final String PACKAGE_SKELETON = "package_skeleton";
+   private static final String DISCOVER_PACKAGE_DEPENDENCIES = "discover_package_dependencies";
 
    private static final String GET_HELP = "get_help";
    private static final String SHOW_HELP_TOPIC = "show_help_topic" ;

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -197,6 +197,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.profiler.model.P
 import org.rstudio.studio.client.workbench.views.source.editors.text.IconvListResult;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkDefinition;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceTheme;
+import org.rstudio.studio.client.workbench.views.source.events.AvailablePackagesReadyEvent;
 import org.rstudio.studio.client.workbench.views.source.model.CheckForExternalEditResult;
 import org.rstudio.studio.client.workbench.views.source.model.CppCapabilities;
 import org.rstudio.studio.client.workbench.views.source.model.CppCompletionResult;
@@ -1708,7 +1709,7 @@ public class RemoteServer implements Server
    
    public void discoverPackageDependencies(String docId,
                                            String fileType,
-                                           ServerRequestCallback<JsArrayString> requestCallback)
+                                           ServerRequestCallback<AvailablePackagesReadyEvent.Data> requestCallback)
    {
       JSONArray params = new JSONArrayBuilder()
             .add(docId)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.java
@@ -311,11 +311,7 @@ public class CodeBrowserEditingTargetWidget extends ResizeComposite
    @Override
    public void showRequiredPackagesMissingWarning(List<String> packages)
    {
-      showWarningImpl(() -> {
-         warningBar_.showRequiredPackagesMissingWarning(packages, (Boolean success) -> {
-            hideWarningBar();
-         });
-      });
+      // no-op for code browser targets
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.java
@@ -309,11 +309,21 @@ public class CodeBrowserEditingTargetWidget extends ResizeComposite
    }
    
    @Override
+   public void showRequiredPackagesMissingWarning(List<String> packages)
+   {
+      showWarningImpl(() -> {
+         warningBar_.showRequiredPackagesMissingWarning(packages, (Boolean success) -> {
+            hideWarningBar();
+         });
+      });
+   }
+   
+   @Override
    public void showWarningBar(final String warning)
    {
       showWarningImpl(() -> warningBar_.setText(warning));
    }
-
+   
    @Override
    public void hideWarningBar()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -465,7 +465,7 @@ public class TextEditingTarget implements
                                          docDisplay_, 
                                          events_, 
                                          this);
-       
+      
       docDisplay_.addKeyDownHandler(new KeyDownHandler()
       {
          public void onKeyDown(KeyDownEvent event)
@@ -1246,6 +1246,11 @@ public class TextEditingTarget implements
       view_.showWarningBar(message);
    }
    
+   public void showRequiredPackagesMissingWarning(List<String> packages)
+   {
+      view_.showRequiredPackagesMissingWarning(packages);
+   }
+   
    private void jumpToPreviousFunction()
    {
       Scope jumpTo = scopeHelper_.getPreviousFunction(
@@ -1302,6 +1307,7 @@ public class TextEditingTarget implements
                                           server_);
 
       roxygenHelper_ = new RoxygenHelper(docDisplay_, view_);
+      packageDependencyHelper_ = new TextEditingTargetPackageDependencyHelper(this, docUpdateSentinel_, docDisplay_);
       
       // create notebook and forward resize events
       chunks_ = new TextEditingTargetChunks(this);
@@ -1338,6 +1344,9 @@ public class TextEditingTarget implements
       name_.setValue(getNameFromDocument(document, defaultNameProvider), true);
       String contents = document.getContents();
       docDisplay_.setCode(contents, false);
+      
+      // Discover dependencies on file first open.
+      packageDependencyHelper_.discoverPackageDependencies();
       
       // Load and apply folds.
       final ArrayList<Fold> folds = Fold.decode(document.getFoldSpec());
@@ -7252,6 +7261,7 @@ public class TextEditingTarget implements
    private boolean ignoreDeletes_;
    private boolean forceSaveCommandActive_ = false;
    private final TextEditingTargetScopeHelper scopeHelper_;
+   private TextEditingTargetPackageDependencyHelper packageDependencyHelper_;
    private TextEditingTargetSpelling spelling_;
    private TextEditingTargetNotebook notebook_;
    private TextEditingTargetChunks chunks_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetPackageDependencyHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetPackageDependencyHelper.java
@@ -1,0 +1,98 @@
+/*
+ * TextEditingTarget.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text;
+
+import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.js.JsUtil;
+import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.server.ServerError;
+import org.rstudio.studio.client.server.ServerRequestCallback;
+import org.rstudio.studio.client.workbench.views.source.events.SaveFileEvent;
+import org.rstudio.studio.client.workbench.views.source.model.DocUpdateSentinel;
+import org.rstudio.studio.client.workbench.views.source.model.SourceServerOperations;
+
+import com.google.gwt.core.client.JsArrayString;
+import com.google.inject.Inject;
+
+public class TextEditingTargetPackageDependencyHelper
+{
+   public TextEditingTargetPackageDependencyHelper(TextEditingTarget target,
+                                                   DocUpdateSentinel sentinel,
+                                                   DocDisplay docDisplay)
+   {
+      target_ = target;
+      sentinel_ = sentinel;
+      docDisplay_ = docDisplay;
+      
+      init();
+   }
+   
+   private void init()
+   {
+      RStudioGinjector.INSTANCE.injectMembers(this);
+      
+      docDisplay_.addSaveCompletedHandler((SaveFileEvent event) -> {
+         discoverPackageDependencies();
+      });
+   }
+   
+   @Inject
+   private void initialize(SourceServerOperations server)
+   {
+      server_ = server;
+   }
+   
+   public void discoverPackageDependencies()
+   {
+      if (discoveringDependencies_)
+         return;
+      
+      if (sentinel_ == null)
+         return;
+      
+      discoveringDependencies_ = true;
+      server_.discoverPackageDependencies(
+            sentinel_.getId(),
+            docDisplay_.getFileType().getDefaultExtension(),
+            new ServerRequestCallback<JsArrayString>()
+            {
+               @Override
+               public void onResponseReceived(JsArrayString response)
+               {
+                  discoveringDependencies_ = false;
+                  if (response.length() > 0)
+                     target_.showRequiredPackagesMissingWarning(JsUtil.toList(response));
+               }
+               
+               @Override
+               public void onError(ServerError error)
+               {
+                  discoveringDependencies_ = false;
+                  Debug.logError(error);
+               }
+            });
+   }
+   
+   boolean discoveringDependencies_ = false;
+   
+   private final TextEditingTarget target_;
+   private final DocUpdateSentinel sentinel_;
+   private final DocDisplay docDisplay_;
+   
+   // Injected ----
+   SourceServerOperations server_;
+   
+   
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetPackageDependencyHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetPackageDependencyHelper.java
@@ -44,7 +44,8 @@ public class TextEditingTargetPackageDependencyHelper
       RStudioGinjector.INSTANCE.injectMembers(this);
       
       docDisplay_.addSaveCompletedHandler((SaveFileEvent event) -> {
-         discoverPackageDependencies();
+         if (!event.isAutosave())
+            discoverPackageDependencies();
       });
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetPackageDependencyHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetPackageDependencyHelper.java
@@ -55,8 +55,7 @@ public class TextEditingTargetPackageDependencyHelper
       // is ready if we haven't yet checked before (this allows for us
       // to check dependencies in open files at the start of a session)
       events_.addHandler(AvailablePackagesReadyEvent.TYPE, (AvailablePackagesReadyEvent event) -> {
-         if (waitingUntilReady_)
-            discoverPackageDependencies();
+         discoverPackageDependencies();
       });
    }
    
@@ -96,10 +95,7 @@ public class TextEditingTargetPackageDependencyHelper
                   discoveringDependencies_ = false;
                   
                   if (!response.isReady())
-                  {
-                     waitingUntilReady_ = true;
                      return;
-                  }
                      
                   JsArrayString packages = response.getPackages();
                   if (packages.length() > 0)
@@ -115,7 +111,6 @@ public class TextEditingTargetPackageDependencyHelper
             });
    }
    
-   boolean waitingUntilReady_ = false;
    boolean discoveringDependencies_ = false;
    
    private final TextEditingTarget target_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetPackageDependencyHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetPackageDependencyHelper.java
@@ -63,6 +63,14 @@ public class TextEditingTargetPackageDependencyHelper
       if (sentinel_ == null)
          return;
       
+      boolean canDiscoverDependencies =
+            docDisplay_.getFileType().isR() ||
+            docDisplay_.getFileType().isRmd() ||
+            docDisplay_.getFileType().isRnw();
+      
+      if (!canDiscoverDependencies)
+         return;
+      
       discoveringDependencies_ = true;
       server_.discoverPackageDependencies(
             sentinel_.getId(),

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -883,12 +883,12 @@ public class TextEditingTargetWidget
       }
       
       Command onInstall = () -> {
-         
          StringBuilder builder = new StringBuilder();
          builder.append("utils::install.packages('")
                 .append(StringUtil.join(packages, "', '"))
                 .append("')");
          events_.fireEvent(new SendToConsoleEvent(builder.toString(), true));
+         hideWarningBar();
       };
       
       Command onDismiss = () -> {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -882,7 +882,8 @@ public class TextEditingTargetWidget
       }
       
       CommandWithArg<Boolean> onInstallComplete = (Boolean success) -> {
-         hideWarningBar();
+         if (success)
+            hideWarningBar();
       };
       
       Command onDismiss = () -> {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -37,7 +37,6 @@ import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.*;
 
 import org.rstudio.core.client.BrowseCap;
-import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.MathUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppCommand;
@@ -73,6 +72,7 @@ import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.SessionUtils;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefsAccessor;
+import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
 import org.rstudio.studio.client.workbench.views.edit.ui.EditDialog;
 import org.rstudio.studio.client.workbench.views.source.DocumentOutlineWidget;
 import org.rstudio.studio.client.workbench.views.source.PanelWithToolbars;
@@ -110,6 +110,7 @@ public class TextEditingTargetWidget
       fileTypeRegistry_ = fileTypeRegistry;
       editor_ = editor;
       extendedType_ = extendedType;
+      events_ = events;
       sourceOnSave_ = new CheckBox();
       srcOnSaveLabel_ =
                   new CheckboxLabel(sourceOnSave_, "Source on Save").getLabel();
@@ -881,9 +882,13 @@ public class TextEditingTargetWidget
          }
       }
       
-      CommandWithArg<Boolean> onInstallComplete = (Boolean success) -> {
-         if (success)
-            hideWarningBar();
+      Command onInstall = () -> {
+         
+         StringBuilder builder = new StringBuilder();
+         builder.append("utils::install.packages('")
+                .append(StringUtil.join(packages, "', '"))
+                .append("')");
+         events_.fireEvent(new SendToConsoleEvent(builder.toString(), true));
       };
       
       Command onDismiss = () -> {
@@ -892,7 +897,7 @@ public class TextEditingTargetWidget
       };
       
       showWarningImpl(() -> {
-         warningBar_.showRequiredPackagesMissingWarning(packages, onInstallComplete, onDismiss);
+         warningBar_.showRequiredPackagesMissingWarning(packages, onInstall, onDismiss);
       });
    }
    
@@ -1483,6 +1488,7 @@ public class TextEditingTargetWidget
    private final TextEditingTarget target_;
    private final DocUpdateSentinel docUpdateSentinel_;
    private final Commands commands_;
+   private final EventBus events_;
    private final UIPrefs uiPrefs_;
    private final Session session_;
    private final FileTypeRegistry fileTypeRegistry_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -869,6 +869,16 @@ public class TextEditingTargetWidget
    }
    
    @Override
+   public void showRequiredPackagesMissingWarning(List<String> packages)
+   {
+      showWarningImpl(() -> {
+         warningBar_.showRequiredPackagesMissingWarning(packages, (Boolean success) -> {
+            hideWarningBar();
+         });
+      });
+   }
+   
+   @Override
    public void showWarningBar(final String warning)
    {
       showWarningImpl(() -> warningBar_.setText(warning));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -37,6 +37,7 @@ import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.*;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.MathUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppCommand;
@@ -871,10 +872,26 @@ public class TextEditingTargetWidget
    @Override
    public void showRequiredPackagesMissingWarning(List<String> packages)
    {
+      if (docUpdateSentinel_.hasProperty("disableDependencyDiscovery"))
+      {
+         String disableDependencyDiscovery = docUpdateSentinel_.getProperty("disableDependencyDiscovery");
+         if (StringUtil.equals(disableDependencyDiscovery, "1"))
+         {
+            return;
+         }
+      }
+      
+      CommandWithArg<Boolean> onInstallComplete = (Boolean success) -> {
+         hideWarningBar();
+      };
+      
+      Command onDismiss = () -> {
+         docUpdateSentinel_.setProperty("disableDependencyDiscovery", "1");
+         hideWarningBar();
+      };
+      
       showWarningImpl(() -> {
-         warningBar_.showRequiredPackagesMissingWarning(packages, (Boolean success) -> {
-            hideWarningBar();
-         });
+         warningBar_.showRequiredPackagesMissingWarning(packages, onInstallComplete, onDismiss);
       });
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/AvailablePackagesReadyEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/AvailablePackagesReadyEvent.java
@@ -1,0 +1,67 @@
+/*
+ * AvailablePackagesReadyEvent.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.events;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class AvailablePackagesReadyEvent extends GwtEvent<AvailablePackagesReadyEvent.Handler>
+{
+   public static class Data extends JavaScriptObject
+   {
+      protected Data()
+      {
+      }
+      
+      public final native boolean isReady()           /*-{ return this["ready"];    }-*/;
+      public final native JsArrayString getPackages() /*-{ return this["packages"]; }-*/;
+   }
+   
+   public AvailablePackagesReadyEvent(Data data)
+   {
+      data_ = data;
+   }
+   
+   public Data getData()
+   {
+      return data_;
+   }
+   
+   private final Data data_;
+
+   // Boilerplate ----
+
+   public interface Handler extends EventHandler
+   {
+      void onAvailablePackagesReady(AvailablePackagesReadyEvent event);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onAvailablePackagesReady(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}
+

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceServerOperations.java
@@ -252,4 +252,9 @@ public interface SourceServerOperations extends FilesServerOperations,
    public void createPlumberAPI(String apiName,
                                 String apiDir,
                                 ServerRequestCallback<JsArrayString> requestCallback);
+   
+   void discoverPackageDependencies(String id,
+                                    String fileType,
+                                    ServerRequestCallback<JsArrayString> requestCallback);
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceServerOperations.java
@@ -35,6 +35,7 @@ import org.rstudio.studio.client.workbench.views.presentation.model.Presentation
 import org.rstudio.studio.client.workbench.views.source.editors.explorer.ObjectExplorerServerOperations;
 import org.rstudio.studio.client.workbench.views.source.editors.text.IconvListResult;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkDefinition;
+import org.rstudio.studio.client.workbench.views.source.events.AvailablePackagesReadyEvent;
 
 import java.util.HashMap;
 import java.util.List;
@@ -255,6 +256,6 @@ public interface SourceServerOperations extends FilesServerOperations,
    
    void discoverPackageDependencies(String id,
                                     String fileType,
-                                    ServerRequestCallback<JsArrayString> requestCallback);
+                                    ServerRequestCallback<AvailablePackagesReadyEvent.Data> requestCallback);
    
 }


### PR DESCRIPTION
NOTE: not quite ready for merge.

I realize this PR is coming in quite late but this is something that we originally wanted to get in for v1.2 and the nonstop deluge of WebEngine bugs was starting to drive me insane :-)

This PR implements automatic R package dependency discovery in R source documents, and prompts the user to install any missing packages with a warning bar when necessary.

![screen shot 2018-07-16 at 4 39 20 pm](https://user-images.githubusercontent.com/1976582/42788906-252360e0-8917-11e8-8595-172f5f20fe92.png)

Clicking the <kbd>Install</kbd> button here opens the typical dependency manager installer, and attempts to install all packages from CRAN.

## TODO

- [x] Need to ensure that we only attempt to install packages from CRAN that actually do live on CRAN.
- [x] Provide some UI to allow users to dismiss dialog permanently (per file? globally?) in case we aren't discovering dependencies directly.
