### PR TITLE
Add some better handling when a theme is unexpectedly missing

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -248,7 +248,6 @@ public class AppearancePreferencesPane extends PreferencesPane
       preview_ = new AceEditorPreview(CODE_SAMPLE);
       preview_.setHeight(previewDefaultHeight_);
       preview_.setWidth("278px");
-      preview_.setTheme(currentTheme.getUrl());
       preview_.setFontSize(Double.parseDouble(fontSize_.getValue()));
       updatePreviewZoomLevel();
       previewPanel.add(preview_);
@@ -316,6 +315,7 @@ public class AppearancePreferencesPane extends PreferencesPane
             
             theme_.setChoices(themeList_.keySet().toArray(new String[0]));
             theme_.setValue(currentTheme.getName());
+            preview_.setTheme(currentTheme.getUrl());
             removeThemeButton_.setEnabled(!currentTheme.isDefaultTheme());
          },
          getProgressIndicator());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -25,6 +25,7 @@ import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.inject.Inject;
 
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.ThemeFonts;
@@ -330,9 +331,13 @@ public class AppearancePreferencesPane extends PreferencesPane
          {
             themeList_ = themeList;
             
-            // Focused theme should be in the list by now.
-            assert(themeList_.containsKey(focusedThemeName));
-            AceTheme focusedTheme = themeList.get(focusedThemeName);
+            String themeName = focusedThemeName;
+            if (!themeList.containsKey(themeName))
+            {
+               Debug.logWarning("The theme \"" + focusedThemeName + "\" does not exist. It may have been manually deleted outside the context of RStudio.");
+               themeName = AceTheme.createDefault().getName();
+            }
+            AceTheme focusedTheme = themeList.get(themeName);
             
             theme_.setChoices(themeList_.keySet().toArray(new String[0]));
             theme_.setValue(focusedTheme.getName());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -312,9 +312,20 @@ public class AppearancePreferencesPane extends PreferencesPane
             AceTheme currentTheme = uiPrefs_.theme().getGlobalValue();
             if (!themeList_.containsKey(currentTheme.getName()))
             {
+               StringBuilder warningMsg = new StringBuilder();
+               warningMsg.append("The active theme \"")
+                  .append(currentTheme.getName())
+                  .append("\" could not be found. It's possible it was removed outside the context of RStudio. Switching the ")
+                  .append(currentTheme.isDark() ? "dark " : "light ")
+                  .append("default theme: \"");
+               
                currentTheme = AceTheme.createDefault(currentTheme.isDark());
                uiPrefs_.theme().setGlobalValue(currentTheme);
                preview_.setTheme(currentTheme.getUrl());
+               
+               warningMsg.append(currentTheme.getName())
+                  .append("\".");
+               Debug.logWarning(warningMsg.toString());
             }
             
             theme_.setChoices(themeList_.keySet().toArray(new String[0]));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -249,6 +249,7 @@ public class AppearancePreferencesPane extends PreferencesPane
       preview_.setHeight(previewDefaultHeight_);
       preview_.setWidth("278px");
       preview_.setFontSize(Double.parseDouble(fontSize_.getValue()));
+      preview_.setTheme(currentTheme.getUrl());
       updatePreviewZoomLevel();
       previewPanel.add(preview_);
 
@@ -311,11 +312,12 @@ public class AppearancePreferencesPane extends PreferencesPane
             if (!themeList_.containsKey(currentTheme.getName()))
             {
                currentTheme = AceTheme.createDefault(currentTheme.isDark());
+               uiPrefs_.theme().setGlobalValue(currentTheme);
+               preview_.setTheme(currentTheme.getUrl());
             }
             
             theme_.setChoices(themeList_.keySet().toArray(new String[0]));
             theme_.setValue(currentTheme.getName());
-            preview_.setTheme(currentTheme.getUrl());
             removeThemeButton_.setEnabled(!currentTheme.isDefaultTheme());
          },
          getProgressIndicator());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -306,8 +306,17 @@ public class AppearancePreferencesPane extends PreferencesPane
          {
             themeList_ = themeList;
          
+            // It's possible the current theme was removed outside the context of
+            // RStudio, so choose a default if it can't be found.
+            AceTheme currentTheme = uiPrefs_.theme().getGlobalValue();
+            if (!themeList_.containsKey(currentTheme.getName()))
+            {
+               currentTheme = AceTheme.createDefault(currentTheme.isDark());
+            }
+            
             theme_.setChoices(themeList_.keySet().toArray(new String[0]));
-            theme_.setValue(uiPrefs_.theme().getGlobalValue().getName());
+            theme_.setValue(currentTheme.getName());
+            removeThemeButton_.setEnabled(!currentTheme.isDefaultTheme());
          },
          getProgressIndicator());
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceTheme.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceTheme.java
@@ -28,7 +28,19 @@ public class AceTheme extends JavaScriptObject
    
    public static final AceTheme createDefault()
    {
-      return create("Textmate (default)", "theme/default/textmate.rstheme", false);
+      return createDefault(false);
+   }
+   
+   public static final AceTheme createDefault(boolean isDark)
+   {
+      if (isDark)
+      {
+         return create("Tomorrow Night", "theme/default/tomorrow_night.rstheme", true);
+      }
+      else
+      {
+         return create("Textmate (default)", "theme/default/textmate.rstheme", false);
+      }
    }
    
    public static final native AceTheme create(String name, String url, Boolean isDark)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
@@ -173,6 +173,12 @@ public class AceThemes
             new ServerRequestCallback<Void>()
             {
                @Override
+               public void onResponseReceived(Void response)
+               {
+                  themes_.remove(themeName);
+               }
+               
+               @Override
                public void onError(ServerError error)
                {
                   errorMessageConsumer.accept(error.getUserMessage());


### PR DESCRIPTION
If a theme is newly added to RStudio, but for some reason it isn't returned in the next call to `get_themes` the Appearance Preferences Pane will try to focus the editor theme select box on a non-existent element. This can also occur when the active theme is removed outside the context of RStudio (i.e. the `rstheme` file is deleted manually) and another theme is deleted, since the UI will try to focus the active theme which no longer exists. This PR address this in two ways:

1. If the active theme isn't in the list of themes, set the active theme to a default (Textmate for light themes and Tomorrow Night for dark themes).
2. If we're updating the theme list and resetting the focused theme, check if the requested theme exists. If not, set to the default. At this point, it's not clear whether the requested theme is dark or light so the light default will be used.

In both cases a warning is logged.