### PR TITLE
Fix output pane when moving between jobs with and without output

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobOutputPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobOutputPanel.java
@@ -41,13 +41,13 @@ public class JobOutputPanel extends Composite
       initWidget(uiBinder.createAndBindUi(this));
       
       // initially empty
-      output_.setVisible(false);
-      empty_.setVisible(true);
+      clearOutput();
    }
    
    public void clearOutput()
    {
       output_.clearOutput();
+      output_.setVisible(false);
       empty_.setVisible(true);
    }
    
@@ -58,6 +58,9 @@ public class JobOutputPanel extends Composite
    
    public void showOutput(CompileOutput output, boolean scrollToBottom)
    {
+      if (output.getOutput().isEmpty())
+         return;
+      
       // make sure output is visible
       empty_.setVisible(false);
       output_.setVisible(true);


### PR DESCRIPTION
Fixes #4014

Also ignore showOutput calls with empty output. Launcher jobs are doing this (that will be fixed separately), but might as well handle it, otherwise the "Job has not emitted output" message is prematurely hidden.