### PR TITLE
build font database on startup in separate thread

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -1262,14 +1262,7 @@ bool isProportionalFont(const QString& fontFamily)
 
 QString GwtCallback::getFixedWidthFontList()
 {
-   QFontDatabase& db = desktop::fontDatabase();
-   QStringList families = db.families();
-
-   QStringList::iterator it = std::remove_if(
-            families.begin(), families.end(), isProportionalFont);
-   families.erase(it, families.end());
-
-   return families.join(QString::fromUtf8("\n"));
+   return desktop::getFixedWidthFontList();
 }
 
 QString GwtCallback::getFixedWidthFont()

--- a/src/cpp/desktop/DesktopInfo.cpp
+++ b/src/cpp/desktop/DesktopInfo.cpp
@@ -27,7 +27,7 @@
 #define kRedhatRelease "/etc/redhat-release"
 #define kOsRelease     "/etc/os-release"
 
-#define kUnknown QStringLiteral("unknown")
+#define kUnknown QStringLiteral("(unknown)")
 
 using namespace rstudio::core;
 
@@ -39,19 +39,9 @@ namespace {
 QString s_platform             = kUnknown;
 QString s_version              = kUnknown;
 QString s_sumatraPdfExePath    = kUnknown;
+QString s_fixedWidthFontList   = kUnknown;
 int     s_chromiumDevtoolsPort = -1;
 double  s_zoomLevel            = 1.0;
-
-QString getFixedWidthFontList()
-{
-   return desktop::getFixedWidthFontList();
-}
-
-QString& fixedWidthFontList()
-{
-   static QString instance = getFixedWidthFontList();
-   return instance;
-}
 
 #ifdef Q_OS_LINUX
 
@@ -138,26 +128,6 @@ DesktopInfo::DesktopInfo(QObject* parent)
    : QObject(parent)
 {
    initialize();
-
-   QObject::connect(
-            this,
-            &DesktopInfo::sumatraPdfExePathChanged,
-            &DesktopInfo::setSumatraPdfExePath);
-
-   QObject::connect(
-            this,
-            &DesktopInfo::fixedWidthFontListChanged,
-            &DesktopInfo::setFixedWidthFontList);
-
-   QObject::connect(
-            this,
-            &DesktopInfo::zoomLevelChanged,
-            &DesktopInfo::setZoomLevel);
-   
-   QObject::connect(
-            this,
-            &DesktopInfo::chromiumDevtoolsPortChanged,
-            &DesktopInfo::setChromiumDevtoolsPort);
 }
 
 QString DesktopInfo::getPlatform()
@@ -183,16 +153,7 @@ QString DesktopInfo::getScrollingCompensationType()
 
 QString DesktopInfo::getFixedWidthFontList()
 {
-   return fixedWidthFontList();
-}
-
-void DesktopInfo::setFixedWidthFontList(QString list)
-{
-   if (fixedWidthFontList() != list)
-   {
-      fixedWidthFontList() = list;
-      emit fixedWidthFontListChanged(list);
-   }
+   return s_fixedWidthFontList;
 }
 
 QString DesktopInfo::getFixedWidthFont()

--- a/src/cpp/desktop/DesktopInfo.hpp
+++ b/src/cpp/desktop/DesktopInfo.hpp
@@ -30,8 +30,11 @@ class DesktopInfo : public QObject
     Q_OBJECT
 
 Q_SIGNALS:
+   void fixedWidthFontListChanged(QString fontList);
+   void fixedWidthFontChanged(QString font);
+   void proportionalFontChanged(QString font);
+   void desktopSynctexViewerChanged(QString viewer);
    void sumatraPdfExePathChanged(QString value);
-   void fixedWidthFontListChanged(QString value);
    void zoomLevelChanged(double value);
    void chromiumDevtoolsPortChanged(quint16 value);
 
@@ -39,28 +42,52 @@ public:
    explicit DesktopInfo(QObject* parent = nullptr);
 
    Q_INVOKABLE QString getPlatform();
-   Q_PROPERTY(QString platform READ getPlatform CONSTANT)
+   Q_PROPERTY(QString platform
+              READ getPlatform
+              CONSTANT)
 
    Q_INVOKABLE QString getVersion();
-   Q_PROPERTY(QString version READ getVersion CONSTANT)
+   Q_PROPERTY(QString version
+              READ getVersion
+              CONSTANT)
 
    Q_INVOKABLE QString getScrollingCompensationType();
-   Q_PROPERTY(QString scrollingCompensationType READ getScrollingCompensationType CONSTANT)
-
-   Q_INVOKABLE QString getFixedWidthFontList();
-   Q_PROPERTY(QString fixedWidthFontList READ getFixedWidthFontList)
-
-   Q_INVOKABLE QString getFixedWidthFont();
-   Q_PROPERTY(QString fixedWidthFont READ getFixedWidthFont)
-
-   Q_INVOKABLE QString getProportionalFont();
-   Q_PROPERTY(QString proportionalFont READ getProportionalFont)
-
-   Q_INVOKABLE QString getDesktopSynctexViewer();
-   Q_PROPERTY(QString desktopSynctexViewer READ getDesktopSynctexViewer)
+   Q_PROPERTY(QString scrollingCompensationType
+              READ getScrollingCompensationType
+              CONSTANT)
 
    Q_INVOKABLE bool desktopHooksAvailable();
-   Q_PROPERTY(bool desktopHooksAvailable READ desktopHooksAvailable)
+   Q_PROPERTY(bool desktopHooksAvailable
+              READ desktopHooksAvailable
+              CONSTANT)
+
+   Q_INVOKABLE QString getFixedWidthFontList();
+   Q_INVOKABLE void setFixedWidthFontList(QString fontList);
+   Q_PROPERTY(QString fixedWidthFontList
+              READ getFixedWidthFontList
+              WRITE setFixedWidthFontList
+              NOTIFY fixedWidthFontListChanged)
+
+   Q_INVOKABLE QString getFixedWidthFont();
+   Q_INVOKABLE void setFixedWidthFont(QString font);
+   Q_PROPERTY(QString fixedWidthFont
+              READ getFixedWidthFont
+              WRITE setFixedWidthFont
+              NOTIFY fixedWidthFontChanged)
+
+   Q_INVOKABLE QString getProportionalFont();
+   Q_INVOKABLE void setProportionalFont(QString font);
+   Q_PROPERTY(QString proportionalFont
+              READ getProportionalFont
+              WRITE setProportionalFont
+              NOTIFY proportionalFontChanged)
+
+   Q_INVOKABLE QString getDesktopSynctexViewer();
+   Q_INVOKABLE void setDesktopSynctexViewer(QString viewer);
+   Q_PROPERTY(QString desktopSynctexViewer
+              READ getDesktopSynctexViewer
+              WRITE setDesktopSynctexViewer
+              NOTIFY desktopSynctexViewerChanged)
 
    Q_INVOKABLE QString getSumatraPdfExePath();
    Q_INVOKABLE void setSumatraPdfExePath(QString path);

--- a/src/cpp/desktop/DesktopInfo.hpp
+++ b/src/cpp/desktop/DesktopInfo.hpp
@@ -48,23 +48,19 @@ public:
    Q_PROPERTY(QString scrollingCompensationType READ getScrollingCompensationType CONSTANT)
 
    Q_INVOKABLE QString getFixedWidthFontList();
-   Q_INVOKABLE void setFixedWidthFontList(QString list);
-   Q_PROPERTY(QString fixedWidthFontList
-              READ getFixedWidthFontList
-              WRITE setFixedWidthFontList
-              NOTIFY fixedWidthFontListChanged)
+   Q_PROPERTY(QString fixedWidthFontList READ getFixedWidthFontList)
 
    Q_INVOKABLE QString getFixedWidthFont();
-   Q_PROPERTY(QString fixedWidthFont READ getFixedWidthFont CONSTANT)
+   Q_PROPERTY(QString fixedWidthFont READ getFixedWidthFont)
 
    Q_INVOKABLE QString getProportionalFont();
-   Q_PROPERTY(QString proportionalFont READ getProportionalFont CONSTANT)
+   Q_PROPERTY(QString proportionalFont READ getProportionalFont)
 
    Q_INVOKABLE QString getDesktopSynctexViewer();
-   Q_PROPERTY(QString desktopSynctexViewer READ getDesktopSynctexViewer CONSTANT)
+   Q_PROPERTY(QString desktopSynctexViewer READ getDesktopSynctexViewer)
 
    Q_INVOKABLE bool desktopHooksAvailable();
-   Q_PROPERTY(bool desktopHooksAvailable READ desktopHooksAvailable CONSTANT)
+   Q_PROPERTY(bool desktopHooksAvailable READ desktopHooksAvailable)
 
    Q_INVOKABLE QString getSumatraPdfExePath();
    Q_INVOKABLE void setSumatraPdfExePath(QString path);

--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -106,7 +106,8 @@ MainWindow::MainWindow(QUrl url) :
            this, SLOT(onCloseWindowShortcut()));
 
    connect(&desktopInfo(), &DesktopInfo::fixedWidthFontListChanged, [this]() {
-      QString js = QStringLiteral("if (window.onFontListReady) window.onFontListReady()");
+      QString js = QStringLiteral(
+         "if (typeof window.onFontListReady === 'function') window.onFontListReady()");
       this->webPage()->runJavaScript(js);
    });
 

--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -105,6 +105,11 @@ MainWindow::MainWindow(QUrl url) :
    connect(webView(), SIGNAL(onCloseWindowShortcut()),
            this, SLOT(onCloseWindowShortcut()));
 
+   connect(&desktopInfo(), &DesktopInfo::fixedWidthFontListChanged, [this]() {
+      QString js = QStringLiteral("if (window.onFontListReady) window.onFontListReady()");
+      this->webPage()->runJavaScript(js);
+   });
+
    connect(qApp, SIGNAL(commitDataRequest(QSessionManager&)),
            this, SLOT(commitDataRequest(QSessionManager&)),
            Qt::DirectConnection);

--- a/src/cpp/desktop/DesktopOptions.cpp
+++ b/src/cpp/desktop/DesktopOptions.cpp
@@ -37,6 +37,8 @@ QString binDirToHomeDir(QString binDir);
 #endif
 
 #define kMainWindowGeometry (QStringLiteral("mainwindow/geometry"))
+#define kFixedWidthFont     (QStringLiteral("font.fixedWidth"))
+#define kProportionalFont   (QStringLiteral("font.proportional"))
 
 QString scratchPath;
 
@@ -134,6 +136,7 @@ void Options::setDesktopRenderingEngine(QString engine)
 }
 
 namespace {
+
 QString findFirstMatchingFont(const QStringList& fonts,
                               QString defaultFont,
                               bool fixedWidthOnly)
@@ -147,14 +150,28 @@ QString findFirstMatchingFont(const QStringList& fonts,
    }
    return defaultFont;
 }
+
 } // anonymous namespace
+
+void Options::setFont(QString key, QString font)
+{
+   if (font.isEmpty())
+      settings_.remove(key);
+   else
+      settings_.setValue(key, font);
+}
+
+void Options::setProportionalFont(QString font)
+{
+   setFont(kProportionalFont, font);
+}
 
 QString Options::proportionalFont() const
 {
    static QString detectedFont;
 
    QString font =
-         settings_.value(QString::fromUtf8("font.proportional")).toString();
+         settings_.value(kProportionalFont).toString();
    if (!font.isEmpty())
    {
       return font;
@@ -198,11 +215,7 @@ QString Options::proportionalFont() const
 
 void Options::setFixedWidthFont(QString font)
 {
-   if (font.isEmpty())
-      settings_.remove(QString::fromUtf8("font.fixedWidth"));
-   else
-      settings_.setValue(QString::fromUtf8("font.fixedWidth"),
-                         font);
+   setFont(kFixedWidthFont, font);
 }
 
 QString Options::fixedWidthFont() const
@@ -210,7 +223,7 @@ QString Options::fixedWidthFont() const
    static QString detectedFont;
 
    QString font =
-         settings_.value(QString::fromUtf8("font.fixedWidth")).toString();
+         settings_.value(kFixedWidthFont).toString();
    if (!font.isEmpty())
    {
       return QString::fromUtf8("\"") + font + QString::fromUtf8("\"");

--- a/src/cpp/desktop/DesktopOptions.hpp
+++ b/src/cpp/desktop/DesktopOptions.hpp
@@ -54,6 +54,8 @@ public:
    void setDesktopRenderingEngine(QString engine);
 
    QString proportionalFont() const;
+   void setProportionalFont(QString font);
+
    QString fixedWidthFont() const;
    void setFixedWidthFont(QString font);
 
@@ -116,6 +118,8 @@ private:
    {
    }
    friend Options& options();
+
+   void setFont(QString key, QString font);
 
    QSettings settings_;
    core::FilePath scriptsPath_;

--- a/src/cpp/desktop/DesktopUtils.cpp
+++ b/src/cpp/desktop/DesktopUtils.cpp
@@ -36,12 +36,6 @@ using namespace rstudio::core;
 namespace rstudio {
 namespace desktop {
 
-QFontDatabase& fontDatabase()
-{
-   static QFontDatabase instance;
-   return instance;
-}
-
 #ifdef Q_OS_WIN
 
 void reattachConsoleIfNecessary()
@@ -129,35 +123,7 @@ bool isGnomeDesktop()
 
 QString getFixedWidthFontList()
 {
-   QFontDatabase& db = desktop::fontDatabase();
-   QStringList fonts;
-   for (const QString& family : db.families())
-   {
-      
-#ifdef _WIN32
-      // screen out annoying Qt warnings when attempting to
-      // initialize incompatible fonts
-      static std::set<std::string> blacklist = {
-         "8514oem",
-         "Fixedsys",
-         "Modern",
-         "MS Sans Serif",
-         "MS Serif",
-         "Roman",
-         "Script",
-         "Small Fonts",
-         "System",
-         "Terminal"
-      };
-
-      if (blacklist.count(family.toStdString()))
-         continue;
-#endif
-
-      if (isFixedWidthFont(QFont(family, 12)))
-         fonts.append(family);
-   }
-   return fonts.join(QStringLiteral("\n"));
+   return desktopInfo().getFixedWidthFontList();
 }
 
 #endif

--- a/src/cpp/desktop/DesktopUtils.hpp
+++ b/src/cpp/desktop/DesktopUtils.hpp
@@ -17,7 +17,6 @@
 #define DESKTOP_UTILS_HPP
 
 #include <QFileDialog>
-#include <QFontDatabase>
 #include <QMainWindow>
 #include <QMessageBox>
 #include <QUrl>
@@ -35,8 +34,6 @@ namespace rstudio {
 namespace desktop {
 
 class MainWindow;
-
-QFontDatabase& fontDatabase();
 
 void reattachConsoleIfNecessary();
 

--- a/src/gwt/src/org/rstudio/core/client/widget/SelectWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SelectWidget.java
@@ -91,27 +91,28 @@ public class SelectWidget extends Composite
       if (horizontalLayout)
       {
          horizontalPanel_ = new HorizontalPanel();
-         Label labelWidget = new Label(label);
+         label_ = new Label(label);
          if (listOnLeft)
          {
             horizontalPanel_.add(listBox_);
-            horizontalPanel_.add(labelWidget);
+            horizontalPanel_.add(label_);
          }
          else
          {
-            horizontalPanel_.add(labelWidget);
+            horizontalPanel_.add(label_);
             horizontalPanel_.add(listBox_);
          }
         
          horizontalPanel_.setCellVerticalAlignment(
-                                          labelWidget, 
+                                          label_, 
                                           HasVerticalAlignment.ALIGN_MIDDLE);
          panel = horizontalPanel_;
       }
       else
       {
+         label_ = new Label(label, true);
          flowPanel_ = new FlowPanel();
-         flowPanel_.add(new Label(label, true));
+         flowPanel_.add(label_);
          panel = flowPanel_;
          panel.add(listBox_);
       }
@@ -136,6 +137,11 @@ public class SelectWidget extends Composite
    public ListBox getListBox()
    {
       return listBox_;
+   }
+   
+   public void setLabel(String label)
+   {
+      label_.setText(label);
    }
    
    public void setChoices(String[] options)
@@ -218,5 +224,6 @@ public class SelectWidget extends Composite
    
    private HorizontalPanel horizontalPanel_ = null;
    private FlowPanel flowPanel_ = null;
+   private Label label_ = null;
    private final ListBox listBox_;
 }


### PR DESCRIPTION
This PR should alleviate https://github.com/rstudio/rstudio/issues/1889 a little more safely, and without introducing issues around caching (+ cache invalidation; + interacting with the filesystem) that could be frustrating.

This PR effectively moves font database generation to a separate thread, which communicates the set of discovered fonts back to the main thread when the font database is ready. If the user navigates to the Appearance dialog before fonts have been enumerated, they'll see:

<img width="176" alt="screen shot 2018-11-07 at 12 21 16 pm" src="https://user-images.githubusercontent.com/1976582/48158652-ea0d4280-e287-11e8-9274-5c8c1f27a9d4.png">

with the currently-selected font displayed, but the font list otherwise empty. I felt that keeping the UI minimal here is fine since this is a condition that will only ever be seen by a very small subset of users (those who choose to install many many fonts on their system)

We could in theory also try to stream fonts as they're discovered but that's overkill for this problem.