### PR TITLE
Fix windows-dependency script to install R 3.5.0

### DIFF
--- a/dependencies/windows/Install-RStudio-Prereqs.ps1
+++ b/dependencies/windows/Install-RStudio-Prereqs.ps1
@@ -28,8 +28,8 @@ If (-Not (Test-Administrator)) {
 if (-Not (Test-Path -Path "C:\R")) {
     $RSetupPackage = "C:\R-3.5.0-win.exe"
     if (-Not (Test-Path -Path $RSetupPackage)) {
-        Write-Host "Downloading R..."
-        Invoke-WebRequest https://cran.rstudio.com/bin/windows/base/R-3.5.0-win.exe -OutFile $RSetupPackage
+        Write-Host "Downloading R 3.5.0..."
+        Invoke-WebRequest https://cran.rstudio.com/bin/windows/base/old/3.5.0/R-3.5.0-win.exe -OutFile $RSetupPackage
     } else {
         Write-Host "Using previously downloaded R installer"
     }


### PR DESCRIPTION
When R was bumped from 3.5.0 to 3.5.1, the URL for downloading latest build changed. Tweak script to pin to 3.5.0 now that it's an older build.