### PR TITLE
fix failure installing ant in windows dockerfile, registing msdia140.dll

### DIFF
--- a/dependencies/windows/Install-RStudio-Prereqs.ps1
+++ b/dependencies/windows/Install-RStudio-Prereqs.ps1
@@ -79,9 +79,6 @@ choco install -y activeperl
 # cpack (an alias from chocolatey) and cmake's cpack conflict.
 Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe'
 
-# register msdia DLL (needed for uploading debug symbols to Sentry)
-regsvr32 /s "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\DIA SDK\bin\msdia140.dll"
-
 [System.Net.ServicePointManager]::SecurityProtocol = $securityProtocolSettingsOriginal
 
 Write-Host "-----------------------------------------------------------"

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -178,4 +178,6 @@ if not defined RSTUDIO_SKIP_QT (
   call install-qt-sdk-win.cmd
 )
 
+regsvr32 /s "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\DIA SDK\bin\msdia140.dll"
+
 call install-crashpad.cmd

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -17,10 +17,10 @@ RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 
 
 # install some deps via chocolatey
 RUN choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=""System""' --fail-on-error-output; ` 
-  choco install -y jdk8 ; `
-  choco install -y ant --version 1.10.5; `
+  choco install -y jdk8; `
+  choco install -y -i ant; `
   choco install -y windows-sdk-10.1 --version 10.1.17134.12; `
-  choco install -y 7zip --version 18.5.0.20180730; `
+  choco install -y 7zip; `
   choco install -y nsis
   
 RUN choco install -y visualstudio2017buildtools --version 15.8.2.0; `
@@ -51,9 +51,6 @@ RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 
     
 # cpack (an alias from chocolatey) and cmake's cpack conflict.
 RUN Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe'
-
-# register msdia DLL (needed for uploading debug symbols to Sentry)
-RUN regsvr32 /s 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\DIA SDK\bin\msdia140.dll'
 
 #### this docker container will currently be used as a jenkins swarm slave, rather than instantiated on a swarm ####
 ##### the items below this are dependencies relevant to jenkins-swarm. #####


### PR DESCRIPTION
Ant was failing to install the JRE (which is already installed via
the JDK). Use -i to have ant not worry about dependencies, and
stop requesting specific version of ant and 7zip (while we're at it)
because having latest version of these tools is fine.

Still having problems getting msdia140.dll to regsvr32 inside the
container so moved it to the install-dependencies script.