### PR TITLE
set timeout when retrieving file completions

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -311,8 +311,12 @@ assign(x = ".rs.acCompletionTypes",
       absolutePaths <- index$paths
    }
    
-   # Merge in completions from the current directory.
-   dirPaths <- .rs.listFilesFuzzy(directory, tokenName)
+   # Merge in completions from the current directory. This can be
+   # slow on networked filesystems so do this with a timeout.
+   dirPaths <- .rs.withTimeLimit(1, .rs.listFilesFuzzy(directory, tokenName))
+   if (is.null(dirPaths))
+      dirPaths <- character()
+   
    if (directoriesOnly)
    {
       dirInfo <- .rs.fileInfo(dirPaths)


### PR DESCRIPTION
This PR should help alleviate issues seen in https://community.rstudio.com/t/diagnosing-a-non-responsive-rstudio-console/4601, where attempts to retrieve file completions on a slow NFS can cause the RStudio console to hang.

We enforce a time limit of 1 second on the file listing attempt, and just return an empty list if it takes longer than that.