### PR TITLE
Print Messages and Warnings differently than Errors

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -263,7 +263,17 @@ public class ShellWidget extends Composite implements ShellDisplay,
    public void consoleWriteError(final String error)
    {
       clearPendingInput();
-      output(error, getErrorClass(), true /*isError*/, false /*ignoreLineCount*/);
+
+      String errClass;
+      if (error.startsWith("Error:")) {
+        errClass = getErrorClass();
+      } else if (error.startsWith("Warning:")) {
+        errClass = getWarningClass();
+      } else {
+        errClass = styles_.output();
+      }
+
+      output(error, errClass, true /*isError*/, false /*ignoreLineCount*/);
 
       // Pick up the elements emitted to the console by this call. If we get 
       // extended information for this error, we'll need to swap out the simple 
@@ -383,6 +393,12 @@ public class ShellWidget extends Composite implements ShellDisplay,
    {
       return styles_.error() + " " + 
              RStudioGinjector.INSTANCE.getUIPrefs().getThemeErrorClass();
+   }
+
+   private String getWarningClass()
+   {
+      return styles_.error() + " " +
+             RStudioGinjector.INSTANCE.getUIPrefs().getThemeWarningClass();
    }
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -74,6 +74,11 @@ public class UIPrefsAccessor extends Prefs
       return bool("use_spaces_for_tab", true);
    }
 
+   public String getThemeWarningClass()
+   {
+         return " ace_constant ace_numeric";
+   }
+
    // NOTE: UserSettings.cpp depends on the name of this value
    public PrefValue<Integer> numSpacesForTab()
    {


### PR DESCRIPTION
This is a simple proof of concept to address https://github.com/rstudio/rstudio/issues/2574

There are some open issues it would be nice to discuss.

Warnings seem to consist of 2 separate error calls resulting in two
separate span blocks. The first is just the text 'Warning:' the second
is the actual warning message. This causes the current code to only color the
text of 'Warning:', which I think actually looks pretty nice, maybe we
could do the same for errors?

Errors (at least short ones) have the entire error in one span, so the
whole thing is colored.

The search string assumes an English locale, it would likely have to be
localized, as the 'Error' text changes when other languages are used.

This only changes the behavior in the R shell, it seems
`getThemeErrorClass()` is called a few more places, they could possibly
need to be changed as well.

We would probably also need to change `consoleWriteExtendedError()`, but I
was unsure when this is called so did not know how to test it.

Fixes https://github.com/rstudio/rstudio/issues/2574