### PR TITLE
support for building with address-sanitizer (ASAN)

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -14,7 +14,7 @@
 #
 
 # set minimum version
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.4.3)
 
 project (RSTUDIO_CPP)
 
@@ -68,6 +68,12 @@ if(UNIX)
 
    # compiler flags
    add_definitions(-Wall -pthread)
+
+   if(RSTUDIO_ASAN)
+      message(STATUS "Compiling with Address Sanitizer (ASAN) support")
+      add_definitions(-fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls -O1)
+      set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
+   endif()
 
    if(APPLE)
       add_definitions(-Wno-unknown-warning-option -Wsign-compare -Wno-unused-local-typedefs


### PR DESCRIPTION
Provide support for building RStudio with Address Sanitizer support on Mac and Linux (works with clang, including Xcode's, or recent gcc's). Diagnostic tool for runtime detection of various C++ memory misuses. To use, run CMake with RSTUDIO_ASAN defined and rebuild. For example, in CLion I do my debug generation via:

![2019-04-09_11-45-47](https://user-images.githubusercontent.com/10569626/55826584-3241c280-5abd-11e9-980f-528401ad0463.png)

In a perfect world we'd have massive automated code coverage with fuzzing, and would run it in conjunction with an address-sanitizer build. For now, I'm just doing my development with it enabled to see if anything crops up in routine usage.

I did confirm this was working by putting in some temporary badness and observing the output (writes oodles of details to stderr and terminates).

To get more details on a problem, will be necessary to have `llvm-symbolizer` in the path or pointed to via `ASAN_SYMBOLIZER_PATH` environment variable, but even without that it gives quite useful information.

There are various other sanitizers in this Google suite; haven't tinkered with them yet.

Good overview here:
https://en.wikipedia.org/wiki/AddressSanitizer

More details here:
https://clang.llvm.org/docs/AddressSanitizer.html

CLion has some integration of this and other Google sanitizers, though I haven't played with it:
https://www.jetbrains.com/help/clion/google-sanitizers.html

