### PR TITLE
Add API method for transforming localhost urls

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -753,3 +753,9 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
 .rs.addApiFunction("buildToolsExec", function(expr) {
    .rs.withBuildTools(expr)
 })
+
+# translate a local URL into an externally accessible URL on RStudio Server
+.rs.addApiFunction("translateLocalUrl", function(url, absolute = FALSE) {
+  .Call("rs_translateLocalUrl", url, absolute, PACKAGE = "(embedding)")
+})
+

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -97,6 +97,9 @@ Error makePortTokenCookie(boost::shared_ptr<HttpConnection> ptrConnection,
    if (error)
       return error;
 
+   // save the base URL to persistent state (for forming absolute URLs)
+   persistentState().setActiveClientUrl(baseURL);
+
    // generate a new port token
    persistentState().setPortToken(server_core::generateNewPortToken());
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -97,6 +97,7 @@
 #include <session/SessionContentUrls.hpp>
 #include <session/SessionScopes.hpp>
 #include <session/SessionClientEventService.hpp>
+#include <session/SessionUrlPorts.hpp>
 #include <session/RVersionSettings.hpp>
 
 #include "SessionAddins.hpp"
@@ -484,6 +485,9 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
 
       // content urls
       (content_urls::initialize)
+
+      // URL port transformations
+      (url_ports::initialize)
 
       // overlay R
       (bind(sourceModuleRFile, "SessionOverlay.R"))

--- a/src/cpp/session/SessionPersistentState.cpp
+++ b/src/cpp/session/SessionPersistentState.cpp
@@ -98,6 +98,16 @@ std::string PersistentState::newActiveClientId()
    }
 }
 
+std::string PersistentState::activeClientUrl() const
+{
+   return settings_.get("activeClientUrl", "");
+}
+
+void PersistentState::setActiveClientUrl(const std::string& url)
+{
+   settings_.set("activeClientUrl", url);
+}
+
 // abend tracking only applies to server mode
 
 bool PersistentState::hadAbend() 

--- a/src/cpp/session/SessionUrlPorts.cpp
+++ b/src/cpp/session/SessionUrlPorts.cpp
@@ -18,6 +18,9 @@
 #include <session/SessionOptions.hpp>
 #include "session-config.h"
 
+#include <r/RSexp.hpp>
+#include <r/RRoutines.hpp>
+
 #ifdef RSTUDIO_SERVER
 #include <server_core/UrlPorts.hpp>
 #endif
@@ -25,6 +28,51 @@
 namespace rstudio {
 namespace session {
 namespace url_ports {
+namespace {
+
+// API method for translating local URLs into externally accessible URLs, for use in R packages and
+// user code that need direct access to the URL (vs. the implicit transformation we do in some
+// places)
+SEXP rs_translateLocalUrl(SEXP url, SEXP absolute)
+{
+   if (options().programMode() == kSessionProgramModeDesktop)
+   {
+      // Return the URL, unchanged, in desktop mode
+      return url;
+   }
+
+   // Transform the URL
+   auto localUrl = r::sexp::safeAsString(url);
+   auto transformed = mapUrlPorts(localUrl);
+   if (transformed == localUrl)
+   {
+      // No transformation was necessary
+      return url;
+   }
+
+   // The URL was transformed. mapUrlPorts takes an absolute URL and returns a relative URL like
+   // "p/08afc455", so make it absolute again if requested by prefixing it with the URL of the
+   // connected client.
+   if (r::sexp::asLogical(absolute))
+   {
+      auto prefix = persistentState().activeClientUrl();
+      if (!prefix.empty())
+      {
+         // Ensure trailing slash before we stick the strings, since mapUrlPorts doesn't return one
+         if (prefix.back() != '/' && transformed.front() != '/')
+            prefix += "/";
+
+         // Prepend to the transformed URL
+         transformed = prefix + transformed;
+      }
+   }
+
+   // Return the transformed URL
+   r::sexp::Protect protect;
+   return r::sexp::create(transformed, &protect);
+}
+
+} // anonymous namespace
 
 // given a url, return a portmap path if applicable (i.e. we're in server
 // mode and the path needs port mapping), and the unmodified url otherwise
@@ -40,6 +88,12 @@ std::string mapUrlPorts(const std::string& url)
    }
 #endif
    return url;
+}
+
+core::Error initialize()
+{
+   RS_REGISTER_CALL_METHOD(rs_translateLocalUrl);
+   return core::Success();
 }
 
 }  // namespace url_ports

--- a/src/cpp/session/include/session/SessionPersistentState.hpp
+++ b/src/cpp/session/include/session/SessionPersistentState.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionPersistentState.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-18 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -43,6 +43,10 @@ public:
    // active-client-id
    std::string activeClientId();
    std::string newActiveClientId();
+
+   // browser-facing url of active client
+   std::string activeClientUrl() const;
+   void setActiveClientUrl(const std::string& url);
    
    // abend
    bool hadAbend();

--- a/src/cpp/session/include/session/SessionUrlPorts.hpp
+++ b/src/cpp/session/include/session/SessionUrlPorts.hpp
@@ -20,10 +20,18 @@
 #include <string>
 
 namespace rstudio {
+namespace core {
+   class Error;
+}
+}
+
+namespace rstudio {
 namespace session {
 namespace url_ports {
 
 std::string mapUrlPorts(const std::string& url);
+
+core::Error initialize();
 
 }  // namespace url_ports
 }  // namespace session


### PR DESCRIPTION
This change adds an API method which makes it possible to transform localhost URLs like these:

    http://localhost:1234/

into URLs which are externally accessible on RStudio Server, like these:

    http://servername/s/003f0cfc78a31de4b4e02/p/c6237f97/

It was previously possible for this transformation to be done without an API call, since you could just put the raw port number right into the URL, but this isn't possible any more; see https://github.com/rstudio/rstudio-pro/pull/738 for a longer discussion of the rationale. 

Part of a fix for https://github.com/rstudio/rstudio/issues/4054.