### PR TITLE
Allow for supplying job name when running a script as a job via API

### DIFF
--- a/src/cpp/session/modules/SessionJobs.R
+++ b/src/cpp/session/modules/SessionJobs.R
@@ -87,6 +87,7 @@
 })
 
 .rs.addApiFunction("runScriptJob", function(path, 
+                                            name = NULL,
                                             encoding = "unknown",
                                             workingDir = NULL, 
                                             importEnv = FALSE,
@@ -95,7 +96,7 @@
       stop("Must specify path to R script to run.")
    if (!file.exists(path))
       stop("The R script '", path, "' does not exist.")
-   .Call("rs_runScriptJob", path, encoding, workingDir, importEnv, exportEnv, 
+   .Call("rs_runScriptJob", path, name, encoding, workingDir, importEnv, exportEnv, 
          PACKAGE = "(embedding)")
 })
 

--- a/src/cpp/session/modules/jobs/SessionJobs.cpp
+++ b/src/cpp/session/modules/jobs/SessionJobs.cpp
@@ -192,7 +192,7 @@ SEXP rs_addJobOutput(SEXP jobSEXP, SEXP outputSEXP, SEXP errorSEXP)
    return R_NilValue;
 }
 
-SEXP rs_runScriptJob(SEXP path, SEXP encoding, SEXP dir, SEXP importEnv, SEXP exportEnv)
+SEXP rs_runScriptJob(SEXP path, SEXP name, SEXP encoding, SEXP dir, SEXP importEnv, SEXP exportEnv)
 {
    r::sexp::Protect protect;
    std::string filePath = r::sexp::safeAsString(path, "");
@@ -220,10 +220,18 @@ SEXP rs_runScriptJob(SEXP path, SEXP encoding, SEXP dir, SEXP importEnv, SEXP ex
       r::exec::error("The requested working directory '" + workingDir + "' does not exist.");
    }
 
-   std::string id;
    FilePath scriptFilePath = module_context::resolveAliasedPath(filePath);
+
+   std::string jobName(r::sexp::safeAsString(name));
+   if (jobName.empty())
+   {
+      // no name was supplied for the job, so derive one from the filename
+      jobName = scriptFilePath.filename();
+   }
+
+   std::string id;
    startScriptJob(ScriptLaunchSpec(
-            scriptFilePath.filename(),
+            jobName,
             scriptFilePath,
             r::sexp::safeAsString(encoding),
             module_context::resolveAliasedPath(workingDir),


### PR DESCRIPTION
This small change makes it possible to specify a job name when running a script job via the API. The job name was formerly derived from the name of the script (and still is, if you don't specify a name explicitly).

Closes #4176.