### PR TITLE
improve completions for SQL chunks / code

### DIFF
--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -217,6 +217,7 @@ set (SESSION_SOURCE_FILES
    modules/rmarkdown/RMarkdownPresentation.cpp
    modules/rmarkdown/RMarkdownTemplates.cpp
    modules/shiny/SessionShiny.cpp
+   modules/sql/SessionSql.cpp
    modules/stan/SessionStan.cpp
    modules/tex/SessionCompilePdf.cpp
    modules/tex/SessionCompilePdfSupervisor.cpp

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -170,6 +170,7 @@
 #include "modules/rmarkdown/SessionRMarkdown.hpp"
 #include "modules/rmarkdown/SessionRmdNotebook.hpp"
 #include "modules/shiny/SessionShiny.hpp"
+#include "modules/sql/SessionSql.hpp"
 #include "modules/stan/SessionStan.hpp"
 #include "modules/viewer/SessionViewer.hpp"
 #include "modules/SessionDiagnostics.hpp"
@@ -530,6 +531,7 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
       (modules::rmarkdown::templates::initialize)
       (modules::rpubs::initialize)
       (modules::shiny::initialize)
+      (modules::sql::initialize)
       (modules::stan::initialize)
       (modules::plumber::initialize)
       (modules::source::initialize)

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2068,7 +2068,16 @@
 
 .rs.addFunction("tryCatch", function(expr)
 {
-   tryCatch(expr, condition = identity)
+   tryCatch(
+      
+      withCallingHandlers(
+         expr,
+         warning = function(w) invokeRestart("muffleWarning"),
+         message = function(m) invokeRestart("muffleMessage")
+      ),
+      
+      error = identity
+   )
 })
 
 .rs.addFunction("resolveAliasedPath", function(path)

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2291,3 +2291,14 @@
       )
    )
 })
+
+.rs.addFunction("withCache", function(name, expr)
+{
+   cache <- .rs.getVar(name)
+   if (!is.null(cache))
+      return(cache)
+   
+   result <- force(expr)
+   .rs.setVar(name, result)
+   result
+})

--- a/src/cpp/session/modules/sql/SessionSql.R
+++ b/src/cpp/session/modules/sql/SessionSql.R
@@ -146,7 +146,7 @@
 
 .rs.addFunction("sql.getCompletionsIdentifiers", function(token, conn, ctx)
 {
-   identifiers <- as.character(ctx$identifiers)
+   identifiers <- setdiff(as.character(ctx$identifiers), token)
    results <- .rs.selectFuzzyMatches(identifiers, token)
    .rs.makeCompletions(
       token = token,

--- a/src/cpp/session/modules/sql/SessionSql.R
+++ b/src/cpp/session/modules/sql/SessionSql.R
@@ -50,7 +50,8 @@
    
    Reduce(.rs.appendCompletions, list(
       .rs.sql.getCompletionsKeywords(token, conn, context),
-      .rs.sql.getCompletionsFields(token, conn, context)
+      .rs.sql.getCompletionsFields(token, conn, context),
+      .rs.sql.getCompletionsTables(token, conn, context)
    ))
 })
 

--- a/src/cpp/session/modules/sql/SessionSql.R
+++ b/src/cpp/session/modules/sql/SessionSql.R
@@ -88,13 +88,12 @@
          tables <- listedTables
    }
    
-   # if we didn't get any tables, user context completions
-   if (!length(tables))
-      tables <- ctx$tables
-   
    # add in alias names since the user might want to use those in lieu
    # of the 'real' table name in certain contexts
    tables <- c(tables, names(ctx$aliases))
+   
+   # remove current token as candidate
+   tables <- setdiff(tables, token)
    
    results <- .rs.selectFuzzyMatches(tables, token)
    .rs.makeCompletions(
@@ -130,6 +129,8 @@
       fields <- .rs.tryCatch(DBI::dbListFields(conn, table))
       if (inherits(fields, "error"))
          return(.rs.emptyCompletions(language = "SQL"))
+      
+      fields <- setdiff(fields, token)
       
       .rs.makeCompletions(
          token = token,

--- a/src/cpp/session/modules/sql/SessionSql.R
+++ b/src/cpp/session/modules/sql/SessionSql.R
@@ -29,12 +29,11 @@
    if (grepl(".", token, fixed = TRUE))
       return(.rs.sql.getCompletionsFields(token, conn, context))
    
-   # if we're requesting completions following 'from' or 'join',
-   # then provide table names as completions
+   # check if we're explicitly requesting table name completions
    if (length(parts) > 1)
    {
       previous <- parts[[length(parts) - 1L]]
-      if (tolower(previous) %in% c("from", "join"))
+      if (tolower(previous) %in% c("from", "into", "join", "update"))
          return(.rs.sql.getCompletionsTables(token, conn, context))
    }
    

--- a/src/cpp/session/modules/sql/SessionSql.R
+++ b/src/cpp/session/modules/sql/SessionSql.R
@@ -49,7 +49,7 @@
       
       .rs.makeCompletions(
          token = token,
-         results = .rs.selectFuzzyMatches(keywords, token),
+         results = .rs.selectFuzzyMatches(keywords, if (nzchar(token)) token else "!"),
          packages = "keyword",
          quote = FALSE,
          type = .rs.acCompletionTypes$KEYWORD,
@@ -60,7 +60,8 @@
          token = token,
          results = .rs.selectFuzzyMatches(names(fields), token),
          packages = "table",
-         type = .rs.acCompletionTypes$DATASET
+         type = .rs.acCompletionTypes$DATASET,
+         language = "SQL"
       ),
       
       
@@ -68,7 +69,8 @@
          token = token,
          results = .rs.selectFuzzyMatches(unlist(fields, use.names = FALSE), token),
          packages = "field",
-         type = .rs.acCompletionTypes$VECTOR
+         type = .rs.acCompletionTypes$VECTOR,
+         language = "SQL"
       )
 
    ))

--- a/src/cpp/session/modules/sql/SessionSql.R
+++ b/src/cpp/session/modules/sql/SessionSql.R
@@ -1,0 +1,69 @@
+#
+# SessionSql.R
+#
+# Copyright (C) 2009-18 by RStudio, Inc.
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+.rs.addJsonRpcHandler("sql_get_completions", function(line)
+{
+   .rs.sql.getCompletions(line)
+})
+
+.rs.addFunction("sql.getCompletions", function(line)
+{
+   # TODO: harvest completion results from associated SQL connection
+   # - handle for mixed-mode documents (request chunk options)
+   # - handle for SQL scripts (look for preview line)
+   # TODO: completion keywords on per-database case
+   # TODO: options for casing
+   # - smart (prefer upper)
+   # - smart (prefer lower)
+   # - upper
+   # - lower
+   
+   # extract token
+   parts <- .rs.strsplit(line, "\\s+")
+   token <- tail(parts, n = 1L)
+   
+   # match against keywords
+   keywords <- .rs.sql.keywords()
+   if (identical(token, tolower(token)))
+      keywords <- tolower(keywords)
+   
+   results <- .rs.selectFuzzyMatches(keywords, token)
+   .rs.makeCompletions(token = token, results = results)
+})
+
+.rs.addFunction("sql.keywords", function()
+{
+   # NOTE: these are the keywords understood by SQLite, as per
+   # https://www.sqlite.org/lang_keywords.html
+   c(
+      "ABORT", "ACTION", "ADD", "AFTER", "ALL", "ALTER", "ANALYZE", "AND",
+      "AS", "ASC", "ATTACH", "AUTOINCREMENT", "BEFORE", "BEGIN", "BETWEEN",
+      "BY", "CASCADE", "CASE", "CAST", "CHECK", "COLLATE", "COLUMN", "COMMIT",
+      "CONFLICT", "CONSTRAINT", "CREATE", "CROSS", "CURRENT_DATE", "CURRENT_TIME",
+      "CURRENT_TIMESTAMP", "DATABASE", "DEFAULT", "DEFERRABLE", "DEFERRED",
+      "DELETE", "DESC", "DETACH", "DISTINCT", "DROP", "EACH", "ELSE", "END",
+      "ESCAPE", "EXCEPT", "EXCLUSIVE", "EXISTS", "EXPLAIN", "FAIL", "FOR",
+      "FOREIGN", "FROM", "FULL", "GLOB", "GROUP", "HAVING", "IF", "IGNORE",
+      "IMMEDIATE", "IN", "INDEX", "INDEXED", "INITIALLY", "INNER", "INSERT",
+      "INSTEAD", "INTERSECT", "INTO", "IS", "ISNULL", "JOIN", "KEY", "LEFT",
+      "LIKE", "LIMIT", "MATCH", "NATURAL", "NO", "NOT", "NOTNULL", "NULL", "OF",
+      "OFFSET", "ON", "OR", "ORDER", "OUTER", "PLAN", "PRAGMA", "PRIMARY", "QUERY",
+      "RAISE", "RECURSIVE", "REFERENCES", "REGEXP", "REINDEX", "RELEASE", "RENAME",
+      "REPLACE", "RESTRICT", "RIGHT", "ROLLBACK", "ROW", "SAVEPOINT", "SELECT",
+      "SET", "TABLE", "TEMP", "TEMPORARY", "THEN", "TO", "TRANSACTION", "TRIGGER",
+      "UNION", "UNIQUE", "UPDATE", "USING", "VACUUM", "VALUES", "VIEW", "VIRTUAL",
+      "WHEN", "WHERE", "WITH", "WITHOUT"
+   )
+})

--- a/src/cpp/session/modules/sql/SessionSql.R
+++ b/src/cpp/session/modules/sql/SessionSql.R
@@ -40,8 +40,9 @@
    # otherwise, gather completions from other sources
    Reduce(.rs.appendCompletions, list(
       .rs.sql.getCompletionsKeywords(token, conn, ctx),
+      .rs.sql.getCompletionsTables(token, conn, ctx),
       .rs.sql.getCompletionsFields(token, conn, ctx),
-      .rs.sql.getCompletionsTables(token, conn, ctx)
+      .rs.sql.getCompletionsIdentifiers(token, conn, ctx)
    ))
 })
 
@@ -141,6 +142,18 @@
       
    }))
    
+})
+
+.rs.addFunction("sql.getCompletionsIdentifiers", function(token, conn, ctx)
+{
+   identifiers <- as.character(ctx$identifiers)
+   results <- .rs.selectFuzzyMatches(identifiers, token)
+   .rs.makeCompletions(
+      token = token,
+      results = results,
+      type = .rs.acCompletionTypes$CONTEXT,
+      language = "SQL"
+   )
 })
 
 .rs.addFunction("sql.listTableFields", function(conn, tables)

--- a/src/cpp/session/modules/sql/SessionSql.R
+++ b/src/cpp/session/modules/sql/SessionSql.R
@@ -76,10 +76,17 @@
 
 .rs.addFunction("sql.getCompletionsTables", function(token, conn, ctx)
 {
+   # use context-completed tables by default
+   tables <- ctx$tables
+   
    # attempt to derive table names from connection
-   conn <- .rs.sql.asConnectionObject(conn)
-   tables <- if (!is.null(conn))
-      .rs.sql.listTables(conn)
+   conn <- .rs.sql.asDBIConnection(conn)
+   if (!is.null(conn))
+   {
+      listedTables <- .rs.sql.listTables(conn)
+      if (length(listedTables))
+         tables <- listedTables
+   }
    
    # if we didn't get any tables, user context completions
    if (!length(tables))
@@ -100,7 +107,7 @@
 
 .rs.addFunction("sql.getCompletionsFields", function(token, conn, ctx)
 {
-   conn <- .rs.sql.asConnectionObject(conn)
+   conn <- .rs.sql.asDBIConnection(conn)
    if (is.null(conn))
       return(.rs.emptyCompletions(language = "SQL"))
    
@@ -149,7 +156,7 @@
 
 .rs.addFunction("sql.listTables", function(conn)
 {
-   conn <- .rs.sql.asConnectionObject(conn)
+   conn <- .rs.sql.asDBIConnection(conn)
    if (is.null(conn))
       return(character())
    
@@ -227,7 +234,7 @@
    )
 })
 
-.rs.addFunction("sql.asConnectionObject", function(conn)
+.rs.addFunction("sql.asDBIConnection", function(conn)
 {
    if (inherits(conn, "DBIConnection"))
       return(conn)

--- a/src/cpp/session/modules/sql/SessionSql.cpp
+++ b/src/cpp/session/modules/sql/SessionSql.cpp
@@ -1,0 +1,43 @@
+/*
+ * SessionSql.cpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "SessionSql.hpp"
+
+#include <core/Exec.hpp>
+#include <session/SessionModuleContext.hpp>
+
+using namespace rstudio;
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace sql {
+
+Error initialize()
+{
+   using namespace module_context;
+   using boost::bind;
+   
+   ExecBlock initBlock;
+   initBlock.addFunctions()
+         (bind(sourceModuleRFile, "SessionSql.R"));
+   return initBlock.execute();
+}
+
+} // end namespace sql
+} // end namespace modules
+} // end namespace session
+} // end namespace rstudio

--- a/src/cpp/session/modules/sql/SessionSql.hpp
+++ b/src/cpp/session/modules/sql/SessionSql.hpp
@@ -1,0 +1,37 @@
+/*
+ * SessionSql.hpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef RSTUDIO_SESSION_MODULES_SQL_HPP
+#define RSTUDIO_SESSION_MODULES_SQL_HPP
+
+namespace rstudio {
+namespace core {
+class Error;
+}
+}
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace sql {
+
+core::Error initialize();
+
+} // end namespace sql
+} // end namespace modules
+} // end namespace session
+} // end namespace rstudio
+
+#endif /* RSTUDIO_SESSION_MODULES_SQL_HPP */

--- a/src/gwt/acesupport/acemixins/token_iterator.js
+++ b/src/gwt/acesupport/acemixins/token_iterator.js
@@ -455,7 +455,7 @@ var Range = require("ace/range").Range;
       return false;
    };
 
-   this.findTokenBwd = function(value, skipMatching)
+   this.findTokenValueBwd = function(value, skipMatching)
    {
       skipMatching = !!skipMatching;
 
@@ -473,7 +473,7 @@ var Range = require("ace/range").Range;
       return false;
    };
 
-   this.findTokenFwd = function(value, skipMatching)
+   this.findTokenValueFwd = function(value, skipMatching)
    {
       skipMatching = !!skipMatching;
 
@@ -490,6 +490,43 @@ var Range = require("ace/range").Range;
 
       return false;
    };
+
+   this.findTokenTypeBwd = function(type, skipMatching)
+   {
+      skipMatching = !!skipMatching;
+
+      do
+      {
+         if (skipMatching && this.bwdToMatchingToken())
+            continue;
+
+         var token = this.getCurrentToken();
+         if (token.type === type)
+            return true;
+
+      } while (this.moveToPreviousToken());
+
+      return false;
+   };
+
+   this.findTokenTypeFwd = function(type, skipMatching)
+   {
+      skipMatching = !!skipMatching;
+
+      do
+      {
+         if (skipMatching && this.fwdToMatchingToken())
+            continue;
+
+         var token = this.getCurrentToken();
+         if (token.type === type)
+            return true;
+
+      } while (this.moveToNextToken());
+
+      return false;
+   };
+
 
 }).call(TokenIterator.prototype);
 

--- a/src/gwt/acesupport/acemode/rmarkdown.js
+++ b/src/gwt/acesupport/acemode/rmarkdown.js
@@ -137,6 +137,10 @@ oop.inherits(Mode, MarkdownMode);
          return "YAML";
       else if (mode === "python")
          return "Python";
+      else if (mode == "sql")
+         return "SQL";
+      else if (mode === "stan")
+         return "Stan";
       else
          return "Markdown";
    };

--- a/src/gwt/acesupport/acemode/sql_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/sql_highlight_rules.js
@@ -94,7 +94,7 @@ define("mode/sql_highlight_rules", ["require", "exports", "module"], function(re
             regex : "[a-zA-Z_$][a-zA-Z0-9_$]*\\b"
         }, {
             token : "keyword.operator",
-            regex : "\\+|\\-|\\/|\\/\\/|%|<@>|@>|<@|&|\\^|~|<|>|<=|=>|==|!=|<>|="
+            regex : "\\+|\\-|\\/|\\/\\/|%|<@>|@>|<@|&|\\^|~|<|>|<=|=>|==|!=|<>|=|\\."
         }, {
             token : "paren.lparen",
             regex : "[\\(]"

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -125,6 +125,7 @@
          <!--<arg line="-style PRETTY"/>-->
          <arg line="-extra ${extras.dir}"/>
          <arg line="${gwt.extra.args}"/>
+         <arg value="-generateJsInteropExports"/>
          <!-- Additional arguments like -logLevel DEBUG -->
          <arg value="${gwt.main.module}"/>
       </java>
@@ -164,6 +165,7 @@
          <arg value="-startupUrl"/>
          <arg value="http://localhost:8787"/>
          <arg line="-bindAddress 127.0.0.1"/>
+         <arg value="-generateJsInteropExports"/>
          <arg value="org.rstudio.studio.RStudioDesktopSuperDevMode"/>
       </java>
    </target>
@@ -185,6 +187,7 @@
          <arg value="-startupUrl"/>
          <arg value="http://localhost:8787"/>
          <arg line="-bindAddress 127.0.0.1"/>
+         <arg value="-generateJsInteropExports"/>
          <!-- Additional arguments like -logLevel DEBUG -->
          <arg value="org.rstudio.studio.RStudioSuperDevMode"/>
       </java>

--- a/src/gwt/src/org/rstudio/core/client/js/JsMapString.java
+++ b/src/gwt/src/org/rstudio/core/client/js/JsMapString.java
@@ -1,0 +1,45 @@
+/*
+ * JsMapString.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.js;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArrayString;
+
+public class JsMapString extends JavaScriptObject
+{
+   protected JsMapString() {}
+   
+   public static native final JsMapString create() /*-{ return {}; }-*/;
+   
+   public native final String get(String key) /*-{
+      return this[key];
+   }-*/;
+   
+   public native final void set(String key, String value) /*-{
+      this[key] = value;
+   }-*/;
+   
+   public native final JsArrayString keys() /*-{
+      return Object.keys(this);
+   }-*/;
+   
+   public native final int size() /*-{
+      return this.size;
+   }-*/;
+   
+   public native final boolean isEmpty() /*-{
+      return this.size === 0;
+   }-*/;
+}

--- a/src/gwt/src/org/rstudio/core/client/js/JsObject.java
+++ b/src/gwt/src/org/rstudio/core/client/js/JsObject.java
@@ -166,6 +166,10 @@ public class JsObject extends JavaScriptObject
       this[key] = value;
    }-*/;
    
+   public final native void setJSO(String key, JavaScriptObject value) /*-{
+      this[key] = value;
+   }-*/;
+   
    public final native void setJsArrayString(String key, JsArrayString value) /*-{
       this[key] = value;
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/common/JSONArrayBuilder.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/JSONArrayBuilder.java
@@ -14,8 +14,7 @@
  */
 package org.rstudio.studio.client.common;
 
-import org.rstudio.core.client.js.JsObject;
-
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONBoolean;
@@ -75,9 +74,16 @@ public class JSONArrayBuilder
       return this;
    }
    
-   public final JSONArrayBuilder add(JsObject value)
+   public final JSONArrayBuilder add(JavaScriptObject object)
    {
-      append(new JSONObject(value));
+      append(new JSONObject(object));
+      return this;
+   }
+   
+   public final JSONArrayBuilder add(Object object)
+   {
+      JavaScriptObject jso = cast(object);
+      append(new JSONObject(jso));
       return this;
    }
    
@@ -98,6 +104,11 @@ public class JSONArrayBuilder
    {
       array_.set(index_++, value);
    }
+   
+   private static final native JavaScriptObject cast(Object object)
+   /*-{
+      return object;
+   }-*/;
    
    private final JSONArray array_;
    private int index_;

--- a/src/gwt/src/org/rstudio/studio/client/common/JSONArrayBuilder.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/JSONArrayBuilder.java
@@ -14,11 +14,14 @@
  */
 package org.rstudio.studio.client.common;
 
+import org.rstudio.core.client.js.JsObject;
+
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONBoolean;
 import com.google.gwt.json.client.JSONNull;
 import com.google.gwt.json.client.JSONNumber;
+import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONString;
 import com.google.gwt.json.client.JSONValue;
 
@@ -69,6 +72,12 @@ public class JSONArrayBuilder
          array.set(i, fromString(value.get(i)));
       append(array);
       
+      return this;
+   }
+   
+   public final JSONArrayBuilder add(JsObject value)
+   {
+      append(new JSONObject(value));
       return this;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/CodeToolsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/CodeToolsServerOperations.java
@@ -20,6 +20,7 @@ import org.rstudio.core.client.js.JsObject;
 import org.rstudio.studio.client.server.*;
 import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.codesearch.model.CodeSearchServerOperations;
+import org.rstudio.studio.client.workbench.views.console.shell.assist.SqlCompletionParseContext;
 import org.rstudio.studio.client.workbench.views.help.model.HelpServerOperations;
 import org.rstudio.studio.client.workbench.views.output.lint.model.AceAnnotation;
 import org.rstudio.studio.client.workbench.views.source.model.CppServerOperations;
@@ -111,7 +112,7 @@ public interface CodeToolsServerOperations extends HelpServerOperations,
    void sqlGetCompletions(
          String line,
          String connection,
-         JsObject context,
+         SqlCompletionParseContext context,
          ServerRequestCallback<Completions> requestCallback);
    
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/CodeToolsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/CodeToolsServerOperations.java
@@ -110,6 +110,8 @@ public interface CodeToolsServerOperations extends HelpServerOperations,
    
    void sqlGetCompletions(
          String line,
+         String connection,
+         boolean preferLowercaseKeywords,
          ServerRequestCallback<Completions> requestCallback);
    
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/CodeToolsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/CodeToolsServerOperations.java
@@ -111,7 +111,7 @@ public interface CodeToolsServerOperations extends HelpServerOperations,
    void sqlGetCompletions(
          String line,
          String connection,
-         boolean preferLowercaseKeywords,
+         JsObject context,
          ServerRequestCallback<Completions> requestCallback);
    
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/CodeToolsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/CodeToolsServerOperations.java
@@ -108,4 +108,8 @@ public interface CodeToolsServerOperations extends HelpServerOperations,
          boolean useSourceDatabase,
          ServerRequestCallback<JsArray<AceAnnotation>> requestCallback);
    
+   void sqlGetCompletions(
+         String line,
+         ServerRequestCallback<Completions> requestCallback);
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/DocumentMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/DocumentMode.java
@@ -25,6 +25,7 @@ public class DocumentMode
       PYTHON,
       C_CPP,
       MARKDOWN,
+      SQL,
       STAN,
       TEX,
       UNKNOWN
@@ -43,6 +44,8 @@ public class DocumentMode
          return Mode.MARKDOWN;
       else if (isPositionInTexMode(docDisplay, position))
          return Mode.TEX;
+      else if (isPositionInSqlMode(docDisplay, position))
+         return Mode.SQL;
       else if (isPositionInStanMode(docDisplay, position))
          return Mode.STAN;
       else
@@ -200,6 +203,15 @@ public class DocumentMode
    {
       return isPositionInPythonMode(docDisplay, docDisplay.getSelectionStart()) &&
              isPositionInPythonMode(docDisplay, docDisplay.getSelectionEnd());
+   }
+   
+   public static boolean isPositionInSqlMode(DocDisplay docDisplay,
+                                             Position position)
+   {
+      if (docDisplay.getFileType().isSql())
+         return true;
+      
+      return isPositionInMode(docDisplay, position, FileType.SQL_LANG_MODE);
    }
    
    // Stan Mode

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileType.java
@@ -27,6 +27,7 @@ public abstract class FileType
    public static final String MARKDOWN_LANG_MODE = "Markdown";
    public static final String C_CPP_LANG_MODE = "C_CPP";
    public static final String TEX_LANG_MODE = "TeX";
+   public static final String SQL_LANG_MODE = "SQL";
    public static final String STAN_LANG_MODE = "Stan";
    public static final String PYTHON_LANG_MODE = "Python";
    

--- a/src/gwt/src/org/rstudio/studio/client/common/reditor/EditorLanguage.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/reditor/EditorLanguage.java
@@ -50,12 +50,16 @@ public class EditorLanguage
          "mode/rhtml", true);
    public static final EditorLanguage LANG_CPP = new EditorLanguage(
          "mode/c_cpp", true);
+   public static final EditorLanguage LANG_SQL = new EditorLanguage(
+         "mode/sql", true);
    public static final EditorLanguage LANG_STAN = new EditorLanguage(
          "mode/stan", true);
    public static final EditorLanguage LANG_YAML = new EditorLanguage(
          "mode/yaml", false, true);
    public static final EditorLanguage LANG_PYTHON = new EditorLanguage(
          "mode/python", true);
+   public static final EditorLanguage LANG_SH = new EditorLanguage(
+         "mode/sh", false, false);
    
    // Modes borrowed from Ace
    public static final EditorLanguage LANG_PLAIN = new EditorLanguage(
@@ -66,10 +70,6 @@ public class EditorLanguage
          "ace/mode/css", false, true);
    public static final EditorLanguage LANG_JAVASCRIPT = new EditorLanguage(
          "ace/mode/javascript", false, true);
-   public static final EditorLanguage LANG_SQL = new EditorLanguage(
-         "mode/sql", false, true);
-   public static final EditorLanguage LANG_SH = new EditorLanguage(
-         "mode/sh", false, false);
    public static final EditorLanguage LANG_TOML = new EditorLanguage(
          "ace/mode/toml", false, true);
    public static final EditorLanguage LANG_XML = new EditorLanguage(

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1065,10 +1065,14 @@ public class RemoteServer implements Server
    }
    
    public void sqlGetCompletions(String line,
+                                 String connection,
+                                 boolean preferLowercaseKeywords,
                                  ServerRequestCallback<Completions> requestCallback)
    {
       JSONArray params = new JSONArrayBuilder()
             .add(line)
+            .add(connection)
+            .add(preferLowercaseKeywords)
             .get();
       
       sendRequest(RPC_SCOPE, SQL_GET_COMPLETIONS, params, requestCallback);

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -169,6 +169,7 @@ import org.rstudio.studio.client.workbench.views.connections.model.Field;
 import org.rstudio.studio.client.workbench.views.connections.model.NewConnectionContext;
 import org.rstudio.studio.client.workbench.views.connections.model.NewConnectionInfo;
 import org.rstudio.studio.client.workbench.views.console.model.ProcessBufferChunk;
+import org.rstudio.studio.client.workbench.views.console.shell.assist.SqlCompletionParseContext;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.DataImportOptions;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportAssembleResponse;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportPreviewResponse;
@@ -1066,7 +1067,7 @@ public class RemoteServer implements Server
    
    public void sqlGetCompletions(String line,
                                  String connection,
-                                 JsObject context,
+                                 SqlCompletionParseContext context,
                                  ServerRequestCallback<Completions> requestCallback)
    {
       JSONArray params = new JSONArrayBuilder()

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1064,6 +1064,16 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, STAN_RUN_DIAGNOSTICS, params, requestCallback);
    }
    
+   public void sqlGetCompletions(String line,
+                                 ServerRequestCallback<Completions> requestCallback)
+   {
+      JSONArray params = new JSONArrayBuilder()
+            .add(line)
+            .get();
+      
+      sendRequest(RPC_SCOPE, SQL_GET_COMPLETIONS, params, requestCallback);
+   }
+   
    public void getHelpAtCursor(String line, int cursorPos,
                                ServerRequestCallback<Void> requestCallback)
    {
@@ -5900,6 +5910,8 @@ public class RemoteServer implements Server
    private static final String STAN_GET_COMPLETIONS = "stan_get_completions";
    private static final String STAN_GET_ARGUMENTS = "stan_get_arguments";
    private static final String STAN_RUN_DIAGNOSTICS = "stan_run_diagnostics";
+   
+   private static final String SQL_GET_COMPLETIONS = "sql_get_completions";
    
    private static final String GET_CPP_CAPABILITIES = "get_cpp_capabilities";
    private static final String INSTALL_BUILD_TOOLS = "install_build_tools";

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1066,13 +1066,13 @@ public class RemoteServer implements Server
    
    public void sqlGetCompletions(String line,
                                  String connection,
-                                 boolean preferLowercaseKeywords,
+                                 JsObject context,
                                  ServerRequestCallback<Completions> requestCallback)
    {
       JSONArray params = new JSONArrayBuilder()
             .add(line)
             .add(connection)
-            .add(preferLowercaseKeywords)
+            .add(context)
             .get();
       
       sendRequest(RPC_SCOPE, SQL_GET_COMPLETIONS, params, requestCallback);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
@@ -274,20 +274,23 @@ public abstract class CompletionManagerBase
       
       String line = docDisplay_.getCurrentLineUpToCursor();
       
-      // don't complete within comments
       Token token = docDisplay_.getTokenAt(docDisplay_.getCursorPosition());
-      if (token.hasType("comment"))
-         return false;
-      
-      // don't complete within multi-line strings
-      if (token.hasType("string"))
+      if (token != null)
       {
-         String cursorTokenValue = token.getValue();
-         boolean isSingleLineString =
-               cursorTokenValue.startsWith("'") ||
-               cursorTokenValue.startsWith("\"");
-         if (!isSingleLineString)
+         // don't complete within comments
+         if (token.hasType("comment"))
             return false;
+
+         // don't complete within multi-line strings
+         if (token.hasType("string"))
+         {
+            String cursorTokenValue = token.getValue();
+            boolean isSingleLineString =
+                  cursorTokenValue.startsWith("'") ||
+                  cursorTokenValue.startsWith("\"");
+            if (!isSingleLineString)
+               return false;
+         }
       }
       
       CompletionRequestContext.Data data = new CompletionRequestContext.Data(

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/SqlCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/SqlCompletionManager.java
@@ -90,7 +90,8 @@ public class SqlCompletionManager extends CompletionManagerBase
          if (token.hasType("keyword"))
          {
             String value = token.getValue().toLowerCase();
-            if (value.contentEquals("from") || value.contentEquals("join"))
+            if (value.contentEquals("from") || value.contentEquals("into") ||
+                value.contentEquals("join") || value.contentEquals("update"))
             {
                // whitespace
                token = it.stepForward();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/SqlCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/SqlCompletionManager.java
@@ -169,12 +169,12 @@ public class SqlCompletionManager extends CompletionManagerBase
    
    private boolean parseSqlJoin(TokenIterator it, SqlCompletionParseContext ctx)
    {
-      return parseSqlTableScopedKeyword("into", it, ctx);
+      return parseSqlTableScopedKeyword("join", it, ctx);
    }
    
    private boolean parseSqlUpdate(TokenIterator it, SqlCompletionParseContext ctx)
    {
-      return parseSqlTableScopedKeyword("into", it, ctx);
+      return parseSqlTableScopedKeyword("update", it, ctx);
    }
    
    private boolean parseSqlIdentifier(TokenIterator it, SqlCompletionParseContext ctx)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/SqlCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/SqlCompletionManager.java
@@ -1,0 +1,64 @@
+/*
+ * SqlCompletionManager.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.console.shell.assist;
+
+import org.rstudio.studio.client.common.codetools.CodeToolsServerOperations;
+import org.rstudio.studio.client.workbench.views.source.editors.text.CompletionContext;
+import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
+
+import com.google.gwt.event.shared.HandlerRegistration;
+
+public class SqlCompletionManager extends CompletionManagerBase
+                                  implements CompletionManager
+{
+   public SqlCompletionManager(DocDisplay docDisplay,
+                               CompletionPopupDisplay popup,
+                               CodeToolsServerOperations server,
+                               CompletionContext context)
+   {
+      super(popup, docDisplay, context);
+      
+      docDisplay_ = docDisplay;
+      server_ = server;
+      context_ = context;
+   }
+   
+   @Override
+   public void goToHelp()
+   {
+   }
+   
+   @Override
+   public void goToDefinition()
+   {
+   }
+   
+   @Override
+   public void getCompletions(String line,
+                              CompletionRequestContext context)
+   {
+      server_.sqlGetCompletions(line, context);
+   }
+   
+   @Override
+   protected HandlerRegistration[] handlers()
+   {
+      return new HandlerRegistration[] {};
+   }
+   
+   private final DocDisplay docDisplay_;
+   private final CodeToolsServerOperations server_;
+   private final CompletionContext context_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/SqlCompletionParseContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/SqlCompletionParseContext.java
@@ -1,0 +1,29 @@
+/*
+ * SqlCompletionParseContext.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.console.shell.assist;
+
+import org.rstudio.core.client.JsVectorString;
+import org.rstudio.core.client.js.JsMapString;
+
+import jsinterop.annotations.JsType;
+
+@JsType
+public class SqlCompletionParseContext
+{
+   public final JsVectorString identifiers = JsVectorString.createVector();
+   public final JsVectorString tables = JsVectorString.createVector();
+   public final JsMapString aliases = JsMapString.create();
+   public boolean preferLowercaseKeywords = true;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/StanCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/StanCompletionManager.java
@@ -39,7 +39,6 @@ import org.rstudio.studio.client.workbench.views.source.events.SaveFileEvent;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.event.dom.client.FocusEvent;
-import com.google.gwt.event.logical.shared.AttachEvent;
 import com.google.gwt.event.shared.HandlerRegistration;
 
 public class StanCompletionManager extends CompletionManagerBase
@@ -80,13 +79,6 @@ public class StanCompletionManager extends CompletionManagerBase
             });
          }
       };
-      
-      docDisplay_.addAttachHandler((AttachEvent event) -> {
-         if (event.isAttached())
-            attachHandlers();
-         else
-            detachHandlers();
-      });
    }
    
    @Override
@@ -167,12 +159,6 @@ public class StanCompletionManager extends CompletionManagerBase
       // TODO Auto-generated method stub
    }
 
-   @Override
-   public void codeCompletion()
-   {
-      beginSuggest(true, false, true);
-   }
-   
    private void runDiagnostics(final boolean useSourceDatabase)
    {
       // TODO: can we enable this in R Markdown documents using Stan?
@@ -243,16 +229,14 @@ public class StanCompletionManager extends CompletionManagerBase
             annotation.type());
    }
    
-   private void attachHandlers()
+   protected HandlerRegistration[] handlers()
    {
-      detachHandlers();
-      
-      handlers_ = new HandlerRegistration[] {
-            
+      return new HandlerRegistration[] {
+
             docDisplay_.addFocusHandler((FocusEvent event) -> {
                runDiagnostics(true);
             }),
-            
+
             docDisplay_.addSaveCompletedHandler((SaveFileEvent event) -> {
                boolean useSourceDatabase = event.isAutosave();
                runDiagnostics(useSourceDatabase);
@@ -261,21 +245,9 @@ public class StanCompletionManager extends CompletionManagerBase
       };
    }
    
-   private void detachHandlers()
-   {
-      if (handlers_ != null)
-      {
-         for (HandlerRegistration handler : handlers_)
-            handler.removeHandler();
-         handlers_ = null;
-      }
-   }
-
    private final DocDisplay docDisplay_;
    private final CodeToolsServerOperations server_;
    private final CompletionContext context_;
    
    private final SignatureToolTipManager sigTips_;
-   
-   private HandlerRegistration[] handlers_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -86,6 +86,7 @@ import org.rstudio.studio.client.workbench.views.console.shell.assist.Delegating
 import org.rstudio.studio.client.workbench.views.console.shell.assist.NullCompletionManager;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.PythonCompletionManager;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.RCompletionManager;
+import org.rstudio.studio.client.workbench.views.console.shell.assist.SqlCompletionManager;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.StanCompletionManager;
 import org.rstudio.studio.client.workbench.views.console.shell.editor.InputEditorDisplay;
 import org.rstudio.studio.client.workbench.views.console.shell.editor.InputEditorPosition;
@@ -766,6 +767,16 @@ public class AceEditor implements DocDisplay,
                         editor,
                         new Filter(),
                         cppContext_));
+               }
+               
+               // SQL completion manager
+               if (fileType_.isSql() || fileType_.isRmd())
+               {
+                  managers.put(DocumentMode.Mode.SQL, new SqlCompletionManager(
+                        editor,
+                        new CompletionPopupPanel(),
+                        server_,
+                        context_));
                }
                
                // Stan completion manager

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Token.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Token.java
@@ -57,6 +57,11 @@ public class Token extends JavaScriptObject
       return value == getValue();
    }
    
+   public final boolean valueMatches(String pattern)
+   {
+      return getValue().matches(pattern);
+   }
+   
    public final boolean hasAllTypes(String... types)
    {
       String tokenType = getType();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/TokenIterator.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/TokenIterator.java
@@ -143,6 +143,29 @@ public class TokenIterator extends JavaScriptObject
       return this.moveToEndOfRow();
    }-*/;
    
+   public final boolean moveToNextSignificantToken()
+   {
+      if (!moveToNextToken())
+         return false;
+      
+      return skipWhitespaceAndComments();
+   }
+   
+   public final boolean skipWhitespaceAndComments()
+   {
+      Token token = getCurrentToken();
+      
+      for (; token != null; token = stepForward())
+      {
+         if (token.hasType("comment") || token.valueMatches("\\s*"))
+            continue;
+         
+         break;
+      }
+      
+      return token != null;
+   }
+   
    public final boolean valueEquals(String value)
    {
       Token token = getCurrentToken();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/TokenIterator.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/TokenIterator.java
@@ -125,6 +125,10 @@ public class TokenIterator extends JavaScriptObject
       return moveToPosition(Position.create(row, column));
    }
    
+   public final native Token moveToStartOfRow() /*-{
+      return this.moveToStartOfRow();
+   }-*/;
+   
    public final native Token moveToEndOfRow() /*-{
       return this.moveToEndOfRow();
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/TokenIterator.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/TokenIterator.java
@@ -90,14 +90,24 @@ public class TokenIterator extends JavaScriptObject
       return this.getCurrentTokenColumn();
    }-*/;
    
-   public native final boolean findTokenBwd(String token, boolean skipMatching)
+   public native final boolean findTokenTypeBwd(String token, boolean skipMatching)
    /*-{
-      return this.findTokenBwd(token, skipMatching);
+      return this.findTokenTypeBwd(token, skipMatching);
    }-*/;
    
-   public native final boolean findTokenFwd(String token, boolean skipMatching)
+   public native final boolean findTokenTypeFwd(String token, boolean skipMatching)
    /*-{
-      return this.findTokenFwd(token, skipMatching);
+      return this.findTokenTypeFwd(token, skipMatching);
+   }-*/;
+   
+   public native final boolean findTokenValueBwd(String token, boolean skipMatching)
+   /*-{
+      return this.findTokenValueBwd(token, skipMatching);
+   }-*/;
+   
+   public native final boolean findTokenValueFwd(String token, boolean skipMatching)
+   /*-{
+      return this.findTokenValueFwd(token, skipMatching);
    }-*/;
    
    public native final boolean fwdToMatchingToken() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/assist/RChunkHeaderParser.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/assist/RChunkHeaderParser.java
@@ -1,0 +1,137 @@
+/*
+ * RChunkHeaderParser.java
+ *
+ * Copyright (C) 2009-12 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text.assist;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.rstudio.core.client.RegexUtil;
+import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.TextCursor;
+import org.rstudio.core.client.regex.Match;
+import org.rstudio.core.client.regex.Pattern;
+
+public class RChunkHeaderParser
+{
+   public static Map<String, String> parse(String header)
+   {
+      Map<String, String> options = new HashMap<String, String>();
+      
+      // determine an appropriate pattern for extracting options from
+      // this header (infer based on the line contents)
+      Pattern pattern = null;
+      if (RegexUtil.RE_RMARKDOWN_CHUNK_BEGIN.test(header))
+         pattern = RegexUtil.RE_RMARKDOWN_CHUNK_BEGIN;
+      else if (RegexUtil.RE_SWEAVE_CHUNK_BEGIN.test(header))
+         pattern = RegexUtil.RE_SWEAVE_CHUNK_BEGIN;
+      else if (RegexUtil.RE_RHTML_CHUNK_BEGIN.test(header))
+         pattern = RegexUtil.RE_RHTML_CHUNK_BEGIN;
+      
+      if (pattern == null)
+         return options;
+      
+      Match match = pattern.match(header,  0);
+      if (match == null)
+         return options;
+      
+      String extracted = match.getGroup(1);
+      String chunkLabel = extractChunkLabel(extracted);
+      
+      // if we had a chunk label, then we want to navigate our cursor to
+      // the first comma in the chunk header; otherwise, we start at the
+      // first space. this is done to accept chunk headers of the form
+      //
+      //    ```{r message=FALSE}
+      //
+      // ie, those with no comma after the engine used
+      int argsStartIdx = StringUtil.isNullOrEmpty(chunkLabel)
+            ? extracted.indexOf(' ')
+            : extracted.indexOf(',');
+      
+      String arguments = extracted.substring(argsStartIdx + 1);
+      TextCursor cursor = new TextCursor(arguments);
+      
+      // consume commas and whitespace if needed
+      cursor.consumeUntilRegex("[^\\s,]");
+      
+      int startIndex = 0;
+      do
+      {
+         if (!cursor.fwdToCharacter('=', false))
+            break;
+         
+         int equalsIndex = cursor.getIndex();
+         int endIndex = arguments.length();
+         if (cursor.fwdToCharacter(',', true) ||
+             cursor.fwdToCharacter(' ', true))
+         {
+            endIndex = cursor.getIndex();
+         }
+         
+         options.put(
+               arguments.substring(startIndex, equalsIndex).trim(),
+               arguments.substring(equalsIndex + 1, endIndex).trim());
+         
+         startIndex = cursor.getIndex() + 1;
+      }
+      while (cursor.moveToNextCharacter());
+      
+      
+      return options;
+   }
+   
+   private static String extractChunkLabel(String extractedChunkHeader)
+   {
+      // if there are no spaces within the chunk header,
+      // there cannot be a label. this implies a header of the form
+      //
+      //    ```{r}
+      //
+      int firstSpaceIdx = extractedChunkHeader.indexOf(' ');
+      if (firstSpaceIdx == -1)
+         return "";
+      
+      // find the indices of the first '=' and ',' characters
+      int firstEqualsIdx = extractedChunkHeader.indexOf('=');
+      int firstCommaIdx  = extractedChunkHeader.indexOf(',');
+      
+      // if we found neither an '=' nor a ',', then the label
+      // must be all the text following the first space. this implies
+      // a layout of the form:
+      //
+      //    ```{r label}
+      //
+      if (firstEqualsIdx == -1 && firstCommaIdx == -1)
+         return extractedChunkHeader.substring(firstSpaceIdx + 1).trim();
+      
+      // if we found an '=' before we found a ',' (or we didn't find
+      // a ',' at all), that implies a chunk header like:
+      //
+      //    ```{r message=TRUE, echo=FALSE}
+      //
+      // and so there is no label.
+      if (firstCommaIdx == -1)
+         return "";
+         
+      if (firstEqualsIdx != -1 && firstEqualsIdx < firstCommaIdx)
+         return "";
+      
+      // otherwise, the text from the first space to that comma gives the label
+      //
+      //    ```{r label, message=TRUE}
+      //
+      return extractedChunkHeader.substring(firstSpaceIdx + 1, firstCommaIdx).trim();
+   }
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/assist/RChunkHeaderParser.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/assist/RChunkHeaderParser.java
@@ -48,6 +48,8 @@ public class RChunkHeaderParser
       
       String extracted = match.getGroup(1);
       String chunkLabel = extractChunkLabel(extracted);
+      if (!StringUtil.isNullOrEmpty(chunkLabel))
+         options.put("label", chunkLabel);
       
       // if we had a chunk label, then we want to navigate our cursor to
       // the first comma in the chunk header; otherwise, we start at the

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/SignatureToolTipManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/SignatureToolTipManager.java
@@ -446,7 +446,7 @@ public class SignatureToolTipManager
           uiPrefs_.showFunctionTooltipOnIdle().getGlobalValue() &&
           !cursor.valueEquals("("))
       {
-         cursor.findTokenBwd("(", true);
+         cursor.findTokenValueBwd("(", true);
       }
       
       Token lookahead = cursor.peekFwd(1);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/SignatureToolTipManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/SignatureToolTipManager.java
@@ -450,9 +450,12 @@ public class SignatureToolTipManager
       }
       
       Token lookahead = cursor.peekFwd(1);
-      if (lookahead.valueEquals("::") || lookahead.valueEquals(":::"))
-         if (!cursor.moveToNextToken())
-            return;
+      if (lookahead != null)
+      {
+         if (lookahead.valueEquals("::") || lookahead.valueEquals(":::"))
+            if (!cursor.moveToNextToken())
+               return;
+      }
       
       if (cursor.valueEquals("::") || cursor.valueEquals(":::"))
          if (!cursor.moveToNextToken())

--- a/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
+++ b/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
@@ -22,6 +22,7 @@ import org.rstudio.core.client.VirtualConsoleTests;
 import org.rstudio.core.client.dom.DomUtilsTests;
 import org.rstudio.studio.client.common.r.RTokenizerTests;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobManagerTests;
+import org.rstudio.studio.client.workbench.views.source.editors.text.assist.RChunkHeaderParserTests;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalLocalEchoTests;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalSessionSocketTests;
 
@@ -31,19 +32,20 @@ import junit.framework.Test;
 
 public class RStudioUnitTestSuite extends GWTTestSuite
 {
-    public static Test suite()
-    {
-        GWTTestSuite suite = new GWTTestSuite("RStudio Unit Test Suite");
-        suite.addTestSuite(RTokenizerTests.class);
-        suite.addTestSuite(VirtualConsoleTests.class);
-        suite.addTestSuite(ConsoleOutputWriterTests.class);
-        suite.addTestSuite(StringUtilTests.class);
-        suite.addTestSuite(DomUtilsTests.class);
-        suite.addTestSuite(AnsiCodeTests.class);
-        suite.addTestSuite(TerminalLocalEchoTests.class);
-        suite.addTestSuite(TerminalSessionSocketTests.class);
-        suite.addTestSuite(JobManagerTests.class);
-        suite.addTestSuite(URIUtilsTests.class);
-        return suite;
-    }
+   public static Test suite()
+   {
+      GWTTestSuite suite = new GWTTestSuite("RStudio Unit Test Suite");
+      suite.addTestSuite(RTokenizerTests.class);
+      suite.addTestSuite(VirtualConsoleTests.class);
+      suite.addTestSuite(ConsoleOutputWriterTests.class);
+      suite.addTestSuite(StringUtilTests.class);
+      suite.addTestSuite(DomUtilsTests.class);
+      suite.addTestSuite(AnsiCodeTests.class);
+      suite.addTestSuite(TerminalLocalEchoTests.class);
+      suite.addTestSuite(TerminalSessionSocketTests.class);
+      suite.addTestSuite(JobManagerTests.class);
+      suite.addTestSuite(URIUtilsTests.class);
+      suite.addTestSuite(RChunkHeaderParserTests.class);
+      return suite;
+   }
 }

--- a/src/gwt/test/org/rstudio/studio/client/workbench/views/source/editors/text/assist/RChunkHeaderParserTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/workbench/views/source/editors/text/assist/RChunkHeaderParserTests.java
@@ -1,0 +1,65 @@
+/*
+ * RChunkHeaderParserTests.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text.assist;
+
+import com.google.gwt.junit.client.GWTTestCase;
+
+import java.util.Map;
+
+public class RChunkHeaderParserTests extends GWTTestCase
+{
+   @Override
+   public String getModuleName()
+   {
+      return "org.rstudio.studio.RStudioTests";
+   }
+   
+   public void testRMarkdownChunkHeader()
+   {
+      String header = "```{r label, echo=TRUE}";
+      Map<String, String> pieces = RChunkHeaderParser.parse(header);
+      assertTrue(pieces.containsKey("label"));
+      assertTrue(pieces.containsKey("echo"));
+      assertTrue(pieces.get("label").contentEquals("label"));
+      assertTrue(pieces.get("echo").contentEquals("TRUE"));
+   }
+   
+   public void testNoCommaBeforeFirstItem()
+   {
+      String header = "```{r echo=TRUE}";
+      Map<String, String> pieces = RChunkHeaderParser.parse(header);
+      assertTrue(pieces.containsKey("echo"));
+      assertTrue(pieces.get("echo").contentEquals("TRUE"));
+   }
+   
+   public void testCommaBeforeFirstItem()
+   {
+      String header = "```{r, echo=TRUE}";
+      Map<String, String> pieces = RChunkHeaderParser.parse(header);
+      assertTrue(pieces.containsKey("echo"));
+      assertTrue(pieces.get("echo").contentEquals("TRUE"));
+   }
+   
+   public void testComplicatedExpression()
+   {
+      String header = "```{r, echo= {1 + 1}, message=FALSE}";
+      Map<String, String> pieces = RChunkHeaderParser.parse(header);
+      assertTrue(pieces.containsKey("echo"));
+      assertTrue(pieces.get("echo").contentEquals("{1 + 1}"));
+      assertTrue(pieces.containsKey("message"));
+      assertTrue(pieces.get("message").contentEquals("FALSE"));
+   }
+
+}


### PR DESCRIPTION
NOTE: Not quite ready for merge (still needs refinement) but putting up for some discussion.

---

This PR implements a completion engine for SQL code:

![screen shot 2018-09-05 at 2 32 48 pm](https://user-images.githubusercontent.com/1976582/45122444-afb4e700-b118-11e8-829e-022de499ea2f.png)

In particular, we provide completions for:

1. SQL keywords,
2. Tables associated with the current connection,
3. Fields associated with all tables on the current connection.

Note: I'm guessing that (2) and (3) could be quite expensive, so I'm curious if there's a way we could more intelligently populate and / or cache these -- suggestions are welcome. Some thoughts:

1. We could enumerate the context wherein a table name is expected, and only provide the table names there;

2. In other contexts, we could draw field names from the set of tables that have been specified thus far.