### PR TITLE
Switch environment variables format to SI standard

### DIFF
--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -462,7 +462,7 @@
          else
          {
             val <- paste("Large ", class, " (", len_desc, 
-                         capture.output(print(size, units="auto")), ")", sep="")
+                         format(size, units="auto", standard="SI"), ")", sep="")
          }
          contents_deferred <- TRUE
       }


### PR DESCRIPTION
Variable size should be represented by units from modern standards (i.e., `MB` instead of `Mb`). This pull request by @Qjammer and I addresses issue #1704 by switching from the legacy representation to the SI representation. It also replaces the combination of `capture.output` and `print` with a simple `format` call.