### PR TITLE
allow user error handlers to run during RStudio R code exec if requested

### DIFF
--- a/src/cpp/r/RExec.cpp
+++ b/src/cpp/r/RExec.cpp
@@ -18,6 +18,8 @@
 
 #include <core/FilePath.hpp>
 #include <core/Log.hpp>
+#include <core/StringUtils.hpp>
+#include <core/system/Environment.hpp>
 
 #include <r/RErrorCategory.hpp>
 #include <r/RSourceManager.hpp>
@@ -57,6 +59,13 @@ public:
    DisableErrorHandlerScope()
       : didDisable_(false)
    {
+      // allow users to enable / disable suppression of error handlers
+      // (primarily for debugging when behind-the-scenes R code emits an error
+      // that we'd like to learn a bit more about)
+      bool suppressed = r::options::getOption("rstudio.errors.suppressed", true, false);
+      if (!suppressed)
+         return;
+      
       SEXP handlerSEXP = r::options::setErrorOption(R_NilValue);
       if (handlerSEXP != R_NilValue)
       {


### PR DESCRIPTION
On occasion, R code executed by RStudio behind the scenes will emit an error that is then printed to the console for the user. Debugging such errors can be frustrating, as the regular R tools for debugging these (e.g. installing an error handler) are explicitly disabled while we evaluate such code (of course, this is for good reason -- we don't want user-defined error handlers that might require user input, e.g. `utils::recover()`, to run if an R error is emitted)

This PR adds an R option, `rstudio.errors.suppressed`, which can be toggled to enable / disable suppression of these errors, so that one can install e.g. a traceback handler if so desired.