### PR TITLE
Show warning when package repos modified outside preferences

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -497,6 +497,16 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    rbind(rstudioDF, cranDF)
 })
 
+.rs.addJsonRpcHandler("get_cran_actives", function()
+{
+   data.frame(name = names(getOption("repos")),
+              host = "",
+              url = as.character(getOption("repos")),
+              country = "",
+              ok = TRUE,
+              stringsAsFactors = FALSE)
+})
+
 .rs.addJsonRpcHandler( "init_default_user_library", function()
 {
   .rs.initDefaultUserLibrary()

--- a/src/gwt/src/org/rstudio/studio/client/common/mirrors/model/MirrorsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mirrors/model/MirrorsServerOperations.java
@@ -30,4 +30,7 @@ public interface MirrorsServerOperations
    void validateCranRepo(
          ServerRequestCallback<Boolean> requestCallback,
          String cranRepoUrl);
+
+   void getCRANActives(
+   		 ServerRequestCallback<JsArray<CRANMirror>> requestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1248,6 +1248,12 @@ public class RemoteServer implements Server
    {
       sendRequest(RPC_SCOPE, GET_CRAN_MIRRORS, requestCallback);
    }
+
+   public void getCRANActives(
+                  ServerRequestCallback<JsArray<CRANMirror>> requestCallback)
+   {
+      sendRequest(RPC_SCOPE, GET_CRAN_ACTIVES, requestCallback);
+   }
    
    public void suggestTopics(String prefix,
                              ServerRequestCallback<JsArrayString> requestCallback)
@@ -5692,6 +5698,7 @@ public class RemoteServer implements Server
    private static final String IS_PACKAGE_LOADED = "is_package_loaded";
    private static final String SET_CRAN_MIRROR = "set_cran_mirror";
    private static final String GET_CRAN_MIRRORS = "get_cran_mirrors";
+   private static final String GET_CRAN_ACTIVES = "get_cran_actives";
    private static final String PACKAGE_SKELETON = "package_skeleton";
    private static final String DISCOVER_PACKAGE_DEPENDENCIES = "discover_package_dependencies";
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
@@ -17,6 +17,7 @@
 package org.rstudio.studio.client.workbench.prefs.views;
 
 import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.core.client.JsArray;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
@@ -33,6 +34,7 @@ import java.util.ArrayList;
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.DialogTabLayoutPanel;
+import org.rstudio.core.client.widget.InfoBar;
 import org.rstudio.core.client.widget.MessageDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.TextBoxWithButton;
@@ -44,6 +46,7 @@ import org.rstudio.studio.client.common.mirrors.DefaultCRANMirror;
 import org.rstudio.studio.client.common.mirrors.model.CRANMirror;
 import org.rstudio.studio.client.common.mirrors.model.MirrorsServerOperations;
 import org.rstudio.studio.client.common.repos.SecondaryReposWidget;
+import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.prefs.model.PackagesPrefs;
@@ -70,6 +73,11 @@ public class PackagesPreferencesPane extends PreferencesPane
       VerticalPanel development = new VerticalPanel();
     
       management.add(headerLabel("Package Management"));
+
+      infoBar_ = new InfoBar(InfoBar.WARNING);
+      infoBar_.setText("CRAN repos were modified outside package preferences.");
+      infoBar_.addStyleName(res_.styles().themeInfobar());
+      spaced(infoBar_);
       
       cranMirrorTextBox_ = new TextBoxWithButton(
             "Primary CRAN repository:",
@@ -128,6 +136,8 @@ public class PackagesPreferencesPane extends PreferencesPane
 
       if (session.getSessionInfo().getAllowCRANReposEdit())
       {
+         management.add(infoBar_);
+
          lessSpaced(cranMirrorTextBox_);
          management.add(cranMirrorTextBox_);
 
@@ -302,6 +312,50 @@ public class PackagesPreferencesPane extends PreferencesPane
       
       useNewlineInMakefiles_.setEnabled(true);
       useNewlineInMakefiles_.setValue(packagesPrefs.getUseNewlineInMakefiles());
+
+      server_.getCRANActives(
+         new SimpleRequestCallback<JsArray<CRANMirror>>() {
+            @Override 
+            public void onResponseReceived(JsArray<CRANMirror> mirrors)
+            {
+               boolean cranDiffers = false;
+
+               ArrayList<CRANMirror> secondary = cranMirror_.getSecondaryRepos();
+
+               if (secondary.size() + 1 != mirrors.length() || mirrors.length() == 0)
+               {
+                  cranDiffers = true;
+               }
+               else
+               {
+                  // First entry should always be CRAN when set by preferences
+                  if (!mirrors.get(0).getName().equals("CRAN") ||
+                      !mirrors.get(0).getURL().equals(cranMirror_.getURL())) {
+                     cranDiffers = true;
+                  }
+                  for(int i=1; i<mirrors.length(); i++)
+                  {
+                     if (!mirrors.get(i).getName().equals(secondary.get(i-1).getName()) ||
+                         !mirrors.get(i).getURL().equals(secondary.get(i-1).getURL()))
+                     {
+                        cranDiffers = true;
+                        break;
+                     }
+                  }
+               }
+
+               if (cranDiffers)
+               {
+                  infoBar_.addStyleName(res_.styles().themeInfobarShowing());
+               }
+            }
+            
+            @Override
+            public void onError(ServerError error)
+            {
+            }
+         }
+      );
    }
 
    @Override
@@ -359,6 +413,7 @@ public class PackagesPreferencesPane extends PreferencesPane
    private final PreferencesDialogResources res_;
    private final GlobalDisplay globalDisplay_;
    private final MirrorsServerOperations server_;
+   private final InfoBar infoBar_;
    
    private CRANMirror cranMirror_ = CRANMirror.empty();
    private CheckBox useInternet2_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
@@ -76,7 +76,7 @@ public class PackagesPreferencesPane extends PreferencesPane
       management.add(headerLabel("Package Management"));
 
       infoBar_ = new InfoBar(InfoBar.WARNING);
-      infoBar_.setText("CRAN repos were modified outside package preferences.");
+      infoBar_.setText("CRAN repositories were modified outside package preferences.");
       infoBar_.addStyleName(res_.styles().themeInfobar());
       spaced(infoBar_);
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
@@ -32,6 +32,7 @@ import com.google.inject.Inject;
 import java.util.ArrayList;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.DialogTabLayoutPanel;
 import org.rstudio.core.client.widget.InfoBar;
@@ -353,6 +354,7 @@ public class PackagesPreferencesPane extends PreferencesPane
             @Override
             public void onError(ServerError error)
             {
+               Debug.logError(error);
             }
          }
       );

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.css
@@ -56,10 +56,6 @@
    display: none;
 }
 
-.themeInfobar > div {
-   border: none;
-}
-
 .themeInfobarShowing {
    display: block;
 }


### PR DESCRIPTION
Fix for https://github.com/rstudio/rstudio/issues/3523. CC: @ronblum @kevinushey 

Some Linux distributions ship R with an override to `options(repos = list(CRAN = "url")` hardcoded which makes the preferences dialog not usable by "design".

An easier way to repro this is to simple run:

```{r}
options(repos = list(CRAN = "https://abc.com")
```

and then open the packages preferences dialog, this PR adds the following warning when the option and our preferences are out of sync.

<img width="634" alt="screen shot 2018-09-21 at 1 04 20 pm" src="https://user-images.githubusercontent.com/3478847/45905437-30c0df00-bda5-11e8-8a71-eee6000be78b.png">

See https://github.com/rstudio/rstudio/issues/3224