### PR TITLE
fix javascript exception at startup by returning a valid widget

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/LauncherJobsPaneWidgets.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/LauncherJobsPaneWidgets.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.jobs.view;
 
+import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.rstudio.core.client.widget.SlidingLayoutPanel;
@@ -32,7 +33,7 @@ public class LauncherJobsPaneWidgets implements JobsPaneOperations
    @Override
    public Widget createMainWidget()
    {
-      return null;
+      return new Label();
    }
    
    @Override


### PR DESCRIPTION
Even though this UI is never shown, it still needs to return a valid widget or some upstream code will throw a null exception.

Fixes #4400 
