### PR TITLE
normalize search query in help page

### DIFF
--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -136,7 +136,7 @@ std::string normalizeHttpdSearchContent(const std::string& content)
       if (query.find('<') != std::string::npos)
          query = string_utils::htmlEscape(query);
 
-      return m[1] + string_utils::htmlEscape(m[2]) + m[3];
+      return m[1] + query + m[3];
    });
 }
 


### PR DESCRIPTION
Ensure that search queries are HTML escaped before display.