### PR TITLE
validate we have a 'real' environment before listEnv

### DIFF
--- a/src/cpp/session/modules/environment/EnvironmentMonitor.cpp
+++ b/src/cpp/session/modules/environment/EnvironmentMonitor.cpp
@@ -114,11 +114,15 @@ SEXP EnvironmentMonitor::getMonitoredEnvironment()
 
 bool EnvironmentMonitor::hasEnvironment()
 {
-   return getMonitoredEnvironment() != NULL;
+   SEXP envir = getMonitoredEnvironment();
+   return envir != nullptr && r::sexp::isPrimitiveEnvironment(envir);
 }
 
 void EnvironmentMonitor::listEnv(std::vector<r::sexp::Variable>* pEnv)
 {
+   if (!hasEnvironment())
+      return;
+
    r::sexp::Protect rProtect;
    r::sexp::listEnvironment(getMonitoredEnvironment(),
                             false,

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -396,12 +396,11 @@ json::Array environmentListAsJson()
     if (s_pEnvironmentMonitor->hasEnvironment())
     {
        SEXP env = s_pEnvironmentMonitor->getMonitoredEnvironment();
-       if (env != NULL)
-          listEnvironment(env,
-                          false,
-                          userSettings().showLastDotValue(),
-                          &rProtect,
-                          &vars);
+       listEnvironment(env,
+                       false,
+                       userSettings().showLastDotValue(),
+                       &rProtect,
+                       &vars);
 
        // get object details and transform to json
        std::transform(vars.begin(),


### PR DESCRIPTION
This PR fixes an issue where the RStudio UI could fail to load if the user `.Rprofile` opened an R debugger. It appears that `getMonitoredEnvironment()` can, in some occasions, return `R_NilValue` (as opposed to a regular C `NULL`) which we weren't properly handling. Since we attempt to list the monitored environment on client init, if that failed due to an R error, it would inhibit RStudio launch.

I'm not exactly sure what changed to cause this to be an error, but I think the extra safety checks are safe.

Closes https://github.com/rstudio/rstudio/issues/4443.