### PR TITLE
Fix quoting of path in windows dockerfile

### DIFF
--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -53,7 +53,7 @@ RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 
 RUN Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe'
 
 # register msdia DLL (needed for uploading debug symbols to Sentry)
-RUN regsvr32 /s "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\DIA SDK\bin\msdia140.dll"
+RUN regsvr32 /s 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\DIA SDK\bin\msdia140.dll'
 
 #### this docker container will currently be used as a jenkins swarm slave, rather than instantiated on a swarm ####
 ##### the items below this are dependencies relevant to jenkins-swarm. #####


### PR DESCRIPTION
Need to use single-quotes around path, not double-quotes. Confirmed this fixes the image build and successfully ran a package build using the image.

Suspect could also have used \\".

With double-quotes, the regsvr32 call fails during image build:

```
Step 12/15 : RUN regsvr32 /s "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\DIA SDK\bin\msdia140.dll"
 ---> Running in 6f8e8eb5f7c6
x86 : The term 'x86' is not recognized as the name of a cmdlet, function,
script file, or operable program. Check the spelling of the name, or if a path
was included, verify that the path is correct and try again.
At line:1 char:31
+ regsvr32 /s C:\Program Files (x86)\Microsoft Visual Studio\2017\Build ...
+                               ~~~
    + CategoryInfo          : ObjectNotFound: (x86:String) [], CommandNotFound
   Exception
    + FullyQualifiedErrorId : CommandNotFoundException

The command 'powershell regsvr32 /s "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\DIA SDK\bin\msdia140.dll"' returned a non-zero code: 1
Produced image.
```