### PR TITLE
Add missing error handler when creating a new project. Fixes #4784

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
@@ -533,7 +533,7 @@ public class Projects implements OpenProjectFileHandler,
                         newProject.getNewPackageOptions(),
                         newProject.getNewShinyAppOptions(),
                         newProject.getProjectTemplateOptions(),
-                        new SimpleRequestCallback<String>()
+                        new ServerRequestCallback<String>()
                         {
                            @Override
                            public void onResponseReceived(String foundProjectFile)
@@ -546,6 +546,14 @@ public class Projects implements OpenProjectFileHandler,
                                  newProject.setProjectFile(foundProjectFile);
                               }
                               continuation.execute();
+                           }
+
+                           @Override
+                           public void onError(ServerError error)
+                           {
+                              Debug.logError(error);
+                              indicator.onError(error.getUserMessage());
+                              notifyTutorialCreateNewResult(newProject, false, error.getUserMessage());
                            }
                         });
                };


### PR DESCRIPTION
Looks like #4784 was just caused by a missing error handler, which I've added here.