### PR TITLE
Make title window color to match menu color not backgorund color

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -160,6 +160,7 @@ public interface DesktopFrame extends JavaScriptPassthrough
    void zoomActualSize();
    
    void setBackgroundColor(JsArrayInteger rgbColor);
+   void changeTitleBarColor(int r, int g, int b);
    void syncToEditorTheme(boolean isDark);
    
    void getEnableAccessibility(CommandWithArg<Boolean> callback);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
@@ -100,6 +100,13 @@ public class AceThemes
                colors.set(2, parsed.blue());
                Desktop.getFrame().setBackgroundColor(colors);
                Desktop.getFrame().syncToEditorTheme(theme.isDark());
+
+               el = DomUtils.getElementsByClassName("rstheme_toolbarWrapper")[0];
+               style = DomUtils.getComputedStyles(el);
+               color = style.getBackgroundColor();
+               parsed = RGBColor.fromCss(color);
+
+               Desktop.getFrame().changeTitleBarColor(parsed.red(), parsed.green(), parsed.blue());
             }
          }
       }.schedule(100);


### PR DESCRIPTION
Follow up to PR (pointed out by @kevinushey): https://github.com/rstudio/rstudio/pull/3365

I just upgraded to Mojave, my first impression felt like the dark theme was a bit broken, since the color cuts between the window and the menu:

<img width="1120" alt="screen shot 2018-10-04 at 5 18 58 pm" src="https://user-images.githubusercontent.com/3478847/46509870-21588180-c7fa-11e8-8e9f-59057db2c85a.png">

I experimented with setting the menu bar to be the same as the background to match the title, but feels a bit weird since there is no color distinction. @kevinushey suggested matching the title with the menu, which I think it works well, but certainly open to other suggestions:

<img width="1120" alt="screen shot 2018-10-04 at 5 18 42 pm" src="https://user-images.githubusercontent.com/3478847/46509869-21588180-c7fa-11e8-812b-676fac6ecd29.png">

Default theme is left unchanged, even though the change is also applied. Seems to me like Mojave only applies title colors that are dark?

Before:

<img width="300" alt="screen shot 2018-10-04 at 5 24 15 pm" src="https://user-images.githubusercontent.com/3478847/46509907-71374880-c7fa-11e8-8c4e-5c26d323452d.png">

After:
<img width="300" alt="screen shot 2018-10-04 at 5 24 41 pm" src="https://user-images.githubusercontent.com/3478847/46509908-71374880-c7fa-11e8-9bf3-55c9d934deb4.png">