### PR TITLE
update Boost installer scripts

### DIFF
--- a/dependencies/windows/install-boost.cmd
+++ b/dependencies/windows/install-boost.cmd
@@ -1,5 +1,14 @@
 @echo off
+
+REM Build Boost.
 cd install-boost
 R --vanilla --slave -f install-boost.R --args debug static
 R --vanilla --slave -f install-boost.R --args release static
 cd ..
+
+REM Build the Boost archive for upload to S3.
+echo --^> Packaging Boost 1.69.0 ...
+zip -r -q -9 boost-1.69.0-win-msvc141.zip ^
+	boost-1.69.0-win-msvc141-debug-static ^
+	boost-1.69.0-win-msvc141-release-static
+echo --^> Done!

--- a/dependencies/windows/install-boost/install-boost.R
+++ b/dependencies/windows/install-boost/install-boost.R
@@ -45,7 +45,7 @@ boost_modules <- c(
    "config", "context", "crc", "date_time", "filesystem", "foreach", "format",
    "function", "interprocess", "iostreams", "lambda", "lexical_cast",
    "optional", "predef", "program_options", "property_tree", "random", "range",
-   "ref", "regex", "scope_exit", "signals", "smart_ptr", "spirit",
+   "ref", "regex", "scope_exit", "signals2", "smart_ptr", "spirit",
    "string_algo", "system", "test", "thread", "tokenizer", "type_traits",
    "typeof", "unordered", "utility", "variant"
 )
@@ -132,25 +132,6 @@ b2_build_args <- function(bitness) {
 # build 64bit Boost
 section("Building Boost 64bit...")
 exec("b2", b2_build_args("64"))
-
-# enter the build directory
-enter(install_dir)
-
-# zip it all up
-section("Creating archive '%s'...", output_name)
-if (file.exists(output_name))
-   unlink(output_name)
-
-zip(output_name, files = c("boost64"), extras = "-q")
-if (!file.exists(output_name))
-   fatal("Failed to create archive '%s'.", output_name)
-progress("Created archive '%s'.", output_name)
-
-# copy the generated file to the boost
-file.rename(output_name, output_file)
-if (!file.exists(output_file))
-   fatal("Failed to move archive to path '%s'.", output_file)
-progress("Moved archive to path '%s'.", output_file)
 
 # rejoice
 progress("Boost built successfully!")

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -195,7 +195,6 @@ list(APPEND BOOST_LIBS
    program_options
    random
    regex
-   signals
    system
    thread
 )
@@ -236,10 +235,10 @@ else()
    add_definitions(-DRSTUDIO_BOOST_NAMESPACE=rstudio_boost)
    set(BOOST_ARCH "64")
    if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-      set(BOOST_SUFFIX "vc141-mt-1_69_0.lib")
+      set(BOOST_SUFFIX "vc141-mt-x64-1_69.lib")
       set(BOOST_ROOT "${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/boost-1.69.0-win-msvc141-release-static/boost${BOOST_ARCH}")
    else()
-      set(BOOST_SUFFIX "vc141-mt-gd-1_69_0.lib")
+      set(BOOST_SUFFIX "vc141-mt-gd-x64-1_69.lib")
       set(BOOST_ROOT "${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/boost-1.69.0-win-msvc141-debug-static/boost${BOOST_ARCH}")
    endif()
    set(BOOST_INCLUDEDIR "${BOOST_ROOT}/include/boost-1_69_0")

--- a/src/cpp/core/http/CSRFToken.cpp
+++ b/src/cpp/core/http/CSRFToken.cpp
@@ -20,7 +20,7 @@
 #include <core/http/Request.hpp>
 #include <core/http/Response.hpp>
 
-#include <core/system/PosixSystem.hpp>
+#include <core/system/System.hpp>
 
 #define kCSRFTokenName "csrf-token"
 

--- a/src/cpp/desktop/DesktopComUtils.hpp
+++ b/src/cpp/desktop/DesktopComUtils.hpp
@@ -16,6 +16,8 @@
 #ifndef DESKTOP_COMUTILS_HPP
 #define DESKTOP_COMUTILS_HPP
 
+#include <string>
+
 // Convenience to convert an HRSULT to our own error type and bail out on
 // failure.
 #define VERIFY_HRESULT(x) hr = (x); \


### PR DESCRIPTION
This PR makes a couple fixes needed for Boost 1.69.0 on Windows:

1. We need to explicitly request `signals2` when building our Boost bundle;
2. We need to update the library suffixes used with Boost in CMake.

Also made some tweaks to build the tarball that we actually want to push to S3, and fixed a couple compile errors I saw when testing Boost.