### PR TITLE
Allow R Notebooks to be published to RPubs

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
@@ -180,7 +180,9 @@ public class RSConnect implements SessionInitHandler,
          return false;
       
       String extension = FileSystemItem.getExtensionFromPath(filename).toLowerCase();
-      return StringUtil.equals(extension, ".html") || StringUtil.equals(extension, ".htm");
+      return StringUtil.equals(extension, ".html") || 
+             StringUtil.equals(extension, ".htm") ||
+             StringUtil.equals(extension, ".nb.html");
    }
 
    private void publishAsRPubs(RSConnectActionEvent event)


### PR DESCRIPTION
This change fixes a regression in which R Notebooks could not be published to RPubs; the change is just to add `.nb.html` to the whitelisted extensions to publish.

Fixes https://github.com/rstudio/rstudio/issues/4234. 