### PR TITLE
disallow horizontal scrollbars for DataGrid

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioDataGrid.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioDataGrid.java
@@ -15,7 +15,6 @@
 package org.rstudio.core.client.widget;
 
 import org.rstudio.core.client.BrowseCap;
-import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
 
 import com.google.gwt.dom.client.Element;
@@ -73,10 +72,7 @@ public class RStudioDataGrid<T> extends DataGrid<T>
       {
          Element el = children.getItem(i);
          com.google.gwt.dom.client.Style style = el.getStyle();
-         String overflow = style.getOverflow();
-         String visibility = style.getVisibility();
-         if (StringUtil.equals(visibility, "hidden") && !StringUtil.isNullOrEmpty(overflow))
-            style.setOverflowX(Overflow.HIDDEN);
+         style.setOverflowX(Overflow.HIDDEN);
       }
       
    }


### PR DESCRIPTION
It seems the prior PR was actually insufficient in resolving this issue. Since we don't ever actually use horizontal scrolling with our DataGrids (we just manage the width of columns visible to the user) I think we can just disable horizontal scrollbars entirely.

Candidate for 1.2 backport.

Closes #4529.