### PR TITLE
systemd: Require network-online.target in the [Unit] section

### DIFF
--- a/src/cpp/server/extras/systemd/rstudio-server.redhat.service.in
+++ b/src/cpp/server/extras/systemd/rstudio-server.redhat.service.in
@@ -1,5 +1,7 @@
 [Unit]
 Description=RStudio Server
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=forking

--- a/src/cpp/server/extras/systemd/rstudio-server.service.in
+++ b/src/cpp/server/extras/systemd/rstudio-server.service.in
@@ -1,5 +1,7 @@
 [Unit]
 Description=RStudio Server
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
At my organization, during a reboot of one of our RStudio hosts (the load balancer), we encountered a race condition where the server would not be able to resolve hosts defined as load balancing targets, and would therefore fail to ~start~ load balance to hosts it was supposed to.

Can't the RStudio unit just be configured to use `network-online.target`, and refuse to start if that is not the case? I could see potential issues with e.g. running on a system that is not online, but at the same time it seems like this makes a lot more sense.  That is what this PR does.