### PR TITLE
clean up handler registrations on dismiss

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/Timers.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/Timers.java
@@ -1,0 +1,33 @@
+/*
+ * Timers.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.common;
+
+import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Timer;
+
+public class Timers
+{
+   public static final void singleShot(int delayMs, final Command command)
+   {
+      new Timer()
+      {
+         @Override
+         public void run()
+         {
+            command.execute();
+         }
+      }.schedule(delayMs);
+   }
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1285,7 +1285,7 @@ public class TextEditingTarget implements
                                                           extendedType_, 
                                                           fileType_);
 
-      themeHelper_ = new TextEditingTargetThemeHelper(this, events_);
+      themeHelper_ = new TextEditingTargetThemeHelper(this, events_, releaseOnDismiss_);
       
       docUpdateSentinel_ = new DocUpdateSentinel(
             server_,


### PR DESCRIPTION
This PR ensures that the global handler used by theme helpers is cleaned up when the associated document is detached.

Also adds a `Timers` utility class, since the `Timer` class in GWT play quite as well with Java 8 tools (e.g. lambdas).