### PR TITLE
use deparse more carefully when forming repos string

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1905,17 +1905,23 @@
    # drop NULL entries
    options <- Filter(Negate(is.null), options)
    
-   # deparse to generate an R string
-   deparsed <- sub("^list", "options", .rs.deparse(options))
+   # deparse values individually (avoid relying on the format
+   # of the deparsed output of the whole expression; see e.g.
+   # https://github.com/rstudio/rstudio/issues/4916)
+   vals <- lapply(options, .rs.deparse)
+   
+   # join keys and values
+   keyvals <- paste(names(options), vals, sep = " = ")
+   
+   # create final options command
+   opts <- sprintf("options(%s)", paste(keyvals, collapse = ", "))
    
    # NOTE: we need to quote arguments with single quotes as the command will be
    # submitted using double quotes, and embedded quotes in the command are not
    # properly escaped.
    #
    # TODO: handle embedded quotes properly
-   deparsed <- gsub("\"", "'", deparsed, fixed = TRUE)
-   
-   deparsed
+   gsub("\"", "'", opts, fixed = TRUE)
    
 })
 


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/4916.

### R 3.4.4

```
> .rs.CRANDownloadOptionsString()
[1] "options(repos = structure('https://cran.rstudio.com', .Names = 'CRAN'), download.file.method = 'libcurl')"
```

### R 3.6.0

```
> .rs.CRANDownloadOptionsString()
[1] "options(repos = c(CRAN = 'https://cran.rstudio.com'), download.file.method = 'libcurl')"
```

The output still differs, but is now at least correct in both cases.