### PR TITLE
Install dictionaries from buildtools

### DIFF
--- a/dependencies/common/install-dictionaries
+++ b/dependencies/common/install-dictionaries
@@ -3,7 +3,7 @@
 #
 # install-dictionaries
 #
-# Copyright (C) 2009-12 by RStudio, Inc.
+# Copyright (C) 2009-19 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -28,9 +28,9 @@ download()
 {
   if [ "$PLATFORM" == "Darwin" ]
   then
-    curl -L https://s3.amazonaws.com/rstudio-dictionaries/$1 > $1
+    curl -L https://s3.amazonaws.com/rstudio-buildtools/dictionaries/$1 > $1
   else
-    wget https://s3.amazonaws.com/rstudio-dictionaries/$1 -O $1
+    wget https://s3.amazonaws.com/rstudio-buildtools/dictionaries/$1 -O $1
   fi
 }
 

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -120,7 +120,7 @@ popd
 pushd ..\common
 set CORE_DICTIONARIES=core-dictionaries.zip
 if not exist "dictionaries\en_US.dic" (
-  wget %WGET_ARGS% "https://s3.amazonaws.com/rstudio-dictionaries/%CORE_DICTIONARIES%"
+  wget %WGET_ARGS% "https://s3.amazonaws.com/rstudio-buildtools/dictionaries/%CORE_DICTIONARIES%"
   if exist "%CORE_DICTIONARIES%" (
      mkdir dictionaries
      echo Unzipping %CORE_DICTIONARIES%


### PR DESCRIPTION
The `rstudio-dictionaries` S3 bucket is using a *very* disproportionate amount of bandwidth. There's no obvious reason for this, but it could be that something's decided to use it as a source, or that its publicly enumerable status is attracting lots of spiders and indexers.

Either way, since our intent is not to be the world's dictionary host, this change moves our dictionaries into the `rstudio-buildtools` bucket, where it is publicly accessible but not enumerable. Once it's been in place for a few weeks, we'll remove the dictionaries from the old location.