### PR TITLE
Use correct relative theme URLs

### DIFF
--- a/src/cpp/session/modules/SessionThemes.R
+++ b/src/cpp/session/modules/SessionThemes.R
@@ -806,11 +806,11 @@
 })
 
 .rs.addFunction("getThemeDirFromUrl", function(url) {
-   if (grepl("^/theme/custom/global.*?\\.rstheme$", url, ignore.case = TRUE))
+   if (grepl("^theme/custom/global.*?\\.rstheme$", url, ignore.case = TRUE))
    {
       file.path(.rs.getThemeInstallDir(TRUE), basename(url))
    }
-   else if (grepl("^/theme/custom/local.*\\.rstheme$", url, ignore.case= TRUE))
+   else if (grepl("^theme/custom/local.*\\.rstheme$", url, ignore.case= TRUE))
    {
       file.path(.rs.getThemeInstallDir(FALSE), basename(url))
    }
@@ -1056,7 +1056,7 @@
    warnings <- c()
    tryCatch(
       withCallingHandlers(
-         .rs.addTheme(themePath, apply = FALSE, force = TRUE, globally = FALSE),
+         .rs.addTheme(themePath, apply = FALSE, force = FALSE, globally = FALSE),
          warning = function(w) 
          { 
             warnings <<- conditionMessage(w)

--- a/src/cpp/session/modules/SessionThemes.cpp
+++ b/src/cpp/session/modules/SessionThemes.cpp
@@ -424,7 +424,6 @@ Error addTheme(const json::JsonRpcRequest& request,
 
    // Find out whether to convert or add.
    std::string funcName = ".rs.internal.convertTheme";
-   bool isConversion = true;
    if (!themeFile.exists())
    {
       error = Error(json::errc::ParamInvalid, ERROR_LOCATION);
@@ -434,7 +433,6 @@ Error addTheme(const json::JsonRpcRequest& request,
    else if (themeFile.extensionLowerCase() == ".rstheme")
    {
       funcName = ".rs.internal.addTheme";
-      isConversion = false;
    }
    else if (!(themeFile.extensionLowerCase() == ".tmtheme"))
    {

--- a/src/cpp/session/modules/SessionThemes.cpp
+++ b/src/cpp/session/modules/SessionThemes.cpp
@@ -49,9 +49,9 @@ namespace themes {
 
 namespace {
 
-const std::string kDefaultThemeLocation = "/theme/default/";
-const std::string kGlobalCustomThemeLocation = "/theme/custom/global/";
-const std::string kLocalCustomThemeLocation = "/theme/custom/local/";
+const std::string kDefaultThemeLocation = "theme/default/";
+const std::string kGlobalCustomThemeLocation = "theme/custom/global/";
+const std::string kLocalCustomThemeLocation = "theme/custom/local/";
 std::vector<std::string> sWarnings;
 
 // A map from the name of the theme to the location of the file and a boolean representing

--- a/src/cpp/session/modules/SessionThemes.cpp
+++ b/src/cpp/session/modules/SessionThemes.cpp
@@ -331,7 +331,7 @@ FilePath getDefaultTheme(const http::Request& request)
 void handleDefaultThemeRequest(const http::Request& request,
                                      http::Response* pResponse)
 {
-   std::string fileName = http::util::pathAfterPrefix(request, kDefaultThemeLocation);
+   std::string fileName = http::util::pathAfterPrefix(request, "/" + kDefaultThemeLocation);
    pResponse->setCacheableFile(getDefaultThemePath().childPath(fileName), request);
 }
 
@@ -346,7 +346,7 @@ void handleGlobalCustomThemeRequest(const http::Request& request,
 {
    // Note: we probably want to return a warning code instead of success so the client has the
    // ability to pop up a warning dialog or something to the user.
-   std::string fileName = http::util::pathAfterPrefix(request, kGlobalCustomThemeLocation);
+   std::string fileName = http::util::pathAfterPrefix(request, "/" + kGlobalCustomThemeLocation);
    FilePath requestedTheme = getGlobalCustomThemePath().childPath(fileName);
    pResponse->setCacheableFile(
       requestedTheme.exists() ? requestedTheme : getDefaultTheme(request),
@@ -364,7 +364,7 @@ void handleLocalCustomThemeRequest(const http::Request& request,
 {
    // Note: we probably want to return a warning code instead of success so the client has the
    // ability to pop up a warning dialog or something to the user.
-   std::string fileName = http::util::pathAfterPrefix(request, kLocalCustomThemeLocation);
+   std::string fileName = http::util::pathAfterPrefix(request, "/" + kLocalCustomThemeLocation);
    FilePath requestedTheme = getLocalCustomThemePath().childPath(fileName);
    pResponse->setCacheableFile(
       requestedTheme.exists() ? requestedTheme : getDefaultTheme(request),
@@ -513,9 +513,9 @@ Error initialize()
       (bind(registerRpcMethod, "get_themes", getThemes))
       (bind(registerRpcMethod, "add_theme", addTheme))
       (bind(registerRpcMethod, "remove_theme", removeTheme))
-      (bind(registerUriHandler, kDefaultThemeLocation, handleDefaultThemeRequest))
-      (bind(registerUriHandler, kGlobalCustomThemeLocation, handleGlobalCustomThemeRequest))
-      (bind(registerUriHandler, kLocalCustomThemeLocation, handleLocalCustomThemeRequest));
+      (bind(registerUriHandler, "/" + kDefaultThemeLocation, handleDefaultThemeRequest))
+      (bind(registerUriHandler, "/" + kGlobalCustomThemeLocation, handleGlobalCustomThemeRequest))
+      (bind(registerUriHandler, "/" + kLocalCustomThemeLocation, handleLocalCustomThemeRequest));
 
    return initBlock.execute();
 }

--- a/src/cpp/tests/testthat/test-themes.R
+++ b/src/cpp/tests/testthat/test-themes.R
@@ -1865,7 +1865,7 @@ test_that_wrapped("rs_getThemes gets default themes correctly", {
       expectedTheme <- defaultThemes[[themeDetails$name]]
       expect_equal(
          themeDetails$url,
-         paste0("/theme/default/", expectedTheme$fileName, ".rstheme"),
+         paste0("theme/default/", expectedTheme$fileName, ".rstheme"),
          info = infoStr)
       expect_equal(themeDetails$isDark, expectedTheme$isDark, info = infoStr)
    })
@@ -1881,8 +1881,8 @@ test_that_wrapped("rs_getThemes works correctly", {
       themeLocation <- if (isGlobal) file.path(globalInstallDir, fileName)
                        else file.path(localInstallDir, fileName)
       file.copy(file.path(inputFileLocation, "rsthemes", fileName), themeLocation)
-      addedThemes[[themeName]] <<- if (isGlobal) paste0("/theme/custom/global/", fileName)
-                                   else paste0("/theme/custom/local/", fileName)
+      addedThemes[[themeName]] <<- if (isGlobal) paste0("theme/custom/global/", fileName)
+                                   else paste0("theme/custom/local/", fileName)
       })
 
    themeList <- .Call("rs_getThemes")
@@ -1922,7 +1922,7 @@ test_that_wrapped("rs_getThemes location override works correctly", {
    dawnTheme <- .Call("rs_getThemes")[[tolower(themeName)]]
    expect_equal(
       dawnTheme$url,
-      paste0("/theme/default/", defaultThemes[[themeName]]$fileName, ".rstheme"),
+      paste0("theme/default/", defaultThemes[[themeName]]$fileName, ".rstheme"),
       info = "default location")
 
    # Install globally
@@ -1935,7 +1935,7 @@ test_that_wrapped("rs_getThemes location override works correctly", {
    dawnTheme <- .Call("rs_getThemes")[[tolower(themeName)]]
    expect_equal(
       dawnTheme$url,
-      paste0("/theme/custom/global/", expectedDawn$fileName, ".rstheme"),
+      paste0("theme/custom/global/", expectedDawn$fileName, ".rstheme"),
       info = "global location")
 
    # Install locally
@@ -1948,7 +1948,7 @@ test_that_wrapped("rs_getThemes location override works correctly", {
    dawnTheme <- .Call("rs_getThemes")[[tolower(themeName)]]
    expect_equal(
       dawnTheme$url,
-      paste0("/theme/custom/local/", expectedDawn$fileName, ".rstheme"),
+      paste0("theme/custom/local/", expectedDawn$fileName, ".rstheme"),
       info = "local location")
 },
 BEFORE_FUN = function() {


### PR DESCRIPTION
Fixes #3179.

This bug was caused by the client requesting themes from absolute paths instead of relative paths. The fix was verified with a server running behind a proxy that was configured to server RStudio from a custom path (e.g. `<host>/rstudio`).