### PR TITLE
Renamed "Replace and Find" to "Find and Replace"

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -420,7 +420,7 @@ public class TextFileType extends EditableFileType
       results.add(commands.findNext());
       results.add(commands.findPrevious());
       results.add(commands.findFromSelection());
-      results.add(commands.replaceAndFind());
+      results.add(commands.findAndReplace());
       results.add(commands.setWorkingDirToActiveDoc());
       results.add(commands.debugDumpContents());
       results.add(commands.debugImportDump());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -187,7 +187,7 @@ well as menu structures (for main menu and popup menus).
          <cmd refid="findNext"/>
          <cmd refid="findPrevious"/>
          <cmd refid="findFromSelection"/>
-         <cmd refid="replaceAndFind"/>
+         <cmd refid="findAndReplace"/>
          <separator/>
          <cmd refid="findInFiles"/>
          <separator/>
@@ -589,7 +589,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="findNext" value="F3" if="org.rstudio.core.client.BrowseCap.isWindows()"/>
          <shortcut refid="findPrevious" value="Cmd+Shift+G" if="!org.rstudio.core.client.BrowseCap.isWindows()"/>
          <shortcut refid="findPrevious" value="Shift+F3" if="org.rstudio.core.client.BrowseCap.isWindows()"/>
-         <shortcut refid="replaceAndFind" value="Cmd+Shift+J"/>
+         <shortcut refid="findAndReplace" value="Cmd+Shift+J"/>
          <shortcut refid="goToFileFunction" value="Ctrl+."/>
          <shortcut refid="goToLine" value="Alt+G" disableModes="default,vim"/>
          <shortcut refid="goToLine" value="Shift+Alt+G" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
@@ -1399,10 +1399,10 @@ well as menu structures (for main menu and popup menus).
         desc="Find and select all matches"
         rebindable="false"/>
         
-   <cmd id="replaceAndFind"
+   <cmd id="findAndReplace"
         buttonLabel="Replace"
-        menuLabel="_Replace and Find"
-        desc="Replace and find next occurrence"
+        menuLabel="Find and _Replace"
+        desc="Find and replace next occurrence"
         rebindable="false"/>
         
    <cmd id="findInFiles"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -129,7 +129,7 @@ public abstract class
    public abstract AppCommand findSelectAll();
    public abstract AppCommand findFromSelection();
    public abstract AppCommand findAll();
-   public abstract AppCommand replaceAndFind();
+   public abstract AppCommand findAndReplace();
    public abstract AppCommand findInFiles();
    public abstract AppCommand fold();
    public abstract AppCommand unfold();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -337,7 +337,7 @@ public class Source implements InsertSourceHandler,
       dynamicCommands_.add(commands.findNext());
       dynamicCommands_.add(commands.findPrevious());
       dynamicCommands_.add(commands.findFromSelection());
-      dynamicCommands_.add(commands.replaceAndFind());
+      dynamicCommands_.add(commands.findAndReplace());
       dynamicCommands_.add(commands.extractFunction());
       dynamicCommands_.add(commands.extractLocalVariable());
       dynamicCommands_.add(commands.commentUncomment());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -218,7 +218,7 @@ public class TextEditingTarget implements
       void findPrevious();
       void findSelectAll();
       void findFromSelection();
-      void replaceAndFind();
+      void findAndReplace();
       
       StatusBar getStatusBar();
 
@@ -5993,9 +5993,9 @@ public class TextEditingTarget implements
    }
    
    @Handler
-   void onReplaceAndFind()
+   void onfindAndReplace()
    {
-      view_.replaceAndFind();
+      view_.findAndReplace();
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetFindReplace.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetFindReplace.java
@@ -168,7 +168,7 @@ public class TextEditingTargetFindReplace
       }
    }
    
-   public void replaceAndFind()
+   public void findAndReplace()
    {
       if (findReplace_ == null)
       {
@@ -182,7 +182,7 @@ public class TextEditingTargetFindReplace
       }
       else
       {
-         findReplace_.replaceAndFind();
+         findReplace_.findAndReplace();
       }
    }
   

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -972,9 +972,9 @@ public class TextEditingTargetWidget
    }
    
    @Override
-   public void replaceAndFind()
+   public void findAndReplace()
    {
-      findReplace_.replaceAndFind();
+      findReplace_.findAndReplace();
    }
 
    public void onActivate()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplace.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplace.java
@@ -177,7 +177,7 @@ public class FindReplace
       find(FindType.Reverse);
    }
    
-   public void replaceAndFind()
+   public void findAndReplace()
    {
       replace();
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.java
@@ -82,7 +82,7 @@ public class FindReplaceBar extends Composite implements Display, RequiresResize
       
       findReplacePanel.add(txtReplace_ = new FindTextBox("Replace"));
       txtReplace_.addStyleName(RES.styles().replaceTextBox());
-      findReplacePanel.add(btnReplace_ = new SmallButton(cmds.replaceAndFind()));
+      findReplacePanel.add(btnReplace_ = new SmallButton(cmds.findAndReplace()));
       findReplacePanel.add(btnReplaceAll_ = new SmallButton("All"));
       
       panel.add(findReplacePanel);


### PR DESCRIPTION
It was quite surprised when I realized RStudio uses this phrase in reverse order. I cannot recall anywhere else that uses it like this. It's always _Find and Replace_, and it makes sense this way, you find something and then replace it and then move on to the next occurrence.  What confused me, even more, was the fact that there is a shortcut for "Find and Replace" (Ctrl + F) and to my understanding, it brings the same UI as "Replace and Find" (Ctrl + Shift + J) brings, and does the same even.

I think this needs some cleanup, and I think I've found and replaced most references to this, also renamed the method name. I'm not sure how we are going to proceed, but let me know if there is anything else that I can check.