### PR TITLE
suppress errors during chunk option evaluation

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1007,9 +1007,11 @@ assign(envir = .rs.Env, ".rs.hasVar", function(name)
    searchPathName <- paste("package", package, sep = ":")
    if (searchPathName %in% search()) {
       env <- as.environment(searchPathName)
-      do.call("unlockBinding", list(binding, env))
-      assign(binding, override, envir = env)
-      do.call("lockBinding", list(binding, env))
+      if (exists(binding, envir = env)) {
+         do.call("unlockBinding", list(binding, env))
+         assign(binding, override, envir = env)
+         do.call("lockBinding", list(binding, env))
+      }
    }
    
    # return original

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -445,7 +445,20 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    # could fail)
    if (exists("eval_lang", envir = asNamespace("knitr")))
    {
-      override <- function(x, envir = knit_global()) if (is.language(x)) NULL else x
+      override <- function(x, envir = knit_global()) {
+         
+         # white-list for the commonly-used 'T' and 'F' options
+         if (identical(x, as.name("T")))
+            return(TRUE)
+         else if (identical(x, as.name("F")))
+            return(FALSE)
+         else if (is.language(x))
+            return(NULL)
+         else
+            return(x)
+         
+      }
+      
       original <- .rs.replaceBinding("eval_lang", "knitr", override)
       on.exit(.rs.replaceBinding("eval_lang", "knitr", original), add = TRUE)
    }

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -438,6 +438,17 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
 
    # set up output_source
    outputOptions <- list(output_source = .rs.rnb.outputSource(rnbData))
+   
+   # override knitr's 'eval_lang' and suppress evaluation of language /
+   # symbol chunk options (necessary since we don't actually execute any
+   # R code while evaluating chunks and so evaluation of such chunk options
+   # could fail)
+   if (exists("eval_lang", envir = asNamespace("knitr")))
+   {
+      override <- function(x, envir = knit_global()) if (is.language(x)) NULL else x
+      original <- .rs.replaceBinding("eval_lang", "knitr", override)
+      on.exit(.rs.replaceBinding("eval_lang", "knitr", original), add = TRUE)
+   }
 
    # knitr outputs relevant information in the form of messages that we attach to the error
    renderMessages <- list()


### PR DESCRIPTION
This PR seeks to resolve an issue where 'call' / 'symbol' objects within a chunk header could cause notebook generation to fail, e.g. as in https://github.com/rstudio/rstudio/issues/3259.

The underlying issue here is that `knitr` will attempt to evaluate non-literal chunk options; e.g. in the chunk:

`````
```{r, echo=var}

```
`````

`knitr` will attempt to evaluate the variable `var` in determining the value of the `echo` option. This is more commonly seen in SQL chunks as the connection object is typically part of the chunk header, e.g.

`````
```{r, connection=conn}
```
`````

but that connection object `conn` won't exist during notebook creation.

Since we typically don't want this behavior within R Notebooks (we never evaluate code during notebook generation), the solution here is to just override `eval_lang` in the `knitr` namespace during notebook generation.