### PR TITLE
Apply Unicode escaping to high ASCII characters

### DIFF
--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -100,8 +100,8 @@ std::string utf8ToConsole(const std::string& string)
    {
       int n = ::wctomb(buffer, wide[i]);
       
-      // use Unicode escaping for characters that cannot be reprsented
-      // as well as for upper ASCII range as well
+      // use Unicode escaping for characters that cannot be represented
+      // as well as for upper ASCII
       if (n == -1 || static_cast<unsigned char>(buffer[0]) > 127)
       {
          output << "\\u{" << std::hex << wide[i] << "}";

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -100,7 +100,9 @@ std::string utf8ToConsole(const std::string& string)
    {
       int n = ::wctomb(buffer, wide[i]);
       
-      if (n == -1)
+      // use Unicode escaping for characters that cannot be reprsented
+      // as well as for upper ASCII range as well
+      if (n == -1 || static_cast<unsigned char>(buffer[0]) > 127)
       {
          output << "\\u{" << std::hex << wide[i] << "}";
       }

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -101,8 +101,8 @@ std::string utf8ToConsole(const std::string& string)
       int n = ::wctomb(buffer, wide[i]);
       
       // use Unicode escaping for characters that cannot be represented
-      // as well as for upper ASCII
-      if (n == -1 || static_cast<unsigned char>(buffer[0]) > 127)
+      // as well as for single-byte upper ASCII
+      if (n == -1 || (n == 1 && static_cast<unsigned char>(buffer[0]) > 127))
       {
          output << "\\u{" << std::hex << wide[i] << "}";
       }


### PR DESCRIPTION
This change fixes an issue in which paths containing characters that are representable in the C locale but aren't in the lower ASCII set cause the Knit command to fail. It extends the work done in https://github.com/rstudio/rstudio/pull/4126 so that applies not only to characters not representable in the C locale but to any character not in the first 127 (7-bit) ASCII set. 

Fixes https://github.com/rstudio/rstudio/issues/4254. 