### PR TITLE
enforce tabs in tsv; show whitespace for csv + tsv

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -6479,12 +6479,17 @@ public class TextEditingTarget implements
       if (item == null)
          return false;
       
-      if ("Makefile".equals(item.getName()) ||
-          "Makevars".equals(item.getName()) ||
-          ".tsv".equals(item.getExtension()))
-      {
+      String[] requiresHardTabs = new String[] {
+            "Makefile", "Makefile.in", "Makefile.win",
+            "Makevars", "Makevars.in", "Makevars.win"
+      };
+      
+      for (String file : requiresHardTabs)
+         if (file.equals(item.getName()))
+            return true;
+      
+      if (".tsv".equals(item.getExtension()))
          return true;
-      }
       
       return false;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1329,15 +1329,9 @@ public class TextEditingTarget implements
          @Override
          public void onValueChange(ValueChangeEvent<String> event)
          {
-            if ("Makefile".equals(event.getValue()) ||
-                "Makefile.in".equals(event.getValue()) ||
-                "Makefile.win".equals(event.getValue()) ||
-                "Makevars".equals(event.getValue()) ||
-                "Makevars.in".equals(event.getValue()) ||
-                "Makevars.win".equals(event.getValue()))
-            {
+            FileSystemItem item = FileSystemItem.createFile(event.getValue());
+            if (shouldEnforceHardTabs(item))
                docDisplay_.setUseSoftTabs(false);
-            }
          }
       });
       
@@ -6480,6 +6474,21 @@ public class TextEditingTarget implements
       return docUpdateSentinel_.getPath() == null;
    }
    
+   private static boolean shouldEnforceHardTabs(FileSystemItem item)
+   {
+      if (item == null)
+         return false;
+      
+      if ("Makefile".equals(item.getName()) ||
+          "Makevars".equals(item.getName()) ||
+          ".tsv".equals(item.getExtension()))
+      {
+         return true;
+      }
+      
+      return false;
+   }
+   
    private CppCompletionContext cppCompletionContext_ = 
                                           new CppCompletionContext() {
       @Override
@@ -6613,12 +6622,7 @@ public class TextEditingTarget implements
       releaseOnDismiss.add(prefs.useSpacesForTab().bind(
             new CommandWithArg<Boolean>() {
                public void execute(Boolean arg) {
-                  // Makefile always uses tabs
-                  FileSystemItem file = context.getActiveFile();
-                  if ((file != null) && 
-                     ("Makefile".equals(file.getName()) ||
-                      "Makevars".equals(file.getName()) ||
-                      "Makevars.win".equals(file.getName())))
+                  if (shouldEnforceHardTabs(context.getActiveFile()))
                   {
                      docDisplay.setUseSoftTabs(false);
                   }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -47,6 +47,7 @@ import org.rstudio.core.client.events.EnsureHeightHandler;
 import org.rstudio.core.client.events.EnsureVisibleEvent;
 import org.rstudio.core.client.events.EnsureVisibleHandler;
 import org.rstudio.core.client.events.MouseDragHandler;
+import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.layout.RequiresVisibilityChanged;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
@@ -574,6 +575,23 @@ public class TextEditingTargetWidget
       
       toolbar.addRightSeparator();
       toolbar.addRightWidget(toggleDocOutlineButton_);
+      
+      showWhitespaceCharactersCheckbox_ = new CheckBox("Show whitespace characters");
+      showWhitespaceCharactersCheckbox_.setVisible(false);
+      showWhitespaceCharactersCheckbox_.setValue(uiPrefs_.showInvisibles().getValue());
+      showWhitespaceCharactersCheckbox_.addValueChangeHandler((ValueChangeEvent<Boolean> event) -> {
+         editor_.setShowInvisibles(event.getValue());
+      });
+      
+      if (docUpdateSentinel_ != null && docUpdateSentinel_.getPath() != null)
+      {
+         FileSystemItem item = FileSystemItem.createFile(docUpdateSentinel_.getPath());
+         String ext = item.getExtension();
+         if (".csv".contentEquals(ext) || ".tsv".equals(ext))
+            showWhitespaceCharactersCheckbox_.setVisible(true);
+      }
+      toolbar.addRightSeparator();
+      toolbar.addRightWidget(showWhitespaceCharactersCheckbox_);
       
       return toolbar;
    }
@@ -1537,6 +1555,7 @@ public class TextEditingTargetWidget
    private ToolbarButton plumberLaunchButton_;
    private ToolbarButton rmdOptionsButton_;
    private LatchingToolbarButton toggleDocOutlineButton_;
+   private CheckBox showWhitespaceCharactersCheckbox_;
    private ToolbarPopupMenuButton rmdFormatButton_;
    private ToolbarPopupMenuButton runDocumentMenuButton_;
    private RSConnectPublishButton publishButton_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -576,7 +576,7 @@ public class TextEditingTargetWidget
       toolbar.addRightSeparator();
       toolbar.addRightWidget(toggleDocOutlineButton_);
       
-      showWhitespaceCharactersCheckbox_ = new CheckBox("Show whitespace characters");
+      showWhitespaceCharactersCheckbox_ = new CheckBox("Show whitespace");
       showWhitespaceCharactersCheckbox_.setVisible(false);
       showWhitespaceCharactersCheckbox_.setValue(uiPrefs_.showInvisibles().getValue());
       showWhitespaceCharactersCheckbox_.addValueChangeHandler((ValueChangeEvent<Boolean> event) -> {
@@ -587,7 +587,7 @@ public class TextEditingTargetWidget
       {
          FileSystemItem item = FileSystemItem.createFile(docUpdateSentinel_.getPath());
          String ext = item.getExtension();
-         if (".csv".contentEquals(ext) || ".tsv".equals(ext))
+         if (".csv".equals(ext) || ".tsv".equals(ext))
             showWhitespaceCharactersCheckbox_.setVisible(true);
       }
       toolbar.addRightSeparator();


### PR DESCRIPTION
Supercedes https://github.com/rstudio/rstudio/pull/2169.

With this PR:

1. We always use hard tabs in `.tsv` files, and
2. We make the 'Show whitespace characters' preference more user-accessible for `.csv` and `.tsv` files (for easier inspection of where rogue whitespace might have sneaked into a particular file)

![screen shot 2018-07-27 at 12 17 36 pm](https://user-images.githubusercontent.com/1976582/43342393-68155d76-9197-11e8-97d1-f4af5e718860.png)
