### PR TITLE
Allow previewing altrep objects

### DIFF
--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -432,7 +432,7 @@
       # some objects (e.g. ALTREP) have compact representations that are forced to materialize if
       # an attempt is made to compute their metrics exactly; avoid computing the size for these
       size <- if (computeSize) object.size(obj) else 0
-      len <- if (computeSize) length(obj) else 0
+      len <- length(obj)
    }
    class <- .rs.getSingleClass(obj)
    contents <- list()
@@ -481,7 +481,17 @@
              is.data.frame(obj) ||
              isS4(obj))
          {
-            contents <- .rs.valueContents(obj)
+            if (computeSize)
+            {
+               # normal object
+               contents <- .rs.valueContents(obj)
+            }
+            else
+            {
+               # don't prefetch content for altreps
+               val <- "NO_VALUE"
+               contents_deferred <- TRUE
+            }
          }
       }
    }


### PR DESCRIPTION
Currently, objects containing ALTREPs cannot be expanded in the Environment pane. This is because we treat them as empty to avoid prematurely unrolling the ALTREPs (which will happen if we try to compute the size of the objects).

This change refines the behavior such that, for data frames containing ALTREP columns (e.g. from sequences or lazy-load packages like vroom), the Environment pane will show the objects as expandable, but not actually ask for data unless the user manually expands the object. This is the same behavior we have today for very large objects.

Fixes https://github.com/rstudio/rstudio/issues/4758.