### PR TITLE
Set drag enabled state from preference

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -1148,12 +1148,7 @@ public class AceEditorWidget extends Composite
    
    public void setDragEnabled(boolean enabled)
    {
-      // the ACE API currently provides no way to disable dropping text 
-      // from external sources specifically (the dragEnabled option affects
-      // only internal ACE dragging); for now, just put the whole editor into
-      // read-only mode while dragging, which prevents it from accepting the
-      // text 
-      editor_.setReadOnly(!enabled);
+      editor_.setDragEnabled(enabled);
    }
    
    public LineWidgetManager getLineWidgetManager()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -816,12 +816,10 @@ public class TextEditingTarget implements
                   boolean enabled = e.getState() == 
                         DocTabDragStateChangedEvent.STATE_NONE;
                   
-                  // disable drag/drop if disabled in preferences
-                  if (enabled)
-                     enabled = prefs.enableTextDrag().getValue();
-                  
-                  // update editor surface
-                  docDisplay_.setDragEnabled(enabled);
+                  // make editor read only while we're dragging and dropping
+                  // tabs; otherwise the editor surface will accept a tab drop
+                  // as text
+                  docDisplay_.setReadOnly(!enabled);
                }
             });
       


### PR DESCRIPTION
The "Enable drag and drop of text" preference -- intended to disable the text drag and drop feature of Ace that some users find annoying -- actually makes the whole editor surface read-only. This change makes it affect only text drag and drop. 

Fixes #3992. 