### PR TITLE
Keyboard support for HelpLinks

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/HyperlinkLabel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/HyperlinkLabel.java
@@ -1,7 +1,7 @@
 /*
  * HyperlinkLabel.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,26 +14,39 @@
  */
 package org.rstudio.core.client.widget;
 
-import com.google.gwt.event.dom.client.*;
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.dom.client.KeyPressEvent;
+import com.google.gwt.event.dom.client.KeyPressHandler;
+import com.google.gwt.event.dom.client.MouseOutEvent;
+import com.google.gwt.event.dom.client.MouseOutHandler;
+import com.google.gwt.event.dom.client.MouseOverEvent;
+import com.google.gwt.event.dom.client.MouseOverHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.Label;
 
 import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 
-public class HyperlinkLabel extends Label 
+public class HyperlinkLabel extends Label
 {
    public HyperlinkLabel()
    {
       super();
       this.setStyleName("rstudio-HyperlinkLabel");
+      Roles.getLinkRole().set(getElement());
+      getElement().setTabIndex(0);
    }
    
-   public HyperlinkLabel(String caption, ClickHandler clickHandler)
+   public HyperlinkLabel(String caption, Command clickHandler)
    {
       super(caption); 
-      clickHandler_ = clickHandler ;
+      clickHandler_ = clickHandler;
       this.setStyleName("rstudio-HyperlinkLabel");
       this.addStyleName(ThemeStyles.INSTANCE.handCursor());
+      Roles.getLinkRole().set(getElement());
+      getElement().setTabIndex(0);
    }
    
    public HyperlinkLabel(String caption)
@@ -42,9 +55,9 @@ public class HyperlinkLabel extends Label
    }
    
    // must call this before the element is loaded
-   public void setClickHandler(ClickHandler clickHandler)
+   public void setClickHandler(Command clickHandler)
    {
-      clickHandler_ = clickHandler; 
+      clickHandler_ = clickHandler;
    }
 
    private class MouseHandlers implements MouseOverHandler,
@@ -76,31 +89,46 @@ public class HyperlinkLabel extends Label
    {
       clearUnderlineOnClick_ = clearOnClick;
    }
-  
-   
+
+   public HandlerRegistration addKeyPressHandler(KeyPressHandler handler) {
+      return addDomHandler(handler, KeyPressEvent.getType());
+   }
+
    @Override 
    protected void onLoad()
    {
       releaseOnUnload_.add(addMouseOverHandler(mouseHandlers_));
       releaseOnUnload_.add(addMouseOutHandler(mouseHandlers_));
       if (clickHandler_ != null)
-         releaseOnUnload_.add(addClickHandler(new ClickHandler() {
+      {
+         releaseOnUnload_.add(addClickHandler(event -> click()));
 
-            public void onClick(ClickEvent event)
+         releaseOnUnload_.add(addKeyPressHandler(event -> {
+            char charCode = event.getCharCode();
+            if (charCode == KeyCodes.KEY_ENTER || charCode == KeyCodes.KEY_SPACE)
             {
-               if (clearUnderlineOnClick_)
-                  removeStyleDependentName("Link");
-               clickHandler_.onClick(event);        
+               event.preventDefault();
+               event.stopPropagation();
+               click();
             }
-            
          }));
+      }
    }
-  
+
+   private void click()
+   {
+      if (clickHandler_ == null)
+         return;
+      
+      if (clearUnderlineOnClick_)
+         removeStyleDependentName("Link");
+      clickHandler_.execute();
+   }
+
    private MouseHandlers mouseHandlers_ = new MouseHandlers();
-   private ClickHandler clickHandler_ ;
+   private Command clickHandler_ ;
    private final HandlerRegistrations releaseOnUnload_ = new HandlerRegistrations();
-  
-   
+
    private boolean alwaysUnderline_ = false;
    private boolean clearUnderlineOnClick_ = false;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -488,9 +488,10 @@ public abstract class ModalDialogBase extends DialogBox
             if (enterDisabled_)
                break;
 
-            // allow Enter on textareas or anchors
+            // allow Enter on textareas or anchors (including custom links)
             Element e = DomUtils.getActiveElement();
-            if (e.hasTagName("TEXTAREA") || e.hasTagName("A"))
+            if (e.hasTagName("TEXTAREA") || e.hasTagName("A") || 
+                  (e.hasAttribute("role") && e.getAttribute("role") == "link"))
                return;
 
             ThemedButton defaultButton = defaultOverrideButton_ == null

--- a/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
@@ -936,6 +936,12 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
                      }
                   }
 
+                  // If Help link has focus, Enter shouldn't close the widget
+                  if (keyCode == KeyCodes.KEY_ENTER && helpLink_.hasFocus())
+                  {
+                     return;
+                  }
+
                   // Otherwise, handle Enter / Escape 'modally' as we might normally do.
                   preview.cancel();
                   preview.getNativeEvent().stopPropagation();
@@ -985,11 +991,11 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
       filterWidget_.getElement().getStyle().setMarginTop(-1, Unit.PX);
       headerPanel.add(filterWidget_);
       
-      HelpLink link = new HelpLink(
+      helpLink_ = new HelpLink(
             "Customizing Keyboard Shortcuts",
             "custom_keyboard_shortcuts");
-      link.getElement().getStyle().setFloat(Style.Float.RIGHT);
-      headerPanel.add(link);
+      helpLink_.getElement().getStyle().setFloat(Style.Float.RIGHT);
+      headerPanel.add(helpLink_);
       
       container.add(headerPanel);
       
@@ -1431,8 +1437,8 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
    
    private final RadioButton radioAll_;
    private final RadioButton radioCustomized_;
-   private static final String RADIO_BUTTON_GROUP =
-         "radioCustomizeKeyboardShortcuts";
+   private static final String RADIO_BUTTON_GROUP = "radioCustomizeKeyboardShortcuts";
+   private HelpLink helpLink_;
    
    private HandlerRegistration previewHandler_;
    private List<KeyboardShortcutEntry> originalBindings_;

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
@@ -24,11 +24,11 @@ import com.google.gwt.dom.client.Style.Cursor;
 import com.google.gwt.dom.client.Style.Position;
 import com.google.gwt.dom.client.Style.TextDecoration;
 import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.Event.NativePreviewHandler;
@@ -444,7 +444,7 @@ public class WebApplicationHeader extends Composite
       return sep;
    }
    
-   private Widget createCommandLink(String caption, ClickHandler clickHandler)
+   private Widget createCommandLink(String caption, Command clickHandler)
    {
       HyperlinkLabel link = new HyperlinkLabel(caption, clickHandler);
       return link;

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/support/SupportPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/support/SupportPopupMenu.java
@@ -15,10 +15,9 @@
 package org.rstudio.studio.client.application.ui.support;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
+import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.FlexTable;
 import com.google.gwt.user.client.ui.PopupPanel;
 import org.rstudio.core.client.widget.HyperlinkLabel;
@@ -71,8 +70,8 @@ public class SupportPopupMenu extends ThemedPopupPanel
       final PopupPanel popupPanel = this;
       
       // create a hyperlink label for this URL
-      HyperlinkLabel link = new HyperlinkLabel(caption, new ClickHandler() {
-         public void onClick(ClickEvent event)
+      HyperlinkLabel link = new HyperlinkLabel(caption, new Command() {
+         public void execute()
          {
             globalDisplay.openEmailComposeWindow(email, null);
             popupPanel.hide();

--- a/src/gwt/src/org/rstudio/studio/client/common/DiagnosticsHelpLink.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/DiagnosticsHelpLink.java
@@ -1,7 +1,7 @@
 /*
  * DiagnosticsHelpLink.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,8 +14,6 @@
  */
 
 package org.rstudio.studio.client.common;
-
-import org.rstudio.studio.client.common.HelpLink;
 
 public class DiagnosticsHelpLink extends HelpLink
 {

--- a/src/gwt/src/org/rstudio/studio/client/common/HelpLink.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/HelpLink.java
@@ -1,7 +1,7 @@
 /*
  * HelpLink.java
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,14 +14,15 @@
  */
 package org.rstudio.studio.client.common;
 
+import com.google.gwt.dom.client.Element;
+import org.rstudio.core.client.a11y.A11y;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.widget.HyperlinkLabel;
 import org.rstudio.studio.client.RStudioGinjector;
 
 import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Image;
@@ -41,9 +42,9 @@ public class HelpLink extends Composite
    
    public HelpLink(String caption,
                    String link,
-                   final boolean withVersionInf)
+                   final boolean withVersionInfo)
    {
-      this(caption, link, true, true);
+      this(caption, link, withVersionInfo, true);
    }
 
    public HelpLink(String caption, 
@@ -59,20 +60,17 @@ public class HelpLink extends Composite
     
       Image helpImage = new Image(new ImageResource2x(ThemeResources.INSTANCE.help2x()));
       helpImage.getElement().getStyle().setMarginRight(4, Unit.PX);
+      A11y.setDecorativeImage(helpImage.getElement());
       helpPanel.add(helpImage);
-      helpLink_ = new HyperlinkLabel(caption);
-      helpLink_.addClickHandler(new ClickHandler() {
-         public void onClick(ClickEvent event)
-         {
-            if (isRStudioLink_) {
-               RStudioGinjector.INSTANCE.getGlobalDisplay().openRStudioLink(
-                  link_,
-                  withVersionInfo_);
-            }
-            else {
-               RStudioGinjector.INSTANCE.getGlobalDisplay().openWindow(link_);
-            }
-         }  
+      helpLink_ = new HyperlinkLabel(caption, () -> {
+         if (isRStudioLink_) {
+            RStudioGinjector.INSTANCE.getGlobalDisplay().openRStudioLink(
+               link_,
+               withVersionInfo_);
+         }
+         else {
+            RStudioGinjector.INSTANCE.getGlobalDisplay().openWindow(link_);
+         }
       });
       helpPanel.add(helpLink_);
 
@@ -116,6 +114,12 @@ public class HelpLink extends Composite
       withVersionInfo_ = withVersionInfo;
    }
    
+   public boolean hasFocus()
+   {
+      Element e = DomUtils.getActiveElement();
+      return e != null && e == helpLink_.getElement();
+   }
+
    private HyperlinkLabel helpLink_;
    private String link_;
    private boolean isRStudioLink_;

--- a/src/gwt/src/org/rstudio/studio/client/common/PackagesHelpLink.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/PackagesHelpLink.java
@@ -1,7 +1,7 @@
 /*
  * PackagesHelpLink.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,8 +14,6 @@
  */
 
 package org.rstudio.studio.client.common;
-
-import org.rstudio.studio.client.common.HelpLink;
 
 public class PackagesHelpLink extends HelpLink
 {

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/RStudioAPI.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/RStudioAPI.java
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client.common.rstudioapi;
 
+import com.google.gwt.user.client.Command;
 import org.rstudio.core.client.MessageDisplay;
 import org.rstudio.core.client.MessageDisplay.PromptWithOptionResult;
 import org.rstudio.core.client.StringUtil;
@@ -32,8 +33,6 @@ import org.rstudio.studio.client.common.rstudioapi.model.RStudioAPIServerOperati
 import org.rstudio.studio.client.common.satellite.Satellite;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.safehtml.shared.SafeHtml;
@@ -94,10 +93,9 @@ public class RStudioAPI implements RStudioAPIShowDialogEvent.Handler
       
       if (!StringUtil.isNullOrEmpty(url))
       {
-         HyperlinkLabel link = new HyperlinkLabel(url, 
-               new ClickHandler() {
+         HyperlinkLabel link = new HyperlinkLabel(url, new Command() {
             @Override
-            public void onClick(ClickEvent event)
+            public void execute()
             {
                RStudioGinjector.INSTANCE.getGlobalDisplay()
                   .openWindow(url);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/CommitDetail.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/CommitDetail.java
@@ -1,7 +1,7 @@
 /*
  * CommitDetail.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -26,6 +26,7 @@ import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.i18n.client.DateTimeFormat.PredefinedFormat;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.*;
 import org.rstudio.core.client.Invalidation;
 import org.rstudio.core.client.Invalidation.Token;
@@ -142,9 +143,9 @@ public class CommitDetail extends Composite implements CommitDetailDisplay
                            null, 
                            commit_.getId(), 
                            view,
-                           new ClickHandler() {
+                           new Command() {
                               @Override
-                              public void onClick(ClickEvent event)
+                              public void execute()
                               { 
                                  fireEvent(new ViewFileRevisionEvent(
                                           commit_.getId(), 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/DiffFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/DiffFrame.java
@@ -15,13 +15,13 @@
 package org.rstudio.studio.client.workbench.views.vcs.dialog;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.resources.client.ImageResource.ImageOptions;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.*;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.theme.res.ThemeResources;
@@ -62,7 +62,7 @@ public class DiffFrame extends Composite
                     String filename2,
                     String commitId,
                     LineTableView diff,
-                    ClickHandler viewFileClickHandler,
+                    Command viewFileClickHandler,
                     boolean suppressViewLink)
    {
       initWidget(GWT.<Binder>create(Binder.class).createAndBindUi(this));


### PR DESCRIPTION
Fixes #4927 

You can now put focus on HelpLinks (e.g. via Tab key), they show a focus rectangle, and can be activated via Enter key or Spacebar.

The question-mark graphic is marked as being cosmetic so won't be seen by screen readers. `HelpLinks` are these controls found in a wide variety of dialog boxes:

![2019-06-10_17-26-57](https://user-images.githubusercontent.com/10569626/59236604-d9b99f00-8bab-11e9-937c-c5e08737fe92.png)

There are probably instances of the lower-level `HyperlinkLabel` object being used (looks like a hyperlink, but doesn't have the preceding question mark icon) that aren't fixed by this due to keyboard interferences from the container. I will open issue(s) when I encounter those.