### PR TITLE
Fix javascript exception triggered by showing Find in Files dialog

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
@@ -1,7 +1,7 @@
 /*
  * FindOutputPresenter.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -185,6 +185,9 @@ public class FindOutputPresenter extends BasePresenter
          @Override
          protected JsObject getValue()
          {
+            if (dialogState_ == null)
+               return dialogState_.cast();
+            
             JsObject object = dialogState_.<JsObject>cast().clone();
             
             // convert path to relative if path is project-relative


### PR DESCRIPTION
Fixes #4478 

This is a regression introduced June 2018 via https://github.com/rstudio/rstudio/commit/468c41cd36431b16ae0c6b3b155e94243145d51c#diff-fd534b720e83ffa9ff478c434ab1c039

- dialogState_ can be null, as seen in onInit()
- in that case, cannot dereference it (but .cast() is ok on a null JavaScriptObject; and this is what the code used to do)

Once the exception is triggered, will keep happening due to ongoing attempt to persist the settings (which is interrupted by the exception).

Presumably once you've done an actual Find in Files search, this field is no longer going to be null, so the problem stops happening.