### PR TITLE
provide separate paste, paste and indent commands

### DIFF
--- a/src/gwt/src/org/rstudio/core/rebind/command/ShortcutsEmitter.java
+++ b/src/gwt/src/org/rstudio/core/rebind/command/ShortcutsEmitter.java
@@ -65,6 +65,7 @@ public class ShortcutsEmitter
          String title = childEl.getAttribute("title");
          String disableModes = childEl.getAttribute("disableModes");
          String handlesEventPropagation = childEl.getAttribute("handlesEventPropagation");
+         String platform = childEl.getAttribute("platform");
 
          // Use null when we don't have a command associated with the shortcut,
          // otherwise refer to the function that returns the command 
@@ -81,7 +82,7 @@ public class ShortcutsEmitter
          {
             printShortcut(writer, condition, shortcut, 
                   command, groupName_, title, disableModes,
-                  handlesEventPropagation);
+                  handlesEventPropagation, platform);
          }
       }
    }
@@ -113,7 +114,8 @@ public class ShortcutsEmitter
                               String shortcutGroup,
                               String title,
                               String disableModes,
-                              String handlesEventPropagation) throws UnableToCompleteException
+                              String handlesEventPropagation,
+                              String platform) throws UnableToCompleteException
    {
       List<Pair<Integer, String>> keys = new ArrayList<Pair<Integer, String>>();
       for (String keyCombination : shortcut.split("\\s+"))
@@ -162,6 +164,20 @@ public class ShortcutsEmitter
       }
       
       // Emit the relevant code registering these shortcuts.
+      if (!platform.isEmpty())
+      {
+         if (platform.equals("desktop"))
+         {
+            writer.println("if (org.rstudio.studio.client.application.Desktop.isDesktop()) {");
+            writer.indent();
+         }
+         else
+         {
+            writer.println("if (!org.rstudio.studio.client.application.Desktop.isDesktop()) {");
+            writer.indent();
+         }
+      }
+      
       if (!condition.isEmpty())
       {
          writer.println("if (" + condition + ") {");
@@ -212,6 +228,12 @@ public class ShortcutsEmitter
       }
 
       if (!condition.isEmpty())
+      {
+         writer.outdent();
+         writer.println("}");
+      }
+      
+      if (!platform.isEmpty())
       {
          writer.outdent();
          writer.println("}");

--- a/src/gwt/src/org/rstudio/studio/client/KeyboardMonitor.java
+++ b/src/gwt/src/org/rstudio/studio/client/KeyboardMonitor.java
@@ -1,0 +1,101 @@
+/*
+ * KeyboardMonitor.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client;
+
+import org.rstudio.core.client.command.KeyboardShortcut;
+
+import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.Event.NativePreviewEvent;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+@Singleton
+public class KeyboardMonitor
+{
+   @Inject
+   public KeyboardMonitor()
+   {
+      Event.addNativePreviewHandler((NativePreviewEvent preview) -> {
+         
+         NativeEvent event = preview.getNativeEvent();
+         
+         if (event.getType().equals("keydown"))
+            toggleState(event, true);
+         else if (event.getType().equals("keyup"))
+            toggleState(event, false);
+         
+      });
+   }
+   
+   public int getModifierValue()
+   {
+      return
+            (isCtrlKeyDown()  ? KeyboardShortcut.CTRL  : 0) +
+            (isAltKeyDown()   ? KeyboardShortcut.ALT   : 0) +
+            (isShiftKeyDown() ? KeyboardShortcut.SHIFT : 0) +
+            (isMetaKeyDown()  ? KeyboardShortcut.META  : 0);
+            
+   }
+   
+   public boolean isCtrlKeyDown()
+   {
+      return ctrl_;
+   }
+   
+   public boolean isAltKeyDown()
+   {
+      return alt_;
+   }
+   
+   public boolean isShiftKeyDown()
+   {
+      return shift_;
+   }
+   
+   public boolean isMetaKeyDown()
+   {
+      return leftMeta_ || meta_ || rightMeta_;
+   }
+   
+   private void toggleState(NativeEvent event, boolean enable)
+   {
+      int keyCode = event.getKeyCode();
+      switch (keyCode)
+      {
+      case CTRL:        ctrl_      = enable;  break;
+      case ALT:         alt_       = enable;  break;
+      case SHIFT:       shift_     = enable;  break;
+      case LEFT_META:   leftMeta_  = enable;  break;
+      case META:        meta_      = enable;  break;
+      case RIGHT_META:  rightMeta_ = enable;  break;
+      }
+   }
+   
+   private boolean ctrl_;
+   private boolean alt_;
+   private boolean shift_;
+   private boolean meta_;
+   private boolean leftMeta_;
+   private boolean rightMeta_;
+   
+   private static final int CTRL       = KeyCodes.KEY_CTRL;
+   private static final int ALT        = KeyCodes.KEY_ALT;
+   private static final int SHIFT      = KeyCodes.KEY_SHIFT;
+   private static final int LEFT_META  = 91;
+   private static final int META       = 92;
+   private static final int RIGHT_META = 93;
+}

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -242,6 +242,14 @@ public class DesktopApplicationHeader implements ApplicationHeader
       fireEditEvent(EditEvent.TYPE_PASTE);
       Desktop.getFrame().clipboardPaste();
    }
+   
+   @Handler
+   void onPasteAndIndent()
+   {
+      fireEditEvent(EditEvent.TYPE_PASTE_AND_INDENT);
+      Desktop.getFrame().clipboardPaste();
+   }
+   
 
    @Handler
    void onShowLogFiles()

--- a/src/gwt/src/org/rstudio/studio/client/events/EditEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/events/EditEvent.java
@@ -38,11 +38,14 @@ public class EditEvent extends GwtEvent<EditEvent.Handler>
    private final boolean before_;
    private final int type_;
    
-   public static final int TYPE_NONE  = 0;
-   public static final int TYPE_CUT   = 1;
-   public static final int TYPE_COPY  = 2;
-   public static final int TYPE_PASTE = 4;
+   public static final int TYPE_NONE             = 0;
+   public static final int TYPE_CUT              = 1;
+   public static final int TYPE_COPY             = 2;
+   public static final int TYPE_PASTE            = 3;
+   public static final int TYPE_PASTE_AND_INDENT = 4;
 	
+   public static final EditEvent NONE = new EditEvent(false, TYPE_NONE);
+   
    // Boilerplate ----
    public interface Handler extends EventHandler
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -34,6 +34,8 @@ well as menu structures (for main menu and popup menus).
      This is primarily used by commands which may be active and dispatched to,
      but opt not to handle the event, thereby allowing the browser default
      behavior in response to the pressed key.
+  @platform: The platform (desktop or server) where this should be registered.
+     By default, commands are registered on all platforms.
 -->
 <commands>
    <menu id="mainMenu" vertical="false">
@@ -787,8 +789,8 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="showOptions" value="Meta+," if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="projectOptions" value="Shift+Meta+," if="org.rstudio.core.client.BrowseCap.isMacintosh()"/> 
          <shortcut refid="goToHelp" value="Ctrl+C Ctrl+V" disableModes="default,vim,sublime"/>
-         <shortcut refid="pasteAndIndent" value="Ctrl+Shift+V" if="!org.rstudio.core.client.BrowseCap.isMacintoshDesktop()"/>
-         <shortcut refid="pasteAndIndent" value="Meta+Shift+V" if="org.rstudio.core.client.BrowseCap.isMacintoshDesktop()"/>
+         <shortcut refid="pasteAndIndent" value="Ctrl+Shift+V" platform="desktop" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="pasteAndIndent" value="Meta+Shift+V" platform="desktop" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
       </shortcutgroup>
       <shortcutgroup name="Console">
          <shortcut refid="consoleClear" value="Ctrl+L" disableModes="emacs"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -787,6 +787,8 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="showOptions" value="Meta+," if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="projectOptions" value="Shift+Meta+," if="org.rstudio.core.client.BrowseCap.isMacintosh()"/> 
          <shortcut refid="goToHelp" value="Ctrl+C Ctrl+V" disableModes="default,vim,sublime"/>
+         <shortcut refid="pasteAndIndent" value="Ctrl+Shift+V" if="!org.rstudio.core.client.BrowseCap.isMacintoshDesktop()"/>
+         <shortcut refid="pasteAndIndent" value="Meta+Shift+V" if="org.rstudio.core.client.BrowseCap.isMacintoshDesktop()"/>
       </shortcutgroup>
       <shortcutgroup name="Console">
          <shortcut refid="consoleClear" value="Ctrl+L" disableModes="emacs"/>
@@ -3002,6 +3004,10 @@ well as menu structures (for main menu and popup menus).
         
    <cmd id="pasteDummy"
         menuLabel="_Paste"
+        rebindable="false"/>
+        
+   <cmd id="pasteAndIndent"
+        menuLabel="_Paste and Indent"
         rebindable="false"/>
         
    <cmd id="yankBeforeCursor"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -506,6 +506,7 @@ public abstract class
    public abstract AppCommand cutDummy();
    public abstract AppCommand copyDummy();
    public abstract AppCommand pasteDummy();
+   public abstract AppCommand pasteAndIndent();
 
    // Placeholder for most recently used files
    public abstract AppCommand mru0();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -289,7 +289,7 @@ public class UIPrefsAccessor extends Prefs
    
    public PrefValue<Boolean> reindentOnPaste()
    {
-      return bool("reindent_on_paste", false);
+      return bool("reindent_on_paste", true);
    }
    
    public PrefValue<Boolean> verticallyAlignArgumentIndent()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -289,7 +289,7 @@ public class UIPrefsAccessor extends Prefs
    
    public PrefValue<Boolean> reindentOnPaste()
    {
-      return bool("reindent_on_paste", true);
+      return bool("reindent_on_paste", false);
    }
    
    public PrefValue<Boolean> verticallyAlignArgumentIndent()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -348,9 +348,13 @@ public class AceEditor implements DocDisplay,
                @Override
                public void execute()
                {
-                  if (activeEditEvent_.getType() == EditEvent.TYPE_PASTE_AND_INDENT ||
-                      monitor_.isShiftKeyDown() ||
-                      uiPrefs_.reindentOnPaste().getValue())
+                  boolean reindent =
+                        activeEditEvent_.getType() == EditEvent.TYPE_PASTE_AND_INDENT ||
+                        monitor_.isShiftKeyDown();
+                  
+                  reindent ^= uiPrefs_.reindentOnPaste().getValue();
+                  
+                  if (reindent)
                   {
                      Range range = Range.fromPoints(start, getSelectionEnd());
                      indentPastedRange(range);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -62,6 +62,7 @@ import org.rstudio.core.client.regex.Match;
 import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.core.client.resources.StaticDataResource;
 import org.rstudio.core.client.widget.DynamicIFrame;
+import org.rstudio.studio.client.KeyboardMonitor;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
@@ -71,6 +72,7 @@ import org.rstudio.studio.client.common.debugging.model.Breakpoint;
 import org.rstudio.studio.client.common.filetypes.DocumentMode;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.common.filetypes.DocumentMode.Mode;
+import org.rstudio.studio.client.events.EditEvent;
 import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.MainWindowObject;
 import org.rstudio.studio.client.workbench.commands.Commands;
@@ -341,13 +343,18 @@ public class AceEditor implements DocDisplay,
 
             final Position start = getSelectionStart();
             
-            Scheduler.get().scheduleDeferred(new ScheduledCommand()
+            Scheduler.get().scheduleFinally(new ScheduledCommand()
             {
                @Override
                public void execute()
                {
-                  Range range = Range.fromPoints(start, getSelectionEnd());
-                  indentPastedRange(range);
+                  if (activeEditEvent_.getType() == EditEvent.TYPE_PASTE_AND_INDENT ||
+                      monitor_.isShiftKeyDown() ||
+                      uiPrefs_.reindentOnPaste().getValue())
+                  {
+                     Range range = Range.fromPoints(start, getSelectionEnd());
+                     indentPastedRange(range);
+                  }
                }
             });
          }
@@ -434,6 +441,20 @@ public class AceEditor implements DocDisplay,
             MainWindowObject.lastFocusedEditorId().set(id);
          }
       });
+      
+      events_.addHandler(
+            EditEvent.TYPE,
+            new EditEvent.Handler()
+            {
+               @Override
+               public void onEdit(EditEvent event)
+               {
+                  if (event.isBeforeEdit())
+                     activeEditEvent_ = event;
+                  else
+                     activeEditEvent_ = EditEvent.NONE;
+               }
+            });
       
       events_.addHandler(
             AceEditorCommandEvent.TYPE,
@@ -623,12 +644,8 @@ public class AceEditor implements DocDisplay,
 
    private void indentPastedRange(Range range)
    {
-      if (fileType_ == null ||
-          !fileType_.canAutoIndent() ||
-          !RStudioGinjector.INSTANCE.getUIPrefs().reindentOnPaste().getValue())
-      {
+      if (fileType_ == null || !fileType_.canAutoIndent())
          return;
-      }
 
       String firstLinePrefix = getSession().getTextRange(
             Range.fromPoints(Position.create(range.getStart().getRow(), 0),
@@ -672,13 +689,15 @@ public class AceEditor implements DocDisplay,
                    UIPrefs uiPrefs,
                    CollabEditor collab,
                    Commands commands,
-                   EventBus events)
+                   EventBus events,
+                   KeyboardMonitor monitor)
    {
       server_ = server;
       uiPrefs_ = uiPrefs;
       collab_ = collab;
       commands_ = commands;
       events_ = events;
+      monitor_ = monitor;
    }
 
    public TextFileType getFileType()
@@ -4082,6 +4101,7 @@ public class AceEditor implements DocDisplay,
    private CollabEditor collab_;
    private Commands commands_;
    private EventBus events_;
+   private KeyboardMonitor monitor_;
    private TextFileType fileType_;
    private boolean passwordMode_;
    private boolean useEmacsKeybindings_ = false;
@@ -4102,6 +4122,7 @@ public class AceEditor implements DocDisplay,
    private int scrollTarget_ = 0;
    private HandlerRegistration scrollCompleteReg_;
    private final AceEditorMixins mixins_;
+   private EditEvent activeEditEvent_ = EditEvent.NONE;
    
    private static final ExternalJavaScriptLoader getLoader(StaticDataResource release)
    {


### PR DESCRIPTION
This PR provides for separate [Paste] and [Paste and Reindent] commands. With the PR, <kbd>Ctrl + V</kbd> pastes without indent, while <kbd>Ctrl + Shift + V</kbd> pastes and reindents. The implementation works with both RStudio Server and RStudio Desktop.

Some open questions if we take this PR:

1. Do we want to change the default behavior so that <kbd>Ctrl + V</kbd> no longer reindents by default?

2. Should we keep the 'reindent on paste' UI preference, or instead document that one should use <kbd>Ctrl + Shift + V</kbd> if they do want to reindent after pasting?