### PR TITLE
Avoid early materialization of ALTREP objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -157,6 +157,7 @@
 * Fix persistence of Evaluate Chunks in Directory global option (#3356)
 * Fix file.choose(new = TRUE) to properly request new file name (#3903)
 * Fix 'Copy Plot to Clipboard' functionality when IDE is zoomed (#3853)
+* Fix early evaluation of `ALTREP` objects (#4171)
 
 ### RStudio Server Pro
 

--- a/src/cpp/core/include/core/r_util/RVersionInfo.hpp
+++ b/src/cpp/core/include/core/r_util/RVersionInfo.hpp
@@ -1,7 +1,7 @@
 /*
  * RVersionInfo.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -74,8 +74,12 @@ public:
    {
    }
 
+   RVersionNumber(int major, int minor, int patch)
+      : versionMajor_(major), versionMinor_(minor), versionPatch_(patch)
+   {
+   }
 public:
-   bool empty() const { return versionMajor_ != 0; }
+   bool empty() const { return versionMajor_ == 0; }
 
    int versionMajor() const { return versionMajor_; }
    int versionMinor() const { return versionMinor_; }
@@ -114,7 +118,6 @@ inline std::ostream& operator<<(std::ostream& os, const RVersionNumber& ver)
    os << ver.versionMajor() << "." << ver.versionMinor() << "." << ver.versionPatch();
    return os;
 }
-
 
 } // namespace r_util
 } // namespace core 

--- a/src/cpp/r/CMakeLists.txt
+++ b/src/cpp/r/CMakeLists.txt
@@ -32,6 +32,7 @@ set (R_SOURCE_FILES
    RSexp.cpp
    RSourceManager.cpp
    RUtil.cpp
+   RVersionInfo.cpp
    session/RClientMetrics.cpp
    session/RClientState.cpp
    session/RConsoleActions.cpp

--- a/src/cpp/r/RVersionInfo.cpp
+++ b/src/cpp/r/RVersionInfo.cpp
@@ -1,0 +1,46 @@
+/*
+ * RVersionInfo.cpp
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <r/RVersionInfo.hpp>
+#include <r/RExec.hpp>
+
+#include <core/Error.hpp>
+
+using namespace rstudio::core;
+using namespace rstudio::core::r_util;
+
+namespace rstudio {
+namespace r {
+namespace version_info {
+
+// Returns a representation of the current version of R
+RVersionNumber currentRVersion()
+{
+   // Cached R version number; this can't change during the session so it's safe to keep a copy
+   static RVersionNumber current;
+   if (current.empty())
+   {
+      // No cache; ask R for its current version
+      std::string currentRVersion;
+      Error error = exec::RFunction(".rs.rVersionString").call(&currentRVersion);
+      if (!error)
+         current = RVersionNumber::parse(currentRVersion);
+   }
+   return current;
+}
+
+} // namespace version_info
+} // namespace r
+} // namespace rstudio

--- a/src/cpp/r/include/r/RSxpInfo.hpp
+++ b/src/cpp/r/include/r/RSxpInfo.hpp
@@ -1,0 +1,47 @@
+/*
+ * RSxpInfo.hpp
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef R_SXPINFO_HPP
+#define R_SXPINFO_HPP
+
+#define TYPE_BITS 5
+#define NAMED_BITS 16
+
+namespace rstudio {
+namespace r {
+
+// This structure definition mirrors sxpinfo_struct from Rinternals.h in R 3.5. The bit fields moved
+// in R 3.5 in order to support ALTREP objects, so this structure definition is only accurate in R >
+// 3.5. 
+struct sxpinfo {
+    unsigned int type  :  TYPE_BITS;
+    unsigned int scalar:  1;
+    unsigned int obj   :  1;
+    unsigned int alt   :  1;
+    unsigned int gp    : 16;
+    unsigned int mark  :  1;
+    unsigned int debug :  1;
+    unsigned int trace :  1;
+    unsigned int spare :  1;
+    unsigned int gcgen :  1;
+    unsigned int gccls :  3;
+    unsigned int named : NAMED_BITS;
+    unsigned int extra : 32 - NAMED_BITS;
+};
+
+} // namespace r
+} // namespace rstudio
+
+#endif

--- a/src/cpp/r/include/r/RVersionInfo.hpp
+++ b/src/cpp/r/include/r/RVersionInfo.hpp
@@ -1,0 +1,32 @@
+/*
+ * RVersionInfo.hpp
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef R_R_VERSION_INFO_HPP
+#define R_R_VERSION_INFO_HPP
+
+#include <core/r_util/RVersionInfo.hpp>
+
+namespace rstudio {
+namespace r {
+namespace version_info {
+
+// Returns the current R version number (cached)
+core::r_util::RVersionNumber currentRVersion();
+
+} // namespace version_info
+} // namespace r
+} // namespace rstudio
+
+#endif // R_R_VERSION_INFO_HPP

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -431,7 +431,7 @@
    return (className)
 })
 
-.rs.addFunction("describeObject", function(env, objName)
+.rs.addFunction("describeObject", function(env, objName, computeSize = TRUE)
 {
    obj <- get(objName, env)
    # objects containing null external pointers can crash when
@@ -448,8 +448,11 @@
    {
       val <- "(unknown)"
       desc <- ""
-      size <- object.size(obj)
-      len <- length(obj)
+
+      # some objects (e.g. ALTREP) have compact representations that are forced to materialize if
+      # an attempt is made to compute their metrics exactly; avoid computing the size for these
+      size <- if (computeSize) object.size(obj) else 0
+      len <- if (computeSize) length(obj) else 0
    }
    class <- .rs.getSingleClass(obj)
    contents <- list()


### PR DESCRIPTION
Currently, ALTREP objects (new in R 3.5.0) are fully materialized by RStudio's environment pane, since it calls `object.size()` on them. This change protects these objects from premature evaluation by avoiding the environment pane's size/length inspection on objects with the `alt` flag set (indicating an ALTREP). 

Note that this does not protect the objects from any type of materialization at all; the first few elements will still be materialized by `str()`, which we continue to call. 

Fixes #4171. 