### PR TITLE
Fixes inline latex math rendering

### DIFF
--- a/src/cpp/core/markdown/sundown/buffer.c
+++ b/src/cpp/core/markdown/sundown/buffer.c
@@ -15,7 +15,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#define BUFFER_MAX_ALLOC_SIZE (1024 * 1024 * 16) //16mb
+#define BUFFER_MAX_ALLOC_SIZE (1024 * 1024 * 16) /* 16mb */
 
 #include "buffer.h"
 
@@ -25,7 +25,7 @@
 #include <assert.h>
 
 /* MSVC compat */
-#if defined(_MSC_VER)
+#if defined(__MINGW32__)
 #	define _buf_vsnprintf _vsnprintf
 #else
 #	define _buf_vsnprintf vsnprintf
@@ -126,7 +126,7 @@ bufprintf(struct buf *buf, const char *fmt, ...)
 	va_end(ap);
 
 	if (n < 0) {
-#ifdef _MSC_VER
+#ifdef __MINGW32__ 
 		va_start(ap, fmt);
 		n = _vscprintf(fmt, ap);
 		va_end(ap);

--- a/src/cpp/core/markdown/sundown/buffer.h
+++ b/src/cpp/core/markdown/sundown/buffer.h
@@ -26,14 +26,9 @@
 extern "C" {
 #endif
 
-#if defined(_MSC_VER)
-#define __attribute__(x)
-#define inline
-#endif
-
 typedef enum {
 	BUF_OK = 0,
-	BUF_ENOMEM = -1,
+	BUF_ENOMEM = -1
 } buferror_t;
 
 /* struct buf: character array buffer */

--- a/src/cpp/core/markdown/sundown/html.c
+++ b/src/cpp/core/markdown/sundown/html.c
@@ -161,6 +161,30 @@ rndr_blockquote(struct buf *ob, const struct buf *text, void *opaque)
 }
 
 static int
+rndr_displayedmath(struct buf *ob, const struct buf *text, void *opaque)
+{
+	if (!text || !text->size)
+		return 0;
+
+	BUFPUTSL(ob, "\\[");
+	if (text) bufput(ob, text->data, text->size);
+	BUFPUTSL(ob, "\\]");
+	return 1;
+}
+
+static int
+rndr_inlinemath(struct buf *ob, const struct buf *text, void *opaque)
+{
+	if (!text || !text->size)
+		return 0;
+
+	BUFPUTSL(ob, "\\(");
+	if (text) bufput(ob, text->data, text->size);
+	BUFPUTSL(ob, "\\)");
+	return 1;
+}
+
+static int
 rndr_codespan(struct buf *ob, const struct buf *text, void *opaque)
 {
 	BUFPUTSL(ob, "<code>");
@@ -566,6 +590,8 @@ sdhtml_toc_renderer(struct sd_callbacks *callbacks, struct html_renderopt *optio
 		rndr_triple_emphasis,
 		rndr_strikethrough,
 		rndr_superscript,
+		NULL,
+		NULL,
 
 		NULL,
 		NULL,
@@ -607,6 +633,8 @@ sdhtml_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options, 
 		rndr_triple_emphasis,
 		rndr_strikethrough,
 		rndr_superscript,
+		rndr_inlinemath,
+		rndr_displayedmath,
 
 		NULL,
 		rndr_normal_text,

--- a/src/cpp/core/markdown/sundown/html.h
+++ b/src/cpp/core/markdown/sundown/html.h
@@ -48,13 +48,13 @@ typedef enum {
 	HTML_TOC = (1 << 6),
 	HTML_HARD_WRAP = (1 << 7),
 	HTML_USE_XHTML = (1 << 8),
-	HTML_ESCAPE = (1 << 9),
+	HTML_ESCAPE = (1 << 9)
 } html_render_mode;
 
 typedef enum {
 	HTML_TAG_NONE = 0,
 	HTML_TAG_OPEN,
-	HTML_TAG_CLOSE,
+	HTML_TAG_CLOSE
 } html_tag;
 
 int

--- a/src/cpp/core/markdown/sundown/markdown.h
+++ b/src/cpp/core/markdown/sundown/markdown.h
@@ -39,7 +39,7 @@ extern "C" {
 enum mkd_autolink {
 	MKDA_NOT_AUTOLINK,	/* used internally when it is not an autolink*/
 	MKDA_NORMAL,		/* normal http/http/ftp/mailto/etc link */
-	MKDA_EMAIL,			/* e-mail link without explit mailto: */
+	MKDA_EMAIL			/* e-mail link without explit mailto: */
 };
 
 enum mkd_tableflags {
@@ -59,6 +59,7 @@ enum mkd_extensions {
 	MKDEXT_SPACE_HEADERS = (1 << 6),
 	MKDEXT_SUPERSCRIPT = (1 << 7),
 	MKDEXT_LAX_SPACING = (1 << 8),
+	MKDEXT_LATEX_MATH = (1 << 9)
 };
 
 /* sd_callbacks - functions for rendering parsed data */
@@ -89,6 +90,8 @@ struct sd_callbacks {
 	int (*triple_emphasis)(struct buf *ob, const struct buf *text, void *opaque);
 	int (*strikethrough)(struct buf *ob, const struct buf *text, void *opaque);
 	int (*superscript)(struct buf *ob, const struct buf *text, void *opaque);
+	int (*inlinemath)(struct buf *ob, const struct buf *text, void *opaque);
+	int (*displayedmath)(struct buf *ob, const struct buf *text, void *opaque);
 
 	/* low level callbacks - NULL copies input directly into the output */
 	void (*entity)(struct buf *ob, const struct buf *entity, void *opaque);


### PR DESCRIPTION
Inline math in this Shiny app fails, but only when tested on RStudio Server.
The correct behavior is for the math to be formatted by MathJax, but on
RStudio Server you see latex markup surrounded by $. The issue seems to be
that the copy of Sundown in rstudio is overriding the copy of Sundown in
the Markdown package, and only the latter contains the logic required to
process inline latex math. @jjallaire said that the intention was to keep
the two in sync, so this commit copies the relevant files over from markdown.
https://github.com/rstudio/shiny-examples/tree/master/020-knit-html

**NOTE:** I'm not set up with an rstudio dev environment right now so I don't know if this compiles, let alone works. Sorry.