### PR TITLE
Fixed a bug where tar.gz files would be corrupted when downloaded from Firefox

### DIFF
--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -735,14 +735,14 @@ void setAttachmentResponse(const http::Request& request,
       pResponse->setHeader("Expires", "Fri, 01 Jan 1990 00:00:00 GMT");
       pResponse->setHeader("Cache-Control", "private");
    }
+
    // Can't rely on "filename*" in Content-Disposition header because not all
    // browsers support non-ASCII characters here (e.g. Safari 5.0.5). If
    // possible, make the requesting URL contain the UTF-8 byte escaped filename
    // as the last path element.
    pResponse->setHeader("Content-Disposition",
                         "attachment; filename*=UTF-8''"
-                        + http::util::urlEncode(filename, false));
-   pResponse->setHeader("Content-Type", "application/octet-stream");
+                           + http::util::urlEncode(filename, false));
    pResponse->setStreamFile(attachmentPath, request);
 }
    


### PR DESCRIPTION
This is corrected by setting the correct content type, and if the content type indicates compression, not recompressing the content in the output stream. Fixes #4270