### PR TITLE
switch title for project library

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageLibraryUtils.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageLibraryUtils.java
@@ -62,7 +62,7 @@ public class PackageLibraryUtils
    public static String nameOfLibraryType(PackageLibraryType type)
    {
       if (type == PackageLibraryType.Project)
-         return "Packrat Library";
+         return "Project Library";
       else if (type == PackageLibraryType.User)
          return "User Library";
       else if (type == PackageLibraryType.System)


### PR DESCRIPTION
This PR renames the title used in the Packages pane from Packrat Library to Project Library.

This is primarily for `renv`, since the private library as created by `renv` is discovered within the project and so called a Packrat library by RStudio.

I think 'Project Library' is still clear enough that it makes sense for both the Packrat + renv cases.

@jmcphers it would be nice to get this in for v1.2 now that we've made `renv` public; let me know what you think.