### PR TITLE
update to latest NSIS installer tool on Windows

### DIFF
--- a/dependencies/windows/Install-RStudio-Prereqs.ps1
+++ b/dependencies/windows/Install-RStudio-Prereqs.ps1
@@ -73,22 +73,7 @@ choco install -y ninja --version 1.7.2
 choco install -y windows-sdk-10.1 --version 10.1.17134.12
 choco install -y visualstudio2017buildtools --version 15.8.2.0
 choco install -y visualstudio2017-workload-vctools --version 1.3.0
-
-# install nsis (version on chocolatey is too new)
-if (-Not (Test-Path -Path "C:\Program Files (x86)\NSIS")) {
-    $NSISSetup = 'C:\nsis-2.50-setup.exe'
-    Write-Host "Downloading NSIS..."
-    if (-Not (Test-Path $NSISSetup)) {
-        Download-File https://s3.amazonaws.com/rstudio-buildtools/test-qt-windows/nsis-2.50-setup.exe $NSISSetup
-    } else {
-        Write-Host "Using previously downloaded NSIS installer"
-    }
-    Write-Host "Installing NSIS..."
-    Start-Process $NSISSetup -Wait -ArgumentList '/S'
-    if ($DeleteDownloads) { Remove-Item $NSISSetup -Force }
-} else {
-    Write-Host "NSIS already found, skipping"
-}
+choco install -y nsis
 
 # cpack (an alias from chocolatey) and cmake's cpack conflict.
 Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe'

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -20,7 +20,8 @@ RUN choco install -y cmake --version 3.12.1 --installargs 'ADD_CMAKE_TO_PATH=""S
   choco install -y jdk8 ; `
   choco install -y ant --version 1.10.5; `
   choco install -y windows-sdk-10.1 --version 10.1.17134.12; `
-  choco install -y 7zip --version 18.5.0.20180730
+  choco install -y 7zip --version 18.5.0.20180730; `
+  choco install -y nsis
   
 RUN choco install -y visualstudio2017buildtools --version 15.8.2.0; `
   choco install -y visualstudio2017-workload-vctools --version 1.3.0
@@ -43,12 +44,6 @@ RUN $ErrorActionPreference = 'Stop' ;`
 # add R to path
 RUN $env:path += ';C:\R\R-3.0.3\bin\i386\' ;`
   [Environment]::SetEnvironmentVariable('Path', $env:path, [System.EnvironmentVariableTarget]::Machine);
-
-# install nsis (version on chocolatey is too new)
-RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48; `
-  (New-Object System.Net.WebClient).DownloadFile('https://s3.amazonaws.com/rstudio-buildtools/test-qt-windows/nsis-2.50-setup.exe', 'C:\nsis-2.50-setup.exe');`
-  Start-Process c:\nsis-2.50-setup.exe -Wait -ArgumentList '/S' ;`
-  Remove-Item c:\nsis-2.50-setup.exe
 
 # install qt (note that we are using the current directory's context)
 RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48; ` 

--- a/package/win32/cmake/modules/NSIS.template.in
+++ b/package/win32/cmake/modules/NSIS.template.in
@@ -142,7 +142,7 @@ Var AR_RegFlags
  "exit_${SecName}:"
 !macroend
  
-!macro RemoveSection SecName
+!macro RemoveSection_CPack SecName
   ;  This macro is used to call section's Remove_... macro
   ;from the uninstaller.
   ;Input: section index constant name specified in Section command.
@@ -914,7 +914,7 @@ Section "Uninstall"
   DeleteRegKey SHCTX "Software\@CPACK_PACKAGE_VENDOR@\@CPACK_PACKAGE_INSTALL_REGISTRY_KEY@"
 
   ; Removes all optional components
-  !insertmacro SectionList "RemoveSection"
+  !insertmacro SectionList "RemoveSection_CPack"
   
   !insertmacro MUI_STARTMENU_GETFOLDER Application $MUI_TEMP
     


### PR DESCRIPTION
- installs NSIS via Chocolately, and gets us on the latest version
- installing newer NSIS does replace older one so if we're using single container image for 1.2 and 1.3 builds this should wait until they are separated
- the tweak to NSIS.template.in matches change made in template included with more recent CMakes ("recent" being several years old at this point)