### PR TITLE
Fix an issue importing themes without names.

### DIFF
--- a/src/cpp/session/modules/SessionThemes.cpp
+++ b/src/cpp/session/modules/SessionThemes.cpp
@@ -150,14 +150,14 @@ void getThemesInLocation(
             themeIFStream.close();
 
             boost::smatch matches;
-            boost::regex_search(
+            bool found = boost::regex_search(
                themeContents,
                matches,
                boost::regex("rs-theme-name\\s*:\\s*([^\\*]+?)\\s*(?:\\*|$)"));
 
             // If there's no name specified,use the name of the file
             std::string name;
-            if ((matches.size() < 2) || (!matches[0].matched) || (matches[1] == ""))
+            if (!found || (matches.size() < 2) || (matches[1] == ""))
             {
                name = themeFile.stem();
             }
@@ -168,13 +168,13 @@ void getThemesInLocation(
             }
 
             // Find out if the theme is dark or not.
-            boost::regex_search(
+            found = boost::regex_search(
                      themeContents,
                      matches,
                      boost::regex("rs-theme-is-dark\\s*:\\s*([^\\*]+?)\\s*(?:\\*|$)"));
 
             bool isDark = false;
-            if (matches.size() >= 2)
+            if (found && (matches.size() >= 2))
             {
                try
                {

--- a/src/cpp/session/modules/SessionThemes.cpp
+++ b/src/cpp/session/modules/SessionThemes.cpp
@@ -157,7 +157,7 @@ void getThemesInLocation(
 
             // If there's no name specified,use the name of the file
             std::string name;
-            if (matches.size() < 2)
+            if ((matches.size() < 2) || (!matches[0].matched) || (matches[1] == ""))
             {
                name = themeFile.stem();
             }


### PR DESCRIPTION
Fixes #4553.

When the theme had no "name" comment, `boost::regex_search` still returned 4 sub_matches. The first had `matched == false`. Since the first element of a `boost::smatch` is the status of the full regex match, we check that value and ignore the rest if it's false. Additionally, this code should now handle when the name comment exists, but the name is empty as well.