### PR TITLE
Upgrade to Pandoc 2.6

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -83,7 +83,7 @@
 * Add option to show the R Markdown render command used when knitting (#1658)
 * Add option to show hidden files in the Files pane (#1769)
 * RStudio uses the fontconfig database to list monospace fonts when available (Linux only; #3897)
-* Upgrade embedded Pandoc to 2.5 on Windows (#1807)
+* Upgrade embedded Pandoc to 2.6 on Windows (#1807)
 * Allow renames that change only file case on Windows (#1886)
 * Remember scroll position when navigating in Help pane (#1947)
 * Show warning when attempting to edit a generated file (#2082)

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -20,7 +20,7 @@ set WINPTY_FILES=winpty-0.4.3-msys2-2.7.0.zip
 set OPENSSL_FILES=openssl-1.0.2p.zip
 set BOOST_FILES=boost-1.65.1-win-msvc141.zip
 
-set PANDOC_VERSION=2.5
+set PANDOC_VERSION=2.6
 set PANDOC_NAME=pandoc-%PANDOC_VERSION%-windows-x86_64
 set PANDOC_FILE=%PANDOC_NAME%.zip
 

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -481,7 +481,7 @@ install(DIRECTORY "resources/connections"
 
 # install pandoc
 if(WIN32)
-   set(PANDOC_VERSION "2.5" CACHE INTERNAL "Pandoc version")
+   set(PANDOC_VERSION "2.6" CACHE INTERNAL "Pandoc version")
 else()
    set(PANDOC_VERSION "2.3.1" CACHE INTERNAL "Pandoc version")
 endif()


### PR DESCRIPTION
This change upgrades to the latest version of Pandoc, 2.6, on Windows (only), primarily to mitigate a large number of user-reported crashes with Pandoc 2.5.

Fixes https://github.com/rstudio/rstudio/issues/4072. 