### PR TITLE
Qt install fixes

### DIFF
--- a/dependencies/linux/install-qt-sdk
+++ b/dependencies/linux/install-qt-sdk
@@ -18,7 +18,7 @@ if [ -z "$QT_VERSION" ]; then
     QT_VERSION=5.12.1
 fi
 if [ -z "$QT_SDK_BINARY" ]; then
-    QT_SDK_BINARY=qt-unified-linux-x64-3.0.6-online.run
+    QT_SDK_BINARY=qt-opensource-linux-x64-${QT_VERSION}.run
 fi
 if [ -z "$QT_PACKAGES" ]; then
     QT_PACKAGES=qt.qt5.5121.gcc_64,qt.qt5.5121.qtwebengine,qt.qt5.5121.qtwebengine.gcc_64
@@ -127,16 +127,10 @@ then
       chmod u+x /tmp/$QT_SDK_BINARY
       write_qt_script
 
-      # online installer sometimes fails, keep trying...
-      retryCounter=0
-      while [ ! -e "$QT_SDK_DIR" ] && [ ! -e "$QT_SDK_DIR2" ] && [ ! -e "$QT_SDK_DIR3" ] && [ $retryCounter -le 5 ] 
-      do
-         echo "Installing Qt, this will take a while."
-         echo " - Ignore warnings about QtAccount credentials and/or XDG_RUNTIME_DIR."
-         echo " - Do not click on any Qt setup dialogs, it is controlled by a script."
-         /tmp/$QT_SDK_BINARY --script $QT_SCRIPT || true
-         ((retryCounter++))
-      done
+      echo "Installing Qt, this will take a while."
+      echo " - Ignore warnings about QtAccount credentials and/or XDG_RUNTIME_DIR."
+      echo " - Do not click on any Qt setup dialogs, it is controlled by a script."
+      /tmp/$QT_SDK_BINARY --script $QT_SCRIPT || true
       rm -f /tmp/$QT_SDK_BINARY $QT_SCRIPT
    else
       QT_SDK_BINARY=$QT_SDK_CUSTOM

--- a/dependencies/osx/install-qt-sdk-osx
+++ b/dependencies/osx/install-qt-sdk-osx
@@ -3,7 +3,7 @@
 #
 # install-qt-sdk-osx
 #
-# Copyright (C) 2009-18 by RStudio, Inc.
+# Copyright (C) 2009-19 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -19,7 +19,7 @@
 # If no location provided, checks against a set of common locations and installs if not found.
 
 QT_VERSION=5.12.1
-QT_SDK_BINARY_BASE=qt-unified-mac-x64-3.0.6-online
+QT_SDK_BINARY_BASE=qt-opensource-mac-x64-${QT_VERSION}
 QT_SDK_BINARY=${QT_SDK_BINARY_BASE}.tar.gz
 QT_SDK_INSTALLER=${QT_SDK_BINARY_BASE}.app
 QT_SDK_INSTALLER_BIN=${QT_SDK_INSTALLER}/Contents/MacOS/${QT_SDK_BINARY_BASE}
@@ -115,16 +115,12 @@ then
    tar xzf /tmp/$QT_SDK_BINARY
    write_qt_script   
    
-   # online installer sometimes fails, keep trying...
-   retryCounter=0
-   while [ ! -e "$QT_SDK_DIR" ] && [ ! -e "$QT_SDK_DIR2" ] && [ ! -e "$QT_SDK_DIR3" ] && [ $retryCounter -le 5 ] 
-   do
-      echo "Installing Qt, this will take a while."
-      echo " - Ignore warnings about QtAccount credentials."
-      echo " - Do not click on the setup interface, it is controlled by a script."
-      ./$QT_SDK_INSTALLER_BIN --script $QT_SCRIPT
-      ((retryCounter++))
-   done
+   echo "Installing Qt, this will take a while."
+   echo " - Ignore warnings about QtAccount credentials."
+   echo " - Do not click on the setup interface, it is controlled by a script."
+
+   ./$QT_SDK_INSTALLER_BIN --script $QT_SCRIPT
+
    rm -f /tmp/$QT_SDK_BINARY $QT_SCRIPT
    rm -rf /tmp/$QT_SDK_INSTALLER
    if [ ! -e "$QT_SDK_DIR" ] && [ ! -e "$QT_SDK_DIR2" ] && [ ! -e "$QT_SDK_DIR3" ]; then

--- a/dependencies/windows/install-qt-sdk-win.cmd
+++ b/dependencies/windows/install-qt-sdk-win.cmd
@@ -5,7 +5,7 @@ setlocal EnableDelayedExpansion
 @rem When updating to a new Qt version, be sure to also update the 
 @rem component versions in qt-noninteractive-install-win.qs
 set QT_VERSION=5.12.1
-set QT_SDK_BINARY=qt-unified-windows-x86-3.0.6-online.exe
+set QT_SDK_BINARY=qt-opensource-windows-x86-${QT_VERSION}.exe
 set QT_SDK_URL=https://s3.amazonaws.com/rstudio-buildtools/%QT_SDK_BINARY%
 set QT_SCRIPT=qt-noninteractive-install-win.qs
 

--- a/dependencies/windows/install-qt-sdk-win.cmd
+++ b/dependencies/windows/install-qt-sdk-win.cmd
@@ -5,7 +5,7 @@ setlocal EnableDelayedExpansion
 @rem When updating to a new Qt version, be sure to also update the 
 @rem component versions in qt-noninteractive-install-win.qs
 set QT_VERSION=5.12.1
-set QT_SDK_BINARY=qt-opensource-windows-x86-${QT_VERSION}.exe
+set QT_SDK_BINARY=qt-opensource-windows-x86-%QT_VERSION%.exe
 set QT_SDK_URL=https://s3.amazonaws.com/rstudio-buildtools/%QT_SDK_BINARY%
 set QT_SCRIPT=qt-noninteractive-install-win.qs
 


### PR DESCRIPTION
Qt updated the online installer, and broke the previous installer in the process. The new one doesn't work with our existing scripted install.

So, switched to scripting the offline installer. This means a bigger initial download, but should be more reliable and (hopefully) not breakable by Qt changes.

Offline installers pushed to S3.

This will also need to go into 1.2-patch.
