### PR TITLE
Fix handling of theme URLs in nested documents.

### DIFF
--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -15,8 +15,6 @@
 
 #include "SessionHelp.hpp"
 
-#include "SessionThemes.hpp"
-
 #include <algorithm>
 
 #include <boost/regex.hpp>
@@ -993,9 +991,6 @@ Error initialize()
       (bind(registerRBrowseUrlHandler, handleLocalHttpUrl))
       (bind(registerRBrowseFileHandler, handleRShowDocFile))
       (bind(registerUriHandler, kHelpLocation, handleHelpRequest))
-      (bind(registerUriHandler, kPythonLocation + "/" + themes::kDefaultThemeLocation, themes::handleDefaultThemeRequest))
-      (bind(registerUriHandler, kPythonLocation + "/" + themes::kGlobalCustomThemeLocation, themes::handleGlobalCustomThemeRequest))
-      (bind(registerUriHandler, kPythonLocation + "/" + themes::kLocalCustomThemeLocation, themes::handleLocalCustomThemeRequest))
       (bind(registerUriHandler, kPythonLocation, handlePythonHelpRequest))
       (bind(sourceModuleRFile, "SessionHelp.R"));
    Error error = initBlock.execute();

--- a/src/cpp/session/modules/SessionProfiler.cpp
+++ b/src/cpp/session/modules/SessionProfiler.cpp
@@ -28,8 +28,6 @@
 #include <r/RUtil.hpp>
 #include <r/ROptions.hpp>
 
-#include "SessionThemes.hpp"
-
 using namespace rstudio::core;
 
 namespace rstudio {
@@ -110,9 +108,6 @@ Error initialize()
 
    initBlock.addFunctions()
       (boost::bind(module_context::sourceModuleRFile, "SessionProfiler.R"))
-      (boost::bind(module_context::registerUriHandler, "/" kProfilesUrlPath "/" + themes::kDefaultThemeLocation, themes::handleDefaultThemeRequest))
-      (boost::bind(module_context::registerUriHandler, "/" kProfilesUrlPath "/" + themes::kGlobalCustomThemeLocation, themes::handleGlobalCustomThemeRequest))
-      (boost::bind(module_context::registerUriHandler, "/" kProfilesUrlPath "/" + themes::kLocalCustomThemeLocation, themes::handleLocalCustomThemeRequest))
       (boost::bind(module_context::registerUriHandler, "/" kProfilesUrlPath "/", handleProfilerResReq))
       (boost::bind(module_context::registerUriHandler, kProfilerResourceLocation, handleProfilerResourceResReq));
 

--- a/src/cpp/session/modules/SessionThemes.cpp
+++ b/src/cpp/session/modules/SessionThemes.cpp
@@ -47,15 +47,11 @@ namespace session {
 namespace modules {
 namespace themes {
 
+namespace {
+
 const std::string kDefaultThemeLocation = "theme/default/";
 const std::string kGlobalCustomThemeLocation = "theme/custom/global/";
 const std::string kLocalCustomThemeLocation = "theme/custom/local/";
-
-namespace {
-
-const std::string kGridResourcePrefix = "grid_resource/";
-const std::string kPythonPrefix = "python/";
-const std::string kProfilesPrefix = "profiles/";
 
 // A map from the name of the theme to the location of the file and a boolean representing
 // whether or not the theme is dark.
@@ -463,12 +459,7 @@ Error removeTheme(const json::JsonRpcRequest& request,
 void handleDefaultThemeRequest(const http::Request& request,
                                      http::Response* pResponse)
 {
-   std::string prefix =
-         "/" +
-         (boost::contains(request.uri(), kGridResourcePrefix) ? kGridResourcePrefix : "") +
-         (boost::contains(request.uri(), kPythonPrefix) ? kPythonPrefix : "") +
-         (boost::contains(request.uri(), kProfilesPrefix) ? kProfilesPrefix : "") +
-         kDefaultThemeLocation;
+   std::string prefix = "/" + kDefaultThemeLocation;
    std::string fileName = http::util::pathAfterPrefix(request, prefix);
    pResponse->setCacheableFile(getDefaultThemePath().childPath(fileName), request);
 }
@@ -484,12 +475,7 @@ void handleGlobalCustomThemeRequest(const http::Request& request,
 {
    // Note: we probably want to return a warning code instead of success so the client has the
    // ability to pop up a warning dialog or something to the user.
-   std::string prefix =
-         "/" +
-         (boost::contains(request.uri(), kGridResourcePrefix) ? kGridResourcePrefix : "") +
-         (boost::contains(request.uri(), kPythonPrefix) ? kPythonPrefix : "") +
-         (boost::contains(request.uri(), kProfilesPrefix) ? kProfilesPrefix : "") +
-         kGlobalCustomThemeLocation;
+   std::string prefix = "/" + kGlobalCustomThemeLocation;
    std::string fileName = http::util::pathAfterPrefix(request, prefix);
    FilePath requestedTheme = getGlobalCustomThemePath().childPath(fileName);
    pResponse->setCacheableFile(
@@ -508,12 +494,7 @@ void handleLocalCustomThemeRequest(const http::Request& request,
 {
    // Note: we probably want to return a warning code instead of success so the client has the
    // ability to pop up a warning dialog or something to the user.
-   std::string prefix =
-         "/" +
-         (boost::contains(request.uri(), kGridResourcePrefix) ? kGridResourcePrefix : "") +
-         (boost::contains(request.uri(), kPythonPrefix) ? kPythonPrefix : "") +
-         (boost::contains(request.uri(), kProfilesPrefix) ? kProfilesPrefix : "") +
-         kLocalCustomThemeLocation;
+   std::string prefix = "/" + kLocalCustomThemeLocation;
    std::string fileName = http::util::pathAfterPrefix(request, prefix);
    FilePath requestedTheme = getLocalCustomThemePath().childPath(fileName);
    pResponse->setCacheableFile(

--- a/src/cpp/session/modules/SessionThemes.hpp
+++ b/src/cpp/session/modules/SessionThemes.hpp
@@ -18,11 +18,6 @@
 namespace rstudio {
 namespace core {
    class Error;
-
-namespace http {
-   class Request;
-   class Response;
-}
 }
 }
 
@@ -30,25 +25,6 @@ namespace rstudio {
 namespace session {
 namespace modules {
 namespace themes {
-
-// These constants and URI handlers need to be public so that they can be registered in
-// DataViewer.cpp before the /grid_resource handler is registered or they won't be invoked (because
-// their path is also a regex match for the less specific `/grid_resource` path). A better long term
-// solution would be to order the set of URI handlers with a reverse lexographical order so that the
-// most specific path always appears first (or use a lexographical order with a reverse search).
-
-extern const std::string kDefaultThemeLocation;
-extern const std::string kGlobalCustomThemeLocation;
-extern const std::string kLocalCustomThemeLocation;
-
-void handleDefaultThemeRequest(const core::http::Request& request,
-                                     core::http::Response* pResponse);
-
-void handleGlobalCustomThemeRequest(const core::http::Request& request,
-                                          core::http::Response* pResponse);
-
-void handleLocalCustomThemeRequest(const core::http::Request& request,
-                                          core::http::Response* pResponse);
 
 core::Error initialize();
 

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -45,8 +45,6 @@
 #include <session/SessionContentUrls.hpp>
 #include <session/SessionSourceDatabase.hpp>
 
-#include "../SessionThemes.hpp"
-
 #ifndef _WIN32
 #include <core/system/FileMode.hpp>
 #endif
@@ -1026,18 +1024,6 @@ Error initialize()
       (bind(sourceModuleRFile, "SessionDataViewer.R"))
       (bind(registerRpcMethod, "remove_cached_data", removeCachedData))
       (bind(registerUriHandler, "/grid_data", getGridData))
-      (bind(
-          registerUriHandler,
-          kGridResourceLocation + session::modules::themes::kDefaultThemeLocation,
-          session::modules::themes::handleDefaultThemeRequest))
-      (bind(
-          registerUriHandler,
-          kGridResourceLocation + session::modules::themes::kGlobalCustomThemeLocation,
-          session::modules::themes::handleGlobalCustomThemeRequest))
-      (bind(
-          registerUriHandler,
-          kGridResourceLocation + session::modules::themes::kLocalCustomThemeLocation,
-          session::modules::themes::handleLocalCustomThemeRequest))
       (bind(registerUriHandler, kGridResourceLocation, handleGridResReq));
 
    Error error = initBlock.execute();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
@@ -70,12 +70,10 @@ public class AceThemes
          docRootUrl_ = currentUrl;
       }
       else if (!currentUrl.equals(docRootUrl_) &&
-         currentUrl.contains(docRootUrl_) &&
          currentUrl.indexOf(docRootUrl_) == 0)
       {
          pathUpCount = currentUrl.substring(docRootUrl_.length()).split("/").length;
       }
-      
       
       // Build the URL.
       StringBuilder urlBuilder = new StringBuilder();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
@@ -55,22 +55,48 @@ public class AceThemes
       events_ = events;
       prefs_ = prefs;
       themes_ = new HashMap<>();
+      docRootUrl_ = null;
 
       prefs.get().theme().bind(theme -> applyTheme(theme));
    }
    
    private void applyTheme(Document document, final AceTheme theme)
    {
-      Element oldStyleEl = document.getElementById(linkId_);
+      // Build a relative path to avoid having to register 80000 theme URI handlers on the server.
+      int pathUpCount = 0;
+      String currentUrl = document.getURL();
+      if (null == docRootUrl_)
+      {
+         docRootUrl_ = currentUrl;
+      }
+      else if (!currentUrl.equals(docRootUrl_) &&
+         currentUrl.contains(docRootUrl_) &&
+         currentUrl.indexOf(docRootUrl_) == 0)
+      {
+         pathUpCount = currentUrl.substring(docRootUrl_.length()).split("/").length;
+      }
+      
+      
+      // Build the URL.
+      StringBuilder urlBuilder = new StringBuilder();
+      for (int i = 0; i < pathUpCount; ++i)
+      {
+         urlBuilder.append("../");
+      }
+      urlBuilder.append(theme.getUrl())
+         .append("?dark=")
+         .append(theme.isDark() ? "1" : "0");
       
       LinkElement currentStyleEl = document.createLinkElement();
       currentStyleEl.setType("text/css");
       currentStyleEl.setRel("stylesheet");
       currentStyleEl.setId(linkId_);
-      currentStyleEl.setHref(theme.getUrl() + "?dark=" + (theme.isDark() ? "1" : "0"));
+      currentStyleEl.setHref(urlBuilder.toString());
+   
+      Element oldStyleEl = document.getElementById(linkId_);
       if (null != oldStyleEl)
       {
-         document.getBody().replaceChild(currentStyleEl, oldStyleEl);
+        document.getBody().replaceChild(currentStyleEl, oldStyleEl);
       }
       else
       {
@@ -243,4 +269,5 @@ public class AceThemes
    private final Provider<UIPrefs> prefs_;
    private final String linkId_ = "rstudio-acethemes-linkelement";
    private HashMap<String, AceTheme> themes_;
+   private String docRootUrl_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.text.themes;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.JsArrayInteger;
 import com.google.gwt.dom.client.Document;
@@ -55,7 +56,6 @@ public class AceThemes
       events_ = events;
       prefs_ = prefs;
       themes_ = new HashMap<>();
-      docRootUrl_ = null;
 
       prefs.get().theme().bind(theme -> applyTheme(theme));
    }
@@ -64,15 +64,12 @@ public class AceThemes
    {
       // Build a relative path to avoid having to register 80000 theme URI handlers on the server.
       int pathUpCount = 0;
+      String baseUrl = GWT.getHostPageBaseURL();
       String currentUrl = document.getURL();
-      if (null == docRootUrl_)
+      if (!currentUrl.equals(baseUrl) &&
+         currentUrl.indexOf(baseUrl) == 0)
       {
-         docRootUrl_ = currentUrl;
-      }
-      else if (!currentUrl.equals(docRootUrl_) &&
-         currentUrl.indexOf(docRootUrl_) == 0)
-      {
-         pathUpCount = currentUrl.substring(docRootUrl_.length()).split("/").length;
+         pathUpCount = currentUrl.substring(baseUrl.length()).split("/").length;
       }
       
       // Build the URL.
@@ -267,5 +264,4 @@ public class AceThemes
    private final Provider<UIPrefs> prefs_;
    private final String linkId_ = "rstudio-acethemes-linkelement";
    private HashMap<String, AceTheme> themes_;
-   private String docRootUrl_;
 }


### PR DESCRIPTION
This PR fixes the handling of theme link elements when they are added to nested documents generally by using `../` for each extra path element introduced by the nested document. It also removes the now unnecessary theme URI handlers on the backend.
Closes #3844.