### PR TITLE
Only initialize satellite dark themes when satellite supports this

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteWindow.java
@@ -72,15 +72,15 @@ public abstract class SatelliteWindow extends Composite
    @Override
    public void onThemeChanged(ThemeChangedEvent event)
    {
-      RStudioThemes.initializeThemes(
-         RStudioGinjector.INSTANCE.getUIPrefs(),
-         Document.get(),
-         mainPanel_.getElement());
-   
       // By default, we only apply the flat theme to match other dialogs, then
       // specific satellites can opt in to full theming using `supportsThemes()`.
       if (supportsThemes())
       {
+         RStudioThemes.initializeThemes(
+            RStudioGinjector.INSTANCE.getUIPrefs(),
+            Document.get(),
+            mainPanel_.getElement());
+            
          RStudioGinjector.INSTANCE.getAceThemes().applyTheme(Document.get());
       }
    }


### PR DESCRIPTION
Fix for https://github.com/rstudio/rstudio/issues/3153

@MariaSemple, would you mind code reviewing this change?

I didn't mean to take this issue from your plate, it's just that @kevinykuo mentioned this to me and it felt like and old bug, which it seems to be, it's just that recent changes in how UIPrefs propagate and other events might uncover this.