### PR TITLE
Fix unnecessary deferred tab triggering for Jobs, Launcher, Terminal and Markers tabs

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/BusyPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/BusyPresenter.java
@@ -1,7 +1,7 @@
 /*
  * BusyPresenter.java
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -46,7 +46,7 @@ public abstract class BusyPresenter extends BasePresenter
    @Override
    public void addBusyHandler(BusyHandler handler)
    {
-      // if a handler is added while when we're already busy, invoke the
+      // if a handler is added when we're already busy, invoke the
       // handler immediately
       if (isBusy())
          handler.onBusy(new BusyEvent(true));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobsPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobsPresenter.java
@@ -24,7 +24,6 @@ import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.BasePresenter;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobUpdatedEvent;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobElapsedTickEvent;
-import org.rstudio.studio.client.workbench.views.jobs.events.JobInitEvent;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobOutputEvent;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobSelectionEvent;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobsPresenterEventHandlers;
@@ -32,6 +31,7 @@ import org.rstudio.studio.client.workbench.views.jobs.events.JobsPresenterEventH
 import org.rstudio.studio.client.workbench.views.jobs.model.Job;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobConstants;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobManager;
+import org.rstudio.studio.client.workbench.views.jobs.model.JobState;
 import org.rstudio.studio.client.workbench.views.jobs.view.JobsDisplay;
 
 import com.google.gwt.user.client.Command;
@@ -70,9 +70,9 @@ public class JobsPresenter extends BasePresenter
    }
 
    @Override
-   public void onJobInit(JobInitEvent event)
+   public void setInitialJobs(JobState state)
    {
-      jobEventHandler_.onJobInit(event);
+      jobEventHandler_.setInitialJobs(state);
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobsTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobsTab.java
@@ -31,6 +31,7 @@ import org.rstudio.studio.client.workbench.views.jobs.events.JobUpdatedEvent;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobsPresenterEventHandlers;
 
 public class JobsTab extends DelayLoadWorkbenchTab<JobsPresenter>
+                     implements JobInitEvent.Handler
 {
    public abstract static class Shim 
         extends DelayLoadTabShim<JobsPresenter, JobsTab>
@@ -57,8 +58,20 @@ public class JobsTab extends DelayLoadWorkbenchTab<JobsPresenter>
       events.addHandler(JobUpdatedEvent.TYPE, shim);
       events.addHandler(JobOutputEvent.TYPE, shim);
       events.addHandler(JobSelectionEvent.TYPE, shim);
-      events.addHandler(JobInitEvent.TYPE, shim);
       events.addHandler(JobElapsedTickEvent.TYPE, shim);
+      
+      events.addHandler(JobInitEvent.TYPE, this);
+   }
+
+   @Override
+   public void onJobInit(JobInitEvent event)
+   {
+      if (event.state() != null && event.state().hasJobs())
+      {
+         // don't message the shim unless there are jobs, otherwise will trigger
+         // unnecessary loading of the deferred tab code
+         shim_.setInitialJobs(event.state());
+      }
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/LauncherJobsPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/LauncherJobsPresenter.java
@@ -18,16 +18,15 @@ package org.rstudio.studio.client.workbench.views.jobs;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
 import org.rstudio.studio.client.workbench.commands.Commands;
-import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.BasePresenter;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobUpdatedEvent;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobElapsedTickEvent;
-import org.rstudio.studio.client.workbench.views.jobs.events.JobInitEvent;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobOutputEvent;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobSelectionEvent;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobsPresenterEventHandlers;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobsPresenterEventHandlersImpl;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobConstants;
+import org.rstudio.studio.client.workbench.views.jobs.model.JobState;
 import org.rstudio.studio.client.workbench.views.jobs.model.LauncherJobManager;
 import org.rstudio.studio.client.workbench.views.jobs.view.JobsDisplay;
 
@@ -45,7 +44,6 @@ public class LauncherJobsPresenter extends BasePresenter
    public LauncherJobsPresenter(Display display,
                                 Binder binder,
                                 Commands commands,
-                                UIPrefs uiPrefs,
                                 LauncherJobManager launcherJobManager)
    {
       super(display);
@@ -53,8 +51,6 @@ public class LauncherJobsPresenter extends BasePresenter
       jobEventHandler_ = new JobsPresenterEventHandlersImpl(JobConstants.JOB_TYPE_LAUNCHER, display);
       
       display_ = display;
-      uiPrefs_ = uiPrefs;
-      commands_ = commands;
       launcherJobManager_ = launcherJobManager;
       binder.bind(commands, this);
     }
@@ -66,9 +62,9 @@ public class LauncherJobsPresenter extends BasePresenter
    }
 
    @Override
-   public void onJobInit(JobInitEvent event)
+   public void setInitialJobs(JobState state)
    {
-      jobEventHandler_.onJobInit(event);
+      jobEventHandler_.setInitialJobs(state);
    }
    
    @Override
@@ -122,7 +118,5 @@ public class LauncherJobsPresenter extends BasePresenter
    
    // injected
    private final Display display_;
-   private final UIPrefs uiPrefs_;
-   private final Commands commands_;
    private final LauncherJobManager launcherJobManager_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/LauncherJobsTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/LauncherJobsTab.java
@@ -31,6 +31,7 @@ import org.rstudio.studio.client.workbench.views.jobs.events.JobUpdatedEvent;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobsPresenterEventHandlers;
 
 public class LauncherJobsTab extends DelayLoadWorkbenchTab<LauncherJobsPresenter>
+                             implements JobInitEvent.Handler
 {
    public abstract static class Shim
         extends DelayLoadTabShim<LauncherJobsPresenter, LauncherJobsTab>
@@ -57,8 +58,20 @@ public class LauncherJobsTab extends DelayLoadWorkbenchTab<LauncherJobsPresenter
       events.addHandler(JobUpdatedEvent.TYPE, shim);
       events.addHandler(JobOutputEvent.TYPE, shim);
       events.addHandler(JobSelectionEvent.TYPE, shim);
-      events.addHandler(JobInitEvent.TYPE, shim);
       events.addHandler(JobElapsedTickEvent.TYPE, shim);
+      
+      events.addHandler(JobInitEvent.TYPE, this);
+   }
+
+   @Override
+   public void onJobInit(JobInitEvent event)
+   {
+      if (event.state() != null && event.state().hasJobs())
+      {
+         // don't message the shim unless there are jobs, otherwise will trigger
+         // unnecessary loading of the deferred tab code
+         shim_.setInitialJobs(event.state());
+      }
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/events/JobsPresenterEventHandlers.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/events/JobsPresenterEventHandlers.java
@@ -14,10 +14,12 @@
  */
 package org.rstudio.studio.client.workbench.views.jobs.events;
 
+import org.rstudio.studio.client.workbench.views.jobs.model.JobState;
+
 public interface JobsPresenterEventHandlers extends JobUpdatedEvent.Handler,
-                                                    JobInitEvent.Handler,
                                                     JobOutputEvent.Handler,
                                                     JobSelectionEvent.Handler,
                                                     JobElapsedTickEvent.Handler
 {
+   void setInitialJobs(JobState state);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/events/JobsPresenterEventHandlersImpl.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/events/JobsPresenterEventHandlersImpl.java
@@ -28,6 +28,7 @@ import org.rstudio.studio.client.workbench.views.jobs.model.Job;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobConstants;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobManager;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobOutput;
+import org.rstudio.studio.client.workbench.views.jobs.model.JobState;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobsServerOperations;
 import org.rstudio.studio.client.workbench.views.jobs.view.JobsDisplay;
 
@@ -67,19 +68,19 @@ public class JobsPresenterEventHandlersImpl implements JobsPresenterEventHandler
    }
    
    @Override
-   public void onJobInit(JobInitEvent event)
+   public void setInitialJobs(JobState state)
    {
       // make an array of all the jobs on the server
       ArrayList<Job> jobs = new ArrayList<>();
-      if (event.state() != null)
+      if (state != null)
       {
-         for (String id : event.state().iterableKeys())
+         for (String id : state.iterableKeys())
          {
-            Job job = event.state().getElement(id);
+            Job job = state.getElement(id);
             if (!isSupportedJobType(job.type))
                continue;
       
-            jobs.add(event.state().getElement(id));
+            jobs.add(state.getElement(id));
          }
       }
       setJobState(jobs);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobState.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobState.java
@@ -65,5 +65,13 @@ public class JobState extends JsObject
    {
       return (JobState)JsObject.createJsObject();
    }
-   
+
+   public final boolean hasJobs()
+   {
+      for (String id : iterableKeys())
+      {
+         return true;
+      }
+      return false;
+   }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/markers/MarkersOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/markers/MarkersOutputPresenter.java
@@ -1,7 +1,7 @@
 /*
  * MarkersOutputPresenter.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -30,7 +30,6 @@ import org.rstudio.core.client.events.HasSelectionCommitHandlers;
 import org.rstudio.core.client.events.SelectionCommitEvent;
 import org.rstudio.core.client.events.SelectionCommitHandler;
 import org.rstudio.core.client.files.FileSystemItem;
-import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.sourcemarkers.SourceMarker;
 import org.rstudio.studio.client.common.sourcemarkers.SourceMarkerList;
@@ -61,7 +60,6 @@ public class MarkersOutputPresenter extends BasePresenter
    @Inject
    public MarkersOutputPresenter(Display view,
                                  MarkersServerOperations server,
-                                 EventBus events,
                                  FileTypeRegistry fileTypeRegistry)
    {
       super(view);
@@ -108,13 +106,10 @@ public class MarkersOutputPresenter extends BasePresenter
       });
    }
 
-   public void initialize(MarkersState state)
+   public void showInitialMarkers(MarkersState state)
    {
-      if (state.hasMarkers())
-      {
-         view_.ensureVisible(false);
-         view_.update(state, SourceMarkerList.AUTO_SELECT_NONE);
-      }
+      view_.ensureVisible(false);
+      view_.update(state, SourceMarkerList.AUTO_SELECT_NONE);
    }
    
    public void onMarkersChanged(MarkersChangedEvent event)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/markers/MarkersOutputTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/markers/MarkersOutputTab.java
@@ -35,7 +35,7 @@ public class MarkersOutputTab extends DelayLoadWorkbenchTab<MarkersOutputPresent
             extends DelayLoadTabShim<MarkersOutputPresenter, MarkersOutputTab>
             implements MarkersChangedEvent.Handler
    {
-      abstract void initialize(MarkersState state);
+      abstract void showInitialMarkers(MarkersState state);
       abstract void onClosing();
    }
 
@@ -57,7 +57,12 @@ public class MarkersOutputTab extends DelayLoadWorkbenchTab<MarkersOutputPresent
          public void onSessionInit(SessionInitEvent sie)
          {
             MarkersState state = session.getSessionInfo().getMarkersState();
-            shim_.initialize(state);
+            if (state.hasMarkers())
+            {
+               // don't talk to the shim unless there are existing markers, doing so will
+               // unnecessarily trigger downloading and loading the deferred-load tab
+               shim_.showInitialMarkers(state);
+            }
          }
       });
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/renderrmd/RenderRmdOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/renderrmd/RenderRmdOutputPresenter.java
@@ -1,7 +1,7 @@
 /*
  * RenderRmdOutputPresenter.java
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -91,10 +91,6 @@ public class RenderRmdOutputPresenter extends BusyPresenter
       globalDisplay_ = globalDisplay;
    }
    
-   public void initialize()
-   {
-   }
-
    public void confirmClose(final Command onConfirmed)
    {
       // if we're in the middle of rendering, presume that the user might be

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/renderrmd/RenderRmdOutputTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/renderrmd/RenderRmdOutputTab.java
@@ -2,7 +2,7 @@
 /*
  * RenderRmdOutputTab.java
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -42,7 +42,6 @@ public class RenderRmdOutputTab
                  RestartStatusEvent.Handler,
                  ProvidesBusy
    {
-      abstract void initialize();
       abstract void confirmClose(Command onConfirmed);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTab.java
@@ -1,7 +1,7 @@
 /*
  * TerminalTab.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -20,12 +20,10 @@ import java.util.ArrayList;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
-import org.rstudio.core.client.widget.model.ProvidesBusy;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.console.ConsoleProcess.ConsoleProcessFactory;
 import org.rstudio.studio.client.common.console.ConsoleProcessInfo;
 import org.rstudio.studio.client.workbench.commands.Commands;
-import org.rstudio.studio.client.workbench.events.BusyHandler;
 import org.rstudio.studio.client.workbench.events.SessionInitEvent;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.ui.DelayLoadTabShim;
@@ -43,14 +41,12 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 
 public class TerminalTab extends DelayLoadWorkbenchTab<TerminalTabPresenter>
-                         implements ProvidesBusy
 {
    public interface Binder extends CommandBinder<Commands, Shim> {}
 
    public abstract static class Shim 
       extends DelayLoadTabShim<TerminalTabPresenter, TerminalTab>
-      implements ProvidesBusy,
-                 CreateTerminalEvent.Handler,
+      implements CreateTerminalEvent.Handler,
                  SendToTerminalEvent.Handler,
                  ClearTerminalEvent.Handler,
                  AddTerminalEvent.Handler,
@@ -141,12 +137,6 @@ public class TerminalTab extends DelayLoadWorkbenchTab<TerminalTabPresenter>
    public void confirmClose(Command onConfirmed)
    {
       shim_.confirmClose(onConfirmed);
-   }
-
-   @Override
-   public void addBusyHandler(BusyHandler handler)
-   {
-      shim_.addBusyHandler(handler);
    }
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
@@ -1,7 +1,7 @@
 /*
  * TerminalTabPresenter.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -24,7 +24,7 @@ import org.rstudio.studio.client.common.console.ConsoleProcessInfo;
 import org.rstudio.studio.client.workbench.WorkbenchView;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
-import org.rstudio.studio.client.workbench.views.BusyPresenter;
+import org.rstudio.studio.client.workbench.views.BasePresenter;
 import org.rstudio.studio.client.workbench.views.terminal.events.ActivateNamedTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.AddTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.ClearTerminalEvent;
@@ -35,14 +35,13 @@ import org.rstudio.studio.client.workbench.views.terminal.events.SendToTerminalE
 import com.google.gwt.user.client.Command;
 import com.google.inject.Inject;
 
-public class TerminalTabPresenter extends BusyPresenter
+public class TerminalTabPresenter extends BasePresenter
                                   implements SendToTerminalEvent.Handler,
                                              ClearTerminalEvent.Handler,
                                              CreateTerminalEvent.Handler,
                                              AddTerminalEvent.Handler,
                                              RemoveTerminalEvent.Handler,
                                              ActivateNamedTerminalEvent.Handler
-
 {
    public interface Binder extends CommandBinder<Commands, TerminalTabPresenter> {}
 


### PR DESCRIPTION
I was wondering why the Launcher tab was triggering deferred tab loading on Open Source, where it shouldn't ever need to. Some investigation revealed quite a few tabs doing this, defeating the purpose of the deferred mechanism's use of GWT code splitting.

The goal is that the presenter and all related goo shouldn't be downloaded and instantiated until a given tab is made visible. Just having the tab present at startup, but unselected, shouldn't be loading that stuff. Same, of course, with tabs that are not even shown.

This fixes Jobs, Launcher (I may need to do additional tweaks in Pro when I merge this in), Terminal, and Markers.

They key is not talking to the Shim unnecessarily, whether from the Tab itself or via an event such as SessionInit; instead the Tab should only pass these along to the Shim if there is stuff to pass along (Jobs, Markers, etc).

The others  to look into are Environment and Plots, but haven't gotten to those yet.