### PR TITLE
fix issue with double-printing of R banner on Windows

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerEventListener.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerEventListener.java
@@ -198,7 +198,8 @@ class RemoteServerEventListener
         //   2) the user navigates Back within a Frame 
         //
         // can only imagine that it could happen in other scenarios!
-        watchdog_.schedule(kWatchdogIntervalMs);
+        if (!watchdog_.isRunning())
+           watchdog_.schedule(kWatchdogIntervalMs);
      }
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerEventListener.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerEventListener.java
@@ -20,6 +20,7 @@ import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.Window.ClosingEvent;
 import com.google.gwt.user.client.Window.ClosingHandler;
+
 import org.rstudio.core.client.jsonrpc.RpcError;
 import org.rstudio.core.client.jsonrpc.RpcRequest;
 import org.rstudio.core.client.jsonrpc.RpcRequestCallback;
@@ -197,9 +198,7 @@ class RemoteServerEventListener
         //   2) the user navigates Back within a Frame 
         //
         // can only imagine that it could happen in other scenarios!
-   
-        if (!watchdog_.isRunning())
-          watchdog_.run(kWatchdogIntervalMs);
+        watchdog_.schedule(kWatchdogIntervalMs);
      }
    }
    
@@ -254,7 +253,7 @@ class RemoteServerEventListener
          public void onResponseReceived(JsArray<ClientEvent> events)
          {
             // keep watchdog appraised of successful receipt of events
-            watchdog_.notifyResponseReceived();
+            watchdog_.cancel();
             
             try
             {
@@ -349,6 +348,10 @@ class RemoteServerEventListener
          }
       };
       
+      // bump the watchdog timer if it's running
+      if (watchdog_.isRunning())
+         watchdog_.schedule(kWatchdogIntervalMs);
+      
       // send request
       activeRequest_ = server_.getEvents(lastEventId_, 
                                          activeRequestCallback_,
@@ -406,51 +409,23 @@ class RemoteServerEventListener
    // were already delivered and subsequently assumes that the service
    // needs to be restarted
    
-   private class Watchdog
+   private class Watchdog extends Timer
    {  
-      public void run(int waitMs)
+      @Override
+      public void run()
       {
-         isRunning_ = true;
-         responseReceived_ = false ;
-         
-         Timer timer = new Timer() {
-            public void run()
-            {
-               try
-               {
-                  if (!responseReceived_)
-                  {
-                     // ensure that the workbench wasn't closed while we
-                     // were waiting for the timer to run
-                     if (!sessionWasQuit_) 
-                        restart();
-                  }
-               }
-               catch(Throwable e)
-               {
-                  GWT.log("Error restarting event source", e);
-               }
-               
-               isRunning_ = false;
-               responseReceived_ = false ;
-            }
-          
-         };
-         timer.schedule(waitMs);
+         try
+         {
+            // ensure that the workbench wasn't closed while we
+            // were waiting for the timer to run
+            if (!sessionWasQuit_)
+               restart();
+         }
+         catch(Throwable e)
+         {
+            GWT.log("Error restarting event source", e);
+         }
       }
-      
-      public boolean isRunning()
-      {
-         return isRunning_ ;
-      }
-      
-      public void notifyResponseReceived()
-      {
-         responseReceived_ = true;
-      }
-      
-      private boolean isRunning_ = false;
-      private boolean responseReceived_ = false;
    }
 
    public void registerAsyncHandle(String asyncHandle,


### PR DESCRIPTION
This PR fixes an issue where the R banner would occasionally be printed twice on startup, primarily on Windows.

The ultimate issue is that we end up making two `get_events` requests with the same event ID `-1`. Here's my understanding as to how we get there:

1. An initial `get_events` call with id `-1` is made. The `console_output` event (alongside some other events) is returned to the client, and that output is sent to the console.

2. A number of other interleaving JSON RPCs are made during initialization. Some of these don't set any response. When this occurs, we assume (as a default) that more pending events are on the way, and so as a side-effect launch a watchdog timer that double-checks that we receive a `get_events` response in a timely manner.

https://github.com/rstudio/rstudio/blob/0a706e50a5284dcad52943195034c1fc0a5beb5b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java#L3148-L3153

https://github.com/rstudio/rstudio/blob/0a706e50a5284dcad52943195034c1fc0a5beb5b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java#L3186-L3193

In particular, note that a null response or 'empty' response won't have the `ep` field set, and so those will prompt the client to start its watchdog timer to check for `get_events`:

https://github.com/rstudio/rstudio/blob/0a706e50a5284dcad52943195034c1fc0a5beb5b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerEventListener.java#L201-L202

3. A new `get_events` request is made, approximately 1 second after the watchdog timer was launched by one of the prior JSON RPCs. This `get_events` request has an updated ID number.

4. The watchdog timer fires, detects that we haven't received a `get_events` response yet (even though a fresh one is now in flight!), and so restarts the service. This implies killing the active `get_events` request, and (most importantly for this bug) resetting the event number to -1.

https://github.com/rstudio/rstudio/blob/343d6a73f8ea0670379c5e3828cc73ba04bd13bb/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerEventListener.java#L111-L122

5. A new `get_events` request is made, with id -1. Note that the server only clears the event queue after it's knowingly serviced a new `get_events` request, with an id greater than the previously-received id. See:

https://github.com/rstudio/rstudio/blob/343d6a73f8ea0670379c5e3828cc73ba04bd13bb/src/cpp/session/SessionClientEventService.cpp#L278-L279

This implies that the server will respond with the same set of events a were seen in (1).

6. The server responses with the same set of events as before, including the console output, and then replays the R banner onto the console a second time.

Based on this, I think the issue is ultimately caused by an over-eager watchdog timer. We relax the watchdog timer a bit by:

1. Re-scheduling the watchdog every time a new JSON RPC response is received (so that `get_events` gets another second to respond after some RPC response is made),

2. We reset the timer when a new `get_events` request is made (so that the watchdog doesn't erroneously shoot a `get_events` request that was just started)

Closes #3439.

cc: @jjallaire