### PR TITLE
upgrade to openssl 1.1.1b for Windows

### DIFF
--- a/dependencies/windows/Install-RStudio-Prereqs.ps1
+++ b/dependencies/windows/Install-RStudio-Prereqs.ps1
@@ -74,6 +74,7 @@ choco install -y windows-sdk-10.1 --version 10.1.17134.12
 choco install -y visualstudio2017buildtools --version 15.8.2.0
 choco install -y visualstudio2017-workload-vctools --version 1.3.0
 choco install -y nsis
+choco install -y activeperl
 
 # cpack (an alias from chocolatey) and cmake's cpack conflict.
 Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe'

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -17,7 +17,7 @@ set MSYS_SSH_FILE=msys-ssh-1000-18.zip
 set SUMATRA_PDF_FILE=SumatraPDF-3.1.1.zip
 set WINUTILS_FILE=winutils-1.0.zip
 set WINPTY_FILES=winpty-0.4.3-msys2-2.7.0.zip
-set OPENSSL_FILES=openssl-1.0.2p.zip
+set OPENSSL_FILES=openssl-1.1.1b.zip
 set BOOST_FILES=boost-1.69.0-win-msvc141.zip
 
 set PANDOC_VERSION=2.6

--- a/dependencies/windows/install-openssl/install-openssl.R
+++ b/dependencies/windows/install-openssl/install-openssl.R
@@ -1,5 +1,5 @@
 OWD <- getwd()
-URL <- "https://www.openssl.org/source/openssl-1.0.2p.tar.gz"
+URL <- "https://www.openssl.org/source/openssl-1.1.1b.tar.gz"
 NAME <- sub(".tar.gz$", "", basename(URL))
 
 source("../tools.R")
@@ -9,12 +9,13 @@ options(log.dir = normalizePath("logs", winslash = "/"))
 # try to find a perl installation directory
 perl <- head(Filter(file.exists, c("C:/Perl64/bin", "C:/Perl/bin")), n = 1)
 if (length(perl) == 0)
-   fatal("No perl installation detected (please install ActiveState Perl from https://www.activestate.com/activeperl/downloads)")
+   fatal("No perl installation detected (please install ActiveState Perl via 'choco install activeperl')")
 
 # try to find MSVC 2017
-msvc <- "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build"
-if (!file.exists(msvc))
-   fatal("No MSVC 2017 installation detected (please install Visual Studio 2017)")
+msvc <- head(Filter(file.exists, c("C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build",
+                                   "C:/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/VC/Auxiliary/Build")), n = 1)
+if (length(msvc) == 0)
+   fatal("No MSVC 2017 installation detected (please install Visual Studio 2017 using 'Install-RStudio-Prereqs.ps1')")
 
 PATH$prepend("../tools")
 PATH$prepend(msvc)
@@ -36,42 +37,18 @@ xcopy <- function(src, dst) {
    exec("cmd.exe", "/C", shQuote(cmd))
 }
 
-OPTS <- "no-asm no-shared -DUNICODE -D_UNICODE --prefix=build"
-
-section("Building OpenSSL 32bit (Debug)")
-TARGET <- sprintf("build-%s-debug-32", NAME)
-unlink(TARGET, recursive = TRUE)
-xcopy(NAME, TARGET)
-setwd(TARGET)
-exec("vcvarsall.bat", "x86 && perl Configure debug-VC-WIN32 -d", OPTS)
-exec("vcvarsall.bat", "x86 && ms\\do_ms.bat")
-exec("vcvarsall.bat", "x86 && nmake -f ms\\nt.mak")
-exec("vcvarsall.bat", "x86 && nmake -f ms\\nt.mak test")
-exec("vcvarsall.bat", "x86 && nmake -f ms\\nt.mak install")
-setwd("..")
-
 section("Building OpenSSL 64bit (Debug)")
 TARGET <- sprintf("build-%s-debug-64", NAME)
 unlink(TARGET, recursive = TRUE)
 xcopy(NAME, TARGET)
 setwd(TARGET)
+prefix <- file.path(getwd(), "build")
+openssldir <- file.path(prefix, "SSL")
+OPTS <- paste("no-asm no-shared -DUNICODE -D_UNICODE --prefix=", prefix, " --openssldir=", openssldir, sep = "")
 exec("vcvarsall.bat", "amd64 && perl Configure debug-VC-WIN64A -d", OPTS)
-exec("vcvarsall.bat", "amd64 && ms\\do_win64a.bat")
-exec("vcvarsall.bat", "amd64 && nmake -f ms\\nt.mak")
-exec("vcvarsall.bat", "amd64 && nmake -f ms\\nt.mak test")
-exec("vcvarsall.bat", "amd64 && nmake -f ms\\nt.mak install")
-setwd("..")
-
-section("Building OpenSSL 32bit (Release)")
-TARGET <- sprintf("build-%s-release-32", NAME)
-unlink(TARGET, recursive = TRUE)
-xcopy(NAME, TARGET)
-setwd(TARGET)
-exec("vcvarsall.bat", "x86 && perl Configure VC-WIN32", OPTS)
-exec("vcvarsall.bat", "x86 && ms\\do_ms.bat")
-exec("vcvarsall.bat", "x86 && nmake -f ms\\nt.mak")
-exec("vcvarsall.bat", "x86 && nmake -f ms\\nt.mak test")
-exec("vcvarsall.bat", "x86 && nmake -f ms\\nt.mak install")
+exec("vcvarsall.bat", "amd64 && nmake")
+exec("vcvarsall.bat", "amd64 && nmake test")
+exec("vcvarsall.bat", "amd64 && nmake install")
 setwd("..")
 
 section("Building OpenSSL 64bit (Release)")
@@ -79,11 +56,13 @@ TARGET <- sprintf("build-%s-release-64", NAME)
 unlink(TARGET, recursive = TRUE)
 xcopy(NAME, TARGET)
 setwd(TARGET)
+prefix <- file.path(getwd(), "build")
+openssldir <- file.path(prefix, "SSL")
+OPTS <- paste("no-asm no-shared -DUNICODE -D_UNICODE --prefix=", prefix, " --openssldir=", openssldir, sep = "")
 exec("vcvarsall.bat", "amd64 && perl Configure VC-WIN64A", OPTS)
-exec("vcvarsall.bat", "amd64 && ms\\do_win64a.bat")
-exec("vcvarsall.bat", "amd64 && nmake -f ms\\nt.mak")
-exec("vcvarsall.bat", "amd64 && nmake -f ms\\nt.mak test")
-exec("vcvarsall.bat", "amd64 && nmake -f ms\\nt.mak install")
+exec("vcvarsall.bat", "amd64 && nmake")
+exec("vcvarsall.bat", "amd64 && nmake test")
+exec("vcvarsall.bat", "amd64 && nmake install")
 setwd("..")
 
 section("Building redistributible")

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # CMakeLists.txt
 #
-# Copyright (C) 2009-18 by RStudio, Inc.
+# Copyright (C) 2009-19 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -350,12 +350,12 @@ if(WIN32)
      endif()
 
      set(OPENSSL_BITNESS "64")
-     set(OPENSSL_NAME "openssl-1.0.2p")
+     set(OPENSSL_NAME "openssl-1.1.1b")
      set(OPENSSL_ROOT_DIR "${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/${OPENSSL_NAME}/${OPENSSL_NAME}-${OPENSSL_BUILD_TYPE}-${OPENSSL_BITNESS}")
      set(OPENSSL_INCLUDE_DIR "${OPENSSL_ROOT_DIR}/include")
      set(OPENSSL_LIBRARY_DIR "${OPENSSL_ROOT_DIR}/lib")
-     set(OPENSSL_CRYPTO_LIBRARY "${OPENSSL_LIBRARY_DIR}/libeay32.lib")
-     set(OPENSSL_SSL_LIBRARY "${OPENSSL_LIBRARY_DIR}/ssleay32.lib")
+     set(OPENSSL_CRYPTO_LIBRARY "${OPENSSL_LIBRARY_DIR}/libcrypto.lib")
+     set(OPENSSL_SSL_LIBRARY "${OPENSSL_LIBRARY_DIR}/libssl.lib")
      list(APPEND OPENSSL_LIBRARIES "${OPENSSL_CRYPTO_LIBRARY}")
      list(APPEND OPENSSL_LIBRARIES "${OPENSSL_SSL_LIBRARY}")
 

--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # CMakeLists.txt
 #
-# Copyright (C) 2009-18 by RStudio, Inc.
+# Copyright (C) 2009-19 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -279,6 +279,7 @@ else()
       RpcRT4
       ShLwApi
       AdvAPI32
+      Crypt32
       ${OPENSSL_LIBRARIES}
    )
 

--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -388,7 +388,7 @@ if(NOT APPLE)
 
    # extra dependencies for Windows
    if(WIN32)
-      target_link_libraries(rstudio Version)
+      target_link_libraries(rstudio Version Crypt32)
    endif()
 
 # for OSX we create a bundle

--- a/src/cpp/desktop/synctex/rsinverse/CMakeLists.txt
+++ b/src/cpp/desktop/synctex/rsinverse/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # CMakeLists.txt
 #
-# Copyright (C) 2009-11 by RStudio, Inc.
+# Copyright (C) 2009-19 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -55,5 +55,11 @@ add_executable(rsinverse
 target_link_libraries(rsinverse
    rstudio-core
 )
+
+if(WIN32)
+   target_link_libraries(rsinverse
+      Crypt32
+   )
+endif()
 
 install(TARGETS rsinverse DESTINATION ${RSTUDIO_INSTALL_BIN})

--- a/src/cpp/desktop/urlopener/CMakeLists.txt
+++ b/src/cpp/desktop/urlopener/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # CMakeLists.txt
 #
-# Copyright (C) 2009-11 by RStudio, Inc.
+# Copyright (C) 2009-19 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -56,5 +56,11 @@ add_executable(urlopener
 target_link_libraries(urlopener
    rstudio-core
 )
+
+if(WIN32)
+   target_link_libraries(urlopener
+      Crypt32
+   )
+endif()
 
 install(TARGETS urlopener DESTINATION ${RSTUDIO_INSTALL_BIN})


### PR DESCRIPTION
My main motivation was to get rid of the hundreds of PDB-related warnings when building (openssl made fixes for this in the 1.1+ series). Plus, probably good to have linked with more complete PDB info for our new crash reporting system.

It's also good to be on a recent openssl build (1.1.1 is the current LTS, supported until 2023, whereas the version we are currently using goes out of support later this year).

I tweaked the build script, rebuilt and uploaded to S3, and made necessary cmake changes.

Note that building 1.1.1 requires a qualified path for the `--prefix`, and requires specifying `--openssldir` (which used to default to a path based on the prefix). Also, newer openssl introduces a dependency on system crypt32.

Developers will need to re-run `install-dependencies.cmd` to pull down the new openssl on dev boxes. This doesn't require a docker-image rebuilt (thankfully).

For testing I did builds (debug and release-with-debug-info) and confirmed I could run them. Not sure what additional testing is important for exercising openssl.