### PR TITLE
Fix publishing RMD website with source from viewer to Connect

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdPreviewParams.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdPreviewParams.java
@@ -1,7 +1,7 @@
 /*
  * RmdPreviewParams.java
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -56,7 +56,7 @@ public class RmdPreviewParams extends JavaScriptObject
    }-*/;
    
    public native final String getWebsiteDir() /*-{
-      return this.website_dir;
+      return this.result.website_dir;
    }-*/;
    
    public native final int getScrollPosition() /*-{


### PR DESCRIPTION
Build an R Markdown website project from the Build Tab, then publish to Connect (with source code), from the Publish Button in the viewer. The resulting Connect artifact had the wrong type set (document instead of site), and had broken links and other problems.

Super-simple fix to a typo(ish) error in the original source (though took me quite a while to find it); was broken since website publishing support was added in IDE v0.99.

Fixes #3345