### PR TITLE
Accessibility fixes to Server sign-in page

### DIFF
--- a/src/gwt/www/rstudio.css
+++ b/src/gwt/www/rstudio.css
@@ -1,7 +1,7 @@
 /*
  * rstudio.css
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * This program is licensed to you under the terms of version 3 of the
  * GNU Affero General Public License. This program is distributed WITHOUT
@@ -18,8 +18,6 @@ body, td {
   font-family: Lucida Grande, Lucida Sans Unicode, Helvetica, sans-serif;
   font-size: 11pt;
 }
-
-
 
 #banner {
   background-color: #e0e2e5;
@@ -71,4 +69,31 @@ a img {
 #login-html {
   margin: 30px 20px 70px 20px;
   padding: 8px;
+}
+
+#skipnav a {
+    position: absolute;
+    clip: rect(0 0 0 0);
+    border: 0;
+    height: 1px; margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    width: 1px;
+    white-space: nowrap;
+}
+#skipnav a:focus {
+    clip:auto;
+    left:0;
+    top:0;
+    width:100%;
+    height:auto;
+    margin:0;
+    padding:10px 0;
+    background:#fdf6e7;
+    border:2px solid #990000;
+    border-left:none;
+    border-right:none;
+    text-align:center;
+    font-weight:bold;
+    color:#990000;
 }

--- a/src/gwt/www/rstudio.css
+++ b/src/gwt/www/rstudio.css
@@ -81,6 +81,7 @@ a img {
     width: 1px;
     white-space: nowrap;
 }
+
 #skipnav a:focus {
     clip:auto;
     left:0;
@@ -96,4 +97,15 @@ a img {
     text-align:center;
     font-weight:bold;
     color:#990000;
+}
+
+.visuallyhidden {
+    position: absolute;
+    clip: rect(0 0 0 0);
+    border: 0;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
 }

--- a/src/gwt/www/templates/encrypted-sign-in.htm
+++ b/src/gwt/www/templates/encrypted-sign-in.htm
@@ -21,7 +21,7 @@
 <title>RStudio Sign In</title>
 <link rel="shortcut icon" href="images/favicon.ico" />
 
-<script language='javascript'>
+<script>
 function verifyMe()
 {
    if(document.getElementById('username').value=='')
@@ -72,13 +72,13 @@ input[type=text], input[type=password] {
 #errorpanel {
   text-align: center;
   padding: 0 25% 0 25%;
-  color: red;
+  color: #e60000;
   display: #errorDisplay#;
   font-weight: bold;
 }
 
 button.fancy {
-  background-color: #75aadb;
+  background-color: #1e77bc;
   border-radius: 4px;
   font-weight: bold;
   font-size: 14px;
@@ -151,9 +151,9 @@ function submitRealForm() {
 </script>
 
 </head>
-
-<h3 id="banner"><a href="http://www.rstudio.com"><img src="images/rstudio.png" width="78" height="27" title="RStudio"/></a></h3>
-
+<div id="skipnav"><a href="#username">Skip navigation</a></div>
+<header role="banner" id="banner"><a href="http://www.rstudio.com"><img src="images/rstudio.png" width="78" height="27" alt="RStudio Logo (goes to external site)"/></a></header>
+<main role="main">
 <div id="errorpanel">
 <p>Error: #errorMessage#</p>
 </div>
@@ -162,7 +162,8 @@ function submitRealForm() {
 <table id="border" align="center">
   <tr>
     <td>
-      <h2 id="caption">Sign in to RStudio</h2>
+      <h1 id="caption">Sign in to RStudio</h1>
+      <div role="group" aria-labelledby="caption">
       <p>
          <label for="username">Username:</label><br />
          <input type='text' 
@@ -192,6 +193,7 @@ function submitRealForm() {
          <input type="checkbox" name="staySignedIn" id="staySignedIn" value="1"/>
          <label for="staySignedIn">Stay signed in</label>
       </p>
+      </div>
        <input type="hidden" name="appUri" value="#appUri#"/>
        <div id="buttonpanel"><button class="fancy" type="submit">Sign In</button></div>
     </td>
@@ -214,5 +216,5 @@ function submitRealForm() {
 <script type="text/javascript">
 document.getElementById('username').focus();
 </script>
-</body>
+</main>
 </html>

--- a/src/gwt/www/templates/encrypted-sign-in.htm
+++ b/src/gwt/www/templates/encrypted-sign-in.htm
@@ -221,7 +221,7 @@ var errorPanel = document.getElementById('errorpanel');
 var displayProp = window.getComputedStyle(errorPanel, null).getPropertyValue("display");
 if (displayProp !== "none")
 {
-   document.title = "Error: RStudio Sign-in Failed";
+   document.title = "Error: RStudio Sign In Failed";
    // If error message displayed, give time for screen reader to catch up then
    // copy error message to aria-live region
    setTimeout(function () {

--- a/src/gwt/www/templates/encrypted-sign-in.htm
+++ b/src/gwt/www/templates/encrypted-sign-in.htm
@@ -116,6 +116,7 @@ function prepare() {
                   var errorDiv = document.getElementById('errorpanel');
                   errorDiv.innerHTML = '';
                   var errorp = document.createElement('p');
+                  errorp.id = "errortext";
                   errorDiv.appendChild(errorp);
                   if (typeof(errorp.innerText) == 'undefined')
                      errorp.textContent = errorMessage;
@@ -155,8 +156,9 @@ function submitRealForm() {
 <header role="banner" id="banner"><a href="http://www.rstudio.com"><img src="images/rstudio.png" width="78" height="27" alt="RStudio Logo (goes to external site)"/></a></header>
 <main role="main">
 <div id="errorpanel">
-<p>Error: #errorMessage#</p>
+<p id="errortext">Error: #errorMessage#</p>
 </div>
+<div aria-live="assertive" class="visuallyhidden" id="live-error"></div>
 
 <form method="POST" #!formAction#>
 <table id="border" align="center">
@@ -212,9 +214,19 @@ function submitRealForm() {
 #!loginPageHtml#
 </div>
 
-
 <script type="text/javascript">
 document.getElementById('username').focus();
+
+// If error message displayed, give time for screen reader to catch up then
+// copy error message to aria-live region
+var errorPanel = document.getElementById('errorpanel');
+var displayProp = window.getComputedStyle(errorPanel, null).getPropertyValue("display");
+if (displayProp !== "none")
+{
+   setTimeout(function () {
+      document.getElementById("live-error").innerText = document.getElementById("errortext").innerText;
+   }, 2000);
+}
 </script>
 </main>
 </html>

--- a/src/gwt/www/templates/encrypted-sign-in.htm
+++ b/src/gwt/www/templates/encrypted-sign-in.htm
@@ -217,12 +217,13 @@ function submitRealForm() {
 <script type="text/javascript">
 document.getElementById('username').focus();
 
-// If error message displayed, give time for screen reader to catch up then
-// copy error message to aria-live region
 var errorPanel = document.getElementById('errorpanel');
 var displayProp = window.getComputedStyle(errorPanel, null).getPropertyValue("display");
 if (displayProp !== "none")
 {
+   document.title = "Error: RStudio Sign-in Failed";
+   // If error message displayed, give time for screen reader to catch up then
+   // copy error message to aria-live region
    setTimeout(function () {
       document.getElementById("live-error").innerText = document.getElementById("errortext").innerText;
    }, 2000);


### PR DESCRIPTION
This is a much (MUCH) more comprehensive accessibility evaluation, and depth of fixes than we are going to get to for the whole product in 1.3; doing it primarily as a self-education exercise both in performing the evaluation, making and evaluating the fixes.

Fixes #4709

I did not do anything about failure of screen readers on macOS to read JavaScript alerts(). That would require a more significant reworking of the page's client-side form validation technique (a good idea, but not critical and more feature-ish than I wanted to get for this change). We'd probably call this out as an exception in our 1.3 VPAT (assuming we don't fix it).

Also did not do anything about the text boxes and button not showing their focus rectangles; fixing this issue will be a product-wide effort, likely involving an accessibility preference, so that'll be done as part of that.

# Summary of fixes:
- added styles from deque.com for creating "Skip Navigation" links at start of pages; this is to enable keyboard users who are tabbing into a page the option to skip to the main part of the page; honestly not a huge deal since our "navigation" here is a single RStudio logo linking to rstudio.com, but we should get in the practice of doing this for all pages
- added the skip-navigation link at top of page (invisible unless you tab to it, the industry standard way of doing this)
- added visuallyhidden class from deque.com for things we want screen readers to see but not visual users
- changed colors of button and error message to meet contrast requirements (this is actually the most serious of all these issues, in terms of meeting even the weakest compliance guidelines); see screenshot at end for how it looks now; I assume people who care about colors will be horrified and suggest new colors at some point
- use semantic tags header role="banner" and main role="main" (the redundancy of tags and roles is to maximize screen reader compatibility)
- wrap the form controls in a div role=group aria-labelled by the existing "Sign in to RStudio" caption; this causes screen readers to read that context, otherwise it is "invisible"; would have been semantically better to use fieldset/legend but that requires applying additional styling to override those element's default behavior and again, didn't want to mess with visuals any more than I had to
- fixed bug where the image in the banner (RStudio Logo) was using title= to describe itself instead of alt=; that's not supported by most screen readers and generally discouraged
- added more info to that alt-tag indicating this is the RStudio Logo and it goes to an external site; otherwise possible a user would think clicking it would start RStudio
- when page goes into error state after a failed sign in attempt, use aria-live region to announce the error message, in addition to the existing visual message; this requires a delay since screen readers work by building their own internal model of the page, and the text in a live region must be changed after that model is complete or it won't be announced; 2 seconds is a generally recommended worst-case delay especially for a simple page like this
- when page is in error state, modify the page title to indicate the error
- removed stray body end tag; there is no body start tag, which I understand is a totally valid thing to leave out in HTML5

(pardon the little LastPass widgets on the edit boxes)
![2019-04-25_15-42-47](https://user-images.githubusercontent.com/10569626/56773505-38999500-6773-11e9-86bb-aff79bfcf923.png)
