### PR TITLE
Use a shinyapp in connection pane without having sparklyr on the system

### DIFF
--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -699,7 +699,7 @@ options(connectionObserver = list(
 
 .rs.addJsonRpcHandler("launch_embedded_shiny_connection_ui", function(package, name)
 {
-   if (package == "sparklyr" & packageVersion("sparklyr") <= "0.5.4") {
+   if (package == "sparklyr" && packageVersion("sparklyr") <= "0.5.4") {
       return(.rs.error(
          "sparklyr ", packageVersion("sparklyr"), " does not support this functionality. ",
          "Please upgrade to sparklyr 0.5.5 or newer."


### PR DESCRIPTION
fixes #3400 

Don't apply the second test if the first if FALSE because it throws an error if sparklyr not installed in the environment .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rstudio/rstudio/3401)
<!-- Reviewable:end -->
