### PR TITLE
Reroute OpenSSL libraries for rpostback

### DIFF
--- a/src/cpp/session/postback/CMakeLists.txt
+++ b/src/cpp/session/postback/CMakeLists.txt
@@ -67,3 +67,14 @@ set(POSTBACK_SCRIPTS ${POSTBACK_SCRIPTS} "askpass-passthrough")
 install(PROGRAMS ${POSTBACK_SCRIPTS}
         DESTINATION ${RSTUDIO_INSTALL_BIN}/postback)
 
+# if doing a package build on MacOS, reroute the OpenSSL libraries to our bundled copies
+if(APPLE AND RSTUDIO_PACKAGE_BUILD)
+   find_package(OpenSSL REQUIRED QUIET)
+   foreach(lib ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
+      get_filename_component(LIB_DIR ${lib} PATH)
+      execute_process(COMMAND readlink ${lib} OUTPUT_VARIABLE LIB_FILE OUTPUT_STRIP_TRAILING_WHITESPACE)
+      add_custom_command (TARGET rpostback POST_BUILD
+         COMMAND install_name_tool -change ${LIB_DIR}/${LIB_FILE} @executable_path/../Frameworks/${LIB_FILE} ${CMAKE_CURRENT_BINARY_DIR}/rpostback)
+   endforeach()
+endif()
+


### PR DESCRIPTION
The `rpostback` executable currently has a dependency on OpenSSL from Homebrew. This change replaces that dependency with one on our bundled copy of OpenSSL (as we do for the other binaries we ship on MacOS). 

Fixes https://github.com/rstudio/rstudio/issues/4297.