### PR TITLE
use an rpc for SQL preview

### DIFF
--- a/src/cpp/session/modules/SessionDataPreview.R
+++ b/src/cpp/session/modules/SessionDataPreview.R
@@ -13,6 +13,11 @@
 #
 #
 
+.rs.addJsonRpcHandler("preview_sql", function(code)
+{
+   eval(parse(text = code), envir = globalenv())
+})
+
 .rs.addFunction("previewDataFrame", function(data, script)
 {
    preparedData <- .rs.prepareViewerData(
@@ -55,7 +60,3 @@
    .rs.previewDataFrame(data, script)
 })
 
-.rs.addGlobalFunction("previewSql", function(conn, statement, ...)
-{
-   .rs.previewSql(conn, statement, ...)
-})

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinModule.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinModule.java
@@ -105,6 +105,7 @@ import org.rstudio.studio.client.shiny.ShinyApplicationPresenter;
 import org.rstudio.studio.client.shiny.ui.ShinyApplicationPanel;
 import org.rstudio.studio.client.shiny.ui.ShinyApplicationView;
 import org.rstudio.studio.client.shiny.ui.ShinyApplicationWindow;
+import org.rstudio.studio.client.sql.model.SqlServerOperations;
 import org.rstudio.studio.client.vcs.VCSApplicationView;
 import org.rstudio.studio.client.vcs.ui.VCSApplicationWindow;
 import org.rstudio.studio.client.workbench.ClientStateUpdater;
@@ -422,6 +423,7 @@ public class RStudioGinModule extends AbstractGinModule
       bind(FindInFilesServerOperations.class).to(RemoteServer.class);
       bind(SynctexServerOperations.class).to(RemoteServer.class);
       bind(HTMLPreviewServerOperations.class).to(RemoteServer.class);
+      bind(SqlServerOperations.class).to(RemoteServer.class);
       bind(ShinyServerOperations.class).to(RemoteServer.class);
       bind(PlumberServerOperations.class).to(RemoteServer.class);
       bind(RSConnectServerOperations.class).to(RemoteServer.class);

--- a/src/gwt/src/org/rstudio/studio/client/server/Server.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/Server.java
@@ -21,11 +21,13 @@ import org.rstudio.studio.client.common.rstudioapi.model.RStudioAPIServerOperati
 import org.rstudio.studio.client.common.shiny.model.ShinyServerOperations;
 import org.rstudio.studio.client.htmlpreview.model.HTMLPreviewServerOperations;
 import org.rstudio.studio.client.rsconnect.model.RSConnectServerOperations;
+import org.rstudio.studio.client.sql.model.SqlServerOperations;
 import org.rstudio.studio.client.workbench.model.WorkbenchServerOperations;
 
 public interface Server extends ApplicationServerOperations,
                                 WorkbenchServerOperations,
                                 HTMLPreviewServerOperations,
+                                SqlServerOperations,
                                 ShinyServerOperations,
                                 RSConnectServerOperations,
                                 RStudioAPIServerOperations,

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1157,6 +1157,15 @@ public class RemoteServer implements Server
                   params,
                   requestCallback);
    }
+   
+   @Override
+   public void previewSql(String command,
+                          ServerRequestCallback<Void> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(command));
+      sendRequest(RPC_SCOPE, PREVIEW_SQL, params, requestCallback);
+   }
 
    public void editCompleted(String text,
                              ServerRequestCallback<Void> requestCallback)
@@ -3739,6 +3748,8 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, "plots_create_rpubs_html", params, callback);
    }
    
+   
+   
    public void previewHTML(HTMLPreviewParams params,
                            ServerRequestCallback<Boolean> callback)
    {
@@ -5386,6 +5397,8 @@ public class RemoteServer implements Server
       params.set(0, new JSONString(code));
       sendRequest(RPC_SCOPE, CONNECTION_TEST, params, callback);
    }
+   
+   
 
    @Override
    public void launchEmbeddedShinyConnectionUI(String packageName, 
@@ -5694,6 +5707,8 @@ public class RemoteServer implements Server
    private static final String DOWNLOAD_DATA_FILE = "download_data_file";
    private static final String GET_DATA_PREVIEW = "get_data_preview";
    private static final String GET_OUTPUT_PREVIEW = "get_output_preview";
+   
+   private static final String PREVIEW_SQL = "preview_sql";
 
    private static final String EDIT_COMPLETED = "edit_completed";
    private static final String CHOOSE_FILE_COMPLETED = "choose_file_completed";

--- a/src/gwt/src/org/rstudio/studio/client/sql/model/SqlServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/sql/model/SqlServerOperations.java
@@ -1,0 +1,24 @@
+/*
+ * SqlServerOperations.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.sql.model;
+
+import org.rstudio.studio.client.server.Void;
+import org.rstudio.studio.client.server.ServerRequestCallback;
+import org.rstudio.studio.client.workbench.views.buildtools.model.BuildServerOperations;
+
+public interface SqlServerOperations extends BuildServerOperations
+{
+   void previewSql(String command, ServerRequestCallback<Void> requestCallback);
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetSqlHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetSqlHelper.java
@@ -16,10 +16,9 @@ package org.rstudio.studio.client.workbench.views.source.editors.text;
 
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.studio.client.RStudioGinjector;
-import org.rstudio.studio.client.application.events.EventBus;
-import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
+import org.rstudio.studio.client.server.VoidServerRequestCallback;
+import org.rstudio.studio.client.sql.model.SqlServerOperations;
 import org.rstudio.studio.client.workbench.views.source.editors.EditingTarget;
-
 import com.google.inject.Inject;
 
 public class TextEditingTargetSqlHelper
@@ -31,9 +30,9 @@ public class TextEditingTargetSqlHelper
    }
    
    @Inject
-   void initialize(EventBus eventBus)
+   void initialize(SqlServerOperations server)
    {
-      eventBus_ = eventBus;
+      server_ = server;
    }
    
    
@@ -47,7 +46,7 @@ public class TextEditingTargetSqlHelper
 
       if (previewSource.getFunction().length() == 0)
       {
-         previewSource.setFunction("previewSql");
+         previewSource.setFunction(".rs.previewSql");
       }
 
       previewSource.buildCommand(
@@ -57,11 +56,11 @@ public class TextEditingTargetSqlHelper
             @Override
             public void execute(String command)
             {
-               eventBus_.fireEvent(new SendToConsoleEvent(command, true));
+               server_.previewSql(command, new VoidServerRequestCallback());
             }
          }
       );
    }
-   private EventBus eventBus_; 
    private DocDisplay docDisplay_;
+   private SqlServerOperations server_;
 }


### PR DESCRIPTION
This PR removes the globally registered `previewSql()` function, and instead performs the preview using a regular RPC.