### PR TITLE
Scan for nested ALTREP objects

### DIFF
--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -650,4 +650,13 @@
    .rs.valueContents(get(objName, env));
 })
 
+.rs.addFunction("isAltrep", function(var)
+{
+   .Call("rs_isAltrep", var, PACKAGE="(embedding)")
+})
+
+.rs.addFunction("hasAltrep", function(var)
+{
+   .Call("rs_hasAltrep", var, PACKAGE="(embedding)")
+})
 

--- a/src/cpp/session/modules/environment/EnvironmentUtils.hpp
+++ b/src/cpp/session/modules/environment/EnvironmentUtils.hpp
@@ -1,7 +1,7 @@
 /*
  * EnvironmentUtils.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -26,6 +26,8 @@ bool isUnevaluatedPromise(SEXP var);
 bool functionDiffersFromSource(SEXP srcRef, const std::string& functionCode);
 void sourceRefToJson(const SEXP srcref, core::json::Object* pObject);
 core::Error sourceFileFromRef(const SEXP srcref, std::string* pFileName);
+bool isAltrep(SEXP var);
+bool hasAltrep(SEXP var);
 
 } // namespace environment
 } // namespace modules

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -203,6 +203,21 @@ SEXP rs_hasExternalPointer(SEXP objSEXP, SEXP nullSEXP)
    return r::sexp::create(hasPtr, &protect);
 }
 
+// Does an object contain an ALTREP anywhere? ALTREP (alternative representation) objects often
+// require special treatment.
+SEXP rs_hasAltrep(SEXP obj)
+{
+   r::sexp::Protect protect;
+   return r::sexp::create(hasAltrep(obj), &protect);
+}
+
+// Is an object an R ALTREP object? 
+SEXP rs_isAltrep(SEXP obj)
+{
+   r::sexp::Protect protect;
+   return r::sexp::create(isAltrep(obj), &protect);
+}
+
 // Construct a simulated source reference from a context containing a
 // function being debugged, and either the context containing the current
 // invocation or a string containing the last debug ouput from R.
@@ -1072,7 +1087,9 @@ Error initialize()
    methodDef.numArgs = 3;
    r::routines::addCallMethod(methodDef);
 
-   RS_REGISTER_CALL_METHOD(rs_hasExternalPointer, 2);
+   RS_REGISTER_CALL_METHOD(rs_hasExternalPointer);
+   RS_REGISTER_CALL_METHOD(rs_hasAltrep);
+   RS_REGISTER_CALL_METHOD(rs_isAltrep);
 
    // subscribe to events
    using boost::bind;


### PR DESCRIPTION
RStudio is already aware of ALTREP objects and avoids attempts to compute their size (which cause them to materialize). However, ALTREP objects can be inside of other objects, and we need to avoid computing the size of those, too. A good example is data frames generated by the vroom package (https://github.com/jimhester/vroom), which are not ALTREP objects themselves but which contain ALTREPs. 

This change implements a simple form of recursive scanning for ALTREP objects. It is intentionally limited to vectors (e.g. data frame columns), and the reentrancy, depth and breadth of the search are also constrained to avoid accidental traversal of large or pathological objects.

Fixes https://github.com/rstudio/rstudio/issues/4171.