### PR TITLE
validate types of registered .Call methods

### DIFF
--- a/src/cpp/core/include/core/type_traits/TypeTraits.hpp
+++ b/src/cpp/core/include/core/type_traits/TypeTraits.hpp
@@ -23,6 +23,15 @@ namespace rstudio {
 namespace core {
 namespace type_traits {
 
+template <typename T>
+struct return_type;
+
+template <typename R, typename... Args>
+struct return_type<R(Args...)>
+{
+   typedef R type;
+};
+
 #define RS_GENERATE_HAS_TYPE_TRAIT(__NAME__)                                   \
    template <typename T> struct has_##__NAME__##_impl                          \
    {                                                                           \

--- a/src/cpp/core/include/core/type_traits/TypeTraits.hpp
+++ b/src/cpp/core/include/core/type_traits/TypeTraits.hpp
@@ -1,7 +1,7 @@
 /*
  * TypeTraits.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/cpp/r/include/r/RRoutines.hpp
+++ b/src/cpp/r/include/r/RRoutines.hpp
@@ -1,7 +1,7 @@
 /*
  * RRoutines.hpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/cpp/r/include/r/RRoutines.hpp
+++ b/src/cpp/r/include/r/RRoutines.hpp
@@ -52,8 +52,8 @@ struct validate_args<T, ArgumentTypes...>
 };
 
 template <typename ReturnType, typename... ArgumentTypes>
-void validate(ReturnType(ArgumentTypes...)) {
-
+void validate(ReturnType(ArgumentTypes...))
+{
    static_assert(
             std::is_same<ReturnType, SEXP>::value,
             "Registered .Call methods should have SEXP return type");
@@ -72,18 +72,19 @@ void registerAll();
 // attempt to declare the number of arguments can continue to do so, while new
 // usages can omit it and still do the right thing. (This is done primarily to
 // avoid noisy diffs across the codebase where this macro is used)
-#define RS_REGISTER_CALL_METHOD(__NAME__, ...)                                \
-   do                                                                         \
-   {                                                                          \
-      using namespace core::type_traits;                                      \
-      ::rstudio::r::routines::internal::validate(__NAME__);                   \
-      int n = ::rstudio::r::routines::internal::n_arguments(__NAME__);        \
-      R_CallMethodDef callMethodDef;                                          \
-      callMethodDef.name = #__NAME__;                                         \
-      callMethodDef.fun = reinterpret_cast<DL_FUNC>(__NAME__);                \
-      callMethodDef.numArgs = n;                                              \
-      ::rstudio::r::routines::addCallMethod(callMethodDef);                   \
-   } while (false)
+#define RS_REGISTER_CALL_METHOD(__NAME__, ...)                         \
+   do                                                                  \
+   {                                                                   \
+      using namespace core::type_traits;                               \
+      ::rstudio::r::routines::internal::validate(__NAME__);            \
+      int n = ::rstudio::r::routines::internal::n_arguments(__NAME__); \
+      R_CallMethodDef callMethodDef;                                   \
+      callMethodDef.name = #__NAME__;                                  \
+      callMethodDef.fun = reinterpret_cast<DL_FUNC>(__NAME__);         \
+      callMethodDef.numArgs = n;                                       \
+      ::rstudio::r::routines::addCallMethod(callMethodDef);            \
+   }                                                                   \
+   while (false)
 
 } // namespace routines   
 } // namespace r

--- a/src/cpp/session/modules/SessionPackages.cpp
+++ b/src/cpp/session/modules/SessionPackages.cpp
@@ -568,38 +568,12 @@ Error initialize()
    module_context::events().onConsolePrompt.connect(onConsolePrompt);
 
    // register routines
-   R_CallMethodDef methodDef ;
-   methodDef.name = "rs_enqueLoadedPackageUpdates" ;
-   methodDef.fun = (DL_FUNC) rs_enqueLoadedPackageUpdates ;
-   methodDef.numArgs = 1;
-   r::routines::addCallMethod(methodDef);
-
-   R_CallMethodDef methodDef2 ;
-   methodDef2.name = "rs_canInstallPackages" ;
-   methodDef2.fun = (DL_FUNC) rs_canInstallPackages ;
-   methodDef2.numArgs = 0;
-   r::routines::addCallMethod(methodDef2);
-
-   R_CallMethodDef methodDef3 ;
-   methodDef3.name = "rs_packageLibraryMutated" ;
-   methodDef3.fun = (DL_FUNC) rs_packageLibraryMutated ;
-   methodDef3.numArgs = 0;
-   r::routines::addCallMethod(methodDef3);
-   
-   r::routines::registerCallMethod(
-            "rs_getCachedAvailablePackages",
-            (DL_FUNC) rs_getCachedAvailablePackages,
-            1);
-   
-   r::routines::registerCallMethod(
-            "rs_downloadAvailablePackages",
-            (DL_FUNC) rs_downloadAvailablePackages,
-            1);
-
-   r::routines::registerCallMethod(
-            "rs_getCranReposUrl",
-            (DL_FUNC) rs_getCranReposUrl,
-            0);
+   RS_REGISTER_CALL_METHOD(rs_enqueLoadedPackageUpdates);
+   RS_REGISTER_CALL_METHOD(rs_canInstallPackages);
+   RS_REGISTER_CALL_METHOD(rs_packageLibraryMutated);
+   RS_REGISTER_CALL_METHOD(rs_getCachedAvailablePackages);
+   RS_REGISTER_CALL_METHOD(rs_downloadAvailablePackages);
+   RS_REGISTER_CALL_METHOD(rs_getCranReposUrl);
    
    using boost::bind;
    using namespace module_context;

--- a/src/cpp/session/modules/SessionPackages.cpp
+++ b/src/cpp/session/modules/SessionPackages.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionPackages.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then


### PR DESCRIPTION
This PR augments `RS_REGISTER_CALL_METHOD()` to validate the types used in the registered functions, making sure that only `SEXP` arguments are passed through or returned.

The goal is to have a compile-time check on the methods we register to catch issues like https://github.com/rstudio/rstudio/pull/4845 in the future.