### PR TITLE
warn before killing session jobs when restarting R or building package

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
@@ -492,19 +492,22 @@ public class ApplicationQuit implements SaveActionChangedHandler,
      
    @Handler
    public void onRestartR()
-   {   
-      terminalHelper_.warnBusyTerminalBeforeCommand(new Command() 
-      {
-         @Override
-         public void execute()
+   {
+         // check for running jobs
+         pJobManager_.get().promptForTermination((confirmed) ->
          {
-            boolean saveChanges = saveAction_.getAction() != SaveAction.NOSAVE;
-            eventBus_.fireEvent(new SuspendAndRestartEvent(
-                  SuspendOptions.createSaveMinimal(saveChanges),
-                  null));  
-         }
-      }, "Restart R", "Terminal jobs will be terminated. Are you sure?",
-         pUiPrefs_.get().terminalBusyMode().getValue());
+            if (confirmed)
+            {
+               terminalHelper_.warnBusyTerminalBeforeCommand(() ->
+               {
+                  boolean saveChanges = saveAction_.getAction() != SaveAction.NOSAVE;
+                  eventBus_.fireEvent(new SuspendAndRestartEvent(
+                        SuspendOptions.createSaveMinimal(saveChanges),
+                        null));
+               }, "Restart R", "Terminal jobs will be terminated. Are you sure?",
+                  pUiPrefs_.get().terminalBusyMode().getValue());
+            }
+         });
    }
    
    @Handler


### PR DESCRIPTION
Fixes #3893

Worst case you will be told about running jobs, agree to killing those, then see warning about busy terminals, and have to agree to that. On the plus side, if you cancel out of the second step, the jobs will not be killed, either.

Suggests that busy terminals might show up as session jobs in this context. This paradigm would also translate to 1.3 concept of having terminals survive their session being closed (these style of terminal jobs would correspond conceptually to launcher jobs).

For 1.2, just doing the two stage warning to avoid users losing work in a way they weren't expecting.