### PR TITLE
Allow column resize in Environment pane

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectGrid.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectGrid.java
@@ -1,7 +1,7 @@
 /*
  * EnvironmentObjectGrid.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.css
@@ -68,6 +68,11 @@ td.expandCol
    width: 20px;
 }
 
+td.resizeCol {
+   width: 1px;
+   position: relative;
+}
+
 td.valueCol
 {
    border: 1px solid #f0f0f0;
@@ -156,4 +161,14 @@ td.decoratedValueCol
 .rstudio-themes-flat .rstudio-themes-alternate .detailRow,
 .rstudio-themes-flat .rstudio-themes-alternate .categoryHeaderRow {
    border-color: THEME_ALTERNATE_BORDER;
+}
+
+.colResizer
+{
+   cursor: ew-resize;
+   width: 4px;
+   top: 0px;
+   left: -2px;
+   height: 100%;
+   position: absolute;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.css
@@ -69,7 +69,8 @@ td.expandCol
 }
 
 td.resizeCol {
-   width: 1px;
+   width: 0px;
+   border: none;
    position: relative;
 }
 
@@ -81,6 +82,7 @@ td.valueCol
    overflow-x: hidden;
    padding-right: 20px;
    background-color: #ffffff;
+   padding-left: 5px;
 }
 
 .rstudio-themes-flat td.valueCol
@@ -142,6 +144,7 @@ td.decoratedValueCol
 .rstudio-themes-flat .rstudio-themes-default td.nameCol,
 .rstudio-themes-flat .rstudio-themes-default td.expandCol,
 .rstudio-themes-flat .rstudio-themes-default td.valueCol,
+.rstudio-themes-flat .rstudio-themes-default td.resizeCol,
 .rstudio-themes-flat .rstudio-themes-default .detailRow,
 .rstudio-themes-flat .rstudio-themes-default .categoryHeaderRow {
    border-color: THEME_DEFAULT_BORDER;
@@ -150,6 +153,7 @@ td.decoratedValueCol
 .rstudio-themes-flat .rstudio-themes-dark-grey td.nameCol,
 .rstudio-themes-flat .rstudio-themes-dark-grey td.expandCol,
 .rstudio-themes-flat .rstudio-themes-dark-grey td.valueCol,
+.rstudio-themes-flat .rstudio-themes-dark-grey td.resizeCol,
 .rstudio-themes-flat .rstudio-themes-dark-grey .detailRow,
 .rstudio-themes-flat .rstudio-themes-dark-grey .categoryHeaderRow {
    border-color: THEME_DARKGREY_BORDER;
@@ -158,6 +162,7 @@ td.decoratedValueCol
 .rstudio-themes-flat .rstudio-themes-alternate td.nameCol,
 .rstudio-themes-flat .rstudio-themes-alternate td.expandCol,
 .rstudio-themes-flat .rstudio-themes-alternate td.valueCol,
+.rstudio-themes-flat .rstudio-themes-alternate td.resizeCol,
 .rstudio-themes-flat .rstudio-themes-alternate .detailRow,
 .rstudio-themes-flat .rstudio-themes-alternate .categoryHeaderRow {
    border-color: THEME_ALTERNATE_BORDER;
@@ -166,9 +171,9 @@ td.decoratedValueCol
 .colResizer
 {
    cursor: ew-resize;
-   width: 4px;
+   width: 6px;
    top: 0px;
-   left: -2px;
+   left: -3px;
    height: 100%;
    position: absolute;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.java
@@ -245,6 +245,8 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
             @Override
             public String getValue(RObjectEntry object)
             {
+               // We don't have ready access to the DOM (still under
+               // construction at this point), so we use a window method here.
                return "<div class=\"" + style_.colResizer() + "\" " +
                       "onmousedown=\"rstudio_beginResize(this, " +
                       "\'" + style_.nameCol() + "'" +
@@ -290,7 +292,6 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
          });
       }
    }-*/;
-   
    
    private void expandObject(final int index, final RObjectEntry object)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.java
@@ -248,7 +248,7 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
                // We don't have ready access to the DOM (still under
                // construction at this point), so we use a window method here.
                return "<div class=\"" + style_.colResizer() + "\" " +
-                      "onmousedown=\"rstudio_beginResize(this, " +
+                      "onmousedown=\"rstudio_beginResize(this, event, " +
                       "\'" + style_.nameCol() + "'" +
                       ");\"></div>";
             }
@@ -256,7 +256,13 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
    }
    
    private final native void exportResizer() /*-{
-      $wnd.rstudio_beginResize = function(ele, clazz) {
+      $wnd.rstudio_beginResize = function(ele, event, clazz) 
+      {
+         // Ignore non-primary buttons
+         if (event.button !== 0)
+         {
+            return;
+         }
 
          // Locate the element to resize
          var tbody = ele.parentElement.parentElement.parentElement;
@@ -271,7 +277,8 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
          var width = resizer.clientWidth;
 
          // Resize method; given a mouse move event, adjust the size accordingly
-         var resize = function(evt) {
+         var resize = function(evt) 
+         {
             if (start === -1)
                start = evt.clientX;
             var newWidth = (width + (evt.clientX - start));
@@ -287,7 +294,8 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
 
          // Wire up event listeners
          $wnd.addEventListener("mousemove", resize);
-         $wnd.addEventListener("mouseup", function(evt) {
+         $wnd.addEventListener("mouseup", function(evt) 
+         {
             $wnd.removeEventListener("mousemove", resize);
          });
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.java
@@ -1,7 +1,7 @@
 /*
  * EnvironmentObjectList.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -51,12 +51,14 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
       String widthSettingRow();
       String expandCol();
       String nameCol();
+      String resizeCol();
       String valueCol();
       String categoryHeaderText();
       String clickableCol();
       String decoratedValueCol();
       String detailRow();
       String objectList();
+      String colResizer();
    }
 
    public interface Resources extends ClientBundle
@@ -82,12 +84,15 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
       createColumns();
       addColumn(objectExpandColumn_);
       addColumn(objectNameColumn_);
+      addColumn(objectResizeColumn_);
       addColumn(objectDescriptionColumn_);
       setSkipRowHoverCheck(true);
       style_ = ((Resources)GWT.create(Resources.class)).style();
       style_.ensureInjected();
       addStyleName(style_.objectList());
       addStyleName("ace_editor_theme");
+      
+      exportResizer();
    }
 
    @Override
@@ -122,6 +127,7 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
    {
       createExpandColumn();
       createNameColumn(filterRenderer_);
+      createResizeColumn();
       createDescriptionColumn(filterRenderer_);
    }
 
@@ -220,6 +226,72 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
               });
    }
    
+   private void createResizeColumn()
+   {
+      SafeHtmlRenderer<String> resizerRenderer =
+         new AbstractSafeHtmlRenderer<String>()
+         {
+            @Override
+            public SafeHtml render(String object)
+            {
+               SafeHtmlBuilder sb = new SafeHtmlBuilder();
+               sb.appendHtmlConstant(object);
+               return sb.toSafeHtml();
+            }
+         };
+      objectResizeColumn_ = new Column<RObjectEntry, String>(
+         new ClickableTextCell(resizerRenderer))
+         {
+            @Override
+            public String getValue(RObjectEntry object)
+            {
+               return "<div class=\"" + style_.colResizer() + "\" " +
+                      "onmousedown=\"rstudio_beginResize(this, " +
+                      "\'" + style_.nameCol() + "'" +
+                      ");\"></div>";
+            }
+         };
+   }
+   
+   private final native void exportResizer() /*-{
+      $wnd.rstudio_beginResize = function(ele, clazz) {
+
+         // Locate the element to resize
+         var tbody = ele.parentElement.parentElement.parentElement;
+         var matches = tbody.firstElementChild.getElementsByClassName(clazz);
+         if (!matches)
+            return;
+         var resizer = matches[0];
+
+         // Initial position of cursor when resizing and initial width of the
+         // element
+         var start = -1;
+         var width = resizer.clientWidth;
+
+         // Resize method; given a mouse move event, adjust the size accordingly
+         var resize = function(evt) {
+            if (start === -1)
+               start = evt.clientX;
+            var newWidth = (width + (evt.clientX - start));
+            
+            // Enforce minimum/maximum width
+            if (newWidth < 40)
+               newWidth = 40;
+            else if (newWidth > 500)
+               newWidth = 500;
+               
+            resizer.style.width = newWidth + "px";
+         };
+
+         // Wire up event listeners
+         $wnd.addEventListener("mousemove", resize);
+         $wnd.addEventListener("mouseup", function(evt) {
+            $wnd.removeEventListener("mousemove", resize);
+         });
+      }
+   }-*/;
+   
+   
    private void expandObject(final int index, final RObjectEntry object)
    {
       if (!object.expanded && 
@@ -272,6 +344,7 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
          // build the columns
          buildExpandColumn(rowValue, row);
          buildNameColumn(rowValue, row);
+         buildResizeColumn(rowValue, row);
          buildDescriptionColumn(rowValue, row);
 
          row.endTR();
@@ -289,6 +362,14 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
          expandCol.className(style_.expandCol() + " " + ThemeStyles.INSTANCE.handCursor());
          renderCell(expandCol, createContext(0), objectExpandColumn_, rowValue);
          expandCol.endTD();
+      }
+      
+      private void buildResizeColumn(RObjectEntry rowValue, TableRowBuilder row)
+      {
+         TableCellBuilder resizeCol = row.startTD();
+         resizeCol.className(style_.resizeCol());
+         renderCell(resizeCol, createContext(0), objectResizeColumn_, rowValue);
+         resizeCol.endTD();
       }
 
       private void buildNameColumn(RObjectEntry rowValue, TableRowBuilder row)
@@ -382,6 +463,7 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
                     style_.widthSettingRow());
             widthSettingRow.startTD().className(style_.expandCol()).endTD();
             widthSettingRow.startTD().className(style_.nameCol()).endTD();
+            widthSettingRow.startTD().className(style_.resizeCol()).endTD();
             widthSettingRow.startTD().className(style_.valueCol()).endTD();
             widthSettingRow.endTR();
          }
@@ -405,7 +487,7 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
             TableRowBuilder leaderRow = startRow().className(
                     style_.categoryHeaderRow());
             TableCellBuilder objectHeader = leaderRow.startTD();
-            objectHeader.colSpan(3)
+            objectHeader.colSpan(4)
                     .className(style_.categoryHeaderText() + " rstudio-themes-background")
                     .text(categoryTitle)
                     .endTD();
@@ -428,7 +510,7 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
             if (content.startsWith(" $") || content.startsWith("  ")) 
                content = content.substring(2, content.length());
             content = content.trim();
-            objectDetail.colSpan(2)
+            objectDetail.colSpan(3)
                     .title(content)
                     .text(content)
                     .endTD();
@@ -441,5 +523,6 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
 
    private Column<RObjectEntry, String> objectExpandColumn_;
    private Column<RObjectEntry, String> objectNameColumn_;
+   private Column<RObjectEntry, String> objectResizeColumn_;
    private Column<RObjectEntry, String> objectDescriptionColumn_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.css
@@ -145,6 +145,7 @@
 }
 
 .widthSettingRow td.expandCol,
+.widthSettingRow td.resizeCol,
 .widthSettingRow td.nameCol,
 .widthSettingRow td.valueCol
 {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentStyle.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentStyle.java
@@ -22,6 +22,7 @@ interface EnvironmentStyle extends CssResource
    int headerRowHeight();
    String expandCol();
    String nameCol();
+   String resizeCol();
    String valueCol();
    String clickableCol();
    String detailRow();


### PR DESCRIPTION
This change makes it possible to adjust the the width of the columns in the Environment pane, useful when you're working with data that has long names (or, conversely, long values).

Closes https://github.com/rstudio/rstudio/issues/4020.