### PR TITLE
Fix an issue where themes are sometimes not loaded due to incorrect relative paths.

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
@@ -71,7 +71,11 @@ public class AceThemes
       if (!currentUrl.equals(baseUrl) &&
          currentUrl.indexOf(baseUrl) == 0)
       {
-         pathUpCount = currentUrl.substring(baseUrl.length()).split("/").length;
+         String[] urlElements = currentUrl.substring(baseUrl.length()).split("/");
+         if (urlElements[urlElements.length - 1].contains("."))
+            pathUpCount = urlElements.length - 1;
+         else
+            pathUpCount = urlElements.length;
       }
       
       // Build the URL.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
@@ -62,29 +62,10 @@ public class AceThemes
    
    private void applyTheme(Document document, final AceTheme theme)
    {
-      // Build a relative path to avoid having to register 80000 theme URI handlers on the server.
-      int pathUpCount = 0;
-      String baseUrl = GWT.getHostPageBaseURL();
-      
-      // Strip any query out of the current URL since it isn't relevant to the path.
-      String currentUrl = document.getURL().split("\\?")[0];
-      if (!currentUrl.equals(baseUrl) &&
-         currentUrl.indexOf(baseUrl) == 0)
-      {
-         String[] urlElements = currentUrl.substring(baseUrl.length()).split("/");
-         if (urlElements[urlElements.length - 1].contains("."))
-            pathUpCount = urlElements.length - 1;
-         else
-            pathUpCount = urlElements.length;
-      }
-      
       // Build the URL.
-      StringBuilder urlBuilder = new StringBuilder();
-      for (int i = 0; i < pathUpCount; ++i)
-      {
-         urlBuilder.append("../");
-      }
-      urlBuilder.append(theme.getUrl())
+      StringBuilder themeUrl = new StringBuilder();
+      themeUrl.append(GWT.getHostPageBaseURL())
+         .append(theme.getUrl())
          .append("?dark=")
          .append(theme.isDark() ? "1" : "0");
       
@@ -92,7 +73,7 @@ public class AceThemes
       currentStyleEl.setType("text/css");
       currentStyleEl.setRel("stylesheet");
       currentStyleEl.setId(linkId_);
-      currentStyleEl.setHref(urlBuilder.toString());
+      currentStyleEl.setHref(themeUrl.toString());
    
       Element oldStyleEl = document.getElementById(linkId_);
       if (null != oldStyleEl)


### PR DESCRIPTION
When the URL ends with a "file" (e.g. grid.html) the "file" part should not be counted when determining how many levels to go up (with "../") for the theme link element.

Fixes #3295.