### PR TITLE
avoid race condition (?) in metric info request

### DIFF
--- a/src/cpp/r/session/graphics/RGraphicsDevice.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsDevice.cpp
@@ -251,14 +251,14 @@ void GD_MetricInfo(int c,
    // re-request metric info.
    //
    // https://github.com/tidyverse/ggplot2/issues/2252
-#ifdef Q_OS_MAC
-   if (*ascent == R_PosInf)
+#ifdef __APPLE__
+   for (int i = 0; i < 10; i++)
    {
-      for (int i = 0; i < 10; i++)
-      {
-         boost::this_thread::sleep_for(boost::chrono::milliseconds(10));
-         handler::metricInfo(c, gc, ascent, descent, width, dev);
-      }
+      if (*ascent != R_PosInf)
+         break;
+
+      boost::this_thread::sleep_for(boost::chrono::milliseconds(10));
+      handler::metricInfo(c, gc, ascent, descent, width, dev);
    }
 #endif
 }


### PR DESCRIPTION
This PR works around an issue noted in https://github.com/tidyverse/ggplot2/issues/2252. Reproducible example adapted from https://gist.github.com/dpseidel/322db7110b8590d77ba20f3db8f399fc; should reproduce on macOS:

```R
library(ggplot2)

# blank plot
blank_base <- ggplot(data.frame(), aes(1, 1)) +
  theme(
    axis.title.y = element_blank(),
    axis.title.x = element_blank(),
    axis.text.y = element_blank(),
    axis.ticks = element_blank(),
    panel.background = element_blank(),
    panel.grid = element_blank()
  )

q <- blank_base + scale_x_continuous(labels = c(
  expr(10 ^ 1), expr(10 ^ 2),
  expr(10 ^ 3), expr(10 ^ 4),
  expr(10 ^ 5)
)) 

repeat print(q)
```

It _seems_ like there is some sort of race condition here -- the errors occur when a metric info request comes immediately after the device in deactivated and then later reactivated; I suspect that we might be requesting metric info before the graphics device is truly ready.

Note that this PR really just papers over the issue (we retry our requests for metric info a few times until something sane comes back) but it seems like a better fix would involve waiting for the graphics device to truly be ready (unfortunately I'm not sure how to detect that)