### PR TITLE
rename jobs as "Session Jobs" in the UI

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -3298,14 +3298,14 @@ well as menu structures (for main menu and popup menus).
          windowMode="main"/>
 
     <cmd id="startJob"
-         menuLabel="Start Job..."
-         buttonLabel="Start Job"
+         menuLabel="Start Session Job..."
+         buttonLabel="Start Session Job"
          desc="Run a background job"
          windowMode="main"/>
 
     <cmd id="sourceAsJob"
-         menuLabel="Source as Job..."
-         desc="Run the current R script as a job"
+         menuLabel="Source as Session Job..."
+         desc="Run the current R script as a session job"
          windowMode="any"/>
 
     <cmd id="clearJobs"
@@ -3314,8 +3314,7 @@ well as menu structures (for main menu and popup menus).
          windowMode="main"/>
         
     <cmd id="runSelectionAsJob"
-         menuLabel="Run Selection as Job"
-         desc="Run the selected code as a job"
+         menuLabel="Run Selection as Session Job"
+         desc="Run the selected code as a session job"
          windowMode="any"/>
-        
 </commands>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobManager.java
@@ -415,7 +415,7 @@ public class JobManager implements JobRefreshEvent.Handler,
    
    private void showJobLauncherDialog(FileSystemItem path)
    {
-      JobLauncherDialog dialog = new JobLauncherDialog("Run Script as Job",
+      JobLauncherDialog dialog = new JobLauncherDialog("Run Script as Session Job",
             path.getName(),
             path,
             spec ->


### PR DESCRIPTION
RSP will have other types of jobs, and we want to make a clearer distinction between them in the UI.

The "Clear jobs" command will be going away, so not bothering to rename it.

Fixes #4001