### PR TITLE
ensure vignettes are opened on request (closes #3443)

### DIFF
--- a/src/cpp/desktop/DesktopUtils.cpp
+++ b/src/cpp/desktop/DesktopUtils.cpp
@@ -409,6 +409,11 @@ QFileDialog::Options standardFileDialogOptions()
 
 #else
 
+void openFile(const QString& file)
+{
+   QDesktopServices::openUrl(QUrl::fromLocalFile(file));
+}
+
 void openUrl(const QUrl& url)
 {
    QDesktopServices::openUrl(url);

--- a/src/cpp/desktop/DesktopUtils.cpp
+++ b/src/cpp/desktop/DesktopUtils.cpp
@@ -362,6 +362,11 @@ double getDpiZoomScaling()
 
 #ifdef _WIN32
 
+void openFile(const QString& file)
+{
+   return openUrl(QUrl::fromLocalFile(file));
+}
+
 // on Win32 open urls using our special urlopener.exe -- this is
 // so that the shell exec is made out from under our windows "job"
 void openUrl(const QUrl& url)

--- a/src/cpp/desktop/DesktopUtils.hpp
+++ b/src/cpp/desktop/DesktopUtils.hpp
@@ -92,6 +92,7 @@ void showFileError(const QString& action,
 
 bool isFixedWidthFont(const QFont& font);
 
+void openFile(const QString& file);
 void openUrl(const QUrl& url);
 
 void enableFullscreenMode(QMainWindow* pMainWindow, bool primary);

--- a/src/cpp/desktop/DesktopWebPage.cpp
+++ b/src/cpp/desktop/DesktopWebPage.cpp
@@ -83,8 +83,8 @@ void onPdfDownloadRequested(QWebEngineDownloadItem* downloadItem)
    // if we're requesting the download of a file with a '.pdf' extension,
    // re-use that file name (since most desktop applications will display the
    /// associated filename somewhere visible)
-   QString fileName = downloadItem->url().fileName();
-   if (fileName.endsWith(QStringLiteral(".pdf")))
+   QString fileName = downloadItem->url().fileName(QUrl::RemoveQuery | QUrl::RemoveFragment);
+   if (fileName.endsWith(QStringLiteral(".pdf"), Qt::CaseInsensitive))
    {
       QTemporaryDir tempDir(QStringLiteral("%1/").arg(scratchDir));
       tempDir.setAutoRemove(false);

--- a/src/cpp/desktop/DesktopWebPage.cpp
+++ b/src/cpp/desktop/DesktopWebPage.cpp
@@ -83,7 +83,7 @@ void onPdfDownloadRequested(QWebEngineDownloadItem* downloadItem)
    // if we're requesting the download of a file with a '.pdf' extension,
    // re-use that file name (since most desktop applications will display the
    // associated filename somewhere visible)
-   QString fileName = downloadItem->url().fileName(QUrl::RemoveQuery | QUrl::RemoveFragment);
+   QString fileName = downloadItem->url().fileName();
    if (fileName.endsWith(QStringLiteral(".pdf"), Qt::CaseInsensitive))
    {
       QTemporaryDir tempDir(QStringLiteral("%1/").arg(scratchDir));

--- a/src/cpp/desktop/DesktopWebPage.cpp
+++ b/src/cpp/desktop/DesktopWebPage.cpp
@@ -82,7 +82,7 @@ void onPdfDownloadRequested(QWebEngineDownloadItem* downloadItem)
    
    // if we're requesting the download of a file with a '.pdf' extension,
    // re-use that file name (since most desktop applications will display the
-   /// associated filename somewhere visible)
+   // associated filename somewhere visible)
    QString fileName = downloadItem->url().fileName(QUrl::RemoveQuery | QUrl::RemoveFragment);
    if (fileName.endsWith(QStringLiteral(".pdf"), Qt::CaseInsensitive))
    {


### PR DESCRIPTION
This PR ensures that attempts to download `.pdf` files will download those files to a temporary directory and immediately open them, rather than prompting the user to download those files to a particular directory. This ensures that attempts to open vignettes from the help page work as expected, and brings us back in line with v1.1 behavior.