### PR TITLE
reduce unnecessary inclusion of websocketpp headers

### DIFF
--- a/dependencies/windows/Install-RStudio-Prereqs.ps1
+++ b/dependencies/windows/Install-RStudio-Prereqs.ps1
@@ -68,7 +68,7 @@ refreshenv
 choco install -y jdk8
 choco install -y ant --version 1.10.5
 choco install -y 7zip --version 18.5.0.20180730
-choco install -y git --version 2.18.0
+choco install -y git
 choco install -y ninja --version 1.7.2
 choco install -y windows-sdk-10.1 --version 10.1.17134.12
 choco install -y visualstudio2017buildtools --version 15.8.2.0

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -19,6 +19,7 @@
 #include <session/projects/SessionProjects.hpp>
 
 #include <session/SessionModuleContext.hpp>
+#include <session/SessionConsoleProcessSocket.hpp>
 
 #include "modules/SessionWorkbench.hpp"
 #include "SessionConsoleProcessTable.hpp"

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -27,7 +27,7 @@
 #include <core/system/Process.hpp>
 #include <core/terminal/PrivateCommand.hpp>
 
-#include <session/SessionConsoleProcessSocket.hpp>
+#include <session/SessionConsoleProcessConnectionCallbacks.hpp>
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/session/include/session/SessionConsoleProcessConnectionCallbacks.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessConnectionCallbacks.hpp
@@ -1,0 +1,47 @@
+/*
+ * SessionConsoleProcessConnectionCallbacks.hpp
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+#ifndef SESSION_CONSOLE_PROCESS_CONNECTION_CALLBACKS_HPP
+#define SESSION_CONSOLE_PROCESS_CONNECTION_CALLBACKS_HPP
+
+#include <string>
+
+#include <boost/function.hpp>
+
+namespace rstudio {
+namespace session {
+namespace console_process {
+
+// ConsoleProcessSocketConnectionCallbacks are related to connections.
+// Each connections made will supply a unique set of these callbacks,
+// and will receive callbacks only related to that connection.
+//
+// IMPORTANT: Callbacks are dispatched on a background thread.
+struct ConsoleProcessSocketConnectionCallbacks
+{
+   // invoked when input arrives on the socket
+   boost::function<void (const std::string& input)> onReceivedInput;
+
+   // invoked when connection opens
+   boost::function<void()> onConnectionOpened;
+
+   // invoked when connection closes
+   boost::function<void ()> onConnectionClosed;
+};
+
+} // namespace console_process
+} // namespace session
+} // namespace rstudio
+
+#endif // SESSION_CONSOLE_PROCESS_CONNECTION_CALLBACKS_HPP

--- a/src/cpp/session/include/session/SessionConsoleProcessSocket.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessSocket.hpp
@@ -33,6 +33,8 @@
 #include <websocketpp/server.hpp>
 #include <websocketpp/frame.hpp>
 
+#include "SessionConsoleProcessConnectionCallbacks.hpp"
+
 namespace rstudio {
 namespace session {
 namespace console_process {
@@ -42,28 +44,10 @@ namespace console_process {
 // speed communication of input/output for interactive terminals
 // spawned by the server, and displayed in the client.
 //
-// ConsoleProcessSocketConnectionCallbacks are related to connections.
-// Each connections made will supply a unique set of these callbacks,
-// and will receive callbacks only related to that connection.
-//
 // Each connection MUST be made with a URL ending with /xxxx/ where "xxxx"
 // is some textual unique handle for that connection. In practice, this is
 // the terminal handle string used elsewhere in the codebase. This uniqueId
 // is used to dispatch callbacks, and to send output to the right connection.
-//
-// IMPORTANT: Callbacks are dispatched on a background thread.
-
-struct ConsoleProcessSocketConnectionCallbacks
-{
-   // invoked when input arrives on the socket
-   boost::function<void (const std::string& input)> onReceivedInput;
-
-   // invoked when connection opens
-   boost::function<void()> onConnectionOpened;
-
-   // invoked when connection closes
-   boost::function<void ()> onConnectionClosed;
-};
 
 typedef websocketpp::server<websocketpp::config::asio> terminalServer;
 typedef terminalServer::message_ptr terminalMessage_ptr;


### PR DESCRIPTION
The websocketpp headers spit out quite a few build-warnings, noticed during Windows build that source files that shouldn't care less about websockets were generating these warnings.

SessionConsoleProcess.hpp was pulling these in via SessionConsoleProcessSocket.hpp, just to get at the ConsoleProcessSocketConnectionCallbacks struct. Refactored that struct into a separate header.

This takes the Windows build warning count (debug) from 144 to a mere 96. Almost respectable. Kinda a hobby at this point.

Also unpinned the git version number in the bootstrapper script; the dockerfile doesn't specify a version, so neither should this script.