### PR TITLE
perform more extensive surgery on GWT DataGrid

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/cellview/ScrollingDataGrid.java
+++ b/src/gwt/src/org/rstudio/core/client/cellview/ScrollingDataGrid.java
@@ -15,7 +15,8 @@
 
 package org.rstudio.core.client.cellview;
 
-import com.google.gwt.user.cellview.client.DataGrid;
+import org.rstudio.core.client.widget.RStudioDataGrid;
+
 import com.google.gwt.user.client.ui.HeaderPanel;
 import com.google.gwt.user.client.ui.ScrollPanel;
 import com.google.gwt.view.client.ProvidesKey;
@@ -23,7 +24,7 @@ import com.google.gwt.view.client.ProvidesKey;
 // this class extends GWT's DataGrid with a single method that gives us access
 // to the scrolling panel used by the grid, which we need in order to
 // manipulate the scroll position directly (e.g. to save and restore it)
-public class ScrollingDataGrid<T> extends DataGrid<T>
+public class ScrollingDataGrid<T> extends RStudioDataGrid<T>
 {
    public ScrollingDataGrid(int pageSize, ProvidesKey<T> keyProvider)
    {

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioDataGrid.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioDataGrid.java
@@ -14,14 +14,9 @@
  */
 package org.rstudio.core.client.widget;
 
-import java.util.List;
-
 import org.rstudio.core.client.BrowseCap;
-import org.rstudio.core.client.dom.DomUtils;
-
 import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.Node;
-import com.google.gwt.dom.client.Style.Overflow;
+import com.google.gwt.dom.client.NodeList;
 import com.google.gwt.user.cellview.client.DataGrid;
 import com.google.gwt.view.client.ProvidesKey;
 
@@ -37,15 +32,20 @@ public class RStudioDataGrid<T> extends DataGrid<T>
       super(max, res);
    }
    
+   public RStudioDataGrid(int max, ProvidesKey<T> keyProvider)
+   {
+      super(max, keyProvider);
+   }
+   
    public RStudioDataGrid(int max, DataGrid.Resources res, ProvidesKey<T> keyProvider)
    {
       super(max, res, keyProvider);
    }
    
    @Override
-   public void onAttach()
+   protected void onLoad()
    {
-      super.onAttach();
+      super.onLoad();
       
       // None of the below is necessary unless on MacOS since that's the only
       // platform that uses overlay scrollbars.
@@ -63,28 +63,21 @@ public class RStudioDataGrid<T> extends DataGrid<T>
       // assigned class, and have all their style attributes applied inline, so
       // instead we scan the attached DOM subtree and change the inline styles.
       Element parent = getElement().getParentElement().getParentElement();
-      List<Node> matches = DomUtils.findNodes(parent, 
-            10,     // Max results 
-            3,      // Recurse depth 
-            false,  // Check siblings
-            node -> 
+      NodeList<Element> children = parent.getElementsByTagName("div");
+      for (int i = 0; i < children.getLength(); i++)
       {
-         // Ignore text nodes, etc.
-         if (node.getNodeType() != Node.ELEMENT_NODE)
-            return false;
-
-         com.google.gwt.dom.client.Style style = Element.as(node).getStyle();
+         Element el = children.getItem(i);
+         com.google.gwt.dom.client.Style style = el.getStyle();
          
-         // The scroll helpers are hidden, and set to appear behind the grid.
-         return style.getZIndex() == "-1" && 
-                style.getOverflow() == "scroll" &&
-                style.getVisibility() == "hidden";
-      });
-      
-      for (Node match: matches)
-      {
-         // Don't show scrollbars on these elements
-         Element.as(match).getStyle().setOverflow(Overflow.HIDDEN);
+         boolean doesNotSparkJoy =
+               style.getZIndex() == "-1" &&
+               style.getOverflow() == "scroll" &&
+               style.getVisibility() == "hidden";
+         
+         if (doesNotSparkJoy)
+            style.setOverflow(com.google.gwt.dom.client.Style.Overflow.HIDDEN);
+         
       }
+      
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/packrat/ui/PackratActionDialogContents.java
+++ b/src/gwt/src/org/rstudio/studio/client/packrat/ui/PackratActionDialogContents.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.packrat.ui;
 import java.util.ArrayList;
 
 import org.rstudio.core.client.JsArrayUtil;
+import org.rstudio.core.client.widget.RStudioDataGrid;
 import org.rstudio.studio.client.packrat.model.PackratPackageAction;
 import org.rstudio.studio.client.workbench.views.packages.ui.PackagesDataGridCommon;
 
@@ -45,7 +46,7 @@ public class PackratActionDialogContents extends Composite {
       prRestoreActionsList_ = new ArrayList<PackratPackageAction>();
       JsArrayUtil.fillList(prRestoreActionsArray, prRestoreActionsList_);
       
-      table_ = new DataGrid<PackratPackageAction>(prRestoreActionsList_.size(),
+      table_ = new RStudioDataGrid<PackratPackageAction>(prRestoreActionsList_.size(),
             (PackagesDataGridCommon)GWT.create(PackagesDataGridCommon.class));
       table_.setRowData(prRestoreActionsList_);
       

--- a/src/gwt/src/org/rstudio/studio/client/packrat/ui/PackratResolveConflictDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/packrat/ui/PackratResolveConflictDialog.java
@@ -20,6 +20,7 @@ import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.widget.MessageDialog;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.core.client.widget.RStudioDataGrid;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.StyleUtils;
 import org.rstudio.studio.client.packrat.model.PackratConflictActions;
@@ -70,7 +71,7 @@ public class PackratResolveConflictDialog
       mainWidget_.add(label);
             
       // table
-      table_ = new DataGrid<PackratConflictActions>(conflictActions.size(),
+      table_ = new RStudioDataGrid<PackratConflictActions>(conflictActions.size(),
             (PackagesDataGridCommon)GWT.create(PackagesDataGridCommon.class));
       StyleUtils.forceMacScrollbars(table_);
       table_.addStyleName(RESOURCES.styles().conflictsTable());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
@@ -47,6 +47,7 @@ import org.rstudio.core.client.widget.FilterWidget;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.ModifyKeyboardShortcutsWidget;
 import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.core.client.widget.RStudioDataGrid;
 import org.rstudio.core.client.widget.ThemedButton;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.HelpLink;
@@ -96,7 +97,7 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
          }
       };
       
-      table_ = new DataGrid<RAddin>(1000, RES, keyProvider_);
+      table_ = new RStudioDataGrid<RAddin>(1000, RES, keyProvider_);
       table_.setWidth("500px");
       table_.setHeight("400px");
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsPane.java
@@ -54,6 +54,7 @@ import org.rstudio.core.client.theme.RStudioDataGridStyle;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.Base64ImageCell;
 import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.core.client.widget.RStudioDataGrid;
 import org.rstudio.core.client.widget.SearchWidget;
 import org.rstudio.core.client.widget.SecondaryToolbar;
 import org.rstudio.core.client.widget.SlidingLayoutPanel;
@@ -100,7 +101,7 @@ public class ConnectionsPane extends WorkbenchPane
       };
       
       selectionModel_ = new SingleSelectionModel<Connection>();
-      connectionsDataGrid_ = new DataGrid<Connection>(1000, RES, keyProvider_);
+      connectionsDataGrid_ = new RStudioDataGrid<Connection>(1000, RES, keyProvider_);
       connectionsDataGrid_.setSelectionModel(selectionModel_);
       selectionModel_.addSelectionChangeHandler(new SelectionChangeEvent.Handler()
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
@@ -25,6 +25,7 @@ import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.core.client.widget.RStudioDataGrid;
 import org.rstudio.core.client.widget.SearchWidget;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
@@ -311,7 +312,7 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
       try
       {
          packagesTableContainer_.clear();
-         packagesTable_ = new DataGrid<PackageInfo>(
+         packagesTable_ = new RStudioDataGrid<PackageInfo>(
             packagesDataProvider_.getList().size(), dataGridRes_);
       }
       catch (Exception e)


### PR DESCRIPTION
This PR augments what was done in https://github.com/rstudio/rstudio/pull/3078 to find and hide rogue `<div>` elements that would cause scrollbars to render in the IDE unnecessarily.

The main changes here are:

1. Use `RStudioDataGrid` rather than `DataGrid` throughout;
2. Use `getElementsByTagName()` to retrieve the list of `<div>`s that might need surgery.

Closes #4431.