### PR TITLE
enable automatic graphics switching

### DIFF
--- a/src/cpp/desktop/Info.plist.in
+++ b/src/cpp/desktop/Info.plist.in
@@ -247,6 +247,8 @@
   <string>RStudio ${CPACK_PACKAGE_VERSION}, © 2009-2018 RStudio, Inc.</string>
   <key>NSHighResolutionCapable</key>
   <true/>
+  <key>NSSupportsAutomaticGraphicsSwitching</key>
+  <true/>
   <key>NSPrincipalClass</key>
   <string>NSApplication</string>
   <key>NSAppleScriptEnabled</key>


### PR DESCRIPTION
Closes #4559.

In theory, this is worth considering for v1.2-patch as we don't want RStudio to suck too much battery life using the GPU, but I'm a little worried about making _another_ GPU-related (/ rendering-related) change so close to release, so I think we should make this v1.3-only.