### PR TITLE
Support for custom source actions with special comment

### DIFF
--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -168,6 +168,7 @@ set (SESSION_SOURCE_FILES
    modules/connections/ConnectionHistory.cpp
    modules/connections/ConnectionsIndexer.cpp
    modules/connections/SessionConnections.cpp
+   modules/customsource/SessionCustomSource.cpp
    modules/data/SessionData.cpp
    modules/data/DataViewer.cpp
    modules/environment/EnvironmentMonitor.cpp

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -153,6 +153,7 @@
 #include "modules/build/SessionBuild.hpp"
 #include "modules/clang/SessionClang.hpp"
 #include "modules/connections/SessionConnections.hpp"
+#include "modules/customsource/SessionCustomSource.hpp"
 #include "modules/data/SessionData.hpp"
 #include "modules/environment/SessionEnvironment.hpp"
 #include "modules/jobs/SessionJobs.hpp"
@@ -522,6 +523,7 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
       (modules::tests::initialize)
       (modules::jobs::initialize)
       (modules::themes::initialize)
+      (modules::customsource::initialize)
 
       // workers
       (workers::web_request::initialize)

--- a/src/cpp/session/modules/customsource/SessionCustomSource.cpp
+++ b/src/cpp/session/modules/customsource/SessionCustomSource.cpp
@@ -1,0 +1,78 @@
+/*
+ * SessionCustomSource.cpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "SessionCustomSource.hpp"
+
+#include <boost/format.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+
+#include <core/Error.hpp>
+#include <core/Exec.hpp>
+
+#include <r/RSexp.hpp>
+#include <r/RRoutines.hpp>
+#include <r/RUtil.hpp>
+#include <r/ROptions.hpp>
+
+#include <r/session/RGraphics.hpp>
+#include <r/session/RSessionUtils.hpp>
+
+#include <session/SessionModuleContext.hpp>
+
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace session {
+namespace modules { 
+namespace customsource {
+
+namespace {
+
+#define kRCustomSource "r-custom-source"
+
+std::string onDetectSourceType(
+      boost::shared_ptr<source_database::SourceDocument> pDoc)
+{
+   if ((pDoc->type() == source_database::SourceDocument::SourceDocumentTypeRSource))
+   {
+      static const boost::regex reCustomSourceComment("^#\\s*!source\\s+\\w+.*$");
+      std::string contents = pDoc->contents();
+      if (regex_utils::search(contents.begin(), contents.end(), reCustomSourceComment))
+      {
+         return kRCustomSource;
+      }
+   }
+
+   return std::string();
+}
+
+} // anonymous namespace
+
+Error initialize()
+{
+   using namespace module_context;
+   module_context::events().onDetectSourceExtendedType
+                                        .connect(onDetectSourceType);
+
+   ExecBlock initBlock ;
+   return initBlock.execute();
+}
+
+
+} // namespace customsource
+} // namespace modules
+} // namespace session
+} // namespace rstudio
+

--- a/src/cpp/session/modules/customsource/SessionCustomSource.hpp
+++ b/src/cpp/session/modules/customsource/SessionCustomSource.hpp
@@ -1,0 +1,37 @@
+/*
+ * SessionCustomSource.hpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef SESSION_CUSTOMSOURCE_HPP
+#define SESSION_CUSTOMSOURCE_HPP
+
+namespace rstudio {
+namespace core {
+   class Error;
+}
+}
+ 
+namespace rstudio {
+namespace session {
+namespace modules { 
+namespace customsource {
+
+core::Error initialize();
+                       
+} // namespace customsource
+} // namespace modules
+} // namespace session
+} // namespace rstudio
+
+#endif // SESSION_CUSTOMSOURCE_HPP

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -126,6 +126,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditorId
 import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditorMixins;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetIdleMonitor;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetJSHelper;
+import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetRHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetPackageDependencyHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetSqlHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditorWidget;
@@ -188,6 +189,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(TextEditingTargetRMarkdownHelper rmarkdownHelper);
    void injectMembers(TextEditingTargetCppHelper cppHelper);
    void injectMembers(TextEditingTargetJSHelper jsHelper);
+   void injectMembers(TextEditingTargetRHelper rHelper);
    void injectMembers(TextEditingTargetSqlHelper sqlHelper);
    void injectMembers(TextEditingTargetChunks chunks);
    void injectMembers(TextEditingTargetPackageDependencyHelper packageDependencyHelper);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -455,6 +455,7 @@ public class TextEditingTarget implements
                                                                   docDisplay_);
       reformatHelper_ = new TextEditingTargetReformatHelper(docDisplay_);
       renameHelper_ = new TextEditingTargetRenameHelper(docDisplay_);
+      rHelper_ = new TextEditingTargetRHelper(docDisplay_);
       
       docDisplay_.setRnwCompletionContext(compilePdfHelper_);
       docDisplay_.setCppCompletionContext(cppCompletionContext_);
@@ -5457,6 +5458,11 @@ public class TextEditingTarget implements
          }
       }); 
    }
+
+   void customSource()
+   {
+      rHelper_.customSource(TextEditingTarget.this);
+   }
    
    void renderRmd()
    {
@@ -6280,6 +6286,11 @@ public class TextEditingTarget implements
                else if (fileType_.canPreviewFromR())
                {
                   previewFromR();
+               }
+               else if (fileType_.isR())
+               {
+                  if (extendedType_ == SourceDocument.XT_R_CUSTOM_SOURCE)
+                     customSource();
                }
                else
                {
@@ -7264,6 +7275,7 @@ public class TextEditingTarget implements
    private final TextEditingTargetSqlHelper sqlHelper_;
    private final TextEditingTargetPresentationHelper presentationHelper_;
    private final TextEditingTargetReformatHelper reformatHelper_;
+   private final TextEditingTargetRHelper rHelper_;
    private TextEditingTargetIdleMonitor bgIdleMonitor_;
    private TextEditingTargetThemeHelper themeHelper_;
    private RoxygenHelper roxygenHelper_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRHelper.java
@@ -1,0 +1,119 @@
+/*
+ * TextEditingTargetRHelper.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.source.editors.text;
+
+import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.regex.Match;
+import org.rstudio.core.client.regex.Pattern;
+import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.common.SimpleRequestCallback;
+import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
+import org.rstudio.studio.client.workbench.views.source.editors.EditingTarget;
+import org.rstudio.studio.client.workbench.views.source.model.SourceServerOperations;
+
+import com.google.inject.Inject;
+
+public class TextEditingTargetRHelper
+{
+   public TextEditingTargetRHelper(DocDisplay docDisplay)
+   {
+      docDisplay_ = docDisplay;
+      RStudioGinjector.INSTANCE.injectMembers(this);
+   }
+
+   @Inject
+   void initialize(GlobalDisplay display, EventBus eventBus, SourceServerOperations server)
+   {
+      display_ = display;
+      eventBus_ = eventBus;
+      server_ = server;
+   }
+
+   public void customSource(EditingTarget editingTarget)
+   {
+      CustomSource customSource = parseCustomSource();
+      if (customSource != null)
+      {
+         server_.getMinimalSourcePath(
+            editingTarget.getPath(), 
+            new SimpleRequestCallback<String>() {
+               @Override
+               public void onResponseReceived(String path)
+               {
+                  String argsString = "";
+                  if (customSource.args.length() > 0)
+                  {
+                     argsString = ", " + customSource.args;
+                  }
+
+                  String command = customSource.function + "(\"" + path + "\"" + argsString + ")";
+                  eventBus_.fireEvent(new SendToConsoleEvent(command, true));
+               }
+            });
+      }
+   }
+
+   private CustomSource parseCustomSource()
+   {
+      Iterable<String> lines = StringUtil.getLineIterator(docDisplay_.getCode());
+      for (String line : lines)
+      {
+         line = line.trim();
+         if (line.length() == 0)
+         {
+            continue;
+         }
+         else if (line.startsWith("#"))
+         {
+            Match match = customSourcePattern_.match(line, 0);
+            if (match != null &&
+                match.hasGroup(1) &&
+                match.hasGroup(2))
+            {
+               String function = match.getGroup(1);
+               String options = match.getGroup(2);
+               
+               return new CustomSource(function, options);
+            }
+            
+         }   
+      }
+      
+      return null;
+   }
+   
+   private class CustomSource 
+   {
+      public CustomSource(String function, String args)
+      {
+         this.function = function;
+         this.args = args;
+      }
+      
+      public final String function;
+      public final String args;
+   }
+   
+   private static final Pattern customSourcePattern_ = 
+         Pattern.create("^#\\s*!source\\s+([.a-zA-Z]+[.a-zA-Z0-9:_]*)\\s*(.*)$", "");
+   
+   private GlobalDisplay display_;
+   private EventBus eventBus_; 
+   private DocDisplay docDisplay_;
+   private SourceServerOperations server_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -694,8 +694,10 @@ public class TextEditingTargetWidget
       
       sourceOnSave_.setVisible(canSourceOnSave);
       srcOnSaveLabel_.setVisible(canSourceOnSave);
-      if (fileType.isRd() || fileType.isJS() || canPreviewFromR || fileType.isSql() )
+      if (fileType.isRd() || fileType.isJS() || canPreviewFromR || fileType.isSql())
          srcOnSaveLabel_.setText(fileType.getPreviewButtonText() + " on Save");
+      else if (hasCustomSource())
+         srcOnSaveLabel_.setText("Custom Action on Save");
       else
          srcOnSaveLabel_.setText("Source on Save");
       codeTransform_.setVisible(
@@ -814,6 +816,11 @@ public class TextEditingTargetWidget
       return extendedType_ != null &&
              extendedType_.startsWith(SourceDocument.XT_TEST_SHINYTEST);
    }
+
+   private boolean hasCustomSource()
+   {
+      return SourceDocument.hasCustomSource(extendedType_);
+   }
    
    @Override
    public void setNotebookUIVisible(boolean visible)
@@ -854,13 +861,20 @@ public class TextEditingTargetWidget
       knitDocumentButton_.setText(width < 450 ? "" : knitCommandText_);
       
       if (editor_.getFileType().isRd() || editor_.getFileType().isJS() || 
-          editor_.getFileType().isSql() ||editor_.getFileType().canPreviewFromR())
+          editor_.getFileType().isSql())
       {
          String preview = editor_.getFileType().getPreviewButtonText();
          srcOnSaveLabel_.setText(width < 450 ? preview : preview + " on Save");
       }
+      else if (hasCustomSource())
+      {
+         srcOnSaveLabel_.setText(width < 450 ? "Custom" : "Custom Action on Save");
+      }
       else
+      {
          srcOnSaveLabel_.setText(width < 450 ? "Source" : "Source on Save");
+      }
+
       sourceButton_.setText(width < 400 ? "" : sourceCommandText_);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceDocument.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceDocument.java
@@ -178,6 +178,11 @@ public class SourceDocument extends JavaScriptObject
    {
       return extendedType != null && extendedType == SourceDocument.XT_PLUMBER_API;
    }
+
+   public static boolean hasCustomSource(String extendedType)
+   {
+      return extendedType != null && extendedType == SourceDocument.XT_R_CUSTOM_SOURCE;
+   }
    
    public final static String XT_RMARKDOWN = "rmarkdown";
    public final static String XT_SHINY_PREFIX = "shiny-";
@@ -191,4 +196,5 @@ public class SourceDocument extends JavaScriptObject
    public final static String XT_JS_PREVIEWABLE = "js-previewable";
    public final static String XT_SQL_PREVIEWABLE = "sql-previewable";
    public final static String XT_PLUMBER_API = "plumber-api";
+   public final static String XT_R_CUSTOM_SOURCE = "r-custom-source";
 }


### PR DESCRIPTION
Some packages like [mlflow](https://github.com/rstudio/mlflow/R/mlflow) would like to customize which operation triggers when an R file gets sourced. For `mlflow`, this would enable tracking model parameters, results, artifacts, etc. just by saving their models.

This PR adds support for a `# !source function args` similar to `-- !preview` and `// !preview` that allows R scripts to override the source action.

<img width="961" alt="screen shot 2018-08-10 at 3 07 21 pm" src="https://user-images.githubusercontent.com/3478847/43983507-ba8cfc8a-9caf-11e8-8d18-df66c9b8e24f.png">

See also [rstudio/mlflow/issues/11](https://github.com/rstudio/mlflow/issues/11)