### PR TITLE
Set secure flag when removing cookies over https

### DIFF
--- a/src/cpp/server/ServerPAMAuth.cpp
+++ b/src/cpp/server/ServerPAMAuth.cpp
@@ -229,9 +229,10 @@ void signIn(const http::Request& request,
             http::Response* pResponse)
 {
    core::http::secure_cookie::remove(request,
-                                     kUserId,
-                                     "/",
-                                     pResponse);
+      kUserId,
+      "/",
+      pResponse,
+      boost::algorithm::starts_with(request.absoluteUri(), "https"));
 
    std::map<std::string,std::string> variables;
    variables["action"] = applicationURL(request, kDoSignIn);
@@ -423,9 +424,10 @@ void signOut(const http::Request& request,
    }
 
    core::http::secure_cookie::remove(request,
-                                     kUserId,
-                                     "/",
-                                     pResponse);
+      kUserId,
+      "/",
+      pResponse,
+      boost::algorithm::starts_with(request.absoluteUri(), "https"));
 
    pResponse->setMovedTemporarily(request, auth::handler::kSignIn);
 }

--- a/src/cpp/server_core/http/SecureCookie.cpp
+++ b/src/cpp/server_core/http/SecureCookie.cpp
@@ -1,7 +1,7 @@
 /*
- * ServerSecureCookie.cpp
+ * SecureCookie.cpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -249,9 +249,10 @@ void set(const std::string& name,
 void remove(const http::Request& request,
             const std::string& name,
             const std::string& path,
-            core::http::Response* pResponse)
+            core::http::Response* pResponse,
+            bool secure)
 {
-   // create vanilla cookie (no need for secure cookie since we are removing)
+   // create cookie
    http::Cookie cookie(request, name, std::string(), path);
 
    // expire delete
@@ -259,6 +260,14 @@ void remove(const http::Request& request,
 
    // secure cookies are set http only, so clear them that way
    cookie.setHttpOnly();
+
+   if (secure)
+   {
+      // set secure flag when removing secure cookies; there's no need for a "secure" empty value
+      // but best practices generally dictate always setting the secure flag on cookies delivered
+      // over https
+      cookie.setSecure();
+   }
 
    // add to response
    pResponse->addCookie(cookie);

--- a/src/cpp/server_core/include/server_core/http/SecureCookie.hpp
+++ b/src/cpp/server_core/include/server_core/http/SecureCookie.hpp
@@ -71,7 +71,8 @@ void set(const std::string& name,
 void remove(const http::Request& request,
             const std::string& name,
             const std::string& path,
-            core::http::Response* pResponse);
+            core::http::Response* pResponse,
+            bool secure);
 
 // initialize with default secure cookie key file
 core::Error initialize();


### PR DESCRIPTION
This isn't strictly necessary since there's no value to secure, but "always mark cookies as secure when serving over HTTPS" is a rule enforced by many auditing tools, even when the cookie is being cleared.

Fixes https://github.com/rstudio/rstudio-pro/issues/964.