### PR TITLE
Always show status for completed jobs

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobProgress.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobProgress.java
@@ -67,6 +67,7 @@ public class JobProgress extends Composite
          progress_.setVisible(false);
          status += " " + StringUtil.friendlyDateTime(new Date(job.completed * 1000));
          elapsed_.setText(StringUtil.conciseElaspedTime(job.completed - job.started));
+         status_.setVisible(true);
       }
       else if (job.max > 0)
       {


### PR DESCRIPTION
Ensures that the job's completion status is visible when the job is finished running.

Fixes https://github.com/rstudio/rstudio/issues/4110.