### PR TITLE
Allow selecting version, build id, and user agent

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.ui.xml
@@ -4,10 +4,6 @@
 	<ui:with field='res' type='org.rstudio.core.client.theme.res.ThemeResources' />
 	<ui:style>
 		@eval fixedWidthFont org.rstudio.core.client.theme.ThemeFonts.getFixedWidthFont();
-		.aboutBox {
-			-webkit-user-select: auto;
-		}
-		
 		.productName {
 			font-size: 20pt;
 			font-weight: bold;
@@ -27,6 +23,7 @@
 			text-align: center;
 			font-size: 8pt;
 			margin-bottom: 3px;
+			user-select: text;
 		}
 		
 		.userAgent {
@@ -61,6 +58,7 @@
 	      margin-left: auto;
 	      margin-right: auto;
 	      width: 50%;
+	      user-select: text;
 	   }
 	   
 	   .outerProductInfo {
@@ -72,7 +70,7 @@
 			text-align: center;
 		}
 	</ui:style>
-	<g:HTMLPanel styleName="{style.aboutBox}">
+	<g:HTMLPanel>
 	   <g:HTMLPanel styleName="{style.outerProductInfo}">
 		   <g:HTMLPanel styleName="{style.productInfo}">
 				<g:Image resource='{res.rstudioLarge2x}'


### PR DESCRIPTION
This small change makes it possible to select the text naming RStudio's version, build, and user agent string (for convenient copy/paste). 

We formerly made the entire dialog selectable, but did so with a deprecated CSS selector (for QtWebKit); we now make just the interesting regions selectable, and do so with a non-prefixed selector.