### PR TITLE
use generic 'build package documentation' language for roxygenize

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -2942,8 +2942,9 @@ well as menu structures (for main menu and popup menus).
         context="packageDevelopment"/>
 
    <cmd id="roxygenizePackage"
+        label="Build Package Documentation"
         menuLabel="_Document"
-        desc="Run roxygen2 to document this package"
+        desc="Build package documentation"
         windowMode="background"
         context="packageDevelopment"/>
 


### PR DESCRIPTION
One part of https://github.com/rstudio/rstudio/issues/3699.