### PR TITLE
Add More menu to Jobs pane with new Hide Completed Jobs toggle

### DIFF
--- a/src/cpp/session/include/session/jobs/Job.hpp
+++ b/src/cpp/session/include/session/jobs/Job.hpp
@@ -44,8 +44,8 @@ enum JobState {
 
 enum JobType {
    JobTypeUnknown = 0,
-   JobTypeSession = 1,
-   JobTypeLauncher = 2
+   JobTypeSession = 1, // local job, child of rsession
+   JobTypeLauncher = 2 // cluster job via job launcher
 };
 
 class Job

--- a/src/cpp/session/include/session/jobs/JobsApi.hpp
+++ b/src/cpp/session/include/session/jobs/JobsApi.hpp
@@ -74,13 +74,13 @@ core::json::Object jobsAsJson();
 
 void removeAllJobs();
 
-void removeAllLocalJobs();
+void removeAllSessionJobs();
 
-void removeCompletedJobs();
+void removeCompletedSessionJobs();
 
 void endAllJobStreaming();
 
-bool localJobsRunning();
+bool sessionJobsRunning();
 
 } // namespace jobs
 } // namespace modules

--- a/src/cpp/session/include/session/jobs/JobsApi.hpp
+++ b/src/cpp/session/include/session/jobs/JobsApi.hpp
@@ -74,13 +74,13 @@ core::json::Object jobsAsJson();
 
 void removeAllJobs();
 
-void removeAllSessionJobs();
+void removeAllLocalJobs();
 
-void removeCompletedSessionJobs();
+void removeCompletedLocalJobs();
 
 void endAllJobStreaming();
 
-bool sessionJobsRunning();
+bool localJobsRunning();
 
 } // namespace jobs
 } // namespace modules

--- a/src/cpp/session/modules/jobs/JobsApi.cpp
+++ b/src/cpp/session/modules/jobs/JobsApi.cpp
@@ -180,7 +180,7 @@ void removeAllJobs()
    s_jobs.clear();
 }
 
-void removeAllSessionJobs()
+void removeAllLocalJobs()
 {
    for (auto it = s_jobs.cbegin(); it != s_jobs.cend() ; )
    {
@@ -195,7 +195,7 @@ void removeAllSessionJobs()
    }
 }
 
-void removeCompletedSessionJobs()
+void removeCompletedLocalJobs()
 {
    // collect completed jobs
    std::vector<boost::shared_ptr<Job> > completed;
@@ -220,7 +220,7 @@ void endAllJobStreaming()
    }
 }
 
-bool sessionJobsRunning()
+bool localJobsRunning()
 {
    for (auto& job: s_jobs)
    {

--- a/src/cpp/session/modules/jobs/JobsApi.cpp
+++ b/src/cpp/session/modules/jobs/JobsApi.cpp
@@ -180,7 +180,7 @@ void removeAllJobs()
    s_jobs.clear();
 }
 
-void removeAllLocalJobs()
+void removeAllSessionJobs()
 {
    for (auto it = s_jobs.cbegin(); it != s_jobs.cend() ; )
    {
@@ -195,13 +195,13 @@ void removeAllLocalJobs()
    }
 }
 
-void removeCompletedJobs()
+void removeCompletedSessionJobs()
 {
    // collect completed jobs
    std::vector<boost::shared_ptr<Job> > completed;
    for (auto& job: s_jobs)
    {
-      if (job.second->complete())
+      if (job.second->complete() && job.second->type() == JobType::JobTypeSession)
          completed.push_back(job.second);
    }
 
@@ -220,7 +220,7 @@ void endAllJobStreaming()
    }
 }
 
-bool localJobsRunning()
+bool sessionJobsRunning()
 {
    for (auto& job: s_jobs)
    {

--- a/src/cpp/session/modules/jobs/SessionJobs.cpp
+++ b/src/cpp/session/modules/jobs/SessionJobs.cpp
@@ -342,7 +342,7 @@ Error runScriptJob(const json::JsonRpcRequest& request,
 Error clearJobs(const json::JsonRpcRequest& request,
                       json::JsonRpcResponse* pResponse)
 {
-   removeCompletedSessionJobs();
+   removeCompletedLocalJobs();
    return Success();
 }
 
@@ -396,7 +396,7 @@ Error executeJobAction(const json::JsonRpcRequest& request,
 
 void onSuspend(const r::session::RSuspendOptions&, core::Settings*)
 {
-   removeAllSessionJobs();
+   removeAllLocalJobs();
 }
 
 void onResume(const Settings& settings)
@@ -414,7 +414,7 @@ void onClientInit()
 
 void onShutdown(bool terminatedNormally)
 {
-   removeAllSessionJobs();
+   removeAllLocalJobs();
 }
 
 } // anonymous namespace
@@ -427,7 +427,7 @@ core::json::Object jobState()
 bool isSuspendable()
 {
    // don't suspend while we're running session jobs
-   return !sessionJobsRunning();
+   return !localJobsRunning();
 }
 
 core::Error initialize()

--- a/src/cpp/session/modules/jobs/SessionJobs.cpp
+++ b/src/cpp/session/modules/jobs/SessionJobs.cpp
@@ -340,7 +340,7 @@ Error runScriptJob(const json::JsonRpcRequest& request,
 Error clearJobs(const json::JsonRpcRequest& request,
                       json::JsonRpcResponse* pResponse)
 {
-   removeCompletedJobs();
+   removeCompletedSessionJobs();
    return Success();
 }
 
@@ -401,7 +401,7 @@ Error executeJobAction(const json::JsonRpcRequest& request,
 
 void onSuspend(const r::session::RSuspendOptions&, core::Settings*)
 {
-   removeAllLocalJobs();
+   removeAllSessionJobs();
 }
 
 void onResume(const Settings& settings)
@@ -419,7 +419,7 @@ void onClientInit()
 
 void onShutdown(bool terminatedNormally)
 {
-   removeAllLocalJobs();
+   removeAllSessionJobs();
 }
 
 } // anonymous namespace
@@ -431,8 +431,8 @@ core::json::Object jobState()
 
 bool isSuspendable()
 {
-   // don't suspend while we're running local jobs
-   return !localJobsRunning();
+   // don't suspend while we're running session jobs
+   return !sessionJobsRunning();
 }
 
 core::Error initialize()

--- a/src/cpp/session/modules/jobs/SessionJobs.cpp
+++ b/src/cpp/session/modules/jobs/SessionJobs.cpp
@@ -426,7 +426,7 @@ core::json::Object jobState()
 
 bool isSuspendable()
 {
-   // don't suspend while we're running session jobs
+   // don't suspend while we're running local jobs
    return !localJobsRunning();
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
@@ -110,6 +110,7 @@ import org.rstudio.studio.client.workbench.views.console.shell.assist.HelpStrate
 import org.rstudio.studio.client.workbench.views.console.shell.assist.PythonCompletionManager;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.RCompletionManager;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobManager;
+import org.rstudio.studio.client.workbench.views.jobs.view.JobsList;
 import org.rstudio.studio.client.workbench.views.output.lint.LintManager;
 import org.rstudio.studio.client.workbench.views.packages.ui.CheckForUpdatesDialog;
 import org.rstudio.studio.client.workbench.views.source.DocsMenu;
@@ -273,6 +274,7 @@ public interface RStudioGinjector extends Ginjector
    void injectMembers(SecondaryReposWidget widget);
    void injectMembers(SecondaryReposDialog widget);
    void injectMembers(CheckForUpdatesDialog dialog);
+   void injectMembers(JobsList widget);
    
    public static final RStudioGinjector INSTANCE = GWT.create(RStudioGinjector.class);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -3322,7 +3322,7 @@ well as menu structures (for main menu and popup menus).
 
     <cmd id="hideCompletedJobs"
          checkable="true"
-         menuLabel="Hide Completed Jobs"
-         desc="Hide all completed jobs"
+         menuLabel="Hide Previously Completed Jobs"
+         desc="Hide all previously completed jobs"
          windowMode="main"/>
  </commands>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -458,8 +458,8 @@ well as menu structures (for main menu and popup menus).
           </menu>
          <menu label="_Jobs">
             <cmd refid="startJob"/>
-            <separator/>
             <cmd refid="clearJobs"/>
+            <separator/>
             <cmd refid="hideCompletedJobs"/>
           </menu>
          <menu label="Addins">
@@ -3300,24 +3300,24 @@ well as menu structures (for main menu and popup menus).
          windowMode="main"/>
 
     <cmd id="startJob"
-         menuLabel="Start Session Job..."
-         buttonLabel="Start Session Job"
-         desc="Run a background session job"
+         menuLabel="Start Local Job..."
+         buttonLabel="Start Local Job"
+         desc="Run a background local job"
          windowMode="main"/>
 
     <cmd id="sourceAsJob"
-         menuLabel="Source as Session Job..."
-         desc="Run the current R script as a session job"
+         menuLabel="Source as Local Job..."
+         desc="Run the current R script as a local job"
          windowMode="any"/>
 
     <cmd id="clearJobs"
-         menuLabel="Clear Session Jobs"
-         desc="Clean up all completed session jobs"
+         menuLabel="Clear Local Jobs"
+         desc="Clean up all completed local jobs"
          windowMode="main"/>
         
     <cmd id="runSelectionAsJob"
-         menuLabel="Run Selection as Session Job"
-         desc="Run the selected code as a session job"
+         menuLabel="Run Selection as Local Job"
+         desc="Run the selected code as a local job"
          windowMode="any"/>
 
     <cmd id="hideCompletedJobs"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -458,7 +458,9 @@ well as menu structures (for main menu and popup menus).
           </menu>
          <menu label="_Jobs">
             <cmd refid="startJob"/>
+            <separator/>
             <cmd refid="clearJobs"/>
+            <cmd refid="hideCompletedJobs"/>
           </menu>
          <menu label="Addins">
             <cmd refid="browseAddins"/>
@@ -3300,7 +3302,7 @@ well as menu structures (for main menu and popup menus).
     <cmd id="startJob"
          menuLabel="Start Session Job..."
          buttonLabel="Start Session Job"
-         desc="Run a background job"
+         desc="Run a background session job"
          windowMode="main"/>
 
     <cmd id="sourceAsJob"
@@ -3309,12 +3311,18 @@ well as menu structures (for main menu and popup menus).
          windowMode="any"/>
 
     <cmd id="clearJobs"
-         menuLabel="Clear Jobs"
-         desc="Clean up all completed jobs"
+         menuLabel="Clear Session Jobs"
+         desc="Clean up all completed session jobs"
          windowMode="main"/>
         
     <cmd id="runSelectionAsJob"
          menuLabel="Run Selection as Session Job"
          desc="Run the selected code as a session job"
          windowMode="any"/>
-</commands>
+
+    <cmd id="hideCompletedJobs"
+         checkable="true"
+         menuLabel="Hide Completed Jobs"
+         desc="Hide all completed jobs"
+         windowMode="main"/>
+ </commands>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -570,6 +570,7 @@ public abstract class
    public abstract AppCommand clearJobs();
    public abstract AppCommand activateJobs();
    public abstract AppCommand runSelectionAsJob();
+   public abstract AppCommand hideCompletedJobs();
 
    // Other
    public abstract AppCommand checkSpelling();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -688,6 +688,11 @@ public class UIPrefsAccessor extends Prefs
       return bool("show_jobs_tab", true);
    }
    
+   public PrefValue<Boolean> hideCompletedJobs()
+   {
+      return bool("hide_completed_jobs", false);
+   }
+   
    public static final int BUSY_DETECT_ALWAYS = 0;
    public static final int BUSY_DETECT_NEVER = 1;
    public static final int BUSY_DETECT_WHITELIST = 2;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobsPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobsPresenter.java
@@ -65,6 +65,7 @@ public class JobsPresenter extends BasePresenter
       void syncElapsedTime(int timestamp);
       void bringToFront();
       void setShowJobsTabPref(boolean show);
+      void refreshPaneStatusMessage();
    }
    
    public interface Binder extends CommandBinder<Commands, JobsPresenter> {}
@@ -94,6 +95,7 @@ public class JobsPresenter extends BasePresenter
       // register handler for hide completed jobs pref
       uiPrefs_.hideCompletedJobs().addValueChangeHandler(hide ->
       {
+         display_.refreshPaneStatusMessage();
          commands_.hideCompletedJobs().setChecked(hide.getValue());
       });
     }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobsPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobsPresenter.java
@@ -178,11 +178,11 @@ public class JobsPresenter extends BasePresenter
       if (running > 0)
       {
          globalDisplay_.showMessage(GlobalDisplay.MSG_INFO, 
-               "Jobs Still Running", 
+               "Local Jobs Still Running", 
                "The Jobs tab cannot be closed while there " +
                (running > 1 ?
-                  "are unfinished jobs" : "is an unfinished job") + "." +
-               "\n\nWait until all jobs have completed.");
+                  "are unfinished local jobs" : "is an unfinished local job") + "." +
+               "\n\nWait until all local jobs have completed.");
          return;
       }
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobsPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobsPresenter.java
@@ -204,7 +204,6 @@ public class JobsPresenter extends BasePresenter
    {
       boolean newValue = !uiPrefs_.hideCompletedJobs().getValue();
       uiPrefs_.hideCompletedJobs().setGlobalValue(newValue);
-      commands_.hideCompletedJobs().setChecked(newValue);
       uiPrefs_.writeUIPrefs();
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobConstants.java
@@ -34,9 +34,8 @@ public class JobConstants
    
    // job types
    public final static int JOB_TYPE_UNKNOWN = 0;
-   public final static int JOB_TYPE_SESSION = 1;
-   public final static int JOB_TYPE_LAUNCHER = 2;
-   
+   public final static int JOB_TYPE_SESSION = 1; // local job, child of rsession
+   public final static int JOB_TYPE_LAUNCHER = 2; // cluster job via job launcher
    
    public final static String stateDescription(int state)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobManager.java
@@ -187,8 +187,8 @@ public class JobManager implements JobRefreshEvent.Handler,
    {
       display_.showYesNoMessage(
             GlobalDisplay.MSG_QUESTION, 
-            "Remove Completed Session Jobs",
-            "Do you want to remove completed session jobs from the list of jobs?\n\nYou can't undo this.",
+            "Remove Completed Local Jobs",
+            "Are you sure you want to remove completed local jobs from the list of jobs?\n\nOnce removed, local jobs cannot be recovered.",
             false, // include cancel
             () ->  server_.clearJobs(new VoidServerRequestCallback()),
             null,  // do nothing on No

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobManager.java
@@ -187,8 +187,8 @@ public class JobManager implements JobRefreshEvent.Handler,
    {
       display_.showYesNoMessage(
             GlobalDisplay.MSG_QUESTION, 
-            "Remove Completed Jobs", 
-            "Do you want to remove completed jobs from the list of jobs?\n\nYou can't undo this.", 
+            "Remove Completed Session Jobs",
+            "Do you want to remove completed session jobs from the list of jobs?\n\nYou can't undo this.",
             false, // include cancel
             () ->  server_.clearJobs(new VoidServerRequestCallback()),
             null,  // do nothing on No

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobManager.java
@@ -415,7 +415,7 @@ public class JobManager implements JobRefreshEvent.Handler,
    
    private void showJobLauncherDialog(FileSystemItem path)
    {
-      JobLauncherDialog dialog = new JobLauncherDialog("Run Script as Session Job",
+      JobLauncherDialog dialog = new JobLauncherDialog("Run Script as Local Job",
             path.getName(),
             path,
             spec ->

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsList.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.jobs.model.Job;
 
 import com.google.gwt.core.client.GWT;
@@ -28,6 +29,7 @@ import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.ScrollPanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
+import com.google.inject.Inject;
 
 public class JobsList extends Composite
 {
@@ -39,11 +41,38 @@ public class JobsList extends Composite
 
    public JobsList()
    {
+      RStudioGinjector.INSTANCE.injectMembers(this);
+      
       jobs_ = new HashMap<String, JobItem>();
 
       initWidget(uiBinder.createAndBindUi(this));
+      
+      // register handler for hide completed jobs pref
+      uiPrefs_.hideCompletedJobs().addValueChangeHandler(hide ->
+      {
+         if (list_ == null)
+            return;
 
+         for (Widget widget : list_)
+         {
+            if (widget instanceof JobItem)
+            {
+               JobItem item = (JobItem) widget;
+               if (item.getJob().completed != 0)
+               {
+                  item.setVisible(!hide.getValue());
+               }
+            }
+         }
+      });
+ 
       updateVisibility();
+   }
+   
+   @Inject
+   private void initialize(UIPrefs uiPrefs)
+   {
+      uiPrefs_ = uiPrefs;
    }
    
    @Override
@@ -130,4 +159,7 @@ public class JobsList extends Composite
    @UiField ScrollPanel scroll_;
 
    private final Map<String, JobItem> jobs_;
+   
+   // Injected ----
+   UIPrefs uiPrefs_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsPane.java
@@ -304,7 +304,6 @@ public class JobsPane extends WorkbenchPane
       StandardIcons icons = StandardIcons.INSTANCE;
       ToolbarPopupMenu moreMenu = new ToolbarPopupMenu();
       moreMenu.addItem(commands_.clearJobs().createMenuItem(false));
-      moreMenu.addSeparator();
       moreMenu.addItem(new UIPrefMenuItem<Boolean>(
             uiPrefs_.hideCompletedJobs(), true, "Hide Completed Jobs", uiPrefs_));
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsPane.java
@@ -13,7 +13,9 @@
  *
  */
 package org.rstudio.studio.client.workbench.views.jobs.view;
+import com.google.gwt.user.client.ui.Label;
 import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.core.client.widget.UIPrefMenuItem;
 import org.rstudio.studio.client.common.icons.StandardIcons;
@@ -263,6 +265,12 @@ public class JobsPane extends WorkbenchPane
          uiPrefs_.writeUIPrefs();
       }
    }
+   
+   @Override
+   public void refreshPaneStatusMessage()
+   {
+      paneStatus_.setText(uiPrefs_.hideCompletedJobs().getValue() ? "(previously completed jobs hidden)" : "");
+   }
 
    // Private methods ---------------------------------------------------------
    
@@ -305,13 +313,19 @@ public class JobsPane extends WorkbenchPane
       ToolbarPopupMenu moreMenu = new ToolbarPopupMenu();
       moreMenu.addItem(commands_.clearJobs().createMenuItem(false));
       moreMenu.addItem(new UIPrefMenuItem<Boolean>(
-            uiPrefs_.hideCompletedJobs(), true, "Hide Completed Jobs", uiPrefs_));
+            uiPrefs_.hideCompletedJobs(), true, "Hide Previously Completed Jobs", uiPrefs_));
       
       ToolbarButton moreButton = new ToolbarButton("More",
                                                   new ImageResource2x(icons.more_actions2x()),
                                                   moreMenu);
 
       toolbar_.addLeftWidget(moreButton);
+      
+      toolbar_.addLeftSeparator();
+      paneStatus_ = new Label();
+      paneStatus_.setStyleName(ThemeStyles.INSTANCE.subtitle());
+      toolbar_.addLeftWidget(paneStatus_);
+      refreshPaneStatusMessage();
       progress_ = null;
    }
 
@@ -321,6 +335,7 @@ public class JobsPane extends WorkbenchPane
    private SlidingLayoutPanel panel_;
    private final Toolbar toolbar_;
    private final ToolbarButton allJobs_;
+   private Label paneStatus_;
    private JobProgress progress_;
 
    // internal state

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsPane.java
@@ -13,13 +13,16 @@
  *
  */
 package org.rstudio.studio.client.workbench.views.jobs.view;
+import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.core.client.widget.ToolbarPopupMenu;
+import org.rstudio.core.client.widget.UIPrefMenuItem;
+import org.rstudio.studio.client.common.icons.StandardIcons;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.jobs.JobsPresenter;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobSelectionEvent;
 import org.rstudio.studio.client.workbench.views.jobs.model.Job;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobConstants;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobOutput;
-import org.rstudio.studio.client.workbench.views.jobs.model.LocalJobProgress;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -296,7 +299,20 @@ public class JobsPane extends WorkbenchPane
       toolbar_.removeAllWidgets();
       toolbar_.addLeftWidget(commands_.startJob().createToolbarButton());
       toolbar_.addLeftSeparator();
-      toolbar_.addLeftWidget(commands_.clearJobs().createToolbarButton());
+
+      // More
+      StandardIcons icons = StandardIcons.INSTANCE;
+      ToolbarPopupMenu moreMenu = new ToolbarPopupMenu();
+      moreMenu.addItem(commands_.clearJobs().createMenuItem(false));
+      moreMenu.addSeparator();
+      moreMenu.addItem(new UIPrefMenuItem<Boolean>(
+            uiPrefs_.hideCompletedJobs(), true, "Hide Completed Jobs", uiPrefs_));
+      
+      ToolbarButton moreButton = new ToolbarButton("More",
+                                                  new ImageResource2x(icons.more_actions2x()),
+                                                  moreMenu);
+
+      toolbar_.addLeftWidget(moreButton);
       progress_ = null;
    }
 


### PR DESCRIPTION
Fixes #4005 
Fixes #4001 

This now includes renaming various UI from "Session Jobs" to "Local Jobs", which we decided makes more sense for users, and softened the language a bit in the "remove local jobs" confirmation dialog.

New **Hide Previously Completed Jobs** command shows up on More dropdown in Jobs pane, and Tools / Job menu. It is a toggle, with a persistent boolean pref. "Previously Completed" refers to fact that jobs which finish after the option is toggled on will remain visible. Otherwise running jobs would disappear from the pane as they complete. Also added a status message that appears at the top of the Jobs Pane when showing the list of jobs, indicating when the "Hide Jobs" toggle is on. I imagine we might add additional job sorting/filtering commands to this More dropdown in the future.

Made existing Clear Jobs command only delete local jobs, since non-local jobs will come back (they are not owned by the session).

![2018-12-06_14-09-07](https://user-images.githubusercontent.com/10569626/49614866-85193b00-f960-11e8-801f-bb393e71c1f1.png)

![2018-12-06_14-09-43](https://user-images.githubusercontent.com/10569626/49614885-97937480-f960-11e8-911b-49069561e063.png)

![2018-12-06_14-10-20](https://user-images.githubusercontent.com/10569626/49614905-ada13500-f960-11e8-9f55-83a3fbfbb13f.png)

![2018-12-06_14-12-03](https://user-images.githubusercontent.com/10569626/49614981-f8bb4800-f960-11e8-8cd5-0e169d332c5c.png)

![2018-12-06_14-11-46](https://user-images.githubusercontent.com/10569626/49615005-0375dd00-f961-11e8-915e-c38d7ae12bfa.png)

![2018-12-06_14-13-19](https://user-images.githubusercontent.com/10569626/49615033-1b4d6100-f961-11e8-9f1a-1b5d861e2c18.png)
