### PR TITLE
Adaptive macOS Title Bar Color

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -1326,6 +1326,10 @@ void GwtCallback::setBackgroundColor(QJsonArray rgbColor)
    QColor color = QColor::fromRgb(red, green, blue);
    pOwner_->webPage()->setBackgroundColor(color);
 #endif
+
+#if defined(Q_OS_MAC)
+    changeTitleBarColor(red, green, blue);
+#endif
 }
 
 void GwtCallback::syncToEditorTheme(bool isDark)

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -194,6 +194,7 @@ public Q_SLOTS:
    void zoomActualSize();
    
    void setBackgroundColor(QJsonArray rgbColor);
+   void changeTitleBarColor(int red, int green, int blue);
    void syncToEditorTheme(bool isDark);
 
    bool getEnableAccessibility();

--- a/src/cpp/desktop/DesktopGwtCallbackMac.mm
+++ b/src/cpp/desktop/DesktopGwtCallbackMac.mm
@@ -23,6 +23,7 @@
 #import <AppKit/NSSavePanel.h>
 #import <AppKit/NSButton.h>
 #import <AppKit/NSImage.h>
+#import <Cocoa/Cocoa.h>
 
 #include <core/FilePath.hpp>
 #include <core/Macros.hpp>
@@ -460,7 +461,26 @@ void GwtCallback::showPptPresentation(QString qPath)
    }
 }
 
+void GwtCallback::changeTitleBarColor(int red, int green, int blue) {
+    WId winId = pOwner_->asWidget()->effectiveWinId();
+    if (winId == 0) return;
+    NSView* view = (NSView*)winId;
+    NSWindow* window = [view window];
+    if (pow(red, 2.) + pow(green, 2.) + pow(blue, 2.) < 48387) {
+        window.appearance = [NSAppearance appearanceNamed: NSAppearanceNameVibrantDark];
+    } else {
+        window.appearance = [NSAppearance appearanceNamed: NSAppearanceNameVibrantLight];
+    }
+    if (pow(red, 2.) + pow(green, 2.) + pow(blue, 2.) > 150000) {
+       // do not change title bar color if the background is very light
+        window.titlebarAppearsTransparent = NO;
+        window.backgroundColor = [NSColor clearColor];
+    } else {
+        window.titlebarAppearsTransparent = YES;
+        window.backgroundColor = [NSColor colorWithRed:red/255. green:green/255. blue:blue/255. alpha:1.];
+    }
+}
+
 
 RS_END_NAMESPACE(desktop)
 RS_END_NAMESPACE(rstudio)
-


### PR DESCRIPTION
Demo:
![aug-24-2018 02-53-08](https://user-images.githubusercontent.com/1690993/44569610-faae2200-a748-11e8-82fe-c462ec19b159.gif)

[Wombat](https://github.com/randy3k/dotfiles/blob/master/.R/rstudio/themes/Wombat.rstheme) is a customized theme with a different dark background other than the default blue.