### PR TITLE
band-aid for encoding issues in rmarkdown render

### DIFF
--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -515,7 +515,9 @@ private:
                              renderOptions);
       
       // un-escape unicode escapes
+#ifdef _WIN32
       cmd = boost::algorithm::replace_all_copy(cmd, "\\\\u{", "\\u{");
+#endif
       
       // environment
       core::system::Options environment;

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -71,6 +71,60 @@ namespace session {
 
 namespace {
 
+#ifdef _WIN32
+
+// TODO: promote to StringUtils?
+std::string utf8ToConsole(const std::string& string)
+{
+   std::vector<wchar_t> wide(string.length() + 1);
+   int chars = ::MultiByteToWideChar(
+            CP_UTF8, 0,
+            string.data(), string.size(),
+            &wide[0], static_cast<int>(wide.size()));
+
+   if (chars == 0)
+   {
+      LOG_ERROR(LAST_SYSTEM_ERROR());
+      return string;
+   }
+   
+   std::ostringstream output;
+   char buffer[16];
+   
+   // force C locale (ensures that any non-ASCII characters
+   // will fail to convert and hence must be unicode escaped)
+   const char* locale = ::setlocale(LC_CTYPE, nullptr);
+   ::setlocale(LC_CTYPE, "C");
+
+   for (int i = 0; i < chars; i++)
+   {
+      int n = ::wctomb(buffer, wide[i]);
+      
+      if (n == -1)
+      {
+         output << "\\u{" << std::hex << wide[i] << "}";
+      }
+      else
+      {
+         output.write(buffer, n);
+      }
+   }
+   
+   ::setlocale(LC_CTYPE, locale);
+   
+   return output.str();
+   
+}
+
+#else
+
+std::string utf8ToConsole(const std::string& string)
+{
+   return string_utils::utf8ToSystem(string);
+}
+
+#endif
+
 enum 
 {
    RExecutionReady = 0,
@@ -400,7 +454,7 @@ private:
 
       std::string extraParams;
       std::string targetFile =
-              string_utils::utf8ToSystem(targetFile_.absolutePath());
+            utf8ToConsole(targetFile_.absolutePath());
 
       std::string renderOptions("encoding = '" + encoding + "'");
 
@@ -413,7 +467,7 @@ private:
       // include params if specified
       if (!paramsFile.empty())
       {
-         renderOptions += ", params = readRDS('" + paramsFile + "')";
+         renderOptions += ", params = readRDS('" + utf8ToConsole(paramsFile) + "')";
       }
 
       // use the stated working directory if specified and we're using the default render function
@@ -421,7 +475,7 @@ private:
       if (!workingDir.empty() && renderFunc == kStandardRenderFunc)
       {
          renderOptions += ", knit_root_dir = '" + 
-                          string_utils::utf8ToSystem(workingDir) + "'";
+                          utf8ToConsole(workingDir) + "'";
       }
 
       // output to a temporary directory if specified (no need to do this
@@ -432,7 +486,7 @@ private:
          Error error = tmpDir.ensureDirectory();
          if (!error)
          {
-            std::string dir = string_utils::utf8ToSystem(tmpDir.absolutePath());
+            std::string dir = utf8ToConsole(tmpDir.absolutePath());
             renderOptions += ", output_dir = '" + dir + "'";
          }
          else
@@ -445,8 +499,8 @@ private:
       {
          extraParams += "shiny_args = list(launch.browser = FALSE), "
                         "auto_reload = FALSE, ";
-         extraParams += "dir = '" + string_utils::utf8ToSystem(
-                     targetFile_.parent().absolutePath()) + "', ";
+         std::string parentDir = utf8ToConsole(targetFile_.parent().absolutePath());
+         extraParams += "dir = '" + parentDir + "', ";
 
          // provide render_args in render_args parameter
          renderOptions = "render_args = list(" + renderOptions + ")";
@@ -459,7 +513,10 @@ private:
                              string_utils::singleQuotedStrEscape(targetFile) %
                              extraParams %
                              renderOptions);
-
+      
+      // un-escape unicode escapes
+      cmd = boost::algorithm::replace_all_copy(cmd, "\\\\u{", "\\u{");
+      
       // environment
       core::system::Options environment;
       std::string tempDir;


### PR DESCRIPTION
This PR is a bandaid for https://github.com/rstudio/rstudio/issues/4075.

The issue here is a bit ugly. When we want to run an asynchronous R process, we generate a command line invocation of the form:

    R -e <command>

This implies that `<command>` needs to be encoded in the 'right' encoding if it contains multibyte characters. What is the correct encoding? Currently, `utf8ToSystem()` attempts to match the encoding associated with the current R locale, but that may not be the actual default encoding used by the system, or the command console.

Fortunately, we can sidestep the issue: R knows how to interpret unicode escapes, so if we replace any multibyte characters by their unicode escape equivalent, the command string should be plain ASCII and will "just work" regardless of the current locale. We then let R interpret those escapes according to the locale used when it launches.

For v1.3, it might be worth considering this approach in general when constructing commands to send to R, but I figure for v1.2 we just want to be as narrowly scoped as possible.

Note that v1.3 also has provisions for running commands with `R -f <file>` as opposed to `R -e <command>`, but we may want to consider a similar escaping regime for the files generated through this process -- e.g. use unicode escapes as opposed to the system encoding.

Closes https://github.com/rstudio/rstudio/issues/4075.