### PR TITLE
fix bug where pane layout customization lost if Viewer moved to other pane

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneConfig.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneConfig.java
@@ -1,7 +1,7 @@
 /*
  * PaneConfig.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -79,8 +79,7 @@ public class PaneConfig extends JavaScriptObject
       // A list of all the tabs. Order matters; the Presentation tab must be the
       // last element in this array that's part of the first tabset (ts1)
       return new String[] {"Environment", "History", "Files", "Plots", "Connections",
-                           "Packages", "Help", "Build", "VCS", "Presentation",
-                           "Viewer"};
+                           "Packages", "Help", "Build", "VCS", "Viewer", "Presentation"};
    }
 
    public static String[] getAlwaysVisibleTabs()


### PR DESCRIPTION
Fixes #2101 

Fixing in 1.3, but this also seems like a good candidate for a 1.2 patch release.

This bug is triggered if you move the Viewer pane to the same pane as the Presentation pane (the upper-right pane, by default). It goes on the end of the tab list for that tabset, triggering failure of pane layout validation here:

https://github.com/rstudio/rstudio/blob/c7879dedea8421c6d27dbab2ba3b7f08cfa90111/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneConfig.java#L214-L223

Easy fix.