### PR TITLE
handle tibbles in data import (#4138)

### DIFF
--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -685,7 +685,7 @@
    }
 
    list(
-      data = unname(data),
+      data = unname(as.list(data)),
       columns = columns
    )
 })


### PR DESCRIPTION
This PR fixes an issue caused by the latest version of `tibble`.

Previously, we relied on the ability to set the names of a `data.frame` to NULL, e.g.

``` r
> names(unname(mtcars))
NULL
```

This is now disallowed by `tibble`, and instead names are filled with `NA`s:

``` r
> names(unname(tibble::as_tibble(mtcars)))
 [1] NA NA NA NA NA NA NA NA NA NA NA
```

The solution is to unclass the data object before calling `unname()`. Since we want to treat the `data.frame` like a list, we just convert it to a list first.

Note that this issue also affects v1.1, unfortunately.

```
> packageVersion("tibble")
[1] '2.0.0'
```