### PR TITLE
Rreduce size of publish account list to fix options overflow

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/WidgetListBox.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/WidgetListBox.css
@@ -50,6 +50,5 @@
 .emptyMessage
 {
 	color: #c0c0c0;
-	padding-top: 30%;
 	text-align: center;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/WidgetListBox.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/WidgetListBox.java
@@ -1,7 +1,7 @@
 /*
  * WidgetListBox.java
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -106,9 +106,13 @@ public class WidgetListBox<T extends Widget>
       add(scrollPanel_);
      
       emptyTextLabel_ = new Label();
-      emptyTextLabel_.addStyleName(style_.scrollPanel());
-      emptyTextLabel_.addStyleName(style_.emptyMessage());
-      
+      emptyTextBox_ = new VerticalPanel();
+      emptyTextBox_.addStyleName(style_.scrollPanel());
+      emptyTextBox_.addStyleName(style_.emptyMessage());
+      emptyTextBox_.add(emptyTextLabel_);
+      emptyTextBox_.setCellHorizontalAlignment(emptyTextLabel_, VerticalPanel.ALIGN_CENTER);
+      emptyTextBox_.setCellVerticalAlignment(emptyTextLabel_, VerticalPanel.ALIGN_MIDDLE);
+
       addKeyDownHandler(new KeyDownHandler()
       {
          @Override
@@ -273,15 +277,15 @@ public class WidgetListBox<T extends Widget>
    
    private void updateEmptyText()
    {
-      if (emptyTextLabel_.getParent() == this && items_.size() > 0)
+      if (emptyTextBox_.getParent() == this && items_.size() > 0)
       {
          clear();
          add(scrollPanel_);
       }
-      else if (emptyTextLabel_.getParent() != this && items_.size() == 0)
+      else if (emptyTextBox_.getParent() != this && items_.size() == 0)
       {
          clear();
-         add(emptyTextLabel_);
+         add(emptyTextBox_);
       }
    }
    
@@ -289,6 +293,7 @@ public class WidgetListBox<T extends Widget>
 
    private ScrollPanel scrollPanel_;
    private VerticalPanel panel_;
+   private VerticalPanel emptyTextBox_;
    private Label emptyTextLabel_;
    private List<HTMLPanel> options_ = new ArrayList<HTMLPanel>();
    private List<T> items_ = new ArrayList<T>();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PublishingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PublishingPreferencesPane.java
@@ -75,7 +75,7 @@ public class PublishingPreferencesPane extends PreferencesPane
       
       accountList_ = new RSConnectAccountList(server, globalDisplay, true, 
             true);
-      accountList_.setHeight("200px");
+      accountList_.setHeight("150px");
       accountList_.setWidth("300px");
       accountList_.getElement().getStyle().setMarginBottom(15, Unit.PX);
       accountList_.getElement().getStyle().setMarginLeft(3, Unit.PX);


### PR DESCRIPTION
This change reduces the height of the publishing account list in Global Options to fix https://github.com/rstudio/rstudio/issues/4346.

The change also ensures that the "No accounts connected" text is correctly centered in the box (it was previously set with 30% margin, which could be very off-center depending on the parent's height). 