### PR TITLE
only trigger external edit checks when focused (closes #3554)

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1558,10 +1558,8 @@ public class TextEditingTarget implements
                return;
 
             // always check for changes if this is the active editor
-            if (commandHandlerReg_ != null)
-            {
+            if (isActiveDocument())
                checkForExternalEdit();
-            }
 
             // also check for changes on modifications if we are not dirty
             // note that we don't check for changes on removed files because
@@ -6317,6 +6315,10 @@ public class TextEditingTarget implements
       if (getPath() == null)
          return;
       
+      // If we're already waiting for the user to respond to an edit event, bail
+      if (isWaitingForUserResponseToExternalEdit_)
+         return;
+      
       final Invalidation.Token token = externalEditCheckInvalidation_.getInvalidationToken();
 
       server_.checkForExternalEdit(
@@ -6334,6 +6336,7 @@ public class TextEditingTarget implements
                      if (ignoreDeletes_)
                         return;
 
+                     isWaitingForUserResponseToExternalEdit_ = true;
                      globalDisplay_.showYesNoMessage(
                            GlobalDisplay.MSG_WARNING,
                            "File Deleted",
@@ -6346,6 +6349,7 @@ public class TextEditingTarget implements
                            {
                               public void execute()
                               {
+                                 isWaitingForUserResponseToExternalEdit_ = false;
                                  CloseEvent.fire(TextEditingTarget.this, null);
                               }
                            },
@@ -6353,6 +6357,7 @@ public class TextEditingTarget implements
                            {
                               public void execute()
                               {
+                                 isWaitingForUserResponseToExternalEdit_ = false;
                                  externalEditCheckInterval_.reset();
                                  ignoreDeletes_ = true;
                                  // Make sure it stays dirty
@@ -6387,6 +6392,7 @@ public class TextEditingTarget implements
                      else
                      {
                         externalEditCheckInterval_.reset();
+                        isWaitingForUserResponseToExternalEdit_ = true;
                         globalDisplay_.showYesNoMessage(
                               GlobalDisplay.MSG_WARNING,
                               "File Changed",
@@ -6398,6 +6404,7 @@ public class TextEditingTarget implements
                               {
                                  public void execute()
                                  {
+                                    isWaitingForUserResponseToExternalEdit_ = false;
                                     docUpdateSentinel_.revert();
                                  }
                               },
@@ -6405,6 +6412,7 @@ public class TextEditingTarget implements
                               {
                                  public void execute()
                                  {
+                                    isWaitingForUserResponseToExternalEdit_ = false;
                                     externalEditCheckInterval_.reset();
                                     docUpdateSentinel_.ignoreExternalEdit();
                                     // Make sure it stays dirty
@@ -7293,7 +7301,9 @@ public class TextEditingTarget implements
    // Prevents external edit checks from happening too soon after each other
    private final IntervalTracker externalEditCheckInterval_ =
          new IntervalTracker(1000, true);
+   private boolean isWaitingForUserResponseToExternalEdit_ = false;
    private EditingTargetCodeExecution codeExecution_;
+   
    
    private SourcePosition debugStartPos_ = null;
    private SourcePosition debugEndPos_ = null;


### PR DESCRIPTION
Note that an external edit check is always triggered when the window is focused, so effectively this PR ensures that 'file changed' events are only shown to the user after they re-focus the IDE instance.