### PR TITLE
Add rstudioapi method for closing documents

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -533,13 +533,13 @@
    invisible(NULL)
 })
 
-.rs.addApiFunction("documentClose", function(id = NULL, force = FALSE) {
+.rs.addApiFunction("documentClose", function(id = NULL, save = TRUE) {
    # If no ID is specified, try to look up the active document.
    if (is.null(id)) {
       context <- .rs.api.getActiveDocumentContext()
       id <- context$id
    }
-   .Call("rs_requestDocumentClose", id, force, PACKAGE = "(embedding)")
+   .Call("rs_requestDocumentClose", id, save, PACKAGE = "(embedding)")
 })
 
 .rs.addApiFunction("getConsoleHasColor", function(name) {

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -533,6 +533,15 @@
    invisible(NULL)
 })
 
+.rs.addApiFunction("documentClose", function(id = NULL, force = FALSE) {
+   # If no ID is specified, try to look up the active document.
+   if (is.null(id)) {
+      context <- .rs.api.getActiveDocumentContext()
+      id <- context$id
+   }
+   .Call("rs_requestDocumentClose", id, force, PACKAGE = "(embedding)")
+})
+
 .rs.addApiFunction("getConsoleHasColor", function(name) {
    value <- .rs.readUiPref("ansi_console_mode")
    if (is.null(value) || value != 1) FALSE else TRUE

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -503,9 +503,16 @@
 })
 
 .rs.addApiFunction("documentSave", function(id = NULL) {
+   # If no ID is specified, try to save the active editor.
    if (is.null(id)) {
-      context <- .rs.api.getActiveDocumentContext()
-      id <- context$id
+      context <- .rs.api.getSourceEditorContext()
+      if (!is.null(context)) {
+         id <- context$id
+      }
+   }
+   if (is.null(id)) {
+      # No ID specified and no document open; succeed without meaning
+      return(TRUE)
    }
    .Call("rs_requestDocumentSave", id, PACKAGE = "(embedding)")
 })
@@ -534,10 +541,16 @@
 })
 
 .rs.addApiFunction("documentClose", function(id = NULL, save = TRUE) {
-   # If no ID is specified, try to look up the active document.
+   # If no ID is specified, try to close the active editor.
    if (is.null(id)) {
-      context <- .rs.api.getActiveDocumentContext()
-      id <- context$id
+      context <- .rs.api.getSourceEditorContext()
+      if (!is.null(context)) {
+         id <- context$id
+      }
+   }
+   if (is.null(id)) {
+      # No ID specified and no document open; succeed without meaning
+      return(TRUE)
    }
    .Call("rs_requestDocumentClose", id, save, PACKAGE = "(embedding)")
 })

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -536,6 +536,10 @@ std::string ClientEvent::typeName() const
          return "plumber_viewer";
       case client_events::kComputeThemeColors:
          return "compute_theme_colors";
+      case client_events::kRequestDocumentClose:
+         return "request_document_close";
+      case client_events::kRequestDocumentCloseCompleted:
+         return "request_document_close_completed";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -193,6 +193,8 @@ const int kNewDocumentWithCode = 174;
 const int kPlumberViewer = 175;
 const int kAvailablePackagesReady = 176;
 const int kComputeThemeColors = 177;
+const int kRequestDocumentClose = 178;
+const int kRequestDocumentCloseCompleted = 179;
 }
 
 void ClientEvent::init(int type, const json::Value& data)

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -194,6 +194,8 @@ extern const int kNewDocumentWithCode;
 extern const int kPlumberViewer;
 extern const int kAvailablePackagesReady;
 extern const int kComputeThemeColors;
+extern const int kRequestDocumentClose;
+extern const int kRequestDocumentCloseCompleted;
 }
    
 class ClientEvent

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionSource.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -1271,7 +1271,7 @@ SEXP rs_requestDocumentClose(SEXP idsSEXP, SEXP forceSXP) {
 
    ClientEvent event(client_events::kRequestDocumentClose, jsonData);
    
-   return r::sexp::create(waitForSuccess(event, s_waitForRequestDocumentClose), protect);
+   return r::sexp::create(waitForSuccess(event, s_waitForRequestDocumentClose), &protect);
 }
 
 SEXP rs_readSourceDocument(SEXP idSEXP)
@@ -1349,6 +1349,7 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_fileEdit, 1);
    RS_REGISTER_CALL_METHOD(rs_requestDocumentSave, 1);
    RS_REGISTER_CALL_METHOD(rs_readSourceDocument, 1);
+   RS_REGISTER_CALL_METHOD(rs_requestDocumentClose, 2);
 
    // install rpc methods
    using boost::bind;

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -1261,13 +1261,13 @@ SEXP rs_requestDocumentSave(SEXP idsSEXP)
    return r::sexp::create(waitForSuccess(event, s_waitForRequestDocumentSave), &protect);
 }
 
-SEXP rs_requestDocumentClose(SEXP idsSEXP, SEXP forceSXP) {
+SEXP rs_requestDocumentClose(SEXP idsSEXP, SEXP saveSXP) {
    r::sexp::Protect protect;
    
    json::Object jsonData;
    fillIds(idsSEXP, &jsonData);
 
-   jsonData["force"] = r::sexp::asLogical(forceSXP);
+   jsonData["save"] = r::sexp::asLogical(saveSXP);
 
    ClientEvent event(client_events::kRequestDocumentClose, jsonData);
    

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -66,6 +66,7 @@ using namespace session::source_database;
 namespace {
 
 module_context::WaitForMethodFunction s_waitForRequestDocumentSave;
+module_context::WaitForMethodFunction s_waitForRequestDocumentClose;
 
 void writeDocToJson(boost::shared_ptr<SourceDocument> pDoc,
                     core::json::Object* pDocJson)
@@ -1222,12 +1223,9 @@ SEXP rs_fileEdit(SEXP fileSEXP)
    return R_NilValue;
 }
 
-SEXP rs_requestDocumentSave(SEXP idsSEXP)
+void fillIds(SEXP idsSEXP, json::Object *pJsonData) 
 {
-   r::sexp::Protect protect;
-   
-   json::Object jsonData;
-   
+   json::Object& jsonData = *pJsonData;
    jsonData["ids"] = json::Value();
    if (TYPEOF(idsSEXP) == STRSXP)
    {
@@ -1235,18 +1233,45 @@ SEXP rs_requestDocumentSave(SEXP idsSEXP)
       r::sexp::fillVectorString(idsSEXP, &ids);
       jsonData["ids"] = json::toJsonArray(ids);
    }
-   
+}
+
+bool waitForSuccess(ClientEvent& event, module_context::WaitForMethodFunction& waitMethod) 
+{
    json::JsonRpcRequest request;
-   ClientEvent event(client_events::kRequestDocumentSave, jsonData);
-   if (!s_waitForRequestDocumentSave(&request, event))
-      return r::sexp::create(false, &protect);
+   if (!waitMethod(&request, event))
+      return false;
    
    bool success = false;
    Error error = json::readParams(request.params, &success);
    if (error)
       LOG_ERROR(error);
    
-   return r::sexp::create(success, &protect);
+   return success;
+}
+
+SEXP rs_requestDocumentSave(SEXP idsSEXP)
+{
+   r::sexp::Protect protect;
+   
+   json::Object jsonData;
+   fillIds(idsSEXP, &jsonData);
+   
+   ClientEvent event(client_events::kRequestDocumentSave, jsonData);
+
+   return r::sexp::create(waitForSuccess(event, s_waitForRequestDocumentSave), &protect);
+}
+
+SEXP rs_requestDocumentClose(SEXP idsSEXP, SEXP forceSXP) {
+   r::sexp::Protect protect;
+   
+   json::Object jsonData;
+   fillIds(idsSEXP, &jsonData);
+
+   jsonData["force"] = r::sexp::asLogical(forceSXP);
+
+   ClientEvent event(client_events::kRequestDocumentClose, jsonData);
+   
+   return r::sexp::create(waitForSuccess(event, s_waitForRequestDocumentClose), protect);
 }
 
 SEXP rs_readSourceDocument(SEXP idSEXP)
@@ -1318,6 +1343,8 @@ Error initialize()
    // register waitfor methods
    s_waitForRequestDocumentSave =
          module_context::registerWaitForMethod("request_document_save_completed");
+   s_waitForRequestDocumentClose =
+         module_context::registerWaitForMethod("request_document_close_completed");
 
    RS_REGISTER_CALL_METHOD(rs_fileEdit, 1);
    RS_REGISTER_CALL_METHOD(rs_requestDocumentSave, 1);

--- a/src/gwt/src/org/rstudio/studio/client/server/model/RequestDocumentCloseEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/model/RequestDocumentCloseEvent.java
@@ -1,0 +1,78 @@
+/*
+ * RequestDocumentCloseEvent.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.server.model;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class RequestDocumentCloseEvent extends GwtEvent<RequestDocumentCloseEvent.Handler>
+{
+   public static class Data extends JavaScriptObject
+   {
+      protected Data()
+      {
+      }
+      
+      public native final JsArrayString getDocumentIds()
+      /*-{
+         return this["ids"];
+      }-*/;
+
+      public native final boolean getForce()
+      /*-{
+         return this["force"];
+      }-*/;
+   }
+   
+   public RequestDocumentCloseEvent(Data data)
+   {
+      data_ = data;
+   }
+   
+   public JsArrayString getDocumentIds()
+   {
+      return data_.getDocumentIds();
+   }
+   
+   public boolean getForce()
+   {
+      return data_.getForce();
+   }
+   
+   private final Data data_;
+   
+   // Boilerplate ----
+
+   public interface Handler extends EventHandler
+   {
+      void onRequestDocumentClose(RequestDocumentCloseEvent event);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onRequestDocumentClose(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/server/model/RequestDocumentCloseEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/model/RequestDocumentCloseEvent.java
@@ -32,9 +32,9 @@ public class RequestDocumentCloseEvent extends GwtEvent<RequestDocumentCloseEven
          return this["ids"];
       }-*/;
 
-      public native final boolean getForce()
+      public native final boolean getSave()
       /*-{
-         return this["force"];
+         return this["save"];
       }-*/;
    }
    
@@ -48,9 +48,9 @@ public class RequestDocumentCloseEvent extends GwtEvent<RequestDocumentCloseEven
       return data_.getDocumentIds();
    }
    
-   public boolean getForce()
+   public boolean getSave()
    {
-      return data_.getForce();
+      return data_.getSave();
    }
    
    private final Data data_;

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -184,6 +184,7 @@ class ClientEvent extends JavaScriptObject
    public static final String AvailablePackagesReady = "available_packages_ready";
    public static final String PlumberViewer = "plumber_viewer";
    public static final String ComputeThemeColors = "compute_theme_colors";
+   public static final String RequestDocumentClose = "request_document_close";
 
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -94,6 +94,7 @@ import org.rstudio.studio.client.rsconnect.events.RSConnectDeploymentCompletedEv
 import org.rstudio.studio.client.rsconnect.events.RSConnectDeploymentFailedEvent;
 import org.rstudio.studio.client.rsconnect.events.RSConnectDeploymentOutputEvent;
 import org.rstudio.studio.client.server.Bool;
+import org.rstudio.studio.client.server.model.RequestDocumentCloseEvent;
 import org.rstudio.studio.client.server.model.RequestDocumentSaveEvent;
 import org.rstudio.studio.client.shiny.events.ShinyApplicationStatusEvent;
 import org.rstudio.studio.client.shiny.events.ShinyFrameNavigatedEvent;
@@ -1018,6 +1019,11 @@ public class ClientEventDispatcher
          else if (type == ClientEvent.ComputeThemeColors)
          {
             eventBus_.dispatchEvent(new ComputeThemeColorsEvent());
+         }
+         else if (type == ClientEvent.RequestDocumentClose)
+         {
+            RequestDocumentCloseEvent.Data data = event.getData();
+            eventBus_.dispatchEvent(new RequestDocumentCloseEvent(data));
          }
          else
          {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -2202,6 +2202,17 @@ public class RemoteServer implements Server
                   requestCallback);
    }
 
+   public void requestDocumentCloseCompleted(boolean isSuccessfulClose,
+                                            ServerRequestCallback<Void> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, JSONBoolean.getInstance(isSuccessfulClose));
+      sendRequest(RPC_SCOPE,
+                  REQUEST_DOCUMENT_CLOSE_COMPLETED,
+                  params,
+                  requestCallback);
+   }
+
    public void modifyDocumentProperties(
          String id,
          HashMap<String, String> properties,
@@ -5959,6 +5970,7 @@ public class RemoteServer implements Server
    private static final String SET_SOURCE_DOCUMENT_ON_SAVE = "set_source_document_on_save";
    private static final String SAVE_ACTIVE_DOCUMENT = "save_active_document";
    private static final String REQUEST_DOCUMENT_SAVE_COMPLETED = "request_document_save_completed";
+   private static final String REQUEST_DOCUMENT_CLOSE_COMPLETED = "request_document_close_completed";
    private static final String MODIFY_DOCUMENT_PROPERTIES = "modify_document_properties";
    private static final String GET_DOCUMENT_PROPERTIES = "get_document_properties";
    private static final String REVERT_DOCUMENT = "revert_document";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -4659,17 +4659,9 @@ public class Source implements InsertSourceHandler,
          }
       };
 
-      if (event.getForce())
+      if (event.getSave())
       {
-         // If force-closing, just close the windows immediately
-         closeEditors.execute();
-      }
-      else
-      {
-         // Not force-closing, so give the user the chance to save any unsaved
-         // documents before closing the tab(s). We do this in batch mode (vs.
-         // each tab individually) so the user is presented with a summary of
-         // the files to be closed/saved.
+         // Saving, so save unsaved documents before closing the tab(s).
          saveDocumentIds(ids, success ->
          {
             if (success)
@@ -4687,6 +4679,11 @@ public class Source implements InsertSourceHandler,
                }
             }
          });
+      }
+      else
+      {
+         // If not saving, just close the windows immediately
+         closeEditors.execute();
       }
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -600,6 +600,7 @@ public class Source implements InsertSourceHandler,
       events.addHandler(SetSelectionRangesEvent.TYPE, this);
       events.addHandler(OpenProfileEvent.TYPE, this);
       events.addHandler(RequestDocumentSaveEvent.TYPE, this);
+      events.addHandler(RequestDocumentCloseEvent.TYPE, this);
 
       // Suppress 'CTRL + ALT + SHIFT + click' to work around #2483 in Ace
       Event.addNativePreviewHandler(new NativePreviewHandler()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -4643,12 +4643,15 @@ public class Source implements InsertSourceHandler,
       Command closeEditors = () ->
       {
          // Close each of the requested tabs
-         for (EditingTarget target: editors_)
+         if (ids != null)
          {
-           if (JsArrayUtil.jsArrayStringContains(ids, target.getId()))
-           {
-              view_.closeTab(target.asWidget(), false /* non interactive */);
-           }
+            for (EditingTarget target: editors_)
+            {
+              if (JsArrayUtil.jsArrayStringContains(ids, target.getId()))
+              {
+                 view_.closeTab(target.asWidget(), false /* non interactive */);
+              }
+            }
          }
          
          // Let the server know we've completed the task

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceServerOperations.java
@@ -248,6 +248,9 @@ public interface SourceServerOperations extends FilesServerOperations,
    public void requestDocumentSaveCompleted(boolean isSuccessfulSave,
                                             ServerRequestCallback<Void> requestCallback);
    
+   public void requestDocumentCloseCompleted(boolean isSuccessfulClose, 
+                                             ServerRequestCallback<Void> requestCallback);                                    
+   
    public void adaptToLanguage(String language, ServerRequestCallback<Void> requestCallback);
 
    public void createPlumberAPI(String apiName,


### PR DESCRIPTION
This change makes it possible to close documents using the rstudioapi (just as it's possible to save them). Documents are saved before closing by default, but this can be overridden by passing `save = FALSE`. 
