### PR TITLE
Add dependency on libxkbcommon

### DIFF
--- a/package/linux/CMakeLists.txt
+++ b/package/linux/CMakeLists.txt
@@ -66,8 +66,11 @@ elseif(RSTUDIO_DESKTOP)
   set(RPM_POSTINST postinst-desktop.sh.in)
   set(RPM_POSTRM postrm-desktop.sh.in)
 
+  # rpm dependencies
+  set(RSTUDIO_RPM_DEPENDS "libxkbcommon-x11, ")
+
   # deb dependencies
-  set(RSTUDIO_DEBIAN_DEPENDS "libedit2, libssl1.0.0 | libssl1.0.2 | libssl1.1, libclang-dev, ")
+  set(RSTUDIO_DEBIAN_DEPENDS "libedit2, libssl1.0.0 | libssl1.0.2 | libssl1.1, libclang-dev, libxkbcommon-x11-0")
   
 endif()
 

--- a/package/linux/CMakeLists.txt
+++ b/package/linux/CMakeLists.txt
@@ -70,7 +70,7 @@ elseif(RSTUDIO_DESKTOP)
   set(RSTUDIO_RPM_DEPENDS "libxkbcommon-x11, ")
 
   # deb dependencies
-  set(RSTUDIO_DEBIAN_DEPENDS "libedit2, libssl1.0.0 | libssl1.0.2 | libssl1.1, libclang-dev, libxkbcommon-x11-0")
+  set(RSTUDIO_DEBIAN_DEPENDS "libedit2, libssl1.0.0 | libssl1.0.2 | libssl1.1, libclang-dev, libxkbcommon-x11-0, ")
   
 endif()
 


### PR DESCRIPTION
On Linux/X11, Qt depends on libxkbcommon, which typically (but not always) installed. This change adds a dependency on the package on both RPM and DEB based systems.

Fixes https://github.com/rstudio/rstudio/issues/4610 and will be backported to 1.2-patch.