### PR TITLE
Obscure ports when connecting to terminal via websocket

### DIFF
--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -312,7 +312,7 @@ void handleClientInit(const boost::function<void()>& initFunction,
    sessionInfo["lists"] = modules::lists::allListsAsJson();
 
    sessionInfo["console_processes"] =
-         console_process::processesAsJson();
+         console_process::processesAsJson(console_process::ClientSerialization);
 
    // send sumatra pdf exe path if we are on windows
 #ifdef _WIN32

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionConsoleProcess.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -730,9 +730,9 @@ void ConsoleProcess::setZombie()
    saveConsoleProcesses();
 }
 
-core::json::Object ConsoleProcess::toJson() const
+core::json::Object ConsoleProcess::toJson(SerializationMode serialMode) const
 {
-   return procInfo_->toJson();
+   return procInfo_->toJson(serialMode);
 }
 
 ConsoleProcessPtr ConsoleProcess::fromJson(
@@ -993,9 +993,9 @@ bool ConsoleProcess::useWebsockets()
                      session::userSettings().terminalWebsockets();
 }
 
-core::json::Array processesAsJson()
+core::json::Array processesAsJson(SerializationMode serialMode)
 {
-   return allProcessesAsJson();
+   return allProcessesAsJson(serialMode);
 }
 
 Error initialize()

--- a/src/cpp/session/SessionConsoleProcessApi.cpp
+++ b/src/cpp/session/SessionConsoleProcessApi.cpp
@@ -177,7 +177,7 @@ SEXP rs_terminalCreate(SEXP captionSEXP, SEXP showSEXP, SEXP shellTypeSEXP)
 
    // notify the client so it adds this new terminal to the UI list and starts it
    json::Object eventData;
-   eventData["process_info"] = ptrProc->toJson();
+   eventData["process_info"] = ptrProc->toJson(ClientSerialization);
    eventData["show"] = show;
    ClientEvent addTerminalEvent(client_events::kAddTerminal, eventData);
    module_context::enqueClientEvent(addTerminalEvent);
@@ -520,7 +520,7 @@ SEXP rs_terminalExecute(SEXP commandSEXP,
 
    // notify the client so it adds this new terminal to the UI list
    json::Object eventData;
-   eventData["process_info"] = ptrProc->toJson();
+   eventData["process_info"] = ptrProc->toJson(ClientSerialization);
    eventData["show"] = show;
    ClientEvent addTerminalEvent(client_events::kAddTerminal, eventData);
    module_context::enqueClientEvent(addTerminalEvent);
@@ -934,7 +934,7 @@ Error startTerminal(const json::JsonRpcRequest& request,
                          ERROR_LOCATION);
    }
 
-   pResponse->setResult(ptrProc->toJson());
+   pResponse->setResult(ptrProc->toJson(ClientSerialization));
 
    return Success();
 }

--- a/src/cpp/session/SessionConsoleProcessInfoTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfoTests.cpp
@@ -242,7 +242,7 @@ TEST_CASE("ConsoleProcessInfo")
       ConsoleProcessInfo cpiOrig(caption, title, handle1, sequence, shellType,
                                   altActive, cwd, cols, rows, zombie, trackEnv);
 
-      core::json::Object origJson = cpiOrig.toJson();
+      core::json::Object origJson = cpiOrig.toJson(PersistentSerialization);
       boost::shared_ptr<ConsoleProcessInfo> pCpiRestored =
             ConsoleProcessInfo::fromJson(origJson);
       CHECK(pCpiRestored);

--- a/src/cpp/session/SessionConsoleProcessTable.cpp
+++ b/src/cpp/session/SessionConsoleProcessTable.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionConsoleProcessTable.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -40,14 +40,14 @@ typedef std::map<std::string, ConsoleProcessPtr> ProcTable;
 
 ProcTable s_procs;
 
-std::string serializeConsoleProcs()
+std::string serializeConsoleProcs(SerializationMode serialMode)
 {
    json::Array array;
    for (ProcTable::const_iterator it = s_procs.begin();
         it != s_procs.end();
         it++)
    {
-      array.push_back(it->second->toJson());
+      array.push_back(it->second->toJson(serialMode));
    }
 
    std::ostringstream ostr;
@@ -93,7 +93,7 @@ bool isKnownProcHandle(const std::string& handle)
 
 void onSuspend(core::Settings* /*pSettings*/)
 {
-   serializeConsoleProcs();
+   serializeConsoleProcs(PersistentSerialization);
    s_visibleTerminalHandle.clear();
 }
 
@@ -173,7 +173,7 @@ std::pair<int, std::string> nextTerminalName()
 
 void saveConsoleProcesses()
 {
-   ConsoleProcessInfo::saveConsoleProcesses(serializeConsoleProcs());
+   ConsoleProcessInfo::saveConsoleProcesses(serializeConsoleProcs(PersistentSerialization));
 }
 
 void saveConsoleProcessesAtShutdown(bool terminatedNormally)
@@ -220,14 +220,14 @@ Error reapConsoleProcess(const ConsoleProcess& proc)
    return Success();
 }
 
-core::json::Array allProcessesAsJson()
+core::json::Array allProcessesAsJson(SerializationMode serialMode)
 {
    json::Array procInfos;
    for (ProcTable::const_iterator it = s_procs.begin();
         it != s_procs.end();
         it++)
    {
-      procInfos.push_back(it->second->toJson());
+      procInfos.push_back(it->second->toJson(serialMode));
    }
    return procInfos;
 }

--- a/src/cpp/session/SessionConsoleProcessTable.hpp
+++ b/src/cpp/session/SessionConsoleProcessTable.hpp
@@ -49,7 +49,7 @@ std::vector<std::string> getAllHandles();
 std::pair<int, std::string> nextTerminalName();
 
 // Get list of all process metadata
-core::json::Array allProcessesAsJson();
+core::json::Array allProcessesAsJson(SerializationMode serialMode);
 
 // Persist the list of ConsoleProcesses.
 void saveConsoleProcesses();

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionConsoleProcess.hpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -198,7 +198,7 @@ public:
 
    void setShowOnOutput(bool showOnOutput) const { procInfo_->setShowOnOutput(showOnOutput); }
 
-   core::json::Object toJson() const;
+   core::json::Object toJson(SerializationMode serialMode) const;
    static ConsoleProcessPtr fromJson( core::json::Object& obj);
 
    void onReceivedInput(const std::string& input);
@@ -281,7 +281,7 @@ private:
    core::terminal::PrivateCommand envCaptureCmd_;
 };
 
-core::json::Array processesAsJson();
+core::json::Array processesAsJson(SerializationMode serialMode);
 core::Error initialize();
 
 } // namespace console_process

--- a/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
@@ -56,6 +56,12 @@ enum AutoCloseMode
    NeverAutoClose = 2, // never auto-close
 };
 
+enum SerializationMode
+{
+   ClientSerialization = 0, // serialize for front-end client
+   PersistentSerialization = 1  // serialize for persistent storage
+};
+
 extern const int kDefaultMaxOutputLines;
 extern const int kDefaultTerminalMaxOutputLines;
 extern const int kNoTerminal;
@@ -190,7 +196,7 @@ public:
    void setTrackEnv(bool trackEnv) { trackEnv_ = trackEnv; }
    bool getTrackEnv() const { return trackEnv_; }
 
-   core::json::Object toJson() const;
+   core::json::Object toJson(SerializationMode serialMode) const;
    static boost::shared_ptr<ConsoleProcessInfo> fromJson(core::json::Object& obj);
 
    static std::string loadConsoleProcessMetadata();

--- a/src/cpp/session/modules/SessionDependencies.cpp
+++ b/src/cpp/session/modules/SessionDependencies.cpp
@@ -411,7 +411,7 @@ Error installDependencies(const json::JsonRpcRequest& request,
             pCPI);
 
    // return console process
-   pResponse->setResult(pCP->toJson());
+   pResponse->setResult(pCP->toJson(console_process::ClientSerialization));
    return Success();
 }
 

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -1708,7 +1708,7 @@ Error vcsCreateBranch(const json::JsonRpcRequest& request,
    if (error)
       return error;
    
-   pResponse->setResult(pCP->toJson());
+   pResponse->setResult(pCP->toJson(console_process::ClientSerialization));
 
    return Success();
 }
@@ -1752,7 +1752,7 @@ Error vcsCheckout(const json::JsonRpcRequest& request,
    if (error)
       return error;
 
-   pResponse->setResult(pCP->toJson());
+   pResponse->setResult(pCP->toJson(console_process::ClientSerialization));
 
    return Success();
 }
@@ -1770,7 +1770,7 @@ Error vcsCheckoutRemote(const json::JsonRpcRequest& request,
    if (error)
       return error;
    
-   pResponse->setResult(pCP->toJson());
+   pResponse->setResult(pCP->toJson(console_process::ClientSerialization));
    
    return Success();
 }
@@ -1853,7 +1853,7 @@ Error vcsCommit(const json::JsonRpcRequest& request,
       return error;
    }
 
-   pResponse->setResult(pCP->toJson());
+   pResponse->setResult(pCP->toJson(console_process::ClientSerialization));
 
    return Success();
 }
@@ -1868,7 +1868,7 @@ Error vcsPush(const json::JsonRpcRequest& request,
 
    ask_pass::setActiveWindow(request.sourceWindow);
 
-   pResponse->setResult(pCP->toJson());
+   pResponse->setResult(pCP->toJson(console_process::ClientSerialization));
 
    return Success();
 }
@@ -1888,7 +1888,7 @@ Error vcsPushBranch(const json::JsonRpcRequest& request,
 
    ask_pass::setActiveWindow(request.sourceWindow);
 
-   pResponse->setResult(pCP->toJson());
+   pResponse->setResult(pCP->toJson(console_process::ClientSerialization));
 
    return Success();
 }
@@ -1903,7 +1903,7 @@ Error vcsPull(const json::JsonRpcRequest& request,
 
    ask_pass::setActiveWindow(request.sourceWindow);
 
-   pResponse->setResult(pCP->toJson());
+   pResponse->setResult(pCP->toJson(console_process::ClientSerialization));
 
    return Success();
 }
@@ -1918,7 +1918,7 @@ Error vcsPullRebase(const json::JsonRpcRequest& request,
 
    ask_pass::setActiveWindow(request.sourceWindow);
 
-   pResponse->setResult(pCP->toJson());
+   pResponse->setResult(pCP->toJson(console_process::ClientSerialization));
 
    return Success();
 }

--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -360,7 +360,7 @@ void runSvnAsync(const ShellArgs& args,
 
    // notify the client about the console process
    json::Object data;
-   data["process_info"] = pCP->toJson();
+   data["process_info"] = pCP->toJson(console_process::ClientSerialization);
    data["target_window"] = ask_pass::activeWindow();
    ClientEvent event(client_events::kConsoleProcessCreated, data);
    module_context::enqueClientEvent(event);
@@ -996,7 +996,7 @@ Error svnUpdate(const json::JsonRpcRequest& request,
 
    maybeAttachPasswordManager(pCP);
 
-   pResponse->setResult(pCP->toJson());
+   pResponse->setResult(pCP->toJson(console_process::ClientSerialization));
 
    return Success();
 }
@@ -1065,7 +1065,7 @@ Error svnCommit(const json::JsonRpcRequest& request,
 
    maybeAttachPasswordManager(pCP);
 
-   pResponse->setResult(pCP->toJson());
+   pResponse->setResult(pCP->toJson(console_process::ClientSerialization));
 
    return Success();
 }

--- a/src/cpp/session/modules/SessionTests.cpp
+++ b/src/cpp/session/modules/SessionTests.cpp
@@ -152,7 +152,7 @@ Error installShinyTestDependencies(const json::JsonRpcRequest& request,
             pCPI);
 
    // return console process
-   pResponse->setResult(pCP->toJson());
+   pResponse->setResult(pCP->toJson(console_process::ClientSerialization));
    return Success();
 }
 

--- a/src/cpp/session/modules/SessionVCS.cpp
+++ b/src/cpp/session/modules/SessionVCS.cpp
@@ -120,7 +120,7 @@ Error vcsClone(const json::JsonRpcRequest& request,
       return systemError(json::errc::ParamInvalid, ERROR_LOCATION);
    }
 
-   pResponse->setResult(pCP->toJson());
+   pResponse->setResult(pCP->toJson(console_process::ClientSerialization));
 
    return Success();
 }

--- a/src/cpp/session/modules/connections/SessionConnections.cpp
+++ b/src/cpp/session/modules/connections/SessionConnections.cpp
@@ -678,7 +678,7 @@ Error installOdbcDriver(const json::JsonRpcRequest& request,
             pCPI);
 
    // return console process
-   pResponse->setResult(pCP->toJson());
+   pResponse->setResult(pCP->toJson(console_process::ClientSerialization));
    return Success();
 }
 


### PR DESCRIPTION
This change fixes a regression introduced by the port obscuration feature. Terminal websockets don't work with this feature since they create websocket URLs using raw port numbers, which are no longer supported.

The fix is to distinguish between the two different types of serialization we use for console processes:

1. **Client** serialization, in which we need to replace the port with an obscured equivalent (used for sending process information to the front end), and
2. **Persistent** serialization, in which we need to save the raw port itself (used for saving process information to disk).

Anywhere that we serialize processes to JSON now requires an explicit opt-in to the appropriate behavior. 