### PR TITLE
Add better handling when adding a duplicate theme 

### DIFF
--- a/src/cpp/session/modules/SessionThemes.R
+++ b/src/cpp/session/modules/SessionThemes.R
@@ -982,7 +982,7 @@
    else if (!is.null(dupTheme))
    {
       willBeOverridden <- if (!globally || .rs.isDefaultTheme()) "The existing theme will be overridden by the new theme."
-                          else "The newly added theme will be overriden by the existing theme."
+                          else "The newly added theme will be overridden by the existing theme."
       warning("There is another theme with the same name, \"",
               name,
               "\". ",

--- a/src/cpp/session/modules/SessionThemes.R
+++ b/src/cpp/session/modules/SessionThemes.R
@@ -806,6 +806,41 @@
    grepl("^theme/default/.*\\.rstheme$", themeUrl, ignore.case = TRUE)
 })
 
+.rs.addFunction("getThemeName", function(themeLines, fileName)
+{
+   tmThemeNameRegex <- "<key>name</key>\\s*<string>([^>]*)</string>"
+   rsthemeNameRegex <- "rs-theme-name\\s*:\\s*([^\\*]+?)\\s*(?:\\*|$)"
+   nameRegex <- tmThemeNameRegex
+   nameLine <- themeLines[grep(tmThemeNameRegex, themeLines, perl = TRUE, ignore.case = TRUE)]
+   if (length(nameLine) == 0)
+   {
+      nameRegex <- rsthemeNameRegex
+      nameLine <- themeLines[grep(rsthemeNameRegex, themeLines, perl = TRUE, ignore.case = TRUE)]
+   }
+   if (length(nameLine) == 0)
+   {
+      regmatches(
+         basename(fileName),
+         regexec(
+            "^([^\\.]*)(?:\\.[^\\.]*)?",
+            basename(fileName),
+            perl = TRUE))[[1]][2]
+   }
+   else
+   {
+      sub(
+         "^\\s*(.+?)\\s*$",
+         "\\1",
+         regmatches(
+            nameLine,
+            regexec(
+               nameRegex,
+               nameLine,
+               perl = TRUE))[[1]][2],
+         perl = TRUE)
+   }
+})
+
 # Gets the install location.
 #
 # @param global    Whether to get the global or local install dir.
@@ -913,12 +948,7 @@
 # Returns the name of the theme on success.
 .rs.addFunction("addTheme", function(themePath, apply, force, globally) {
    # Get the name of the file without extension.
-   fileName <- regmatches(
-      basename(themePath),
-      regexec(
-         "^([^\\.]*)(?:\\.[^\\.]*)?",
-         basename(themePath),
-         perl = TRUE))[[1]][2]
+   fileName <- basename(themePath)
    
    # Get the name of the theme either from the first occurence of "rs-theme-name:" in the css or 
    # the name of the file.
@@ -926,27 +956,9 @@
    themeLines <- readLines(conn)
    close(conn)
    
-   nameRegex <- "rs-theme-name\\s*:\\s*([^\\*]+?)\\s*(?:\\*|$)"
-   nameLine <- themeLines[grep(nameRegex, themeLines, perl = TRUE)]
-   name <- ""
-   if (length(nameLine) > 0)
-   {
-      name <- sub(
-         "^\\s*(.+?)\\s*$",
-         "\\1",
-         regmatches(
-            nameLine,
-            regexec(
-               nameRegex,
-               nameLine,
-               perl = TRUE))[[1]][2],
-         perl = TRUE)
-   }
+   name <- .rs.getThemeName(paste0(themeLines, collapse = "\n"), fileName)
    
-   # If there's no name in the file, use the name of the file.
-   if (is.na(name) || (name == "")) name <- fileName
-   
-   if (is.na(name) || (name == ""))
+   if (is.na(name) || (name == "") || is.null(name))
    {
       stop(
          "Unable to find a name for the new theme. Please check that the file \"",
@@ -1003,7 +1015,7 @@
       stop(
          "A file with the same name, \"",
          fileName,
-         ".rstheme\", already exists in the target location. To add the theme anyway, try again with `force = TRUE`.",
+         "\", already exists in the target location. To add the theme anyway, try again with `force = TRUE`.",
          call. = FALSE)
    }
 

--- a/src/cpp/session/modules/SessionThemes.R
+++ b/src/cpp/session/modules/SessionThemes.R
@@ -1219,3 +1219,12 @@
       theme[names(theme) != "url"]
    })
 })
+
+# RPC Functions ====================================================================================
+.rs.addJsonRpcHandler("get_theme_name", function(themeFile) {
+   conn <- file(themeFile)
+   lines <- readLines(conn)
+   close(conn)
+   
+   .rs.scalar(.rs.getThemeName(paste0(lines, collapse = "\n"), themeFile))
+})

--- a/src/cpp/session/modules/SessionThemes.R
+++ b/src/cpp/session/modules/SessionThemes.R
@@ -1222,9 +1222,6 @@
 
 # RPC Functions ====================================================================================
 .rs.addJsonRpcHandler("get_theme_name", function(themeFile) {
-   conn <- file(themeFile)
-   lines <- readLines(conn)
-   close(conn)
-   
+   lines <- readLines(themeFile)
    .rs.scalar(.rs.getThemeName(paste0(lines, collapse = "\n"), themeFile))
 })

--- a/src/cpp/session/modules/SessionThemes.cpp
+++ b/src/cpp/session/modules/SessionThemes.cpp
@@ -452,62 +452,6 @@ Error removeTheme(const json::JsonRpcRequest& request,
    return error;
 }
 
-Error getThemeName(const json::JsonRpcRequest& request,
-                         json::JsonRpcResponse* pResponse)
-{
-   std::string themeFile;
-   Error error = json::readParams(request.params, &themeFile);
-
-   if (!error)
-   {
-      r::exec::RFunction openFile("file");
-      r::exec::RFunction readLines("readLines");
-      r::exec::RFunction paste0("paste0");
-      r::exec::RFunction getThemeName(".rs.getThemeName");
-      r::exec::RFunction close("close");
-
-      r::sexp::Protect protect;
-      SEXP conn, lines, joinedLines, name;
-
-      openFile.addParam(themeFile);
-      error = openFile.call(&conn, &protect);
-
-      if (!error)
-      {
-         readLines.addParam(conn);
-         error = readLines.call(&lines, &protect);
-         close.addParam(conn);
-         close.call();
-
-         if (!error)
-         {
-            paste0.addParam(lines);
-            paste0.addParam("collapse", "\n");
-            error = paste0.call(&joinedLines, &protect);
-
-            if (!error)
-            {
-               getThemeName.addParam("themeLines", joinedLines);
-               getThemeName.addParam("fileName", themeFile);
-               error = getThemeName.call(&name, &protect);
-
-               if (!error)
-               {
-                  std::string strName;
-                  error = r::sexp::extract(name, &strName);
-                  if (!error)
-                  {
-                     pResponse->setResult(strName);
-                  }
-               }
-            }
-         }
-      }
-   }
-
-   return error;
-}
-
 } // anonymous namespace
 
 /**
@@ -589,7 +533,6 @@ Error initialize()
       (bind(registerRpcMethod, "get_themes", getThemes))
       (bind(registerRpcMethod, "add_theme", addTheme))
       (bind(registerRpcMethod, "remove_theme", removeTheme))
-      (bind(registerRpcMethod, "get_theme_name", getThemeName))
       (bind(registerUriHandler, "/" + kDefaultThemeLocation, handleDefaultThemeRequest))
       (bind(registerUriHandler, "/" + kGlobalCustomThemeLocation, handleGlobalCustomThemeRequest))
       (bind(registerUriHandler, "/" + kLocalCustomThemeLocation, handleLocalCustomThemeRequest));

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/FileSystemDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/FileSystemDialog.java
@@ -351,11 +351,6 @@ public abstract class FileSystemDialog extends ModalDialogBase
             while (singleMatch != null)
             {
                filters.add(singleMatch.getGroup(1));
-               if (!Desktop.isDesktop())
-               {
-                  // only extract first extension
-                  return filters;
-               }
                singleMatch = singleMatch.nextMatch();
             }
             listMatch = listMatch.nextMatch();

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -5595,6 +5595,14 @@ public class RemoteServer implements Server
    }
 
    @Override
+   public void getThemeName(ServerRequestCallback<String> callback, String themeLocation)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(themeLocation));
+      sendRequest(RPC_SCOPE, GET_THEME_NAME, params, callback);
+   }
+   
+   @Override
    public void replaceCommentHeader(String command,
                                     String path,
                                     String code,
@@ -6058,6 +6066,7 @@ public class RemoteServer implements Server
    private static final String GET_THEMES = "get_themes";
    private static final String ADD_THEME = "add_theme";
    private static final String REMOVE_THEME = "remove_theme";
+   private static final String GET_THEME_NAME = "get_theme_name";
 
    private static final String REPLACE_COMMENT_HEADER = "replace_comment_header";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceTheme.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceTheme.java
@@ -69,17 +69,17 @@ public class AceTheme extends JavaScriptObject
    
    public final Boolean isDefaultTheme()
    {
-      return Pattern.create("^/theme/default/.+?\\.rstheme$").test(getUrl());
+      return Pattern.create("^theme/default/.+?\\.rstheme$").test(getUrl());
    }
    
    public final Boolean isLocalCustomTheme()
    {
-      return Pattern.create("^/theme/custom/local/.+?\\.rstheme$").test(getUrl());
+      return Pattern.create("^theme/custom/local/.+?\\.rstheme$").test(getUrl());
    }
    
-   public final Boolean isGlobalCustonTheme()
+   public final Boolean isGlobalCustomTheme()
    {
-      return Pattern.create("^/theme/custom/global/.+?\\.rstheme$").test(getUrl());
+      return Pattern.create("^theme/custom/global/.+?\\.rstheme$").test(getUrl());
    }
    
    public final String getFileStem()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
@@ -28,6 +28,7 @@ import com.google.inject.Singleton;
 import org.rstudio.core.client.ColorUtil.RGBColor;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.dom.DomUtils;
+import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
@@ -139,7 +140,10 @@ public class AceThemes
       });
    }
    
-   public void addTheme(String themeLocation, Consumer<String> stringConsumer, Consumer<String> errorMessageConsumer)
+   public void addTheme(
+      String themeLocation,
+      Consumer<String> stringConsumer,
+      Consumer<String> errorMessageConsumer)
    {
       themeServerOperations_.addTheme(new ServerRequestCallback<String>()
       {
@@ -157,7 +161,10 @@ public class AceThemes
       }, themeLocation);
    }
    
-   public void removeTheme(String themeName, Consumer<String> errorMessageConsumer)
+   public void removeTheme(
+      String themeName,
+      Consumer<String> errorMessageConsumer,
+      Operation afterOperation)
    {
       if (!themes_.containsKey(themeName))
       {
@@ -176,6 +183,7 @@ public class AceThemes
                public void onResponseReceived(Void response)
                {
                   themes_.remove(themeName);
+                  afterOperation.execute();
                }
                
                @Override
@@ -186,6 +194,31 @@ public class AceThemes
             },
             themeName);
       }
+   }
+   
+   // This function can be used to get the name of a theme without adding it to RStudio. It is not
+   // used to get the name of an existing theme.
+   public void getThemeName(
+      String themeLocation,
+      Consumer<String> stringConsumer,
+      Consumer<String> errorMessageConsumer)
+   {
+      themeServerOperations_.getThemeName(
+         new ServerRequestCallback<String>()
+         {
+            @Override
+            public void onResponseReceived(String result)
+            {
+               stringConsumer.accept(result);
+            }
+            
+            @Override
+            public void onError(ServerError error)
+            {
+               errorMessageConsumer.accept(error.getUserMessage());
+            }
+         },
+         themeLocation);
    }
 
    private ThemeServerOperations themeServerOperations_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/model/ThemeServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/model/ThemeServerOperations.java
@@ -28,4 +28,6 @@ public interface ThemeServerOperations
    void addTheme(ServerRequestCallback<String> request, String themeLocation);
    
    void removeTheme(ServerRequestCallback<Void> request, String themeName);
+   
+   void getThemeName(ServerRequestCallback<String> request, String themeLocation);
 }


### PR DESCRIPTION
The API will now return an error if a theme with the same name is added to the same location (e.g. local vs. global). The API will emit a warning if a theme with the same name is added to a different location.

The UI will post an error asking the user to confirm that they wish to delete in the original theme when a theme with the same name is added to the same location. The UI will post a warning indicating that while the existing theme will be overridden, no loss will actually occur and asking for confirmation when a theme with the same name is added to a different location.

![duperror](https://user-images.githubusercontent.com/37987486/46106693-4875da00-c18e-11e8-9900-c4ba5d0fa200.png)
![dupwarning](https://user-images.githubusercontent.com/37987486/46106701-4dd32480-c18e-11e8-9e0c-c389faa7eab4.png)
