### PR TITLE
don't show launcher jobs in open source

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -313,7 +313,6 @@ well as menu structures (for main menu and popup menus).
          <cmd refid="activateBuild"/>
          <cmd refid="activateConnections"/>
          <cmd refid="activateJobs"/>
-         <cmd refid="activateLauncherJobs"/>
 
          <separator/>
          <cmd refid="synctexSearch"/>


### PR DESCRIPTION
Closes #4677.

IIUC, after merging this we'll have to merge back to Pro, and then make a Pro-only change to add the command back in. Does that sound correct?