### PR TITLE
fix exceptions caused by gwt 2.8.2 checking charAt bounds

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -1,7 +1,7 @@
 /*
  * StringUtil.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -1373,6 +1373,25 @@ public class StringUtil
             return "\\" + m.getValue();
          }
       });
+   }
+   
+   /**
+    * Checks if a character is at a given position in a string. Will not throw an exception
+    * if attempting to look at an invalid index, or if the input string is null.
+    * @param str String to examine
+    * @param ch Character to find at given position
+    * @param pos Position to check
+    * @return true if ch is found at pos in str
+    */
+   public static boolean isCharAt(String str, char ch, int pos)
+   {
+      if (isNullOrEmpty(str))
+         return false;
+      
+      if (pos < 0 || pos >= str.length())
+         return false;
+      
+      return str.charAt(pos) == ch;
    }
    
    private static final NumberFormat FORMAT = NumberFormat.getFormat("0.#");

--- a/src/gwt/src/org/rstudio/core/client/TextCursor.java
+++ b/src/gwt/src/org/rstudio/core/client/TextCursor.java
@@ -56,11 +56,16 @@ public class TextCursor
    
    public boolean contentEquals(char ch)
    {
+      if (index_ == n_)
+         return false;
       return data_.charAt(index_) == ch;
    }
    
    public boolean fwdToMatchingCharacter()
    {
+      if (index_ == n_)
+         return false;
+      
       char lhs = data_.charAt(index_);
       char rhs = complement(lhs);
       
@@ -99,6 +104,9 @@ public class TextCursor
    
    public boolean bwdToMatchingCharacter()
    {
+      if (index_ == n_)
+         return false;
+      
       char lhs = data_.charAt(index_);
       char rhs = complement(lhs);
       
@@ -178,6 +186,9 @@ public class TextCursor
    
    public boolean consume(char expected)
    {
+      if (index_ == n_)
+         return false;
+      
       boolean matches = data_.charAt(index_) == expected;
       index_ += matches ? 1 : 0;
       return matches;
@@ -226,23 +237,31 @@ public class TextCursor
    
    public boolean isLeftBracket()
    {
+      if (index_ == n_)
+         return false;
       char ch = data_.charAt(index_);
       return ch == '{' || ch == '[' || ch == '(';
    }
    
    public boolean isRightBracket()
    {
+      if (index_ == n_)
+         return false;
       char ch = data_.charAt(index_);
       return ch == '}' || ch == ']' || ch == ')';
    }
    
    public boolean isSingleQuote()
    {
+      if (index_ == n_)
+         return false;
       return data_.charAt(index_) == '\'';
    }
    
    public boolean isDoubleQuote()
    {
+      if (index_ == n_)
+         return false;
       return data_.charAt(index_) == '"';
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1,7 +1,7 @@
 /*
  * RCompletionManager.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -805,30 +805,33 @@ public class RCompletionManager implements CompletionManager
             return false;
          
          // Immediately display completions after '$', '::', etc.
-         char prevChar = docDisplay_.getCurrentLine().charAt(
-               input_.getCursorPosition().getColumn() - 1);
-         if (
-               (c == ':' && prevChar == ':') ||
-               (c == '$') ||
-               (c == '@')
-               )
+         if (input_.getCursorPosition().getColumn() > 0)
          {
-            // Bail if we're in Vim but not in insert mode
-            if (docDisplay_.isVimModeOn() &&
-                !docDisplay_.isVimInInsertMode())
+            char prevChar = docDisplay_.getCurrentLine().charAt(
+                  input_.getCursorPosition().getColumn() - 1);
+            if (
+                  (c == ':' && prevChar == ':') ||
+                        (c == '$') ||
+                        (c == '@')
+            )
             {
+               // Bail if we're in Vim but not in insert mode
+               if (docDisplay_.isVimModeOn() &&
+                     !docDisplay_.isVimInInsertMode())
+               {
+                  return false;
+               }
+      
+               Scheduler.get().scheduleDeferred(new ScheduledCommand()
+               {
+                  @Override
+                  public void execute()
+                  {
+                     beginSuggest(true, true, false);
+                  }
+               });
                return false;
             }
-            
-            Scheduler.get().scheduleDeferred(new ScheduledCommand()
-            {
-               @Override
-               public void execute()
-               {
-                  beginSuggest(true, true, false);
-               }
-            });
-            return false;
          }
          
          // Check for a valid number of R identifier characters for autopopup

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitChangelistTable.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitChangelistTable.java
@@ -1,7 +1,7 @@
 /*
  * GitChangelistTable.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -18,6 +18,7 @@ import com.google.gwt.cell.client.FieldUpdater;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.text.shared.SafeHtmlRenderer;
 import com.google.gwt.user.cellview.client.Column;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.cellview.TriStateCheckboxCell;
 import org.rstudio.studio.client.common.vcs.StatusAndPath;
 import org.rstudio.studio.client.workbench.views.vcs.common.ChangelistTable;
@@ -34,7 +35,7 @@ public class GitChangelistTable extends ChangelistTable
       ArrayList<StatusAndPath> items = getSelectedItems();
       if (items.size() > 0)
       {
-         boolean unstage = items.get(0).getStatus().charAt(1) == ' ';
+         boolean unstage = StringUtil.isCharAt(items.get(0).getStatus(), ' ', 1);
          fireEvent(new StageUnstageEvent(unstage, items));
 
          if (moveSelection)
@@ -60,8 +61,8 @@ public class GitChangelistTable extends ChangelistTable
          public Boolean getValue(StatusAndPath object)
          {
             return "??".equals(object.getStatus()) ? Boolean.FALSE :
-                   object.getStatus().charAt(1) == ' ' ? Boolean.TRUE :
-                   object.getStatus().charAt(0) == ' ' ? Boolean.FALSE :
+                   StringUtil.isCharAt(object.getStatus(), ' ', 1) ? Boolean.TRUE :
+                   StringUtil.isCharAt(object.getStatus(), ' ', 0) ? Boolean.FALSE :
                    null;
          }
       };

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPresenter.java
@@ -1,7 +1,7 @@
 /*
  * GitReviewPresenter.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -576,7 +576,7 @@ public class GitReviewPresenter implements ReviewPresenter
                         continue;
                      
                      String status = info.getStatus();
-                     if (status.charAt(0) != 'A')
+                     if (!StringUtil.isCharAt(status, 'A', 0))
                         continue;
                      
                      // warn if we're trying to commit a file >10MB in size
@@ -749,8 +749,8 @@ public class GitReviewPresenter implements ReviewPresenter
       {
          if (!softModeSwitch_)
          {
-            boolean staged = item.getStatus().charAt(0) != ' ' &&
-                             item.getStatus().charAt(1) == ' ';
+            boolean staged = !StringUtil.isCharAt(item.getStatus(), ' ', 0) &&
+                              StringUtil.isCharAt(item.getStatus(), ' ', 1);
             HasValue<Boolean> checkbox = staged ?
                                          view_.getStagedCheckBox() :
                                          view_.getUnstagedCheckBox();
@@ -763,13 +763,14 @@ public class GitReviewPresenter implements ReviewPresenter
          else
          {
             if (view_.getStagedCheckBox().getValue()
-                && (item.getStatus().charAt(0) == ' ' || item.getStatus().charAt(0) == '?'))
+                && (StringUtil.isCharAt(item.getStatus(), ' ', 0) || 
+                    StringUtil.isCharAt(item.getStatus(), '?', 0)))
             {
                clearDiff();
                view_.getUnstagedCheckBox().setValue(true, true);
             }
             else if (view_.getUnstagedCheckBox().getValue()
-                     && item.getStatus().charAt(1) == ' ')
+                     && StringUtil.isCharAt(item.getStatus(), ' ', 1))
             {
                clearDiff();
                view_.getStagedCheckBox().setValue(true, true);

--- a/src/gwt/test/org/rstudio/core/client/StringUtilTests.java
+++ b/src/gwt/test/org/rstudio/core/client/StringUtilTests.java
@@ -1,7 +1,7 @@
 /*
  * StringUtilTests.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -34,10 +34,10 @@ public class StringUtilTests extends GWTTestCase
    {
       String orig = null;
       int minWidth = 5;
-      try 
+      try
       {
-    	  StringUtil.padRight(orig, minWidth);
-    	  fail("Expected exception to be thrown");
+         StringUtil.padRight(orig, minWidth);
+         fail("Expected exception to be thrown");
       } 
       catch (NullPointerException ex) { }
       catch (JavaScriptException ex) { }
@@ -76,10 +76,10 @@ public class StringUtilTests extends GWTTestCase
 
    public void testParseIntNullInput()
    {
-	   String input = null;
-	   int def = 999;
-	   int result = StringUtil.parseInt(input, def);
-	   assertEquals(def, result);
+      String input = null;
+      int def = 999;
+      int result = StringUtil.parseInt(input, def);
+      assertEquals(def, result);
    }
 
    public void testParseIntNonNumericInput()
@@ -123,20 +123,20 @@ public class StringUtilTests extends GWTTestCase
 
    public void testFormatDateNullInput()
    {
-	  Date input = null;
-	  String expected = "";
-	  String result = StringUtil.formatDate(input);
-	  assertEquals(expected, result);
+      Date input = null;
+      String expected = "";
+      String result = StringUtil.formatDate(input);
+      assertEquals(expected, result);
    }
-
+   
    public void testFormatDate()
    {
-	   String result = StringUtil.formatDate(new Date());
-	   
-	   // just check that it's got minimum valid length; don't want to 
-	   // mess with timezone awareness to do exact check
-	   // MMM d, yyyy, h:mm AM
-	   assertTrue(result.length() >= 20);
+      String result = StringUtil.formatDate(new Date());
+      
+      // just check that it's got minimum valid length; don't want to 
+      // mess with timezone awareness to do exact check
+      // MMM d, yyyy, h:mm AM
+      assertTrue(result.length() >= 20);
    }
    
    public void testNewlineCount()
@@ -277,5 +277,20 @@ public class StringUtilTests extends GWTTestCase
       String expected = "\\~/Something\\ Special\\ Here\\!\\ 129,\\ ._\\ +@%/-\\>";
       String result = StringUtil.escapeBashPath(input, true);
       assertTrue(StringUtil.equals(result, expected));
+   }
+   
+   public void testIsCharAt()
+   {
+      assertTrue(StringUtil.isCharAt("abcd", 'a', 0));
+      assertTrue(StringUtil.isCharAt("abcd", 'b', 1));
+      assertTrue(StringUtil.isCharAt("abcd", 'c', 2));
+      assertTrue(StringUtil.isCharAt("abcd", 'd', 3));
+   }
+   
+   public void testIsCharAtOOB()
+   {
+      assertFalse(StringUtil.isCharAt("abcd", 'a', -1));
+      assertFalse(StringUtil.isCharAt(null, 'a', 0));
+      assertFalse(StringUtil.isCharAt("012345", '6', 6));
    }
 }


### PR DESCRIPTION
One of the fixes listed for GWT 2.8.2 is `Missing bounds check in String.charAt`.

Sure enough this is causing some exceptions in our code where we try to get chars off the end of a string (or before in one case, i.e. -1).

Fixes #4416 

Also fixes case where typing with cursor at column zero of the Console would throw an exception.

I did a quick survey of the uses of `charAt` and put in some preventative measures, but certainly possible there are things I missed so we should keep an eye out for this.