### PR TITLE
Show status rather than progress bar for non-ranged jobs

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobProgressPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobProgressPresenter.java
@@ -16,6 +16,7 @@ package org.rstudio.studio.client.workbench.views.jobs;
 
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobElapsedTickEvent;
+import org.rstudio.studio.client.workbench.views.jobs.model.Job;
 import org.rstudio.studio.client.workbench.views.jobs.model.LocalJobProgress;
 
 import com.google.gwt.user.client.ui.IsWidget;
@@ -29,6 +30,7 @@ public class JobProgressPresenter implements JobElapsedTickEvent.Handler,
    {
       void updateElapsed(int timestamp);
       void showProgress(LocalJobProgress progress);
+      void showJob(Job job);
       void setComplete();
    }
    
@@ -55,6 +57,11 @@ public class JobProgressPresenter implements JobElapsedTickEvent.Handler,
    public void showProgress(LocalJobProgress progress)
    {
       display_.showProgress(progress);
+   }
+   
+   public void showJob(Job job)
+   {
+      display_.showJob(job);
    }
    
    public void setComplete()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobConstants.java
@@ -37,4 +37,23 @@ public class JobConstants
    public final static int JOB_TYPE_UNKNOWN = 0;
    public final static int JOB_TYPE_SESSION = 1;
    public final static int JOB_TYPE_LAUNCHER = 2;
+   
+   
+   public final static String stateDescription(int state)
+   {
+      switch(state)
+      {
+         case JobConstants.STATE_RUNNING:
+            return "Running";
+         case JobConstants.STATE_IDLE:
+            return "Idle";
+         case JobConstants.STATE_CANCELLED:
+            return "Cancelled";
+         case JobConstants.STATE_FAILED:
+            return "Failed";
+         case JobConstants.STATE_SUCCEEDED:
+            return "Succeeded";
+      }
+      return "Unknown " + state;
+   }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.java
@@ -224,6 +224,12 @@ public class JobItem extends Composite
             stop_.setVisible(true);
             stopOrKill_.setVisible(false);
          }
+         else
+         {
+            // can't stop OR kill
+            stop_.setVisible(false);
+            stopOrKill_.setVisible(false);
+         }
       }
       else
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.java
@@ -144,29 +144,24 @@ public class JobItem extends Composite
       job_ = job;
       
       String clazz = "";
-      String state = "";
+      String state = JobConstants.stateDescription(job_.state);
 
       switch(job_.state)
       {
          case JobConstants.STATE_RUNNING:
             clazz = styles_.running();
-            state = "Running";
             break;
          case JobConstants.STATE_IDLE:
             clazz = styles_.idle();
-            state = "Idle";
             break;
          case JobConstants.STATE_CANCELLED:
             clazz = styles_.cancelled();
-            state = "Cancelled";
             break;
          case JobConstants.STATE_FAILED:
             clazz = styles_.failed();
-            state = "Failed";
             break;
          case JobConstants.STATE_SUCCEEDED:
             clazz = styles_.succeeded();
-            state = "Succeeded";
             break;
       }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobProgress.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobProgress.java
@@ -14,9 +14,13 @@
  */
 package org.rstudio.studio.client.workbench.views.jobs.view;
 
+import java.util.Date;
+
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.widget.ProgressBar;
 import org.rstudio.studio.client.workbench.views.jobs.JobProgressPresenter;
+import org.rstudio.studio.client.workbench.views.jobs.model.Job;
+import org.rstudio.studio.client.workbench.views.jobs.model.JobConstants;
 import org.rstudio.studio.client.workbench.views.jobs.model.LocalJobProgress;
 
 import com.google.gwt.core.client.GWT;
@@ -51,6 +55,36 @@ public class JobProgress extends Composite
       progress_.setProgress(progress.units(), progress.max());
       jobProgress_ = progress;
    }
+   
+   @Override
+   public void showJob(Job job)
+   {
+      name_.setText(job.name);
+      if (job.max > 0)
+      {
+         progress_.setVisible(true);
+         progress_.setProgress(job.progress, job.max);
+      }
+      else
+      {
+         progress_.setVisible(false);
+         status_.setVisible(true);
+         String status = JobConstants.stateDescription(job.state);
+         if (job.completed > 0)
+         {
+            // Job is not running; show its completion status and time
+            status += " " + StringUtil.friendlyDateTime(new Date(job.completed * 1000));
+            elapsed_.setText(StringUtil.conciseElaspedTime(job.completed - job.started));
+         }
+         else if (!StringUtil.isNullOrEmpty(job.status))
+         {
+            // Still running; show its status
+            status = job.status;
+         }
+         status_.setText(status);
+      }
+      jobProgress_ = new LocalJobProgress(job);
+   }
 
    @Override
    public void updateElapsed(int timestamp)
@@ -66,13 +100,13 @@ public class JobProgress extends Composite
    public void setComplete()
    {
       progress_.setVisible(false);
-      elapsed_.setVisible(false);
       complete_ = true;
    }
 
    @UiField Label name_;
    @UiField ProgressBar progress_;
    @UiField Label elapsed_;
+   @UiField Label status_;
    
    private LocalJobProgress jobProgress_;
    private boolean complete_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobProgress.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobProgress.ui.xml
@@ -4,11 +4,16 @@
 	xmlns:rw="urn:import:org.rstudio.core.client.widget">
 	<ui:style>
 	
-	.name, .elapsed
+	.name, .elapsed, .status
 	{
 		text-overflow: ellipsis;
 		overflow: hidden;
 		word-wrap: nowrap;
+	}
+	
+	.status
+	{
+		color: #808080;
 	}
 	
 	.host
@@ -30,10 +35,13 @@
 		        width="20%">
 			<g:Label styleName="{style.name}" ui:field="name_"></g:Label>
 		</g:cell>
-		<g:cell horizontalAlignment="ALIGN_CENTER" 
+		<g:cell horizontalAlignment="ALIGN_RIGHT" 
 		        verticalAlignment="ALIGN_MIDDLE"
 		        width="70%">
-			<rw:ProgressBar ui:field="progress_"></rw:ProgressBar>
+			<g:HTMLPanel styleName="{style.host}">
+				<g:Label styleName="{style.status}" ui:field="status_"></g:Label>
+				<rw:ProgressBar ui:field="progress_"></rw:ProgressBar>
+			</g:HTMLPanel>
 		</g:cell>
 		<g:cell horizontalAlignment="ALIGN_RIGHT" 
 		        verticalAlignment="ALIGN_MIDDLE"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsPane.java
@@ -130,7 +130,7 @@ public class JobsPane extends WorkbenchPane
                      progress_ = new JobProgress();
                      toolbar_.addLeftWidget(progress_);
                   }
-                  progress_.showProgress(new LocalJobProgress(job));
+                  progress_.showJob(job);
                }
             }
             break;
@@ -190,12 +190,12 @@ public class JobsPane extends WorkbenchPane
          progress_ = null;
       }
 
+      // save job id as current job
+      current_ = id;
+
       // show the output pane
       panel_.slideWidgets(SlidingLayoutPanel.Direction.SlideRight,
             animate, this::installJobToolbar);
-      
-      // save job id as current job
-      current_ = id;
    }
 
    @Override
@@ -281,7 +281,7 @@ public class JobsPane extends WorkbenchPane
          // show progress
          progress_ = new JobProgress();
          toolbar_.addLeftWidget(progress_);
-         progress_.showProgress(new LocalJobProgress(job));
+         progress_.showJob(job);
 
          // if job is complete, mark that
          if (job.completed > 0)


### PR DESCRIPTION
This change makes a few minor improvements to the toolbar when viewing a job.

1. If the job does not have ranged progress, no progress bar is shown. Instead we show the job's descriptive status text (if it has it), or its status (if it doesn't).
2. When the job is complete, the completion state (succeeded, failed, etc.) are now shown in its toolbar, along with the elapsed runtime.

![image](https://user-images.githubusercontent.com/470418/49105844-7f23ab80-f236-11e8-92a9-b4736a2ec2cb.png)

![image](https://user-images.githubusercontent.com/470418/49105952-babe7580-f236-11e8-92c0-33bf5d27dd8a.png)
