### PR TITLE
Update dependencies for package versions in 1.2

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -152,6 +152,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
          new Dependency[] {
             Dependency.cranPackage("htmltools", "0.3.6"),
             Dependency.cranPackage("htmlwidgets", "1.2", true),
+            Dependency.cranPackage("jsonlite", "0.9.19"),
             Dependency.cranPackage("r2d3", "0.2.0", true)
          },
          true,
@@ -292,11 +293,11 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       deps.add(Dependency.cranPackage("yaml", "2.1.5"));
       deps.add(Dependency.cranPackage("Rcpp", "0.11.5"));
       deps.add(Dependency.cranPackage("htmltools", "0.3.5"));
-      deps.add(Dependency.cranPackage("bitops", "1.0-6"));
       deps.add(Dependency.cranPackage("knitr", "1.18"));
       deps.add(Dependency.cranPackage("jsonlite", "0.9.19"));
       deps.add(Dependency.cranPackage("base64enc", "0.1-3"));
       deps.add(Dependency.cranPackage("rprojroot", "1.0"));
+      deps.add(Dependency.cranPackage("mime", "0.5"));
       deps.add(Dependency.cranPackage("rmarkdown", "1.9"));
       return deps;
    }
@@ -391,20 +392,24 @@ public class DependencyManager implements InstallShinyEvent.Handler,
    }
 
    private ArrayList<Dependency> shinyDependencies()
-         {
+   {
       ArrayList<Dependency> deps = new ArrayList<Dependency>();
       deps.add(Dependency.cranPackage("Rcpp", "0.11.5"));
-      deps.add(Dependency.cranPackage("httpuv", "1.3.3"));
-      deps.add(Dependency.cranPackage("mime", "0.3"));
+      deps.add(Dependency.cranPackage("httpuv", "1.4.4"));
+      deps.add(Dependency.cranPackage("mime", "0.5"));
       deps.add(Dependency.cranPackage("jsonlite", "0.9.19"));
       deps.add(Dependency.cranPackage("xtable", "1.7"));
       deps.add(Dependency.cranPackage("digest", "0.6"));
       deps.add(Dependency.cranPackage("R6", "2.0"));
       deps.add(Dependency.cranPackage("sourcetools", "0.1.5"));
       deps.add(Dependency.cranPackage("htmltools", "0.3.5"));
-      deps.add(Dependency.cranPackage("shiny", "1.0", true));
+      deps.add(Dependency.cranPackage("promises", "1.0.1"));
+      deps.add(Dependency.cranPackage("crayon", "1.3.4"));
+      deps.add(Dependency.cranPackage("rlang", "0.2.2"));
+      deps.add(Dependency.cranPackage("later", "0.7.2"));
+      deps.add(Dependency.cranPackage("shiny", "1.2.0", true));
       return deps;
-         }
+   }
    
    @Override
    public void onInstallShiny(InstallShinyEvent event)
@@ -421,8 +426,9 @@ public class DependencyManager implements InstallShinyEvent.Handler,
             progressCaption,
             userPrompt,
             new Dependency[] {
+                  Dependency.cranPackage("jsonlite", "0.9.19"),
+                  Dependency.cranPackage("png", "0.1-7"),
                   Dependency.cranPackage("reticulate", "1.6"),
-                  Dependency.cranPackage("png", "0.1-7")
             },
             true,
             new CommandWithArg<Boolean>()


### PR DESCRIPTION
This change is the result of a short audit to ensure that the dependencies in DependencyManager are aligned with actual package dependencies.

Fixes #3552.