### PR TITLE
Add error option if necessary

### DIFF
--- a/src/cpp/r/ROptions.cpp
+++ b/src/cpp/r/ROptions.cpp
@@ -108,6 +108,15 @@ SEXP setErrorOption(SEXP value)
          return previous;
       }
 
+      if (CDR(option) == R_NilValue && value != R_NilValue)
+      {
+         // no error option exists at all; add it so we can set the value
+         SETCDR(option, Rf_allocList(1));
+         SETCAR(CDR(option), value);
+         SET_TAG(CDR(option), errorTag);
+         break;
+      }
+
       // next option
       option = CDR(option);
    }


### PR DESCRIPTION
This change completes the (unintentionally) incomplete work in https://github.com/rstudio/rstudio/commit/78e10db4675bad47b5e0c8cc4da3b164e4d4b1cb. Now that we're removing the `error` option entirely when setting it to NULL, we also need to allocate a new options entry when restoring the option. 

Fixes https://github.com/rstudio/rstudio/issues/4787.