### PR TITLE
Allow secondary repos to be completely removed

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -519,18 +519,10 @@ assign(envir = .rs.Env, ".rs.hasVar", function(name)
 .rs.addFunction( "setCRANRepos", function(cran, secondary)
 {
   local({
-      if (nchar(secondary) > 0)
-      {
-        r <- c(
-          list(CRAN = cran),
-          .rs.parseCRANReposList(secondary)
-        )
-      }
-      else
-      {
-        r <- getOption("repos");
-        r["CRAN"] <- cran;
-      }
+      r <- c(
+        list(CRAN = cran),
+        .rs.parseCRANReposList(secondary)
+      )
 
       # attribute indicating the repos was set from rstudio prefs
       attr(r, "RStudio") <- TRUE

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
@@ -76,7 +76,7 @@ public class PackagesPreferencesPane extends PreferencesPane
       management.add(headerLabel("Package Management"));
 
       infoBar_ = new InfoBar(InfoBar.WARNING);
-      infoBar_.setText("CRAN repositories were modified outside package preferences.");
+      infoBar_.setText("CRAN repositories modified outside package preferences.");
       infoBar_.addStyleName(res_.styles().themeInfobar());
       spaced(infoBar_);
       


### PR DESCRIPTION
Fix for https://github.com/rstudio/rstudio/issues/3621

When changing secondary repos, if all are removed changes do not take effect for the secondary repos. This has always been the case, to my knowledge since we were only modifying repos when secondaries where non-empty.

The fix is to always is the secondaries field; however, `setCRANRepos()` is only called if `.rs.isCRANReposFromSettings()` and `!cranMirrorConfigured` which checks the repos for the special `RStudio` attribute to ensure we don't modify CRAN settings set through the RProfile or in other ways, we simply never modify repos that were not set by RStudio.

Also fixes this:

<img width="367" alt="screen shot 2018-10-09 at 1 35 48 pm" src="https://user-images.githubusercontent.com/3478847/46699019-71a25b80-cbcd-11e8-9c0a-21b0db2ad4aa.png">

To...

<img width="379" alt="screen shot 2018-10-09 at 2 06 56 pm" src="https://user-images.githubusercontent.com/3478847/46699020-723af200-cbcd-11e8-9967-b4b057a778e3.png">
