### PR TITLE
maintain cache of installed monospace fonts

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -1262,14 +1262,7 @@ bool isProportionalFont(const QString& fontFamily)
 
 QString GwtCallback::getFixedWidthFontList()
 {
-   QFontDatabase& db = desktop::fontDatabase();
-   QStringList families = db.families();
-
-   QStringList::iterator it = std::remove_if(
-            families.begin(), families.end(), isProportionalFont);
-   families.erase(it, families.end());
-
-   return families.join(QString::fromUtf8("\n"));
+   return desktop::getFixedWidthFontList();
 }
 
 QString GwtCallback::getFixedWidthFont()

--- a/src/cpp/desktop/DesktopInfo.cpp
+++ b/src/cpp/desktop/DesktopInfo.cpp
@@ -42,17 +42,6 @@ QString s_sumatraPdfExePath    = kUnknown;
 int     s_chromiumDevtoolsPort = -1;
 double  s_zoomLevel            = 1.0;
 
-QString getFixedWidthFontList()
-{
-   return desktop::getFixedWidthFontList();
-}
-
-QString& fixedWidthFontList()
-{
-   static QString instance = getFixedWidthFontList();
-   return instance;
-}
-
 #ifdef Q_OS_LINUX
 
 void readEntry(
@@ -138,26 +127,6 @@ DesktopInfo::DesktopInfo(QObject* parent)
    : QObject(parent)
 {
    initialize();
-
-   QObject::connect(
-            this,
-            &DesktopInfo::sumatraPdfExePathChanged,
-            &DesktopInfo::setSumatraPdfExePath);
-
-   QObject::connect(
-            this,
-            &DesktopInfo::fixedWidthFontListChanged,
-            &DesktopInfo::setFixedWidthFontList);
-
-   QObject::connect(
-            this,
-            &DesktopInfo::zoomLevelChanged,
-            &DesktopInfo::setZoomLevel);
-   
-   QObject::connect(
-            this,
-            &DesktopInfo::chromiumDevtoolsPortChanged,
-            &DesktopInfo::setChromiumDevtoolsPort);
 }
 
 QString DesktopInfo::getPlatform()
@@ -183,16 +152,7 @@ QString DesktopInfo::getScrollingCompensationType()
 
 QString DesktopInfo::getFixedWidthFontList()
 {
-   return fixedWidthFontList();
-}
-
-void DesktopInfo::setFixedWidthFontList(QString list)
-{
-   if (fixedWidthFontList() != list)
-   {
-      fixedWidthFontList() = list;
-      emit fixedWidthFontListChanged(list);
-   }
+   return desktop::getFixedWidthFontList();
 }
 
 QString DesktopInfo::getFixedWidthFont()

--- a/src/cpp/desktop/DesktopInfo.hpp
+++ b/src/cpp/desktop/DesktopInfo.hpp
@@ -48,11 +48,7 @@ public:
    Q_PROPERTY(QString scrollingCompensationType READ getScrollingCompensationType CONSTANT)
 
    Q_INVOKABLE QString getFixedWidthFontList();
-   Q_INVOKABLE void setFixedWidthFontList(QString list);
-   Q_PROPERTY(QString fixedWidthFontList
-              READ getFixedWidthFontList
-              WRITE setFixedWidthFontList
-              NOTIFY fixedWidthFontListChanged)
+   Q_PROPERTY(QString fixedWidthFontList READ getFixedWidthFontList CONSTANT)
 
    Q_INVOKABLE QString getFixedWidthFont();
    Q_PROPERTY(QString fixedWidthFont READ getFixedWidthFont CONSTANT)


### PR DESCRIPTION
This PR seeks to further improve startup performance, especially in the case when there are a very large number of fonts installed on the system.

The QFontDatabase object is unfortunately quite slow -- it takes a long time (especially when many fonts are installed) to read and parse installed fonts on the system. This PR tries to mitigate some of that cost by maintaining a local cache of monospace fonts.

The font cache is rebuilt eagerly when it doesn't exist, and in a separate thread (anticipating that new fonts might have been added) when it does. One must still restart RStudio to have it pick up any newly-installed fonts, and while that's not great I don't think it's too detrimental since font installation is done fairly infrequently.

Closes https://github.com/rstudio/rstudio/issues/1889.