### PR TITLE
tweaks for C++ diagnostics on macOS

### DIFF
--- a/src/cpp/core/libclang/LibClang.cpp
+++ b/src/cpp/core/libclang/LibClang.cpp
@@ -93,10 +93,15 @@ std::vector<std::string> systemClangVersions()
    std::vector<std::string> clangVersions;
    
 #if defined(__APPLE__)
+   // NOTE: the version of libclang.dylib bundled with Xcode
+   // doesn't seem to work well when loaded as a library
+   // (there seems to be extra orchestration required to get
+   // include paths set up; easier to just depend on command
+   // line tools since we request their installation in other
+   // contexts)
    clangVersions = {
-      "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/libclang.dylib",
       "/Library/Developer/CommandLineTools/usr/lib/libclang.dylib",
-      "/usr/local/opt/llvm/lib/libclang.dylib"
+      "/usr/local/opt/llvm/lib/libclang.dylib",
    };
 #elif defined(__unix__)
    // default set of versions

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -120,18 +120,39 @@ std::vector<std::string> extractCompileArgs(const std::string& line)
    std::vector<std::string> compileArgs;
 
    // find arguments libclang might care about
+   // (we implement a poor man's shell arguments parser here:
+   // consider a true solution using e.g. a tokenizer)
    try
    {
-      boost::regex re("[ \\t]-(?:[IDif]|std)(?:\\\"[^\\\"]+\\\"|[^ ]+)");
-      boost::sregex_token_iterator it(line.begin(), line.end(), re, 0);
-      boost::sregex_token_iterator end;
+      boost::regex re(
+               "([ \\t])"                           // look for preceding space
+               "(-isysroot|-isystem|-I|-D|-i|-f)"   // find flags we care about
+               "([ \\t]+)?"                         // allow for optional whitespace
+               "(\\\"[^\\\"]+\\\"|[^ ]+)");         // parse the argument passed
+
+      boost::sregex_iterator it(line.begin(), line.end(), re);
+      boost::sregex_iterator end;
       for ( ; it != end; ++it)
       {
-         // remove quotes and add it to the compile args
-         std::string arg = *it;
-         boost::algorithm::trim_all(arg);
-         boost::algorithm::replace_all(arg, "\"", "");
-         compileArgs.push_back(arg);
+         boost::smatch match = *it;
+
+         std::string whitespace = match[3];
+         if (whitespace.empty())
+         {
+            std::string argument = match[2] + match[4];
+            boost::algorithm::replace_all(argument, "\"", "");
+            compileArgs.push_back(argument);
+         }
+         else
+         {
+            std::string first = match[2];
+            boost::algorithm::replace_all(first, "\"", "");
+            compileArgs.push_back(first);
+
+            std::string second = match[4];
+            boost::algorithm::replace_all(second, "\"", "");
+            compileArgs.push_back(second);
+         }
       }
    }
    CATCH_UNEXPECTED_EXCEPTION;


### PR DESCRIPTION
Should fix some issues with C++ diagnostics on macOS.

Candidate for v1.2-patch since I think this implies C++ autocompletion / diagnostics can be broken if Xcode is also installed in addition to command line tools.