### PR TITLE
Update bootstrap scripts to use Qt 3.0.6 online installer

### DIFF
--- a/dependencies/linux/install-qt-sdk
+++ b/dependencies/linux/install-qt-sdk
@@ -18,7 +18,7 @@ if [ -z "$QT_VERSION" ]; then
     QT_VERSION=5.11.1
 fi
 if [ -z "$QT_SDK_BINARY" ]; then
-    QT_SDK_BINARY=qt-unified-linux-x64-3.0.5-online.run
+    QT_SDK_BINARY=qt-unified-linux-x64-3.0.6-online.run
 fi
 if [ -z "$QT_PACKAGES" ]; then
     QT_PACKAGES=qt.qt5.5111.gcc_64,qt.qt5.5111.qtwebengine,qt.qt5.5111.qtwebengine.gcc_64

--- a/dependencies/osx/install-qt-sdk-osx
+++ b/dependencies/osx/install-qt-sdk-osx
@@ -19,7 +19,7 @@
 # If no location provided, checks against a set of common locations and installs if not found.
 
 QT_VERSION=5.11.1
-QT_SDK_BINARY_BASE=qt-unified-mac-x64-3.0.5-online
+QT_SDK_BINARY_BASE=qt-unified-mac-x64-3.0.6-online
 QT_SDK_BINARY=${QT_SDK_BINARY_BASE}.tar.gz
 QT_SDK_INSTALLER=${QT_SDK_BINARY_BASE}.app
 QT_SDK_INSTALLER_BIN=${QT_SDK_INSTALLER}/Contents/MacOS/${QT_SDK_BINARY_BASE}

--- a/dependencies/windows/install-qt-sdk-win.cmd
+++ b/dependencies/windows/install-qt-sdk-win.cmd
@@ -3,7 +3,7 @@
 setlocal EnableDelayedExpansion
 
 set QT_VERSION=5.11.1
-set QT_SDK_BINARY=qt-unified-windows-x86-3.0.5-online.exe
+set QT_SDK_BINARY=qt-unified-windows-x86-3.0.6-online.exe
 set QT_SDK_URL=https://s3.amazonaws.com/rstudio-buildtools/%QT_SDK_BINARY%
 set QT_SCRIPT=qt-noninteractive-install-win.qs
 


### PR DESCRIPTION
Qt released a new build of their installer framework and thus their online installer. Supposed to have some performance improvements (less metadata download) and other assorted stuff.

https://blog.qt.io/blog/2018/12/17/qt-installer-framework-3-0-6-released/

Tested on Mac, Windows, Linux by uninstall Qt and reinstalling with these updated dependency scripts after pushing new bits to S3.

No compelling reason to take this for 1.2 (3.0.5 continues to work AFAIK), so suggest just merging into 1.3.

See also updated notes at https://github.com/rstudio/rstudio-pro/wiki/Updating-Qt-SDK on what gets pushed to S3.