### PR TITLE
hide size gripper when copying plot as metafile

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/dom/ElementEx.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/ElementEx.java
@@ -64,6 +64,19 @@ public class ElementEx extends Element
       return top;
    }
    
+   // NOTE: these static methods are provided only because
+   // GWT seems unable to find the instance methods of the
+   // same name in some contexts in devmode
+   public static final int getClientLeft(Element el)
+   {
+      return ((ElementEx) el).getClientLeft();
+   }
+   
+   public static final int getClientTop(Element el)
+   {
+      return ((ElementEx) el).getClientTop();
+   }
+   
    public final native DOMRect getBoundingClientRect() /*-{
       return this.getBoundingClientRect();
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/clipboard/CopyPlotToClipboardDesktopDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/clipboard/CopyPlotToClipboardDesktopDialog.java
@@ -21,6 +21,7 @@ import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.DesktopFrame;
+import org.rstudio.studio.client.common.Timers;
 import org.rstudio.studio.client.workbench.exportplot.ExportPlotPreviewer;
 import org.rstudio.studio.client.workbench.exportplot.ExportPlotSizeEditor;
 import org.rstudio.studio.client.workbench.exportplot.model.ExportPlotOptions;
@@ -48,6 +49,18 @@ public class CopyPlotToClipboardDesktopDialog
    protected void copyAsBitmap(final Operation onCompleted)
    {
       final ExportPlotSizeEditor sizeEditor = getSizeEditor();
+      sizeEditor.setGripperVisible(false);
+      
+      // NOTE: we use a timer here just to be absolutely sure the
+      // browser has re-rendered and hidden the gripper before attempting
+      // to get a screenshot. note that the usual tools, e.g. scheduleDeferred(),
+      // don't work as expected here
+      Timers.singleShot(200, () -> { doCopyAsBitmap(onCompleted); });
+   }
+   
+   private void doCopyAsBitmap(final Operation onCompleted)
+   {
+      final ExportPlotSizeEditor sizeEditor = getSizeEditor();
       
       final Command completed = new Command()
       {
@@ -58,8 +71,6 @@ public class CopyPlotToClipboardDesktopDialog
             onCompleted.execute();
          }
       };
-      
-      sizeEditor.setGripperVisible(false);
       
       sizeEditor.prepareForExport(() -> {
          if (BrowseCap.isMacintoshDesktop())
@@ -76,11 +87,14 @@ public class CopyPlotToClipboardDesktopDialog
             NodeList<Element> images = doc.getElementsByTagName("img");
             if (images.getLength() > 0)
             {
-               ElementEx img = images.getItem(0).cast();
+               Element img = images.getItem(0);
                DesktopFrame frame = Desktop.getFrame();
+               
+               // NOTE: we use a one-pixel fudge factor here to avoid copying
+               // bits of the border; see https://github.com/rstudio/rstudio/issues/4864
                frame.copyPageRegionToClipboard(
-                     img.getClientLeft(),
-                     img.getClientTop(),
+                     ElementEx.getClientLeft(img) + 1,
+                     ElementEx.getClientTop(img) + 1,
                      img.getClientWidth(),
                      img.getClientHeight(),
                      completed);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/clipboard/CopyPlotToClipboardDesktopMetafileDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/clipboard/CopyPlotToClipboardDesktopMetafileDialog.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.exportplot.clipboard;
 
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.studio.client.common.Timers;
 import org.rstudio.studio.client.workbench.exportplot.ExportPlotPreviewer;
 import org.rstudio.studio.client.workbench.exportplot.ExportPlotResources;
 import org.rstudio.studio.client.workbench.exportplot.ExportPlotSizeEditor;
@@ -96,6 +97,18 @@ public class CopyPlotToClipboardDesktopMetafileDialog extends CopyPlotToClipboar
    private void copyAsMetafile(final Operation onCompleted)
    {
       ExportPlotSizeEditor sizeEditor = getSizeEditor();
+      sizeEditor.setGripperVisible(false);
+      
+      // NOTE: we use a timer here just to be absolutely sure the
+      // browser has re-rendered and hidden the gripper before attempting
+      // to get a screenshot. note that the usual tools, e.g. scheduleDeferred(),
+      // don't work as expected here
+      Timers.singleShot(200, () -> doCopyAsMetafile(onCompleted));
+   }
+   
+   private void doCopyAsMetafile(final Operation onCompleted)
+   {
+      ExportPlotSizeEditor sizeEditor = getSizeEditor();
       clipboard_.copyPlotToClipboardMetafile(
             sizeEditor.getImageWidth(),
             sizeEditor.getImageHeight(),
@@ -104,6 +117,7 @@ public class CopyPlotToClipboardDesktopMetafileDialog extends CopyPlotToClipboar
                @Override
                public void execute()
                {
+                  sizeEditor.setGripperVisible(true);
                   onCompleted.execute();
                }
             });


### PR DESCRIPTION
Closes #4864. Candidate for v1.2-patch backport.