### PR TITLE
Ensure import preview runs from files pane to fix #4563

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -137,7 +137,9 @@ public class DataImport extends Composite
          }
       });
       
-      assembleDataImport(null);
+      if (path.isEmpty()) {
+         assembleDataImport(null);
+      }
       
       Scheduler.get().scheduleDeferred(new ScheduledCommand()
       {


### PR DESCRIPTION
Fix for https://github.com/rstudio/rstudio/issues/4563

Looks like events are triggering slightly different between 1.1 and 1.2, in 1.1 importing a file for the first time triggers:

<img width="309" alt="Screen Shot 2019-04-03 at 10 34 35 AM" src="https://user-images.githubusercontent.com/3478847/55500511-586aec80-55fd-11e9-8e83-8fdf679f44be.png">

While in 1.2,

![rstudio-1 2-events](https://user-images.githubusercontent.com/3478847/55500562-6de01680-55fd-11e9-94b4-9a0b58bdc3c6.png)

Regardless, a better fix is to not trigger both events to update preview when the import preview is launched from the files menu, we don't need to update the preview if we have a path while initializing the dialog.

Notice that this only triggers from the files pane, the "Import Dataset" menus work just fine. The workaround is to click once "Update" in the dialog and this only happens after restarting the R session.

The fix is safe; however, I would encourage significant testing around previewing datasets since this code has not changed in more than a year.