### PR TITLE
Persist visibility of Jobs tab

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobsPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobsPresenter.java
@@ -63,6 +63,7 @@ public class JobsPresenter extends BasePresenter
       void hideJobOutput(String id, boolean animate);
       void syncElapsedTime(int timestamp);
       void bringToFront();
+      void setShowJobsTabPref(boolean show);
    }
    
    public interface Binder extends CommandBinder<Commands, JobsPresenter> {}
@@ -72,7 +73,6 @@ public class JobsPresenter extends BasePresenter
                         JobsServerOperations server,
                         Binder binder,
                         Commands commands,
-                        EventBus events,
                         GlobalDisplay globalDisplay,
                         Provider<JobManager> pJobManager,
                         EventBus eventBus)
@@ -139,7 +139,10 @@ public class JobsPresenter extends BasePresenter
       
       // if there are no jobs, go ahead and let the tab close
       if (jobs.isEmpty())
+      {
+         display_.setShowJobsTabPref(false);
          onConfirmed.execute();
+      }
 
       // count the number of running session jobs
       long running = jobs.stream()
@@ -158,6 +161,7 @@ public class JobsPresenter extends BasePresenter
       }
       
       // done, okay to close
+      display_.setShowJobsTabPref(false);
       onConfirmed.execute();
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsPane.java
@@ -13,6 +13,7 @@
  *
  */
 package org.rstudio.studio.client.workbench.views.jobs.view;
+import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.jobs.JobsPresenter;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobSelectionEvent;
 import org.rstudio.studio.client.workbench.views.jobs.model.Job;
@@ -42,11 +43,13 @@ public class JobsPane extends WorkbenchPane
 {
    @Inject
    public JobsPane(Commands commands,
+                   UIPrefs uiPrefs,
                    final EventBus events)
    {
       super("Jobs");
       commands_ = commands;
       events_ = events;
+      uiPrefs_ = uiPrefs;
 
       allJobs_ = new ToolbarButton(
             commands.helpBack().getImageResource(), evt ->
@@ -247,6 +250,23 @@ public class JobsPane extends WorkbenchPane
          progress_.updateElapsed(timestamp);
       }
    }
+   
+   @Override
+   public void bringToFront()
+   {
+      setShowJobsTabPref(true);
+      super.bringToFront();
+   }
+   
+   @Override
+   public void setShowJobsTabPref(boolean show)
+   {
+      if (uiPrefs_.showJobsTab().getValue() != show)
+      {
+         uiPrefs_.showJobsTab().setGlobalValue(show);
+         uiPrefs_.writeUIPrefs();
+      }
+   }
 
    // Private methods ---------------------------------------------------------
    
@@ -301,4 +321,5 @@ public class JobsPane extends WorkbenchPane
    // injected
    final Commands commands_;
    final EventBus events_;
+   final UIPrefs uiPrefs_;
 }


### PR DESCRIPTION
If you close the Jobs tab, the next time you start the IDE the tab will not be shown. This is same model as the Terminal Tab. Allows a user who never uses the feature to hide it once and not see it again.

To get Jobs tab back, use "View/Show Jobs" or run a script as a job via editor drop down "Source / Source as Job" or "Tools/Jobs/Start Job".

Fixes #3743