### PR TITLE
Dislable autocomplete/capitalize/etc for rstudio server login form

### DIFF
--- a/src/gwt/www/templates/encrypted-sign-in.htm
+++ b/src/gwt/www/templates/encrypted-sign-in.htm
@@ -167,6 +167,10 @@ function submitRealForm() {
          <label for="username">Username:</label><br />
          <input type='text' 
                 name='username' 
+                autocomplete='off'
+                autocorrect='off'
+                autocapitalize='off'
+                spellcheck='false'
                 value='' 
                 id='username' 
                 size='45'/><br />
@@ -175,6 +179,10 @@ function submitRealForm() {
          <label for="password">Password:</label><br />
          <input type='password' 
                 name='password' 
+                autocomplete='off'
+                autocorrect='off'
+                autocapitalize='off'
+                spellcheck='false'
                 value='' 
                 id='password' 
                 size='45'


### PR DESCRIPTION
Suggested input form changes to the RStudio Server login form to suppress all the "helpful" things iOS and Android OS try to do on web pages so it's less frustrating for end-users (these rly aren't bad defaults anyway IMO but I totally grok if this is an undesired PR).