### PR TITLE
set wantsLayer properpty of NSView

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallbackMac.mm
+++ b/src/cpp/desktop/DesktopGwtCallbackMac.mm
@@ -462,19 +462,25 @@ void GwtCallback::showPptPresentation(QString qPath)
 }
 
 void GwtCallback::changeTitleBarColor(int red, int green, int blue) {
+    const int kAverageColor = pow(127.0, 2.0) * 3;
+    const int kBrightColor = pow(217.0, 2.0) * 3;
+
     WId winId = pOwner_->asWidget()->effectiveWinId();
     if (winId == 0) return;
     NSView* view = (NSView*)winId;
     NSWindow* window = [view window];
-    if (pow(red, 2.) + pow(green, 2.) + pow(blue, 2.) < 48387) {
+    // we need to set `wantsLayer` to make sure the title color is set correctly
+    // https://github.com/rstudio/rstudio/pull/3365#issuecomment-415845021
+    view.wantsLayer = YES;
+    if (pow(red, 2.) + pow(green, 2.) + pow(blue, 2.) < kAverageColor) {
         window.appearance = [NSAppearance appearanceNamed: NSAppearanceNameVibrantDark];
     } else {
         window.appearance = [NSAppearance appearanceNamed: NSAppearanceNameVibrantLight];
     }
-    if (pow(red, 2.) + pow(green, 2.) + pow(blue, 2.) > 150000) {
+    if (pow(red, 2.) + pow(green, 2.) + pow(blue, 2.) > kBrightColor) {
        // do not change title bar color if the background is very light
         window.titlebarAppearsTransparent = NO;
-        window.backgroundColor = [NSColor clearColor];
+        window.backgroundColor = [NSColor colorWithCalibratedWhite: 1.0 alpha: 1.];
     } else {
         window.titlebarAppearsTransparent = YES;
         window.backgroundColor = [NSColor colorWithRed:red/255. green:green/255. blue:blue/255. alpha:1.];


### PR DESCRIPTION
Fix a bug spotted by @kevinushey 
> I tried playing with this a bit but I'm seeing something odd: the text color in the title bar changes when I move the window around. Initially, when the window is focused, the color is closer to white; if I move the window around or interact with the window a bit; the text changes to a more grey color.

Solution inspired by https://forums.xamarin.com/discussion/99677/nswindow-titlebarappearstransparent-titlebar-corner-does-not-change-color

Additionally, use white background instead of `clearColor` because otherwise, the title bar would become transparent.
