### PR TITLE
Fix a bug where the default theme cannot be loaded when using certain configurations.

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceTheme.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceTheme.java
@@ -28,7 +28,7 @@ public class AceTheme extends JavaScriptObject
    
    public static final AceTheme createDefault()
    {
-      return create("Textmate (default)", "/theme/default/textmate.rstheme", false);
+      return create("Textmate (default)", "theme/default/textmate.rstheme", false);
    }
    
    public static final native AceTheme create(String name, String url, Boolean isDark)


### PR DESCRIPTION
When using a proxy with a custom path (e.g. <hostname>/rstudio is the home page) the default theme cannot be loaded because it was using an absolute path. This PR changes the default theme to use a relative path.