### PR TITLE
Fix test file in testthat integration

### DIFF
--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -1157,7 +1157,7 @@ private:
       std::vector<std::string> rSourceCommands;
       
       boost::format fmt(
-         "if (nzchar('%1%')) devtools::load_all(devtools::as.package(dirname('%2%'))$path);"
+         "if (nzchar('%1%')) devtools::load_all(dirname('%2%'));"
          "testthat::test_file('%2%')"
       );
 

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -1157,7 +1157,7 @@ private:
       std::vector<std::string> rSourceCommands;
       
       boost::format fmt(
-         "if (nzchar('%1%')) devtools::load_all(devtools::as.package(dirname('%2%')));"
+         "if (nzchar('%1%')) devtools::load_all(devtools::as.package(dirname('%2%'))$path);"
          "testthat::test_file('%2%')"
       );
 


### PR DESCRIPTION
Follow up on https://github.com/rstudio/rstudio/pull/3629, ugh, not sure exactly how this worked or maybe I checked-in the wrong fix, tried to look for changes in `devtools`, `pkgload`, `rprojroot`, etc, but couldn't spot.

Currently, testing a package file triggers:

```
==> Testing R file using 'testthat'

Error in path.expand(path) : invalid 'path' argument
Calls: <Anonymous> ... rprojroot_find_root -> get_start_path -> normalizePath -> path.expand
Execution halted

Exited with status 1.
```