### PR TITLE
Fix additional logger level bug

### DIFF
--- a/src/cpp/core/SyslogLogWriter.cpp
+++ b/src/cpp/core/SyslogLogWriter.cpp
@@ -68,7 +68,8 @@ SyslogLogWriter::~SyslogLogWriter()
 SyslogLogWriter::SyslogLogWriter(const std::string& programIdentity,
                                  int logLevel)
    : programIdentity_(programIdentity),
-     logToStderr_(core::system::stderrIsTerminal())
+     logToStderr_(core::system::stderrIsTerminal()),
+     logLevel_(logLevel)
 {
    // copy program identity into new string whose buffer will stay
    // around long enough to successfully register with openlog

--- a/src/cpp/core/include/core/FileLogWriter.hpp
+++ b/src/cpp/core/include/core/FileLogWriter.hpp
@@ -40,6 +40,8 @@ public:
                      core::system::LogLevel level,
                      const std::string& message);
 
+    virtual int logLevel() { return logLevel_; }
+
 
 private:
     void createFile();

--- a/src/cpp/core/include/core/LogWriter.hpp
+++ b/src/cpp/core/include/core/LogWriter.hpp
@@ -26,6 +26,8 @@ class LogWriter
 public:
    virtual ~LogWriter() {}
 
+   virtual int logLevel() = 0;
+
    virtual void log(core::system::LogLevel level,
                     const std::string& message) = 0;
 

--- a/src/cpp/core/include/core/StderrLogWriter.hpp
+++ b/src/cpp/core/include/core/StderrLogWriter.hpp
@@ -34,6 +34,8 @@ public:
                      core::system::LogLevel level,
                      const std::string& message);
 
+    virtual int logLevel() { return logLevel_; }
+
 private:
     std::string programIdentity_;
     int logLevel_;

--- a/src/cpp/core/include/core/SyslogLogWriter.hpp
+++ b/src/cpp/core/include/core/SyslogLogWriter.hpp
@@ -37,9 +37,12 @@ public:
        logToStderr_ = logToStderr;
     }
 
+    virtual int logLevel() { return logLevel_; }
+
 private:
     std::string programIdentity_;
     bool logToStderr_;
+    int logLevel_;
 };
 
 } // namespace core

--- a/src/cpp/core/system/System.cpp
+++ b/src/cpp/core/system/System.cpp
@@ -184,7 +184,13 @@ LogLevel lowestLogLevel()
       if (!s_logOptions)
          return kLogLevelWarning;
 
-      return static_cast<LogLevel>(s_logOptions->lowestLogLevel());
+      int lowestLevel = s_logOptions->lowestLogLevel();
+      for (const boost::shared_ptr<LogWriter>& logWriter : s_additionalLogWriters)
+      {
+         if (logWriter->logLevel() < lowestLevel)
+            lowestLevel = logWriter->logLevel();
+      }
+      return static_cast<LogLevel>(lowestLevel);
    }
    END_LOCK_MUTEX
 

--- a/src/cpp/monitor/MonitorClient.cpp
+++ b/src/cpp/monitor/MonitorClient.cpp
@@ -44,6 +44,8 @@ public:
       client().logMessage(programIdentity, level, message);
    }
 
+   virtual int logLevel() { return core::system::kLogLevelDebug; }
+
 private:
    std::string programIdentity_;
 };


### PR DESCRIPTION
Fixed bug where additional (programmatic) loggers that were set at a lower priority than the configured loggers would not be logged to due to not taking into account the additional logger levels in the lowest log level calculation