### PR TITLE
Delay job name computation until file choice is final

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobManager.java
@@ -1,7 +1,7 @@
 /*
  * JobManager.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -399,9 +399,8 @@ public class JobManager implements JobRefreshEvent.Handler,
    
    private void showJobLauncherDialog(FileSystemItem path, FileSystemItem workingDir, String code)
    {
-      String name = (path == null ? "Current" : path.getName()) + " selection";
       JobLauncherDialog dialog = new JobLauncherDialog("Run Selection as Job",
-            name,
+            JobLauncherDialog.JobSource.Selection,
             path,
             workingDir,
             code,
@@ -422,7 +421,7 @@ public class JobManager implements JobRefreshEvent.Handler,
    private void showJobLauncherDialog(FileSystemItem path)
    {
       JobLauncherDialog dialog = new JobLauncherDialog("Run Script as Local Job",
-            path.getName(),
+            JobLauncherDialog.JobSource.Script,
             path,
             spec ->
             {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobLauncherDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobLauncherDialog.java
@@ -1,7 +1,7 @@
 /*
  * JobLauncherDialog.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -24,16 +24,22 @@ import com.google.gwt.user.client.ui.Widget;
 
 public class JobLauncherDialog extends ModalDialog<JobLaunchSpec>
 {
+   public enum JobSource
+   {
+      Script,
+      Selection
+   }
+
    public JobLauncherDialog(String caption,
-                            String jobName,
+                            JobSource source,
                             FileSystemItem scriptPath,
                             OperationWithInput<JobLaunchSpec> operation)
    {
-      this(caption, jobName, scriptPath, scriptPath.getParentPath(), null, operation);
+      this(caption, source, scriptPath, scriptPath.getParentPath(), null, operation);
    }
    
    public JobLauncherDialog(String caption,
-                            String jobName,
+                            JobSource source,
                             FileSystemItem scriptPath,
                             FileSystemItem workingDir,
                             String code,
@@ -53,7 +59,7 @@ public class JobLauncherDialog extends ModalDialog<JobLaunchSpec>
          controls_.hideScript();
       
       code_ = code;
-      jobName_ = jobName;
+      source_ = source;
 
       setOkButtonCaption("Start");
    }
@@ -61,9 +67,27 @@ public class JobLauncherDialog extends ModalDialog<JobLaunchSpec>
    @Override
    protected JobLaunchSpec collectInput()
    {
+      // Compute a reasonable name for the job based on the selected script (if any)
+      String jobName;
+      if (source_ == JobSource.Selection)
+      {
+         if (StringUtil.isNullOrEmpty(controls_.scriptPath()))
+         {
+            jobName = "Current selection";
+         }
+         else
+         {
+            jobName = FileSystemItem.getNameFromPath(controls_.scriptPath()) + " selection";
+         }
+      }
+      else 
+      {
+         jobName = FileSystemItem.getNameFromPath(controls_.scriptPath());
+      }
+
       if (code_ == null)
       {
-         return JobLaunchSpec.create(jobName_,
+         return JobLaunchSpec.create(jobName,
                controls_.scriptPath(), 
                "unknown", // encoding unknown (will try to look it up later)
                controls_.workingDir(),
@@ -72,7 +96,7 @@ public class JobLauncherDialog extends ModalDialog<JobLaunchSpec>
       }
       else
       {
-         return JobLaunchSpec.create(jobName_,
+         return JobLaunchSpec.create(jobName,
                code_, 
                controls_.workingDir(), 
                controls_.importEnv(), 
@@ -95,6 +119,6 @@ public class JobLauncherDialog extends ModalDialog<JobLaunchSpec>
    }
    
    private final String code_;
-   private final String jobName_;
+   private final JobSource source_;
    private JobLauncherControls controls_;
 }


### PR DESCRIPTION
This change addresses an issue in which selecting a different script doesn't update the name of the job in the Jobs pane. The fix is to delay the generation of the job name until the dialog has been dismissed.

Fixes https://github.com/rstudio/rstudio/issues/4114.