### PR TITLE
Depend on new Shinytest package

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -827,7 +827,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
    {
       String message = "Using shinytest";
       Dependency[] dependencies = new Dependency[] {
-         Dependency.cranPackage("shinytest", "1.2")
+         Dependency.cranPackage("shinytest", "1.3.1")
       };
 
       if (useTestThat) {


### PR DESCRIPTION
The version of the `shinytest` package we currently depend on does not work on RStudio Server; this change causes us to depend on a new version shinytest that does work on RStudio Server.

Fixes https://github.com/rstudio/rstudio/issues/4565.