### PR TITLE
Use existing .rproj file (if any) when opening directory

### DIFF
--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionProjects.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -339,19 +339,7 @@ Error createProjectFile(const json::JsonRpcRequest& request,
    }
 
    // Check for an existing project file in the directory
-   std::vector<FilePath> children;
-   error = projDirPath.children(&children);
-   if (error)
-      return error;
-   for (const FilePath& child: children)
-   {
-      if (child.hasExtensionLowerCase(".rproj"))
-      {
-         // Found one!
-         projFilePath = child;
-         break;
-      }
-   }
+   projFilePath = r_util::projectFromDirectory(projDirPath);
 
    if (projFilePath.empty())
    {

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -325,16 +325,41 @@ Error createProjectFile(const json::JsonRpcRequest& request,
 {
    using namespace projects;
    
-   std::string projFile;
-   Error error = json::readParams(request.params, &projFile);
+   std::string projDir;
+   Error error = json::readParams(request.params, &projDir);
    if (error)
       return error;
    
-   FilePath projPath = module_context::resolveAliasedPath(projFile);
-   if (!projPath.exists())
+   // Resolve the path and ensure it exists
+   FilePath projDirPath = module_context::resolveAliasedPath(projDir);
+   FilePath projFilePath;
+   if (!projDirPath.exists())
    {
-      Error error = r_util::writeProjectFile(
-               projPath,
+      return pathNotFoundError(projDir, ERROR_LOCATION);
+   }
+
+   // Check for an existing project file in the directory
+   std::vector<FilePath> children;
+   error = projDirPath.children(&children);
+   if (error)
+      return error;
+   for (const FilePath& child: children)
+   {
+      if (child.hasExtensionLowerCase(".rproj"))
+      {
+         // Found one!
+         projFilePath = child;
+         break;
+      }
+   }
+
+   if (projFilePath.empty())
+   {
+      // We didn't find a project file, so we need to make one. Use the name of the project
+      // directory as the filename.
+      projFilePath = projDirPath.complete(projDirPath.filename() + ".Rproj");
+      error = r_util::writeProjectFile(
+               projFilePath,
                ProjectContext::buildDefaults(),
                ProjectContext::defaultConfig());
       
@@ -342,7 +367,8 @@ Error createProjectFile(const json::JsonRpcRequest& request,
          LOG_ERROR(error);
    }
    
-   pResponse->setResult(projPath.exists());
+   // Return the name of the discovered and/or created .Rproj filename
+   pResponse->setResult(module_context::createAliasedPath(projFilePath));
    return Success();
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/projects/ProjectOpener.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ProjectOpener.java
@@ -87,22 +87,30 @@ public class ProjectOpener
                   
                   if (input.isDirectory())
                   {
-                     final String rprojPath = input.completePath(input.getName() + ".Rproj");
-                     final FileSystemItem rprojFile = FileSystemItem.createFile(rprojPath);
+                     // Locate or create the .Rproj associated with this directory
                      server_.createProjectFile(
-                           rprojFile.getPath(),
-                           new ServerRequestCallback<Boolean>()
+                           input.getPath(),
+                           new ServerRequestCallback<String>()
                            {
                               @Override
-                              public void onResponseReceived(Boolean success)
+                              public void onResponseReceived(String rproj)
                               {
-                                 onProjectFileReady.execute(rprojFile);
+                                 // Found the .Rproj; open it.
+                                 onProjectFileReady.execute(FileSystemItem.createFile(rproj));
                               }
 
                               @Override
                               public void onError(ServerError error)
                               {
                                  Debug.logError(error);
+
+                                 // There's a chance that there's an Rproj even
+                                 // if we couldn't find or create it; make a best-effort
+                                 // attempt to open it.
+                                 String rprojPath = 
+                                       input.completePath(input.getName() + ".Rproj");
+                                 FileSystemItem rprojFile = 
+                                       FileSystemItem.createFile(rprojPath);
                                  onProjectFileReady.execute(rprojFile);
                               }
                            });

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/ProjectsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/ProjectsServerOperations.java
@@ -44,8 +44,8 @@ public interface ProjectsServerOperations extends PrefsServerOperations,
                       ProjectTemplateOptions projectTemplateOptions,
                       ServerRequestCallback<String> callback);
    
-   void createProjectFile(String projectFile,
-                          ServerRequestCallback<Boolean> callback);
+   void createProjectFile(String projectDir,
+                          ServerRequestCallback<String> callback);
    
    void packageSkeleton(String packageName,
                         String packageDirectory,

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1935,11 +1935,11 @@ public class RemoteServer implements Server
    }
    
    @Override
-   public void createProjectFile(String projectFile,
-                                 ServerRequestCallback<Boolean> requestCallback)
+   public void createProjectFile(String projectDir,
+                                 ServerRequestCallback<String> requestCallback)
    {
       JSONArray params = new JSONArray();
-      params.set(0, new JSONString(StringUtil.notNull(projectFile)));
+      params.set(0, new JSONString(StringUtil.notNull(projectDir)));
       sendRequest(RPC_SCOPE, CREATE_PROJECT_FILE, params, requestCallback);
    }
    


### PR DESCRIPTION
This change improves the "open directory as project" feature introduced in https://github.com/rstudio/rstudio/pull/1030. Formerly, we always created an .Rproj file in the directory if one matching the directory name was not found; this can result in multiple .Rproj files in the directory (which cause a good deal of confusion downstream). Now, we use an .Rproj in the directory if we can, regardless of its name.

There's probably a separate bug here regarding dealing with two or more .Rproj files in a directory gracefully, but it's less like we could make a scoped fix for that. This change only touches code that runs when opening a directory as a project.

Fixes https://github.com/rstudio/rstudio/issues/4382.