### PR TITLE
Add config option to send package build output to package folder

### DIFF
--- a/src/cpp/core/include/core/r_util/RPackageInfo.hpp
+++ b/src/cpp/core/include/core/r_util/RPackageInfo.hpp
@@ -1,7 +1,7 @@
 /*
  * RPackageInfo.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -71,6 +71,10 @@ private:
 };
 
 bool isPackageDirectory(const FilePath& dir);
+
+// Determine name of a package project in given directory. Returns empty string
+// if not a package or any other error.
+std::string packageNameFromDirectory(const FilePath& dir);
 
 } // namespace r_util
 } // namespace core 

--- a/src/cpp/core/r_util/RPackageInfo.cpp
+++ b/src/cpp/core/r_util/RPackageInfo.cpp
@@ -1,7 +1,7 @@
 /*
  * RPackageInfo.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -127,6 +127,26 @@ bool isPackageDirectory(const FilePath& dir)
    else
    {
       return false;
+   }
+}
+
+std::string packageNameFromDirectory(const FilePath& dir)
+{
+   if (dir.childPath("DESCRIPTION").exists())
+   {
+      RPackageInfo pkgInfo;
+      Error error = pkgInfo.read(dir);
+      if (error)
+      {
+         LOG_ERROR(error);
+         return "";
+      }
+
+      return pkgInfo.name(); 
+   }
+   else
+   {
+      return "";
    }
 }
 

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -243,7 +243,10 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
        "WebSocket keep-alive ping interval (seconds)")
       (kWebSocketConnectTimeout,
        value<int>(&webSocketConnectTimeout_)->default_value(3),
-       "WebSocket initial connection timeout (seconds)");
+       "WebSocket initial connection timeout (seconds)")
+      (kPackageOutputInPackageFolder,
+         value<bool>(&packageOutputToPackageFolder_)->default_value(false),
+         "devtools check and devtools build output to package project folder");
 
    // allow options
    options_description allow("allow");

--- a/src/cpp/session/include/session/SessionConstants.hpp
+++ b/src/cpp/session/include/session/SessionConstants.hpp
@@ -71,6 +71,8 @@
 #define kWebSocketPingInterval            "websocket-ping-seconds"
 #define kWebSocketConnectTimeout          "websocket-connect-timeout"
 
+#define kPackageOutputInPackageFolder     "package-output-to-package-folder"
+
 // NOTE: literal versions of these are depended upon by the desktop/rsinverse
 // project so they should be updated there as well if they are changed
 #define kLocalUriLocationPrefix           "/rsession-local/"

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -542,6 +542,11 @@ public:
    {
       return webSocketConnectTimeout_;
    }
+   
+   bool packageOutputInPackageFolder() const
+   {
+      return packageOutputToPackageFolder_;   
+   }
 
    std::string getOverlayOption(const std::string& name)
    {
@@ -648,6 +653,7 @@ private:
    bool verifySignatures_;
    int webSocketPingSeconds_;
    int webSocketConnectTimeout_;
+   bool packageOutputToPackageFolder_;
    std::string terminalPort_;
 
    // r

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -645,7 +645,7 @@ private:
       // track build type
       type_ = type;
 
-      // add testthat and shinyteset result parsers
+      // add testthat and shinytest result parsers
       if (type == kTestFile) {
          openErrorList_ = false;
          parsers.add(testthatErrorParser(packagePath.parent()));
@@ -749,25 +749,49 @@ private:
       else if (type == kBuildSourcePackage)
       {
          if (useDevtools())
+         {
             devtoolsBuildPackage(packagePath, false, pkgOptions, cb);
+         }
          else
+         {
+            if (session::options().packageOutputInPackageFolder())
+            {
+               pkgOptions.workingDir = packagePath;
+            }
             buildSourcePackage(rBinDir, packagePath, pkgOptions, cb);
+         }
       }
 
       else if (type == kBuildBinaryPackage)
       {
          if (useDevtools())
+         {
             devtoolsBuildPackage(packagePath, true, pkgOptions, cb);
+         }
          else
+         {
+            if (session::options().packageOutputInPackageFolder())
+            {
+               pkgOptions.workingDir = packagePath;
+            }
             buildBinaryPackage(rBinDir, packagePath, pkgOptions, cb);
+         }
       }
 
       else if (type == kCheckPackage)
       {
          if (useDevtools())
+         {
             devtoolsCheckPackage(packagePath, pkgOptions, cb);
+         }
          else
+         {
+            if (session::options().packageOutputInPackageFolder())
+            {
+               pkgOptions.workingDir = packagePath;
+            }
             checkPackage(rBinDir, packagePath, pkgOptions, cb);
+         }
       }
 
       else if (type == kTestPackage)
@@ -799,7 +823,10 @@ private:
       rCmd << extraArgs;
 
       // add filename as a FilePath so it is escaped
-      rCmd << FilePath(packagePath.filename());
+      if (session::options().packageOutputInPackageFolder())
+         rCmd << FilePath(".");
+      else
+         rCmd << FilePath(packagePath.filename());
 
       // show the user the command
       enqueCommandString(rCmd.commandString());
@@ -831,7 +858,10 @@ private:
       rCmd << extraArgs;
 
       // add filename as a FilePath so it is escaped
-      rCmd << FilePath(packagePath.filename());
+      if (session::options().packageOutputInPackageFolder())
+         rCmd << FilePath(".");
+      else
+         rCmd << FilePath(packagePath.filename());
 
       // show the user the command
       enqueCommandString(rCmd.commandString());
@@ -852,7 +882,7 @@ private:
    {
       // first build then check
 
-      // compose the build command
+      // compose  the build command
       module_context::RCommand rCmd(rBinDir);
       rCmd << "build";
 
@@ -867,7 +897,10 @@ private:
          rCmd << "--no-build-vignettes";
 
       // add filename as a FilePath so it is escaped
-      rCmd << FilePath(packagePath.filename());
+      if (session::options().packageOutputInPackageFolder())
+         rCmd << FilePath(".");
+      else
+         rCmd << FilePath(packagePath.filename());
 
       // compose the check command (will be executed by the onExit
       // handler of the build cmd)

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -882,7 +882,7 @@ private:
    {
       // first build then check
 
-      // compose  the build command
+      // compose the build command
       module_context::RCommand rCmd(rBinDir);
       rCmd << "build";
 


### PR DESCRIPTION
Normally the `Check Package`, `Build Source Package`, and `Build Binary Package` commands write to the parent folder of the package itself. So for `/home/me/mypackage`, files are written to `/home/me`.

This change supports writing these files inside the package folder itself, for a case where users don't have write access to the folder containing the package project. This was requested by the cloud team (see https://github.com/rstudio/rstudio-pro/issues/482). Implementing in open-source server.

This can be enabled in `rsession.conf` by adding:

`package-output-to-package-folder=1`

Note: this only works if package operations are being done via devtools package; if they are being done directly via R CMD check/install/build, this setting will not change the output location.

In addition to changing the output location, the .gitignore and .Rbuildignore files have additional exclusions dynamically added, covering the files generated by these operations.

These exclusions will be added only when this setting is enabled, and can happen when first creating a project or when opening an existing project.

FYI @ssinnott