### PR TITLE
use 64-bit version of Pandoc 2.5 on Windows (#3965)

### DIFF
--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -21,7 +21,7 @@ set OPENSSL_FILES=openssl-1.0.2p.zip
 set BOOST_FILES=boost-1.65.1-win-msvc141.zip
 
 set PANDOC_VERSION=2.5
-set PANDOC_NAME=pandoc-%PANDOC_VERSION%-windows-i386
+set PANDOC_NAME=pandoc-%PANDOC_VERSION%-windows-x86_64
 set PANDOC_FILE=%PANDOC_NAME%.zip
 
 set LIBCLANG_VERSION=5.0.2


### PR DESCRIPTION
Since users have reported the 64-bit binary build works better than the 32-bit build in this case. (See: #3965)