### PR TITLE
Fix / suppress current GWT compile-time deprecation warnings

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcResponse.java
+++ b/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcResponse.java
@@ -1,7 +1,7 @@
 /*
  * RpcResponse.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -43,6 +43,7 @@ public class RpcResponse extends JavaScriptObject
             // server isn't parsable by parseStrict (for example,
             // see bug #3025). for these situations we call 
             // parseLenient (which in turn calls eval)
+            @SuppressWarnings("deprecation")
             JSONValue val = JSONParser.parseLenient(json);
             return val.isObject().getJavaScriptObject().cast();
          }

--- a/src/gwt/src/org/rstudio/core/client/resources/ImageResourceUrl.java
+++ b/src/gwt/src/org/rstudio/core/client/resources/ImageResourceUrl.java
@@ -1,7 +1,7 @@
 /*
  * ImageResourceUrl.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -59,6 +59,7 @@ public class ImageResourceUrl implements ImageResource
    }
 
    @Override
+   @SuppressWarnings("deprecation")
    public String getURL()
    {
       return url_.asString();

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.java
@@ -16,7 +16,7 @@ package org.rstudio.studio.client.application.ui;
 
 import com.google.gwt.aria.client.Id;
 import com.google.gwt.aria.client.Roles;
-import com.google.gwt.user.client.Element;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.Anchor;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.studio.client.application.Desktop;

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/ProjectTemplateIconImageResource.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/ProjectTemplateIconImageResource.java
@@ -1,3 +1,17 @@
+/*
+ * ProjectTemplateIconImageResource.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
 package org.rstudio.studio.client.projects.model;
 
 import com.google.gwt.resources.client.ImageResource;
@@ -50,6 +64,7 @@ public class ProjectTemplateIconImageResource implements ImageResource
    }
 
    @Override
+   @SuppressWarnings("deprecation")
    public String getURL()
    {
       return uri_;


### PR DESCRIPTION
These are easy to find later, and will be the least of our problems if we ever go to a major new release of GWT