### PR TITLE
eliminate batch of new c++ warnings from latest macOS compiler

### DIFF
--- a/src/cpp/core/json/JsonTests.cpp
+++ b/src/cpp/core/json/JsonTests.cpp
@@ -1,7 +1,7 @@
 /*
  * JsonTests.cpp
  *
- * Copyright (C) 2018 by RStudio, Inc.
+ * Copyright (C) 2018-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -83,7 +83,7 @@ json::Object returnObject()
 json::Value createValue()
 {
    json::Object obj = createObject();
-   return obj;
+   return std::move(obj);
 }
 
 json::Value getValue()

--- a/src/cpp/monitor/metrics/Metric.cpp
+++ b/src/cpp/monitor/metrics/Metric.cpp
@@ -1,7 +1,7 @@
 /*
  * Metric.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -63,7 +63,7 @@ json::Value toMetricDataJson(const MetricData& data)
    json::Object dataJson;
    dataJson["name"] = data.name;
    dataJson["value"] = data.value;
-   return dataJson;
+   return std::move(dataJson);
 }
 
 

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionModuleContext.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -2375,7 +2375,7 @@ json::Value sourceMarkerJson(const SourceMarker& sourceMarker)
    obj["log_path"] = "";
    obj["log_line"] = -1;
    obj["show_error_list"] = sourceMarker.showErrorList;
-   return obj;
+   return std::move(obj);
 }
 
 } // anonymous namespace

--- a/src/cpp/session/modules/SessionAgreement.cpp
+++ b/src/cpp/session/modules/SessionAgreement.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionAgreement.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -160,7 +160,7 @@ json::Value pendingAgreement()
          jsonAgreement["contents"] = agreement.contents;
          jsonAgreement["hash"] = agreement.hash;
          jsonAgreement["updated"] = agreement.updated;
-         return jsonAgreement;
+         return std::move(jsonAgreement);
       }
       else
       {

--- a/src/cpp/session/modules/SessionErrors.cpp
+++ b/src/cpp/session/modules/SessionErrors.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionErrors.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -186,7 +186,7 @@ json::Value errorStateAsJson()
 {
    json::Object state;
    state["error_handler_type"] = userSettings().errorHandlerType();
-   return state;
+   return std::move(state);
 }
 
 Error initialize()

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionGit.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -178,7 +178,7 @@ struct RemoteBranchInfo
          json::Object remoteInfoJson;
          remoteInfoJson["name"] = name;
          remoteInfoJson["commits_behind"] = commitsBehind;
-         return remoteInfoJson;
+         return std::move(remoteInfoJson);
       }
       else
       {

--- a/src/cpp/session/modules/SessionProjectTemplate.cpp
+++ b/src/cpp/session/modules/SessionProjectTemplate.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionProjectTemplate.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -185,7 +185,7 @@ json::Value ProjectTemplateWidgetDescription::toJson() const
    object["position"]  = position;
    object["fields"]    = core::json::toJsonArray(fields);
 
-   return object;
+   return std::move(object);
 }
 
 Error fromJson(
@@ -252,7 +252,7 @@ json::Value ProjectTemplateDescription::toJson() const
    }
    object["widgets"] = widgetsJson;
 
-   return object;
+   return std::move(object);
 }
 
 namespace {
@@ -462,7 +462,7 @@ public:
          object[pkgName] = array;
       }
       
-      return object;
+      return std::move(object);
    }
 
    std::map<

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionBuild.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -2094,7 +2094,7 @@ json::Value buildStateAsJson()
       stateJson["errors_base_dir"] = s_pBuild->errorsBaseDir();
       stateJson["type"] = s_pBuild->type();
       stateJson["errors"] = s_pBuild->errorsAsJson();
-      return stateJson;
+      return std::move(stateJson);
    }
    else if (!s_suspendBuildContext.empty())
    {
@@ -2104,7 +2104,7 @@ json::Value buildStateAsJson()
       stateJson["errors_base_dir"] = s_suspendBuildContext.errorsBaseDir;
       stateJson["type"] = s_suspendBuildContext.type;
       stateJson["errors"] = s_suspendBuildContext.errors;
-      return stateJson;
+      return std::move(stateJson);
    }
    else
    {

--- a/src/cpp/session/modules/build/SessionSourceCpp.cpp
+++ b/src/cpp/session/modules/build/SessionSourceCpp.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionSourceCpp.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -64,7 +64,7 @@ struct SourceCppState
       stateJson["target_file"] = targetFile;
       stateJson["outputs"] = outputs;
       stateJson["errors"] = errors;
-      return stateJson;
+      return std::move(stateJson);
    }
 
    std::string targetFile;

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -1,7 +1,7 @@
 /*
  * DataViewer.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -356,7 +356,7 @@ json::Value makeDataItem(SEXP dataSEXP,
       http::util::urlEncode(cacheKey, true);
    dataItem["preview"] = preview;
 
-   return dataItem;
+   return std::move(dataItem);
 }
 
 SEXP rs_viewData(SEXP dataSEXP, SEXP exprSEXP, SEXP captionSEXP, SEXP nameSEXP, 
@@ -695,7 +695,7 @@ json::Value getData(SEXP dataSEXP, const http::Fields& fields)
    result["recordsTotal"] = nrow;
    result["recordsFiltered"] = filteredNRow;
    result["data"] = data;
-   return result;
+   return std::move(result);
 }
 
 Error getGridData(const http::Request& request,

--- a/src/cpp/session/modules/environment/EnvironmentUtils.cpp
+++ b/src/cpp/session/modules/environment/EnvironmentUtils.cpp
@@ -230,7 +230,7 @@ json::Value varToJson(SEXP env, const r::sexp::Variable& var)
             return val;
       }
    }
-   return varJson;
+   return std::move(varJson);
 }
 
 bool functionDiffersFromSource(

--- a/src/cpp/session/modules/presentation/PresentationState.cpp
+++ b/src/cpp/session/modules/presentation/PresentationState.cpp
@@ -1,7 +1,7 @@
 /*
  * PresentationState.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -216,7 +216,7 @@ json::Value asJson()
    stateJson["file_path"] = module_context::createAliasedPath(
                                                 s_presentationState.filePath);
    stateJson["slide_index"] = s_presentationState.slideIndex;
-   return stateJson;
+   return std::move(stateJson);
 }
 
 Error initialize()

--- a/src/cpp/session/modules/rmarkdown/RMarkdownPresentation.cpp
+++ b/src/cpp/session/modules/rmarkdown/RMarkdownPresentation.cpp
@@ -1,7 +1,7 @@
 /*
  * RMarkdownPresentation.cpp
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -54,7 +54,7 @@ json::Value itemAsJson(const SlideNavigationItem& item)
    slideJson["indent"] = item.indent;
    slideJson["index"] = item.index;
    slideJson["line"] = item.line;
-   return slideJson;
+   return std::move(slideJson);
 }
 
 } // anonymous namespace

--- a/src/cpp/session/modules/tex/SessionSynctex.cpp
+++ b/src/cpp/session/modules/tex/SessionSynctex.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionSynctex.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -52,7 +52,7 @@ json::Value toJson(const FilePath& pdfFile,
       pdfJson["width"] = pdfLoc.width();
       pdfJson["height"] = pdfLoc.height();
       pdfJson["from_click"] = fromClick;
-      return pdfJson;
+      return std::move(pdfJson);
    }
    else
    {
@@ -68,7 +68,7 @@ json::Value toJson(const core::tex::SourceLocation& srcLoc)
       srcJson["file"] = module_context::createAliasedPath(srcLoc.file());
       srcJson["line"] = srcLoc.line();
       srcJson["column"] = srcLoc.column();
-      return srcJson;
+      return std::move(srcJson);
    }
    else
    {


### PR DESCRIPTION
- triggered by the pattern of returning a `json::Object` from a method declared to return `json::Value`
- because the types don't match (Object is a subclass of Value), RVO is not applied so use `std::move` to suggest move semantics