### PR TITLE
implement document outline for Stan code

### DIFF
--- a/src/gwt/acesupport/acemode/r_scope_tree.js
+++ b/src/gwt/acesupport/acemode/r_scope_tree.js
@@ -136,6 +136,12 @@ define('mode/r_scope_tree', ["require", "exports", "module"], function(require, 
          ));
       };
 
+      /**
+       * @param chunkLabel The actual label associated with the chunk.
+       * @param label An alternate label with more information (e.g. used in the status bar)
+       * @param chunkStartPos The start position of the chunk header.
+       * @param chunkPos The start position of the chunk, excluding the chunk header.
+       */
       this.onChunkStart = function(chunkLabel, label, chunkStartPos, chunkPos) {
          // Starting a chunk means closing the previous chunk, if any
          var prev = this.$root.closeScope(chunkStartPos, ScopeNode.TYPE_CHUNK);
@@ -332,9 +338,7 @@ define('mode/r_scope_tree', ["require", "exports", "module"], function(require, 
       this.isBrace = function() { return this.scopeType == ScopeNode.TYPE_BRACE; };
       this.isChunk = function() { return this.scopeType == ScopeNode.TYPE_CHUNK; };
       this.isSection = function() { return this.scopeType == ScopeNode.TYPE_SECTION; };
-      this.isFunction = function() {
-         return this.isBrace() && !!this.label;
-      };
+      this.isFunction = function() { return this.isBrace() && !!this.attributes.args; };
 
       this.equals = function(node) {
          if (this.scopeType !== node.scopeType ||

--- a/src/gwt/acesupport/acemode/stan.js
+++ b/src/gwt/acesupport/acemode/stan.js
@@ -32,72 +32,72 @@ oop.inherits(Mode, TextMode);
 
 (function() {
 
-    this.lineCommentStart = ["//", "#"];
-    this.blockComment = {start: "/*", end: "*/"};
+   this.lineCommentStart = ["//", "#"];
+   this.blockComment = {start: "/*", end: "*/"};
 
-    this.toggleCommentLines = function(state, doc, startRow, endRow) {
-        var outdent = true;
-        var re = /^(\s*)\/\//;
+   this.toggleCommentLines = function(state, doc, startRow, endRow) {
+      var outdent = true;
+      var re = /^(\s*)\/\//;
 
-        for (var i=startRow; i<= endRow; i++) {
-            if (!re.test(doc.getLine(i))) {
-                outdent = false;
-                break;
-            }
-        }
-
-         if (outdent) {
-             var deleteRange = new Range(0, 0, 0, 0);
-             for (var i=startRow; i<= endRow; i++)
-             {
-                 var line = doc.getLine(i);
-                 var m = line.match(re);
-                 deleteRange.start.row = i;
-                 deleteRange.end.row = i;
-                 deleteRange.end.column = m[0].length;
-                 doc.replace(deleteRange, m[1]);
-             }
+      for (var i=startRow; i<= endRow; i++) {
+         if (!re.test(doc.getLine(i))) {
+            outdent = false;
+            break;
          }
-         else {
-             doc.indentRows(startRow, endRow, "//");
+      }
+
+      if (outdent) {
+         var deleteRange = new Range(0, 0, 0, 0);
+         for (var i = startRow; i <= endRow; i++)
+         {
+            var line = doc.getLine(i);
+            var m = line.match(re);
+            deleteRange.start.row = i;
+            deleteRange.end.row = i;
+            deleteRange.end.column = m[0].length;
+            doc.replace(deleteRange, m[1]);
          }
-    };
+      }
+      else {
+         doc.indentRows(startRow, endRow, "//");
+      }
+   };
 
-    this.getLanguageMode = function(position) {
-        return "Stan";
-    };
+   this.getLanguageMode = function(position) {
+      return "Stan";
+   };
 
-    this.getNextLineIndent = function(state, line, tab) {
-        var indent = this.$getIndent(line);
+   this.getNextLineIndent = function(state, line, tab) {
+      var indent = this.$getIndent(line);
 
-        var tokenizedLine = this.getTokenizer().getLineTokens(line, state);
-        var tokens = tokenizedLine.tokens;
-        var endState = tokenizedLine.state;
+      var tokenizedLine = this.getTokenizer().getLineTokens(line, state);
+      var tokens = tokenizedLine.tokens;
+      var endState = tokenizedLine.state;
 
-        if (tokens.length && tokens[tokens.length-1].type == "comment") {
-            return indent;
-        }
+      if (tokens.length && tokens[tokens.length - 1].type == "comment") {
+         return indent;
+      }
 
-        if (state == "start") {
-            var match = line.match(/^.*(?:[\{\(\[])\s*$/);
-            if (match) {
-                indent += tab;
-            }
-        }
+      if (state == "start") {
+         var match = line.match(/^.*(?:[\{\(\[])\s*$/);
+         if (match) {
+            indent += tab;
+         }
+      }
 
-        return indent;
-    };
+      return indent;
+   };
 
 
-    this.checkOutdent = function(state, line, input) {
-        return this.$outdent.checkOutdent(line, input);
-    };
+   this.checkOutdent = function(state, line, input) {
+      return this.$outdent.checkOutdent(line, input);
+   };
 
-    this.autoOutdent = function(state, doc, row) {
-        this.$outdent.autoOutdent(doc, row);
-    };
+   this.autoOutdent = function(state, doc, row) {
+      this.$outdent.autoOutdent(doc, row);
+   };
 
-    this.$id = "mode/stan";
+   this.$id = "mode/stan";
 
 }).call(Mode.prototype);
 

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -132,6 +132,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditing
 import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditorWidget;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ChunkSatellite;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ChunkWindowManager;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ScopeTreeManager;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetChunks;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetCompilePdfHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetCppHelper;
@@ -171,6 +172,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(CompletionManagerBase completionManagerBase);
    void injectMembers(RCompletionManager rCompletionManager);
    void injectMembers(PythonCompletionManager pythonCompletionManager);
+   void injectMembers(ScopeTreeManager scopeTreeManager);
    void injectMembers(SVNCommandHandler svnCommandHandler);
    void injectMembers(CaptionWithHelp captionWithHelp);
    void injectMembers(RnwWeaveSelectWidget selectWidget);

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/GraphvizFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/GraphvizFileType.java
@@ -23,6 +23,7 @@ public class GraphvizFileType extends PreviewableFromRFileType
    public GraphvizFileType()
    {
       super("graphviz", "GraphViz", EditorLanguage.LANG_GRAPHVIZ, ".gv",
-            new ImageResource2x(FileIconResources.INSTANCE.iconGraphviz2x()), "DiagrammeR::grViz");
+            new ImageResource2x(FileIconResources.INSTANCE.iconGraphviz2x()), "DiagrammeR::grViz",
+            false);
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/MermaidFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/MermaidFileType.java
@@ -23,6 +23,7 @@ public class MermaidFileType extends PreviewableFromRFileType
    public MermaidFileType()
    {
       super("mermaid", "Mermaid", EditorLanguage.LANG_MERMAID, ".mmd",
-            new ImageResource2x(FileIconResources.INSTANCE.iconMermaid2x()), "DiagrammeR::mermaid");
+            new ImageResource2x(FileIconResources.INSTANCE.iconMermaid2x()), "DiagrammeR::mermaid",
+            false);
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/PreviewableFromRFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/PreviewableFromRFileType.java
@@ -29,11 +29,12 @@ public class PreviewableFromRFileType extends TextFileType
                                    EditorLanguage editorLanguage,
                                    String defaultExtension,
                                    ImageResource icon,
-                                   String previewFunction)
+                                   String previewFunction,
+                                   boolean canShowScopeTree)
    {
       super(id, label, editorLanguage, defaultExtension, icon,
             true, true, false, false, false, false, 
-            false, false, false, false, false, false, true);
+            false, false, false, false, false, canShowScopeTree, true);
       
       previewFunction_ = previewFunction;
    }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/StanFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/StanFileType.java
@@ -27,7 +27,8 @@ public class StanFileType extends PreviewableFromRFileType
    public StanFileType()
    {
       super("stan", "Stan", EditorLanguage.LANG_STAN, ".stan",
-            new ImageResource2x(FileIconResources.INSTANCE.iconStan2x()), "rstan:::rstudio_stanc");
+            new ImageResource2x(FileIconResources.INSTANCE.iconStan2x()), "rstan:::rstudio_stanc",
+            true);
    }
    
    public String getPreviewButtonText()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
@@ -27,6 +27,7 @@ import org.rstudio.studio.client.workbench.prefs.model.UIPrefsAccessor;
 import org.rstudio.studio.client.workbench.views.source.editors.text.Scope;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ScopeFunction;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTarget;
+import org.rstudio.studio.client.workbench.views.source.editors.text.events.ActiveScopeChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.CursorChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.CursorChangedHandler;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorThemeStyleChangedEvent;
@@ -257,6 +258,17 @@ public class DocumentOutlineWidget extends Composite
          public void onScopeTreeReady(ScopeTreeReadyEvent event)
          {
             rebuildScopeTree(event.getScopeTree(), event.getCurrentScope());
+            resetTreeStyles();
+         }
+      }));
+      
+      handlers_.add(target_.getDocDisplay().addActiveScopeChangedHandler(new ActiveScopeChangedEvent.Handler()
+      {
+         @Override
+         public void onActiveScopeChanged(ActiveScopeChangedEvent event)
+         {
+            currentScope_ = event.getScope();
+            currentVisibleScope_ = getCurrentVisibleScope(currentScope_);
             resetTreeStyles();
          }
       }));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -44,6 +44,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ace.TokenIt
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.spelling.CharClassifier;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.spelling.TokenPredicate;
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionContext;
+import org.rstudio.studio.client.workbench.views.source.editors.text.events.ActiveScopeChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.BreakpointMoveEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.BreakpointSetEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.CommandClickEvent;
@@ -229,6 +230,7 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
 
    boolean isScopeTreeReady(int row);
    HandlerRegistration addScopeTreeReadyHandler(ScopeTreeReadyEvent.Handler handler);
+   HandlerRegistration addActiveScopeChangedHandler(ActiveScopeChangedEvent.Handler handler);
    
    Position getCursorPosition();
    void setCursorPosition(Position position);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ScopeManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ScopeManager.java
@@ -1,0 +1,104 @@
+/*
+ * ScopeManager.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text;
+
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArray;
+
+public class ScopeManager extends JavaScriptObject
+{
+   protected ScopeManager()
+   {
+   }
+   
+   public static final native ScopeManager create()
+   /*-{
+      var module = $wnd.require("mode/r_scope_tree");
+      var ScopeManager = module.ScopeManager;
+      var ScopeNode    = module.ScopeNode;
+      return new ScopeManager(ScopeNode);
+   }-*/;
+   
+   public final native Position getParsePosition()
+   /*-{
+      return this.parsePos;
+   }-*/;
+   
+   public final native void setParsePosition(Position position)
+   /*-{
+      this.parsePos = position;
+   }-*/;
+   
+   public final native void onSectionStart(String label, Position position)
+   /*-{
+      this.onSectionHead(label, position);
+   }-*/;
+   
+   public final native void onSectionEnd(Position position)
+   /*-{
+      this.onSectionEnd(position);
+   }-*/;
+   
+   public final native void onChunkStart(String chunkLabel,
+                                         String label,
+                                         Position chunkStartPos,
+                                         Position chunkPos)
+   /*-{
+      this.onChunkStart(chunkLabel, label, chunkStartPos, chunkPos);
+   }-*/;
+   
+   public final native void onChunkEnd(Position position)
+   /*-{
+      this.onChunkEnd(position);
+   }-*/;
+   
+   public final native void onNamedScopeStart(String label, Position position)
+   /*-{
+      this.onNamedScopeStart(label, position);
+   }-*/;
+   
+   public final native void onScopeStart(Position position)
+   /*-{
+      this.onScopeStart(position);
+   }-*/;
+   
+   public final native void onScopeEnd(Position position)
+   /*-{
+      this.onScopeEnd(position);
+   }-*/;
+   
+   public final native JsArray<Scope> getActiveScopes(Position position)
+   /*-{
+      return this.getActiveScopes(position);
+   }-*/;
+   
+   public final native JsArray<Scope> getScopeList()
+   /*-{
+      return this.getScopeList();
+   }-*/;
+   
+   public final native void invalidateFrom(Position position)
+   /*-{
+      this.invalidateFrom(position);
+   }-*/;
+   
+   public final Scope getScopeAt(Position position)
+   {
+      JsArray<Scope> scopes = getActiveScopes(position);
+      return scopes.get(scopes.length() - 1);
+   }
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ScopeTreeManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ScopeTreeManager.java
@@ -1,0 +1,159 @@
+/*
+ * ScopeTreeManager.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text;
+
+import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Token;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.TokenIterator;
+import org.rstudio.studio.client.workbench.views.source.editors.text.events.ActiveScopeChangedEvent;
+import org.rstudio.studio.client.workbench.views.source.editors.text.events.CursorChangedEvent;
+import org.rstudio.studio.client.workbench.views.source.editors.text.events.DocumentChangedEvent;
+import org.rstudio.studio.client.workbench.views.source.editors.text.events.ScopeTreeReadyEvent;
+
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.event.logical.shared.AttachEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.Timer;
+
+// NOTE: Historically, scope tree management was implemented as part of
+// an accompanying code model, written as part of our JavaScript Ace
+// support files. Unfortunately the interface required by a particular
+// code model and its associated scope tree was never made explicit,
+// and implementing these tools in a dynamic language like JavaScript
+// is somewhat cumbersome. This class provides a re-imagined interface
+// towards the development of a scope tree.
+public abstract class ScopeTreeManager
+{
+   public abstract void onToken(Token token,
+                                Position position,
+                                ScopeManager manager);
+   
+   public ScopeTreeManager(DocDisplay docDisplay)
+   {
+      RStudioGinjector.INSTANCE.injectMembers(this);
+      
+      docDisplay_ = docDisplay;
+      worker_ = new Worker();
+      scopeManager_ = ScopeManager.create();
+      
+      handlers_ = new HandlerRegistration[] {
+            
+            docDisplay.addAttachHandler((AttachEvent event) -> {
+               if (!event.isAttached())
+                  detach();
+            }),
+            
+            docDisplay.addDocumentChangedHandler((DocumentChangedEvent event) -> {
+               final Position position = event.getEvent().getRange().getStart();
+               Scheduler.get().scheduleDeferred(() -> {
+                  scopeManager_.invalidateFrom(Position.create(position));
+                  worker_.rebuildScopeTreeFromRow(position.getRow());
+               });
+            }),
+            
+            docDisplay.addCursorChangedHandler((CursorChangedEvent event) -> {
+               final Position position = event.getPosition();
+               Scope scope = scopeManager_.getScopeAt(position);
+               if (lastActiveScope_ != scope)
+               {
+                  lastActiveScope_ = scope;
+                  docDisplay_.fireEvent(new ActiveScopeChangedEvent(scope));
+               }
+            })
+            
+      };
+   }
+   
+   public void detach()
+   {
+      for (HandlerRegistration handler : handlers_)
+         handler.removeHandler();
+   }
+   
+   private class Worker
+   {
+      private Worker()
+      {
+         timer_ = new Timer()
+         {
+            @Override
+            public void run()
+            {
+               work();
+            }
+         };
+      }
+      
+      public void rebuildScopeTreeFromRow(int row)
+      {
+         startRow_ = row;
+         endRow_ = Math.min(docDisplay_.getRowCount(), startRow_ + ROWS_TOKENIZED_PER_ITERATION);
+         work();
+      }
+      
+      private void work()
+      {
+         Position position = Position.create(startRow_ - 1, 0);
+         
+         TokenIterator it = docDisplay_.createTokenIterator();
+         Token token = it.moveToPosition(position);
+         if (token == null)
+            token = it.stepForward();
+         
+         while (true)
+         {
+            if (token == null)
+            {
+               scopeManager_.setParsePosition(Position.create(it.getCurrentTokenRow(), -1));
+               JsArray<Scope> scopeTree = scopeManager_.getScopeList();
+               Scope currentScope = scopeManager_.getScopeAt(docDisplay_.getCursorPosition());
+               ScopeTreeReadyEvent event = new ScopeTreeReadyEvent(scopeTree, currentScope);
+               docDisplay_.fireEvent(event);
+               return;
+            }
+            
+            int row = it.getCurrentTokenRow();
+            if (row >= endRow_)
+               break;
+            
+            onToken(token, it.getCurrentTokenPosition(), scopeManager_);
+            
+            token = it.stepForward();
+         }
+         
+         scopeManager_.setParsePosition(Position.create(it.getCurrentTokenRow(), -1));
+         startRow_ = it.getCurrentTokenRow();
+         if (startRow_ < endRow_)
+            timer_.schedule(DELAY_MS);
+      }
+      
+      private int startRow_;
+      private int endRow_;
+      
+      private final Timer timer_;
+      
+      private static final int DELAY_MS = 5;
+      private static final int ROWS_TOKENIZED_PER_ITERATION = 200;
+   }
+   
+   protected Scope lastActiveScope_;
+   
+   protected final DocDisplay docDisplay_;
+   private final Worker worker_;
+   private final ScopeManager scopeManager_;
+   private final HandlerRegistration[] handlers_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/StanScopeTreeManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/StanScopeTreeManager.java
@@ -1,0 +1,83 @@
+/*
+ * StanScopeTreeManager.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text;
+
+import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.regex.Match;
+import org.rstudio.core.client.regex.Pattern;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Token;
+
+public class StanScopeTreeManager extends ScopeTreeManager
+{
+   @Override
+   public void onToken(Token token,
+                       Position position,
+                       ScopeManager manager)
+   {
+      if (token.hasType("comment.line"))
+      {
+         String line = docDisplay_.getLine(position.getRow());
+         Match match = RE_SECTION.match(line, 0);
+         if (match == null)
+            return;
+         
+         String label = match.getGroup(1).trim();
+         manager.onSectionStart(label, position);
+      }
+      
+      else if (token.valueEquals("{"))
+      {
+         String line = docDisplay_.getLine(position.getRow());
+         for (String block : STAN_BLOCKS)
+         {
+            if (line.startsWith(block))
+            {
+               String label = StringUtil.capitalizeAllWords(block);
+               Position blockPosition = Position.create(position.getRow(), 0);
+               manager.onSectionStart(label, blockPosition);
+               return;
+            }
+         }
+         
+         manager.onScopeStart(position);
+      }
+      
+      else if (token.valueEquals("}"))
+      {
+         Scope scope = manager.getScopeAt(position);
+         Position endPosition = Position.create(position.getRow(), position.getColumn() + 1);
+         if (scope.isSection())
+            manager.onSectionEnd(endPosition);
+         else
+            manager.onScopeEnd(endPosition);
+      }
+   }
+   
+   public StanScopeTreeManager(DocDisplay docDisplay)
+   {
+      super(docDisplay);
+   }
+   
+   private static final Pattern RE_SECTION = Pattern.create("^\\s*//(.*)(?:====|----)\\s*", "");
+   
+   private static final String[] STAN_BLOCKS = new String[] {
+         "functions",
+         "data", "transformed data",
+         "parameters", "transformed parameters",
+         "model",
+         "generated quantities"
+   };
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/events/ActiveScopeChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/events/ActiveScopeChangedEvent.java
@@ -1,0 +1,53 @@
+/*
+ * ActiveScopeChangedEvent.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text.events;
+
+import org.rstudio.studio.client.workbench.views.source.editors.text.Scope;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class ActiveScopeChangedEvent extends GwtEvent<ActiveScopeChangedEvent.Handler>
+{
+   public ActiveScopeChangedEvent(Scope scope)
+   {
+      scope_ = scope;
+   }
+   
+   public Scope getScope() { return scope_; }
+   
+   private final Scope scope_;
+   
+   // Boilerplate ----
+   
+   public interface Handler extends EventHandler
+   {
+      void onActiveScopeChanged(ActiveScopeChangedEvent event);
+   }
+   
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onActiveScopeChanged(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}


### PR DESCRIPTION
This PR implements the document outline for Stan code.

Some notes: normally, scope tree generation is handled on the JavaScript side, using the mode's associated code model (+ some special methods) for building the scope tree as needed while the document mutates. Unfortunately, the exact interface required by a code model was never documented, and building new code models in JavaScript is quite cumbersome and bug-prone.

Since we don't need an explicit code model to produce a scope tree for Stan code, I instead opted to factor out the minimal components into (reusable) GWT code. The underlying JavaScript 'classes' are still being used (the scope nodes + scope tree implementations), but for Stan they're used on the GWT side.

The majority of the scope management code is language-agnostic, and so that has been implemented in an abstract base class 'ScopeTreeManager', with 'StanScopeTreeManager' providing the single required 'onToken()' method. (This will also hopefully imply that if we want to implement scope trees for other languages in the future that the process will be quite seamless).

This also helps avoid any potential pitfalls caused by an attempted refactor of the underlying JavaScript components -- I think we definitely want to avoid touching these so close to a v1.2 release! In the future if we so desire we could consider moving some of these components to GWT, or even refactoring them using Typescript (so that we might be able to actually leverage some static type-checking for potential errors).