### PR TITLE
Add explicit CSRF validation to all session RPCs

### DIFF
--- a/src/cpp/core/http/CSRFToken.cpp
+++ b/src/cpp/core/http/CSRFToken.cpp
@@ -22,8 +22,6 @@
 
 #include <core/system/System.hpp>
 
-#define kCSRFTokenName "csrf-token"
-
 using namespace rstudio::core;
 
 namespace rstudio {
@@ -43,7 +41,7 @@ void setCSRFTokenCookie(const http::Request& request,
    // generate CSRF token cookie
    http::Cookie cookie(
             request, 
-            kCSRFTokenName, 
+            kCSRFTokenCookie, 
             csrfToken, 
             "/",  // cookie for root path
             true, // HTTP only
@@ -61,13 +59,13 @@ bool validateCSRFForm(const http::Request& request,
                       http::Response* pResponse)
 {
    // extract token from HTTP cookie (set above)
-   std::string headerToken = request.cookieValue(kCSRFTokenName);
+   std::string headerToken = request.cookieValue(kCSRFTokenCookie);
    http::Fields fields;
 
    // parse the form and check for a matching token
    http::util::parseForm(request.body(), &fields);
    std::string bodyToken = http::util::fieldValue<std::string>(fields,
-         kCSRFTokenName, "");
+         kCSRFTokenCookie, "");
 
    // report an error if they don't match
    if (headerToken.empty() || bodyToken != headerToken) 

--- a/src/cpp/core/http/CSRFToken.cpp
+++ b/src/cpp/core/http/CSRFToken.cpp
@@ -79,6 +79,17 @@ bool validateCSRFForm(const http::Request& request,
    return true;
 }
 
+bool validateCSRFHeaders(const http::Request& request)
+{
+   std::string headerToken = request.headerValue(kCSRFTokenHeader);
+   std::string cookieToken = request.cookieValue(kCSRFTokenCookie);
+   if (headerToken.empty() || headerToken != cookieToken)
+   {
+      return false;
+   }
+   return true;
+}
+
 } // namespace http
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/include/core/http/CSRFToken.hpp
+++ b/src/cpp/core/include/core/http/CSRFToken.hpp
@@ -38,6 +38,10 @@ void setCSRFTokenCookie(const Request& request,
 // a valid CSRF token.
 bool validateCSRFForm(const Request&, Response*);
 
+// Validates any other HTTP request by ensuring that the CSRF HTTP header matches the accompanying
+// token cookie.
+bool validateCSRFHeaders(const Request& request);
+
 } // namespace http
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/include/core/http/CSRFToken.hpp
+++ b/src/cpp/core/include/core/http/CSRFToken.hpp
@@ -20,6 +20,9 @@
 #include <boost/optional.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
+#define kCSRFTokenHeader "X-CSRF-Token"
+#define kCSRFTokenCookie "csrf-token"
+
 namespace rstudio {
 namespace core {
 namespace http {

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -54,6 +54,7 @@
 #include <core/http/Request.hpp>
 #include <core/http/Response.hpp>
 #include <core/http/Cookie.hpp>
+#include <core/http/CSRFToken.hpp>
 #include <core/system/Environment.hpp>
 
 #include <session/SessionConsoleProcess.hpp>
@@ -136,6 +137,14 @@ void handleClientInit(const boost::function<void()>& initFunction,
    // alias options
    Options& options = session::options();
    
+   // check for valid CSRF headers in server mode 
+   if (options.programMode() == kSessionProgramModeServer && 
+       !core::http::validateCSRFHeaders(ptrConnection->request()))
+   {
+      ptrConnection->sendJsonRpcError(Error(json::errc::Unauthorized, ERROR_LOCATION));
+      return;
+   }
+
    // calculate initialization parameters
    std::string clientId = persistentState().newActiveClientId();
    bool resumed = suspend::sessionResumed() || init::isSessionInitialized();


### PR DESCRIPTION
Currently, session RPCs have implicit CSRF validation via client ID validation. This change adds additional explicit validation. 

Fixes https://github.com/rstudio/rstudio-pro/issues/865; see that issue for further details. 