### PR TITLE
properly quote repository names/values (closes #3560)

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1925,8 +1925,8 @@
       data[["repos"]] <- sprintf(
          "c(%s)",
          paste(
-            names(repos),
-            .rs.surround(as.character(repos), with = "'"),
+            shQuote(names(repos)),
+            shQuote(as.character(repos)),
             sep = " = ",
             collapse = ", "
          )


### PR DESCRIPTION
Note that `shQuote()` also takes care of escaping embedded quotes as necessary, something not done by the previous implementation.