### PR TITLE
prevent javascript console message when starting session job

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -5630,7 +5630,7 @@ public class RemoteServer implements Server
 
    @Override
    public void startJob(JobLaunchSpec spec, 
-                        ServerRequestCallback<Void> callback)
+                        ServerRequestCallback<String> callback)
    {
       JSONArray params = new JSONArray();
       params.set(0, new JSONObject(spec));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobManager.java
@@ -27,6 +27,8 @@ import org.rstudio.core.client.command.Handler;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.server.ServerError;
+import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.events.SessionInitEvent;
@@ -371,7 +373,13 @@ public class JobManager implements JobRefreshEvent.Handler,
                }
                
                // tell the server to start running this script
-               server_.startJob(spec, new VoidServerRequestCallback());
+               server_.startJob(spec, new ServerRequestCallback<String>() {
+                  @Override
+                  public void onError(ServerError error)
+                  {
+                     Debug.logError(error);
+                  }
+               });
             });
       dialog.showModal();
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobsServerOperations.java
@@ -23,7 +23,7 @@ public interface JobsServerOperations
 {
    void setJobListening(String id, boolean listening,
                         ServerRequestCallback<JsArray<JobOutput> > output);
-   void startJob(JobLaunchSpec spec, ServerRequestCallback<Void> callback); 
+   void startJob(JobLaunchSpec spec, ServerRequestCallback<String> callback);
    void clearJobs(ServerRequestCallback<Void> callback);
    void executeJobAction(String id, String action, ServerRequestCallback<Void> callback);
 }


### PR DESCRIPTION
Due to mismatch of Gwt side's expectation (Void) vs. what the rsession RPC returns (String), getting a message in Javascript console when starting a session job:

![2018-10-31_20-50-06](https://user-images.githubusercontent.com/10569626/47831943-0a04a980-dd50-11e8-9f86-cc4a76e9faee.png)

FWIW, the return value being ignored is the new job ID; leaving it in the RPC (but continuing to ignore it).