### PR TITLE
Remove superfluous whitespaces in shiny template 

### DIFF
--- a/src/cpp/session/resources/templates/shiny/app.R
+++ b/src/cpp/session/resources/templates/shiny/app.R
@@ -11,10 +11,10 @@ library(shiny)
 
 # Define UI for application that draws a histogram
 ui <- fluidPage(
-    
+
     # Application title
     titlePanel("Old Faithful Geyser Data"),
-    
+
     # Sidebar with a slider input for number of bins 
     sidebarLayout(
         sidebarPanel(
@@ -24,7 +24,7 @@ ui <- fluidPage(
                         max = 50,
                         value = 30)
         ),
-        
+
         # Show a plot of the generated distribution
         mainPanel(
            plotOutput("distPlot")
@@ -34,12 +34,12 @@ ui <- fluidPage(
 
 # Define server logic required to draw a histogram
 server <- function(input, output) {
-    
+
     output$distPlot <- renderPlot({
         # generate bins based on input$bins from ui.R
-        x    <- faithful[, 2] 
+        x    <- faithful[, 2]
         bins <- seq(min(x), max(x), length.out = input$bins + 1)
-        
+
         # draw the histogram with the specified number of bins
         hist(x, breaks = bins, col = 'darkgray', border = 'white')
     })
@@ -47,4 +47,3 @@ server <- function(input, output) {
 
 # Run the application 
 shinyApp(ui = ui, server = server)
-

--- a/src/cpp/session/resources/templates/shiny/server.R
+++ b/src/cpp/session/resources/templates/shiny/server.R
@@ -1,9 +1,9 @@
 #
-# This is the server logic of a Shiny web application. You can run the 
+# This is the server logic of a Shiny web application. You can run the
 # application by clicking 'Run App' above.
 #
 # Find out more about building applications with Shiny here:
-# 
+#
 #    http://shiny.rstudio.com/
 #
 
@@ -11,16 +11,16 @@ library(shiny)
 
 # Define server logic required to draw a histogram
 shinyServer(function(input, output) {
-     
+
     output$distPlot <- renderPlot({
-      
+
         # generate bins based on input$bins from ui.R
-        x    <- faithful[, 2] 
+        x    <- faithful[, 2]
         bins <- seq(min(x), max(x), length.out = input$bins + 1)
-        
+
         # draw the histogram with the specified number of bins
         hist(x, breaks = bins, col = 'darkgray', border = 'white')
-      
+
     })
-    
+
 })

--- a/src/cpp/session/resources/templates/shiny/ui.R
+++ b/src/cpp/session/resources/templates/shiny/ui.R
@@ -3,7 +3,7 @@
 # run the application by clicking 'Run App' above.
 #
 # Find out more about building applications with Shiny here:
-# 
+#
 #    http://shiny.rstudio.com/
 #
 
@@ -11,11 +11,11 @@ library(shiny)
 
 # Define UI for application that draws a histogram
 shinyUI(fluidPage(
-  
+
     # Application title
     titlePanel("Old Faithful Geyser Data"),
-    
-    # Sidebar with a slider input for number of bins 
+
+    # Sidebar with a slider input for number of bins
     sidebarLayout(
         sidebarPanel(
             sliderInput("bins",
@@ -24,7 +24,7 @@ shinyUI(fluidPage(
                         max = 50,
                         value = 30)
         ),
-        
+
         # Show a plot of the generated distribution
         mainPanel(
             plotOutput("distPlot")


### PR DESCRIPTION
Just a minor thing, but I noticed that the shiny template has superfluous whitespaces when I added it to git.

Disclaimer: I used the web interface of Github to make the changes, so I haven't build RStudio and tested it. I also could not figure out how to add multiple files to a single commit, so I created three commits with the same message. Needs squashing :)