### PR TITLE
update to Qt 5.12.1

### DIFF
--- a/dependencies/common/install-boost
+++ b/dependencies/common/install-boost
@@ -87,8 +87,8 @@ then
    if [ "$PLATFORM" == "Darwin" ]
    then
 
-     BJAM_CXXFLAGS="cxxflags=-fPIC -std=c++11"
-     BJAM_LDFLAGS=""     
+     BJAM_CXXFLAGS="cxxflags=-fPIC -std=c++11 -mmacosx-version-min=10.12"
+     BJAM_LDFLAGS=""
 
      sudo ./bjam              \
         "${BOOST_BJAM_FLAGS}" \

--- a/dependencies/linux/README
+++ b/dependencies/linux/README
@@ -9,22 +9,22 @@ systems. Specific version requirements for various components include:
 - R 3.0.1
 - CMake 2.8 (3.1.0 for Desktop)
 - Boost 1.63
-- Qt 5.11.1 [Required only for Desktop]
+- Qt 5.12.1 [Required only for Desktop]
 - some older Linux platforms (OpenSUSE 42.3, Ubuntu Trusty) can only
-  build Desktop with Qt 5.10.1 due to unsatisfied dependencies in 5.11.1
+  build Desktop with Qt 5.10.1 due to unsatisfied dependencies in 5.12.1
 
-Installation of Qt SDK 5.11.1
+Installation of Qt SDK 5.12.1
 =============================================================================
 
-RStudio Desktop requires Qt 5.11.1. The install-dependencies scripts 
-referenced below install a version of the Qt 5.11.1 SDK into 
+RStudio Desktop requires Qt 5.12.1. The install-dependencies scripts 
+referenced below install a version of the Qt 5.12.1 SDK into 
 /opt/RStudio-QtSDK (the special RStudio prefix on the directory is included 
 so this installation doesn't conflict with any other versions of Qt installed 
 on the system).
 
 If you are either building RStudio Server or running a Linux distribution 
-that already includes Qt 5.11.1 you may wish to prevent installation of the
-Qt 5.11.1 SDK. To do this pass the --exclude-qt-sdk flag to the install 
+that already includes Qt 5.12.1 you may wish to prevent installation of the
+Qt 5.12.1 SDK. To do this pass the --exclude-qt-sdk flag to the install 
 dependencies script, for example:
 
 ./install-dependencies-debian --exclude-qt-sdk
@@ -44,7 +44,7 @@ installing it using the system standard package management tools (apt-get,
 yum, etc).
 
 2) Run the install-dependencies script appropriate to your platform's
-package management system (to optionally exclude installation of the Qt 5.11.1
+package management system (to optionally exclude installation of the Qt 5.12.1
 SDK be sure to specify the --exclude-qt-sdk flag as described above).
 
    ./install-dependencies-debian  
@@ -76,7 +76,7 @@ Hunspell dictionaries, MathJax, and Boost 1.63):
          install-common
 
 3) Optionally install the Qt SDK. You should do this if you are building the
-Desktop version and don't have Qt 5.11.1 installed on the system:
+Desktop version and don't have Qt 5.12.1 installed on the system:
 
    dependencies
       linux

--- a/dependencies/linux/install-qt-sdk
+++ b/dependencies/linux/install-qt-sdk
@@ -15,13 +15,13 @@
 #
 
 if [ -z "$QT_VERSION" ]; then
-    QT_VERSION=5.11.1
+    QT_VERSION=5.12.1
 fi
 if [ -z "$QT_SDK_BINARY" ]; then
     QT_SDK_BINARY=qt-unified-linux-x64-3.0.5-online.run
 fi
 if [ -z "$QT_PACKAGES" ]; then
-    QT_PACKAGES=qt.qt5.5111.gcc_64,qt.qt5.5111.qtwebengine,qt.qt5.5111.qtwebengine.gcc_64
+    QT_PACKAGES=qt.qt5.5121.gcc_64,qt.qt5.5121.qtwebengine,qt.qt5.5121.qtwebengine.gcc_64
 fi
 if [ -z "$QT_SDK_CUSTOM" ]; then
     echo Using online Qt installer

--- a/dependencies/osx/install-qt-sdk-osx
+++ b/dependencies/osx/install-qt-sdk-osx
@@ -18,7 +18,7 @@
 # Installs Qt via the online installer at the location in $QT_SDK_DIR.
 # If no location provided, checks against a set of common locations and installs if not found.
 
-QT_VERSION=5.11.1
+QT_VERSION=5.12.1
 QT_SDK_BINARY_BASE=qt-unified-mac-x64-3.0.5-online
 QT_SDK_BINARY=${QT_SDK_BINARY_BASE}.tar.gz
 QT_SDK_INSTALLER=${QT_SDK_BINARY_BASE}.app
@@ -65,10 +65,10 @@ Controller.prototype.TargetDirectoryPageCallback = function()
 Controller.prototype.ComponentSelectionPageCallback = function() {
     var widget = gui.currentPageWidget();
      
-    widget.selectComponent("qt.qt5.5111.clang_64");
-    widget.selectComponent("qt.qt5.5111.qtwebengine");
-    widget.selectComponent("qt.qt5.5111.qtwebengine.clang_64");
-    widget.deselectComponent("qt.qt5.5111.src");
+    widget.selectComponent("qt.qt5.5121.clang_64");
+    widget.selectComponent("qt.qt5.5121.qtwebengine");
+    widget.selectComponent("qt.qt5.5121.qtwebengine.clang_64");
+    widget.deselectComponent("qt.qt5.5121.src");
     gui.clickButton(buttons.NextButton);
 }
 

--- a/dependencies/windows/install-qt-sdk-win.cmd
+++ b/dependencies/windows/install-qt-sdk-win.cmd
@@ -2,7 +2,7 @@
 
 setlocal EnableDelayedExpansion
 
-set QT_VERSION=5.12.0
+set QT_VERSION=5.12.1
 set QT_SDK_BINARY=qt-unified-windows-x86-3.0.5-online.exe
 set QT_SDK_URL=https://s3.amazonaws.com/rstudio-buildtools/%QT_SDK_BINARY%
 set QT_SCRIPT=qt-noninteractive-install-win.qs

--- a/docker/jenkins/Dockerfile.bionic-amd64
+++ b/docker/jenkins/Dockerfile.bionic-amd64
@@ -83,7 +83,7 @@ RUN /bin/bash /tmp/install-dependencies
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.11.1 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.1 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/docker/jenkins/Dockerfile.centos7-x86_64
+++ b/docker/jenkins/Dockerfile.centos7-x86_64
@@ -62,7 +62,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.11.1 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.1 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/docker/jenkins/Dockerfile.debian9-x86_64
+++ b/docker/jenkins/Dockerfile.debian9-x86_64
@@ -64,7 +64,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.11.1 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.1 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/docker/jenkins/Dockerfile.opensuse15-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse15-x86_64
@@ -60,7 +60,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.11.1 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.1 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -52,9 +52,9 @@ RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 
 
 # install qt (note that we are using the current directory's context)
 RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48; ` 
-  (New-Object System.Net.WebClient).DownloadFile('https://s3.amazonaws.com/rstudio-buildtools/QtSDK-5.12.0-msvc2017_64.7z', 'c:\QtSDK-5.12.0-msvc2017_64.7z'); `
-  7z x c:\QtSDK-5.12.0-msvc2017_64.7z -oc:\ ; `
-  Remove-Item c:\QtSDK-5.12.0-msvc2017_64.7z -Force
+  (New-Object System.Net.WebClient).DownloadFile('https://s3.amazonaws.com/rstudio-buildtools/QtSDK-5.12.1-msvc2017_64.7z', 'c:\QtSDK-5.12.1-msvc2017_64.7z'); `
+  7z x c:\QtSDK-5.12.1-msvc2017_64.7z -oc:\ ; `
+  Remove-Item c:\QtSDK-5.12.1-msvc2017_64.7z -Force
     
 # cpack (an alias from chocolatey) and cmake's cpack conflict.
 RUN Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe'

--- a/docker/jenkins/Dockerfile.xenial-amd64
+++ b/docker/jenkins/Dockerfile.xenial-amd64
@@ -81,7 +81,7 @@ RUN /bin/bash /tmp/install-dependencies
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.11.1 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.1 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -28,6 +28,7 @@ rm -f CMakeCache.txt
 rm -rf build/_CPack_Packages
 
 cmake -DRSTUDIO_TARGET=Desktop \
+      -DCMAKE_OSX_DEPLOYMENT_TARGET="10.12" \
       -DCMAKE_BUILD_TYPE=Release \
       -DRSTUDIO_PACKAGE_BUILD=1 \
       -DGWT_BIN_DIR="$BUILD_DIR/gwt/bin" \

--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -74,7 +74,7 @@ if(NOT WIN32)
    endif()
 else()
    # Windows
-   set(QT_VERSION "5.12.0")
+   set(QT_VERSION "5.12.1")
    set(QT_VERSION_SUBDIR "${QT_VERSION}")   
    if(NOT QT_QMAKE_EXECUTABLE)
 

--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -38,9 +38,9 @@ if(NOT WIN32)
       endif()
          
       if(APPLE)
-         set(QT_CANDIDATES 5.11.1)   
+         set(QT_CANDIDATES 5.12.1)   
       else()
-         set(QT_CANDIDATES 5.11.1 5.10.1)
+         set(QT_CANDIDATES 5.12.1 5.10.1)
       endif()
 
       # find the newest installed Qt version among the versions we build

--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -515,7 +515,9 @@ int main(int argc, char* argv[])
             */
             
             std::vector<std::string> gpuBlacklist = {
+#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
                "AMD FirePro"
+#endif
             };
             
             for (const std::string& entry : gpuBlacklist)

--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -491,7 +491,7 @@ int main(int argc, char* argv[])
          if (!stdOut.empty())
          {
             // NOTE: temporarily backed out as it appears the rasterization
-            // issues do not occur anymore with Qt 5.11.1; re-enable if we
+            // issues do not occur anymore with Qt 5.12.1; re-enable if we
             // receive more reports in the wild.
             //
             // https://github.com/rstudio/rstudio/issues/2176


### PR DESCRIPTION
This PR updates us from 5.11.1 to 5.12.1 (on Linux + macOS), and 5.12.0 to 5.12.1 (on Windows).

The associated SDKs for Linux and Windows have been generated and uploaded to S3, so hopefully build machines should be ready to go after this PR.

Older Linux desktop environments with old dbus will remain on Qt 5.10.1 as we don't have any clean mechanism for bringing them to Qt 5.12.1.

We'll want to wait until the macOS build machine has been updated to Mojave before merging this as well.