### PR TITLE
Add unique IDs to workbench tabs, panels, and file dialog actions

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -28,10 +28,10 @@ public class ElementIds
       return ID_PREFIX + id;
    }
    
-   public static String idFromLabel(String label)
+   public static String idSafeString(String text)
    {
       // replace all non-alphanumerics with underscores
-      String id = label.replaceAll("[^a-zA-Z0-0]", "_");
+      String id = text.replaceAll("[^a-zA-Z0-0]", "_");
       
       // collapse multiple underscores to a single underscore
       id = id.replaceAll("_+", "_");
@@ -41,7 +41,12 @@ public class ElementIds
       id = id.replaceAll("_+$", "");
       
       // convert to lowercase and return
-      return ID_PREFIX + "label_" + id.toLowerCase();
+      return id.toLowerCase();
+   }
+   
+   public static String idFromLabel(String label)
+   {
+      return ID_PREFIX + "label_" + idSafeString(label);
    }
    
    public final static String ID_PREFIX = "rstudio_";
@@ -67,4 +72,8 @@ public class ElementIds
    public final static String SOURCE_TEXT_EDITOR = "source_text_editor";
    public final static String XTERM_WIDGET = "xterm_widget";
    public final static String FILE_DIALOG_NAME_PROMPT = "file_dialog_name_prompt";
+   public final static String WORKBENCH_PANEL = "workbench_panel";
+   public final static String WORKBENCH_TAB = "workbench_tab";
+   public final static String FILE_ACCEPT_BUTTON = "file_accept";
+   public final static String FILE_CANCEL_BUTTON = "file_cancel";
 }

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/FileSystemDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/FileSystemDialog.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.events.SelectionCommitEvent;
 import org.rstudio.core.client.events.SelectionCommitHandler;
@@ -116,8 +117,12 @@ public abstract class FileSystemDialog extends ModalDialogBase
          addLeftButton(new ThemedButton("New Folder", new NewFolderHandler()));
       }
 
-      addOkButton(new ThemedButton(buttonName, event -> maybeAccept()));
-      addCancelButton(
+      ThemedButton okButton = new ThemedButton(buttonName, event -> maybeAccept());
+      ElementIds.assignElementId(okButton.getElement(), 
+            ElementIds.FILE_ACCEPT_BUTTON + "_" + ElementIds.idSafeString(buttonName));
+      addOkButton(okButton);
+      
+      ThemedButton cancelButton = 
          new ThemedButton("Cancel",
          event -> {
             if (invokeOperationEvenOnCancel_)
@@ -125,7 +130,10 @@ public abstract class FileSystemDialog extends ModalDialogBase
                operation_.execute(null, FileSystemDialog.this);
             }
             closeDialog();
-         }));
+         });
+      ElementIds.assignElementId(cancelButton.getElement(), 
+            ElementIds.FILE_CANCEL_BUTTON + "_" + ElementIds.idSafeString(buttonName));
+      addCancelButton(cancelButton);
 
       addDomHandler(event ->
          {

--- a/src/gwt/src/org/rstudio/core/client/theme/ModuleTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ModuleTabLayoutPanel.java
@@ -24,6 +24,7 @@ import com.google.gwt.event.dom.client.MouseDownHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.*;
 
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.events.*;
 import org.rstudio.core.client.layout.WindowState;
 import org.rstudio.core.client.resources.ImageResource2x;
@@ -43,6 +44,10 @@ public class ModuleTabLayoutPanel extends TabLayoutPanel
       {
          layoutPanel_ = new HorizontalPanel();
          layoutPanel_.setStylePrimaryName(styles.tabLayout());
+         
+         // Assign a unique element ID based on the tab's title
+         ElementIds.assignElementId(layoutPanel_.getElement(), 
+               ElementIds.WORKBENCH_TAB + "_" + ElementIds.idSafeString(title));
 
          HTML left = new HTML();
          left.setStylePrimaryName(styles.tabLayoutLeft());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/DelayLoadWorkbenchTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/DelayLoadWorkbenchTab.java
@@ -1,7 +1,7 @@
 /*
  * DelayLoadWorkbenchTab.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -22,6 +22,8 @@ import com.google.gwt.user.client.ui.DockLayoutPanel;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Panel;
 import com.google.gwt.user.client.ui.Widget;
+
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.SerializedCommandQueue;
 import org.rstudio.core.client.events.EnsureHiddenEvent;
 import org.rstudio.core.client.events.EnsureHiddenHandler;
@@ -145,6 +147,10 @@ public abstract class DelayLoadWorkbenchTab<T extends IsWidget>
       assert !initialized_;
 
       initialized_ = true;
+
+      // Assign a unique ID to the pane based on its title
+      ElementIds.assignElementId(pane.getElement(), 
+            ElementIds.WORKBENCH_PANEL + "_" + ElementIds.idSafeString(title_));
 
       pane.ensureWidget();
       panel.add(pane);


### PR DESCRIPTION
This change adds predictable element IDs to workbench tabs and panels, as well as common file dialog actions such as "save" and "cancel", to ease test automation of these features.