### PR TITLE
Fix an issue caused by old versions of RStudio saving themes with a leading slash.

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceTheme.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceTheme.java
@@ -59,7 +59,10 @@ public class AceTheme extends JavaScriptObject
    
    public native final String getUrl()
    /*-{
-      return this.url;
+      if (this.url.startsWith("/"))
+         return this.url.substr(1);
+      else
+         return this.url;
    }-*/;
    
    public native final Boolean isDark()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceTheme.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceTheme.java
@@ -59,7 +59,10 @@ public class AceTheme extends JavaScriptObject
    
    public native final String getUrl()
    /*-{
-      if (this.url.charAt(0) == '/')
+      if ((this.url !== null) &&
+          (this.url !== undefined) &&
+          (this.url !== "") &&
+          (this.url.charAt(0) === '/'))
          return this.url.substr(1);
       else
          return this.url;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceTheme.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceTheme.java
@@ -59,7 +59,7 @@ public class AceTheme extends JavaScriptObject
    
    public native final String getUrl()
    /*-{
-      if (this.url.startsWith("/"))
+      if (this.url.charAt(0) == '/')
          return this.url.substr(1);
       else
          return this.url;


### PR DESCRIPTION
Closes #4488.