### PR TITLE
JSON parsing and validation improvements

### DIFF
--- a/src/cpp/core/Error.cpp
+++ b/src/cpp/core/Error.cpp
@@ -89,6 +89,25 @@ std::string Error::summary() const
    return ostr.str();
 }
 
+std::string Error::description() const
+{
+   std::ostringstream ostr;
+   ostr << summary();
+   auto& props = properties();
+   if (!props.empty())
+   {
+      ostr << " (";
+      for (size_t i = 0; i < props.size(); i++)
+      {
+         ostr << props[i].first << ": " << props[i].second;
+         if (i < props.size() - 1)
+            ostr << ", ";
+      }
+      ostr << ") at " << location().asString();
+   }
+   return ostr.str();
+}
+
 const Error& Error::cause() const
 {
    return impl().cause ;

--- a/src/cpp/core/include/core/Error.hpp
+++ b/src/cpp/core/include/core/Error.hpp
@@ -86,6 +86,8 @@ public:
    const boost::system::error_code& code() const;
 
    std::string summary() const;
+
+   std::string description() const;
    
    const Error& cause() const ;
 

--- a/src/cpp/core/json/Json.cpp
+++ b/src/cpp/core/json/Json.cpp
@@ -308,7 +308,7 @@ json::Object getSchemaDefaults(const Object& schema)
       else
       {
          // Use the default
-         result[prop.name()] = (*def).value();
+         result[prop.name()] = (*def).value().clone();
       }
    }
    return result;
@@ -326,7 +326,7 @@ Object merge(const Object& base, const Object& overlay)
       if (it == overlay.end())
       {
          // The property does not exist in the overlay object, so use the base copy.
-         merged[prop.name()] = prop.value();
+         merged[prop.name()] = prop.value().clone();
       }
       else
       {
@@ -341,7 +341,7 @@ Object merge(const Object& base, const Object& overlay)
          else
          {
             // Not objects, so just take the overlay value
-            merged[prop.name()] = (*it).value();
+            merged[prop.name()] = (*it).value().clone();
          }
       }
    }
@@ -353,7 +353,7 @@ Object merge(const Object& base, const Object& overlay)
       auto it = base.find(prop.name());
       if (it == base.end())
       {
-         merged[prop.name()] = prop.value();
+         merged[prop.name()] = prop.value().clone();
       }
    }
    return merged; 

--- a/src/cpp/core/json/Json.cpp
+++ b/src/cpp/core/json/Json.cpp
@@ -1,7 +1,7 @@
 /*
  * Json.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -21,6 +21,8 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/regex.hpp>
+#include <core/json/rapidjson/error/en.h>
+#include <core/json/rapidjson/schema.h>
 
 namespace rstudio {
 namespace core {
@@ -100,6 +102,18 @@ template <>
 std::string Value::get_value<std::string>() const
 {
    return std::string(get_impl().GetString(), get_impl().GetStringLength());
+}
+
+Error Value::parse(const std::string& input, const ErrorLocation& location)
+{
+   rapidjson::ParseResult result = get_impl().Parse(input.c_str());
+   if (result.IsError())
+   {
+      Error error(result.Code(), location);
+      error.addProperty("offset", result.Offset());
+      return error;
+   }
+   return Success();
 }
 
 Object toJsonObject(const std::vector<std::pair<std::string,std::string> >& options)
@@ -245,6 +259,162 @@ bool parse(const std::string& input, Value* pValue)
    return pValue->parse(input);
 }
 
+Error parse(const std::string& input, const ErrorLocation& location, Value* pValue)
+{
+   return pValue->parse(input, location);
+}
+
+json::Object getSchemaDefaults(const Object& schema)
+{
+   json::Object result;
+   Object::iterator objType = schema.find("type");
+   if (objType == schema.end() ||
+       (*objType).value().type() != json::StringType ||
+       (*objType).value().get_str() != "object")
+   {
+      // Nothing to do for non-object types
+      return result;
+   }
+
+   Object::iterator objProperties = schema.find("properties");
+   if (objProperties == schema.end() ||
+       (*objProperties).value().type() != json::ObjectType)
+   {
+      // Nothing to do for types with no properties
+      return result;
+   }
+
+   // Iterate over all the properties specified in the schema
+   const json::Object& properties = (*objProperties).value().get_obj();
+   for (auto prop: properties)
+   {
+      // JSON schema specifies that properties are defined with objects
+      if (prop.value().type() != json::ObjectType)
+         continue;
+
+      const json::Object& definition = prop.value().get_obj();
+      Object::iterator def = definition.find("default");
+      if (def == definition.end())
+      {
+         // We didn't find a default value for this property, so recurse and see if it is an
+         // object with its own defaults.
+         json::Object child = getSchemaDefaults(definition);
+         if (!child.empty())
+         {
+            // We found defaults inside the object; use them
+            result[prop.name()] = child;
+         }
+      }
+      else
+      {
+         // Use the default
+         result[prop.name()] = (*def).value();
+      }
+   }
+   return result;
+}
+
+Object merge(const Object& base, const Object& overlay)
+{
+   Object merged;
+
+   // Begin by enumerating all the properties in the base object and replacing them with any
+   // properties also present in the overlay object.
+   for (auto prop: base)
+   {
+      auto it = overlay.find(prop.name());
+      if (it == overlay.end())
+      {
+         // The property does not exist in the overlay object, so use the base copy.
+         merged[prop.name()] = prop.value();
+      }
+      else
+      {
+         // The property exists in the overlay object.
+         if (prop.value().type() == json::ObjectType &&
+             (*it).value().type() == json::ObjectType)
+         {
+            // If the properties exist in both objects and both are object types, then we
+            // recursively merge the objects (instead of just taking the overlay).
+            merged[prop.name()] = merge(prop.value().get_obj(), (*it).value().get_obj());
+         }
+         else
+         {
+            // Not objects, so just take the overlay value
+            merged[prop.name()] = (*it).value();
+         }
+      }
+   }
+
+   // Next, we need to fill in any properties in the overlay object that are not present in the
+   // base.
+   for (auto prop: overlay)
+   {
+      auto it = base.find(prop.name());
+      if (it == base.end())
+      {
+         merged[prop.name()] = prop.value();
+      }
+   }
+   return merged; 
+}
+
+Error getSchemaDefaults(const std::string& schema, Value* pValue)
+{
+   json::Value value;
+   Error error = parse(schema, ERROR_LOCATION, &value);
+   if (error)
+   {
+      return error;
+   }
+
+   if (value.type() != json::ObjectType)
+   {
+      return Error(rapidjson::kParseErrorValueInvalid, ERROR_LOCATION);
+   }
+
+   *pValue = getSchemaDefaults(value.get_obj());
+   return Success();
+}
+
+Error parseAndValidate(const std::string& input, const std::string& schema,
+      const ErrorLocation& location, Value* pValue)
+{
+   Error error;
+
+   // Parse the schema first.
+   rapidjson::Document sd;
+   rapidjson::ParseResult result = sd.Parse(schema);
+   if (result.IsError())
+   {
+      error = Error(result.Code(), location);
+      error.addProperty("offset", result.Offset());
+      return error;
+   }
+
+   // Next, parse the input.
+   error = pValue->parse(input, location);
+   if (error)
+      return error;
+
+   // Validate the input according to the schema.
+   rapidjson::SchemaDocument schemaDoc(sd) ;
+   rapidjson::SchemaValidator validator(schemaDoc);
+   if (!pValue->get_impl().Accept(validator))
+   {
+      rapidjson::StringBuffer sb;
+      error = Error(rapidjson::kParseErrorUnspecificSyntaxError, location);
+      validator.GetInvalidSchemaPointer().StringifyUriFragment(sb);
+      error.addProperty("schema", sb.GetString());
+      error.addProperty("keyword", validator.GetInvalidSchemaKeyword());
+      validator.GetInvalidDocumentPointer().StringifyUriFragment(sb);
+      error.addProperty("document", sb.GetString());
+      return error;
+   }
+
+   return Success();
+}
+
 void write(const Value& value, std::ostream& os)
 {
    os << write(value);
@@ -271,6 +441,29 @@ std::string writeFormatted(const Value& value)
 
    value.get_impl().Accept(writer);
    return std::string(buffer.GetString(), buffer.GetLength());
+}
+
+class JsonParseErrorCategory : public boost::system::error_category
+{
+public:
+   virtual const char * name() const BOOST_NOEXCEPT;
+   virtual std::string message(int ev) const;
+};
+
+const boost::system::error_category& jsonParseCategory()
+{
+   static JsonParseErrorCategory jsonParseErrorCategoryConst;
+   return jsonParseErrorCategoryConst;
+}
+
+const char * JsonParseErrorCategory::name() const BOOST_NOEXCEPT
+{
+   return "json-parse";
+}
+
+std::string JsonParseErrorCategory::message(int ev) const
+{
+   return rapidjson::GetParseError_En(static_cast<rapidjson::ParseErrorCode>(ev));
 }
 
 } // namespace json

--- a/src/cpp/core/json/JsonTests.cpp
+++ b/src/cpp/core/json/JsonTests.cpp
@@ -320,7 +320,7 @@ TEST_CASE("Json")
 
    SECTION("Ref/copy semantics")
    {
-      std::string json = "{\"a\":\"Hello\",\"b\":\"world\",\"c\":25,\"c2\":25.5,\"d\":[1,2,3],\"e\":{\"a\":\"Inner hello\"}}";
+      std::string json = R"({"a":"Hello","b":"world","c":25,"c2":25.5,"d":[1,2,3],"e":{"a":"Inner hello"}})";
 
       json::Value value;
       REQUIRE(json::parse(json, &value));
@@ -759,6 +759,143 @@ TEST_CASE("Json")
    {
       json::Value val = getValue();
       REQUIRE(val.get_int() == 5);
+   }
+
+   SECTION("Parse errors")
+   {
+      std::string invalid = R"({ key: value )";
+      json::Value val;
+      Error err = json::parse(invalid, ERROR_LOCATION, &val);
+      REQUIRE(err != Success());
+   }
+
+   SECTION("Schema default parse") {
+      std::string schema = R"(
+      {
+         "$id": "https://rstudio.com/rstudio.preferences.json",
+         "$schema": "http://json-schema.org/draft-07/schema#",
+         "title": "Defaults Test Example Schema",
+         "type": "object",
+         "properties": {
+             "first": {
+                 "type": "int",
+                 "default": 5,
+                 "description": "A number. How about 5?"
+             },
+             "second": {
+                 "type": "object",
+                 "description": "An object which contains defaults.",
+                 "properties": {
+                     "foo": {
+                        "type": "int",
+                        "default": 10,
+                        "description": "Another number. How about 10?"
+                     }
+                 }
+             }
+           }
+        })";
+
+      json::Object defaults;
+      Error err = json::getSchemaDefaults(schema, &defaults);
+      INFO(err.description());
+      REQUIRE(err == Success());
+      
+      REQUIRE(defaults["first"] == 5);
+      json::Object second = defaults["second"].get_obj();
+      REQUIRE(second["foo"] == 10);
+   }
+
+   SECTION("Object merge") {
+      json::Object base;
+      json::Object overlay;
+
+      // Property 1: has an overlay
+      base["p1"] = "base";
+      overlay["p1"] = "overlay";
+
+      // Property 2: no overlay
+      base["p2"] = "base";
+
+      // Property 3: an object with non-overlapping properties
+      json::Object p3base, p3overlay;
+      p3base["p3-a"] = "base";
+      p3overlay["p3-b"] = "overlay";
+      base["p3"] = p3base;
+      overlay["p3"] = p3overlay;
+      
+      // Regular properties should pick up values from the overlay
+      auto result = json::merge(base, overlay);
+      REQUIRE(result["p1"] == "overlay");
+
+      // Properties with no overlay should pick up values from the base
+      REQUIRE(result["p2"] == "base");
+
+      // Sub-objects with interleaved properties should inherit the union of properties
+      auto p3result = result["p3"].get_obj();
+      REQUIRE(p3result["p3-a"] == "base");
+      REQUIRE(p3result["p3-b"] == "overlay");
+   }
+
+   SECTION("Schema validation")
+   {
+      std::string schema = R"(
+      {
+         "$id": "https://rstudio.com/rstudio.preferences.json",
+         "$schema": "http://json-schema.org/draft-07/schema#",
+         "title": "Unit Test Example Schema",
+         "type": "object",
+         "properties": {
+             "first": {
+                 "type": "boolean",
+                 "default": false,
+                 "description": "The first example property"
+             },
+             "second": {
+                 "type": "string",
+                 "enum": ["a", "b", "c"],
+                 "default": "b",
+                 "description": "The second example property"
+             }
+           }
+        })";
+         
+      // do valid documents pass validation?
+      std::string valid = R"(
+         { "first": true, "second": "a" }
+      )";
+
+      json::Value val;
+      Error err = json::parseAndValidate(valid, schema, ERROR_LOCATION, &val);
+      REQUIRE(err == Success());
+      REQUIRE(val.get_obj()["first"].get_bool());
+
+      // do invalid documents fail?
+      std::string invalid = R"(
+         { "first": 1, "second": "d" }
+      )";
+      err = json::parseAndValidate(invalid, schema, ERROR_LOCATION, &val);
+      REQUIRE(err != Success());
+
+      // finally, test the defaults:
+      std::string partial = R"(
+         { "first": true }
+      )";
+      // ... parse according to the schema
+      err = json::parseAndValidate(partial, schema, ERROR_LOCATION, &val);
+      REQUIRE(err == Success());
+
+      // ... extract defaults from the schema (RapidJSON doesn't do defaults)
+      json::Value defaults;
+      err = json::getSchemaDefaults(schema, &defaults);
+      REQUIRE(err == Success());
+
+      // ... overlay the document on the defaults
+      json::Object result = json::merge(defaults.get_obj(), val.get_obj());
+
+      // ... see if we got what we expected.
+      REQUIRE(result["first"] == true);   // non-default value
+      REQUIRE(result["second"] == "b");   // default value
    }
 }
 

--- a/src/cpp/core/json/JsonTests.cpp
+++ b/src/cpp/core/json/JsonTests.cpp
@@ -824,12 +824,16 @@ TEST_CASE("Json")
       base["p3"] = p3base;
       overlay["p3"] = p3overlay;
       
-      // Regular properties should pick up values from the overlay
+      // Regular properties should pick up values from the overlay (ensure they are copied, not
+      // moved)
       auto result = json::merge(base, overlay);
       REQUIRE(result["p1"] == "overlay");
+      REQUIRE(overlay["p1"] == "overlay");
 
-      // Properties with no overlay should pick up values from the base
+      // Properties with no overlay should pick up values from the base (ensure they are copied, not
+      // moved)
       REQUIRE(result["p2"] == "base");
+      REQUIRE(base["p2"] == "base");
 
       // Sub-objects with interleaved properties should inherit the union of properties
       auto p3result = result["p3"].get_obj();


### PR DESCRIPTION
This change lays some groundwork necessary for future user configurability improvements (see #1607), but it's useful on its own. It contains the following improvements to our core JSON library:

**Richer parsing errors** -- there is now an overloaded version of `parse()` that returns an `Error`. It also accepts an error location, so that the parse error can be traced from the point where the parse was attempted rather than from inside the JSON routine itself. The errors returned are part of a new error enum that maps RapidJSON parse errors into a Boost error code for easy routing through the rest of our error management code.

In most cases we'll prefer this to the current version of `parse()` that only tells you whether or not the parse worked (without any diagnostic information about the failure). 

**Object merging** -- There's now a way to join (union) two JSON objects. This is eventually going to be used to overlay successive layers of preferences (defaults -> global -> user). 

**Schema validation** -- You can now validate against a [JSON schema](https://json-schema.org/) after parsing. Default values can also be extracted from a schema. 
