### PR TITLE
Use software rendering on Windows remote desktop

### DIFF
--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -283,6 +283,12 @@ QString inferDefaultRenderingEngine()
 
 QString inferDefaultRenderingEngine()
 {
+   if (::GetSystemMetrics(SM_REMOTESESSION))
+   {
+       // use software rendering over remote desktop
+       return QStringLiteral("software");
+   }
+
    // prefer software rendering for certain graphics cards
    std::vector<std::string> blacklist = {
       "Intel(R) HD Graphics 520",
@@ -311,12 +317,6 @@ QString inferDefaultRenderingEngine()
             return QStringLiteral("software");
          }
       }
-   }
-
-   if (::GetSystemMetrics(SM_REMOTESESSION))
-   {
-       // use software rendering over remote desktop
-       return QStringLiteral("software");
    }
 
    return QStringLiteral("auto");

--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -313,6 +313,12 @@ QString inferDefaultRenderingEngine()
       }
    }
 
+   if (::GetSystemMetrics(SM_REMOTESESSION))
+   {
+       // use software rendering over remote desktop
+       return QStringLiteral("software");
+   }
+
    return QStringLiteral("auto");
 }
 


### PR DESCRIPTION
Prefers the software render mode over Remote Desktop due to known issues trying to use the accelerated render engine; fixes https://github.com/rstudio/rstudio/issues/4313.