### PR TITLE
Persist console processes outside project folder

### DIFF
--- a/src/cpp/session/SessionConsoleProcessPersist.cpp
+++ b/src/cpp/session/SessionConsoleProcessPersist.cpp
@@ -21,6 +21,7 @@
 
 #include <session/SessionModuleContext.hpp>
 #include <session/SessionOptions.hpp>
+#include <session/projects/SessionProjects.hpp>
 
 using namespace rstudio::core;
 
@@ -66,11 +67,14 @@ void initialize()
    if (session::options().multiSession() &&
        session::options().programMode() == kSessionProgramModeServer)
    {
+      // In multi-session mode, persist per session
       s_consoleProcPath = module_context::sessionScratchPath().complete(kConsoleDir);
    }
    else
    {
-      s_consoleProcPath = module_context::scopedScratchPath().complete(kConsoleDir);
+      // In single-session mode, persist in external project storage (not internally in the project
+      // since contents include environment values and can be sensitive)
+      s_consoleProcPath = projects::projectContext().externalStoragePath().complete(kConsoleDir);
    }
 
    Error error = s_consoleProcPath.ensureDirectory();

--- a/src/cpp/session/include/session/projects/SessionProjects.hpp
+++ b/src/cpp/session/include/session/projects/SessionProjects.hpp
@@ -96,17 +96,24 @@ public:
 
    core::Error initialize();
 
-public:
    // these functions can be called even when there is no project
    bool hasProject() const { return !file_.empty(); }
 
+   // Path to the .RProj file representing the project
    const core::FilePath& file() const { return file_; }
+
+   // Path to the directory in which the project resides
    const core::FilePath& directory() const { return directory_; }
+
+   // Path to the project user scratch path; user-specific and stored in .Rproj.user
    const core::FilePath& scratchPath() const { return scratchPath_; }
-   const core::FilePath& sharedScratchPath() const 
-   { 
-      return sharedScratchPath_; 
-   }
+
+   // Path to storage shared among users; stored in .Rproj.user
+   const core::FilePath& sharedScratchPath() const { return sharedScratchPath_; }
+
+   // Path to external user and project-specific storage folder outside .Rproj.user (in e.g.
+   // .rstudio or .rstudio-desktop)
+   const core::FilePath& externalStoragePath() const { return storagePath_; }
 
    core::FilePath oldScratchPath() const;
    core::FilePath websitePath() const;
@@ -217,6 +224,7 @@ private:
    core::FilePath directory_;
    core::FilePath scratchPath_;
    core::FilePath sharedScratchPath_;
+   core::FilePath storagePath_;
    core::r_util::RProjectConfig config_;
    std::string defaultEncoding_;
    core::FilePath buildTargetPath_;

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -35,6 +35,7 @@
 
 #include <session/SessionUserSettings.hpp>
 #include <session/SessionModuleContext.hpp>
+#include <session/SessionScopes.hpp>
 
 #include <session/projects/ProjectsSettings.hpp>
 #include <session/projects/SessionProjectSharing.hpp>
@@ -42,6 +43,8 @@
 #include <sys/stat.h>
 
 #include "SessionProjectFirstRun.hpp"
+
+#define kStorageFolder "projects"
 
 using namespace rstudio::core;
 
@@ -410,7 +413,9 @@ Error ProjectContext::initialize()
             "rs_hasFileMonitor",
             (DL_FUNC) rs_hasFileMonitor,
             0);
-   
+
+   std::string projectId(kProjectNone);
+
    if (hasProject())
    {
       // update activeSession
@@ -440,12 +445,20 @@ Error ProjectContext::initialize()
          module_context::events().onDeferredInit.connect(
                       boost::bind(&ProjectContext::onDeferredInit, this, _1));
       }
+
+      // compute project ID
+      projectId = projectToProjectId(module_context::userScratchPath(), FilePath(),
+            directory().absolutePath()).id();
    }
    else
    {
       // update activeSession
       activeSession().setProject(kProjectNone);
    }
+
+   // compute storage path from project ID
+   storagePath_ = module_context::userScratchPath().complete(kStorageFolder).complete(projectId);
+   
    return Success();
 }
 


### PR DESCRIPTION
On RStudio Desktop, and on Server when in single-session mode, we currently persist console process information (such as history and environment values) inside RStudio project folders, in the hidden `.Rproj.user` folder.

This change creates a new "external storage" folder for projects, which lives in e.g. `~/.rstudio/projects`. It uses the project ID mapping table (formerly dormant outside server multi-session mode) to create a persistent map of projects to unique IDs, and uses those IDs to make unique folder paths. Console process information is stored in the external storage folder instead of inside the project.

Note that this doesn't fix any of the subtle issues which result from the impedance mismatch between project and session storage for terminals (e.g. when you have two sessions open against the same project in Desktop). Revamping the desktop session model will require a more holistic change probably best saved for 1.3. 

Also worth noting: no migration or deletion is planned for 1.1's terminal sets. After this change, "resetting RStudio's state" by deleting your `~/.rstudio` folder or equivalent will also reset all of your terminals.

Fixes https://github.com/rstudio/rstudio-pro/issues/746. 