### PR TITLE
remove desktop-specific dialog sizing bits

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.css
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.css
@@ -15,19 +15,9 @@
  
 @external .gwt-CheckBox;
 
-@if rstudio.desktop true {
-@def appDetailsWidth 250px
-@def accountListWidth 262px
-@def deployIllustrationMarginLeft 12px
-} @else {
-@def appDetailsWidth 238px
-@def accountListWidth 250px
-@def deployIllustrationMarginLeft 0
-}
-
 .deployIllustration
 {
-   margin-left: deployIllustrationMarginLeft;
+   margin-left: 0;
 }
 
 .sourceDestLabels
@@ -143,7 +133,7 @@
 .accountList
 {
    height: 100px;
-   width: accountListWidth;
+   width: 250px;
 }
 
 .accountList.accountListCondensed
@@ -188,7 +178,7 @@
    padding: 5px;
    margin: 0px;
    overflow: hidden;
-   width: appDetailsWidth;
+   width: 238px;
 }
 
 .appDetailsPanel 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -1280,7 +1280,7 @@ public class RSConnectDeploy extends Composite
       appErrorMessage_.setText(lines[lines.length - 1]);
       appErrorMessage_.setTitle(error);
    }
-
+   
    @UiField Anchor addAccountAnchor_;
    @UiField Anchor createNewAnchor_;
    @UiField Anchor urlAnchor_;


### PR DESCRIPTION
Fixes https://github.com/rstudio/rstudio/issues/1925. Some notes:

1. `@def` within conditions does not appear to be supported anymore (?). In the generated CSS, I saw the actual variable names (rather than their substituted values) meaning that we were assigning 'garbage' for the widths. Unless that's a devmode-only quirk, but to the best of my knowledge this did work before.

2. The browser-specific styling seems to no longer be necessary now that we're using Chromium in the desktop products.