### PR TITLE
Fix startup failure when using R 3.6.0 and options(error) in .Rprofile

### DIFF
--- a/src/cpp/r/ROptions.cpp
+++ b/src/cpp/r/ROptions.cpp
@@ -87,6 +87,18 @@ SEXP setErrorOption(SEXP value)
    SEXP option = SYMVALUE(Rf_install(".Options"));
    while (option != R_NilValue)
    {
+      // are we removing the option?
+      if (value == R_NilValue)
+      {
+         // remove the error option from the list
+         if (TAG(CDR(option)) == errorTag)
+         {
+            SEXP previous = CAR(CDR(option));
+            SETCDR(option, CDDR(option));
+            return previous;
+         }
+      }
+
       // is this the error option?
       if (TAG(option) == errorTag)
       {


### PR DESCRIPTION
This change fixes an issue causing RStudio to fail to start when the `error` option is set in .Rprofile.

The problem is that, when temporarily disabling a user error handler to execute our own code, we set the `error` option to NULL (`R_NilValue`). In R 3.6.0 this became illegal; the option should be removed, not set to NULL. 

Fixes https://github.com/rstudio/rstudio/issues/4723; fixes https://github.com/rstudio/rstudio/issues/4441.