### PR TITLE
provide default RStudio HTTP user agent

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -84,19 +84,11 @@
 
 .rs.addApiFunction("versionInfo", function() {
   info <- list()
-  info$citation <- .Call(getNativeSymbolInfo("rs_rstudioCitation",
-                                             PACKAGE=""))
-
-  info$mode <- .Call(getNativeSymbolInfo("rs_rstudioProgramMode",
-                                         PACKAGE=""))
-
-  info$edition <- .Call(getNativeSymbolInfo("rs_rstudioEdition",
-                                            PACKAGE=""))
-
-  info$version <- package_version(
-    .Call(getNativeSymbolInfo("rs_rstudioVersion", PACKAGE=""))
-  )
-
+  info$citation <- .Call("rs_rstudioCitation", PACKAGE = "(embedding)")
+  info$mode <- .Call("rs_rstudioProgramMode", PACKAGE = "(embedding)")
+  info$edition <- .Call("rs_rstudioEdition", PACKAGE = "(embedding)")
+  info$version <- .Call("rs_rstudioVersion", PACKAGE = "(embedding)")
+  info$version <- package_version(info$version)
   info
 })
 

--- a/src/cpp/r/R/Options.R
+++ b/src/cpp/r/R/Options.R
@@ -143,3 +143,5 @@ options(profvis.keep_output = TRUE)
 # indicate that we're not in a notebook by default
 options(rstudio.notebook.executing = FALSE)
 
+# provide a custom HTTP user agent
+.rs.initHttpUserAgent()

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1026,3 +1026,40 @@ assign(envir = .rs.Env, ".rs.hasVar", function(name)
 {
   .Call("rs_completeUrl", url, path)
 })
+
+.rs.addFunction("defaultHttpUserAgent", function()
+{
+   fields <- c(
+      format(getRversion()),
+      format(R.version$platform),
+      format(R.version$arch),
+      format(R.version$os)
+   )
+   
+   sprintf("R (%s)", paste(fields, collapse = " "))
+})
+
+.rs.addFunction("initHttpUserAgent", function()
+{
+   utils <- asNamespace("utils")
+   
+   defaultAgent <- if (is.function(utils$defaultUserAgent))
+      utils$defaultUserAgent()
+   else
+      .rs.defaultHttpUserAgent()
+   
+   if (identical(defaultAgent, getOption("HTTPUserAgent")))
+   {
+      info <- .rs.api.versionInfo()
+      fields <- c(
+         "RStudio",
+         if (info$mode == "desktop") "Desktop" else "Server",
+         if (!is.null(info$edition)) "Pro",
+         paste("(", format(info$version), ")", sep = "")
+      )
+      
+      rstudioAgent <- paste(fields, collapse = " ")
+      newAgent <- paste(rstudioAgent, defaultAgent, sep = "; ")
+      options(HTTPUserAgent = newAgent)
+   }
+})

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -327,6 +327,11 @@ SEXP rs_rstudioCitation()
    FilePath resPath = session::options().rResourcesPath();
    FilePath citationPath = resPath.childPath("CITATION");
 
+   // the citation file may not exist when working in e.g.
+   // development configurations so just ignore if it's missing
+   if (!citationPath.exists())
+      return R_NilValue;
+
    SEXP citationSEXP;
    r::sexp::Protect rProtect;
    Error error = r::exec::RFunction("utils:::readCitationFile",


### PR DESCRIPTION
Closes #4826.

With this change, the user agent is reported as:

```
> getOption("HTTPUserAgent")
[1] "RStudio Desktop (99.9.9); R (3.6.0 x86_64-apple-darwin15.6.0 x86_64 darwin15.6.0)"
```

but only if the user hasn't explicitly configured their own user agent.

IIUC, this could be a candidate for backport to v1.2 since we might need this change for RStudio Cloud.

@jmcphers let me know if you think we should be including other fields.