### PR TITLE
Add odbcinstlib entry in OS X for ODBC drivers

### DIFF
--- a/src/cpp/session/modules/SessionConnectionsInstaller.R
+++ b/src/cpp/session/modules/SessionConnectionsInstaller.R
@@ -391,16 +391,16 @@
 .rs.addFunction("odbcOdbcInstLibPath", function() {
    odbcinstLib <- NULL
 
-   odbcinstBin <- system2("which", "odbcinst", stdout = TRUE)
-   if (is.null(odbcinstBin) || length(odbcinstBin) == 0) {
+   odbcinstBin <- Sys.which("odbcinst")
+   if (nchar(odbcinstBin) == 0) {
       warning("Could not find path to odbcinst.")
    }
    else {
-      odbcinstLink <- system2("readlink", odbcinstBin, stdout = T)
-      if (!is.null(odbcinstLink) && length(odbcinstLink) > 0) {
+      odbcinstLink <- Sys.readlink(odbcinstBin)
+      if (!is.na(odbcinstLink)) {
          odbcinstBinPath <- normalizePath(file.path(dirname(odbcinstBin), dirname(odbcinstLink)))
          odbcinstLibPath <- normalizePath(file.path(odbcinstBinPath, "..", "lib"))
-         odbcinstLib <- dir(odbcinstLibPath, pattern = "libodbcinst.*\\.dylib", full.names = T)[[1]]
+         odbcinstLib <- dir(odbcinstLibPath, pattern = "libodbcinst.*\\.dylib", full.names = TRUE)[[1]]
       }
    }
 
@@ -426,7 +426,7 @@
 })
 
 .rs.addFunction("odbcBundleDriverIniPath", function(name, driverPath) {
-   dir(driverPath, pattern = paste(tolower(name), ".*\\.ini", sep = ""), recursive = T, full.names = T)
+   dir(driverPath, pattern = paste(tolower(name), ".*\\.ini", sep = ""), recursive = TRUE, full.names = T)
 })
 
 .rs.addFunction("odbcBundleRegisterOSX", function(name, driverPath, version, installPath) {

--- a/src/cpp/session/modules/SessionConnectionsInstaller.R
+++ b/src/cpp/session/modules/SessionConnectionsInstaller.R
@@ -407,7 +407,7 @@
    odbcinstLib
 })
 
-.rs.addFunction("odbcBundleRegisterLinux", function(name, driverPath, version) {
+.rs.addFunction("odbcBundleRegisterLinux", function(name, driverPath, version, installPath) {
    # Find odbcinst.ini file
    odbcinstPath <- .rs.odbcBundleOdbcinstPath()
    
@@ -420,23 +420,44 @@
       paste("Version", "=", version),
       paste("Installer", "=", "RStudio")
    )
-
-   # In OSX register to use unixODBC
-   if (identical(.rs.odbcBundleOsName(), "osx")) {
-      odbcinstLib <- .rs.odbcOdbcInstLibPath()
-      if (!is.null(odbcinstLib)) {
-         odbcinst[[name]] <- c(
-            odbcinst[[name]],
-            paste("ODBCInstLib", "=", odbcinstLib)
-         )
-      }
-   }
    
    # Write odbcinst.ini
    .rs.odbcBundleWriteIni(odbcinstPath, odbcinst)
 })
 
-.rs.addFunction("odbcBundleRegisterWindows", function(name, driverPath, version) {
+.rs.addFunction("odbcBundleDriverIniPath", function(name, driverPath) {
+   dir(driverPath, pattern = paste(tolower(name), ".*\\.ini", sep = ""), recursive = T, full.names = T)
+})
+
+.rs.addFunction("odbcBundleRegisterOSX", function(name, driverPath, version, installPath) {
+   # Update odbcinst.ini
+   .rs.odbcBundleRegisterLinux(name, driverPath, version, installPath)
+
+   # Find driver.ini file
+   driverIniFile <- .rs.odbcBundleDriverIniPath(name, installPath)
+   
+   if (length(driverIniFile) == 0) {
+      warning("Could not find '", name, "' driver INI file under: ", installPath)
+   }
+   else {
+      # Read driver.ini
+      driverIni <- .rs.odbcBundleReadIni(driverIniFile)
+
+      # In OSX register to use unixODBC
+      odbcinstLib <- .rs.odbcOdbcInstLibPath()
+      if (!is.null(odbcinstLib)) {
+         driverIni[["Driver"]] <- c(
+            driverIni[["Driver"]],
+            paste("ODBCInstLib", "=", odbcinstLib)
+         )
+      }
+      
+      # Write odbcinst.ini
+      .rs.odbcBundleWriteIni(driverIniFile, driverIni)
+   }
+})
+
+.rs.addFunction("odbcBundleRegisterWindows", function(name, driverPath, version, installPath) {
    .rs.odbcBundleRegistryAdd(
       list(
          list(
@@ -497,16 +518,16 @@
    normalizePath(driverPath)
 })
 
-.rs.addFunction("odbcBundleRegister", function(name, driverPath, version) {
+.rs.addFunction("odbcBundleRegister", function(name, driverPath, version, installPath) {
    osRegistrations <- list(
-      osx = .rs.odbcBundleRegisterLinux,
+      osx = .rs.odbcBundleRegisterOSX,
       windows = .rs.odbcBundleRegisterWindows,
       linux = .rs.odbcBundleRegisterLinux
    )
    
    osRegistration <- osRegistrations[[.rs.odbcBundleOsName()]]
    
-   osRegistration(name, driverPath, version) 
+   osRegistration(name, driverPath, version, installPath) 
 })
 
 .rs.addFunction("odbcBundleValidate", function(bundleFile, md5) {
@@ -557,7 +578,7 @@
    driverPath <- .rs.odbcBundleFindDriver(name, installPath, libraryPattern)
    
    message("Registering driver")
-   .rs.odbcBundleRegister(name, driverPath, version)
+   .rs.odbcBundleRegister(name, driverPath, version, installPath)
 
    message("")
    message("Installation complete")


### PR DESCRIPTION
In OS X, iODBC takes precedence over unixODBC and therefore, ODBC drivers should be hinted that unixODBC should be used to get DSN to work properly.