### PR TITLE
update win32 manifests to state support for 8, 8.1, 10

### DIFF
--- a/src/cpp/desktop/rstudio.exe.manifest
+++ b/src/cpp/desktop/rstudio.exe.manifest
@@ -14,10 +14,16 @@
    </trustInfo>
    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
       <application>
-         <!--The ID below indicates application support for Windows Vista -->
+         <!-- Windows 10 -->
+         <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+         <!-- Windows 8.1 -->
+         <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+         <!-- Windows Vista -->
          <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-         <!--The ID below indicates application support for Windows 7 -->
+         <!-- Windows 7 -->
          <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+         <!-- Windows 8 -->
+         <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
       </application>
    </compatibility>
 </assembly>

--- a/src/cpp/desktop/synctex/rsinverse/rsinverse.exe.manifest
+++ b/src/cpp/desktop/synctex/rsinverse/rsinverse.exe.manifest
@@ -14,10 +14,16 @@
    </trustInfo>
    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
       <application>
-         <!--The ID below indicates application support for Windows Vista -->
+         <!-- Windows 10 -->
+         <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+         <!-- Windows 8.1 -->
+         <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+         <!-- Windows Vista -->
          <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-         <!--The ID below indicates application support for Windows 7 -->
+         <!-- Windows 7 -->
          <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+         <!-- Windows 8 -->
+         <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
       </application>
    </compatibility>
 </assembly>

--- a/src/cpp/desktop/urlopener/urlopener.exe.manifest
+++ b/src/cpp/desktop/urlopener/urlopener.exe.manifest
@@ -14,10 +14,16 @@
    </trustInfo>
    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
       <application>
-         <!--The ID below indicates application support for Windows Vista -->
+         <!-- Windows 10 -->
+         <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+         <!-- Windows 8.1 -->
+         <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+         <!-- Windows Vista -->
          <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-         <!--The ID below indicates application support for Windows 7 -->
+         <!-- Windows 7 -->
          <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+         <!-- Windows 8 -->
+         <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
       </application>
    </compatibility>
 </assembly>

--- a/src/cpp/diagnostics/diagnostics.exe.manifest
+++ b/src/cpp/diagnostics/diagnostics.exe.manifest
@@ -14,10 +14,16 @@
    </trustInfo>
    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
       <application>
-         <!--The ID below indicates application support for Windows Vista -->
+         <!-- Windows 10 -->
+         <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+         <!-- Windows 8.1 -->
+         <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+         <!-- Windows Vista -->
          <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-         <!--The ID below indicates application support for Windows 7 -->
+         <!-- Windows 7 -->
          <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+         <!-- Windows 8 -->
+         <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
       </application>
    </compatibility>
 </assembly>

--- a/src/cpp/session/consoleio/consoleio.exe.manifest
+++ b/src/cpp/session/consoleio/consoleio.exe.manifest
@@ -14,10 +14,16 @@
    </trustInfo>
    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
       <application>
-         <!--The ID below indicates application support for Windows Vista -->
+         <!-- Windows 10 -->
+         <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+         <!-- Windows 8.1 -->
+         <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+         <!-- Windows Vista -->
          <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-         <!--The ID below indicates application support for Windows 7 -->
+         <!-- Windows 7 -->
          <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+         <!-- Windows 8 -->
+         <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
       </application>
    </compatibility>
 </assembly>

--- a/src/cpp/session/rsession.exe.manifest
+++ b/src/cpp/session/rsession.exe.manifest
@@ -14,10 +14,16 @@
    </trustInfo>
    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
       <application>
-         <!--The ID below indicates application support for Windows Vista -->
+         <!-- Windows 10 -->
+         <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+         <!-- Windows 8.1 -->
+         <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+         <!-- Windows Vista -->
          <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-         <!--The ID below indicates application support for Windows 7 -->
+         <!-- Windows 7 -->
          <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+         <!-- Windows 8 -->
+         <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
       </application>
    </compatibility>
 </assembly>


### PR DESCRIPTION
fixes #2899 

Use same Windows version list in the application manifest as used by R GUI (adding 8, 8.1, and 10 in addition to existing Vista and Win-7 GUIDs).

On Windows 8.1+ this causes the RStudio processes (including rstudio.exe and rsession.exe) to run in the actual operating system context, instead of the downlevel context.

More specifically, causes `win.version()` to return the actual Windows build instead of being stuck on showing build 9200.

This seems worth taking for 1.2 because it makes RStudio behavior match R GUI in this regard, and is "only" a metadata update (i.e. we can easily remove this if we discover any issues). That said, if we'd rather wait for 1.3, I'd understand.

https://docs.microsoft.com/en-us/windows/desktop/sbscs/application-manifests
