### PR TITLE
use '-f' rather than '-e' when executing async processes

### DIFF
--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -260,7 +260,18 @@ void AsyncRProcess::onProcessStderr(const std::string& output)
 void AsyncRProcess::onProcessCompleted(int exitStatus)
 {
    markCompleted();
-   scriptPath_.removeIfExists();
+   
+   if (exitStatus)
+   {
+      LOG_ERROR_MESSAGE(
+               "Error executing background script " +
+               scriptPath_.absolutePath());
+   }
+   else
+   {
+      scriptPath_.removeIfExists();
+   }
+   
    onCompleted(exitStatus);
 }
 

--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -119,7 +119,7 @@ void AsyncRProcess::start(const char* rCommand,
    {
       ss << "# RStudio Source Files ----" << std::endl;
       for (const FilePath& filePath : rSourceFiles)
-         ss << "source('" << filePath.absolutePath() << "')" << std::endl;
+         ss << "source('" << filePath.absolutePathNative() << "')" << std::endl;
       ss << std::endl;
    }
    

--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -94,19 +94,7 @@ void AsyncRProcess::start(const std::string& command,
    args.push_back("-f");
    
    // generate path to temporary file
-   std::string path;
-   error = r::exec::RFunction("base:::tempfile")
-         .addParam("pattern", "rstudio-async-process-")
-         .addParam("tmpdir", workingDir.absolutePathNative())
-         .addParam("fileext", ".R")
-         .call(&path);
-   if (error)
-   {
-      LOG_ERROR(error);
-      onCompleted(EXIT_FAILURE);
-      return;
-   }
-   scriptPath_ = module_context::resolveAliasedPath(path);
+   scriptPath_ = module_context::tempFile("rstudio-async-process-", ".R");
    
    // set this as the file to run
    args.push_back(scriptPath_.absolutePathNative());
@@ -119,7 +107,10 @@ void AsyncRProcess::start(const std::string& command,
    {
       ss << "# RStudio Source Files ----" << std::endl;
       for (const FilePath& filePath : rSourceFiles)
-         ss << "source('" << filePath.absolutePathNative() << "')" << std::endl;
+      {
+         std::string path = string_utils::singleQuotedStrEscape(filePath.absolutePathNative());
+         ss << "source('" << path << "')" << std::endl;
+      }
       ss << std::endl;
    }
    

--- a/src/cpp/session/include/session/SessionAsyncRProcess.hpp
+++ b/src/cpp/session/include/session/SessionAsyncRProcess.hpp
@@ -84,7 +84,6 @@ protected:
    virtual bool onContinue();
    virtual void onStdout(const std::string& output);
    virtual void onStderr(const std::string& output);
-
    virtual void onCompleted(int exitStatus) = 0;
 
 private:
@@ -92,6 +91,7 @@ private:
    bool isRunning_;
    bool terminationRequested_;
    std::string input_;
+   core::FilePath scriptPath_;
 };
 
 } // namespace async_r

--- a/src/cpp/session/include/session/SessionAsyncRProcess.hpp
+++ b/src/cpp/session/include/session/SessionAsyncRProcess.hpp
@@ -55,24 +55,22 @@ public:
    AsyncRProcess();
    virtual ~AsyncRProcess();
 
-   void start(const char* rCommand,
+   void start(const std::string& rCommand,
               const core::FilePath& workingDir,
               AsyncRProcessOptions rOptions,
-              std::vector<core::FilePath> rSourceFiles = 
-                 std::vector<core::FilePath>(),
-              const std::string &input = std::string())
+              std::vector<core::FilePath> rSourceFiles = {},
+              const std::string &input = {})
    {
       start(rCommand, core::system::Options(), workingDir, rOptions, 
             rSourceFiles, input);
    }
 
-   void start(const char* rCommand,
+   void start(const std::string& command,
               core::system::Options environment,
               const core::FilePath& workingDir,
               AsyncRProcessOptions rOptions,
-              std::vector<core::FilePath> rSourceFiles = 
-                 std::vector<core::FilePath>(),
-              const std::string& input = std::string());
+              std::vector<core::FilePath> rSourceFiles = {},
+              const std::string& input = {});
 
    bool isRunning();
    void terminate();
@@ -80,14 +78,21 @@ public:
    bool terminationRequested();
 
 protected:
+   // NOTE: implementing these methods is optional; deriving classes
+   // do not need to call the associated base-class method
    virtual void onStarted(core::system::ProcessOperations& operations);
    virtual bool onContinue();
    virtual void onStdout(const std::string& output);
    virtual void onStderr(const std::string& output);
-   virtual void onCompleted(int exitStatus) = 0;
+   virtual void onCompleted(int exitStatus);
 
 private:
+   void onProcessStarted(core::system::ProcessOperations& operations);
+   bool onProcessContinue();
+   void onProcessStdout(const std::string& output);
+   void onProcessStderr(const std::string& output);
    void onProcessCompleted(int exitStatus);
+   
    bool isRunning_;
    bool terminationRequested_;
    std::string input_;

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -1461,16 +1461,31 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    
    # define our helper script that will download + save available.packages
    template <- .rs.trimCommonIndent('
-      options(repos = %s, pkgType = %s)
+      
+      # Variables defined from parent session
+      repos <- %s
+      pkgType <- %s
+      targetDir <- %s
+      
+      # Request available packages
+      options(repos = repos, pkgType = pkgType)
       packages <- available.packages()
+      
+      # Copy repository cache to parent session
+      cache <- list.files(tempdir(), "^repos_", full.names = TRUE)
+      file.copy(cache, targetDir, overwrite = FALSE)
+      
+      # Generate packages database
       attr(packages, "time") <- Sys.time()
       saveRDS(packages, file = "packages.rds")
+
    ')
    
    script <- sprintf(
       template,
       .rs.deparse(getOption("repos")),
-      .rs.deparse(getOption("pkgType"))
+      .rs.deparse(getOption("pkgType")),
+      .rs.deparse(tempdir())
    )
    
    # fire off the process

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -479,24 +479,15 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("getCompletionsInstallPackages", function(token)
 {
-   contrib.url <- contrib.url(getOption("repos"), getOption("pkgType"))
+   # request available packages, but don't pause the session
+   # with a request if they aren't yet available
+   state <- .rs.availablePackages()
+   packages <- if (is.null(state$value))
+      character()
+   else
+      rownames(state$value)
    
-   packages <- Reduce(union, lapply(contrib.url, function(url) {
-      
-      # Try to get a package list from the cache
-      result <- .rs.getCachedAvailablePackages(url)
-      
-      # If it's null, there were no packages available
-      if (is.null(result))
-         .rs.downloadAvailablePackages(url)
-      
-      # Try again
-      result <- .rs.getCachedAvailablePackages(url)
-      
-      # And return
-      result
-   }))
-   
+   # produce completions
    .rs.makeCompletions(token = token,
                        results = .rs.selectFuzzyMatches(packages, token),
                        quote = TRUE,

--- a/src/cpp/session/modules/SessionRUtil.cpp
+++ b/src/cpp/session/modules/SessionRUtil.cpp
@@ -283,7 +283,6 @@ SEXP rs_runAsyncRProcess(SEXP codeSEXP,
    
    std::string code = r::sexp::asString(codeSEXP);
    std::string workingDir = r::sexp::asString(workingDirSEXP);
-   boost::algorithm::replace_all(code, "\n", "; ");
    launchProcess(code, module_context::resolveAliasedPath(workingDir), callbacksSEXP);
    
    r::sexp::Protect protect;


### PR DESCRIPTION
This PR tweaks the launcher for asynchronous R processes. Rather than generating a whole command line of code, we instead write the requested script to a file, and then instruct R to source that file.

This helps in a couple ways:

1. We can eschew some of the more complicated code around escaping (especially for Windows),
2. The executed scripts can contain multiple lines, as well as R comments (which can occasionally be useful for larger in-line scripts).

The primary downside I can think of is that we're now introducing an extra file write + read + delete operation into the whole "run an R process" workflow, but given that we already explicitly source our helper scripts in a number of these operations I think we're already in that realm anyhow. And, since R itself regularly reads / writes into the temporary directory (which is where we park our generated scripts) I think we can feel comfortable doing the same.

Also bundled in this PR: re-use of the repository cache generated by R.