### PR TITLE
Allow disabling connection installers without warnings

### DIFF
--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -877,7 +877,7 @@ options(connectionObserver = list(
    if (!.rs.isDesktop()) return(list())
 
    # once per session, attempt to download driver updates
-   if (!is.null(installerUrl)) {
+   if (!is.null(installerUrl) && nchar(installerUrl) > 0) {
       installerHostName <- gsub("https?://|/[^:].+$", "", installerUrl)
 
       connectionsWarning <- tryCatch({


### PR DESCRIPTION
It is possible to disable ODBC installer connections with:

```
options("connections-installer" = "")
```

However, a warning triggers that is not desirable.