### PR TITLE
Install gpg 1.4 from source on OpenSUSE 15

### DIFF
--- a/docker/jenkins/Dockerfile.opensuse15-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse15-x86_64
@@ -64,6 +64,16 @@ RUN mkdir -p /opt/RStudio-QtSDK && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 
+# install GnuPG 1.4 from source (needed for release signing)
+RUN cd /tmp && \
+    wget https://gnupg.org/ftp/gcrypt/gnupg/gnupg-1.4.23.tar.bz2 && \
+    bzip2 -d gnupg-1.4.23.tar.bz2 && \
+    tar xvf gnupg-1.4.23.tar && \
+    cd gnupg-1.4.23 && \
+    ./configure && \
+    make && \
+    make install
+
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
 ARG JENKINS_GID=999
 ARG JENKINS_UID=999


### PR DESCRIPTION
This change adds gpg 1.4 on the OpenSUSE 15 container. We use gpg to sign releases, but don't support gpg 2 since it's not nearly as amenable to scripting. 

Unfortunately OpenSUSE 15 does not provide a package for gpg 1, so this change builds it from source as part of the Docker image. 