### PR TITLE
Annotate checkbox and radio menuitems so a11y tools can see the state

### DIFF
--- a/src/gwt/src/com/google/gwt/updatesources.sh
+++ b/src/gwt/src/com/google/gwt/updatesources.sh
@@ -32,7 +32,7 @@ patch SplitPanel.java < SplitPanel.java.diff
 patch SplitLayoutPanel.java < SplitLayoutPanel.java.diff
 
 cd ${SRCBASE}/com/google/gwt/core/ext/linker/impl
-patch XinstallLocationIframe.js < installLocationIframe.js.diff
+patch installLocationIframe.js < installLocationIframe.js.diff
 
 cd ${SRCBASE}/com/google/gwt/core/linker
-patch XCrossSiteIframeLinker.java < CrossSiteIframeLinker.java.diff
+patch CrossSiteIframeLinker.java < CrossSiteIframeLinker.java.diff

--- a/src/gwt/src/com/google/gwt/user/client/ui/MenuBar.java
+++ b/src/gwt/src/com/google/gwt/user/client/ui/MenuBar.java
@@ -16,6 +16,7 @@
 package com.google.gwt.user.client.ui;
 
 import com.google.gwt.aria.client.Id;
+import com.google.gwt.aria.client.MenuitemRole;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
@@ -393,7 +394,7 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
    * @return the {@link MenuItem} object created
    */
   public MenuItem addItem(SafeHtml html, ScheduledCommand cmd) {
-    return addItem(new MenuItem(html, cmd));
+    return addItem(new MenuItem(html, Roles.getMenuitemRole(), false, cmd));
   }
 
   /**
@@ -406,7 +407,7 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
    * @return the {@link MenuItem} object created
    */
   public MenuItem addItem(@IsSafeHtml String text, boolean asHTML, ScheduledCommand cmd) {
-    return addItem(new MenuItem(text, asHTML, cmd));
+    return addItem(new MenuItem(text, asHTML, Roles.getMenuitemRole(), false, cmd));
   }
 
   /**
@@ -443,7 +444,50 @@ public class MenuBar extends Widget implements PopupListener, HasAnimation,
    * @return the {@link MenuItem} object created
    */
   public MenuItem addItem(String text, ScheduledCommand cmd) {
-    return addItem(new MenuItem(text, cmd));
+    return addItem(new MenuItem(text, Roles.getMenuitemRole(), false, cmd));
+  }
+
+  /**
+   * Adds a menu item to the bar, that will fire the given command when it is
+   * selected.
+   *
+   * @param text the item's text
+   * @param role the item's a11y role
+   * @param checked <code>true</code> if item is checked
+   * @param cmd the command to be fired
+   * @return the {@link MenuItem} object created
+   */
+  public MenuItem addItem(String text, MenuitemRole role, boolean checked, ScheduledCommand cmd) {
+    return addItem(new MenuItem(text, role, checked, cmd));
+  }
+
+  /**
+   * Adds a menu item to the bar, that will fire the given command when it is
+   * selected.
+   *
+   * @param text the item's text
+   * @param asHTML <code>true</code> to treat the specified text as html
+   * @param role the item's a11y role
+   * @param checked <code>true</code> if item is checked
+   * @param cmd the command to be fired
+   * @return the {@link MenuItem} object created
+   */
+  public MenuItem addItem(@IsSafeHtml String text, boolean asHTML, MenuitemRole role, boolean checked, ScheduledCommand cmd) {
+    return addItem(new MenuItem(text, asHTML, role, checked, cmd));
+  }
+
+ /**
+   * Adds a menu item to the bar containing SafeHtml, that will fire the given
+   * command when it is selected.
+   *
+   * @param html the item's html text
+   * @param role the item's a11y role
+   * @param checked <code>true</code> if item is checked
+   * @param cmd the command to be fired
+   * @return the {@link MenuItem} object created
+   */
+  public MenuItem addItem(SafeHtml html, MenuitemRole role, boolean checked, ScheduledCommand cmd) {
+    return addItem(new MenuItem(html, role, checked, cmd));
   }
 
   /**

--- a/src/gwt/src/com/google/gwt/user/client/ui/MenuBar.java.diff
+++ b/src/gwt/src/com/google/gwt/user/client/ui/MenuBar.java.diff
@@ -1,16 +1,73 @@
-304a305
+18a19
+> import com.google.gwt.aria.client.MenuitemRole;
+304a306
 >   private MenuItem expandedMenuItem;
-515a517,521
+395c397
+<     return addItem(new MenuItem(html, cmd));
+---
+>     return addItem(new MenuItem(html, Roles.getMenuitemRole(), false, cmd));
+408c410
+<     return addItem(new MenuItem(text, asHTML, cmd));
+---
+>     return addItem(new MenuItem(text, asHTML, Roles.getMenuitemRole(), false, cmd));
+445c447,490
+<     return addItem(new MenuItem(text, cmd));
+---
+>     return addItem(new MenuItem(text, Roles.getMenuitemRole(), false, cmd));
+>   }
+> 
+>   /**
+>    * Adds a menu item to the bar, that will fire the given command when it is
+>    * selected.
+>    *
+>    * @param text the item's text
+>    * @param role the item's a11y role
+>    * @param checked <code>true</code> if item is checked
+>    * @param cmd the command to be fired
+>    * @return the {@link MenuItem} object created
+>    */
+>   public MenuItem addItem(String text, MenuitemRole role, boolean checked, ScheduledCommand cmd) {
+>     return addItem(new MenuItem(text, role, checked, cmd));
+>   }
+> 
+>   /**
+>    * Adds a menu item to the bar, that will fire the given command when it is
+>    * selected.
+>    *
+>    * @param text the item's text
+>    * @param asHTML <code>true</code> to treat the specified text as html
+>    * @param role the item's a11y role
+>    * @param checked <code>true</code> if item is checked
+>    * @param cmd the command to be fired
+>    * @return the {@link MenuItem} object created
+>    */
+>   public MenuItem addItem(@IsSafeHtml String text, boolean asHTML, MenuitemRole role, boolean checked, ScheduledCommand cmd) {
+>     return addItem(new MenuItem(text, asHTML, role, checked, cmd));
+>   }
+> 
+>  /**
+>    * Adds a menu item to the bar containing SafeHtml, that will fire the given
+>    * command when it is selected.
+>    *
+>    * @param html the item's html text
+>    * @param role the item's a11y role
+>    * @param checked <code>true</code> if item is checked
+>    * @param cmd the command to be fired
+>    * @return the {@link MenuItem} object created
+>    */
+>   public MenuItem addItem(SafeHtml html, MenuitemRole role, boolean checked, ScheduledCommand cmd) {
+>     return addItem(new MenuItem(html, role, checked, cmd));
+515a561,565
 >       if (expandedMenuItem != null)
 >       {
 >         expandedMenuItem.setAriaExpanded(false);
 >         expandedMenuItem = null;
 >       }
-788c794
+788c838
 <     onHide(!autoClosed && focusOnHover);
 ---
 >     onHide(!autoClosed);
-861a868,874
+861a912,918
 > 
 >         if (shownChildMenu != null
 >             && shownChildMenu == selectedItem.getSubMenu())
@@ -18,39 +75,39 @@
 >           hideChildMenu(false);
 >           shownChildMenu = null;
 >         }
-980c993
+980c1037
 <   void doItemAction(final MenuItem item, boolean fireCommand, boolean focus) {
 ---
 >   protected void doItemAction(final MenuItem item, boolean fireCommand, boolean focus) {
-1009,1010c1022
+1009,1010c1066
 <         shownChildMenu.onHide(focus);
 <         popup.hide();
 ---
 >         hideChildMenu(focus);
-1020,1021c1032
+1020,1021c1076
 <         shownChildMenu.onHide(focus);
 <         popup.hide();
 ---
 >         hideChildMenu(focus);
-1025,1026c1036
+1025,1026c1080
 <         shownChildMenu.onHide(focus);
 <         popup.hide();
 ---
 >         hideChildMenu(focus);
-1032,1033c1042
+1032,1033c1086
 <       shownChildMenu.onHide(focus);
 <       popup.hide();
 ---
 >       hideChildMenu(focus);
-1092c1101
+1092c1145
 <   void updateSubmenuIcon(MenuItem item) {
 ---
 >   protected void updateSubmenuIcon(MenuItem item) {
-1108c1117
+1108c1161
 <     if (submenu == null) {
 ---
 >     if (submenu == null || !item.isVisible()) {
-1119c1128,1133
+1119c1172,1177
 <       td.setInnerSafeHtml(subMenuIcon.getSafeHtml());
 ---
 >       String indicatorHtml = subMenuIcon.getSafeHtml().asString();
@@ -59,21 +116,21 @@
 >         indicatorHtml = indicatorHtml.substring(0, indicatorHtml.length() - 1) + " alt>";
 >       td.setInnerHTML(indicatorHtml);
 > 
-1197a1212
+1197a1256
 >     Roles.getPresentationRole().set(table);
-1273,1274c1288
+1273,1274c1332
 <       shownChildMenu.onHide(focus);
 <       popup.hide();
 ---
 >       hideChildMenu(focus);
-1289a1304,1305
+1289a1348,1349
 >     expandedMenuItem = item;
 >     item.setAriaExpanded(true);
-1334c1350
+1334c1394
 <         if (nextItem.isEnabled()) {
 ---
 >         if (nextItem.isEnabled() && nextItem.isVisible()) {
-1336c1352,1358
+1336c1396,1402
 <           break;
 ---
 >           return true;
@@ -83,15 +140,15 @@
 >         if (nextItem.isVisible()) {
 >           selectItem(nextItem);
 >           return true;
-1369c1391
+1369c1435
 <         if (itemToBeSelected.isEnabled()) {
 ---
 >         if (itemToBeSelected.isEnabled() && itemToBeSelected.isVisible()) {
-1406c1428
+1406c1472
 <         if (itemToBeSelected.isEnabled()) {
 ---
 >         if (itemToBeSelected.isEnabled() && itemToBeSelected.isVisible()) {
-1426a1449,1463
+1426a1493,1507
 > 
 >   /**
 >    * Hide currently displayed child menu and mark the associate menu item as closed.

--- a/src/gwt/src/com/google/gwt/user/client/ui/MenuItem.java
+++ b/src/gwt/src/com/google/gwt/user/client/ui/MenuItem.java
@@ -15,6 +15,10 @@
  */
 package com.google.gwt.user.client.ui;
 
+import com.google.gwt.aria.client.CheckedValue;
+import com.google.gwt.aria.client.MenuitemRole;
+import com.google.gwt.aria.client.MenuitemcheckboxRole;
+import com.google.gwt.aria.client.MenuitemradioRole;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.safehtml.client.HasSafeHtml;
@@ -42,6 +46,7 @@ public class MenuItem extends UIObject implements HasHTML, HasEnabled, HasSafeHt
   private ScheduledCommand command;
   private MenuBar parentMenu, subMenu;
   private boolean enabled = true;
+  private final MenuitemRole menurole;
 
   /**
    * Constructs a new menu item that fires a command when it is selected.
@@ -49,7 +54,7 @@ public class MenuItem extends UIObject implements HasHTML, HasEnabled, HasSafeHt
    * @param html the item's html text
    */
   public MenuItem(SafeHtml html) {
-    this(html.asString(), true);
+    this(html.asString(), true, Roles.getMenuitemRole(), false);
   }
 
   /**
@@ -80,7 +85,7 @@ public class MenuItem extends UIObject implements HasHTML, HasEnabled, HasSafeHt
    * @param cmd the command to be fired when it is selected
    */
   public MenuItem(@IsSafeHtml String text, boolean asHTML, ScheduledCommand cmd) {
-    this(text, asHTML);
+    this(text, asHTML, Roles.getMenuitemRole(), false);
     setScheduledCommand(cmd);
   }
 
@@ -92,7 +97,7 @@ public class MenuItem extends UIObject implements HasHTML, HasEnabled, HasSafeHt
    * @param subMenu the sub-menu to be displayed when it is selected
    */
   public MenuItem(@IsSafeHtml String text, boolean asHTML, MenuBar subMenu) {
-    this(text, asHTML);
+    this(text, asHTML, Roles.getMenuitemRole(), false);
     setSubMenu(subMenu);
   }
 
@@ -104,7 +109,7 @@ public class MenuItem extends UIObject implements HasHTML, HasEnabled, HasSafeHt
    */
   @SuppressIsSafeHtmlCastCheck
   public MenuItem(String text, ScheduledCommand cmd) {
-    this(text, false);
+    this(text, false, Roles.getMenuitemRole(), false);
     setScheduledCommand(cmd);
   }
 
@@ -116,13 +121,78 @@ public class MenuItem extends UIObject implements HasHTML, HasEnabled, HasSafeHt
    */
   @SuppressIsSafeHtmlCastCheck
   public MenuItem(String text, MenuBar subMenu) {
-    this(text, false);
+    this(text, false, Roles.getMenuitemRole(), false);
     setSubMenu(subMenu);
   }
 
   MenuItem(@IsSafeHtml String text, boolean asHTML) {
+    this(text, asHTML, Roles.getMenuitemRole(), false);
+  }
+
+  /**
+   * Constructs a new menu item that fires a command when it is selected.
+   *
+   * @param text the item's text
+   * @param asHTML <code>true</code> to treat the specified text as html
+   * @param role the item's a11y role
+   * @param checked <code>true</code> if item is checked
+   * @param cmd the command to be fired when it is selected
+   */
+  public MenuItem(@IsSafeHtml String text, boolean asHTML, MenuitemRole role, boolean checked, ScheduledCommand cmd) {
+    this(text, asHTML, role, checked);
+    setScheduledCommand(cmd);
+  }
+
+  /**
+   * Constructs a new menu item that fires a command when it is selected.
+   *
+   * @param html the item's text
+   * @param role the item's a11y role
+   * @param checked <code>true</code> if item is checked
+   * @param cmd the command to be fired when it is selected
+   */
+  public MenuItem(SafeHtml html, MenuitemRole role, boolean checked, ScheduledCommand cmd) {
+    this(html.asString(), true, role, checked, cmd);
+  }
+
+  /**
+   * Constructs a new menu item that fires a command when it is selected.
+   *
+   * @param text the item's text
+   * @param role the item's a11y role
+   * @param checked <code>true</code> if item is checked
+   * @param cmd the command to be fired when it is selected
+   */
+  @SuppressIsSafeHtmlCastCheck
+  public MenuItem(String text, MenuitemRole role, boolean checked, ScheduledCommand cmd) {
+    this(text, false, role, checked);
+    setScheduledCommand(cmd);
+  }
+
+   /**
+   * Constructs a new menu item that fires a command when it is selected.
+   *
+   * @param html the item's html text
+   * @param role the item's a11y role
+   * @param checked <code>true</code> if item is checked
+   */
+  public MenuItem(SafeHtml html, MenuitemRole role, boolean checked) {
+    this(html.asString(), true, role, checked);
+  }
+
+  public void setChecked(boolean checked)
+  {
+    CheckedValue value = checked ? CheckedValue.TRUE : CheckedValue.FALSE;
+    if (menurole instanceof MenuitemcheckboxRole)
+      Roles.getMenuitemcheckboxRole().setAriaCheckedState(getElement(), value);
+    else if (menurole instanceof MenuitemradioRole)
+      Roles.getMenuitemradioRole().setAriaCheckedState(getElement(), value);
+  }
+
+  MenuItem(@IsSafeHtml String text, boolean asHTML, MenuitemRole role, boolean checked) {
     setElement(DOM.createTD());
     setSelectionStyle(false);
+    menurole = role;
 
     if (asHTML) {
       setHTML(text);
@@ -132,8 +202,21 @@ public class MenuItem extends UIObject implements HasHTML, HasEnabled, HasSafeHt
     setStyleName("gwt-MenuItem");
 
     getElement().setAttribute("id", DOM.createUniqueId());
-    // Add a11y role "menuitem"
-    Roles.getMenuitemRole().set(getElement());
+    CheckedValue checkedValue = checked ? CheckedValue.TRUE : CheckedValue.FALSE;
+    if (role instanceof MenuitemcheckboxRole)
+    {
+      Roles.getMenuitemcheckboxRole().set(getElement());
+      Roles.getMenuitemcheckboxRole().setAriaCheckedState(getElement(), checkedValue);
+    }
+    else if (role instanceof MenuitemradioRole)
+    {
+      Roles.getMenuitemradioRole().set(getElement());
+      Roles.getMenuitemradioRole().setAriaCheckedState(getElement(), checkedValue);
+    }
+    else
+    {
+      Roles.getMenuitemRole().set(getElement());
+    }
   }
 
   /**

--- a/src/gwt/src/com/google/gwt/user/client/ui/MenuItem.java
+++ b/src/gwt/src/com/google/gwt/user/client/ui/MenuItem.java
@@ -183,10 +183,10 @@ public class MenuItem extends UIObject implements HasHTML, HasEnabled, HasSafeHt
   public void setChecked(boolean checked)
   {
     CheckedValue value = checked ? CheckedValue.TRUE : CheckedValue.FALSE;
-    if (menurole instanceof MenuitemcheckboxRole)
-      Roles.getMenuitemcheckboxRole().setAriaCheckedState(getElement(), value);
-    else if (menurole instanceof MenuitemradioRole)
+    if (menurole instanceof MenuitemradioRole)
       Roles.getMenuitemradioRole().setAriaCheckedState(getElement(), value);
+    else if (menurole instanceof MenuitemcheckboxRole)
+      Roles.getMenuitemcheckboxRole().setAriaCheckedState(getElement(), value);
   }
 
   MenuItem(@IsSafeHtml String text, boolean asHTML, MenuitemRole role, boolean checked) {
@@ -203,15 +203,15 @@ public class MenuItem extends UIObject implements HasHTML, HasEnabled, HasSafeHt
 
     getElement().setAttribute("id", DOM.createUniqueId());
     CheckedValue checkedValue = checked ? CheckedValue.TRUE : CheckedValue.FALSE;
-    if (role instanceof MenuitemcheckboxRole)
-    {
-      Roles.getMenuitemcheckboxRole().set(getElement());
-      Roles.getMenuitemcheckboxRole().setAriaCheckedState(getElement(), checkedValue);
-    }
-    else if (role instanceof MenuitemradioRole)
+    if (role instanceof MenuitemradioRole)
     {
       Roles.getMenuitemradioRole().set(getElement());
       Roles.getMenuitemradioRole().setAriaCheckedState(getElement(), checkedValue);
+    }
+    else if (role instanceof MenuitemcheckboxRole)
+    {
+      Roles.getMenuitemcheckboxRole().set(getElement());
+      Roles.getMenuitemcheckboxRole().setAriaCheckedState(getElement(), checkedValue);
     }
     else
     {

--- a/src/gwt/src/com/google/gwt/user/client/ui/MenuItem.java.diff
+++ b/src/gwt/src/com/google/gwt/user/client/ui/MenuItem.java.diff
@@ -1,10 +1,123 @@
-25a26
+17a18,21
+> import com.google.gwt.aria.client.CheckedValue;
+> import com.google.gwt.aria.client.MenuitemRole;
+> import com.google.gwt.aria.client.MenuitemcheckboxRole;
+> import com.google.gwt.aria.client.MenuitemradioRole;
+25a30
 > import org.rstudio.core.client.a11y.A11y;
-228a230
+43a49
+>   private final MenuitemRole menurole;
+51c57
+<     this(html.asString(), true);
+---
+>     this(html.asString(), true, Roles.getMenuitemRole(), false);
+82c88
+<     this(text, asHTML);
+---
+>     this(text, asHTML, Roles.getMenuitemRole(), false);
+94c100
+<     this(text, asHTML);
+---
+>     this(text, asHTML, Roles.getMenuitemRole(), false);
+106c112
+<     this(text, false);
+---
+>     this(text, false, Roles.getMenuitemRole(), false);
+118c124
+<     this(text, false);
+---
+>     this(text, false, Roles.getMenuitemRole(), false);
+122a129,192
+>     this(text, asHTML, Roles.getMenuitemRole(), false);
+>   }
+> 
+>   /**
+>    * Constructs a new menu item that fires a command when it is selected.
+>    *
+>    * @param text the item's text
+>    * @param asHTML <code>true</code> to treat the specified text as html
+>    * @param role the item's a11y role
+>    * @param checked <code>true</code> if item is checked
+>    * @param cmd the command to be fired when it is selected
+>    */
+>   public MenuItem(@IsSafeHtml String text, boolean asHTML, MenuitemRole role, boolean checked, ScheduledCommand cmd) {
+>     this(text, asHTML, role, checked);
+>     setScheduledCommand(cmd);
+>   }
+> 
+>   /**
+>    * Constructs a new menu item that fires a command when it is selected.
+>    *
+>    * @param html the item's text
+>    * @param role the item's a11y role
+>    * @param checked <code>true</code> if item is checked
+>    * @param cmd the command to be fired when it is selected
+>    */
+>   public MenuItem(SafeHtml html, MenuitemRole role, boolean checked, ScheduledCommand cmd) {
+>     this(html.asString(), true, role, checked, cmd);
+>   }
+> 
+>   /**
+>    * Constructs a new menu item that fires a command when it is selected.
+>    *
+>    * @param text the item's text
+>    * @param role the item's a11y role
+>    * @param checked <code>true</code> if item is checked
+>    * @param cmd the command to be fired when it is selected
+>    */
+>   @SuppressIsSafeHtmlCastCheck
+>   public MenuItem(String text, MenuitemRole role, boolean checked, ScheduledCommand cmd) {
+>     this(text, false, role, checked);
+>     setScheduledCommand(cmd);
+>   }
+> 
+>    /**
+>    * Constructs a new menu item that fires a command when it is selected.
+>    *
+>    * @param html the item's html text
+>    * @param role the item's a11y role
+>    * @param checked <code>true</code> if item is checked
+>    */
+>   public MenuItem(SafeHtml html, MenuitemRole role, boolean checked) {
+>     this(html.asString(), true, role, checked);
+>   }
+> 
+>   public void setChecked(boolean checked)
+>   {
+>     CheckedValue value = checked ? CheckedValue.TRUE : CheckedValue.FALSE;
+>     if (menurole instanceof MenuitemcheckboxRole)
+>       Roles.getMenuitemcheckboxRole().setAriaCheckedState(getElement(), value);
+>     else if (menurole instanceof MenuitemradioRole)
+>       Roles.getMenuitemradioRole().setAriaCheckedState(getElement(), value);
+>   }
+> 
+>   MenuItem(@IsSafeHtml String text, boolean asHTML, MenuitemRole role, boolean checked) {
+124a195
+>     menurole = role;
+134,135c205,219
+<     // Add a11y role "menuitem"
+<     Roles.getMenuitemRole().set(getElement());
+---
+>     CheckedValue checkedValue = checked ? CheckedValue.TRUE : CheckedValue.FALSE;
+>     if (role instanceof MenuitemcheckboxRole)
+>     {
+>       Roles.getMenuitemcheckboxRole().set(getElement());
+>       Roles.getMenuitemcheckboxRole().setAriaCheckedState(getElement(), checkedValue);
+>     }
+>     else if (role instanceof MenuitemradioRole)
+>     {
+>       Roles.getMenuitemradioRole().set(getElement());
+>       Roles.getMenuitemradioRole().setAriaCheckedState(getElement(), checkedValue);
+>     }
+>     else
+>     {
+>       Roles.getMenuitemRole().set(getElement());
+>     }
+228a313
 >     Roles.getMenuitemRole().setAriaDisabledState(getElement(), !enabled);
-267a270
+267a353
 >       setAriaExpanded(false);
-273a277,281
+273a360,364
 >   public void setAriaExpanded(boolean expanded)
 >   {
 >     A11y.setARIAMenuItemExpanded(getElement(), expanded);

--- a/src/gwt/src/com/google/gwt/user/client/ui/MenuItem.java.diff
+++ b/src/gwt/src/com/google/gwt/user/client/ui/MenuItem.java.diff
@@ -85,10 +85,10 @@
 >   public void setChecked(boolean checked)
 >   {
 >     CheckedValue value = checked ? CheckedValue.TRUE : CheckedValue.FALSE;
->     if (menurole instanceof MenuitemcheckboxRole)
->       Roles.getMenuitemcheckboxRole().setAriaCheckedState(getElement(), value);
->     else if (menurole instanceof MenuitemradioRole)
+>     if (menurole instanceof MenuitemradioRole)
 >       Roles.getMenuitemradioRole().setAriaCheckedState(getElement(), value);
+>     else if (menurole instanceof MenuitemcheckboxRole)
+>       Roles.getMenuitemcheckboxRole().setAriaCheckedState(getElement(), value);
 >   }
 > 
 >   MenuItem(@IsSafeHtml String text, boolean asHTML, MenuitemRole role, boolean checked) {
@@ -99,15 +99,15 @@
 <     Roles.getMenuitemRole().set(getElement());
 ---
 >     CheckedValue checkedValue = checked ? CheckedValue.TRUE : CheckedValue.FALSE;
->     if (role instanceof MenuitemcheckboxRole)
->     {
->       Roles.getMenuitemcheckboxRole().set(getElement());
->       Roles.getMenuitemcheckboxRole().setAriaCheckedState(getElement(), checkedValue);
->     }
->     else if (role instanceof MenuitemradioRole)
+>     if (role instanceof MenuitemradioRole)
 >     {
 >       Roles.getMenuitemradioRole().set(getElement());
 >       Roles.getMenuitemradioRole().setAriaCheckedState(getElement(), checkedValue);
+>     }
+>     else if (role instanceof MenuitemcheckboxRole)
+>     {
+>       Roles.getMenuitemcheckboxRole().set(getElement());
+>       Roles.getMenuitemcheckboxRole().setAriaCheckedState(getElement(), checkedValue);
 >     }
 >     else
 >     {

--- a/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.core.client.command;
 
+import com.google.gwt.aria.client.MenuitemRole;
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.shared.HandlerManager;
@@ -215,7 +217,10 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
 
    public void setCheckable(boolean isCheckable)
    {
-      checkable_ = isCheckable;
+      if (isRadio())
+         checkable_ = true;
+      else
+         checkable_ = isCheckable;
    }
 
    public boolean isChecked()
@@ -231,6 +236,28 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
       checked_ = checked;
       if (Desktop.isDesktop())
          DesktopMenuCallback.setCommandChecked(id_, checked_);
+   }
+
+   public void setRadio(boolean isRadio)
+   {
+      radio_ = isRadio;
+      if (radio_)
+         setCheckable(true);
+   }
+
+   public boolean isRadio()
+   {
+      return radio_;
+   }
+
+   public MenuitemRole getMenuRole()
+   {
+      if (isRadio())
+         return Roles.getMenuitemradioRole();
+      else if (isCheckable())
+         return Roles.getMenuitemcheckboxRole();
+      else
+         return Roles.getMenuitemRole();
    }
 
    public String getWindowMode()
@@ -681,6 +708,7 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
    private boolean visible_ = true;
    private boolean removed_ = false;
    private boolean checkable_ = false;
+   private boolean radio_ = false;
    private boolean checked_ = false;
    private String windowMode_ = "any";
    private final HandlerManager handlers_ = new HandlerManager(this);

--- a/src/gwt/src/org/rstudio/core/client/command/AppMenuBar.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppMenuBar.java
@@ -1,7 +1,7 @@
 /*
  * AppMenuBar.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,6 +14,7 @@
  */
 package org.rstudio.core.client.command;
 
+import com.google.gwt.aria.client.MenuitemRole;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -36,18 +37,20 @@ public class AppMenuBar extends BaseMenuBar
    }
 
    @Override
-   public MenuItem addItem(String text, ScheduledCommand cmd)
+   public MenuItem addItem(String text, MenuitemRole role, boolean checked, ScheduledCommand cmd)
    {
-      return addItem(text, false, cmd);
+      return addItem(text, false, role, checked, cmd);
    }
 
    @Override
-   public MenuItem addItem(String text, boolean asHTML, ScheduledCommand cmd)
+   public MenuItem addItem(String text, boolean asHTML, MenuitemRole role, boolean checked, ScheduledCommand cmd)
    {
       if (vertical_ && !asHTML)
          text = AppCommand.formatMenuLabel(null, text, null);
       return super.addItem(text,
                            true,
+                           role,
+                           checked,
                            cmd);
    }
 

--- a/src/gwt/src/org/rstudio/core/client/command/AppMenuItem.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppMenuItem.java
@@ -53,6 +53,7 @@ public class AppMenuItem extends MenuItem
 
       setHTML(cmd_.getMenuHTML(mainMenu_));
       setTitle(cmd_.getDesc());
+      setChecked(cmd_.isChecked());
    }
 
    public boolean cmdVisible()

--- a/src/gwt/src/org/rstudio/core/client/command/AppMenuItem.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppMenuItem.java
@@ -1,7 +1,7 @@
 /*
  * AppMenuItem.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -24,7 +24,7 @@ public class AppMenuItem extends MenuItem
 {
    public AppMenuItem(AppCommand cmd, boolean mainMenu)
    {
-      super(cmd.getMenuHTML(mainMenu), true, cmd);
+      super(cmd.getMenuHTML(mainMenu), true, cmd.getMenuRole(), cmd.isChecked(), cmd);
       cmd_ = cmd;
       mainMenu_ = mainMenu;
       setTitle(cmd_.getDesc());

--- a/src/gwt/src/org/rstudio/core/client/widget/CheckableMenuItem.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/CheckableMenuItem.java
@@ -1,5 +1,20 @@
+/*
+ * CheckableMenuItem.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
 package org.rstudio.core.client.widget;
 
+import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
@@ -15,17 +30,26 @@ public abstract class CheckableMenuItem extends MenuItem
 {
    public CheckableMenuItem()
    {
-      this("", false);
+      this("", false, false);
    }
 
    public CheckableMenuItem(String label)
    {
-      this (label, false);
+      this (label, false, false);
    }
 
    public CheckableMenuItem(String label, boolean html)
    {
-      super(label, html, (Scheduler.ScheduledCommand)null);
+      this(label, html, false);
+   }
+
+   public CheckableMenuItem(String label, boolean html, boolean checked)
+   {
+      super(label, 
+            html,
+            Roles.getMenuitemcheckboxRole(),
+            checked, 
+            (Scheduler.ScheduledCommand)null);
       if (!html)
          setHTML(getHTMLContent());
       setScheduledCommand(new ScheduledCommand()
@@ -36,11 +60,13 @@ public abstract class CheckableMenuItem extends MenuItem
             onInvoked();
          }
       });
+      setChecked(checked);
    }
 
    public void onStateChanged()
    {
       setHTML(getHTMLContent());
+      setChecked(isChecked());
    }
 
    public abstract String getLabel();

--- a/src/gwt/src/org/rstudio/core/rebind/command/CommandBundleGenerator.java
+++ b/src/gwt/src/org/rstudio/core/rebind/command/CommandBundleGenerator.java
@@ -330,6 +330,7 @@ class CommandBundleGeneratorHelper
       setPropertyBool(writer, name, props.get(name), "checkable");
       setPropertyBool(writer, name, props.get(name), "checked");
       setPropertyBool(writer, name, props.get(name), "rebindable");
+      setPropertyBool(writer, name, props.get(name), "radio");
       
       if (images.hasImage(name))
       {

--- a/src/gwt/src/org/rstudio/studio/client/common/ImageMenuItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/ImageMenuItem.java
@@ -1,3 +1,17 @@
+/*
+ * ImageMenuItem.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
 package org.rstudio.studio.client.common;
 
 import org.rstudio.core.client.command.AppCommand;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -22,9 +22,12 @@ well as menu structures (for main menu and popup menus).
    @checkable: Indicates whether the command has a stateful checked state,
       which is shown by the command when rendered in a menu (both GWT and
       native menus)
-  @preventShortcutWhenDisabled: Whether the command's shortcut should be
+   @radio: Same as @checkable but indicates that the command is part of a
+      group of mutually exclusive checkable commands; management of the mutually
+      exclusive behavior is not automatic and must be managed in code
+   @preventShortcutWhenDisabled: Whether the command's shortcut should be
       suppressed when the command is disabled
-  @windowMode: Which window the command wants to operate on; possible values:
+   @windowMode: Which window the command wants to operate on; possible values:
       "any": operates on current window (the default),
       "main": always operates on main window, and raises main window
       "background": always operates on main window, but in the background

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -1379,13 +1379,13 @@ well as menu structures (for main menu and popup menus).
         windowMode="main"/>
         
    <cmd id="layoutConsoleOnLeft"
-        checkable="true"
+        radio="true"
         label="Console on Left"
         menuLabel="Console on _Left"
         windowMode="main"/>
         
    <cmd id="layoutConsoleOnRight"
-        checkable="true"
+        radio="true"
         label="Console on Right"
         menuLabel="Console on _Right"
         windowMode="main"/>
@@ -3130,19 +3130,19 @@ well as menu structures (for main menu and popup menus).
    <cmd id="errorsMessage"
         menuLabel="_Message Only"
         desc="Print the error message when an unhandled error occurs"
-        checkable="true"
+        radio="true"
         rebindable="false"/>
         
    <cmd id="errorsTraceback"
         menuLabel="_Error Inspector"
         desc="Show the error inspector when an unhandled error occurs"
-        checkable="true"
+        radio="true"
         rebindable="false"/>
         
    <cmd id="errorsBreak"
         menuLabel="_Break in Code"
         desc="Break when any unhandled error occurs"
-        checkable="true"
+        radio="true"
         rebindable="false"/>
         
    <cmd id="startProfiler"


### PR DESCRIPTION
Fixes #4911 

Menu items for checkable commands are now marked with `role=menuitemcheckbox` and the `aria-checked` property is set to match.

Menu items that are checkable and part of a mutually exclusive set (only one can be selected) are now marked with `role=menuitemradio` and `aria-checked` is set to match state.

For testing, recommend NVDA on Windows (VoiceOver doesn't currently distinguish between regular and radio-variations).

Try out checkable items on the main menu (RStudio server only; the main menu on desktop is native code and not impacted by these changes), including regular checkable items and, for example, this menuitemradio set under Debug / On Error:

![2019-06-07_17-07-28](https://user-images.githubusercontent.com/10569626/59139377-95c66000-8947-11e9-8f36-94663d82a3fc.png)

Also test non-main-menu checkable items, as those involve different code paths and are on both server and desktop. For example, in the File pane More dropdown, the `Show Hidden Files` item:

![2019-06-07_17-07-45](https://user-images.githubusercontent.com/10569626/59139399-b1316b00-8947-11e9-951b-56072b3b9dd3.png)

