### PR TITLE
upgrade to Qt 5.12.0

### DIFF
--- a/dependencies/common/install-boost
+++ b/dependencies/common/install-boost
@@ -87,8 +87,8 @@ then
    if [ "$PLATFORM" == "Darwin" ]
    then
 
-     BJAM_CXXFLAGS="cxxflags=-fPIC -std=c++11"
-     BJAM_LDFLAGS=""     
+     BJAM_CXXFLAGS="cxxflags=-fPIC -std=c++11 -mmacosx-version-min=10.12"
+     BJAM_LDFLAGS=""
 
      sudo ./bjam              \
         "${BOOST_BJAM_FLAGS}" \

--- a/dependencies/linux/README
+++ b/dependencies/linux/README
@@ -9,22 +9,22 @@ systems. Specific version requirements for various components include:
 - R 3.0.1
 - CMake 2.8 (3.1.0 for Desktop)
 - Boost 1.63
-- Qt 5.11.1 [Required only for Desktop]
+- Qt 5.12.0 [Required only for Desktop]
 - some older Linux platforms (OpenSUSE 42.3, Ubuntu Trusty) can only
-  build Desktop with Qt 5.10.1 due to unsatisfied dependencies in 5.11.1
+  build Desktop with Qt 5.10.1 due to unsatisfied dependencies in 5.12.0
 
-Installation of Qt SDK 5.11.1
+Installation of Qt SDK 5.12.0
 =============================================================================
 
-RStudio Desktop requires Qt 5.11.1. The install-dependencies scripts 
-referenced below install a version of the Qt 5.11.1 SDK into 
+RStudio Desktop requires Qt 5.12.0. The install-dependencies scripts 
+referenced below install a version of the Qt 5.12.0 SDK into 
 /opt/RStudio-QtSDK (the special RStudio prefix on the directory is included 
 so this installation doesn't conflict with any other versions of Qt installed 
 on the system).
 
 If you are either building RStudio Server or running a Linux distribution 
-that already includes Qt 5.11.1 you may wish to prevent installation of the
-Qt 5.11.1 SDK. To do this pass the --exclude-qt-sdk flag to the install 
+that already includes Qt 5.12.0 you may wish to prevent installation of the
+Qt 5.12.0 SDK. To do this pass the --exclude-qt-sdk flag to the install 
 dependencies script, for example:
 
 ./install-dependencies-debian --exclude-qt-sdk
@@ -44,7 +44,7 @@ installing it using the system standard package management tools (apt-get,
 yum, etc).
 
 2) Run the install-dependencies script appropriate to your platform's
-package management system (to optionally exclude installation of the Qt 5.11.1
+package management system (to optionally exclude installation of the Qt 5.12.0
 SDK be sure to specify the --exclude-qt-sdk flag as described above).
 
    ./install-dependencies-debian  
@@ -76,7 +76,7 @@ Hunspell dictionaries, MathJax, and Boost 1.63):
          install-common
 
 3) Optionally install the Qt SDK. You should do this if you are building the
-Desktop version and don't have Qt 5.11.1 installed on the system:
+Desktop version and don't have Qt 5.12.0 installed on the system:
 
    dependencies
       linux

--- a/dependencies/linux/install-qt-sdk
+++ b/dependencies/linux/install-qt-sdk
@@ -21,7 +21,7 @@ if [ -z "$QT_SDK_BINARY" ]; then
     QT_SDK_BINARY=qt-unified-linux-x64-3.0.5-online.run
 fi
 if [ -z "$QT_PACKAGES" ]; then
-    QT_PACKAGES=qt.qt5.5111.gcc_64,qt.qt5.5111.qtwebengine,qt.qt5.5111.qtwebengine.gcc_64
+    QT_PACKAGES=qt.qt5.5120.gcc_64,qt.qt5.5120.qtwebengine,qt.qt5.5120.qtwebengine.gcc_64
 fi
 if [ -z "$QT_SDK_CUSTOM" ]; then
     echo Using online Qt installer

--- a/dependencies/linux/install-qt-sdk
+++ b/dependencies/linux/install-qt-sdk
@@ -15,7 +15,7 @@
 #
 
 if [ -z "$QT_VERSION" ]; then
-    QT_VERSION=5.11.1
+    QT_VERSION=5.12.0
 fi
 if [ -z "$QT_SDK_BINARY" ]; then
     QT_SDK_BINARY=qt-unified-linux-x64-3.0.5-online.run

--- a/dependencies/osx/install-qt-sdk-osx
+++ b/dependencies/osx/install-qt-sdk-osx
@@ -65,10 +65,10 @@ Controller.prototype.TargetDirectoryPageCallback = function()
 Controller.prototype.ComponentSelectionPageCallback = function() {
     var widget = gui.currentPageWidget();
      
-    widget.selectComponent("qt.qt5.5111.clang_64");
-    widget.selectComponent("qt.qt5.5111.qtwebengine");
-    widget.selectComponent("qt.qt5.5111.qtwebengine.clang_64");
-    widget.deselectComponent("qt.qt5.5111.src");
+    widget.selectComponent("qt.qt5.5120.clang_64");
+    widget.selectComponent("qt.qt5.5120.qtwebengine");
+    widget.selectComponent("qt.qt5.5120.qtwebengine.clang_64");
+    widget.deselectComponent("qt.qt5.5120.src");
     gui.clickButton(buttons.NextButton);
 }
 

--- a/dependencies/osx/install-qt-sdk-osx
+++ b/dependencies/osx/install-qt-sdk-osx
@@ -18,7 +18,7 @@
 # Installs Qt via the online installer at the location in $QT_SDK_DIR.
 # If no location provided, checks against a set of common locations and installs if not found.
 
-QT_VERSION=5.11.1
+QT_VERSION=5.12.0
 QT_SDK_BINARY_BASE=qt-unified-mac-x64-3.0.5-online
 QT_SDK_BINARY=${QT_SDK_BINARY_BASE}.tar.gz
 QT_SDK_INSTALLER=${QT_SDK_BINARY_BASE}.app

--- a/dependencies/windows/install-qt-sdk-win.cmd
+++ b/dependencies/windows/install-qt-sdk-win.cmd
@@ -2,7 +2,7 @@
 
 setlocal EnableDelayedExpansion
 
-set QT_VERSION=5.11.1
+set QT_VERSION=5.12.0
 set QT_SDK_BINARY=qt-unified-windows-x86-3.0.5-online.exe
 set QT_SDK_URL=https://s3.amazonaws.com/rstudio-buildtools/%QT_SDK_BINARY%
 set QT_SCRIPT=qt-noninteractive-install-win.qs

--- a/dependencies/windows/qt-noninteractive-install-win.qs
+++ b/dependencies/windows/qt-noninteractive-install-win.qs
@@ -30,10 +30,10 @@ Controller.prototype.TargetDirectoryPageCallback = function()
 Controller.prototype.ComponentSelectionPageCallback = function() {
     var widget = gui.currentPageWidget();
 
-    widget.selectComponent("qt.qt5.5111.win64_msvc2017_64");
-    widget.selectComponent("qt.qt5.5111.qtwebengine");
-    widget.selectComponent("qt.qt5.5111.qtwebengine.win64_msvc2017_64");
-    widget.deselectComponent("qt.qt5.5111.src");
+    widget.selectComponent("qt.qt5.5120.win64_msvc2017_64");
+    widget.selectComponent("qt.qt5.5120.qtwebengine");
+    widget.selectComponent("qt.qt5.5120.qtwebengine.win64_msvc2017_64");
+    widget.deselectComponent("qt.qt5.5120.src");
     gui.clickButton(buttons.NextButton);
 }
 

--- a/docker/jenkins/Dockerfile.centos7-x86_64
+++ b/docker/jenkins/Dockerfile.centos7-x86_64
@@ -62,7 +62,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.11.1 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.0 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/docker/jenkins/Dockerfile.debian9-x86_64
+++ b/docker/jenkins/Dockerfile.debian9-x86_64
@@ -64,7 +64,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.11.1 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.0 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/docker/jenkins/Dockerfile.opensuse15-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse15-x86_64
@@ -60,7 +60,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.11.1 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.0 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -52,9 +52,9 @@ RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 
 
 # install qt (note that we are using the current directory's context)
 RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48; ` 
-  (New-Object System.Net.WebClient).DownloadFile('https://s3.amazonaws.com/rstudio-buildtools/QtSDK-5.11.1-msvc2017_64.7z', 'c:\QtSDK-5.11.1-msvc2017_64.7z'); `
-  7z x c:\QtSDK-5.11.1-msvc2017_64.7z -oc:\ ; `
-  Remove-Item c:\QtSDK-5.11.1-msvc2017_64.7z -Force
+  (New-Object System.Net.WebClient).DownloadFile('https://s3.amazonaws.com/rstudio-buildtools/QtSDK-5.12.0-msvc2017_64.7z', 'c:\QtSDK-5.12.0-msvc2017_64.7z'); `
+  7z x c:\QtSDK-5.12.0-msvc2017_64.7z -oc:\ ; `
+  Remove-Item c:\QtSDK-5.12.0-msvc2017_64.7z -Force
     
 # cpack (an alias from chocolatey) and cmake's cpack conflict.
 RUN Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe'

--- a/docker/jenkins/Dockerfile.xenial-amd64
+++ b/docker/jenkins/Dockerfile.xenial-amd64
@@ -81,7 +81,7 @@ RUN /bin/bash /tmp/install-dependencies
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.11.1 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.0 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -2,9 +2,6 @@
 
 set -e
 
-# target macOS Sierra by default
-: "${CMAKE_OSX_DEPLOYMENT_TARGET="10.12"}"
-
 PACKAGE_DIR=`pwd`
 
 BUILD_DIR=$(pwd)/build
@@ -32,6 +29,7 @@ rm -rf build/_CPack_Packages
 
 cmake -DRSTUDIO_TARGET=Desktop \
       -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_OSX_DEPLOYMENT_TARGET="10.12" \
       -DRSTUDIO_PACKAGE_BUILD=1 \
       -DGWT_BIN_DIR="$BUILD_DIR/gwt/bin" \
       -DGWT_WWW_DIR="$BUILD_DIR/gwt/www" \

--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -2,6 +2,9 @@
 
 set -e
 
+# target macOS Sierra by default
+: "${CMAKE_OSX_DEPLOYMENT_TARGET="10.12"}"
+
 PACKAGE_DIR=`pwd`
 
 BUILD_DIR=$(pwd)/build
@@ -26,12 +29,6 @@ mkdir -p $BUILD_DIR/gwt
 cd $BUILD_DIR
 rm -f CMakeCache.txt
 rm -rf build/_CPack_Packages
-
-# if we have a 10.7 SDK, we can produce a Snow Leopard-compatible build
-if [ -x /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk ]; then
-   export CMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk
-   export CMAKE_OSX_DEPLOYMENT_TARGET="10.6"
-fi
 
 cmake -DRSTUDIO_TARGET=Desktop \
       -DCMAKE_BUILD_TYPE=Release \

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -79,20 +79,32 @@ if(UNIX)
    add_definitions(-DBOOST_ASIO_DISABLE_KQUEUE)
 
    if(APPLE)
+
       # if present, set osx deployment target variables from environment vars
       if(NOT $ENV{CMAKE_OSX_SYSROOT} STREQUAL "")
          set(CMAKE_OSX_SYSROOT $ENV{CMAKE_OSX_SYSROOT})
          message(STATUS "Set CMAKE_OSX_SYSROOT to ${CMAKE_OSX_SYSROOT}")
       endif()
+
       if(NOT $ENV{CMAKE_OSX_DEPLOYMENT_TARGET} STREQUAL "")
          set(CMAKE_OSX_DEPLOYMENT_TARGET $ENV{CMAKE_OSX_DEPLOYMENT_TARGET})
          message(STATUS "Set CMAKE_OSX_DEPLOYMENT_TARGET to ${CMAKE_OSX_DEPLOYMENT_TARGET}")
       endif()
+
+      # default to macOS 10.12 as a deployment target
+      if(NOT CMAKE_OSX_DEPLOYMENT_TARGET)
+         set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12)
+      endif()
+
       # Figure out what version of Mac OS X this is. Unfortunately 
       # CMAKE_SYSTEM_VERSION does not match uname -r, so get the Mac OS
       # version number another way.
-      EXECUTE_PROCESS(COMMAND /usr/bin/sw_vers -productVersion OUTPUT_VARIABLE MACOSX_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+      execute_process(COMMAND /usr/bin/sw_vers -productVersion OUTPUT_VARIABLE MACOSX_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+      # notify the user of our selection
       message(STATUS "Mac OS X version: ${MACOSX_VERSION}")
+      message(STATUS "Mac OS X deployment target: ${CMAKE_OSX_DEPLOYMENT_TARGET}")
+
    endif()
 
    # gcc hardending options (see: http://wiki.debian.org/Hardening)

--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -37,11 +37,7 @@ if(NOT WIN32)
          endif()
       endif()
          
-      if(APPLE)
-         set(QT_CANDIDATES 5.11.1)   
-      else()
-         set(QT_CANDIDATES 5.11.1 5.10.1)
-      endif()
+      set(QT_CANDIDATES 5.12.0)   
 
       # find the newest installed Qt version among the versions we build
       # against
@@ -73,7 +69,7 @@ if(NOT WIN32)
       endforeach()
    endif()
 else()
-   set(QT_VERSION "5.11.1")
+   set(QT_VERSION "5.12.0")
    set(QT_VERSION_SUBDIR "${QT_VERSION}")   
    if(NOT QT_QMAKE_EXECUTABLE)
 

--- a/src/cpp/desktop/DesktopBrowserWindow.cpp
+++ b/src/cpp/desktop/DesktopBrowserWindow.cpp
@@ -214,20 +214,5 @@ WebPage* BrowserWindow::opener()
    return pOpener_;
 }
 
-void BrowserWindow::showEvent(QShowEvent* event)
-{
-   QMainWindow::showEvent(event);
-
-   // work around a Qt 5.12 issue where windows don't render when first shown
-   // (they just appear as a blank screen until resized or prompted otherwise)
-#if QT_VERSION == QT_VERSION_CHECK(5, 12, 0)
-   QTimer::singleShot(0, [this]() {
-      resize(width() - 1, height() - 1);
-      resize(width() + 1, height() + 1);
-   });
-#endif
-
-}
-
 } // namespace desktop
 } // namespace rstudio

--- a/src/cpp/desktop/DesktopBrowserWindow.hpp
+++ b/src/cpp/desktop/DesktopBrowserWindow.hpp
@@ -55,8 +55,6 @@ public:
      WebPage* opener();
 
 protected:
-     void showEvent(QShowEvent* event) override;
-
      WebView* pView_;
      QToolBar* pToolbar_;
      QString getName();

--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -478,65 +478,6 @@ int main(int argc, char* argv[])
       // https://github.com/rstudio/rstudio/issues/1953
       static char disableCompositorPref[] = "--disable-prefer-compositing-to-lcd-text";
       arguments.push_back(disableCompositorPref);
-      
-      // disable GPU features for certain machine configurations. see e.g.
-      //
-      // https://bugs.chromium.org/p/chromium/issues/detail?id=773705
-      // https://github.com/rstudio/rstudio/issues/2093
-      // https://github.com/rstudio/rstudio/issues/3148
-      //
-      // because the issue seems to only affect certain video cards on macOS
-      // High Sierra, we scope that change to that particular configuration
-      // for now (we can expand this list if more users report issues)
-      {
-         core::system::ProcessResult processResult;
-         core::system::runCommand(
-                  "/usr/sbin/system_profiler SPDisplaysDataType",
-                  core::system::ProcessOptions(),
-                  &processResult);
-
-         std::string stdOut = processResult.stdOut;
-         if (!stdOut.empty())
-         {
-            // NOTE: temporarily backed out as it appears the rasterization
-            // issues do not occur anymore with Qt 5.12.0; re-enable if we
-            // receive more reports in the wild.
-            //
-            // https://github.com/rstudio/rstudio/issues/2176
-            
-            /*
-            std::vector<std::string> rasterBlacklist = {
-               "NVIDIA GeForce GT 650M",
-               "NVIDIA GeForce GT 750M",
-               "Intel Iris Graphics 6100"
-            };
-
-            for (const std::string& entry : rasterBlacklist)
-            {
-               if (stdOut.find(entry) != std::string::npos)
-               {
-                  static char disableGpuRasterization[] = "--disable-gpu-rasterization";
-                  arguments.push_back(disableGpuRasterization);
-                  break;
-               }
-            }
-            */
-            
-            std::vector<std::string> gpuBlacklist = {
-               "AMD FirePro"
-            };
-            
-            for (const std::string& entry : gpuBlacklist)
-            {
-               if (stdOut.find(entry) != std::string::npos)
-               {
-                  static char disableGpu[] = "--disable-gpu";
-                  arguments.push_back(disableGpu);
-                  break;
-               }
-            }
-         }
-      }
 #endif
       
       // allow users to supply extra command-line arguments

--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -499,7 +499,7 @@ int main(int argc, char* argv[])
          if (!stdOut.empty())
          {
             // NOTE: temporarily backed out as it appears the rasterization
-            // issues do not occur anymore with Qt 5.11.1; re-enable if we
+            // issues do not occur anymore with Qt 5.12.0; re-enable if we
             // receive more reports in the wild.
             //
             // https://github.com/rstudio/rstudio/issues/2176

--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -440,17 +440,6 @@ int main(int argc, char* argv[])
       static char enableViewport[] = "--enable-viewport";
       arguments.push_back(enableViewport);
       
-#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
-      
-#ifndef NDEBUG
-      // disable web security for development builds (so we can
-      // get access to sourcemaps)
-      static char disableWebSecurity[] = "--disable-web-security";
-      arguments.push_back(disableWebSecurity);
-#endif
-      
-#endif
-      
       // disable chromium renderer accessibility by default (it can cause
       // slowdown when used in conjunction with some applications; see e.g.
       // https://github.com/rstudio/rstudio/issues/1990)
@@ -462,14 +451,6 @@ int main(int argc, char* argv[])
          static char disableRendererAccessibility[] = "--disable-renderer-accessibility";
          arguments.push_back(disableRendererAccessibility);
       }
-
-#if defined(Q_OS_LINUX) && (QT_VERSION == QT_VERSION_CHECK(5,10,1))
-      // workaround for Qt 5.10.1 bug "Could not find QtWebEngineProcess"
-      // https://bugreports.qt.io/browse/QTBUG-67023
-      // https://bugreports.qt.io/browse/QTBUG-66346
-      static char noSandbox[] = "--no-sandbox";
-      arguments.push_back(noSandbox);
-#endif
 
 #ifdef Q_OS_MAC
       // don't prefer compositing to LCD text rendering. when enabled, this causes the compositor to

--- a/src/cpp/desktop/DesktopWebView.cpp
+++ b/src/cpp/desktop/DesktopWebView.cpp
@@ -39,8 +39,6 @@ namespace desktop {
 
 namespace {
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
-
 class DevToolsWindow : public QMainWindow
 {
 public:
@@ -71,8 +69,6 @@ private:
 };
 
 std::map<QWebEnginePage*, DevToolsWindow*> s_devToolsWindows;
-
-#endif
 
 } // end anonymous namespace
 
@@ -257,12 +253,10 @@ void WebView::contextMenuEvent(QContextMenuEvent* event)
          
       case QWebEngineContextMenuData::MediaTypeAudio:
          
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
          if (data.mediaFlags().testFlag(QWebEngineContextMenuData::MediaPaused))
             menu->addAction(label(tr("&Play")), [&]() { triggerPageAction(QWebEnginePage::ToggleMediaPlayPause); });
          else
             menu->addAction(label(tr("&Pause")), [&]() { triggerPageAction(QWebEnginePage::ToggleMediaPlayPause); });
-#endif
          
          menu->addAction(label(tr("&Loop")),            [&]() { triggerPageAction(QWebEnginePage::ToggleMediaLoop); });
          menu->addAction(label(tr("Toggle &controls")), [&]() { triggerPageAction(QWebEnginePage::ToggleMediaControls); });
@@ -274,12 +268,10 @@ void WebView::contextMenuEvent(QContextMenuEvent* event)
          
       case QWebEngineContextMenuData::MediaTypeVideo:
          
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
          if (data.mediaFlags().testFlag(QWebEngineContextMenuData::MediaPaused))
             menu->addAction(label(tr("&Play")), [&]() { triggerPageAction(QWebEnginePage::ToggleMediaPlayPause); });
          else
             menu->addAction(label(tr("&Pause")), [&]() { triggerPageAction(QWebEnginePage::ToggleMediaPlayPause); });
-#endif
          
          menu->addAction(label(tr("&Loop")),            [&]() { triggerPageAction(QWebEnginePage::ToggleMediaLoop); });
          menu->addAction(label(tr("Toggle &controls")), [&]() { triggerPageAction(QWebEnginePage::ToggleMediaControls); });
@@ -332,8 +324,6 @@ void WebView::contextMenuEvent(QContextMenuEvent* event)
       menu->addAction(selectAll);
    }
    
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
-   
    menu->addSeparator();
    menu->addAction(label(tr("&Reload")), [&]() { triggerPageAction(QWebEnginePage::Reload); });
    menu->addAction(label(tr("I&nspect element")), [&]() {
@@ -358,18 +348,6 @@ void WebView::contextMenuEvent(QContextMenuEvent* event)
       // we have a window; invoke Inspect Element now
       webPage()->triggerAction(QWebEnginePage::InspectElement);
    });
-   
-#else
-   
-# ifndef NDEBUG
-   
-   menu->addAction(label(tr("&Reload")), [&]() { triggerPageAction(QWebEnginePage::Reload); });
-   menu->addSeparator();
-   menu->addAction(label(tr("I&nspect element")), [&]() { triggerPageAction(QWebEnginePage::InspectElement); });
-   
-# endif
-   
-#endif
    
    menu->setAttribute(Qt::WA_DeleteOnClose, true);
    

--- a/src/cpp/desktop/DesktopWin32ApplicationLaunch.cpp
+++ b/src/cpp/desktop/DesktopWin32ApplicationLaunch.cpp
@@ -182,12 +182,7 @@ bool ApplicationLaunch::nativeEvent(const QByteArray & eventType,
                                     void * msg,
                                     long * result)
 {
-#if QT_VERSION == QT_VERSION_CHECK(5, 11, 1)
-   // https://bugreports.qt.io/browse/QTBUG-69074
-   MSG* message = *reinterpret_cast<MSG**>(msg);
-#else
    MSG* message = reinterpret_cast<MSG*>(msg);
-#endif
 
    if (message->message == WM_COPYDATA)
    {


### PR DESCRIPTION
This PR upgrades RStudio to Qt 5.12.0. Some notable changes:

1. We now explicitly specify a platform target on macOS; targeting macOS Sierra (10.12). This appears necessary to work around some Qt bugs that seem to appear only when no macOS target is specified; at least as seen in my local development builds on Mojave.

2. Some of the workarounds we had included for Qt 5.11.1 are no longer necessary.
