### PR TITLE
fixup for edit of C++ files living outside of current project

### DIFF
--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -624,13 +624,17 @@ bool RCompilationDatabase::isProjectTranslationUnit(
                                           const std::string& filename) const
 {
    using namespace projects;
+
+   if (projectContext().config().buildType != r_util::kBuildTypePackage)
+      return false;
+
    FilePath filePath(filename);
    FilePath pkgPath = projectContext().buildTargetPath();
    FilePath srcDirPath = pkgPath.childPath("src");
    FilePath includePath = pkgPath.childPath("inst/include");
-   return ((projectContext().config().buildType == r_util::kBuildTypePackage) &&
-          (!filePath.relativePath(srcDirPath).empty() ||
-           !filePath.relativePath(includePath).empty()));
+   return
+         filePath.isWithin(srcDirPath) ||
+         filePath.isWithin(includePath);
 }
 
 namespace {


### PR DESCRIPTION
This PR fixes an issue where:

1. The user is working within a R package project, and
2. The user is editing a C++ file that lives outside of that project.

In that case, we were erroneously detecting the file as living within the project, and applying project-specific compilation options that were incompatible with how the file actually needed to be compiled, leading to compile errors.

I belive the issue ultimately resulted from the change in definition with `relativePath()` with the Boost update: https://github.com/rstudio/rstudio/commit/5a80dfed9aa5b6fb121df7df000fd716424e8629

This is a regression from v1.1, but not a major issue, so perhaps worth considering for v1.2-patch.