### PR TITLE
forward keydown events to shortcut manager

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/dataviewer/DataTable.java
+++ b/src/gwt/src/org/rstudio/studio/client/dataviewer/DataTable.java
@@ -19,12 +19,16 @@ import java.util.ArrayList;
 
 import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.CommandWith2Args;
+import org.rstudio.core.client.command.ShortcutManager;
 import org.rstudio.core.client.dom.IFrameElementEx;
 import org.rstudio.core.client.dom.WindowEx;
+import org.rstudio.core.client.events.NativeKeyDownEvent;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.*;
 
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
@@ -196,6 +200,24 @@ public class DataTable
    {
       IFrameElementEx frameEl = (IFrameElementEx) host_.getDataTableFrame().getElement().cast();
       return frameEl.getContentWindow();
+   }
+   
+   public void addKeyDownHandler()
+   {
+      addKeyDownHandlerImpl(getWindow().getDocument().getBody());
+   }
+   
+   private final native void addKeyDownHandlerImpl(Element body)
+   /*-{
+      var self = this;
+      body.addEventListener("keydown", $entry(function(event) {
+         self.@org.rstudio.studio.client.dataviewer.DataTable::onKeyDown(*)(event);
+      }));
+   }-*/;
+   
+   private void onKeyDown(NativeEvent event)
+   {
+      ShortcutManager.INSTANCE.onKeyDown(new NativeKeyDownEvent(event));
    }
 
    public boolean setFilterUIVisible(boolean visible)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTargetWidget.java
@@ -113,9 +113,12 @@ public class DataEditingTargetWidget extends Composite
                      "[[" + col + "]]" + 
                      "[[" + row + "]])", true));
          };
+         
+         table_.addKeyDownHandler();
          table_.setDataViewerCallback(view);
          table_.setListViewerCallback(view);
          table_.setColumnFrameCallback();
+         
       });
 
       Widget mainWidget;


### PR DESCRIPTION
Closes #4944. Also ensures other shortcuts (like move to next tab, move to previous tab) work as expected if a Data Viewer frame has focus.