### PR TITLE
Allow for attribute-free Markdown images

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ImagePreviewer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ImagePreviewer.java
@@ -244,24 +244,27 @@ public class ImagePreviewer
       String srcPath = imgSrcPathFromHref(sentinel, href);
       final Image image = new Image(srcPath);
       image.addStyleName(RES.styles().image());
-      
-      // parse and inject attributes
-      Attributes parsedAttributes = HTMLAttributesParser.parseAttributes(attributes);
       final Element imgEl = image.getElement();
-      for (Map.Entry<String, String> entry : parsedAttributes.getAttributes().entrySet())
-      {
-         String key = entry.getKey();
-         String val = entry.getValue();
-         if (StringUtil.isNullOrEmpty(key) || StringUtil.isNullOrEmpty(val))
-            continue;
-         imgEl.setAttribute(key, val);
-      }
       
-      if (!parsedAttributes.getIdentifier().isEmpty())
-         imgEl.setId(parsedAttributes.getIdentifier());
+      // parse and inject attributes, if we have any
+      if (attributes != null)
+      {
+         Attributes parsedAttributes = HTMLAttributesParser.parseAttributes(attributes);
+         for (Map.Entry<String, String> entry : parsedAttributes.getAttributes().entrySet())
+         {
+            String key = entry.getKey();
+            String val = entry.getValue();
+            if (StringUtil.isNullOrEmpty(key) || StringUtil.isNullOrEmpty(val))
+               continue;
+            imgEl.setAttribute(key, val);
+         }
 
-      for (String className : parsedAttributes.getClasses())
-         imgEl.addClassName(className);
+         if (!parsedAttributes.getIdentifier().isEmpty())
+            imgEl.setId(parsedAttributes.getIdentifier());
+
+         for (String className : parsedAttributes.getClasses())
+            imgEl.addClassName(className);
+      }
       
       // add load handlers to image
       DOM.sinkEvents(imgEl, Event.ONLOAD | Event.ONERROR);


### PR DESCRIPTION
This change addresses an issue which prevents Markdown images from showing when they don't have any attributes; it simply adds a `null` check so that these images can be correctly previewed.

Fixes https://github.com/rstudio/rstudio/issues/4087.