### PR TITLE
disable horizontal overflow for DataGrid

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioDataGrid.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioDataGrid.java
@@ -15,6 +15,7 @@
 package org.rstudio.core.client.widget;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
 
 import com.google.gwt.dom.client.Element;
@@ -55,32 +56,7 @@ public class RStudioDataGrid<T> extends DataGrid<T>
       if (!BrowseCap.isMacintosh())
          return;
       
-      // GWT's DataGrid implementation adds a handful of nodes with aggressive
-      // inline styles in the header and footer of the grid. They're designed to
-      // help with scrolling, but in newer versions of Chromium, they cause
-      // horizontal overlay scrollbars to appear when the grid is created and
-      // whenever it's resized. The below tweaks these elements so that they
-      // don't have a scrollbar.
-      //
-      // Typically we'd use CSS here but these elements are buried, have no
-      // assigned class, and have all their style attributes applied inline, so
-      // instead we scan the attached DOM subtree and change the inline styles.
       Element parent = getElement().getParentElement().getParentElement();
-      NodeList<Element> children = DomUtils.querySelectorAll(parent, "div[style*='z-index: -1']");
-      for (int i = 0; i < children.getLength(); i++)
-      {
-         Element el = children.getItem(i);
-         com.google.gwt.dom.client.Style style = el.getStyle();
-         
-         boolean doesNotSparkJoy =
-               style.getZIndex() == "-1" &&
-               style.getOverflow() == "scroll" &&
-               style.getVisibility() == "hidden";
-         
-         if (doesNotSparkJoy)
-            style.setOverflow(com.google.gwt.dom.client.Style.Overflow.HIDDEN);
-         
-      }
       
       // GWT's DataGrid also occasionally displays unwanted horizontal
       // scroll bars. Since we don't ever require horizontal scrolling
@@ -92,12 +68,14 @@ public class RStudioDataGrid<T> extends DataGrid<T>
       // have no class we must resort to JavaScript + inline styles.
       //
       // https://github.com/rstudio/rstudio/issues/4529
-      children = DomUtils.querySelectorAll(parent, "div[style*='overflow:']");
+      NodeList<Element> children = DomUtils.querySelectorAll(parent, "div[style*='overflow:']");
       for (int i = 0; i < children.getLength(); i++)
       {
          Element el = children.getItem(i);
          com.google.gwt.dom.client.Style style = el.getStyle();
-         style.setOverflowX(Overflow.HIDDEN);
+         String overflow = style.getOverflow();
+         if (!StringUtil.isNullOrEmpty(overflow))
+            style.setOverflowX(Overflow.HIDDEN);
       }
       
    }

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioDataGrid.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioDataGrid.java
@@ -19,6 +19,7 @@ import org.rstudio.core.client.dom.DomUtils;
 
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NodeList;
+import com.google.gwt.dom.client.Style.Overflow;
 import com.google.gwt.user.cellview.client.DataGrid;
 import com.google.gwt.view.client.ProvidesKey;
 
@@ -79,6 +80,24 @@ public class RStudioDataGrid<T> extends DataGrid<T>
          if (doesNotSparkJoy)
             style.setOverflow(com.google.gwt.dom.client.Style.Overflow.HIDDEN);
          
+      }
+      
+      // GWT's DataGrid also occasionally displays unwanted horizontal
+      // scroll bars. Since we don't ever require horizontal scrolling
+      // in the DataGrid objects we show, we just suppress horizontal
+      // overflow in any div element that does something with overflow.
+      //
+      // Again, this is something we'd normally do with CSS but because
+      // we need to perform surgery on arbitrary sub-divs which otherwise
+      // have no class we must resort to JavaScript + inline styles.
+      //
+      // https://github.com/rstudio/rstudio/issues/4529
+      children = DomUtils.querySelectorAll(parent, "div[style*='overflow:']");
+      for (int i = 0; i < children.getLength(); i++)
+      {
+         Element el = children.getItem(i);
+         com.google.gwt.dom.client.Style style = el.getStyle();
+         style.setOverflowX(Overflow.HIDDEN);
       }
       
    }


### PR DESCRIPTION
Closes #4529.

@jmcphers, to the best of my knowledge we don't ever actually want horizontal scrolling for any of the GWT DataGrids we use; we always show and resize columns such that they fill their container. For that reason, I think this PR should be safe, but can you think of any cases where this might not be true?