### PR TITLE
whitelist '.circleci' directory

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1804,7 +1804,8 @@ bool fileListingFilter(const core::FileInfo& fileInfo)
        ext == ".httr-oauth" ||
        ext == ".github" ||
        ext == ".gitignore" ||
-       ext == ".gitattributes")
+       ext == ".gitattributes" ||
+       ext == ".circleci")
    {
       return true;
    }


### PR DESCRIPTION
The official configuration file for CircleCI 2.x is `.circleci/config.yml` ([source](https://circleci.com/docs/2.0/configuration-reference/)). It is inconvenient to edit this file in RStudio because it is ignored by default in the Files pane.

I whitelisted the `.circleci` directory using the same strategy to whitelist `.github` used in commit d35d41a36bd77177c889e1618b0c0acaef545c51.

xref: #2293 