### PR TITLE
implement tri-state toggle

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/Toggle.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/Toggle.java
@@ -62,29 +62,31 @@ public class Toggle
       initWidget(container_);
    }
    
-   public void setState(State state)
+   public void setState(State state, boolean animate)
    {
-      clearToggleStyles();
-      
       if (!indeterminateStateEnabled_ && state == State.INDETERMINATE)
       {
          assert false : "Attempted to set indeterminate state on binary toggle";
       }
       
+      if (animate)
+         knob_.removeStyleName(styles_.transitionDisabled());
+      else
+         knob_.addStyleName(styles_.transitionDisabled());
+      
+      clearToggleStyles();
+      
       switch (state)
       {
       case OFF:
-         track_.addStyleName(styles_.trackLeft());
          knob_.addStyleName(styles_.knobLeft());
          break;
          
       case INDETERMINATE:
-         track_.addStyleName(styles_.trackMiddle());
          knob_.addStyleName(styles_.knobMiddle());
          break;
          
       case ON:
-         track_.addStyleName(styles_.trackRight());
          knob_.addStyleName(styles_.knobRight());
          break;
       }
@@ -94,6 +96,11 @@ public class Toggle
          state_ = state;
          ValueChangeEvent.fire(this, state);
       }
+   }
+   
+   public void setState(State state)
+   {
+      setState(state, false);
    }
    
    public void setValue(boolean value)
@@ -123,25 +130,21 @@ public class Toggle
       switch (state_)
       {
       case OFF:
-         setState(indeterminateStateEnabled_ ? State.INDETERMINATE : State.ON);
+         setState(indeterminateStateEnabled_ ? State.INDETERMINATE : State.ON, true);
          break;
          
       case INDETERMINATE:
-         setState(State.ON);
+         setState(State.ON, true);
          break;
          
       case ON:
-         setState(State.OFF);
+         setState(State.OFF, true);
          break;
       }
    }
    
    private void clearToggleStyles()
    {
-      track_.removeStyleName(styles_.trackLeft());
-      track_.removeStyleName(styles_.trackMiddle());
-      track_.removeStyleName(styles_.trackRight());
-      
       knob_.removeStyleName(styles_.knobLeft());
       knob_.removeStyleName(styles_.knobMiddle());
       knob_.removeStyleName(styles_.knobRight());
@@ -166,20 +169,15 @@ public class Toggle
    static interface Binder extends UiBinder<Widget, Toggle>
    {
    }
-
+   
    public interface Styles extends CssResource
    {
       String track();
-      
-      String trackLeft();
-      String trackMiddle();
-      String trackRight();
-      
       String knob();
-      
       String knobLeft();
       String knobMiddle();
       String knobRight();
+      String transitionDisabled();
    }
 
    private static final Binder BINDER = GWT.create(Binder.class);

--- a/src/gwt/src/org/rstudio/core/client/widget/Toggle.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/Toggle.java
@@ -1,0 +1,187 @@
+/*
+ * Toggle.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.widget;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.resources.client.CssResource;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.Widget;
+
+public class Toggle
+      extends Composite
+      implements HasValueChangeHandlers<Toggle.State>
+{
+   public static enum State
+   {
+      OFF,
+      INDETERMINATE,
+      ON
+   }
+   
+   public Toggle(String label, boolean indeterminateStateEnabled)
+   {
+      this();
+      setText(label);
+      setIndeterminateStateEnabled(indeterminateStateEnabled);
+      setState(indeterminateStateEnabled ? State.INDETERMINATE : State.OFF);
+   }
+   
+   public Toggle(String label)
+   {
+      this();
+      setText(label);
+      setState(State.INDETERMINATE);
+   }
+   
+   private Toggle()
+   {
+      BINDER.createAndBindUi(this);
+      container_.addDomHandler((ClickEvent event) -> { toggleState(); }, ClickEvent.getType());
+      initWidget(container_);
+   }
+   
+   public void setState(State state)
+   {
+      clearToggleStyles();
+      
+      if (!indeterminateStateEnabled_ && state == State.INDETERMINATE)
+      {
+         assert false : "Attempted to set indeterminate state on binary toggle";
+      }
+      
+      switch (state)
+      {
+      case OFF:
+         track_.addStyleName(styles_.trackLeft());
+         knob_.addStyleName(styles_.knobLeft());
+         break;
+         
+      case INDETERMINATE:
+         track_.addStyleName(styles_.trackMiddle());
+         knob_.addStyleName(styles_.knobMiddle());
+         break;
+         
+      case ON:
+         track_.addStyleName(styles_.trackRight());
+         knob_.addStyleName(styles_.knobRight());
+         break;
+      }
+      
+      if (state_ != state)
+      {
+         state_ = state;
+         ValueChangeEvent.fire(this, state);
+      }
+   }
+   
+   public void setValue(boolean value)
+   {
+      setState(value ? State.ON : State.OFF);
+   }
+   
+   public void setText(String text)
+   {
+      label_.setText(text);
+   }
+   
+   public void setIndeterminateStateEnabled(boolean enabled)
+   {
+      indeterminateStateEnabled_ = enabled;
+   }
+   
+   public State getState()
+   {
+      return state_;
+   }
+   
+   private void toggleState()
+   {
+      clearToggleStyles();
+      
+      switch (state_)
+      {
+      case OFF:
+         setState(indeterminateStateEnabled_ ? State.INDETERMINATE : State.ON);
+         break;
+         
+      case INDETERMINATE:
+         setState(State.ON);
+         break;
+         
+      case ON:
+         setState(State.OFF);
+         break;
+      }
+   }
+   
+   private void clearToggleStyles()
+   {
+      track_.removeStyleName(styles_.trackLeft());
+      track_.removeStyleName(styles_.trackMiddle());
+      track_.removeStyleName(styles_.trackRight());
+      
+      knob_.removeStyleName(styles_.knobLeft());
+      knob_.removeStyleName(styles_.knobMiddle());
+      knob_.removeStyleName(styles_.knobRight());
+   }
+   
+   @Override
+   public HandlerRegistration addValueChangeHandler(ValueChangeHandler<State> handler)
+   {
+      return addHandler(handler, ValueChangeEvent.getType());
+   }
+   
+   private State state_ = State.OFF;
+   private boolean indeterminateStateEnabled_ = true;
+   
+   @UiField HorizontalPanel container_;
+   @UiField FlowPanel track_;
+   @UiField FlowPanel knob_;
+   @UiField Label label_;
+   @UiField Styles styles_;
+   
+   // UI Binder ----
+   static interface Binder extends UiBinder<Widget, Toggle>
+   {
+   }
+
+   public interface Styles extends CssResource
+   {
+      String track();
+      
+      String trackLeft();
+      String trackMiddle();
+      String trackRight();
+      
+      String knob();
+      
+      String knobLeft();
+      String knobMiddle();
+      String knobRight();
+   }
+
+   private static final Binder BINDER = GWT.create(Binder.class);
+
+}

--- a/src/gwt/src/org/rstudio/core/client/widget/Toggle.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/Toggle.ui.xml
@@ -13,54 +13,57 @@
 
 .track {
    position: relative;
-   width: 14px;
+   width: 16px;
    height: 10px;
+   border: 1px solid rgb(150, 150, 150);
+   margin-top: 1px;
    border-radius: 10px 10px;
 }
 
 .trackLeft {
-   background-color: rgb(214, 124, 113);
+   background-color: rgb(217, 217, 217);
    transition: 500ms;
 }
 
 .trackMiddle {
-   background-color: rgb(180, 180, 180);
+   background-color: rgb(217, 217, 217);
    transition: 500ms;
 }
 
 .trackRight {
-   background-color: rgb(97, 192, 123);
+   background-color: rgb(217, 217, 217);
    transition: 500ms;
 }
 
 .knob {
    position: absolute;
-   width: 8px;
-   height: 8px;
+   width: 10px;
+   height: 10px;
+   top: -1px;
    border-radius: 10px 10px;
    background-color: white;
 }
 
 .knobLeft {
-   margin-left: 0;
-   border: 1px solid rgb(214, 124, 113);
+   margin-left: -1px;
+   border: 1px solid rgb(150, 150, 150);
    transition: 500ms;
 }
 
 .knobMiddle {
    margin-left: 2px;
-   border: 1px solid rgb(180, 180, 180);
+   border: 1px solid rgb(150, 150, 150);
    transition: 500ms;
 }
 
 .knobRight {
-   margin-left: 4px;
-   border: 1px solid rgb(97, 192, 123);
+   margin-left: 5px;
+   border: 1px solid rgb(150, 150, 150);
    transition: 500ms;
 }
 
 .label {
-   margin-left: 2px;
+   margin-left: 5px;
 }
 
 </ui:style>

--- a/src/gwt/src/org/rstudio/core/client/widget/Toggle.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/Toggle.ui.xml
@@ -1,0 +1,77 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder" xmlns:g="urn:import:com.google.gwt.user.client.ui">
+
+<ui:style field="styles_" type="org.rstudio.core.client.widget.Toggle.Styles">
+
+.container {
+   margin: 2px 0 2px 1px;
+}
+
+.container td {
+   vertical-align: middle !important;
+}
+
+.track {
+   position: relative;
+   width: 14px;
+   height: 10px;
+   border-radius: 10px 10px;
+}
+
+.trackLeft {
+   background-color: rgb(214, 124, 113);
+   transition: 500ms;
+}
+
+.trackMiddle {
+   background-color: rgb(180, 180, 180);
+   transition: 500ms;
+}
+
+.trackRight {
+   background-color: rgb(97, 192, 123);
+   transition: 500ms;
+}
+
+.knob {
+   position: absolute;
+   width: 8px;
+   height: 8px;
+   border-radius: 10px 10px;
+   background-color: white;
+}
+
+.knobLeft {
+   margin-left: 0;
+   border: 1px solid rgb(214, 124, 113);
+   transition: 500ms;
+}
+
+.knobMiddle {
+   margin-left: 2px;
+   border: 1px solid rgb(180, 180, 180);
+   transition: 500ms;
+}
+
+.knobRight {
+   margin-left: 4px;
+   border: 1px solid rgb(97, 192, 123);
+   transition: 500ms;
+}
+
+.label {
+   margin-left: 2px;
+}
+
+</ui:style>
+
+<g:HorizontalPanel ui:field="container_" styleName="{styles_.container}">
+	<g:FlowPanel ui:field="track_" styleName="{styles_.track}">
+		<g:FlowPanel ui:field="knob_" styleName="{styles_.knob}">
+		</g:FlowPanel>
+	</g:FlowPanel>
+	<g:Label ui:field="label_" styleName="{styles_.label}">
+	</g:Label>
+</g:HorizontalPanel>
+
+</ui:UiBinder> 

--- a/src/gwt/src/org/rstudio/core/client/widget/Toggle.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/Toggle.ui.xml
@@ -29,7 +29,7 @@
    top: -1px;
    border: 1px solid rgb(115, 115, 115);
    border-radius: 10px 10px;
-   box-shadow: 1px 1px 1px rgba(115, 115, 115, 0.5);
+   box-shadow: 1px 1px 1px rgba(115, 115, 115, 0.25);
    background-color: white;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/widget/Toggle.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/Toggle.ui.xml
@@ -15,55 +15,45 @@
    position: relative;
    width: 18px;
    height: 10px;
-   border: 1px solid rgb(115, 115, 115);
    margin-top: 1px;
+   background-color: rgb(217, 217, 217);
+   border: 1px solid rgb(115, 115, 115);
    border-radius: 10px 10px;
-}
-
-.trackLeft {
-   background-color: rgb(217, 217, 217);
-   transition: 500ms;
-}
-
-.trackMiddle {
-   background-color: rgb(217, 217, 217);
-   transition: 500ms;
-}
-
-.trackRight {
-   background-color: rgb(217, 217, 217);
-   transition: 500ms;
 }
 
 .knob {
    position: absolute;
    width: 10px;
    height: 10px;
+   margin-left: -1px;
    top: -1px;
+   border: 1px solid rgb(115, 115, 115);
    border-radius: 10px 10px;
+   box-shadow: 1px 1px 1px rgba(115, 115, 115, 0.5);
    background-color: white;
 }
 
-.knobLeft {
+.knob.knobLeft {
    margin-left: -1px;
-   border: 1px solid rgb(115, 115, 115);
    transition: 500ms;
 }
 
-.knobMiddle {
+.knob.knobMiddle {
    margin-left: 3px;
-   border: 1px solid rgb(115, 115, 115);
    transition: 500ms;
 }
 
-.knobRight {
+.knob.knobRight {
    margin-left: 7px;
-   border: 1px solid rgb(115, 115, 115);
    transition: 500ms;
 }
 
 .label {
    margin-left: 6px;
+}
+
+.transitionDisabled {
+   transition: none !important;
 }
 
 </ui:style>

--- a/src/gwt/src/org/rstudio/core/client/widget/Toggle.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/Toggle.ui.xml
@@ -13,9 +13,9 @@
 
 .track {
    position: relative;
-   width: 16px;
+   width: 18px;
    height: 10px;
-   border: 1px solid rgb(150, 150, 150);
+   border: 1px solid rgb(115, 115, 115);
    margin-top: 1px;
    border-radius: 10px 10px;
 }
@@ -46,24 +46,24 @@
 
 .knobLeft {
    margin-left: -1px;
-   border: 1px solid rgb(150, 150, 150);
+   border: 1px solid rgb(115, 115, 115);
    transition: 500ms;
 }
 
 .knobMiddle {
-   margin-left: 2px;
-   border: 1px solid rgb(150, 150, 150);
+   margin-left: 3px;
+   border: 1px solid rgb(115, 115, 115);
    transition: 500ms;
 }
 
 .knobRight {
-   margin-left: 5px;
-   border: 1px solid rgb(150, 150, 150);
+   margin-left: 7px;
+   border: 1px solid rgb(115, 115, 115);
    transition: 500ms;
 }
 
 .label {
-   margin-left: 5px;
+   margin-left: 6px;
 }
 
 </ui:style>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
@@ -31,10 +31,9 @@ import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.ProgressOperationWithInput;
 import org.rstudio.core.client.widget.SmallButton;
 import org.rstudio.core.client.widget.TextBoxWithCue;
-import org.rstudio.core.client.widget.ThemedCheckBox;
-import org.rstudio.core.client.widget.TriStateCheckBox;
+import org.rstudio.core.client.widget.Toggle;
 import org.rstudio.core.client.widget.VerticalSpacer;
-import org.rstudio.core.client.widget.TriStateCheckBox.State;
+import org.rstudio.core.client.widget.Toggle.State;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.FileDialogs;
 import org.rstudio.studio.client.common.FilePathUtils;
@@ -231,30 +230,30 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
       
       panel_.add(nameAndOutputGrid);
       
-      showWarningsInOutputCb_ = makeTriStateCheckBox(
+      showWarningsInOutputCb_ = makeTriStateToggle(
             "Show warnings",
             "warning");
       panel_.add(showWarningsInOutputCb_);
       
-      showMessagesInOutputCb_ = makeTriStateCheckBox(
+      showMessagesInOutputCb_ = makeTriStateToggle(
             "Show messages",
             "message");
       panel_.add(showMessagesInOutputCb_);
 
-      printTableAsTextCb_ = makeTriStateCheckBox(
+      printTableAsTextCb_ = makeTriStateToggle(
             "Use paged tables",
             "paged.print");
       panel_.add(printTableAsTextCb_);
       printTableAsTextCb_.setVisible(false);
       
-      useCustomFigureCheckbox_ = new ThemedCheckBox("Use custom figure size");
+      useCustomFigureCheckbox_ = new Toggle("Use custom figure size", false);
       useCustomFigureCheckbox_.addStyleName(RES.styles().checkBox());
-      useCustomFigureCheckbox_.addValueChangeHandler(new ValueChangeHandler<Boolean>()
+      useCustomFigureCheckbox_.addValueChangeHandler(new ValueChangeHandler<Toggle.State>()
       {
          @Override
-         public void onValueChange(ValueChangeEvent<Boolean> event)
+         public void onValueChange(ValueChangeEvent<Toggle.State> event)
          {
-            boolean value = event.getValue();
+            boolean value = event.getValue() == Toggle.State.ON;
             figureDimensionsPanel_.setVisible(value);
             
             if (!value)
@@ -439,27 +438,26 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
       return box;
    }
    
-   private TriStateCheckBox makeTriStateCheckBox(String label, final String option)
+   private Toggle makeTriStateToggle(String label, final String option)
    {
-      TriStateCheckBox checkBox = new TriStateCheckBox(label);
-      checkBox.addValueChangeHandler(
-            new ValueChangeHandler<TriStateCheckBox.State>()
-            {
-               @Override
-               public void onValueChange(ValueChangeEvent<State> event)
-               {
-                  State state = event.getValue();
-                  if (state == TriStateCheckBox.STATE_INDETERMINATE)
-                     unset(option);
-                  else if (state == TriStateCheckBox.STATE_OFF)
-                     set(option, "FALSE");
-                  else if (state == TriStateCheckBox.STATE_ON)
-                     set(option, "TRUE");
-                  synchronize();
-               }
-            });
-      checkBox.getElement().getStyle().setMargin(2, Unit.PX);
-      return checkBox;
+      Toggle toggle = new Toggle(label, true);
+      toggle.addValueChangeHandler((ValueChangeEvent<State> event) -> {
+         State state = event.getValue();
+         switch (state)
+         {
+         case INDETERMINATE:
+            unset(option);
+            break;
+         case OFF:
+            set(option, "FALSE");
+            break;
+         case ON:
+            set(option, "TRUE");
+            break;
+         }
+         synchronize();
+      });
+      return toggle;
    }
    
    protected boolean has(String key)
@@ -664,10 +662,10 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
    protected final TextBox engineOptsBox_;
    protected final SmallButton revertButton_;
    protected final SmallButton applyButton_;
-   protected final ThemedCheckBox useCustomFigureCheckbox_;
-   protected final TriStateCheckBox showWarningsInOutputCb_;
-   protected final TriStateCheckBox showMessagesInOutputCb_;
-   protected final TriStateCheckBox printTableAsTextCb_;
+   protected final Toggle useCustomFigureCheckbox_;
+   protected final Toggle showWarningsInOutputCb_;
+   protected final Toggle showMessagesInOutputCb_;
+   protected final Toggle printTableAsTextCb_;
    
    protected String originalLine_;
    protected String chunkPreamble_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/SetupChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/SetupChunkOptionsPopupPanel.java
@@ -23,7 +23,7 @@ import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.js.JsUtil;
-import org.rstudio.core.client.widget.TriStateCheckBox;
+import org.rstudio.core.client.widget.Toggle;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.codetools.CodeToolsServerOperations;
 import org.rstudio.studio.client.server.ServerError;
@@ -93,11 +93,21 @@ public class SetupChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
    }
    
    private void addCheckboxParam(Map<String, String> options,
-                                 TriStateCheckBox checkBox,
+                                 Toggle toggle,
                                  String name)
    {
-      if (!checkBox.isIndeterminate())
-         options.put(name, trueString(checkBox.isChecked()));
+      switch (toggle.getState())
+      {
+      case INDETERMINATE:
+         options.remove(name);
+         break;
+      case OFF:
+         options.put(name, "FALSE");
+         break;
+      case ON:
+         options.put(name, "TRUE");
+         break;
+      }
    }
    
    private void addTextBoxParam(Map<String, String> options,


### PR DESCRIPTION
This PR implements a new tri-state toggle for the chunk options popup panel (hat tip to @nwstephens)

![screen shot 2018-07-24 at 9 24 14 am](https://user-images.githubusercontent.com/1976582/43153051-14d33c7e-8f25-11e8-971f-5c9e4cf37cb3.png)

The intention of this toggle is to make it more clear to the user that three possible states are supported by the toggle, and make it a bit more clear what the 'indeterminate' state is. Compare with the old treatment:

![screen shot 2018-07-24 at 9 37 54 am](https://user-images.githubusercontent.com/1976582/43153135-4bc178a4-8f25-11e8-8a76-58c7d5783209.png)

I think the new UI is overall an improvement, although I'm somewhat torn as to whether we should use color or greyscale here. Example of what that might look like:

![screen shot 2018-07-24 at 9 39 31 am](https://user-images.githubusercontent.com/1976582/43153348-eac45872-8f25-11e8-84a0-6fcf6d526482.png)

Also wonder if it's worth increasing the contrast a bit on the 'knob' to make it stand out a bit more.