### PR TITLE
RStudio 1.21335 fails to start if `_R_CHECK_LENGTH_1_LOGIC2_=true` is set

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -423,7 +423,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
 {
    # cran mirror configured
    repos = getOption("repos")
-   cranMirrorConfigured <- !is.null(repos) && repos != "@CRAN@"
+   cranMirrorConfigured <- !is.null(repos) && !any(repos == "@CRAN@")
    
    # selected repository names (assume an unnamed repo == CRAN)
    selectedRepositoryNames <- names(repos)


### PR DESCRIPTION
RStudio 1.21335 fails to start if `_R_CHECK_LENGTH_1_LOGIC2_=true` is set.  The error message is:

>     The R session had a fatal error.
>     
>     ERROR r error 4 (R code execution error) [errormsg=Error in !is.null(repos) && repos != "@CRAN@" :
>       'length(x) = 5 > 1' in coercion to 'logical(1)'
>     ]; OCCURRED AT: rstudio::core::Error rstudio::r::exec::{anonymous}::evaluateExpressionsUnsafe(SEXP, SEXP, SEXPREC**, rstudio::r::sexp::Protect*, rstudio::r::exec::{anonymous}::EvalType) /var/lib/jenkins/workspace/IDE_open-source-pipeline_v1.2/src/cpp/r/RExec.cpp:171


Setting `options(rstudio.errors.suppressed = FALSE)` in `~/.Rprofile` is _not_ sufficient to workaround this.
