### PR TITLE
Only format numeric values when preparing data for viewing

### DIFF
--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -29,24 +29,25 @@
    if (is.numeric(col)) {
      # show numbers as doubles
      storage.mode(col) <- "double"
+
+     # remember which values are NA 
+     naVals <- is.na(col) 
+
+     # format all the numeric values; this drops NAs (the na.encode option only
+     # preserves NA for character cols)
+     vals <- format(col, trim = TRUE, justify = "none", ...)
+
+     # restore NA values if there were any
+     if (any(naVals)) {
+       vals[naVals] <- col[naVals]
+     } 
+
+     # return formatted values
+     vals
    } else {
      # show everything else as characters
-     col <- as.character(col)
+     as.character(col)
    }
-
-   # remember which values are NA 
-   naVals <- is.na(col) 
-
-   # format all the values; this drops NAs (the na.encode option only preserves
-   # NA for character cols)
-   vals <- format(col, trim = TRUE, justify = "none", ...)
-
-   # restore NA values if there were any
-   if (any(naVals)) {
-     vals[naVals] <- col[naVals]
-   } 
-
-   vals
 })
 
 .rs.addFunction("describeCols", function(x, maxFactors) 


### PR DESCRIPTION
This small change addresses an issue on Windows in which characters that cannot be represented in the system encoding are not shown correctly in the data viewer.

The problem is that R's `format()` method mangles these characters, and the fix is to not call `format()` on character columns -- `format()` is, as its docs state, typically used for numerics. 

A possible downside is that, since `format()` is a generic, it's no longer possible for packages to provide their own formatters (pretty printers) for non-numeric data hosted in the data viewer.

Fixes https://github.com/rstudio/rstudio/issues/4193.