### PR TITLE
enforce macOS 10.12 minimum version for Boost

### DIFF
--- a/dependencies/common/install-boost
+++ b/dependencies/common/install-boost
@@ -87,8 +87,8 @@ then
    if [ "$PLATFORM" == "Darwin" ]
    then
 
-     BJAM_CXXFLAGS="cxxflags=-fPIC -std=c++11"
-     BJAM_LDFLAGS=""     
+     BJAM_CXXFLAGS="cxxflags=-fPIC -std=c++11 -mmacosx-version-min=10.12"
+     BJAM_LDFLAGS=""
 
      sudo ./bjam              \
         "${BOOST_BJAM_FLAGS}" \


### PR DESCRIPTION
When attempting to produce a package build on the (newly-coming) Vagrant build machine, the following compiler warnings are emitted during link:

```
[ 61%] Linking CXX executable RStudio.app/Contents/MacOS/RStudio
ld: warning: object file (/opt/rstudio-tools/boost/boost_1_63_0/lib/libboost_system.a(error_code.o)) was built for newer OSX version (10.14) than being linked (10.12)
ld: warning: object file (/opt/rstudio-tools/boost/boost_1_63_0/lib/libboost_filesystem.a(operations.o)) was built for newer OSX version (10.14) than being linked (10.12)
ld: warning: object file (/opt/rstudio-tools/boost/boost_1_63_0/lib/libboost_filesystem.a(unique_path.o)) was built for newer OSX version (10.14) than being linked (10.12)
ld: warning: object file (/opt/rstudio-tools/boost/boost_1_63_0/lib/libboost_regex.a(instances.o)) was built for newer OSX version (10.14) than being linked (10.12)
ld: warning: object file (/opt/rstudio-tools/boost/boost_1_63_0/lib/libboost_thread.a(thread.o)) was built for newer OSX version (10.14) than being linked (10.12)
ld: warning: object file (/opt/rstudio-tools/boost/boost_1_63_0/lib/libboost_regex.a(regex.o)) was built for newer OSX version (10.14) than being linked (10.12)
ld: warning: object file (/opt/rstudio-tools/boost/boost_1_63_0/lib/libboost_regex.a(regex_traits_defaults.o)) was built for newer OSX version (10.14) than being linked (10.12)
ld: warning: object file (/opt/rstudio-tools/boost/boost_1_63_0/lib/libboost_iostreams.a(zlib.o)) was built for newer OSX version (10.14) than being linked (10.12)
ld: warning: object file (/opt/rstudio-tools/boost/boost_1_63_0/lib/libboost_filesystem.a(path.o)) was built for newer OSX version (10.14) than being linked (10.12)
ld: warning: object file (/opt/rstudio-tools/boost/boost_1_63_0/lib/libboost_filesystem.a(path_traits.o)) was built for newer OSX version (10.14) than being linked (10.12)
ld: warning: object file (/opt/rstudio-tools/boost/boost_1_63_0/lib/libboost_filesystem.a(utf8_codecvt_facet.o)) was built for newer OSX version (10.14) than being linked (10.12)
ld: warning: object file (/opt/rstudio-tools/boost/boost_1_63_0/lib/libboost_thread.a(once.o)) was built for newer OSX version (10.14) than being linked (10.12)
ld: warning: object file (/opt/rstudio-tools/boost/boost_1_63_0/lib/libboost_regex.a(regex_raw_buffer.o)) was built for newer OSX version (10.14) than being linked (10.12)
ld: warning: object file (/opt/rstudio-tools/boost/boost_1_63_0/lib/libboost_regex.a(cpp_regex_traits.o)) was built for newer OSX version (10.14) than being linked (10.12)
ld: warning: object file (/opt/rstudio-tools/boost/boost_1_63_0/lib/libboost_regex.a(static_mutex.o)) was built for newer OSX version (10.14) than being linked (10.12)
ld: warning: object file (/opt/rstudio-tools/boost/boost_1_63_0/lib/libboost_date_time.a(greg_month.o)) was built for newer OSX version (10.14) than being linked (10.12)
ld: warning: object file (/opt/rstudio-tools/boost/boost_1_63_0/lib/libboost_date_time.a(greg_weekday.o)) was built for newer OSX version (10.14) than being linked (10.12)
ld: warning: object file (/opt/rstudio-tools/boost/boost_1_63_0/lib/libboost_filesystem.a(codecvt_error_category.o)) was built for newer OSX version (10.14) than being linked (10.12)
```

While it's just a warning, I think it's better to silence the warning if possible.