### PR TITLE
Make console double-click selection optional

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -1,7 +1,7 @@
 /*
  * ShellWidget.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -34,6 +34,7 @@ import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.debugging.model.UnhandledError;
 import org.rstudio.studio.client.common.debugging.ui.ConsoleError;
 import org.rstudio.studio.client.workbench.model.ConsoleAction;
+import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.console.ConsoleResources;
 import org.rstudio.studio.client.workbench.views.console.events.RunCommandWithDebugEvent;
 import org.rstudio.studio.client.workbench.views.console.shell.editor.InputEditorDisplay;
@@ -72,10 +73,11 @@ public class ShellWidget extends Composite implements ShellDisplay,
                                                       RequiresResize,
                                                       ConsoleError.Observer
 {
-   public ShellWidget(AceEditor editor, EventBus events)
+   public ShellWidget(AceEditor editor, UIPrefs prefs, EventBus events)
    {
       styles_ = ConsoleResources.INSTANCE.consoleStyles();
       events_ = events;
+      prefs_ = prefs;
       
       SelectInputClickHandler secondaryInputHandler = new SelectInputClickHandler();
 
@@ -523,7 +525,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
    
    /**
     * Directs focus/selection to the input box when a (different) widget
-    * is clicked.
+    * is clicked.)
     */
    private class SelectInputClickHandler implements ClickHandler,
                                                     KeyDownHandler,
@@ -538,14 +540,22 @@ public class ShellWidget extends Composite implements ShellDisplay,
             return;
          }
 
-         // Some clicks can result in selection (e.g. double clicks). We don't
-         // want to grab focus for those clicks, but we don't know yet if this
-         // click can generate a selection. Wait 400ms (unfortunately it's not
-         // possible to get the OS double-click timeout) for a selection to
-         // appear; if it doesn't then drive focus to the input box.
-         if (inputFocus_.isRunning())
-            inputFocus_.cancel();
-         inputFocus_.schedule(400);
+         if (prefs_ != null && prefs_.consoleDoubleClickSelect().getValue())
+         {
+            // Some clicks can result in selection (e.g. double clicks). We don't
+            // want to grab focus for those clicks, but we don't know yet if this
+            // click can generate a selection. Wait 400ms (unfortunately it's not
+            // possible to get the OS double-click timeout) for a selection to
+            // appear; if it doesn't then drive focus to the input box.
+            if (inputFocus_.isRunning())
+               inputFocus_.cancel();
+            inputFocus_.schedule(400);
+         }
+         else
+         {
+            // No selection check needed
+            inputFocus_.run();
+         }
       }
 
       public void onKeyDown(KeyDownEvent event)
@@ -759,6 +769,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
    private final TimeBufferedCommand resizeCommand_;
    private boolean suppressPendingInput_;
    private final EventBus events_;
+   private final UIPrefs prefs_;
    
    // A list of errors that have occurred between console prompts. 
    private Map<String, List<Element>> errorNodes_ = new TreeMap<String, List<Element>>();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UIPrefsAccessor.java
@@ -760,6 +760,11 @@ public class UIPrefsAccessor extends Prefs
       return bool("git_diff_ignore_whitespace", false);
    }
    
+   public PrefValue<Boolean> consoleDoubleClickSelect()
+   {
+      return bool("console_double_click_select", false);
+   }
+   
    // Meant to be called when the satellite window receives the sessionInfo.
    protected void UpdateSessionInfo(SessionInfo sessionInfo)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -314,9 +314,15 @@ public class GeneralPreferencesPane extends PreferencesPane
          spacedBefore(otherLabel);
       advanced.add(otherLabel);
       firstHeader = false;
+
       showLastDotValue_ = new CheckBox("Show .Last.value in environment listing");
       lessSpaced(showLastDotValue_);
       advanced.add(showLastDotValue_);
+
+      advanced.add(spaced(checkboxPref(
+            "Double-click to select words in Console pane", 
+            prefs_.consoleDoubleClickSelect())));
+      
       showServerHomePage_.setEnabled(false);
       reuseSessionsForProjectLinks_.setEnabled(false);
       saveWorkspace_.setEnabled(false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/ShellPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/ShellPane.java
@@ -30,7 +30,7 @@ public class ShellPane extends ShellWidget implements Shell.Display
    @Inject
    public ShellPane(final AceEditor editor, UIPrefs uiPrefs, EventBus events)
    {
-      super(editor, events);
+      super(editor, uiPrefs, events);
 
       editor.setDisableOverwrite(true);
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressWidget.java
@@ -22,7 +22,7 @@ public class ConsoleProgressWidget extends ShellWidget implements ShellDisplay
 {
    public ConsoleProgressWidget()
    {
-      super(new AceEditor(), null);
+      super(new AceEditor(), null, null);
       getEditor().setInsertMatching(false);
    }
    


### PR DESCRIPTION
A while back, we fixed https://github.com/rstudio/rstudio/issues/2264 by adding a short delay from the time you click in the output in the Console to the time that we send focus to the input element, so that we have time to receive a second (double) click if it occurs. 

This delay is widely reported as being much more irritating than the issue it addresses, so this change hides it behind a preference that defaults to off (so that folks who are fond of double-clicking to extract words from the console output can still do so).

Ideally we'd have our cake and eat it too, by detecting double-clicks retroactively, but this is very difficult to do and certainly more bug prone than we'd want to take at this point in the release.