### PR TITLE
Reapply theme after chunk HTML widgets load

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkHtmlPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkHtmlPage.java
@@ -1,7 +1,7 @@
 /*
  * ChunkHtmlPage.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -24,6 +24,7 @@ import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -105,7 +106,14 @@ public class ChunkHtmlPage extends ChunkOutputPage
          }
       };
 
-      frame_.runAfterRender(afterRender_);
+      Event.sinkEvents(frame_.getElement(), Event.ONLOAD);
+      Event.setEventListener(frame_.getElement(), e ->
+      {
+         if (Event.ONLOAD == e.getTypeInt() && themeColors_ != null)
+         {
+            afterRender_.execute();
+         }
+      });
    }
    
    public static void syncThemeTextColor(Colors themeColors, Element body)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -1,7 +1,7 @@
 /*
  * ChunkOutputStream.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -42,6 +42,7 @@ import com.google.gwt.dom.client.Style.Overflow;
 import com.google.gwt.dom.client.Style.Position;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Widget;
@@ -256,16 +257,22 @@ public class ChunkOutputStream extends FlowPanel
       });
 
       themeColors_ = ChunkOutputWidget.getEditorColors();
-      afterRender_ = new Command()
+      
+      afterRender_ = () -> 
       {
-         @Override
-         public void execute()
-         {
-            ChunkHtmlPage.syncThemeTextColor(themeColors_, frame.getDocument().getBody());
-         }
+         ChunkHtmlPage.syncThemeTextColor(themeColors_, frame.getDocument().getBody());
       };
 
-      frame.runAfterRender(afterRender_);
+      // when the frame loads, sync its text color -- note that a frame may load
+      // more than once as it's reloaded if gets moved around in the DOM
+      Event.sinkEvents(frame.getElement(), Event.ONLOAD);
+      Event.setEventListener(frame.getElement(), e ->
+      {
+         if (Event.ONLOAD == e.getTypeInt())
+         {
+            afterRender_.execute();
+         }
+      });
    }
 
    @Override


### PR DESCRIPTION
After HTML widgets load in R Notebooks, we inject a few key theme colors into them so that they match the editor theme. 

However, when HTML widgets in chunks are detached and reattached to another point in the DOM, the `<iframe>` reloads its URL. We don't currently have a mechanism to detect this, so the newly reloaded page doesn't get its styles re-injected, and looks unthemed.

This change fixes that by reapplying colors every time the frame loads its URL.

Fixes #3882. 