### PR TITLE
Added HEAD to the list of allowed HTTP methods. 

### DIFF
--- a/src/cpp/core/include/core/http/AsyncServerImpl.hpp
+++ b/src/cpp/core/include/core/http/AsyncServerImpl.hpp
@@ -365,8 +365,9 @@ private:
             // flow all traffic like a proxy
             const std::string& method = pRequest->method();
             if (method != "GET" &&
-                method != "PUT" &&
-                method != "POST")
+                method != "POST" &&
+                method != "HEAD" &&
+                method != "PUT")
             {
                // invalid method - fail out
                LOG_ERROR_MESSAGE("Invalid method " + method + " requested for uri: " + pRequest->uri());


### PR DESCRIPTION
HEAD should always be allowed, but this was an oversight for the change made in https://github.com/rstudio/rstudio/pull/1452. 

Made in response to community post: https://community.rstudio.com/t/502-errors-with-nginx-proxy-and-rstudio-server-preview/16614/1