### PR TITLE
re-encoding of Help pane URIs no longer necessary

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -187,19 +187,7 @@ public class HelpPane extends WorkbenchPane
             thiz.@org.rstudio.studio.client.workbench.views.help.HelpPane::unload()();
          });
       } ;
-      $wnd.helpNavigate = function(url, encode) {
-         // on some platforms url may arrive unencoded; on others it will already be encoded. to
-         // ascertain the difference, check to see if the url contains any characters that require
-         // encoding. 
-         if (encode)
-         {
-            var re = new RegExp("^([!#$&-;=?-[]_a-z~]|%[0-9a-fA-F]{2})+$");
-            if (!re.test(url)) 
-            {
-               url = encodeURI(url);
-            }
-         }
-         
+      $wnd.helpNavigate = function(url) {
          if (url.length)
             thiz.@org.rstudio.studio.client.workbench.views.help.HelpPane::showHelp(Ljava/lang/String;)(url);
       } ;
@@ -286,12 +274,9 @@ public class HelpPane extends WorkbenchPane
             // they can participate in virtual session history. This
             // won't have any effect for right-click > Show in New Window
             // but that's a good thing.
-            
-            a.setAttribute("onclick",
-                           "window.parent.helpNavigate(this.href, " + 
-                           (BrowseCap.isLinuxDesktop() || BrowseCap.isWindowsDesktop() ?
-                                 "true" : "false") +
-                           "); return false");
+            a.setAttribute(
+                  "onclick",
+                  "window.parent.helpNavigate(this.href); return false");
          }
       }
       


### PR DESCRIPTION
Fixes #4829.

I'm guessing that the update to Chromium changed the way URIs are passed around on Linux / macOS Desktop; now, they're always encoded and so we do not need to attempt to re-encode the URI.

(As an aside, I believe the bug arose because we weren't successfully detecting that the URI component "graphical%20parameters.html" was already HTML encoded)