### PR TITLE
replace BOOST_FOREACH with native C++ range-based for loops

### DIFF
--- a/src/cpp/core/DateTime.cpp
+++ b/src/cpp/core/DateTime.cpp
@@ -1,7 +1,7 @@
 /*
  * DateTime.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,7 +17,6 @@
 
 #include "boost/date_time/c_local_time_adjustor.hpp"
 #include <boost/date_time/local_time/local_time.hpp>
-#include <boost/foreach.hpp>
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/file_lock/LinkBasedFileLock.cpp
+++ b/src/cpp/core/file_lock/LinkBasedFileLock.cpp
@@ -40,7 +40,6 @@
 #include <core/system/Process.hpp>
 #include <core/system/System.hpp>
 
-#include <boost/foreach.hpp>
 #include <boost/system/error_code.hpp>
 
 #define LOG(__X__)                                                             \
@@ -176,8 +175,8 @@ void cleanStaleLockfiles(const FilePath& dir)
    Error error = dir.children(&children);
    if (error)
       LOG_ERROR(error);
-   
-   BOOST_FOREACH(const FilePath& filePath, children)
+
+   for (const FilePath& filePath : children )
    {
       if (boost::algorithm::starts_with(filePath.filename(), kFileLockPrefix) &&
           isLockFileStale(filePath))
@@ -215,7 +214,7 @@ public:
    {
       LOCK_MUTEX(mutex_)
       {
-         BOOST_FOREACH(const FilePath& lockFilePath, registration_)
+         for (const FilePath& lockFilePath : registration_)
          {
             LOG("Bumping write time: " << lockFilePath.absolutePath());
             lockFilePath.setLastWriteTime();
@@ -228,7 +227,7 @@ public:
    {
       LOCK_MUTEX(mutex_)
       {
-         BOOST_FOREACH(const FilePath& lockFilePath, registration_)
+         for (const FilePath& lockFilePath : registration_)
          {
             Error error = lockFilePath.removeIfExists();
             if (error)

--- a/src/cpp/core/gwt/GwtLogHandler.cpp
+++ b/src/cpp/core/gwt/GwtLogHandler.cpp
@@ -16,7 +16,6 @@
 #include <core/gwt/GwtLogHandler.hpp>
 
 #include <boost/format.hpp>
-#include <boost/foreach.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
@@ -57,7 +56,7 @@ Error parseClientException(const json::Object exJson, ClientException* pEx)
    if (error)
        return error;
 
-   BOOST_FOREACH(const json::Value& elementJson, stackJson)
+   for (const json::Value& elementJson : stackJson)
    {
       if (!json::isType<json::Object>(elementJson))
          return Error(json::errc::ParamTypeMismatch, ERROR_LOCATION);
@@ -142,7 +141,7 @@ void handleLogExceptionRequest(const std::string& username,
    // build the log message
    bool printFrame = false;
    std::ostringstream ostr;
-   BOOST_FOREACH(const StackElement& element, stack)
+   for (const StackElement& element : stack)
    {
       // skip past java/lang/Exception entries
       if (!printFrame)

--- a/src/cpp/core/gwt/GwtSymbolMaps.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMaps.cpp
@@ -1,7 +1,7 @@
 /*
  * GwtSymbolMaps.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -21,7 +21,6 @@
 #include <algorithm>
 
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 #include <boost/regex.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/predicate.hpp>
@@ -105,7 +104,7 @@ public:
          }
 
           std::map<std::string,std::string>& map = cache_[strongName];
-          BOOST_FOREACH(const std::string& symbol, symbols)
+          for (const std::string& symbol : symbols)
           {
              std::map<std::string,std::string>::const_iterator it =
                                                          map.find(symbol);
@@ -173,7 +172,7 @@ struct SymbolMaps::Impl
       }
 
       // mark all remaining symbols as having been looked for
-      BOOST_FOREACH(const std::string& symbol, symbolsLeftToFind)
+      for (const std::string& symbol : symbolsLeftToFind)
       {
          toReturn[symbol] = SYMBOL_DATA_UNKNOWN;
       }
@@ -214,7 +213,7 @@ std::vector<StackElement> SymbolMaps::resymbolize(
 {
    // warm the symbol cache
    std::set<std::string> requiredSymbols;
-   BOOST_FOREACH(const StackElement& stackElement, stack)
+   for (const StackElement& stackElement : stack)
    {
       requiredSymbols.insert(stackElement.methodName);
    }
@@ -222,7 +221,7 @@ std::vector<StackElement> SymbolMaps::resymbolize(
 
    // perform the resymbolization
    std::vector<StackElement> resymbolizedStack;
-   BOOST_FOREACH(const StackElement& se, stack)
+   for (const StackElement& se : stack)
    {
       resymbolizedStack.push_back(resymbolize(se, strongName));
    }

--- a/src/cpp/core/include/core/http/AsyncClient.hpp
+++ b/src/cpp/core/include/core/http/AsyncClient.hpp
@@ -1,7 +1,7 @@
 /*
  * AsyncClient.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,7 +16,6 @@
 #ifndef CORE_HTTP_ASYNC_CLIENT_HPP
 #define CORE_HTTP_ASYNC_CLIENT_HPP
 
-#include <boost/foreach.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/function.hpp>
 #include <boost/enable_shared_from_this.hpp>

--- a/src/cpp/core/include/core/http/AsyncServerImpl.hpp
+++ b/src/cpp/core/include/core/http/AsyncServerImpl.hpp
@@ -1,7 +1,7 @@
 /*
  * AsyncServerImpl.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -21,7 +21,6 @@
 #include <boost/utility.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/function.hpp>
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string.hpp>
 
 #include <boost/asio/io_service.hpp>

--- a/src/cpp/core/include/core/r_util/RSourceIndex.hpp
+++ b/src/cpp/core/include/core/r_util/RSourceIndex.hpp
@@ -1,7 +1,7 @@
 /*
  * RSourceIndex.hpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -23,7 +23,6 @@
 #include <boost/function.hpp>
 #include <boost/utility.hpp>
 #include <boost/regex.hpp>
-#include <boost/foreach.hpp>
 #include <boost/range/adaptors.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
@@ -275,7 +274,7 @@ private:
    const RSourceItem& get(const std::string& name,
                           const RSourceItem::Type type = RSourceItem::Function)
    {
-      BOOST_FOREACH(const RSourceItem& item, items_)
+      for (const RSourceItem& item : items_)
       {
          if (item.name() == name && item.type() == type)
             return item;
@@ -395,7 +394,7 @@ public:
    static void setImportFromDirectives(const ImportFromMap& map)
    {
       s_importFromDirectives_ = map;
-      BOOST_FOREACH(const std::string& pkg, map | boost::adaptors::map_keys)
+      for (const std::string& pkg : map | boost::adaptors::map_keys)
       {
          s_allInferredPkgNames_.insert(pkg);
       }

--- a/src/cpp/core/libclang/LibClang.cpp
+++ b/src/cpp/core/libclang/LibClang.cpp
@@ -19,7 +19,6 @@
 #include <vector>
 
 #include <boost/regex.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/Log.hpp>
 #include <core/FilePath.hpp>
@@ -165,7 +164,7 @@ bool LibClang::load(EmbeddedLibrary embedded,
    std::vector<std::string> sysVersions = systemClangVersions();
    versions.insert(versions.end(), sysVersions.begin(), sysVersions.end());
 
-   BOOST_FOREACH(const std::string& version, versions)
+   for (const std::string& version : versions)
    {
       FilePath versionPath(version);
       ostr << versionPath << std::endl;
@@ -584,7 +583,7 @@ LibraryVersion LibClang::version() const
    std::vector<boost::regex> patterns;
    patterns.push_back(boost::regex("LLVM " + verRegex));
    patterns.push_back(boost::regex(verRegex));
-   BOOST_FOREACH(boost::regex re, patterns)
+   for (boost::regex re : patterns)
    {
       boost::smatch match;
       if (regex_utils::search(versionString, match, re))

--- a/src/cpp/core/libclang/SourceIndex.cpp
+++ b/src/cpp/core/libclang/SourceIndex.cpp
@@ -15,8 +15,6 @@
 
 #include <core/libclang/SourceIndex.hpp>
 
-#include <boost/foreach.hpp>
-
 #include <core/FilePath.hpp>
 #include <core/PerformanceTimer.hpp>
 
@@ -141,7 +139,7 @@ std::map<std::string,TranslationUnit>
                            SourceIndex::getIndexedTranslationUnits()
 {
    std::map<std::string,TranslationUnit> units;
-   BOOST_FOREACH(TranslationUnits::value_type& t, translationUnits_)
+   for (TranslationUnits::value_type& t : translationUnits_)
    {
       TranslationUnit unit(t.first, t.second.tu, &unsavedFiles_);
       units.insert(std::make_pair(t.first, unit));

--- a/src/cpp/core/markdown/Markdown.cpp
+++ b/src/cpp/core/markdown/Markdown.cpp
@@ -17,7 +17,6 @@
 
 #include <iostream>
 
-#include <boost/foreach.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/regex.hpp>
 #include <boost/algorithm/string/join.hpp>
@@ -218,7 +217,7 @@ void stripMetadata(std::string* pInput)
 
    // check the first non-empy line for metadata
    bool hasFrontMatter = false, hasPandocTitleBlock = false;
-   BOOST_FOREACH(const std::string& line, lines)
+   for (const std::string& line : lines)
    {
       if (boost::algorithm::trim_copy(line).empty())
       {

--- a/src/cpp/core/markdown/MathJax.cpp
+++ b/src/cpp/core/markdown/MathJax.cpp
@@ -1,7 +1,7 @@
 /*
  * MathJax.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,7 +19,6 @@
 
 #include <boost/bind.hpp>
 #include <boost/function.hpp>
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string.hpp>
 
 #include <core/RegexUtils.hpp>
@@ -57,7 +56,7 @@ MathJaxFilter::MathJaxFilter(const std::vector<html_utils::ExcludePattern>& excl
    {
       // try all of the exclude patterns
       std::vector<TextRange> matchedRanges;
-      BOOST_FOREACH(const html_utils::ExcludePattern& pattern, excludePatterns)
+      for (const html_utils::ExcludePattern& pattern : excludePatterns)
       {
          boost::smatch m;
          if (regex_utils::search(pos, inputEnd, m, pattern.begin))
@@ -115,7 +114,7 @@ MathJaxFilter::MathJaxFilter(const std::vector<html_utils::ExcludePattern>& excl
 
    // now iterate through the ranges and substitute a guid for math blocks
    std::string filteredInput;
-   BOOST_FOREACH(const TextRange& range, ranges)
+   for (const TextRange& range : ranges)
    {
       std::string rangeText(range.begin, range.end);
 

--- a/src/cpp/core/r_util/RActiveSessions.cpp
+++ b/src/cpp/core/r_util/RActiveSessions.cpp
@@ -1,7 +1,7 @@
 /*
  * RActiveSessions.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,7 +16,6 @@
 #include <core/r_util/RActiveSessions.hpp>
 
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
 #include <core/StringUtils.hpp>
@@ -150,7 +149,7 @@ std::vector<boost::shared_ptr<ActiveSession> > ActiveSessions::list(
       return sessions;
    }
    std::string prefix = kSessionDirPrefix;
-   BOOST_FOREACH(const FilePath& child, children)
+   for (const FilePath& child : children)
    {
       if (boost::algorithm::starts_with(child.filename(), prefix))
       {
@@ -225,7 +224,7 @@ GlobalActiveSessions::list() const
       return sessions;
    }
 
-   BOOST_FOREACH(const FilePath& sessionFile, sessionFiles)
+   for (const FilePath& sessionFile : sessionFiles)
    {
       sessions.push_back(boost::shared_ptr<GlobalActiveSession>(new GlobalActiveSession(sessionFile)));
    }

--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -1,7 +1,7 @@
 /*
  * RProjectFile.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,7 +19,6 @@
 #include <iomanip>
 #include <ostream>
 
-#include <boost/foreach.hpp>
 #include <boost/format.hpp>
 #include <boost/regex.hpp>
 
@@ -337,7 +336,7 @@ Error findProjectFile(FilePath filePath,
    for (; filePath.exists(); filePath = filePath.parent())
    {
       // bail if we've hit our anchor
-      BOOST_FOREACH(const FilePath& anchorPath, anchorPaths)
+      for (const FilePath& anchorPath : anchorPaths)
       {
          if (filePath == anchorPath)
             return fileNotFoundError(ERROR_LOCATION);

--- a/src/cpp/core/r_util/RSessionLaunchProfile.cpp
+++ b/src/cpp/core/r_util/RSessionLaunchProfile.cpp
@@ -1,7 +1,7 @@
 /*
  * RSessionLaunchProfile.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,8 +14,6 @@
  */
 
 #include <core/r_util/RSessionLaunchProfile.hpp>
-
-#include <boost/foreach.hpp>
 
 #include <core/SafeConvert.hpp>
 

--- a/src/cpp/core/r_util/RSourceIndex.cpp
+++ b/src/cpp/core/r_util/RSourceIndex.cpp
@@ -1,7 +1,7 @@
 /*
  * RSourceIndex.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -468,7 +468,7 @@ RSourceIndex::RSourceIndex(const std::string& context, const std::string& code)
    do
    {
       status.update(cursor);
-      BOOST_FOREACH(const Indexer& indexer, indexers)
+      for (const Indexer& indexer : indexers)
       {
          indexer(cursor, status, this);
       }

--- a/src/cpp/core/r_util/RTokenizerTests.cpp
+++ b/src/cpp/core/r_util/RTokenizerTests.cpp
@@ -1,7 +1,7 @@
 /*
  * RTokenizerTests.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -18,8 +18,6 @@
 #include <core/r_util/RTokenizer.hpp>
 
 #include <iostream>
-
-#include <boost/foreach.hpp>
 
 #include <tests/TestThat.hpp>
 
@@ -75,7 +73,7 @@ public:
 
    void verify(int tokenType, const std::deque<std::wstring>& values)
    {
-      BOOST_FOREACH(const std::wstring& value, values)
+      for (const std::wstring& value : values)
          verify(tokenType, value);
    }
 

--- a/src/cpp/core/r_util/RToolsInfo.cpp
+++ b/src/cpp/core/r_util/RToolsInfo.cpp
@@ -1,7 +1,7 @@
 /*
  * RToolsInfo.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,7 +16,6 @@
 #include <core/Version.hpp>
 #include <core/r_util/RToolsInfo.hpp>
 
-#include <boost/foreach.hpp>
 #include <boost/format.hpp>
 #include <boost/algorithm/string.hpp>
 
@@ -195,7 +194,7 @@ RToolsInfo::RToolsInfo(const std::string& name,
       boost::format fmt("getRversion() >= \"%1%\" && getRversion() <= \"%2%\"");
       versionPredicate_ = boost::str(fmt % versionMin % versionMax);
 
-      BOOST_FOREACH(const std::string& relativePath, relativePathEntries)
+      for (const std::string& relativePath : relativePathEntries)
       {
          pathEntries_.push_back(installPath_.childPath(relativePath));
       }
@@ -218,11 +217,11 @@ std::ostream& operator<<(std::ostream& os, const RToolsInfo& info)
 {
    os << "Rtools " << info.name() << std::endl;
    os << info.versionPredicate() << std::endl;
-   BOOST_FOREACH(const FilePath& pathEntry, info.pathEntries())
+   for (const FilePath& pathEntry : info.pathEntries())
    {
      os << pathEntry << std::endl;
    }
-   BOOST_FOREACH(const core::system::Option& var, info.environmentVars())
+   for (const core::system::Option& var : info.environmentVars())
    {
       os << var.first << "=" << var.second << std::endl;
    }

--- a/src/cpp/core/r_util/RVersionsPosix.cpp
+++ b/src/cpp/core/r_util/RVersionsPosix.cpp
@@ -1,7 +1,7 @@
 /*
  * RVersionsPosix.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,7 +19,6 @@
 #include <algorithm>
 
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/Algorithm.hpp>
 #include <core/FileSerializer.hpp>
@@ -43,7 +42,7 @@ namespace {
 std::vector<FilePath> realPaths(const std::vector<FilePath>& paths)
 {
    std::vector<FilePath> realPaths;
-   BOOST_FOREACH(const FilePath& path, paths)
+   for (const FilePath& path : paths)
    {
       FilePath realPath;
       Error error = core::system::realPath(path.absolutePath(), &realPath);
@@ -58,7 +57,7 @@ std::vector<FilePath> realPaths(const std::vector<FilePath>& paths)
 std::vector<FilePath> removeNonExistent(const std::vector<FilePath>& paths)
 {
    std::vector<FilePath> filteredPaths;
-   BOOST_FOREACH(const FilePath& path, paths)
+   for (const FilePath& path : paths)
    {
       if (path.exists())
          filteredPaths.push_back(path);
@@ -75,7 +74,7 @@ void scanForRHomePaths(const core::FilePath& rootDir,
       Error error = rootDir.children(&rDirs);
       if (error)
          LOG_ERROR(error);
-      BOOST_FOREACH(const FilePath& rDir, rDirs)
+      for (const FilePath& rDir : rDirs)
       {
          if (rDir.childPath("bin/R").exists())
             pHomePaths->push_back(rDir);
@@ -95,7 +94,7 @@ std::ostream& operator<<(std::ostream& os, const RVersion& version)
 
    os << std::endl;
    os << version.homeDir() << std::endl;
-   BOOST_FOREACH(const core::system::Option& option, version.environment())
+   for (const core::system::Option& option : version.environment())
    {
       os << option.first << "=" << option.second << std::endl;
    }
@@ -139,7 +138,7 @@ std::vector<RVersion> enumerateRVersions(
    // resolve user defined r entries first
    // when duplicates are removed, the default paths
    // that are equivalent to the user defined entries (but which contain less metadata) will be removed
-   BOOST_FOREACH(r_util::RVersion& rEntry, rEntries)
+   for (r_util::RVersion& rEntry : rEntries)
    {
       // compute R script path
       FilePath rScriptPath = rEntry.homeDir().childPath("bin/R");
@@ -172,13 +171,13 @@ std::vector<RVersion> enumerateRVersions(
          core::system::Options mergedEnv;
 
          // set automatically found variables first
-         BOOST_FOREACH(const core::system::Option& option, env)
+         for (const core::system::Option& option : env)
          {
             core::system::setenv(&mergedEnv, option.first, option.second);
          }
 
          // override them with whatever was explicitly set by the user
-         BOOST_FOREACH(const core::system::Option& option, userEnv)
+         for (const core::system::Option& option : userEnv)
          {
             // do not override R_HOME as it was corrected while detecting the environment
             // this is necessary because the user-specified path might be just the root directory
@@ -203,7 +202,7 @@ std::vector<RVersion> enumerateRVersions(
    }
 
    // probe versions
-   BOOST_FOREACH(const FilePath& rHomePath, rHomePaths)
+   for (const FilePath& rHomePath : rHomePaths)
    {
       // compute R script path
       FilePath rScriptPath = rHomePath.childPath("bin/R");
@@ -238,7 +237,7 @@ std::vector<RVersion> enumerateRVersions(
    Error error = rFrameworkVersions.children(&versionPaths);
    if (error)
       LOG_ERROR(error);
-   BOOST_FOREACH(const FilePath& versionPath, versionPaths)
+   for (const FilePath& versionPath : versionPaths)
    {
       if (!versionPath.isHidden() && (versionPath.filename() != "Current"))
       {
@@ -502,7 +501,7 @@ Error validatedReadRVersionsFromFile(const FilePath& filePath,
       return error;
 
    // ensure the home path exists before returning
-   BOOST_FOREACH(const r_util::RVersion& version, versions)
+   for (const r_util::RVersion& version : versions)
    {
       if (version.homeDir().exists())
       {

--- a/src/cpp/core/spelling/HunspellDictionaryManager.cpp
+++ b/src/cpp/core/spelling/HunspellDictionaryManager.cpp
@@ -16,7 +16,6 @@
 #include <core/spelling/HunspellDictionaryManager.hpp>
 
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/Algorithm.hpp>
 

--- a/src/cpp/core/spelling/HunspellSpellingEngine.cpp
+++ b/src/cpp/core/spelling/HunspellSpellingEngine.cpp
@@ -1,7 +1,7 @@
 /*
  * HunspellSpellingEngine.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,7 +15,6 @@
 
 #include <core/spelling/HunspellSpellingEngine.hpp>
 
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string.hpp>
 
 #include <core/Error.hpp>
@@ -243,7 +242,7 @@ private:
       // parse lines for words
       bool added;
       std::string word, affix, example;
-      BOOST_FOREACH(const std::string& line, lines)
+      for (const std::string& line : lines)
       {
          if (parseDicDeltaLine(line, &word, &affix))
          {
@@ -290,7 +289,7 @@ public:
       int ns = pHunspell_->suggest(&wlst,encoded.c_str());
       copyAndFreeHunspellVector(pSug,wlst,ns);
 
-      BOOST_FOREACH(std::string& sug, *pSug)
+      for (std::string& sug : *pSug)
       {
          error = iconvstrFunc_(sug, encoding_, "UTF-8", true, &sug);
          if (error)
@@ -417,7 +416,7 @@ private:
          {
             currentLangId_ = langId;
             currentCustomDicts_ = dictManager_.custom().dictionaries();
-            BOOST_FOREACH(const std::string& dict, currentCustomDicts_)
+            for (const std::string& dict : currentCustomDicts_)
             {
                bool added;
                FilePath dicPath = dictManager_.custom().dictionaryPath(dict);

--- a/src/cpp/core/system/PosixFileScanner.cpp
+++ b/src/cpp/core/system/PosixFileScanner.cpp
@@ -1,7 +1,7 @@
 /*
  * PosixFileScanner.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,8 +17,6 @@
 
 #include <dirent.h>
 #include <sys/stat.h>
-
-#include <boost/foreach.hpp>
 
 #include <core/Error.hpp>
 #include <core/Log.hpp>
@@ -129,7 +127,7 @@ Error scanFiles(const tree<FileInfo>::iterator_base& fromNode,
       return error;
 
    // iterate over the names
-   BOOST_FOREACH(const std::string& name, names)
+   for (const std::string& name : names)
    {
       // compute the path
       std::string path = rootPath.childPath(name).absolutePath();

--- a/src/cpp/core/system/PosixProcess.cpp
+++ b/src/cpp/core/system/PosixProcess.cpp
@@ -1,7 +1,7 @@
 /*
  * PosixProcess.cpp
  *
- * Copyright (C) 2017-18 by RStudio, Inc.
+ * Copyright (C) 2017-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,7 +17,6 @@
 
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/BoostThread.hpp>
 #include <core/Thread.hpp>
@@ -91,7 +90,7 @@ struct AsioProcessSupervisor::Impl
       END_LOCK_MUTEX
 
       // call terminate on all of our children
-      BOOST_FOREACH(const boost::shared_ptr<AsioAsyncChildProcess>& pChild, childCopies)
+      for (const boost::shared_ptr<AsioAsyncChildProcess>& pChild : childCopies)
       {
          if (killChildProcs)
          {

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -21,7 +21,6 @@
 #include <vector>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/foreach.hpp>
 #include <boost/range/as_array.hpp>
 
 #include <signal.h>
@@ -1024,7 +1023,7 @@ std::vector<SubprocInfo> getSubprocessesViaPgrep(PidType pid)
    {
       boost::regex re("^(\\d+)\\s+(.+)");
       std::vector<std::string> lines = algorithm::split(result.stdOut, "\n");
-      BOOST_FOREACH(const std::string& line, lines)
+      for (const std::string& line : lines)
       {
          if (boost::algorithm::trim_copy(line).empty())
          {
@@ -1126,7 +1125,7 @@ std::vector<SubprocInfo> getSubprocessesViaProcFs(PidType pid)
       return subprocs;
    }
 
-   BOOST_FOREACH(const FilePath& child, children)
+   for (const FilePath& child : children)
    {
       // only interested in the numeric directories (pid)
       std::string filename = child.filename();
@@ -1507,7 +1506,7 @@ namespace  {
 
 void toPids(const std::vector<std::string>& lines, std::vector<PidType>* pPids)
 {
-   BOOST_FOREACH(const std::string& line, lines)
+   for (const std::string& line : lines)
    {
       PidType pid = safe_convert::stringTo<PidType>(line, -1);
       if (pid != -1)
@@ -1744,7 +1743,7 @@ Error ProcessInfo::creationTime(boost::posix_time::ptime* pCreationTime) const
    Error error = core::readStringVectorFromFile(FilePath("/proc/stat"), &lines);
    if (error)
       return error;
-   BOOST_FOREACH(const std::string& line, lines)
+   for (const std::string& line : lines)
    {
       if (boost::algorithm::starts_with(line, "btime"))
       {
@@ -1829,7 +1828,7 @@ Error processInfo(const std::string& process, std::vector<ProcessInfo>* pInfo, b
                            result.stdOut,
                            boost::algorithm::is_any_of("\n"));
 
-   BOOST_FOREACH(const std::string& line, lines)
+   for (const std::string& line : lines)
    {
       if (line.empty()) continue;
        
@@ -2292,7 +2291,7 @@ void createProcessTree(const std::vector<ProcessInfo>& processes,
                        ProcessTreeT *pOutTree)
 {
    // first pass, create the nodes in the tree
-   BOOST_FOREACH(const ProcessInfo& process, processes)
+   for (const ProcessInfo& process : processes)
    {
       ProcessTreeT::iterator iter = pOutTree->find(process.pid);
       if (iter == pOutTree->end())
@@ -2308,7 +2307,7 @@ void createProcessTree(const std::vector<ProcessInfo>& processes,
    }
 
    // second pass, link the nodes together
-   BOOST_FOREACH(ProcessTreeT::value_type& element, *pOutTree)
+   for (ProcessTreeT::value_type& element : *pOutTree)
    {
       pid_t parent = element.second->data->ppid;
       ProcessTreeT::iterator iter = pOutTree->find(parent);
@@ -2325,7 +2324,7 @@ void createProcessTree(const std::vector<ProcessInfo>& processes,
 void getChildren(const boost::shared_ptr<ProcessTreeNode>& node,
                  std::vector<ProcessInfo> *pOutChildren)
 {
-   BOOST_FOREACH(const boost::shared_ptr<ProcessTreeNode>& child, node->children)
+   for (const boost::shared_ptr<ProcessTreeNode>& child : node->children)
    {
       pOutChildren->push_back(*child->data.get());
       getChildren(child, pOutChildren);
@@ -2382,7 +2381,7 @@ Error terminateChildProcesses(pid_t pid,
    if (error)
       return error;
 
-   BOOST_FOREACH(const ProcessInfo& process, childProcesses)
+   for (const ProcessInfo& process : childProcesses)
    {
       if (::kill(process.pid, signal) != 0)
       {

--- a/src/cpp/core/system/PosixSystemTests.cpp
+++ b/src/cpp/core/system/PosixSystemTests.cpp
@@ -15,8 +15,6 @@
 
 #ifndef _WIN32
 
-#include <boost/foreach.hpp>
-
 #include <core/system/PosixSystem.hpp>
 #include <signal.h>
 #include <sys/wait.h>
@@ -71,7 +69,7 @@ test_context("PosixSystemTests")
          if (children.size() >= 1)
          {
             bool found = false;
-            BOOST_FOREACH(SubprocInfo info, children)
+            for (SubprocInfo info : children)
             {
                if (info.exe.compare(exe) == 0)
                {
@@ -203,7 +201,7 @@ test_context("PosixSystemTests")
          if (children.size() >= 1)
          {
             bool found = false;
-            BOOST_FOREACH(SubprocInfo info, children)
+            for (SubprocInfo info : children)
             {
                if (info.exe.compare(exe) == 0)
                {

--- a/src/cpp/core/system/Process.cpp
+++ b/src/cpp/core/system/Process.cpp
@@ -1,7 +1,7 @@
 /*
  * Process.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,7 +19,6 @@
 
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/Scope.hpp>
 #include <core/Error.hpp>
@@ -346,8 +345,7 @@ bool ProcessSupervisor::poll()
 void ProcessSupervisor::terminateAll()
 {
    // call terminate on all of our children
-   BOOST_FOREACH(boost::shared_ptr<AsyncChildProcess> pChild,
-                 pImpl_->children)
+   for (boost::shared_ptr<AsyncChildProcess> pChild : pImpl_->children)
    {
       Error error = pChild->terminate();
       if (error)

--- a/src/cpp/core/system/ProcessTests.cpp
+++ b/src/cpp/core/system/ProcessTests.cpp
@@ -1,7 +1,7 @@
 /*
  * ProcessTests.cpp
  *
- * Copyright (C) 2017-18 by RStudio, Inc.
+ * Copyright (C) 2017-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -18,7 +18,6 @@
 #include <atomic>
 
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 #include <boost/thread.hpp>
 
 #include <core/SafeConvert.hpp>

--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -21,7 +21,6 @@
 #include <windows.h>
 #include <Shlwapi.h>
 
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
 #include <core/system/ChildProcess.hpp>
@@ -461,7 +460,7 @@ Error ChildProcess::run()
    if (exeQuot)
       cmdLine.push_back(L'"');
 
-   BOOST_FOREACH(std::string& arg, args_)
+   for (std::string& arg : args_)
    {
       cmdLine.push_back(L' ');
 
@@ -487,7 +486,7 @@ Error ChildProcess::run()
    if (options_.environment)
    {
       const Options& env = options_.environment.get();
-      BOOST_FOREACH(const Option& envVar, env)
+      for (const Option& envVar : env)
       {
          std::wstring key = string_utils::utf8ToWide(envVar.first);
          std::wstring value = string_utils::utf8ToWide(envVar.second);

--- a/src/cpp/core/system/Win32FileScanner.cpp
+++ b/src/cpp/core/system/Win32FileScanner.cpp
@@ -1,7 +1,7 @@
 /*
  * Win32FileScanner.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,7 +15,6 @@
 
 #include <core/system/FileScanner.hpp>
 
-#include <boost/foreach.hpp>
 #include <boost/system/windows_error.hpp>
 
 #include <core/Error.hpp>
@@ -112,7 +111,7 @@ Error scanFiles(const tree<FileInfo>::iterator_base& fromNode,
              fileInfoPathLessThan);
 
    // iterate over entries
-   BOOST_FOREACH(const FileInfo& childFileInfo, childrenFileInfo)
+   for (const FileInfo& childFileInfo : childrenFileInfo)
    {
       // apply filter if we have one
       if (options.filter && !options.filter(childFileInfo))

--- a/src/cpp/core/system/Win32Pty.cpp
+++ b/src/cpp/core/system/Win32Pty.cpp
@@ -1,7 +1,7 @@
 /*
  * Win32Pty.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,8 +14,6 @@
  */
 
 #include "Win32Pty.hpp"
-
-#include <boost/foreach.hpp>
 
 #include <core/Error.hpp>
 #include <core/StringUtils.hpp>
@@ -267,7 +265,7 @@ public:
       if (options.environment)
       {
          const Options& env = options.environment.get();
-         BOOST_FOREACH(const Option& envVar, env)
+         for (const Option& envVar : env)
          {
             std::wstring key = string_utils::utf8ToWide(envVar.first);
             std::wstring value = string_utils::utf8ToWide(envVar.second);
@@ -507,7 +505,7 @@ Error WinPty::runProcess(HANDLE* pProcess)
    // process command line arguments (copy of approach done by non-pseudoterm
    // code path in ChildProcess::run for Win32)
    std::string cmdLine;
-   BOOST_FOREACH(std::string& arg, args_)
+   for (std::string& arg : args_)
    {
       cmdLine.push_back(' ');
 

--- a/src/cpp/core/system/Win32System.cpp
+++ b/src/cpp/core/system/Win32System.cpp
@@ -29,7 +29,6 @@
 #include <tlhelp32.h>
 #include <VersionHelpers.h>
 
-#include <boost/foreach.hpp>
 #include <boost/bind.hpp>
 #include <boost/system/windows_error.hpp>
 #include <boost/lexical_cast.hpp>
@@ -390,7 +389,7 @@ FilePath userHomePath(std::string envOverride)
    sources.push_back(std::make_pair("HOMEDRIVE",
                                     homedriveHomePath));
 
-   BOOST_FOREACH(const HomePathSource& source, sources)
+   for (const HomePathSource& source : sources)
    {
       FilePath homePath = source.second();
       if (!homePath.empty())
@@ -1058,7 +1057,7 @@ void createProcessTree(const std::vector<ProcessInfo>& processes,
                        ProcessTreeT *pOutTree)
 {
    // first pass, create the nodes in the tree
-   BOOST_FOREACH(const ProcessInfo& process, processes)
+   for (const ProcessInfo& process : processes)
    {
       ProcessTreeT::iterator iter = pOutTree->find(process.processId);
       if (iter == pOutTree->end())
@@ -1074,7 +1073,7 @@ void createProcessTree(const std::vector<ProcessInfo>& processes,
    }
 
    // second pass, link the nodes together
-   BOOST_FOREACH(ProcessTreeT::value_type& element, *pOutTree)
+   for (ProcessTreeT::value_type& element : *pOutTree)
    {
       DWORD parent = element.second->data->parentProcessId;
       ProcessTreeT::iterator iter = pOutTree->find(parent);
@@ -1091,7 +1090,7 @@ void createProcessTree(const std::vector<ProcessInfo>& processes,
 void getChildren(const boost::shared_ptr<ProcessTreeNode>& node,
                  std::vector<ProcessInfo> *pOutChildren)
 {
-   BOOST_FOREACH(const boost::shared_ptr<ProcessTreeNode>& child, node->children)
+   for (const boost::shared_ptr<ProcessTreeNode>& child : node->children)
    {
       pOutChildren->push_back(*child->data.get());
       getChildren(child, pOutChildren);
@@ -1160,7 +1159,7 @@ Error terminateChildProcesses()
    if (error)
       return error;
 
-   BOOST_FOREACH(const ProcessInfo& process, childProcesses)
+   for (const ProcessInfo& process : childProcesses)
    {
       HANDLE hChildProc = ::OpenProcess(PROCESS_ALL_ACCESS, FALSE, process.processId);
       if (hChildProc)

--- a/src/cpp/core/system/Win32SystemTests.cpp
+++ b/src/cpp/core/system/Win32SystemTests.cpp
@@ -18,7 +18,6 @@
 #include <core/system/System.hpp>
 #include <core/FilePath.hpp>
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/foreach.hpp>
 
 #define RSTUDIO_NO_TESTTHAT_ALIASES
 #include <tests/TestThat.hpp>
@@ -156,7 +155,7 @@ TEST_CASE("Win32SystemTests")
       if (children.size() >= 1)
       {
          bool found = false;
-         BOOST_FOREACH(SubprocInfo info, children)
+         for (SubprocInfo info : children)
          {
             if (info.exe.compare(exe) == 0)
             {

--- a/src/cpp/core/system/file_monitor/FileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/FileMonitor.cpp
@@ -1,7 +1,7 @@
 /*
  * FileMonitor.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,7 +19,6 @@
 #include <list>
 
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string.hpp>
 
 #include <core/Log.hpp>
@@ -329,7 +328,7 @@ Error discoverAndProcessFileChanges(
 
       // build up actual file changes and mutate the tree as appropriate
       std::vector<FileChangeEvent> fileChanges;
-      BOOST_FOREACH(const FileChangeEvent& fileChange, childrenFileChanges)
+      for (const FileChangeEvent& fileChange : childrenFileChanges)
       {
          switch(fileChange.type())
          {

--- a/src/cpp/core/system/file_monitor/LinuxFileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/LinuxFileMonitor.cpp
@@ -1,7 +1,7 @@
 /*
  * LinuxFileMonitor.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -24,7 +24,6 @@
 #include <set>
 
 #include <boost/utility.hpp>
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
 #include <boost/multi_index_container.hpp>
@@ -359,7 +358,7 @@ Error processEvent(FileEventContext* pContext,
                                      &removeEvents);
 
             // for each directory remove event remove any watches we have for it
-            BOOST_FOREACH(const FileChangeEvent& event, removeEvents)
+            for (const FileChangeEvent& event : removeEvents)
             {
                if (event.fileInfo().isDirectory())
                {
@@ -536,7 +535,7 @@ void run(const boost::function<void()>& checkForInput)
    while(true)
    {
       std::list<void*> contexts = impl::activeEventContexts();
-      BOOST_FOREACH(void* ctx, contexts)
+      for (void* ctx : contexts)
       {
          // cast to context
          FileEventContext* pContext = (FileEventContext*)ctx;

--- a/src/cpp/core/system/file_monitor/MacFileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/MacFileMonitor.cpp
@@ -17,7 +17,6 @@
 
 #include <CoreServices/CoreServices.h>
 
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/classification.hpp>
 

--- a/src/cpp/core/tex/TexLogParser.cpp
+++ b/src/cpp/core/tex/TexLogParser.cpp
@@ -15,7 +15,6 @@
 
 #include <core/tex/TexLogParser.hpp>
 
-#include <boost/foreach.hpp>
 #include <boost/regex.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string.hpp>

--- a/src/cpp/core/tex/TexMagicComment.cpp
+++ b/src/cpp/core/tex/TexMagicComment.cpp
@@ -1,7 +1,7 @@
 /*
  * TexMagicComment.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -20,7 +20,6 @@
 #include <core/FileSerializer.hpp>
 #include <core/RegexUtils.hpp>
 
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/regex.hpp>
@@ -38,7 +37,7 @@ Error parseMagicComments(const FilePath& texFile,
       return error;
 
    boost::regex mcRegex("%{1,2}\\s*!(\\w+)\\s+(\\w+)\\s*=\\s*(.*)$");
-   BOOST_FOREACH(std::string line, lines)
+   for (std::string line : lines)
    {
       boost::algorithm::trim(line);
       if (line.empty())

--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -1,7 +1,7 @@
 /*
  * DesktopGwtCallback.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,8 +19,6 @@
 #ifdef _WIN32
 #include <shlobj.h>
 #endif
-
-#include <boost/foreach.hpp>
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -1285,7 +1283,7 @@ void GwtCallback::setFixedWidthFont(QString font)
 QString GwtCallback::getZoomLevels()
 {
    QStringList zoomLevels;
-   BOOST_FOREACH(double zoomLevel, pMainWindow_->zoomLevels())
+   for (double zoomLevel : pMainWindow_->zoomLevels())
    {
       zoomLevels.append(QString::fromStdString(
                            safe_convert::numberToString(zoomLevel)));

--- a/src/cpp/monitor/metrics/Metric.cpp
+++ b/src/cpp/monitor/metrics/Metric.cpp
@@ -17,8 +17,6 @@
 
 #include <ostream>
 
-#include <boost/foreach.hpp>
-
 #include <core/Error.hpp>
 #include <core/DateTime.hpp>
 
@@ -146,7 +144,7 @@ Error metricFromJson(const json::Object& multiMetricJson,
 
    // create vector of metric data
    std::vector<MetricData> data;
-   BOOST_FOREACH(const json::Value& value, dataJson)
+   for (const json::Value& value : dataJson)
    {
       if (!json::isType<json::Object>(value))
          return Error(json::errc::ParamTypeMismatch, ERROR_LOCATION);

--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -24,7 +24,6 @@
 
 #include <boost/bind.hpp>
 #include <boost/function.hpp>
-#include <boost/foreach.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/optional.hpp>
 
@@ -358,7 +357,7 @@ void listEnvironment(SEXP env,
    }
 
    // populate pVariables
-   BOOST_FOREACH(const std::string& var, vars)
+   for (const std::string& var : vars)
    {
       SEXP varSEXP = R_NilValue;
       // Merely calling Rf_findVar on an active binding will fire the binding.
@@ -1596,7 +1595,7 @@ void examineSymbolUsage(
    }
    
    // fill output
-   BOOST_FOREACH(FormalInformation& info, pInfo->formals())
+   for (FormalInformation& info : pInfo->formals())
    {
       const std::string& name = info.name();
       info.setIsUsed(usage.symbolsUsed.contains(name.c_str()));

--- a/src/cpp/r/session/RRestartContext.cpp
+++ b/src/cpp/r/session/RRestartContext.cpp
@@ -1,7 +1,7 @@
 /*
  * RRestartContext.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,7 +15,6 @@
 
 #include "RRestartContext.hpp"
 
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string.hpp>
 
 #include <core/Log.hpp>

--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -1,7 +1,7 @@
 /*
  * RSessionState.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -18,7 +18,6 @@
 #include <algorithm>
 
 #include <boost/function.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/Error.hpp>
 #include <core/FilePath.hpp>
@@ -139,7 +138,7 @@ Error saveEnvironmentVars(const FilePath& envFile)
    core::system::Options env;
    core::system::environment(&env);
    envSettings.beginUpdate();
-   BOOST_FOREACH(const core::system::Option& var, env)
+   for (const core::system::Option& var : env)
    {
       envSettings.set(var.first, var.second);
    }

--- a/src/cpp/r/session/graphics/RGraphicsPlotManager.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsPlotManager.cpp
@@ -1,7 +1,7 @@
 /*
  * RGraphicsPlotManager.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -21,7 +21,6 @@
 #include <boost/function.hpp>
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/Log.hpp>
 #include <core/Error.hpp>
@@ -688,7 +687,7 @@ Error copyDirectory(const FilePath& srcDir, const FilePath& targetDir)
    error = srcDir.children(&srcFiles);
    if (error)
       return error;
-   BOOST_FOREACH(const FilePath& srcFile, srcFiles)
+   for (const FilePath& srcFile : srcFiles)
    {
       FilePath targetFile = targetDir.complete(srcFile.filename());
       Error error = srcFile.copy(targetFile);

--- a/src/cpp/server/ServerSessionManager.cpp
+++ b/src/cpp/server/ServerSessionManager.cpp
@@ -17,7 +17,6 @@
 
 #include <server/ServerSessionManager.hpp>
 
-#include <boost/foreach.hpp>
 #include <boost/format.hpp>
 
 #include <core/SafeConvert.hpp>
@@ -254,7 +253,7 @@ Error SessionManager::launchSession(boost::asio::io_service& ioService,
    profile.config = sessionProcessConfig(context, args);
 
    // pass the profile to any filters we have
-   BOOST_FOREACH(SessionLaunchProfileFilter f, sessionLaunchProfileFilters_)
+   for (SessionLaunchProfileFilter f : sessionLaunchProfileFilters_)
    {
       f(&profile);
    }

--- a/src/cpp/server/auth/ServerValidateUser.cpp
+++ b/src/cpp/server/auth/ServerValidateUser.cpp
@@ -1,7 +1,7 @@
 /*
  * ServerValidateUser.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,7 +15,6 @@
 
 #include <server/auth/ServerValidateUser.hpp>
 
-#include <boost/foreach.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/format.hpp>
 
@@ -81,7 +80,7 @@ bool validateUser(const std::string& username,
       using namespace boost ;
       char_separator<char> comma(",");
       tokenizer<char_separator<char> > groups(requiredGroup, comma);
-      BOOST_FOREACH(const std::string& group, groups)
+      for (const std::string& group : groups)
       {
          // check group membership
          Error error = core::system::userBelongsToGroup(user,

--- a/src/cpp/server_core/RVersionsScanner.cpp
+++ b/src/cpp/server_core/RVersionsScanner.cpp
@@ -1,7 +1,7 @@
 /*
  * RVersionsScanner.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,7 +15,6 @@
 
 #include <server_core/RVersionsScanner.hpp>
 
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
@@ -225,7 +224,7 @@ void RVersionsScanner::parseRVersionsFile(const std::string& contents,
       bool skipEntry = true;
       std::vector<std::string> rEntryLines;
       boost::algorithm::split(rEntryLines, rEntry, boost::is_any_of("\n"));
-      BOOST_FOREACH(const std::string& line, rEntryLines)
+      for (const std::string& line : rEntryLines)
       {
          std::string trimmedLine = string_utils::trimWhitespace(line);
 
@@ -249,7 +248,7 @@ void RVersionsScanner::parseRVersionsFile(const std::string& contents,
          else
          {
             // dcf parse failed, so treat each line as a regular file path (legacy mode)
-            BOOST_FOREACH(const std::string& line, rEntryLines)
+            for (const std::string& line : rEntryLines)
             {
                if (boost::algorithm::starts_with(line, "#"))
                   continue;

--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionAsyncRProcess.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -12,8 +12,6 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
-
-#include <boost/foreach.hpp>
 
 #include <session/SessionUserSettings.hpp>
 #include <session/SessionConsoleProcess.hpp>
@@ -153,7 +151,7 @@ void AsyncRProcess::start(const char* rCommand,
       core::system::setenv(&childEnv, "R_LIBS", libPaths);
    }
    // forward passed environment variables
-   BOOST_FOREACH(const core::system::Option& var, environment)
+   for (const core::system::Option& var : environment)
    {
       core::system::setenv(&childEnv, var.first, var.second);
    }

--- a/src/cpp/session/SessionClientEventQueue.cpp
+++ b/src/cpp/session/SessionClientEventQueue.cpp
@@ -17,9 +17,6 @@
 
 #include "modules/SessionConsole.hpp"
 
-#include <boost/foreach.hpp>
-
-
 #include <core/BoostThread.hpp>
 #include <core/Thread.hpp>
 #include <core/json/Json.hpp>

--- a/src/cpp/session/SessionConsoleProcessPersist.cpp
+++ b/src/cpp/session/SessionConsoleProcessPersist.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionConsoleProcessPersist.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,8 +14,6 @@
  */
 
 #include <session/SessionConsoleProcessPersist.hpp>
-
-#include <boost/foreach.hpp>
 
 #include <core/FileSerializer.hpp>
 
@@ -289,7 +287,7 @@ void deleteOrphanedLogs(bool (*validHandle)(const std::string&))
       LOG_ERROR(error);
       return;
    }
-   BOOST_FOREACH(const FilePath& child, children)
+   for (const FilePath& child : children)
    {
       // Don't erase the INDEXnnn or any subfolders
       if (!child.filename().compare(kConsoleIndex) || child.isDirectory())
@@ -358,7 +356,7 @@ void loadConsoleEnvironment(const std::string& handle, core::system::Options* pE
    }
 
    core::system::Options loadedEnvironment = json::optionsFromJson(envJson.get_obj());
-   BOOST_FOREACH(const core::system::Option& var, loadedEnvironment)
+   for (const core::system::Option& var : loadedEnvironment)
    {
       core::system::setenv(pEnv, var.first, var.second);
    }

--- a/src/cpp/session/SessionConsoleProcessPersistTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessPersistTests.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionConsoleProcessPersistTests.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,8 +19,6 @@
 #include <tests/TestThat.hpp>
 
 #include <sstream>
-
-#include <boost/foreach.hpp>
 
 #include <core/system/Environment.hpp>
 
@@ -212,10 +210,10 @@ TEST_CASE("ConsoleProcess Persistence")
       console_persist::loadConsoleEnvironment(handle1, &loadEnv);
       CHECK((loadEnv.size() == env.size()));
 
-      BOOST_FOREACH(const core::system::Option& varOrig, env)
+      for (const core::system::Option& varOrig : env)
       {
          bool match = false;
-         BOOST_FOREACH(const core::system::Option& varLoaded, loadEnv)
+         for (const core::system::Option& varLoaded : loadEnv)
          {
             if (varLoaded.first == varOrig.first)
             {

--- a/src/cpp/session/SessionConsoleProcessTable.cpp
+++ b/src/cpp/session/SessionConsoleProcessTable.cpp
@@ -15,7 +15,6 @@
 
 #include "SessionConsoleProcessTable.hpp"
 
-#include <boost/foreach.hpp>
 #include <boost/range/adaptor/map.hpp>
 
 #include <core/SafeConvert.hpp>
@@ -123,7 +122,7 @@ ConsoleProcessPtr findProcByHandle(const std::string& handle)
 
 ConsoleProcessPtr findProcByCaption(const std::string& caption)
 {
-   BOOST_FOREACH(ConsoleProcessPtr& proc, s_procs | boost::adaptors::map_values)
+   for (ConsoleProcessPtr& proc : s_procs | boost::adaptors::map_values)
    {
       if (proc->getCaption() == caption)
          return proc;
@@ -160,7 +159,7 @@ std::vector<std::string> getAllHandles()
 std::pair<int, std::string> nextTerminalName()
 {
    int maxNum = kNoTerminal;
-   BOOST_FOREACH(ConsoleProcessPtr& proc, s_procs | boost::adaptors::map_values)
+   for (ConsoleProcessPtr& proc : s_procs | boost::adaptors::map_values)
    {
       maxNum = std::max(maxNum, proc->getTerminalSequence());
    }

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -27,7 +27,6 @@
 #include "session-config.h"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/gwt/GwtLogHandler.hpp>
 #include <core/gwt/GwtFileHandler.hpp>
@@ -230,7 +229,7 @@ bool isTimedOut(const boost::posix_time::ptime& timeoutTime)
 
 bool isWaitForMethodUri(const std::string& uri)
 {
-   BOOST_FOREACH(const std::string& methodName, s_waitForMethodNames)
+   for (const std::string& methodName : s_waitForMethodNames)
    {
       if (isMethod(uri, methodName))
          return true;

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -633,7 +633,7 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
    error = rstudio::r::json::getRpcMethods(&rMethods);
    if (error)
       return error ;
-   BOOST_FOREACH(const json::JsonRpcMethod& method, rMethods)
+   for (const json::JsonRpcMethod& method : rMethods)
    {
       registerRpcMethod(json::adaptMethodToAsync(method));
    }

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -517,7 +517,7 @@ bool monitoredScratchFilter(const FileInfo& fileInfo)
 
 void onFilesChanged(const std::vector<core::system::FileChangeEvent>& changes)
 {
-   BOOST_FOREACH(const core::system::FileChangeEvent& fileChange, changes)
+   for (const core::system::FileChangeEvent& fileChange : changes)
    {
       FilePath changedFilePath(fileChange.fileInfo().absolutePath());
       for (MonitoredScratchPaths::const_iterator
@@ -1225,7 +1225,7 @@ std::vector<FilePath> getLibPaths()
       LOG_ERROR(error);
 
    std::vector<FilePath> libPaths;
-   BOOST_FOREACH(const std::string& path, libPathsString)
+   for (const std::string& path : libPathsString)
    {
       libPaths.push_back(module_context::resolveAliasedPath(path));
    }
@@ -1866,7 +1866,7 @@ void enqueFileChangedEvents(const core::FilePath& vcsStatusRoot,
 
    // try to find the common parent of the events
    FilePath commonParentPath = FilePath(events.front().fileInfo().absolutePath()).parent();
-   BOOST_FOREACH(const core::system::FileChangeEvent& event, events)
+   for (const core::system::FileChangeEvent& event : events)
    {
       // if not within the common parent then revert to the vcs status root
       if (!FilePath(event.fileInfo().absolutePath()).isWithin(commonParentPath))
@@ -1881,7 +1881,7 @@ void enqueFileChangedEvents(const core::FilePath& vcsStatusRoot,
                                   fileDecorationContext(commonParentPath);
 
    // fire client events as necessary
-   BOOST_FOREACH(const core::system::FileChangeEvent& event, events)
+   for (const core::system::FileChangeEvent& event : events)
    {
       enqueFileChangedEvent(event, pCtx);
    }

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -15,7 +15,6 @@
 
 #include <session/SessionOptions.hpp>
 
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string/trim.hpp>
 
 #include <boost/property_tree/ptree.hpp>

--- a/src/cpp/session/SessionSSH.cpp
+++ b/src/cpp/session/SessionSSH.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionSSH.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -13,8 +13,6 @@
  *
  */
 #include <session/SessionSSH.hpp>
-
-#include <boost/foreach.hpp>
 
 #include <core/system/Environment.hpp>
 
@@ -59,7 +57,7 @@ core::system::ProcessOptions ProcessOptionsCreator::processOptions() const
    core::system::Options envOpts;
    core::system::environment(&envOpts);
    typedef std::pair<std::string, std::string> StringPair;
-   BOOST_FOREACH(StringPair var, env_)
+   for (StringPair var : env_)
    {
       if (var.second.empty())
          core::system::unsetenv(&envOpts, var.first);
@@ -70,7 +68,7 @@ core::system::ProcessOptions ProcessOptionsCreator::processOptions() const
    if (!pathDirs_.empty())
    {
       std::string path = core::system::getenv(envOpts, "PATH");
-      BOOST_FOREACH(FilePath pathDir, pathDirs_)
+      for (FilePath pathDir : pathDirs_)
       {
 #ifdef _WIN32
          path += ";";

--- a/src/cpp/session/SessionSourceDatabase.cpp
+++ b/src/cpp/session/SessionSourceDatabase.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionSourceDatabase.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -20,7 +20,6 @@
 #include <algorithm>
 
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 #include <boost/regex.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
@@ -797,7 +796,7 @@ Error list(std::vector<boost::shared_ptr<SourceDocument> >* pDocs)
    if (error)
       return error ;
    
-   BOOST_FOREACH( FilePath& filePath, files )
+   for (FilePath& filePath : files)
    {
       if (isSourceDocument(filePath))
       {
@@ -867,7 +866,7 @@ Error removeAll()
    if (error)
       return error ;
    
-   BOOST_FOREACH( FilePath& filePath, files )
+   for (FilePath& filePath : files)
    {
       Error error = filePath.remove();
       if (error)

--- a/src/cpp/session/SessionSourceDatabaseSupervisor.cpp
+++ b/src/cpp/session/SessionSourceDatabaseSupervisor.cpp
@@ -23,7 +23,6 @@
 
 #include <vector>
 
-#include <boost/foreach.hpp>
 #include <boost/scope_exit.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
@@ -157,7 +156,7 @@ Error removeSessionDir(const FilePath& sessionDir)
    Error error = sessionDir.children(&children);
    if (error)
       LOG_ERROR(error);
-   BOOST_FOREACH(const FilePath& filePath, children)
+   for (const FilePath& filePath : children)
    {
       error = filePath.remove();
       if (error)
@@ -202,7 +201,7 @@ void attemptToMoveSourceDbFiles(const FilePath& fromPath,
       LOG_ERROR(error);
 
    // move the files
-   BOOST_FOREACH(const FilePath& filePath, children)
+   for (const FilePath& filePath : children)
    {
       // skip directories (directories can exist because multi-session
       // mode writes top level directories into the /sdb/t and /sdb/u
@@ -327,7 +326,7 @@ bool reclaimOrphanedSession()
       return false;
    }
 
-   BOOST_FOREACH(const FilePath& sessionDir, sessionDirs)
+   for (const FilePath& sessionDir : sessionDirs)
    {
       // if the suspend file exists, this session is only sleeping, not dead
       if (sessionSuspendFilePath(sessionDir).exists())
@@ -494,7 +493,7 @@ Error saveMostRecentDocuments()
          return error;
 
       // write the docs into the mru directories
-      BOOST_FOREACH(boost::shared_ptr<SourceDocument> pDoc, sourceDocs)
+      for (boost::shared_ptr<SourceDocument> pDoc : sourceDocs)
       {
          FilePath targetDir = pDoc->isUntitled() ? mostRecentDirUntitled :
                                                    mostRecentDir;
@@ -534,7 +533,7 @@ Error detachFromSourceDatabase()
       return error;
 
    // now write the source database entries to the appropriate places
-   BOOST_FOREACH(boost::shared_ptr<SourceDocument> pDoc, sourceDocs)
+   for (boost::shared_ptr<SourceDocument> pDoc : sourceDocs)
    {
       if (pDoc->isUntitled())
       {

--- a/src/cpp/session/SessionUserSettings.cpp
+++ b/src/cpp/session/SessionUserSettings.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionUserSettings.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,7 +17,6 @@
 
 #include <iostream>
 
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
 #include <core/Error.hpp>
@@ -560,7 +559,7 @@ std::vector<std::string> UserSettings::spellingCustomDictionaries() const
 {
    json::Array dictsJson = readUiPref<json::Array>(pSpellingCustomDicts_);
    std::vector<std::string> dicts;
-   BOOST_FOREACH(const json::Value& dictJson, dictsJson)
+   for (const json::Value& dictJson : dictsJson)
    {
       if (json::isType<std::string>(dictJson))
          dicts.push_back(dictJson.get_str());
@@ -751,7 +750,7 @@ std::vector<std::string> UserSettings::terminalBusyWhitelist() const
 {
    json::Array whitelistJson = readUiPref<json::Array>(pTerminalBusyWhitelist_);
    std::vector<std::string> whitelist;
-   BOOST_FOREACH(const json::Value& exeJson, whitelistJson)
+   for (const json::Value& exeJson : whitelistJson)
    {
       if (json::isType<std::string>(exeJson))
          whitelist.push_back(exeJson.get_str());

--- a/src/cpp/session/include/session/SessionProjectTemplate.hpp
+++ b/src/cpp/session/include/session/SessionProjectTemplate.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionProjectTemplate.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -24,7 +24,6 @@
 #include <core/text/CsvParser.hpp>
 
 #include <boost/system/error_code.hpp>
-#include <boost/foreach.hpp>
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/session/include/session/SessionScopes.hpp
+++ b/src/cpp/session/include/session/SessionScopes.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionScopes.hpp
  *
- * Copyright (C) 2009-2015 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -20,7 +20,6 @@
 #define SESSION_SCOPES_HPP
 
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/range/adaptor/map.hpp>
 
@@ -261,7 +260,7 @@ inline std::string sharedProjectId(const core::FilePath& sharedStoragePath,
       return "";
    }
 
-   BOOST_FOREACH(const core::FilePath& projectEntry, projectEntries)
+   for (const core::FilePath& projectEntry : projectEntries)
    {
       // skip files that don't look like project entries
       if (projectEntry.extensionLowerCase() != kProjectEntryExt)

--- a/src/cpp/session/include/session/projects/SessionProjects.hpp
+++ b/src/cpp/session/include/session/projects/SessionProjects.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionProjects.hpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -21,7 +21,6 @@
 
 #include <boost/utility.hpp>
 #include <boost/shared_ptr.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/BoostSignals.hpp>
 #include <core/FileInfo.hpp>

--- a/src/cpp/session/modules/SessionBreakpoints.cpp
+++ b/src/cpp/session/modules/SessionBreakpoints.cpp
@@ -20,7 +20,6 @@
 #include <boost/bind.hpp>
 #include <boost/format.hpp>
 #include <boost/utility.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/Error.hpp>
 #include <core/Log.hpp>
@@ -160,7 +159,7 @@ boost::shared_ptr<ShinyFunction> findShinyFunction(std::string filename,
 {
    boost::shared_ptr<ShinyFunction> bestPsf;
    int bestSize = INT_MAX;
-   BOOST_FOREACH(boost::shared_ptr<ShinyFunction> psf, s_shinyFunctions)
+   for (boost::shared_ptr<ShinyFunction> psf : s_shinyFunctions)
    {
       if (psf->contains(filename, line) &&
           psf->getSize() < bestSize)
@@ -194,7 +193,7 @@ boost::shared_ptr<Breakpoint> breakpointFromJson(const json::Object& obj)
 std::vector<int> getShinyBreakpointLines(const ShinyFunction& sf)
 {
    std::vector<int> lines;
-   BOOST_FOREACH(boost::shared_ptr<Breakpoint> pbp, s_breakpoints)
+   for (boost::shared_ptr<Breakpoint> pbp : s_breakpoints)
    {
       if (sf.contains(pbp->path, pbp->lineNumber) &&
           pbp->type == TYPE_TOPLEVEL)
@@ -468,7 +467,7 @@ SEXP rs_debugSourceFile(SEXP filename, SEXP encoding, SEXP local)
 
    // Find all the lines in the file that have breakpoints
    std::vector<int> lines;
-   BOOST_FOREACH(boost::shared_ptr<Breakpoint> pbp, s_breakpoints)
+   for (boost::shared_ptr<Breakpoint> pbp : s_breakpoints)
    {
       if (module_context::resolveAliasedPath(pbp->path) == filePath)
       {
@@ -541,7 +540,7 @@ Error initBreakpoints()
       {
          json::Array breakpointArray = jsonBreakpointArray.get_array();
          s_breakpoints.clear();
-         BOOST_FOREACH(json::Value bp, breakpointArray)
+         for (json::Value bp : breakpointArray)
          {
             if (json::isType<core::json::Object>(bp))
             {
@@ -563,7 +562,7 @@ Error updateBreakpoints(const json::JsonRpcRequest& request,
    if (error)
       return error;
 
-   BOOST_FOREACH(json::Value bp, breakpointArr)
+   for (json::Value bp : breakpointArr)
    {
       boost::shared_ptr<Breakpoint> breakpoint
             (breakpointFromJson(bp.get_obj()));

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -524,7 +524,7 @@ public:
                            r_util::RSourceItem* pFunctionItem)
    {
       std::vector<r_util::RSourceItem> sourceItems;
-      BOOST_FOREACH(const Entry& entry, *pEntries_)
+      for (const Entry& entry : *pEntries_)
       {
          // bail if there is no index
          if (!entry.hasIndex())
@@ -561,7 +561,7 @@ public:
                      const std::set<std::string>& excludeContexts,
                      std::vector<r_util::RSourceItem>* pItems)
    {
-      BOOST_FOREACH(const Entry& entry, *pEntries_)
+      for (const Entry& entry : *pEntries_)
       {
          // skip if it has no index
          if (!entry.hasIndex())
@@ -998,7 +998,7 @@ void RSourceIndexes::update(const boost::shared_ptr<SourceDocument>& pDoc)
    std::set<std::string> implicitlyAvailable =
          r_utils::implicitlyAvailablePackages(filePath, pDoc->contents());
    
-   BOOST_FOREACH(const std::string& package, implicitlyAvailable)
+   for (const std::string& package : implicitlyAvailable)
    {
       pIndex->addInferredPackage(package);
    }
@@ -1063,7 +1063,7 @@ bool findGlobalFunctionInSourceDatabase(
                                                    rSourceIndex().indexes();
 
    std::vector<r_util::RSourceItem> sourceItems;
-   BOOST_FOREACH(boost::shared_ptr<r_util::RSourceIndex>& pIndex, indexes)
+   for (boost::shared_ptr<r_util::RSourceIndex>& pIndex : indexes)
    {
       // apply the filter
       if (!sourceDatabaseFilter(*pIndex))
@@ -1100,7 +1100,7 @@ void searchSourceDatabase(const std::string& term,
    std::vector<boost::shared_ptr<r_util::RSourceIndex> > indexes
                                                 = rSourceIndex().indexes();
 
-   BOOST_FOREACH(boost::shared_ptr<r_util::RSourceIndex>& pIndex, indexes)
+   for (boost::shared_ptr<r_util::RSourceIndex>& pIndex : indexes)
    {
       // apply the filter
       if (!sourceDatabaseFilter(*pIndex))
@@ -1168,7 +1168,7 @@ void searchSource(const std::string& term,
                                &projItems);
 
    // add project items to the list
-   BOOST_FOREACH(const r_util::RSourceItem& sourceItem, projItems)
+   for (const r_util::RSourceItem& sourceItem : projItems)
    {
       // add the item
       pItems->push_back(sourceItem);
@@ -1202,7 +1202,7 @@ void searchSourceDatabaseFiles(const std::string& term,
    std::vector<boost::shared_ptr<r_util::RSourceIndex> > indexes =
                                                    rSourceIndex().indexes();
 
-   BOOST_FOREACH(boost::shared_ptr<r_util::RSourceIndex>& pIndex, indexes)
+   for (boost::shared_ptr<r_util::RSourceIndex>& pIndex : indexes)
    {
       // bail if there is no path
       std::string context = pIndex->context();
@@ -1600,7 +1600,7 @@ Error searchCode(const json::JsonRpcRequest& request,
                   std::back_inserter(srcItems),
                   fromCppDefinition);
 
-   // typedef necessary for BOOST_FOREACH to work with pairs
+   // typedef necessary for range-based-for to work with pairs
    typedef std::pair<int, int> PairIntInt;
 
    // score matches -- returned as a pair, mapping index to score
@@ -1642,14 +1642,14 @@ Error searchCode(const json::JsonRpcRequest& request,
    // get filtered results
    std::vector<std::string> namesFiltered;
    std::vector<std::string> pathsFiltered;
-   BOOST_FOREACH(PairIntInt const& pair, fileScores)
+   for (PairIntInt const& pair : fileScores)
    {
       namesFiltered.push_back(names[pair.first]);
       pathsFiltered.push_back(paths[pair.first]);
    }
 
    std::vector<SourceItem> srcItemsFiltered;
-   BOOST_FOREACH(PairIntInt const& pair, srcItemScores)
+   for (PairIntInt const& pair : srcItemScores)
    {
       srcItemsFiltered.push_back(srcItems[pair.first]);
    }
@@ -1920,7 +1920,7 @@ json::Object createFunctionDefinition(const std::string& name,
    {
       // append the lines to the code and set it
       std::string code;
-      BOOST_FOREACH(const std::string& line, lines)
+      for (const std::string& line : lines)
       {
          code.append(line);
          code.append("\n");
@@ -2039,7 +2039,7 @@ json::Value createS3MethodDefinition(const std::string& name)
    std::string packagePrefix = "package:";
    std::string namespacePrefix = "namespace:";
    std::string namespaceName;
-   BOOST_FOREACH(const std::string& where, whereList)
+   for (const std::string& where : whereList)
    {
       if (boost::algorithm::starts_with(where, packagePrefix))
       {
@@ -2518,7 +2518,7 @@ void addAllProjectSymbols(const Entry& entry,
       return;
    
    const std::vector<r_util::RSourceItem>& items = entry.pIndex->items();
-   BOOST_FOREACH(const r_util::RSourceItem& item, items)
+   for (const r_util::RSourceItem& item : items)
    {
       pSymbols->insert(string_utils::strippedOfQuotes(item.name()));
    } 

--- a/src/cpp/session/modules/SessionCodeSearch.hpp
+++ b/src/cpp/session/modules/SessionCodeSearch.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionCodeSearch.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -18,7 +18,6 @@
 
 #include <core/r_util/RSourceIndex.hpp>
 #include <session/SessionSourceDatabase.hpp>
-#include <boost/foreach.hpp>
 
 namespace rstudio {
 namespace core {
@@ -74,7 +73,7 @@ public:
    std::vector< boost::shared_ptr<RSourceIndex> > indexes()
    {
       std::vector< boost::shared_ptr<RSourceIndex> > indexes;
-      BOOST_FOREACH(const IDMap::value_type& index, idMap_)
+      for (const IDMap::value_type& index : idMap_)
       {
          indexes.push_back(index.second);
       }

--- a/src/cpp/session/modules/SessionDependencies.cpp
+++ b/src/cpp/session/modules/SessionDependencies.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionDependencies.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,7 +16,6 @@
 #include "SessionDependencies.hpp"
 
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string/join.hpp>
 
 #include <core/Error.hpp>
@@ -76,7 +75,7 @@ EmbeddedPackage embeddedPackageInfo(const std::string& name)
    re.assign(name + "_([0-9]+\\.[0-9]+\\.[0-9]+)_([\\d\\w]+)\\.tar\\.gz");
    */
 
-   BOOST_FOREACH(const FilePath& child, children)
+   for (const FilePath& child : children)
    {
       boost::smatch match;
       std::string filename = child.filename();
@@ -164,7 +163,7 @@ std::vector<Dependency> dependenciesFromJson(const json::Array& depsJson)
 json::Array dependenciesToJson(const std::vector<Dependency>& deps)
 {
    json::Array depsJson;
-   BOOST_FOREACH(const Dependency& dep, deps)
+   for (const Dependency& dep : deps)
    {
       json::Object depJson;
       depJson["type"] = dep.type;
@@ -220,7 +219,7 @@ Error unsatisfiedDependencies(const json::JsonRpcRequest& request,
    // build the list of unsatisifed dependencies
    using namespace module_context;
    std::vector<Dependency> unsatisfiedDeps;
-   BOOST_FOREACH(Dependency& dep, deps)
+   for (Dependency& dep : deps)
    {
       switch(dep.type)
       {
@@ -325,7 +324,7 @@ Error installDependencies(const json::JsonRpcRequest& request,
    std::vector<std::string> cranPackages;
    std::vector<std::string> cranSourcePackages;
    std::vector<std::string> embeddedPackages;
-   BOOST_FOREACH(const Dependency& dep, deps)
+   for (const Dependency& dep : deps)
    {
       switch(dep.type)
       {
@@ -360,7 +359,7 @@ Error installDependencies(const json::JsonRpcRequest& request,
              "repos = '"+ module_context::CRANReposURL() + "', ";
       cmd += "type = 'source');";
    }
-   BOOST_FOREACH(const std::string& pkg, embeddedPackages)
+   for (const std::string& pkg : embeddedPackages)
    {
       cmd += "utils::install.packages('" + pkg + "', "
                                       "repos = NULL, type = 'source');";

--- a/src/cpp/session/modules/SessionDiagnostics.cpp
+++ b/src/cpp/session/modules/SessionDiagnostics.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionDiagnostics.cpp
  *
- * Copyright (C) 2009-2019 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -42,7 +42,6 @@
 
 #include <boost/shared_ptr.hpp>
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 #include <boost/range/adaptor/map.hpp>
 
 #include <r/RSexp.hpp>
@@ -88,7 +87,7 @@ void addUnreferencedSymbol(const ParseItem& item,
    if (symbols.count(item.symbol))
    {
       ParseNode::Positions positions = symbols[item.symbol];
-      BOOST_FOREACH(const Position& position, positions)
+      for (const Position& position : positions)
       {
          lint.symbolDefinedAfterUsage(item, position);
       }
@@ -127,7 +126,7 @@ void doCheckDefinedButNotUsed(ParseNode* pNode, ParseResults& results)
 void checkDefinedButNotUsed(ParseResults& results)
 {
    ParseNode::Children children = results.parseTree()->getChildren();
-   BOOST_FOREACH(const boost::shared_ptr<ParseNode>& child, children)
+   for (const boost::shared_ptr<ParseNode>& child : children)
    {
       doCheckDefinedButNotUsed(child.get(), results);
    }
@@ -152,7 +151,7 @@ void addInferredSymbols(const FilePath& filePath,
    
    // We have the index -- now list the packages discovered in
    // 'library' calls, and add those here.
-   BOOST_FOREACH(const std::string& package, pIndex->getInferredPackages())
+   for (const std::string& package : pIndex->getInferredPackages())
    {
       const PackageInformation& completions =
             pIndex->getPackageInformation(package);
@@ -184,7 +183,7 @@ void addNamespaceSymbols(std::set<std::string>* pSymbols)
 {
    // Add symbols specifically mentioned as 'importFrom'
    // directives in the NAMESPACE.
-   BOOST_FOREACH(const std::set<std::string>& symbolNames,
+   for (const std::set<std::string>& symbolNames :
                  RSourceIndex::getImportFromDirectives() | boost::adaptors::map_values)
    {
       pSymbols->insert(symbolNames.begin(), symbolNames.end());
@@ -192,8 +191,7 @@ void addNamespaceSymbols(std::set<std::string>* pSymbols)
    
    // Make all (exported) symbols published by packages
    // that are 'import'ed in the NAMESPACE.
-   BOOST_FOREACH(const std::string& package,
-                 RSourceIndex::getImportedPackages())
+   for (const std::string& package : RSourceIndex::getImportedPackages())
    {
       DEBUG("- Adding imports for package '" << package << "'");
       const PackageInformation& pkgInfo =
@@ -487,7 +485,7 @@ void checkNoDefinitionInScope(const FilePath& origin,
    
    // For each unresolved symbol, add it to the lint if it's not on the search
    // path.
-   BOOST_FOREACH(const ParseItem& item, unresolvedItems)
+   for (const ParseItem& item : unresolvedItems)
    {
       if (!r::util::isRKeyword(item.symbol) &&
           !r::util::isWindowsOnlyFunction(item.symbol) &&
@@ -534,7 +532,7 @@ void parseLintOptionGlobals(const std::string& text, FileLocalLintOptions* pOpti
    std::string::const_iterator end = text.end();
    
    ParsedCSVLine parsed = parseCsvLine(begin + 1, end, true);
-   BOOST_FOREACH(const std::string element, parsed.first)
+   for (const std::string element : parsed.first)
    {
       pOptions->globals.insert(string_utils::trimWhitespace(element));
    }
@@ -550,7 +548,7 @@ void parseLintOption(const std::string& text, FileLocalLintOptions* pOptions)
    
    ParsedCSVLine line = parseCsvLine(text.begin(), text.end(), true);
    
-   BOOST_FOREACH(const std::string& entry, line.first)
+   for (const std::string& entry : line.first)
    {
       std::string::const_iterator it = 
             std::find(entry.begin(), entry.end(), '=');
@@ -566,7 +564,7 @@ void parseLintOption(const std::string& text, FileLocalLintOptions* pOptions)
 FileLocalLintOptions parseLintOptions(const std::vector<std::string>& lintText)
 {
    FileLocalLintOptions options;
-   BOOST_FOREACH(const std::string text, lintText)
+   for (const std::string text : lintText)
    {
       parseLintOption(text, &options);
    }
@@ -581,7 +579,7 @@ void applyOptions(const FileLocalLintOptions& fileOptions,
                                  fileOptions.globals.end());
    
    typedef std::pair<std::string, std::string> PairStringString;
-   BOOST_FOREACH(const PairStringString& option, fileOptions.options)
+   for (const PairStringString& option : fileOptions.options)
    {
       if (option.first == "style")
          pOptions->setRecordStyleLint(lintOptionValueAsBool(option.second));
@@ -706,7 +704,7 @@ json::Array lintAsJson(const LintItems& items)
 {
    json::Array jsonArray;
    
-   BOOST_FOREACH(const LintItem& item, items)
+   for (const LintItem& item : items)
    {
       json::Object jsonObject;
       
@@ -730,7 +728,7 @@ module_context::SourceMarkerSet asSourceMarkerSet(const LintItems& items,
    using namespace module_context;
    std::vector<SourceMarker> markers;
    markers.reserve(items.size());
-   BOOST_FOREACH(const LintItem& item, items)
+   for (const LintItem& item : items)
    {
       markers.push_back(SourceMarker(
                            sourceMarkerTypeFromString(lintTypeToString(item.type)),
@@ -754,7 +752,7 @@ module_context::SourceMarkerSet asSourceMarkerSet(
    {
       const FilePath& path = it->first;
       const LintItems& lintItems = it->second;
-      BOOST_FOREACH(const LintItem& item, lintItems)
+      for (const LintItem& item : lintItems)
       {
          markers.push_back(SourceMarker(
                               sourceMarkerTypeFromString(lintTypeToString(item.type)),
@@ -948,7 +946,7 @@ void onFilesChanged(const std::vector<core::system::FileChangeEvent>& events)
    std::string namespacePath =
          projects::projectContext().directory().complete("NAMESPACE").absolutePath();
    
-   BOOST_FOREACH(const core::system::FileChangeEvent& event, events)
+   for (const core::system::FileChangeEvent& event : events)
    {
       std::string eventPath = event.fileInfo().absolutePath();
       if (eventPath == namespacePath)

--- a/src/cpp/session/modules/SessionDiagnosticsTests.cpp
+++ b/src/cpp/session/modules/SessionDiagnosticsTests.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionDiagnosticsTests.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -26,7 +26,6 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 
 #include <session/SessionOptions.hpp>
 #include "SessionRParser.hpp"

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionFiles.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -24,7 +24,6 @@
 #include <sstream>
 #include <algorithm>
 
-#include <boost/foreach.hpp>
 #include <boost/lexical_cast.hpp>
 
 #include <core/Error.hpp>

--- a/src/cpp/session/modules/SessionFilesListingMonitor.cpp
+++ b/src/cpp/session/modules/SessionFilesListingMonitor.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionFilesListingMonitor.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -18,7 +18,6 @@
 #include <algorithm>
 
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/Error.hpp>
 #include <core/Log.hpp>
@@ -202,7 +201,7 @@ Error FilesListingMonitor::listFiles(const FilePath& rootPath,
    std::sort(pFiles->begin(), pFiles->end(), core::compareAbsolutePathNoCase);
 
    // produce json listing
-   BOOST_FOREACH( core::FilePath& filePath, *pFiles)
+   for (core::FilePath& filePath : *pFiles)
    {
       // files which may have been deleted after the listing or which
       // are not end-user visible

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -511,7 +511,7 @@ core::Error beginFind(const json::JsonRpcRequest& request,
    if (!asRegex)
       cmd << "-F";
 
-   BOOST_FOREACH(json::Value filePattern, filePatterns)
+   for (json::Value filePattern : filePatterns)
    {
       cmd << "--include=" + filePattern.get_str();
    }

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -31,7 +31,6 @@
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/foreach.hpp>
 #include <boost/format.hpp>
 #include <boost/function.hpp>
 #include <boost/lexical_cast.hpp>
@@ -342,7 +341,7 @@ Error gitExec(const ShellArgs& args,
 bool commitIsMatch(const std::vector<std::string>& patterns,
                    const CommitInfo& commit)
 {
-   BOOST_FOREACH(std::string pattern, patterns)
+   for (std::string pattern : patterns)
    {
       if (!boost::algorithm::ifind_first(commit.author, pattern)
           && !boost::algorithm::ifind_first(commit.description, pattern)
@@ -458,7 +457,7 @@ protected:
       // we could, so below we use git root relative paths whenever we can
       // on OSX, but on other platforms continue to use full absolute paths
 #ifdef __APPLE__
-      BOOST_FOREACH(const FilePath& filePath, filePaths)
+      for (const FilePath& filePath : filePaths)
       {
          if (filePath.isWithin(root_))
             *pArgs << filePath.relativePath(root_);
@@ -592,7 +591,7 @@ public:
       std::vector<FilePath> filesToAdd;
       std::vector<FilePath> filesToRm;
 
-      BOOST_FOREACH(const FilePath& path, filePaths)
+      for (const FilePath& path : filePaths)
       {
          std::string status = statusResult.getStatus(path).status();
          if (status.size() < 2)
@@ -749,7 +748,7 @@ public:
       // split and parse remotes output
       boost::regex reSpaces("\\s+");
       std::vector<std::string> splat = split(trimmed);
-      BOOST_FOREACH(const std::string& line, splat)
+      for (const std::string& line : splat)
       {
          boost::smatch match;
          if (!regex_utils::search(line, match, reSpaces))
@@ -1136,7 +1135,7 @@ public:
             boost::algorithm::split(refs,
                                     static_cast<const std::string>(smatch[3]),
                                     boost::algorithm::is_any_of(","));
-            BOOST_FOREACH(std::string ref, refs)
+            for (std::string ref : refs)
             {
                boost::algorithm::trim(ref);
                if (boost::algorithm::starts_with(ref, "tag: "))
@@ -2957,7 +2956,7 @@ Error addFilesToGitIgnore(const FilePath& gitIgnoreFile,
       if (addExtraNewline)
          *ptrOs << kNewline;
 
-      BOOST_FOREACH(const std::string& line, filesToIgnore)
+      for (const std::string& line : filesToIgnore)
       {
          *ptrOs << line << kNewline;
       }

--- a/src/cpp/session/modules/SessionLists.cpp
+++ b/src/cpp/session/modules/SessionLists.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionLists.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,7 +19,6 @@
 #include <map>
 
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 #include <boost/utility.hpp>
 #include <boost/circular_buffer.hpp>
 
@@ -111,7 +110,7 @@ Error writeList(const std::string& name, const T& list)
 json::Array listToJson(const std::list<std::string>& list)
 {
    json::Array jsonArray;
-   BOOST_FOREACH(const std::string& val, list)
+   for (const std::string& val : list)
    {
       jsonArray.push_back(val);
    }
@@ -203,7 +202,7 @@ Error listSetContents(const json::JsonRpcRequest& request,
       return error;
 
    std::list<std::string> list;
-   BOOST_FOREACH(const json::Value& val, jsonList)
+   for (const json::Value& val : jsonList)
    {
       if (!json::isType<std::string>(val))
       {

--- a/src/cpp/session/modules/SessionMarkers.cpp
+++ b/src/cpp/session/modules/SessionMarkers.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionMarkers.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,7 +15,6 @@
 
 #include "SessionMarkers.hpp"
 
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
 #include <core/Exec.hpp>
@@ -125,7 +124,7 @@ public:
 
       MarkerSets markerSets;
 
-      BOOST_FOREACH(const json::Value& setJson, setsJson)
+      for (const json::Value& setJson : setsJson)
       {
          if (json::isType<json::Object>(setJson))
          {
@@ -141,7 +140,7 @@ public:
                continue;
             }
             std::vector<module_context::SourceMarker> markers;
-            BOOST_FOREACH(json::Value markerJson, markersJson)
+            for (json::Value markerJson : markersJson)
             {
                if (json::isType<json::Object>(markerJson))
                {
@@ -217,7 +216,7 @@ public:
       {
          // names
          json::Array namesJson;
-         BOOST_FOREACH(const module_context::SourceMarkerSet& set, markerSets_)
+         for (const module_context::SourceMarkerSet& set : markerSets_)
          {
             namesJson.push_back(set.name);
          }

--- a/src/cpp/session/modules/SessionObjectExplorer.cpp
+++ b/src/cpp/session/modules/SessionObjectExplorer.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionObjectExplorer.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -18,7 +18,6 @@
 #include "SessionObjectExplorer.hpp"
 
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/Algorithm.hpp>
 #include <core/Error.hpp>
@@ -74,7 +73,7 @@ void removeOrphanedCacheItems()
    typedef boost::shared_ptr<SourceDocument> Document;
    
    std::vector<Document> documents;
-   BOOST_FOREACH(const FilePath& docPath, docPaths)
+   for (const FilePath& docPath : docPaths)
    {
       Document pDoc(new SourceDocument());
       Error error = source_database::get(docPath.filename(), false, pDoc);
@@ -97,12 +96,12 @@ void removeOrphanedCacheItems()
    
    // remove any objects for which we don't have an associated
    // source document available
-   BOOST_FOREACH(const FilePath& cacheFile, cachedFiles)
+   for (const FilePath& cacheFile : cachedFiles)
    {
       std::string id = cacheFile.filename();
       
       bool foundId = false;
-      BOOST_FOREACH(Document pDoc, documents)
+      for (Document pDoc : documents)
       {
          if (id == pDoc->getProperty("id"))
          {

--- a/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
+++ b/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionPackageProvidedExtension.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,7 +16,6 @@
 #include <session/SessionPackageProvidedExtension.hpp>
 
 #include <boost/regex.hpp>
-#include <boost/foreach.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <core/Algorithm.hpp>
@@ -112,7 +111,7 @@ bool Indexer::work()
    // invoke workers with package name + path
    FilePath pkgPath = pkgDirs_[index];
    std::string pkgName = pkgPath.filename();
-   BOOST_FOREACH(boost::shared_ptr<Worker> pWorker, workers_)
+   for (boost::shared_ptr<Worker> pWorker : workers_)
    {
       FilePath resourcePath = pkgPath.childPath(pWorker->resourcePath());
       if (!resourcePath.exists())
@@ -135,7 +134,7 @@ void Indexer::beginIndexing()
 
    // discover packages available on the current library paths
    std::vector<core::FilePath> libPaths = module_context::getLibPaths();
-   BOOST_FOREACH(const core::FilePath& libPath, libPaths)
+   for (const core::FilePath& libPath : libPaths)
    {
       if (!libPath.exists())
          continue;
@@ -152,7 +151,7 @@ void Indexer::beginIndexing()
    }
    n_ = pkgDirs_.size();
    
-   BOOST_FOREACH(boost::shared_ptr<Worker> pWorker, workers_)
+   for (boost::shared_ptr<Worker> pWorker : workers_)
    {
       try
       {
@@ -167,7 +166,7 @@ void Indexer::endIndexing()
    running_ = false;
    payload_.clear();
    
-   BOOST_FOREACH(boost::shared_ptr<Worker> pWorker, workers_)
+   for (boost::shared_ptr<Worker> pWorker : workers_)
    {
       try
       {
@@ -229,7 +228,7 @@ void onConsoleInput(const std::string& input)
    };
    
    std::string inputTrimmed = boost::algorithm::trim_copy(input);
-   BOOST_FOREACH(const char* command, commands)
+   for (const char* command : commands)
    {
       if (boost::algorithm::starts_with(inputTrimmed, command))
       {

--- a/src/cpp/session/modules/SessionPackrat.cpp
+++ b/src/cpp/session/modules/SessionPackrat.cpp
@@ -601,7 +601,7 @@ void onFileChanged(FilePath sourceFilePath)
 
 void onFilesChanged(const std::vector<core::system::FileChangeEvent>& changes)
 {
-   BOOST_FOREACH(const core::system::FileChangeEvent& fileChange, changes)
+   for (const core::system::FileChangeEvent& fileChange : changes)
    {
       FilePath changedFilePath(fileChange.fileInfo().absolutePath());
       onFileChanged(changedFilePath);

--- a/src/cpp/session/modules/SessionProjectTemplate.cpp
+++ b/src/cpp/session/modules/SessionProjectTemplate.cpp
@@ -15,7 +15,6 @@
 #include <session/SessionProjectTemplate.hpp>
 
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 #include <boost/function.hpp>
 #include <boost/range/adaptors.hpp>
 
@@ -62,7 +61,7 @@ void reportErrorsToConsole(const std::vector<Error>& errors,
    
    std::string pkgName = projectContext().packageInfo().name();
    std::vector<Error> localErrors;
-   BOOST_FOREACH(const Error& error, errors)
+   for (const Error& error : errors)
    {
       std::string resourcePath = error.getProperty("resource");
       if (resourcePath.find("/" + pkgName + "/"))
@@ -76,7 +75,7 @@ void reportErrorsToConsole(const std::vector<Error>& errors,
          << "Error(s) found while parsing '" + resourcePath.filename() + "':"
          << std::endl;
    
-   BOOST_FOREACH(const Error& error, localErrors)
+   for (const Error& error : localErrors)
    {
       std::string description = error.getProperty("description");
       std::cout << description << std::endl;
@@ -213,7 +212,7 @@ Error fromJson(
    if (error)
       return error;
    
-   BOOST_FOREACH(const json::Value& value, array)
+   for (const json::Value& value : array)
    {
       if (!json::isType<json::Object>(value))
          return json::errors::typeMismatch(
@@ -246,7 +245,7 @@ json::Value ProjectTemplateDescription::toJson() const
    object["open_files"] = json::toJsonArray(openFiles);
 
    core::json::Array widgetsJson;
-   BOOST_FOREACH(const ProjectTemplateWidgetDescription& widgetDescription, widgets)
+   for (const ProjectTemplateWidgetDescription& widgetDescription : widgets)
    {
       widgetsJson.push_back(widgetDescription.toJson());
    }
@@ -415,7 +414,7 @@ std::vector<Error> validate(const ProjectTemplateDescription& description,
    if (description.title.empty())
       result.push_back(errors::missingField("Title", resourcePath, location));
    
-   BOOST_FOREACH(const ProjectTemplateWidgetDescription widget, description.widgets)
+   for (const ProjectTemplateWidgetDescription widget : description.widgets)
    {
       std::vector<Error> widgetErrors =
             validateWidget(widget, resourcePath, location);
@@ -452,10 +451,10 @@ public:
    {
       json::Object object;
       
-      BOOST_FOREACH(const std::string& pkgName, registry_ | boost::adaptors::map_keys)
+      for (const std::string& pkgName : registry_ | boost::adaptors::map_keys)
       {
          json::Array array;
-         BOOST_FOREACH(const ProjectTemplateDescription& description, registry_[pkgName])
+         for (const ProjectTemplateDescription& description : registry_[pkgName])
          {
             array.push_back(description.toJson());
          }
@@ -529,7 +528,7 @@ private:
       if (error)
          LOG_ERROR(error);
       
-      BOOST_FOREACH(const FilePath& childPath, children)
+      for (const FilePath& childPath : children)
       {
          // skip files that don't have a dcf extension
          if (childPath.extension() != ".dcf")

--- a/src/cpp/session/modules/SessionRAddins.cpp
+++ b/src/cpp/session/modules/SessionRAddins.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionRAddins.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -23,7 +23,6 @@
 #include <core/text/DcfParser.hpp>
 
 #include <boost/regex.hpp>
-#include <boost/foreach.hpp>
 #include <boost/bind.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/system/error_code.hpp>
@@ -253,7 +252,7 @@ public:
    {
       json::Object object;
       
-      BOOST_FOREACH(const std::string& key, addins_ | boost::adaptors::map_keys)
+      for (const std::string& key : addins_ | boost::adaptors::map_keys)
       {
          object[key] = addins_.at(key).toJson();
       }
@@ -359,7 +358,7 @@ class AddinWorker : public ppe::Worker
 
       // handle pending continuations
       json::Object registryJson = addinRegistry().toJson();
-      BOOST_FOREACH(json::JsonRpcFunctionContinuation continuation, continuations_)
+      for (json::JsonRpcFunctionContinuation continuation : continuations_)
       {
          json::JsonRpcResponse response;
          response.setResult(registryJson);

--- a/src/cpp/session/modules/SessionRCompletions.cpp
+++ b/src/cpp/session/modules/SessionRCompletions.cpp
@@ -188,7 +188,7 @@ SourceIndexCompletions getSourceIndexCompletions(const std::string& token)
                                       &moreAvailable);
 
    SourceIndexCompletions srcCompletions;
-   BOOST_FOREACH(const core::r_util::RSourceItem& item, items)
+   for (const core::r_util::RSourceItem& item : items)
    {
       if (item.braceLevel() == 0)
       {
@@ -329,12 +329,12 @@ SEXP rs_getNAMESPACEImportedSymbols(SEXP documentIdSEXP)
    using namespace core::r_util;
    std::vector<std::string> pkgs;
    
-   BOOST_FOREACH(const std::string& pkg, RSourceIndex::getImportedPackages())
+   for (const std::string& pkg : RSourceIndex::getImportedPackages())
    {
       pkgs.push_back(pkg);
    }
    
-   BOOST_FOREACH(const std::string& pkg,
+   for (const std::string& pkg :
                  RSourceIndex::getImportFromDirectives() | boost::adaptors::map_keys)
    {
       pkgs.push_back(pkg);
@@ -344,7 +344,7 @@ SEXP rs_getNAMESPACEImportedSymbols(SEXP documentIdSEXP)
    Protect protect;
    r::sexp::ListBuilder builder(&protect);
    
-   BOOST_FOREACH(const std::string& pkg, pkgs)
+   for (const std::string& pkg : pkgs)
    {
       const PackageInformation& completions = RSourceIndex::getPackageInformation(pkg);
       r::sexp::ListBuilder child(&protect);
@@ -361,7 +361,7 @@ SEXP rs_getNAMESPACEImportedSymbols(SEXP documentIdSEXP)
          std::set<std::string>& directives =
                RSourceIndex::getImportFromDirectives()[pkg];
          
-         BOOST_FOREACH(const std::string& item, directives)
+         for (const std::string& item : directives)
          {
             std::vector<std::string>::const_iterator it =
                   std::find(completions.exports.begin(),
@@ -486,7 +486,7 @@ SEXP rs_listIndexedPackages()
    
    const std::vector<FilePath>& pkgPaths = libpaths::getInstalledPackages();
    pkgNames.reserve(pkgPaths.size());
-   BOOST_FOREACH(const FilePath& pkgPath, pkgPaths)
+   for (const FilePath& pkgPath : pkgPaths)
    {
       pkgNames.push_back(pkgPath.absolutePath());
    }

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -141,7 +141,7 @@ public:
    NSEDatabase()
    {
       // Add in a set of 'known' NSE-performing functinos.
-      BOOST_FOREACH(const std::string& name, r::sexp::nsePrimitives())
+      for (const std::string& name : r::sexp::nsePrimitives())
       {
          addNseFunction(name, "base");
       }
@@ -286,7 +286,7 @@ std::set<std::wstring> makeWideNsePrimitives()
    std::set<std::wstring> wide;
    const std::set<std::string>& nsePrimitives = r::sexp::nsePrimitives();
    
-   BOOST_FOREACH(const std::string& primitive, nsePrimitives)
+   for (const std::string& primitive : nsePrimitives)
    {
       wide.insert(string_utils::utf8ToWide(primitive));
    }
@@ -1184,9 +1184,9 @@ public:
        * 1. Identify perfect matches in the set of formals to search.
        */
       std::vector<std::size_t> matchedIndices;
-      BOOST_FOREACH(const std::string& argName, userSuppliedArgNames)
+      for (const std::string& argName : userSuppliedArgNames)
       {
-         BOOST_FOREACH(std::size_t index, formalIndices)
+         for (std::size_t index : formalIndices)
          {
             const std::string& formalName = formalNames[index];
             if (argName == formalName)
@@ -1211,9 +1211,9 @@ public:
        * 2. Identify prefix matches in the set of remaining formals.
        */
       std::vector<std::pair<std::string, std::string> > prefixMatchedPairs;
-      BOOST_FOREACH(const std::string& userSuppliedArgName, userSuppliedArgNames)
+      for (const std::string& userSuppliedArgName : userSuppliedArgNames)
       {
-         BOOST_FOREACH(std::size_t index, formalIndices)
+         for (std::size_t index : formalIndices)
          {
             const std::string& formalName = formalNames[index];
             if (boost::algorithm::starts_with(formalName, userSuppliedArgName))
@@ -1239,7 +1239,7 @@ public:
        * 3. Match other formals positionally.
        */
       std::size_t index = 0;
-      BOOST_FOREACH(const std::string& argument, unnamedArguments)
+      for (const std::string& argument : unnamedArguments)
       {
          if (index == formalIndices.size())
             break;
@@ -1324,7 +1324,7 @@ public:
       if (cursor.contentEquals(L"trace"))
       {
          std::vector<FormalInformation>& formals = pCall->functionInfo().formals();
-         BOOST_FOREACH(FormalInformation& formal, formals)
+         for (FormalInformation& formal : formals)
          {
             formal.setMissingnessHandled(true);
          }

--- a/src/cpp/session/modules/SessionRParser.hpp
+++ b/src/cpp/session/modules/SessionRParser.hpp
@@ -42,7 +42,6 @@
 #include <boost/bind.hpp>
 #include <boost/container/flat_set.hpp>
 #include <boost/shared_ptr.hpp>
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string.hpp>
 
 #include <core/Macros.hpp>
@@ -864,7 +863,7 @@ public:
            ++it)
       {
          const std::string& symbol = it->first;
-         BOOST_FOREACH(const Position& position, it->second)
+         for (const Position& position : it->second)
          {
             DEBUG("-- Checking for symbol '" << symbol << "' " << position.toString());
             if (!symbolHasDefinitionInTree(symbol, position) &&
@@ -886,7 +885,7 @@ public:
    
    bool isSymbolUsedInChildNode(const std::string& symbolName)
    {
-      BOOST_FOREACH(const boost::shared_ptr<ParseNode>& pChild, children_)
+      for (const boost::shared_ptr<ParseNode>& pChild : children_)
       {
          if (pChild->getReferencedSymbols().count(symbolName))
             return true;
@@ -947,7 +946,7 @@ public:
          DEBUG("-- '" << it->first << "'");
          if (nameLower == boost::algorithm::to_lower_copy(it->first))
          {
-            BOOST_FOREACH(const Position& position, it->second)
+            for (const Position& position : it->second)
             {
                if (position < item.position)
                {

--- a/src/cpp/session/modules/SessionRSConnect.cpp
+++ b/src/cpp/session/modules/SessionRSConnect.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionRSConnect.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,7 +16,6 @@
 #include "SessionRSConnect.hpp"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/Error.hpp>
 #include <core/Exec.hpp>
@@ -252,7 +251,7 @@ private:
       boost::algorithm::split(lines, output,
                               boost::algorithm::is_any_of("\n\r"));
       int ncharMarker = sizeof(kFinishedMarker) - 1;
-      BOOST_FOREACH(std::string& line, lines)
+      for (std::string& line : lines)
       {
          if (line.substr(0, ncharMarker) == kFinishedMarker)
             deployedUrl_ = line.substr(ncharMarker, line.size() - ncharMarker);
@@ -434,7 +433,7 @@ Error getEditPublishedDocs(const json::JsonRpcRequest& request,
       shinyPaths.push_back(appPath.childPath("ui.R"));
       shinyPaths.push_back(appPath.childPath("server.R"));
       shinyPaths.push_back(appPath.childPath("www/index.html"));
-      BOOST_FOREACH(const FilePath& filePath, shinyPaths)
+      for (const FilePath& filePath : shinyPaths)
       {
          if (filePath.exists())
             docPaths.push_back(filePath);

--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -743,14 +743,14 @@ Error svnRevert(const json::JsonRpcRequest& request,
    
    // build map (indexed on file path) for easy lookup
    std::map<std::string, source_control::FileWithStatus> fileStatusMap;
-   BOOST_FOREACH(const source_control::FileWithStatus& file, fileStatusVector)
+   for (const source_control::FileWithStatus& file : fileStatusVector)
    {
       fileStatusMap[file.path.absolutePath()] = file;
    }
    
    std::vector<FilePath> recursiveReverts;
    std::vector<FilePath> nonRecursiveReverts;
-   BOOST_FOREACH(const FilePath& filePath, paths)
+   for (const FilePath& filePath : paths)
    {
       if (!filePath.isDirectory())
       {
@@ -956,7 +956,7 @@ Error status(const FilePath& filePath,
    if (error)
       return error;
 
-   BOOST_FOREACH(source_control::FileWithStatus file, files)
+   for (source_control::FileWithStatus file : files)
    {
       json::Object fileObj;
       error = statusToJson(file.path, file.status, &fileObj);
@@ -1196,7 +1196,7 @@ struct CommitInfo
 bool commitIsMatch(const std::vector<std::string>& patterns,
                    const CommitInfo& commit)
 {
-   BOOST_FOREACH(std::string pattern, patterns)
+   for (std::string pattern : patterns)
    {
       if (!boost::algorithm::ifind_first(commit.author, pattern)
           && !boost::algorithm::ifind_first(commit.description, pattern)

--- a/src/cpp/session/modules/SessionSnippets.cpp
+++ b/src/cpp/session/modules/SessionSnippets.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionSnippets.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -21,7 +21,6 @@
 #include <core/json/Json.hpp>
 
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 
 #include <session/SessionModuleContext.hpp>
 
@@ -67,7 +66,7 @@ Error saveSnippets(const json::JsonRpcRequest& request,
       return error;
 
    FilePath snippetsDir = getSnippetsDir(true);
-   BOOST_FOREACH(const json::Value& valueJson, snippetsJson)
+   for (const json::Value& valueJson : snippetsJson)
    {
       if (json::isType<json::Object>(valueJson))
       {
@@ -119,7 +118,7 @@ Error getSnippetsAsJson(json::Array* pJsonData)
    if (error)
       return error;
    
-   BOOST_FOREACH(const FilePath& filePath, snippetPaths)
+   for (const FilePath& filePath : snippetPaths)
    {
       // bail if this doesn't appear to be a snippets file
       std::string mode;

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -20,7 +20,6 @@
 #include <map>
 
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 #include <boost/utility.hpp>
 
 #include <core/r_util/RSourceIndex.hpp>
@@ -1042,7 +1041,7 @@ Error setDocOrder(const json::JsonRpcRequest& request,
       return error;
    source_database::list(&docs);
 
-   BOOST_FOREACH( boost::shared_ptr<SourceDocument>& pDoc, docs )
+   for (boost::shared_ptr<SourceDocument>& pDoc : docs)
    {
       for (unsigned i = 0; i < ids.size(); i++) 
       {
@@ -1304,7 +1303,7 @@ Error clientInitDocuments(core::json::Array* pJsonDocs)
 
    // populate the array
    pJsonDocs->clear();
-   BOOST_FOREACH( boost::shared_ptr<SourceDocument>& pDoc, docs )
+   for (boost::shared_ptr<SourceDocument>& pDoc : docs)
    {
       // Force dirty state to be checked.
       // Client and server dirty state can get out of sync because

--- a/src/cpp/session/modules/SessionTests.cpp
+++ b/src/cpp/session/modules/SessionTests.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionTests.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,7 +16,6 @@
 #include "SessionTests.hpp"
 
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/Algorithm.hpp>
 #include <core/Error.hpp>

--- a/src/cpp/session/modules/SessionVCS.cpp
+++ b/src/cpp/session/modules/SessionVCS.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionVCS.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,8 +14,6 @@
  */
 
 #include "SessionVCS.hpp"
-
-#include <boost/foreach.hpp>
 
 #include <core/Exec.hpp>
 #include <core/StringUtils.hpp>

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionWorkbench.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -242,7 +242,7 @@ FilePath detectedTerminalPath()
       terminalPaths.push_back(FilePath("/usr/bin/xfce4-terminal"));
       terminalPaths.push_back(FilePath("/usr/bin/xterm"));
 
-      BOOST_FOREACH(const FilePath& terminalPath, terminalPaths)
+      for (const FilePath& terminalPath : terminalPaths)
       {
          if (terminalPath.exists())
             return terminalPath;

--- a/src/cpp/session/modules/build/SessionBuildEnvironment.cpp
+++ b/src/cpp/session/modules/build/SessionBuildEnvironment.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionBuildEnvironment.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -18,7 +18,6 @@
 
 #include <boost/regex.hpp>
 #include <boost/format.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/Error.hpp>
 #include <core/FilePath.hpp>
@@ -215,7 +214,7 @@ bool addRtoolsToPathIfNecessary(std::string* pPath,
                                     &environmentVars,
                                     pWarningMessage))
    {
-      BOOST_FOREACH(const core::system::Option& var, environmentVars)
+      for (const core::system::Option& var : environmentVars)
       {
          core::system::setenv(var.first, var.second);
       }
@@ -235,7 +234,7 @@ bool addRtoolsToPathIfNecessary(core::system::Options* pEnvironment,
                                     &environmentVars,
                                     pWarningMessage))
    {
-      BOOST_FOREACH(const core::system::Option& var, environmentVars)
+      for (const core::system::Option& var : environmentVars)
       {
          core::system::setenv(pEnvironment, var.first, var.second);
       }

--- a/src/cpp/session/modules/build/SessionBuildErrors.cpp
+++ b/src/cpp/session/modules/build/SessionBuildErrors.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionBuildErrors.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,7 +19,6 @@
 
 #include <boost/bind.hpp>
 #include <boost/regex.hpp>
-#include <boost/foreach.hpp>
 #include <boost/format.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
@@ -75,7 +74,7 @@ FilePath scanForRSourceFile(const FilePath& basePath,
       return FilePath();
    }
 
-   BOOST_FOREACH(const FilePath& child, children)
+   for (const FilePath& child : children)
    {
       if (isRSourceFile(child))
       {

--- a/src/cpp/session/modules/build/SessionBuildErrors.hpp
+++ b/src/cpp/session/modules/build/SessionBuildErrors.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionBuildErrors.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -20,7 +20,6 @@
 #include <vector>
 
 #include <boost/function.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/FilePath.hpp>
 #include <core/json/Json.hpp>
@@ -52,7 +51,7 @@ public:
    {
       using namespace module_context;
       std::vector<SourceMarker> allErrors;
-      BOOST_FOREACH(const CompileErrorParser& parser, parsers_)
+      for (const CompileErrorParser& parser : parsers_)
       {
          std::vector<SourceMarker> errors = parser(output);
          std::copy(errors.begin(), errors.end(), std::back_inserter(allErrors));

--- a/src/cpp/session/modules/build/SessionInstallRtools.cpp
+++ b/src/cpp/session/modules/build/SessionInstallRtools.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionInstallRtools.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,7 +16,6 @@
 #include "SessionInstallRtools.hpp"
 
 #include <boost/format.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/Error.hpp>
 #include <core/StringUtils.hpp>
@@ -76,7 +75,7 @@ Error installRtools()
    availableRtools.push_back(r_util::RToolsInfo("2.13", installPath, gcc49));
    availableRtools.push_back(r_util::RToolsInfo("2.12", installPath, gcc49));
    availableRtools.push_back(r_util::RToolsInfo("2.11", installPath, gcc49));
-   BOOST_FOREACH(const r_util::RToolsInfo& rTools, availableRtools)
+   for (const r_util::RToolsInfo& rTools : availableRtools)
    {
       if (module_context::isRtoolsCompatible(rTools))
       {

--- a/src/cpp/session/modules/clang/CodeCompletion.cpp
+++ b/src/cpp/session/modules/clang/CodeCompletion.cpp
@@ -1,7 +1,7 @@
 /*
  * CodeCompletion.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -178,7 +178,7 @@ void discoverTranslationUnitIncludePaths(const FilePath& filePath,
          rCompilationDatabase().compileArgsForTranslationUnit(
             filePath.absolutePathNative(), false);
    
-   BOOST_FOREACH(const std::string& arg, args)
+   for (const std::string& arg : args)
    {
       if (boost::algorithm::starts_with(arg, "-I"))
       {
@@ -410,7 +410,7 @@ Error getHeaderCompletionsImpl(const std::string& token,
    std::set<std::string> discoveredEntries;
    json::Array completionsJson;
    
-   BOOST_FOREACH(const std::string& path, includePaths)
+   for (const std::string& path : includePaths)
    {
       FilePath includePath(path);
       if (!includePath.exists())
@@ -425,7 +425,7 @@ Error getHeaderCompletionsImpl(const std::string& token,
       if (error)
          LOG_ERROR(error);
       
-      BOOST_FOREACH(const FilePath& childPath, children)
+      for (const FilePath& childPath : children)
       {
          std::string name = childPath.filename();
          if (discoveredEntries.count(name))

--- a/src/cpp/session/modules/clang/DefinitionIndex.cpp
+++ b/src/cpp/session/modules/clang/DefinitionIndex.cpp
@@ -338,7 +338,7 @@ FileLocation findDefinitionLocation(const FileLocation& location)
    {
       // first inspect translation units we have an in-memory index for
       TranslationUnits units = rSourceIndex().getIndexedTranslationUnits();
-      BOOST_FOREACH(const TranslationUnits::value_type& unit, units)
+      for (const TranslationUnits::value_type& unit : units)
       {
          // search for the definition
          CppDefinition def;
@@ -358,10 +358,9 @@ FileLocation findDefinitionLocation(const FileLocation& location)
 
       // if we didn't find it there then look for it in our index
       // of all saved files
-      BOOST_FOREACH(const DefinitionsByFile::value_type& defs,
-                    s_definitionsByFile)
+      for (const DefinitionsByFile::value_type& defs : s_definitionsByFile)
       {
-         BOOST_FOREACH(const CppDefinition& def, defs.second.definitions)
+         for (const CppDefinition& def : defs.second.definitions)
          {
             if (def.USR == USR)
                return def.location;
@@ -511,7 +510,7 @@ void loadDefinitionIndex()
       if (!FilePath::exists(definitions.file))
          continue;
 
-      BOOST_FOREACH(const json::Value& defJson, defsArrayJson)
+      for (const json::Value& defJson : defsArrayJson)
       {
          if (!json::isType<json::Object>(defJson))
          {
@@ -534,7 +533,7 @@ void saveDefinitionIndex()
    using namespace safe_convert;
 
    json::Array indexJson;
-   BOOST_FOREACH(const DefinitionsByFile::value_type& defs, s_definitionsByFile)
+   for (const DefinitionsByFile::value_type& defs : s_definitionsByFile)
    {
       const CppDefinitions& definitions = defs.second;
       json::Object definitionsJson;
@@ -580,7 +579,7 @@ void searchDefinitions(const std::string& term,
    // first search translation units we have an in-memory index for
    // (this will reflect unsaved changes in editor buffers)
    TranslationUnits units = rSourceIndex().getIndexedTranslationUnits();
-   BOOST_FOREACH(const TranslationUnits::value_type& unit, units)
+   for (const TranslationUnits::value_type& unit : units)
    {
       // search for matching definitions
       DefinitionVisitor visitor =
@@ -598,13 +597,13 @@ void searchDefinitions(const std::string& term,
    // for within the in-memory index)
    // if we didn't find it there then look for it in our index
    // of all saved files
-   BOOST_FOREACH(const DefinitionsByFile::value_type& defs, s_definitionsByFile)
+   for (const DefinitionsByFile::value_type& defs : s_definitionsByFile)
    {
       // skip files we've already searched
       if (units.find(defs.first) != units.end())
          continue;
 
-      BOOST_FOREACH(const CppDefinition& def, defs.second.definitions)
+      for (const CppDefinition& def : defs.second.definitions)
       {
          if (matches(term, pattern, def))
             pDefinitions->push_back(def);

--- a/src/cpp/session/modules/clang/FindReferences.cpp
+++ b/src/cpp/session/modules/clang/FindReferences.cpp
@@ -15,8 +15,6 @@
 
 #include "FindReferences.hpp"
 
-#include <boost/foreach.hpp>
-
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/split.hpp>
 
@@ -123,7 +121,7 @@ CXChildVisitResult findReferencesVisitor(CXCursor cxCursor,
          }
 
          // cycle through the tokens
-         BOOST_FOREACH(unsigned i, indexes)
+         for (unsigned i : indexes)
          {
             Token token = tokens.getToken(i);
             if (token.kind() == CXToken_Identifier &&
@@ -169,7 +167,7 @@ public:
       using namespace module_context;
       std::vector<SourceMarker> markers;
 
-      BOOST_FOREACH(const libclang::FileRange& loc, locations)
+      for (const libclang::FileRange& loc : locations)
       {
          FileLocation startLoc = loc.start;
 
@@ -340,7 +338,7 @@ core::Error findReferences(const core::libclang::FileLocation& location,
       std::map<std::string,TranslationUnit> indexedUnits =
                            rSourceIndex().getIndexedTranslationUnits();
 
-      BOOST_FOREACH(const std::string& filename, files)
+      for (const std::string& filename : files)
       {
          // first look in already indexed translation units
          // (this will pickup unsaved files)

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -140,7 +140,7 @@ std::vector<std::string> extractCompileArgs(const std::string& line)
 
 std::string extractStdArg(const std::vector<std::string>& args)
 {
-   BOOST_FOREACH(const std::string& arg, args)
+   for (const std::string& arg : args)
    {
       if (boost::algorithm::starts_with(arg, "-std="))
          return arg;
@@ -190,7 +190,7 @@ std::vector<std::string> parseCompilationResults(const std::string& results)
 
    // find the line with the compilation and add it's args
    boost::regex re("-c [^\\.]+\\.c\\w* -o");
-   BOOST_FOREACH(const std::string& line, lines)
+   for (const std::string& line : lines)
    {
       if (regex_utils::search(line, re))
       {
@@ -233,7 +233,7 @@ bool packageIsCpp(const std::string& linkingTo, const FilePath& srcDir)
          return false;
       }
 
-      BOOST_FOREACH(const FilePath& srcFile, allSrcFiles)
+      for (const FilePath& srcFile : allSrcFiles)
       {
          std::string ext = srcFile.extensionLowerCase();
          if (ext == ".cpp" || ext == ".cc")
@@ -334,7 +334,7 @@ void RCompilationDatabase::updateForCurrentPackage()
    if (!compileArgs.empty())
    {
       // do path substitutions
-      BOOST_FOREACH(std::string arg, compileArgs)
+      for (std::string arg : compileArgs)
       {
          // do path substitutions
          boost::algorithm::replace_first(
@@ -477,7 +477,7 @@ void RCompilationDatabase::restorePackageCompilationConfig()
    }
 
    packageCompilationConfig_.args.clear();
-   BOOST_FOREACH(const json::Value& argJson, argsJson)
+   for (const json::Value& argJson : argsJson)
    {
       if (json::isType<std::string>(argJson))
          packageCompilationConfig_.args.push_back(argJson.get_str());
@@ -707,7 +707,7 @@ bool RCompilationDatabase::shouldIndexConfig(const CompilationConfig& config)
 
    // using RcppNT2/Boost.SIMD means don't index (expression templates
    // are too much for the way we do indexing)
-   BOOST_FOREACH(const std::string& arg, config.args)
+   for (const std::string& arg : config.args)
    {
       if (boost::algorithm::contains(arg, "RcppNT2"))
          return false;

--- a/src/cpp/session/modules/connections/Connection.cpp
+++ b/src/cpp/session/modules/connections/Connection.cpp
@@ -1,7 +1,7 @@
 /*
  * Connection.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,8 +14,6 @@
  */
 
 #include "Connection.hpp"
-
-#include <boost/foreach.hpp>
 
 #include <core/Base64.hpp>
 #include <core/StringUtils.hpp>
@@ -117,14 +115,14 @@ json::Object connectionJson(const Connection& connection)
 {
    // form the action array
    json::Array actions;
-   BOOST_FOREACH(const ConnectionAction& action, connection.actions)
+   for (const ConnectionAction& action : connection.actions)
    {
       actions.push_back(connectionActionJson(action));
    }
 
    // form the object type array
    json::Array objectTypes;
-   BOOST_FOREACH(const ConnectionObjectType& type, connection.objectTypes)
+   for (const ConnectionObjectType& type : connection.objectTypes)
    {
       objectTypes.push_back(connectionObjectTypeJson(type));
    }
@@ -191,7 +189,7 @@ Error connectionFromJson(const json::Object& connectionJson,
             "last_used", &(pConnection->lastUsed));
 
    // read each action
-   BOOST_FOREACH(const json::Value& action, actions) 
+   for (const json::Value& action : actions)
    {
       if (action.type() != json::ObjectType)
          continue;
@@ -208,7 +206,7 @@ Error connectionFromJson(const json::Object& connectionJson,
    }
 
    // read each object type
-   BOOST_FOREACH(const json::Value& objectType, objectTypes) 
+   for (const json::Value& objectType : objectTypes)
    {
       if (objectType.type() != json::ObjectType)
          continue;

--- a/src/cpp/session/modules/connections/ConnectionsIndexer.cpp
+++ b/src/cpp/session/modules/connections/ConnectionsIndexer.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionConnectionsWorker.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -23,7 +23,6 @@
 #include <core/text/DcfParser.hpp>
 
 #include <boost/regex.hpp>
-#include <boost/foreach.hpp>
 #include <boost/bind.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/system/error_code.hpp>
@@ -160,7 +159,7 @@ public:
    {
       json::Object object;
       
-      BOOST_FOREACH(const std::string& key, connections_ | boost::adaptors::map_keys)
+      for (const std::string& key : connections_ | boost::adaptors::map_keys)
       {
          object[key] = connections_.at(key).toJson();
       }
@@ -237,7 +236,7 @@ class ConnectionsWorker : public ppe::Worker
 
       // handle pending continuations
       json::Object registryJson = connectionsRegistry().toJson();
-      BOOST_FOREACH(json::JsonRpcFunctionContinuation continuation, continuations_)
+      for (json::JsonRpcFunctionContinuation continuation : continuations_)
       {
          json::JsonRpcResponse response;
          response.setResult(registryJson);

--- a/src/cpp/session/modules/connections/SessionConnections.cpp
+++ b/src/cpp/session/modules/connections/SessionConnections.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionConnections.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,7 +15,6 @@
 
 #include "SessionConnections.hpp"
 
-#include <boost/foreach.hpp>
 #include <boost/format.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/predicate.hpp>
@@ -78,7 +77,7 @@ SEXP rs_connectionOpened(SEXP connectionSEXP)
    {
       std::vector<std::string> actionNames;
       r::sexp::getNames(actionList, &actionNames);
-      BOOST_FOREACH(const std::string& actionName, actionNames)
+      for (const std::string& actionName : actionNames)
       {
          std::string icon;
          SEXP action;
@@ -210,7 +209,7 @@ SEXP rs_availableRemoteServers()
    // get list of previous connections and extract unique remote servers
    std::vector<std::string> remoteServers;
    json::Array connectionsJson = connectionHistory().connectionsAsJson();
-   BOOST_FOREACH(const json::Value connectionJson, connectionsJson)
+   for (const json::Value connectionJson : connectionsJson)
    {
       // don't inspect if not an object -- this should never happen
       // but we screen it anyway to prevent a crash on corrupt data

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -20,7 +20,6 @@
 #include <sstream>
 
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 #include <boost/format.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
@@ -960,7 +959,7 @@ void onDeferredInit(bool newSession)
    }
 
    std::vector<std::string> sourceKeys;
-   BOOST_FOREACH(boost::shared_ptr<source_database::SourceDocument> pDoc, docs)
+   for (boost::shared_ptr<source_database::SourceDocument> pDoc : docs)
    {
       std::string key = pDoc->getProperty("cacheKey");
       if (!key.empty())
@@ -981,7 +980,7 @@ void onDeferredInit(bool newSession)
    }
 
    std::vector<std::string> cacheKeys;
-   BOOST_FOREACH(const FilePath& cacheFile, cacheFiles)
+   for (const FilePath& cacheFile : cacheFiles)
    {
       cacheKeys.push_back(cacheFile.stem());
    }
@@ -996,7 +995,7 @@ void onDeferredInit(bool newSession)
                        std::back_inserter(orphanKeys));
 
    // remove each key no longer bound to a source file
-   BOOST_FOREACH(const std::string& orphanKey, orphanKeys)
+   for (const std::string& orphanKey : orphanKeys)
    {
       error = cache.complete(orphanKey + ".Rdata").removeIfExists();
       if (error)

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -35,8 +35,6 @@
 #include <session/SessionPersistentState.hpp>
 #include <session/SessionUserSettings.hpp>
 
-#include <boost/foreach.hpp>
-
 #include "EnvironmentUtils.hpp"
 
 using namespace rstudio::core;

--- a/src/cpp/session/modules/presentation/PresentationLog.cpp
+++ b/src/cpp/session/modules/presentation/PresentationLog.cpp
@@ -1,7 +1,7 @@
 /*
  * PresentationLog.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,7 +17,6 @@
 #include "PresentationLog.hpp"
 
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
@@ -96,13 +95,13 @@ void Log::onSlideDeckChanged(const SlideDeck& slideDeck)
       slideTypes_.push_back(slides[i].type());
 
       const std::vector<Command>& commands = slides[i].commands();
-      BOOST_FOREACH(const Command& command, commands)
+      for (const Command& command : commands)
       {
          recordCommand(i, command);
       }
 
       const std::vector<AtCommand>& atCommands = slides[i].atCommands();
-      BOOST_FOREACH(const AtCommand& atCommand, atCommands)
+      for (const AtCommand& atCommand : atCommands)
       {
          recordCommand(i, atCommand.command());
       }

--- a/src/cpp/session/modules/presentation/SessionPresentation.cpp
+++ b/src/cpp/session/modules/presentation/SessionPresentation.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionPresentation.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -305,7 +305,7 @@ Error getSlideNavigation(const std::string& code,
       return error;
 
    SlideNavigationList navigationList("slide");
-   BOOST_FOREACH(const Slide& slide, slideDeck.slides())
+   for (const Slide& slide : slideDeck.slides())
    {
       navigationList.add(slide);
    }

--- a/src/cpp/session/modules/presentation/SlideMediaRenderer.cpp
+++ b/src/cpp/session/modules/presentation/SlideMediaRenderer.cpp
@@ -1,7 +1,7 @@
 /*
  * SlideMediaRenderer.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,7 +19,6 @@
 #include <iostream>
 #include <sstream>
 
-#include <boost/foreach.hpp>
 #include <boost/format.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
@@ -82,7 +81,7 @@ std::vector<MediaSource> discoverMediaSources(
    {
       // get the filename without extension
       std::string stem = mediaFile.stem();
-      BOOST_FOREACH(std::string fmt, formats)
+      for (std::string fmt : formats)
       {
          FilePath targetPath = mediaFile.parent().complete(stem + "." + fmt);
          if (targetPath.exists())
@@ -107,7 +106,7 @@ std::vector<MediaSource> discoverMediaSources(
 std::string atCommandsAsJsonArray(const std::vector<AtCommand>& atCommands)
 {
    json::Array cmdsArray;
-   BOOST_FOREACH(const AtCommand atCmd, atCommands)
+   for (const AtCommand atCmd : atCommands)
    {
       cmdsArray.push_back(atCmd.asJson());
    }
@@ -137,7 +136,7 @@ void renderMedia(const std::string& type,
                                                                 baseDir,
                                                                 fileName);
    std::string sources;
-   BOOST_FOREACH(const MediaSource& source, mediaSources)
+   for (const MediaSource& source : mediaSources)
    {
       sources += (source.asTag() + "\n");
    }

--- a/src/cpp/session/modules/presentation/SlideNavigationList.cpp
+++ b/src/cpp/session/modules/presentation/SlideNavigationList.cpp
@@ -1,7 +1,7 @@
 /*
  * SlideNavigationList.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,8 +17,6 @@
 #include "SlideNavigationList.hpp"
 
 #include <sstream>
-
-#include <boost/foreach.hpp>
 
 #include <session/SessionModuleContext.hpp>
 

--- a/src/cpp/session/modules/presentation/SlideParser.cpp
+++ b/src/cpp/session/modules/presentation/SlideParser.cpp
@@ -1,7 +1,7 @@
 /*
  * SlideParser.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -18,7 +18,6 @@
 
 #include <iostream>
 
-#include <boost/foreach.hpp>
 #include <boost/regex.hpp>
 #include <boost/algorithm/string.hpp>
 
@@ -133,7 +132,7 @@ bool Slide::showTitle() const
 std::vector<Command> Slide::commands() const
 {
    std::vector<Command> commands;
-   BOOST_FOREACH(const Slide::Field& field, fields_)
+   for (const Slide::Field& field : fields_)
    {
       if (isCommandField(field.first))
          commands.push_back(Command(field.first, field.second));
@@ -148,7 +147,7 @@ std::vector<AtCommand> Slide::atCommands() const
 
 
    std::vector<std::string> atFields = fieldValues("at");
-   BOOST_FOREACH(const std::string& atField, atFields)
+   for (const std::string& atField : atFields)
    {
       boost::smatch match;
       if (regex_utils::match(atField, match, re))
@@ -182,7 +181,7 @@ std::vector<AtCommand> Slide::atCommands() const
 std::vector<std::string> Slide::fields() const
 {
    std::vector<std::string> fields;
-   BOOST_FOREACH(const Field& field, fields_)
+   for (const Field& field : fields_)
    {
       fields.push_back(field.first);
    }
@@ -204,7 +203,7 @@ std::string Slide::fieldValue(const std::string& name,
 std::vector<std::string> Slide::fieldValues(const std::string& name) const
 {
    std::vector<std::string> values;
-   BOOST_FOREACH(const Field& field, fields_)
+   for (const Field& field : fields_)
    {
       if (boost::iequals(name, field.first))
          values.push_back(normalizeFieldValue(field.second));
@@ -476,7 +475,7 @@ Error SlideDeck::readSlides(const std::string& slides, const FilePath& baseDir)
 
       // validate all of the fields
       std::vector<std::string> invalidFields;
-      BOOST_FOREACH(const Slide::Field& field, slideFields)
+      for (const Slide::Field& field : slideFields)
       {
          if (!isValidField(field.first))
             invalidFields.push_back(field.first);

--- a/src/cpp/session/modules/presentation/SlideRenderer.cpp
+++ b/src/cpp/session/modules/presentation/SlideRenderer.cpp
@@ -1,7 +1,7 @@
 /*
  * SlideRenderer.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,7 +16,6 @@
 
 #include "SlideRenderer.hpp"
 
-#include <boost/foreach.hpp>
 #include <boost/format.hpp>
 #include <boost/regex.hpp>
 #include <boost/algorithm/string.hpp>
@@ -49,7 +48,7 @@ std::string commandsAsJsonArray(const Slide& slide)
    json::Array commandsJsonArray;
 
    std::vector<Command> commands = slide.commands();
-   BOOST_FOREACH(const Command& command, commands)
+   for (const Command& command : commands)
    {
       commandsJsonArray.push_back(command.asJson());
    }
@@ -239,7 +238,7 @@ Error slideToHtml(const Slide& slide,
    {
       std::ostringstream ostr;
       ostr << "<div class=\"fieldError\">";
-      BOOST_FOREACH(const std::string& field, slide.invalidFields())
+      for (const std::string& field : slide.invalidFields())
       {
          ostr << "<span>Unrecognized slide field:</span> "
               << "<code>" << field << "</code><br/>";
@@ -517,20 +516,20 @@ Error renderSlides(const SlideDeck& slideDeck,
       ostr << "</section>" << "\n";
 
       // reveal config actions
-      BOOST_FOREACH(const std::string& config, revealConfig)
+      for (const std::string& config : revealConfig)
       {
          ostrRevealConfig << config << "," << "\n";
       }
 
       // javascript actions to take on slide deck init
-      BOOST_FOREACH(const std::string& jsAction, initActions)
+      for (const std::string& jsAction : initActions)
       {
          ostrInitActions <<  jsAction << ";" << "\n";
       }
 
       // javascript actions to take on slide load
       ostrSlideActions << cmdPad << "case " << slideNumber << ":" << "\n";
-      BOOST_FOREACH(const std::string& jsAction, slideActions)
+      for (const std::string& jsAction : slideActions)
       {
          ostrSlideActions << cmdPad << "  " << jsAction << ";" << "\n";
       }

--- a/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
+++ b/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
@@ -1,7 +1,7 @@
 /*
  * SlideRequestHandler.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,7 +19,6 @@
 #include <iostream>
 
 #include <boost/utility.hpp>
-#include <boost/foreach.hpp>
 #include <boost/format.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/predicate.hpp>
@@ -663,7 +662,7 @@ void fontVars(const SlideDeck& slideDeck,
       std::vector<std::string> fontImports =
             slideDeck.slides().at(0).fieldValues("font-import");
 
-      BOOST_FOREACH(const std::string& fontImport, fontImports)
+      for (const std::string& fontImport : fontImports)
       {
          ostr << "@import url('" << fontImport << "');" << std::endl;
       }
@@ -803,7 +802,7 @@ void loadSlideDeckDependencies(const SlideDeck& slideDeck)
                            boost::algorithm::is_any_of(","));
 
    // load any dependencies
-   BOOST_FOREACH(std::string pkg, depends)
+   for (std::string pkg : depends)
    {
       boost::algorithm::trim(pkg);
 

--- a/src/cpp/session/modules/presentation/TutorialInstaller.cpp
+++ b/src/cpp/session/modules/presentation/TutorialInstaller.cpp
@@ -1,15 +1,21 @@
 /*
  * TutorialInstaller.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
-
 
 #include "TutorialInstaller.hpp"
 
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/Log.hpp>
 #include <core/Error.hpp>
@@ -156,7 +162,7 @@ void installFiles(const FilePath& fromDir,
    }
 
    // recursively copy the files
-   BOOST_FOREACH(const std::string& file, files)
+   for (const std::string& file : files)
    {
       FilePath sourceFilePath = fromDir.childPath(file);
       FilePath targetFilePath = toDir.childPath(file);

--- a/src/cpp/session/modules/rmarkdown/NotebookCache.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookCache.cpp
@@ -21,7 +21,6 @@
 #include "NotebookHtmlWidgets.hpp"
 
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 
 #include <session/SessionUserSettings.hpp>
 #include <session/SessionModuleContext.hpp>
@@ -75,7 +74,7 @@ void cleanUnusedCaches()
    }
 
    std::string nbCtxId = notebookCtxId();
-   BOOST_FOREACH(const FilePath cache, caches)
+   for (const FilePath cache : caches)
    {
       // make sure this looks like a notebook cache
       if (!cache.isDirectory())
@@ -123,7 +122,7 @@ void cleanUnusedCaches()
          continue;
       }
 
-      BOOST_FOREACH(const FilePath context, contexts)
+      for (const FilePath context : contexts)
       {
          // skip if not our context or the saved context
          if (context.filename() != kSavedCtx &&
@@ -433,7 +432,7 @@ void onDocSaved(FilePath path)
       LOG_ERROR(error);
       return;
    }
-   BOOST_FOREACH(const FilePath source, children)
+   for (const FilePath source : children)
    {
       // compute the target path 
       FilePath target = saved.complete(source.filename());

--- a/src/cpp/session/modules/rmarkdown/NotebookChunkDefs.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookChunkDefs.cpp
@@ -17,8 +17,6 @@
 #include "NotebookCache.hpp"
 #include "NotebookChunkDefs.hpp"
 
-#include <boost/foreach.hpp>
-
 #include <core/json/Json.hpp>
 #include <core/json/JsonRpc.hpp>
 #include <core/Exec.hpp>
@@ -91,7 +89,7 @@ void cleanChunks(const FilePath& cacheDir,
                        std::back_inserter(staleIds));
 
    // remove each stale folder from the system
-   BOOST_FOREACH(const std::string& staleId, staleIds)
+   for (const std::string& staleId : staleIds)
    {
       error = cacheDir.complete(staleId).removeIfExists();
    }

--- a/src/cpp/session/modules/rmarkdown/NotebookData.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookData.cpp
@@ -1,7 +1,7 @@
 /*
  * NotebookData.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,7 +19,6 @@
 
 #include <iostream>
 
-#include <boost/foreach.hpp>
 #include <boost/format.hpp>
 
 #include <r/RExec.hpp>

--- a/src/cpp/session/modules/rmarkdown/NotebookDocQueue.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookDocQueue.cpp
@@ -1,7 +1,7 @@
 /*
  * NotebookDocQueue.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,8 +15,6 @@
 
 #include "NotebookDocQueue.hpp"
 #include "NotebookChunkDefs.hpp"
-
-#include <boost/foreach.hpp>
 
 #include <session/SessionModuleContext.hpp>
 #include <session/SessionSourceDatabase.hpp>
@@ -92,7 +90,7 @@ json::Object NotebookDocQueue::toJson() const
 {
    // serialize all the queue units 
    json::Array units;
-   BOOST_FOREACH(const boost::shared_ptr<NotebookQueueUnit> unit, queue_) 
+   for (const boost::shared_ptr<NotebookQueueUnit> unit : queue_)
    {
       units.push_back(unit->toJson());
    }
@@ -136,7 +134,7 @@ core::Error NotebookDocQueue::fromJson(const core::json::Object& source,
          maxUnits);
 
    // populate the queue units
-   BOOST_FOREACH(const json::Value val, units)
+   for (const json::Value val : units)
    {
       // ignore non-objects
       if (val.type() != json::ObjectType)

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
@@ -1,7 +1,7 @@
 /*
  * NotebookExec.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -23,8 +23,6 @@
 #include "NotebookErrors.hpp"
 #include "NotebookWorkingDir.hpp"
 #include "NotebookConditions.hpp"
-
-#include <boost/foreach.hpp>
 
 #include <core/Error.hpp>
 #include <core/text/CsvParser.hpp>
@@ -282,7 +280,7 @@ bool ChunkExecContext::onCondition(Condition condition,
    }
 
    // give each capturing module a chance to handle the condition
-   BOOST_FOREACH(boost::shared_ptr<NotebookCapture> pCapture, captures_)
+   for (boost::shared_ptr<NotebookCapture> pCapture : captures_)
    {
       if (pCapture->onCondition(condition, message))
          return true;
@@ -441,7 +439,7 @@ void ChunkExecContext::disconnect()
    Error error;
 
    // clean up capturing modules (includes plots, errors, and HTML widgets)
-   BOOST_FOREACH(boost::shared_ptr<NotebookCapture> pCapture, captures_)
+   for (boost::shared_ptr<NotebookCapture> pCapture : captures_)
    {
       pCapture->disconnect();
    }
@@ -466,7 +464,7 @@ void ChunkExecContext::disconnect()
    }
 
    // unhook all our event handlers
-   BOOST_FOREACH(const RSTUDIO_BOOST_CONNECTION& connection, connections_)
+   for (const RSTUDIO_BOOST_CONNECTION& connection : connections_)
    {
       connection.disconnect();
    }
@@ -524,7 +522,7 @@ ExecScope ChunkExecContext::execScope()
 void ChunkExecContext::onExprComplete()
 {
    // notify capturing submodules
-   BOOST_FOREACH(boost::shared_ptr<NotebookCapture> pCapture, captures_)
+   for (boost::shared_ptr<NotebookCapture> pCapture : captures_)
    {
       pCapture->onExprComplete();
    }

--- a/src/cpp/session/modules/rmarkdown/NotebookHtmlWidgets.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookHtmlWidgets.cpp
@@ -1,7 +1,7 @@
 /*
  * NotebookHtmlWidgets.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,7 +19,6 @@
 
 #include <iostream>
 
-#include <boost/foreach.hpp>
 #include <boost/format.hpp>
 
 #include <r/RExec.hpp>

--- a/src/cpp/session/modules/rmarkdown/NotebookOutput.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookOutput.cpp
@@ -18,7 +18,6 @@
 #include "NotebookOutput.hpp"
 #include "NotebookPlots.hpp"
 
-#include <boost/foreach.hpp>
 #include <boost/format.hpp>
 #include <boost/algorithm/string.hpp>
 
@@ -366,7 +365,7 @@ OutputPair lastChunkOutput(const std::string& docId,
    }
 
    OutputPair last;
-   BOOST_FOREACH(const FilePath& path, outputPaths)
+   for (const FilePath& path : outputPaths)
    {
       // extract ordinal and update if it's the most recent we've seen so far
       unsigned ordinal = static_cast<unsigned>(
@@ -496,7 +495,7 @@ Error enqueueChunkOutput(
       std::sort(outputPaths.begin(), outputPaths.end());
 
       // loop through each and build an array of the outputs
-      BOOST_FOREACH(const FilePath& outputPath, outputPaths)
+      for (const FilePath& outputPath : outputPaths)
       {
          json::Object output;
 

--- a/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
@@ -1,7 +1,7 @@
 /*
  * NotebookPlotReplay.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -21,7 +21,6 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/StringUtils.hpp>
 #include <core/Exec.hpp>
@@ -61,7 +60,7 @@ public:
       // create the text to send to the process (it'll be read on stdin
       // inside R)
       std::string input;
-      BOOST_FOREACH(const FilePath snapshot, snapshotFiles)
+      for (const FilePath snapshot : snapshotFiles)
       {
          input.append(string_utils::utf8ToSystem(snapshot.absolutePath()));
          input.append("\n");
@@ -117,7 +116,7 @@ private:
       std::vector<std::string> paths;
       boost::algorithm::split(paths, output,
                               boost::algorithm::is_any_of("\n\r"));
-      BOOST_FOREACH(std::string& path, paths)
+      for (std::string& path : paths)
       {
          // ensure path exists
          FilePath png(string_utils::trimWhitespace(path));
@@ -225,7 +224,7 @@ Error replayPlotOutput(const json::JsonRpcRequest& request,
 
    // look for snapshot files
    std::vector<FilePath> snapshotFiles;
-   BOOST_FOREACH(const std::string chunkId, chunkIds)
+   for (const std::string chunkId : chunkIds)
    {
       // find the storage location for this chunk output
       FilePath path = chunkOutputPath(docPath, docId, chunkId, notebookCtxId(),
@@ -241,7 +240,7 @@ Error replayPlotOutput(const json::JsonRpcRequest& request,
          LOG_ERROR(error);
          continue;
       }
-      BOOST_FOREACH(const FilePath content, contents)
+      for (const FilePath content : contents)
       {
          if (content.hasExtensionLowerCase(kDisplayListExt))
             snapshotFiles.push_back(content);
@@ -303,7 +302,7 @@ Error replayChunkPlotOutput(const json::JsonRpcRequest& request,
       return Success();
    }
 
-   BOOST_FOREACH(const FilePath content, contents)
+   for (const FilePath content : contents)
    {
       if (content.hasExtensionLowerCase(kDisplayListExt))
          snapshotFiles.push_back(content);

--- a/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
@@ -1,7 +1,7 @@
 /*
  * NotebookPlots.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,7 +19,6 @@
 #include "../SessionPlots.hpp"
 
 #include <boost/format.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/BoostSignals.hpp>
 #include <core/Exec.hpp>
@@ -58,7 +57,7 @@ SEXP rs_recordExternalPlot(SEXP plotFilesSEXP)
    std::vector<std::string> plotFiles;
    if (r::sexp::fillVectorString(plotFilesSEXP, &plotFiles))
    {
-      BOOST_FOREACH(const std::string& plotFile, plotFiles)
+      for (const std::string& plotFile : plotFiles)
       {
          if (plotFile.empty())
             continue;
@@ -102,7 +101,7 @@ void PlotCapture::processPlots(bool ignoreEmpty)
             folderContents.end(),
             std::less<FilePath>());
    
-   BOOST_FOREACH(const FilePath& path, folderContents)
+   for (const FilePath& path : folderContents)
    {
       if (isPlotPath(path))
       {
@@ -295,7 +294,7 @@ core::Error PlotCapture::connectPlots(const std::string& docId,
    if (error)
       return error;
 
-   BOOST_FOREACH(const core::FilePath& file, folderContents)
+   for (const core::FilePath& file : folderContents)
    {
       // remove if it looks like a plot 
       if (isPlotPath(file)) 

--- a/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
@@ -1,7 +1,7 @@
 /*
  * NotebookQueue.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -29,8 +29,6 @@
 #include "NotebookCache.hpp"
 #include "NotebookAlternateEngines.hpp"
 #include "NotebookChunkOptions.hpp"
-
-#include <boost/foreach.hpp>
 
 #include <r/RCntxtUtils.hpp>
 #include <r/RInterface.hpp>
@@ -87,7 +85,7 @@ public:
       pInput_->enque(kThreadQuitCommand);
 
       // unregister handlers
-      BOOST_FOREACH(RSTUDIO_BOOST_CONNECTION& connection, handlers_)
+      for (RSTUDIO_BOOST_CONNECTION& connection : handlers_)
       {
          connection.disconnect();
       }
@@ -183,7 +181,7 @@ public:
       const std::string& before)
    {
       // find the document queue corresponding to this unit
-      BOOST_FOREACH(const boost::shared_ptr<NotebookDocQueue> queue, queue_)
+      for (const boost::shared_ptr<NotebookDocQueue> queue : queue_)
       {
          if (queue->docId() == pUnit->docId())
          {
@@ -214,7 +212,7 @@ public:
 
    json::Value getDocQueue(const std::string& docId)
    {
-      BOOST_FOREACH(boost::shared_ptr<NotebookDocQueue> pQueue, queue_)
+      for (boost::shared_ptr<NotebookDocQueue> pQueue : queue_)
       {
          if (pQueue->docId() == docId)
             return pQueue->toJson();

--- a/src/cpp/session/modules/rmarkdown/NotebookQueueUnit.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueueUnit.cpp
@@ -1,7 +1,7 @@
 /*
  * NotebookQueueUnit.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,7 +17,6 @@
 
 #include <session/SessionModuleContext.hpp>
 
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string.hpp>
 
 #include <core/json/JsonRpc.hpp>
@@ -68,7 +67,7 @@ Error fillExecRange(const json::Array& in, std::list<ExecRange>* pOut)
 
 void fillJsonRange(const std::list<ExecRange>& in, json::Array* pOut)
 {
-   BOOST_FOREACH(const ExecRange range, in)
+   for (const ExecRange range : in)
    {
       pOut->push_back(range.toJson());
    }

--- a/src/cpp/session/modules/rmarkdown/RMarkdownTemplates.cpp
+++ b/src/cpp/session/modules/rmarkdown/RMarkdownTemplates.cpp
@@ -1,7 +1,7 @@
 /*
  * RMarkdownTemplates.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -12,8 +12,6 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
-
-#include <boost/foreach.hpp>
 
 #include "RMarkdownTemplates.hpp"
 
@@ -72,7 +70,7 @@ class Worker : public ppe::Worker
       }
 
       // for each template folder found, look for a valid template inside
-      BOOST_FOREACH(const FilePath& templateDir, templateDirs)
+      for (const FilePath& templateDir : templateDirs)
       {
          // skip if not a directory
          if (!templateDir.isDirectory())

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionRMarkdown.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -24,7 +24,6 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/iostreams/filter/regex.hpp>
 #include <boost/format.hpp>
-#include <boost/foreach.hpp>
 #include <boost/scope_exit.hpp>
 
 #include <core/FileSerializer.hpp>
@@ -185,7 +184,7 @@ FilePath extractOutputFileCreated(const FilePath& inputFile,
    std::stringstream outputStream(output);
    while (std::getline(outputStream, renderLine))
    {
-      BOOST_FOREACH(const std::string& marker, completeMarkers)
+      for (const std::string& marker : completeMarkers)
       {
          if (boost::algorithm::starts_with(renderLine, marker))
          {
@@ -597,7 +596,7 @@ private:
       std::vector<std::string> outputLines;
       boost::algorithm::split(outputLines, output,
                               boost::algorithm::is_any_of("\n\r"));
-      BOOST_FOREACH(std::string& outputLine, outputLines)
+      for (std::string& outputLine : outputLines)
       {
          // if this is a Shiny render, check to see if Shiny started listening
          if (isShiny_)

--- a/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionRmdNotebook.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -29,7 +29,6 @@
 
 #include <iostream>
 
-#include <boost/foreach.hpp>
 #include <boost/format.hpp>
 
 #include <r/RJson.hpp>
@@ -73,7 +72,7 @@ void replayChunkOutputs(const std::string& docPath, const std::string& docId,
    if (singleChunkId.empty())
    {
       // find all the chunks and play them back to the client
-      BOOST_FOREACH(const std::string& chunkId, chunkIds)
+      for (const std::string& chunkId : chunkIds)
       {
          enqueueChunkOutput(docPath, docId, chunkId, notebookCtxId(), requestId);
       }

--- a/src/cpp/session/modules/shiny/SessionShiny.cpp
+++ b/src/cpp/session/modules/shiny/SessionShiny.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionShiny.cpp
  *
- * Copyright (C) 2009-15 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,7 +16,6 @@
 #include "SessionShiny.hpp"
 
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/Algorithm.hpp>
 #include <core/Error.hpp>
@@ -312,7 +311,7 @@ Error createShinyApp(const json::JsonRpcRequest& request,
    
    // if any files already exist, report that as an error
    std::vector<std::string> existingFiles;
-   BOOST_FOREACH(const std::string& fileName, templateFiles)
+   for (const std::string& fileName : templateFiles)
    {
       FilePath filePath = shinyDir.complete(fileName);
       std::string aliasedPath = module_context::createAliasedPath(shinyDir.complete(fileName));
@@ -345,7 +344,7 @@ Error createShinyApp(const json::JsonRpcRequest& request,
    }
    
    // copy the files (updates success in 'result')
-   BOOST_FOREACH(const std::string& fileName, templateFiles)
+   for (const std::string& fileName : templateFiles)
    {
       FilePath target = shinyDir.complete(fileName);
       Error error = copyTemplateFile(fileName, target);

--- a/src/cpp/session/modules/tex/SessionCompilePdf.cpp
+++ b/src/cpp/session/modules/tex/SessionCompilePdf.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionCompilePdf.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -18,7 +18,6 @@
 #include <set>
 
 #include <boost/format.hpp>
-#include <boost/foreach.hpp>
 #include <boost/enable_shared_from_this.hpp>
 
 #include <core/FilePath.hpp>
@@ -273,7 +272,7 @@ void showLogEntries(const core::tex::LogEntries& logEntries,
                                              rnw_concordance::Concordances())
 {
    json::Array logEntriesJson;
-   BOOST_FOREACH(const core::tex::LogEntry& logEntry, logEntries)
+   for (const core::tex::LogEntry& logEntry : logEntries)
    {
       using namespace tex::rnw_concordance;
       core::tex::LogEntry rnwEntry = rnwConcordances.fixup(logEntry);
@@ -289,7 +288,7 @@ void writeLogEntriesOutput(const core::tex::LogEntries& logEntries)
       return;
 
    std::string output = "\n";
-   BOOST_FOREACH(const core::tex::LogEntry& logEntry, logEntries)
+   for (const core::tex::LogEntry& logEntry : logEntries)
    {
       switch(logEntry.type())
       {
@@ -399,7 +398,7 @@ std::string buildIssuesMessage(const core::tex::LogEntries& logEntries)
 
    // count error types
    int errors = 0, warnings = 0, badBoxes = 0;
-   BOOST_FOREACH(const core::tex::LogEntry& logEntry, logEntries)
+   for (const core::tex::LogEntry& logEntry : logEntries)
    {
       if (logEntry.type() == core::tex::LogEntry::Error)
          errors++;
@@ -475,7 +474,7 @@ public:
    void preserveLogReferencedFiles(
                const core::tex::LogEntries& logEntries)
    {
-      BOOST_FOREACH(const core::tex::LogEntry& logEntry, logEntries)
+      for (const core::tex::LogEntry& logEntry : logEntries)
       {
          logRefFiles_.insert(logEntry.filePath());
       }

--- a/src/cpp/session/modules/tex/SessionPdfLatex.cpp
+++ b/src/cpp/session/modules/tex/SessionPdfLatex.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionPdfLatex.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -64,7 +64,7 @@ public:
 
    bool isValidTypeName(const std::string& name) const
    {
-      BOOST_FOREACH(const std::string& type, types_)
+      for (const std::string& type : types_)
       {
          if (boost::algorithm::iequals(name, type))
             return true;
@@ -107,7 +107,7 @@ const LatexProgramTypes& programTypes()
 std::string latexProgramMagicComment(
                      const core::tex::TexMagicComments& magicComments)
 {
-   BOOST_FOREACH(const core::tex::TexMagicComment& mc, magicComments)
+   for (const core::tex::TexMagicComment& mc : magicComments)
    {
       if (boost::algorithm::iequals(mc.scope(), "tex") &&
           (boost::algorithm::iequals(mc.variable(), "program") ||

--- a/src/cpp/session/modules/tex/SessionRnwConcordance.cpp
+++ b/src/cpp/session/modules/tex/SessionRnwConcordance.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionRnwConcordance.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,7 +17,6 @@
 
 #include <iostream>
 
-#include <boost/foreach.hpp>
 #include <boost/regex.hpp>
 
 #include <boost/algorithm/string/trim.hpp>
@@ -97,7 +96,7 @@ Error Concordance::parse(const FilePath& sourceFile,
    // paste them back together (removing trailing %)
    using namespace boost::algorithm;
    std::string concordance;
-   BOOST_FOREACH(const std::string& line, lines)
+   for (const std::string& line : lines)
    {
       concordance.append(trim_right_copy_if(line, is_any_of("%")));
    }
@@ -388,7 +387,7 @@ Error readIfExists(const core::FilePath& srcFile, Concordances* pConcordances)
    boost::regex re("\\" + std::string(kConcordance));
    std::vector<std::string> concordances;
    boost::algorithm::split_regex(concordances, contents, re);
-   BOOST_FOREACH(const std::string& concordance, concordances)
+   for (const std::string& concordance : concordances)
    {
       std::string entry = boost::algorithm::trim_copy(concordance);
       if (!entry.empty())

--- a/src/cpp/session/modules/tex/SessionRnwWeave.cpp
+++ b/src/cpp/session/modules/tex/SessionRnwWeave.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionRnwWeave.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,7 +16,6 @@
 #include "SessionRnwWeave.hpp"
 
 #include <boost/utility.hpp>
-#include <boost/foreach.hpp>
 #include <boost/format.hpp>
 
 #include <boost/algorithm/string/split.hpp>
@@ -393,7 +392,7 @@ public:
    boost::shared_ptr<RnwWeave> findTypeIgnoreCase(const std::string& name)
                                                                         const
    {
-      BOOST_FOREACH(boost::shared_ptr<RnwWeave> weaveType, weaveTypes_)
+      for (boost::shared_ptr<RnwWeave> weaveType : weaveTypes_)
       {
          if (boost::algorithm::iequals(weaveType->name(), name))
             return weaveType;
@@ -416,7 +415,7 @@ const RnwWeaveRegistry& weaveRegistry()
 std::string weaveTypeForFile(const core::tex::TexMagicComments& magicComments)
 {
    // first see if the file contains an rnw weave magic comment
-   BOOST_FOREACH(const core::tex::TexMagicComment& mc, magicComments)
+   for (const core::tex::TexMagicComment& mc : magicComments)
    {
       if (boost::algorithm::iequals(mc.scope(), "rnw") &&
           boost::algorithm::iequals(mc.variable(), "weave"))
@@ -434,7 +433,7 @@ std::string weaveTypeForFile(const core::tex::TexMagicComments& magicComments)
 
 std::string driverForFile(const core::tex::TexMagicComments& magicComments)
 {
-   BOOST_FOREACH(const core::tex::TexMagicComment& mc, magicComments)
+   for (const core::tex::TexMagicComment& mc : magicComments)
    {
       if (boost::algorithm::iequals(mc.scope(), "rnw") &&
           boost::algorithm::iequals(mc.variable(), "driver"))
@@ -585,8 +584,7 @@ core::json::Array supportedTypes()
 {
    // query for list of supported types
    json::Array array;
-   BOOST_FOREACH(boost::shared_ptr<RnwWeave> pRnwWeave,
-                 weaveRegistry().weaveTypes())
+   for (boost::shared_ptr<RnwWeave> pRnwWeave : weaveRegistry().weaveTypes())
    {
       json::Object object;
       object["name"] = pRnwWeave->name();
@@ -602,8 +600,7 @@ core::json::Array supportedTypes()
 void getTypesInstalledStatus(json::Object* pObj)
 {
    // query for status of all rnw weave types
-   BOOST_FOREACH(boost::shared_ptr<RnwWeave> pRnwWeave,
-                 weaveRegistry().weaveTypes())
+   for (boost::shared_ptr<RnwWeave> pRnwWeave : weaveRegistry().weaveTypes())
    {
       std::string n = string_utils::toLower(pRnwWeave->name() + "_installed");
       (*pObj)[n] = pRnwWeave->isInstalled();

--- a/src/cpp/session/modules/tex/SessionTexUtils.cpp
+++ b/src/cpp/session/modules/tex/SessionTexUtils.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionTexUtils.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,7 +15,6 @@
 
 #include "SessionTexUtils.hpp"
 
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string.hpp>
 
 #include <core/system/Process.hpp>
@@ -142,7 +141,7 @@ Error runTexCompile(const FilePath& texProgramPath,
    // copy extra environment variables
    core::system::Options env;
    core::system::environment(&env);
-   BOOST_FOREACH(const core::system::Option& var, envVars)
+   for (const core::system::Option& var : envVars)
    {
       core::system::setenv(&env, var.first, var.second);
    }

--- a/src/cpp/session/modules/viewer/ViewerHistory.cpp
+++ b/src/cpp/session/modules/viewer/ViewerHistory.cpp
@@ -1,7 +1,7 @@
 /*
  * ViewerHistory.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,7 +16,6 @@
 #include "ViewerHistory.hpp"
 
 #include <boost/format.hpp>
-#include <boost/foreach.hpp>
 
 #include <core/SafeConvert.hpp>
 #include <core/FileSerializer.hpp>
@@ -172,7 +171,7 @@ void ViewerHistory::saveTo(const core::FilePath& serializationPath) const
 
    // copy the files
    FilePath tempDir = module_context::tempDir();
-   BOOST_FOREACH(const ViewerHistoryEntry& entry, entries_)
+   for (const ViewerHistoryEntry& entry : entries_)
    {
       Error error = entry.copy(tempDir, serializationPath);
       if (error)
@@ -223,7 +222,7 @@ void ViewerHistory::restoreFrom(const core::FilePath& serializationPath)
 
    // copy the files to the session temp dir
    FilePath tempDir = module_context::tempDir();
-   BOOST_FOREACH(const ViewerHistoryEntry& entry, entries_)
+   for (const ViewerHistoryEntry& entry : entries_)
    {
       Error error = entry.copy(serializationPath, tempDir);
       if (error)

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionProjectContext.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -668,7 +668,7 @@ json::Array ProjectContext::openDocs() const
 {
    json::Array openDocsJson;
    std::vector<std::string> docs = projects::collectFirstRunDocs(file());
-   BOOST_FOREACH(const std::string& doc, docs)
+   for (const std::string& doc : docs)
    {
       FilePath docPath = directory().childPath(doc);
       openDocsJson.push_back(module_context::createAliasedPath(docPath));

--- a/src/cpp/session/projects/SessionProjectFirstRun.cpp
+++ b/src/cpp/session/projects/SessionProjectFirstRun.cpp
@@ -15,8 +15,6 @@
 
 #include "SessionProjectFirstRun.hpp"
 
-#include <boost/foreach.hpp>
-
 #include <core/FilePath.hpp>
 #include <core/FileSerializer.hpp>
 

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -439,7 +439,7 @@ json::Object projectVcsContextJson()
    json::Object contextJson;
    contextJson["detected_vcs"] = vcsContext.detectedVcs;
    json::Array applicableJson;
-   BOOST_FOREACH(const std::string& vcs, vcsContext.applicableVcs)
+   for (const std::string& vcs : vcsContext.applicableVcs)
    {
       applicableJson.push_back(vcs);
    }
@@ -707,7 +707,7 @@ void onQuit()
 
 void onFilesChanged(const std::vector<core::system::FileChangeEvent>& events)
 {
-   BOOST_FOREACH(const core::system::FileChangeEvent& event, events)
+   for (const core::system::FileChangeEvent& event : events)
    {
       // if the project file changed then sync its changes
       if (event.fileInfo().absolutePath() ==
@@ -880,7 +880,7 @@ void startup(const std::string& firstProjectPath)
       std::vector<std::string> docs;
       boost::algorithm::split(docs, defaultOpenDocs, boost::is_any_of(":"));
 
-      BOOST_FOREACH(std::string& doc, docs)
+      for (std::string& doc : docs)
       {
          boost::algorithm::trim(doc);
 
@@ -919,7 +919,7 @@ SEXP rs_addFirstRunDoc(SEXP projectFileAbsolutePathSEXP, SEXP docRelativePathsSE
    if (!success)
       return R_NilValue;
    
-   BOOST_FOREACH(const std::string& path, docRelativePaths)
+   for (const std::string& path : docRelativePaths)
    {
       addFirstRunDoc(projectFilePath, path);
    }


### PR DESCRIPTION
This was the other big thing (along with NULL -> nullptr) on my "modernize C++" TODO list for early in the project.

BOOST_FOREACH, in addition to SHOUTING and being unnecessary in modern C++, is a gnarly macro that confuses code analysis in clang and CLion, adding a lot of extra noise to wade through.

I did leave in our one use of BOOST_REVERSE_FOREACH since it is still cleaner than anything built-in (at least as far as I'm aware).