### PR TITLE
URL encode theme names for client

### DIFF
--- a/src/cpp/session/modules/SessionThemes.cpp
+++ b/src/cpp/session/modules/SessionThemes.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionThemes.cpp
  *
- * Copyright (C) 2018 by RStudio, Inc.
+ * Copyright (C) 2018-2019 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -192,7 +192,7 @@ void getThemesInLocation(
 
             (*themeMap)[boost::algorithm::to_lower_copy(name)] = std::make_tuple(
                name,
-               urlPrefix + themeFile.filename(),
+               urlPrefix + http::util::urlEncode(themeFile.filename()),
                isDark);
          }
       }
@@ -533,7 +533,7 @@ void handleGlobalCustomThemeRequest(const http::Request& request,
 }
 
 /**
- * @brief Gets a custom theme that is installed for all users.
+ * @brief Gets a custom theme that is installed for this user.
  *
  * @param request       The HTTP request from the client.
  * @param pResponse     The HTTP response, which will contain the theme CSS.


### PR DESCRIPTION
Today, themes do not work in RStudio if their filenames contain URL-escaped characters. 

This happens because the theme filenames are not URL-encoded, but they are URL-decoded. Consequently, any character in the filename that could be interpreted as URL-encoded causes a replacement, after which the filename is incorrect.

The fix is simply to URL-encode the filename before passing it to the client.

Fixes https://github.com/rstudio/rstudio/issues/4372