### PR TITLE
encode URL components in R help

### DIFF
--- a/src/cpp/core/include/core/Algorithm.hpp
+++ b/src/cpp/core/include/core/Algorithm.hpp
@@ -281,6 +281,17 @@ inline std::string join(Iterator begin, Iterator end, const std::string& delim)
    return result;
 }
 
+template <typename F>
+inline std::string spliterate(const std::string& string,
+                              const std::string& delimiter,
+                              F&& f)
+{
+   std::vector<std::string> pieces = split(string, delimiter);
+   for (auto&& piece : pieces)
+      piece = f(piece);
+   return join(pieces, delimiter);
+}
+
 } // namespace algorithm
 } // namespace core
 } // namespace rstudio


### PR DESCRIPTION
Encode URL components used for links within R help pages, as some links will contain invalid characters (e.g. the `seq()` help page contains a link to `:`, but does not URL encode it).

Closes #3648.