### PR TITLE
console input buffer not ready after interrupt

### DIFF
--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -363,7 +363,8 @@ int RReadConsole (const char *pmt,
       }
       else
       {
-         return 0; // terminate
+         // buffer not ready
+         return 0;
       }
    }
    catch(r::exec::InterruptException&)
@@ -377,8 +378,8 @@ int RReadConsole (const char *pmt,
       r::exec::checkUserInterrupt();
 #endif
 
-      // return success
-      return 1;
+      // buffer not ready
+      return 0;
    }
    catch(const std::exception& e)
    {
@@ -393,7 +394,7 @@ int RReadConsole (const char *pmt,
       rSuicide(msg);
    }
       
-   return 0 ; // keep compiler happy
+   return 0; // keep compiler happy
 }
    
 void RShowMessage(const char* msg)


### PR DESCRIPTION
This fixes an issue seen with the `later` package where sending an interrupt would cause RStudio to re-evaluate the last-processed console input a second time.

Closes #3394.

