### PR TITLE
Sublime Text key bindings

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/KeyboardShortcut.java
+++ b/src/gwt/src/org/rstudio/core/client/command/KeyboardShortcut.java
@@ -473,4 +473,5 @@ public class KeyboardShortcut
    public static final int MODE_DEFAULT = 1;
    public static final int MODE_VIM = 2;
    public static final int MODE_EMACS = 4;
+   public static final int MODE_SUBLIME = 8;
 }

--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.Pair;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.KeyMap.CommandBinding;
@@ -40,6 +41,7 @@ import org.rstudio.studio.client.events.EditEvent;
 import org.rstudio.studio.client.workbench.addins.AddinsCommandManager;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.commands.RStudioCommandExecutedFromShortcutEvent;
+import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditor;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEditorNative;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceKeyboardActivityEvent;
 import org.rstudio.studio.client.workbench.views.terminal.xterm.XTermWidget;
@@ -473,6 +475,28 @@ public class ShortcutManager implements NativePreviewHandler,
       
       keyBuffer_.add(keyCombination);
       
+      // we handle `Ctrl+L` for the sublime mode here
+      // because it is conflicted with `consoleClear`
+      if (editorMode_ == KeyboardShortcut.MODE_SUBLIME)
+         {
+            if (keyCombination.getKeyCode() == KeyCodes.KEY_L &&
+                keyCombination.getModifier() == KeyboardShortcut.CTRL)
+         {
+            Element target = Element.as(event.getEventTarget());
+            AceEditor editor = AceEditor.getEditor(target);
+            AceEditorNative nativeEditor = AceEditorNative.getEditor(target);
+            if (editor != null && nativeEditor != null &&
+                  nativeEditor == editor.getWidget().getEditor() &&
+                  editor.getWidget().getElement().getId() ==
+                     ElementIds.getElementId(ElementIds.SOURCE_TEXT_EDITOR))
+            {
+               keyBuffer_.clear();
+               commands_.expandToLine().execute();
+               return true;
+            }
+         }
+      }
+
       // Loop through all active key maps, and attempt to find an active
       // binding. 'pending' is used to indicate whether there are any bindings
       // following the current state of the keybuffer.

--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
@@ -300,6 +300,8 @@ public class ShortcutManager implements NativePreviewHandler,
             mode |= KeyboardShortcut.MODE_VIM;
          else if (item == "emacs")
             mode |= KeyboardShortcut.MODE_EMACS;
+         else if (item == "sublime")
+            mode |= KeyboardShortcut.MODE_SUBLIME;
          else
             assert false: "Unrecognized 'disableModes' value '" + item + "'";
       }

--- a/src/gwt/src/org/rstudio/core/rebind/command/ShortcutsEmitter.java
+++ b/src/gwt/src/org/rstudio/core/rebind/command/ShortcutsEmitter.java
@@ -276,6 +276,10 @@ public class ShortcutsEmitter
          return "189";
       if (val.equals("Backspace"))
          return "8";
+      if (val.equals("["))
+         return "219";
+      if (val.equals("]"))
+         return "221";
       return null;
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -239,7 +239,7 @@ public class DesktopApplicationHeader implements ApplicationHeader
                int row = session.getSelection().getRange().getStart().getRow();
                String text = session.getLine(row) + "\n";
                Desktop.getFrame().setClipboardText(StringUtil.notNull(text));
-               editor.removeLines();
+               editor.execCommand("removeline");
          }
          return;
       }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -19,8 +19,6 @@ import java.util.ArrayList;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
-import org.rstudio.core.client.command.KeyboardShortcut;
-import org.rstudio.core.client.command.ShortcutManager;
 import org.rstudio.core.client.command.impl.DesktopMenuCallback;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.WindowEx;
@@ -59,7 +57,6 @@ import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEve
 import org.rstudio.studio.client.workbench.views.files.events.ShowFolderEvent;
 import org.rstudio.studio.client.workbench.views.files.events.ShowFolderHandler;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEditorNative;
-import org.rstudio.studio.client.workbench.views.source.editors.text.ace.EditSession;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Selection;
 
 import com.google.gwt.core.client.GWT;
@@ -226,48 +223,15 @@ public class DesktopApplicationHeader implements ApplicationHeader
    @Handler
    void onCutDummy()
    {
-      Element activeElement = DomUtils.getActiveElement();
-      AceEditorNative editor = AceEditorNative.getEditor(activeElement);
-      if (editor != null)
-      {
-         // cut the whole line if sublime mode
-         Selection selection = editor.getSession().getSelection();
-         if (selection.isEmpty()) {
-            if (ShortcutManager.INSTANCE.getEditorMode() == KeyboardShortcut.MODE_SUBLIME)
-            {
-               EditSession session = editor.getSession();
-               int row = session.getSelection().getRange().getStart().getRow();
-               String text = session.getLine(row) + "\n";
-               Desktop.getFrame().setClipboardText(StringUtil.notNull(text));
-               editor.execCommand("removeline");
-         }
-         return;
-      }
-      }
-      fireEditEvent(EditEvent.TYPE_COPY);
+      if (isSelectionEmpty()) return;
+      fireEditEvent(EditEvent.TYPE_CUT);
       Desktop.getFrame().clipboardCut();
    }
 
    @Handler
    void onCopyDummy()
    {
-      Element activeElement = DomUtils.getActiveElement();
-      AceEditorNative editor = AceEditorNative.getEditor(activeElement);
-      if (editor != null)
-      {
-         // copy the whole line if sublime mode
-         Selection selection = editor.getSession().getSelection();
-         if (selection.isEmpty()) {
-            if (ShortcutManager.INSTANCE.getEditorMode() == KeyboardShortcut.MODE_SUBLIME)
-            {
-               EditSession session = editor.getSession();
-               int row = session.getSelection().getRange().getStart().getRow();
-               String text = session.getLine(row) + "\n";
-               Desktop.getFrame().setClipboardText(StringUtil.notNull(text));
-            }
-               return;
-            }
-         }
+      if (isSelectionEmpty()) return;
       fireEditEvent(EditEvent.TYPE_COPY);
       Desktop.getFrame().clipboardCopy();
    }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -19,6 +19,8 @@ import java.util.ArrayList;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
+import org.rstudio.core.client.command.KeyboardShortcut;
+import org.rstudio.core.client.command.ShortcutManager;
 import org.rstudio.core.client.command.impl.DesktopMenuCallback;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.WindowEx;
@@ -57,6 +59,7 @@ import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEve
 import org.rstudio.studio.client.workbench.views.files.events.ShowFolderEvent;
 import org.rstudio.studio.client.workbench.views.files.events.ShowFolderHandler;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEditorNative;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.EditSession;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Selection;
 
 import com.google.gwt.core.client.GWT;
@@ -223,15 +226,48 @@ public class DesktopApplicationHeader implements ApplicationHeader
    @Handler
    void onCutDummy()
    {
-      if (isSelectionEmpty()) return;
-      fireEditEvent(EditEvent.TYPE_CUT);
+      Element activeElement = DomUtils.getActiveElement();
+      AceEditorNative editor = AceEditorNative.getEditor(activeElement);
+      if (editor != null)
+      {
+         // cut the whole line if sublime mode
+         Selection selection = editor.getSession().getSelection();
+         if (selection.isEmpty()) {
+            if (ShortcutManager.INSTANCE.getEditorMode() == KeyboardShortcut.MODE_SUBLIME)
+            {
+               EditSession session = editor.getSession();
+               int row = session.getSelection().getRange().getStart().getRow();
+               String text = session.getLine(row) + "\n";
+               Desktop.getFrame().setClipboardText(StringUtil.notNull(text));
+               editor.removeLines();
+         }
+         return;
+      }
+      }
+      fireEditEvent(EditEvent.TYPE_COPY);
       Desktop.getFrame().clipboardCut();
    }
 
    @Handler
    void onCopyDummy()
    {
-      if (isSelectionEmpty()) return;
+      Element activeElement = DomUtils.getActiveElement();
+      AceEditorNative editor = AceEditorNative.getEditor(activeElement);
+      if (editor != null)
+      {
+         // copy the whole line if sublime mode
+         Selection selection = editor.getSession().getSelection();
+         if (selection.isEmpty()) {
+            if (ShortcutManager.INSTANCE.getEditorMode() == KeyboardShortcut.MODE_SUBLIME)
+            {
+               EditSession session = editor.getSession();
+               int row = session.getSelection().getRange().getStart().getRow();
+               String text = session.getLine(row) + "\n";
+               Desktop.getFrame().setClipboardText(StringUtil.notNull(text));
+            }
+               return;
+            }
+         }
       fireEditEvent(EditEvent.TYPE_COPY);
       Desktop.getFrame().clipboardCopy();
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -1478,6 +1478,30 @@ well as menu structures (for main menu and popup menus).
         menuLabel="Add Cursor Below Current Cursor"
         context="editor"/>
         
+   <cmd id="moveLinesUp"
+        menuLabel="Move Lines Up"
+        context="editor"/>
+      
+   <cmd id="moveLinesDown"
+        menuLabel="Move Lines Down"
+        context="editor"/>
+
+   <cmd id="expandToLine"
+        menuLabel="Expand Selection to Line"
+        context="editor"/>
+
+   <cmd id="copyLinesDown"
+        menuLabel="Copy Lines Down"
+        context="editor"/>
+
+   <cmd id="joinLines"
+        menuLabel="Join Lines"
+        context="editor"/>
+
+   <cmd id="removeLine"
+        menuLabel="Remove Line"
+        context="editor"/>
+
    <cmd id="splitIntoLines"
         menuLabel="Split Into Lines"
         desc="Create a new cursor on each line in current selection"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -543,6 +543,9 @@ well as menu structures (for main menu and popup menus).
       <!-- Use spaces for key sequences, e.g. 'Ctrl+X Ctrl+F' -->
       <!-- Separate shortcuts with '|', e.g. 'Ctrl+X Ctrl+F|Cmd+O' -->
       <shortcutgroup name="Source Editor">
+         <shortcut refid="copyDummy" value="Cmd+C"/>
+         <shortcut refid="cutDummy" value="Cmd+X"/>
+         <!-- <shortcut refid="pasteDummy" value="Cmd+V"/> -->
          <shortcut refid="insertChunk" value="Cmd+Alt+I"/>
          <shortcut refid="insertSection" value="Cmd+Shift+R"/>
          <shortcut refid="extractFunction" value="Cmd+Alt+X"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -577,6 +577,8 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="expandToLine" value="Meta+L" title="Expand Selection to line" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs" />
          <!-- Ctrl+L to be handled by ShortcutManager -->
          <!-- <shortcut refid="expandToLine" value="Ctrl+L" title="Expand Selection to line" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs" /> -->
+         <shortcut refid="copyLinesDown" value="Cmd+Shift+D" title="Copy Lines Down" disableModes="default,vim,emacs" />
+         <shortcut refid="joinLines" value="Cmd+J" title="Join Lines" disableModes="default,vim,emacs" />
          <shortcut refid="removeLine" value="Ctrl+Shift+K" title="Delete Line" disableModes="default,vim,emacs" />
          <shortcut refid="yankRegion" value="Ctrl+W" title="Kill Region" disableModes="default,vim,sublime"/>
          <shortcut refid="yankBeforeCursor" value="Ctrl+U" title="Yank Line Up to Cursor" disableModes="vim"/>
@@ -722,7 +724,8 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="checkPackage" value="Cmd+Shift+E"/>
          <shortcut refid="testPackage" value="Cmd+Shift+T" if="org.rstudio.studio.client.application.Desktop.isDesktop()"/>
          <shortcut refid="testPackage" value="Cmd+Alt+F7" if="!org.rstudio.studio.client.application.Desktop.isDesktop()"/>
-         <shortcut refid="roxygenizePackage" value="Cmd+Shift+D"/>
+         <shortcut refid="roxygenizePackage" value="Cmd+Shift+D" disableModes="sublime"/>
+         <shortcut refid="roxygenizePackage" value="Ctrl+Shift+D" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
       </shortcutgroup>
       <shortcutgroup name="Execute">
          <shortcut refid="sourceActiveDocument" value="Cmd+Shift+S" title="Source Active File"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -547,10 +547,12 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="cutDummy" value="Cmd+X"/>
          <!-- <shortcut refid="pasteDummy" value="Cmd+V"/> -->
          <shortcut refid="insertChunk" value="Cmd+Alt+I"/>
-         <shortcut refid="insertSection" value="Cmd+Shift+R"/>
+         <shortcut refid="insertSection" value="Cmd+Shift+R" disableModes="sublime"/>
+         <shortcut refid="insertSection" value="Ctrl+Shift+R" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="extractFunction" value="Cmd+Alt+X"/>
          <shortcut refid="extractLocalVariable" value="Cmd+Alt+V"/>
          <shortcut refid="commentUncomment" value="Cmd+Shift+C"/>
+         <shortcut refid="commentUncomment" value="Cmd+/" disableModes="default,vim,emacs"/>
          <shortcut refid="blockOutdent" value="Meta+[" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
          <shortcut refid="blockIndent" value="Meta+]" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
          <shortcut refid="reindent" value="Cmd+I"/>
@@ -571,7 +573,6 @@ well as menu structures (for main menu and popup menus).
          <shortcut value="Alt+Down" title="Move Lines Down" />
          <shortcut value="Ctrl+D" title="Delete Line" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="sublime"/>
          <shortcut value="Cmd+D" title="Delete Line" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="sublime" />
-         <shortcut refid="quickAddNext" value="Cmd+D" title="Find and Add Next" disableModes="default,vim,emacs" />
          <shortcut refid="removeLine" value="Ctrl+Shift+K" title="Delete Line" disableModes="default,vim,emacs" />
          <shortcut refid="yankRegion" value="Ctrl+W" title="Kill Region" disableModes="default,vim,sublime"/>
          <shortcut refid="yankBeforeCursor" value="Ctrl+U" title="Yank Line Up to Cursor" disableModes="vim"/>
@@ -579,7 +580,8 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="pasteLastYank" value="Ctrl+Y" title="Insert Yanked Text" />
          <shortcut value="Ctrl+T" title="Transpose Letters" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="insertAssignmentOperator" value="Alt+-" title="Insert Assignment Operator"/>
-         <shortcut refid="insertPipeOperator" value="Cmd+Shift+M" title="Insert Pipe Operator" />
+         <shortcut refid="insertPipeOperator" value="Meta+Shift+M" title="Insert Pipe Operator" />
+         <shortcut refid="insertPipeOperator" value="Ctrl+Shift+M" title="Insert Pipe Operator" disableModes="sublime"/>
          <shortcut refid="renameInScope" value="Cmd+Alt+Shift+M" />
          <shortcut refid="insertRoxygenSkeleton" value="Cmd+Shift+Alt+R" title="Insert Roxygen Skeleton" />
          <shortcut refid="insertSnippet" value="Shift+Tab" title="Insert Snippet" handlesEventPropagation="true" />
@@ -587,26 +589,34 @@ well as menu structures (for main menu and popup menus).
       <shortcutgroup name="Source Navigation">
          <shortcut refid="sourceNavigateBack" value="Cmd+F9"/>
          <shortcut refid="sourceNavigateForward" value="Cmd+F10"/>
+         <shortcut refid="quickAddNext" value="Cmd+D" title="Find and Add Next" disableModes="default,vim,emacs" />
          <shortcut refid="findUsages" value="Cmd+Alt+U"/>
          <shortcut refid="findFromSelection" value="Meta+E" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="findFromSelection" value="Ctrl+F3" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="findReplace" value="Meta+F"/>
          <shortcut refid="findReplace" value="Ctrl+F" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="vim,emacs"/>
          <shortcut refid="findNext" value="Meta+G" if="!org.rstudio.core.client.BrowseCap.isWindows()"/>
-         <shortcut refid="findNext" value="Ctrl+G" if="!org.rstudio.core.client.BrowseCap.isWindows()" disableModes="emacs"/>
+         <shortcut refid="findNext" value="Ctrl+G" if="!org.rstudio.core.client.BrowseCap.isWindows()" disableModes="emacs,sublime"/>
          <shortcut refid="findNext" value="F3" if="org.rstudio.core.client.BrowseCap.isWindows()"/>
          <shortcut refid="findPrevious" value="Cmd+Shift+G" if="!org.rstudio.core.client.BrowseCap.isWindows()"/>
          <shortcut refid="findPrevious" value="Shift+F3" if="org.rstudio.core.client.BrowseCap.isWindows()"/>
          <shortcut refid="replaceAndFind" value="Cmd+Shift+J"/>
          <shortcut refid="goToFileFunction" value="Ctrl+."/>
+         <shortcut refid="goToFileFunction" value="Cmd+P" disableModes="default,vim,emacs"/>
+         <shortcut refid="goToFileFunction" value="Meta+Shift+R" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
+         <shortcut refid="goToFileFunction" value="Ctrl+Shift+R" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
          <shortcut refid="goToLine" value="Alt+G" disableModes="default,vim,sublime"/>
+         <shortcut refid="goToLine" value="Alt+G" disableModes="default,vim,sublime"/>
+         <shortcut refid="goToLine" value="Ctrl+G" disableModes="default,vim,emacs"/>
          <shortcut refid="goToLine" value="Shift+Alt+G" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="goToLine" value="Cmd+Shift+Alt+G" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="jumpTo" value="Shift+Alt+J" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="jumpTo" value="Cmd+Shift+Alt+J" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
-         <shortcut refid="jumpToMatching" value="Ctrl+P" disableModes="emacs"/>
+         <shortcut refid="jumpToMatching" value="Ctrl+P" disableModes="emacs,sublime"/>
+         <shortcut refid="jumpToMatching" value="Ctrl+M" disableModes="default,vim,emacs"/>
          <shortcut refid="expandToMatching" value="Ctrl+Shift+E" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="expandToMatching" value="Ctrl+Shift+Alt+E" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="expandToMatching" value="Ctrl+Shift+M" disableModes="default,vim,emacs"/>
          <shortcut refid="toggleDocumentOutline" value="Cmd+Shift+O"/>
          <shortcut refid="addCursorAbove" value="Ctrl+Alt+Up"/>
          <shortcut refid="addCursorBelow" value="Ctrl+Alt+Down"/>
@@ -616,8 +626,9 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="shrinkSelection" value="Cmd+Alt+Shift+Down" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="goToNextSection" value="Cmd+PageDown"/>
          <shortcut refid="goToPrevSection" value="Cmd+PageUp"/>
-         <shortcut refid="splitIntoLines" value="Ctrl+Alt+A" disableModes="emacs,sublime"/>
-         <shortcut refid="splitIntoLines" value="Cmd+Shift+L" disableModes="default,vim,emacs"/>
+         <shortcut refid="splitIntoLines" value="Ctrl+Alt+A" disableModes="emacs"/>
+         <shortcut refid="splitIntoLines" value="Meta+Shift+L" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
+         <shortcut refid="splitIntoLines" value="Ctrl+Shift+L" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
          <shortcut refid="goToStartOfCurrentScope" value="Ctrl+Alt+A" disableModes="default,vim,sublime"/>
          <shortcut refid="goToEndOfCurrentScope" value="Ctrl+Alt+E" disableModes="default,vim,sublime"/>
          <shortcut value="Ctrl+Alt+Shift+Up" title="Move active cursor up"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -550,8 +550,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="commentUncomment" value="Cmd+Shift+C"/>
          <shortcut refid="blockOutdent" value="Meta+[" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
          <shortcut refid="blockIndent" value="Meta+]" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
-         <shortcut refid="reindent" value="Cmd+I" disableModes="default,vim"/>
-         <shortcut refid="reindent" value="Cmd+I" disableModes="default,vim"/>
+         <shortcut refid="reindent" value="Cmd+I"/>
          <shortcut refid="reflowComment" value="Cmd+Shift+/" if="!(org.rstudio.core.client.BrowseCap.isMacintosh() &amp;&amp; org.rstudio.core.client.BrowseCap.isChromeServer())"/>
          <shortcut refid="reflowComment" value="Cmd+Alt+Shift+/" if="org.rstudio.core.client.BrowseCap.isMacintosh() &amp;&amp; org.rstudio.core.client.BrowseCap.isChromeServer()"/>
          <shortcut refid="reformatCode" value="Cmd+Shift+A"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -574,7 +574,9 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="moveLinesDown" value="Ctrl+Shift+Down" title="Move Lines Down" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
          <shortcut value="Ctrl+D" title="Delete Line" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="sublime"/>
          <shortcut value="Cmd+D" title="Delete Line" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="sublime" />
-         <shortcut refid="expandToLine" value="Cmd+L" title="Expand Selection to line" disableModes="default,vim,emacs" />
+         <shortcut refid="expandToLine" value="Meta+L" title="Expand Selection to line" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs" />
+         <!-- Ctrl+L to be handled by ShortcutManager -->
+         <!-- <shortcut refid="expandToLine" value="Ctrl+L" title="Expand Selection to line" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs" /> -->
          <shortcut refid="removeLine" value="Ctrl+Shift+K" title="Delete Line" disableModes="default,vim,emacs" />
          <shortcut refid="yankRegion" value="Ctrl+W" title="Kill Region" disableModes="default,vim,sublime"/>
          <shortcut refid="yankBeforeCursor" value="Ctrl+U" title="Yank Line Up to Cursor" disableModes="vim"/>
@@ -784,9 +786,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="goToHelp" value="Ctrl+C Ctrl+V" disableModes="default,vim,sublime"/>
       </shortcutgroup>
       <shortcutgroup name="Console">
-         <shortcut refid="consoleClear" value="Ctrl+L" disableModes="emacs,sublime"/>
-         <shortcut refid="consoleClear" value="Ctrl+L" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="emacs"/>
-         <shortcut value="Cmd+Up" title="Popup Command History"/>
+         <shortcut refid="consoleClear" value="Ctrl+L" disableModes="emacs"/>
       </shortcutgroup>
       <shortcutgroup name="Terminal">
          <shortcut refid="newTerminal" value="Alt+Shift+R"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -570,7 +570,11 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="unfoldAll" value="Cmd+Shift+Alt+O" if="org.rstudio.core.client.BrowseCap.isMacintosh()" title="Expand All Folds"/>
          <shortcut value="Ctrl+K" title="Delete to Line End" if="org.rstudio.core.client.BrowseCap.isMacintosh()" />
          <shortcut value="Alt+Up" title="Move Lines Up" />
+         <shortcut value="Meta+Ctrl+Up" title="Move Lines Up" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
+         <shortcut value="Ctrl+Shift+Up" title="Move Lines Up" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
          <shortcut value="Alt+Down" title="Move Lines Down" />
+         <shortcut value="Meta+Ctrl+Down" title="Move Lines Down" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
+         <shortcut value="Ctrl+Shift+Down" title="Move Lines Down" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
          <shortcut value="Ctrl+D" title="Delete Line" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="sublime"/>
          <shortcut value="Cmd+D" title="Delete Line" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="sublime" />
          <shortcut refid="removeLine" value="Ctrl+Shift+K" title="Delete Line" disableModes="default,vim,emacs" />
@@ -620,8 +624,8 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="toggleDocumentOutline" value="Cmd+Shift+O"/>
          <shortcut refid="addCursorAbove" value="Ctrl+Alt+Up"/>
          <shortcut refid="addCursorBelow" value="Ctrl+Alt+Down"/>
-         <shortcut refid="expandSelection" value="Ctrl+Shift+Up" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
-         <shortcut refid="shrinkSelection" value="Ctrl+Shift+Down" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="expandSelection" value="Ctrl+Shift+Up" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="sublime"/>
+         <shortcut refid="shrinkSelection" value="Ctrl+Shift+Down" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="sublime"/>
          <shortcut refid="expandSelection" value="Cmd+Alt+Shift+Up" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="shrinkSelection" value="Cmd+Alt+Shift+Down" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="goToNextSection" value="Cmd+PageDown"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -548,7 +548,10 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="extractFunction" value="Cmd+Alt+X"/>
          <shortcut refid="extractLocalVariable" value="Cmd+Alt+V"/>
          <shortcut refid="commentUncomment" value="Cmd+Shift+C"/>
-         <shortcut refid="reindent" value="Cmd+I"/>
+         <shortcut refid="blockOutdent" value="Meta+[" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
+         <shortcut refid="blockIndent" value="Meta+]" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
+         <shortcut refid="reindent" value="Cmd+I" disableModes="default,vim"/>
+         <shortcut refid="reindent" value="Cmd+I" disableModes="default,vim"/>
          <shortcut refid="reflowComment" value="Cmd+Shift+/" if="!(org.rstudio.core.client.BrowseCap.isMacintosh() &amp;&amp; org.rstudio.core.client.BrowseCap.isChromeServer())"/>
          <shortcut refid="reflowComment" value="Cmd+Alt+Shift+/" if="org.rstudio.core.client.BrowseCap.isMacintosh() &amp;&amp; org.rstudio.core.client.BrowseCap.isChromeServer()"/>
          <shortcut refid="reformatCode" value="Cmd+Shift+A"/>
@@ -564,9 +567,11 @@ well as menu structures (for main menu and popup menus).
          <shortcut value="Ctrl+K" title="Delete to Line End" if="org.rstudio.core.client.BrowseCap.isMacintosh()" />
          <shortcut value="Alt+Up" title="Move Lines Up" />
          <shortcut value="Alt+Down" title="Move Lines Down" />
-         <shortcut value="Ctrl+D" title="Delete Line" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" />
-         <shortcut value="Cmd+D" title="Delete Line" if="org.rstudio.core.client.BrowseCap.isMacintosh()" />
-         <shortcut refid="yankRegion" value="Ctrl+W" title="Kill Region" disableModes="default,vim"/>
+         <shortcut value="Ctrl+D" title="Delete Line" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="sublime"/>
+         <shortcut value="Cmd+D" title="Delete Line" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="sublime" />
+         <shortcut refid="findUnderExpand" value="Cmd+D" title="Find Under Expansion" disableModes="default,vim,emacs" />
+         <shortcut refid="removeLines" value="Ctrl+Shift+K" title="Delete Line" disableModes="default,vim,emacs" />
+         <shortcut refid="yankRegion" value="Ctrl+W" title="Kill Region" disableModes="default,vim,sublime"/>
          <shortcut refid="yankBeforeCursor" value="Ctrl+U" title="Yank Line Up to Cursor" disableModes="vim"/>
          <shortcut refid="yankAfterCursor" value="Ctrl+K" title="Yank Line After Cursor" />
          <shortcut refid="pasteLastYank" value="Ctrl+Y" title="Insert Yanked Text" />
@@ -592,7 +597,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="findPrevious" value="Shift+F3" if="org.rstudio.core.client.BrowseCap.isWindows()"/>
          <shortcut refid="replaceAndFind" value="Cmd+Shift+J"/>
          <shortcut refid="goToFileFunction" value="Ctrl+."/>
-         <shortcut refid="goToLine" value="Alt+G" disableModes="default,vim"/>
+         <shortcut refid="goToLine" value="Alt+G" disableModes="default,vim,sublime"/>
          <shortcut refid="goToLine" value="Shift+Alt+G" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="goToLine" value="Cmd+Shift+Alt+G" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="jumpTo" value="Shift+Alt+J" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
@@ -609,9 +614,10 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="shrinkSelection" value="Cmd+Alt+Shift+Down" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="goToNextSection" value="Cmd+PageDown"/>
          <shortcut refid="goToPrevSection" value="Cmd+PageUp"/>
-         <shortcut refid="splitIntoLines" value="Ctrl+Alt+A" disableModes="emacs"/>
-         <shortcut refid="goToStartOfCurrentScope" value="Ctrl+Alt+A" disableModes="default,vim"/>
-         <shortcut refid="goToEndOfCurrentScope" value="Ctrl+Alt+E" disableModes="default,vim"/>
+         <shortcut refid="splitIntoLines" value="Ctrl+Alt+A" disableModes="emacs,sublime"/>
+         <shortcut refid="splitIntoLines" value="Cmd+Shift+L" disableModes="default,vim,emacs"/>
+         <shortcut refid="goToStartOfCurrentScope" value="Ctrl+Alt+A" disableModes="default,vim,sublime"/>
+         <shortcut refid="goToEndOfCurrentScope" value="Ctrl+Alt+E" disableModes="default,vim,sublime"/>
          <shortcut value="Ctrl+Alt+Shift+Up" title="Move active cursor up"/>
          <shortcut value="Ctrl+Alt+Shift+Down" title="Move active cursor down"/>
       </shortcutgroup>
@@ -621,8 +627,8 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="zoomActualSize" value="Meta+0" if="org.rstudio.core.client.BrowseCap.isMacintoshDesktop()"/>
       </shortcutgroup>
       <shortcutgroup name="Panes">
-         <shortcut refid="switchFocusSourceConsole" value="Ctrl+X O|Ctrl+X Ctrl+O" disableModes="default,vim"/>
-         <shortcut refid="activateConsole" value="Alt+X" disableModes="default,vim"/>
+         <shortcut refid="switchFocusSourceConsole" value="Ctrl+X O|Ctrl+X Ctrl+O" disableModes="default,vim,sublime"/>
+         <shortcut refid="activateConsole" value="Alt+X" disableModes="default,vim,sublime"/>
          
          <shortcut refid="activateSource" value="Ctrl+1"/>
          <shortcut refid="activateConsole" value="Ctrl+2"/>
@@ -644,18 +650,20 @@ well as menu structures (for main menu and popup menus).
       </shortcutgroup>
       <shortcutgroup name="Tabs">
          <shortcut refid="switchToTab" value="Ctrl+X B" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
-         <shortcut refid="switchToTab" value="Ctrl+X B" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim"/>
+         <shortcut refid="switchToTab" value="Ctrl+X B" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,sublime"/>
          <shortcut refid="switchToTab" value="Ctrl+Shift+."/>
          <shortcut refid="nextTab" value="Ctrl+Alt+Right" if="!org.rstudio.core.client.BrowseCap.isLinux()"/>
          <shortcut refid="nextTab" value="Ctrl+PageDown" if="org.rstudio.core.client.BrowseCap.isLinux()"/>
-         <shortcut refid="nextTab" value="Ctrl+X Right" disableModes="default,vim"/>
+         <shortcut refid="nextTab" value="Ctrl+X Right" disableModes="default,vim,sublime"/>
          <shortcut refid="nextTab" value="Ctrl+F12"/>
          <shortcut refid="nextTab" value="Ctrl+Tab" if="org.rstudio.studio.client.application.Desktop.isDesktop()"/>
+         <shortcut refid="nextTab" value="Cmd+Shift+]" disableModes="default,vim,emacs"/>
          <shortcut refid="previousTab" value="Ctrl+Alt+Left" if="!org.rstudio.core.client.BrowseCap.isLinux()"/>
          <shortcut refid="previousTab" value="Ctrl+F11"/>
          <shortcut refid="previousTab" value="Ctrl+PageUp" if="org.rstudio.core.client.BrowseCap.isLinux()"/>
-         <shortcut refid="previousTab" value="Ctrl+X Left" disableModes="default,vim"/>
+         <shortcut refid="previousTab" value="Ctrl+X Left" disableModes="default,vim,sublime"/>
          <shortcut refid="previousTab" value="Ctrl+Shift+Tab" if="org.rstudio.studio.client.application.Desktop.isDesktop()"/>
+         <shortcut refid="previousTab" value="Cmd+Shift+[" disableModes="default,vim,emacs"/>
          <shortcut refid="firstTab" value="Ctrl+Alt+Shift+Left"/>
          <shortcut refid="firstTab" value="Ctrl+Shift+F11"/>
          <shortcut refid="lastTab" value="Ctrl+Alt+Shift+Right"/>
@@ -663,21 +671,21 @@ well as menu structures (for main menu and popup menus).
       </shortcutgroup>
       <shortcutgroup name="Files">
       
-         <shortcut refid="saveSourceDoc" value="Ctrl+X Ctrl+S" disableModes="default,vim"/>
+         <shortcut refid="saveSourceDoc" value="Ctrl+X Ctrl+S" disableModes="default,vim,sublime"/>
          <shortcut refid="saveSourceDoc" value="Ctrl+S" disableModes="emacs"/>
          <shortcut refid="saveSourceDoc" value="Meta+S" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          
          <shortcut refid="saveAllSourceDocs" value="Cmd+Alt+S"/>
          
-         <shortcut refid="newSourceDoc" value="Ctrl+X Ctrl+N" disableModes="default,vim"/>
+         <shortcut refid="newSourceDoc" value="Ctrl+X Ctrl+N" disableModes="default,vim,sublime"/>
          <shortcut refid="newSourceDoc" value="Cmd+Shift+N" if="!org.rstudio.core.client.BrowseCap.isChromeServer()" title="New R Script"/>
          <shortcut refid="newSourceDoc" value="Cmd+Shift+Alt+N" if="org.rstudio.core.client.BrowseCap.isChromeServer()" title="New R Script"/>
          
-         <shortcut refid="openSourceDoc" value="Ctrl+X Ctrl+F" disableModes="default,vim"/>
+         <shortcut refid="openSourceDoc" value="Ctrl+X Ctrl+F" disableModes="default,vim,sublime"/>
          <shortcut refid="openSourceDoc" value="Ctrl+O" disableModes="emacs"/>
          <shortcut refid="openSourceDoc" value="Meta+O" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          
-         <shortcut refid="closeSourceDoc" value="Ctrl+X K" disableModes="default,vim"/>
+         <shortcut refid="closeSourceDoc" value="Ctrl+X K" disableModes="default,vim,sublime"/>
          <shortcut refid="closeSourceDoc" value="Cmd+W" disableModes="emacs"/>
          
          <shortcut refid="closeOtherSourceDocs" value="Cmd+Shift+Alt+W"/>
@@ -685,11 +693,15 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="findInFiles" value="Cmd+Shift+F"/>
       </shortcutgroup>
       <shortcutgroup name="Build">
-         <shortcut refid="compilePDF" value="Cmd+Shift+K"/>
-         <shortcut refid="previewHTML" value="Cmd+Shift+K" />
-         <shortcut refid="knitDocument" value="Cmd+Shift+K" />
+         <shortcut refid="compilePDF" value="Ctrl+Shift+K" disableModes="sublime"/>
+         <shortcut refid="previewHTML" value="Ctrl+Shift+K" disableModes="sublime"/>
+         <shortcut refid="knitDocument" value="Ctrl+Shift+K" disableModes="sublime"/>
+         <shortcut refid="compilePDF" value="Meta+Shift+K" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="previewHTML" value="Meta+Shift+K" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="knitDocument" value="Meta+Shift+K" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="buildAll" value="Cmd+Shift+B"/>
-         <shortcut refid="devtoolsLoadAll" value="Cmd+Shift+L"/>
+         <shortcut refid="devtoolsLoadAll" value="Cmd+Shift+L" disableModes="sublime"/>
+         <shortcut refid="devtoolsLoadAll" value="Ctrl+Shift+L" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="checkPackage" value="Cmd+Shift+E"/>
          <shortcut refid="testPackage" value="Cmd+Shift+T" if="org.rstudio.studio.client.application.Desktop.isDesktop()"/>
          <shortcut refid="testPackage" value="Cmd+Alt+F7" if="!org.rstudio.studio.client.application.Desktop.isDesktop()"/>
@@ -702,13 +714,13 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="previewSql" value="Cmd+Shift+Enter"/>;
          <shortcut refid="sourceFile" value="Ctrl+Alt+G" title="Source a File..."/>
          <shortcut refid="executeLastCode" value="Cmd+Shift+P"/>
-         <shortcut refid="executeCode" value="Ctrl+C Ctrl+N" disableModes="default,vim"/>
+         <shortcut refid="executeCode" value="Ctrl+C Ctrl+N" disableModes="default,vim,sublime"/>
          <shortcut refid="executeCode" value="Cmd+Enter"/>
          <shortcut refid="executeCodeWithoutMovingCursor" value="Alt+Enter"/>
          <shortcut refid="executeAllCode" value="Cmd+Alt+R"/>
          <shortcut refid="executeToCurrentLine" value="Cmd+Alt+B"/>
          <shortcut refid="executeFromCurrentLine" value="Cmd+Alt+E" disableModes="emacs"/>
-         <shortcut refid="executeCurrentFunction" value="Ctrl+C Ctrl+F" disableModes="default,vim"/>
+         <shortcut refid="executeCurrentFunction" value="Ctrl+C Ctrl+F" disableModes="default,vim,sublime"/>
          <shortcut refid="executeCurrentFunction" value="Cmd+Alt+F"/>
          <shortcut refid="executeCurrentSection" value="Cmd+Alt+T"/>
          <shortcut refid="executePreviousChunks" value="Cmd+Alt+P"/>
@@ -754,7 +766,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="toggleFullScreen" value="Ctrl+Meta+F" if="org.rstudio.core.client.BrowseCap.isMacintoshDesktop()"/>
          <shortcut refid="showOptions" value="Meta+," if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="projectOptions" value="Shift+Meta+," if="org.rstudio.core.client.BrowseCap.isMacintosh()"/> 
-         <shortcut refid="goToHelp" value="Ctrl+C Ctrl+V" disableModes="default,vim"/>
+         <shortcut refid="goToHelp" value="Ctrl+C Ctrl+V" disableModes="default,vim,sublime"/>
       </shortcutgroup>
       <shortcutgroup name="Console">
          <shortcut refid="consoleClear" value="Ctrl+L" disableModes="emacs"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -612,7 +612,6 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="goToFileFunction" value="Meta+Shift+R" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
          <shortcut refid="goToFileFunction" value="Ctrl+Shift+R" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
          <shortcut refid="goToLine" value="Alt+G" disableModes="default,vim,sublime"/>
-         <shortcut refid="goToLine" value="Alt+G" disableModes="default,vim,sublime"/>
          <shortcut refid="goToLine" value="Ctrl+G" disableModes="default,vim,emacs"/>
          <shortcut refid="goToLine" value="Shift+Alt+G" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="goToLine" value="Cmd+Shift+Alt+G" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
@@ -790,6 +789,7 @@ well as menu structures (for main menu and popup menus).
       </shortcutgroup>
       <shortcutgroup name="Console">
          <shortcut refid="consoleClear" value="Ctrl+L" disableModes="emacs"/>
+         <shortcut value="Cmd+Up" title="Popup Command History"/>
       </shortcutgroup>
       <shortcutgroup name="Terminal">
          <shortcut refid="newTerminal" value="Alt+Shift+R"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -577,6 +577,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="moveLinesDown" value="Ctrl+Shift+Down" title="Move Lines Down" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
          <shortcut value="Ctrl+D" title="Delete Line" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="sublime"/>
          <shortcut value="Cmd+D" title="Delete Line" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="sublime" />
+         <shortcut refid="expandToLine" value="Cmd+L" title="Expand Selection to line" disableModes="default,vim,emacs" />
          <shortcut refid="removeLine" value="Ctrl+Shift+K" title="Delete Line" disableModes="default,vim,emacs" />
          <shortcut refid="yankRegion" value="Ctrl+W" title="Kill Region" disableModes="default,vim,sublime"/>
          <shortcut refid="yankBeforeCursor" value="Ctrl+U" title="Yank Line Up to Cursor" disableModes="vim"/>
@@ -786,7 +787,8 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="goToHelp" value="Ctrl+C Ctrl+V" disableModes="default,vim,sublime"/>
       </shortcutgroup>
       <shortcutgroup name="Console">
-         <shortcut refid="consoleClear" value="Ctrl+L" disableModes="emacs"/>
+         <shortcut refid="consoleClear" value="Ctrl+L" disableModes="emacs,sublime"/>
+         <shortcut refid="consoleClear" value="Ctrl+L" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="emacs"/>
          <shortcut value="Cmd+Up" title="Popup Command History"/>
       </shortcutgroup>
       <shortcutgroup name="Terminal">

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -572,7 +572,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut value="Ctrl+D" title="Delete Line" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="sublime"/>
          <shortcut value="Cmd+D" title="Delete Line" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="sublime" />
          <shortcut refid="quickAddNext" value="Cmd+D" title="Find and Add Next" disableModes="default,vim,emacs" />
-         <shortcut refid="removeLines" value="Ctrl+Shift+K" title="Delete Line" disableModes="default,vim,emacs" />
+         <shortcut refid="removeLine" value="Ctrl+Shift+K" title="Delete Line" disableModes="default,vim,emacs" />
          <shortcut refid="yankRegion" value="Ctrl+W" title="Kill Region" disableModes="default,vim,sublime"/>
          <shortcut refid="yankBeforeCursor" value="Ctrl+U" title="Yank Line Up to Cursor" disableModes="vim"/>
          <shortcut refid="yankAfterCursor" value="Ctrl+K" title="Yank Line After Cursor" />

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -543,9 +543,6 @@ well as menu structures (for main menu and popup menus).
       <!-- Use spaces for key sequences, e.g. 'Ctrl+X Ctrl+F' -->
       <!-- Separate shortcuts with '|', e.g. 'Ctrl+X Ctrl+F|Cmd+O' -->
       <shortcutgroup name="Source Editor">
-         <shortcut refid="copyDummy" value="Cmd+C"/>
-         <shortcut refid="cutDummy" value="Cmd+X"/>
-         <!-- <shortcut refid="pasteDummy" value="Cmd+V"/> -->
          <shortcut refid="insertChunk" value="Cmd+Alt+I"/>
          <shortcut refid="insertSection" value="Cmd+Shift+R" disableModes="sublime"/>
          <shortcut refid="insertSection" value="Ctrl+Shift+R" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -570,11 +570,11 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="unfoldAll" value="Cmd+Shift+Alt+O" if="org.rstudio.core.client.BrowseCap.isMacintosh()" title="Expand All Folds"/>
          <shortcut value="Ctrl+K" title="Delete to Line End" if="org.rstudio.core.client.BrowseCap.isMacintosh()" />
          <shortcut value="Alt+Up" title="Move Lines Up" />
-         <shortcut value="Meta+Ctrl+Up" title="Move Lines Up" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
-         <shortcut value="Ctrl+Shift+Up" title="Move Lines Up" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
+         <shortcut refid="moveLinesUp" value="Ctrl+Meta+Up" title="Move Lines Up" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
+         <shortcut refid="moveLinesUp" value="Ctrl+Shift+Up" title="Move Lines Up" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
          <shortcut value="Alt+Down" title="Move Lines Down" />
-         <shortcut value="Meta+Ctrl+Down" title="Move Lines Down" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
-         <shortcut value="Ctrl+Shift+Down" title="Move Lines Down" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
+         <shortcut refid="moveLinesDown" value="Ctrl+Meta+Down" title="Move Lines Down" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
+         <shortcut refid="moveLinesDown" value="Ctrl+Shift+Down" title="Move Lines Down" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
          <shortcut value="Ctrl+D" title="Delete Line" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="sublime"/>
          <shortcut value="Cmd+D" title="Delete Line" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="sublime" />
          <shortcut refid="removeLine" value="Ctrl+Shift+K" title="Delete Line" disableModes="default,vim,emacs" />

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -569,7 +569,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut value="Alt+Down" title="Move Lines Down" />
          <shortcut value="Ctrl+D" title="Delete Line" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="sublime"/>
          <shortcut value="Cmd+D" title="Delete Line" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="sublime" />
-         <shortcut refid="findUnderExpand" value="Cmd+D" title="Find Under Expansion" disableModes="default,vim,emacs" />
+         <shortcut refid="quickAddNext" value="Cmd+D" title="Find and Add Next" disableModes="default,vim,emacs" />
          <shortcut refid="removeLines" value="Ctrl+Shift+K" title="Delete Line" disableModes="default,vim,emacs" />
          <shortcut refid="yankRegion" value="Ctrl+W" title="Kill Region" disableModes="default,vim,sublime"/>
          <shortcut refid="yankBeforeCursor" value="Ctrl+U" title="Yank Line Up to Cursor" disableModes="vim"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -130,6 +130,7 @@ public abstract class
    public abstract AppCommand findSelectAll();
    public abstract AppCommand findFromSelection();
    public abstract AppCommand findAll();
+   public abstract AppCommand findUnderExpand();
    public abstract AppCommand replaceAndFind();
    public abstract AppCommand findInFiles();
    public abstract AppCommand fold();
@@ -141,6 +142,7 @@ public abstract class
    public abstract AppCommand expandToMatching();
    public abstract AppCommand addCursorAbove();
    public abstract AppCommand addCursorBelow();
+   public abstract AppCommand removeLines();
    public abstract AppCommand splitIntoLines();
    public abstract AppCommand toggleDocumentOutline();
    public abstract AppCommand expandSelection();
@@ -155,6 +157,8 @@ public abstract class
    public abstract AppCommand extractFunction();
    public abstract AppCommand extractLocalVariable();
    public abstract AppCommand commentUncomment();
+   public abstract AppCommand blockIndent();
+   public abstract AppCommand blockOutdent();
    public abstract AppCommand reindent();
    public abstract AppCommand reflowComment();
    public abstract AppCommand setWorkingDirToActiveDoc();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -141,7 +141,7 @@ public abstract class
    public abstract AppCommand expandToMatching();
    public abstract AppCommand addCursorAbove();
    public abstract AppCommand addCursorBelow();
-   public abstract AppCommand removeLines();
+   public abstract AppCommand removeLine();
    public abstract AppCommand splitIntoLines();
    public abstract AppCommand toggleDocumentOutline();
    public abstract AppCommand expandSelection();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -141,6 +141,8 @@ public abstract class
    public abstract AppCommand expandToMatching();
    public abstract AppCommand addCursorAbove();
    public abstract AppCommand addCursorBelow();
+   public abstract AppCommand moveLinesUp();
+   public abstract AppCommand moveLinesDown();
    public abstract AppCommand removeLine();
    public abstract AppCommand splitIntoLines();
    public abstract AppCommand toggleDocumentOutline();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -130,7 +130,6 @@ public abstract class
    public abstract AppCommand findSelectAll();
    public abstract AppCommand findFromSelection();
    public abstract AppCommand findAll();
-   public abstract AppCommand findUnderExpand();
    public abstract AppCommand replaceAndFind();
    public abstract AppCommand findInFiles();
    public abstract AppCommand fold();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -144,6 +144,8 @@ public abstract class
    public abstract AppCommand moveLinesUp();
    public abstract AppCommand moveLinesDown();
    public abstract AppCommand expandToLine();
+   public abstract AppCommand copyLinesDown();
+   public abstract AppCommand joinLines();
    public abstract AppCommand removeLine();
    public abstract AppCommand splitIntoLines();
    public abstract AppCommand toggleDocumentOutline();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -143,6 +143,7 @@ public abstract class
    public abstract AppCommand addCursorBelow();
    public abstract AppCommand moveLinesUp();
    public abstract AppCommand moveLinesDown();
+   public abstract AppCommand expandToLine();
    public abstract AppCommand removeLine();
    public abstract AppCommand splitIntoLines();
    public abstract AppCommand toggleDocumentOutline();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefs.java
@@ -201,6 +201,10 @@ public class UIPrefs extends UIPrefsAccessor implements UiPrefsChangedHandler, S
          continueCommentsOnNewline().setGlobalValue(
                               newUiPrefs.continueCommentsOnNewline().getGlobalValue());
          
+         // sublime keybindings
+         enableSublimeKeybindings().setGlobalValue(
+                              newUiPrefs.enableSublimeKeybindings().getGlobalValue());
+
          // insert matching
          insertMatching().setGlobalValue(
                                  newUiPrefs.insertMatching().getGlobalValue());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -117,6 +117,7 @@ public class UIPrefsAccessor extends Prefs
    public static final String EDITOR_KEYBINDINGS_DEFAULT = "default";
    public static final String EDITOR_KEYBINDINGS_VIM = "vim";
    public static final String EDITOR_KEYBINDINGS_EMACS = "emacs";
+   public static final String EDITOR_KEYBINDINGS_SUBLIME = "sublime";
    
    public PrefValue<Boolean> useVimMode()
    {
@@ -128,6 +129,11 @@ public class UIPrefsAccessor extends Prefs
       return bool("enable_emacs_keybindings", false);
    }
    
+   public PrefValue<Boolean> enableSublimeKeybindings()
+   {
+      return bool("enable_sublime_keybindings", false);
+   }
+
    public PrefValue<Boolean> insertMatching()
    {
       return bool("insert_matching", true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -109,12 +109,14 @@ public class EditingPreferencesPane extends PreferencesPane
             new String[] {
                   "Default",
                   "Vim",
-                  "Emacs"
+                  "Emacs",
+                  "Sublime Text"
             },
             new String[] {
                   UIPrefsAccessor.EDITOR_KEYBINDINGS_DEFAULT,
                   UIPrefsAccessor.EDITOR_KEYBINDINGS_VIM,
-                  UIPrefsAccessor.EDITOR_KEYBINDINGS_EMACS
+                  UIPrefsAccessor.EDITOR_KEYBINDINGS_EMACS,
+                  UIPrefsAccessor.EDITOR_KEYBINDINGS_SUBLIME,
             },
             false,
             true,
@@ -499,6 +501,8 @@ public class EditingPreferencesPane extends PreferencesPane
          editorMode_.setValue(UIPrefsAccessor.EDITOR_KEYBINDINGS_VIM);
       else if (prefs_.enableEmacsKeybindings().getValue())
          editorMode_.setValue(UIPrefsAccessor.EDITOR_KEYBINDINGS_EMACS);
+      else if (prefs_.enableSublimeKeybindings().getValue())
+         editorMode_.setValue(UIPrefsAccessor.EDITOR_KEYBINDINGS_SUBLIME);
       else
          editorMode_.setValue(UIPrefsAccessor.EDITOR_KEYBINDINGS_DEFAULT);
       
@@ -525,14 +529,18 @@ public class EditingPreferencesPane extends PreferencesPane
       String editorMode = editorMode_.getValue();
       boolean isVim = editorMode == UIPrefsAccessor.EDITOR_KEYBINDINGS_VIM;
       boolean isEmacs = editorMode == UIPrefsAccessor.EDITOR_KEYBINDINGS_EMACS;
+      boolean isSublime = editorMode == UIPrefsAccessor.EDITOR_KEYBINDINGS_SUBLIME;
       
       prefs_.useVimMode().setGlobalValue(isVim);
       prefs_.enableEmacsKeybindings().setGlobalValue(isEmacs);
+      prefs_.enableSublimeKeybindings().setGlobalValue(isSublime);
       
       if (isVim)
          ShortcutManager.INSTANCE.setEditorMode(KeyboardShortcut.MODE_VIM);
       else if (isEmacs)
          ShortcutManager.INSTANCE.setEditorMode(KeyboardShortcut.MODE_EMACS);
+      else if (isSublime)
+         ShortcutManager.INSTANCE.setEditorMode(KeyboardShortcut.MODE_SUBLIME);
       else
          ShortcutManager.INSTANCE.setEditorMode(KeyboardShortcut.MODE_DEFAULT);
            

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -671,6 +671,8 @@ public class Source implements InsertSourceHandler,
          ShortcutManager.INSTANCE.setEditorMode(KeyboardShortcut.MODE_VIM);
       else if (uiPrefs_.enableEmacsKeybindings().getGlobalValue())
          ShortcutManager.INSTANCE.setEditorMode(KeyboardShortcut.MODE_EMACS);
+      else if (uiPrefs_.enableSublimeKeybindings().getGlobalValue())
+         ShortcutManager.INSTANCE.setEditorMode(KeyboardShortcut.MODE_SUBLIME);
       else
          ShortcutManager.INSTANCE.setEditorMode(KeyboardShortcut.MODE_DEFAULT);
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -2587,6 +2587,12 @@ public class AceEditor implements DocDisplay,
    }
 
    @Override
+   public void expandToLine()
+   {
+      widget_.getEditor().execCommand("expandtoline");
+   }
+
+   @Override
    public void removeLine()
    {
       widget_.getEditor().execCommand("removeline");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -463,6 +463,16 @@ public class AceEditor implements DocDisplay,
                   case AceEditorCommandEvent.ADD_CURSOR_ABOVE:           addCursorAbove();           break;
                   case AceEditorCommandEvent.ADD_CURSOR_BELOW:           addCursorBelow();           break;
                   case AceEditorCommandEvent.INSERT_SNIPPET:             onInsertSnippet();          break;
+                  case AceEditorCommandEvent.MOVE_LINES_UP:              moveLinesUp();              break;
+                  case AceEditorCommandEvent.MOVE_LINES_DOWN:            moveLinesDown();            break;
+                  case AceEditorCommandEvent.EXPAND_TO_LINE:             expandToLine();             break;
+                  case AceEditorCommandEvent.COPY_LINES_DOWN:            copyLinesDown();            break;
+                  case AceEditorCommandEvent.JOIN_LINES:                 joinLines();                break;
+                  case AceEditorCommandEvent.REMOVE_LINE:                removeLine();               break;
+                  case AceEditorCommandEvent.SPLIT_INTO_LINES:           splitIntoLines();           break;
+                  case AceEditorCommandEvent.BLOCK_INDENT:               blockIndent();              break;
+                  case AceEditorCommandEvent.BLOCK_OUTDENT:              blockOutdent();             break;
+                  case AceEditorCommandEvent.REINDENT:                   reindent();                 break;
                   }
                }
             });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -2593,6 +2593,18 @@ public class AceEditor implements DocDisplay,
    }
 
    @Override
+   public void copyLinesDown()
+   {
+      widget_.getEditor().execCommand("copylinesdown");
+   }
+
+   @Override
+   public void joinLines()
+   {
+      widget_.getEditor().execCommand("joinlines");
+   }
+
+   @Override
    public void removeLine()
    {
       widget_.getEditor().execCommand("removeline");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -2575,6 +2575,12 @@ public class AceEditor implements DocDisplay,
    }
 
    @Override
+   public void removeLines()
+   {
+      widget_.getEditor().removeLines();
+   }
+
+   @Override
    public void splitIntoLines()
    {
       widget_.getEditor().splitIntoLines();
@@ -3164,6 +3170,11 @@ public class AceEditor implements DocDisplay,
       widget_.getEditor().moveCursorRight(times);
    }
 
+   public void selectMoreAfter()
+   {
+      widget_.getEditor().selectMoreAfter();
+   }
+
    public void expandSelectionLeft(int times)
    {
       widget_.getEditor().expandSelectionLeft(times);
@@ -3628,6 +3639,11 @@ public class AceEditor implements DocDisplay,
    public int getLastVisibleRow()
    {
       return widget_.getEditor().getLastVisibleRow();
+   }
+
+   public void blockIndent()
+   {
+      widget_.getEditor().blockIndent();
    }
 
    public void blockOutdent()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -3170,11 +3170,6 @@ public class AceEditor implements DocDisplay,
       widget_.getEditor().moveCursorRight(times);
    }
 
-   public void selectMoreAfter()
-   {
-      widget_.getEditor().selectMoreAfter();
-   }
-
    public void expandSelectionLeft(int times)
    {
       widget_.getEditor().expandSelectionLeft(times);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -2575,9 +2575,9 @@ public class AceEditor implements DocDisplay,
    }
 
    @Override
-   public void removeLines()
+   public void removeLine()
    {
-      widget_.getEditor().removeLines();
+      widget_.getEditor().execCommand("removeline");
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -2575,6 +2575,18 @@ public class AceEditor implements DocDisplay,
    }
 
    @Override
+   public void moveLinesUp()
+   {
+      widget_.getEditor().execCommand("movelinesup");
+   }
+
+   @Override
+   public void moveLinesDown()
+   {
+      widget_.getEditor().execCommand("movelinesdown");
+   }
+
+   @Override
    public void removeLine()
    {
       widget_.getEditor().execCommand("removeline");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -392,6 +392,8 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    void moveLinesUp();
    void moveLinesDown();
    void expandToLine();
+   void copyLinesDown();
+   void joinLines();
    void removeLine();
 
    void blockIndent();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -140,7 +140,6 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    boolean moveSelectionToNextLine(boolean skipBlankLines);
    boolean moveSelectionToBlankLine(); 
    
-   void selectMoreAfter();
    void expandSelection();
    void shrinkSelection();
    void clearSelectionHistory();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -389,6 +389,8 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    long getLastModifiedTime();
    long getLastCursorChangedTime();
    
+   void moveLinesUp();
+   void moveLinesDown();
    void removeLine();
 
    void blockIndent();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -140,6 +140,7 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    boolean moveSelectionToNextLine(boolean skipBlankLines);
    boolean moveSelectionToBlankLine(); 
    
+   void selectMoreAfter();
    void expandSelection();
    void shrinkSelection();
    void clearSelectionHistory();
@@ -389,6 +390,9 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    long getLastModifiedTime();
    long getLastCursorChangedTime();
    
+   void removeLines();
+
+   void blockIndent();
    void blockOutdent();
    void splitIntoLines();
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -389,7 +389,7 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    long getLastModifiedTime();
    long getLastCursorChangedTime();
    
-   void removeLines();
+   void removeLine();
 
    void blockIndent();
    void blockOutdent();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -391,6 +391,7 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    
    void moveLinesUp();
    void moveLinesDown();
+   void expandToLine();
    void removeLine();
 
    void blockIndent();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3296,6 +3296,12 @@ public class TextEditingTarget implements
    }
 
    @Handler
+   void onExpandToLine()
+   {
+      docDisplay_.expandToLine();
+   }
+
+   @Handler
    void onRemoveLine()
    {
       docDisplay_.removeLine();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3284,48 +3284,6 @@ public class TextEditingTarget implements
    }
 
    @Handler
-   void onMoveLinesUp()
-   {
-      docDisplay_.moveLinesUp();
-   }
-
-   @Handler
-   void onMoveLinesDown()
-   {
-      docDisplay_.moveLinesDown();
-   }
-
-   @Handler
-   void onExpandToLine()
-   {
-      docDisplay_.expandToLine();
-   }
-
-   @Handler
-   void onCopyLinesDown()
-   {
-      docDisplay_.copyLinesDown();
-   }
-
-   @Handler
-   void onJoinLines()
-   {
-      docDisplay_.joinLines();
-   }
-
-   @Handler
-   void onRemoveLine()
-   {
-      docDisplay_.removeLine();
-   }
-
-   @Handler
-   void onSplitIntoLines()
-   {
-      docDisplay_.splitIntoLines();
-   }
-
-   @Handler
    void onCommentUncomment()
    {
       if (isCursorInTexMode())
@@ -3626,27 +3584,6 @@ public class TextEditingTarget implements
                colEnd + diff);
          docDisplay_.setSelectionRange(newRange);
       }
-   }
-
-   @Handler
-   void onBlockIndent()
-   {
-      docDisplay_.blockIndent();
-      docDisplay_.focus();
-   }
-
-   @Handler
-   void onBlockOutdent()
-   {
-      docDisplay_.blockOutdent();
-      docDisplay_.focus();
-   }
-
-   @Handler
-   void onReindent()
-   {
-      docDisplay_.reindent();
-      docDisplay_.focus();
    }
 
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -6011,17 +6011,6 @@ public class TextEditingTarget implements
    }
    
    @Handler
-   void onFindUnderExpand()
-   {
-      Range selRange = docDisplay_.getSelectionRange();
-      if (selRange.isEmpty()) {
-        docDisplay_.expandSelection();
-      } else {
-        docDisplay_.selectMoreAfter();
-      }
-   }
-
-   @Handler
    void onFindFromSelection()
    {
       view_.findFromSelection();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3302,6 +3302,18 @@ public class TextEditingTarget implements
    }
 
    @Handler
+   void onCopyLinesDown()
+   {
+      docDisplay_.copyLinesDown();
+   }
+
+   @Handler
+   void onJoinLines()
+   {
+      docDisplay_.joinLines();
+   }
+
+   @Handler
    void onRemoveLine()
    {
       docDisplay_.removeLine();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3284,6 +3284,12 @@ public class TextEditingTarget implements
    }
 
    @Handler
+   void onRemoveLines()
+   {
+      docDisplay_.removeLines();
+   }
+
+   @Handler
    void onSplitIntoLines()
    {
       docDisplay_.splitIntoLines();
@@ -3593,9 +3599,16 @@ public class TextEditingTarget implements
    }
 
    @Handler
-   void onReindent()
+   void onBlockIndent()
    {
-      docDisplay_.reindent();
+      docDisplay_.blockIndent();
+      docDisplay_.focus();
+   }
+
+   @Handler
+   void onBlockOutdent()
+   {
+      docDisplay_.blockOutdent();
       docDisplay_.focus();
    }
 
@@ -5997,6 +6010,17 @@ public class TextEditingTarget implements
       view_.findSelectAll();
    }
    
+   @Handler
+   void onFindUnderExpand()
+   {
+      Range selRange = docDisplay_.getSelectionRange();
+      if (selRange.isEmpty()) {
+        docDisplay_.expandSelection();
+      } else {
+        docDisplay_.selectMoreAfter();
+      }
+   }
+
    @Handler
    void onFindFromSelection()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3613,6 +3613,13 @@ public class TextEditingTarget implements
    }
 
    @Handler
+   void onReindent()
+   {
+      docDisplay_.reindent();
+      docDisplay_.focus();
+   }
+
+   @Handler
    void onReflowComment()
    {
       if (DocumentMode.isSelectionInRMode(docDisplay_) ||

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3284,9 +3284,9 @@ public class TextEditingTarget implements
    }
 
    @Handler
-   void onRemoveLines()
+   void onRemoveLine()
    {
-      docDisplay_.removeLines();
+      docDisplay_.removeLine();
    }
 
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3284,6 +3284,18 @@ public class TextEditingTarget implements
    }
 
    @Handler
+   void onMoveLinesUp()
+   {
+      docDisplay_.moveLinesUp();
+   }
+
+   @Handler
+   void onMoveLinesDown()
+   {
+      docDisplay_.moveLinesDown();
+   }
+
+   @Handler
    void onRemoveLine()
    {
       docDisplay_.removeLine();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorCommandDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorCommandDispatcher.java
@@ -136,6 +136,87 @@ public class AceEditorCommandDispatcher
             AceEditorCommandEvent.EXECUTION_POLICY_FOCUSED);
    }
    
+   @Handler
+   public void onMoveLinesUp()
+   {
+      fireEvent(
+            AceEditorCommandEvent.MOVE_LINES_UP,
+            AceEditorCommandEvent.EXECUTION_POLICY_FOCUSED);
+   }
+
+   @Handler
+   public void onMoveLinesDown()
+   {
+      fireEvent(
+            AceEditorCommandEvent.MOVE_LINES_DOWN,
+            AceEditorCommandEvent.EXECUTION_POLICY_FOCUSED);
+   }
+
+   @Handler
+   public void onExpandToLine()
+   {
+      fireEvent(
+            AceEditorCommandEvent.EXPAND_TO_LINE,
+            AceEditorCommandEvent.EXECUTION_POLICY_FOCUSED);
+   }
+
+   @Handler
+   public void onCopyLinesDown()
+   {
+      fireEvent(
+            AceEditorCommandEvent.COPY_LINES_DOWN,
+            AceEditorCommandEvent.EXECUTION_POLICY_FOCUSED);
+   }
+
+   @Handler
+   public void onJoinLines()
+   {
+      fireEvent(
+            AceEditorCommandEvent.JOIN_LINES,
+            AceEditorCommandEvent.EXECUTION_POLICY_FOCUSED);
+   }
+
+   @Handler
+   public void onRemoveLine()
+   {
+      fireEvent(
+            AceEditorCommandEvent.REMOVE_LINE,
+            AceEditorCommandEvent.EXECUTION_POLICY_FOCUSED);
+   }
+
+   @Handler
+   public void onSplitIntoLines()
+   {
+      fireEvent(
+            AceEditorCommandEvent.SPLIT_INTO_LINES,
+            AceEditorCommandEvent.EXECUTION_POLICY_FOCUSED);
+   }
+
+
+   @Handler
+   public void onBlockIndent()
+   {
+      fireEvent(
+            AceEditorCommandEvent.BLOCK_INDENT,
+            AceEditorCommandEvent.EXECUTION_POLICY_FOCUSED);
+   }
+
+   @Handler
+   public void onBlockOutdent()
+   {
+      fireEvent(
+            AceEditorCommandEvent.BLOCK_OUTDENT,
+            AceEditorCommandEvent.EXECUTION_POLICY_FOCUSED);
+   }
+
+   @Handler
+   public void onReindent()
+   {
+      fireEvent(
+            AceEditorCommandEvent.REINDENT,
+            AceEditorCommandEvent.EXECUTION_POLICY_FOCUSED);
+   }
+
    // Private methods ----
    
    private void fireEvent(int type, int policy)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorCommandEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorCommandEvent.java
@@ -34,6 +34,16 @@ public class AceEditorCommandEvent extends CrossWindowEvent<AceEditorCommandEven
    public static final int ADD_CURSOR_ABOVE           = 10;
    public static final int ADD_CURSOR_BELOW           = 11;
    public static final int INSERT_SNIPPET             = 12;
+   public static final int MOVE_LINES_UP              = 13;
+   public static final int MOVE_LINES_DOWN            = 14;
+   public static final int EXPAND_TO_LINE             = 15;
+   public static final int COPY_LINES_DOWN            = 16;
+   public static final int JOIN_LINES                 = 17;
+   public static final int REMOVE_LINE                = 18;
+   public static final int SPLIT_INTO_LINES           = 19;
+   public static final int BLOCK_INDENT               = 20;
+   public static final int BLOCK_OUTDENT              = 21;
+   public static final int REINDENT                   = 22;
    
    public static final int EXECUTION_POLICY_FOCUSED = 1;
    public static final int EXECUTION_POLICY_ALWAYS  = 2;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -295,6 +295,8 @@ public class AceEditorNative extends JavaScriptObject {
       this.centerSelection();
    }-*/;
 
+   public final native void removeLines() /*-{ this.removeLines(); }-*/;
+
    public final native void scrollToLine(int line, boolean center) /*-{
       this.scrollToLine(line, center);
    }-*/;
@@ -416,10 +418,18 @@ public class AceEditorNative extends JavaScriptObject {
       return this.getCursorPositionScreen();
    }-*/;
    
+   public final native void blockIndent() /*-{
+      return this.blockIndent();
+   }-*/;
+
    public final native void blockOutdent() /*-{
       return this.blockOutdent();
    }-*/;
    
+   public final native void selectMoreAfter() /*-{
+      return this.selectMore(1);
+   }-*/;
+
    public final native void expandSelection() /*-{
       return this.$expandSelection();
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -426,10 +426,6 @@ public class AceEditorNative extends JavaScriptObject {
       return this.blockOutdent();
    }-*/;
    
-   public final native void selectMoreAfter() /*-{
-      return this.selectMore(1);
-   }-*/;
-
    public final native void expandSelection() /*-{
       return this.$expandSelection();
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -295,8 +295,6 @@ public class AceEditorNative extends JavaScriptObject {
       this.centerSelection();
    }-*/;
 
-   public final native void removeLines() /*-{ this.removeLines(); }-*/;
-
    public final native void scrollToLine(int line, boolean center) /*-{
       this.scrollToLine(line, center);
    }-*/;


### PR DESCRIPTION
I am trying to add Sublime Text key bindings to RStudio and I got some partial success. Just to make sure I am doing things legitimately, I want to get some feedback from RStudio developers before I implement all the features. If they give me a green light, I'd map out the rest of the other keys.

What implemented so far:
- [x] `c+shift+]` and `c+shift+[`: change tab
- [x] `c+shift+l`: split into lines
- [x] `cmd+]` and `cmd+[`: indent and outdent (mac only)
- [x] `ctrl+g`: go to line
- [x] `c+l`: expand selection to line
- [x] `c+j`: join lines
- [x] `c+shift+d`: duplicate line
- [x] `c+d`: add selection and cursor
- [x] `ctrl+shift+m`: expand selection to brackets
- [x] `ctrl+m`: move between bracket pair
- [x] `c+p`: show all files
- [x] `c+shift+r`: show functions
- [x] `ctrl+cmd+up/down` or `ctrl+shift+up`: swap line up/down 
       In mac, a beep sound may occur. Atom has the same issue and it is a known mac issue: https://apple.stackexchange.com/questions/23981/command-control-arrow-beeps-plays-alert-sound-in-lion
- [x] `c+/`: toggle comment
- [x] `ctrl+shift+k`: remove line


<img width="583" alt="screen shot 2018-08-20 at 3 36 27 pm" src="https://user-images.githubusercontent.com/1690993/44362363-d3c4c700-a48e-11e8-842b-881f6c6fefcc.png">


close #3341 