### PR TITLE
Allow session URLs to work without trailing slashes

### DIFF
--- a/src/cpp/core/r_util/RSessionContext.cpp
+++ b/src/cpp/core/r_util/RSessionContext.cpp
@@ -244,7 +244,7 @@ void parseSessionUrl(const std::string& url,
                      std::string* pUrlPrefix,
                      std::string* pUrlWithoutPrefix)
 {
-   static boost::regex re("/s/([A-Fa-f0-9]{5})([A-Fa-f0-9]{8})([A-Fa-f0-9]{8})/?");
+   static boost::regex re("/s/([A-Fa-f0-9]{5})([A-Fa-f0-9]{8})([A-Fa-f0-9]{8})(/|$)");
 
    boost::smatch match;
    if (regex_utils::search(url, match, re))

--- a/src/cpp/core/r_util/RSessionContext.cpp
+++ b/src/cpp/core/r_util/RSessionContext.cpp
@@ -244,7 +244,7 @@ void parseSessionUrl(const std::string& url,
                      std::string* pUrlPrefix,
                      std::string* pUrlWithoutPrefix)
 {
-   static boost::regex re("/s/([A-Fa-f0-9]{5})([A-Fa-f0-9]{8})([A-Fa-f0-9]{8})/");
+   static boost::regex re("/s/([A-Fa-f0-9]{5})([A-Fa-f0-9]{8})([A-Fa-f0-9]{8})/?");
 
    boost::smatch match;
    if (regex_utils::search(url, match, re))


### PR DESCRIPTION
## Repro

1. Open an session on RStudio Server Pro
2. Remove the trailing slash from the URL, e.g. `https://rstudio-server.example/s/003f08241028fde4b4e02`
3. Open the new URL

## Result

This returns a 404. 

## Expected

This URL should work. We've found that some proxies strip trailing slashes from URLs (perhaps as a form of canonicalization?); these consequently don't work with Server Pro because it requires a trailing slash.

## Fix

This change fixes the issue by making the trailing slash optional (but only at the end of the URL). Targeted for 1.3 since messing with URL routing carries some risk.