### PR TITLE
Enable editing of GitLab CI files in RStudio by not hiding them from the file pane

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1805,6 +1805,10 @@ bool fileListingFilter(const core::FileInfo& fileInfo)
    {
       return true;
    }
+   else if (name == ".gitlab-ci.yml")
+   {
+      return true;
+   }
    else if (userSettings().hideObjectFiles() &&
             (ext == ".o" || ext == ".so" || ext == ".dll") &&
             filePath.parent().filename() == "src")


### PR DESCRIPTION
GitHub seems to be a first-class citizen, relegating GitLab into the void. This PR adds an `else` section to at least enable selecting and editing of gitlab CI yaml files without having to go the route of opening a file dialog manually, un-hiding dot files and selecting the gitlab CI yml file.