### PR TITLE
Publish static assets such as PPT, PDF, Word Files from RStudio to Connect

### DIFF
--- a/src/cpp/session/modules/SessionRSConnect.cpp
+++ b/src/cpp/session/modules/SessionRSConnect.cpp
@@ -148,7 +148,9 @@ public:
       {
          FilePath docFile = module_context::resolveAliasedPath(file);
          std::string extension = docFile.extensionLowerCase();
-         if (extension == ".rmd" || extension == ".html" || extension == ".r") 
+         if (extension == ".rmd" || extension == ".html" || extension == ".r" ||
+             extension == ".pdf" || extension == ".docx" || extension == ".rtf" || 
+             extension == ".odt" || extension == ".pptx") 
          {
             primaryDoc = string_utils::utf8ToSystem(file);
          }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSource.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSource.java
@@ -135,7 +135,9 @@ public class RSConnectPublishSource
    public boolean isDocument()
    {
       return isSourceExt("rmd") || isSourceExt("md") || isSourceExt("html") ||
-             isSourceExt("htm") || isSourceExt("rpres");
+             isSourceExt("htm") || isSourceExt("rpres") || isSourceExt("pdf") ||
+             isSourceExt("docx") || isSourceExt("odt") || isSourceExt("rtf") ||
+             isSourceExt("pptx");
    }
    
    public String getDeployKey()


### PR DESCRIPTION
With the reintroduction of publishing rendered static content from editor via #3266, request was made to also support publishing other static types to Connect directly from the IDE instead of having to manually run `rsconnect::deployDoc`.

Can now publish PDF, Word (.docx, .rtf, .odt), and PPT (.pptx) files to Connect. This doesn't change the Connect-side behavior for rendering these types, so that will depend what the browser and/or Connect is capable of showing. On my Mac/Chrome, PDFs show in the browser, but Word and PPT files show a download link.

Fixes #3265 

FYI @nwstephens