### PR TITLE
In Firefox, ignore disconnect event during reload

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/SatelliteFramePanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SatelliteFramePanel.java
@@ -49,6 +49,11 @@ public abstract class SatelliteFramePanel <T extends RStudioFrame>
    
    protected void showUrl(String url, boolean removeToolbar)
    {
+      showUrl(url, false, null);
+   }
+
+   protected void showUrl(String url, boolean removeToolbar, LoadHandler onLoad)
+   {
       if (appFrame_ != null)
       {
          // first set the frame to about:blank so that the 
@@ -72,6 +77,12 @@ public abstract class SatelliteFramePanel <T extends RStudioFrame>
       rootPanel_.add(glassPanel_);
       rootPanel_.setWidgetLeftRight(glassPanel_,  0, Unit.PX, 0, Unit.PX);
       rootPanel_.setWidgetTopBottom(glassPanel_, widgetTop, Unit.PX, 0, Unit.PX);
+
+      if (onLoad != null)
+      {
+         // run supplied load handler if present
+         appFrame_.addLoadHandler(onLoad);
+      }
    }
    
    protected T getFrame()

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ui/ShinyApplicationPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ui/ShinyApplicationPanel.java
@@ -1,7 +1,7 @@
 /*
  * ShinyApplicationPanel.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.shiny.ui;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.dom.client.LoadHandler;
 import com.google.gwt.user.client.ui.Label;
 import com.google.inject.Inject;
 
@@ -74,7 +75,7 @@ public class ShinyApplicationPanel extends SatelliteFramePanel<RStudioFrame>
    }
    
    @Override
-   public void showApp(ShinyApplicationParams params)
+   public void showApp(ShinyApplicationParams params, LoadHandler handler)
    {
       appParams_ = params;
       publishButton_.setShinyPreview(params);
@@ -88,7 +89,7 @@ public class ShinyApplicationPanel extends SatelliteFramePanel<RStudioFrame>
 
       boolean removeTolbar = (appParams_.getViewerOptions() & ShinyViewerOptions.SHINY_VIEWER_OPTIONS_NOTOOLS) > 0;
 
-      showUrl(url, removeTolbar);
+      showUrl(url, removeTolbar, handler);
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
@@ -1,7 +1,7 @@
 /*
  * ViewerPane.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * This program is licensed to you under the terms of version 3 of the
  * GNU Affero General Public License. This program is distributed WITHOUT
@@ -12,6 +12,8 @@
  */
 package org.rstudio.studio.client.workbench.views.viewer;
 
+import com.google.gwt.event.dom.client.LoadHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
@@ -243,6 +245,13 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
          frame_.setUrl(url);
    }
    
+
+   @Override
+   public HandlerRegistration addLoadHandler(LoadHandler handler)
+   {
+      return frame_.addLoadHandler(handler);
+   }
+
    @Override
    public Size getViewerFrameSize()
    {


### PR DESCRIPTION
Currently, the _Reload App_ button for Shiny applications does not work in Firefox. 

This is because, unlike Chrome, Firefox allows Shiny to broadcast its `disconnected` PostMessage when it is being torn down during a reload, and RStudio responds to this message by treating the app as stopped.

The fix is to ignore the `disconnected` PostMessage during a reload, which we do by suppressing the notification (for that specific app URL only) from the time that the reload is initiated until the frame hosting the app has loaded.

Will be backported to 1.2-patch.

Fixes https://github.com/rstudio/rstudio/issues/4527.