### PR TITLE
Redirect kill rsession error

### DIFF
--- a/src/cpp/server/extras/admin/rstudio-server.in
+++ b/src/cpp/server/extras/admin/rstudio-server.in
@@ -40,14 +40,14 @@ case "$1" in
 
     stop)
         daemonCmd "stop"
-        killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rsession 2>/dev/null
+        if (pidof rsession >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rsession; fi
         killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rworkspaces 2>/dev/null
         ;;
 
     restart)
         testConfig || return $?
         daemonCmd "restart"
-        killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rsession 2>/dev/null
+        if (pidof rsession >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rsession; fi
         killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rworkspaces 2>/dev/null
         ;;
 
@@ -79,7 +79,7 @@ case "$1" in
         ;;
 
     suspend-all)
-        killall -s USR1 $2 $3 $4 $5 $6 $7 $8 $9 rsession 2>/dev/null
+        if (pidof rsession >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rsession; fi
         killall -s USR1 $2 $3 $4 $5 $6 $7 $8 $9 rworkspaces 2>/dev/null
         ;;
 
@@ -94,7 +94,7 @@ case "$1" in
         ;;
 
     force-suspend-all)
-        killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rsession 2>/dev/null
+        if (pidof rsession >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rsession; fi
         killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rworkspaces 2>/dev/null
         ;;
 
@@ -109,7 +109,7 @@ case "$1" in
         ;;
 
     kill-all)
-        killall -s KILL $2 $3 $4 $5 $6 $7 $8 $9  rsession 2>/dev/null
+        if (pidof rsession >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rsession; fi
         killall -s KILL $2 $3 $4 $5 $6 $7 $8 $9  rworkspaces 2>/dev/null
         ;;
 
@@ -117,7 +117,7 @@ case "$1" in
         mkdir -p /var/lib/rstudio-server
         touch /var/lib/rstudio-server/offline
         daemonCmd "restart"
-        killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rsession 2>/dev/null
+        if (pidof rsession >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rsession; fi
         killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rworkspaces 2>/dev/null
         ;;
 

--- a/src/cpp/server/extras/admin/rstudio-server.in
+++ b/src/cpp/server/extras/admin/rstudio-server.in
@@ -79,7 +79,7 @@ case "$1" in
         ;;
 
     suspend-all)
-        if (pidof rsession >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rsession; fi
+        if (pidof rsession >/dev/null); then killall -s USR1 $2 $3 $4 $5 $6 $7 $8 $9 rsession; fi
         killall -s USR1 $2 $3 $4 $5 $6 $7 $8 $9 rworkspaces 2>/dev/null
         ;;
 
@@ -109,7 +109,7 @@ case "$1" in
         ;;
 
     kill-all)
-        if (pidof rsession >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rsession; fi
+        if (pidof rsession >/dev/null); then killall -s KILL $2 $3 $4 $5 $6 $7 $8 $9 rsession; fi
         killall -s KILL $2 $3 $4 $5 $6 $7 $8 $9  rworkspaces 2>/dev/null
         ;;
 

--- a/src/cpp/server/extras/admin/rstudio-server.in
+++ b/src/cpp/server/extras/admin/rstudio-server.in
@@ -40,14 +40,14 @@ case "$1" in
 
     stop)
         daemonCmd "stop"
-        killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rsession
+        killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rsession 2>/dev/null
         killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rworkspaces 2>/dev/null
         ;;
 
     restart)
         testConfig || return $?
         daemonCmd "restart"
-        killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rsession
+        killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rsession 2>/dev/null
         killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rworkspaces 2>/dev/null
         ;;
 
@@ -79,7 +79,7 @@ case "$1" in
         ;;
 
     suspend-all)
-        killall -s USR1 $2 $3 $4 $5 $6 $7 $8 $9 rsession
+        killall -s USR1 $2 $3 $4 $5 $6 $7 $8 $9 rsession 2>/dev/null
         killall -s USR1 $2 $3 $4 $5 $6 $7 $8 $9 rworkspaces 2>/dev/null
         ;;
 
@@ -94,7 +94,7 @@ case "$1" in
         ;;
 
     force-suspend-all)
-        killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rsession
+        killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rsession 2>/dev/null
         killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rworkspaces 2>/dev/null
         ;;
 
@@ -109,7 +109,7 @@ case "$1" in
         ;;
 
     kill-all)
-        killall -s KILL $2 $3 $4 $5 $6 $7 $8 $9  rsession
+        killall -s KILL $2 $3 $4 $5 $6 $7 $8 $9  rsession 2>/dev/null
         killall -s KILL $2 $3 $4 $5 $6 $7 $8 $9  rworkspaces 2>/dev/null
         ;;
 
@@ -117,8 +117,8 @@ case "$1" in
         mkdir -p /var/lib/rstudio-server
         touch /var/lib/rstudio-server/offline
         daemonCmd "restart"
-        killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rsession
-        killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rworkspaces
+        killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rsession 2>/dev/null
+        killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rworkspaces 2>/dev/null
         ;;
 
     online)

--- a/src/cpp/server/extras/admin/rstudio-server.in
+++ b/src/cpp/server/extras/admin/rstudio-server.in
@@ -41,14 +41,14 @@ case "$1" in
     stop)
         daemonCmd "stop"
         if (pidof rsession >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rsession; fi
-        killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rworkspaces 2>/dev/null
+        if (pidof rworkspaces >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rworkspaces; fi
         ;;
 
     restart)
         testConfig || return $?
         daemonCmd "restart"
         if (pidof rsession >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rsession; fi
-        killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rworkspaces 2>/dev/null
+        if (pidof rworkspaces >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rworkspaces; fi
         ;;
 
     test-config)
@@ -80,7 +80,7 @@ case "$1" in
 
     suspend-all)
         if (pidof rsession >/dev/null); then killall -s USR1 $2 $3 $4 $5 $6 $7 $8 $9 rsession; fi
-        killall -s USR1 $2 $3 $4 $5 $6 $7 $8 $9 rworkspaces 2>/dev/null
+        if (pidof rworkspaces >/dev/null); then killall -s USR1 $2 $3 $4 $5 $6 $7 $8 $9 rworkspaces; fi
         ;;
 
     force-suspend-session)
@@ -95,7 +95,7 @@ case "$1" in
 
     force-suspend-all)
         if (pidof rsession >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rsession; fi
-        killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rworkspaces 2>/dev/null
+        if (pidof rworkspaces >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rworkspaces; fi
         ;;
 
     kill-session)
@@ -110,7 +110,7 @@ case "$1" in
 
     kill-all)
         if (pidof rsession >/dev/null); then killall -s KILL $2 $3 $4 $5 $6 $7 $8 $9 rsession; fi
-        killall -s KILL $2 $3 $4 $5 $6 $7 $8 $9  rworkspaces 2>/dev/null
+        if (pidof rworkspaces >/dev/null); then killall -s KILL $2 $3 $4 $5 $6 $7 $8 $9 rworkspaces; fi
         ;;
 
     offline)
@@ -118,7 +118,7 @@ case "$1" in
         touch /var/lib/rstudio-server/offline
         daemonCmd "restart"
         if (pidof rsession >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rsession; fi
-        killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9  rworkspaces 2>/dev/null
+        if (pidof rworkspaces >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rworkspaces; fi
         ;;
 
     online)


### PR DESCRIPTION
Adds ` 2>/dev/null` to kill rsession commands, so that rstudio-server "restart" and "stop" type commands exit successfully when no sessions are actively running