### PR TITLE
Don't timeout dev RStudio Server sessions

### DIFF
--- a/src/cpp/conf/rserver-dev.conf
+++ b/src/cpp/conf/rserver-dev.conf
@@ -45,6 +45,10 @@ rldpath-path=${CMAKE_CURRENT_BINARY_DIR}/session/r-ldpath
 # on OS X UIDs start at 500 and there's no /etc/login.defs
 auth-minimum-user-id=500
 
+# by default signouts happen after 30 minutes of inactivity; setting this to 0
+# causes the auth-stay-signed-in-days default to be used instead
+auth-timeout-minutes=0
+
 # use dev config for rsession
 rsession-config-file=${CMAKE_CURRENT_BINARY_DIR}/conf/rsession-dev.conf
 


### PR DESCRIPTION
We currently time out after 30 minutes of inactivity, which is more secure in real-world installations but not necessary when running the server in dev mode. This change allows developers to stay signed in for longer.