### PR TITLE
clamp popup menu size and make scrollable

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/BaseMenuBar.java
+++ b/src/gwt/src/org/rstudio/core/client/command/BaseMenuBar.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.core.client.command;
 
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.user.client.DOM;
@@ -149,6 +150,7 @@ public class BaseMenuBar extends MenuBar
       if (vertical_ && glass++ == 0)
          eventBus_.fireEvent(new GlassVisibilityEvent(true));
       super.onLoad();
+      
       for (MenuItem child : getItems())
       {
          if (child instanceof AppMenuItem)
@@ -171,8 +173,11 @@ public class BaseMenuBar extends MenuBar
             }
          }
       }
+      
       if (autoHideRedundantSeparators_)
          manageSeparators();
+      
+      Scheduler.get().scheduleFinally(() -> DomUtils.clampHeight(getElement(), 400));
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/core/client/command/BaseMenuBar.java
+++ b/src/gwt/src/org/rstudio/core/client/command/BaseMenuBar.java
@@ -14,7 +14,6 @@
  */
 package org.rstudio.core.client.command;
 
-import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.user.client.DOM;
@@ -177,7 +176,7 @@ public class BaseMenuBar extends MenuBar
       if (autoHideRedundantSeparators_)
          manageSeparators();
       
-      Scheduler.get().scheduleFinally(() -> DomUtils.clampHeight(getElement(), 400));
+      DomUtils.clampHeight(getElement(), 400);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -39,6 +39,7 @@ import java.util.List;
 
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.MathUtil;
 import org.rstudio.core.client.Point;
 import org.rstudio.core.client.Rectangle;
 import org.rstudio.core.client.command.KeyboardShortcut;
@@ -1135,6 +1136,15 @@ public class DomUtils
       return width;
       
    }-*/;
+   
+   public static final void clampHeight(Element element, int requestedHeight)
+   {
+      int windowHeight = Window.getClientHeight();
+      int currentTop = element.getAbsoluteTop();
+      int newHeight = MathUtil.clamp(requestedHeight, 20, windowHeight - currentTop - 10);
+      element.getStyle().setPropertyPx("maxHeight", newHeight);
+      element.getStyle().setOverflowY(Style.Overflow.AUTO);
+   }
    
    public static final int ESTIMATED_SCROLLBAR_WIDTH = 19;
    private static int SCROLLBAR_WIDTH = -1;


### PR DESCRIPTION
This PR limits the size of menu bars, and makes them scrollable by default.

<img width="200" alt="screen shot 2018-10-09 at 10 15 36 am" src="https://user-images.githubusercontent.com/1976582/46686161-4bb88f00-cbac-11e8-86cb-3fee4fe75c07.png">

<img width="197" alt="screen shot 2018-10-09 at 10 15 18 am" src="https://user-images.githubusercontent.com/1976582/46686162-4bb88f00-cbac-11e8-9832-54c21c9cc241.png">


Closes #1760, #1794, #2330.