### PR TITLE
warn when attempting to launch before ready

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/RStudio.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudio.java
@@ -188,10 +188,16 @@ public class RStudio implements EntryPoint
             // window)
             setTimeout(function() {
                if (typeof $wnd.rstudioDelayLoadApplication == "function") {
+                  
+                  // let the user know things might go wrong
+                  var msg = "WARNING: RStudio launched before desktop initialization known to be complete!";
+                  @org.rstudio.core.client.Debug::log(Ljava/lang/String;)(msg);
+                  
+                  // begin load
                   $wnd.rstudioDelayLoadApplication();
                   $wnd.rstudioDelayLoadApplication = null;
                }
-            }, 5000);
+            }, 60000);
          }
       }
       else


### PR DESCRIPTION
I suspect some users are having an RStudio failure to launch due to the front-end attempting initialization before Qt is ready, e.g.

https://community.rstudio.com/t/rstudio-daily-build-never-loads/7972/30

This PR increases the initial wait delay to 1 minute, and also logs when we do this sort of un-synchronized launch.