### PR TITLE
Disable desktop main menu when modal GWT dialog is shown

### DIFF
--- a/src/cpp/desktop/DesktopMenuCallback.cpp
+++ b/src/cpp/desktop/DesktopMenuCallback.cpp
@@ -341,7 +341,8 @@ void MenuCallback::setCommandChecked(QString commandId, bool checked)
 
 void MenuCallback::setMainMenuEnabled(bool enabled)
 {
-   pMainMenu_->setEnabled(enabled);
+   if (pMainMenu_)
+      pMainMenu_->setEnabled(enabled);
 }
 
 MenuActionBinder::MenuActionBinder(QMenu* pMenu, QAction* pAction) : QObject(pAction)

--- a/src/cpp/desktop/DesktopMenuCallback.cpp
+++ b/src/cpp/desktop/DesktopMenuCallback.cpp
@@ -1,7 +1,7 @@
 /*
  * DesktopMenuCallback.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -337,6 +337,11 @@ void MenuCallback::setCommandChecked(QString commandId, bool checked)
        return;
 
    it.value()->setChecked(checked);
+}
+
+void MenuCallback::setMainMenuEnabled(bool enabled)
+{
+   pMainMenu_->setEnabled(enabled);
 }
 
 MenuActionBinder::MenuActionBinder(QMenu* pMenu, QAction* pAction) : QObject(pAction)

--- a/src/cpp/desktop/DesktopMenuCallback.hpp
+++ b/src/cpp/desktop/DesktopMenuCallback.hpp
@@ -1,7 +1,7 @@
 /*
  * DesktopMenuCallback.hpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -53,6 +53,7 @@ public Q_SLOTS:
     void setCommandVisible(QString commandId, bool visible);
     void setCommandLabel(QString commandId, QString label);
     void setCommandChecked(QString commandId, bool checked);
+    void setMainMenuEnabled(bool enabled);
 
 Q_SIGNALS:
     void menuBarCompleted(QMenuBar* menuBar);

--- a/src/cpp/desktop/DesktopMenuCallback.hpp
+++ b/src/cpp/desktop/DesktopMenuCallback.hpp
@@ -79,7 +79,7 @@ private:
                                     QKeySequence keySequence,
                                     bool checkable);
 private:
-    QMenuBar* pMainMenu_;
+    QMenuBar* pMainMenu_ = nullptr;
     QStack<SubMenu*> menuStack_;
     QMap<QString, QAction*> actions_;
 };

--- a/src/gwt/src/org/rstudio/core/client/command/impl/DesktopMenuCallback.java
+++ b/src/gwt/src/org/rstudio/core/client/command/impl/DesktopMenuCallback.java
@@ -1,7 +1,7 @@
 /*
  * DesktopMenuCallback.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -90,6 +90,11 @@ public class DesktopMenuCallback implements MenuCallback
    private native static final void setCommandCheckedImpl(String commandId, boolean checked, JavaScriptObject callbacks)
    /*-{
       callbacks.setCommandChecked(commandId, checked);
+   }-*/;
+
+   public native static final void setMainMenuEnabled(boolean enabled)
+   /*-{
+       $wnd.desktopMenuCallback.setMainMenuEnabled(enabled);
    }-*/;
 
    public static final void setCommandLabel(String commandId, String label)

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogTracker.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogTracker.java
@@ -1,7 +1,7 @@
 /*
  * ModalDialogTracker.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,6 +15,8 @@
 package org.rstudio.core.client.widget;
 
 import com.google.gwt.user.client.ui.PopupPanel;
+import org.rstudio.core.client.command.impl.DesktopMenuCallback;
+import org.rstudio.studio.client.application.Desktop;
 
 import java.util.ArrayList;
 
@@ -23,6 +25,8 @@ public class ModalDialogTracker
    public static void onShow(PopupPanel panel)
    {
       dialogStack_.add(panel);
+      if (Desktop.isDesktop())
+         DesktopMenuCallback.setMainMenuEnabled(false);
    }
 
    public static boolean isTopMost(PopupPanel panel)
@@ -33,8 +37,9 @@ public class ModalDialogTracker
 
    public static void onHide(PopupPanel panel)
    {
-      while (dialogStack_.remove(panel))
-      {}
+      dialogStack_.removeIf(panel::equals);
+      if (Desktop.isDesktop() && numModalsShowing() == 0)
+         DesktopMenuCallback.setMainMenuEnabled(true);
    }
    
    public static int numModalsShowing()
@@ -42,6 +47,5 @@ public class ModalDialogTracker
       return dialogStack_.size();
    }
 
-   private static ArrayList<PopupPanel> dialogStack_ =
-         new ArrayList<PopupPanel>();
+   private static final ArrayList<PopupPanel> dialogStack_ = new ArrayList<>();
 }


### PR DESCRIPTION
- When a GWT-based "modal dialog" is shown, the main menu is now disabled.
- When the last modal dialog is closed, the main menu is reenabled

Fixes #2481 
Fixes #2482 
