### PR TITLE
Let main window handle closure of source windows

### DIFF
--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -279,7 +279,7 @@ void MainWindow::closeEvent(QCloseEvent* pEvent)
                   QStringLiteral("window.desktopHooks.quitR()"),
                   [&](QVariant ignored)
          {
-            closeAllSatellites(this);
+            // don't close all the satellites here since the user hasn't confirmed quit yet
          });
       }
    });

--- a/src/cpp/desktop/DesktopSatelliteWindow.cpp
+++ b/src/cpp/desktop/DesktopSatelliteWindow.cpp
@@ -76,10 +76,15 @@ void SatelliteWindow::closeSatellite(QCloseEvent *event)
 
 void SatelliteWindow::closeEvent(QCloseEvent *event)
 {
-   // the source window has special close semantics; if we're not currently
-   // closing, then invoke custom close handlers
+   // the source window has special close semantics; if we're not currently closing, then invoke
+   // custom close handlers. 
+   //
+   // we only do this for spontaneous (user-initiated) closures; when the window gets shut down by
+   // its parent or by the OS, we don't prompt since in those cases unsaved document accumulation
+   // and prompting is handled by the parent.
    if (getName().startsWith(QString::fromUtf8(SOURCE_WINDOW_PREFIX)) &&
-       close_ == CloseStageOpen)
+       close_ == CloseStageOpen &&
+       event->spontaneous())
    {
       // ignore this event; we need to make sure the window can be
       // closed ourselves


### PR DESCRIPTION
We're now manually closing all satellites on application quit (see https://github.com/rstudio/rstudio/commit/a9b27f65c705c95de95b3d4694258e58c077acc3#diff-ad46e0cfc533781d577d1f2e13754c14). However, we're doing this *before* the user has confirmed quit, with the result that every satellite thinks it's being closed manually by the user. That's a problem in source satellites since we generally want unsaved file prompting to be coordinated by the main window.

The fix is to:

1. have the source satellites respond only to spontaneous closure, and
2. don't close all satellites after returning from `quitR()` (this function returns before the user has confirmed quit)

Fixes #3210.