### PR TITLE
rebuild boost to fix warnings with newer MSVC

### DIFF
--- a/dependencies/windows/install-boost/install-boost.R
+++ b/dependencies/windows/install-boost/install-boost.R
@@ -70,6 +70,23 @@ if (!file.exists(boost_dirname)) {
    progress("Extracting archive -- please wait a moment...")
    progress("Feel free to get up and grab a coffee.")
    exec("7z.exe", "x -mmt4", boost_filename)
+   
+   
+   # Building RStudio using boost 1.65.1 and recent VS releases
+   # will output a warning "Unknown compiler version..." for each source file,
+   # Newer boost versions have this warning commented out, so let's do the 
+   # same until we upgrade to a newer boost release.
+   replace_one_line(file.path(boost_dirname, "boost", "config", "compiler", "visualc.hpp"),
+      '#     pragma message("Unknown compiler version - please run the configure tests and report the results")',
+      '#     // pragma message("Unknown compiler version - please run the configure tests and report the results")')
+   
+   # Building RStudio using boost 1.65.1 and recent VS releases will
+   # output many warnings of the form "warning STL4019: The member std::fpos::seekpos() is non-Standard...".
+   # This was fixed more recently in Boost: https://github.com/boostorg/iostreams/pull/57/files
+   # Apply that same fix to our build of Boost.
+   replace_one_line(file.path(boost_dirname, "boost", "iostreams", "detail", "config", "fpos.hpp"),
+                    '     !defined(_STLPORT_VERSION) && !defined(__QNX__) && !defined(_VX_CPU)',
+                    '     !defined(_STLPORT_VERSION) && !defined(__QNX__) && !defined(_VX_CPU) && !(defined(BOOST_MSVC) && _MSVC_STL_VERSION >= 141)')
 }
 
 # double-check that we generated the boost folder

--- a/dependencies/windows/tools.R
+++ b/dependencies/windows/tools.R
@@ -119,3 +119,27 @@ ensure_dir <- function(...) {
             fatal("Failed to create directory '%s'\n", dir)
    }))
 }
+
+replace_one_line = function(filepath, orig_line, new_line) {
+   new_file <- tempfile()
+   unlink(new_file)
+   con <- file(filepath, "r")
+   found_line <- FALSE
+   while (TRUE) {
+      line = readLines(con, n = 1)
+      if (length(line) == 0) {
+         break
+      }
+      if (!found_line && line == orig_line) {
+         line <- new_line
+         found_line <- TRUE
+      }
+      write(line, file=new_file, append=TRUE)
+   }
+   close(con)
+   if (!found_line) {
+      fatal("Failed to locate expected line '%s' in '%s'.", orig_line, filepath)
+   }
+   unlink(filepath)
+   file.rename(new_file, filepath)
+}

--- a/dependencies/windows/tools.R
+++ b/dependencies/windows/tools.R
@@ -121,25 +121,8 @@ ensure_dir <- function(...) {
 }
 
 replace_one_line = function(filepath, orig_line, new_line) {
-   new_file <- tempfile()
-   unlink(new_file)
-   con <- file(filepath, "r")
-   found_line <- FALSE
-   while (TRUE) {
-      line = readLines(con, n = 1)
-      if (length(line) == 0) {
-         break
-      }
-      if (!found_line && line == orig_line) {
-         line <- new_line
-         found_line <- TRUE
-      }
-      write(line, file=new_file, append=TRUE)
-   }
-   close(con)
-   if (!found_line) {
-      fatal("Failed to locate expected line '%s' in '%s'.", orig_line, filepath)
-   }
-   unlink(filepath)
-   file.rename(new_file, filepath)
+   contents <- readLines(filepath)
+   replaced <- gsub(contents, orig_line, new_line)
+   if (!identical(contents, replaced))
+      writeLines(replaced, filepath)
 }


### PR DESCRIPTION
Modified scripts to patch the two issues that are throwing several hundred warnings during build of IDE on Windows. I chose to make these small tweaks on the current version of Boost we are using, and not upgrading. Safer to upgrade Boost early in 1.3.

One fix is to comment out pragma message complaining about unknown compiler version; this is what newer Boost does (literally comments this line out rather than continuing to track MSVC versions).

Other fix ia a pre-proc tweak to prevent use of a non-standard STL method in iostreams that recent MSVC warns about.

Between these, on my machine, a release build of the IDE goes from 816 warnings to 402. The remainder are more significant (size_t vs. int, that sort of thing, and will be easier to look at them when we decide to work on this).

Note that debug builds still throw a bunch more warnings due to missing PDBs, there's a separate issue open on that #3477.

This also removed the 32-bit boost builds, so archive is half the size it used to be. The script was changed to do this a while ago but didn't rebuild boost at that time.

Built and uploaded boost archive to S3, using same name as previous archive (boost-1.65.1-win-msvc141.zip); the previous archive is renamed to boost-1.65.1-win-msvc141_warnings.zip in case there's a reason to put it back.

### Dev Action Needed

To get this updated boost on a dev box, need to blow away the boost folders under dependencies\windows and rerun install-dependencies.cmd. Likely need to do same on Jenkins build environment (I _think_ we preserve the dependencies\windows between builds). Not urgent in either case. No expected change in the build output, just the compile-time warnings.

Fixes #3140 
