### PR TITLE
install latest cmake on Windows to fix a build break caused by recent boost tweaks

### DIFF
--- a/dependencies/windows/Install-RStudio-Prereqs.ps1
+++ b/dependencies/windows/Install-RStudio-Prereqs.ps1
@@ -63,7 +63,7 @@ iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/in
 refreshenv
 
 # install some deps via chocolatey
-choco install -y cmake --version 3.12.1 --installargs 'ADD_CMAKE_TO_PATH=""System""' --fail-on-error-output
+choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=""System""' --fail-on-error-output
 refreshenv
 choco install -y jdk8
 choco install -y ant --version 1.10.5

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -27,9 +27,7 @@ RUN choco install -y visualstudio2017buildtools --version 15.8.2.0; `
   choco install -y visualstudio2017-workload-vctools --version 1.3.0
   
 # install aws cli
-# awscli bug where cp65001 is not understood by internal python.
-RUN choco install -y awscli ;`
-  cp 'C:\Program Files\Amazon\AWSCLI\encodings\utf_8.pyc' 'C:\Program Files\Amazon\AWSCLI\encodings\cp65001.pyc'
+RUN choco install -y awscli
 
 # we use "R" for its real purpose, remove the Invoke-History powershell alias
 RUN "echo 'Remove-Item alias:r' | Out-File $PsHome\Profile.ps1"

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -16,7 +16,7 @@ RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 
     iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
 # install some deps via chocolatey
-RUN choco install -y cmake --version 3.12.1 --installargs 'ADD_CMAKE_TO_PATH=""System""' --fail-on-error-output; ` 
+RUN choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=""System""' --fail-on-error-output; ` 
   choco install -y jdk8 ; `
   choco install -y ant --version 1.10.5; `
   choco install -y windows-sdk-10.1 --version 10.1.17134.12; `


### PR DESCRIPTION
Requires rebuilding the Windows build docker image.

- on a dev box setup with the prereqs powershell script, you'll need to uninstall cmake 3.12.1 via `choco uninstall cmake` then run the updated powershell script