### PR TITLE
Fix Source on Save for R scripts

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -6280,10 +6280,9 @@ public class TextEditingTarget implements
                {
                   previewFromR();
                }
-               else if (fileType_.isR())
+               else if (fileType_.isR() && extendedType_ == SourceDocument.XT_R_CUSTOM_SOURCE)
                {
-                  if (extendedType_ == SourceDocument.XT_R_CUSTOM_SOURCE)
-                     customSource();
+                  customSource();
                }
                else
                {


### PR DESCRIPTION
Currently, R scripts are only sourced on save if they have a custom source command. This change restores ordinary `source()` behavior for ordinary R scripts. 

Fixes https://github.com/rstudio/rstudio/issues/3566.