### PR TITLE
simplify implementation of timebuffered command

### DIFF
--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -552,14 +552,16 @@ int main(int argc, char* argv[])
 
       // determine the filename that was passed to us
       QString filename;
+
 #ifdef __APPLE__
-      // get filename from OpenFile apple-event. pump to ensure delivery
-      // (empirically, pumping twice is required as the event is not always
-      // ready in time for the first call)
-      pApp->processEvents();
-      pApp->processEvents();
-      filename = verifyAndNormalizeFilename(
-                              pAppLaunch->startupOpenFileRequest());
+      // run an event loop for a short period of time just to ensure
+      // that the OpenFile startup event (if any) gets pumped
+      QEventLoop loop;
+      QTimer::singleShot(100, &loop, &QEventLoop::quit);
+      loop.exec();
+
+      // grab the startup file request (if any)
+      filename = verifyAndNormalizeFilename(pAppLaunch->startupOpenFileRequest());
 #endif
       // allow all platforms (including OSX) to check the command line.
       // we include OSX because the way Qt handles apple events is to

--- a/src/cpp/session/modules/SessionConnectionsInstaller.R
+++ b/src/cpp/session/modules/SessionConnectionsInstaller.R
@@ -391,16 +391,16 @@
 .rs.addFunction("odbcOdbcInstLibPath", function() {
    odbcinstLib <- NULL
 
-   odbcinstBin <- system2("which", "odbcinst", stdout = TRUE)
-   if (is.null(odbcinstBin) || length(odbcinstBin) == 0) {
+   odbcinstBin <- Sys.which("odbcinst")
+   if (nchar(odbcinstBin) == 0) {
       warning("Could not find path to odbcinst.")
    }
    else {
-      odbcinstLink <- system2("readlink", odbcinstBin, stdout = T)
-      if (!is.null(odbcinstLink) && length(odbcinstLink) > 0) {
+      odbcinstLink <- Sys.readlink(odbcinstBin)
+      if (!is.na(odbcinstLink)) {
          odbcinstBinPath <- normalizePath(file.path(dirname(odbcinstBin), dirname(odbcinstLink)))
          odbcinstLibPath <- normalizePath(file.path(odbcinstBinPath, "..", "lib"))
-         odbcinstLib <- dir(odbcinstLibPath, pattern = "libodbcinst.*\\.dylib", full.names = T)[[1]]
+         odbcinstLib <- dir(odbcinstLibPath, pattern = "libodbcinst.*\\.dylib", full.names = TRUE)[[1]]
       }
    }
 
@@ -426,7 +426,7 @@
 })
 
 .rs.addFunction("odbcBundleDriverIniPath", function(name, driverPath) {
-   dir(driverPath, pattern = paste(tolower(name), ".*\\.ini", sep = ""), recursive = T, full.names = T)
+   dir(driverPath, pattern = paste(tolower(name), ".*\\.ini", sep = ""), recursive = TRUE, full.names = T)
 })
 
 .rs.addFunction("odbcBundleRegisterOSX", function(name, driverPath, version, installPath) {

--- a/src/cpp/session/modules/SessionConnectionsInstaller.R
+++ b/src/cpp/session/modules/SessionConnectionsInstaller.R
@@ -407,7 +407,7 @@
    odbcinstLib
 })
 
-.rs.addFunction("odbcBundleRegisterLinux", function(name, driverPath, version) {
+.rs.addFunction("odbcBundleRegisterLinux", function(name, driverPath, version, installPath) {
    # Find odbcinst.ini file
    odbcinstPath <- .rs.odbcBundleOdbcinstPath()
    
@@ -420,23 +420,44 @@
       paste("Version", "=", version),
       paste("Installer", "=", "RStudio")
    )
-
-   # In OSX register to use unixODBC
-   if (identical(.rs.odbcBundleOsName(), "osx")) {
-      odbcinstLib <- .rs.odbcOdbcInstLibPath()
-      if (!is.null(odbcinstLib)) {
-         odbcinst[[name]] <- c(
-            odbcinst[[name]],
-            paste("ODBCInstLib", "=", odbcinstLib)
-         )
-      }
-   }
    
    # Write odbcinst.ini
    .rs.odbcBundleWriteIni(odbcinstPath, odbcinst)
 })
 
-.rs.addFunction("odbcBundleRegisterWindows", function(name, driverPath, version) {
+.rs.addFunction("odbcBundleDriverIniPath", function(name, driverPath) {
+   dir(driverPath, pattern = paste(tolower(name), ".*\\.ini", sep = ""), recursive = T, full.names = T)
+})
+
+.rs.addFunction("odbcBundleRegisterOSX", function(name, driverPath, version, installPath) {
+   # Update odbcinst.ini
+   .rs.odbcBundleRegisterLinux(name, driverPath, version, installPath)
+
+   # Find driver.ini file
+   driverIniFile <- .rs.odbcBundleDriverIniPath(name, installPath)
+   
+   if (length(driverIniFile) == 0) {
+      warning("Could not find '", name, "' driver INI file under: ", installPath)
+   }
+   else {
+      # Read driver.ini
+      driverIni <- .rs.odbcBundleReadIni(driverIniFile)
+
+      # In OSX register to use unixODBC
+      odbcinstLib <- .rs.odbcOdbcInstLibPath()
+      if (!is.null(odbcinstLib)) {
+         driverIni[["Driver"]] <- c(
+            driverIni[["Driver"]],
+            paste("ODBCInstLib", "=", odbcinstLib)
+         )
+      }
+      
+      # Write odbcinst.ini
+      .rs.odbcBundleWriteIni(driverIniFile, driverIni)
+   }
+})
+
+.rs.addFunction("odbcBundleRegisterWindows", function(name, driverPath, version, installPath) {
    .rs.odbcBundleRegistryAdd(
       list(
          list(
@@ -497,16 +518,16 @@
    normalizePath(driverPath)
 })
 
-.rs.addFunction("odbcBundleRegister", function(name, driverPath, version) {
+.rs.addFunction("odbcBundleRegister", function(name, driverPath, version, installPath) {
    osRegistrations <- list(
-      osx = .rs.odbcBundleRegisterLinux,
+      osx = .rs.odbcBundleRegisterOSX,
       windows = .rs.odbcBundleRegisterWindows,
       linux = .rs.odbcBundleRegisterLinux
    )
    
    osRegistration <- osRegistrations[[.rs.odbcBundleOsName()]]
    
-   osRegistration(name, driverPath, version) 
+   osRegistration(name, driverPath, version, installPath) 
 })
 
 .rs.addFunction("odbcBundleValidate", function(bundleFile, md5) {
@@ -557,7 +578,7 @@
    driverPath <- .rs.odbcBundleFindDriver(name, installPath, libraryPattern)
    
    message("Registering driver")
-   .rs.odbcBundleRegister(name, driverPath, version)
+   .rs.odbcBundleRegister(name, driverPath, version, installPath)
 
    message("")
    message("Installation complete")

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -311,8 +311,12 @@ assign(x = ".rs.acCompletionTypes",
       absolutePaths <- index$paths
    }
    
-   # Merge in completions from the current directory.
-   dirPaths <- .rs.listFilesFuzzy(directory, tokenName)
+   # Merge in completions from the current directory. This can be
+   # slow on networked filesystems so do this with a timeout.
+   dirPaths <- .rs.withTimeLimit(1, .rs.listFilesFuzzy(directory, tokenName))
+   if (is.null(dirPaths))
+      dirPaths <- character()
+   
    if (directoriesOnly)
    {
       dirInfo <- .rs.fileInfo(dirPaths)

--- a/src/gwt/src/org/rstudio/core/client/TimeBufferedCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/TimeBufferedCommand.java
@@ -1,7 +1,7 @@
 /*
  * TimeBufferedCommand.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,8 +16,6 @@ package org.rstudio.core.client;
 
 import com.google.gwt.user.client.Timer;
 
-import java.util.Date;
-
 /**
  * Manages the execution of logic that should not be run too frequently.
  * Multiple calls over a (caller-defined) period of time will be coalesced
@@ -25,13 +23,18 @@ import java.util.Date;
  *
  * The command can optionally be run on a scheduled ("passive") basis; use
  * the two- or three-arg constructor. IMPORTANT NOTE: The implementation of
- * performAction must check if shouldSchedulePassive is true, and if it is,
- * then it should call schedulePassive() whenever it is done with the
+ * performAction must check if shouldReschedule is true, and if it is,
+ * then it should call reschedule() whenever it is done with the
  * operation. Failure to do so correctly (e.g. in error cases) will cause
  * the passive runs to immediately stop occurring. 
  */
 public abstract class TimeBufferedCommand
 {
+   /**
+    * See class javadoc for details about shouldReschedule flag.
+    */
+   protected abstract void performAction(boolean shouldReschedule);
+   
    /**
     * Creates a TimeBufferedCommand that will only run when nudged.
     */
@@ -45,7 +48,7 @@ public abstract class TimeBufferedCommand
     * passiveIntervalMillis milliseconds, whichever comes first.
     */
    public TimeBufferedCommand(int passiveIntervalMillis,
-                                 int activeIntervalMillis)
+                              int activeIntervalMillis)
    {
       this(passiveIntervalMillis, passiveIntervalMillis, activeIntervalMillis);
    }
@@ -56,97 +59,83 @@ public abstract class TimeBufferedCommand
     * custom period before the first "passive" run.
     */
    public TimeBufferedCommand(int initialIntervalMillis,
-                                 int passiveIntervalMillis,
-                                 int activeIntervalMillis)
+                              int passiveIntervalMillis,
+                              int activeIntervalMillis)
    {
       this.initialIntervalMillis_ = initialIntervalMillis;
       this.passiveIntervalMillis_ = passiveIntervalMillis;
       this.activeIntervalMillis_ = activeIntervalMillis;
-
-      if (initialIntervalMillis_ >= 0 && passiveIntervalMillis_ > 0)
-         scheduleExecution(true, Math.max(1, initialIntervalMillis_));
-   }
-
-   /**
-    * See class javadoc for details about shouldSchedulePassive flag.
-    */
-   protected abstract void performAction(boolean shouldSchedulePassive);
-
-   /**
-    * Request that this command execute soon. (How soon depends
-    * on the activeIntervalMillis constructor param.) 
-    */
-   public final void nudge()
-   {
-      scheduleExecution(false, activeIntervalMillis_);
-   }
-
-   public final void suspend()
-   {
-      stopped_ = true;
-   }
-
-   public final void resume()
-   {
-      assert passiveIntervalMillis_ <= 0 : "Cannot call start() on a " +
-                                           "TimeBufferedCommand that fires on " +
-                                           "passive intervals. Once stopped, " +
-                                           "they stay stopped.";
-      if (passiveIntervalMillis_ > 0)
-         throw new IllegalStateException("Cannot call start() on a " +
-                                         "TimeBufferedCommand that fires on " +
-                                         "passive intervals. Once stopped, " +
-                                         "they stay stopped.");
-      stopped_ = false;
-   }
-
-   private final void scheduleExecution(final boolean passive, final int millis)
-   {
-      new Timer() {
+      this.timer_ = new Timer()
+      {
          @Override
          public void run()
          {
-            execute(passive, millis);
+            isNudged_ = false;
+            boolean shouldReschedule = passiveIntervalMillis_ > 0;
+            performAction(shouldReschedule);
          }
-      }.schedule(millis);
+      };
+      
+      if (initialIntervalMillis_ >= 0 && passiveIntervalMillis_ > 0)
+         timer_.schedule(initialIntervalMillis_);
+   }
+   
+   /**
+    * Re-schedule the timer. If the timer is already running, it will be
+    * canceled and re-scheduled. Useful when receiving a flood of events
+    * when the timer should only fire after all events have been processed.
+    * Ignored if the timer was recently nudged.
+    */
+   public final void reschedule()
+   {
+      if (isSuspended_ || isNudged_)
+         return;
+      
+      timer_.schedule(passiveIntervalMillis_);
    }
 
-   private final void execute(final boolean passive, int millisAgo)
+   /**
+    * Nudge the timer. If the timer was originally scheduled passively, then
+    * the timer will be re-scheduled using the active internal.
+    */
+   public final void nudge()
    {
-      if (stopped_)
+      if (isSuspended_ || isNudged_)
          return;
 
-      Date now = new Date();
-      // see if we were preempted by someone else executing
-      if (lastExecuted_ != null)
-      {
-         long millisSinceLast = now.getTime() - lastExecuted_.getTime();
-         if (millisSinceLast < millisAgo - 50) // some fudge factor
-         {
-            // Someone executed in front of us. Abort this execute, but
-            // if we're in the passive chain of execution, then reschedule.
-            if (passive)
-            {
-               int gap = passiveIntervalMillis_ - (int)millisSinceLast;
-               gap = Math.max(1, gap); // a non-positive value will cause error
-               scheduleExecution(true, gap);
-            }
-            return;
-         }
-      }
-      lastExecuted_ = now;
-
-      performAction(passive);
+      isNudged_ = true;
+      timer_.schedule(activeIntervalMillis_);
    }
 
-   protected final void schedulePassive()
+   /**
+    * Suspend execution of the timer.
+    */
+   public final void suspend()
    {
-      scheduleExecution(true, passiveIntervalMillis_);
+      isSuspended_ = true;
+      isNudged_ = false;
+      
+      timer_.cancel();
    }
 
+   /**
+    * Resume execution of the timer.
+    */
+   public final void resume()
+   {
+      isSuspended_ = false;
+      isNudged_ = false;
+      
+      if (passiveIntervalMillis_ > 0)
+         timer_.schedule(passiveIntervalMillis_);
+   }
+   
    private final int initialIntervalMillis_;
    private final int passiveIntervalMillis_;
    private final int activeIntervalMillis_;
-   protected Date lastExecuted_;
-   private boolean stopped_;
+   private final Timer timer_;
+   
+   private boolean isSuspended_ = false;
+   private boolean isNudged_ = false;
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ClientStateUpdater.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ClientStateUpdater.java
@@ -58,11 +58,7 @@ public class ClientStateUpdater extends TimeBufferedCommand
       {
          public void onPushClientState(PushClientStateEvent event)
          {
-            // Don't allow active pushes until after the initial interval
-            // has elapsed. This lets us avoid storms of requests during
-            // startup.
-            if (lastExecuted_ != null)
-               nudge();
+            reschedule();
          }
       });
 
@@ -141,8 +137,9 @@ public class ClientStateUpdater extends TimeBufferedCommand
    {
       if (barrierToken_ != null)
          barrierToken_.release();
+      
       if (shouldSchedulePassive)
-         schedulePassive();
+         reschedule();
    }
 
    private static final int INITIAL_INTERVAL_MILLIS = 2000;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
@@ -162,7 +162,7 @@ public class Workbench implements BusyHandler,
       eventBus.addHandler(ShowPageViewerEvent.TYPE, this);
 
       // We don't want to send setWorkbenchMetrics more than once per 1/2-second
-      metricsChangedCommand_ = new TimeBufferedCommand(-1, -1, 500)
+      metricsChangedCommand_ = new TimeBufferedCommand(500)
       {
          @Override
          protected void performAction(boolean shouldSchedulePassive)


### PR DESCRIPTION
This PR simplifies the implementation of our TimeBufferedCommand class, and should also improve performance in the process.

Effectively, TimeBufferedCommand is used to throttle a high volume of calls into a set of periodic calls. This is useful when e.g. streaming console output, where one needs to keep focus near the bottom of the associated widget without immediately responding to each line of output (since that could be expensive).

TimeBufferedCommand does its job in a somewhat roundabout way:

1. Every time it is scheduled (either passively or actively), a new Timer is created and scheduled.
2. When a timer is run, it records the time when it executed.
3. If another timer comes and attempts to run, it checks when the last timer executed. If that old timer executed too recently, that timer avoids performing its action.
4. This repeats for each scheduled timer.

This can be somewhat expensive when multiple TimeBufferedCommands are in play, since each attempt to nudge or schedule the command will create a new timer, and even re-scheduling a TimeBufferedCommand creates a new timer.

This PR alleviates the above issues by re-implementing TimeBufferedCommand in terms of a single timer.

In theory, the behavior has changed a little bit. If a passively-scheduled timer is nudged, the timer is re-scheduled using the active interval delay. In theory, if the timer that was passively-scheduled were just about to execute, this could imply delaying the timer for a brief amount of time. In practice, this shouldn't matter as the ClientStateUpdater is the only entity that can be scheduled both passively and actively, with a passive delay of 2000ms and an active delay of 100ms (or 350ms on server).

Should help alleviate #3757 a bit as well.