### PR TITLE
avoid binding conflict for Ctrl+Page{Up/Down}

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -673,14 +673,12 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="switchToTab" value="Ctrl+X B" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,sublime"/>
          <shortcut refid="switchToTab" value="Ctrl+Shift+."/>
          <shortcut refid="nextTab" value="Ctrl+Alt+Right" if="!org.rstudio.core.client.BrowseCap.isLinux()"/>
-         <shortcut refid="nextTab" value="Ctrl+PageDown" if="org.rstudio.core.client.BrowseCap.isLinux()"/>
          <shortcut refid="nextTab" value="Ctrl+X Right" disableModes="default,vim,sublime"/>
          <shortcut refid="nextTab" value="Ctrl+F12"/>
          <shortcut refid="nextTab" value="Ctrl+Tab" if="org.rstudio.studio.client.application.Desktop.isDesktop()"/>
          <shortcut refid="nextTab" value="Cmd+Shift+]" disableModes="default,vim,emacs"/>
          <shortcut refid="previousTab" value="Ctrl+Alt+Left" if="!org.rstudio.core.client.BrowseCap.isLinux()"/>
          <shortcut refid="previousTab" value="Ctrl+F11"/>
-         <shortcut refid="previousTab" value="Ctrl+PageUp" if="org.rstudio.core.client.BrowseCap.isLinux()"/>
          <shortcut refid="previousTab" value="Ctrl+X Left" disableModes="default,vim,sublime"/>
          <shortcut refid="previousTab" value="Ctrl+Shift+Tab" if="org.rstudio.studio.client.application.Desktop.isDesktop()"/>
          <shortcut refid="previousTab" value="Cmd+Shift+[" disableModes="default,vim,emacs"/>


### PR DESCRIPTION
Closes #3727.

Users can still rebind these commands locally if they prefer these keybindings on their Linux machines.