### PR TITLE
Install rsconnect from CRAN

### DIFF
--- a/dependencies/common/install-packages
+++ b/dependencies/common/install-packages
@@ -79,8 +79,7 @@ mv $PACKAGE_ARCHIVE $PACKAGE_ARCHIVE_SHA1
 
 # we often embed these packages but are not currently
 # install rmarkdown master rstudio
-
-install rsconnect master rstudio
+# install rsconnect master rstudio
 
 # back to install-dir
 cd $INSTALL_DIR

--- a/dependencies/common/install-packages.cmd
+++ b/dependencies/common/install-packages.cmd
@@ -9,7 +9,7 @@ set "PATH=C:\Program Files (x86)\Git\bin;%PATH%"
 
 set PATH=%PATH%;%CD%\tools
 
-call:install rsconnect master rstudio --no-build-vignettes
+REM call:install rsconnect master rstudio --no-build-vignettes
 REM call:install rmarkdown master rstudio --no-build-vignettes
 GOTO:EOF
 

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -34,9 +34,9 @@ endif()
 # if(NOT EXISTS "${RSTUDIO_DEPENDENCIES_DIR}/common/rmarkdown")
 #   message(FATAL_ERROR "rmarkdown package not found (re-run install-dependencies script to install)")
 # endif()
-if(NOT EXISTS "${RSTUDIO_DEPENDENCIES_DIR}/common/rsconnect")
-  message(FATAL_ERROR "rsconnect package not found (re-run install-dependencies script to install)")
-endif()
+# if(NOT EXISTS "${RSTUDIO_DEPENDENCIES_DIR}/common/rsconnect")
+#   message(FATAL_ERROR "rsconnect package not found (re-run install-dependencies script to install)")
+# endif()
 
 # verify libclang is installed (Windows only)
 if(WIN32)
@@ -491,9 +491,9 @@ install(FILES ${PANDOC_FILES}
 #         DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/R/packages)
 
 # install rsconnect package
-file(GLOB RSCONNECT_PACKAGE "${RSTUDIO_DEPENDENCIES_DIR}/common/rsconnect*.tar.gz")
-install(FILES ${RSCONNECT_PACKAGE}
-        DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/R/packages)
+# file(GLOB RSCONNECT_PACKAGE "${RSTUDIO_DEPENDENCIES_DIR}/common/rsconnect*.tar.gz")
+# install(FILES ${RSCONNECT_PACKAGE}
+#         DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/R/packages)
 
 # install PDF.js
 install(DIRECTORY "resources/pdfjs"

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -224,8 +224,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       if (requiresRmarkdown)
          deps.addAll(rmarkdownDependencies());
       deps.add(Dependency.cranPackage("packrat", "0.4.8-1", true));
-      // deps.add(Dependency.cranPackage("rsconnect", "0.8.8"));
-      deps.add(Dependency.embeddedPackage("rsconnect"));
+      deps.add(Dependency.cranPackage("rsconnect", "0.8.11"));
       
       withDependencies(
         "Publishing",


### PR DESCRIPTION
We've been embedding rsconnect for a while, since we [introduced a new parameter to `deployApp`](https://github.com/rstudio/rsconnect/commit/91cc3c7a33dc81182d90594c50bc98353fd062c8) that wasn't in the CRAN version of rsconnect. 

rsconnect 0.8.11 is now on CRAN. It includes this new parameter and a few other important changes (modernizes dependencies, adds pre/post deploy hooks). This change removes our embedded copy in favor of the CRAN version.

Fixes #3499. 