### PR TITLE
remove RGui escapes leaked in with R 3.6

### DIFF
--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -292,16 +292,31 @@
         paste0("<", summary, ">")
       })
 
+  # R 3.6.0 on Windows has an issue where RGui escapes can 'leak'
+  # into encoded strings; detect and remove those post-hoc.
+  # (should be fixed in R 3.6.1)
+  #
+  # https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17567
+  needsEncodeFix <-
+    .Platform$OS.type == "windows" &&
+    getRversion() == "3.6.0"
+  
   data <- as.data.frame(
     lapply(
       data,
       function (y) {
+        
         # escape NAs from character columns
         if (typeof(y) == "character") {
           y[y == "NA"] <- "__NA__"
         }
 
+        # encode string (ensure control characters are escaped)
         y <- encodeString(format(y))
+        if (needsEncodeFix) {
+          y <- gsub("^\002\377\376", "", y)
+          y <- gsub("\003\377\376$", "", y)
+        }
 
         # trim spaces
         gsub("^\\s+|\\s+$", "", y)
@@ -309,7 +324,7 @@
     ),
     stringsAsFactors = FALSE,
     optional = TRUE)
-
+  
   pagedTableOptions <- list(
     columns = list(
       min = options[["cols.min.print"]],


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/3163.