### PR TITLE
avoid out-of-bounds read in empty data.frames

### DIFF
--- a/src/cpp/r/RJson.cpp
+++ b/src/cpp/r/RJson.cpp
@@ -292,7 +292,14 @@ Error jsonObjectFromList(SEXP listSEXP, core::json::Value* pValue)
 // and returned true for this list (validates a name for each element)
 //   
 Error jsonObjectArrayFromDataFrame(SEXP listSEXP, core::json::Value* pValue)
-{      
+{
+   // handle empty-list case up-front
+   if (Rf_length(listSEXP) == 0)
+   {
+      *pValue = core::json::Array();
+      return Success();
+   }
+   
    // get the names of the list elements
    std::vector<std::string> fieldNames ;
    Error error = sexp::getNames(listSEXP, &fieldNames);


### PR DESCRIPTION
This PR fixes a small issue caught by ASAN where we would accidentally perform an out-of-bounds read when attempting to convert an empty `data.frame` to JSON. (See the call to `int values = Rf_length(VECTOR_ELT(listSEXP, 0));` below)