### PR TITLE
Fix hang when running R session unit tests

### DIFF
--- a/src/cpp/r/session/RScriptCallbacks.cpp
+++ b/src/cpp/r/session/RScriptCallbacks.cpp
@@ -99,6 +99,11 @@ void RWriteStdout (const char *buf, int buflen, int otype)
    std::cout << buf;
 }
 
+void RScriptCleanUp(SA_TYPE saveact, int status, int runLast)
+{
+   // override save action for script runs
+   stdInternalCallbacks()->cleanUp(SA_NOSAVE, status, runLast);
+}
    
 } // namespace session
 } // namespace r

--- a/src/cpp/r/session/RScriptCallbacks.hpp
+++ b/src/cpp/r/session/RScriptCallbacks.hpp
@@ -26,6 +26,7 @@ int RReadScript (const char *pmt, CONSOLE_BUFFER_CHAR* buf, int buflen, int hist
 
 void RWriteStdout (const char *buf, int buflen, int otype);
 
+void RScriptCleanUp(SA_TYPE saveact, int status, int runLast);
 
 } // namespace session
 } // namespace r

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -347,6 +347,7 @@ Error run(const ROptions& options, const RCallbacks& callbacks)
       // normal session: read/write from browser
       cb.readConsole = RReadConsole;
       cb.writeConsoleEx = RWriteConsoleEx;
+      cb.cleanUp = RCleanUp;
    }
    else
    {
@@ -354,6 +355,7 @@ Error run(const ROptions& options, const RCallbacks& callbacks)
       setRunScript(options.runScript);
       cb.readConsole = RReadScript;
       cb.writeConsoleEx = RWriteStdout;
+      cb.cleanUp = RScriptCleanUp;
    }
 
    cb.showMessage = RShowMessage;
@@ -365,7 +367,6 @@ Error run(const ROptions& options, const RCallbacks& callbacks)
    cb.savehistory = Rsavehistory;
    cb.addhistory = Raddhistory;
    cb.suicide = RSuicide;
-   cb.cleanUp = RCleanUp;
    r::session::runEmbeddedR(FilePath(rLocations.homePath),
                             options.userHomePath,
                             quiet,


### PR DESCRIPTION
This change fixes an issue that occurs when the R session unit tests are run on a machine where RStudio is configured to ask the user whether to save the workspace on exiting.

The fix is to skip our usual interactive session cleanup routines when we're running a test script, and instead to invoke R's own cleanup handler directly without saving the workspace. 

Fixes #4867.