### PR TITLE
defend against unreliable mtime

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -1433,9 +1433,18 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    
    # in some cases, mtime may not be available -- in that case, fall
    # back to the time that was serialized when the process was launched
+   #
    # https://github.com/rstudio/rstudio/issues/4312
-   if (is.na(time))
-      time <- readRDS(file.path(dir, "time.rds"))
+   #
+   # if all-else fails, just use the current time. this effectively means
+   # that we will never mark the directory as 'stale', which means that
+   # the dependency discovery feature may not work -- but at this point
+   # there's not much else we can do
+   if (is.na(time)) {
+      time <- .rs.tryCatch(readRDS(file.path(dir, "time.rds")))
+      if (inherits(time, "error"))
+         time <- Sys.time()
+   }
    
    # check to see if the directory is 'stale'
    diff <- difftime(Sys.time(), time, units = "secs")


### PR DESCRIPTION
Attempts to access `mtime` may be unreliable -- in some cases, they can return `NA` if the modification time is either unknown or not available to the user for some reason.

To avoid this, we now serialize the current time as reported by `Sys.time()` when the directory is created, and use that in lieu of the `mtime` if it is unreadable for some reason.

Closes #4312.