### PR TITLE
Remove GPL notice in RStudio Pro

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.java
@@ -23,6 +23,7 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.InlineLabel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.TextArea;
@@ -59,13 +60,20 @@ public class AboutDialogContents extends Composite
       noticeBox.setValue(info.notice);
       productName.setText(editionInfo.editionName());
       
-      if (editionInfo.proLicense() && Desktop.isDesktop())
+      if (editionInfo.proLicense())
       {
-         noticeBox.setVisibleLines(9);
-         licenseBox.setVisibleLines(3);
-         licenseLabel.setVisible(true);
-         licenseBox.setVisible(true);
-         licenseBox.setText("Loading...");
+         // no need to show GPL notice in pro edition
+         gplNotice.setVisible(false);
+
+         if (Desktop.isDesktop())
+         {
+             // load license status in desktop mode
+             noticeBox.setVisibleLines(9);
+             licenseBox.setVisibleLines(3);
+             licenseLabel.setVisible(true);
+             licenseBox.setVisible(true);
+             licenseBox.setText("Loading...");
+         }
       }
    }
    
@@ -85,6 +93,7 @@ public class AboutDialogContents extends Composite
    @UiField InlineLabel userAgentLabel;
    @UiField InlineLabel buildLabel;
    @UiField TextArea noticeBox;
+   @UiField HTMLPanel gplNotice;
    @UiField Label licenseLabel;
    @UiField TextArea licenseBox;
    @UiField Label productName;

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.ui.xml
@@ -93,11 +93,13 @@
 		<g:HTMLPanel styleName="{style.userAgent}">
 			<g:InlineLabel ui:field="userAgentLabel"></g:InlineLabel>
 		</g:HTMLPanel>
-		<g:InlineLabel
-			text="Unless you have received this program directly from RStudio pursuant to the terms of a commercial license agreement with RStudio, then this program is licensed to you under the terms of version 3 of the GNU"></g:InlineLabel>
-		<g:Anchor href="http://www.gnu.org/licenses/agpl-3.0.txt"
-			text="Affero General Public License."
-			target="_blank"></g:Anchor>
+		<g:HTMLPanel ui:field="gplNotice">
+			<g:InlineLabel
+				text="Unless you have received this program directly from RStudio pursuant to the terms of a commercial license agreement with RStudio, then this program is licensed to you under the terms of version 3 of the GNU"></g:InlineLabel>
+			<g:Anchor href="http://www.gnu.org/licenses/agpl-3.0.txt"
+				text="Affero General Public License."
+				target="_blank"></g:Anchor>
+		</g:HTMLPanel>
 		<g:TextArea ui:field="noticeBox" styleName="{style.noticeBox}"
 			visibleLines="15" readOnly="true"></g:TextArea>
 		<g:Label ui:field="licenseLabel" visible="false" text="RStudio Pro License Status" styleName="{style.licenseLabel}"></g:Label>
@@ -106,3 +108,4 @@
 
 	</g:HTMLPanel>
 </ui:UiBinder> 
+


### PR DESCRIPTION
The Help -> About dialog currently has a paragraph that opens:

>  Unless you have received this program directly from RStudio pursuant to the terms of a commercial license agreement...

This is redundant in RStudio Pro, since it is by definition received directly from RStudio pursuant to the terms of a commercial license agreement. 