### PR TITLE
Support to sources header comments with no parameters

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCommentHeaderHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCommentHeaderHelper.java
@@ -88,7 +88,7 @@ public class TextEditingTargetCommentHeaderHelper
       RStudioGinjector.INSTANCE.injectMembers(this);
 
       customHeaderPattern_ = Pattern.create(
-         "^" + comment + "\\s*!" + keyword + "\\s*([.a-zA-Z]+[.a-zA-Z0-9:_]*)?\\s*(\\s+|\\()(.*)$",
+         "^" + comment + "\\s*!" + keyword + "\\s*([.a-zA-Z]+[.a-zA-Z0-9:_]*)?\\s*(\\s+|\\(|$)(.*)$",
          ""
       );
 


### PR DESCRIPTION
Follow up on https://github.com/rstudio/rstudio/pull/3301 with fix for https://github.com/rstudio/rstudio/issues/3518, we want to also support custom source comments that don't include any parameters, as in:

```r
# !source print
```

and

```r
# !source mlflow::mlflow_run
```