### PR TITLE
prefer UTF-8 for .Rmd documents

### DIFF
--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -239,6 +239,11 @@ Error openDocument(const json::JsonRpcRequest& request,
       return Success();
    }
 
+   // prefer UTF-8 encoding for R Markdown documents if no
+   // encoding is set
+   if (type == "r_markdown" && encoding == "")
+      encoding = "UTF-8";
+
    // set the doc contents to the specified file
    boost::shared_ptr<SourceDocument> pDoc(new SourceDocument(type)) ;
    pDoc->setEncoding(encoding);

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -218,8 +218,16 @@ Error openDocument(const json::JsonRpcRequest& request,
    error = json::readParam(request.params, 2, &encoding);
    if (error && error.code() != core::json::errc::ParamTypeMismatch)
       return error ;
+
    if (encoding.empty())
-      encoding = ::locale2charset(NULL);
+   {
+      // prefer UTF-8 encoding for R Markdown documents if no
+      // encoding is set
+      if (type == "r_markdown" && encoding == "")
+         encoding = "UTF-8";
+      else
+         encoding = ::locale2charset(NULL);
+   }
    
    // ensure the file exists
    FilePath documentPath = module_context::resolveAliasedPath(path);
@@ -238,11 +246,6 @@ Error openDocument(const json::JsonRpcRequest& request,
                                  "be opened by the source editor.");
       return Success();
    }
-
-   // prefer UTF-8 encoding for R Markdown documents if no
-   // encoding is set
-   if (type == "r_markdown" && encoding == "")
-      encoding = "UTF-8";
 
    // set the doc contents to the specified file
    boost::shared_ptr<SourceDocument> pDoc(new SourceDocument(type)) ;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2457,8 +2457,8 @@ public class TextEditingTarget implements
       
       final String encoding = StringUtil.firstNotNullOrEmpty(new String[] {
             encodingOverride,
-            preferredDocumentEncoding,
             docUpdateSentinel_.getEncoding(),
+            preferredDocumentEncoding,
             prefs_.defaultEncoding().getValue()
       });
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2451,8 +2451,13 @@ public class TextEditingTarget implements
          final String encodingOverride,
          final CommandWithArg<String> command)
    {
+      String preferredDocumentEncoding = null;
+      if (docDisplay_.getFileType().isRmd())
+         preferredDocumentEncoding = "UTF-8";
+      
       final String encoding = StringUtil.firstNotNullOrEmpty(new String[] {
             encodingOverride,
+            preferredDocumentEncoding,
             docUpdateSentinel_.getEncoding(),
             prefs_.defaultEncoding().getValue()
       });


### PR DESCRIPTION
This PR enforces a UTF-8 encoding for R Markdown documents. The document-preferred encoding overrides:

1. A previously-known encoding for the document; I believe this is necessary since we'll want to convert pre-existing R Markdown documents to UTF-8 as appropriate;

2. The default encoding preference.

The `encodingOverride` argument will still take precedence.

Closes #4028.

NOTE: We may need to also to enforce UTF-8 when reading R Markdown documents; or at least 'guess' if the document is UTF-8 versus the system encoding.