### PR TITLE
Wait for session info to arrive in satellite before loading theme

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteApplication.java
@@ -74,13 +74,6 @@ public class SatelliteApplication
       pAceThemes_ = pAceThemes;
       uncaughtExHandler_ = uncaughtExHandler;
       
-      // Register an event handler for themes so it will be triggered after a UIPrefsChangedEvent
-      // updates the theme.
-      UIPrefs uiPrefs = RStudioGinjector.INSTANCE.getUIPrefs();
-      EventBus events = RStudioGinjector.INSTANCE.getEventBus();
-      uiPrefs.theme().bind(theme -> events.fireEvent(new ThemeChangedEvent()));
-      uiPrefs.getFlatTheme().bind(theme -> events.fireEvent(new ThemeChangedEvent()));
-      
       commands.showRequestLog().addHandler(new CommandHandler()
       {
          public void onCommand(AppCommand command)

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteWindow.java
@@ -24,6 +24,8 @@ import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.ThemeChangedEvent;
 import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.common.satellite.events.SatelliteWindowEventHandlers;
+import org.rstudio.studio.client.workbench.events.SessionInitEvent;
+import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.ui.FontSizeManager;
 
 import com.google.gwt.core.client.JavaScriptObject;
@@ -57,6 +59,17 @@ public abstract class SatelliteWindow extends Composite
 
       // create application panel
       mainPanel_ = new LayoutPanel();
+      
+      // Register an event handler for themes so it will be triggered after a
+      // UIPrefsChangedEvent updates the theme. Do this after SessionInit (if we
+      // do it beforehand we'll trigger the event before the SessionInfo object
+      // arrives with the theme settings)
+      pEventBus.get().addHandler(SessionInitEvent.TYPE, (evt) ->
+      {
+         UIPrefs uiPrefs = RStudioGinjector.INSTANCE.getUIPrefs();
+         uiPrefs.theme().bind(theme -> pEventBus_.get().fireEvent(new ThemeChangedEvent()));
+         uiPrefs.getFlatTheme().bind(theme -> pEventBus_.get().fireEvent(new ThemeChangedEvent()));
+      });
        
       // init widget
       initWidget(mainPanel_);


### PR DESCRIPTION
This change fixes an issue with theme application in satellite windows. A request log reveals that satellite windows perform an unnecessary load of the default theme before loading the actual theme.

The problem is that satellite windows are registering their theme change event handlers too soon -- before they have received a SessionInfo with the UiPrefs that contain the correct theme. The fix here is to move the event handler registration to after the UiPrefs are initialized.

Fixes https://github.com/rstudio/rstudio/issues/3884. 