### PR TITLE
Make publish cancellable

### DIFF
--- a/src/cpp/session/modules/SessionRSConnect.cpp
+++ b/src/cpp/session/modules/SessionRSConnect.cpp
@@ -285,6 +285,25 @@ private:
 
 boost::shared_ptr<RSConnectPublish> s_pRSConnectPublish_;
 
+Error cancelPublish(const json::JsonRpcRequest& request,
+                       json::JsonRpcResponse* pResponse)
+{
+   if (s_pRSConnectPublish_ &&
+       s_pRSConnectPublish_->isRunning())
+   {
+      // There is a running publish operation; end it.
+      s_pRSConnectPublish_->terminate();
+      pResponse->setResult(true);
+   }
+   else
+   {
+      // No running publish operation.
+      pResponse->setResult(false);
+   }
+
+   return Success();
+}
+
 Error rsconnectPublish(const json::JsonRpcRequest& request,
                        json::JsonRpcResponse* pResponse)
 {
@@ -561,6 +580,7 @@ Error initialize()
    initBlock.addFunctions()
       (bind(registerRpcMethod, "get_rsconnect_deployments", rsconnectDeployments))
       (bind(registerRpcMethod, "rsconnect_publish", rsconnectPublish))
+      (bind(registerRpcMethod, "cancel_publish", cancelPublish))
       (bind(registerRpcMethod, "get_edit_published_docs", getEditPublishedDocs))
       (bind(registerRpcMethod, "get_rmd_publish_details", getRmdPublishDetails))
       (bind(sourceModuleRFile, "SessionRSConnect.R"))

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeploymentCancelledEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeploymentCancelledEvent.java
@@ -1,0 +1,45 @@
+/*
+ * RSConnectDeploymentCancelledEvent.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.rsconnect.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class RSConnectDeploymentCancelledEvent extends GwtEvent<RSConnectDeploymentCancelledEvent.Handler>
+{ 
+   public interface Handler extends EventHandler
+   {
+      void onRSConnectDeploymentCancelled(RSConnectDeploymentCancelledEvent event);
+   }
+
+   public static final GwtEvent.Type<RSConnectDeploymentCancelledEvent.Handler> TYPE =
+      new GwtEvent.Type<RSConnectDeploymentCancelledEvent.Handler>();
+   
+   public RSConnectDeploymentCancelledEvent()
+   {
+   };
+   
+   @Override
+   protected void dispatch(RSConnectDeploymentCancelledEvent.Handler handler)
+   {
+      handler.onRSConnectDeploymentCancelled(this);
+   }
+
+   @Override
+   public GwtEvent.Type<RSConnectDeploymentCancelledEvent.Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+}

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectServerOperations.java
@@ -49,6 +49,8 @@ public interface RSConnectServerOperations
                RSConnectPublishSettings settings,
                ServerRequestCallback<Boolean> requestCallback);
    
+   void cancelPublish(ServerRequestCallback<Boolean> requestCallback);
+   
    void getServerUrls(
                ServerRequestCallback<JsArray<RSConnectServerEntry>> requestCallback);
 

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4643,6 +4643,14 @@ public class RemoteServer implements Server
    }
    
    @Override
+   public void cancelPublish(ServerRequestCallback<Boolean> requestCallback)
+   {
+      sendRequest(RPC_SCOPE,
+            CANCEL_PUBLISH,
+            requestCallback);
+   }
+   
+   @Override
    public void validateServerUrl(String url, 
          ServerRequestCallback<RSConnectServerInfo> requestCallback)
    {
@@ -6108,6 +6116,7 @@ public class RemoteServer implements Server
    private static final String GET_RSCONNECT_APP = "get_rsconnect_app";
    private static final String GET_RSCONNECT_DEPLOYMENTS = "get_rsconnect_deployments";
    private static final String RSCONNECT_PUBLISH = "rsconnect_publish";
+   private static final String CANCEL_PUBLISH = "cancel_publish";
    private static final String GET_DEPLOYMENT_FILES = "get_deployment_files";
    private static final String VALIDATE_SERVER_URL = "validate_server_url";
    private static final String GET_SERVER_URLS = "get_server_urls";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/rsconnectdeploy/RSConnectDeployOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/rsconnectdeploy/RSConnectDeployOutputPresenter.java
@@ -22,6 +22,7 @@ import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.RestartStatusEvent;
 import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.rsconnect.events.RSConnectDeploymentCancelledEvent;
 import org.rstudio.studio.client.rsconnect.events.RSConnectDeploymentCompletedEvent;
 import org.rstudio.studio.client.rsconnect.events.RSConnectDeploymentOutputEvent;
 import org.rstudio.studio.client.rsconnect.events.RSConnectDeploymentStartedEvent;
@@ -44,7 +45,10 @@ public class RSConnectDeployOutputPresenter extends BusyPresenter
       super(outputFactory.create("Deploy", ""));
       view_ = (CompileOutputPaneDisplay) getView();
       view_.setHasLogs(false);
-      view_.setCanStop(false);
+      view_.setCanStop(true);
+      view_.stopButton().addClickHandler(evt -> {
+         events.fireEvent(new RSConnectDeploymentCancelledEvent());
+      });
       events_ = events;
    }
    


### PR DESCRIPTION
This small change makes it possible to terminate the R process hosting the Publish operation. 

It's helpful for two cases:

1. When you accidentally click Publish, and realize it right away (i.e. while the application is still being bundled and uploaded)

2. When something has gone awry and you need to kill a publish process that won't terminate on its own (otherwise the only way to kill it is to restart the IDE)

Ideally it would function as a Cancel button for Connect, too; in other words, if the deployment task has already started, it would tell Connect to stop the task. Right now however there's no API that will allow us to do this, and the IDE also currently doesn't know what phase the deployment is in. For now, then, we just show a dialog to ensure that you know that you're cancelling on the client, not the server.