### PR TITLE
Update to Pandoc 2.7.2 on Windows

### DIFF
--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -20,7 +20,7 @@ set WINPTY_FILES=winpty-0.4.3-msys2-2.7.0.zip
 set OPENSSL_FILES=openssl-1.1.1b.zip
 set BOOST_FILES=boost-1.69.0-win-msvc141.zip
 
-set PANDOC_VERSION=2.6
+set PANDOC_VERSION=2.7.2
 set PANDOC_NAME=pandoc-%PANDOC_VERSION%-windows-x86_64
 set PANDOC_FILE=%PANDOC_NAME%.zip
 


### PR DESCRIPTION
Addresses crash issues described in https://github.com/jgm/pandoc/issues/5037. Closes https://github.com/rstudio/rstudio/issues/4618, and will be backported to 1.2-patch.