### PR TITLE
properly report attached packages in Packages pane (#4083)

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -390,8 +390,11 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    # combine into a data.frame
    info <- .rs.rbindList(parts)
    
-   # find which packages are loaded
-   info$Loaded <- info$Package %in% loadedNamespaces()
+   # find which packages are currently attached (be careful to handle
+   # cases where package is installed into multiple libraries)
+   loaded <-
+      normalizePath(file.path(info$LibPath, info$Package), winslash = "/", mustWork = FALSE) %in%
+      normalizePath(find.package(.packages(), quiet = TRUE), winslash = "/", mustWork = FALSE)
    
    # extract fields relevant to us
    packages <- data.frame(
@@ -401,7 +404,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
       library_index    = match(info$LibPath, .libPaths(), nomatch = 0L),
       version          = info$Version,
       desc             = info$Title,
-      loaded           = info$Loaded,
+      loaded           = loaded,
       source           = info$Source,
       browse_url       = info$BrowseUrl,
       check.rows       = TRUE,


### PR DESCRIPTION
Closes #4083. There was confusion in my refactoring of the old `.rs.listInstalledPackages()` routine around loaded vs. attached packages; we use the name 'loaded' here but are referring to attached packages.

We also make sure we properly handle the case where a package is installed in multiple libraries by checking the attached package's path explicitly.