### PR TITLE
Bionic dev bootstrapper script

### DIFF
--- a/dependencies/linux/install-dependencies-bionic
+++ b/dependencies/linux/install-dependencies-bionic
@@ -36,14 +36,12 @@ sudo apt-get -y install \
   libclang-6.0-dev \
   libclang-dev \
   libcurl4-openssl-dev \
-  libdbi1 \
   libegl1-mesa \
   libfuse2 \
   libgl1-mesa-dev \
   libgtk-3-0 \
   libpam-dev \
   libpango1.0-dev \
-  librrd8 \
   libssl-dev \
   libuser1-dev \
   libxslt1-dev \

--- a/dependencies/linux/install-dependencies-bionic
+++ b/dependencies/linux/install-dependencies-bionic
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+#
+# install-dependencies-bionic
+#
+# Copyright (C) 2009-19 by RStudio, Inc.
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+set -e
+
+sudo apt-get update
+
+sudo apt-get -y install ant
+sudo apt-get -y install build-essential
+sudo apt-get -y install clang
+sudo apt-get -y install cmake
+sudo apt-get -y install debsigs
+sudo apt-get -y install dpkg-sig
+sudo apt-get -y install expect
+sudo apt-get -y install fakeroot
+sudo apt-get -y install gnupg1
+sudo apt-get -y install libacl1-dev
+sudo apt-get -y install libattr1-dev
+sudo apt-get -y install libbz2-dev
+sudo apt-get -y install libcap-dev
+sudo apt-get -y install libcurl4-openssl-dev
+sudo apt-get -y install libegl1-mesa
+sudo apt-get -y install libfuse2
+sudo apt-get -y install libgl1-mesa-dev
+sudo apt-get -y install libgl1-mesa-dev
+sudo apt-get -y install libgtk-3-0
+sudo apt-get -y install libpam-dev
+sudo apt-get -y install libpango1.0-dev
+sudo apt-get -y install libssl-dev
+sudo apt-get -y install libuser1-dev
+sudo apt-get -y install libxslt1-dev
+sudo apt-get -y install lsof
+sudo apt-get -y install pkg-config
+sudo apt-get -y install python
+sudo apt-get -y install software-properties-common
+sudo apt-get -y install unzip
+sudo apt-get -y install uuid-dev
+sudo apt-get -y install wget
+sudo apt-get -y install zlib1g-dev
+
+# Java 8 (not in official repo for bionic)
+sudo add-apt-repository -y ppa:openjdk-r/ppa
+sudo apt-get update
+sudo apt-get -y install openjdk-8-jdk
+sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+
+# R
+if ! [ -x "$(command -v R)" ]; then
+  sudo apt-get -y  install apt-transport-https software-properties-common
+  sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+  sudo add-apt-repository -y 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/'
+  sudo apt update
+  sudo apt-get -y install r-base
+fi
+
+# overlay
+if [ -e install-overlay-common ]
+then
+  ./install-overlay-common
+fi
+
+# common
+cd ../common
+./install-common
+cd ../linux
+
+# Qt for desktop
+if [ "$1" != "--exclude-qt-sdk" ]
+then
+   ./install-qt-sdk
+fi
+

--- a/dependencies/linux/install-dependencies-bionic
+++ b/dependencies/linux/install-dependencies-bionic
@@ -19,38 +19,43 @@ set -e
 
 sudo apt-get update
 
-sudo apt-get -y install ant
-sudo apt-get -y install build-essential
-sudo apt-get -y install clang
-sudo apt-get -y install cmake
-sudo apt-get -y install debsigs
-sudo apt-get -y install dpkg-sig
-sudo apt-get -y install expect
-sudo apt-get -y install fakeroot
-sudo apt-get -y install gnupg1
-sudo apt-get -y install libacl1-dev
-sudo apt-get -y install libattr1-dev
-sudo apt-get -y install libbz2-dev
-sudo apt-get -y install libcap-dev
-sudo apt-get -y install libcurl4-openssl-dev
-sudo apt-get -y install libegl1-mesa
-sudo apt-get -y install libfuse2
-sudo apt-get -y install libgl1-mesa-dev
-sudo apt-get -y install libgl1-mesa-dev
-sudo apt-get -y install libgtk-3-0
-sudo apt-get -y install libpam-dev
-sudo apt-get -y install libpango1.0-dev
-sudo apt-get -y install libssl-dev
-sudo apt-get -y install libuser1-dev
-sudo apt-get -y install libxslt1-dev
-sudo apt-get -y install lsof
-sudo apt-get -y install pkg-config
-sudo apt-get -y install python
-sudo apt-get -y install software-properties-common
-sudo apt-get -y install unzip
-sudo apt-get -y install uuid-dev
-sudo apt-get -y install wget
-sudo apt-get -y install zlib1g-dev
+sudo apt-get -y install \
+  ant \
+  build-essential \
+  clang \
+  cmake \
+  debsigs \
+  dpkg-sig \
+  expect \
+  fakeroot \
+  gnupg1 \
+  libacl1-dev \
+  libattr1-dev \
+  libbz2-dev \
+  libcap-dev \
+  libclang-6.0-dev \
+  libclang-dev \
+  libcurl4-openssl-dev \
+  libdbi1 \
+  libegl1-mesa \
+  libfuse2 \
+  libgl1-mesa-dev \
+  libgtk-3-0 \
+  libpam-dev \
+  libpango1.0-dev \
+  librrd8 \
+  libssl-dev \
+  libuser1-dev \
+  libxslt1-dev \
+  lsof \
+  pkg-config \
+  python \
+  rrdtool \
+  software-properties-common \
+  unzip \
+  uuid-dev \
+  wget \
+  zlib1g-dev
 
 # Java 8 (not in official repo for bionic)
 sudo add-apt-repository -y ppa:openjdk-r/ppa

--- a/dependencies/linux/install-dependencies-bionic
+++ b/dependencies/linux/install-dependencies-bionic
@@ -17,6 +17,14 @@
 
 set -e
 
+platform_codename=$(lsb_release -sc)
+if [ $platform_codename != "bionic" ] ; then
+    echo Error: This script is only for use on Ubuntu Bionic
+    exit 1
+fi
+
+echo Installing RStudio dependencies for Ubuntu Bionic
+
 sudo apt-get update
 
 sudo apt-get -y install \

--- a/dependencies/linux/install-dependencies-debian
+++ b/dependencies/linux/install-dependencies-debian
@@ -3,7 +3,7 @@
 #
 # install-dependencies-debian
 #
-# Copyright (C) 2009-18 by RStudio, Inc.
+# Copyright (C) 2009-19 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -16,6 +16,16 @@
 #
 
 set -e
+
+# delegate to specific platform scripts if available
+if command -v lsb_release &> /dev/null; then
+  platform_codename=$(lsb_release -sc)
+  platform_script="install-dependencies-$platform_codename"
+  if [ -e $platform_script ] ; then
+    ./$platform_script
+    exit 
+  fi
+fi
 
 # build/development tools
 sudo apt-get -y install build-essential


### PR DESCRIPTION
Setting up a new Ubuntu Bionic dev VM, and discovered that `install-dependencies-debian` script doesn't quite work for it. Openssl, among other things.

Maybe we could/should fix our debian script to handle all permutations and the new 1.3 dependencies, but instead I created a new bionic-specific script, based on installing the same stuff as the bionic Dockerfile.

I didn't try to separate out Pro-only stuff, so this script can be used to configure a machine for both open source and Pro development. It doesn't seem worth the effort or the minor disk-space savings to figure out what's Pro-only.

Unlike our other scripts, this also installs R (if not already installed), and the java-8 openjdk.

You can get a Linux dev environment up and running with the following:

- Install Ubuntu Bionic desktop (18.04.2)
- Install and configure git
- Clone open-source and/or pro repo
- `cd rstudio(-pro)/dependencies/linux`
- `sudo ./install-dependencies-bionic`
- for for lunch, then you can build RStudio using usual techniques

Need to "sudo" the install-dependencies script because the `install-crashpad` script that it invokes doesn't do its own "sudo-ing", unlike the other scripts. Not sure this is on purpose, or just an omission.