### PR TITLE
additional diagnostic tools for terminal websockets

### DIFF
--- a/src/cpp/session/SessionConsoleProcessSocket.cpp
+++ b/src/cpp/session/SessionConsoleProcessSocket.cpp
@@ -111,11 +111,8 @@ Error ConsoleProcessSocket::ensureServerRunning()
 
       pwsServer_->init_asio();
       
-      // Increase websocketpp handshake timeouts to 15 seconds (default is 5). Could set to
-      // zero and eliminate altogether, but they could be helpful in reducing load under a
-      // DOS attack.
-      pwsServer_->set_open_handshake_timeout(15000);
-      pwsServer_->set_close_handshake_timeout(15000);
+      pwsServer_->set_open_handshake_timeout(session::options().webSocketHandshakeTimeoutMs());
+      pwsServer_->set_close_handshake_timeout(session::options().webSocketHandshakeTimeoutMs());
 
       pwsServer_->set_message_handler(
                boost::bind(&ConsoleProcessSocket::onMessage, this, &*pwsServer_, _1, _2));

--- a/src/cpp/session/SessionConsoleProcessSocket.cpp
+++ b/src/cpp/session/SessionConsoleProcessSocket.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionConsoleProcessSocket.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -87,9 +87,35 @@ Error ConsoleProcessSocket::ensureServerRunning()
    try
    {
       pwsServer_.reset(new terminalServer());
+     
+      switch (session::options().webSocketLogLevel())
+      {
+         case 0:
+         default:
+            pwsServer_->set_access_channels(websocketpp::log::alevel::none);
+            pwsServer_->set_error_channels(websocketpp::log::elevel::none);
+            break;
+         case 1:
+            pwsServer_->set_access_channels(websocketpp::log::alevel::none);
+            pwsServer_->set_error_channels(websocketpp::log::elevel::all);
+            break;
+         case 2:
+            pwsServer_->set_access_channels(websocketpp::log::alevel::access_core);
+            pwsServer_->set_error_channels(websocketpp::log::elevel::none);
+            break;
+         case 3:
+            pwsServer_->set_access_channels(websocketpp::log::alevel::all);
+            pwsServer_->set_error_channels(websocketpp::log::elevel::all);
+            break;
+      }
 
-      pwsServer_->set_access_channels(websocketpp::log::alevel::none);
       pwsServer_->init_asio();
+      
+      // Increase websocketpp handshake timeouts to 15 seconds (default is 5). Could set to
+      // zero and eliminate altogether, but they could be helpful in reducing load under a
+      // DOS attack.
+      pwsServer_->set_open_handshake_timeout(15000);
+      pwsServer_->set_close_handshake_timeout(15000);
 
       pwsServer_->set_message_handler(
                boost::bind(&ConsoleProcessSocket::onMessage, this, &*pwsServer_, _1, _2));
@@ -99,6 +125,8 @@ Error ConsoleProcessSocket::ensureServerRunning()
                boost::bind(&ConsoleProcessSocket::onClose, this, &*pwsServer_, _1));
       pwsServer_->set_open_handler(
                boost::bind(&ConsoleProcessSocket::onOpen, this, &*pwsServer_, _1));
+      pwsServer_->set_fail_handler(
+            boost::bind(&ConsoleProcessSocket::onFail, this, &*pwsServer_, _1));
 
       // try to bind to the given port
       do
@@ -348,6 +376,13 @@ void ConsoleProcessSocket::onHttp(terminalServer* s, websocketpp::connection_hdl
    // We could return diagnostics here if we had some, but for now just 404
    terminalServer::connection_ptr con = s->get_con_from_hdl(hdl);
    con->set_status(websocketpp::http::status_code::not_found);
+}
+
+void ConsoleProcessSocket::onFail(terminalServer* s, websocketpp::connection_hdl hdl)
+{
+   terminalServer::connection_ptr con = s->get_con_from_hdl(hdl);
+   std::string message = "Terminal websocket failure: " + con->get_ec().message();
+   LOG_ERROR_MESSAGE(message);
 }
 
 std::string ConsoleProcessSocket::getHandle(terminalServer* s, websocketpp::connection_hdl hdl)

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -244,7 +244,10 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
       (kWebSocketConnectTimeout,
        value<int>(&webSocketConnectTimeout_)->default_value(3),
        "WebSocket initial connection timeout (seconds)")
-      (kPackageOutputInPackageFolder,
+      (kWebSocketLogLevel,
+       value<int>(&webSocketLogLevel_)->default_value(0),
+       "WebSocket log level (0=none, 1=errors, 2=activity, 3=all)")
+       (kPackageOutputInPackageFolder,
          value<bool>(&packageOutputToPackageFolder_)->default_value(false),
          "devtools check and devtools build output to package project folder");
 

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -247,9 +247,12 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
       (kWebSocketLogLevel,
        value<int>(&webSocketLogLevel_)->default_value(0),
        "WebSocket log level (0=none, 1=errors, 2=activity, 3=all)")
-       (kPackageOutputInPackageFolder,
-         value<bool>(&packageOutputToPackageFolder_)->default_value(false),
-         "devtools check and devtools build output to package project folder");
+      (kWebSocketHandshakeTimeout,
+       value<int>(&webSocketHandshakeTimeoutMs_)->default_value(5000),
+       "WebSocket protocol handshake timeout (ms)")
+      (kPackageOutputInPackageFolder,
+       value<bool>(&packageOutputToPackageFolder_)->default_value(false),
+       "devtools check and devtools build output to package project folder");
 
    // allow options
    options_description allow("allow");

--- a/src/cpp/session/include/session/SessionConsoleProcessSocket.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessSocket.hpp
@@ -63,9 +63,6 @@ struct ConsoleProcessSocketConnectionCallbacks
 
    // invoked when connection closes
    boost::function<void ()> onConnectionClosed;
-   
-   // invoked when connection fails to connect
-   boost::function<void (const std::string& errorMessage)> onConnectionFailed;
 };
 
 typedef websocketpp::server<websocketpp::config::asio> terminalServer;

--- a/src/cpp/session/include/session/SessionConsoleProcessSocket.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessSocket.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionConsoleProcessSocket.hpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -63,6 +63,9 @@ struct ConsoleProcessSocketConnectionCallbacks
 
    // invoked when connection closes
    boost::function<void ()> onConnectionClosed;
+   
+   // invoked when connection fails to connect
+   boost::function<void (const std::string& errorMessage)> onConnectionFailed;
 };
 
 typedef websocketpp::server<websocketpp::config::asio> terminalServer;
@@ -123,8 +126,7 @@ private:
    void onClose(terminalServer* s, websocketpp::connection_hdl hdl);
    void onOpen(terminalServer* s, websocketpp::connection_hdl hdl);
    void onHttp(terminalServer* s, websocketpp::connection_hdl hdl);
-
-   void onServerTimeout(boost::system::error_code ec);
+   void onFail(terminalServer* s, websocketpp::connection_hdl hdl);
 
 private:
    core::thread::ThreadsafeMap<std::string, ConsoleProcessSocketConnectionDetails> connections_;

--- a/src/cpp/session/include/session/SessionConstants.hpp
+++ b/src/cpp/session/include/session/SessionConstants.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionConstants.hpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -74,6 +74,7 @@
 
 #define kWebSocketPingInterval            "websocket-ping-seconds"
 #define kWebSocketConnectTimeout          "websocket-connect-timeout"
+#define kWebSocketLogLevel                "websocket-log-level"
 
 #define kPackageOutputInPackageFolder     "package-output-to-package-folder"
 

--- a/src/cpp/session/include/session/SessionConstants.hpp
+++ b/src/cpp/session/include/session/SessionConstants.hpp
@@ -75,6 +75,7 @@
 #define kWebSocketPingInterval            "websocket-ping-seconds"
 #define kWebSocketConnectTimeout          "websocket-connect-timeout"
 #define kWebSocketLogLevel                "websocket-log-level"
+#define kWebSocketHandshakeTimeout        "websocket-handshake-timeout"
 
 #define kPackageOutputInPackageFolder     "package-output-to-package-folder"
 

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -548,6 +548,11 @@ public:
       return webSocketConnectTimeout_;
    }
    
+   int webSocketLogLevel() const
+   {
+      return webSocketLogLevel_;
+   }
+    
    bool packageOutputInPackageFolder() const
    {
       return packageOutputToPackageFolder_;   
@@ -658,6 +663,7 @@ private:
    bool verifySignatures_;
    int webSocketPingSeconds_;
    int webSocketConnectTimeout_;
+   int webSocketLogLevel_;
    bool packageOutputToPackageFolder_;
    std::string terminalPort_;
 

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -552,7 +552,12 @@ public:
    {
       return webSocketLogLevel_;
    }
-    
+   
+   int webSocketHandshakeTimeoutMs() const
+   {
+      return webSocketHandshakeTimeoutMs_;
+
+   }
    bool packageOutputInPackageFolder() const
    {
       return packageOutputToPackageFolder_;   
@@ -664,6 +669,7 @@ private:
    int webSocketPingSeconds_;
    int webSocketConnectTimeout_;
    int webSocketLogLevel_;
+   int webSocketHandshakeTimeoutMs_;
    bool packageOutputToPackageFolder_;
    std::string terminalPort_;
 


### PR DESCRIPTION
This was motivated by some symptoms reported by a customer and should hopefully help us understand this and other websocket failures we've hit in the wild.

- added another rsession config option so our websocket library will emit diagnostics to the R console when terminal websockets are being used. Intended for troubleshooting tricky customer scenarios when they are getting their installations configured (outputs to R console, so not something that will be left enabled for long!).
- lengthen the previously implicit websocketpp handshake timeout from 5 seconds to 15 seconds
- catch and log websocketpp fail handler; may help us identify some failure modes we aren't currently aware of

Have another PR to update the RSP admin guide to mention this new option, plus two other terminal websocket settings that are in the code but weren't documented (websocket keep alive frequency and RPC-fallback timeout setting).