### PR TITLE
Update dracula.rstheme

### DIFF
--- a/src/cpp/session/resources/themes/dracula.rstheme
+++ b/src/cpp/session/resources/themes/dracula.rstheme
@@ -205,7 +205,7 @@
   color: #cc6666 !important;
 }
 .nocolor.ace_editor .ace_line span {
-  color: #de935f !important;
+  color: #ff79c6 !important;
 }
 .ace_bracket {
   margin: 0 !important;


### PR DESCRIPTION
Changed the console input color #de935f for Dracula theme to match executed console input color #ff79c6.
So when your type code in the console it doesn't change color when executed.