### PR TITLE
make open-source and Pro dockerfiles the same

### DIFF
--- a/docker/jenkins/Dockerfile.bionic-amd64
+++ b/docker/jenkins/Dockerfile.bionic-amd64
@@ -39,6 +39,7 @@ RUN apt-get update && \
     libegl1-mesa \
     libpam-dev \
     libpango1.0-dev \
+    libuser1-dev \
     libssl-dev \
     libxslt1-dev \
     lsof \

--- a/docker/jenkins/Dockerfile.centos6-x86_64
+++ b/docker/jenkins/Dockerfile.centos6-x86_64
@@ -31,7 +31,8 @@ RUN yum install -y \
     sudo \
     wget \
     xml-commons-apis \
-    zlib-devel
+    zlib-devel \
+    libuser-devel
 
 # update gcc for C++11 support
 RUN wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo

--- a/docker/jenkins/Dockerfile.centos7-x86_64
+++ b/docker/jenkins/Dockerfile.centos7-x86_64
@@ -18,6 +18,8 @@ RUN yum install -y \
     java-1.8.0-openjdk \
     java-1.8.0-openjdk-devel \
     libcurl-devel \
+    libacl-devel \
+    libcap-devel \ 
     libffi \
     libuuid-devel \
     libXcursor-devel \
@@ -37,7 +39,8 @@ RUN yum install -y \
     sudo \
     wget \
     xml-commons-apis \
-    zlib-devel
+    zlib-devel \
+    libuser-devel
 
 # add scl repo and install additional dependencies
 RUN yum install -y \

--- a/docker/jenkins/Dockerfile.debian9-x86_64
+++ b/docker/jenkins/Dockerfile.debian9-x86_64
@@ -43,7 +43,9 @@ RUN apt-get update -y && apt-get install -y \
     libcap-dev \
     libacl1-dev \
     lsof \
-    python
+    python \
+    libuser1-dev \
+    libglib2.0-dev
 
 ## run install-boost twice - boost exits 1 even though it has installed good enough for our uses.
 ## https://github.com/rstudio/rstudio/blob/master/vagrant/provision-primary-user.sh#L12-L15

--- a/docker/jenkins/Dockerfile.opensuse-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse-x86_64
@@ -34,7 +34,8 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     unzip \
     wget \
     xml-commons-apis \
-    zlib-devel
+    zlib-devel \
+    libuser-devel
 
 ## run install-boost twice - boost exits 1 even though it has installed good enough for our uses.
 ## https://github.com/rstudio/rstudio/blob/master/vagrant/provision-primary-user.sh#L12-L15

--- a/docker/jenkins/Dockerfile.trusty-amd64
+++ b/docker/jenkins/Dockerfile.trusty-amd64
@@ -46,7 +46,9 @@ RUN apt-get update && \
     unzip \
     uuid-dev \
     wget \
-    zlib1g-dev
+    zlib1g-dev \
+    libuser1-dev \
+    libglib2.0-dev
 
 # ensure we use the java 8 compiler
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java


### PR DESCRIPTION
Noticed while doing file-diffs across open-source and pro that the dockerfiles are slightly different. 

Additional dependencies are installed for Pro, but it seems unnecessarily complex to have these files be different just to save installing a couple packages.

Also, added what is needed to Dockerfile.centos7 to build server (pro), not just desktop. In case we need to do that eventually.