### PR TITLE
companion to https://github.com/rstudio/rstudio-pro/pull/1055

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarButton.java
@@ -14,33 +14,24 @@
  */
 package org.rstudio.core.client.widget;
 
-import com.google.gwt.aria.client.ExpandedValue;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.*;
 import com.google.gwt.dom.client.Style.Display;
 import com.google.gwt.event.dom.client.*;
-import com.google.gwt.event.logical.shared.CloseEvent;
-import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.event.shared.*;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.FocusWidget;
 import com.google.gwt.user.client.ui.Image;
-import com.google.gwt.user.client.ui.PopupPanel;
-import com.google.gwt.user.client.ui.PopupPanel.PositionCallback;
 import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.command.ImageResourceProvider;
 import org.rstudio.core.client.command.SimpleImageResourceProvider;
-import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.theme.res.ThemeStyles;
-
 
 public class ToolbarButton extends FocusWidget
 {
@@ -96,159 +87,11 @@ public class ToolbarButton extends FocusWidget
       this(text, title, new SimpleImageResourceProvider(leftImage), clickHandler);
    }
    
-   public ToolbarButton(String text, String title, ToolbarPopupMenu menu, boolean rightAlignMenu)
-   {
-      this(text,
-           title,
-           new ImageResource2x(ThemeResources.INSTANCE.menuDownArrow2x()),
-           (ImageResource) null,
-           (ClickHandler) null);
-      
-      leftImageWidget_.addStyleName("rstudio-themes-inverts");
-      
-      addMenuHandlers(menu, rightAlignMenu);
-      
-      addStyleName(styles_.toolbarButtonMenu());
-      addStyleName(styles_.toolbarButtonMenuOnly());
-   }
-      
    public ToolbarButton(String text,
                         String title,
                         ImageResource leftImage,
-                        ToolbarPopupMenu menu)
-   {
-      this(text, title, leftImage, menu, false);
-   }
-   
-   public ToolbarButton(String text,
-                        String title,
-                        ImageResourceProvider leftImage,
-                        ToolbarPopupMenu menu)
-   {
-      this(text, title, leftImage, menu, false);
-   }
-    
-   public ToolbarButton(String text,
-                        String title,
-                        ImageResource leftImage,
-                        ToolbarPopupMenu menu,
-                        boolean rightAlignMenu)
-   {
-      this(text,
-           title,
-           new SimpleImageResourceProvider(leftImage),
-           menu, 
-           rightAlignMenu);
-   }
-
-   public ToolbarButton(String text,
-                        String title,
-                        ImageResourceProvider leftImage,
-                        ToolbarPopupMenu menu,
-                        boolean rightAlignMenu)
-   {
-      this(text, title, leftImage, new ImageResource2x(ThemeResources.INSTANCE.menuDownArrow2x()), null);
-      
-      rightImageWidget_.addStyleName("rstudio-themes-inverts");
-
-      addMenuHandlers(menu, rightAlignMenu);
-      
-      addStyleName(styles_.toolbarButtonMenu());
-   }
-   
-   private void addMenuHandlers(final ToolbarPopupMenu popupMenu,
-                                final boolean rightAlignMenu)
-   {
-      Roles.getButtonRole().setAriaHaspopupProperty(getElement(), true);
-      
-      menu_ = popupMenu;
-      rightAlignMenu_ = rightAlignMenu;
-      
-      /*
-       * We want clicks on this button to toggle the visibility of the menu,
-       * as well as having the menu auto-hide itself as it normally does.
-       * It's necessary to manually track the visibility (menuShowing) because
-       * in the case where the menu is showing, clicking on this button first
-       * causes the menu to auto-hide and then our mouseDown handler is called
-       * (so we can't rely on menu.isShowing(), it'll always be false by the
-       * time you get into the mousedown handler).
-       */
-
-      final boolean[] menuShowing = new boolean[1];
-
-      addMouseDownHandler(new MouseDownHandler()
-      {
-         public void onMouseDown(MouseDownEvent event)
-         {
-            event.preventDefault();
-            event.stopPropagation();
-            addStyleName(styles_.toolbarButtonPushed());
-            // Some menus are rebuilt on every invocation. Ask the menu for 
-            // the most up-to-date version before proceeding.
-            popupMenu.getDynamicPopupMenu(
-               new ToolbarPopupMenu.DynamicPopupMenuCallback()
-            {
-               @Override
-               public void onPopupMenu(final ToolbarPopupMenu menu)
-               {
-                  if (menuShowing[0])
-                  {
-                     removeStyleName(styles_.toolbarButtonPushed());
-                     menu.hide();
-                     Roles.getButtonRole().setAriaExpandedState(getElement(), ExpandedValue.FALSE);
-                  }
-                  else
-                  {
-                     if (rightAlignMenu_)
-                     {
-                        menu.setPopupPositionAndShow(new PositionCallback() 
-                        {
-                           @Override
-                           public void setPosition(int offsetWidth, 
-                                                   int offsetHeight)
-                           {
-                              menu.setPopupPosition(
-                                 (rightImageWidget_ != null ?
-                                       rightImageWidget_.getAbsoluteLeft() :
-                                       leftImageWidget_.getAbsoluteLeft())
-                                 + 20 - offsetWidth, 
-                                 ToolbarButton.this.getAbsoluteTop() +
-                                 ToolbarButton.this.getOffsetHeight());
-                           } 
-                        });
-                     }
-                     else
-                     {
-                        menu.showRelativeTo(ToolbarButton.this);
-                     }
-                     menuShowing[0] = true;
-                     Roles.getButtonRole().setAriaExpandedState(getElement(), ExpandedValue.TRUE);
-                  }
-               }
-            });
-         }
-      });
-      popupMenu.addCloseHandler(new CloseHandler<PopupPanel>()
-      {
-         public void onClose(CloseEvent<PopupPanel> popupPanelCloseEvent)
-         {
-            removeStyleName(styles_.toolbarButtonPushed());
-            Scheduler.get().scheduleDeferred(new ScheduledCommand()
-            {
-               public void execute()
-               {
-                  menuShowing[0] = false;
-               }
-            });
-         }
-      });
-   }
-
-   private ToolbarButton(String text,
-                         String title,
-                         ImageResource leftImage,
-                         ImageResource rightImage,
-                         ClickHandler clickHandler)
+                        ImageResource rightImage,
+                        ClickHandler clickHandler)
    {
       this(text,
            title,
@@ -412,11 +255,6 @@ public class ToolbarButton extends FocusWidget
       return null;
    }
 
-   public ToolbarPopupMenu getMenu()
-   {
-      return menu_;
-   }
-
    public void setLeftImage(ImageResource imageResource)
    {
       leftImageWidget_.setResource(imageResource);
@@ -455,11 +293,6 @@ public class ToolbarButton extends FocusWidget
       return StringUtil.notNull(label_.getInnerText());
    }
    
-   public void setRightAlignMenu(boolean rightAlignMenu)
-   {
-      rightAlignMenu_ = rightAlignMenu;
-   }
-   
    public void setTitle(String title)
    {
       super.setTitle(title);
@@ -473,11 +306,9 @@ public class ToolbarButton extends FocusWidget
    
    interface Binder extends UiBinder<Element, ToolbarButton> { }
 
-   private ToolbarPopupMenu menu_;
-   private boolean rightAlignMenu_;
    private static final Binder binder = GWT.create(Binder.class);
 
-   private static final ThemeStyles styles_ = ThemeResources.INSTANCE.themeStyles();
+   protected static final ThemeStyles styles_ = ThemeResources.INSTANCE.themeStyles();
 
    @UiField
    TableCellElement leftImageCell_;
@@ -489,6 +320,6 @@ public class ToolbarButton extends FocusWidget
    DivElement infoLabel_;
    @UiField
    TableElement wrapper_;
-   private Image leftImageWidget_;
-   private Image rightImageWidget_;
+   protected Image leftImageWidget_;
+   protected Image rightImageWidget_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarMenuButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarMenuButton.java
@@ -1,0 +1,168 @@
+/*
+ * ToolbarMenuButton.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.widget;
+
+import com.google.gwt.aria.client.ExpandedValue;
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.user.client.ui.PopupPanel.PositionCallback;
+import org.rstudio.core.client.command.ImageResourceProvider;
+import org.rstudio.core.client.command.SimpleImageResourceProvider;
+import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.core.client.theme.res.ThemeResources;
+
+public class ToolbarMenuButton extends ToolbarButton
+{
+   public ToolbarMenuButton(String text, String title, ToolbarPopupMenu menu, boolean rightAlignMenu)
+   {
+      super(text,
+            title,
+            new ImageResource2x(ThemeResources.INSTANCE.menuDownArrow2x()),
+            (ImageResource) null,
+            (ClickHandler) null);
+      
+      leftImageWidget_.addStyleName("rstudio-themes-inverts");
+      
+      addMenuHandlers(menu, rightAlignMenu);
+      
+      addStyleName(styles_.toolbarButtonMenu());
+      addStyleName(styles_.toolbarButtonMenuOnly());
+   }
+
+   public ToolbarMenuButton(String text,
+                            String title,
+                            ImageResource leftImage,
+                            ToolbarPopupMenu menu)
+   {
+      this(text, title, leftImage, menu, false);
+   }
+
+   public ToolbarMenuButton(String text,
+                            String title,
+                            ImageResourceProvider leftImage,
+                            ToolbarPopupMenu menu)
+   {
+      this(text, title, leftImage, menu, false);
+   }
+
+   public ToolbarMenuButton(String text,
+                        String title,
+                        ImageResource leftImage,
+                        ToolbarPopupMenu menu,
+                        boolean rightAlignMenu)
+   {
+      this(text,
+           title,
+           new SimpleImageResourceProvider(leftImage),
+           menu, 
+           rightAlignMenu);
+   }
+
+   private ToolbarMenuButton(String text,
+                             String title,
+                             ImageResourceProvider leftImage,
+                             ToolbarPopupMenu menu,
+                             boolean rightAlignMenu)
+   {
+      super(text, title, leftImage, new ImageResource2x(ThemeResources.INSTANCE.menuDownArrow2x()), null);
+      
+      rightImageWidget_.addStyleName("rstudio-themes-inverts");
+      addMenuHandlers(menu, rightAlignMenu);
+      addStyleName(styles_.toolbarButtonMenu());
+   }
+
+   private void addMenuHandlers(final ToolbarPopupMenu popupMenu,
+                                final boolean rightAlignMenu)
+   {
+      Roles.getButtonRole().setAriaHaspopupProperty(getElement(), true);
+      
+      menu_ = popupMenu;
+      rightAlignMenu_ = rightAlignMenu;
+
+      /*
+       * We want clicks on this button to toggle the visibility of the menu,
+       * as well as having the menu auto-hide itself as it normally does.
+       * It's necessary to manually track the visibility (menuShowing) because
+       * in the case where the menu is showing, clicking on this button first
+       * causes the menu to auto-hide and then our mouseDown handler is called
+       * (so we can't rely on menu.isShowing(), it'll always be false by the
+       * time you get into the mousedown handler).
+       */
+
+      final boolean[] menuShowing = new boolean[1];
+
+      addMouseDownHandler(event -> {
+         event.preventDefault();
+         event.stopPropagation();
+         addStyleName(styles_.toolbarButtonPushed());
+         // Some menus are rebuilt on every invocation. Ask the menu for 
+         // the most up-to-date version before proceeding.
+         popupMenu.getDynamicPopupMenu(menu -> {
+            if (menuShowing[0])
+            {
+               removeStyleName(styles_.toolbarButtonPushed());
+               menu.hide();
+               Roles.getButtonRole().setAriaExpandedState(getElement(), ExpandedValue.FALSE);
+            }
+            else
+            {
+               if (rightAlignMenu_)
+               {
+                  menu.setPopupPositionAndShow(new PositionCallback() 
+                  {
+                     @Override
+                     public void setPosition(int offsetWidth, 
+                                             int offsetHeight)
+                     {
+                        menu.setPopupPosition(
+                           (rightImageWidget_ != null ?
+                                 rightImageWidget_.getAbsoluteLeft() :
+                                 leftImageWidget_.getAbsoluteLeft())
+                           + 20 - offsetWidth, 
+                           ToolbarMenuButton.this.getAbsoluteTop() +
+                           ToolbarMenuButton.this.getOffsetHeight());
+                     } 
+                  });
+               }
+               else
+               {
+                  menu.showRelativeTo(ToolbarMenuButton.this);
+               }
+               menuShowing[0] = true;
+               Roles.getButtonRole().setAriaExpandedState(getElement(), ExpandedValue.TRUE);
+            }
+         });
+      });
+      popupMenu.addCloseHandler(popupPanelCloseEvent -> {
+         removeStyleName(styles_.toolbarButtonPushed());
+         Scheduler.get().scheduleDeferred(() -> menuShowing[0] = false);
+      });
+   }
+
+   public void setRightAlignMenu(boolean rightAlignMenu)
+   {
+      rightAlignMenu_ = rightAlignMenu;
+   }
+
+   public ToolbarPopupMenu getMenu()
+   {
+      return menu_;
+   }
+
+   private ToolbarPopupMenu menu_;
+   private boolean rightAlignMenu_;
+}

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenuButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenuButton.java
@@ -26,7 +26,7 @@ import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.MenuBar;
 import com.google.gwt.user.client.ui.MenuItem;
 
-public class ToolbarPopupMenuButton extends ToolbarButton
+public class ToolbarPopupMenuButton extends ToolbarMenuButton
                                     implements HasValueChangeHandlers<String>
 {
    public ToolbarPopupMenuButton()

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
@@ -21,6 +21,7 @@ import org.rstudio.core.client.widget.FocusContext;
 import org.rstudio.core.client.widget.FocusHelper;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.application.ui.addins.AddinsToolbarButton;
 import org.rstudio.studio.client.common.icons.StandardIcons;
@@ -73,10 +74,10 @@ public class GlobalToolbar extends Toolbar
       
       // create and add new menu
       StandardIcons icons = StandardIcons.INSTANCE;
-      ToolbarButton newButton = new ToolbarButton(ToolbarButton.NoText,
-                                                  "New File",
-                                                  new ImageResource2x(icons.stock_new2x()),
-                                                  newMenu_);
+      ToolbarMenuButton newButton = new ToolbarMenuButton(ToolbarButton.NoText,
+                                                          "New File",
+                                                          new ImageResource2x(icons.stock_new2x()),
+                                                          newMenu_);
       addLeftWidget(newButton);
       addLeftSeparator();
       
@@ -105,10 +106,10 @@ public class GlobalToolbar extends Toolbar
       mruMenu.addSeparator();
       mruMenu.addItem(commands.clearRecentFiles().createMenuItem(false));
       
-      ToolbarButton mruButton = new ToolbarButton(ToolbarButton.NoText, 
-                                                  "Open recent files", 
-                                                  mruMenu, 
-                                                  false);
+      ToolbarMenuButton mruButton = new ToolbarMenuButton(ToolbarButton.NoText, 
+                                                          "Open recent files", 
+                                                          mruMenu, 
+                                                          false);
       addLeftWidget(mruButton);
       addLeftSeparator();
       
@@ -121,7 +122,7 @@ public class GlobalToolbar extends Toolbar
       
       addLeftSeparator();
       CodeSearch codeSearch = pCodeSearch_.get();
-      codeSearch.setObserver(new CodeSearch.Observer() {     
+      codeSearch.setObserver(new CodeSearch.Observer() {
          @Override
          public void onCancel()
          {
@@ -192,7 +193,7 @@ public class GlobalToolbar extends Toolbar
          else if (sessionInfo.getVcsName() == VCSConstants.SVN_ID)
             vcsIcon = new ImageResource2x(icons.svn2x());
          
-         ToolbarButton vcsButton = new ToolbarButton(
+         ToolbarMenuButton vcsButton = new ToolbarMenuButton(
                ToolbarButton.NoText,
                "Version control",
                vcsIcon, 
@@ -227,7 +228,7 @@ public class GlobalToolbar extends Toolbar
       paneLayoutMenu.addItem(commands_.layoutZoomConnections().createMenuItem(false));
       
       ImageResource paneLayoutIcon = new ImageResource2x(ThemeResources.INSTANCE.paneLayoutIcon2x());
-      ToolbarButton paneLayoutButton = new ToolbarButton(
+      ToolbarMenuButton paneLayoutButton = new ToolbarMenuButton(
             ToolbarButton.NoText,
             "Workspace Panes",
             paneLayoutIcon,

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/ProjectPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/ProjectPopupMenu.java
@@ -19,6 +19,7 @@ import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.Desktop;
@@ -80,7 +81,7 @@ public class ProjectPopupMenu extends ToolbarPopupMenu
                   mruList_.getQualifiedLabel(activeProjectFile_) :
                   "Project: (None)";
           
-         toolbarButton_ = new ToolbarButton(
+         toolbarButton_ = new ToolbarMenuButton(
                 buttonText,
                 ToolbarButton.NoTitle,
                 new ImageResource2x(RESOURCES.projectMenu2x()),
@@ -281,7 +282,7 @@ public class ProjectPopupMenu extends ToolbarPopupMenu
    private static final int MAX_SHARED_PROJECTS = 5;
    private static final int MAX_MRU_ENTRIES = 10;
    private final String activeProjectFile_;
-   private ToolbarButton toolbarButton_ = null;
+   private ToolbarMenuButton toolbarButton_ = null;
 
    private ProjectMRUList mruList_;
    private Commands commands_;

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/addins/AddinsToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/addins/AddinsToolbarButton.java
@@ -28,6 +28,7 @@ import org.rstudio.core.client.widget.CustomMenuItemSeparator;
 import org.rstudio.core.client.widget.ScrollableToolbarPopupMenu;
 import org.rstudio.core.client.widget.SearchWidget;
 import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.workbench.addins.Addins.AddinExecutor;
@@ -51,7 +52,7 @@ import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.MenuItem;
 import com.google.inject.Inject;
 
-public class AddinsToolbarButton extends ToolbarButton
+public class AddinsToolbarButton extends ToolbarMenuButton
 {
    public AddinsToolbarButton()
    {

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewPanel.java
@@ -38,6 +38,7 @@ import org.rstudio.core.client.widget.AnchorableFrame;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.core.client.widget.ToolbarLabel;
+import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.Desktop;
@@ -75,7 +76,7 @@ public class HTMLPreviewPanel extends ResizeComposite
    {
       toolbar_.setVisible(visible);
       int frameTop = visible ? tbHeight_+1 : 0;
-      layoutPanel_.setWidgetTopBottom(previewFrame_, frameTop, Unit.PX, 0, Unit.PX);    
+      layoutPanel_.setWidgetTopBottom(previewFrame_, frameTop, Unit.PX, 0, Unit.PX);
    }
    
    private Toolbar createToolbar(Commands commands)
@@ -108,7 +109,7 @@ public class HTMLPreviewPanel extends ResizeComposite
          menu.addItem(commands.saveHtmlPreviewAs().createMenuItem(false));
          menu.addItem(commands.saveHtmlPreviewAsLocalFile().createMenuItem(false));
       
-         saveHtmlPreviewAs_ = toolbar.addLeftWidget(new ToolbarButton(
+         saveHtmlPreviewAs_ = toolbar.addLeftWidget(new ToolbarMenuButton(
                "Save As",
                ToolbarButton.NoTitle,
                commands.saveSourceDoc().getImageResource(),

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishButton.java
@@ -26,6 +26,7 @@ import org.rstudio.core.client.command.VisibleChangedHandler;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
@@ -116,7 +117,7 @@ public class RSConnectPublishButton extends Composite
       
       // create drop menu of previous deployments/other commands
       publishMenu_ = new DeploymentPopupMenu();
-      publishMenuButton_ = new ToolbarButton(ToolbarButton.NoText, "Publish options", publishMenu_, true);
+      publishMenuButton_ = new ToolbarMenuButton(ToolbarButton.NoText, "Publish options", publishMenu_, true);
       publishMenuButton_.getElement().setId(ElementIds.ID_PREFIX + 
             ElementIds.PUBLISH_SHOW_DEPLOYMENTS + "_" + host);
       panel.add(publishMenuButton_);
@@ -948,7 +949,7 @@ public class RSConnectPublishButton extends Composite
    
    private final ToolbarButton publishButton_;
    private final DeploymentPopupMenu publishMenu_;
-   private ToolbarButton publishMenuButton_;
+   private ToolbarMenuButton publishMenuButton_;
 
    private RSConnectServerOperations server_;
    private RMarkdownServerOperations rmdServer_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPane.java
@@ -31,6 +31,7 @@ import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.CheckableMenuItem;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.compile.CompileOutput;
@@ -92,7 +93,7 @@ public class BuildPane extends WorkbenchPane
       if (sessionInfo.getBuildToolsBookdownWebsite())
       {
          BookdownBuildPopupMenu buildPopupMenu = new BookdownBuildPopupMenu();
-         ToolbarButton buildMenuButton = new ToolbarButton(ToolbarButton.NoText,
+         ToolbarMenuButton buildMenuButton = new ToolbarMenuButton(ToolbarButton.NoText,
                "Build book options", buildPopupMenu, true);
          toolbar.addLeftWidget(buildMenuButton);
       }
@@ -137,11 +138,11 @@ public class BuildPane extends WorkbenchPane
          moreMenu.addItem(commands_.buildToolsProjectSetup().createMenuItem(false));
          
          // add more menu
-         ToolbarButton moreButton = new ToolbarButton(
-                                      "More",
-                                      ToolbarButton.NoTitle,
-                                      new ImageResource2x(StandardIcons.INSTANCE.more_actions2x()),
-                                      moreMenu);
+         ToolbarMenuButton moreButton = new ToolbarMenuButton(
+               "More",
+               ToolbarButton.NoTitle,
+               new ImageResource2x(StandardIcons.INSTANCE.more_actions2x()),
+               moreMenu);
          toolbar.addLeftWidget(moreButton);
       }
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsPane.java
@@ -61,6 +61,7 @@ import org.rstudio.core.client.widget.SlidingLayoutPanel;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.core.client.widget.ToolbarLabel;
+import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.workbench.commands.Commands;
@@ -388,7 +389,7 @@ public class ConnectionsPane extends WorkbenchPane
                "Copy to Clipboard",
                ConnectionOptions.CONNECT_COPY_TO_CLIPBOARD));
       }
-      connectMenuButton_ = new ToolbarButton(
+      connectMenuButton_ = new ToolbarMenuButton(
             "Connect",
             ToolbarButton.NoTitle,
             commands_.newConnection().getImageResource(), 
@@ -591,7 +592,7 @@ public class ConnectionsPane extends WorkbenchPane
    private SearchWidget searchWidget_;
    private SearchWidget objectSearchWidget_;
    private ToolbarButton backToConnectionsButton_;
-   private ToolbarButton connectMenuButton_;
+   private ToolbarMenuButton connectMenuButton_;
    
    private SecondaryToolbar secondaryToolbar_;
    private ToolbarLabel connectionName_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -30,6 +30,7 @@ import org.rstudio.core.client.widget.SearchWidget;
 import org.rstudio.core.client.widget.SecondaryToolbar;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.ui.RStudioThemes;
@@ -129,7 +130,7 @@ public class EnvironmentPane extends WorkbenchPane
       ToolbarPopupMenu menu = new ToolbarPopupMenu();
       menu.addItem(createViewMenuItem(EnvironmentObjects.OBJECT_LIST_VIEW));
       menu.addItem(createViewMenuItem(EnvironmentObjects.OBJECT_GRID_VIEW));
-      viewButton_ = new ToolbarButton(
+      viewButton_ = new ToolbarMenuButton(
             nameOfViewType(EnvironmentObjects.OBJECT_LIST_VIEW),
             ToolbarButton.NoTitle,
             imageOfViewType(EnvironmentObjects.OBJECT_LIST_VIEW),
@@ -152,7 +153,8 @@ public class EnvironmentPane extends WorkbenchPane
             AppCommand.formatMenuLabel(null, "Refresh Now", null),
             true, // as HTML
             () -> commands_.refreshEnvironment().execute()));
-      toolbar.addRightWidget(new ToolbarButton(ToolbarButton.NoText, "Refresh options", refreshMenu, false));
+      toolbar.addRightWidget(
+            new ToolbarMenuButton(ToolbarButton.NoText, "Refresh options", refreshMenu, false));
 
       return toolbar;
    }
@@ -163,7 +165,7 @@ public class EnvironmentPane extends WorkbenchPane
       SecondaryToolbar toolbar = new SecondaryToolbar();
       
       environmentMenu_ = new EnvironmentPopupMenu();
-      environmentButton_ = new ToolbarButton(
+      environmentButton_ = new ToolbarMenuButton(
             friendlyEnvironmentName(),
             ToolbarButton.NoTitle,
             imageOfEnvironment(environmentName_, environmentIsLocal_),
@@ -491,7 +493,7 @@ public class EnvironmentPane extends WorkbenchPane
       menu.addSeparator();
       menu.addItem(commands_.importDatasetFromMongo().createMenuItem(false));
       
-      dataImportButton_ = new ToolbarButton(
+      dataImportButton_ = new ToolbarMenuButton(
               "Import Dataset",
               ToolbarButton.NoTitle,
               new ImageResource2x(StandardIcons.INSTANCE.import_dataset2x()),
@@ -719,10 +721,10 @@ public class EnvironmentPane extends WorkbenchPane
    private final UIPrefs prefs_;
    private final Value<Boolean> environmentMonitoring_;
 
-   private ToolbarButton dataImportButton_;
+   private ToolbarMenuButton dataImportButton_;
    private ToolbarPopupMenu environmentMenu_;
-   private ToolbarButton environmentButton_;
-   private ToolbarButton viewButton_;
+   private ToolbarMenuButton environmentButton_;
+   private ToolbarMenuButton viewButton_;
    private ToolbarButton refreshButton_; 
    private EnvironmentObjects objects_;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FileCommandToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FileCommandToolbar.java
@@ -20,6 +20,7 @@ import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.core.client.widget.UIPrefMenuItem;
 import org.rstudio.studio.client.common.icons.StandardIcons;
@@ -58,12 +59,12 @@ public class FileCommandToolbar extends Toolbar
       moreMenu.addItem(new UIPrefMenuItem<Boolean>(
             prefs.showHiddenFiles(), true, "Show Hidden Files", prefs));
 
-      ToolbarButton moreButton = new ToolbarButton("More",
-                                                   "More file commands",
-                                                   new ImageResource2x(icons.more_actions2x()),
-                                                   moreMenu);
+      ToolbarMenuButton moreButton = new ToolbarMenuButton(
+            "More",
+            "More file commands",
+            new ImageResource2x(icons.more_actions2x()),
+            moreMenu);
       addLeftWidget(moreButton);
-      
 
       // Refresh
       ToolbarButton refreshButton = commands.refreshFiles().createToolbarButton();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/markers/MarkerSetsToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/markers/MarkerSetsToolbarButton.java
@@ -16,6 +16,7 @@ package org.rstudio.studio.client.workbench.views.output.markers;
 
 import org.rstudio.core.client.widget.ScrollableToolbarPopupMenu;
 import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.common.icons.StandardIcons;
 
@@ -28,10 +29,9 @@ import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.ui.MenuItem;
 
-public class MarkerSetsToolbarButton extends ToolbarButton
+public class MarkerSetsToolbarButton extends ToolbarMenuButton
                                      implements HasValueChangeHandlers<String>
 {
-
    public MarkerSetsToolbarButton()
    {
       super(ToolbarButton.NoText,
@@ -75,13 +75,9 @@ public class MarkerSetsToolbarButton extends ToolbarButton
       }
    }
    
-   
    @Override
    public HandlerRegistration addValueChangeHandler(ValueChangeHandler<String> handler)
    {
       return addHandler(handler, ValueChangeEvent.getType());
    }
-
-   
- 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
@@ -29,6 +29,7 @@ import org.rstudio.core.client.widget.RStudioDataGrid;
 import org.rstudio.core.client.widget.SearchWidget;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
@@ -212,7 +213,7 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
       packratMenu.addItem(commands_.packratBundle().createMenuItem(false));
       packratMenu.addSeparator();
       packratMenu.addItem(commands_.packratOptions().createMenuItem(false));
-      packratMenuButton_ = new ToolbarButton(
+      packratMenuButton_ = new ToolbarMenuButton(
             "Packrat", 
             ToolbarButton.NoTitle,
             commands_.packratBootstrap().getImageResource(),
@@ -670,7 +671,7 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
    private PackagesDisplayObserver observer_ ;
    
    private ToolbarButton packratBootstrapButton_;
-   private ToolbarButton packratMenuButton_;
+   private ToolbarMenuButton packratMenuButton_;
    private Widget prePackratSeparator_;
    private LayoutPanel packagesTableContainer_;
    private int gridRenderRetryCount_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/PlotsToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/PlotsToolbar.java
@@ -19,6 +19,7 @@ import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.HasCustomizableToolbar;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.common.icons.StandardIcons;
 import org.rstudio.studio.client.rsconnect.ui.RSConnectPublishButton;
@@ -62,7 +63,7 @@ public class PlotsToolbar extends Toolbar implements HasCustomizableToolbar
       exportMenu.addItem(commands_.savePlotAsPdf().createMenuItem(false));
       exportMenu.addSeparator();
       exportMenu.addItem(commands_.copyPlotToClipboard().createMenuItem(false));
-      ToolbarButton exportButton = new ToolbarButton(
+      ToolbarMenuButton exportButton = new ToolbarMenuButton(
             "Export", ToolbarButton.NoTitle, 
             new ImageResource2x(StandardIcons.INSTANCE.export_menu2x()),
             exportMenu);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/presentation/PresentationPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/presentation/PresentationPane.java
@@ -40,6 +40,7 @@ import org.rstudio.core.client.widget.FullscreenPopupPanel;
 import org.rstudio.core.client.widget.AnchorableFrame;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.common.AutoGlassPanel;
 import org.rstudio.studio.client.common.GlobalDisplay;
@@ -91,12 +92,11 @@ public class PresentationPane extends WorkbenchPane implements Presentation.Disp
       moreMenu.addSeparator();
       moreMenu.addItem(commands_.presentationViewInBrowser().createMenuItem(false));
       moreMenu.addItem(commands_.presentationSaveAsStandalone().createMenuItem(false));
-      
-      ToolbarButton moreButton = new ToolbarButton("More",
-                                                   "More presentation commands",
-                                                   new ImageResource2x(
-                                                      StandardIcons.INSTANCE.more_actions2x()),
-                                                   moreMenu);
+
+      ToolbarMenuButton moreButton = new ToolbarMenuButton("More",
+            "More presentation commands",
+            new ImageResource2x(StandardIcons.INSTANCE.more_actions2x()),
+            moreMenu);
 
       toolbar.addRightWidget(moreButton);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.java
@@ -38,6 +38,7 @@ import org.rstudio.core.client.widget.InfoBar;
 import org.rstudio.core.client.widget.SecondaryToolbar;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
@@ -406,7 +407,7 @@ public class CodeBrowserEditingTargetWidget extends ResizeComposite
       ToolbarPopupMenu menu = new ToolbarPopupMenu();
       menu.addItem(commands_.goToHelp().createMenuItem(false));
       menu.addItem(commands_.goToDefinition().createMenuItem(false));
-      ToolbarButton codeTools = new ToolbarButton(ToolbarButton.NoText, "Code Tools", icon, menu);
+      ToolbarMenuButton codeTools = new ToolbarMenuButton(ToolbarButton.NoText, "Code Tools", icon, menu);
       toolbar.addLeftWidget(codeTools);
       
       toolbar.addRightWidget(commands_.executeCode().createToolbarButton());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -340,7 +340,7 @@ public class TextEditingTargetWidget
 
       ToolbarPopupMenu shinyTestMenu = shinyTestMenu_;
       if (fileType.canKnitToHTML()) {
-         shinyLaunchButton_ = new ToolbarButton(
+         shinyLaunchButton_ = new ToolbarMenuButton(
                ToolbarButton.NoText,
                "Shiny test options",
                shinyTestMenu, true);
@@ -365,7 +365,7 @@ public class TextEditingTargetWidget
       ToolbarPopupMenu rmdOptionsMenu = new ToolbarPopupMenu();
       rmdOptionsMenu.addItem(commands_.editRmdFormatOptions().createMenuItem(false));
       
-      rmdOptionsButton_ = new ToolbarButton(
+      rmdOptionsButton_ = new ToolbarMenuButton(
             ToolbarButton.NoText,
             commands_.editRmdFormatOptions().getTooltip(),
             new ImageResource2x(StandardIcons.INSTANCE.options2x()),
@@ -389,7 +389,7 @@ public class TextEditingTargetWidget
       insertChunksMenu.addItem(commands_.insertChunkSQL().createMenuItem(false));
       insertChunksMenu.addItem(commands_.insertChunkStan().createMenuItem(false));
 
-      insertChunkMenu_ = new ToolbarButton(
+      insertChunkMenu_ = new ToolbarMenuButton(
                        "Insert",
                        commands_.insertChunk().getTooltip(),
                        commands_.insertChunk().getImageResource(),
@@ -454,7 +454,7 @@ public class TextEditingTargetWidget
       sourceMenu.addItem(commands_.sourceAsLauncherJob().createMenuItem(false));
       sourceMenu.addItem(commands_.sourceAsJob().createMenuItem(false));
          
-      sourceMenuButton_ = new ToolbarButton(ToolbarButton.NoText, "Source options", sourceMenu, true);
+      sourceMenuButton_ = new ToolbarMenuButton(ToolbarButton.NoText, "Source options", sourceMenu, true);
       toolbar.addRightWidget(sourceMenuButton_);
 
       //toolbar.addRightSeparator();
@@ -482,7 +482,7 @@ public class TextEditingTargetWidget
       }
       chunksMenu.addSeparator();
       chunksMenu.addItem(commands_.executeAllCode().createMenuItem(false));
-      chunksButton_ = new ToolbarButton(
+      chunksButton_ = new ToolbarMenuButton(
                        "Run",
                        ToolbarButton.NoTitle,
                        commands_.executeCode().getImageResource(),
@@ -492,7 +492,7 @@ public class TextEditingTargetWidget
       
       ToolbarPopupMenu shinyLaunchMenu = shinyViewerMenu_;
       if (!fileType.canKnitToHTML()) {
-         shinyLaunchButton_ = new ToolbarButton(
+         shinyLaunchButton_ = new ToolbarMenuButton(
                ToolbarButton.NoText,
                "Run app options",
                shinyLaunchMenu, 
@@ -501,7 +501,7 @@ public class TextEditingTargetWidget
       }
       shinyLaunchButton_.setVisible(false);
 
-      plumberLaunchButton_ = new ToolbarButton(
+      plumberLaunchButton_ = new ToolbarMenuButton(
             ToolbarButton.NoText,
             "Run API options",
             plumberViewerMenu_, 
@@ -621,7 +621,7 @@ public class TextEditingTargetWidget
       ToolbarPopupMenu texMenu = new TextEditingTargetLatexFormatMenu(editor_,
                                                                       uiPrefs_);
     
-      ToolbarButton texButton = new ToolbarButton(
+      ToolbarMenuButton texButton = new ToolbarMenuButton(
                            "Format", 
                            ToolbarButton.NoTitle,
                            fileTypeRegistry_.getIconForFilename("foo.tex"), 
@@ -658,7 +658,7 @@ public class TextEditingTargetWidget
          menu.addItem(commands_.showDiagnosticsProject().createMenuItem(false));
          menu.addSeparator();
          menu.addItem(commands_.profileCode().createMenuItem(false));
-         codeTransform_ = new ToolbarButton(ToolbarButton.NoText, "Code Tools", icon, menu);
+         codeTransform_ = new ToolbarMenuButton(ToolbarButton.NoText, "Code Tools", icon, menu);
       }
       
       return codeTransform_;
@@ -1555,11 +1555,11 @@ public class TextEditingTargetWidget
    private Toolbar toolbar_;
    private InfoBar warningBar_;
    private final TextEditingTargetFindReplace findReplace_;
-   private ToolbarButton codeTransform_;
+   private ToolbarMenuButton codeTransform_;
    private ToolbarButton compilePdfButton_;
    private ToolbarButton previewHTMLButton_;
    private ToolbarButton knitDocumentButton_;
-   private ToolbarButton insertChunkMenu_;
+   private ToolbarMenuButton insertChunkMenu_;
    private ToolbarButton insertChunkButton_;
    private ToolbarButton goToPrevButton_;
    private ToolbarButton goToNextButton_;
@@ -1571,12 +1571,12 @@ public class TextEditingTargetWidget
    private ToolbarButton testThatButton_;
    private ToolbarButton testShinyButton_;
    private ToolbarButton compareTestButton_;
-   private ToolbarButton sourceMenuButton_;
+   private ToolbarMenuButton sourceMenuButton_;
    private UIPrefMenuItem<Boolean> runSetupChunkOptionMenu_;
-   private ToolbarButton chunksButton_;
-   private ToolbarButton shinyLaunchButton_;
-   private ToolbarButton plumberLaunchButton_;
-   private ToolbarButton rmdOptionsButton_;
+   private ToolbarMenuButton chunksButton_;
+   private ToolbarMenuButton shinyLaunchButton_;
+   private ToolbarMenuButton plumberLaunchButton_;
+   private ToolbarMenuButton rmdOptionsButton_;
    private LatchingToolbarButton toggleDocOutlineButton_;
    private CheckBox showWhitespaceCharactersCheckbox_;
    private ToolbarPopupMenuButton rmdFormatButton_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
@@ -19,6 +19,7 @@ import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
@@ -114,7 +115,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
       {
          String buttonText = "Terminal";
          
-         toolbarButton_ = new ToolbarButton(
+         toolbarButton_ = new ToolbarMenuButton(
                 buttonText, 
                 ToolbarButton.NoTitle,
                 StandardIcons.INSTANCE.empty_command(),
@@ -303,7 +304,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
       return null;
    }
 
-   private ToolbarButton toolbarButton_;
+   private ToolbarMenuButton toolbarButton_;
    private String activeTerminalHandle_;
    private TerminalList terminals_;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
@@ -59,13 +59,14 @@ import org.rstudio.core.client.widget.CustomMenuItemSeparator;
 import org.rstudio.core.client.widget.ScrollableToolbarPopupMenu;
 import org.rstudio.core.client.widget.SearchWidget;
 import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.common.icons.StandardIcons;
 import org.rstudio.studio.client.workbench.views.vcs.common.events.VcsRefreshEvent;
 import org.rstudio.studio.client.workbench.views.vcs.common.events.VcsRefreshHandler;
 import org.rstudio.studio.client.workbench.views.vcs.git.model.GitState;
 
-public class BranchToolbarButton extends ToolbarButton
+public class BranchToolbarButton extends ToolbarMenuButton
                                  implements HasValueChangeHandlers<String>,
                                             VcsRefreshHandler
 {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/CommitFilterToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/CommitFilterToolbarButton.java
@@ -17,7 +17,7 @@ package org.rstudio.studio.client.workbench.views.vcs.dialog;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.ProgressOperationWithInput;
-import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.common.FileDialogs;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
@@ -33,7 +33,7 @@ import com.google.gwt.user.client.ui.HasValue;
 import com.google.gwt.user.client.ui.MenuItem;
 import com.google.inject.Inject;
 
-public class CommitFilterToolbarButton extends ToolbarButton
+public class CommitFilterToolbarButton extends ToolbarMenuButton
                                        implements HasValue<FileSystemItem>
 {
    @Inject

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
@@ -30,6 +30,7 @@ import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.common.icons.StandardIcons;
@@ -56,7 +57,7 @@ public class GitPane extends WorkbenchPane implements Display
       
       commands_ = commands;
       switchBranchToolbarButton_ = switchBranchToolbarButton;
-      createBranchToolbarButton_ = createBranchToolbarButton;     
+      createBranchToolbarButton_ = createBranchToolbarButton;
       
       table_ = changelistTablePresenter.getView();
       table_.addStyleName("ace_editor_theme");
@@ -92,13 +93,13 @@ public class GitPane extends WorkbenchPane implements Display
       toolbar.addLeftWidget(commands_.vcsCommit().createToolbarButton());
       toolbar.addLeftSeparator();
       toolbar.addLeftWidget(pullButton_ = commands_.vcsPull().createToolbarButton());
-      toolbar.addLeftWidget(new ToolbarButton(ToolbarButton.NoText, "Pull options", pullMoreMenu, true));
+      toolbar.addLeftWidget(new ToolbarMenuButton(ToolbarButton.NoText, "Pull options", pullMoreMenu, true));
       toolbar.addLeftSeparator();
       toolbar.addLeftWidget(pushButton_ = commands_.vcsPush().createToolbarButton());
       toolbar.addLeftSeparator();
       toolbar.addLeftWidget(historyButton_ = commands_.vcsShowHistory().createToolbarButton());
       toolbar.addLeftSeparator();
-      toolbar.addLeftWidget(moreButton_ = new ToolbarButton(
+      toolbar.addLeftWidget(moreButton_ = new ToolbarMenuButton(
             "More",
             ToolbarButton.NoTitle,
             new ImageResource2x(StandardIcons.INSTANCE.more_actions2x()),
@@ -229,13 +230,13 @@ public class GitPane extends WorkbenchPane implements Display
          @Override
          public void setPosition(int offsetWidth, int offsetHeight)
          {
-            menu.setPopupPosition(clientX, clientY);     
+            menu.setPopupPosition(clientX, clientY);
          }
       });
    }
 
    private ToolbarButton historyButton_;
-   private ToolbarButton moreButton_;
+   private ToolbarMenuButton moreButton_;
    private ToolbarButton pullButton_;
    private ToolbarButton pushButton_;
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNPane.java
@@ -21,6 +21,7 @@ import com.google.inject.Inject;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.common.icons.StandardIcons;
 import org.rstudio.studio.client.common.vcs.StatusAndPath;
@@ -84,7 +85,7 @@ public class SVNPane extends WorkbenchPane implements Display
       moreMenu.addSeparator();
       moreMenu.addItem(commands_.showShellDialog().createMenuItem(false));
 
-      toolbar.addLeftWidget(new ToolbarButton(
+      toolbar.addLeftWidget(new ToolbarMenuButton(
           "More",
           ToolbarButton.NoTitle,
           new ImageResource2x(StandardIcons.INSTANCE.more_actions2x()),

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
@@ -26,6 +26,7 @@ import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.RStudioFrame;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
@@ -82,10 +83,10 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
       exportMenu.addSeparator();
       exportMenu.addItem(commands_.viewerSaveAsWebPage().createMenuItem(false));
       
-      exportButton_ = new ToolbarButton(
+      exportButton_ = new ToolbarMenuButton(
             "Export", ToolbarButton.NoTitle, new ImageResource2x(StandardIcons.INSTANCE.export_menu2x()),
             exportMenu);
-      toolbar_.addLeftWidget(exportButton_);  
+      toolbar_.addLeftWidget(exportButton_);
       exportButton_.setVisible(false);
       exportButtonSeparator_.setVisible(false);
       
@@ -346,13 +347,10 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
    
    private RSConnectPublishButton publishButton_;
    
-   private ToolbarButton exportButton_;
+   private ToolbarMenuButton exportButton_;
    private Widget exportButtonSeparator_;
 
    public static final String ABOUT_BLANK = "about:blank";
 
-   private static boolean initializedMessageListeners_;
-   private static ViewerPane activeViewerPane_;
-   
    private HtmlMessageListener htmlMessageListener_;
 }


### PR DESCRIPTION
Mechanical refactoring to extract ToolbarMenuButton class from ToolbarButton, and change call sites to use the appropriate one. There were a small number of pro-specific uses as well, so this is a companion to that change. https://github.com/rstudio/rstudio-pro/pull/1055