### PR TITLE
eliminate another 150 or so Windows build warnings in third-party code

### DIFF
--- a/src/cpp/core/spelling/hunspell/CMakeLists.txt
+++ b/src/cpp/core/spelling/hunspell/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # CMakeLists.txt
 #
-# Copyright (C) 2009-11 by RStudio, Inc.
+# Copyright (C) 2009-19 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -22,6 +22,12 @@ if(NOT MSVC)
    add_definitions(-w)
 endif()
 add_definitions(-DHUNSPELL_STATIC)
+
+if(MSVC)
+  # disable C4267 warning (typical example is assigning size_t to int)
+  # we don't want to try fixing these in this third-party code
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267")
+endif()
 
 # include files
 file(GLOB_RECURSE CORE_HUNSPELL_HEADER_FILES "*.h*")

--- a/src/cpp/core/tex/synctex/CMakeLists.txt
+++ b/src/cpp/core/tex/synctex/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # CMakeLists.txt
 #
-# Copyright (C) 2009-11 by RStudio, Inc.
+# Copyright (C) 2009-19 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -17,6 +17,19 @@ project (SYNCTEX)
 
 # include files
 file(GLOB_RECURSE SYNCTEX_HEADER_FILES "*.h*")
+
+if(MSVC)
+  # disable noisy warnings; third-party code we try to avoid changing
+
+  # C4267: assigning size_t to int
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4267")
+
+  # C4244: possible loss of data such as assigning double to float
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4244")
+
+  # C4018: comparing signed and unsigned integers
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4018")
+endif()
 
 # source files
 set(SYNCTEX_SOURCE_FILES

--- a/src/cpp/core/zlib/CMakeLists.txt
+++ b/src/cpp/core/zlib/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # CMakeLists.txt
 #
-# Copyright (C) 2009-11 by RStudio, Inc.
+# Copyright (C) 2009-19 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -28,6 +28,12 @@ include(CheckCSourceCompiles)
 
 # disable gcc visiblity attribute (not supported by some mingw versinos)
 set(EXTRA_COMPILE_DEFINITIONS "NO_VIZ")
+
+if(MSVC)
+  # disable noisy warnings; third-party code we try to avoid changing
+  # C4013: using undefined function (assumes extern returning int)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4013")
+endif()
 
 # add largefile support if we can
 check_type_size(off64_t OFF64_T)


### PR DESCRIPTION
Crusty old C and C++ third-party code we use; don't want to muck around with it directly, so just turn off the noisy warnings.