### PR TITLE
Pass completed job instead of separate completed flag

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobProgressPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobProgressPresenter.java
@@ -31,7 +31,6 @@ public class JobProgressPresenter implements JobElapsedTickEvent.Handler,
       void updateElapsed(int timestamp);
       void showProgress(LocalJobProgress progress);
       void showJob(Job job);
-      void setComplete();
    }
    
    @Inject
@@ -64,10 +63,5 @@ public class JobProgressPresenter implements JobElapsedTickEvent.Handler,
       display_.showJob(job);
    }
    
-   public void setComplete()
-   {
-      display_.setComplete();
-   }
-
    private final Display display_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobProgress.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobProgress.java
@@ -60,31 +60,35 @@ public class JobProgress extends Composite
    public void showJob(Job job)
    {
       name_.setText(job.name);
-      if (job.max > 0)
+      String status = JobConstants.stateDescription(job.state);
+      if (job.completed > 0)
       {
+         // Job is not running; show its completion status and time
+         progress_.setVisible(false);
+         status += " " + StringUtil.friendlyDateTime(new Date(job.completed * 1000));
+         elapsed_.setText(StringUtil.conciseElaspedTime(job.completed - job.started));
+      }
+      else if (job.max > 0)
+      {
+         // Job is running and has a progress bar; show it and hide the status indicator
          progress_.setVisible(true);
          progress_.setProgress(job.progress, job.max);
          status_.setVisible(false);
       }
       else
       {
+         // Job is running but does not have progress; show the status field
          progress_.setVisible(false);
          status_.setVisible(true);
-         String status = JobConstants.stateDescription(job.state);
-         if (job.completed > 0)
-         {
-            // Job is not running; show its completion status and time
-            status += " " + StringUtil.friendlyDateTime(new Date(job.completed * 1000));
-            elapsed_.setText(StringUtil.conciseElaspedTime(job.completed - job.started));
-         }
-         else if (!StringUtil.isNullOrEmpty(job.status))
+         if (!StringUtil.isNullOrEmpty(job.status))
          {
             // Still running; show its status
             status = job.status;
          }
-         status_.setText(status);
       }
+      status_.setText(status);
       jobProgress_ = new LocalJobProgress(job);
+      complete_ = job.completed > 0;
    }
 
    @Override
@@ -95,13 +99,6 @@ public class JobProgress extends Composite
       
       int delta = timestamp - jobProgress_.received();
       elapsed_.setText(StringUtil.conciseElaspedTime(jobProgress_.elapsed() + delta));
-   }
-
-   @Override
-   public void setComplete()
-   {
-      progress_.setVisible(false);
-      complete_ = true;
    }
 
    @UiField Label name_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsPane.java
@@ -132,20 +132,13 @@ public class JobsPane extends WorkbenchPane
             list_.updateJob(job);
             if (job.id == current_)
             {
-               if (job.completed > 0 && progress_ != null)
+               // update progress
+               if (progress_ == null)
                {
-                  progress_.setComplete();
+                  progress_ = new JobProgress();
+                  toolbar_.addLeftWidget(progress_);
                }
-               else
-               {
-                  // update progress
-                  if (progress_ == null)
-                  {
-                     progress_ = new JobProgress();
-                     toolbar_.addLeftWidget(progress_);
-                  }
-                  progress_.showJob(job);
-               }
+               progress_.showJob(job);
             }
             break;
             
@@ -338,12 +331,6 @@ public class JobsPane extends WorkbenchPane
          progress_ = new JobProgress();
          toolbar_.addLeftWidget(progress_);
          progress_.showJob(job);
-
-         // if job is complete, mark that
-         if (job.completed > 0)
-         {
-            progress_.setComplete();
-         }
       }
    }
    


### PR DESCRIPTION
This change simplifies the job progress presenter slightly: it no longer requires an explicit invocation to enter completed mode; instead, it enters it automatically when given a completed job. 

Fixes https://github.com/rstudio/rstudio-pro/issues/748. 