### PR TITLE
Compile RStudio Server for OpenSUSE 15

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -141,6 +141,7 @@ try {
           [os: 'opensuse',   arch: 'x86_64', flavor: 'server',  variant: ''],
           [os: 'opensuse',   arch: 'x86_64', flavor: 'desktop', variant: ''],
           [os: 'opensuse15', arch: 'x86_64', flavor: 'desktop', variant: ''],
+          [os: 'opensuse15', arch: 'x86_64', flavor: 'server',  variant: ''],
           [os: 'centos7',    arch: 'x86_64', flavor: 'desktop', variant: ''],
           [os: 'trusty',     arch: 'amd64',  flavor: 'server',  variant: ''],
           [os: 'trusty',     arch: 'amd64',  flavor: 'desktop', variant: ''],


### PR DESCRIPTION
This change adds RStudio Server for OpenSUSE 15 to our build matrix. It was not formerly possible to compile on this platform because of a third-party header library we use; I've added a workaround to make it possible to do this in https://github.com/rstudio/rstudio/commit/66a8428397ace06c2be0e1da445c01f3c9f1abaa. See #3146 for further discussion. 

Fixes https://github.com/rstudio/rstudio/issues/3146.