### PR TITLE
Ensure chunk execution context cleanup on parse error

### DIFF
--- a/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
@@ -458,7 +458,7 @@ void ChunkExecContext::disconnect()
    }
 
    // unhook all our event handlers
-   BOOST_FOREACH(const RSTUDIO_BOOST_CONNECTION connection, connections_) 
+   BOOST_FOREACH(const RSTUDIO_BOOST_CONNECTION& connection, connections_)
    {
       connection.disconnect();
    }

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.hpp
@@ -60,8 +60,10 @@ public:
    ExecScope execScope();
    const ChunkOptions& options();
 
-   // inject console input manually
+   // inject console input/output manually
    void onConsoleInput(const std::string& input);
+   void onConsoleOutput(module_context::ConsoleOutputType type,
+         const std::string& output);
 
    // invoked to indicate that an expression has finished evaluating
    void onExprComplete();
@@ -72,8 +74,6 @@ public:
    void disconnect();
 
 private:
-   void onConsoleOutput(module_context::ConsoleOutputType type, 
-         const std::string& output);
    void onConsoleText(int type, const std::string& output, bool truncate);
    void onConsolePrompt(const std::string&);
    void onFileOutput(const core::FilePath& file, const core::FilePath& sidecar,

--- a/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
@@ -87,10 +87,13 @@ public:
       pInput_->enque(kThreadQuitCommand);
 
       // unregister handlers
-      BOOST_FOREACH(RSTUDIO_BOOST_CONNECTION connection, handlers_)
+      BOOST_FOREACH(RSTUDIO_BOOST_CONNECTION& connection, handlers_)
       {
          connection.disconnect();
       }
+
+      // clear queue state and any active execution contexts
+      clear();
    }
 
    bool complete()
@@ -350,9 +353,7 @@ private:
       // extract the default chunk options, then augment with the unit's 
       // chunk-specific options
       json::Object chunkOptions;
-      error = unit->parseOptions(&chunkOptions);
-      if (error)
-         LOG_ERROR(error);
+      Error optionsError = unit->parseOptions(&chunkOptions);
       ChunkOptions options(docQueue->defaultChunkOptions(), chunkOptions);
 
       // establish execution context for the unit
@@ -419,6 +420,14 @@ private:
                workingDir, options, docQueue->pixelWidth(), 
                docQueue->charWidth());
             execContext_->connect();
+
+            // if there was an error parsing the options for the chunk, display
+            // that as an error inside the chunk itself
+            if (optionsError)
+            {
+                execContext_->onConsoleOutput(module_context::ConsoleOutputError,
+                                              optionsError.summary());
+            }
          }
          execUnit_ = unit;
          enqueueExecStateChanged(ChunkExecStarted, options.chunkOptions());


### PR DESCRIPTION
This change fixes a crash that can occur when there's an error evaluating chunk options. When this happens, the object that manages the associated chunk's execution context (`ChunkExecContext`) can leak event handlers. Executing these leaked handlers when the underlying object has been cleaned up can cause a crash.

There are two lines of defense added here:

1. As chunk option evaluation errors are intended to be tolerable, we now track them with a separate error variable (and log them to the chunk, not to the log file). The chunk is still executed.

2. When all of the notebook chunks are done executing, we double-check that our current execution context gets safely shut down.

