### PR TITLE
Ensure all short UUIDs are 8 chars long

### DIFF
--- a/src/cpp/core/Hash.cpp
+++ b/src/cpp/core/Hash.cpp
@@ -1,7 +1,7 @@
 /*
  * Hash.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,6 +16,7 @@
 #include <core/Hash.hpp>
 
 #include <sstream>
+#include <iomanip>
 
 #include <boost/crc.hpp>
 #include <boost/lexical_cast.hpp>
@@ -39,9 +40,10 @@ std::string crc32HexHash(const std::string& content)
    boost::crc_32_type result;
    result.process_bytes(content.data(), content.length());
 
-   // return hex representation
+   // return hex representation; ensure padded to 8 characters
    std::ostringstream output;
-   output << std::uppercase << std::hex << result.checksum();
+   output << std::uppercase << std::setw(8) << std::setfill('0') 
+          << std::hex << result.checksum();
    return output.str();
 }
    


### PR DESCRIPTION
We use short UUIDs everywhere, as identifiers for source documents, jobs, and all kinds of other things. We generate them by CRC32 hashing a longer UUID to get a 4-byte value.

These UUIDs are currently returned without leading zeroes, so they have a variable length, and can be shorter than 8 characters (rarely, a *lot* shorter). This change ensures that they have a predictable length. It ought to be relatively safe, but we use this in so many places that it's targeted against 1.3 to be safe.

Fixes https://github.com/rstudio/rstudio-pro/issues/730. 