### PR TITLE
tweak a11y landmarks to fix violations

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -169,6 +169,11 @@ public class Application implements ApplicationEventHandlers
       Widget w = view_.getWidget();
       rootPanel.add(w);
 
+      // a11y landmarks, we are a role=application, but wrapping that in a role=main helps
+      // placate various automated accessibility checks
+      rootPanel.getElement().setAttribute("role", "main");
+      w.getElement().setAttribute("role", "application");
+
       rootPanel.setWidgetTopBottom(w, 0, Style.Unit.PX, 0, Style.Unit.PX);
       rootPanel.setWidgetLeftRight(w, 0, Style.Unit.PX, 0, Style.Unit.PX);
 

--- a/src/gwt/www/index.htm
+++ b/src/gwt/www/index.htm
@@ -29,7 +29,7 @@
     <script type="text/javascript" language="javascript" src="#!gwt_prefix#rstudio/rstudio.nocache.js"></script>
   </head>
 
-  <body role="application">
+  <body>
   </body>
 
 </html>


### PR DESCRIPTION
Working on noise-reduction by cleaning violations flagged by automated tools (Lighthouse audit in Chrome, axe from deque).

I had the body element marked as role=application, but axe gives best-practice violation on that, "ARIA role must be appropriate for the element".

Both Lighthouse and axe give best-practice violation for lack of a top-level main landmark (i.e. a main landmark not inside another landmark).

Both give MUST fix WCAG level A violations from lack of a "skip navigation" link ("page must have means to bypass repeated blocks" from axe, and "The page does not contain a heading, skip link, or landmark region" from Lighthouse).

These latter two are fixed by introduction of the "main" landmark.