### PR TITLE
add bug report helper

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1059,7 +1059,12 @@ assign(envir = .rs.Env, ".rs.hasVar", function(name)
       R_VERSION = rVersion
    ))
    
-   writeLines(rendered, con = stdout())
+   if (requireNamespace("clipr", quietly = TRUE)) {
+      clipr::write_clip(rendered)
+      writeLines("* The bug report template has been written to the clipboard.")
+   } else {
+      writeLines(rendered, con = stdout())
+   }
    
    url <- "https://github.com/rstudio/rstudio/issues/new?template=bug_report.md"
    utils::browseURL(url)

--- a/src/cpp/session/resources/bug_report.md
+++ b/src/cpp/session/resources/bug_report.md
@@ -1,0 +1,22 @@
+
+### System details
+
+    RStudio Edition : ${RSTUDIO_EDITION}
+    RStudio Version : ${RSTUDIO_VERSION}
+    OS Version      : ${OS_VERSION}
+    R Version       : ${R_VERSION}
+
+### Steps to reproduce the problem
+
+### Describe the problem in detail
+
+### Describe the behavior you expected
+
+<!-- Depending on the problem, the following may also be helpful
+
+1. The output of sessionInfo() 
+2. The R code in question
+3. A diagnostics report; see https://support.rstudio.com/hc/en-us/articles/200321257-Running-a-Diagnostics-Report
+
+Thank you for taking the time to file an issue!  -->
+


### PR DESCRIPTION
This PR adds a (currently internal) helper for bug reports. This is primarily to save us (and, if we make this an official API, our users) the time in pre-populating some of the fields we care about when forming a bug report.

One can call `.rs.bugReport()` to generate the template. When `clipr` is available, we write the rendered template to the clipboard; otherwise, we just write it to the console and let the user copy + paste.