### PR TITLE
implement fallback + validation for locale detection on macOS

### DIFF
--- a/src/cpp/desktop/DesktopUtilsMac.mm
+++ b/src/cpp/desktop/DesktopUtilsMac.mm
@@ -159,6 +159,11 @@ NSString* readSystemLocale()
    // Now, try looking for the active locale using NSLocale.
    std::string localeIdentifier = [[[NSLocale currentLocale] localeIdentifier] UTF8String];
 
+   // Remove trailing @ components (macOS uses @ suffix to append locale overrides)
+   auto idx = localeIdentifier.find('@');
+   if (idx != std::string::npos)
+      localeIdentifier = localeIdentifier.substr(0, idx);
+
    // Enforce a UTF-8 locale.
    localeIdentifier += ".UTF-8";
 
@@ -174,6 +179,11 @@ NSString* readSystemLocale()
       LOG_ERROR(error);
 
    std::string defaultsLocale = string_utils::trimWhitespace(defaultsResult.stdOut);
+
+   // Remove trailing @ components (macOS uses @ suffix to append locale overrides)
+   idx = defaultsLocale.find('@');
+   if (idx != std::string::npos)
+      defaultsLocale = defaultsLocale.substr(0, idx);
 
    // Enforce a UTF-8 locale.
    defaultsLocale += ".UTF-8";

--- a/src/cpp/desktop/DesktopUtilsMac.mm
+++ b/src/cpp/desktop/DesktopUtilsMac.mm
@@ -17,6 +17,8 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 
+#include <core/Algorithm.hpp>
+#include <core/StringUtils.hpp>
 #include <core/system/Environment.hpp>
 
 #import <Foundation/NSString.h>
@@ -136,6 +138,54 @@ void toggleFullscreenMode(QMainWindow* pMainWindow)
       [pWindow toggleFullScreen:nil];
 }
 
+namespace {
+
+NSString* readSystemLocale()
+{
+   using namespace core;
+   using namespace core::algorithm;
+   using namespace core::system;
+   Error error;
+
+   // First, read all available locales so we can validate whether we've received
+   // a valid locale.
+   ProcessResult localeResult;
+   error = runCommand("/usr/bin/locale -a", ProcessOptions(), &localeResult);
+   if (error)
+      LOG_ERROR(error);
+
+   std::string allLocales = localeResult.stdOut;
+
+   // Now, try looking for the active locale using NSLocale.
+   std::string localeIdentifier = [[[NSLocale currentLocale] localeIdentifier] UTF8String];
+
+   // Enforce a UTF-8 locale.
+   localeIdentifier += ".UTF-8";
+
+   if (allLocales.find(localeIdentifier) != std::string::npos)
+      return [NSString stringWithCString: localeIdentifier.c_str()];
+
+   // If that failed, fall back to reading the defaults value. Note that Mojave
+   // (at least with 10.14) reports the wrong locale above and so we rely on this
+   // as a fallback.
+   ProcessResult defaultsResult;
+   error = runCommand("defaults read NSGlobalDomain AppleLocale", ProcessOptions(), &defaultsResult);
+   if (error)
+      LOG_ERROR(error);
+
+   std::string defaultsLocale = string_utils::trimWhitespace(defaultsResult.stdOut);
+
+   // Enforce a UTF-8 locale.
+   defaultsLocale += ".UTF-8";
+
+   if (allLocales.find(defaultsLocale) != std::string::npos)
+      return [NSString stringWithUTF8String: defaultsLocale.c_str()];
+
+   return nullptr;
+}
+
+} // end anonymous namespace
+
 void initializeLang()
 {
    // Not sure what the memory management rules are here, i.e. whether an
@@ -155,7 +205,7 @@ void initializeLang()
       // If force.LANG is present but empty, don't touch LANG at all.
       return;
    }
-
+   
    // Next highest precedence: ignore.system.locale. If it has a value,
    // hardcode to en_US.UTF-8.
    if (!lang && [defaults boolForKey:@"ignore.system.locale"])
@@ -178,21 +228,7 @@ void initializeLang()
    // locale.
    if (!lang)
    {
-      NSString* lcid = [[NSLocale currentLocale] localeIdentifier];
-      if (lcid)
-      {
-         // Eliminate trailing @ components (OS X uses the @ suffix to append
-         // locale overrides like alternate currency formats)
-         std::string localeId = std::string([lcid UTF8String]);
-         std::size_t atLoc = localeId.find('@');
-         if (atLoc != std::string::npos)
-         {
-            localeId = localeId.substr(0, atLoc);
-            lcid = [NSString stringWithUTF8String: localeId.c_str()];
-         }
-
-         lang = [lcid stringByAppendingString:@".UTF-8"];
-      }
+      lang = readSystemLocale();
    }
 
    // None of the above worked. Just hard code it.
@@ -212,7 +248,7 @@ void finalPlatformInitialize(MainWindow* pMainWindow)
 {
    // https://bugreports.qt.io/browse/QTBUG-61707
    [NSWindow setAllowsAutomaticWindowTabbing: NO];
-   
+
    if (!s_pDockMenu)
    {
       s_pDockMenu = new DockMenu(pMainWindow);

--- a/src/cpp/desktop/DesktopUtilsMac.mm
+++ b/src/cpp/desktop/DesktopUtilsMac.mm
@@ -17,7 +17,6 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 
-#include <core/Algorithm.hpp>
 #include <core/StringUtils.hpp>
 #include <core/system/Environment.hpp>
 
@@ -143,7 +142,6 @@ namespace {
 NSString* readSystemLocale()
 {
    using namespace core;
-   using namespace core::algorithm;
    using namespace core::system;
    Error error;
 


### PR DESCRIPTION
Mojave can report nonsensical locales in certain configurations. For example, on my machine, after switching to an Italian locale I see:

```R
$ defaults read NSGlobalDomain AppleLocale
en_IT
```

and because no locale called `en_IT.UTF-8` exists on the system, when RStudio is launched a number of warnings are emitted, and R's unicode support fails in general:

```
Warning: Setting LC_CTYPE failed, using "C"
Warning: Setting LC_COLLATE failed, using "C"
Warning: Setting LC_TIME failed, using "C"
Warning: Setting LC_MESSAGES failed, using "C"
Warning: Setting LC_MONETARY failed, using "C"
```

Note: we should consider backporting this to v1.1.

See also:

https://community.rstudio.com/t/strange-locale-problems-in-r-after-update-to-mojave/15533