### PR TITLE
use functor instead of lambda

### DIFF
--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -122,19 +122,25 @@ bool isLocalURL(const std::string& url,
    return false;
 }
 
-std::string normalizeHttpdSearchContent(const std::string& content)
+class EscapeHttpdQuery
 {
-   return boost::regex_replace(
-            content,
-            boost::regex("(The search string was <b>\")(.*)(\"</b>)"),
-            [](const boost::smatch& m)
+public:
+   std::string operator()(const boost::smatch& m)
    {
       std::string query = m[2];
       if (query.find('<') != std::string::npos)
          query = string_utils::htmlEscape(query);
 
       return m[1] + query + m[3];
-   });
+   }
+};
+
+std::string normalizeHttpdSearchContent(const std::string& content)
+{
+   return boost::regex_replace(
+            content,
+            boost::regex("(The search string was <b>\")(.*)(\"</b>)"),
+            EscapeHttpdQuery());
 }
 
 template <typename F>


### PR DESCRIPTION
RStudio v1.1 still needs to build with C++98, which precludes the use of lambdas. Use a functor here instead.