### PR TITLE
allow users to customize rendering engine in choose R version dialog

### DIFF
--- a/src/cpp/desktop/DesktopChooseRHome.cpp
+++ b/src/cpp/desktop/DesktopChooseRHome.cpp
@@ -32,6 +32,18 @@ using namespace rstudio::desktop;
 
 namespace {
 
+static std::map<std::string, std::string> s_engineValueTolabel = {
+   {"auto", "Auto-detect (recommended)"},
+   {"desktop", "Desktop OpenGL"},
+   {"software", "Software"}
+};
+
+static std::map<std::string, std::string> s_engineLabelToValue = {
+   {"Auto-detect (recommended)", "auto"},
+   {"Desktop OpenGL", "desktop"},
+   {"Software", "software"}
+};
+
 QListWidgetItem* toItem(const RVersion& version)
 {
    QListWidgetItem* pItem = new QListWidgetItem();
@@ -55,13 +67,20 @@ ChooseRHome::ChooseRHome(QList<RVersion> list, QWidget *parent) :
     pOK_(nullptr)
 {
     ui->setupUi(this);
-
+    
     setWindowIcon(QIcon(QString::fromUtf8(":/icons/RStudio.ico")));
 
     setWindowFlags(
           (windowFlags() | Qt::Dialog)
           & ~Qt::WindowContextHelpButtonHint
           );
+    
+    QStringList engines = {
+       QStringLiteral("Auto-detect (recommended)"),
+       QStringLiteral("Desktop OpenGL"),
+       QStringLiteral("Software")
+    };
+    ui->comboRenderingEngines->addItems(engines);
 
     pOK_ = new QPushButton(QString::fromUtf8("OK"));
     ui->buttonBox->addButton(pOK_, QDialogButtonBox::AcceptRole);
@@ -239,6 +258,8 @@ void ChooseRHome::done(int r)
             }
          }
       }
+      
+      
    }
 
    this->QDialog::done(r);
@@ -254,7 +275,7 @@ void ChooseRHome::validateSelection()
 
    if (ui->radioCustom->isChecked())
    {
-      pOK_->setEnabled(this->value().isValid());
+      pOK_->setEnabled(this->version().isValid());
    }
    else
    {
@@ -267,7 +288,7 @@ void ChooseRHome::onModeChanged()
    validateSelection();
 }
 
-RVersion ChooseRHome::value()
+RVersion ChooseRHome::version()
 {
    if (!ui->radioCustom->isChecked())
       return QString();
@@ -279,7 +300,7 @@ RVersion ChooseRHome::value()
              : toVersion(selectedItems.at(0));
 }
 
-void ChooseRHome::setValue(const RVersion& value)
+void ChooseRHome::setVersion(const RVersion& value)
 {
    if (value.isEmpty())
    {
@@ -296,3 +317,20 @@ void ChooseRHome::setValue(const RVersion& value)
    }
 }
 
+QString ChooseRHome::renderingEngine()
+{
+   std::string entry = ui->comboRenderingEngines->currentText().toStdString();
+   if (s_engineLabelToValue.count(entry))
+      return QString::fromStdString(s_engineLabelToValue[entry]);
+   else
+      return QStringLiteral("auto");
+}
+
+void ChooseRHome::setRenderingEngine(const QString& renderingEngine)
+{
+   std::string engine = renderingEngine.toStdString();
+   if (s_engineValueTolabel.count(engine))
+      ui->comboRenderingEngines->setCurrentText(QString::fromStdString(s_engineValueTolabel[engine]));
+   else
+      ui->comboRenderingEngines->setCurrentText(QStringLiteral("Auto-detect (recommended)"));
+}

--- a/src/cpp/desktop/DesktopChooseRHome.hpp
+++ b/src/cpp/desktop/DesktopChooseRHome.hpp
@@ -35,8 +35,11 @@ public:
    ~ChooseRHome();
 
    // "" means auto-detect
-   rstudio::desktop::RVersion value();
-   void setValue(const rstudio::desktop::RVersion& value);
+   rstudio::desktop::RVersion version();
+   void setVersion(const rstudio::desktop::RVersion& version);
+   
+   QString renderingEngine();
+   void setRenderingEngine(const QString& renderingEngine);
 
 protected Q_SLOTS:
    void chooseOther();

--- a/src/cpp/desktop/DesktopChooseRHome.ui
+++ b/src/cpp/desktop/DesktopChooseRHome.ui
@@ -58,7 +58,7 @@
    <item>
     <widget class="QRadioButton" name="radioDefault64">
      <property name="text">
-      <string>Use your machine's default version of R64 (64-bit)</string>
+      <string>Use your machine's default version of R</string>
      </property>
     </widget>
    </item>
@@ -145,6 +145,69 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>You can also customize the rendering engine used by RStudio.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <property name="spacing">
+      <number>6</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="labelRenderingEngine">
+       <property name="text">
+        <string>Rendering Engine:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="comboRenderingEngines">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">

--- a/src/cpp/desktop/DesktopRVersion.cpp
+++ b/src/cpp/desktop/DesktopRVersion.cpp
@@ -22,6 +22,7 @@
 #include <core/system/Environment.hpp>
 #include <core/system/RegistryKey.hpp>
 
+#include "DesktopInfo.hpp"
 #include "DesktopChooseRHome.hpp"
 
 #ifndef KEY_WOW64_32KEY
@@ -414,16 +415,17 @@ RVersion detectRVersion(bool forceUi, QWidget* parent)
    // Either forceUi was true, xor the manually specified R version is
    // no longer valid, xor we tried to autodetect and failed.
    // Now we show the dialog and make the user choose.
-
    ChooseRHome dialog(allRVersions(QList<RVersion>() << rVersion), parent);
-   dialog.setValue(rVersion);
+   dialog.setVersion(rVersion);
+   dialog.setRenderingEngine(desktop::options().desktopRenderingEngine());
    if (dialog.exec() == QDialog::Accepted)
    {
       // Keep in mind this value might be "", if the user indicated
       // they want to use the system default. The dialog won't let
       // itself be accepted unless a valid installation is detected.
-      rVersion = dialog.value();
+      rVersion = dialog.version();
       options.setRBinDir(rVersion.binDir());
+      options.setDesktopRenderingEngine(dialog.renderingEngine());
 
       // Recurse. The ChooseRHome dialog should've validated that
       // the values are acceptable, so this recursion will never

--- a/src/cpp/desktop/DesktopRVersion.cpp
+++ b/src/cpp/desktop/DesktopRVersion.cpp
@@ -434,11 +434,15 @@ RVersion detectRVersion(bool forceUi, QWidget* parent)
       // restart the application.
       if (renderingEngine != dialog.renderingEngine())
       {
-         QMessageBox::information(
-                  nullptr,
-                  QStringLiteral("Rendering Engine Changed"),
-                  QStringLiteral("The desktop rendering engine has been changed. Please "
-                                 "restart RStudio for these changes to take affect."));
+         QMessageBox* messageBox = new QMessageBox(nullptr);
+         messageBox->setAttribute(Qt::WA_DeleteOnClose, true);
+         messageBox->setIcon(QMessageBox::Information);
+         messageBox->setWindowIcon(QIcon(QStringLiteral(":/icons/RStudio.ico")));
+         messageBox->setWindowTitle(QStringLiteral("Rendering Engine Changed"));
+         messageBox->setText(QStringLiteral(
+                  "The desktop rendering engine has been changed. "
+                  "Please restart RStudio for these changes to take effect."));
+         messageBox->exec();
          
          return QString();
       }


### PR DESCRIPTION
This PR makes it possible for users to customize the rendering engine used by RStudio in the choose R version dialog:

![screen shot 2018-11-27 at 10 14 23 am](https://user-images.githubusercontent.com/1976582/49102274-3f0bfb00-f22d-11e8-9402-b76bf5c6ea2d.png)

The intention is that this could be used as an escape hatch for users with rendering issues on Windows that make the IDE unusable; e.g. as described in https://community.rstudio.com/t/rstudio-preview-ide-rstudio-1-2-1139-screen-is-black/18819/3. The intention is that, with this feature, we could instruct such users to launch RStudio by holding down <kbd>Ctrl</kbd> when RStudio is launched, and then they could try changing the rendering engine used in this dialog.

Note that the user will technically still need to restart the IDE once more (since these settings are applied too late; ie, after GPU-related things are initialized in the QApplication object). Is there a clean way we could communicate this requirement? Or should we just display a dialog requesting the user restart RStudio if they change the rendering engine here? 