### PR TITLE
allow reactlog windows to open (closes #4045)

### DIFF
--- a/src/cpp/desktop/DesktopWebPage.cpp
+++ b/src/cpp/desktop/DesktopWebPage.cpp
@@ -188,8 +188,8 @@ QWebEnginePage* WebPage::createWindow(QWebEnginePage::WebWindowType type)
    BrowserWindow* pWindow = nullptr;
    bool show = true;
 
-   // check if this is target="_blank";
-   if (type == QWebEnginePage::WebWindowType::WebBrowserTab)
+   // check if this is target="_blank" from an IDE window
+   if (!baseUrl_.isEmpty() && type == QWebEnginePage::WebWindowType::WebBrowserTab)
    {
       // QtWebEngine behavior is to open a new browser window and send it the 
       // acceptNavigationRequest we use to redirect to system browser; don't want


### PR DESCRIPTION
Closes #4045 by ensuring that our `target="_blank"` workaround only fires when an IDE-surfaced window is opening a link. This effectively allows for `window.open()` to work as expected in Shiny applications; this is required for e.g. the reactlog.