### PR TITLE
Fix themes under satellite chunks

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkSatelliteWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkSatelliteWindow.java
@@ -175,8 +175,6 @@ public class ChunkSatelliteWindow extends SatelliteWindow
    @Override
    public void onChunkSatelliteCacheEditorStyle(ChunkSatelliteCacheEditorStyleEvent event)
    {
-      Debug.logToConsole("receiveEvent ChunkSatelliteCacheEditorStyleEvent: " + event.getDocId());
-
       String docId = chunkWindowParams_.getDocId();
       
       if (event.getDocId() != docId)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkSatelliteWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkSatelliteWindow.java
@@ -75,6 +75,12 @@ public class ChunkSatelliteWindow extends SatelliteWindow
    }
 
    @Override
+   public boolean supportsThemes()
+   {
+      return true;
+   }
+
+   @Override
    protected void onInitialize(LayoutPanel mainPanel, JavaScriptObject params)
    {
       chunkWindowParams_ = params.cast();
@@ -169,6 +175,8 @@ public class ChunkSatelliteWindow extends SatelliteWindow
    @Override
    public void onChunkSatelliteCacheEditorStyle(ChunkSatelliteCacheEditorStyleEvent event)
    {
+      Debug.logToConsole("receiveEvent ChunkSatelliteCacheEditorStyleEvent: " + event.getDocId());
+
       String docId = chunkWindowParams_.getDocId();
       
       if (event.getDocId() != docId)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkWindowManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkWindowManager.java
@@ -28,6 +28,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.events.Chun
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.ChunkSatelliteCodeExecutingEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.ChunkSatelliteOpenWindowEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.ChunkSatelliteWindowOpenedEvent;
+import org.rstudio.studio.client.workbench.views.source.editors.text.events.ChunkSatelliteWindowRegisteredEvent;
 import org.rstudio.studio.client.workbench.views.source.events.ChunkChangeEvent;
 
 import com.google.inject.Inject;
@@ -117,8 +118,10 @@ public class ChunkWindowManager
       String chunkId = event.getChunkId();
 
       satelliteChunks_.add(new Pair<String, String>(docId, chunkId));
-
       events_.fireEventToAllSatellites(event);
+
+      ChunkSatelliteWindowRegisteredEvent registeredEvent = new ChunkSatelliteWindowRegisteredEvent(docId, chunkId);
+      events_.fireEvent(registeredEvent);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/events/ChunkSatelliteWindowRegisteredEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/events/ChunkSatelliteWindowRegisteredEvent.java
@@ -1,0 +1,66 @@
+/*
+ * ChunkSatelliteWindowRegisteredEvent.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.source.editors.text.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class ChunkSatelliteWindowRegisteredEvent extends GwtEvent<ChunkSatelliteWindowRegisteredEvent.Handler>
+{  
+   public interface Handler extends EventHandler
+   {
+      void onChunkSatelliteWindowRegistered(ChunkSatelliteWindowRegisteredEvent event);
+   }
+
+   public ChunkSatelliteWindowRegisteredEvent()
+   {
+   }
+   
+   public ChunkSatelliteWindowRegisteredEvent(
+      String docId,
+      String chunkId)
+   {
+      docId_ = docId;
+      chunkId_ = chunkId;
+   }
+
+   public String getDocId()
+   {
+      return docId_;
+   }
+
+   public String getChunkId()
+   {
+      return chunkId_;
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onChunkSatelliteWindowRegistered(this);
+   }
+
+   private String docId_;
+   private String chunkId_;
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -76,7 +76,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.events.Scop
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.ChunkSatelliteCacheEditorStyleEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.ChunkSatelliteCloseAllWindowEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.ChunkSatelliteCodeExecutingEvent;
-import org.rstudio.studio.client.workbench.views.source.editors.text.events.ChunkSatelliteWindowOpenedEvent;
+import org.rstudio.studio.client.workbench.views.source.editors.text.events.ChunkSatelliteWindowRegisteredEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorThemeStyleChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.events.InterruptChunkEvent;
 import org.rstudio.studio.client.workbench.views.source.events.ChunkChangeEvent;
@@ -123,7 +123,7 @@ public class TextEditingTargetNotebook
                           PinnedLineWidget.Host,
                           SourceDocAddedEvent.Handler,
                           RenderFinishedEvent.Handler,
-                          ChunkSatelliteWindowOpenedEvent.Handler
+                          ChunkSatelliteWindowRegisteredEvent.Handler
 {
    public TextEditingTargetNotebook(final TextEditingTarget editingTarget,
                                     TextEditingTargetChunks chunks,
@@ -309,7 +309,7 @@ public class TextEditingTargetNotebook
       releaseOnDismiss_.add(
             events_.addHandler(SourceDocAddedEvent.TYPE, this));
       releaseOnDismiss_.add(
-            events_.addHandler(ChunkSatelliteWindowOpenedEvent.TYPE, this));
+            events_.addHandler(ChunkSatelliteWindowRegisteredEvent.TYPE, this));
       
       // subscribe to global rmd output inline preference and sync
       // again when it changes
@@ -914,7 +914,7 @@ public class TextEditingTargetNotebook
    }
 
    @Override
-   public void onChunkSatelliteWindowOpened(ChunkSatelliteWindowOpenedEvent event)
+   public void onChunkSatelliteWindowRegistered(ChunkSatelliteWindowRegisteredEvent event)
    {
       String docId = event.getDocId();
       String chunkId = event.getChunkId();


### PR DESCRIPTION
@MariaSemple and I troubleshooted this one, couple issues:
1. We recently enabled proper theming in satellite chunks but we missed to also mark the window as themeable.
2. At launch, the satellite chunk would not get the right theme. The problem here is that we were listening for the same event in the SatelliteChunkManager and the text editor which would cause us at times to send an event to a window that was not registered. Fixed this by separating the events to ensure the SatelliteChunkManager processes first chunk registration.