### PR TITLE
set default jenkins swarm version to 3.15 for win builder

### DIFF
--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -64,6 +64,6 @@ RUN Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe'
 ##### follow https://issues.jenkins-ci.org/browse/JENKINS-36776 to track docker windows support on jenkins #####
 
 RUN choco install -y git cygwin
-ENV JENKINS_SWARM_VERSION 3.3
+ENV JENKINS_SWARM_VERSION 3.15
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
   Invoke-WebRequest $('https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/{0}/swarm-client-{0}.jar' -f $env:JENKINS_SWARM_VERSION) -OutFile 'C:\swarm-client.jar' -UseBasicParsing ;


### PR DESCRIPTION
no rush on this, and it can land wherever makes the most sense -- we'll start setting it using the env variable when building the image as soon as we need it!