### PR TITLE
rebuild compilation database when library mutated

### DIFF
--- a/src/cpp/core/include/core/libclang/SourceIndex.hpp
+++ b/src/cpp/core/include/core/libclang/SourceIndex.hpp
@@ -39,6 +39,7 @@ struct CompilationDatabase
    boost::function<std::vector<std::string>()> translationUnits;
    boost::function<std::vector<std::string>(const std::string&, bool)>
                                     compileArgsForTranslationUnit;
+   boost::function<void()> rebuildPackageCompilationDatabase;
 };
 
 class SourceIndex : boost::noncopyable

--- a/src/cpp/core/libclang/SourceIndex.cpp
+++ b/src/cpp/core/libclang/SourceIndex.cpp
@@ -17,6 +17,7 @@
 
 #include <gsl/gsl>
 
+#include <core/Debug.hpp>
 #include <core/FilePath.hpp>
 #include <core/PerformanceTimer.hpp>
 
@@ -233,6 +234,13 @@ TranslationUnit SourceIndex::getTranslationUnit(const std::string& filename,
    // add verbose output if requested
    if (verbose_ >= 2)
      args.push_back("-v");
+
+   // report to user if requested
+   if (verbose_ > 1)
+   {
+      std::cerr << "COMPILATION ARGUMENTS:" << std::endl;
+      core::debug::print(args);
+   }
 
    // get the args in the fashion libclang expects (char**)
    core::system::ProcessArgs argsArray(args);

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -720,6 +720,10 @@ std::vector<std::string> RCompilationDatabase::projectTranslationUnits() const
    return units;
 }
 
+void RCompilationDatabase::rebuildPackageCompilationDatabase()
+{
+   packageBuildFileHash_.clear();
+}
 
 bool RCompilationDatabase::shouldIndexConfig(const CompilationConfig& config)
 {
@@ -1131,6 +1135,7 @@ core::libclang::CompilationDatabase rCompilationDatabase()
    static RCompilationDatabase instance;
 
    CompilationDatabase compilationDatabase;
+
    compilationDatabase.hasTranslationUnit =
       boost::bind(&RCompilationDatabase::isProjectTranslationUnit,
                   &instance, _1);
@@ -1140,6 +1145,10 @@ core::libclang::CompilationDatabase rCompilationDatabase()
    compilationDatabase.compileArgsForTranslationUnit =
       boost::bind(&RCompilationDatabase::compileArgsForTranslationUnit,
                   &instance, _1, _2);
+   compilationDatabase.rebuildPackageCompilationDatabase =
+         boost::bind(&RCompilationDatabase::rebuildPackageCompilationDatabase,
+                     &instance);
+
    return compilationDatabase;
 }
 

--- a/src/cpp/session/modules/clang/RCompilationDatabase.hpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.hpp
@@ -50,6 +50,8 @@ public:
 
    std::vector<std::string> projectTranslationUnits() const;
 
+   void rebuildPackageCompilationDatabase();
+
 private:
 
    core::Error executeSourceCpp(core::system::Options env,

--- a/src/cpp/session/modules/clang/SessionClang.cpp
+++ b/src/cpp/session/modules/clang/SessionClang.cpp
@@ -37,6 +37,7 @@
 #include "GoToDefinition.hpp"
 #include "CodeCompletion.hpp"
 #include "RSourceIndex.hpp"
+#include "RCompilationDatabase.hpp"
 
 using namespace rstudio::core ;
 using namespace rstudio::core::libclang;
@@ -153,6 +154,11 @@ void onAllSourceDocsRemoved()
    rSourceIndex().removeAllTranslationUnits();
 }
 
+void onPackageLibraryMutated()
+{
+   rCompilationDatabase().rebuildPackageCompilationDatabase();
+}
+
 bool cppIndexingDisabled()
 {
    return ! r::options::getOption<bool>("rstudio.indexCpp", true, false);
@@ -243,6 +249,10 @@ Error initialize()
    source_database::events().onDocUpdated.connect(onSourceDocUpdated);
    source_database::events().onDocRemoved.connect(onSourceDocRemoved);
    source_database::events().onRemoveAll.connect(onAllSourceDocsRemoved);
+
+   // listen for package install / remove events (required in case we
+   // need to rebuild package compilation db)
+   module_context::events().onPackageLibraryMutated.connect(onPackageLibraryMutated);
 
    return Success();
 }


### PR DESCRIPTION
When the package library is mutated, we signal that files will need to be re-indexed in packages. This is necessary for LinkingTo dependencies -- if we build the compilation index while a required package is not installed, we'll end up missing a required compilation include path.

Without this change, a package with a broken compilation database would not get updated even if the required package was later installed. Only a forceful eviction of the cached compilation arguments (delete `.Rproj.user`; trigger by editing e.g. `src/Makevars`) would cause that to happen.