### PR TITLE
improve ordering + display of SQL completions (#4377)

### DIFF
--- a/src/cpp/session/modules/sql/SessionSql.R
+++ b/src/cpp/session/modules/sql/SessionSql.R
@@ -36,7 +36,7 @@
    # a schema. use the context keyword to figure out which
    if (grepl(".", token, fixed = TRUE))
    {
-      if (identical(ctx$contextKeyword, "from"))
+      if (.rs.sql.isTableScopedKeyword(ctx$contextKeyword))
          return(.rs.sql.getCompletionsTables(token, conn, ctx))
       else
          return(.rs.sql.getCompletionsFields(token, conn, ctx))
@@ -44,7 +44,7 @@
    
    # if we're requesting completions within 'from', we either want
    # schemas or table names
-   if (identical(ctx$contextKeyword, "from"))
+   if (.rs.sql.isTableScopedKeyword(ctx$contextKeyword))
    {
       completions <- Reduce(.rs.appendCompletions, list(
          .rs.sql.getCompletionsTables(token, conn, ctx),
@@ -191,11 +191,13 @@
       
       fields <- setdiff(fields, token)
       
+      # NOTE: not really a function but this ensures that the source
+      # table is used in the popup displayed for the user, which is helpful
       .rs.makeCompletions(
          token = token,
          results = .rs.selectFuzzyMatches(fields, token),
          packages = table,
-         type = .rs.acCompletionTypes$UNKNOWN
+         type = .rs.acCompletionTypes$FUNCTION
       )
       
    }))
@@ -359,4 +361,8 @@
    
    objects <- DBI::dbListObjects(conn, DBI::Id(schema = schema))
    vapply(objects$table, function(object) tail(object@name, n = 1), character(1))
+})
+
+.rs.addFunction("sql.isTableScopedKeyword", function(keyword) {
+   keyword %in% c("from", "into", "join", "update", "drop")
 })

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/SqlCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/SqlCompletionManager.java
@@ -86,16 +86,7 @@ public class SqlCompletionManager extends CompletionManagerBase
                uppercaseKeywordCount += 1;
          }
          
-         if (parseSqlFrom(it, ctx))
-            continue;
-         
-         if (parseSqlInto(it, ctx))
-            continue;
-         
-         if (parseSqlJoin(it, ctx))
-            continue;
-         
-         if (parseSqlUpdate(it, ctx))
+         if (parseSqlTableScopedKeyword(it, ctx))
             continue;
          
          if (parseSqlIdentifier(it, ctx))
@@ -131,10 +122,21 @@ public class SqlCompletionManager extends CompletionManagerBase
       return "";
    }
    
-   private boolean parseSqlFrom(TokenIterator it, SqlCompletionParseContext ctx)
+   private boolean parseSqlTableScopedKeyword(TokenIterator it,
+                                              SqlCompletionParseContext ctx)
    {
-      // consume initial from
-      if (!consumeKeyword(it, "from"))
+      // check for a SQL keyword that commonly precedes a table name
+      String keyword = null;
+      for (String candidate : new String[] { "from", "into", "join", "update", "drop" })
+      {
+         if (consumeKeyword(it, candidate))
+         {
+            keyword = candidate;
+            break;
+         }
+      }
+      
+      if (keyword == null)
          return false;
       
       TokenIterator clone = it.clone();
@@ -201,21 +203,6 @@ public class SqlCompletionManager extends CompletionManagerBase
       return true;
    }
    
-   private boolean parseSqlInto(TokenIterator it, SqlCompletionParseContext ctx)
-   {
-      return parseSqlTableScopedKeyword("into", it, ctx);
-   }
-   
-   private boolean parseSqlJoin(TokenIterator it, SqlCompletionParseContext ctx)
-   {
-      return parseSqlTableScopedKeyword("join", it, ctx);
-   }
-   
-   private boolean parseSqlUpdate(TokenIterator it, SqlCompletionParseContext ctx)
-   {
-      return parseSqlTableScopedKeyword("update", it, ctx);
-   }
-   
    private boolean parseSqlIdentifier(TokenIterator it, SqlCompletionParseContext ctx)
    {
       if (!isSqlIdentifier(it))
@@ -223,22 +210,6 @@ public class SqlCompletionManager extends CompletionManagerBase
       
       String identifier = sqlIdentifierValue(it);
       ctx.identifiers.push(identifier);
-      return true;
-   }
-   
-   private boolean parseSqlTableScopedKeyword(String keyword,
-                                              TokenIterator it,
-                                              SqlCompletionParseContext ctx)
-   {
-      if (!consumeKeyword(it, keyword))
-         return false;
-      
-      if (!isSqlIdentifier(it))
-         return false;
-      
-      String table = sqlIdentifierValue(it);
-      ctx.schemas.push("");
-      ctx.tables.push(table);
       return true;
    }
    


### PR DESCRIPTION
This PR improves the display + ordering of completions in the following ways:

1. In contexts where tables are expected, tables (and schemas) are shown;
2. In other contexts, we assume field names are most useful and show those first;
3. For fields with a known source, we also display that source in the completion list.

Examples:

![screen shot 2019-02-28 at 12 30 36 pm](https://user-images.githubusercontent.com/1976582/53596615-f5e18500-3b54-11e9-9826-6414d82b80a4.png)
![screen shot 2019-02-28 at 12 30 45 pm](https://user-images.githubusercontent.com/1976582/53596621-fa0da280-3b54-11e9-9719-18e47e83f92e.png)
![screen shot 2019-02-28 at 12 31 09 pm](https://user-images.githubusercontent.com/1976582/53596622-fa0da280-3b54-11e9-856d-2c3c18ca740a.png)
![screen shot 2019-02-28 at 12 31 20 pm](https://user-images.githubusercontent.com/1976582/53596623-faa63900-3b54-11e9-8486-c2b88a1b14ae.png)

One downside is that, for field names which exist in multiple databases, we don't properly complete / disambiguate the completions in the shown completion list, but I don't think that's worth fixing for v1.2.