### PR TITLE
Use dbExecute() for SQLs that don't produce the results

### DIFF
--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -404,7 +404,10 @@
   # execute query -- when we are printing with an enforced max.print we
   # use dbFetch so as to only pull down the required number of records
   query <- interpolate_from_env(conn, sql)
-  if (is.null(varname) && max.print > 0 && !is_sql_update_query(query)) {
+  if (is_sql_update_query(query)) {
+    DBI::dbExecute(conn, query)
+    data <- NULL
+  } else if (is.null(varname) && max.print > 0) {
     res <- DBI::dbSendQuery(conn, query)
     data <- DBI::dbFetch(res, n = max.print)
     DBI::dbClearResult(res)
@@ -416,7 +419,7 @@
   if (!is.null(varname)) {
     assign(varname, data, envir = globalenv())
   }
-  else {
+  else if(!is.null(data)) {
     x <- data
     save(
       x, 

--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -342,7 +342,7 @@
       query <- gsub(".*\\*\\/", "", query)
     }
 
-    grepl("^\\s*(INSERT|UPDATE|DELETE|CREATE).*", query, ignore.case = TRUE)
+    grepl("^\\s*(INSERT|UPDATE|DELETE|CREATE|DROP).*", query, ignore.case = TRUE)
   }
 
   # precreate directories if needed


### PR DESCRIPTION
(Fixes yihui/knitr#1637)

Currently, RStudio always uses `dbFetch()` (directly or via `dbGetQuery()`) to execute SQLs, but it should use `dbExecute()` for SQLs that don't return result sets.

This PR brings the changes made on the same source code in knitr's repo.