### PR TITLE
use RS_REGISTER_CALL_METHOD for .Call method registration

### DIFF
--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -306,56 +306,14 @@ Error run(const ROptions& options, const RCallbacks& callbacks)
    restartContext().initialize(s_options.scopedScratchPath,
                                s_options.sessionPort);
 
-   // register browseURL method
-   R_CallMethodDef browseURLMethod ;
-   browseURLMethod.name = "rs_browseURL";
-   browseURLMethod.fun = (DL_FUNC)rs_browseURL;
-   browseURLMethod.numArgs = 1;
-   r::routines::addCallMethod(browseURLMethod);
-
-   // register editFile method
-   R_CallMethodDef editFileMethod;
-   editFileMethod.name = "rs_editFile";
-   editFileMethod.fun = (DL_FUNC)rs_editFile;
-   editFileMethod.numArgs = 1;
-   r::routines::addCallMethod(editFileMethod);
-
-   // register showFile method
-   R_CallMethodDef showFileMethod;
-   showFileMethod.name = "rs_showFile";
-   showFileMethod.fun = (DL_FUNC)rs_showFile;
-   showFileMethod.numArgs = 3;
-   r::routines::addCallMethod(showFileMethod);
-
-   // register createUUID method
-   R_CallMethodDef createUUIDMethodDef ;
-   createUUIDMethodDef.name = "rs_createUUID" ;
-   createUUIDMethodDef.fun = (DL_FUNC) rs_createUUID ;
-   createUUIDMethodDef.numArgs = 0;
-   r::routines::addCallMethod(createUUIDMethodDef);
-
-   // register loadHistory method
-   R_CallMethodDef loadHistoryMethodDef ;
-   loadHistoryMethodDef.name = "rs_loadHistory" ;
-   loadHistoryMethodDef.fun = (DL_FUNC) rs_loadHistory ;
-   loadHistoryMethodDef.numArgs = 1;
-   r::routines::addCallMethod(loadHistoryMethodDef);
-
-   // register saveHistory method
-   R_CallMethodDef saveHistoryMethodDef ;
-   saveHistoryMethodDef.name = "rs_saveHistory" ;
-   saveHistoryMethodDef.fun = (DL_FUNC) rs_saveHistory ;
-   saveHistoryMethodDef.numArgs = 1;
-   r::routines::addCallMethod(saveHistoryMethodDef);
-
-   // complete url
-   R_CallMethodDef completeUrlDef ;
-   completeUrlDef.name = "rs_completeUrl" ;
-   completeUrlDef.fun = (DL_FUNC) rs_completeUrl ;
-   completeUrlDef.numArgs = 2;
-   r::routines::addCallMethod(completeUrlDef);
-
-   // register graphics methods
+   // register methods
+   RS_REGISTER_CALL_METHOD(rs_browseURL);
+   RS_REGISTER_CALL_METHOD(rs_editFile);
+   RS_REGISTER_CALL_METHOD(rs_showFile);
+   RS_REGISTER_CALL_METHOD(rs_createUUID);
+   RS_REGISTER_CALL_METHOD(rs_loadHistory);
+   RS_REGISTER_CALL_METHOD(rs_saveHistory);
+   RS_REGISTER_CALL_METHOD(rs_completeUrl);
    RS_REGISTER_CALL_METHOD(rs_GEcopyDisplayList, 1);
    RS_REGISTER_CALL_METHOD(rs_GEplayDisplayList, 0);
 

--- a/src/cpp/r/session/graphics/RGraphicsDevice.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsDevice.cpp
@@ -445,7 +445,7 @@ void resizeGraphicsDevice()
 }   
    
 // routine which creates device  
-SEXP createGD()
+SEXP rs_createGD()
 {   
    // error if there is already an RStudio device
    if (s_pGEDevDesc != nullptr)
@@ -567,7 +567,7 @@ Error makeActive()
    if (s_pGEDevDesc == nullptr)
    {
       SEXP ignoredSEXP;
-      Error error = r::exec::executeSafely<SEXP>(boost::bind(createGD), 
+      Error error = r::exec::executeSafely<SEXP>(boost::bind(rs_createGD),
                                                  &ignoredSEXP);
       if (error)
          return error;
@@ -736,19 +736,8 @@ Error initialize(
    std::string message;
    if (graphics::validateRequirements(&message))
    {
-      // register device creation routine
-      R_CallMethodDef createGDMethodDef ;
-      createGDMethodDef.name = "rs_createGD" ;
-      createGDMethodDef.fun = (DL_FUNC) createGD ;
-      createGDMethodDef.numArgs = 0;
-      r::routines::addCallMethod(createGDMethodDef);
-
-      // regsiter device activiation routine
-      R_CallMethodDef activateGDMethodDef ;
-      activateGDMethodDef.name = "rs_activateGD" ;
-      activateGDMethodDef.fun = (DL_FUNC) rs_activateGD ;
-      activateGDMethodDef.numArgs = 0;
-      r::routines::addCallMethod(activateGDMethodDef);
+      RS_REGISTER_CALL_METHOD(rs_createGD);
+      RS_REGISTER_CALL_METHOD(rs_activateGD);
 
       // initialize
       return r::exec::RFunction(".rs.initGraphicsDevice").call();

--- a/src/cpp/r/session/graphics/RGraphicsPlotManipulatorManager.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsPlotManipulatorManager.cpp
@@ -152,33 +152,11 @@ Error PlotManipulatorManager::initialize(
    // save reference to device conversion function
    convert_ = convert;
 
-   // register R entry points for this class
-   R_CallMethodDef execManipulatorMethodDef ;
-   execManipulatorMethodDef.name = "rs_executeAndAttachManipulator" ;
-   execManipulatorMethodDef.fun = (DL_FUNC) rs_executeAndAttachManipulator;
-   execManipulatorMethodDef.numArgs = 1;
-   r::routines::addCallMethod(execManipulatorMethodDef);
-
-   // register has active manipulator routine
-   R_CallMethodDef hasActiveManipulatorMethodDef ;
-   hasActiveManipulatorMethodDef.name = "rs_hasActiveManipulator" ;
-   hasActiveManipulatorMethodDef.fun = (DL_FUNC) rs_hasActiveManipulator;
-   hasActiveManipulatorMethodDef.numArgs = 0;
-   r::routines::addCallMethod(hasActiveManipulatorMethodDef);
-
-   // register active manipulator routine
-   R_CallMethodDef activeManipulatorMethodDef ;
-   activeManipulatorMethodDef.name = "rs_activeManipulator" ;
-   activeManipulatorMethodDef.fun = (DL_FUNC) rs_activeManipulator;
-   activeManipulatorMethodDef.numArgs = 0;
-   r::routines::addCallMethod(activeManipulatorMethodDef);
-
-   // register ensure manipulator saved routine
-   R_CallMethodDef ensureManipulatorSavedMethodDef ;
-   ensureManipulatorSavedMethodDef.name = "rs_ensureManipulatorSaved" ;
-   ensureManipulatorSavedMethodDef.fun = (DL_FUNC) rs_ensureManipulatorSaved;
-   ensureManipulatorSavedMethodDef.numArgs = 0;
-   r::routines::addCallMethod(ensureManipulatorSavedMethodDef);
+   // register .Call methods
+   RS_REGISTER_CALL_METHOD(rs_executeAndAttachManipulator);
+   RS_REGISTER_CALL_METHOD(rs_hasActiveManipulator);
+   RS_REGISTER_CALL_METHOD(rs_activeManipulator);
+   RS_REGISTER_CALL_METHOD(rs_ensureManipulatorSaved);
 
    return Success();
 }

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -2440,162 +2440,36 @@ bool usingMingwGcc49()
 
 Error initialize()
 {
-   // register rs_enqueClientEvent with R 
-   R_CallMethodDef methodDef ;
-   methodDef.name = "rs_enqueClientEvent" ;
-   methodDef.fun = (DL_FUNC) rs_enqueClientEvent ;
-   methodDef.numArgs = 2;
-   r::routines::addCallMethod(methodDef);
-      
-   // register rs_showErrorMessage with R 
-   R_CallMethodDef methodDef3 ;
-   methodDef3.name = "rs_showErrorMessage" ;
-   methodDef3.fun = (DL_FUNC) rs_showErrorMessage ;
-   methodDef3.numArgs = 2;
-   r::routines::addCallMethod(methodDef3);
-   
-   // register rs_logErrorMessage with R 
-   R_CallMethodDef methodDef4 ;
-   methodDef4.name = "rs_logErrorMessage" ;
-   methodDef4.fun = (DL_FUNC) rs_logErrorMessage ;
-   methodDef4.numArgs = 1;
-   r::routines::addCallMethod(methodDef4);
-   
-   // register rs_logWarningMessage with R 
-   R_CallMethodDef methodDef5 ;
-   methodDef5.name = "rs_logWarningMessage" ;
-   methodDef5.fun = (DL_FUNC) rs_logWarningMessage ;
-   methodDef5.numArgs = 1;
-   r::routines::addCallMethod(methodDef5);
-
-   // register rs_threadSleep with R (debugging function used to test rpc/abort)
-   R_CallMethodDef methodDef6 ;
-   methodDef6.name = "rs_threadSleep" ;
-   methodDef6.fun = (DL_FUNC) rs_threadSleep ;
-   methodDef6.numArgs = 1;
-   r::routines::addCallMethod(methodDef6);
-
-   // register rs_rstudioProgramMode with R
-   R_CallMethodDef methodDef7 ;
-   methodDef7.name = "rs_rstudioProgramMode" ;
-   methodDef7.fun = (DL_FUNC) rs_rstudioProgramMode ;
-   methodDef7.numArgs = 0;
-   r::routines::addCallMethod(methodDef7);
-
-   // register rs_ensureFileHidden with R
-   R_CallMethodDef methodDef8;
-   methodDef8.name = "rs_ensureFileHidden" ;
-   methodDef8.fun = (DL_FUNC) rs_ensureFileHidden ;
-   methodDef8.numArgs = 1;
-   r::routines::addCallMethod(methodDef8);
-
-   // register rs_sourceDiagnostics
-   R_CallMethodDef methodDef9;
-   methodDef9.name = "rs_sourceDiagnostics" ;
-   methodDef9.fun = (DL_FUNC) rs_sourceDiagnostics;
-   methodDef9.numArgs = 0;
-   r::routines::addCallMethod(methodDef9);
-
-   // register rs_activatePane
-   R_CallMethodDef methodDef10;
-   methodDef10.name = "rs_activatePane" ;
-   methodDef10.fun = (DL_FUNC) rs_activatePane;
-   methodDef10.numArgs = 1;
-   r::routines::addCallMethod(methodDef10);
-
-   // register rs_packageLoaded
-   R_CallMethodDef methodDef11;
-   methodDef11.name = "rs_packageLoaded" ;
-   methodDef11.fun = (DL_FUNC) rs_packageLoaded;
-   methodDef11.numArgs = 1;
-   r::routines::addCallMethod(methodDef11);
-
-   // register rs_packageUnloaded
-   R_CallMethodDef methodDef12;
-   methodDef12.name = "rs_packageUnloaded" ;
-   methodDef12.fun = (DL_FUNC) rs_packageUnloaded;
-   methodDef12.numArgs = 1;
-   r::routines::addCallMethod(methodDef12);
-
-   // register rs_userPrompt
-   R_CallMethodDef methodDef13;
-   methodDef13.name = "rs_userPrompt" ;
-   methodDef13.fun = (DL_FUNC) rs_userPrompt;
-   methodDef13.numArgs = 7;
-   r::routines::addCallMethod(methodDef13);
-
-   // register rs_restartR
-   R_CallMethodDef methodDef14;
-   methodDef14.name = "rs_restartR" ;
-   methodDef14.fun = (DL_FUNC) rs_restartR;
-   methodDef14.numArgs = 1;
-   r::routines::addCallMethod(methodDef14);
-
-   // register rs_restartR
-   R_CallMethodDef methodDef15;
-   methodDef15.name = "rs_rstudioCRANReposUrl" ;
-   methodDef15.fun = (DL_FUNC) rs_rstudioCRANReposUrl;
-   methodDef15.numArgs = 0;
-   r::routines::addCallMethod(methodDef15);
-
-   // register rs_rstudioEdition with R
-   R_CallMethodDef methodDef16 ;
-   methodDef16.name = "rs_rstudioEdition" ;
-   methodDef16.fun = (DL_FUNC) rs_rstudioEdition ;
-   methodDef16.numArgs = 0;
-   r::routines::addCallMethod(methodDef16);
-
-   R_CallMethodDef methodDef17;
-   methodDef17.name = "rs_markdownToHTML";
-   methodDef17.fun = (DL_FUNC) rs_markdownToHTML;
-   methodDef17.numArgs = 1;
-   r::routines::addCallMethod(methodDef17);
-   
-   // register persistent value functions
-   RS_REGISTER_CALL_METHOD(rs_setPersistentValue, 2);
-   RS_REGISTER_CALL_METHOD(rs_getPersistentValue, 1);
-
-   // register rs_isRScriptInPackageBuildTarget
-   r::routines::registerCallMethod(
-            "rs_isRScriptInPackageBuildTarget",
-            (DL_FUNC) rs_isRScriptInPackageBuildTarget,
-            1);
-   
-   // register rs_packageNameForSourceFile
-   r::routines::registerCallMethod(
-            "rs_packageNameForSourceFile",
-            (DL_FUNC) rs_packageNameForSourceFile,
-            1);
-
-   // register rs_rstudioVersion
-   r::routines::registerCallMethod(
-            "rs_rstudioVersion",
-            (DL_FUNC) rs_rstudioVersion,
-            0);
-
-   // regsiter rs_rstudioCitation
-   r::routines::registerCallMethod(
-            "rs_rstudioCitation",
-            (DL_FUNC) rs_rstudioCitation,
-            0);
-
-   // register rs_setUsingMingwGcc49
-   r::routines::registerCallMethod(
-            "rs_setUsingMingwGcc49",
-            (DL_FUNC)rs_setUsingMingwGcc49,
-            1);
-
-   r::routines::registerCallMethod(
-            "rs_generateShortUuid",
-            (DL_FUNC)rs_generateShortUuid, 
-            0);
-
-   RS_REGISTER_CALL_METHOD(rs_base64encode, 2);
-   RS_REGISTER_CALL_METHOD(rs_base64encodeFile, 1);
-   RS_REGISTER_CALL_METHOD(rs_base64decode, 2);
-   
-   RS_REGISTER_CALL_METHOD(rs_resolveAliasedPath, 1);
-   RS_REGISTER_CALL_METHOD(rs_sessionModulePath, 0);
+   // register .Call methods
+   RS_REGISTER_CALL_METHOD(rs_activatePane);
+   RS_REGISTER_CALL_METHOD(rs_base64decode);
+   RS_REGISTER_CALL_METHOD(rs_base64encode);
+   RS_REGISTER_CALL_METHOD(rs_base64encodeFile);
+   RS_REGISTER_CALL_METHOD(rs_enqueClientEvent);
+   RS_REGISTER_CALL_METHOD(rs_ensureFileHidden);
+   RS_REGISTER_CALL_METHOD(rs_generateShortUuid);
+   RS_REGISTER_CALL_METHOD(rs_getPersistentValue);
+   RS_REGISTER_CALL_METHOD(rs_isRScriptInPackageBuildTarget);
+   RS_REGISTER_CALL_METHOD(rs_logErrorMessage);
+   RS_REGISTER_CALL_METHOD(rs_logWarningMessage);
+   RS_REGISTER_CALL_METHOD(rs_markdownToHTML);
+   RS_REGISTER_CALL_METHOD(rs_packageLoaded);
+   RS_REGISTER_CALL_METHOD(rs_packageNameForSourceFile);
+   RS_REGISTER_CALL_METHOD(rs_packageUnloaded);
+   RS_REGISTER_CALL_METHOD(rs_resolveAliasedPath);
+   RS_REGISTER_CALL_METHOD(rs_restartR);
+   RS_REGISTER_CALL_METHOD(rs_rstudioCitation);
+   RS_REGISTER_CALL_METHOD(rs_rstudioCRANReposUrl);
+   RS_REGISTER_CALL_METHOD(rs_rstudioEdition);
+   RS_REGISTER_CALL_METHOD(rs_rstudioProgramMode);
+   RS_REGISTER_CALL_METHOD(rs_rstudioVersion);
+   RS_REGISTER_CALL_METHOD(rs_sessionModulePath);
+   RS_REGISTER_CALL_METHOD(rs_setPersistentValue);
+   RS_REGISTER_CALL_METHOD(rs_setUsingMingwGcc49);
+   RS_REGISTER_CALL_METHOD(rs_showErrorMessage);
+   RS_REGISTER_CALL_METHOD(rs_sourceDiagnostics);
+   RS_REGISTER_CALL_METHOD(rs_threadSleep);
+   RS_REGISTER_CALL_METHOD(rs_userPrompt);
 
    // initialize monitored scratch dir
    initializeMonitoredUserScratchDir();

--- a/src/cpp/session/SessionRpc.cpp
+++ b/src/cpp/session/SessionRpc.cpp
@@ -316,10 +316,7 @@ Error initialize()
    // the OS to clean up memory itself after the process is gone)
    s_pJsonRpcMethods = new core::json::JsonRpcAsyncMethods;
 
-   r::routines::registerCallMethod(
-            "rs_invokeRpc",
-            (DL_FUNC) rs_invokeRpc,
-            2);
+   RS_REGISTER_CALL_METHOD(rs_invokeRpc);
 
    return Success();
 }

--- a/src/cpp/session/modules/SessionAskPass.cpp
+++ b/src/cpp/session/modules/SessionAskPass.cpp
@@ -154,12 +154,8 @@ Error initialize()
    s_waitForAskPass = module_context::registerWaitForMethod(
                                                 "askpass_completed");
 
-   // register rs_askForPassword with R
-   R_CallMethodDef methodDefAskPass ;
-   methodDefAskPass.name = "rs_askForPassword" ;
-   methodDefAskPass.fun = (DL_FUNC) rs_askForPassword ;
-   methodDefAskPass.numArgs = 1;
-   r::routines::addCallMethod(methodDefAskPass);
+   // register .Call methods
+   RS_REGISTER_CALL_METHOD(rs_askForPassword);
 
    // complete initialization
    ExecBlock initBlock ;

--- a/src/cpp/session/modules/SessionAskSecret.cpp
+++ b/src/cpp/session/modules/SessionAskSecret.cpp
@@ -205,12 +205,8 @@ Error initialize()
    s_waitForAskPass = module_context::registerWaitForMethod(
                                                 "asksecret_completed");
 
-   // register rs_askForSecret with R
-   R_CallMethodDef methodDefAskPass ;
-   methodDefAskPass.name = "rs_askForSecret" ;
-   methodDefAskPass.fun = (DL_FUNC) rs_askForSecret ;
-   methodDefAskPass.numArgs = 5;
-   r::routines::addCallMethod(methodDefAskPass);
+   // register .Call methods
+   RS_REGISTER_CALL_METHOD(rs_askForSecret);
 
    // complete initialization
    ExecBlock initBlock ;

--- a/src/cpp/session/modules/SessionAuthoring.cpp
+++ b/src/cpp/session/modules/SessionAuthoring.cpp
@@ -208,11 +208,7 @@ json::Object compilePdfStateAsJson()
 Error initialize()
 {
    // register tanble function
-   R_CallMethodDef methodDef ;
-   methodDef.name = "rs_rnwTangle" ;
-   methodDef.fun = (DL_FUNC) rs_rnwTangle ;
-   methodDef.numArgs = 3;
-   r::routines::addCallMethod(methodDef);
+   RS_REGISTER_CALL_METHOD(rs_rnwTangle);
 
    // install rpc methods
    using boost::bind;

--- a/src/cpp/session/modules/SessionBreakpoints.cpp
+++ b/src/cpp/session/modules/SessionBreakpoints.cpp
@@ -195,6 +195,10 @@ std::vector<int> getShinyBreakpointLines(const ShinyFunction& sf)
    std::vector<int> lines;
    for (boost::shared_ptr<Breakpoint> pbp : s_breakpoints)
    {
+      // silence gcc warning
+      if (pbp == nullptr)
+         continue;
+
       if (sf.contains(pbp->path, pbp->lineNumber) &&
           pbp->type == TYPE_TOPLEVEL)
          lines.push_back(pbp->lineNumber);
@@ -502,19 +506,9 @@ SEXP rs_debugSourceFile(SEXP filename, SEXP encoding, SEXP local)
 
 Error initBreakpoints()
 {
-   // Register rs_debugSourceFile; called from the console (as debugSource)
-   R_CallMethodDef debugSource;
-   debugSource.name = "rs_debugSourceFile";
-   debugSource.fun = (DL_FUNC)rs_debugSourceFile;
-   debugSource.numArgs = 3;
-   r::routines::addCallMethod(debugSource);
-
-   // Register rs_registerShinyFunction; called from registerShinyDebugHook
-   R_CallMethodDef registerShiny;
-   registerShiny.name = "rs_registerShinyFunction";
-   registerShiny.fun = (DL_FUNC)rs_registerShinyFunction;
-   registerShiny.numArgs = 1;
-   r::routines::addCallMethod(registerShiny);
+   // register .Call methods
+   RS_REGISTER_CALL_METHOD(rs_debugSourceFile);
+   RS_REGISTER_CALL_METHOD(rs_registerShinyFunction);
 
    // Initializes the set of breakpoints the server knows about by populating
    // it from client state. This set is used for synchronous breakpoint

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -2465,35 +2465,14 @@ Error initialize()
    cb.onMonitoringDisabled = onFileMonitorDisabled;
    projects::projectContext().subscribeToFileMonitor("R source file indexing",
                                                      cb);
-   
-   // register viewFunction method
-   R_CallMethodDef methodDef ;
-   methodDef.name = "rs_viewFunction" ;
-   methodDef.fun = (DL_FUNC) rs_viewFunction ;
-   methodDef.numArgs = 3;
-   r::routines::addCallMethod(methodDef);
 
-   // register call methods
-   r::routines::registerCallMethod(
-            "rs_scoreMatches",
-            (DL_FUNC) rs_scoreMatches,
-            2);
-   
-   r::routines::registerCallMethod(
-            "rs_listIndexedFiles",
-            (DL_FUNC) rs_listIndexedFiles,
-            3);
-   
-   r::routines::registerCallMethod(
-            "rs_listIndexedFolders",
-            (DL_FUNC) rs_listIndexedFolders,
-            3);
+   // register .Call methods
+   RS_REGISTER_CALL_METHOD(rs_viewFunction);
+   RS_REGISTER_CALL_METHOD(rs_scoreMatches);
+   RS_REGISTER_CALL_METHOD(rs_listIndexedFiles);
+   RS_REGISTER_CALL_METHOD(rs_listIndexedFolders);
+   RS_REGISTER_CALL_METHOD(rs_listIndexedFilesAndFolders);
 
-   r::routines::registerCallMethod(
-            "rs_listIndexedFilesAndFolders",
-            (DL_FUNC) rs_listIndexedFilesAndFolders,
-            3);
-   
    // initialize r source indexes
    rSourceIndex().initialize();
    

--- a/src/cpp/session/modules/SessionConsole.cpp
+++ b/src/cpp/session/modules/SessionConsole.cpp
@@ -163,12 +163,7 @@ Error initialize()
    }
 
    // register routines
-   R_CallMethodDef methodDef ;
-   methodDef.name = "rs_getPendingInput" ;
-   methodDef.fun = (DL_FUNC) rs_getPendingInput ;
-   methodDef.numArgs = 0;
-   r::routines::addCallMethod(methodDef);
-
+   RS_REGISTER_CALL_METHOD(rs_getPendingInput);
    
    // subscribe to events
    using boost::bind;

--- a/src/cpp/session/modules/SessionHistory.cpp
+++ b/src/cpp/session/modules/SessionHistory.cpp
@@ -428,11 +428,7 @@ Error initialize()
    r::session::consoleHistory().connectOnAdd(onHistoryAdd);
 
    // register timestamp function
-   R_CallMethodDef methodDef;
-   methodDef.name = "rs_timestamp" ;
-   methodDef.fun = (DL_FUNC) rs_timestamp;
-   methodDef.numArgs = 1;
-   r::routines::addCallMethod(methodDef);   
+   RS_REGISTER_CALL_METHOD(rs_timestamp);
 
    // install handlers
    using boost::bind;

--- a/src/cpp/session/modules/SessionPackrat.cpp
+++ b/src/cpp/session/modules/SessionPackrat.cpp
@@ -972,11 +972,7 @@ Error initialize()
    module_context::events().afterSessionInitHook.connect(afterSessionInitHook);
 
    // register packrat action hook
-   R_CallMethodDef onPackratActionMethodDef ;
-   onPackratActionMethodDef.name = "rs_onPackratAction" ;
-   onPackratActionMethodDef.fun = (DL_FUNC) rs_onPackratAction ;
-   onPackratActionMethodDef.numArgs = 3;
-   r::routines::addCallMethod(onPackratActionMethodDef);
+   RS_REGISTER_CALL_METHOD(rs_onPackratAction);
 
    using boost::bind;
    using namespace module_context;

--- a/src/cpp/session/modules/SessionPlumberViewer.cpp
+++ b/src/cpp/session/modules/SessionPlumberViewer.cpp
@@ -206,11 +206,7 @@ Error initialize()
 
    boost::shared_ptr<int> pPlumberViewerType = boost::make_shared<int>(PLUMBER_VIEWER_NONE);
 
-   R_CallMethodDef methodDefViewer;
-   methodDefViewer.name = "rs_plumberviewer";
-   methodDefViewer.fun = (DL_FUNC) rs_plumberviewer;
-   methodDefViewer.numArgs = 3;
-   r::routines::addCallMethod(methodDefViewer);
+   RS_REGISTER_CALL_METHOD(rs_plumberviewer);
 
    userSettings().onChanged.connect(bind(onUserSettingsChanged, pPlumberViewerType));
 

--- a/src/cpp/session/modules/SessionShinyViewer.cpp
+++ b/src/cpp/session/modules/SessionShinyViewer.cpp
@@ -285,11 +285,7 @@ Error initialize()
    json::JsonRpcFunction setShinyViewerTypeRpc =
          boost::bind(setShinyViewer, pShinyViewerType, _1, _2);
 
-   R_CallMethodDef methodDefViewer;
-   methodDefViewer.name = "rs_shinyviewer";
-   methodDefViewer.fun = (DL_FUNC) rs_shinyviewer;
-   methodDefViewer.numArgs = 3;
-   r::routines::addCallMethod(methodDefViewer);
+   RS_REGISTER_CALL_METHOD(rs_shinyviewer);
 
    events().onConsoleInput.connect(onConsoleInput);
    userSettings().onChanged.connect(bind(onUserSettingsChanged,

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -2140,35 +2140,12 @@ void onDeferredInit(bool newSession)
 
 Error initialize()
 {
-   R_CallMethodDef canBuildMethodDef ;
-   canBuildMethodDef.name = "rs_canBuildCpp" ;
-   canBuildMethodDef.fun = (DL_FUNC) rs_canBuildCpp ;
-   canBuildMethodDef.numArgs = 0;
-   r::routines::addCallMethod(canBuildMethodDef);
-
-   R_CallMethodDef addRToolsToPathMethodDef ;
-   addRToolsToPathMethodDef.name = "rs_addRToolsToPath" ;
-   addRToolsToPathMethodDef.fun = (DL_FUNC) rs_addRToolsToPath ;
-   addRToolsToPathMethodDef.numArgs = 0;
-   r::routines::addCallMethod(addRToolsToPathMethodDef);
-
-   R_CallMethodDef restorePreviousPathMethodDef ;
-   restorePreviousPathMethodDef.name = "rs_restorePreviousPath" ;
-   restorePreviousPathMethodDef.fun = (DL_FUNC) rs_restorePreviousPath ;
-   restorePreviousPathMethodDef.numArgs = 0;
-   r::routines::addCallMethod(restorePreviousPathMethodDef);
-
-   R_CallMethodDef installPackageMethodDef ;
-   installPackageMethodDef.name = "rs_installPackage" ;
-   installPackageMethodDef.fun = (DL_FUNC) rs_installPackage;
-   installPackageMethodDef.numArgs = 2;
-   r::routines::addCallMethod(installPackageMethodDef);
-
-   R_CallMethodDef installBuildToolsMethodDef;
-   installBuildToolsMethodDef.name = "rs_installBuildTools" ;
-   installBuildToolsMethodDef.fun = (DL_FUNC) rs_installBuildTools;
-   installBuildToolsMethodDef.numArgs = 0;
-   r::routines::addCallMethod(installBuildToolsMethodDef);
+   // register .Call methods
+   RS_REGISTER_CALL_METHOD(rs_canBuildCpp);
+   RS_REGISTER_CALL_METHOD(rs_addRToolsToPath);
+   RS_REGISTER_CALL_METHOD(rs_restorePreviousPath);
+   RS_REGISTER_CALL_METHOD(rs_installPackage);
+   RS_REGISTER_CALL_METHOD(rs_installBuildTools);
 
    // subscribe to deferredInit for build tools fixup
    module_context::events().onDeferredInit.connect(onDeferredInit);

--- a/src/cpp/session/modules/build/SessionSourceCpp.cpp
+++ b/src/cpp/session/modules/build/SessionSourceCpp.cpp
@@ -274,21 +274,8 @@ SEXP rs_sourceCppOnBuildComplete(SEXP sSucceeded, SEXP sOutput)
 
 Error initialize()
 {
-
-   // onBuild hook
-   R_CallMethodDef sourceCppOnBuildMethodDef ;
-   sourceCppOnBuildMethodDef.name = "rs_sourceCppOnBuild" ;
-   sourceCppOnBuildMethodDef.fun = (DL_FUNC)rs_sourceCppOnBuild ;
-   sourceCppOnBuildMethodDef.numArgs = 3;
-   r::routines::addCallMethod(sourceCppOnBuildMethodDef);
-
-   // onBuildCompleted hook
-   R_CallMethodDef sourceCppOnBuildCompleteMethodDef ;
-   sourceCppOnBuildCompleteMethodDef.name = "rs_sourceCppOnBuildComplete";
-   sourceCppOnBuildCompleteMethodDef.fun = (DL_FUNC)rs_sourceCppOnBuildComplete;
-   sourceCppOnBuildCompleteMethodDef.numArgs = 2;
-   r::routines::addCallMethod(sourceCppOnBuildCompleteMethodDef);
-
+   RS_REGISTER_CALL_METHOD(rs_sourceCppOnBuild);
+   RS_REGISTER_CALL_METHOD(rs_sourceCppOnBuildComplete);
    return Success();
 }
 

--- a/src/cpp/session/modules/clang/SessionClang.cpp
+++ b/src/cpp/session/modules/clang/SessionClang.cpp
@@ -206,17 +206,8 @@ bool isAvailable()
 Error initialize()
 {
    // register diagnostics functions
-   R_CallMethodDef methodDef1 ;
-   methodDef1.name = "rs_isLibClangAvailable" ;
-   methodDef1.fun = (DL_FUNC)rs_isLibClangAvailable;
-   methodDef1.numArgs = 0;
-   r::routines::addCallMethod(methodDef1);
-
-   R_CallMethodDef methodDef2 ;
-   methodDef2.name = "rs_setClangDiagnostics" ;
-   methodDef2.fun = (DL_FUNC)rs_setClangDiagnostics;
-   methodDef2.numArgs = 1;
-   r::routines::addCallMethod(methodDef2);
+   RS_REGISTER_CALL_METHOD(rs_isLibClangAvailable);
+   RS_REGISTER_CALL_METHOD(rs_setClangDiagnostics);
 
    ExecBlock initBlock ;
    using boost::bind;

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -1011,11 +1011,7 @@ Error initialize()
    using namespace module_context;
 
    // register viewData method
-   R_CallMethodDef methodDef ;
-   methodDef.name = "rs_viewData" ;
-   methodDef.fun = (DL_FUNC) rs_viewData ;
-   methodDef.numArgs = 7;
-   r::routines::addCallMethod(methodDef);
+   RS_REGISTER_CALL_METHOD(rs_viewData);
 
    source_database::events().onDocPendingRemove.connect(onDocPendingRemove);
 

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -1073,17 +1073,8 @@ Error initialize()
    boost::shared_ptr<bool> pCapturingDebugOutput =
          boost::make_shared<bool>(false);
 
-   r::routines::registerCallMethod(
-            "rs_isBrowserActive",
-            (DL_FUNC) rs_isBrowserActive,
-            0);
-
-   R_CallMethodDef methodDef ;
-   methodDef.name = "rs_jumpToFunction" ;
-   methodDef.fun = (DL_FUNC) rs_jumpToFunction ;
-   methodDef.numArgs = 3;
-   r::routines::addCallMethod(methodDef);
-
+   RS_REGISTER_CALL_METHOD(rs_isBrowserActive);
+   RS_REGISTER_CALL_METHOD(rs_jumpToFunction);
    RS_REGISTER_CALL_METHOD(rs_hasExternalPointer);
    RS_REGISTER_CALL_METHOD(rs_hasAltrep);
    RS_REGISTER_CALL_METHOD(rs_isAltrep);

--- a/src/cpp/session/modules/presentation/SessionPresentation.cpp
+++ b/src/cpp/session/modules/presentation/SessionPresentation.cpp
@@ -461,18 +461,8 @@ json::Value presentationStateAsJson()
 Error initialize()
 {
    // register rs_showPresentation
-   R_CallMethodDef methodDefShowPresentation;
-   methodDefShowPresentation.name = "rs_showPresentation" ;
-   methodDefShowPresentation.fun = (DL_FUNC) rs_showPresentation;
-   methodDefShowPresentation.numArgs = 1;
-   r::routines::addCallMethod(methodDefShowPresentation);
-
-   // register rs_showPresentationHelpDoc
-   R_CallMethodDef methodDefShowHelpDoc;
-   methodDefShowHelpDoc.name = "rs_showPresentationHelpDoc" ;
-   methodDefShowHelpDoc.fun = (DL_FUNC) rs_showPresentationHelpDoc;
-   methodDefShowHelpDoc.numArgs = 1;
-   r::routines::addCallMethod(methodDefShowHelpDoc);
+   RS_REGISTER_CALL_METHOD(rs_showPresentation);
+   RS_REGISTER_CALL_METHOD(rs_showPresentationHelpDoc);
 
    // initialize presentation log
    Error error = log().initialize();

--- a/src/cpp/session/modules/shiny/SessionShiny.cpp
+++ b/src/cpp/session/modules/shiny/SessionShiny.cpp
@@ -484,12 +484,8 @@ Error initialize()
 {
    using namespace module_context;
    using boost::bind;
-   
-   R_CallMethodDef methodDef ;
-   methodDef.name = "rs_showShinyGadgetDialog" ;
-   methodDef.fun = (DL_FUNC)rs_showShinyGadgetDialog ;
-   methodDef.numArgs = 4;
-   r::routines::addCallMethod(methodDef);
+
+   RS_REGISTER_CALL_METHOD(rs_showShinyGadgetDialog);
 
    events().onPackageLoaded.connect(onPackageLoaded);
 

--- a/src/cpp/session/modules/viewer/SessionViewer.cpp
+++ b/src/cpp/session/modules/viewer/SessionViewer.cpp
@@ -384,11 +384,7 @@ void onClientInit()
 
 Error initialize()
 {
-   R_CallMethodDef methodDefViewer ;
-   methodDefViewer.name = "rs_viewer" ;
-   methodDefViewer.fun = (DL_FUNC) rs_viewer ;
-   methodDefViewer.numArgs = 2;
-   r::routines::addCallMethod(methodDefViewer);
+   RS_REGISTER_CALL_METHOD(rs_viewer);
 
    // install event handlers
    using namespace module_context;

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -404,15 +404,8 @@ Error ProjectContext::initialize()
 {
    using namespace module_context;
 
-   r::routines::registerCallMethod(
-            "rs_getProjectDirectory",
-            (DL_FUNC) rs_getProjectDirectory,
-            0);
-   
-   r::routines::registerCallMethod(
-            "rs_hasFileMonitor",
-            (DL_FUNC) rs_hasFileMonitor,
-            0);
+   RS_REGISTER_CALL_METHOD(rs_getProjectDirectory);
+   RS_REGISTER_CALL_METHOD(rs_hasFileMonitor);
 
    std::string projectId(kProjectNone);
 


### PR DESCRIPTION
This PR ports all of our `.Call()` method registration to use `RS_REGISTER_CALL_METHOD()`.

`RS_REGISTER_CALL_METHOD()` is preferred for a couple reasons:

1. It validates that the registered function accepts and returns only SEXPs;
2. It automatically computed the number of arguments accepted by the function. (it's easy to forget to update the argument count if you change the signature of a registered function)

Fortunately all of our existing registrations look correct. The only minor change was the renaming of an internal function `createGD` -> `rs_createGD`, for consistency.