### PR TITLE
use 32-bit version of Pandoc for now

### DIFF
--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -21,7 +21,7 @@ set OPENSSL_FILES=openssl-1.0.2p.zip
 set BOOST_FILES=boost-1.65.1-win-msvc141.zip
 
 set PANDOC_VERSION=2.3.1
-set PANDOC_NAME=pandoc-%PANDOC_VERSION%-windows-x86_64
+set PANDOC_NAME=pandoc-%PANDOC_VERSION%-windows-i386
 set PANDOC_FILE=%PANDOC_NAME%.zip
 
 set LIBCLANG_VERSION=5.0.2


### PR DESCRIPTION
This PR seeks to work around the crashes seen in https://github.com/rstudio/rstudio/issues/3661 by switching to the 32-bit build of Pandoc, which (at least from a bit of testing locally) does not crash as the 64-bit version does.