### PR TITLE
Downgrade to Qt 5.11.1

### DIFF
--- a/dependencies/common/install-boost
+++ b/dependencies/common/install-boost
@@ -87,8 +87,8 @@ then
    if [ "$PLATFORM" == "Darwin" ]
    then
 
-     BJAM_CXXFLAGS="cxxflags=-fPIC -std=c++11 -mmacosx-version-min=10.12"
-     BJAM_LDFLAGS=""
+     BJAM_CXXFLAGS="cxxflags=-fPIC -std=c++11"
+     BJAM_LDFLAGS=""     
 
      sudo ./bjam              \
         "${BOOST_BJAM_FLAGS}" \

--- a/dependencies/linux/README
+++ b/dependencies/linux/README
@@ -9,22 +9,22 @@ systems. Specific version requirements for various components include:
 - R 3.0.1
 - CMake 2.8 (3.1.0 for Desktop)
 - Boost 1.63
-- Qt 5.12.0 [Required only for Desktop]
+- Qt 5.11.1 [Required only for Desktop]
 - some older Linux platforms (OpenSUSE 42.3, Ubuntu Trusty) can only
-  build Desktop with Qt 5.10.1 due to unsatisfied dependencies in 5.12.0
+  build Desktop with Qt 5.10.1 due to unsatisfied dependencies in 5.11.1
 
-Installation of Qt SDK 5.12.0
+Installation of Qt SDK 5.11.1
 =============================================================================
 
-RStudio Desktop requires Qt 5.12.0. The install-dependencies scripts 
-referenced below install a version of the Qt 5.12.0 SDK into 
+RStudio Desktop requires Qt 5.11.1. The install-dependencies scripts 
+referenced below install a version of the Qt 5.11.1 SDK into 
 /opt/RStudio-QtSDK (the special RStudio prefix on the directory is included 
 so this installation doesn't conflict with any other versions of Qt installed 
 on the system).
 
 If you are either building RStudio Server or running a Linux distribution 
-that already includes Qt 5.12.0 you may wish to prevent installation of the
-Qt 5.12.0 SDK. To do this pass the --exclude-qt-sdk flag to the install 
+that already includes Qt 5.11.1 you may wish to prevent installation of the
+Qt 5.11.1 SDK. To do this pass the --exclude-qt-sdk flag to the install 
 dependencies script, for example:
 
 ./install-dependencies-debian --exclude-qt-sdk
@@ -44,7 +44,7 @@ installing it using the system standard package management tools (apt-get,
 yum, etc).
 
 2) Run the install-dependencies script appropriate to your platform's
-package management system (to optionally exclude installation of the Qt 5.12.0
+package management system (to optionally exclude installation of the Qt 5.11.1
 SDK be sure to specify the --exclude-qt-sdk flag as described above).
 
    ./install-dependencies-debian  
@@ -76,7 +76,7 @@ Hunspell dictionaries, MathJax, and Boost 1.63):
          install-common
 
 3) Optionally install the Qt SDK. You should do this if you are building the
-Desktop version and don't have Qt 5.12.0 installed on the system:
+Desktop version and don't have Qt 5.11.1 installed on the system:
 
    dependencies
       linux

--- a/dependencies/linux/install-qt-sdk
+++ b/dependencies/linux/install-qt-sdk
@@ -15,13 +15,13 @@
 #
 
 if [ -z "$QT_VERSION" ]; then
-    QT_VERSION=5.12.0
+    QT_VERSION=5.11.1
 fi
 if [ -z "$QT_SDK_BINARY" ]; then
     QT_SDK_BINARY=qt-unified-linux-x64-3.0.5-online.run
 fi
 if [ -z "$QT_PACKAGES" ]; then
-    QT_PACKAGES=qt.qt5.5120.gcc_64,qt.qt5.5120.qtwebengine,qt.qt5.5120.qtwebengine.gcc_64
+    QT_PACKAGES=qt.qt5.5111.gcc_64,qt.qt5.5111.qtwebengine,qt.qt5.5111.qtwebengine.gcc_64
 fi
 if [ -z "$QT_SDK_CUSTOM" ]; then
     echo Using online Qt installer

--- a/dependencies/osx/install-qt-sdk-osx
+++ b/dependencies/osx/install-qt-sdk-osx
@@ -18,7 +18,7 @@
 # Installs Qt via the online installer at the location in $QT_SDK_DIR.
 # If no location provided, checks against a set of common locations and installs if not found.
 
-QT_VERSION=5.12.0
+QT_VERSION=5.11.1
 QT_SDK_BINARY_BASE=qt-unified-mac-x64-3.0.5-online
 QT_SDK_BINARY=${QT_SDK_BINARY_BASE}.tar.gz
 QT_SDK_INSTALLER=${QT_SDK_BINARY_BASE}.app
@@ -65,10 +65,10 @@ Controller.prototype.TargetDirectoryPageCallback = function()
 Controller.prototype.ComponentSelectionPageCallback = function() {
     var widget = gui.currentPageWidget();
      
-    widget.selectComponent("qt.qt5.5120.clang_64");
-    widget.selectComponent("qt.qt5.5120.qtwebengine");
-    widget.selectComponent("qt.qt5.5120.qtwebengine.clang_64");
-    widget.deselectComponent("qt.qt5.5120.src");
+    widget.selectComponent("qt.qt5.5111.clang_64");
+    widget.selectComponent("qt.qt5.5111.qtwebengine");
+    widget.selectComponent("qt.qt5.5111.qtwebengine.clang_64");
+    widget.deselectComponent("qt.qt5.5111.src");
     gui.clickButton(buttons.NextButton);
 }
 

--- a/docker/docker-compile-all.sh
+++ b/docker/docker-compile-all.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+
+# read canonical list of flavors from Jenkinsfile
+SOURCEDIR=$(dirname "${BASH_SOURCE[0]}")
+CONTAINERS=$(cat $SOURCEDIR/../Jenkinsfile | grep "\[os: ")
+HOSTLIST=$(echo "$CONTAINERS" | cut -d \' -f 2 | tr '\n' ' ')
+PLATFORMLIST=$(echo "$CONTAINERS" | cut -d \' -f 4 | tr '\n' ' ')
+FLAVORLIST=$(echo "$CONTAINERS" | cut -d \' -f 6 | tr '\n' ' ')
+
+# convert to formal arrays
+IFS=' ' read -a HOSTS <<< "$HOSTLIST"
+IFS=' ' read -a PLATFORMS <<< "$PLATFORMLIST"
+IFS=' ' read -a FLAVORS <<< "$FLAVORLIST"
+
+# iterate through array and perform a docker compile
+for ((i = 0; i < ${#HOSTS[@]}; i++))
+do
+    echo "=== Building platform $((i+1))/${#HOSTS[@]}: ${HOSTS[$i]} ${FLAVORS[$i]} ==="
+    "$SOURCEDIR/docker-compile.sh" "${HOSTS[$i]}-${PLATFORMS[$i]}" "${FLAVORS[$i]}"
+done

--- a/docker/jenkins/Dockerfile.centos7-x86_64
+++ b/docker/jenkins/Dockerfile.centos7-x86_64
@@ -62,7 +62,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.0 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.11.1 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/docker/jenkins/Dockerfile.debian9-x86_64
+++ b/docker/jenkins/Dockerfile.debian9-x86_64
@@ -64,7 +64,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.0 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.11.1 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/docker/jenkins/Dockerfile.opensuse15-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse15-x86_64
@@ -60,7 +60,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.0 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.11.1 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/docker/jenkins/Dockerfile.xenial-amd64
+++ b/docker/jenkins/Dockerfile.xenial-amd64
@@ -81,7 +81,7 @@ RUN /bin/bash /tmp/install-dependencies
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.0 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.11.1 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -37,7 +37,11 @@ if(NOT WIN32)
          endif()
       endif()
          
-      set(QT_CANDIDATES 5.12.0 5.10.1)
+      if(APPLE)
+         set(QT_CANDIDATES 5.11.1)   
+      else()
+         set(QT_CANDIDATES 5.11.1 5.10.1)
+      endif()
 
       # find the newest installed Qt version among the versions we build
       # against
@@ -69,6 +73,7 @@ if(NOT WIN32)
       endforeach()
    endif()
 else()
+   # Windows
    set(QT_VERSION "5.12.0")
    set(QT_VERSION_SUBDIR "${QT_VERSION}")   
    if(NOT QT_QMAKE_EXECUTABLE)

--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -440,6 +440,17 @@ int main(int argc, char* argv[])
       static char enableViewport[] = "--enable-viewport";
       arguments.push_back(enableViewport);
       
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
+      
+#ifndef NDEBUG
+      // disable web security for development builds (so we can
+      // get access to sourcemaps)
+      static char disableWebSecurity[] = "--disable-web-security";
+      arguments.push_back(disableWebSecurity);
+#endif
+      
+#endif
+      
       // disable chromium renderer accessibility by default (it can cause
       // slowdown when used in conjunction with some applications; see e.g.
       // https://github.com/rstudio/rstudio/issues/1990)
@@ -452,6 +463,14 @@ int main(int argc, char* argv[])
          arguments.push_back(disableRendererAccessibility);
       }
 
+#if defined(Q_OS_LINUX) && (QT_VERSION == QT_VERSION_CHECK(5,10,1))
+      // workaround for Qt 5.10.1 bug "Could not find QtWebEngineProcess"
+      // https://bugreports.qt.io/browse/QTBUG-67023
+      // https://bugreports.qt.io/browse/QTBUG-66346
+      static char noSandbox[] = "--no-sandbox";
+      arguments.push_back(noSandbox);
+#endif
+
 #ifdef Q_OS_MAC
       // don't prefer compositing to LCD text rendering. when enabled, this causes the compositor to
       // be used too aggressively on Retina displays on macOS, with the side effect that the
@@ -459,6 +478,65 @@ int main(int argc, char* argv[])
       // https://github.com/rstudio/rstudio/issues/1953
       static char disableCompositorPref[] = "--disable-prefer-compositing-to-lcd-text";
       arguments.push_back(disableCompositorPref);
+      
+      // disable GPU features for certain machine configurations. see e.g.
+      //
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=773705
+      // https://github.com/rstudio/rstudio/issues/2093
+      // https://github.com/rstudio/rstudio/issues/3148
+      //
+      // because the issue seems to only affect certain video cards on macOS
+      // High Sierra, we scope that change to that particular configuration
+      // for now (we can expand this list if more users report issues)
+      {
+         core::system::ProcessResult processResult;
+         core::system::runCommand(
+                  "/usr/sbin/system_profiler SPDisplaysDataType",
+                  core::system::ProcessOptions(),
+                  &processResult);
+
+         std::string stdOut = processResult.stdOut;
+         if (!stdOut.empty())
+         {
+            // NOTE: temporarily backed out as it appears the rasterization
+            // issues do not occur anymore with Qt 5.11.1; re-enable if we
+            // receive more reports in the wild.
+            //
+            // https://github.com/rstudio/rstudio/issues/2176
+            
+            /*
+            std::vector<std::string> rasterBlacklist = {
+               "NVIDIA GeForce GT 650M",
+               "NVIDIA GeForce GT 750M",
+               "Intel Iris Graphics 6100"
+            };
+
+            for (const std::string& entry : rasterBlacklist)
+            {
+               if (stdOut.find(entry) != std::string::npos)
+               {
+                  static char disableGpuRasterization[] = "--disable-gpu-rasterization";
+                  arguments.push_back(disableGpuRasterization);
+                  break;
+               }
+            }
+            */
+            
+            std::vector<std::string> gpuBlacklist = {
+               "AMD FirePro"
+            };
+            
+            for (const std::string& entry : gpuBlacklist)
+            {
+               if (stdOut.find(entry) != std::string::npos)
+               {
+                  static char disableGpu[] = "--disable-gpu";
+                  arguments.push_back(disableGpu);
+                  break;
+               }
+            }
+         }
+      }
 #endif
 
 #if defined(Q_OS_LINUX) && (QT_VERSION == QT_VERSION_CHECK(5, 10, 1))

--- a/src/cpp/desktop/DesktopWebView.cpp
+++ b/src/cpp/desktop/DesktopWebView.cpp
@@ -357,6 +357,16 @@ void WebView::contextMenuEvent(QContextMenuEvent* event)
       // we have a window; invoke Inspect Element now
       webPage()->triggerAction(QWebEnginePage::InspectElement);
    });
+#else
+   
+# ifndef NDEBUG
+   
+   menu->addAction(label(tr("&Reload")), [&]() { triggerPageAction(QWebEnginePage::Reload); });
+   menu->addSeparator();
+   menu->addAction(label(tr("I&nspect element")), [&]() { triggerPageAction(QWebEnginePage::InspectElement); });
+   
+# endif
+   
 #endif
    
    menu->setAttribute(Qt::WA_DeleteOnClose, true);


### PR DESCRIPTION
This change partially rolls back the Qt 5.12 update (see https://github.com/rstudio/rstudio/pull/4015/files) on MacOS and desktop Linux, due to the following problems:

- Qt 5.12 causes significant issues on MacOS. https://github.com/rstudio/rstudio/issues/4086
- Qt 5.12 cannot be compiled on CentOS 7. https://bugreports.qt.io/browse/QTBUG-71945?jql=text%20~%20%22compile%20gcc%204.8%22%20ORDER%20BY%20created%20DESC

We expect that both of these (or at least the last one) will be (as usual) resolved in the *next* update of Qt, so will wait for that one to do our next upgrade. 

This change also adds a new `docker-compile-all` script which can be used to programmatically compile all Linux desktop and server images. This should make it easier for us to do fire-and-forget local testing of changes which may break one of the Linux variants. 

NOTE: Not ready for merge yet; still validating locally.