### PR TITLE
a11y fixes for toolbar buttons and menubuttons

### DIFF
--- a/src/gwt/src/com/google/gwt/user/client/ui/MenuItem.java
+++ b/src/gwt/src/com/google/gwt/user/client/ui/MenuItem.java
@@ -15,7 +15,6 @@
  */
 package com.google.gwt.user.client.ui;
 
-import com.google.gwt.aria.client.ExpandedValue;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.safehtml.client.HasSafeHtml;
@@ -24,6 +23,7 @@ import com.google.gwt.safehtml.shared.annotations.IsSafeHtml;
 import com.google.gwt.safehtml.shared.annotations.SuppressIsSafeHtmlCastCheck;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.DOM;
+import org.rstudio.core.client.a11y.A11y;
 
 /**
  * An entry in a
@@ -276,9 +276,7 @@ public class MenuItem extends UIObject implements HasHTML, HasEnabled, HasSafeHt
 
   public void setAriaExpanded(boolean expanded)
   {
-    Roles.getMenubarRole().setAriaExpandedState(
-          getElement(), 
-          expanded ? ExpandedValue.TRUE : ExpandedValue.FALSE);
+    A11y.setARIAMenuItemExpanded(getElement(), expanded);
   }
 
   @Override

--- a/src/gwt/src/com/google/gwt/user/client/ui/MenuItem.java.diff
+++ b/src/gwt/src/com/google/gwt/user/client/ui/MenuItem.java.diff
@@ -1,14 +1,12 @@
-17a18
-> import com.google.gwt.aria.client.ExpandedValue;
+25a26
+> import org.rstudio.core.client.a11y.A11y;
 228a230
 >     Roles.getMenuitemRole().setAriaDisabledState(getElement(), !enabled);
 267a270
 >       setAriaExpanded(false);
-273a277,283
+273a277,281
 >   public void setAriaExpanded(boolean expanded)
 >   {
->     Roles.getMenubarRole().setAriaExpandedState(
->           getElement(), 
->           expanded ? ExpandedValue.TRUE : ExpandedValue.FALSE);
+>     A11y.setARIAMenuItemExpanded(getElement(), expanded);
 >   }
 > 

--- a/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
+++ b/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
@@ -38,7 +38,11 @@ public class A11y
 
    public static void setARIAMenuItemExpanded(Element element, boolean expanded)
    {
-      element.setAttribute("aria-expanded", expanded ? "true" : "false");
+      // W3C recommends having no aria-expanded state when value is false
+      if (expanded)
+         element.setAttribute("aria-expanded", "true");
+      else
+         element.removeAttribute("aria-expanded");
    }
 
    public static void setARIATablistOrientation(Element element, boolean vertical)

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarButton.java
@@ -216,6 +216,16 @@ public class ToolbarButton extends FocusWidget
          }
       });
 
+      final HandlerRegistration keyPress = addKeyPressHandler(event -> {
+         char charCode = event.getCharCode();
+         if (charCode == KeyCodes.KEY_ENTER || charCode == KeyCodes.KEY_SPACE)
+         {
+            event.preventDefault();
+            event.stopPropagation();
+            click();
+         }
+      });
+
       return new HandlerRegistration()
       {
          public void removeHandler()
@@ -223,6 +233,7 @@ public class ToolbarButton extends FocusWidget
             mouseDown.removeHandler();
             mouseOut.removeHandler();
             mouseUp.removeHandler();
+            keyPress.removeHandler();
          }
       }; 
    }

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
@@ -259,10 +259,11 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
                         selectLast();
                         break;
                      case KeyCodes.KEY_ENTER:
-                        e.cancel();
+                     case KeyCodes.KEY_SPACE:
                         final MenuItem menuItem = getSelectedItem();
                         if (menuItem != null)
                         {
+                           e.cancel();
                            NativeEvent evt = Document.get().createClickEvent(
                                  0,
                                  0,


### PR DESCRIPTION
- fixes #4899 to enable button click via enter or space key
- if menu is opened but nothing yet selected, allow enter key and space key to close it
- sets focus on popup menu so screen reader sees it
- when menu button is collapsed, remove aria-expanded altogether instead of aria-expanded=false per w3c recommendation