### PR TITLE
Support PowerShell core and Custom for Windows terminal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 * Add automated crash handling and reporting
 * Upgrade internal JSON parsing engine for speed improvements (#1830)
 * Add "Safe Mode" for opening sessions without profile scripts or workspace restoration (#4338)
+* PowerShell Core option in terminal (Windows-only)
+* Custom terminal shell option for Windows desktop (previously only on Mac, Linux, and server)
 
 ### Bugfixes
 

--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -1186,14 +1186,14 @@ void GwtCallback::openTerminal(QString terminalPath,
 
 #elif defined(Q_OS_WIN)
 
-   // TODO: (gary) make these shell type constants shared with
-   // SessionTerminalShell.hpp instead of duplicating them
+   // keep these shell type constants consistent with SessionTerminalShell.hpp
    const int GitBash = 1; // Win32: Bash from Windows Git
    const int WSLBash = 2; // Win32: Windows Services for Linux
    const int Cmd32 = 3; // Win32: Windows command shell (32-bit)
    const int Cmd64 = 4; // Win32: Windows command shell (64-bit)
    const int PS32 = 5; // Win32: PowerShell (32-bit)
    const int PS64 = 6; // Win32: PowerShell (64-bit)
+   const int PSCore = 10; // Win32: PowerShell Core (v6)
 
    if (terminalPath.length() == 0)
    {

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -704,9 +704,8 @@ std::string ConsoleProcess::getChannelMode() const
       return "rpc";
    case Websocket:
       return "websocket";
-   default:
-      return "unknown";
    }
+   return "unknown";
 }
 
 void ConsoleProcess::setRpcMode()
@@ -855,7 +854,12 @@ ConsoleProcessPtr ConsoleProcess::createTerminalProcess(
          if (cp->getShellType() == TerminalShell::ShellType::Cmd32 ||
              cp->getShellType() == TerminalShell::ShellType::Cmd64 ||
              cp->getShellType() == TerminalShell::ShellType::PS32 ||
-             cp->getShellType() == TerminalShell::ShellType::PS64)
+             cp->getShellType() == TerminalShell::ShellType::PS64 ||
+#ifdef _WIN32
+             // Ditto for custom shell on Windows.
+             cp->getShellType() == TerminalShell::ShellType::CustomShell ||
+#endif
+             cp->getShellType() == TerminalShell::ShellType::PSCore)
          {
             cp->deleteLogFile();
          }

--- a/src/cpp/session/include/session/SessionTerminalShell.hpp
+++ b/src/cpp/session/include/session/SessionTerminalShell.hpp
@@ -45,8 +45,9 @@ struct TerminalShell
       PosixBash    = 7, // Posix: Bash
       CustomShell  = 8, // User-specified shell command
       NoShell      = 9, // Non-interactive job with no shell
+      PSCore      = 10, // PowerShell Core (v6)
 
-      Max          = NoShell
+      Max          = PSCore
    };
 
    TerminalShell() = default;

--- a/src/cpp/session/modules/SessionTerminalShell.cpp
+++ b/src/cpp/session/modules/SessionTerminalShell.cpp
@@ -20,6 +20,7 @@
 #include <core/StringUtils.hpp>
 
 #include <session/SessionUserSettings.hpp>
+#include <session/SessionModuleContext.hpp>
 #include "SessionGit.hpp"
 
 namespace rstudio {
@@ -86,7 +87,6 @@ void scanAvailableShells(std::vector<TerminalShell>* pShells)
       }
    }
 
-#ifndef _WIN32
    // Add user-selectable shell command option
    TerminalShell customShell;
    if (AvailableTerminalShells::getCustomShell(&customShell))
@@ -95,7 +95,6 @@ void scanAvailableShells(std::vector<TerminalShell>* pShells)
                customShell.args, pShells,
                false /*checkPathExists*/);
    }
-#endif // !_WIN32
 }
 
 } // anonymous namespace
@@ -241,7 +240,7 @@ bool AvailableTerminalShells::getCustomShell(TerminalShell* pShellInfo)
 {
    pShellInfo->name = "Custom";
    pShellInfo->type = TerminalShell::ShellType::CustomShell;
-   pShellInfo->path = userSettings().customShellCommand();
+   pShellInfo->path = module_context::resolveAliasedPath(userSettings().customShellCommand().absolutePath());
 
    // arguments are space separated, currently no way to represent a literal space
    std::vector<std::string> args;

--- a/src/cpp/session/modules/SessionTerminalShell.cpp
+++ b/src/cpp/session/modules/SessionTerminalShell.cpp
@@ -49,6 +49,7 @@ void scanAvailableShells(std::vector<TerminalShell>* pShells)
    const std::string cmd("cmd.exe");
    const std::string ps("WindowsPowerShell\\v1.0\\powershell.exe");
    const std::string bash("bash.exe");
+   const std::string pscore("PowerShell\\6\\pwsh.exe");
 
    std::string windir;
    core::Error err = core::system::expandEnvironmentVariables("%windir%\\", &windir);
@@ -57,19 +58,24 @@ void scanAvailableShells(std::vector<TerminalShell>* pShells)
       LOG_ERROR(err);
       return;
    }
+   std::string progfiles;
+   err = core::system::expandEnvironmentVariables("%ProgramFiles%\\", &progfiles);
+   if (err)
+   {
+      LOG_ERROR(err);
+      return;
+   }
 
    addShell(getGitBashShell(), TerminalShell::ShellType::GitBash, "Git Bash", args, pShells);
 
-   core::FilePath cmd64;
-   core::FilePath ps64;
-   core::FilePath bashWSL; // Windows Subsystem for Linux
-
-   cmd64 = core::FilePath(windir + sys32 + cmd);
-   ps64 = core::FilePath(windir + sys32 + ps);
-   bashWSL = core::FilePath(windir + sys32 + bash);
+   core::FilePath cmd64 = core::FilePath(windir + sys32 + cmd);
+   core::FilePath ps64 = core::FilePath(windir + sys32 + ps);
+   core::FilePath bashWSL = core::FilePath(windir + sys32 + bash);
+   core::FilePath psCore = core::FilePath(progfiles + pscore);
 
    addShell(cmd64, TerminalShell::ShellType::Cmd64, "Command Prompt", args, pShells);
    addShell(ps64, TerminalShell::ShellType::PS64, "Windows PowerShell", args, pShells);
+   addShell(psCore, TerminalShell::ShellType::PSCore, "PowerShell Core", args, pShells);
 
    // Is there a better way to detect WSL? This will match any 64-bit
    // bash.exe found in same location as the WSL bash.
@@ -124,6 +130,8 @@ std::string TerminalShell::getShellName(ShellType type)
    case ShellType::PS32:
    case ShellType::PS64:
       return "PowerShell";
+   case ShellType::PSCore:
+      return "PowerShell Core";
    case ShellType::PosixBash:
       return "Bash";
    case ShellType::CustomShell:
@@ -146,6 +154,10 @@ TerminalShell::ShellType TerminalShell::shellTypeFromString(const std::string& s
    else if (typeStr == "win-ps")
    {
       return TerminalShell::ShellType::PS64;
+   }
+   else if (typeStr == "ps-core")
+   {
+      return TerminalShell::ShellType::PSCore;
    }
    else if (typeStr == "win-git-bash")
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -322,6 +322,7 @@ public class TerminalPane extends WorkbenchPane
          @Override
          public void onFailure(String msg)
          {
+            globalDisplay_.showErrorMessage("Terminal Creation Failure", msg);
             Debug.log(msg);
             creatingTerminal_ = false;
          }
@@ -708,6 +709,12 @@ public class TerminalPane extends WorkbenchPane
                autoCloseMode = ConsoleProcessInfo.AUTOCLOSE_ALWAYS;
             else
                autoCloseMode = ConsoleProcessInfo.AUTOCLOSE_NEVER;
+         }
+
+         // always keep pane open for non-zero exit code so user can see what happened
+         if (exitCode != 0)
+         {
+            autoCloseMode = ConsoleProcessInfo.AUTOCLOSE_NEVER;
          }
 
          if (autoCloseMode == ConsoleProcessInfo.AUTOCLOSE_NEVER)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -294,7 +294,9 @@ public class TerminalSession extends XTermWidget
          if (shellType == TerminalShellInfo.SHELL_CMD32 ||
                shellType == TerminalShellInfo.SHELL_CMD64 ||
                shellType == TerminalShellInfo.SHELL_PS32 ||
-               shellType == TerminalShellInfo.SHELL_PS64)
+               shellType == TerminalShellInfo.SHELL_PS64 ||
+               shellType == TerminalShellInfo.SHELL_PSCORE ||
+               (BrowseCap.isWindowsDesktop() && shellType == TerminalShellInfo.SHELL_CUSTOM))
          {
             inputText = StringUtil.normalizeNewLinesToCR(inputText);
          }
@@ -700,10 +702,19 @@ public class TerminalSession extends XTermWidget
       case TerminalShellInfo.SHELL_CMD64:
       case TerminalShellInfo.SHELL_PS32:
       case TerminalShellInfo.SHELL_PS64:
+      case TerminalShellInfo.SHELL_PSCORE:
          // Do load the buffer if terminal was just created via API, as
          // the initial message and prompt may have been sent before the
          // client/server channel was opened.
          return createdByApi_;
+
+      case TerminalShellInfo.SHELL_CUSTOM:
+         // on Windows we don't know if custom shell supports reload so
+         // assume it does not
+         if (BrowseCap.isWindowsDesktop())
+            return createdByApi_;
+         else
+            return true;
 
       default:
          return true;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalShellInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalShellInfo.java
@@ -1,7 +1,7 @@
 /*
  * TerminalShellInfo.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -32,7 +32,8 @@ public class TerminalShellInfo extends JavaScriptObject
 
    public static final int SHELL_PS32 = 5; // Powershell
    public static final int SHELL_PS64 = 6;
-   // -- End Windows-only	
+   public static final int SHELL_PSCORE = 10;
+   // -- End Windows-only
    
    public static final int SHELL_POSIX_BASH = 7;
    public static final int SHELL_CUSTOM = 8;
@@ -64,6 +65,8 @@ public class TerminalShellInfo extends JavaScriptObject
       case SHELL_PS32:
       case SHELL_PS64:
          return "PowerShell";
+      case SHELL_PSCORE:
+         return "PowerShell Core";
       case SHELL_POSIX_BASH:
          return "Bash";
       case SHELL_CUSTOM:


### PR DESCRIPTION
Fixes #4596
Fixes #4592 

- Detect PowerShell Core (v6) and offer as a shell type
- 1.1 and 1.2 didn't allow specifying a custom shell on Windows, now it does
- add file picker for selecting custom shell instead of just a text field
- if shell exits with non-zero return code, don't close the session pane (helps with troubleshooting)
- if shell startup fails in a way that was logging an error, show the error message via error dialog as well; otherwise these errors look like no-ops in the UI