### PR TITLE
use RSTUDIO_CRASHPAD_DISABLED to disable crashpad integration

### DIFF
--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -202,7 +202,7 @@ include(RStudioCMakeUtils)
 # define custom installation macro to strip symbols from the binary
 macro(add_stripped_executable _target)
    add_executable(${_target} ${ARGN})
-   if(CMAKE_BUILD_TYPE STREQUAL RelWithDebInfo)
+   if(RSTUDIO_CRASHPAD_ENABLED AND CMAKE_BUILD_TYPE STREQUAL RelWithDebInfo)
       if(UNIX AND NOT APPLE)
          add_custom_command(TARGET ${_target} POST_BUILD
                             COMMAND objcopy --only-keep-debug ${_target} ${_target}.debug

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -319,8 +319,11 @@ list(LENGTH CRASHPAD_LIBRARIES CRASHPAD_LIB_COUNT)
 
 if (CRASHPAD_LIB_COUNT EQUAL 0)
    message(STATUS "No Crashpad libraries found under ${CRASHPAD_LIBRARY_DIR}. Crashpad integration disabled.")
+elseif(RSTUDIO_CRASHPAD_DISABLED)
+   message(STATUS "RSTUDIO_CRASHPAD_DISABLED was set. Crashpad integration disabled.")
 else()
    message(STATUS "Crashpad libraries found under ${CRASHPAD_LIBRARY_DIR}. Crashpad integration enabled.")
+   set(RSTUDIO_CRASHPAD_ENABLED CACHE INTERNAL "Crashpad integration enabled")
    add_definitions(-DRSTUDIO_CRASHPAD_ENABLED=1)
 
    # ensure the desired crashpad binaries are installed with the installation package

--- a/src/tools/clang-ubsan-build
+++ b/src/tools/clang-ubsan-build
@@ -10,6 +10,7 @@ mkdir -p "${BUILD_DIR}"
 cd "${BUILD_DIR}"
 cmake ../cpp                                    \
     -DLIBR_HOME="${R_HOME}"                     \
+    -DRSTUDIO_CRASHPAD_DISABLED=1               \
     -DCMAKE_BUILD_TYPE="RelWithDebugInfo"       \
     -DCMAKE_C_FLAGS="${ASANFLAGS} ${LDFLAGS}"   \
     -DCMAKE_CXX_FLAGS="${ASANFLAGS} ${LDFLAGS}" \


### PR DESCRIPTION
This PR allows one to set `RSTUDIO_CRASHPAD_DISABLED` to disable Crashpad integration for a build. This is primarily for local development builds using release with debug info where we don't want to strip binaries.