### PR TITLE
can't safely get address of empty vector

### DIFF
--- a/src/cpp/core/include/core/SafeConvert.hpp
+++ b/src/cpp/core/include/core/SafeConvert.hpp
@@ -1,7 +1,7 @@
 /*
  * SafeConvert.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -137,10 +137,18 @@ boost::optional<TOutput> numberTo(TInput input)
    return result;
 }
 
+// Indexing into an empty vector causes assertion failures on some platforms.
+// Cannot rely on vector::data() as it is not guaranteed to be nullptr for
+// empty vectors.
+template <typename T>
+T* safe_vec_addr(std::vector<T>& vec)
+{
+   return vec.size() ? &vec[0] : nullptr;
+}
+
 } // namespace safe_convert
 } // namespace core 
 } // namespace rstudio
-
 
 #endif // CORE_SAFE_CONVERT_HPP
 

--- a/src/cpp/core/system/PosixGroup.cpp
+++ b/src/cpp/core/system/PosixGroup.cpp
@@ -1,7 +1,7 @@
 /*
  * PosixGroup.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -55,10 +55,10 @@ Error groupFrom(const boost::function<int(
    int result = 0;
    do
    {
-      buffer.reserve(buffSize);
+      buffer.resize(buffSize);
 
       // attempt the read
-      result = getGroup(value, &grp, &(buffer[0]), buffSize, &temp);
+      result = getGroup(value, &grp, safe_convert::safe_vec_addr(buffer), buffer.size(), &temp);
 
       // if we fail, double the buffer prior to retry
       if (result == ERANGE)


### PR DESCRIPTION
Ran into this doing Pro Server work on an Ubuntu Bionic (18) VM, with a Debug build of the product.

Server would assert and terminate on startup. This is same issue that httpuv project was hitting here:

https://github.com/rstudio/httpuv/issues/133

Debug build uses _GLIBCXX_ASSERTIONS and which asserts on usage of this pattern:

&v[0], where "v" is a vector

Take address of first element of a potentially empty vector is undefined behavior in C++.

Also can't just use vector::data(), because the return value of data() may or may not be nullptr for an empty vector, per C++ docs. (D'oh)

So added `safe_vec_addr` as used by httuv. I only fixed the one case that was preventing me from starting the server with a Debug build. This case isn't an actual runtime problem, but other cases could be, at least in theory.

I will open an issue to do a comprehensive survey of the codebase to find other potential problems of this sort and/or fix them as I hit them.