### PR TITLE
more fixes for new behavior of String.charAt in GWT 2.8.2

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -1393,6 +1393,27 @@ public class StringUtil
       
       return str.charAt(pos) == ch;
    }
+
+   /**
+    * Prior to GWT 2.8.2, the String.charAt method was not range-checked and would not
+    * throw exceptions when invoked with an out-of-range position. We have code that assumes
+    * this old behavior.
+    * 
+    * Starting with 2.8.2 it will throw StringIndexOutOfBoundsException per Java standard.
+    * In cases where it's not obvious how to safely switch to the new behavior, this method
+    * can be substituted.
+    */
+   public static char charAt(String str, int pos)
+   {
+      try
+      {
+         return str.charAt(pos);         
+      }
+      catch (StringIndexOutOfBoundsException ex)
+      {
+         return '\0';         
+      }
+   }
    
    private static final NumberFormat FORMAT = NumberFormat.getFormat("0.#");
    private static final NumberFormat PRETTY_NUMBER_FORMAT = NumberFormat.getFormat("#,##0.#####");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -605,8 +605,8 @@ public class RCompletionManager implements CompletionManager
             // also halt suggestions if we're about to remove the only character on the line
             if (cursorColumn > 0)
             {
-               char ch = currentLine.charAt(cursorColumn - 2);
-               char prevCh = currentLine.charAt(cursorColumn - 3);
+               char ch = StringUtil.charAt(currentLine, cursorColumn - 2);
+               char prevCh = StringUtil.charAt(currentLine, cursorColumn - 3);
                
                boolean isAcceptableCharSequence = isValidForRIdentifier(ch) ||
                      (ch == ':' && prevCh == ':') ||
@@ -623,7 +623,7 @@ public class RCompletionManager implements CompletionManager
                   InputEditorPosition start = selection.getStart().movePosition(-1, true);
                   InputEditorPosition end = selection.getStart();
 
-                  if (currentLine.charAt(cursorColumn) == ')' && currentLine.charAt(cursorColumn - 1) == '(')
+                  if (StringUtil.charAt(currentLine, cursorColumn) == ')' && StringUtil.charAt(currentLine, cursorColumn - 1) == '(')
                   {
                      // flush cache as old completions no longer relevant
                      requester_.flushCache();
@@ -688,7 +688,7 @@ public class RCompletionManager implements CompletionManager
       {
          for (int i = 0; i < lookbackLimit; i++)
          {
-            if (!isValidForRIdentifier(currentLine.charAt(cursorColumn - i - 1)))
+            if (!isValidForRIdentifier(StringUtil.charAt(currentLine, cursorColumn - i - 1)))
             {
                canAutoPopup = false;
                break;

--- a/src/gwt/test/org/rstudio/core/client/StringUtilTests.java
+++ b/src/gwt/test/org/rstudio/core/client/StringUtilTests.java
@@ -292,4 +292,20 @@ public class StringUtilTests extends GWTTestCase
       assertFalse(StringUtil.isCharAt(null, 'a', 0));
       assertFalse(StringUtil.isCharAt("012345", '6', 6));
    }
+   
+   public void testSafeCharAt()
+   {
+      String str = "";
+      
+      assertEquals(StringUtil.charAt(str, 0), '\0');
+      assertEquals(StringUtil.charAt(str, -1), '\0');
+      assertEquals(StringUtil.charAt(str, 100), '\0');
+      
+      str = "abcd";
+
+      assertEquals(StringUtil.charAt(str, 0), 'a');
+      assertEquals(StringUtil.charAt(str, 1), 'b');
+      assertEquals(StringUtil.charAt(str, 2), 'c');
+      assertEquals(StringUtil.charAt(str, 3), 'd');
+   }
 }


### PR DESCRIPTION
GWT 2.8.2 added range check + exception to String.charAt (standard Java behavior, but was previously missing).

Per advice from @kevinushey in prior round of fixes, added a "safe" StringUtil.charAt that can be used in places where it isn't trivial to accommodate the new behavior.

This particular instance was being hit by autocomplete code when typing near first column of the R Console.