### PR TITLE
Use RTools release for R 3.6

### DIFF
--- a/src/cpp/core/r_util/RToolsInfo.cpp
+++ b/src/cpp/core/r_util/RToolsInfo.cpp
@@ -150,7 +150,7 @@ RToolsInfo::RToolsInfo(const std::string& name,
       versionMax = "3.2.99";
       gcc463Configuration(installPath, &relativePathEntries, &clangArgs);
    }
-   else if (name == "3.4" || name == "3.5")
+   else if (name == "3.4" || name == "3.5" || name == "3.6")
    {
       versionMin = "3.3.0";
       if (name == "3.4")


### PR DESCRIPTION
This change speculatively adds RTools support for R 3.6.

Fixes https://github.com/rstudio/rstudio/issues/4350.