### PR TITLE
Work around Chromium bug affecting checkbox rendering

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesListDataGridStyle.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesListDataGridStyle.css
@@ -9,6 +9,13 @@
 .dataGridCell input[type=checkbox] {
    margin-top: 0;
    margin-bottom: 0;
+   zoom: 1.000001;
+}
+
+.rstudio-themes-flat .dataGridCell input[type=checkbox] {
+   margin-top: 0;
+   margin-bottom: 0;
+   zoom: 1;
 }
 
 .dataGridLastColumnHeader {


### PR DESCRIPTION
In RStudio's Classic theme, the checkboxes in the Files pane disappear when you click on them. This is a known issue in Chromium, and this change works around it by applying an infinitesimal zoom to the checkboxes when we're using the Classic theme.