### PR TITLE
Fix error when attempting to publish rendered website from non-website project

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
@@ -338,7 +338,8 @@ public class RSConnect implements SessionInitHandler,
             publishAsStatic(input);
          }
       }
-      else if (input.getContentType() == CONTENT_TYPE_WEBSITE)
+      else if (input.getContentType() == CONTENT_TYPE_WEBSITE ||
+               (input.getContentType() == CONTENT_TYPE_DOCUMENT && input.isWebsiteRmd()))
       {
          if (input.hasDocOutput())
          {

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -881,6 +881,17 @@ public class RSConnectDeploy extends Composite
                      source_.getWebsiteDir() :
                   source_.getDeployFile() : 
             source_.getDeployDir();
+                  
+      // getDeploymentFiles fails if we don't give it a source -- this should
+      // never happen, but if it does this error message will be more useful
+      if (StringUtil.isNullOrEmpty(fileSource))
+      {
+         indicator.onError("Could not determine the list of files to deploy. " +
+                  "Try re-rendering and ensuring that you're publishing to a " +
+                  "server which supports this kind of content.");
+         indicator.onCompleted();
+         return;
+      }
 
       indicator.onProgress("Collecting files...");
       server_.getDeploymentFiles(


### PR DESCRIPTION
Currently, trying to publish websites from RStudio when not using a website project results in some unexpected behavior. The worst of this is that if you try to publish the website as rendered content, you'll get an indecipherable error. 

This change does not make it possible to publish static websites conveniently from the IDE. However, it does make the scenario less broken in two ways:

- Clicking Publish on an R Markdown document in a website folder now works the same whether you're in a website project or not.
- If we ever get into a situation where we're collecting files to deploy but have no actual folder to collect them from, we bail earlier with a more useful error.

Fixes https://github.com/rstudio/rstudio/issues/3754.