### PR TITLE
Improved ExponentialBackoff to be thread safe

### DIFF
--- a/src/cpp/core/ExponentialBackoff.cpp
+++ b/src/cpp/core/ExponentialBackoff.cpp
@@ -21,21 +21,22 @@ namespace rstudio {
 namespace core {
 
 ExponentialBackoff::ExponentialBackoff(boost::asio::io_service& ioService,
-                                       const boost::posix_time::milliseconds& initialWait,
-                                       const boost::posix_time::milliseconds& maxWait,
+                                       const boost::posix_time::time_duration& initialWait,
+                                       const boost::posix_time::time_duration& maxWait,
                                        const boost::function<void(ExponentialBackoffPtr)>& action) :
    ioService_(ioService),
    initialWait_(initialWait),
    maxWait_(maxWait),
    maxNumRetries_(0),
    totalNumTries_(0),
-   action_(action)
+   action_(action),
+   lastWait_(boost::posix_time::not_a_date_time)
 {
 }
 
 ExponentialBackoff::ExponentialBackoff(boost::asio::io_service& ioService,
-                                       const boost::posix_time::milliseconds& initialWait,
-                                       const boost::posix_time::milliseconds& maxWait,
+                                       const boost::posix_time::time_duration& initialWait,
+                                       const boost::posix_time::time_duration& maxWait,
                                        unsigned int maxNumRetries,
                                        const boost::function<void(ExponentialBackoffPtr)>& action) :
    ioService_(ioService),
@@ -43,7 +44,8 @@ ExponentialBackoff::ExponentialBackoff(boost::asio::io_service& ioService,
    maxWait_(maxWait),
    maxNumRetries_(maxNumRetries),
    totalNumTries_(0),
-   action_(action)
+   action_(action),
+   lastWait_(boost::posix_time::not_a_date_time)
 {
 }
 
@@ -51,51 +53,80 @@ bool ExponentialBackoff::next()
 {
    ExponentialBackoffPtr instance = shared_from_this();
 
-   // we should not continue trying if we've hit the max retries
-   if (totalNumTries_ == maxNumRetries_ + 1 && maxNumRetries_ != 0)
+   LOCK_MUTEX(mutex_)
    {
-      // reset action so that all captured references are freed
-      action_ = boost::function<void(ExponentialBackoffPtr)>();
-      return false;
-   }
+      // we should not continue trying if we've hit the max retries
+      if (maxNumRetries_ != 0 &&
+          totalNumTries_ >= maxNumRetries_ + 1)
+      {
+         // reset action so that all captured references are freed
+         action_ = boost::function<void(ExponentialBackoffPtr)>();
+         return false;
+      }
 
-   if (totalNumTries_ == 0)
-   {
-      // initial invocation of the action
-      action_(instance);
+      if (totalNumTries_ == 0)
+      {
+         // initial invocation of the action
+         ++totalNumTries_;
+         action_(instance);
+         return true;
+      }
 
-      ++totalNumTries_;
+      boost::posix_time::time_duration nextWait;
+      if (lastWait_.is_not_a_date_time())
+      {
+         // we have not waited yet, so set the first wait to the initial wait value
+         nextWait = initialWait_;
+      }
+      else
+      {
+         // calculate the next amount of time to wait by doubling the previous time
+         nextWait = lastWait_ * 2;
+      }
+
+      // construct timeout with overflow protection
+      // it is possible doubling the last amount of time caused an overflow
+      // if that is the case, we will just use the maximum wait time
+      boost::posix_time::time_duration timeout =
+            (nextWait > maxWait_ || nextWait.is_negative()) ?
+               maxWait_ :
+               nextWait;
+
+      lastWait_ = timeout;
+
+      if (maxNumRetries_ == 0 && timeout == maxWait_)
+      {
+         // maxNumTries is 0 and we've reached the max wait
+         // this indicates that the we should only try the operation one more time
+         maxNumRetries_ = totalNumTries_ + 2;
+      }
+
+      boost::shared_ptr<boost::asio::deadline_timer> timer =
+            boost::make_shared<boost::asio::deadline_timer>(ioService_, timeout);
+
+      timer->async_wait([=](const boost::system::error_code& error) mutable
+      {
+         // timer expired - explicitly free it
+         // capturing the timer pointer must be done here in order to keep it alive
+         // if it were not captured, it would go out of scope and the callback would not
+         // fire properly
+         timer.reset();
+
+         // wait has finished - update state and perform the action
+         LOCK_MUTEX(instance->mutex_)
+         {
+            ++instance->totalNumTries_;
+         }
+         END_LOCK_MUTEX
+
+         instance->action_(instance);
+      });
+
       return true;
    }
+   END_LOCK_MUTEX
 
-   int factor = std::pow(2.0, totalNumTries_);
-   boost::posix_time::milliseconds nextWait(initialWait_.total_milliseconds() * factor);
-   boost::posix_time::milliseconds timeout = (nextWait > maxWait_) ? maxWait_ : nextWait;
-
-   if (maxNumRetries_ == 0 && timeout == maxWait_)
-   {
-      // maxNumTries is 0 and we've reached the max wait
-      // this indicates that the we should only try the operation one more time
-      maxNumRetries_ = totalNumTries_ + 2;
-   }
-
-   boost::shared_ptr<boost::asio::deadline_timer> timer =
-         boost::make_shared<boost::asio::deadline_timer>(ioService_, timeout);
-
-   timer->async_wait([=](const boost::system::error_code& error) mutable
-   {
-      // timer expired - explicitly free it
-      // capturing the timer pointer must be done here in order to keep it alive
-      // if it were not captured, it would go out of scope and the callback would not
-      // fire properly
-      timer.reset();
-
-      // wait has finished - perform the action and update state
-      instance->action_(instance);
-      ++instance->totalNumTries_;
-   });
-
-   return true;
+   return false;
 }
 
 } // namespace core 

--- a/src/cpp/core/include/core/ExponentialBackoff.hpp
+++ b/src/cpp/core/include/core/ExponentialBackoff.hpp
@@ -21,6 +21,8 @@
 #include <boost/date_time.hpp>
 #include <boost/function.hpp>
 
+#include <core/Thread.hpp>
+
 namespace rstudio {
 namespace core {
 
@@ -31,13 +33,13 @@ class ExponentialBackoff : public boost::enable_shared_from_this<ExponentialBack
 {
 public:
    ExponentialBackoff(boost::asio::io_service& ioService,
-                      const boost::posix_time::milliseconds& initialWait,
-                      const boost::posix_time::milliseconds& maxWait,
+                      const boost::posix_time::time_duration& initialWait,
+                      const boost::posix_time::time_duration& maxWait,
                       const boost::function<void(ExponentialBackoffPtr)>& action);
 
    ExponentialBackoff(boost::asio::io_service& ioService,
-                      const boost::posix_time::milliseconds& initialWait,
-                      const boost::posix_time::milliseconds& maxWait,
+                      const boost::posix_time::time_duration& initialWait,
+                      const boost::posix_time::time_duration& maxWait,
                       unsigned int maxNumRetries,
                       const boost::function<void(ExponentialBackoffPtr)>& action);
 
@@ -52,11 +54,14 @@ public:
 
 private:
    boost::asio::io_service& ioService_;
-   boost::posix_time::milliseconds initialWait_;
-   boost::posix_time::milliseconds maxWait_;
+   boost::posix_time::time_duration initialWait_;
+   boost::posix_time::time_duration maxWait_;
    unsigned int maxNumRetries_;
    unsigned int totalNumTries_;
    boost::function<void(ExponentialBackoffPtr)> action_;
+
+   boost::posix_time::time_duration lastWait_;
+   boost::mutex mutex_;
 };
 
 } // namespace core 


### PR DESCRIPTION
Also ensure callback is only run up to and never more than max tries. Also reworked calculation of exponential timer so that it works for any time duration, not just milliseconds, and made it resilient to overflow. Fixes https://github.com/rstudio/rstudio-pro/issues/918