### PR TITLE
remove unneeded close window binding for satellites

### DIFF
--- a/src/cpp/desktop/DesktopWebPage.cpp
+++ b/src/cpp/desktop/DesktopWebPage.cpp
@@ -243,14 +243,6 @@ QWebEnginePage* WebPage::createWindow(QWebEnginePage::WebWindowType type)
       pWindow = new SatelliteWindow(pMainWindow, name, this);
       pWindow->resize(width, height);
 
-      // allow for Ctrl + W to close window (NOTE: Ctrl means Meta on macOS)
-      QAction* action = new QAction(pWindow);
-      action->setShortcut(Qt::CTRL + Qt::Key_W);
-      pWindow->addAction(action);
-      QObject::connect(
-               action, &QAction::triggered,
-               static_cast<SatelliteWindow*>(pWindow), &SatelliteWindow::onCloseWindowShortcut);
-
       if (x >= 0 && y >= 0)
       {
          // if the window specified its location, use it


### PR DESCRIPTION
This PR removes an unneeded (and conflicting) binding for closing windows in satellites. These bindings are already defined by GWT so this should be unneeded.

https://github.com/rstudio/rstudio/blob/48e906ecceb606f7287deab7131d95282faccbb0/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml#L716-L717

Closes https://github.com/rstudio/rstudio/issues/4727.