### PR TITLE
tweaks to text within Global, Project Option dialogs

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/SshKeyWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/SshKeyWidget.java
@@ -49,7 +49,7 @@ public class SshKeyWidget extends Composite
       HorizontalPanel captionPanel = new HorizontalPanel();
       captionPanel.addStyleName(RES.styles().captionPanel());
       captionPanel.setWidth(textWidth);
-      Label sshKeyPathLabel = new Label("SSH RSA Key:");
+      Label sshKeyPathLabel = new Label("SSH RSA key:");
       captionPanel.add(sshKeyPathLabel);
       captionPanel.setCellHorizontalAlignment(
                                           sshKeyPathLabel,

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectCompilePdfPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectCompilePdfPreferencesPane.java
@@ -38,7 +38,7 @@ public class ProjectCompilePdfPreferencesPane extends ProjectPreferencesPane
    @Inject
    public ProjectCompilePdfPreferencesPane()
    {
-      addHeader("Program defaults");
+      addHeader("PDF Generation");
         
       defaultSweaveEngine_ = new RnwWeaveSelectWidget();
       add(defaultSweaveEngine_);  
@@ -46,7 +46,7 @@ public class ProjectCompilePdfPreferencesPane extends ProjectPreferencesPane
       defaultLatexProgram_ = new LatexProgramSelectWidget();
       add(defaultLatexProgram_);
       
-      addHeader("PDF preview");
+      addHeader("PDF Preview");
       
       rootDoc_ = new RootDocumentChooser();
       nudgeRight(rootDoc_);
@@ -104,7 +104,7 @@ public class ProjectCompilePdfPreferencesPane extends ProjectPreferencesPane
    {
       public RootDocumentChooser()
       {
-         super("Compile PDF root document", 
+         super("Compile PDF root document:", 
                "(Current Document)", 
                "Browse...", 
                new HelpButton("pdf_root_document"),

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -15,15 +15,11 @@
 package org.rstudio.studio.client.workbench.prefs.views;
 
 import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.SelectElement;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.resources.client.ImageResource;
-import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
@@ -36,7 +32,6 @@ import org.rstudio.core.client.widget.SelectWidget;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.DesktopInfo;
 import org.rstudio.studio.client.application.events.EventBus;
-import org.rstudio.studio.client.application.events.ThemeChangedEvent;
 import org.rstudio.studio.client.workbench.prefs.model.RPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceTheme;
@@ -162,7 +157,7 @@ public class AppearancePreferencesPane extends PreferencesPane
       for (int i = 0; i < labels.length; i++)
          values[i] = Double.parseDouble(labels[i]) + "";
 
-      fontSize_ = new SelectWidget("Editor Font size:",
+      fontSize_ = new SelectWidget("Editor font size:",
                                    labels,
                                    values,
                                    false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CompilePdfPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CompilePdfPreferencesPane.java
@@ -42,7 +42,7 @@ public class CompilePdfPreferencesPane extends PreferencesPane
       res_ = res;
       PreferencesDialogBaseResources baseRes = PreferencesDialogBaseResources.INSTANCE;
    
-      add(headerLabel("Program defaults (when not in a project)"));
+      add(headerLabel("PDF Generation"));
      
       defaultSweaveEngine_ = new RnwWeaveSelectWidget();
       defaultSweaveEngine_.setValue(
@@ -64,7 +64,7 @@ public class CompilePdfPreferencesPane extends PreferencesPane
       spaced(perProjectLabel);
       add(perProjectLabel);
        
-      add(headerLabel("LaTeX editing and compilation"));
+      add(headerLabel("LaTeX Editing and Compilation"));
       chkCleanTexi2DviOutput_ = new CheckBox(
                                      "Clean auxiliary output after compile");
       spaced(chkCleanTexi2DviOutput_);
@@ -78,7 +78,7 @@ public class CompilePdfPreferencesPane extends PreferencesPane
             "Insert numbered sections and subsections",
             prefs_.insertNumberedLatexSections(), false /*defaultSpace*/)));
             
-      Label previewingOptionsLabel = headerLabel("PDF preview");
+      Label previewingOptionsLabel = headerLabel("PDF Preview");
       previewingOptionsLabel.getElement().getStyle().setMarginTop(8, Unit.PX);
       add(previewingOptionsLabel);
      

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
@@ -69,7 +69,7 @@ public class PackagesPreferencesPane extends PreferencesPane
       VerticalPanel management = new VerticalPanel();
       VerticalPanel development = new VerticalPanel();
     
-      management.add(headerLabel("Package management"));
+      management.add(headerLabel("Package Management"));
       
       cranMirrorTextBox_ = new TextBoxWithButton(
             "Primary CRAN repository:",
@@ -175,7 +175,7 @@ public class PackagesPreferencesPane extends PreferencesPane
 
       management.add(spacedBefore(new HelpLink("Managing Packages", "managing_packages")));
       
-      development.add(headerLabel("Package development"));
+      development.add(headerLabel("Package Development"));
       
       useDevtools_ = new CheckBox("Use devtools package functions if available");
       lessSpaced(useDevtools_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/RMarkdownPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/RMarkdownPreferencesPane.java
@@ -43,7 +43,7 @@ public class RMarkdownPreferencesPane extends PreferencesPane
       add(checkboxPref("Show document outline by default", prefs_.showDocumentOutlineRmd()));
       
       docOutlineDisplay_ = new SelectWidget(
-            "Show in Document Outline: ",
+            "Show in document outline: ",
             new String[] {
                   "Sections Only",
                   "Sections and Named Chunks",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/SourceControlPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/SourceControlPreferencesPane.java
@@ -235,6 +235,7 @@ public class SourceControlPreferencesPane extends PreferencesPane
       chooser.setTextWidth(textWidth);
       nudgeRight(chooser);
       textBoxWithChooser(chooser);
+      spaced(chooser);
       add(chooser);
    }
 


### PR DESCRIPTION
This PR makes some minor tweaks to the text used within the Global + Project Options dialogs, mainly for consistency in use of spaces, trailing colons for text box labels, and so on.

I changed a couple labels in the Sweave dialog since I think it's (mostly) well understood that Global Options are global, and Project Options are scoped to the project.