### PR TITLE
Use modified data grid for keyboard shortcuts to avoid scroll flashing

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
@@ -234,7 +234,7 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
       changes_ = new HashMap<KeyboardShortcutEntry, KeyboardShortcutEntry>();
       buffer_ = new KeySequence();
       
-      table_ = new DataGrid<KeyboardShortcutEntry>(1000, RES, KEY_PROVIDER);
+      table_ = new RStudioDataGrid<KeyboardShortcutEntry>(1000, RES, KEY_PROVIDER);
       
       FlowPanel emptyWidget = new FlowPanel();
       Label emptyLabel = new Label("No bindings available");


### PR DESCRIPTION
We use GWT's DataGrid control for the Modify Keyboard Shortcuts dialog. This has some known issues with flashing scrollbars in unexpected places under Chromium. 

As part of an earlier fix, I created the RStudioDataGrid class, which is effectively just a DataGrid plus some DOM surgery to clean up the elements that cause the issue. This change uses that class for the Modify Keyboard Shortcuts dialog.

Fixes #3707. 