### PR TITLE
log git commands with RSTUDIO_GIT_LOG envvar

### DIFF
--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -215,6 +215,23 @@ std::string gitBin()
 }
 #endif
 
+std::string gitText(const ShellArgs& args)
+{
+   std::stringstream ss;
+
+   ss << ">>> ";
+
+   if (s_gitExePath.empty())
+      ss << "git ";
+   else
+      ss << s_gitExePath << " ";
+
+   std::string arguments = core::algorithm::join(args, " ");
+   ss << arguments << "\n";
+
+   return ss.str();
+}
+
 bool waitForIndexLock(const FilePath& workingDir)
 {
    using namespace boost::posix_time;
@@ -296,6 +313,10 @@ Error gitExec(const ShellArgs& args,
    options.detachProcess = true;
 #endif
 
+   std::string log = core::system::getenv("RSTUDIO_GIT_LOG");
+   if (!log.empty())
+      std::cout << gitText(args);
+
 #ifdef _WIN32
       return runProgram(gitBin(),
                         args.args(),
@@ -308,23 +329,6 @@ Error gitExec(const ShellArgs& args,
                         options,
                         pResult);
 #endif
-}
-
-std::string gitText(const ShellArgs& args)
-{
-   std::stringstream ss;
-   
-   ss << ">>> ";
-   
-   if (s_gitExePath.empty())
-      ss << "git ";
-   else
-      ss << s_gitExePath << " ";
-   
-   std::string arguments = core::algorithm::join(args, " ");
-   ss << arguments << "\n";
-   
-   return ss.str();
 }
 
 bool commitIsMatch(const std::vector<std::string>& patterns,


### PR DESCRIPTION
This is primarily a debugging convenience. By setting the RSTUDIO_GIT_LOG environment variable, we can have RStudio dump all of the commands it's executing to stdout (which typically means it's routed to the R console output).