### PR TITLE
provide ability to change rendering engine

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -221,12 +221,16 @@ FilePath userHomePath()
    return core::system::userHomePath("R_USER|HOME");
 }
 
+#ifndef Q_OS_MAC
+
 QString createAliasedPath(const QString& path)
 {
    std::string aliased = FilePath::createAliasedPath(
          FilePath(path.toUtf8().constData()), userHomePath());
    return QString::fromUtf8(aliased.c_str());
 }
+
+#endif
 
 QString resolveAliasedPath(const QString& path)
 {
@@ -956,6 +960,16 @@ void GwtCallback::bringMainFrameToFront()
 void GwtCallback::bringMainFrameBehindActive()
 {
    desktop::moveWindowBeneath(QApplication::activeWindow(), pMainWindow_);
+}
+
+QString GwtCallback::desktopRenderingEngine()
+{
+   return desktop::options().desktopRenderingEngine();
+}
+
+void GwtCallback::setDesktopRenderingEngine(QString engine)
+{
+   desktop::options().setDesktopRenderingEngine(engine);
 }
 
 QString GwtCallback::filterText(QString text)

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -163,6 +163,9 @@ public Q_SLOTS:
 
    void bringMainFrameToFront();
    void bringMainFrameBehindActive();
+   
+   QString desktopRenderingEngine();
+   void setDesktopRenderingEngine(QString engine);
 
    QString filterText(QString text);
 

--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -265,6 +265,42 @@ bool useRemoteDevtoolsDebugging()
 #endif
 }
 
+void initializeRenderingEngine()
+{
+   QString engine = desktop::options().desktopRenderingEngine();
+   if (engine.isEmpty())
+      return;
+   
+   using namespace core::system;
+   if (engine == QStringLiteral("desktop"))
+   {
+      setenv("QT_OPENGL", "desktop");
+   }
+   
+#ifdef Q_OS_WIN32
+   else if (engine == QStringLiteral("angle_d3d11"))
+   {
+      setenv("QT_OPENGL", "angle");
+      setenv("QT_ANGLE_PLATFORM", "d3d11");
+   }
+   else if (engine == QStringLiteral("angle_d3d9"))
+   {
+      setenv("QT_OPENGL", "angle");
+      setenv("QT_ANGLE_PLATFORM", "d3d9");
+   }
+   else if (engine == QStringLiteral("angle_warp"))
+   {
+      setenv("QT_OPENGL", "angle");
+      setenv("QT_ANGLE_PLATFORM", "warp");
+   }
+#endif
+   
+   else if (engine == QStringLiteral("software"))
+   {
+      setenv("QT_OPENGL", "software");
+   }
+}
+
 } // anonymous namespace
 
 int main(int argc, char* argv[])
@@ -274,6 +310,7 @@ int main(int argc, char* argv[])
    try
    {
       initializeLang();
+      initializeRenderingEngine();
       
       if (useRemoteDevtoolsDebugging())
       {

--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -272,7 +272,13 @@ void initializeRenderingEngine(std::vector<char*>* pArguments)
       return;
    
    using namespace core::system;
-   if (engine == QStringLiteral("desktop"))
+   
+   if (engine == QStringLiteral("auto"))
+   {
+      // nothing to do -- let Qt + Chromium try to figure out the most
+      // appropriate rendering engine
+   }
+   else if (engine == QStringLiteral("desktop"))
    {
       static char useGlDesktop[] = "--use-gl=desktop";
       setenv("QT_OPENGL", "desktop");

--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -265,7 +265,7 @@ bool useRemoteDevtoolsDebugging()
 #endif
 }
 
-void initializeRenderingEngine()
+void initializeRenderingEngine(std::vector<char*>* pArguments)
 {
    QString engine = desktop::options().desktopRenderingEngine();
    if (engine.isEmpty())
@@ -274,25 +274,37 @@ void initializeRenderingEngine()
    using namespace core::system;
    if (engine == QStringLiteral("desktop"))
    {
+      static char useGlDesktop[] = "--use-gl=desktop";
       setenv("QT_OPENGL", "desktop");
+      pArguments->push_back(useGlDesktop);
    }
    
 #ifdef Q_OS_WIN32
+   
    else if (engine == QStringLiteral("angle_d3d11"))
    {
+      static char useAngleD3D11[] = "--use-angle=d3d11";
       setenv("QT_OPENGL", "angle");
       setenv("QT_ANGLE_PLATFORM", "d3d11");
+      pArguments->push_back(useAngleD3D11);
    }
+   
    else if (engine == QStringLiteral("angle_d3d9"))
    {
+      static char useAngleD3D9[] = "--use-angle=d3d9";
       setenv("QT_OPENGL", "angle");
       setenv("QT_ANGLE_PLATFORM", "d3d9");
+      pArguments->push_back(useAngleD3D9);
    }
+   
    else if (engine == QStringLiteral("angle_warp"))
    {
+      static char useAngleWarp[] = "--use-angle=warp";
       setenv("QT_OPENGL", "angle");
       setenv("QT_ANGLE_PLATFORM", "warp");
+      pArguments->push_back(useAngleWarp);
    }
+   
 #endif
    
    else if (engine == QStringLiteral("software"))
@@ -309,8 +321,10 @@ int main(int argc, char* argv[])
 
    try
    {
+      static std::vector<char*> arguments(argv, argv + argc);
+      
       initializeLang();
-      initializeRenderingEngine();
+      initializeRenderingEngine(&arguments);
       
       if (useRemoteDevtoolsDebugging())
       {
@@ -345,9 +359,6 @@ int main(int argc, char* argv[])
 
       // set application attributes
       QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-      
-      // prepare command line arguments
-      static std::vector<char*> arguments(argv, argv + argc);
       
       // enable viewport meta (allows us to control / restrict
       // certain touch gestures)

--- a/src/cpp/desktop/DesktopOptions.cpp
+++ b/src/cpp/desktop/DesktopOptions.cpp
@@ -125,6 +125,15 @@ std::string Options::localPeer() const
    return localPeer_;
 }
 
+QString Options::desktopRenderingEngine() const
+{
+   return settings_.value(QStringLiteral("desktop.renderingEngine")).toString();
+}
+
+void Options::setDesktopRenderingEngine(QString engine)
+{
+   settings_.setValue(QStringLiteral("desktop.renderingEngine"), engine);
+}
 
 namespace {
 QString findFirstMatchingFont(const QStringList& fonts,

--- a/src/cpp/desktop/DesktopOptions.hpp
+++ b/src/cpp/desktop/DesktopOptions.hpp
@@ -49,6 +49,9 @@ public:
    QString portNumber() const;
    QString newPortNumber();
    std::string localPeer() const; // derived from portNumber
+   
+   QString desktopRenderingEngine() const;
+   void setDesktopRenderingEngine(QString engine);
 
    QString proportionalFont() const;
    QString fixedWidthFont() const;

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -213,6 +213,10 @@ select {
 }
 }
 
+input[type="radio"] + label {
+   margin-left: 2px;
+}
+
 input[type=text] {
    font-family: proportionalFont;
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -123,6 +123,9 @@ public interface DesktopFrame extends JavaScriptPassthrough
 
    void bringMainFrameToFront();
    void bringMainFrameBehindActive();
+   
+   void desktopRenderingEngine(CommandWithArg<String> callback);
+   void setDesktopRenderingEngine(String engine);
 
    // R version selection currently Win32 only
    void getRVersion(CommandWithArg<String> callback);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -248,12 +248,14 @@ public class GeneralPreferencesPane extends PreferencesPane
          advanced.add(engineLabel);
          firstHeader = false;
          
-         RadioButton desktopButton = graphicsButton("OpenGL (recommended)", ENGINE_DESKTOP);
+         RadioButton defaultButton = graphicsButton("Auto-detect (recommended)", ENGINE_AUTO);
+         RadioButton desktopButton = graphicsButton("OpenGL", ENGINE_DESKTOP);
          RadioButton angleD3D11Button = graphicsButton("ANGLE (Direct3D 11)", ENGINE_ANGLE_D3D11);
          RadioButton angleD3D9Button = graphicsButton("ANGLE (Direct3D 9)", ENGINE_ANGLE_D3D9);
          RadioButton angleWarpButton = graphicsButton("ANGLE (Direct3D WARP)", ENGINE_ANGLE_WARP);
          RadioButton softwareButton = graphicsButton("Software", ENGINE_SOFTWARE);
          
+         advanced.add(defaultButton);
          advanced.add(desktopButton);
          if (BrowseCap.isWindows())
          {
@@ -263,11 +265,14 @@ public class GeneralPreferencesPane extends PreferencesPane
          }
          advanced.add(softwareButton);
          
+         defaultButton.setValue(true);
          Desktop.getFrame().desktopRenderingEngine((String engine) -> {
             if (StringUtil.isNullOrEmpty(engine))
                return;
             
-            if (engine.equals(ENGINE_DESKTOP))
+            if (engine.equals(ENGINE_AUTO))
+               defaultButton.setValue(true);
+            else if (engine.equals(ENGINE_DESKTOP))
                desktopButton.setValue(true);
             else if (engine.equals(ENGINE_ANGLE_D3D11))
                angleD3D11Button.setValue(true);
@@ -511,6 +516,7 @@ public class GeneralPreferencesPane extends PreferencesPane
          return false;
    }
    
+   private static final String ENGINE_AUTO        = "auto";
    private static final String ENGINE_DESKTOP     = "desktop";
    private static final String ENGINE_ANGLE_D3D11 = "angle_d3d11";
    private static final String ENGINE_ANGLE_D3D9  = "angle_d3d9";


### PR DESCRIPTION
This PR allows user to select an alternate rendering engine with RStudio Desktop. This is primarily intended to be an escape hatch for users who are bumping into rendering problems or crashes when using the default hardware accelerated renderer.

<img width="606" alt="screen shot 2018-08-07 at 2 57 49 pm" src="https://user-images.githubusercontent.com/1976582/43804841-4bf23574-9a52-11e8-8528-4bb14a65791c.png">

At least in my own local testing, ANGLE + Software are much slower than regular desktop rendering. However, I no longer see crashes or hangs when using the software renderer in my virtual machine, so there is additional evidence that this will help users avoid some classes of issues.