### PR TITLE
allow for user-defined exclusions for Find in Files

### DIFF
--- a/src/cpp/r/R/Options.R
+++ b/src/cpp/r/R/Options.R
@@ -143,3 +143,5 @@ options(profvis.keep_output = TRUE)
 # indicate that we're not in a notebook by default
 options(rstudio.notebook.executing = FALSE)
 
+# find in files: exclude things in platform-specific subdirs
+options(rstudio.find_in_files.excludes = R.version$platform)

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -28,6 +28,7 @@
 #include <core/system/Process.hpp>
 #include <core/system/ShellUtils.hpp>
 
+#include <r/ROptions.hpp>
 #include <r/RUtil.hpp>
 
 #include <session/SessionModuleContext.hpp>
@@ -504,6 +505,12 @@ core::Error beginFind(const json::JsonRpcRequest& request,
 
    if (ignoreCase)
       cmd << "-i";
+
+   // add exclusions
+   std::vector<std::string> excludes;
+   excludes = r::options::getOption("rstudio.find_in_files.excludes", excludes, false);
+   for (auto&& exclude : excludes)
+      cmd << std::string("--exclude-dir=") + exclude;
 
    // Use -f to pass pattern via file, so we don't have to worry about
    // escaping double quotes, etc.


### PR DESCRIPTION
This PR adds an option, `rstudio.find_in_files.excludes`, and uses it to determine which folders should be excluded from a Find in Files search. By default, we use `R.version$platform`. This effectively allows RStudio to ignore R library directories (either from Packrat or renv) when using Find in Files, which should speed things up substantially when these tools are in use.

It might also be worth surfacing this as a UI preference somewhere, but I'm not sure what the best place for that might be -- since I doubt many users will need explicit control here, making it an R option (for power users) seems sufficient.