### PR TITLE
disable synthetic tablet events

### DIFF
--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -488,6 +488,13 @@ int main(int argc, char* argv[])
 
       // set application attributes
       QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+
+      // don't synthesize mouse events for unhandled tablet events,
+      // as this causes tablet clicks to be duplicated (effectively
+      // leading to single clicks registering as double clicks)
+      //
+      // https://bugreports.qt.io/browse/QTBUG-76347
+      QCoreApplication::setAttribute(Qt::AA_SynthesizeMouseForUnhandledTabletEvents, false);
       
       // enable viewport meta (allows us to control / restrict
       // certain touch gestures)


### PR DESCRIPTION
This PR fixes an issue where single-clicks with a Tablet pen would actually be registered as double-clicks.

See e.g. https://community.rstudio.com/t/rstudio-1-2-1335-on-ubuntu-18-04-2-with-wacom-intuos-small-tablet