### PR TITLE
better defaults when invoking Copy To w/directory (#3071)

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
@@ -388,10 +388,14 @@ public class Files
          return;
       }
 
+      FileSystemItem initialFile = selectedFiles.get(0);
+      if (initialFile.isDirectory())
+         initialFile = initialFile.getParentPath();
+      
       view_.showFilePicker(
                         "Choose Destination", 
                         fileSystemContext_,
-                        selectedFiles.get(0),
+                        initialFile,
                         new ProgressOperationWithInput<FileSystemItem>() {
 
          public void execute(FileSystemItem targetFile,


### PR DESCRIPTION
This PR improves the default behavior of Copy To, making it a bit easier to ensure that one doesn't accidentally recursively copy a folder into itself.

When attempting to copy a directory, we now initialize the file picker from the parent directory of the associated directory.

Closes #3071.