### PR TITLE
Add CriticMarkup highlighting

### DIFF
--- a/src/gwt/acesupport/acemode/markdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/markdown_highlight_rules.js
@@ -169,27 +169,27 @@ var MarkdownHighlightRules = function() {
         "criticmarkup" : [{ // CriticMarkup syntax (http://criticmarkup.com/spec.php)
             token : "criticmarkup_insertion",
             regex : "\\{\\+\\+",
-            next  : "cm-insertion"
+            push  : "cm-insertion"
         },
         {
             token : "criticmarkup_deletion",
             regex : "\\{--",
-            next  : "cm-deletion"
+            push  : "cm-deletion"
         },
         {
             token : "criticmarkup_highlight",
             regex : "\\{==",
-            next  : "cm-highlight"
+            push  : "cm-highlight"
         },
         {
             token : "criticmarkup_substitution",
             regex : "\\{~~",
-            next  : "cm-substitution-start"
+            push  : "cm-substitution-start"
         },
         {
             token : "criticmarkup_comment",
             regex : "\\{>>",
-            next  : "cm-comment"
+            push  : "cm-comment"
         }],
 
         "start": [{
@@ -330,7 +330,7 @@ var MarkdownHighlightRules = function() {
         "cm-insertion" : [{
            token: "criticmarkup_insertion",
            regex: "\\+\\+\\}",
-           next: "start"
+           next: "pop"
         },{
            defaultToken: "criticmarkup_insertion.text"
         }],
@@ -339,7 +339,7 @@ var MarkdownHighlightRules = function() {
         "cm-deletion" : [{
            token: "criticmarkup_deletion",
            regex: "--\\}",
-           next: "start"
+           next: "pop"
         },{
            defaultToken: "criticmarkup_deletion.text"
         }],
@@ -347,7 +347,7 @@ var MarkdownHighlightRules = function() {
         "cm-highlight" : [{
            token: "criticmarkup_highlight",
            regex: "==\\}",
-           next: "start"
+           next: "pop"
         },{
            defaultToken: "criticmarkup_highlight.text"
         }],
@@ -355,7 +355,7 @@ var MarkdownHighlightRules = function() {
         "cm-substitution-start" : [{
            token: "criticmarkup_substitution",
            regex: "~~\\}",
-           next: "start"
+           next: "pop"
         },
         {
            token: "criticmarkup_substitution",
@@ -369,7 +369,7 @@ var MarkdownHighlightRules = function() {
         "cm-substitution-end" : [{
             token: "criticmarkup_substitution",
             regex: "~~\\}",
-            next: "start"
+            next: "pop"
         },{
             defaultToken: "criticmarkup_substitution.text.new"
         }],
@@ -377,7 +377,7 @@ var MarkdownHighlightRules = function() {
         "cm-comment" : [{
            token: "criticmarkup_comment",
            regex: "<<\\}",
-           next: "start"
+           next: "pop"
         },{
            defaultToken: "criticmarkup_comment.text"
         }],

--- a/src/gwt/acesupport/acemode/markdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/markdown_highlight_rules.js
@@ -83,7 +83,7 @@ var MarkdownHighlightRules = function() {
         ("title|author|date|rtl|depends|autosize|width|height|transition|transition-speed|font-family|css|class|navigation|incremental|left|right|id|audio|video|type|at|help-doc|help-topic|source|console|console-input|execute|pause")
             .split("|")
     );
-    
+
     // regexp must not have capturing parentheses
     // regexps are ordered -> the first match is used
 
@@ -165,8 +165,36 @@ var MarkdownHighlightRules = function() {
             emphasisStars,
             emphasisUnderscore
         ],
-       
+
+        "criticmarkup" : [{ // CriticMarkup syntax (http://criticmarkup.com/spec.php)
+            token : "criticmarkup_insertion",
+            regex : "\\{\\+\\+",
+            next  : "cm-insertion"
+        },
+        {
+            token : "criticmarkup_deletion",
+            regex : "\\{--",
+            next  : "cm-deletion"
+        },
+        {
+            token : "criticmarkup_highlight",
+            regex : "\\{==",
+            next  : "cm-highlight"
+        },
+        {
+            token : "criticmarkup_substitution",
+            regex : "\\{~~",
+            next  : "cm-substitution-start"
+        },
+        {
+            token : "criticmarkup_comment",
+            regex : "\\{>>",
+            next  : "cm-comment"
+        }],
+
         "start": [{
+            include : "criticmarkup"
+        },{
            token : "empty_line",
            regex : '^\\s*$',
            next: "allowBlock"
@@ -196,7 +224,7 @@ var MarkdownHighlightRules = function() {
             regex : /^#{1,6}(?=\s*[^ #]|\s+#.)/,
             next : "header"
         },
-                                     
+
         github_embed("(?:javascript|js)", "jscode-"),
         github_embed("xml", "xmlcode-"),
         github_embed("html", "htmlcode-"),
@@ -210,7 +238,7 @@ var MarkdownHighlightRules = function() {
         github_embed("stan", "stancode-"),
         github_embed("sql", "sqlcode-"),
         github_embed("d3", "jscode-"),
-        
+
         { // Github style block
             token : "support.function",
             regex : "^\\s*```\\s*\\S*(?:{.*?\\})?\\s*$",
@@ -295,8 +323,63 @@ var MarkdownHighlightRules = function() {
             token : "comment",
             regex : "<\\!--",
             next  : "html-comment"
-        }, {
+        },{
             include : "basic"
+        }],
+
+        "cm-insertion" : [{
+           token: "criticmarkup_insertion",
+           regex: "\\+\\+\\}",
+           next: "start"
+        },{
+           defaultToken: "criticmarkup_insertion.text"
+        }],
+
+
+        "cm-deletion" : [{
+           token: "criticmarkup_deletion",
+           regex: "--\\}",
+           next: "start"
+        },{
+           defaultToken: "criticmarkup_deletion.text"
+        }],
+
+        "cm-highlight" : [{
+           token: "criticmarkup_highlight",
+           regex: "==\\}",
+           next: "start"
+        },{
+           defaultToken: "criticmarkup_highlight.text"
+        }],
+
+        "cm-substitution-start" : [{
+           token: "criticmarkup_substitution",
+           regex: "~~\\}",
+           next: "start"
+        },
+        {
+           token: "criticmarkup_substitution",
+           regex: "~>",
+           next: "cm-substitution-end"
+        },
+        {
+           defaultToken: "criticmarkup_substitution.text.old"
+        }],
+
+        "cm-substitution-end" : [{
+            token: "criticmarkup_substitution",
+            regex: "~~\\}",
+            next: "start"
+        },{
+            defaultToken: "criticmarkup_substitution.text.new"
+        }],
+
+        "cm-comment" : [{
+           token: "criticmarkup_comment",
+           regex: "<<\\}",
+           next: "start"
+        },{
+           defaultToken: "criticmarkup_comment.text"
         }],
 
         "html-comment" : [{
@@ -306,7 +389,7 @@ var MarkdownHighlightRules = function() {
         }, {
            defaultToken: "comment.text"
         }],
-       
+
         // code block
         "allowBlock": [{
            token : "support.function",
@@ -424,7 +507,7 @@ var MarkdownHighlightRules = function() {
             token : "latex.support.function",
             regex : "[^\\$]+"
         }],
-        
+
         "mathjaxnativedisplay" : [{
             token : "latex.markup.list.string.end",
             regex : "\\\\\\]",
@@ -433,7 +516,7 @@ var MarkdownHighlightRules = function() {
             token : "latex.support.function",
             regex : "[\\s\\S]+?"
         }],
-        
+
         "mathjaxnativeinline" : [{
             token : "latex.markup.list.string.end",
             regex : "\\\\\\)",
@@ -468,25 +551,25 @@ var MarkdownHighlightRules = function() {
         regex : "^\\s*```",
         next  : "pop"
     }]);
-    
+
     this.embedRules(PerlHighlightRules, "perlcode-", [{
         token : "support.function",
         regex : "^\\s*```",
         next  : "pop"
     }]);
-    
+
     this.embedRules(PythonHighlightRules, "pythoncode-", [{
         token : "support.function",
         regex : "^\\s*```",
         next  : "pop"
     }]);
-    
+
     this.embedRules(RubyHighlightRules, "rubycode-", [{
         token : "support.function",
         regex : "^\\s*```",
         next  : "pop"
     }]);
-    
+
     this.embedRules(ScalaHighlightRules, "scalacode-", [{
         token : "support.function",
         regex : "^\\s*```",


### PR DESCRIPTION
This PR adds Critic Markup highlighting support, closing #4811.  Highlighting is implemented as part of the Ace Editor markdown mode.

I've successfully compiled and tested on OSX and don't see any performance issues.

Highlighting is not applied by default in any theme, but you can see it if you apply this modified Textmate theme:

```
rstudioapi::addTheme("https://raw.githubusercontent.com/noamross/redoc/criticmarkup-theme/inst/themes/cm-textmate.rstheme", apply = TRUE)
```

Which looks like this:

<img width="686" alt="Screenshot 2019-05-25 13 15 20" src="https://user-images.githubusercontent.com/571752/58372936-77964400-7ef3-11e9-9759-b26b2a14aecc.png">

As with HTML comments, the interior of editorial marks also have the class `.ace_text` should one want to distinguish them from the markup, and in the case of substitution marks they also also marked with `.ace_old` and `.ace_new`.

Should there be interest after some user feedback, I'd be happy to make a PR to modify the themes bundled with RStudio to include this by default.

I have previously signed an RStudio Individual Contributor Agreement.