### PR TITLE
support both Boost.Signals and Boost.Signals2

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -230,6 +230,18 @@ else()
    message(STATUS "Using RStudio-provided Boost ${BOOST_VERSION}: ${BOOST_ROOT}")
 endif()
 
+# allow opt-in to using Boost.Signals2
+# TODO: remove this in RStudio v1.3 and port to signals2
+if(NOT RSTUDIO_BOOST_SIGNALS_VERSION)
+   if (BOOST_VERSION VERSION_LESS 1.69.0)
+      set(RSTUDIO_BOOST_SIGNALS_VERSION 1)
+   else()
+      set(RSTUDIO_BOOST_SIGNALS_VERSION 2)
+   endif()
+endif()
+
+message(STATUS "Using Booost.Signals version ${RSTUDIO_BOOST_SIGNALS_VERSION}")
+add_definitions(-DRSTUDIO_BOOST_SIGNALS_VERSION=${RSTUDIO_BOOST_SIGNALS_VERSION})
 
 # add boost as system include directory
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/src/cpp/core/include/core/BoostSignals.hpp
+++ b/src/cpp/core/include/core/BoostSignals.hpp
@@ -1,0 +1,40 @@
+/*
+ * BoostSignals.hpp
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef CORE_RSTUDIO_BOOST_SIGNALS_HPP
+#define CORE_RSTUDIO_BOOST_SIGNALS_HPP
+
+#if RSTUDIO_BOOST_SIGNALS_VERSION == 1
+
+# include <boost/signals.hpp>
+# define RSTUDIO_BOOST_SIGNAL boost::signal
+# define RSTUDIO_BOOST_CONNECTION boost::signals::connection
+# define RSTUDIO_BOOST_SCOPED_CONNECTION boost::signals::scoped_connection
+# define RSTUDIO_BOOST_LAST_VALUE boost::last_value
+
+#elif RSTUDIO_BOOST_SIGNALS_VERSION == 2
+
+# include <boost/signals2.hpp>
+# define RSTUDIO_BOOST_SIGNAL boost::signals2::signal
+# define RSTUDIO_BOOST_CONNECTION boost::signals2::connection
+# define RSTUDIO_BOOST_SCOPED_CONNECTION boost::signals2::scoped_connection
+# define RSTUDIO_BOOST_LAST_VALUE boost::signals2::last_value
+
+#else
+# error "Unrecognized RSTUDIO_BOOST_SIGNALS_VERSION"
+#endif
+
+#endif // CORE_RSTUDIO_BOOST_SIGNALS_HPP
+

--- a/src/cpp/r/include/r/session/RConsoleHistory.hpp
+++ b/src/cpp/r/include/r/session/RConsoleHistory.hpp
@@ -20,8 +20,8 @@
 
 #include <boost/utility.hpp>
 #include <boost/circular_buffer.hpp>
-#include <boost/signal.hpp>
 
+#include <core/BoostSignals.hpp>
 #include <core/json/Json.hpp>
 
 namespace rstudio {
@@ -44,7 +44,7 @@ class ConsoleHistory : boost::noncopyable
 public:
    typedef boost::circular_buffer<std::string>::value_type value_type;
    typedef boost::circular_buffer<std::string>::const_iterator const_iterator;
-   typedef boost::signal<void (const std::string&)> AddSignal;
+   typedef RSTUDIO_BOOST_SIGNAL<void (const std::string&)> AddSignal;
 
 private:
    ConsoleHistory();
@@ -86,8 +86,7 @@ public:
    core::Error loadFromFile(const core::FilePath& filePath, bool verifyFile);
    core::Error saveToFile(const core::FilePath& filePath) const;
    
-   boost::signals::connection connectOnAdd(
-                                 const AddSignal::slot_function_type& slot)
+   RSTUDIO_BOOST_CONNECTION connectOnAdd(const AddSignal::slot_function_type& slot)
    {
       return onAdd_.connect(slot);
    }

--- a/src/cpp/r/include/r/session/RGraphics.hpp
+++ b/src/cpp/r/include/r/session/RGraphics.hpp
@@ -19,6 +19,8 @@
 #include <boost/system/error_code.hpp>
 #include <boost/date_time/posix_time/ptime.hpp>
 
+#include <core/BoostSignals.hpp>
+
 namespace rstudio {
 namespace r {
 namespace session {
@@ -56,8 +58,8 @@ struct is_error_code_enum<rstudio::r::session::graphics::errc::errc_t>
 #include <vector>
 
 #include <boost/function.hpp>
-#include <boost/signal.hpp>
 
+#include <core/BoostSignals.hpp>
 #include <core/Error.hpp>
 #include <core/json/Json.hpp>
 
@@ -162,7 +164,7 @@ public:
    virtual void clear() = 0;
 
    // subscribe to showManipulator event
-   virtual boost::signal<void ()>& onShowManipulator() = 0;
+   virtual RSTUDIO_BOOST_SIGNAL<void ()>& onShowManipulator() = 0;
 
    // set manipulator values
    virtual void setPlotManipulatorValues(const core::json::Object& values) = 0;

--- a/src/cpp/r/session/graphics/RGraphicsPlotManager.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsPlotManager.cpp
@@ -540,7 +540,7 @@ void PlotManager::clear()
 
 
 
-boost::signal<void ()>& PlotManager::onShowManipulator()
+RSTUDIO_BOOST_SIGNAL<void ()>& PlotManager::onShowManipulator()
 {
    return plotManipulatorManager().onShowManipulator();
 }

--- a/src/cpp/r/session/graphics/RGraphicsPlotManager.hpp
+++ b/src/cpp/r/session/graphics/RGraphicsPlotManager.hpp
@@ -22,10 +22,10 @@
 #include <boost/utility.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/function.hpp>
-#include <boost/signal.hpp>
 #include <boost/regex.hpp>
 #include <boost/circular_buffer.hpp>
 
+#include <core/BoostSignals.hpp>
 #include <core/Error.hpp>
 #include <core/FilePath.hpp>
 
@@ -45,10 +45,10 @@ PlotManager& plotManager();
 
 struct GraphicsDeviceEvents
 {
-   boost::signal<void (SEXP)> onNewPage; 
-   boost::signal<void ()> onDrawing;
-   boost::signal<void ()> onResized;
-   boost::signal<void ()> onClosed;
+   RSTUDIO_BOOST_SIGNAL<void (SEXP)> onNewPage; 
+   RSTUDIO_BOOST_SIGNAL<void ()> onDrawing;
+   RSTUDIO_BOOST_SIGNAL<void ()> onResized;
+   RSTUDIO_BOOST_SIGNAL<void ()> onClosed;
 };
 
 class PlotManipulatorManager;
@@ -110,7 +110,7 @@ public:
    
    virtual void clear();
 
-   virtual boost::signal<void ()>& onShowManipulator() ;
+   virtual RSTUDIO_BOOST_SIGNAL<void ()>& onShowManipulator() ;
    virtual void setPlotManipulatorValues(const core::json::Object& values);
    virtual void manipulatorPlotClicked(int x, int y);
 

--- a/src/cpp/r/session/graphics/RGraphicsPlotManipulatorManager.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsPlotManipulatorManager.cpp
@@ -184,7 +184,7 @@ Error PlotManipulatorManager::initialize(
 }
 
 
-boost::signal<void ()>& PlotManipulatorManager::onShowManipulator()
+RSTUDIO_BOOST_SIGNAL<void ()>& PlotManipulatorManager::onShowManipulator()
 {
    return onShowManipulator_;
 }

--- a/src/cpp/r/session/graphics/RGraphicsPlotManipulatorManager.hpp
+++ b/src/cpp/r/session/graphics/RGraphicsPlotManipulatorManager.hpp
@@ -16,8 +16,7 @@
 #ifndef R_SESSION_GRAPHICS_PLOT_MANIPULATOR_MANAGER_HPP
 #define R_SESSION_GRAPHICS_PLOT_MANIPULATOR_MANAGER_HPP
 
-#include <boost/signal.hpp>
-
+#include <core/BoostSignals.hpp>
 #include <core/Error.hpp>
 #include <core/json/Json.hpp>
 
@@ -53,7 +52,7 @@ public:
 public:
    core::Error initialize(const UnitConversionFunctions& convert);
 
-   boost::signal<void ()>& onShowManipulator() ;
+   RSTUDIO_BOOST_SIGNAL<void ()>& onShowManipulator() ;
    void setPlotManipulatorValues(const core::json::Object& values);
    void manipulatorPlotClicked(int x, int y);
    
@@ -85,7 +84,7 @@ private:
    bool replayingManipulator_;
 
    // manipulator event hook
-   boost::signal<void ()> onShowManipulator_;
+   RSTUDIO_BOOST_SIGNAL<void ()> onShowManipulator_;
 
    // unit conversion function
    UnitConversionFunctions convert_;

--- a/src/cpp/server/include/server/ServerSessionManager.hpp
+++ b/src/cpp/server/include/server/ServerSessionManager.hpp
@@ -20,9 +20,9 @@
 #include <vector>
 #include <map>
 
-#include <boost/signals.hpp>
 #include <boost/asio/io_service.hpp>
 
+#include <core/BoostSignals.hpp>
 #include <core/http/AsyncClient.hpp>
 #include <core/http/Request.hpp>
 #include <core/Thread.hpp>

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -38,12 +38,12 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/format.hpp>
 
-#include <boost/signals.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/join.hpp>
 
 #include <core/Error.hpp>
+#include <core/BoostSignals.hpp>
 #include <core/BoostThread.hpp>
 #include <core/ConfigUtils.hpp>
 #include <core/FilePath.hpp>

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -19,10 +19,10 @@
 
 #include <boost/assert.hpp>
 #include <boost/utility.hpp>
-#include <boost/signal.hpp>
 #include <boost/format.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <core/BoostSignals.hpp>
 #include <core/BoostThread.hpp>
 #include <core/Error.hpp>
 #include <core/FilePath.hpp>
@@ -654,13 +654,13 @@ private:
    
    int nextGroup_; 
    
-   boost::signal<void(const r::session::RSuspendOptions&,Settings*),
-                 boost::last_value<void>,
+   RSTUDIO_BOOST_SIGNAL<void(const r::session::RSuspendOptions&,Settings*),
+                 RSTUDIO_BOOST_LAST_VALUE<void>,
                  int,
                  std::less<int> > suspendSignal_;
                   
-   boost::signal<void(const Settings&),
-                 boost::last_value<void>,
+   RSTUDIO_BOOST_SIGNAL<void(const Settings&),
+                 RSTUDIO_BOOST_LAST_VALUE<void>,
                  int,
                  std::greater<int> > resumeSignal_;
 };

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -20,10 +20,10 @@
 #include <deque>
 
 #include <boost/regex.hpp>
-#include <boost/signals.hpp>
 #include <boost/circular_buffer.hpp>
 #include <boost/enable_shared_from_this.hpp>
 
+#include <core/BoostSignals.hpp>
 #include <core/system/Process.hpp>
 #include <core/terminal/PrivateCommand.hpp>
 
@@ -146,7 +146,7 @@ public:
    void setPromptHandler(
          const boost::function<bool(const std::string&, Input*)>& onPrompt);
 
-   boost::signal<void(int)>& onExit() { return onExit_; }
+   RSTUDIO_BOOST_SIGNAL<void(int)>& onExit() { return onExit_; }
 
    std::string handle() const { return procInfo_->getHandle(); }
    InteractionMode interactionMode() const { return procInfo_->getInteractionMode(); }
@@ -264,7 +264,7 @@ private:
    boost::mutex inputOutputQueueMutex_;
 
    boost::function<bool(const std::string&, Input*)> onPrompt_;
-   boost::signal<void(int)> onExit_;
+   RSTUDIO_BOOST_SIGNAL<void(int)> onExit_;
 
    // regex for prompt detection
    boost::regex controlCharsPattern_;

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -21,9 +21,9 @@
 
 #include <boost/utility.hpp>
 #include <boost/function.hpp>
-#include <boost/signals.hpp>
 #include <boost/shared_ptr.hpp>
 
+#include <core/BoostSignals.hpp>
 #include <core/HtmlUtils.hpp>
 #include <core/system/System.hpp>
 #include <core/system/ShellUtils.hpp>
@@ -321,35 +321,35 @@ struct firstNonEmpty
 // session events
 struct Events : boost::noncopyable
 {
-   boost::signal<void (core::json::Object*)> onSessionInfo;
-   boost::signal<void ()>                    onClientInit;
-   boost::signal<void ()>                    onBeforeExecute;
-   boost::signal<void(const std::string&)>   onConsolePrompt;
-   boost::signal<void(const std::string&)>   onConsoleInput;
-   boost::signal<void(const std::string&, const std::string&)>  
+   RSTUDIO_BOOST_SIGNAL<void (core::json::Object*)> onSessionInfo;
+   RSTUDIO_BOOST_SIGNAL<void ()>                    onClientInit;
+   RSTUDIO_BOOST_SIGNAL<void ()>                    onBeforeExecute;
+   RSTUDIO_BOOST_SIGNAL<void(const std::string&)>   onConsolePrompt;
+   RSTUDIO_BOOST_SIGNAL<void(const std::string&)>   onConsoleInput;
+   RSTUDIO_BOOST_SIGNAL<void(const std::string&, const std::string&)>  
                                              onActiveConsoleChanged;
-   boost::signal<void (ConsoleOutputType, const std::string&)>
+   RSTUDIO_BOOST_SIGNAL<void (ConsoleOutputType, const std::string&)>
                                              onConsoleOutput;
-   boost::signal<void()>                     onUserInterrupt;
-   boost::signal<void (ChangeSource)>        onDetectChanges;
-   boost::signal<void (core::FilePath)>      onSourceEditorFileSaved;
-   boost::signal<void(bool)>                 onDeferredInit;
-   boost::signal<void(bool)>                 afterSessionInitHook;
-   boost::signal<void(bool)>                 onBackgroundProcessing;
-   boost::signal<void(bool)>                 onShutdown;
-   boost::signal<void ()>                    onQuit;
-   boost::signal<void ()>                    onDestroyed;
-   boost::signal<void (const std::vector<std::string>&)>
+   RSTUDIO_BOOST_SIGNAL<void()>                     onUserInterrupt;
+   RSTUDIO_BOOST_SIGNAL<void (ChangeSource)>        onDetectChanges;
+   RSTUDIO_BOOST_SIGNAL<void (core::FilePath)>      onSourceEditorFileSaved;
+   RSTUDIO_BOOST_SIGNAL<void(bool)>                 onDeferredInit;
+   RSTUDIO_BOOST_SIGNAL<void(bool)>                 afterSessionInitHook;
+   RSTUDIO_BOOST_SIGNAL<void(bool)>                 onBackgroundProcessing;
+   RSTUDIO_BOOST_SIGNAL<void(bool)>                 onShutdown;
+   RSTUDIO_BOOST_SIGNAL<void ()>                    onQuit;
+   RSTUDIO_BOOST_SIGNAL<void ()>                    onDestroyed;
+   RSTUDIO_BOOST_SIGNAL<void (const std::vector<std::string>&)>
                                              onLibPathsChanged;
-   boost::signal<void (const std::string&)>  onPackageLoaded;
-   boost::signal<void ()>                    onPackageLibraryMutated;
-   boost::signal<void ()>                    onPreferencesSaved;
-   boost::signal<void (const server_core::DistributedEvent&)>
+   RSTUDIO_BOOST_SIGNAL<void (const std::string&)>  onPackageLoaded;
+   RSTUDIO_BOOST_SIGNAL<void ()>                    onPackageLibraryMutated;
+   RSTUDIO_BOOST_SIGNAL<void ()>                    onPreferencesSaved;
+   RSTUDIO_BOOST_SIGNAL<void (const server_core::DistributedEvent&)>
                                              onDistributedEvent;
-   boost::signal<void (core::FilePath)>      onPermissionsChanged;
+   RSTUDIO_BOOST_SIGNAL<void (core::FilePath)>      onPermissionsChanged;
 
    // signal for detecting extended type of documents
-   boost::signal<std::string(boost::shared_ptr<source_database::SourceDocument>),
+   RSTUDIO_BOOST_SIGNAL<std::string(boost::shared_ptr<source_database::SourceDocument>),
                  firstNonEmpty<std::string> > onDetectSourceExtendedType;
 };
 

--- a/src/cpp/session/include/session/SessionSourceDatabase.hpp
+++ b/src/cpp/session/include/session/SessionSourceDatabase.hpp
@@ -21,8 +21,8 @@
 
 #include <boost/utility.hpp>
 #include <boost/shared_ptr.hpp>
-#include <boost/signals.hpp>
 
+#include <core/BoostSignals.hpp>
 #include <core/FilePath.hpp>
 #include <core/json/Json.hpp>
 
@@ -212,14 +212,14 @@ core::Error rename(const core::FilePath& from, const core::FilePath& to);
 // source database events
 struct Events : boost::noncopyable
 {
-   boost::signal<void(boost::shared_ptr<SourceDocument>)>      onDocUpdated;
-   boost::signal<void(const std::string&,
+   RSTUDIO_BOOST_SIGNAL<void(boost::shared_ptr<SourceDocument>)>      onDocUpdated;
+   RSTUDIO_BOOST_SIGNAL<void(const std::string&,
                       boost::shared_ptr<SourceDocument>)>      onDocRenamed;
-   boost::signal<void(const std::string&)>                     onDocAdded;
-   boost::signal<void(
+   RSTUDIO_BOOST_SIGNAL<void(const std::string&)>                     onDocAdded;
+   RSTUDIO_BOOST_SIGNAL<void(
       boost::shared_ptr<source_database::SourceDocument>)>     onDocPendingRemove;
-   boost::signal<void(const std::string&, const std::string&)> onDocRemoved;
-   boost::signal<void()>                                       onRemoveAll;
+   RSTUDIO_BOOST_SIGNAL<void(const std::string&, const std::string&)> onDocRemoved;
+   RSTUDIO_BOOST_SIGNAL<void()>                                       onRemoveAll;
 };
 
 Events& events();

--- a/src/cpp/session/include/session/SessionUserSettings.hpp
+++ b/src/cpp/session/include/session/SessionUserSettings.hpp
@@ -20,8 +20,8 @@
 
 #include <boost/utility.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/signal.hpp>
 
+#include <core/BoostSignals.hpp>
 #include <core/Settings.hpp>
 #include <core/FilePath.hpp>
 #include <core/StringUtils.hpp>
@@ -64,7 +64,7 @@ private:
    friend UserSettings& userSettings();
 
 public:
-   boost::signal<void()> onChanged;
+   RSTUDIO_BOOST_SIGNAL<void()> onChanged;
 
 public:
    // COPYING: boost::noncopyable

--- a/src/cpp/session/include/session/projects/SessionProjects.hpp
+++ b/src/cpp/session/include/session/projects/SessionProjects.hpp
@@ -22,8 +22,8 @@
 #include <boost/utility.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/foreach.hpp>
-#include <boost/signals.hpp>
 
+#include <core/BoostSignals.hpp>
 #include <core/FileInfo.hpp>
 #include <core/FilePath.hpp>
 #include <core/Settings.hpp>
@@ -225,10 +225,10 @@ private:
 
    bool hasFileMonitor_;
    std::vector<std::string> monitorSubscribers_;
-   boost::signal<void(const tree<core::FileInfo>&)> onMonitoringEnabled_;
-   boost::signal<void(const std::vector<core::system::FileChangeEvent>&)>
+   RSTUDIO_BOOST_SIGNAL<void(const tree<core::FileInfo>&)> onMonitoringEnabled_;
+   RSTUDIO_BOOST_SIGNAL<void(const std::vector<core::system::FileChangeEvent>&)>
                                                             onFilesChanged_;
-   boost::signal<void()> onMonitoringDisabled_;
+   RSTUDIO_BOOST_SIGNAL<void()> onMonitoringDisabled_;
 };
 
 ProjectContext& projectContext();

--- a/src/cpp/session/modules/SessionPlots.hpp
+++ b/src/cpp/session/modules/SessionPlots.hpp
@@ -16,7 +16,7 @@
 #ifndef SESSION_PLOTS_HPP
 #define SESSION_PLOTS_HPP
 
-#include <boost/signals.hpp>
+#include <core/BoostSignals.hpp>
 
 namespace rstudio {
 namespace core {
@@ -35,9 +35,9 @@ core::Error initialize();
 
 struct Events : boost::noncopyable
 {
-   boost::signal<void()> onBeforeNewPlot;
-   boost::signal<void()> onBeforeNewGridPage;
-   boost::signal<void()> onNewPlot;
+   RSTUDIO_BOOST_SIGNAL<void()> onBeforeNewPlot;
+   RSTUDIO_BOOST_SIGNAL<void()> onBeforeNewGridPage;
+   RSTUDIO_BOOST_SIGNAL<void()> onNewPlot;
 };
 
 Events& events();

--- a/src/cpp/session/modules/SessionRAddins.cpp
+++ b/src/cpp/session/modules/SessionRAddins.cpp
@@ -45,7 +45,7 @@ namespace r_addins {
 
 namespace {
 
-boost::signals::connection s_consolePromptHandler;
+RSTUDIO_BOOST_CONNECTION s_consolePromptHandler;
 
 bool isDevtoolsLoadAllActive()
 {

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -722,7 +722,7 @@ Error adaptToLanguage(const json::JsonRpcRequest& request,
       // we screen out consecutive transition attempts (otherwise we can
       // get multiple interleaved attempts to launch the REPL with console
       // input)
-      static boost::signals::connection conn;
+      static RSTUDIO_BOOST_CONNECTION conn;
       if (conn.connected())
          return Success();
       

--- a/src/cpp/session/modules/build/SessionSourceCpp.cpp
+++ b/src/cpp/session/modules/build/SessionSourceCpp.cpp
@@ -15,11 +15,11 @@
 
 #include "SessionSourceCpp.hpp"
 
-#include <boost/signal.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/join.hpp>
 
+#include <core/BoostSignals.hpp>
 #include <core/Error.hpp>
 #include <core/FilePath.hpp>
 #include <core/StringUtils.hpp>

--- a/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.cpp
@@ -165,7 +165,7 @@ Error executeRcppEngineChunk(const std::string& docId,
       LOG_ERROR(error);
    
    // capture console output, error
-   boost::signals::scoped_connection consoleHandler =
+   RSTUDIO_BOOST_SCOPED_CONNECTION consoleHandler =
          module_context::events().onConsoleOutput.connect(
             boost::bind(chunkConsoleOutputHandler,
                         _1,
@@ -242,7 +242,7 @@ Error executeStanEngineChunk(const std::string& docId,
       LOG_ERROR(error);
    
    // capture console output, error
-   boost::signals::scoped_connection consoleHandler =
+   RSTUDIO_BOOST_SCOPED_CONNECTION consoleHandler =
          module_context::events().onConsoleOutput.connect(
             boost::bind(chunkConsoleOutputHandler,
                         _1,
@@ -386,7 +386,7 @@ Error executeSqlEngineChunk(const std::string& docId,
       LOG_ERROR(error);
    
    // capture console output, error
-   boost::signals::scoped_connection consoleHandler =
+   RSTUDIO_BOOST_SCOPED_CONNECTION consoleHandler =
          module_context::events().onConsoleOutput.connect(
             boost::bind(chunkConsoleOutputHandler,
                         _1,
@@ -591,7 +591,7 @@ Error runUserDefinedEngine(const std::string& docId,
       }
    };
    
-   boost::signals::scoped_connection handler =
+   RSTUDIO_BOOST_SCOPED_CONNECTION handler =
          module_context::events().onConsoleOutput.connect(consoleHandler);
    
    // run the user-defined engine

--- a/src/cpp/session/modules/rmarkdown/NotebookCapture.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookCapture.cpp
@@ -16,6 +16,8 @@
 #include "SessionRmdNotebook.hpp"
 #include "NotebookCapture.hpp"
 
+#include <boost/make_shared.hpp>
+
 namespace rstudio {
 namespace session {
 namespace modules {

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
@@ -458,7 +458,7 @@ void ChunkExecContext::disconnect()
    }
 
    // unhook all our event handlers
-   BOOST_FOREACH(const boost::signals::connection connection, connections_) 
+   BOOST_FOREACH(const RSTUDIO_BOOST_CONNECTION connection, connections_) 
    {
       connection.disconnect();
    }

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.hpp
@@ -18,8 +18,7 @@
 
 #include <session/SessionModuleContext.hpp>
 
-#include <boost/signal.hpp>
-
+#include <core/BoostSignals.hpp>
 #include <core/json/Json.hpp>
 
 #include <r/RSexp.hpp>
@@ -103,7 +102,7 @@ private:
    bool hasErrors_;
 
    std::vector<boost::shared_ptr<NotebookCapture> > captures_;
-   std::vector<boost::signals::connection> connections_;
+   std::vector<RSTUDIO_BOOST_CONNECTION> connections_;
 };
 
 } // namespace notebook

--- a/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
@@ -20,11 +20,12 @@
 
 #include <boost/format.hpp>
 #include <boost/foreach.hpp>
-#include <boost/signals/connection.hpp>
+
+#include <core/BoostSignals.hpp>
+#include <core/Exec.hpp>
+#include <core/StringUtils.hpp>
 
 #include <core/system/FileMonitor.hpp>
-#include <core/StringUtils.hpp>
-#include <core/Exec.hpp>
 
 #include <session/SessionModuleContext.hpp>
 

--- a/src/cpp/session/modules/rmarkdown/NotebookPlots.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlots.hpp
@@ -18,8 +18,10 @@
 #define SESSION_NOTEBOOK_PLOTS_HPP
 
 #include <boost/function.hpp>
-#include <boost/signals/connection.hpp>
+
+#include <core/BoostSignals.hpp>
 #include <core/FilePath.hpp>
+
 #include <r/RSexp.hpp>
 
 #include "NotebookCapture.hpp"
@@ -80,9 +82,9 @@ private:
 
    unsigned lastOrdinal_;
 
-   boost::signals::connection onBeforeNewPlot_;
-   boost::signals::connection onBeforeNewGridPage_;
-   boost::signals::connection onNewPlot_;
+   RSTUDIO_BOOST_CONNECTION onBeforeNewPlot_;
+   RSTUDIO_BOOST_CONNECTION onBeforeNewGridPage_;
+   RSTUDIO_BOOST_CONNECTION onNewPlot_;
 
    double width_;
    double height_;

--- a/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
@@ -87,7 +87,7 @@ public:
       pInput_->enque(kThreadQuitCommand);
 
       // unregister handlers
-      BOOST_FOREACH(boost::signals::connection connection, handlers_)
+      BOOST_FOREACH(RSTUDIO_BOOST_CONNECTION connection, handlers_)
       {
          connection.disconnect();
       }
@@ -652,7 +652,7 @@ private:
    boost::shared_ptr<ChunkExecContext> execContext_;
 
    // registered signal handlers
-   std::vector<boost::signals::connection> handlers_;
+   std::vector<RSTUDIO_BOOST_CONNECTION> handlers_;
 
    // the thread which submits console input, and the queue which feeds it
    boost::thread console_;

--- a/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.hpp
@@ -18,7 +18,8 @@
 #define SESSION_RMARKDOWN_NOTEBOOK_HPP
 
 #include <ctime>
-#include <boost/signals.hpp>
+
+#include <core/BoostSignals.hpp>
 #include <core/json/Json.hpp>
 
 #define kChunkLibDir "lib"
@@ -76,24 +77,24 @@ std::string notebookCtxId();
 struct Events : boost::noncopyable
 {
    // Document {0}, chunk {1} from context id {3} execution completed
-   boost::signal<void(const std::string&, const std::string&,
+   RSTUDIO_BOOST_SIGNAL<void(const std::string&, const std::string&,
                       const std::string&)> 
                 onChunkExecCompleted;
 
    // Document {0}, chunk {1} had console output of type {2} and text {3}
-   boost::signal<void(const std::string&, const std::string&, int, 
+   RSTUDIO_BOOST_SIGNAL<void(const std::string&, const std::string&, int, 
                 const std::string&)>
                 onChunkConsoleOutput;
 
-   boost::signal<void(const core::FilePath&, const core::FilePath&, 
+   RSTUDIO_BOOST_SIGNAL<void(const core::FilePath&, const core::FilePath&, 
                       const core::json::Value& metadata, unsigned ordinal)> 
                          onPlotOutput;
-   boost::signal<void(const core::FilePath&, const core::FilePath&,
+   RSTUDIO_BOOST_SIGNAL<void(const core::FilePath&, const core::FilePath&,
                       const core::json::Value& metadata)> onHtmlOutput;
-   boost::signal<void(const core::json::Object&)> onErrorOutput;
-   boost::signal<void(const core::FilePath&, const core::FilePath&,
+   RSTUDIO_BOOST_SIGNAL<void(const core::json::Object&)> onErrorOutput;
+   RSTUDIO_BOOST_SIGNAL<void(const core::FilePath&, const core::FilePath&,
                       const core::json::Value& metadata)> onDataOutput;
-   boost::signal<void(Condition condition, const std::string& message)> 
+   RSTUDIO_BOOST_SIGNAL<void(Condition condition, const std::string& message)> 
                          onCondition;
 };
 


### PR DESCRIPTION
This PR makes it possible to build RStudio against either Boost.Signals or Boost.Signals2. When using Boost 1.69.0 or greater, RStudio uses and builds against Boost.Signals2.

Will likely require similar work in the Pro repository.

re: https://github.com/rstudio/rstudio/issues/3760