### PR TITLE
report SQL preview errors to user

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2333,3 +2333,13 @@
 {
    if (is.null(x)) y else x
 })
+
+.rs.addFunction("truncate", function(string, n = 200, marker = "<...>")
+{
+   if (nchar(string) <= n)
+      return(string)
+   
+   truncated <- substring(string, 1, n - nchar(marker))
+   return(paste(truncated, marker))
+   
+})

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1161,7 +1161,7 @@ public class RemoteServer implements Server
    
    @Override
    public void previewSql(String command,
-                          ServerRequestCallback<Void> requestCallback)
+                          ServerRequestCallback<String> requestCallback)
    {
       JSONArray params = new JSONArray();
       params.set(0, new JSONString(command));

--- a/src/gwt/src/org/rstudio/studio/client/sql/model/SqlServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/sql/model/SqlServerOperations.java
@@ -14,11 +14,10 @@
  */
 package org.rstudio.studio.client.sql.model;
 
-import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.workbench.views.buildtools.model.BuildServerOperations;
 
 public interface SqlServerOperations extends BuildServerOperations
 {
-   void previewSql(String command, ServerRequestCallback<Void> requestCallback);
+   void previewSql(String command, ServerRequestCallback<String> requestCallback);
 }


### PR DESCRIPTION
With this PR, errors during SQL preview are reported to the user, e.g.

<img width="426" alt="screen shot 2018-12-17 at 12 33 08 pm" src="https://user-images.githubusercontent.com/1976582/50113842-f2965880-01f7-11e9-9347-427e78df606b.png">

Closes https://github.com/rstudio/rstudio-pro/issues/633.