### PR TITLE
prevent creation of crashpad console window

### DIFF
--- a/src/cpp/core/CrashHandler.cpp
+++ b/src/cpp/core/CrashHandler.cpp
@@ -244,7 +244,7 @@ Error initialize(ProgramMode programMode)
             handlerPath = googleFilePath(exePath.parent().childPath("crashpad_handler").absolutePath());
          #endif
       #else
-         handlerPath = googleFilePath(exePath.parent().childPath("crashpad_handler.com").absolutePath());
+         handlerPath = googleFilePath(exePath.parent().childPath("crashpad_handler.exe").absolutePath());
 #endif
    }
 

--- a/src/cpp/rstudio.bat.in
+++ b/src/cpp/rstudio.bat.in
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 
-set "RS_CRASH_HANDLER_PATH=@CMAKE_SOURCE_DIR@/../../dependencies/windows/crashpad-release/bin/crashpad_handler.com"
+set "RS_CRASH_HANDLER_PATH=@CMAKE_SOURCE_DIR@/../../dependencies/windows/crashpad-release/bin/crashpad_handler.exe"
 set "QT_PLUGIN_PATH=@QT_PLUGIN_PATH@"
 set "PATH=@QT_BINARY_PATH@;%PATH%"
 desktop\rstudio.exe


### PR DESCRIPTION
Closes #4499. It looks like `crashpad_handler.exe` launches without issue in package builds, so we now direct RStudio to use that version in those cases.

I also noticed that our package builds were selecting `/subsystem:console` when linking `rstudio.exe`, but (to my surprise) avoiding that and enforcing `/subsystem:windows` didn't seem to make a difference. Fortunately, this does and `crashpad_handler.exe` does seem to launch without issue.