### PR TITLE
Allow previewing SQL files without RSQLite

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -858,6 +858,27 @@ public class DependencyManager implements InstallShinyEvent.Handler,
         "DBI",
          userAction,
          new Dependency[] {
+            Dependency.cranPackage("DBI", "0.8")
+         },
+         true,
+         new CommandWithArg<Boolean>()
+        {
+           @Override
+           public void execute(Boolean succeeded)
+           {
+              if (succeeded)
+                 command.execute();
+           }
+        }
+      );
+   }
+
+   public void withRSQLite(String userAction, final Command command)
+   {
+      withDependencies(
+        "RSQLite",
+         userAction,
+         new Dependency[] {
             Dependency.cranPackage("DBI", "0.8"),
             Dependency.cranPackage("RSQLite", "2.1.0")
          },

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -1403,7 +1403,7 @@ public class Source implements InsertSourceHandler,
            @Override
            public void execute(EditingTarget target)
            {
-              target.verifySqlPrerequisites(); 
+              target.verifyNewSqlPrerequisites(); 
               target.setSourceOnSave(true);
            }
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
@@ -67,7 +67,7 @@ public interface EditingTarget extends IsWidget,
    void verifyCppPrerequisites();
    void verifyPythonPrerequisites();
    void verifyD3Prerequisites();
-   void verifySqlPrerequisites();
+   void verifyNewSqlPrerequisites();
 
    void focus();
    void onActivate();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
@@ -478,7 +478,7 @@ public class CodeBrowserEditingTarget implements EditingTarget
    }
 
    @Override
-   public void verifySqlPrerequisites()
+   public void verifyNewSqlPrerequisites()
    {
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -220,7 +220,7 @@ public class ProfilerEditingTarget implements EditingTarget,
    }
 
    @Override
-   public void verifySqlPrerequisites()
+   public void verifyNewSqlPrerequisites()
    {
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2151,12 +2151,12 @@ public class TextEditingTarget implements
    }
 
    @Override
-   public void verifySqlPrerequisites()
+   public void verifyNewSqlPrerequisites()
    {
-      verifyPreviewSqlPrerequisites(null);
+      verifyNewSqlPrerequisites(null);
    }
 
-   private void verifyPreviewSqlPrerequisites(final Command command) 
+   private void verifyNewSqlPrerequisites(final Command command) 
    {
       dependencyManager_.withRSQLite("Previewing SQL scripts", new Command() {
          @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2153,10 +2153,21 @@ public class TextEditingTarget implements
    @Override
    public void verifySqlPrerequisites()
    {
-      verifySqlPrequisites(null);
+      verifyPreviewSqlPrerequisites(null);
+   }
+
+   private void verifyPreviewSqlPrerequisites(final Command command) 
+   {
+      dependencyManager_.withRSQLite("Previewing SQL scripts", new Command() {
+         @Override
+         public void execute() {
+            if (command != null)
+               command.execute();
+         }
+      });
    }
    
-   private void verifySqlPrequisites(final Command command) 
+   private void verifySqlPrerequisites(final Command command) 
    {
       dependencyManager_.withDBI("Previewing SQL scripts", new Command() {
          @Override
@@ -5431,7 +5442,7 @@ public class TextEditingTarget implements
 
    void previewSql()
    {
-      verifySqlPrequisites(new Command() {
+      verifySqlPrerequisites(new Command() {
          @Override
          public void execute()
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
@@ -180,7 +180,7 @@ public class UrlContentEditingTarget implements EditingTarget
    }
 
    @Override
-   public void verifySqlPrerequisites()
+   public void verifyNewSqlPrerequisites()
    {
    }
       


### PR DESCRIPTION
I believe we need to split the Preview SQL dependencies into:
- Creating a SQL File: In this case, we want to suggest `DBI` and `RSQLite` for the preview to work.
- Previewing a SQL File: In this case, we don't really need `RSQLite` for the preview to work.

I hit this while using `sparklyr` in a cluster, which shouldn't need `RSQLite` installed, same for ODBC drivers, some users might actually have restrictions to install the `RSQLite` package so I don't think we should enforce this.