### PR TITLE
avoid global binding for snippet insertion

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
@@ -90,8 +90,6 @@ public class ShortcutManager implements NativePreviewHandler,
       for (KeyMapType type : KeyMapType.values())
          keyMaps_.put(type, new KeyMap());
       
-      commandHandlesEventPropagation_ = new HashSet<String>();
-      
       // Defer injection because the ShortcutManager is constructed
       // very eagerly (to allow for codegen stuff in ShortcutsEmitter
       // to work)
@@ -266,16 +264,6 @@ public class ShortcutManager implements NativePreviewHandler,
          // Cache the binding (so we can reset later if required)
          defaultBindings_.add(new Pair<KeySequence, AppCommandBinding>(keys, binding));
       }
-   }
-   
-   public void registerCommandHandlesEventPropagation(AppCommand command)
-   {
-      commandHandlesEventPropagation_.add(command.getId());
-   }
-   
-   private boolean commandHandlesEventPropagation(String id)
-   {
-      return commandHandlesEventPropagation_.contains(id);
    }
    
    public void resetAppCommandBindings()
@@ -549,17 +537,9 @@ public class ShortcutManager implements NativePreviewHandler,
                }
             }
             
-            if (commandHandlesEventPropagation(binding.getId()))
-            {
-               binding.execute();
-               return false;
-            }
-            else
-            {
-               event.stopPropagation();
-               binding.execute();
-               return true;
-            }
+            event.stopPropagation();
+            binding.execute();
+            return true;
          }
          
          if (map.isPrefix(keyBuffer_))
@@ -757,7 +737,6 @@ public class ShortcutManager implements NativePreviewHandler,
    private int activeEditEventType_ = EditEvent.TYPE_NONE;
    
    private final Map<KeyMapType, KeyMap> keyMaps_;
-   private final Set<String> commandHandlesEventPropagation_;
    private final List<ShortcutInfo> shortcutInfo_;
    private final List<Pair<KeySequence, AppCommandBinding>> defaultBindings_;
    

--- a/src/gwt/src/org/rstudio/core/rebind/command/ShortcutsEmitter.java
+++ b/src/gwt/src/org/rstudio/core/rebind/command/ShortcutsEmitter.java
@@ -64,7 +64,6 @@ public class ShortcutsEmitter
          String shortcutValue = childEl.getAttribute("value");
          String title = childEl.getAttribute("title");
          String disableModes = childEl.getAttribute("disableModes");
-         String handlesEventPropagation = childEl.getAttribute("handlesEventPropagation");
 
          // Use null when we don't have a command associated with the shortcut,
          // otherwise refer to the function that returns the command 
@@ -80,8 +79,7 @@ public class ShortcutsEmitter
          for (String shortcut : shortcuts)
          {
             printShortcut(writer, condition, shortcut, 
-                  command, groupName_, title, disableModes,
-                  handlesEventPropagation);
+                  command, groupName_, title, disableModes);
          }
       }
    }
@@ -112,8 +110,7 @@ public class ShortcutsEmitter
                               String command,
                               String shortcutGroup,
                               String title,
-                              String disableModes,
-                              String handlesEventPropagation) throws UnableToCompleteException
+                              String disableModes) throws UnableToCompleteException
    {
       List<Pair<Integer, String>> keys = new ArrayList<Pair<Integer, String>>();
       for (String keyCombination : shortcut.split("\\s+"))
@@ -206,11 +203,6 @@ public class ShortcutsEmitter
          throw new UnableToCompleteException();
       }
       
-      if (handlesEventPropagation.equals("true"))
-      {
-         writer.println("ShortcutManager.INSTANCE.registerCommandHandlesEventPropagation(" + command + ");");
-      }
-
       if (!condition.isEmpty())
       {
          writer.outdent();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -30,10 +30,6 @@ well as menu structures (for main menu and popup menus).
       "background": always operates on main window, but in the background
       "<satellite name>": operates on named satellite; sent to the main window
         for processing unless fired from the named satellite
-  @handlesEventPropagation: Whether the command itself handles event propagation.
-     This is primarily used by commands which may be active and dispatched to,
-     but opt not to handle the event, thereby allowing the browser default
-     behavior in response to the pressed key.
 -->
 <commands>
    <menu id="mainMenu" vertical="false">
@@ -590,7 +586,6 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="insertPipeOperator" value="Ctrl+Shift+M" title="Insert Pipe Operator" disableModes="sublime"/>
          <shortcut refid="renameInScope" value="Cmd+Alt+Shift+M" />
          <shortcut refid="insertRoxygenSkeleton" value="Cmd+Shift+Alt+R" title="Insert Roxygen Skeleton" />
-         <shortcut refid="insertSnippet" value="Shift+Tab" title="Insert Snippet" handlesEventPropagation="true" />
       </shortcutgroup>
       <shortcutgroup name="Source Navigation">
          <shortcut refid="sourceNavigateBack" value="Cmd+F9"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -38,7 +38,6 @@ import com.google.gwt.event.shared.GwtEvent;
 import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.ScrollPanel;
@@ -3812,14 +3811,7 @@ public class AceEditor implements DocDisplay,
    
    private boolean onInsertSnippet()
    {
-      boolean executed = snippets_.onInsertSnippet();
-      if (executed)
-      {
-         Event evt = Event.getCurrentEvent();
-         evt.stopPropagation();
-         evt.preventDefault();
-      }
-      return executed;
+      return snippets_.onInsertSnippet();
    }
    
    public void toggleTokenInfo()


### PR DESCRIPTION
Fixes #3790.

The completion managers we define for languages that support snippet insertion already handle Shift + Tab for snippet insertion; see e.g.

https://github.com/rstudio/rstudio/blob/master/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java#L490-L499

Because of this, we no longer need the global command binding as this ultimately causes issues with double-insertion of snippets.

I also discovered that the 'handlesEventPropagation' item doesn't work as expected -- `Event.getCurrentEvent()` doesn't actually return the current live event, because the command is executed in response to a GWT-generated _preview_ event, which GWT unfortunately doesn't make available. (https://developer.mozilla.org/en-US/docs/Web/API/Window/event does exist, but its use is in general not recommended, although for reasons that are not completely obvious to me)