### PR TITLE
Annotate crash with Sentry release

### DIFF
--- a/src/cpp/core/CrashHandler.cpp
+++ b/src/cpp/core/CrashHandler.cpp
@@ -293,6 +293,7 @@ Error initialize(ProgramMode programMode)
    // initialize and start crashpad client
    s_crashpadClient.reset(new crashpad::CrashpadClient());
    std::map<std::string, std::string> annotations;
+   annotations["sentry[release]"] = RSTUDIO_VERSION;
    std::vector<std::string> args {"--no-rate-limit"};
 
 #ifdef __linux__

--- a/src/cpp/core/config.h.in
+++ b/src/cpp/core/config.h.in
@@ -13,6 +13,10 @@
  *
  */
 
+#ifndef RSTUDIO_VERSION
+#define RSTUDIO_VERSION "${CPACK_PACKAGE_VERSION}"
+#endif
+
 #cmakedefine HAVE_SA_NOCLDWAIT
 #cmakedefine HAVE_INOTIFY_INIT1
 #cmakedefine HAVE_SO_PEERCRED


### PR DESCRIPTION
This change adds the RStudio release version as an annotation to the crash upload, so that crashes can be paired with version numbers.

> [...] to support this, the annotations from all the CrashpadInfo structures found in the crashing process are merged to create the Breakpad “crash keys” as form data. 

https://chromium.googlesource.com/crashpad/crashpad/+/HEAD/doc/overview_design.md

> You can add more information to crash reports simply by adding more fields to the upload HTTP request. [...] For example, to set the release and add a tag, send: `-F 'sentry[release]=1.0.0'`

https://docs.sentry.io/platforms/minidump/#minidump-additional

