### PR TITLE
Ignore .Rproj.user directory

### DIFF
--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -3020,10 +3020,10 @@ Error augmentGitIgnore(const FilePath& gitIgnoreFile)
          return error;
 
       std::vector<std::string> filesToIgnore;
-      
-      if (!regex_utils::search(strIgnore, boost::regex(R"(^\.Rproj\.user$)")))
+
+      if (!regex_utils::search(strIgnore, boost::regex(R"(^\.Rproj\.user/?$)")))
          filesToIgnore.push_back(".Rproj.user");
-      
+
       if (session::options().packageOutputInPackageFolder())
       {
          // add any missing exclusions for package build/check output


### PR DESCRIPTION
If `.Rproj.user/` exists in .gitignore, don't add `.Rproj.user` to .gitignore.

Closes #3326.

Individual contributor agreement sent to jj@rstudio.com.