### PR TITLE
Add API method for executing app commands

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -802,3 +802,8 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
   .Call("rs_translateLocalUrl", url, absolute, PACKAGE = "(embedding)")
 })
 
+# execute an arbitrary RStudio application command (AppCommand)
+.rs.addApiFunction("executeCommand", function(commandId, quiet = FALSE) {
+  .Call("rs_executeAppCommand", commandId, quiet, PACKAGE = "(embedding)")
+})
+

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionClientEvent.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -195,6 +195,7 @@ const int kAvailablePackagesReady = 176;
 const int kComputeThemeColors = 177;
 const int kRequestDocumentClose = 178;
 const int kRequestDocumentCloseCompleted = 179;
+const int kExecuteAppCommand = 180;
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -540,6 +541,8 @@ std::string ClientEvent::typeName() const
          return "request_document_close";
       case client_events::kRequestDocumentCloseCompleted:
          return "request_document_close_completed";
+      case client_events::kExecuteAppCommand:
+         return "execute_app_command";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionClientEvent.hpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -196,6 +196,7 @@ extern const int kAvailablePackagesReady;
 extern const int kComputeThemeColors;
 extern const int kRequestDocumentClose;
 extern const int kRequestDocumentCloseCompleted;
+extern const int kExecuteAppCommand;
 }
    
 class ClientEvent

--- a/src/cpp/session/modules/RStudioAPI.cpp
+++ b/src/cpp/session/modules/RStudioAPI.cpp
@@ -1,7 +1,7 @@
 /*
  * RStudioAPI.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -38,6 +38,17 @@ namespace rstudioapi {
 namespace {
 module_context::WaitForMethodFunction s_waitForShowDialog;
 module_context::WaitForMethodFunction s_waitForOpenFileDialog;
+
+SEXP rs_executeAppCommand(SEXP commandSEXP, SEXP quietSEXP)
+{
+   json::Object data;
+   data["command"] = r::sexp::safeAsString(commandSEXP);
+   data["quiet"] = r::sexp::asLogical(quietSEXP);
+   ClientEvent event(client_events::kExecuteAppCommand, data);
+   module_context::enqueClientEvent(event);
+   return R_NilValue;
+}
+
 } // end anonymous namespace
 
 
@@ -198,8 +209,9 @@ Error initialize()
    s_waitForShowDialog     = registerWaitForMethod("rstudioapi_show_dialog_completed");
    s_waitForOpenFileDialog = registerWaitForMethod("open_file_dialog_completed");
 
-   RS_REGISTER_CALL_METHOD(rs_showDialog, 8);
-   RS_REGISTER_CALL_METHOD(rs_openFileDialog, 6);
+   RS_REGISTER_CALL_METHOD(rs_showDialog);
+   RS_REGISTER_CALL_METHOD(rs_openFileDialog);
+   RS_REGISTER_CALL_METHOD(rs_executeAppCommand);
 
    return Success();
 }

--- a/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
@@ -697,7 +697,8 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
    private boolean executedFromShortcut_ = false;
  
    private static boolean enableNoHandlerAssertions_ = true;
-   private static final String WINDOW_MODE_BACKGROUND = "background";
-   private static final String WINDOW_MODE_MAIN = "main";
-   private static final String WINDOW_MODE_ANY = "any";
+
+   public static final String WINDOW_MODE_BACKGROUND = "background";
+   public static final String WINDOW_MODE_MAIN = "main";
+   public static final String WINDOW_MODE_ANY = "any";
 }

--- a/src/gwt/src/org/rstudio/core/client/command/ApplicationCommandManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ApplicationCommandManager.java
@@ -1,7 +1,7 @@
 /*
  * ApplicationCommandManager.java
  *
- * Copyright (C) 2009-15 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -20,9 +20,11 @@ import org.rstudio.core.client.command.EditorCommandManager.EditorKeyBindings;
 import org.rstudio.core.client.command.KeyMap.KeyMapType;
 import org.rstudio.core.client.command.KeyboardShortcut.KeySequence;
 import org.rstudio.core.client.files.FileBacked;
+import org.rstudio.core.client.events.ExecuteAppCommandEvent;
 import org.rstudio.core.client.events.RStudioKeybindingsChangedEvent;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.files.model.FilesServerOperations;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorLoadedEvent;
@@ -69,6 +71,29 @@ public class ApplicationCommandManager
                   loadBindings(event.getBindings(), null);
                }
             });
+
+      events_.addHandler(ExecuteAppCommandEvent.TYPE, evt ->
+      {
+         AppCommand command = commands_.getCommandById(evt.getData().command());
+         if (command == null && !evt.getData().quiet())
+         {
+            RStudioGinjector.INSTANCE.getGlobalDisplay().showErrorMessage("Invalid Command", 
+                  "The command '" + evt.getData().command() + "' does not exist.");
+            return;
+         }
+         if (Satellite.isCurrentWindowSatellite() && 
+             command.getWindowMode() != AppCommand.WINDOW_MODE_ANY)
+         {
+            // If this command doesn't want to run in satellites, attempting to
+            // execute will forward it to the main window (which already knows
+            // to execute it), causing the execution to occur multiple times.
+            return;
+         }
+
+         command.execute();
+         return;
+      });
+      
    }
    
    @Inject
@@ -175,3 +200,4 @@ public class ApplicationCommandManager
    private FilesServerOperations server_;
    private Commands commands_;
 }
+

--- a/src/gwt/src/org/rstudio/core/client/events/ExecuteAppCommandEvent.java
+++ b/src/gwt/src/org/rstudio/core/client/events/ExecuteAppCommandEvent.java
@@ -1,0 +1,68 @@
+/*
+ * ExecuteAppCommandEvent.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.events;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class ExecuteAppCommandEvent extends GwtEvent<ExecuteAppCommandEvent.Handler>
+{
+   public static class Data extends JavaScriptObject
+   {
+      protected Data()
+      {
+      }
+
+      public final native String command() /*-{
+         return this.command;
+      }-*/;
+
+      public final native boolean quiet() /*-{
+         return this.quiet;
+      }-*/;
+   }
+
+   public interface Handler extends EventHandler
+   {
+      void onExecuteAppCommand(ExecuteAppCommandEvent event);
+   }
+   
+   public ExecuteAppCommandEvent(Data data)
+   {
+      data_ = data;
+   }
+   
+   public Data getData()
+   {
+      return data_;
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onExecuteAppCommand(this);
+   }
+
+   private final Data data_;
+   
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -185,6 +185,7 @@ class ClientEvent extends JavaScriptObject
    public static final String PlumberViewer = "plumber_viewer";
    public static final String ComputeThemeColors = "compute_theme_colors";
    public static final String RequestDocumentClose = "request_document_close";
+   public static final String ExecuteAppCommand = "execute_app_command";
 
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -21,6 +21,7 @@ import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.RepeatingCommand;
 
+import org.rstudio.core.client.events.ExecuteAppCommandEvent;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.files.filedialog.events.OpenFileDialogEvent;
 import org.rstudio.core.client.js.JsObject;
@@ -1024,6 +1025,11 @@ public class ClientEventDispatcher
          {
             RequestDocumentCloseEvent.Data data = event.getData();
             eventBus_.dispatchEvent(new RequestDocumentCloseEvent(data));
+         }
+         else if (type == ClientEvent.ExecuteAppCommand)
+         {
+            ExecuteAppCommandEvent.Data data = event.getData();
+            eventBus_.dispatchEvent(new ExecuteAppCommandEvent(data));
          }
          else
          {


### PR DESCRIPTION
This adds a thin API method that can be used to execute arbitrary RStudio application commands (just as though the user had executed the commands themselves). 

The goal is to make it possible to trigger actions in the IDE without building special-case API wrappers for each action (see https://github.com/rstudio/rstudioapi/issues/129). 