### PR TITLE
avoid using regex when building PATH (closes #2079)

### DIFF
--- a/src/cpp/session/modules/SessionPath.cpp
+++ b/src/cpp/session/modules/SessionPath.cpp
@@ -70,14 +70,20 @@ void addToPathIfNecessary(
       const std::string& entry,
       std::vector<std::string>* pPathComponents)
 {
-   auto it = std::find(
-            pPathComponents->begin(),
-            pPathComponents->end(),
-            entry);
+   // tolerate paths with trailing slashes
+   for (std::string item : {entry, entry + "/"})
+   {
+      auto it = std::find(
+               pPathComponents->begin(),
+               pPathComponents->end(),
+               item);
 
-   if (it != pPathComponents->end())
-      return;
+      // if we find the path component, bail (no need to add to PATH)
+      if (it != pPathComponents->end())
+         return;
+   }
 
+   // failed to find PATH component; add it to the PATH
    pPathComponents->push_back(entry);
 }
 


### PR DESCRIPTION
Previously, we were constructing regular expressions based on entries within files located within `/etc/paths.d`, and this could cause failures to launch if files with entries that were not valid regular expressions were present.

The fix here is to avoid the use of regular expressions and just handle the path entries as regular strings.