### PR TITLE
accommodate changes in QProcess API on Windows

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -1209,9 +1209,16 @@ void GwtCallback::openTerminal(QString terminalPath,
       break;
    }
 
-   QProcess::startDetached(terminalPath,
-                           args,
-                           resolveAliasedPath(workingDirectory));
+   QProcess process;
+   process.setProgram(terminalPath);
+   process.setArguments(args);
+   process.setWorkingDirectory(resolveAliasedPath(workingDirectory));
+   process.setCreateProcessArgumentsModifier([](QProcess::CreateProcessArguments* cpa)
+   {
+      cpa->flags |= CREATE_NEW_CONSOLE;
+      cpa->startupInfo->dwFlags &= ~STARTF_USESTDHANDLES;
+   });
+   process.startDetached();
 
    // revert to previous home
    core::system::setenv("HOME", previousHome);


### PR DESCRIPTION
Closes #3309.

Qt has in the changelog for Qt 5.8.0:

>  - [QTBUG-53833] QProcess::startDetached() changed behavior on Windows:
>    it no longer creates a new console window unconditionally, instead it
>    passes the same creation flags to CreateProcess as QProcess::start().

So we need to explicitly request a console window when launching e.g. Git Bash.