### PR TITLE
enforce required '-std=' argument when generating precompiled headers

### DIFF
--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -1059,10 +1059,6 @@ std::vector<std::string> RCompilationDatabase::precompiledHeaderArgs(
       // start with base args
       std::vector<std::string> args = baseCompilationArgs(true);
 
-      // -std argument
-      if (!stdArg.empty())
-         args.push_back(stdArg);
-
       // run R CMD SHLIB
       core::system::Options env = compilationEnvironment();
       FilePath tempSrcFile = module_context::tempFile("clang", "cpp");
@@ -1072,6 +1068,15 @@ std::vector<std::string> RCompilationDatabase::precompiledHeaderArgs(
       // add this package's path to the args
       std::vector<std::string> pkgArgs = includesForLinkingTo(pkgName);
       std::copy(pkgArgs.begin(), pkgArgs.end(), std::back_inserter(args));
+
+      // enforce compilation with requested standard
+      core::algorithm::expel_if(args, [](const std::string& arg) {
+         return arg.find("-std=") == 0;
+      });
+
+      // add in '-std' argument (if any)
+      if (!stdArg.empty())
+         args.push_back(stdArg);
 
       // create args array
       core::system::ProcessArgs argsArray(args);


### PR DESCRIPTION
Fixes https://github.com/rstudio/rstudio/issues/4724.

This one was a bit tricky to unravel, but here's the story...

With R 3.6.0, the default C++ compiler is now C++11. R accomplishes this on macOS by setting the CXX Make variable in `etc/Makeconf`, as:

```
CXX = clang++ -std=gnu++11
```

However, when working with a package project, one might request a different C++ standard -- for example, by setting `CXX_STD = CXX14`, or `SystemRequirements: C++14`. There is machinery in R (and RStudio) to ensure these compilation options are respected.

The problem: RStudio tries to generate precompiled headers (PCH) for packages, to speed up compilation for diagnostics. These PCH are also sensitive to the C++ standard used during compilation. However, rather than reusing the previously-computed and known compilation arguments, we attempted to re-compute the compilation arguments -- e.g. by running `R CMD SHLIB` on a dummy file.

The problem with doing this is that we're now attempting to compile a file outside of the context of a package project. This means that all the previously-mentioned mechanisms for setting the C++ standard are no longer being considered, and so the default C++ standard (in this case, C++11) is being used when generating the precompiled headers.

This means that eventually, the diagnostic system will request compilation with the C++14 standard, but try to use C++11 precompiled headers -- and that fails with the error

```
error: C++14 was disabled in PCH file but is currently enabled
```

The fix here is to just propagate the compile arguments we've already generated when attempting to generate precompiled headers as well.