### PR TITLE
fix conversions from utf8 to system codepage

### DIFF
--- a/src/cpp/core/include/core/StringUtils.hpp
+++ b/src/cpp/core/include/core/StringUtils.hpp
@@ -78,11 +78,15 @@ bool subsequenceIndices(std::string const& sequence,
 
 std::string getExtension(std::string const& str);
 
-std::string utf8ToSystem(const std::string& str,
-                         bool escapeInvalidChars=false);
+#ifdef _WIN32
+std::string reencode(const std::string& input,
+                     unsigned int inputCodepage,
+                     unsigned int outputCodepage,
+                     bool escapeInvalidCharacters = false);
+#endif
 
+std::string utf8ToSystem(const std::string& str);
 std::string systemToUtf8(const std::string& str);
-std::string systemToUtf8(const std::string& str, int codepage);
 
 std::string toLower(const std::string& str);
 std::string toUpper(const std::string& str);

--- a/src/cpp/desktop/DesktopUtils.cpp
+++ b/src/cpp/desktop/DesktopUtils.cpp
@@ -138,6 +138,7 @@ QString getFixedWidthFontList()
       // screen out annoying Qt warnings when attempting to
       // initialize incompatible fonts
       static std::set<std::string> blacklist = {
+         "8514oem",
          "Fixedsys",
          "Modern",
          "MS Sans Serif",

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -50,6 +50,7 @@ extern "C" {
 SA_TYPE SaveAction;
 #else
 __declspec(dllimport) SA_TYPE SaveAction;
+__declspec(dllimport) unsigned int localeCP;
 #endif
 
 }
@@ -337,7 +338,12 @@ int RReadConsole (const char *pmt,
             
             // ensure that our input fits within the buffer
             std::string::size_type maxLen = buflen - 2; // for \n\0
-            rInput = string_utils::utf8ToSystem(rInput, true);
+
+#ifdef _WIN32
+            // convert from UTF-8 to R's active code page
+            rInput = string_utils::reencode(rInput, CP_UTF8, localeCP, true);
+#endif
+
             if (rInput.length() > maxLen)
                rInput.resize(maxLen);
             std::string::size_type inputLen = rInput.length();
@@ -413,7 +419,7 @@ void RWriteConsoleEx (const char *buf, int buflen, int otype)
       if (!s_suppressOutput)
       {
          // get output
-         std::string output = std::string(buf,buflen);
+         std::string output = std::string(buf, buflen);
          output = util::rconsole2utf8(output);
          
          // add to console actions


### PR DESCRIPTION
This PR fixes an issue with conversion of UTF-8 text to the system encoding on Windows. It looks like the behavior of `::MultiByteToWideChar()` is different between MinGW and MSVC; in fact, the 'escapeInvalidChars' codepath was never actually being triggered before with MinGW because their implementation of `::MultiByteToWideChar()` was doing its own escaping of invalid characters.

In RStudio v1.2, we _were_ tripping the 'escapeInvalidChars' code path, but that was producing invalid R code. For example:

```R
data.frame(Φ = 1)
```

was being sent to the R console as

```R
data.frame(\u3a6 = 1)
```

which isn't actually valid R code (and so gives a parse error). This PR effectively brings us back to the v1.1 behavior (and conforms with what R does).

This PR also optimizes the active codepage check -- R actually maintains this state as part of an exported variable `localeCP` so we can use that value directly rather than calling back through R.

Closes #3496, #3526.