### PR TITLE
Restore foreground/background colors to themes API

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -721,10 +721,23 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
       "Classic"
    )
 
+   # default/fallback theme colors 
+   foreground <- "#000000";
+   background <- "#FFFFFF";
+
+   # attempt to read colors from browser
+   colors <- .Call("rs_getThemeColors", PACKAGE = "(embedding)")
+   if (!is.null(colors)) {
+      foreground <- colors$foreground
+      background <- colors$background
+   }
+
    list(
       editor = theme$name,
       global = global,
-      dark = theme$isDark
+      dark = theme$isDark,
+      foreground = foreground,
+      background = background
    )
 })
 

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -192,6 +192,7 @@ const int kDataOutputCompleted = 173;
 const int kNewDocumentWithCode = 174;
 const int kPlumberViewer = 175;
 const int kAvailablePackagesReady = 176;
+const int kComputeThemeColors = 177;
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -531,6 +532,8 @@ std::string ClientEvent::typeName() const
          return "available_packages_ready";
       case client_events::kPlumberViewer:
          return "plumber_viewer";
+      case client_events::kComputeThemeColors:
+         return "compute_theme_colors";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -240,6 +240,8 @@ SEXP rs_enqueClientEvent(SEXP nameSEXP, SEXP dataSEXP)
          type = session::client_events::kNewDocumentWithCode;
       else if (name == "available_packages_ready")
          type = session::client_events::kAvailablePackagesReady;
+      else if (name == "compute_theme_colors")
+         type = session::client_events::kComputeThemeColors;
 
       if (type != -1)
       {

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -193,6 +193,7 @@ extern const int kDataOutputCompleted;
 extern const int kNewDocumentWithCode;
 extern const int kPlumberViewer;
 extern const int kAvailablePackagesReady;
+extern const int kComputeThemeColors;
 }
    
 class ClientEvent

--- a/src/cpp/session/modules/SessionThemes.cpp
+++ b/src/cpp/session/modules/SessionThemes.cpp
@@ -49,6 +49,8 @@ namespace themes {
 
 namespace {
 
+module_context::WaitForMethodFunction s_waitForThemeColors;
+
 const std::string kDefaultThemeLocation = "theme/default/";
 const std::string kGlobalCustomThemeLocation = "theme/custom/global/";
 const std::string kLocalCustomThemeLocation = "theme/custom/local/";
@@ -291,6 +293,43 @@ SEXP rs_getThemes()
 }
 
 /**
+ * @brief Returns the foreground and background color of the active theme.
+ *
+ * @return An R list with the foreground and background, or NULL if the color could not be
+ *         determined.
+ */
+SEXP rs_getThemeColors()
+{
+   r::sexp::Protect protect;
+   json::JsonRpcRequest request;
+   r::sexp::ListBuilder themeColors(&protect);
+
+   // Query the client for its current theme colors
+   if (!s_waitForThemeColors(&request, 
+            ClientEvent(client_events::kComputeThemeColors, json::Value())))
+   {
+      // Client did not return colors
+      r::exec::warning("Active theme colors not available.");
+      return R_NilValue;
+   }
+   
+   // Parse the theme colors returned by the client
+   std::string foreground, background;
+   Error error = json::readParams(request.params, &foreground, &background);
+   if (error)
+   {
+      // Client returned something we didn't understand
+      r::exec::warning("No theme colors could be determined: " + error.summary());
+      return R_NilValue;
+   }
+
+   // Form the list and return to caller 
+   themeColors.add("foreground", foreground);
+   themeColors.add("background", background);
+   return r::sexp::create(themeColors, &protect);
+}
+
+/**
  * @brief Gets the default theme based on the request from the client.
  *
  * @param request    The request from the client.
@@ -507,7 +546,10 @@ Error initialize()
    using boost::bind;
    using namespace module_context;
 
+   s_waitForThemeColors = registerWaitForMethod("set_computed_theme_colors");
+
    RS_REGISTER_CALL_METHOD(rs_getThemes);
+   RS_REGISTER_CALL_METHOD(rs_getThemeColors);
 
    // We need to register our URI handlers twice to cover the data viewer grid document because those
    // links have a different prefix.

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -107,7 +107,7 @@ public class Application implements ApplicationEventHandlers
                       Provider<ApplicationClientInit> pClientInit,
                       Provider<ApplicationQuit> pApplicationQuit,
                       Provider<ApplicationInterrupt> pApplicationInterrupt,
-                      Provider<AceThemes> pAceThemes,
+                      Provider<ApplicationThemes> pAppThemes,
                       Provider<ProductEditionInfo> pEdition)
    {
       // save references
@@ -125,8 +125,8 @@ public class Application implements ApplicationEventHandlers
       pClientInit_ = pClientInit;
       pApplicationQuit_ = pApplicationQuit;
       pApplicationInterrupt_ = pApplicationInterrupt;
-      pAceThemes_ = pAceThemes;
       pEdition_ = pEdition;
+      pAppThemes_ = pAppThemes;
 
       // bind to commands
       binder.bind(commands_, this);
@@ -149,7 +149,6 @@ public class Application implements ApplicationEventHandlers
       events.addHandler(ServerOfflineEvent.TYPE, this);
       events.addHandler(InvalidSessionEvent.TYPE, this);
       events.addHandler(SwitchToRVersionEvent.TYPE, this);
-      events.addHandler(ThemeChangedEvent.TYPE, this);
       
       // register for uncaught exceptions
       uncaughtExHandler.register();
@@ -664,14 +663,6 @@ public class Application implements ApplicationEventHandlers
       view_.showSessionAbendWarning();
    }
    
-   @Override
-   public void onThemeChanged(ThemeChangedEvent event)
-   {
-      RStudioThemes.initializeThemes(uiPrefs_.get(),
-                                     Document.get(),
-                                     rootPanel_.getElement());
-   }
-   
    private void verifyAgreement(SessionInfo sessionInfo,
                               final Operation verifiedOperation)
    {
@@ -763,13 +754,8 @@ public class Application implements ApplicationEventHandlers
    }
    private void initializeWorkbench()
    {
-      // Bind theme change handlers to the uiPrefs and immediately fire a theme changed event to
-      // set the initial theme.
-      uiPrefs_.get().getFlatTheme().bind(theme -> events_.fireEvent(new ThemeChangedEvent()));
-      uiPrefs_.get().theme().bind(theme -> events_.fireEvent(new ThemeChangedEvent()));
-      events_.fireEvent(new ThemeChangedEvent());
-
-      pAceThemes_.get();
+      // Initialize application theme system
+      pAppThemes_.get().initializeThemes(rootPanel_.getElement());
 
       // subscribe to ClientDisconnected event (wait to do this until here
       // because there were spurious ClientDisconnected events occurring
@@ -1119,8 +1105,8 @@ public class Application implements ApplicationEventHandlers
    private final Provider<ApplicationClientInit> pClientInit_;
    private final Provider<ApplicationQuit> pApplicationQuit_;
    private final Provider<ApplicationInterrupt> pApplicationInterrupt_;
-   private final Provider<AceThemes> pAceThemes_;
    private final Provider<ProductEditionInfo> pEdition_;
+   private final Provider<ApplicationThemes> pAppThemes_;
    
    private AboutDialog aboutDialog_;
    

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationThemes.java
@@ -1,0 +1,121 @@
+/*
+ * ApplicationThemes.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.application;
+
+import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.dom.DomUtils;
+import org.rstudio.studio.client.application.events.ComputeThemeColorsEvent;
+import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.application.events.ThemeChangedEvent;
+import org.rstudio.studio.client.application.ui.RStudioThemes;
+import org.rstudio.studio.client.server.VoidServerRequestCallback;
+import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
+import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
+import org.rstudio.studio.client.workbench.views.source.editors.text.themes.model.ThemeServerOperations;
+
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.Style.Position;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.dom.client.Style.Visibility;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
+public class ApplicationThemes implements ThemeChangedEvent.Handler,
+                                          ComputeThemeColorsEvent.Handler
+{
+   @Inject
+   public ApplicationThemes(Provider<UIPrefs> pUiPrefs,
+                            Provider<AceThemes> pAceThemes,
+                            EventBus events,
+                            ThemeServerOperations server)
+   {
+      uiPrefs_ = pUiPrefs;
+      pAceThemes_ = pAceThemes;
+      events_ = events;
+      server_ = server;
+      
+      events_.addHandler(ThemeChangedEvent.TYPE, this);
+      events_.addHandler(ComputeThemeColorsEvent.TYPE, this);
+   }
+
+   public void initializeThemes(Element root)
+   {
+      // Save reference to root element
+      root_ = root;
+      
+      // Bind theme change handlers to the uiPrefs and immediately fire a theme changed event to
+      // set the initial theme.
+      uiPrefs_.get().getFlatTheme().bind(theme -> events_.fireEvent(new ThemeChangedEvent()));
+      uiPrefs_.get().theme().bind(theme -> events_.fireEvent(new ThemeChangedEvent()));
+      events_.fireEvent(new ThemeChangedEvent());
+      
+      // Ensure creation of the Ace themes instance
+      pAceThemes_.get();
+   }
+
+   @Override
+   public void onComputeThemeColors(ComputeThemeColorsEvent event)
+   {
+      // Establish defaults
+      String foreground = "#000000";
+      String background = "#FFFFFF";
+
+      // We're very exception sensitive here since this code runs in a
+      // WaitForMethod (and therefore can hold the server while we wait for it
+      // to return).
+      try
+      {
+         // Create a sampler element to read runtime styles; hide it and position
+         // it offscreen to ensure it doesn't flicker.
+         Element sampler = Document.get().createElement("div");
+         sampler.addClassName("ace_editor ace_content");
+         sampler.getStyle().setVisibility(Visibility.HIDDEN);
+         sampler.getStyle().setPosition(Position.ABSOLUTE);
+         sampler.getStyle().setTop(-10000, Unit.PX);
+         sampler.getStyle().setLeft(-10000, Unit.PX);
+
+         // Append the sampler element to the root panel, read its content, and
+         // remove it.
+         root_.appendChild(sampler);
+         Style style = DomUtils.getComputedStyles(sampler);
+         foreground = style.getColor();
+         background = style.getBackgroundColor();
+         root_.removeChild(sampler);
+      }
+      catch (Exception e)
+      {
+         Debug.logException(e);
+      }
+      
+      // Send the server the computed colors
+      server_.setComputedThemeColors(foreground, background, new VoidServerRequestCallback());
+   }
+
+   @Override
+   public void onThemeChanged(ThemeChangedEvent event)
+   {
+      RStudioThemes.initializeThemes(uiPrefs_.get(),
+                                     Document.get(),
+                                     root_);
+   }
+   
+   private final Provider<UIPrefs> uiPrefs_;
+   private final Provider<AceThemes> pAceThemes_;
+   private final EventBus events_;
+   private final ThemeServerOperations server_;
+   private Element root_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/application/events/ApplicationEventHandlers.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/ApplicationEventHandlers.java
@@ -28,7 +28,6 @@ public interface ApplicationEventHandlers extends LogoutRequestedHandler,
                                                   ClientDisconnectedHandler,
                                                   InvalidClientVersionHandler,
                                                   ServerOfflineHandler,
-                                                  InvalidSessionEvent.Handler,
-                                                  ThemeChangedEvent.Handler
+                                                  InvalidSessionEvent.Handler
 {
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/events/ComputeThemeColorsEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/ComputeThemeColorsEvent.java
@@ -1,0 +1,47 @@
+/*
+ * ComputeThemeColorsEvent.java
+ *
+ * Copyright (C) 2009-18 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.application.events;
+
+import com.google.gwt.event.shared.GwtEvent;
+import org.rstudio.core.client.js.JavaScriptSerializable;
+
+import com.google.gwt.event.shared.EventHandler;
+
+@JavaScriptSerializable
+public class ComputeThemeColorsEvent extends GwtEvent<ComputeThemeColorsEvent.Handler>
+{
+   public interface Handler extends EventHandler
+   {
+      void onComputeThemeColors(ComputeThemeColorsEvent event);
+   }
+
+   public ComputeThemeColorsEvent()
+   {
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onComputeThemeColors(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -183,6 +183,7 @@ class ClientEvent extends JavaScriptObject
    public static final String NewDocumentWithCode = "new_document_with_code";
    public static final String AvailablePackagesReady = "available_packages_ready";
    public static final String PlumberViewer = "plumber_viewer";
+   public static final String ComputeThemeColors = "compute_theme_colors";
 
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -1015,6 +1015,10 @@ public class ClientEventDispatcher
             PlumberAPIParams data = event.getData();
             eventBus_.dispatchEvent(new PlumberAPIStatusEvent(data, true));
          }
+         else if (type == ClientEvent.ComputeThemeColors)
+         {
+            eventBus_.dispatchEvent(new ComputeThemeColorsEvent());
+         }
          else
          {
             GWT.log("WARNING: Server event not dispatched: " + type, null);

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -130,6 +130,7 @@ import org.rstudio.studio.client.server.Server;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
+import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.shiny.model.ShinyRunCmd;
 import org.rstudio.studio.client.shiny.model.ShinyViewerType;
 import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
@@ -5802,6 +5803,15 @@ public class RemoteServer implements Server
    }
    
    @Override
+   public void setComputedThemeColors(String foreground, String background, VoidServerRequestCallback callback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(foreground));
+      params.set(1, new JSONString(background));
+      sendRequest(RPC_SCOPE, SET_COMPUTED_THEME_COLORS, params, callback);
+   }
+
+   @Override
    public void replaceCommentHeader(String command,
                                     String path,
                                     String code,
@@ -6277,6 +6287,7 @@ public class RemoteServer implements Server
    private static final String ADD_THEME = "add_theme";
    private static final String REMOVE_THEME = "remove_theme";
    private static final String GET_THEME_NAME = "get_theme_name";
+   private static final String SET_COMPUTED_THEME_COLORS = "set_computed_theme_colors";
 
    private static final String REPLACE_COMMENT_HEADER = "replace_comment_header";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/model/ThemeServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/model/ThemeServerOperations.java
@@ -19,6 +19,7 @@ import com.google.gwt.core.client.JsArray;
 
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
+import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceTheme;
 
 public interface ThemeServerOperations
@@ -30,4 +31,6 @@ public interface ThemeServerOperations
    void removeTheme(ServerRequestCallback<Void> request, String themeName);
    
    void getThemeName(ServerRequestCallback<String> request, String themeLocation);
+   
+   void setComputedThemeColors(String foreground, String background, VoidServerRequestCallback callback);
 }


### PR DESCRIPTION
The R2D3 package (and perhaps others) is able to adapt to the active RStudio theme by reading its foreground and background colors from rstudioapi (a new feature in 1.2). Unfortunately, this adaptation was short-lived; later in 1.2 we had to remove the fore/background color accessors when we did the custom theme work, as RStudio no longer has any knowledge of the theme colors (it just applies CSS).

This change adds the accessors back, in such a way that they work without a priori knowledge of the theme and without CSS parsing of any kind. Instead, we now ask the browser (using a client event) for the theme colors, and it reads them from a dummy element. 

Fixes https://github.com/rstudio/rstudio/issues/4055.