### PR TITLE
Fixes for attempting to publish unrendered Rmd as final document

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishReportSourcePage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishReportSourcePage.java
@@ -1,7 +1,7 @@
 /*
  * PublishReportSourcePage.java
  *
- * Copyright (C) 2009-15 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -35,7 +35,7 @@ public class PublishReportSourcePage
          RSConnectPublishInput input,
          boolean asMultiple)
    {
-      super(title, subTitle, "Publish Source Code", icon, null, 
+      super(title, subTitle, "Publish to RStudio Connect", icon, null,
             createPages(input, asMultiple));
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -64,6 +64,7 @@ import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Anchor;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Grid;
@@ -830,12 +831,27 @@ public class RSConnectDeploy extends Composite
       {
          if (StringUtil.isNullOrEmpty(source_.getDeployFile()))
          {
-            indicator.onError(
-                  "Only rendered documents can be published to RStudio Connect. " +
-                  "To publish this document, click Knit to render it, then click " +
-                  "the Publish button above the rendered document.");
-            indicator.onCompleted(); 
-            return; 
+            indicator.onCompleted();
+
+            // Want to make sure the publish wizard has gone away before this message is shown.
+            // On Desktop (macOS, at least), trying to do this with indicator.onError(msg)
+            // leaves the publish wizard visible in an incomplete state and it doesn't dismiss
+            // until the message is dismissed, so defer message display a bit.
+            Timer timer = new Timer()
+            {
+               @Override
+               public void run()
+               {
+                  RStudioGinjector.INSTANCE.getGlobalDisplay().showMessage(
+                        GlobalDisplay.MSG_INFO,
+                        "Finished Document Not Found",
+                        "To publish finished document to RStudio Connect, you must first render " +
+                              "it. Dismiss this message, click Knit to render the document, " +
+                              "then try publishing again.");
+               }
+            };
+            timer.schedule(250);
+            return;
          }
          ArrayList<String> files = new ArrayList<String>();
          FileSystemItem selfContained = FileSystemItem.createFile(
@@ -1245,7 +1261,7 @@ public class RSConnectDeploy extends Composite
       {
          onError(error.getMessage());
       }
-   };
+   }
    
    private void showAppError(String error)
    {

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -831,26 +831,40 @@ public class RSConnectDeploy extends Composite
       {
          if (StringUtil.isNullOrEmpty(source_.getDeployFile()))
          {
-            indicator.onCompleted();
-
-            // Want to make sure the publish wizard has gone away before this message is shown.
-            // On Desktop (macOS, at least), trying to do this with indicator.onError(msg)
-            // leaves the publish wizard visible in an incomplete state and it doesn't dismiss
-            // until the message is dismissed, so defer message display a bit.
-            Timer timer = new Timer()
+            // Want to make sure the dialog (e.g. publish wizard) has gone away before the message
+            // is shown. In some scenarios, varying both by dialog and by platform (desktop vs.
+            // server), the message is showing while the dialog is still visible but not fully
+            // initialized. In another scenario, the dialog does not dismiss when
+            // indicator.onCompleted() is invoked unless we delay the invocation a bit. This is
+            // all rather unsatisfying.
+            Timer onCompletedTimer = new Timer()
             {
                @Override
                public void run()
                {
-                  RStudioGinjector.INSTANCE.getGlobalDisplay().showMessage(
-                        GlobalDisplay.MSG_INFO,
-                        "Finished Document Not Found",
-                        "To publish finished document to RStudio Connect, you must first render " +
-                              "it. Dismiss this message, click Knit to render the document, " +
-                              "then try publishing again.");
+                  indicator.onCompleted();
+         
+                  // Want to make sure the publish wizard has gone away before this message is shown.
+                  // On Desktop (macOS, at least), trying to do this with indicator.onError(msg)
+                  // leaves the publish wizard visible in an incomplete state and it doesn't dismiss
+                  // until the message is dismissed, so defer message display a bit.
+                  Timer showMessageTimer = new Timer()
+                  {
+                     @Override
+                     public void run()
+                     {
+                        RStudioGinjector.INSTANCE.getGlobalDisplay().showMessage(
+                              GlobalDisplay.MSG_INFO,
+                              "Finished Document Not Found",
+                              "To publish finished document to RStudio Connect, you must first render " +
+                                    "it. Dismiss this message, click Knit to render the document, " +
+                                    "then try publishing again.");
+                     }
+                  };
+                  showMessageTimer.schedule(100);
                }
             };
-            timer.schedule(250);
+            onCompletedTimer.schedule(100);
             return;
          }
          ArrayList<String> files = new ArrayList<String>();


### PR DESCRIPTION
Timing issues when trying to dismiss publish wizard in scenarios described in #3752.

In one case the wizard dialog is shown in an incomplete state while an error message is displayed to user, then goes away when the error message is dismissed. In the other case, the dialog fails to dismiss via `indicator.onCompleted()`.

Fixed by using nested timers; not very satisfying, but fixes both cases in my testing on on desktop and server.

Secondary wording fix; change "Publish Source Code" in this dialog (which doesn't match the intent of the dialog) to "Publish to RStudio Connect".

BEFORE:
![2018-10-28_17-07-40](https://user-images.githubusercontent.com/10569626/47632649-3e862480-db08-11e8-926a-b17071f275bb.png)

AFTER:
![2018-10-28_16-56-25](https://user-images.githubusercontent.com/10569626/47632691-64132e00-db08-11e8-879a-bae690783e31.png)



Fixes #3752 
