### PR TITLE
enable publish/republish of rendered websites from editor publish button

### DIFF
--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -133,7 +133,13 @@
    outputFormat <- rmarkdown:::output_format_from_yaml_front_matter(lines)
    outputFormat <- rmarkdown:::create_output_format(outputFormat$name, outputFormat$options)
    outputFile <- rmarkdown:::pandoc_output_file(target, outputFormat$pandoc)
-   outputPath <- file.path(dirname(target), outputFile) 
+
+   # determine location of output file, accounting for possibility of a website project which
+   # puts the output in a different location than the source file
+   outputDir <- .Call("rs_getWebsiteOutputDir")
+   if (is.null(outputDir))
+      outputDir <- dirname(target)
+   outputPath <- file.path(outputDir, outputFile)
    
    # ensure output file exists
    fileExists <- file.exists(outputPath)

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -1293,6 +1293,18 @@ SEXP rs_paramsFileForRmd(SEXP fileSEXP)
    return r::sexp::create(s_paramsFiles[file], &rProtect);
 }
 
+SEXP rs_getWebsiteOutputDir()
+{
+   SEXP absolutePathSEXP = R_NilValue;
+
+   FilePath outputDir(module_context::websiteOutputDir());
+   if (!outputDir.empty())
+   {
+      r::sexp::Protect protect;
+      absolutePathSEXP = r::sexp::create(outputDir.absolutePath(), &protect);
+   }
+   return absolutePathSEXP;
+}
 
 void onShutdown(bool terminatedNormally)
 {
@@ -1371,6 +1383,11 @@ Error initialize()
    methodDef.fun = (DL_FUNC)rs_paramsFileForRmd ;
    methodDef.numArgs = 1;
    r::routines::addCallMethod(methodDef);
+
+   r::routines::registerCallMethod(
+         "rs_getWebsiteOutputDir",
+         (DL_FUNC) rs_getWebsiteOutputDir,
+         0);
 
    initEnvironment();
 

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -1378,16 +1378,8 @@ Error initialize()
    using boost::bind;
    using namespace module_context;
 
-   R_CallMethodDef methodDef ;
-   methodDef.name = "rs_paramsFileForRmd" ;
-   methodDef.fun = (DL_FUNC)rs_paramsFileForRmd ;
-   methodDef.numArgs = 1;
-   r::routines::addCallMethod(methodDef);
-
-   r::routines::registerCallMethod(
-         "rs_getWebsiteOutputDir",
-         (DL_FUNC) rs_getWebsiteOutputDir,
-         0);
+   RS_REGISTER_CALL_METHOD(rs_paramsFileForRmd);
+   RS_REGISTER_CALL_METHOD(rs_getWebsiteOutputDir);
 
    initEnvironment();
 


### PR DESCRIPTION
- detect rendered files for website project in correct location (e.g. _site)
- remove old code that stripped out previous static website publishes from dropdown
- removed unnecessary arguments to private helper `fireDeployDocEvent()`; no need to pass it member variables

Fixes #3430 

Note: this was a scenario missed when implementing #3266