### PR TITLE
work around Qt 5.12 issue (?) where window blank when first shown

### DIFF
--- a/src/cpp/desktop/DesktopBrowserWindow.cpp
+++ b/src/cpp/desktop/DesktopBrowserWindow.cpp
@@ -214,5 +214,20 @@ WebPage* BrowserWindow::opener()
    return pOpener_;
 }
 
+void BrowserWindow::showEvent(QShowEvent* event)
+{
+   QMainWindow::showEvent(event);
+
+   // work around a Qt 5.12 issue where windows don't render when first shown
+   // (they just appear as a blank screen until resized or prompted otherwise)
+#if QT_VERSION == QT_VERSION_CHECK(5, 12, 0)
+   QTimer::singleShot(0, [this]() {
+      resize(width() - 1, height() - 1);
+      resize(width() + 1, height() + 1);
+   });
+#endif
+
+}
+
 } // namespace desktop
 } // namespace rstudio

--- a/src/cpp/desktop/DesktopBrowserWindow.hpp
+++ b/src/cpp/desktop/DesktopBrowserWindow.hpp
@@ -55,6 +55,8 @@ public:
      WebPage* opener();
 
 protected:
+     void showEvent(QShowEvent* event) override;
+
      WebView* pView_;
      QToolBar* pToolbar_;
      QString getName();


### PR DESCRIPTION
This PR fixes an issue seen when building RStudio against Qt 5.12 RC, where windows are blank when first shown, and remain blank until resized.