### PR TITLE
Bugfix/backport win dockerfile tweaks

### DIFF
--- a/dependencies/windows/Install-RStudio-Prereqs.ps1
+++ b/dependencies/windows/Install-RStudio-Prereqs.ps1
@@ -73,22 +73,7 @@ choco install -y ninja --version 1.7.2
 choco install -y windows-sdk-10.1 --version 10.1.17134.12
 choco install -y visualstudio2017buildtools --version 15.8.2.0
 choco install -y visualstudio2017-workload-vctools --version 1.3.0
-
-# install nsis (version on chocolatey is too new)
-if (-Not (Test-Path -Path "C:\Program Files (x86)\NSIS")) {
-    $NSISSetup = 'C:\nsis-2.50-setup.exe'
-    Write-Host "Downloading NSIS..."
-    if (-Not (Test-Path $NSISSetup)) {
-        Download-File https://s3.amazonaws.com/rstudio-buildtools/test-qt-windows/nsis-2.50-setup.exe $NSISSetup
-    } else {
-        Write-Host "Using previously downloaded NSIS installer"
-    }
-    Write-Host "Installing NSIS..."
-    Start-Process $NSISSetup -Wait -ArgumentList '/S'
-    if ($DeleteDownloads) { Remove-Item $NSISSetup -Force }
-} else {
-    Write-Host "NSIS already found, skipping"
-}
+choco install -y nsis
 
 # cpack (an alias from chocolatey) and cmake's cpack conflict.
 Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe'

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -63,7 +63,7 @@ RUN Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe'
 ##### the items below this are dependencies relevant to jenkins-swarm. #####
 ##### follow https://issues.jenkins-ci.org/browse/JENKINS-36776 to track docker windows support on jenkins #####
 
-RUN choco install -y git cygwin
+RUN choco install -y git
 ENV JENKINS_SWARM_VERSION 3.15
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
   Invoke-WebRequest $('https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/{0}/swarm-client-{0}.jar' -f $env:JENKINS_SWARM_VERSION) -OutFile 'C:\swarm-client.jar' -UseBasicParsing ;

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -26,9 +26,7 @@ RUN choco install -y visualstudio2017buildtools --version 15.8.2.0; `
   choco install -y visualstudio2017-workload-vctools --version 1.3.0
   
 # install aws cli
-# awscli bug where cp65001 is not understood by internal python.
-RUN choco install -y awscli ;`
-  cp 'C:\Program Files\Amazon\AWSCLI\encodings\utf_8.pyc' 'C:\Program Files\Amazon\AWSCLI\encodings\cp65001.pyc'
+RUN choco install -y awscli
 
 # we use "R" for its real purpose, remove the Invoke-History powershell alias
 RUN "echo 'Remove-Item alias:r' | Out-File $PsHome\Profile.ps1"

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -20,7 +20,8 @@ RUN choco install -y cmake --version 3.12.1 --installargs 'ADD_CMAKE_TO_PATH=""S
   choco install -y jdk8 ; `
   choco install -y ant --version 1.10.5; `
   choco install -y windows-sdk-10.1 --version 10.1.17134.12; `
-  choco install -y 7zip --version 18.5.0.20180730
+  choco install -y 7zip --version 18.5.0.20180730; `
+  choco install -y nsis
   
 RUN choco install -y visualstudio2017buildtools --version 15.8.2.0; `
   choco install -y visualstudio2017-workload-vctools --version 1.3.0
@@ -41,12 +42,6 @@ RUN $ErrorActionPreference = 'Stop' ;`
 # add R to path
 RUN $env:path += ';C:\R\R-3.0.3\bin\i386\' ;`
   [Environment]::SetEnvironmentVariable('Path', $env:path, [System.EnvironmentVariableTarget]::Machine);
-
-# install nsis (version on chocolatey is too new)
-RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48; `
-  (New-Object System.Net.WebClient).DownloadFile('https://s3.amazonaws.com/rstudio-buildtools/test-qt-windows/nsis-2.50-setup.exe', 'C:\nsis-2.50-setup.exe');`
-  Start-Process c:\nsis-2.50-setup.exe -Wait -ArgumentList '/S' ;`
-  Remove-Item c:\nsis-2.50-setup.exe
 
 # install qt (note that we are using the current directory's context)
 RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48; ` 

--- a/package/win32/cmake/modules/NSIS.template.in
+++ b/package/win32/cmake/modules/NSIS.template.in
@@ -142,7 +142,7 @@ Var AR_RegFlags
  "exit_${SecName}:"
 !macroend
  
-!macro RemoveSection SecName
+!macro RemoveSection_CPack SecName
   ;  This macro is used to call section's Remove_... macro
   ;from the uninstaller.
   ;Input: section index constant name specified in Section command.
@@ -914,7 +914,7 @@ Section "Uninstall"
   DeleteRegKey SHCTX "Software\@CPACK_PACKAGE_VENDOR@\@CPACK_PACKAGE_INSTALL_REGISTRY_KEY@"
 
   ; Removes all optional components
-  !insertmacro SectionList "RemoveSection"
+  !insertmacro SectionList "RemoveSection_CPack"
   
   !insertmacro MUI_STARTMENU_GETFOLDER Application $MUI_TEMP
     


### PR DESCRIPTION
- cygwin wasn't installing last time we tried, and doesn't seem necessary
- newer awscli doesn't need that `cp` and trying to do so fails
- update to latest NSIS

We'd also want this in the 1.2 branch in case we need to rebuild that at some point.