### PR TITLE
Support for testing testthat files with any package dir name

### DIFF
--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -1157,7 +1157,7 @@ private:
       std::vector<std::string> rSourceCommands;
       
       boost::format fmt(
-         "if (nzchar('%1%')) devtools::load_all('%1%');"
+         "if (nzchar('%1%')) devtools::load_all(devtools::as.package(dirname('%2%')));"
          "testthat::test_file('%2%')"
       );
 


### PR DESCRIPTION
When testing `testthat` tests with a package that matches the folder, this works just fine. However, testing a file does not work if the package folder does not match the package name.

Repro:
- Clone https://github.com/rstudio/sparklyr or https://github.com/apache/arrow.
- Rename sparklyr folder to `sparklyr2` or use `arrow/r` path.
- Run test `test-config.R` or `test-RecordBatch.R`.

Actual:

```
==> Testing R file using 'testthat'

Error: Can't find 'arrow'.
Execution halted

Exited with status 1.
```

Expected, test file to run properly.

The problem is that `devtools::load_all()` expects a package name or a package object, which we can retrieve with `devtools::as.package()`.