### PR TITLE
Limit recursion depth when eliminating DataGrid cruft

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -626,7 +626,27 @@ public class DomUtils
                                boolean siblings, 
                                NodePredicate filter)
    {
-      List<Node> results = findNodes(start, 1, recursive, siblings, filter);
+      List<Node> results = findNodes(start, 1, recursive ? 99 : 0, siblings, filter);
+      if (results.isEmpty())
+         return null;
+      return results.get(0);
+   }
+   
+   /**
+    * Finds a node that matches the predicate.
+    * 
+    * @param start The node from which to start.
+    * @param depth The maximum recursive depth
+    * @param siblings If true, looks at the next sibling from "start".
+    * @param filter The predicate that determines a match.
+    * @return The first matching node encountered in documented order, or null.
+    */
+   public static Node findNode(Node start, 
+                               int depth, 
+                               boolean siblings, 
+                               NodePredicate filter)
+   {
+      List<Node> results = findNodes(start, 1, depth, siblings, filter);
       if (results.isEmpty())
          return null;
       return results.get(0);
@@ -637,14 +657,14 @@ public class DomUtils
     * 
     * @param start The node from which to start.
     * @param max The maximum number of nodes to find.
-    * @param recursive If true, recurses into child nodes.
+    * @param depth The maximum recursive depth.
     * @param siblings If true, looks at the next sibling from "start".
     * @param filter The predicate that determines a match.
     * @return The first matching node encountered in documented order, or null.
     */
    public static List<Node> findNodes(Node start,
                                       int max,
-                                      boolean recursive,
+                                      int depth,
                                       boolean siblings,
                                       NodePredicate filter)
    {
@@ -661,11 +681,11 @@ public class DomUtils
             return results;
       }
       
-      if (recursive)
+      if (depth > 0)
       {
          remaining = max - results.size();
          List<Node> matched = findNodes(start.getFirstChild(), remaining,
-               true, true, filter);
+               depth - 1, true, filter);
          results.addAll(matched);
       }
       
@@ -673,7 +693,7 @@ public class DomUtils
       {
          remaining = max - results.size();
          List<Node> matched = findNodes(start.getNextSibling(), remaining,
-               recursive, true, filter);
+               depth, true, filter);
          results.addAll(matched);
       }
       

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioDataGrid.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioDataGrid.java
@@ -63,7 +63,11 @@ public class RStudioDataGrid<T> extends DataGrid<T>
       // assigned class, and have all their style attributes applied inline, so
       // instead we scan the attached DOM subtree and change the inline styles.
       Element parent = getElement().getParentElement().getParentElement();
-      List<Node> matches = DomUtils.findNodes(parent, 10, true, false, node -> 
+      List<Node> matches = DomUtils.findNodes(parent, 
+            10,     // Max results 
+            3,      // Recurse depth 
+            false,  // Check siblings
+            node -> 
       {
          // Ignore text nodes, etc.
          if (node.getNodeType() != Node.ELEMENT_NODE)


### PR DESCRIPTION
Currently, we scan the DOM tree recursively for DataGrid scroll helper elements (see #2808 and #3707 for the unhappy history). When the DataGrid is large, however, this can take a Long Time and possibly overflow the stack.

This change fixes the issue by limiting the recursive depth at which these elements are searched (they are predictably in the first three levels). 

Fixes #4023. Note however that this doesn't necessarily make the Files pane performant when there are many thousands of files. 