### PR TITLE
Modify material theme editor margin color to make it visible

### DIFF
--- a/src/cpp/session/resources/themes/material.rstheme
+++ b/src/cpp/session/resources/themes/material.rstheme
@@ -7,7 +7,7 @@
 
 .ace_print-margin {
   width: 1px;
-  background: #263238
+  background: #3D5059
 }
 
 .ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {


### PR DESCRIPTION
The material theme's editor max-width column's color is modified to subtly distinguish it from the background and makes it visible, where it previously was not.

partially addresses #3420