### PR TITLE
only warn when closing job tab if there are running session jobs

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -310,6 +310,7 @@ well as menu structures (for main menu and popup menus).
          <cmd refid="activateVcs"/>
          <cmd refid="activateBuild"/>
          <cmd refid="activateConnections"/>
+         <cmd refid="activateJobs"/>
          
          <separator/>
          <cmd refid="synctexSearch"/>
@@ -1252,6 +1253,11 @@ well as menu structures (for main menu and popup menus).
         menuLabel = "Show Co_nnections"
         windowMode="main"/>
         
+   <cmd id="activateJobs"
+        label="Show Jobs Pane"
+        menuLabel = "Show _Jobs"
+        windowMode="main"/>
+         
    <cmd id="layoutZoomSource"
         checkable="true"
         label="Zoom Source"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -568,6 +568,7 @@ public abstract class
    public abstract AppCommand startJob();
    public abstract AppCommand sourceAsJob();
    public abstract AppCommand clearJobs();
+   public abstract AppCommand activateJobs();
 
    // Other
    public abstract AppCommand checkSpelling();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobsPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobsPresenter.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.command.CommandBinder;
+import org.rstudio.core.client.command.Handler;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
@@ -35,6 +36,7 @@ import org.rstudio.studio.client.workbench.views.jobs.events.JobInitEvent;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobOutputEvent;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobSelectionEvent;
 import org.rstudio.studio.client.workbench.views.jobs.model.Job;
+import org.rstudio.studio.client.workbench.views.jobs.model.JobConstants;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobManager;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobOutput;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobState;
@@ -60,6 +62,7 @@ public class JobsPresenter extends BasePresenter
       void addJobOutput(String id, int type, String output);
       void hideJobOutput(String id, boolean animate);
       void syncElapsedTime(int timestamp);
+      void bringToFront();
    }
    
    public interface Binder extends CommandBinder<Commands, JobsPresenter> {}
@@ -138,12 +141,10 @@ public class JobsPresenter extends BasePresenter
       if (jobs.isEmpty())
          onConfirmed.execute();
 
-      // count the number of running jobs
-      int running = 0;
-      for (int i = 0; i < jobs.size(); i++)
-      {
-         running++;
-      }
+      // count the number of running session jobs
+      long running = jobs.stream()
+            .filter(t -> t.type == JobConstants.JOB_TYPE_SESSION &&
+                         t.state == JobConstants.STATE_RUNNING).count();
       
       if (running > 0)
       {
@@ -158,6 +159,12 @@ public class JobsPresenter extends BasePresenter
       
       // done, okay to close
       onConfirmed.execute();
+   }
+   
+   @Handler
+   public void onActivateJobs()
+   {
+      display_.bringToFront();
    }
    
    // Private methods ---------------------------------------------------------

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobsTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobsTab.java
@@ -18,6 +18,7 @@ import com.google.gwt.user.client.Command;
 import com.google.inject.Inject;
 
 import org.rstudio.core.client.command.CommandBinder;
+import org.rstudio.core.client.command.Handler;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.ui.DelayLoadTabShim;
@@ -39,6 +40,9 @@ public class JobsTab extends DelayLoadWorkbenchTab<JobsPresenter>
                    JobElapsedTickEvent.Handler
    {
       abstract void confirmClose(Command onConfirmed);
+      
+      @Handler
+      public abstract void onActivateJobs();
    }
    
    public interface Binder extends CommandBinder<Commands, JobsTab.Shim> {}


### PR DESCRIPTION
We won't prevent closing Jobs tab if there are launcher jobs (those are not tied to the session, and will show again if you re-open the jobs tab). Also, don't want to prevent closing the tab if there are only completed jobs.

Also added command for showing Jobs tab to View menu. Without this, the only way to get the Jobs pane back is to restart the UI, or start another job with the Tools / Jobs menu (part of #3743).