### PR TITLE
unbind old packages display from data provider

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
@@ -16,7 +16,6 @@ package org.rstudio.studio.client.workbench.views.packages;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.cellview.ImageButtonColumn;
 import org.rstudio.core.client.cellview.ImageButtonColumn.TitleProvider;
@@ -70,6 +69,7 @@ import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.LayoutPanel;
 import com.google.gwt.user.client.ui.SuggestOracle;
 import com.google.gwt.user.client.ui.Widget;
+import com.google.gwt.view.client.HasData;
 import com.google.gwt.view.client.ListDataProvider;
 import com.google.gwt.view.client.NoSelectionModel;
 import com.google.inject.Inject;
@@ -518,6 +518,10 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
       
       packagesTableContainer_.add(packagesTable_);
       layoutPackagesTable();
+      
+      // unbind old table from data provider incase we've re-generated the pane
+      for (HasData<PackageInfo> display : packagesDataProvider_.getDataDisplays())
+         packagesDataProvider_.removeDataDisplay(display);
       
       packagesDataProvider_.addDataDisplay(packagesTable_);
    }


### PR DESCRIPTION
This PR fixes an issue where RStudio could seem to accumulate lag after session restarts, if the library paths had changed between each session.

The issue occurs because we re-generate the package table somewhat eagerly here:

https://github.com/rstudio/rstudio/blob/6018fb82c4df77d9af39e0ade4982219b70662e3/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java#L107

but we never unbind the old `packagesTable_` element from the data display. This means that, as time goes on, we will eventually have a single data provider attempting to update the display of multiple (invisible) package panes, with the cost of building the HTML for package tables that are never actually attached to the DOM.