### PR TITLE
enforce scrollbar widths on Windows

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2632,6 +2632,11 @@ body.rstudio-themes-flat .rstudio-themes-alternate {
 .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar,
 .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
    background: #FFF;
+}
+
+.windows.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar,
+.windows.rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar,
+.windows.rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
    width: 17px;
    height: 17px;
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2632,6 +2632,8 @@ body.rstudio-themes-flat .rstudio-themes-alternate {
 .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar,
 .rstudio-themes-flat.rstudio-themes-dark-menus .rstudio-themes-scrollbars ::-webkit-scrollbar {
    background: #FFF;
+   width: 17px;
+   height: 17px;
 }
 
 .rstudio-themes-flat .rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar-thumb,

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.css
@@ -9,6 +9,11 @@
 .rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar
 {
    background: #FFF;
+}
+
+.windows.rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar,
+.windows.rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar
+{
    width: 17px;
    height: 17px;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.css
@@ -1,0 +1,35 @@
+@charset "UTF-8";
+
+@external rstudio-themes-flat, rstudio-themes-dark, rstudio-themes-scrollbars;
+
+@eval THEME_DARKGREY_BACKGROUND org.rstudio.core.client.theme.ThemeColors.darkGreyBackground;
+@eval THEME_DARKGREY_MOST_INACTIVE org.rstudio.core.client.theme.ThemeColors.darkGreyMostInactiveBackground;
+
+.rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar,
+.rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar
+{
+   background: #FFF;
+   width: 17px;
+   height: 17px;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar-thumb,
+.rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar-thumb
+{
+   -webkit-border-radius: 10px;
+   background: THEME_DARKGREY_BACKGROUND;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar-track,
+.rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar-track,
+.rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar-corner,
+.rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar-corner
+{
+   background: THEME_DARKGREY_MOST_INACTIVE;
+}
+
+.rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar-thumb,
+.rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar-thumb
+{
+   border: solid 3px THEME_DARKGREY_MOST_INACTIVE;
+}

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.css
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 
-@external rstudio-themes-flat, rstudio-themes-dark, rstudio-themes-scrollbars;
+@external windows, rstudio-themes-flat, rstudio-themes-dark, rstudio-themes-scrollbars;
 
 @eval THEME_DARKGREY_BACKGROUND org.rstudio.core.client.theme.ThemeColors.darkGreyBackground;
 @eval THEME_DARKGREY_MOST_INACTIVE org.rstudio.core.client.theme.ThemeColors.darkGreyMostInactiveBackground;

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
@@ -15,18 +15,20 @@
 
 package org.rstudio.core.client.widget;
 
-import org.rstudio.core.client.theme.ThemeColors;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.ThemeChangedEvent;
 import org.rstudio.studio.client.application.ui.RStudioThemes;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.BodyElement;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.LinkElement;
 import com.google.gwt.dom.client.StyleElement;
 import com.google.gwt.event.dom.client.LoadEvent;
 import com.google.gwt.event.dom.client.LoadHandler;
+import com.google.gwt.resources.client.ClientBundle;
+import com.google.gwt.resources.client.CssResource;
 import com.google.inject.Inject;
 
 public class RStudioThemedFrame extends RStudioFrame
@@ -112,29 +114,7 @@ public class RStudioThemedFrame extends RStudioFrame
          if (customStyle == null)
             customStyle = "";
          
-         customStyle += "\n" +
-         ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar,\n" +
-         ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar {\n" +
-         "   background: #FFF;\n" +
-         "}\n" +
-         "\n" +
-         ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar-thumb,\n" +
-         ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar-thumb {\n" +
-         "   -webkit-border-radius: 10px;\n" +
-         "   background: " + ThemeColors.darkGreyBackground + ";\n" +
-         "}\n" +
-         "\n" +
-         ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar-track,\n" + 
-         ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar-track,\n" + 
-         ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar-corner,\n" +
-         ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar-corner {\n" +
-         "   background: " + ThemeColors.darkGreyMostInactiveBackground + ";\n" +
-         "}\n" + 
-         ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars::-webkit-scrollbar-thumb,\n" +
-         ".rstudio-themes-flat.rstudio-themes-dark.rstudio-themes-scrollbars ::-webkit-scrollbar-thumb{\n" +
-         "   border: solid 3px " + ThemeColors.darkGreyMostInactiveBackground + ";" +
-         "}\n";
-         
+         customStyle += RES.styles().getText();
          StyleElement style = document.createStyleElement();
          style.setInnerHTML(customStyle);
          document.getHead().appendChild(style);
@@ -187,7 +167,25 @@ public class RStudioThemedFrame extends RStudioFrame
       return articles.length === 0;
    }-*/;
    
+   // Resources ----
+   public interface Resources extends ClientBundle
+   {
+      @Source("RStudioThemedFrame.css")
+      Styles styles();
+   }
 
+   public interface Styles extends CssResource
+   {
+   }
+
+   private static Resources RES = GWT.create(Resources.class);
+   static
+   {
+      RES.styles().ensureInjected();
+   }
+
+   // Private members ----
+   
    private EventBus events_;
    private String customStyle_;
    private String urlStyle_;


### PR DESCRIPTION
Closes #3272.

Worth noting: our Safari-specific styling now evidently also applies on Windows. (These styles are applied within an ` @if user.agent safari { ... }` block)