### PR TITLE
only apply overflow styles to 'large' cells

### DIFF
--- a/src/cpp/session/resources/grid/dtstyles.css
+++ b/src/cpp/session/resources/grid/dtstyles.css
@@ -309,7 +309,8 @@ th:focus {
     text-align: right;
 }
 
-.numberCell, .textCell, .listCell, .dataCell {
+.largeCell {
+    display: inline-block;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -82,7 +82,7 @@ var createTag = function(tag, content, attributes) {
   // if content is an object and attributes is undefined,
   // treat this as request to create tag with attributes
   // but no content
-  if (typeof content === 'object' && typeof attributes == 'undefined')
+  if (typeof content === 'object' && typeof attributes === 'undefined')
   {
     attributes = content;
     content = '';
@@ -262,9 +262,9 @@ var renderCellClass = function (data, type, row, meta, clazz) {
     classes.push('largeCell');
 
   // compute title (if any)
-  var title = undefined;
+  var title;
   if (typeof data === "string")
-    title = data.replace(/"/g, "&quot;");
+    title = data;
 
   // produce tag
   return createTag('span', contents, {

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -1260,7 +1260,7 @@ var addResizeHandlers = function(ele) {
          initTableWidth = $("#rsGridData").width();
          boundsExceeded = 0;
 
-         if (origColWidths[col] == null)
+         if (typeof origColWidths[col] === 'undefined')
             origColWidths[col] = initColWidth;
 
          $("#rsGridData td:nth-child(" + col + ")").css(

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -95,9 +95,6 @@ var createTag = function(tag, content, attributes) {
   var parts = [];
   for (var key in attributes) {
 
-    if (key === 'class')
-      debugger;
-
     // extract value
     var value = attributes[key];
 


### PR DESCRIPTION
This is another attempt to improve data viewer performance when viewing tables containing a large number of columns.

Most of the overhead during scrolling is due to browser layout computation, which unfortunately includes recomputing things like text overflow (even though in theory scrolling the table shouldn't trigger that at all since we're not resizing any inner cells).

This PR helps to paper over the problem a little bit. Now, we only apply overflow styles to 'big enough' cells. This should ensure that existing large cells are resized as needed (with the associated performance hit) while small cells won't.

To help support this, we disallow shrinking the initial column width of small-ish cells beyond the initial width (since that would run afoul of our now disabling overflow in those cells).

The net result is that scrolling performance is vastly improved in large datasets, but most of the functionality around column resize will remain.