### PR TITLE
ensure spellcheck label

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -1942,7 +1942,8 @@ well as menu structures (for main menu and popup menus).
         desc="Sync PDF view to editor location (Ctrl+Click)"/>
 
    <cmd id="checkSpelling"
-        menuLabel="Check _Spelling..."/>
+	    menuLabel="Check _Spelling..."
+	    desc="Check spelling in document"/>
 
    <cmd id="newFolder"
         label="Create a New Folder..."


### PR DESCRIPTION
The spellcheck button was missing a description (for e.g. mouse hover); this PR adds it back in.

Before:

![screen shot 2018-08-10 at 10 47 37 am](https://user-images.githubusercontent.com/1976582/43972926-d66fa698-9c8a-11e8-8ea1-26820eab9646.png)

After:

![screen shot 2018-08-10 at 10 48 24 am](https://user-images.githubusercontent.com/1976582/43972959-ed6bd024-9c8a-11e8-839b-de2a07a21309.png)
