### PR TITLE
Content doesn't fit on General Prefs pane, pushing some off bottom (Pro server only)

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -128,24 +128,6 @@ public class GeneralPreferencesPane extends PreferencesPane
       nudgeRight(dirChooser_);
       textBoxWithChooser(dirChooser_);
 
-      showServerHomePage_ = new SelectWidget(
-            "Show server home page:",
-            new String[] {
-                  "Multiple active sessions",
-                  "Always",
-                  "Never"
-            },
-            new String[] {
-                 "sessions",
-                 "always",
-                 "never"
-            },
-            false,
-            true,
-            false);
-      
-      reuseSessionsForProjectLinks_ = new CheckBox("Re-use idle sessions for project links");
-     
       restoreLastProject_ = new CheckBox("Restore most recently opened project at startup");
       lessSpaced(restoreLastProject_);
       basic.add(restoreLastProject_);
@@ -197,19 +179,42 @@ public class GeneralPreferencesPane extends PreferencesPane
       }
 
       VerticalPanel advanced = new VerticalPanel();
+
+      showServerHomePage_ = new SelectWidget(
+            "Show server home page:",
+            new String[] {
+                  "Multiple active sessions",
+                  "Always",
+                  "Never"
+            },
+            new String[] {
+                 "sessions",
+                 "always",
+                 "never"
+            },
+            false,
+            true,
+            false);
       
+      reuseSessionsForProjectLinks_ = new CheckBox("Re-use idle sessions for project links");
+      lessSpaced(reuseSessionsForProjectLinks_);
+      boolean firstHeader = true;
+
       if (!Desktop.isDesktop())
       {
          if (session_.getSessionInfo().getShowUserHomePage() ||
              session_.getSessionInfo().getMultiSession())
          {
-            advanced.add(headerLabel("Home Page"));
+            Label homePageLabel = headerLabel("Home Page");
+            if (!firstHeader)
+               spacedBefore(homePageLabel);
+            advanced.add(homePageLabel);
+            firstHeader = false;
          }
          if (session_.getSessionInfo().getShowUserHomePage())
          {
-            spaced(showServerHomePage_);
+            tight(showServerHomePage_);
             advanced.add(showServerHomePage_);
-            lessSpaced(reuseSessionsForProjectLinks_);
          }
          if (session_.getSessionInfo().getMultiSession())
             advanced.add(reuseSessionsForProjectLinks_);
@@ -219,7 +224,11 @@ public class GeneralPreferencesPane extends PreferencesPane
       // version doesn't support them, don't show these options. 
       if (session_.getSessionInfo().getHaveSrcrefAttribute())
       {
-         advanced.add(headerLabel("Debugging"));
+         Label debuggingLabel = headerLabel("Debugging");
+         if (!firstHeader)
+            spacedBefore(debuggingLabel);
+         advanced.add(debuggingLabel);
+         firstHeader = false;
          advanced.add(checkboxPref(
                "Use debug error handler only when my code contains errors", 
                prefs_.handleErrorsInUserCodeOnly()));
@@ -231,7 +240,11 @@ public class GeneralPreferencesPane extends PreferencesPane
       
       if (Desktop.isDesktop())
       {
-         advanced.add(headerLabel("OS Integration (quit required)"));
+         Label osIntegrationLabel = headerLabel("OS Integration (quit required)");
+         if (!firstHeader)
+            spacedBefore(osIntegrationLabel);
+         advanced.add(osIntegrationLabel);
+         firstHeader = false;
          enableAccessibility_ = new CheckBox("Enable DOM accessibility");
          advanced.add(spaced(enableAccessibility_));
          Desktop.getFrame().getEnableAccessibility(enabled -> 
@@ -252,7 +265,11 @@ public class GeneralPreferencesPane extends PreferencesPane
          }
       }
       
-      advanced.add(headerLabel("Other"));
+      Label otherLabel = headerLabel("Other");
+      if (!firstHeader)
+         spacedBefore(otherLabel);
+      advanced.add(otherLabel);
+      firstHeader = false;
       showLastDotValue_ = new CheckBox("Show .Last.value in environment listing");
       lessSpaced(showLastDotValue_);
       advanced.add(showLastDotValue_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -145,20 +145,7 @@ public class GeneralPreferencesPane extends PreferencesPane
             false);
       
       reuseSessionsForProjectLinks_ = new CheckBox("Re-use idle sessions for project links");
-      
-      if (!Desktop.isDesktop())
-      {
-         if (session_.getSessionInfo().getShowUserHomePage())
-         {
-            spaced(showServerHomePage_);
-            basic.add(showServerHomePage_);
-            lessSpaced(reuseSessionsForProjectLinks_);  
-         }
-         
-         if (session_.getSessionInfo().getMultiSession())
-            basic.add(reuseSessionsForProjectLinks_);
-      }
-      
+     
       restoreLastProject_ = new CheckBox("Restore most recently opened project at startup");
       lessSpaced(restoreLastProject_);
       basic.add(restoreLastProject_);
@@ -210,6 +197,23 @@ public class GeneralPreferencesPane extends PreferencesPane
       }
 
       VerticalPanel advanced = new VerticalPanel();
+      
+      if (!Desktop.isDesktop())
+      {
+         if (session_.getSessionInfo().getShowUserHomePage() ||
+             session_.getSessionInfo().getMultiSession())
+         {
+            advanced.add(headerLabel("Home Page"));
+         }
+         if (session_.getSessionInfo().getShowUserHomePage())
+         {
+            spaced(showServerHomePage_);
+            advanced.add(showServerHomePage_);
+            lessSpaced(reuseSessionsForProjectLinks_);
+         }
+         if (session_.getSessionInfo().getMultiSession())
+            advanced.add(reuseSessionsForProjectLinks_);
+      }
       
       // The error handler features require source references; if this R
       // version doesn't support them, don't show these options. 


### PR DESCRIPTION
Fixed by moving Home Page-related items to Advanced tab.

Note, this only manifests on RStudio Server Pro but fix is in shared code.

See https://github.com/rstudio/rstudio-pro/issues/522

## Before fix
![42596222-e3a600d4-8522-11e8-9a46-70f4cb1cda9f](https://user-images.githubusercontent.com/10569626/42915737-8b38d626-8ab6-11e8-8b32-d502f380a091.png)

## After fix
![2018-07-18_16-43-53](https://user-images.githubusercontent.com/10569626/42915746-97ff59b6-8ab6-11e8-868b-0e3a8f7b396a.png)

## Advanced after fix
![2018-07-18_18-12-42](https://user-images.githubusercontent.com/10569626/42915769-b05bcfbc-8ab6-11e8-9bfc-b664fff29574.png)
