### PR TITLE
Improve spellcheck markdown coverage

### DIFF
--- a/src/gwt/acesupport/acemode/markdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/markdown_highlight_rules.js
@@ -91,22 +91,22 @@ var MarkdownHighlightRules = function() {
     // handle highlighting for *abc*, _abc_ separately, as pandoc's
     // parser is a bit more strict about where '_' can appear
     var strongUnderscore = {
-        token: ["text", "constant.numeric"],
+        token: ["text", "constant.numeric.text"],
         regex: "(\\s+|^)(__\\S.+?\\S__)\\b"
     };
 
     var emphasisUnderscore = {
-        token: ["text", "constant.language.boolean"],
+        token: ["text", "constant.language.boolean.text"],
         regex: "(\\s+|^)(_(?=[^\\s_])(?:(?:\\\\.)|(?:[^\\s_\\\\]))*?_)\\b"
     };
 
     var strongStars = {
-        token: ["constant.numeric"],
+        token: ["constant.numeric.text"],
         regex: "([*][*]\\S.+?\\S[*][*])"
     };
 
     var emphasisStars = {
-        token: ["constant.language.boolean"],
+        token: ["constant.language.boolean.text"],
         regex: "([*](?=[^\\s*])(?:(?:\\\\.)|(?:[^\\s*\\\\]))*?[*])"
     };
 
@@ -286,7 +286,7 @@ var MarkdownHighlightRules = function() {
            regex: "-->",
            next: "start"
         }, {
-           defaultToken: "comment"
+           defaultToken: "comment.text"
         }],
        
         // code block

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -450,8 +450,12 @@ public class TextFileType extends EditableFileType
          @Override
          public boolean test(Token token, int row, int column)
          {
-            return reTextType_.match(token.getType(), 0) != null
-                  && reNospellType_.match(token.getType(), 0) == null;
+            if (reNospellType_.match(token.getType(), 0) != null) {
+               return false;
+            }
+
+            return reTextType_.match(token.getType(), 0) != null ||
+               reHeaderType_.match(token.getType(), 0) != null;
          }
       };
    }
@@ -504,5 +508,6 @@ public class TextFileType extends EditableFileType
    private final String defaultExtension_;
 
    private static Pattern reTextType_ = Pattern.create("\\btext\\b");
+   private static Pattern reHeaderType_ = Pattern.create("\\bheading\\b");
    private static Pattern reNospellType_ = Pattern.create("\\bnospell\\b");
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -455,6 +455,7 @@ public class TextFileType extends EditableFileType
             }
 
             return reTextType_.match(token.getType(), 0) != null ||
+               reStringType_.match(token.getType(), 0) != null ||
                reHeaderType_.match(token.getType(), 0) != null;
          }
       };
@@ -508,6 +509,7 @@ public class TextFileType extends EditableFileType
    private final String defaultExtension_;
 
    private static Pattern reTextType_ = Pattern.create("\\btext\\b");
+   private static Pattern reStringType_ = Pattern.create("\\bstring\\b");
    private static Pattern reHeaderType_ = Pattern.create("\\bheading\\b");
    private static Pattern reNospellType_ = Pattern.create("\\bnospell\\b");
 }


### PR DESCRIPTION
Bugfix for: https://github.com/rstudio/rstudio/issues/1588

Previously spellchecking an R markdown document would only check tokens labeled with the "text" type. Due to how highlighting is set up many tokens that are actually text types have other classes such as "constant" and "numeric". This PR adds the "text" type to existing types as well as adds "string" and "header" as valid types to check.

![aejnhiy](https://user-images.githubusercontent.com/136863/44283541-b98bae80-a22c-11e8-81f2-6aca6b108a6a.png)