### PR TITLE
pin server-core 1709 in windows dockerfile

### DIFF
--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -1,9 +1,9 @@
 # escape=`
 
-# Use the latest Windows Server Core image with .NET Framework 4.7.1.
+# Use the latest Windows Server Core 1709 image with .NET Framework 4.7.1.
 # Otherwise there are problems installing Visual Studio 2017 buildtools into containers
 # See https://docs.microsoft.com/en-us/visualstudio/install/build-tools-container
-FROM microsoft/dotnet-framework:4.7.1
+FROM microsoft/dotnet-framework:4.7.1-windowsservercore-1709
 
 # set RUN commands to use powershell
 SHELL ["powershell"]


### PR DESCRIPTION
Windows docker image builds started failing with:

```
`CreateComputeSystem .......... The operating system of the container does not match the operating system of the host`
```

This is due to the version of server-core we build with no longer being supported by the image we pull: https://github.com/dotnet/announcements/issues/105

Short-term fix is to specify server-core 1709 instead of letting it pickup default OS for the .NET image. Eventually we'll want to spend quality time with Docker on Windows getting updated to a newer base image.

