### PR TITLE
bring back v1.1-style transliteration during encoding

### DIFF
--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -279,24 +279,9 @@ std::string utf8ToSystem(const std::string& str,
    char buffer[16];
    for (int i = 0; i < chars; i++)
    {
-      // allow transliteration because R on Windows typically
-      // transliterates unicode characters that cannot be exactly
-      // represented in the active code page.
-      //
-      // TODO: in the future, we should consider making it possible
-      // for callers to request transliteration vs. no transliteration,
-      // since this API is often used for text not directly intended for
-      // consumption by R
-      //
-      // TODO: should also allow users to supply requested code page for
-      // conversion, but that's a bit too late to bring in for v1.2
-      int n = ::WideCharToMultiByte(
-               CP_ACP, WC_COMPOSITECHECK,
-               &wide[i], 1,
-               buffer, 16,
-               nullptr, nullptr);
+      int n = wctomb(buffer, wide[i]);
 
-      if (n == 0)
+      if (n == -1)
       {
          if (escapeInvalidChars)
             output << "\\u{" << std::hex << wide[i] << "}";

--- a/src/cpp/r/RUtil.cpp
+++ b/src/cpp/r/RUtil.cpp
@@ -41,6 +41,8 @@ extern "C" {
 __declspec(dllimport) unsigned int localeCP;
 }
 
+unsigned int s_codepage = 0;
+
 #endif
 
 using namespace rstudio::core;
@@ -277,7 +279,12 @@ bool isPackageAttached(const std::string& packageName)
 void synchronizeLocale()
 {
 #ifdef _WIN32
-   // check to see if the R locale has changed and update if so
+
+   // bail if the codepages are still in sync
+   if (s_codepage == localeCP)
+      return;
+
+   // ask R what the current locale is and then update
    std::string rLocale;
    Error error = r::exec::RFunction("base:::Sys.getlocale")
          .addParam("LC_ALL")
@@ -291,6 +298,10 @@ void synchronizeLocale()
       if (locale != rLocale)
          ::setlocale(LC_ALL, rLocale.c_str());
    }
+
+   // save the updated codepage
+   s_codepage = localeCP;
+
 #endif
 }
 

--- a/src/cpp/r/RUtil.cpp
+++ b/src/cpp/r/RUtil.cpp
@@ -274,6 +274,26 @@ bool isPackageAttached(const std::string& packageName)
    return false;
 }
 
+void synchronizeLocale()
+{
+#ifdef _WIN32
+   // check to see if the R locale has changed and update if so
+   std::string rLocale;
+   Error error = r::exec::RFunction("base:::Sys.getlocale")
+         .addParam("LC_ALL")
+         .call(&rLocale);
+   if (error)
+      LOG_ERROR(error);
+
+   if (!rLocale.empty())
+   {
+      std::string locale = ::setlocale(LC_ALL, nullptr);
+      if (locale != rLocale)
+         ::setlocale(LC_ALL, rLocale.c_str());
+   }
+#endif
+}
+
 } // namespace util
 } // namespace r
 } // namespace rstudio

--- a/src/cpp/r/RUtil.cpp
+++ b/src/cpp/r/RUtil.cpp
@@ -93,9 +93,11 @@ std::string rconsole2utf8(const std::string& encoded)
    return encoded;
 #else
    unsigned int codepage = localeCP;
+
    std::string output;
    std::string::const_iterator pos = encoded.begin();
    boost::smatch m;
+   boost::regex utf8("\x02\xFF\xFE(.*?)(\x03\xFF\xFE)");
    while (pos != encoded.end() && regex_utils::search(pos, encoded.end(), m, utf8))
    {
       if (pos < m[0].first)

--- a/src/cpp/r/RUtil.cpp
+++ b/src/cpp/r/RUtil.cpp
@@ -94,6 +94,17 @@ std::string rconsole2utf8(const std::string& encoded)
 #else
    unsigned int codepage = localeCP;
 
+   // NOTE: On Windows with GUIs, when R attempts to write text to
+   // the console, it will surround UTF-8 text with 3-byte escapes:
+   //
+   //    \002\377\376 <text> \003\377\376
+   //
+   // strangely, we see these escapes around text that is not UTF-8
+   // encoded but rather is encoded according to the active locale.
+   // extract those pieces of text (discarding the escapes) and
+   // convert to UTF-8. (still not exactly sure what the cause of this
+   // behavior is; perhaps there is an extra UTF-8 <-> system conversion
+   // happening somewhere in the pipeline?)
    std::string output;
    std::string::const_iterator pos = encoded.begin();
    boost::smatch m;

--- a/src/cpp/r/include/r/RUtil.hpp
+++ b/src/cpp/r/include/r/RUtil.hpp
@@ -58,6 +58,8 @@ bool isWindowsOnlyFunction(const std::string& name);
 // Is package attached to search path?
 bool isPackageAttached(const std::string& packageName);
 
+void synchronizeLocale();
+
 } // namespace util   
 } // namespace r
 } // namespace rstudio

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -278,6 +278,9 @@ int RReadConsole (const char *pmt,
          // user has to wait in any case we might as well help them out by
          // never having to start from scratch
          r::exec::IgnoreInterruptsScope ignoreInterrupts;
+
+         // synchronize locale with R
+         r::util::synchronizeLocale();
          
          // attempt to initialize 
          Error initError;
@@ -412,6 +415,9 @@ void RWriteConsoleEx (const char *buf, int buflen, int otype)
    {
       if (!s_suppressOutput)
       {
+         // synchronize locale with R
+         r::util::synchronizeLocale();
+
          // get output
          std::string output = std::string(buf,buflen);
          output = util::rconsole2utf8(output);

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -279,9 +279,6 @@ int RReadConsole (const char *pmt,
          // never having to start from scratch
          r::exec::IgnoreInterruptsScope ignoreInterrupts;
 
-         // synchronize locale with R
-         r::util::synchronizeLocale();
-         
          // attempt to initialize 
          Error initError;
          Error error = r::exec::executeSafely<Error>(initialize, &initError);
@@ -415,9 +412,6 @@ void RWriteConsoleEx (const char *buf, int buflen, int otype)
    {
       if (!s_suppressOutput)
       {
-         // synchronize locale with R
-         r::util::synchronizeLocale();
-
          // get output
          std::string output = std::string(buf,buflen);
          output = util::rconsole2utf8(output);
@@ -451,7 +445,13 @@ void RBusy(int which)
 {
    try
    {
-      s_callbacks.busy(which == 1) ;
+      // synchronize locale whenever R busy state changes
+      // (done relatively eagerly to ensure synchronization
+      // happens on each REPL iteration after user code is run)
+      r::util::synchronizeLocale();
+
+      // invoke callback
+      s_callbacks.busy(which == 1);
    }
    CATCH_UNEXPECTED_EXCEPTION 
 }


### PR DESCRIPTION
Closes #3526, #3496.