### PR TITLE
Allow publishing rendered content from the Source pane

### DIFF
--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -136,12 +136,14 @@
    outputPath <- file.path(dirname(target), outputFile) 
    
    # ensure output file exists
-   current <- file.exists(outputPath) && 
+   fileExists <- file.exists(outputPath)
+   current <- fileExists && 
       file.info(outputPath)$mtime >= file.info(target)$mtime
    
    list(
       output_file = .rs.scalar(outputPath),
-      is_current  = .rs.scalar(current)
+      is_current  = .rs.scalar(current),
+      output_file_exists = .rs.scalar(fileExists)
    )
 })
 

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdOutputInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdOutputInfo.java
@@ -1,7 +1,7 @@
 /*
  * RmdOutputInfo.java
  *
- * Copyright (C) 2009-15 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,19 +15,13 @@
  */
 package org.rstudio.studio.client.rmarkdown.model;
 
-import com.google.gwt.core.client.JavaScriptObject;
+import jsinterop.annotations.JsType;
+import jsinterop.annotations.JsPackage;
 
-public class RmdOutputInfo extends JavaScriptObject
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class RmdOutputInfo
 {
-   protected RmdOutputInfo()
-   {
-   }
-   
-   public final native boolean isCurrent() /*-{
-      return this.is_current;
-   }-*/;
-
-   public final native String getOutputFile() /*-{
-      return this.output_file;
-   }-*/;
+   public boolean is_current;
+   public String output_file;
+   public boolean output_file_exists;
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
@@ -203,10 +203,7 @@ public class RSConnect implements SessionInitHandler,
             (event.getContentType() == CONTENT_TYPE_DOCUMENT && 
                   !supportedRPubsDocExtension(event.getHtmlFile())))
       {
-         display_.showErrorMessage("Unsupported Document Format",
-               "Only documents rendered to HTML can be published to RPubs. " +
-               "To publish this document, click Knit or Preview to render it to HTML, then " +
-               "click the Publish button above the rendered document.");
+         showUnsupportedRPubsFormatMessage();
          return;         
       }
 
@@ -816,20 +813,35 @@ public class RSConnect implements SessionInitHandler,
    }
    
    // Private methods ---------------------------------------------------------
-   
+   private void showUnsupportedRPubsFormatMessage()
+   {
+      display_.showErrorMessage("Unsupported Document Format",
+            "Only documents rendered to HTML can be published to RPubs. " +
+            "To publish this document, click Knit or Preview to render it to HTML, then " +
+            "click the Publish button above the rendered document.");         
+   }
+
    private void uploadToRPubs(RSConnectPublishInput input, 
          RSConnectPublishResult result,
          final ProgressIndicator indicator)
    {
-      if (input.getContentType() == CONTENT_TYPE_DOCUMENT && 
-            (!input.hasDocOutput() || !supportedRPubsDocExtension(input.getDocOutput())))
+      if (input.getContentType() == CONTENT_TYPE_DOCUMENT)
       {
-         display_.showErrorMessage("Publish Document",
-               "Only rendered R Markdown documents can be published to RPubs. " +
-               "To publish this document, click Knit to render it to HTML, then " +
-               "click the Publish button above the rendered document.");
-         indicator.onCompleted();
-         return;
+         if (!input.hasDocOutput())
+         {
+            display_.showErrorMessage("Publish Document",
+                  "Only rendered documents can be published to RPubs. " +
+                  "To publish this document, click Knit or Preview to render it to HTML, then " +
+                  "click the Publish button above the rendered document.");
+            indicator.onCompleted();
+            return;
+         }
+         else if (!supportedRPubsDocExtension(input.getDocOutput()))
+         {
+            showUnsupportedRPubsFormatMessage();
+            indicator.onCompleted();
+            return;
+         }
       }
       
       RPubsUploader uploader = new RPubsUploader(rpubsServer_, display_, 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishInput.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishInput.java
@@ -1,7 +1,7 @@
 /*
  * RSConnectPublishInput.java
  *
- * Copyright (C) 2009-15 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -80,6 +80,13 @@ public class RSConnectPublishInput
                   originatingEvent_.getFromPreview().getOutputFile());
    }
    
+   public String getDocOutput()
+   {
+      if (!hasDocOutput())
+         return null;
+      return originatingEvent_.getFromPreview().getOutputFile();
+   }
+    
    public void setExternalUIEnabled(boolean enabled)
    {
       isExternalUIEnabled_ = enabled;

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -828,6 +828,15 @@ public class RSConnectDeploy extends Composite
       if (source_.isSelfContained() && source_.isStatic() && 
           !source_.isWebsiteRmd())
       {
+         if (StringUtil.isNullOrEmpty(source_.getDeployFile()))
+         {
+            indicator.onError(
+                  "Only rendered documents can be published to RStudio Connect. " +
+                  "To publish this document, click Knit to render it, then click " +
+                  "the Publish button above the rendered document.");
+            indicator.onCompleted(); 
+            return; 
+         }
          ArrayList<String> files = new ArrayList<String>();
          FileSystemItem selfContained = FileSystemItem.createFile(
                      source_.getDeployFile());

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishButton.java
@@ -874,6 +874,9 @@ public class RSConnectPublishButton extends Composite
                   public void onError(ServerError error)
                   {
                      Debug.logError(error);
+                     display_.showErrorMessage("Content Publish Failed",
+                           "Unable to determine file to be published. Click Knit or Preview " +
+                           "to render it again, then click the Publish button above the rendered document.");
                      rmdInfoPending_ = false;
                   }
                });


### PR DESCRIPTION
In RStudio 1.0 you could publish rendered content from the Source pane. The IDE would auto-run rendering before showing the publishing wizard (if current output was missing or out-of-date) to ensure it was available if user went down a publish-wizard path that needed it. However, publishing source to Connect does not need it, and often rendering on the client is not going to work at all for Connect users, so it was confusing and time-consuming.

RStudio 1.1 removed the ability to publish rendered content from the Source pane. It would only publish source from editor (i.e. publish source to Connect). To publish rendered content, had to use the Publish button on the rendered preview in viewer/window. Though this is logical, many users were used to using the editor's publish button and thought the ability to publish to RPubs or publish output-only to Connect had been removed.

This change puts back the ability to publish content from the Source pane. However, it does not do auto-render as in 1.0 to avoid the problems mentioned. Per conversation with @jmcphers, chose to show an error message if user goes down a publish path requiring rendered content, and it was missing, telling them to go do the render and try again. Injecting auto-render into the appropriate place in publishing wizard was deemed too messy, at least for 1.2.

Also detect when an attempt is made to publish unsupported rendered output to RPubs (e.g. PDF, MS-Word), instead of letting the deployment package show an obscure error in the console.

Did not do the work to support publishing of other static-content formats such as PDF, Word, PPT, directly from the IDE. Broke that out into a separate issue to work on next.

Fixes #2816 
Fixes #3262
