### PR TITLE
properly compute resources path for dev vs. pkg build

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -145,6 +145,10 @@ else()
       -DBOOST_USE_WINDOWS_H)
 endif()
 
+if(RSTUDIO_PACKAGE_BUILD)
+   add_definitions(-DRSTUDIO_PACKAGE_BUILD)
+endif()
+
 # determine whether we should statically link boost. we always do this
 # unless we are building a non-packaged build on linux (in which case
 # boost dynamic libraries are presumed to be installed on the system ldpath)

--- a/src/cpp/desktop/DesktopOptions.cpp
+++ b/src/cpp/desktop/DesktopOptions.cpp
@@ -358,18 +358,15 @@ FilePath Options::resourcesPath() const
 {
    if (resourcesPath_.empty())
    {
-      if (scriptsPath().complete("resources").exists())
-      {
-         // developer configuration: the 'resources' folder is
-         // a sibling of the RStudio executable
-         resourcesPath_ = scriptsPath().complete("resources");
-      }
-      else
-      {
-         // release configuration: the 'resources' folder is
-         // part of the supporting files folder
-         resourcesPath_ = supportingFilePath().complete("resources");
-      }
+#ifdef RSTUDIO_PACKAGE_BUILD
+      // release configuration: the 'resources' folder is
+      // part of the supporting files folder
+      resourcesPath_ = supportingFilePath().complete("resources");
+#else
+      // developer configuration: the 'resources' folder is
+      // a sibling of the RStudio executable
+      resourcesPath_ = scriptsPath().complete("resources");
+#endif
    }
 
    return resourcesPath_;


### PR DESCRIPTION
This should fix issues where light vs. dark stylesheets fail to apply on Windows. Log entries of the form:

> 17 Aug 2018 16:25:25 [rdesktop] ERROR system error 3 (The system cannot find the path specified) [path=C:/Program Files/RStudio/bin/resources/stylesheets/rstudio-windows-dark.qss]; OCCURRED AT: auto __cdecl rstudio::core::FilePath::open_r::<lambda_d4246793555dd4e209de8cc0cf7ef3ce>::operator ()(void) const c:\jenkins\workspace\ide\windows\src\cpp\core\filepath.cpp:1072; LOGGED FROM: void __cdecl rstudio::desktop::applyDesktopTheme(class QWidget *,bool) c:\jenkins\workspace\ide\windows\src\cpp\desktop\desktoputils.cpp:145

are emitted to the logs.

The issue here is that on Windows, folders exist _both_ at `<root>/bin/resources` and `<root>/resources`; the prior logic attempting to look for both paths (not expecting to find the first one in release builds) and erroneously used that.