### PR TITLE
A11y for RStudio Server main menu

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * Add "Safe Mode" for opening sessions without profile scripts or workspace restoration (#4338)
 * PowerShell Core option in terminal (Windows-only)
 * Custom terminal shell option for Windows desktop (previously only on Mac, Linux, and server)
+* Keyboard shortcuts for main menu items on RStudio Server (e.g. Ctrl+Alt+F for File menu)
 
 ### Bugfixes
 

--- a/src/gwt/src/com/google/gwt/user/README.md
+++ b/src/gwt/src/com/google/gwt/user/README.md
@@ -3,21 +3,26 @@ GWT Patches
 This folder contains selected GWT source files pulled from the GWT 2.8.2
 release, then modified to fix issues or add needed functionality.
 
-This has been happening since early in RStudio development, but was not
-noticed during the last few GWT updates. Thus, we were using increasingly
-out-of-date copies of these files.
-
-To edit an existing modified GWT source file:
+To edit a previously modified GWT source file:
 
 - make the changes
 - execute `updatepatches.sh` from this folder
 - commit both the modified source file and the updated .diff file
 
+To modify a previously unmodified GWT source file:
+
+- update `updatesources.sh` and `updatepatches.sh` to reference the source file
+- execute `updatesources.sh` to extract the source file (ignore warning about 
+  missing diff file)
+- make the changes
+- execute `updatepatches.sh` from this folder
+- add and commit the source file and .diff file
+
 To upgrade to a new GWT version:
 
 - update `updatesources.sh`, and `updatespatches.sh` to refer to new GWT
 - execute `updatesources.sh` to stomp over the modified GWT files with the
-latest copies and reapply patches
+  latest copies and reapply patches
 - resolve any conflicts, test, etc.
-- run `updatepatches.sh` to create updated copies of the patch files
+- run `updatepatches.sh` to create updated copies of the .diff files
 

--- a/src/gwt/src/com/google/gwt/user/README.md
+++ b/src/gwt/src/com/google/gwt/user/README.md
@@ -7,11 +7,17 @@ This has been happening since early in RStudio development, but was not
 noticed during the last few GWT updates. Thus, we were using increasingly
 out-of-date copies of these files.
 
+To edit an existing modified GWT source file:
+
+- make the changes
+- execute `updatepatches.sh` from this folder
+- commit both the modified source file and the updated .diff file
+
 To upgrade to a new GWT version:
 
 - update `updatesources.sh`, and `updatespatches.sh` to refer to new GWT
 - execute `updatesources.sh` to stomp over the modified GWT files with the
 latest copies and reapply patches
 - resolve any conflicts, test, etc.
-- run `createpatches.sh` to create updated copies of the patch files
+- run `updatepatches.sh` to create updated copies of the patch files
 

--- a/src/gwt/src/com/google/gwt/user/client/ui/MenuBar.java
+++ b/src/gwt/src/com/google/gwt/user/client/ui/MenuBar.java
@@ -1345,9 +1345,15 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
   private boolean selectFirstItemIfNoneSelected() {
     if (selectedItem == null) {
       for (MenuItem nextItem : items) {
+        if (nextItem.isEnabled() && nextItem.isVisible()) {
+          selectItem(nextItem);
+          return true;
+        }
+      }
+      for (MenuItem nextItem : items) {
         if (nextItem.isVisible()) {
           selectItem(nextItem);
-          break;
+          return true;
         }
       }
       return true;
@@ -1380,7 +1386,7 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
         break;
       } else {
         itemToBeSelected = items.get(index);
-        if (itemToBeSelected.isVisible()) {
+        if (itemToBeSelected.isEnabled() && itemToBeSelected.isVisible()) {
           break;
         }
       }
@@ -1417,7 +1423,7 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
         break;
       } else {
         itemToBeSelected = items.get(index);
-        if (itemToBeSelected.isVisible()) {
+        if (itemToBeSelected.isEnabled() && itemToBeSelected.isVisible()) {
           break;
         }
       }

--- a/src/gwt/src/com/google/gwt/user/client/ui/MenuBar.java
+++ b/src/gwt/src/com/google/gwt/user/client/ui/MenuBar.java
@@ -985,7 +985,7 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
    * <code>true</code> if the item's command should be fired, <code>false</code>
    * otherwise.
    */
-  void doItemAction(final MenuItem item, boolean fireCommand, boolean focus) {
+  protected void doItemAction(final MenuItem item, boolean fireCommand, boolean focus) {
     // Should not perform any action if the item is disabled
     if (!item.isEnabled()) {
       return;

--- a/src/gwt/src/com/google/gwt/user/client/ui/MenuBar.java
+++ b/src/gwt/src/com/google/gwt/user/client/ui/MenuBar.java
@@ -859,6 +859,14 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
           Element td = DOM.getChild(tr, 1);
           setStyleName(td, "subMenuIcon-selected", true);
         }
+
+        if (shownChildMenu != null
+            && shownChildMenu == selectedItem.getSubMenu())
+        {
+          shownChildMenu.onHide(false);
+          popup.hide();
+          shownChildMenu = null;
+        }
       }
 
       Roles.getMenubarRole().setAriaActivedescendantProperty(getElement(),
@@ -1116,7 +1124,12 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
       setItemColSpan(item, 1);
       Element td = DOM.createTD();
       td.setPropertyString("vAlign", "middle");
-      td.setInnerSafeHtml(subMenuIcon.getSafeHtml());
+      String indicatorHtml = subMenuIcon.getSafeHtml().asString();
+      // add null alt attribute for a11y
+      if (indicatorHtml.startsWith("<img") && indicatorHtml.endsWith(">"))
+        indicatorHtml = indicatorHtml.substring(0, indicatorHtml.length() - 1) + " alt>";
+      td.setInnerHTML(indicatorHtml);
+
       setStyleName(td, "subMenuIcon");
       DOM.appendChild(tr, td);
     }
@@ -1332,7 +1345,7 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
   private boolean selectFirstItemIfNoneSelected() {
     if (selectedItem == null) {
       for (MenuItem nextItem : items) {
-        if (nextItem.isEnabled()) {
+        if (nextItem.isVisible()) {
           selectItem(nextItem);
           break;
         }
@@ -1367,7 +1380,7 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
         break;
       } else {
         itemToBeSelected = items.get(index);
-        if (itemToBeSelected.isEnabled()) {
+        if (itemToBeSelected.isVisible()) {
           break;
         }
       }
@@ -1404,7 +1417,7 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
         break;
       } else {
         itemToBeSelected = items.get(index);
-        if (itemToBeSelected.isEnabled()) {
+        if (itemToBeSelected.isVisible()) {
           break;
         }
       }

--- a/src/gwt/src/com/google/gwt/user/client/ui/MenuBar.java
+++ b/src/gwt/src/com/google/gwt/user/client/ui/MenuBar.java
@@ -302,6 +302,7 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
   private MenuPopup popup;
   private MenuItem selectedItem;
   private MenuBar shownChildMenu;
+  private MenuItem expandedMenuItem;
   private boolean vertical, autoOpen;
   private boolean focusOnHover = true;
 
@@ -513,6 +514,11 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
   public void closeAllChildren(boolean focus) {
     if (shownChildMenu != null) {
       // Hide any open submenus of this item
+      if (expandedMenuItem != null)
+      {
+        expandedMenuItem.setAriaExpanded(false);
+        expandedMenuItem = null;
+      }
       shownChildMenu.onHide(focus);
       shownChildMenu = null;
       selectItem(null);
@@ -863,8 +869,7 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
         if (shownChildMenu != null
             && shownChildMenu == selectedItem.getSubMenu())
         {
-          shownChildMenu.onHide(false);
-          popup.hide();
+          hideChildMenu(false);
           shownChildMenu = null;
         }
       }
@@ -1014,8 +1019,7 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
 
       // hide any open submenus of this item
       if (shownChildMenu != null) {
-        shownChildMenu.onHide(focus);
-        popup.hide();
+        hideChildMenu(focus);
         shownChildMenu = null;
         selectItem(null);
       }
@@ -1025,20 +1029,17 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
         openPopup(item);
       } else if (item.getSubMenu() != shownChildMenu) {
         // close the other submenu and open this one
-        shownChildMenu.onHide(focus);
-        popup.hide();
+        hideChildMenu(focus);
         openPopup(item);
       } else if (fireCommand && !autoOpen) {
         // close this submenu
-        shownChildMenu.onHide(focus);
-        popup.hide();
+        hideChildMenu(focus);
         shownChildMenu = null;
         selectItem(item);
       }
     } else if (autoOpen && shownChildMenu != null) {
       // close submenu
-      shownChildMenu.onHide(focus);
-      popup.hide();
+      hideChildMenu(focus);
       shownChildMenu = null;
     }
   }
@@ -1284,8 +1285,7 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
    */
   private void onHide(boolean focus) {
     if (shownChildMenu != null) {
-      shownChildMenu.onHide(focus);
-      popup.hide();
+      hideChildMenu(focus);
       if (focus) {
         focus();
       }
@@ -1301,6 +1301,8 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
     shownChildMenu = item.getSubMenu();
     shownChildMenu.selectItem(null);
     shownChildMenu.parentMenu = this;
+    expandedMenuItem = item;
+    item.setAriaExpanded(true);
 
     popup = new MenuPopup();
     popup.setWidget(shownChildMenu);
@@ -1443,5 +1445,20 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
    */
   private void setItemColSpan(UIObject item, int colspan) {
     item.getElement().setPropertyInt("colSpan", colspan);
+  }
+
+  /**
+   * Hide currently displayed child menu and mark the associate menu item as closed.
+   * @param focus
+   */
+  private void hideChildMenu(boolean focus)
+  {
+    if (expandedMenuItem != null)
+    {
+      expandedMenuItem.setAriaExpanded(false);
+      expandedMenuItem = null;
+    }
+    shownChildMenu.onHide(focus);
+    popup.hide();
   }
 }

--- a/src/gwt/src/com/google/gwt/user/client/ui/MenuBar.java.diff
+++ b/src/gwt/src/com/google/gwt/user/client/ui/MenuBar.java.diff
@@ -1,29 +1,56 @@
-788c788
+304a305
+>   private MenuItem expandedMenuItem;
+515a517,521
+>       if (expandedMenuItem != null)
+>       {
+>         expandedMenuItem.setAriaExpanded(false);
+>         expandedMenuItem = null;
+>       }
+788c794
 <     onHide(!autoClosed && focusOnHover);
 ---
 >     onHide(!autoClosed);
-861a862,869
+861a868,874
 > 
 >         if (shownChildMenu != null
 >             && shownChildMenu == selectedItem.getSubMenu())
 >         {
->           shownChildMenu.onHide(false);
->           popup.hide();
+>           hideChildMenu(false);
 >           shownChildMenu = null;
 >         }
-980c988
+980c993
 <   void doItemAction(final MenuItem item, boolean fireCommand, boolean focus) {
 ---
 >   protected void doItemAction(final MenuItem item, boolean fireCommand, boolean focus) {
-1092c1100
+1009,1010c1022
+<         shownChildMenu.onHide(focus);
+<         popup.hide();
+---
+>         hideChildMenu(focus);
+1020,1021c1032
+<         shownChildMenu.onHide(focus);
+<         popup.hide();
+---
+>         hideChildMenu(focus);
+1025,1026c1036
+<         shownChildMenu.onHide(focus);
+<         popup.hide();
+---
+>         hideChildMenu(focus);
+1032,1033c1042
+<       shownChildMenu.onHide(focus);
+<       popup.hide();
+---
+>       hideChildMenu(focus);
+1092c1101
 <   void updateSubmenuIcon(MenuItem item) {
 ---
 >   protected void updateSubmenuIcon(MenuItem item) {
-1108c1116
+1108c1117
 <     if (submenu == null) {
 ---
 >     if (submenu == null || !item.isVisible()) {
-1119c1127,1132
+1119c1128,1133
 <       td.setInnerSafeHtml(subMenuIcon.getSafeHtml());
 ---
 >       String indicatorHtml = subMenuIcon.getSafeHtml().asString();
@@ -32,13 +59,21 @@
 >         indicatorHtml = indicatorHtml.substring(0, indicatorHtml.length() - 1) + " alt>";
 >       td.setInnerHTML(indicatorHtml);
 > 
-1197a1211
+1197a1212
 >     Roles.getPresentationRole().set(table);
-1334c1348
+1273,1274c1288
+<       shownChildMenu.onHide(focus);
+<       popup.hide();
+---
+>       hideChildMenu(focus);
+1289a1304,1305
+>     expandedMenuItem = item;
+>     item.setAriaExpanded(true);
+1334c1350
 <         if (nextItem.isEnabled()) {
 ---
 >         if (nextItem.isEnabled() && nextItem.isVisible()) {
-1336c1350,1356
+1336c1352,1358
 <           break;
 ---
 >           return true;
@@ -48,11 +83,27 @@
 >         if (nextItem.isVisible()) {
 >           selectItem(nextItem);
 >           return true;
-1369c1389
+1369c1391
 <         if (itemToBeSelected.isEnabled()) {
 ---
 >         if (itemToBeSelected.isEnabled() && itemToBeSelected.isVisible()) {
-1406c1426
+1406c1428
 <         if (itemToBeSelected.isEnabled()) {
 ---
 >         if (itemToBeSelected.isEnabled() && itemToBeSelected.isVisible()) {
+1426a1449,1463
+> 
+>   /**
+>    * Hide currently displayed child menu and mark the associate menu item as closed.
+>    * @param focus
+>    */
+>   private void hideChildMenu(boolean focus)
+>   {
+>     if (expandedMenuItem != null)
+>     {
+>       expandedMenuItem.setAriaExpanded(false);
+>       expandedMenuItem = null;
+>     }
+>     shownChildMenu.onHide(focus);
+>     popup.hide();
+>   }

--- a/src/gwt/src/com/google/gwt/user/client/ui/MenuBar.java.diff
+++ b/src/gwt/src/com/google/gwt/user/client/ui/MenuBar.java.diff
@@ -2,13 +2,43 @@
 <     onHide(!autoClosed && focusOnHover);
 ---
 >     onHide(!autoClosed);
-1092c1092
+861a862,869
+> 
+>         if (shownChildMenu != null
+>             && shownChildMenu == selectedItem.getSubMenu())
+>         {
+>           shownChildMenu.onHide(false);
+>           popup.hide();
+>           shownChildMenu = null;
+>         }
+1092c1100
 <   void updateSubmenuIcon(MenuItem item) {
 ---
 >   protected void updateSubmenuIcon(MenuItem item) {
-1108c1108
+1108c1116
 <     if (submenu == null) {
 ---
 >     if (submenu == null || !item.isVisible()) {
-1197a1198
+1119c1127,1132
+<       td.setInnerSafeHtml(subMenuIcon.getSafeHtml());
+---
+>       String indicatorHtml = subMenuIcon.getSafeHtml().asString();
+>       // add null alt attribute for a11y
+>       if (indicatorHtml.startsWith("<img") && indicatorHtml.endsWith(">"))
+>         indicatorHtml = indicatorHtml.substring(0, indicatorHtml.length() - 1) + " alt>";
+>       td.setInnerHTML(indicatorHtml);
+> 
+1197a1211
 >     Roles.getPresentationRole().set(table);
+1334c1348
+<         if (nextItem.isEnabled()) {
+---
+>         if (nextItem.isVisible()) {
+1369c1383
+<         if (itemToBeSelected.isEnabled()) {
+---
+>         if (itemToBeSelected.isVisible()) {
+1406c1420
+<         if (itemToBeSelected.isEnabled()) {
+---
+>         if (itemToBeSelected.isVisible()) {

--- a/src/gwt/src/com/google/gwt/user/client/ui/MenuBar.java.diff
+++ b/src/gwt/src/com/google/gwt/user/client/ui/MenuBar.java.diff
@@ -11,6 +11,10 @@
 >           popup.hide();
 >           shownChildMenu = null;
 >         }
+980c988
+<   void doItemAction(final MenuItem item, boolean fireCommand, boolean focus) {
+---
+>   protected void doItemAction(final MenuItem item, boolean fireCommand, boolean focus) {
 1092c1100
 <   void updateSubmenuIcon(MenuItem item) {
 ---

--- a/src/gwt/src/com/google/gwt/user/client/ui/MenuBar.java.diff
+++ b/src/gwt/src/com/google/gwt/user/client/ui/MenuBar.java.diff
@@ -33,12 +33,22 @@
 1334c1348
 <         if (nextItem.isEnabled()) {
 ---
+>         if (nextItem.isEnabled() && nextItem.isVisible()) {
+1336c1350,1356
+<           break;
+---
+>           return true;
+>         }
+>       }
+>       for (MenuItem nextItem : items) {
 >         if (nextItem.isVisible()) {
-1369c1383
+>           selectItem(nextItem);
+>           return true;
+1369c1389
 <         if (itemToBeSelected.isEnabled()) {
 ---
->         if (itemToBeSelected.isVisible()) {
-1406c1420
+>         if (itemToBeSelected.isEnabled() && itemToBeSelected.isVisible()) {
+1406c1426
 <         if (itemToBeSelected.isEnabled()) {
 ---
->         if (itemToBeSelected.isVisible()) {
+>         if (itemToBeSelected.isEnabled() && itemToBeSelected.isVisible()) {

--- a/src/gwt/src/com/google/gwt/user/client/ui/MenuItem.java
+++ b/src/gwt/src/com/google/gwt/user/client/ui/MenuItem.java
@@ -15,6 +15,7 @@
  */
 package com.google.gwt.user.client.ui;
 
+import com.google.gwt.aria.client.ExpandedValue;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.safehtml.client.HasSafeHtml;
@@ -266,10 +267,18 @@ public class MenuItem extends UIObject implements HasHTML, HasEnabled, HasSafeHt
 
       // Update a11y role "haspopup"
       Roles.getMenuitemRole().setAriaHaspopupProperty(getElement(), true);
+      setAriaExpanded(false);
     } else {
       // Update a11y role "haspopup"
       Roles.getMenuitemRole().setAriaHaspopupProperty(getElement(), false);
     }
+  }
+
+  public void setAriaExpanded(boolean expanded)
+  {
+    Roles.getMenubarRole().setAriaExpandedState(
+          getElement(), 
+          expanded ? ExpandedValue.TRUE : ExpandedValue.FALSE);
   }
 
   @Override

--- a/src/gwt/src/com/google/gwt/user/client/ui/MenuItem.java
+++ b/src/gwt/src/com/google/gwt/user/client/ui/MenuItem.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2008 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.user.client.ui;
+
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import com.google.gwt.safehtml.client.HasSafeHtml;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.safehtml.shared.annotations.IsSafeHtml;
+import com.google.gwt.safehtml.shared.annotations.SuppressIsSafeHtmlCastCheck;
+import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.DOM;
+
+/**
+ * An entry in a
+ * {@link com.google.gwt.user.client.ui.MenuBar}. Menu items can either fire a
+ * {@link com.google.gwt.core.client.Scheduler.ScheduledCommand} when they are clicked, or open a
+ * cascading sub-menu.
+ *
+ * Each menu item is assigned a unique DOM id in order to support ARIA. See
+ * {@link com.google.gwt.user.client.ui.Accessibility} for more information.
+ */
+public class MenuItem extends UIObject implements HasHTML, HasEnabled, HasSafeHtml {
+
+  private static final String DEPENDENT_STYLENAME_SELECTED_ITEM = "selected";
+  private static final String DEPENDENT_STYLENAME_DISABLED_ITEM = "disabled";
+
+  private ScheduledCommand command;
+  private MenuBar parentMenu, subMenu;
+  private boolean enabled = true;
+
+  /**
+   * Constructs a new menu item that fires a command when it is selected.
+   *
+   * @param html the item's html text
+   */
+  public MenuItem(SafeHtml html) {
+    this(html.asString(), true);
+  }
+
+  /**
+   * Constructs a new menu item that fires a command when it is selected.
+   *
+   * @param html the item's text
+   * @param cmd the command to be fired when it is selected
+   */
+  public MenuItem(SafeHtml html, ScheduledCommand cmd) {
+    this(html.asString(), true, cmd);
+  }
+
+  /**
+   * Constructs a new menu item that cascades to a sub-menu when it is selected.
+   *
+   * @param html the item's text
+   * @param subMenu the sub-menu to be displayed when it is selected
+   */
+  public MenuItem(SafeHtml html, MenuBar subMenu) {
+    this(html.asString(), true, subMenu);
+  }
+
+  /**
+   * Constructs a new menu item that fires a command when it is selected.
+   *
+   * @param text the item's text
+   * @param asHTML <code>true</code> to treat the specified text as html
+   * @param cmd the command to be fired when it is selected
+   */
+  public MenuItem(@IsSafeHtml String text, boolean asHTML, ScheduledCommand cmd) {
+    this(text, asHTML);
+    setScheduledCommand(cmd);
+  }
+
+  /**
+   * Constructs a new menu item that cascades to a sub-menu when it is selected.
+   *
+   * @param text the item's text
+   * @param asHTML <code>true</code> to treat the specified text as html
+   * @param subMenu the sub-menu to be displayed when it is selected
+   */
+  public MenuItem(@IsSafeHtml String text, boolean asHTML, MenuBar subMenu) {
+    this(text, asHTML);
+    setSubMenu(subMenu);
+  }
+
+  /**
+   * Constructs a new menu item that fires a command when it is selected.
+   *
+   * @param text the item's text
+   * @param cmd the command to be fired when it is selected
+   */
+  @SuppressIsSafeHtmlCastCheck
+  public MenuItem(String text, ScheduledCommand cmd) {
+    this(text, false);
+    setScheduledCommand(cmd);
+  }
+
+  /**
+   * Constructs a new menu item that cascades to a sub-menu when it is selected.
+   *
+   * @param text the item's text
+   * @param subMenu the sub-menu to be displayed when it is selected
+   */
+  @SuppressIsSafeHtmlCastCheck
+  public MenuItem(String text, MenuBar subMenu) {
+    this(text, false);
+    setSubMenu(subMenu);
+  }
+
+  MenuItem(@IsSafeHtml String text, boolean asHTML) {
+    setElement(DOM.createTD());
+    setSelectionStyle(false);
+
+    if (asHTML) {
+      setHTML(text);
+    } else {
+      setText(text);
+    }
+    setStyleName("gwt-MenuItem");
+
+    getElement().setAttribute("id", DOM.createUniqueId());
+    // Add a11y role "menuitem"
+    Roles.getMenuitemRole().set(getElement());
+  }
+
+  /**
+   * Gets the command associated with this item.  If a scheduled command
+   * is associated with this item a command that can be used to execute the
+   * scheduled command will be returned.
+   *
+   * @return the command
+   * @deprecated use {@link #getScheduledCommand()} instead
+   */
+  @Deprecated
+  public Command getCommand() {
+    Command rtnVal;
+
+    if (command == null) {
+      rtnVal = null;
+    } else if (command instanceof Command) {
+      rtnVal = (Command) command;
+    } else {
+      rtnVal = new Command() {
+        @Override
+        public void execute() {
+          if (command != null) {
+            command.execute();
+          }
+        }
+      };
+    }
+
+    return rtnVal;
+  }
+
+  @Override
+  public String getHTML() {
+    return getElement().getInnerHTML();
+  }
+
+  /**
+   * Gets the menu that contains this item.
+   *
+   * @return the parent menu, or <code>null</code> if none exists.
+   */
+  public MenuBar getParentMenu() {
+    return parentMenu;
+  }
+
+  /**
+   * Gets the scheduled command associated with this item.
+   *
+   * @return this item's scheduled command, or <code>null</code> if none exists
+   */
+  public ScheduledCommand getScheduledCommand() {
+    return command;
+  }
+
+  /**
+   * Gets the sub-menu associated with this item.
+   *
+   * @return this item's sub-menu, or <code>null</code> if none exists
+   */
+  public MenuBar getSubMenu() {
+    return subMenu;
+  }
+
+  @Override
+  public String getText() {
+    return getElement().getInnerText();
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  /**
+   * Sets the command associated with this item.
+   *
+   * @param cmd the command to be associated with this item
+   * @deprecated use {@link #setScheduledCommand(ScheduledCommand)} instead
+   */
+  @Deprecated
+  public void setCommand(Command cmd) {
+    command = cmd;
+  }
+
+  @Override
+  public void setEnabled(boolean enabled) {
+    if (enabled) {
+      removeStyleDependentName(DEPENDENT_STYLENAME_DISABLED_ITEM);
+    } else {
+      addStyleDependentName(DEPENDENT_STYLENAME_DISABLED_ITEM);
+    }
+    this.enabled = enabled;
+    Roles.getMenuitemRole().setAriaDisabledState(getElement(), !enabled);
+  }
+
+  @Override
+  public void setHTML(SafeHtml html) {
+    setHTML(html.asString());
+  }
+
+  @Override
+  public void setHTML(@IsSafeHtml String html) {
+    getElement().setInnerHTML(html);
+  }
+
+  /**
+   * Sets the scheduled command associated with this item.
+   *
+   * @param cmd the scheduled command to be associated with this item
+   */
+  public void setScheduledCommand(ScheduledCommand cmd) {
+    command = cmd;
+  }
+
+  /**
+   * Sets the sub-menu associated with this item.
+   *
+   * @param subMenu this item's new sub-menu
+   */
+  public void setSubMenu(MenuBar subMenu) {
+    this.subMenu = subMenu;
+    if (this.parentMenu != null) {
+      this.parentMenu.updateSubmenuIcon(this);
+    }
+
+    if (subMenu != null) {
+      // Change tab index from 0 to -1, because only the root menu is supposed
+      // to be in the tab order
+      FocusPanel.impl.setTabIndex(subMenu.getElement(), -1);
+
+      // Update a11y role "haspopup"
+      Roles.getMenuitemRole().setAriaHaspopupProperty(getElement(), true);
+    } else {
+      // Update a11y role "haspopup"
+      Roles.getMenuitemRole().setAriaHaspopupProperty(getElement(), false);
+    }
+  }
+
+  @Override
+  public void setText(String text) {
+    getElement().setInnerText(text);
+  }
+
+  /**
+   * Also sets the Debug IDs of MenuItems in the submenu of this
+   * {@link MenuItem} if a submenu exists.
+   *
+   * @see UIObject#onEnsureDebugId(String)
+   */
+  @Override
+  protected void onEnsureDebugId(String baseID) {
+    super.onEnsureDebugId(baseID);
+    if (subMenu != null) {
+      subMenu.setMenuItemDebugIds(baseID);
+    }
+  }
+
+  protected void setSelectionStyle(boolean selected) {
+    if (selected) {
+      addStyleDependentName(DEPENDENT_STYLENAME_SELECTED_ITEM);
+    } else {
+      removeStyleDependentName(DEPENDENT_STYLENAME_SELECTED_ITEM);
+    }
+  }
+
+  void setParentMenu(MenuBar parentMenu) {
+    this.parentMenu = parentMenu;
+  }
+}

--- a/src/gwt/src/com/google/gwt/user/client/ui/MenuItem.java.diff
+++ b/src/gwt/src/com/google/gwt/user/client/ui/MenuItem.java.diff
@@ -1,2 +1,14 @@
-228a229
+17a18
+> import com.google.gwt.aria.client.ExpandedValue;
+228a230
 >     Roles.getMenuitemRole().setAriaDisabledState(getElement(), !enabled);
+267a270
+>       setAriaExpanded(false);
+273a277,283
+>   public void setAriaExpanded(boolean expanded)
+>   {
+>     Roles.getMenubarRole().setAriaExpandedState(
+>           getElement(), 
+>           expanded ? ExpandedValue.TRUE : ExpandedValue.FALSE);
+>   }
+> 

--- a/src/gwt/src/com/google/gwt/user/client/ui/MenuItem.java.diff
+++ b/src/gwt/src/com/google/gwt/user/client/ui/MenuItem.java.diff
@@ -1,0 +1,2 @@
+228a229
+>     Roles.getMenuitemRole().setAriaDisabledState(getElement(), !enabled);

--- a/src/gwt/src/com/google/gwt/user/updatepatches.sh
+++ b/src/gwt/src/com/google/gwt/user/updatepatches.sh
@@ -7,6 +7,7 @@ mkdir tmp
 cd tmp
 
 jar xvf ../../../lib/gwt/2.8.2/gwt-user.jar \
+  com/google/gwt/user/client/ui/MenuItem.java \
   com/google/gwt/user/client/ui/DecoratorPanel.java \
   com/google/gwt/user/client/ui/VerticalPanel.java \
   com/google/gwt/user/client/ui/HorizontalPanel.java \
@@ -16,6 +17,7 @@ jar xvf ../../../lib/gwt/2.8.2/gwt-user.jar \
 
 cd ../google/gwt/user/client/ui
 
+diff ../../../../../tmp/com/google/gwt/user/client/ui/MenuItem.java MenuItem.java > MenuItem.java.diff
 diff ../../../../../tmp/com/google/gwt/user/client/ui/DecoratorPanel.java DecoratorPanel.java > DecoratorPanel.java.diff
 diff ../../../../../tmp/com/google/gwt/user/client/ui/VerticalPanel.java VerticalPanel.java > VerticalPanel.java.diff
 diff ../../../../../tmp/com/google/gwt/user/client/ui/HorizontalPanel.java HorizontalPanel.java > HorizontalPanel.java.diff

--- a/src/gwt/src/com/google/gwt/user/updatesources.sh
+++ b/src/gwt/src/com/google/gwt/user/updatesources.sh
@@ -9,6 +9,7 @@ pwd
 
 # extract over previously modified sources
 jar xvf ../lib/gwt/2.8.2/gwt-user.jar \
+  com/google/gwt/user/client/ui/MenuItem.java \
   com/google/gwt/user/client/ui/DecoratorPanel.java \
   com/google/gwt/user/client/ui/VerticalPanel.java \
   com/google/gwt/user/client/ui/HorizontalPanel.java \
@@ -19,6 +20,7 @@ jar xvf ../lib/gwt/2.8.2/gwt-user.jar \
 cd com/google/gwt/user/client/ui
 
 # apply previous patches
+patch MenuItem.java < MenuItem.java.diff
 patch DecoratorPanel.java < DecoratorPanel.java.diff
 patch VerticalPanel.java < VerticalPanel.java.diff
 patch HorizontalPanel.java < HorizontalPanel.java.diff

--- a/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
@@ -566,7 +566,7 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
       int topOffset = -2;
       if (iconOffsetY != null)
          topOffset += iconOffsetY;
-      text.append("<table ");
+      text.append("<table role=\"presentation\"");
       if (label != null)
       {
          text.append("id=\"" + ElementIds.idFromLabel(label) + "_command\" ");
@@ -656,10 +656,12 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
       sb.append(SafeHtmlUtil.createOpenTag("img",
         "class", ThemeStyles.INSTANCE.menuRightImage(),
         "title", StringUtil.notNull(desc),
+        "aria-label", StringUtil.notNull(desc),
         "width", Integer.toString(image.getWidth()),
         "height", Integer.toString(image.getHeight()),
-        "src", image.getSafeUri().asString()));
-      sb.appendHtmlConstant("</img>");   
+        "src", image.getSafeUri().asString(),
+        "alt", ""));
+      sb.appendHtmlConstant("</img>");
       return sb.toSafeHtml();
    }
 
@@ -669,8 +671,9 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
       sb.append(SafeHtmlUtil.createOpenTag("img",
         "width", Integer.toString(image.getWidth()),
         "height", Integer.toString(image.getHeight()),
-        "src", image.getSafeUri().asString()));
-      sb.appendHtmlConstant("</img>");   
+        "src", image.getSafeUri().asString(),
+        "alt", ""));
+      sb.appendHtmlConstant("</img>");
       return sb.toSafeHtml();
    }
    

--- a/src/gwt/src/org/rstudio/core/client/command/AppMenuItem.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppMenuItem.java
@@ -49,11 +49,12 @@ public class AppMenuItem extends MenuItem
          getElement().addClassName("disabled");
 
       setVisible(cmd_.isVisible());
+      setEnabled(cmd_.isEnabled());
 
       setHTML(cmd_.getMenuHTML(mainMenu_));
       setTitle(cmd_.getDesc());
    }
-   
+
    public boolean cmdVisible()
    {
       return cmd_.isVisible();

--- a/src/gwt/src/org/rstudio/core/client/command/BaseMenuBar.java
+++ b/src/gwt/src/org/rstudio/core/client/command/BaseMenuBar.java
@@ -1,7 +1,7 @@
 /*
  * BaseMenuBar.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -260,6 +260,44 @@ public class BaseMenuBar extends MenuBar
          if (item.isVisible())
             items.add(item);
       return items;
+   }
+
+   public MenuItem getItem(int index)
+   {
+      int count = getItemCount();
+      if (count == 0)
+         return null;
+
+      if (index < 0)
+         index = 0;
+
+      if (index >= count - 1)
+         index = count - 1;
+
+      List<MenuItem> items = getItems();
+      return items.get(index);
+   }
+
+   public void selectItem(int index)
+   {
+      MenuItem item = getItem(index);
+      if (item == null)
+         return;
+
+      selectItem(item);
+   }
+
+   public void keyboardActivateItem(int index)
+   {
+      MenuItem item = getItem(index);
+      if (item == null)
+         return;
+      
+      // set focus
+      getElement().focus();
+
+      // activate item
+      doItemAction(item, true, true);
    }
 
    /**

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -26,13 +26,11 @@ import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.*;
 import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.HasHorizontalAlignment.HorizontalAlignmentConstant;
 
-import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.Point;
 import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.command.ShortcutManager;

--- a/src/gwt/src/org/rstudio/core/client/widget/ShortcutInfoPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ShortcutInfoPanel.java
@@ -1,7 +1,7 @@
 /*
  * ShortcutInfoPanel.java
  *
- * Copyright (C) 2009-13 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -80,7 +80,7 @@ public class ShortcutInfoPanel extends Composite
       List<ShortcutInfo> shortcuts = 
             ShortcutManager.INSTANCE.getActiveShortcutInfo();
       String[][] groupNames = { 
-            new String[] { "Tabs", "Panes", "Files" },
+            new String[] { "Tabs", "Panes", "Files", "Main Menu (Server)" },
             new String[] { "Source Navigation", "Execute" },
             new String[] { "Source Editor", "Debug" }, 
             new String[] { "Source Control", "Build", "Console", "Terminal", "Other" }

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
@@ -318,22 +318,6 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
       {
          selectItem(getItemCount());
       }
-      
-      private void selectItem(int index)
-      {
-         int count = getItemCount();
-         
-         if (count == 0) return;
-         
-         if (index < 0)
-            index = 0;
-         
-         if (index >= count - 1)
-            index = count - 1;
-         
-         List<MenuItem> items = getItems();
-         selectItem(items.get(index));
-      }
 
       private HandlerRegistration nativePreviewReg_;
    }

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -986,6 +986,22 @@ public class Application implements ApplicationEventHandlers
          commands_.zoomOut().remove();
       }
       
+      // remove main menu commands in desktop mode
+      if (Desktop.isDesktop())
+      {
+         commands_.showFileMenu().remove();
+         commands_.showEditMenu().remove();
+         commands_.showCodeMenu().remove();
+         commands_.showViewMenu().remove();
+         commands_.showPlotsMenu().remove();
+         commands_.showSessionMenu().remove();
+         commands_.showBuildMenu().remove();
+         commands_.showDebugMenu().remove();
+         commands_.showProfileMenu().remove();
+         commands_.showToolsMenu().remove();
+         commands_.showHelpMenu().remove();
+      }
+      
       // show new session when appropriate
       if (!Desktop.isDesktop())
       {

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
@@ -63,6 +63,7 @@ import org.rstudio.studio.client.workbench.codesearch.CodeSearch;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.events.SessionInitEvent;
 import org.rstudio.studio.client.workbench.events.SessionInitHandler;
+import org.rstudio.studio.client.workbench.events.ShowMainMenuEvent;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.SessionInfo;
 
@@ -209,6 +210,10 @@ public class WebApplicationHeader extends Composite
             overlay_.setGlobalToolbarVisible(WebApplicationHeader.this, 
                                              toolbar_.isVisible());
          }
+      });
+      
+      eventBus.addHandler(ShowMainMenuEvent.TYPE, event -> {
+         mainMenu_.keyboardActivateItem(event.getMenu().ordinal());
       });
       
       // create toolbar

--- a/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
@@ -68,6 +68,7 @@ import org.rstudio.studio.client.shiny.ShinyApplication;
 import org.rstudio.studio.client.shiny.ui.ShinyGadgetDialog;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.events.*;
+import org.rstudio.studio.client.workbench.events.ShowMainMenuEvent.Menu;
 import org.rstudio.studio.client.workbench.model.*;
 import org.rstudio.studio.client.workbench.prefs.model.UIPrefs;
 import org.rstudio.studio.client.workbench.views.choosefile.ChooseFile;
@@ -444,7 +445,73 @@ public class Workbench implements BusyHandler,
       if (Desktop.isDesktop())
          Desktop.getFrame().toggleFullscreenMode();
    }
-   
+
+   @Handler
+   public void onShowFileMenu()
+   {
+      eventBus_.fireEvent(new ShowMainMenuEvent(Menu.File));
+   }
+
+   @Handler
+   public void onShowEditMenu()
+   {
+      eventBus_.fireEvent(new ShowMainMenuEvent(Menu.Edit));
+   }
+
+   @Handler
+   public void onShowCodeMenu()
+   {
+      eventBus_.fireEvent(new ShowMainMenuEvent(Menu.Code));
+   }
+
+   @Handler
+   public void onShowViewMenu()
+   {
+      eventBus_.fireEvent(new ShowMainMenuEvent(Menu.View));
+   }
+
+   @Handler
+   public void onShowPlotsMenu()
+   {
+      eventBus_.fireEvent(new ShowMainMenuEvent(Menu.Plots));
+   }
+
+   @Handler
+   public void onShowSessionMenu()
+   {
+      eventBus_.fireEvent(new ShowMainMenuEvent(Menu.Session));
+   }
+
+   @Handler
+   public void onShowBuildMenu()
+   {
+      eventBus_.fireEvent(new ShowMainMenuEvent(Menu.Build));
+   }
+
+   @Handler
+   public void onShowDebugMenu()
+   {
+      eventBus_.fireEvent(new ShowMainMenuEvent(Menu.Debug));
+   }
+
+   @Handler
+   public void onShowProfileMenu()
+   {
+      eventBus_.fireEvent(new ShowMainMenuEvent(Menu.Profile));
+   }
+
+   @Handler
+   public void onShowToolsMenu()
+   {
+      eventBus_.fireEvent(new ShowMainMenuEvent(Menu.Tools));
+   }
+
+   @Handler
+   public void onShowHelpMenu()
+   {
+      eventBus_.fireEvent(new ShowMainMenuEvent(Menu.Help));
+   }
+
    private void checkForInitMessages()
    {
       if (!Desktop.isDesktop())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -2619,13 +2619,13 @@ well as menu structures (for main menu and popup menus).
    <cmd id="showShellDialog"
         label="Open Shell"
         menuLabel="_Shell..."
-        desc="Execute shell commands(s)"
+        desc="Execute shell commands"
         windowMode="main"/>
         
    <cmd id="newTerminal"
         label="New Terminal"
         menuLabel="_New Terminal"
-        desc="Execute shell commands(s)"
+        desc="Create a new terminal"
         windowMode="main"/>
 
    <cmd id="activateTerminal"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -822,7 +822,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="showProfileMenu" value="Ctrl+Alt+O"/>
          <shortcut refid="showToolsMenu" value="Ctrl+Alt+T"/>
          <shortcut refid="showHelpMenu" value="Ctrl+Alt+H"/>
-      </shortcutgroup>s
+      </shortcutgroup>
 
       <!-- 
       Shortcuts in this group won't be shown in the quick reference card. 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -33,7 +33,9 @@ well as menu structures (for main menu and popup menus).
 -->
 <commands>
    <menu id="mainMenu" vertical="false">
-
+      <!-- 
+         Keep ShowMainMenuEvent.Menu enum in sync with top-level main-menu entries (File, Edit...)
+      -->
       <separator/>
 
       <menu label="_File">
@@ -806,6 +808,20 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="previousTerminal" value="Ctrl+Alt+F11"/>
          <shortcut refid="nextTerminal" value="Ctrl+Alt+F12"/>
       </shortcutgroup>
+
+      <shortcutgroup name="Main Menu (Server)">
+         <shortcut refid="showFileMenu" value="Ctrl+Alt+F"/>
+         <shortcut refid="showEditMenu" value="Ctrl+Alt+I"/>
+         <shortcut refid="showCodeMenu" value="Ctrl+Alt+C"/>
+         <shortcut refid="showViewMenu" value="Ctrl+Alt+V"/>
+         <shortcut refid="showPlotsMenu" value="Ctrl+Alt+P"/>
+         <shortcut refid="showSessionMenu" value="Ctrl+Alt+S"/>
+         <shortcut refid="showBuildMenu" value="Ctrl+Alt+B"/>
+         <shortcut refid="showDebugMenu" value="Ctrl+Alt+U"/>
+         <shortcut refid="showProfileMenu" value="Ctrl+Alt+O"/>
+         <shortcut refid="showToolsMenu" value="Ctrl+Alt+T"/>
+         <shortcut refid="showHelpMenu" value="Ctrl+Alt+H"/>
+      </shortcutgroup>s
 
       <!-- 
       Shortcuts in this group won't be shown in the quick reference card. 
@@ -3364,5 +3380,49 @@ well as menu structures (for main menu and popup menus).
          rebindable="false"
          checkable="true"
          windowMode="any"/>
+
+   <cmd id="showFileMenu"
+         menuLabel="Show File Menu"
+         windowMode="main"/>
+
+   <cmd id="showEditMenu"
+         menuLabel="Show Edit Menu"
+         windowMode="main"/>
+
+   <cmd id="showCodeMenu"
+        menuLabel="Show Code Menu"
+        windowMode="main"/>
+
+   <cmd id="showViewMenu"
+        menuLabel="Show View Menu"
+        windowMode="main"/>
+
+   <cmd id="showPlotsMenu"
+        menuLabel="Show Plots Menu"
+        windowMode="main"/>
+
+   <cmd id="showSessionMenu"
+        menuLabel="Show Session Menu"
+        windowMode="main"/>
+
+   <cmd id="showBuildMenu"
+        menuLabel="Show Build Menu"
+        windowMode="main"/>
+
+   <cmd id="showDebugMenu"
+        menuLabel="Show Debug Menu"
+        windowMode="main"/>
+
+   <cmd id="showProfileMenu"
+        menuLabel="Show Profile Menu"
+        windowMode="main"/>
+
+   <cmd id="showToolsMenu"
+        menuLabel="Show Tools Menu"
+        windowMode="main"/>
+
+   <cmd id="showHelpMenu"
+        menuLabel="Show Help Menu"
+        windowMode="main"/>
 
 </commands>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -591,4 +591,17 @@ public abstract class
    
    public static final String KEYBINDINGS_PATH =
          "~/.R/keybindings/rstudio_commands.json";
+
+   // Main menu (server)
+   public abstract AppCommand showFileMenu();
+   public abstract AppCommand showEditMenu();
+   public abstract AppCommand showCodeMenu();
+   public abstract AppCommand showViewMenu();
+   public abstract AppCommand showPlotsMenu();
+   public abstract AppCommand showSessionMenu();
+   public abstract AppCommand showBuildMenu();
+   public abstract AppCommand showDebugMenu();
+   public abstract AppCommand showProfileMenu();
+   public abstract AppCommand showToolsMenu();
+   public abstract AppCommand showHelpMenu();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/events/ShowMainMenuEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/events/ShowMainMenuEvent.java
@@ -1,0 +1,68 @@
+/*
+ * ShowMainMenuEvent.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import org.rstudio.core.client.js.JavaScriptSerializable;
+import org.rstudio.studio.client.application.events.CrossWindowEvent;
+
+/**
+ * Activate main menu and give it keyboard focus.
+ */
+@JavaScriptSerializable
+public class ShowMainMenuEvent extends CrossWindowEvent<ShowMainMenuEvent.Handler>
+{
+   public enum Menu
+   {
+      // keep in sync with mainMenu declared in Commands.cmd.xml
+      File, Edit, Code, View, Plots, Session, Build, Debug, Profile, Tools, Help
+   }
+   
+   public interface Handler extends EventHandler
+   {
+      void onShowMainMenu(ShowMainMenuEvent event);
+   }
+
+   public ShowMainMenuEvent()
+   {
+      this(Menu.File);
+   }
+
+   public ShowMainMenuEvent(Menu menu)
+   {
+      menu_ = menu;
+   }
+
+   public Menu getMenu()
+   {
+      return menu_;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onShowMainMenu(this);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   private final Menu menu_;
+
+   public static final Type<Handler> TYPE = new Type<>();
+}

--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 
 <head>
 
@@ -8,7 +9,7 @@
 
 <style type="text/css">
 #banner {
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }
 .shortcuts th {
   text-align: left;
@@ -24,11 +25,10 @@
 
 <body>
 
-<h3 id="banner"><img src="../images/rstudio.png" width="73" height="17" title="RStudio"/></h3>
+<header role="banner" id="banner"><img src="../images/rstudio.png" alt="RStudio logo"/></header>
+<main><div style="margin-left: 20px; margin-right: 20px">
 
-<div style="margin-left: 20px; margin-right: 20px">
-
-<h2>Keyboard Shortcuts</h2>
+<h1>Keyboard Shortcuts</h1>
 
 <style type='text/css'> 
   .shortcuts td, .shortcuts th {
@@ -36,7 +36,7 @@
     padding-bottom: 0.5em; }
 </style> 
 <table class='shortcuts'>
-  <tr><td colspan="3"><h3>Console</h3></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
+  <tr><td colspan="3"><h2>Console</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
   <tr>
     <td>Move cursor to Console</td>
     <td>Ctrl+2</td>
@@ -78,7 +78,7 @@
     <td>Ctrl+Shift+H</td>
   </tr>
   <tr><td><br/></td></tr>
-  <tr><td colspan="3"><h3>Source</h3></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
+  <tr><td colspan="3"><h2>Source</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
    <tr>
     <td>Goto File/Function</td>
     <td>Ctrl+.</td>
@@ -410,7 +410,7 @@
     <td>F7</td>
   </tr>
   <tr><td><br/></td></tr>
-  <tr><td colspan="3"><h3>Editing (Console and Source)</h3></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
+  <tr><td colspan="3"><h2>Editing (Console and Source)</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
   <tr>
     <td>Undo</td>
     <td>Ctrl+Z</td>
@@ -557,7 +557,7 @@
     <td>Cmd+Option+U</td>
   </tr>
   <tr><td><br/></td></tr>
-  <tr><td colspan="3"><h3>Completions (Console and Source)</h3></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
+  <tr><td colspan="3"><h2>Completions (Console and Source)</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
   <tr>
     <td>Attempt completion</td>
     <td>Tab or Ctrl+Space</td>
@@ -579,7 +579,7 @@
     <td>Esc</td>
   </tr>
   <tr><td><br/></td></tr>
-  <tr><td colspan="3"><h3>Views</h3></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
+  <tr><td colspan="3"><h2>Views</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
   <tr>
     <td>Move focus to Source Editor</td>
     <td>Ctrl+1</td>
@@ -642,7 +642,7 @@
   </tr>
   <tr><td><br/></td></tr>
   
-  <tr><td colspan="3"><h3>Build</h3></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
+  <tr><td colspan="3"><h2>Build</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
   <tr>
     <td>Install and Restart</td>
     <td>Ctrl+Shift+B</td>
@@ -675,7 +675,7 @@
   </tr>
   <tr><td><br/></td></tr>
 
-  <tr><td colspan="3"><h3>Debug</h3></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
+  <tr><td colspan="3"><h2>Debug</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
   <tr>
    <td>Toggle Breakpoint</td>
    <td>Shift+F9</td>
@@ -708,7 +708,7 @@
   </tr>   
   <tr><td><br/></td></tr>
 
-  <tr><td colspan="3"><h3>Plots</h3></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
+  <tr><td colspan="3"><h2>Plots</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
   <tr>
     <td>Previous plot</td>
     <td>Ctrl+Alt+F11</td>
@@ -720,7 +720,7 @@
     <td>Command+Option+F12</td>
   </tr>
   <tr><td><br/></td></tr>
-  <tr><td colspan="3"><h3>Git/SVN</h3></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
+  <tr><td colspan="3"><h2>Git/SVN</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
   <tr>
     <td>Diff active source document</td>
     <td>Ctrl+Alt+D</td>
@@ -747,7 +747,7 @@
     <td>Enter</td>
   </tr>
   <tr><td><br/></td></tr>
-  <tr><td colspan="3"><h3>Session</h3></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
+  <tr><td colspan="3"><h2>Session</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
   <tr>
     <td>Quit Session (desktop only)</td>
     <td>Ctrl+Q</td>
@@ -759,7 +759,7 @@
     <td>Command+Shift+F10</td>
   </tr>
   <tr><td><br/></td></tr>
-  <tr><td colspan="3"><h3>Terminal</h3></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
+  <tr><td colspan="3"><h2>Terminal</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
   <tr>
     <td>New Terminal</td>
     <td>Shift+Alt+T</td>
@@ -791,8 +791,65 @@
     <td>Ctrl+Option+F12</td>
   </tr>
   <tr><td><br/></td></tr>
+  <tr><td colspan="3"><h2>Main Menu (Server)</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
+  <tr>
+    <td>File Menu</td>
+    <td>Ctrl+Alt+F</td>
+    <td>Ctrl+Option+F</td>
+  </tr>
+  <tr>
+    <td>Edit Menu</td>
+    <td>Ctrl+Alt+I</td>
+    <td>Ctrl+Option+I</td>
+  </tr>
+  <tr>
+    <td>Code Menu</td>
+    <td>Ctrl+Alt+C</td>
+    <td>Ctrl+Option+C</td>
+  </tr>
+  <tr>
+    <td>View Menu</td>
+    <td>Ctrl+Alt+V</td>
+    <td>Ctrl+Option+V</td>
+  </tr>
+  <tr>
+    <td>Plots Menu</td>
+    <td>Ctrl+Alt+P</td>
+    <td>Ctrl+Option+P</td>
+  </tr>
+  <tr>
+    <td>Session Menu</td>
+    <td>Ctrl+Alt+S</td>
+    <td>Ctrl+Option+S</td>
+  </tr>
+  <tr>
+    <td>Build Menu</td>
+    <td>Ctrl+Alt+B</td>
+    <td>Ctrl+Option+B</td>
+  </tr>
+  <tr>
+    <td>Debug Menu</td>
+    <td>Ctrl+Alt+U</td>
+    <td>Ctrl+Option+U</td>
+  </tr>
+  <tr>
+    <td>Profile Menu</td>
+    <td>Ctrl+Alt+O</td>
+    <td>Ctrl+Option+O</td>
+  </tr>
+  <tr>
+    <td>Tools Menu</td>
+    <td>Ctrl+Alt+T</td>
+    <td>Ctrl+Option+T</td>
+  </tr>
+  <tr>
+    <td>Help Menu</td>
+    <td>Ctrl+Alt+H</td>
+    <td>Ctrl+Option+H</td>
+  </tr>
+  <tr><td><br/></td></tr>
 </table>
-</div>
+</div></main>
    
 </body>
 </html>


### PR DESCRIPTION
Fixes #4855 

A11y fixes to server main menu, so it can be used with keyboard and screen readers:

- aria roles, states, and properties to permit screen reader access
- keyboard focus fixes to allow navigation of menus with keyboard
- new server-only commands and shortcuts to access main menu via keyboard (desktop already has native techniques for getting to main menu with keyboard)
- null `alt` attribute on cosmetic menu graphics (icons, expando-arrows)
- mark menu layout tables as role=presentation to avoid having rows/columns read out and/or screen readers entering table-navigation mode

I followed the example of Google Docs, and used following keyboard shortcuts:

File - Ctrl+Alt+F
Edit - Ctrl+Alt+I ("i")
Code - Ctrl+Alt+C
View - Ctrl+Alt+V
Plots - Ctrl+Alt+P
Session - Ctrl+Alt+S
Build - Ctrl+Alt+B
Debug - Ctrl+Alt+U
Profile - Ctrl+Alt+O
Tools - Ctrl+Alt+T
Help - Ctrl+Alt+H

Use of "I" and "O" are generally discouraged, as they are hard to distinguish from L and zero, but available combinations are scarce.

Some of these clash with VoiceOver shortcuts, so need to use the "ignore next keypress" command (VO+Tab) first. Not an issue with NVDA on Windows as it disables almost all of its shortcuts when working in RStudio (due to role=application).

In addition to this PR, other already-merged PRs also contributed to this effort:

- https://github.com/rstudio/rstudio/pull/4828
- https://github.com/rstudio/rstudio/pull/4827
