### PR TITLE
work around Mojave bug with invisible inputs in addins

### DIFF
--- a/src/cpp/session/modules/SessionRAddins.R
+++ b/src/cpp/session/modules/SessionRAddins.R
@@ -1,7 +1,7 @@
 #
 # SessionRAddins.R
 #
-# Copyright (C) 2014 by RStudio, Inc.
+# Copyright (C) 2014-18 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -14,3 +14,36 @@
 #
 
 assign(".rs.rAddinsEnv", new.env(parent = emptyenv()), envir = .rs.toolsEnv())
+
+.rs.addJsonRpcHandler("prepare_for_addin", function()
+{
+   assign(
+      ".rs.addins.savedShinyResponseFilter",
+      getOption("shiny.http.response.filter"),
+      envir = .rs.toolsEnv())
+   
+   options(shiny.http.response.filter = .rs.addins.shinyResponseFilter)
+})
+
+.rs.addFunction("addins.shinyResponseFilter", function(request, response)
+{
+   # bail if this isn't the root response
+   if (!identical(request$PATH_INFO, "/"))
+      return(response)
+   
+   # remove our old handler
+   options(shiny.http.response.filter = .rs.addins.savedShinyResponseFilter)
+   rm(".rs.addins.savedShinyResponseFilter", envir = .rs.toolsEnv())
+   
+   # ensure text is character rather than raw (not sure if this can happen
+   # but other shiny.http.response.filters do this so best to be safe)
+   if (is.raw(response$content))
+      response$content <- rawToChar(response$content)
+   
+   # inject our CSS into the response
+   css <- '<style type="text/css">select, input { zoom: 1.000001; }</style>'
+   response$content <- sub('<head>', paste('<head>', css, sep = ""), response$content, fixed = TRUE)
+   
+   # return the response
+   response
+})

--- a/src/cpp/session/modules/SessionRAddins.cpp
+++ b/src/cpp/session/modules/SessionRAddins.cpp
@@ -30,6 +30,7 @@
 
 #include <r/RSexp.hpp>
 #include <r/RExec.hpp>
+#include <r/RRoutines.hpp>
 
 #include <session/projects/SessionProjects.hpp>
 #include <session/SessionModuleContext.hpp>
@@ -43,6 +44,8 @@ namespace modules {
 namespace r_addins {
 
 namespace {
+
+boost::signals::connection s_consolePromptHandler;
 
 bool isDevtoolsLoadAllActive()
 {
@@ -487,6 +490,24 @@ Error executeRAddin(const json::JsonRpcRequest& request,
    return Success();
 }
 
+void onConsolePrompt(const std::string&)
+{
+   Error error = r::exec::RFunction(".rs.addins.removeShinyResponseFilter").call();
+   if (error)
+      LOG_ERROR(error);
+
+   s_consolePromptHandler.disconnect();
+}
+
+SEXP rs_registerAddinConsolePromptHandler()
+{
+   using namespace module_context;
+
+   s_consolePromptHandler = events().onConsolePrompt.connect(onConsolePrompt);
+
+   return R_NilValue;
+}
+
 } // end anonymous namespace
 
 core::json::Value addinRegistryAsJson()
@@ -504,6 +525,9 @@ Error initialize()
    
    // register worker
    ppe::indexer().addWorker(addinWorker());
+
+   // register call methods
+   RS_REGISTER_CALL_METHOD(rs_registerAddinConsolePromptHandler);
    
    ExecBlock initBlock;
    initBlock.addFunctions()

--- a/src/gwt/src/org/rstudio/core/client/BrowseCap.java
+++ b/src/gwt/src/org/rstudio/core/client/BrowseCap.java
@@ -92,6 +92,12 @@ public class BrowseCap
    {
       return Desktop.isDesktop() && isMacintosh();
    }
+   
+   public static boolean isMacintoshDesktopMojave()
+   {
+      return isMacintoshDesktop() && isUserAgent("mac os x 10_14");
+            
+   }
   
    public static boolean isWindows()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4378,6 +4378,12 @@ public class RemoteServer implements Server
    }
    
    @Override
+   public void prepareForAddin(ServerRequestCallback<Void> requestCallback)
+   {
+      sendRequest(RPC_SCOPE, PREPARE_FOR_ADDIN, requestCallback);
+   }
+   
+   @Override
    public void executeRAddinNonInteractively(String commandId, ServerRequestCallback<Void> requestCallback)
    {
       JSONArray params = new JSONArray();
@@ -5984,6 +5990,7 @@ public class RemoteServer implements Server
    private static final String GET_PRODUCT_INFO = "get_product_info";
    
    private static final String GET_R_ADDINS = "get_r_addins";
+   private static final String PREPARE_FOR_ADDIN = "prepare_for_addin";
    private static final String EXECUTE_R_ADDIN = "execute_r_addin";
 
    private static final String CREATE_SHINY_APP = "create_shiny_app";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/addins/AddinsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/addins/AddinsServerOperations.java
@@ -8,5 +8,9 @@ public interface AddinsServerOperations
 {
    void getRAddins(boolean reindex,
                    ServerRequestCallback<RAddins> requestCallback);
-   void executeRAddinNonInteractively(String commandId, ServerRequestCallback<Void> requestCallback);
+   
+   void prepareForAddin(ServerRequestCallback<Void> requestCallback);
+   
+   void executeRAddinNonInteractively(String commandId,
+                                      ServerRequestCallback<Void> requestCallback);
 }


### PR DESCRIPTION
Closes #3602.

Note that while I would've preferred to do this entirely in the front-end, cross-site origin rules disallow us from modifying the Shiny gadget window (as its running on a different port, and so a different origin).