### PR TITLE
sync Jobs plumbing tweaks between pro and open-source

### DIFF
--- a/src/cpp/session/include/session/jobs/Job.hpp
+++ b/src/cpp/session/include/session/jobs/Job.hpp
@@ -63,7 +63,8 @@ public:
        JobType type,
        bool autoRemove,
        SEXP actions,
-       bool show);
+       bool show,
+       const std::vector<std::string>& tags);
 
    // job ID (machine-generated)
    std::string id() const;
@@ -89,6 +90,9 @@ public:
    // type of job
    JobType type() const;
 
+   // job tags
+   std::vector<std::string> tags() const;
+
    // whether the job is complete
    bool complete() const;
 
@@ -100,7 +104,6 @@ public:
 
    // execute a custom (user-defined) action
    core::Error executeAction(const std::string& name);
-   void setActions(SEXP actions);
 
    // add and retrieve output
    void addOutput(const std::string& output, bool error); 
@@ -154,6 +157,8 @@ private:
    bool show_;
 
    r::sexp::PreservedSEXP actions_;
+
+   std::vector<std::string> tags_;
 };
 
 

--- a/src/cpp/session/include/session/jobs/JobsApi.hpp
+++ b/src/cpp/session/include/session/jobs/JobsApi.hpp
@@ -16,7 +16,7 @@
 #ifndef SESSION_JOBS_HPP
 #define SESSION_JOBS_HPP
 
-#include "Job.hpp"
+#include <session/jobs/Job.hpp>
 
 namespace rstudio {
 namespace core {
@@ -30,6 +30,7 @@ namespace modules {
 namespace jobs {
 
 boost::shared_ptr<Job> addJob(
+      const std::string& id,
       const std::string& name,
       const std::string& status,
       const std::string& group,
@@ -38,7 +39,20 @@ boost::shared_ptr<Job> addJob(
       JobType type,
       bool autoRemove,
       SEXP actions,
-      bool show);
+      bool show,
+      std::vector<std::string> tags);
+
+boost::shared_ptr<Job> addJob(
+      const std::string& name,
+      const std::string& status,
+      const std::string& group,
+      int progress,
+      JobState state,
+      JobType type,
+      bool autoRemove,
+      SEXP actions,
+      bool show,
+      std::vector<std::string> tags);
 
 void removeJob(boost::shared_ptr<Job> pJob);
 
@@ -55,6 +69,8 @@ void setJobStatus(boost::shared_ptr<Job> pJob, const std::string& status);
 core::json::Object jobsAsJson();
 
 void removeAllJobs();
+
+void removeAllLocalJobs();
 
 void removeCompletedJobs();
 

--- a/src/cpp/session/modules/SessionJobs.R
+++ b/src/cpp/session/modules/SessionJobs.R
@@ -24,8 +24,8 @@
 # API functions --------------------------------------------------------------
 
 .rs.addApiFunction("addJob", function(name, status = "", progressUnits = 0L,
-      actions = NULL, running = FALSE, autoRemove = TRUE, group = "", show = TRUE, 
-      launcherJob = FALSE) {
+      actions = NULL, running = FALSE, autoRemove = TRUE, group = "", show = TRUE,
+      launcherJob = FALSE, tags = NULL) {
 
    # validate arguments
    if (missing(name))
@@ -35,7 +35,7 @@
 
    # begin tracking job
    .Call("rs_addJob", name, status, progressUnits,
-      actions, running, autoRemove, group, show, launcherJob, PACKAGE = "(embedding)")
+      actions, running, autoRemove, group, show, launcherJob, tags, PACKAGE = "(embedding)")
 })
 
 .rs.addApiFunction("removeJob", function(job) {

--- a/src/cpp/session/modules/jobs/Job.cpp
+++ b/src/cpp/session/modules/jobs/Job.cpp
@@ -1,5 +1,5 @@
 /*
- * SessionJob.cpp
+ * Job.cpp
  *
  * Copyright (C) 2009-18 by RStudio, Inc.
  *
@@ -13,6 +13,8 @@
  *
  */
 
+#include <session/jobs/Job.hpp>
+
 #include <ctime>
 
 #include <boost/make_shared.hpp>
@@ -21,8 +23,6 @@
 #include <session/SessionModuleContext.hpp>
 
 #include <r/RExec.hpp>
-
-#include "Job.hpp"
 
 #define kJobId          "id"
 #define kJobName        "name"
@@ -36,6 +36,7 @@
 #define kJobCompleted   "completed"
 #define kJobElapsed     "elapsed"
 #define kJobShow        "show"
+#define kJobTags        "tags"
 
 #define kJobStateIdle      "idle"
 #define kJobStateRunning   "running"
@@ -60,7 +61,8 @@ Job::Job(const std::string& id,
          JobType type,
          bool autoRemove,
          SEXP actions,
-         bool show):
+         bool show,
+         const std::vector<std::string>& tags):
    id_(id), 
    name_(name),
    status_(status),
@@ -75,7 +77,8 @@ Job::Job(const std::string& id,
    autoRemove_(autoRemove),
    listening_(false),
    show_(show),
-   actions_(actions)
+   actions_(actions),
+   tags_(tags)
 {
    setState(state);
 }
@@ -135,6 +138,11 @@ JobType Job::type() const
    return type_;
 }
 
+std::vector<std::string> Job::tags() const
+{
+   return tags_;
+}
+
 json::Object Job::toJson() const
 {
    Error error;
@@ -188,6 +196,7 @@ json::Object Job::toJson() const
    }
 
    job["actions"] = actions;
+   job[kJobTags] = json::toJsonArray(tags_);
 
    return job;
 }
@@ -209,7 +218,8 @@ Error Job::fromJson(const json::Object& src, boost::shared_ptr<Job> *pJobOut)
       kJobCompleted, &completed,
       kJobState,     &state,
       kJobType,      &type,
-      kJobShow,      &pJob->show_);
+      kJobShow,      &pJob->show_,
+      kJobTags,      &pJob->tags_);
    if (error)
       return error;
 

--- a/src/cpp/session/modules/jobs/ScriptJob.cpp
+++ b/src/cpp/session/modules/jobs/ScriptJob.cpp
@@ -21,9 +21,9 @@
 
 #include <session/SessionModuleContext.hpp>
 #include <session/SessionAsyncRProcess.hpp>
- 
+#include <session/jobs/JobsApi.hpp>
+
 #include "ScriptJob.hpp"
-#include "JobsApi.hpp"
 
 #define kProgressDelim  "__"
 #define kProgressStart  kProgressDelim "rs_progress_0" kProgressDelim " " 
@@ -79,7 +79,7 @@ private:
          LOG_ERROR(error);
 
       // add the job -- currently idle until we get some content from it
-      job_ = addJob(spec_.path().filename(), "", "", 0, JobIdle, JobTypeSession, false, actions, true);
+      job_ = addJob(spec_.path().filename(), "", "", 0, JobIdle, JobTypeSession, false, actions, true, {});
       
       std::string importRdata = "NULL";
       std::string exportRdata = "NULL";

--- a/src/cpp/session/modules/jobs/ScriptJob.hpp
+++ b/src/cpp/session/modules/jobs/ScriptJob.hpp
@@ -16,7 +16,7 @@
 #ifndef SESSION_SCRIPT_JOB_HPP
 #define SESSION_SCRIPT_JOB_HPP
 
-#include "Job.hpp"
+#include <session/jobs/Job.hpp>
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/tests/testthat/test-jobs.R
+++ b/src/cpp/tests/testthat/test-jobs.R
@@ -141,3 +141,11 @@ test_that("custom job actions are executed", {
    expect_equal(1, mutable)
 })
 
+test_that("job tags can be set and retrieved", {
+   theTags <- c("one", "two", "four")
+   jobId <- .rs.api.addJob(name = "job11", tags=theTags)
+   jobs <- .rs.invokeRpc("get_jobs")
+   job <- jobs[[jobId]]
+   expect_true(sum(job[["tags"]] == theTags) == length(theTags))
+})
+

--- a/src/gwt/src/org/rstudio/core/client/widget/ProgressBar.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ProgressBar.java
@@ -43,6 +43,12 @@ public class ProgressBar extends Composite
    
    public void setProgress(int units, int max)
    {
+      if (max == 0)
+      {
+         // avoid div/0 if max of zero
+         max = 1;
+         units = 0;
+      }
       double percent = ((double)units / (double)max) * 100.0;
       setProgress(percent);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/Job.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/Job.java
@@ -35,7 +35,7 @@ public class Job
    // the job's state (idle, running, completed, etc.)
    public int state;
 
-   // the job's type (session, ad-hoc)
+   // the job's type (session, launcher)
    public int type;
    
    // the number of progress units the job has completed so far
@@ -64,4 +64,7 @@ public class Job
 
    // whether the job pane should should be shown at start
    public boolean show;
+
+   // the job's tags
+   public JsArrayString tags;
 }


### PR DESCRIPTION
While I'm waiting for my power to come on so I can use my Pro VM... taking the opportunity to reduce drift between pro and open-source code.

- move Job.hpp and JobsApi.hpp into a location where they can be used by the launcher-jobs code
- support returning tags (array of strings) as part of Job metadata; will potentially be used for sorting launcher jobs
- ability to add Job object (C++) with a pre-determined id (launcher id) instead of auto-creating one
- tweaks to remove only local jobs, only check local jobs when deciding if local jobs are running, and so on; should be no-ops in open-source but important for Pro
- avoid a divide by zero in Javascript code for ProgressBar that was being hit with launcher jobs (probably no longer important with pane UI changes, but might as well put it in)
- a couple Java language tweaks Intelli-J was very excited about