### PR TITLE
lazily refresh Git branch menu

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/JsVector.java
+++ b/src/gwt/src/org/rstudio/core/client/JsVector.java
@@ -171,15 +171,30 @@ public class JsVector<T> extends JavaScriptObject
       return shift(defaultValue());
    }
    
+   private final native T shift(T defaultValue)
+   /*-{
+      return this.shift() || defaultValue;
+   }-*/;
+   
    public final int size()
    {
       return length();
    }
    
-   private final native T shift(T defaultValue)
+   public final native JsVector<T> slice(int begin, int end)
    /*-{
-      return this.shift() || defaultValue;
+      return this.slice(begin, end);
    }-*/;
+   
+   public final JsVector<T> slice(int begin)
+   {
+      return slice(begin, length());
+   }
+   
+   public final JsVector<T> slice()
+   {
+      return slice(0, length());
+   }
    
    public final native void splice(int start, int deleteCount, JsVector<T> vector)
    /*-{

--- a/src/gwt/src/org/rstudio/core/client/JsVectorBoolean.java
+++ b/src/gwt/src/org/rstudio/core/client/JsVectorBoolean.java
@@ -171,15 +171,30 @@ public class JsVectorBoolean extends JavaScriptObject
       return shift(defaultValue());
    }
    
+   private final native boolean shift(boolean defaultValue)
+   /*-{
+      return this.shift() || defaultValue;
+   }-*/;
+   
    public final int size()
    {
       return length();
    }
    
-   private final native boolean shift(boolean defaultValue)
+   public final native JsVectorBoolean slice(int begin, int end)
    /*-{
-      return this.shift() || defaultValue;
+      return this.slice(begin, end);
    }-*/;
+   
+   public final JsVectorBoolean slice(int begin)
+   {
+      return slice(begin, length());
+   }
+   
+   public final JsVectorBoolean slice()
+   {
+      return slice(0, length());
+   }
    
    public final native void splice(int start, int deleteCount, JsVectorBoolean vector)
    /*-{

--- a/src/gwt/src/org/rstudio/core/client/JsVectorInteger.java
+++ b/src/gwt/src/org/rstudio/core/client/JsVectorInteger.java
@@ -171,15 +171,30 @@ public class JsVectorInteger extends JavaScriptObject
       return shift(defaultValue());
    }
    
+   private final native int shift(int defaultValue)
+   /*-{
+      return this.shift() || defaultValue;
+   }-*/;
+   
    public final int size()
    {
       return length();
    }
    
-   private final native int shift(int defaultValue)
+   public final native JsVectorInteger slice(int begin, int end)
    /*-{
-      return this.shift() || defaultValue;
+      return this.slice(begin, end);
    }-*/;
+   
+   public final JsVectorInteger slice(int begin)
+   {
+      return slice(begin, length());
+   }
+   
+   public final JsVectorInteger slice()
+   {
+      return slice(0, length());
+   }
    
    public final native void splice(int start, int deleteCount, JsVectorInteger vector)
    /*-{

--- a/src/gwt/src/org/rstudio/core/client/JsVectorNumber.java
+++ b/src/gwt/src/org/rstudio/core/client/JsVectorNumber.java
@@ -171,15 +171,30 @@ public class JsVectorNumber extends JavaScriptObject
       return shift(defaultValue());
    }
    
+   private final native double shift(double defaultValue)
+   /*-{
+      return this.shift() || defaultValue;
+   }-*/;
+   
    public final int size()
    {
       return length();
    }
    
-   private final native double shift(double defaultValue)
+   public final native JsVectorNumber slice(int begin, int end)
    /*-{
-      return this.shift() || defaultValue;
+      return this.slice(begin, end);
    }-*/;
+   
+   public final JsVectorNumber slice(int begin)
+   {
+      return slice(begin, length());
+   }
+   
+   public final JsVectorNumber slice()
+   {
+      return slice(0, length());
+   }
    
    public final native void splice(int start, int deleteCount, JsVectorNumber vector)
    /*-{

--- a/src/gwt/src/org/rstudio/core/client/JsVectorString.java
+++ b/src/gwt/src/org/rstudio/core/client/JsVectorString.java
@@ -171,15 +171,30 @@ public class JsVectorString extends JavaScriptObject
       return shift(defaultValue());
    }
    
+   private final native String shift(String defaultValue)
+   /*-{
+      return this.shift() || defaultValue;
+   }-*/;
+   
    public final int size()
    {
       return length();
    }
    
-   private final native String shift(String defaultValue)
+   public final native JsVectorString slice(int begin, int end)
    /*-{
-      return this.shift() || defaultValue;
+      return this.slice(begin, end);
    }-*/;
+   
+   public final JsVectorString slice(int begin)
+   {
+      return slice(begin, length());
+   }
+   
+   public final JsVectorString slice()
+   {
+      return slice(0, length());
+   }
    
    public final native void splice(int start, int deleteCount, JsVectorString vector)
    /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
@@ -323,6 +323,8 @@ public class BranchToolbarButton extends ToolbarButton
             });
             menu.addSeparator();
             
+            // truncate list when we have too many branches
+            int n = 0;
             for (String branch : branches)
             {
                // skip detached branches
@@ -334,12 +336,15 @@ public class BranchToolbarButton extends ToolbarButton
                   continue;
                
                // construct branch label without remotes prefix
-
                final String branchLabel = branch.replaceAll("^remotes/" + caption + "/", "");
                final String branchValue = branch.replaceAll("\\s+\\-\\>.*", "");
                menu.addItem(new MenuItem(
                      branchLabel,
                      new SwitchBranchCommand(branchLabel, branchValue)));
+               
+               // update branch count
+               if (n++ > MAX_BRANCHES)
+                  break;
             }
          }
       });
@@ -490,6 +495,8 @@ public class BranchToolbarButton extends ToolbarButton
    
    private String lastSearchValue_;
    private final Timer searchValueChangeTimer_;
+   
+   private static final int MAX_BRANCHES = 100;
 
    private static final String NO_BRANCH = "(no branch)";
    private static final String NO_BRANCHES_AVAILABLE = "(no branches available)";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
@@ -189,6 +189,7 @@ public class BranchToolbarButton extends ToolbarButton
       {
          branches_ = branches.slice().cast();
          menuRebuildRequired_ = true;
+         return;
       }
       
       for (int i = 0; i < branches.length(); i++)
@@ -197,7 +198,7 @@ public class BranchToolbarButton extends ToolbarButton
          {
             branches_ = branches.slice();
             menuRebuildRequired_ = true;
-            break;
+            return;
          }
       }
    }


### PR DESCRIPTION
When the RStudio window is focused, we attempt to refresh Git-related state to ensure that elements in the Git pane are up to date. This includes rebuilding the Git branch menu. Unfortunately, this operation can be very slow when there are a large number of branches, as we don't make any effort to truncate the list of branch menu items when populating that list. This can cause an IDE pause (~1 second or more) for projects with a lot of branches (RStudio itself being one).

This PR mitigates the issue in a couple ways:

1. We re-populate the branch menu on-demand; that is, we wait until the user actually clicks on the git branch toolbar button and actually requests the menu (no need to build the menu before we show it to the user),

2. We cache the last-used set of branches, and only update the branch menu if the set of branches has indeed changed since the last git status check;

3. We only show 100 results at a time in the menu, with the onus on the user to filter using the search widget if they desire a more specific branch.

This PR also brings in a wrapper for `slice()` as part of our `JsVector<T>` classes. (These are effectively augmented versions of `JsArray<T>` and provide access to more array methods + other utility functions)

Closes https://github.com/rstudio/rstudio/issues/3338.