### PR TITLE
avoid animating progress spinners when not visible

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ProgressPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ProgressPanel.java
@@ -40,6 +40,20 @@ public class ProgressPanel extends Composite
    
    public ProgressPanel(Widget progressImage, int verticalOffset)
    { 
+      timer_ = new Timer()
+      {
+         public void run()
+         {
+            progressImage_.setVisible(true);
+            progressSpinner_.setVisible(true);
+            if (message_ != null)
+            {
+               progressLabel_.setText(message_);
+               progressLabel_.setVisible(true);
+            }
+         }
+      };
+      
       progressImage_ = progressImage;
 
       progressSpinner_ = new ProgressSpinner(getSpinnerColor());
@@ -75,33 +89,21 @@ public class ProgressPanel extends Composite
    
    public void beginProgressOperation(int delayMs, final String message)
    {
-      clearTimer();
+      timer_.cancel();
 
       progressSpinner_.setColorType(getSpinnerColor());
       progressSpinner_.setVisible(false);
       progressImage_.setVisible(false);
       progressLabel_.setVisible(false);
+      message_ = message;
 
-      timer_ = new Timer() {
-         public void run() {
-            if (timer_ != this)
-               return; // This should never happen, but, just in case
-
-            progressImage_.setVisible(true);
-            progressSpinner_.setVisible(true);
-            if (message != null)
-            {
-               progressLabel_.setText(message);
-               progressLabel_.setVisible(true);
-            }
-         }
-      };
       timer_.schedule(delayMs);
    }
 
    public void endProgressOperation()
    {
-      clearTimer();
+      timer_.cancel();
+      
       progressImage_.setVisible(false);
       progressSpinner_.setVisible(false);
       progressLabel_.setVisible(false);
@@ -115,17 +117,9 @@ public class ProgressPanel extends Composite
       return isDark ? ProgressSpinner.COLOR_WHITE : ProgressSpinner.COLOR_BLACK;
    }
 
-   private void clearTimer()
-   {
-      if (timer_ != null)
-      {
-         timer_.cancel();
-         timer_ = null;
-      }
-   }
-
    private final Widget progressImage_ ;
    private final ProgressSpinner progressSpinner_;
    private final Label progressLabel_;
    private Timer timer_;
+   private String message_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ProgressSpinner.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ProgressSpinner.java
@@ -101,7 +101,7 @@ public class ProgressSpinner extends Composite
    
    public void startAnimating()
    {
-      if (isAnimating_)
+      if (isAnimating_ || requestStopAnimating_)
          return;
       
       isAnimating_ = true;
@@ -111,7 +111,7 @@ public class ProgressSpinner extends Composite
    
    public void stopAnimating()
    {
-      requestStopAnimating_ = false;
+      requestStopAnimating_ = true;
    }
    
    private boolean animate()

--- a/src/gwt/src/org/rstudio/core/client/widget/ProgressSpinner.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ProgressSpinner.java
@@ -69,19 +69,24 @@ public class ProgressSpinner extends Composite
       // initialize canvas
       canvas_.setCoordinateSpaceWidth(COORD_SIZE);
       canvas_.setCoordinateSpaceHeight(COORD_SIZE);
-
-      // perform initial draw and start animation
-      redraw();
-      Scheduler.get().scheduleFixedPeriod(new Scheduler.RepeatingCommand()
-      {
-         @Override
-         public boolean execute()
-         {
-            frame_++;
-            if (isVisible()) redraw();
-            return !complete_;
-         }
-      }, FRAME_RATE_MS);
+   }
+   
+   @Override
+   public void setVisible(boolean visible)
+   {
+      if (visible)
+         startAnimating();
+      else
+         stopAnimating();
+      
+      super.setVisible(visible);
+   }
+   
+   @Override
+   public void onUnload()
+   {
+      stopAnimating();
+      super.onUnload();
    }
 
    public boolean isSupported()
@@ -89,14 +94,39 @@ public class ProgressSpinner extends Composite
       return canvas_ != null;
    }
    
-   public void detach()
-   {
-      complete_ = true;
-   }
-
    public void setColorType(int color)
    {
       colorType_ = color;
+   }
+   
+   public void startAnimating()
+   {
+      if (isAnimating_)
+         return;
+      
+      isAnimating_ = true;
+      animate();
+      Scheduler.get().scheduleFixedPeriod(() -> { return animate(); }, FRAME_RATE_MS);
+   }
+   
+   public void stopAnimating()
+   {
+      requestStopAnimating_ = false;
+   }
+   
+   private boolean animate()
+   {
+      frame_++;
+      redraw();
+      
+      if (requestStopAnimating_)
+      {
+         requestStopAnimating_ = false;
+         isAnimating_ = false;
+         return false;
+      }
+      
+      return true;
    }
    
    private void redraw()
@@ -148,5 +178,6 @@ public class ProgressSpinner extends Composite
    private int colorType_;
 
    private int frame_ = 0;
-   private boolean complete_ = false;
+   private boolean isAnimating_ = false;
+   private boolean requestStopAnimating_ = false;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/ToolbarPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/ToolbarPane.java
@@ -41,7 +41,9 @@ public abstract class ToolbarPane extends LazyPanel implements RequiresResize,
       ensureWidget();
 
       if (progress)
+      {
          progressPanel_.showProgress(progressDelayMs_);
+      }
       else
       {
          progressPanel_.setWidget(mainWidget_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -679,7 +679,6 @@ public class ChunkOutputWidget extends Composite
       if (spinner_ != null)
       {
          spinner_.removeFromParent();
-         spinner_.detach();
          spinner_ = null;
       }
       // create a black or white spinner as appropriate
@@ -694,6 +693,7 @@ public class ChunkOutputWidget extends Composite
       spinner_.getElement().getStyle().setOpacity(1);
       root_.getElement().getStyle().setOpacity(0.2);
 
+      spinner_.setVisible(true);
       clear_.setVisible(false);
       expand_.setVisible(false);
       popout_.setVisible(false);
@@ -708,8 +708,8 @@ public class ChunkOutputWidget extends Composite
 
       if (spinner_ != null)
       {
+         spinner_.setVisible(false);
          spinner_.removeFromParent();
-         spinner_.detach();
          spinner_ = null;
       }
 


### PR DESCRIPTION
This PR fixes an issue where any progress spinners generated would animate in the background, even when not visible.

The issue here: we schedule a timer to run relatively frequently for every progress spinner, but never actually stop / detach those (except in the case of Notebook chunk outputs, where detach was done explicitly).

Rather than place the onus of remembering whether these things should be detached / stopped to the clients of ProgressSpinner, this PR makes ProgressSpinner keep track of its own animation -- starting and stopping it as appropriate when it's focused, and also ensuring the animation stops when the widget is detached.

Part of fix for #3757.