### PR TITLE
fix alerts/errors shown on sign in page

### DIFF
--- a/src/gwt/www/templates/encrypted-sign-in.htm
+++ b/src/gwt/www/templates/encrypted-sign-in.htm
@@ -26,14 +26,14 @@ function verifyMe()
 {
    if(document.getElementById('username').value=='')
    {
-      alert('You must enter a username');
       document.getElementById('username').focus();
+      showError('You must enter a username');
       return false;
    }
    if(document.getElementById('password').value=='')
    {
-      alert('You must enter a password');
       document.getElementById('password').focus();
+      showError('You must enter a password');
       return false;
    }
    return true;
@@ -95,6 +95,25 @@ button.fancy {
 
 <script type="text/javascript" src="js/encrypt.min.js"></script>
 <script type="text/javascript">
+
+function speakError() {
+   document.getElementById("live-error").innerText = document.getElementById("errortext").innerText;
+}
+
+function showError(errorMessage) {
+   var errorDiv = document.getElementById('errorpanel');
+   errorDiv.innerHTML = '';
+   var errorp = document.createElement('p');
+   errorp.id = "errortext";
+   errorDiv.appendChild(errorp);
+   if (typeof(errorp.innerText) == 'undefined')
+      errorp.textContent = errorMessage;
+   else
+      errorp.innerText = errorMessage;
+   errorDiv.style.display = 'block';
+   speakError();
+}
+
 function prepare() {
    if (!verifyMe())
       return false;
@@ -112,17 +131,7 @@ function prepare() {
                      errorMessage = "Error: Could not reach server--check your internet connection";
                   else
                      errorMessage = "Error: " + xhr.statusText;
-                     
-                  var errorDiv = document.getElementById('errorpanel');
-                  errorDiv.innerHTML = '';
-                  var errorp = document.createElement('p');
-                  errorp.id = "errortext";
-                  errorDiv.appendChild(errorp);
-                  if (typeof(errorp.innerText) == 'undefined')
-                     errorp.textContent = errorMessage;
-                  else
-                     errorp.innerText = errorMessage;
-                  errorDiv.style.display = 'block';
+                  showError(errorMessage);
                }
                else {
                   var response = xhr.responseText;
@@ -137,12 +146,12 @@ function prepare() {
                }
             }
          } catch (exception) {
-            alert("Error: " + exception);
+            showError("Error: " + exception);
          }
       };
       xhr.send(null);
    } catch (exception) {
-      alert("Error: " + exception);
+      showError("Error: " + exception);
    }
 }
 function submitRealForm() {
@@ -158,7 +167,7 @@ function submitRealForm() {
 <div id="errorpanel">
 <p id="errortext">Error: #errorMessage#</p>
 </div>
-<div aria-live="assertive" class="visuallyhidden" id="live-error"></div>
+<div role="alert" aria-atomic="true" class="visuallyhidden" id="live-error"></div>
 
 <form method="POST" #!formAction#>
 <table id="border" align="center">
@@ -223,9 +232,9 @@ if (displayProp !== "none")
 {
    document.title = "Error: RStudio Sign In Failed";
    // If error message displayed, give time for screen reader to catch up then
-   // copy error message to aria-live region
+   // copy error message to aria-live region to trigger announcement
    setTimeout(function () {
-      document.getElementById("live-error").innerText = document.getElementById("errortext").innerText;
+      speakError();
    }, 2000);
 }
 </script>


### PR DESCRIPTION
Additional accessibility improvements to the sign-in page. I will update #4709 to reflect this.

- don't use `alert()`, it is not consistently supported by screen readers; instead just leverage the page's existing error reporting mechanism and show "You must enter a username" and so forth directly and trigger screen reader to say it (see below)
- switch the error message live-region to be role="alert" since that's more semantically correct
- add `aria-atomic="true"` to the alert div to improve screen reader behavior as recommended https://www.w3.org/TR/WCAG20-TECHS/ARIA19.html

![2019-04-26_16-17-10](https://user-images.githubusercontent.com/10569626/56840870-e9b93180-683e-11e9-8642-f1ca938ab54b.png)
