### PR TITLE
Add "run selection as job" command

### DIFF
--- a/src/cpp/session/modules/jobs/ScriptJob.hpp
+++ b/src/cpp/session/modules/jobs/ScriptJob.hpp
@@ -33,17 +33,33 @@ namespace jobs {
 class ScriptLaunchSpec 
 {
 public:
-   ScriptLaunchSpec(const core::FilePath& path,
+   // A script consisting of a named code snippet
+   ScriptLaunchSpec(
+         const std::string& name,
+         const std::string& code,
+         const core::FilePath& workingDir,
+         bool importEnv,
+         const std::string& exportEnv);
+
+   // A script consisting of an R file on disk
+   ScriptLaunchSpec(
+         const std::string& name,
+         const core::FilePath& path,
          const std::string& encoding,
          const core::FilePath& workingDir,
          bool importEnv,
          const std::string& exportEnv);
+
+   std::string name();
+   std::string code();
    core::FilePath path();
    std::string encoding();
    core::FilePath workingDir();
    bool importEnv();
    std::string exportEnv();
 private:
+   std::string name_;
+   std::string code_;
    core::FilePath path_;
    std::string encoding_;
    core::FilePath workingDir_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -239,6 +239,7 @@ well as menu structures (for main menu and popup menus).
             <separator/>
             <cmd refid="executeAllCode"/>
          </menu>
+         <cmd refid="runSelectionAsJob"/>
          <cmd refid="sendToTerminal"/>
          <separator/>
          <cmd refid="previewJS"/>
@@ -3313,5 +3314,10 @@ well as menu structures (for main menu and popup menus).
          menuLabel="Clear Jobs"
          desc="Clean up all completed jobs"
          windowMode="main"/>
+        
+    <cmd id="runSelectionAsJob"
+         menuLabel="Run Selection as Job"
+         desc="Run the selected code as a job"
+         windowMode="any"/>
         
 </commands>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -569,6 +569,7 @@ public abstract class
    public abstract AppCommand sourceAsJob();
    public abstract AppCommand clearJobs();
    public abstract AppCommand activateJobs();
+   public abstract AppCommand runSelectionAsJob();
 
    // Other
    public abstract AppCommand checkSpelling();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/events/JobRunSelectionEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/events/JobRunSelectionEvent.java
@@ -1,0 +1,68 @@
+/*
+ * JobRunSelectionEvent.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.jobs.events;
+
+import org.rstudio.core.client.js.JavaScriptSerializable;
+import org.rstudio.studio.client.application.events.CrossWindowEvent;
+
+import com.google.gwt.event.shared.EventHandler;
+
+@JavaScriptSerializable
+public class JobRunSelectionEvent extends CrossWindowEvent<JobRunSelectionEvent.Handler>
+{
+   public interface Handler extends EventHandler
+   {
+      void onJobRunSelection(JobRunSelectionEvent event);
+   }
+
+   public JobRunSelectionEvent()
+   {
+      code_ = "";
+      path_ = "";
+   }
+   
+   public JobRunSelectionEvent(String path, String code)
+   {
+      path_ = path;
+      code_ = code;
+   }
+
+   public String code()
+   {
+      return code_;
+   }
+   
+   public String path()
+   {
+      return path_;
+   }
+   
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onJobRunSelection(this);
+   }
+
+   private final String code_;
+   private final String path_;
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobLaunchSpec.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobLaunchSpec.java
@@ -24,6 +24,10 @@ public class JobLaunchSpec extends JavaScriptObject
       return this.path;
    }-*/;
    
+   public final native String code() /*-{
+      return this.code;
+   }-*/;
+   
    public final native String encoding() /*-{
       return this.encoding;
    }-*/;
@@ -45,13 +49,31 @@ public class JobLaunchSpec extends JavaScriptObject
    }-*/;
    
    public final native static JobLaunchSpec create(
+      String name,
       String path,
       String encoding,
       String workingDir,
       boolean importEnv,
       String exportEnv) /*-{
-      return { "path": path,
+      return { "name": name,
+               "path": path,
+               "code": "",
                "encoding": encoding,
+               "working_dir": workingDir,
+               "import_env": importEnv,
+               "export_env": exportEnv };
+   }-*/;
+
+   public final native static JobLaunchSpec create(
+      String name,
+      String code,
+      String workingDir,
+      boolean importEnv,
+      String exportEnv) /*-{
+      return { "name": name,
+               "code": code,
+               "path": "",
+               "encoding": "",
                "working_dir": workingDir,
                "import_env": importEnv,
                "export_env": exportEnv };

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobLauncherControls.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobLauncherControls.java
@@ -47,10 +47,19 @@ public class JobLauncherControls extends Composite
       exportEnv_.addItem("To results object in global environment", "local");
    }
    
-   public void setScriptPath(String path)
+   public void setScriptPath(FileSystemItem path)
    {
-      file_.setText(path);
-      dir_.setText(FileSystemItem.createFile(path).getParentPathString());
+      file_.setText(path.getPath());
+   }
+   
+   public void setWorkingDir(FileSystemItem dir)
+   {
+      dir_.setText(dir.getPath());
+   }
+   
+   public void hideScript()
+   {
+      file_.setVisible(false);
    }
    
    public String scriptPath()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobLauncherDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobLauncherDialog.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.workbench.views.jobs.view;
 
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobLaunchSpec;
@@ -23,15 +24,36 @@ import com.google.gwt.user.client.ui.Widget;
 
 public class JobLauncherDialog extends ModalDialog<JobLaunchSpec>
 {
-   public JobLauncherDialog(String caption, 
-                            String scriptPath,
+   public JobLauncherDialog(String caption,
+                            String jobName,
+                            FileSystemItem scriptPath,
+                            OperationWithInput<JobLaunchSpec> operation)
+   {
+      this(caption, jobName, scriptPath, scriptPath.getParentPath(), null, operation);
+   }
+   
+   public JobLauncherDialog(String caption,
+                            String jobName,
+                            FileSystemItem scriptPath,
+                            FileSystemItem workingDir,
+                            String code,
                             OperationWithInput<JobLaunchSpec> operation)
    {
       super(caption, operation);
 
       controls_ = new JobLauncherControls();
+
       if (scriptPath != null)
          controls_.setScriptPath(scriptPath);
+
+      if (workingDir != null)
+         controls_.setWorkingDir(workingDir);
+
+      if (code != null)
+         controls_.hideScript();
+      
+      code_ = code;
+      jobName_ = jobName;
 
       setOkButtonCaption("Start");
    }
@@ -39,17 +61,31 @@ public class JobLauncherDialog extends ModalDialog<JobLaunchSpec>
    @Override
    protected JobLaunchSpec collectInput()
    {
-      return JobLaunchSpec.create(controls_.scriptPath(), 
-            "unknown", // encoding unknown (will try to look it up later)
-            controls_.workingDir(),
-            controls_.importEnv(),
-            controls_.exportEnv());
+      if (code_ == null)
+      {
+         return JobLaunchSpec.create(jobName_,
+               controls_.scriptPath(), 
+               "unknown", // encoding unknown (will try to look it up later)
+               controls_.workingDir(),
+               controls_.importEnv(),
+               controls_.exportEnv());
+      }
+      else
+      {
+         return JobLaunchSpec.create(jobName_,
+               code_, 
+               controls_.workingDir(), 
+               controls_.importEnv(), 
+               controls_.exportEnv());
+      }
    }
    
    @Override
    protected boolean validate(JobLaunchSpec spec)
    {
-      return !StringUtil.isNullOrEmpty(spec.path());
+      // we need either a path to a script to run or a code snippet
+      return !StringUtil.isNullOrEmpty(spec.path()) || 
+             !StringUtil.isNullOrEmpty(code_);
    }
 
    @Override
@@ -58,5 +94,7 @@ public class JobLauncherDialog extends ModalDialog<JobLaunchSpec>
       return controls_;
    }
    
+   private final String code_;
+   private final String jobName_;
    private JobLauncherControls controls_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
@@ -1,7 +1,7 @@
 /*
  * EditingTargetCodeExecution.java
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -27,6 +27,7 @@ import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefsAccessor;
 import org.rstudio.studio.client.workbench.views.console.events.ConsoleExecutePendingInputEvent;
 import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
+import org.rstudio.studio.client.workbench.views.jobs.events.JobRunSelectionEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay.AnchoredSelection;
 import org.rstudio.studio.client.workbench.views.source.editors.text.Scope;
@@ -181,6 +182,19 @@ public class EditingTargetCodeExecution
             true,
             null,
             false);
+   }
+   
+   public void runSelectionAsJob()
+   {
+      Range selectionRange = docDisplay_.getSelectionRange();
+      boolean noSelection = selectionRange.isEmpty();
+      if (noSelection)
+      {
+         // nothing to execute; don't guess
+         return;
+      }
+      String code = codeExtractor_.extractCode(docDisplay_, selectionRange);
+      events_.fireEvent(new JobRunSelectionEvent(target_.getPath(), code));
    }
    
    public void executeRange(Range range)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -4171,6 +4171,12 @@ public class TextEditingTarget implements
    }
    
    @Handler
+   void onRunSelectionAsJob()
+   {
+      codeExecution_.runSelectionAsJob();
+   }
+   
+   @Handler
    void onExecuteCurrentLine()
    {
       codeExecution_.executeBehavior(UIPrefsAccessor.EXECUTE_LINE);


### PR DESCRIPTION
This change makes it possible to run any selected R code as a background job. It works by much the same mechanism as running an entire script, but allows running pieces of scripts as well as R code from unsaved and untitled scratch buffers.