### PR TITLE
ensure link clicks successfully open URLs (closes #3359)

### DIFF
--- a/src/cpp/desktop/DesktopWebPage.hpp
+++ b/src/cpp/desktop/DesktopWebPage.hpp
@@ -96,7 +96,7 @@ public:
 public Q_SLOTS:
    bool shouldInterruptJavaScript();
    void closeRequested();
-   void onUrlIntercepted(QUrl url, int type);
+   void onUrlIntercepted(const QUrl& url, int type);
 
 protected:
    QWebEnginePage* createWindow(QWebEnginePage::WebWindowType type) override;


### PR DESCRIPTION
This PR fixes a regression from https://github.com/rstudio/rstudio/pull/2987, which had sought to fix https://bugreports.qt.io/browse/QTBUG-56805.

For some reason, link clicks in QtWebEngine are interpreted as attempts to load subframes. Since we were screening out non-local subframes before, the navigation attempt was blocked and nothing happened on the link click.

This PR works around the issue by tracking the currently hovered URL. If QtWebEngine happens to attempt to navigate to a URL that the mouse is currently hovering over, we surmise that the user must have clicked that URL (ie: it must not be a non-interactive subframe load in a page) and allow that page to be navigated to.