### PR TITLE
properly infer completion path for .Rmd documents

### DIFF
--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -20,40 +20,48 @@
 .rs.addJsonRpcHandler("markdown_get_completions", function(type, data)
 {
    if (type == .rs.markdown.acCompletionTypes$COMPLETION_HREF)
-   {
-      # extract parameters
-      token <- data$token
-      path <- data$path
-      id <- data$id
-      
-      # figure out working directory
-      workingDir <- .Call("rs_getRmdWorkingDir", path, id, PACKAGE = "(embedding)")
-      if (is.null(workingDir))
-         workingDir <- getwd()
-      
-      # determine dirname, basename (need to handle trailing slashes properly
-      # so can't just use dirname / basename)
-      slashes <- gregexpr("[/\\]", token)[[1]]
-      idx <- tail(slashes, n = 1)
-      lhs <- substring(token, 1, idx - 1)
-      rhs <- substring(token, idx + 1)
-      
-      # check to see if user is providing absolute path, and construct
-      # completion directory appropriately
-      isAbsolute <- grepl("^(?:[A-Z]:|/|\\\\|~)", token, perl = TRUE)
-      if (!isAbsolute)
-         lhs <- file.path(workingDir, lhs)
-      
-      # retrieve completions
-      completions <- .rs.getCompletionsFile(
-         token = rhs,
-         path = lhs,
-         quote = FALSE,
-         directoriesOnly = FALSE
-      )
-      
-      return(completions)
-   }
+      return(.rs.markdown.getCompletionsHref(data))
+})
+
+.rs.addFunction("markdown.getCompletionsHref", function(data)
+{
+   # extract parameters
+   token <- data$token
+   path <- data$path
+   
+   # figure out working directory
+   props <- .rs.getSourceDocumentProperties(path)
+   workingDirProp <- props$properties$working_dir
+   workingDir <- if (identical(workingDirProp, "project"))
+      props$project_path
+   else if (identical(workingDirProp, "current"))
+      getwd()
+   else
+      dirname(path)
+   
+   # determine dirname, basename (need to handle trailing slashes properly
+   # so can't just use dirname / basename)
+   slashes <- gregexpr("[/\\]", token)[[1]]
+   idx <- tail(slashes, n = 1)
+   lhs <- substring(token, 1, idx - 1)
+   rhs <- substring(token, idx + 1)
+   
+   # check to see if user is providing absolute path, and construct
+   # completion directory appropriately
+   isAbsolute <- grepl("^(?:[A-Z]:|/|\\\\|~)", token, perl = TRUE)
+   if (!isAbsolute)
+      lhs <- file.path(workingDir, lhs)
+   
+   # retrieve completions
+   completions <- .rs.getCompletionsFile(
+      token = rhs,
+      path = lhs,
+      quote = FALSE,
+      directoriesOnly = FALSE
+   )
+   
+   return(completions)
+   
 })
 
 .rs.addFunction("scalarListFromList", function(l, expressions = FALSE)


### PR DESCRIPTION
Closes #3996.

`.Call("rs_getRmdWorkingDir")` was not working as I initially expected -- IIUC, it reads from the chunk definitions for a file in the source database, and those definitions may not be active if no chunk has been executed yet. (Or perhaps it's only valid while a chunk is executing?)

Either way, the correct way to handle this is to read the preference from the document properties directly, so this PR does that.