### PR TITLE
Update to rsconnect 0.8.12

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -224,7 +224,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       if (requiresRmarkdown)
          deps.addAll(rmarkdownDependencies());
       deps.add(Dependency.cranPackage("packrat", "0.4.8-1", true));
-      deps.add(Dependency.cranPackage("rsconnect", "0.8.11"));
+      deps.add(Dependency.cranPackage("rsconnect", "0.8.12"));
       
       withDependencies(
         "Publishing",


### PR DESCRIPTION
This change picks up a new version of the rsconnect package. The previous version had a bug which affected a small portion of users on HTTP/2. 

Fixes #3947.