### PR TITLE
use query selector to avoid capturing too many divs

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -1168,6 +1168,11 @@ public class DomUtils
      return ele.pathname;
    }-*/;
    
+   public static final native NodeList<Element> querySelectorAll(Element element, String query)
+   /*-{
+      return element.querySelectorAll(query);
+   }-*/;
+   
    public static final int ESTIMATED_SCROLLBAR_WIDTH = 19;
    private static int SCROLLBAR_WIDTH = -1;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioDataGrid.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioDataGrid.java
@@ -15,6 +15,8 @@
 package org.rstudio.core.client.widget;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.dom.DomUtils;
+
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NodeList;
 import com.google.gwt.user.cellview.client.DataGrid;
@@ -63,7 +65,7 @@ public class RStudioDataGrid<T> extends DataGrid<T>
       // assigned class, and have all their style attributes applied inline, so
       // instead we scan the attached DOM subtree and change the inline styles.
       Element parent = getElement().getParentElement().getParentElement();
-      NodeList<Element> children = parent.getElementsByTagName("div");
+      NodeList<Element> children = DomUtils.querySelectorAll(parent, "div[style*='z-index: -1']");
       for (int i = 0; i < children.getLength(); i++)
       {
          Element el = children.getItem(i);


### PR DESCRIPTION
This refines the previous PR #4436, avoiding the potential need to iterate over a large number of elements in JavaScript.

(This of course does still ask Chromium to iterate through all child elements of the DataGrid, but it's far faster to do that through the `querySelectorAll()` API than manually in JavaScript)

Some profiling suggests that the time spent drawing rows of a DataGrid dwarfs the time spent enumerating these elements so I think this should be good enough.