### PR TITLE
fix for emacs-style kill / yank

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -579,6 +579,7 @@ public class AceEditor implements DocDisplay,
       {
          Desktop.getFrame().getClipboardText((String text) -> {
             replaceSelection(text);
+            setCursorPosition(getSelectionEnd());
          });
       }
       else

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -492,7 +492,8 @@ public class AceEditor implements DocDisplay,
       
       if (Desktop.isDesktop() && isEmacsModeOn())
       {
-         Desktop.getFrame().clipboardCut();
+         Desktop.getFrame().setClipboardText(selectionValue);
+         replaceSelection("");
          clearEmacsMark();
       }
       else
@@ -576,7 +577,9 @@ public class AceEditor implements DocDisplay,
       
       if (Desktop.isDesktop() && isEmacsModeOn())
       {
-         Desktop.getFrame().clipboardPaste();
+         Desktop.getFrame().getClipboardText((String text) -> {
+            replaceSelection(text);
+         });
       }
       else
       {


### PR DESCRIPTION
Fixes #2740. It appears that the clipboard-related commands are unreliably when not executed through a menu item; instead, we use the APIs directly to read / write clipboard text.