### PR TITLE
skip braces within strings (#4452)

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -3526,6 +3526,15 @@ public class AceEditor implements DocDisplay,
       
       while (endRow <= endRowLimit)
       {
+         // continue search if we're in a multi-line string
+         // (forego updating our bracket counts)
+         String state = getSession().getState(endRow);
+         if (state == "qstring" || state == "qqstring")
+         {
+            endRow++;
+            continue;
+         }
+         
          // update bracket token counts
          JsArray<Token> tokens = getTokens(endRow);
          for (Token token : JsUtil.asIterable(tokens))
@@ -3551,14 +3560,6 @@ public class AceEditor implements DocDisplay,
          
          // continue search if we have unbalanced brackets
          if (parenCount > 0 || braceCount > 0 || bracketCount > 0)
-         {
-            endRow++;
-            continue;
-         }
-         
-         // continue search if we're in a multi-line string
-         String state = getSession().getState(endRow);
-         if (state == "qstring" || state == "qqstring")
          {
             endRow++;
             continue;


### PR DESCRIPTION
Fixes a buglet where our attempts to build the range for a multi-line expression fail with single brackets within strings.

Not a major issue, not a regression, but also not a high risk change so marking as v1.2-patch.