### PR TITLE
fix duplication of scope tree elements

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ScopeManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ScopeManager.java
@@ -35,7 +35,7 @@ public class ScopeManager
    public final native void onScopeEnd(Position position);
    public final native JsArray<Scope> getActiveScopes(Position position);
    public final native JsArray<Scope> getScopeList();
-   public final native void invalidateFrom(Position position);
+   public final native Position invalidateFrom(Position position);
    
    @JsOverlay
    public final Scope getScopeAt(Position position)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ScopeTreeManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ScopeTreeManager.java
@@ -60,8 +60,12 @@ public abstract class ScopeTreeManager
             docDisplay.addDocumentChangedHandler((DocumentChangedEvent event) -> {
                final Position position = event.getEvent().getRange().getStart();
                Scheduler.get().scheduleDeferred(() -> {
-                  scopeManager_.invalidateFrom(Position.create(position));
-                  worker_.rebuildScopeTreeFromRow(position.getRow());
+                  
+                  Position rebuildPos = scopeManager_.invalidateFrom(Position.create(position));
+                  if (rebuildPos == null)
+                     rebuildPos = position;
+                     
+                  worker_.rebuildScopeTreeFromRow(rebuildPos.getRow());
                });
             }),
             
@@ -129,7 +133,7 @@ public abstract class ScopeTreeManager
          // to find any initial token. in that case, just step forward (this should
          // walk to the first token in the document)
          TokenIterator it = docDisplay_.createTokenIterator();
-         Token token = it.moveToPosition(position);
+         Token token = it.moveToPosition(position, true);
          if (token == null)
             token = it.stepForward();
          


### PR DESCRIPTION
This PR fixes a token OB1 error where we could accidentally re-commit a brace to the scope tree, leading to duplicated elements in the document outline.

![screen shot 2018-10-11 at 3 18 51 pm](https://user-images.githubusercontent.com/1976582/46837165-1311e480-cd69-11e8-9ec3-57f89fefa7da.png)

The fix here ensures that the token iteration occurs _after_ the last-parsed position, rather than on it.

Note that this bug only affects Stan, as this is the only programming language using the newly-implemented (code-model decoupled) scope tree thus far.