### PR TITLE
avoid double quotes in repos option string (closes #3686)

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1920,13 +1920,19 @@
    else
       getOption("download.file.extra")
    
+   # NOTE: we need to quote arguments with single quotes below,
+   # as this command will be submitted using double quotes (and
+   # embedded quotes in the command are not properly escaped)
+   escape <- function(string)
+      sprintf("'%s'", gsub("'", "\\'", string, fixed = TRUE))
+   
    data <- list()
    if (length(repos)) {
       data[["repos"]] <- sprintf(
          "c(%s)",
          paste(
-            shQuote(names(repos)),
-            shQuote(as.character(repos)),
+            escape(names(repos)),
+            escape(as.character(repos)),
             sep = " = ",
             collapse = ", "
          )


### PR DESCRIPTION
`shQuote()` will quote arguments using double quotes on Windows by default, but this unfortunately doesn't work as expected when we construct our R command invocations.

Avoid this by explicitly quoting pieces with single-quotes.