### PR TITLE
be more selective in hiding scrollbars

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioDataGrid.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioDataGrid.java
@@ -74,7 +74,8 @@ public class RStudioDataGrid<T> extends DataGrid<T>
          Element el = children.getItem(i);
          com.google.gwt.dom.client.Style style = el.getStyle();
          String overflow = style.getOverflow();
-         if (!StringUtil.isNullOrEmpty(overflow))
+         String visibility = style.getVisibility();
+         if (StringUtil.equals(visibility, "hidden") && !StringUtil.isNullOrEmpty(overflow))
             style.setOverflowX(Overflow.HIDDEN);
       }
       


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/4662.

Note for testing: I wasn't able to reproduce the bug when working with my laptop's builtin display + builtin trackpad, but was able to reproduce when using an external display + mouse. It may be worth figuring out what the common element is (e.g. is it related to having a mouse plugged in, or having an external display)