### PR TITLE
Resolve absolute URLs using the browser

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -500,28 +500,6 @@ public class StringUtil
       return result;
    }
    
-   // Given an input URL which may be relative, return an absolute URL. Has
-   // no effect on URLs which are already absolute.
-   public static String makeAbsoluteUrl(String inputUrl)
-   {
-      String url = inputUrl;
-      if (!(url.startsWith("http://") || url.startsWith("https://")))
-      {
-         String thisUrl = Window.Location.getProtocol() + "//" +
-                          Window.Location.getHost() + "/";
-         if (Window.Location.getPath().length() > 0 &&
-             !Window.Location.getPath().equals("/"))
-            thisUrl += Window.Location.getPath();
-         if (!thisUrl.endsWith("/"))
-            thisUrl += "/";
-         if (url.startsWith("/"))
-            url = url.substring(1);
-         url = thisUrl + url;
-      }
-      return url;
-      
-   }
-   
    /**
     * Given a URL, attempt to infer and return the authority (host name and
     * port) from the URL. The URL is always presumed to have a hostname (if it

--- a/src/gwt/src/org/rstudio/core/client/URIUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/URIUtils.java
@@ -15,6 +15,8 @@
 
 package org.rstudio.core.client;
 
+import org.rstudio.core.client.dom.DomUtils;
+
 import com.google.gwt.http.client.URL;
 
 public class URIUtils
@@ -52,7 +54,7 @@ public class URIUtils
    public static boolean isLocalUrl(String url)
    {
       // ensure URL is absolute
-      String absolute = StringUtil.makeAbsoluteUrl(url);
+      String absolute = DomUtils.makeAbsoluteUrl(url);
       
       // extract host and see if it's on the whitelist of loopback hosts
       String host = StringUtil.getHostFromUrl(absolute);

--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -1093,6 +1093,19 @@ public class DomUtils
       disableAutoBehavior(w.getElement());
    }
    
+   /**
+    * Given any URL, resolves it to an absolute URL (using the current window as
+    * the base URL), and returns the result.
+    * 
+    * @param url A relative or absolute URL.
+    * @return The same URL, in absolute form.
+    */
+   public final static native String makeAbsoluteUrl(String url) /*-{
+     var ele = document.createElement("a")
+     ele.href = url;
+     return ele.href;
+   }-*/;
+   
    public static final int getScrollbarWidth()
    {
       if (SCROLLBAR_WIDTH == -1)

--- a/src/gwt/src/org/rstudio/studio/client/plumber/ui/PlumberAPIPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/plumber/ui/PlumberAPIPanel.java
@@ -20,7 +20,7 @@ import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.client.ui.Label;
 import com.google.inject.Inject;
 
-import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.RStudioFrame;
 import org.rstudio.core.client.widget.SatelliteFramePanel;
@@ -108,7 +108,7 @@ public class PlumberAPIPanel extends SatelliteFramePanel<RStudioFrame>
    @Override
    public String getAbsoluteUrl()
    {
-      return StringUtil.makeAbsoluteUrl(appParams_.getUrl());
+      return DomUtils.makeAbsoluteUrl(appParams_.getUrl());
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdOutputFramePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdOutputFramePane.java
@@ -15,7 +15,7 @@
 package org.rstudio.studio.client.rmarkdown.ui;
 
 import org.rstudio.core.client.ScrollUtil;
-import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.RStudioFrame;
@@ -80,7 +80,7 @@ public class RmdOutputFramePane extends RmdOutputFrameBase
          if (params.isShinyDocument())
          {
             shinyFrame_.initialize(
-               StringUtil.makeAbsoluteUrl(params.getOutputUrl()),
+               DomUtils.makeAbsoluteUrl(params.getOutputUrl()),
                new Operation() {
                   @Override
                   public void execute()

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdOutputPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdOutputPanel.java
@@ -1,7 +1,7 @@
 /*
  * RmdOutputPanel.java
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -31,7 +31,7 @@ import com.google.inject.Inject;
 
 import org.rstudio.core.client.FilePosition;
 import org.rstudio.core.client.ScrollUtil;
-import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.IFrameElementEx;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.files.FileSystemItem;
@@ -101,7 +101,7 @@ public class RmdOutputPanel extends SatelliteFramePanel<AnchorableFrame>
       {
          fileLabel_.setVisible(false);
          fileLabelSeparator_.setVisible(false);
-         shinyUrl_ = StringUtil.makeAbsoluteUrl(params.getOutputUrl());
+         shinyUrl_ = DomUtils.makeAbsoluteUrl(params.getOutputUrl());
          isShiny_ = true;
       }
       else

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdOutputPresenter.java
@@ -1,7 +1,7 @@
 /*
  * RmdOutputPresenter.java
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,9 +14,9 @@
  */
 package org.rstudio.studio.client.rmarkdown.ui;
 
-import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
@@ -115,7 +115,7 @@ public class RmdOutputPresenter implements
    @Override
    public String getShinyUrl()
    {
-      return StringUtil.makeAbsoluteUrl(params_.getOutputUrl());
+      return DomUtils.makeAbsoluteUrl(params_.getOutputUrl());
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ui/ShinyApplicationPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ui/ShinyApplicationPanel.java
@@ -1,7 +1,7 @@
 /*
  * ShinyApplicationPanel.java
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -20,7 +20,7 @@ import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.client.ui.Label;
 import com.google.inject.Inject;
 
-import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.RStudioFrame;
 import org.rstudio.core.client.widget.SatelliteFramePanel;
@@ -114,7 +114,7 @@ public class ShinyApplicationPanel extends SatelliteFramePanel<RStudioFrame>
    @Override
    public String getAbsoluteUrl()
    {
-      return StringUtil.makeAbsoluteUrl(appParams_.getUrl());
+      return DomUtils.makeAbsoluteUrl(appParams_.getUrl());
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyHost.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyHost.java
@@ -18,6 +18,7 @@ package org.rstudio.studio.client.workbench.views.connections.ui;
 
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.RStudioFrame;
@@ -223,7 +224,7 @@ public class NewConnectionShinyHost extends Composite
       if (Desktop.isDesktop())
          Desktop.getFrame().setShinyDialogUrl(StringUtil.notNull(url));
 
-      frame_.setUrl(StringUtil.makeAbsoluteUrl(url));
+      frame_.setUrl(DomUtils.makeAbsoluteUrl(url));
       appendStyleOnLoad(frame_);
    }
    

--- a/src/gwt/test/org/rstudio/core/client/dom/DomUtilsTests.java
+++ b/src/gwt/test/org/rstudio/core/client/dom/DomUtilsTests.java
@@ -50,4 +50,17 @@ public class DomUtilsTests extends GWTTestCase
       Assert.assertEquals("Line3\n", pre.getInnerText());
       Assert.assertEquals(trimmed, 2);
    }
+   
+   public void testMakeAbsoluteUrl()
+   {
+      // test prefixing relative URLs
+      String url1 = "path/to/file";
+      String absolute1 = DomUtils.makeAbsoluteUrl(url1);
+      Assert.assertEquals(absolute1.substring(0, 4), "http");
+      
+      // already-absolute URLs should be untouched
+      String url2 = "https://hostname:port/endpoint?query=yes";
+      String absolute2 = DomUtils.makeAbsoluteUrl(url2);
+      Assert.assertEquals(url2, absolute2);
+   }
 }


### PR DESCRIPTION
This change fixes a bug observed by rstudio.cloud in which an R Markdown document URL had too many slashes. 

The problem is string math in `StringUtil.makeAbsoluteUrl()`, which incorrectly presumes that `window.location.pathname` doesn't start with a `/`. This causes it to produce URLs that have two consecutive slashes, which isn't usually an issue but causes a problem on rstudio.cloud. 

Instead of trying to manipulate URLs with string math (which is demonstrably error-prone), this change uses the browser itself to resolve relative URLs to absolute ones, by creating a dummy `<a>` tag and having the browser resolve its `href`. 