### PR TITLE
replace cran ubuntu fingerprint with full key id

### DIFF
--- a/docker/jenkins/Dockerfile.trusty-amd64
+++ b/docker/jenkins/Dockerfile.trusty-amd64
@@ -6,7 +6,7 @@ ARG AWS_REGION=us-east-1
 RUN set -x \
     && sed -i "s/archive.ubuntu.com/$AWS_REGION.ec2.archive.ubuntu.com/" /etc/apt/sources.list \
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9 \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0x51716619e084dab9 \
     && echo 'deb http://cran.rstudio.com/bin/linux/ubuntu trusty/' >> /etc/apt/sources.list \
     && apt-get update
 

--- a/docker/jenkins/Dockerfile.xenial-amd64
+++ b/docker/jenkins/Dockerfile.xenial-amd64
@@ -6,7 +6,7 @@ ARG AWS_REGION=us-east-1
 RUN set -x \
     && sed -i "s/archive.ubuntu.com/$AWS_REGION.ec2.archive.ubuntu.com/" /etc/apt/sources.list \
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9 \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0x51716619e084dab9 \
     && echo 'deb http://cran.rstudio.com/bin/linux/ubuntu xenial/' >> /etc/apt/sources.list \
     && apt-get update
 

--- a/vagrant/bootstrap-debian.sh
+++ b/vagrant/bootstrap-debian.sh
@@ -4,7 +4,7 @@
 cp /rstudio/vagrant/build.motd.tail /etc/motd
 
 # add repo for R 
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0x51716619e084dab9
 echo "deb https://cran.rstudio.com/bin/linux/ubuntu trusty/" >> /etc/apt/sources.list
 
 # bring apt database up to date with R packages


### PR DESCRIPTION
there's a fingerprint collision on keyserver.ubuntu.com that we certainly want to avoid:

```
$ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
gpg: requesting key E084DAB9 from hkp server keyserver.ubuntu.com
Executing: /tmp/tmp.nEi6CqSbz5/gpg.1.sh --keyserver
keyserver.ubuntu.com
--recv-keys
E084DAB9
gpg: key E084DAB9: public key "Totally Legit Signing Key <mallory@example.org>" imported
gpg: key E084DAB9: public key "Michael Rutter <marutter@gmail.com>" imported
gpg: Total number processed: 2
gpg:               imported: 2  (RSA: 2)
```