### PR TITLE
Fix issues with magic source comments

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -5197,27 +5197,8 @@ public class TextEditingTarget implements
                   @Override
                   public void execute()
                   {
-                     if (docDisplay_.hasBreakpoints())
-                     {
-                        hideBreakpointWarningBar();
-                     }
-                     if (fileType_.isR() && extendedType_ == SourceDocument.XT_R_CUSTOM_SOURCE)
-                     {
-                        // use the custom source command if known
-                        customSource();
-                     }
-                     else
-                     {
-                        // otherwise, execute the source() command
-                        consoleDispatcher_.executeSourceCommand(
-                              getPath(),
-                              fileType_,
-                              docUpdateSentinel_.getEncoding(),
-                              activeCodeIsAscii(),
-                              forceEcho ? true : echo,
-                              prefs_.focusConsoleAfterExec().getValue(),
-                              docDisplay_.hasBreakpoints());
-                     }
+                     executeRSourceCommand(forceEcho ? true : echo, 
+                        prefs_.focusConsoleAfterExec().getValue());
                   }
                };
             
@@ -5459,9 +5440,9 @@ public class TextEditingTarget implements
       }); 
    }
 
-   void customSource()
+   boolean customSource()
    {
-      rHelper_.customSource(TextEditingTarget.this);
+      return rHelper_.customSource(TextEditingTarget.this);
    }
    
    void renderRmd()
@@ -6287,28 +6268,41 @@ public class TextEditingTarget implements
                {
                   previewFromR();
                }
-               else if (fileType_.isR() && extendedType_ == SourceDocument.XT_R_CUSTOM_SOURCE)
-               {
-                  customSource();
-               }
                else
                {
-                  if (docDisplay_.hasBreakpoints())
-                  {
-                     hideBreakpointWarningBar();
-                  }
-                  consoleDispatcher_.executeSourceCommand(
-                                             docUpdateSentinel_.getPath(), 
-                                             fileType_,
-                                             docUpdateSentinel_.getEncoding(), 
-                                             activeCodeIsAscii(),
-                                             false,
-                                             false,
-                                             docDisplay_.hasBreakpoints());
+                  executeRSourceCommand(false, false);
                }
             }
          }
       };
+   }
+   
+   private void executeRSourceCommand(boolean forceEcho, boolean focusAfterExec)
+   {
+      // Hide breakpoint warning bar if visible (since we will re-evaluate
+      // breakpoints after source)
+      if (docDisplay_.hasBreakpoints())
+      {
+         hideBreakpointWarningBar();
+      }
+
+      if (fileType_.isR() && extendedType_ == SourceDocument.XT_R_CUSTOM_SOURCE)
+      {
+         // If this R script looks like it has a custom source
+         // command, try to execute it; if successful, we're done.
+         if (customSource())
+            return;
+      }
+
+      // Execute the R source() command
+      consoleDispatcher_.executeSourceCommand(
+                                 docUpdateSentinel_.getPath(), 
+                                 fileType_,
+                                 docUpdateSentinel_.getEncoding(), 
+                                 activeCodeIsAscii(),
+                                 forceEcho,
+                                 focusAfterExec,
+                                 docDisplay_.hasBreakpoints());
    }
 
    public void checkForExternalEdit()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -5201,14 +5201,23 @@ public class TextEditingTarget implements
                      {
                         hideBreakpointWarningBar();
                      }
-                     consoleDispatcher_.executeSourceCommand(
-                           getPath(),
-                           fileType_,
-                           docUpdateSentinel_.getEncoding(),
-                           activeCodeIsAscii(),
-                           forceEcho ? true : echo,
-                           prefs_.focusConsoleAfterExec().getValue(),
-                           docDisplay_.hasBreakpoints());   
+                     if (fileType_.isR() && extendedType_ == SourceDocument.XT_R_CUSTOM_SOURCE)
+                     {
+                        // use the custom source command if known
+                        customSource();
+                     }
+                     else
+                     {
+                        // otherwise, execute the source() command
+                        consoleDispatcher_.executeSourceCommand(
+                              getPath(),
+                              fileType_,
+                              docUpdateSentinel_.getEncoding(),
+                              activeCodeIsAscii(),
+                              forceEcho ? true : echo,
+                              prefs_.focusConsoleAfterExec().getValue(),
+                              docDisplay_.hasBreakpoints());
+                     }
                   }
                };
             

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCommentHeaderHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCommentHeaderHelper.java
@@ -133,8 +133,7 @@ public class TextEditingTargetCommentHeaderHelper
 
                commentHeader_ = new CommentHeader(function, optionsArr);
             }
-            
-         }   
+         }
       }
    }
 
@@ -158,6 +157,11 @@ public class TextEditingTargetCommentHeaderHelper
       
       public String function;
       public String[] args;
+   }
+   
+   public boolean hasCommentHeader()
+   {
+      return commentHeader_ != null;
    }
    
    private Pattern customHeaderPattern_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetJSHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetJSHelper.java
@@ -39,13 +39,16 @@ public class TextEditingTargetJSHelper
    }
    
    
-   public void previewJS(EditingTarget editingTarget)
+   public boolean previewJS(EditingTarget editingTarget)
    {
       TextEditingTargetCommentHeaderHelper previewSource = new TextEditingTargetCommentHeaderHelper(
          docDisplay_.getCode(),
          "preview",
          "//"
       );
+      
+      if (!previewSource.hasCommentHeader())
+         return false;
 
       if (!previewSource.getFunction().equals("r2d3"))
       {
@@ -70,6 +73,8 @@ public class TextEditingTargetJSHelper
             }
          );
       }
+      
+      return true;
    }
    
    private GlobalDisplay display_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRHelper.java
@@ -36,13 +36,17 @@ public class TextEditingTargetRHelper
       eventBus_ = eventBus;
    }
 
-   public void customSource(EditingTarget editingTarget)
+   public boolean customSource(EditingTarget editingTarget)
    {
       TextEditingTargetCommentHeaderHelper customSource = new TextEditingTargetCommentHeaderHelper(
          docDisplay_.getCode(),
          "source",
          "#"
       );
+      
+      // No work to do if we didn't find a comment header
+      if (!customSource.hasCommentHeader())
+         return false;
 
       customSource.buildCommand(
          editingTarget.getPath(),
@@ -55,6 +59,8 @@ public class TextEditingTargetRHelper
             }
          }
       );
+
+      return true;
    }
 
    private EventBus eventBus_; 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetSqlHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetSqlHelper.java
@@ -36,13 +36,16 @@ public class TextEditingTargetSqlHelper
    }
    
    
-   public void previewSql(EditingTarget editingTarget)
+   public boolean previewSql(EditingTarget editingTarget)
    {
       TextEditingTargetCommentHeaderHelper previewSource = new TextEditingTargetCommentHeaderHelper(
          docDisplay_.getCode(),
          "preview",
          "--"
       );
+      
+      if (!previewSource.hasCommentHeader())
+         return false;
 
       if (previewSource.getFunction().length() == 0)
       {
@@ -60,6 +63,8 @@ public class TextEditingTargetSqlHelper
             }
          }
       );
+      
+      return true;
    }
    private DocDisplay docDisplay_;
    private SqlServerOperations server_;


### PR DESCRIPTION
This change fixes a couple of issues I ran into with magic `!source` comments.

1. Magic comments worked with Source on Save, but not with the regular Source command. I'm not sure if this was intentional, but it seems very counter-intuitive, so I've updated the Source command to use the magic comment if it's present.

2. A JS exception can occur if you delete the magic comment and then save the file; this happens because the comment header is gone but we still think the file's type is `XT_CUSTOM_SOURCE`. The fix is to fall back on executing the ordinary `source()` command if we fail to locate the magic comment header, even if we think it should be there.
