### PR TITLE
guard against errors when building primitive wrappers

### DIFF
--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -1630,9 +1630,7 @@ public:
       if (error)
          LOG_ERROR(error);
 
-      if (Rf_isFunction(wrapperSEXP))
-         put(primitiveSEXP, wrapperSEXP);
-
+      put(primitiveSEXP, wrapperSEXP);
       return wrapperSEXP;
    }
    
@@ -1649,7 +1647,8 @@ private:
    
    void put(SEXP primitiveSEXP, SEXP wrapperSEXP)
    {
-      R_PreserveObject(wrapperSEXP);
+      if (wrapperSEXP != R_NilValue)
+         R_PreserveObject(wrapperSEXP);
       database_[primitiveSEXP] = wrapperSEXP;
    }
    

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1737,8 +1737,17 @@
 
 .rs.addFunction("makePrimitiveWrapper", function(x)
 {
-   code <- paste(format(args(x))[[1]], format(x), sep = "")
-   eval(parse(text = code), envir = baseenv())
+   # from the R documentation, args returns:
+   #
+   #   For a closure, a closure with identical formal argument list but an empty
+   #   (NULL) body.
+   #
+   #   For a primitive, a closure with the documented usage and NULL body. Note
+   #   that some primitives do not make use of named arguments and match by
+   #   position rather than name.
+   #
+   # we just need an R closure with the right formals, so args fits nicely
+   args(x)
 })
 
 .rs.addFunction("extractNativeSymbols", function(DLL, collapse = TRUE)

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1735,8 +1735,10 @@
    object
 })
 
-.rs.addFunction("makePrimitiveWrapper", function(x) {
-   eval(parse(text = capture.output(x)), envir = parent.frame(1))
+.rs.addFunction("makePrimitiveWrapper", function(x)
+{
+   code <- paste(format(args(x))[[1]], format(x), sep = "")
+   eval(parse(text = code), envir = baseenv())
 })
 
 .rs.addFunction("extractNativeSymbols", function(DLL, collapse = TRUE)


### PR DESCRIPTION
A segfault was reported to Sentry here: https://sentry.io/organizations/rstudio/issues/1050032194

It looks like we don't guard well against failures to create the primitive wrapper functions used by the diagnostics engine. This PR adds the necessary guards and handles failure more appropriately.

We also no longer rely on `capture.output()` as that may be brittle if the user already has their own sinks set up.