### PR TITLE
Asynchronous loading for Typo.js, updated markdown link parsing

### DIFF
--- a/src/gwt/acesupport/acemode/markdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/markdown_highlight_rules.js
@@ -125,13 +125,14 @@ var MarkdownHighlightRules = function() {
     };
 
     var linkByUrl = {
-        token : ["text", "keyword", "text", "markup.href", "string", "text"],
+        token : ["text", "keyword", "text", "markup.href", "string", "text", "paren.keyword.operator", "nospell", "paren.keyword.operator"],
         regex : "(\\s*\\[)(" +                            // [
             escaped("]") +                                // link text
             ")(\\]\\()" +                                 // ](
             '((?:[^\\)\\s\\\\]|\\\\.|\\s(?=[^"]))*)' +    // href
             '(\\s*"' +  escaped('"') + '"\\s*)?' +        // "title"
-            "(\\))"                                       // )
+            "(\\))" +                                     // )
+            "(?:(\\s*{)((?:[^\\}]+))(\\s*}))?"            // { block text }
     };
 
     var urlLink = {

--- a/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoNative.java
@@ -22,7 +22,7 @@ import jsinterop.annotations.JsType;
 @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Typo")
 public class TypoNative
 {
-   TypoNative(String dictionary, JavaScriptObject affData, JavaScriptObject wordsData, JavaScriptObject settings) {}
+   TypoNative(String dictionary, String affData, String wordsData, JavaScriptObject settings) {}
 
    public native boolean check(String word);
    public native String[] suggest(String word);

--- a/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.common.spelling;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.http.client.Request;
@@ -200,7 +201,7 @@ public class TypoSpellChecker
    private void loadDictionary()
    {
       String dictLanguage = uiPrefs_.spellingDictionaryLanguage().getValue();
-      String path = "/dictionaries/" + dictLanguage + "/" + dictLanguage;
+      String path = GWT.getHostPageBaseURL() + "dictionaries/" + dictLanguage + "/" + dictLanguage;
 
       RequestLogEntry affLogEntry = RequestLog.log(dictLanguage + "_aff_request", "");
       RequestLogEntry dicLogEntry = RequestLog.log(dictLanguage + "_dic_request", "");

--- a/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
@@ -14,11 +14,17 @@
  */
 package org.rstudio.studio.client.common.spelling;
 
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.http.client.Request;
+import com.google.gwt.http.client.RequestBuilder;
+import com.google.gwt.http.client.RequestCallback;
+import com.google.gwt.http.client.RequestException;
+import com.google.gwt.http.client.Response;
 import com.google.inject.Inject;
 import org.rstudio.core.client.ExternalJavaScriptLoader;
+import org.rstudio.core.client.jsonrpc.RequestLog;
+import org.rstudio.core.client.jsonrpc.RequestLogEntry;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.spelling.model.SpellCheckerResult;
 import org.rstudio.studio.client.server.ServerRequestCallback;
@@ -53,10 +59,12 @@ public class TypoSpellChecker
       contextDictionary_ = context_.readDictionary();
 
       // subscribe to spelling prefs changes (invalidateAll on changes)
-      uiPrefs_.realTimeSpellChecking().addValueChangeHandler(prefChangedHandler_);
-      uiPrefs_.ignoreWordsInUppercase().addValueChangeHandler(prefChangedHandler_);
-      uiPrefs_.ignoreWordsWithNumbers().addValueChangeHandler(prefChangedHandler_);
-      uiPrefs_.spellingDictionaryLanguage().addValueChangeHandler(languageChangedHandler_);
+      ValueChangeHandler<Boolean> prefChangedHandler = (event) -> context_.invalidateAllWords();
+      ValueChangeHandler<String> dictChangedHandler = (event) -> loadDictionary();
+      uiPrefs_.realTimeSpellChecking().addValueChangeHandler(prefChangedHandler);
+      uiPrefs_.ignoreWordsInUppercase().addValueChangeHandler(prefChangedHandler);
+      uiPrefs_.ignoreWordsWithNumbers().addValueChangeHandler(prefChangedHandler);
+      uiPrefs_.spellingDictionaryLanguage().addValueChangeHandler(dictChangedHandler);
 
       // subscribe to user dictionary changes
       context_.releaseOnDismiss(userDictionary_.addListChangedHandler((ListChangedEvent event) ->
@@ -191,33 +199,50 @@ public class TypoSpellChecker
 
    private void loadDictionary()
    {
-      ExternalJavaScriptLoader.Callback loadTypoCallback = () -> {
-         typoNative_ = new TypoNative(
-            uiPrefs_.spellingDictionaryLanguage().getValue(),
-            null,
-            null,
-            null
-         );
-      };
-      new ExternalJavaScriptLoader(TypoResources.INSTANCE.typojs().getSafeUri().asString()).addCallback(loadTypoCallback);
+      String dictLanguage = uiPrefs_.spellingDictionaryLanguage().getValue();
+      String path = "/dictionaries/" + dictLanguage + "/" + dictLanguage;
+
+      RequestLogEntry affLogEntry = RequestLog.log(dictLanguage + "_aff_request", "");
+      RequestLogEntry dicLogEntry = RequestLog.log(dictLanguage + "_dic_request", "");
+
+      try
+      {
+         new RequestBuilder(RequestBuilder.GET, path + ".aff").sendRequest("", new RequestCallback() {
+            @Override
+            public void onResponseReceived(Request affReq, Response affResp) {
+               try
+               {
+                  new RequestBuilder(RequestBuilder.GET, path + ".dic").sendRequest("", new RequestCallback() {
+                     @Override
+                     public void onResponseReceived(Request dicReq, Response dicResp) {
+                        ExternalJavaScriptLoader.Callback loadTypoCallback = () ->
+                           typoNative_ = new TypoNative(dictLanguage, affResp.getText(), dicResp.getText(), null);
+                        new ExternalJavaScriptLoader(TypoResources.INSTANCE.typojs().getSafeUri().asString()).addCallback(loadTypoCallback);
+                     }
+
+                     @Override
+                     public void onError(Request res, Throwable throwable) {
+                        dicLogEntry.logResponse(RequestLogEntry.ResponseType.Error, throwable.getLocalizedMessage());
+                     }
+                  });
+               }
+               catch (RequestException e)
+               {
+                  dicLogEntry.logResponse(RequestLogEntry.ResponseType.Unknown, e.getLocalizedMessage());
+               }
+            }
+
+            @Override
+            public void onError(Request res, Throwable throwable) {
+               affLogEntry.logResponse(RequestLogEntry.ResponseType.Error, throwable.getLocalizedMessage());
+            }
+         });
+      }
+      catch (RequestException e)
+      {
+         affLogEntry.logResponse(RequestLogEntry.ResponseType.Unknown, e.getLocalizedMessage());
+      }
    }
-
-   private ValueChangeHandler<Boolean> prefChangedHandler_ = new ValueChangeHandler<Boolean>() {
-      @Override
-      public void onValueChange(ValueChangeEvent<Boolean> event)
-      {
-         context_.invalidateAllWords();
-      }
-   };
-
-   private ValueChangeHandler<String> languageChangedHandler_ = new ValueChangeHandler<String>() {
-      @Override
-      public void onValueChange(ValueChangeEvent<String> event)
-      {
-         loadDictionary();
-      }
-   };
-
    private final Context context_;
 
    private TypoNative typoNative_;


### PR DESCRIPTION
Load the dictionary data in GWT before loading Typo.js to avoid synchronous GET requests. I tried other approaches here and I'm jumping through hoops a bit to avoid modifying Typo.js and, while I think it's still worth it, we're probably pretty close to wanting to fork it for our own purposes as soon as we want to do something just a touch fancier. Considering the library hasn't been touched in any substantial way in over a year this is probably safe to do anyway, it's just the burden of ownership that we'll be taking on.

Markdown parsing rule update: I was originally doing fancier stuff that touched the spelling system and DocDisplay itself to try to be more comprehensive but I think leaning more on our existing rules will keep things simple and we have enough tools to get by. This will likely be a piece by piece feature as we extend our parsing and tokenization to interact with the spelling system but it's lower risk and more robust than other options. https://github.com/rstudio/rstudio/issues/4418, the catalyst for this change, was not a regression but just the realtime spellchecking bringing past deficiencies to light due to it being much more obvious.