### PR TITLE
disable obfuscation of CSS styles

### DIFF
--- a/src/gwt/src/org/rstudio/studio/RStudio.gwt.xml
+++ b/src/gwt/src/org/rstudio/studio/RStudio.gwt.xml
@@ -105,7 +105,7 @@
    <set-property name="compiler.stackMode" value="emulated,native"/>
    <set-configuration-property name="compiler.emulatedStack.recordLineNumbers" value="true" />
 
-   <!--<set-configuration-property name="CssResource.style" value="pretty" />-->
+   <set-configuration-property name="CssResource.style" value="stable" />
    <set-configuration-property name="UiBinder.useSafeHtmlTemplates" value="true" />
 
    <!-- work around incompatibility between GWT 2.8 and Gin 2.1.2 -->


### PR DESCRIPTION
This PR switches to the use of stable CSS class names, allowing editor themes which would like to style other elements of the IDE (for advanced users only) to do so.

(Currently, this is already possible using the obfuscated CSS themes, but as the obfuscated names are bound to change such attempts are brittle)

There might be some reasons for us to preserve obfuscation so we'll have to think a bit more about this before merging.

Closes #3368.