### PR TITLE
Continue processing open file queue after cancellation

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -3045,6 +3045,13 @@ public class Source implements InsertSourceHandler,
                }
 
                @Override
+               public void onCancelled()
+               {
+                  super.onCancelled();
+                  processNextEntry.execute();
+               }
+
+               @Override
                public void onFailure(ServerError error)
                {
                   String message = error.getUserMessage();


### PR DESCRIPTION
This change fixes a long-standing issue in which a cancelled file open (for example, because the file is too big) makes it impossible to open any more files.

The problem is that the file open queue processing doesn't proceed unless success or failure to open occurs (and cancellation is neither); the fix is simply to keep processing after a cancellation (as we already do after a failure). 

Fixes https://github.com/rstudio/rstudio/issues/4341. 