### PR TITLE
Only clamp notebook chunk output height for HTML widgets

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputGallery.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputGallery.java
@@ -219,6 +219,17 @@ public class ChunkOutputGallery extends Composite
    }
    
    @Override
+   public boolean hasHtmlWidgets()
+   {
+      for (ChunkOutputPage page: pages_)
+      {
+         if (page instanceof ChunkHtmlPage)
+            return true;
+      }
+      return false;
+   }
+
+   @Override
    public boolean hasErrors()
    {
       if (console_ != null)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputPresenter.java
@@ -59,6 +59,7 @@ public interface ChunkOutputPresenter extends IsWidget, EditorThemeListener
    boolean hasOutput();
    boolean hasPlots();
    boolean hasErrors();
+   boolean hasHtmlWidgets();
    
    // notify of size changes
    void onResize();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -438,6 +438,20 @@ public class ChunkOutputStream extends FlowPanel
    }
    
    @Override
+   public boolean hasHtmlWidgets()
+   {
+      for (Widget w: this)
+      {
+         if (w instanceof ChunkOutputFrame)
+         {
+            return true;
+         }
+      }
+      
+      return false;
+   }
+   
+   @Override
    public boolean hasErrors()
    {
       return hasErrors_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -328,8 +328,12 @@ public class ChunkOutputWidget extends Composite
          int contentHeight = root_.getElement().getOffsetHeight() + 19;
          height = Math.max(ChunkOutputUi.MIN_CHUNK_HEIGHT, contentHeight);
          
-         // clamp height of widgets
-         height = Math.min(height, ChunkOutputUi.MAX_CHUNK_HEIGHT);
+         // clamp height of widgets if there's an htmlwidget present; if HTML
+         // widgets fill the editor surface, the resulting UX is unpleasant.
+         if (presenter_.hasHtmlWidgets())
+         {
+            height = Math.min(height, ChunkOutputUi.MAX_CHUNK_HEIGHT);
+         }
 
          // if we have renders pending, don't shrink until they're loaded 
          if (pendingRenders_ > 0 && height < renderedHeight_)


### PR DESCRIPTION
Chunk output height has always been a little problematic. There are basically three choices, and each has significant drawbacks that result in bugs. 

1. If we allow it to grow without constraint, it can take over the editor surface, with unpleasant results. See #2174. 
2. If we constrain its height with a scrollbar, you wind up with two vertical scrollbars right next to each other, which is unpleasant and almost unusable.
3. If we constrain its height with no scrollbar (just clip it), users can't see all the content. This is what we currently do; see #3536. 

Since we originally clamped the height to avoid HTML widget iframes from consuming the whole editor surface, this change creates a compromise between (1) and (3) that preserves the clamping behavior for HTML widgets while letting other types of content (which don't use iframes) grow unconstrained. 

Fixes #3536. 