### PR TITLE
adding css rules to fix the text colouring problems in the help pane.

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPaneEditorStyles.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPaneEditorStyles.css
@@ -5,9 +5,9 @@
 @external rstudio-themes-scrollbars;
 @external editor_dark;
 @external ace_editor_theme;
-@external sourceLine
-@external odd
-@external even
+@external sourceLine;
+@external odd;
+@external even;
 
 .rstudio-themes-flat.editor_dark div#TOC,
 .rstudio-themes-flat.editor_dark h1,
@@ -15,7 +15,14 @@
 .rstudio-themes-flat.editor_dark h3,
 .rstudio-themes-flat.editor_dark h4,
 .rstudio-themes-flat.editor_dark table {
+   color: white !important;
    background: none !important;
+}
+
+.rstudio-themes-flat.editor_dark.ace_editor_theme p,
+.rstudio-themes-flat.editor_dark.ace_editor_theme a,
+.rstudio-themes-dark.editor_dark.ace_editor_theme div {
+   color: white !important;
 }
 
 .rstudio-themes-flat.editor_dark h1,


### PR DESCRIPTION
Closes #3258.

It adds `color: white !important;` to all the elements that should have been white that weren't. I think this is more explicit than what we had before ee68a86, so it's possible that there's something going wrong with style inheritance, but this change does replicate what we had in 1.1 and doesn't seem to impact any other elements.