### PR TITLE
ensure ordering of files when processing plots

### DIFF
--- a/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
@@ -95,6 +95,12 @@ void PlotCapture::processPlots(bool ignoreEmpty)
    Error error = plotFolder_.children(&folderContents);
    if (error)
       LOG_ERROR(error);
+
+   // sort entries by filename
+   std::sort(
+            folderContents.begin(),
+            folderContents.end(),
+            std::less<FilePath>());
    
    BOOST_FOREACH(const FilePath& path, folderContents)
    {


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/1795. The underlying issue, IIUC, is that `FilePath.children()` does not return files in lexically-sorted order; rather, it just uses whatever ordering the underlying inodes have on the filesystem.

Since we construct lexically-ordered names for these files, pre-sorting should resolve the behavior.