### PR TITLE
preserve addin ordering in display

### DIFF
--- a/src/cpp/session/modules/SessionRAddins.cpp
+++ b/src/cpp/session/modules/SessionRAddins.cpp
@@ -153,20 +153,28 @@ public:
             {
                bool interactive;
                std::string name, package, title, description, binding;
-               int ordinal = 0;
                Error error = json::readObject(valueJson.get_obj(),
                                               "name", &name,
                                               "package", &package,
                                               "title", &title,
                                               "description", &description,
                                               "interactive", &interactive,
-                                              "binding", &binding,
-                                              "ordinal", &ordinal);
+                                              "binding", &binding);
                if (error)
                {
                   LOG_ERROR(error);
                   continue;
                }
+               
+               // attempt read to ordinal (note that this was not persisted
+               // as part of older addin databases so we read it separately
+               // and simply log errors rather than treating them as failures
+               // to read an entry from the database)
+               int ordinal = 0;
+               error = json::readObject(valueJson.get_obj(),
+                                        "ordinal", &ordinal);
+               if (error)
+                  LOG_ERROR(error);
 
                addins_[key] = AddinSpecification(name,
                                                  package,

--- a/src/cpp/session/modules/SessionRAddins.cpp
+++ b/src/cpp/session/modules/SessionRAddins.cpp
@@ -65,10 +65,11 @@ public:
                       const std::string& title,
                       const std::string& description,
                       bool interactive,
-                      const std::string& binding)
+                      const std::string& binding,
+                      int ordinal)
       : name_(name), package_(package), title_(title),
         description_(description), interactive_(interactive),
-        binding_(binding)
+        binding_(binding), ordinal_(ordinal)
    {
    }
    
@@ -78,6 +79,7 @@ public:
    const std::string& getDescription() const { return description_; }
    bool isInteractive() const { return interactive_; }
    const std::string& getBinding() const { return binding_; }
+   int getOrdinal() const { return ordinal_; }
    
    json::Object toJson() const
    {
@@ -89,6 +91,7 @@ public:
       object["description"] = description_;
       object["interactive"] = interactive_;
       object["binding"] = binding_;
+      object["ordinal"] = ordinal_;
       
       return object;
    }
@@ -100,6 +103,7 @@ private:
    std::string description_;
    bool interactive_;
    std::string binding_;
+   int ordinal_;
 };
 
 class AddinRegistry : boost::noncopyable
@@ -145,17 +149,19 @@ public:
          BOOST_FOREACH(const std::string& key, addinsJson | boost::adaptors::map_keys)
          {
             json::Value valueJson = addinsJson.at(key);
-            if(json::isType<json::Object>(valueJson))
+            if (json::isType<json::Object>(valueJson))
             {
                bool interactive;
                std::string name, package, title, description, binding;
+               int ordinal = 0;
                Error error = json::readObject(valueJson.get_obj(),
                                               "name", &name,
                                               "package", &package,
                                               "title", &title,
                                               "description", &description,
                                               "interactive", &interactive,
-                                              "binding", &binding);
+                                              "binding", &binding,
+                                              "ordinal", &ordinal);
                if (error)
                {
                   LOG_ERROR(error);
@@ -167,7 +173,8 @@ public:
                                                  title,
                                                  description,
                                                  interactive,
-                                                 binding);
+                                                 binding,
+                                                 ordinal);
             }
          }
 
@@ -194,7 +201,8 @@ public:
             fields["Title"],
             fields["Description"],
             interactive,
-            fields["Binding"]));
+            fields["Binding"],
+            addins_.size() + 1));
    }
 
    void add(const std::string& pkgName, const FilePath& addinPath)

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/addins/AddinsToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/addins/AddinsToolbarButton.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.application.ui.addins;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -159,6 +160,15 @@ public class AddinsToolbarButton extends ToolbarButton
                }
             });
             menu_.addSeparator();
+            
+            addins.sort(new Comparator<RAddin>()
+            {
+               @Override
+               public int compare(RAddin o1, RAddin o2)
+               {
+                  return Integer.compare(o1.getOrdinal(), o2.getOrdinal());
+               }
+            });
             
             for (RAddin addin : addins)
                menu_.addItem(menuItem(addin));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/addins/Addins.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/addins/Addins.java
@@ -29,7 +29,8 @@ public class Addins
                                                String title,
                                                String description,
                                                boolean interactive,
-                                               String binding)
+                                               String binding,
+                                               int ordinal)
       /*-{
          return {
             "name": name,
@@ -37,7 +38,8 @@ public class Addins
             "title": title,
             "description": description,
             "interactive": interactive,
-            "binding": binding
+            "binding": binding,
+            "ordinal": ordinal
          };
       }-*/;
       
@@ -47,6 +49,7 @@ public class Addins
       public final native String getDescription() /*-{ return this["description"]; }-*/;
       public final native boolean isInteractive() /*-{ return this["interactive"]; }-*/;
       public final native String getBinding() /*-{ return this["binding"]; }-*/;
+      public final native int getOrdinal() /*-{ return this["ordinal"] || 0; }-*/;
       
       public final String getId()
       {
@@ -62,7 +65,8 @@ public class Addins
                addin.getTitle(),
                addin.getDescription(),
                addin.isInteractive() ? "true" : "false",
-               addin.getBinding());
+               addin.getBinding(),
+               "" + addin.getOrdinal());
       }
       
       public final static RAddin decode(String decoded)
@@ -80,7 +84,8 @@ public class Addins
                splat[2],
                splat[3],
                splat[4] == "false" ? false : true,
-               splat[5]);
+               splat[5],
+               StringUtil.parseInt(splat[6], 0));
       }
    }
    


### PR DESCRIPTION
This PR ensures that addins are displayed in the same order as defined within a package's `addins.dcf`.

Closes https://github.com/rstudio/rstudio/issues/3174.