### PR TITLE
automatically keep keyboard focus in modal dialogs when tabbing

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/FileDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/FileDialog.java
@@ -196,7 +196,7 @@ public abstract class FileDialog extends FileSystemDialog
    }
 
    @Override
-   protected void onDialogShown()
+   protected void focusInitialControl()
    {
       browser_.setFilenameFocus(true);
       browser_.selectFilename();

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/FileSystemDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/FileSystemDialog.java
@@ -235,11 +235,6 @@ public abstract class FileSystemDialog extends ModalDialogBase
    }
 
    @Override
-   protected void onDialogShown()
-   {
-   }
-
-   @Override
    public void onPreviewNativeEvent(Event.NativePreviewEvent event)
    {
       if (event.getTypeInt() == Event.ONKEYDOWN

--- a/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBase.java
@@ -164,23 +164,6 @@ public abstract class PreferencesDialogBase<T> extends ModalDialogBase
       return panel_;
    }
 
-   @Override
-   protected void onDialogShown()
-   {
-      focusOkButton();
-   }
-
-   @Override
-   protected void focusFirstControl()
-   {
-      Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand() {
-         public void execute()
-         {
-            sectionChooser_.focus();
-         }
-      });
-   }
-
    protected void hidePane(int index)
    {
       sectionChooser_.hideSection(index);

--- a/src/gwt/src/org/rstudio/core/client/widget/MessageDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/MessageDialog.java
@@ -144,13 +144,13 @@ public class MessageDialog extends ModalDialogBase
                      ThemeResources.INSTANCE.themeStyles().dialogMessage());
       return label;
    }
-    
+
    @Override
-   protected void onDialogShown()
+   protected void focusInitialControl()
    {
       focusOkButton();
    }
-   
+
    private int type_ ;
    private Widget messageWidget_ ;
    private ProgressIndicator progress_ ;

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -18,10 +18,10 @@ package org.rstudio.core.client.widget;
 import com.google.gwt.animation.client.Animation;
 import com.google.gwt.aria.client.DialogRole;
 import com.google.gwt.aria.client.Id;
-import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.dom.client.NodeList;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.*;
@@ -31,6 +31,7 @@ import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.HasHorizontalAlignment.HorizontalAlignmentConstant;
 
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.Point;
 import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.command.ShortcutManager;
@@ -45,6 +46,9 @@ import java.util.ArrayList;
 
 public abstract class ModalDialogBase extends DialogBox
 {
+   private static final String firstFocusClass = "__rstudio_modal_first_focus";
+   private static final String lastFocusClass = "__rstudio_modal_last_focus";
+
    protected ModalDialogBase(DialogRole role)
    {
       this(null, role);
@@ -63,12 +67,6 @@ public abstract class ModalDialogBase extends DialogBox
       role_ = role;
       role_.set(getElement());
       A11y.setARIADialogModal(getElement());
-      firstControl_ = new Button("First");
-      lastControl_ = new Button("Last");
-      Roles.getButtonRole().setAriaHiddenState(firstControl_.getElement(), true);
-      Roles.getButtonRole().setAriaHiddenState(lastControl_.getElement(), true);
-      DomUtils.visuallyHide(firstControl_.getElement());
-      DomUtils.visuallyHide(lastControl_.getElement());
 
       // main panel used to host UI
       mainPanel_ = new VerticalPanel();
@@ -79,9 +77,7 @@ public abstract class ModalDialogBase extends DialogBox
       leftButtonPanel_ = new HorizontalPanel();
       bottomPanel_.add(leftButtonPanel_);
       bottomPanel_.add(buttonPanel_);
-      bottomPanel_.add(lastControl_);
       setButtonAlignment(HasHorizontalAlignment.ALIGN_RIGHT);
-      mainPanel_.add(firstControl_);
       mainPanel_.add(bottomPanel_);
 
       // embed main panel in a custom container if specified
@@ -105,16 +101,6 @@ public abstract class ModalDialogBase extends DialogBox
             event.stopPropagation();
          }
       }, KeyDownEvent.getType());
-
-      firstControl_.addFocusHandler(event -> {
-         // hidden first control in dialog got focus, wrap around to last control
-         focusLastControl();
-      });
-      
-      lastControl_.addFocusHandler(event -> {
-         // hidden last control in dialog got focus, wrap around to first control
-         focusFirstControl();
-      });
    }
 
    @Override
@@ -188,9 +174,7 @@ public abstract class ModalDialogBase extends DialogBox
 
          // get the main widget to line up with the right edge of the buttons.
          mainWidget_.getElement().getStyle().setMarginRight(2, Unit.PX);
-
-         // insert after hidden control used to wrap focus when tabbing through dialog
-         mainPanel_.insert(mainWidget_, 1);
+         mainPanel_.insert(mainWidget_, 0);
       }
 
       originallyActiveElement_ = DomUtils.getActiveElement();
@@ -203,7 +187,7 @@ public abstract class ModalDialogBase extends DialogBox
          public void execute()
          {
             // defer shown notification to allow all elements to render
-            // before attempting to interact w/ them programatically (e.g. setFocus)
+            // before attempting to interact w/ them programmatically (e.g. setFocus)
             Timer timer = new Timer() {
                public void run() {
                   onDialogShown();
@@ -225,6 +209,15 @@ public abstract class ModalDialogBase extends DialogBox
 
    protected void onDialogShown()
    {
+      refreshFocusableElements();
+      focusInitialControl();
+      
+      // try hard to make sure focus ends up in dialog
+      Element focused = DomUtils.getActiveElement();
+      if (focused == null || !DomUtils.contains(getElement(), focused))
+      {
+        focusFirstControl();
+      }
    }
 
    protected void addOkButton(ThemedButton okButton)
@@ -335,7 +328,6 @@ public abstract class ModalDialogBase extends DialogBox
       button.addStyleDependentName("DialogAction");
       buttonPanel_.add(button);
       allButtons_.add(button);
-      lastVisibleButton_ = button;
    }
 
    // inserts an action button--in the same panel as OK/cancel, but preceding
@@ -510,6 +502,23 @@ public abstract class ModalDialogBase extends DialogBox
                break;
             onEscapeKeyDown(event);
             break;
+            
+         case KeyCodes.KEY_TAB:
+            if (nativeEvent.getShiftKey() && DomUtils.getActiveElement().hasClassName(firstFocusClass))
+            {
+               nativeEvent.preventDefault();
+               nativeEvent.stopPropagation();
+               event.cancel();
+               focusLastControl();
+            }
+            else if (!nativeEvent.getShiftKey() && DomUtils.getActiveElement().hasClassName(lastFocusClass))
+            {
+               nativeEvent.preventDefault();
+               nativeEvent.stopPropagation();
+               event.cancel();
+               focusFirstControl();
+            }
+            break;
          }
       }
    }
@@ -604,16 +613,104 @@ public abstract class ModalDialogBase extends DialogBox
       role_.setAriaDescribedbyProperty(getElement(), value);
    }
 
-   // invoked when user hits Tab key with focus on last control in dialog
+   /**
+    * Set focus on first keyboard focusable element in dialog, as set by 
+    * <code>refreshFocusableElements</code> or <code>setFirstFocusableElement</code>.
+    */
    protected void focusFirstControl()
    {
+      Element first = getByClass(firstFocusClass);
+      if (first != null)
+         first.focus();
+   }
+
+    /**
+    * Set focus on last keyboard focusable element in dialog, as set by 
+    * <code>refreshFocusableElements</code> or <code>setLastFocusableElement</code>.
+    */  protected void focusLastControl()
+   {
+      Element last = getByClass(lastFocusClass);
+      if (last != null)
+         last.focus();
+   }
+
+   /**
+    * Invoked when dialog first loads to set initial focus. By default sets focus on the 
+    * first control in the dialog; override to set initial focus elsewhere.
+    */
+   protected void focusInitialControl()
+   {
+      focusFirstControl();
+   }
+
+   /**
+    * @param element first keyboard focusable element in the dialog
+    */
+   private void setFirstFocusableElement(Element element)
+   {
+      removeExisting(firstFocusClass);
+      element.addClassName(firstFocusClass);
+   }
+
+   /**
+    * @param element last keyboard focusable element in the dialog
+    */
+   private void setLastFocusableElement(Element element)
+   {
+      removeExisting(lastFocusClass);
+      element.addClassName(lastFocusClass);
+   }
+
+   /**
+    * Gets a list of keyboard focusable elements in the dialog, and tracks which ones are
+    * first and last. This is used to keep keyboard focus in the dialog when Tabbing and
+    * Shift+Tabbing off end or beginning of dialog.
+    * 
+    * If the dialog is dynamic, and the first and/or last focusable elements change over time,
+    * call this function again to update the information; or, if the auto-detection
+    * is not suitable, call setFirstFocusableElement and/or setLastFocusableElement to directly
+    * control first/last.
+    */
+   public void refreshFocusableElements()
+   {
+      // css selector from https://github.com/scottaohara/accessible_modal_window
+      String focusableElements = 
+            "button:not([hidden]):not([disabled]), [href]:not([hidden]), " +
+            "input:not([hidden]):not([type=\"hidden\"]):not([disabled]), " +
+            "select:not([hidden]):not([disabled]), textarea:not([hidden]):not([disabled]), " +
+            "[tabindex=\"0\"]:not([hidden]):not([disabled]), summary:not([hidden]), " +
+            "[contenteditable]:not([hidden]), audio[controls]:not([hidden]), " +
+            "video[controls]:not([hidden])";
+      NodeList<Element> focusable = DomUtils.querySelectorAll(getElement(), focusableElements);
+      if (focusable.getLength() == 0)
+      {
+         Debug.logWarning("No focusable controls found in modal dialog");
+         return;
+      }
+      setFirstFocusableElement(focusable.getItem(0));
+      setLastFocusableElement(focusable.getItem(focusable.getLength() - 1));
    }
    
-   // invoked when user hits Shift+Tab key with focus on first control in dialog
-   protected void focusLastControl()
+   private void removeExisting(String classname)
    {
-      if (lastVisibleButton_ != null)
-         FocusHelper.setFocusDeferred(lastVisibleButton_);
+      Element current = getByClass(classname);
+      if (current != null)
+         current.removeClassName(classname);
+   }
+
+   private Element getByClass(String classname)
+   {
+      NodeList<Element> current = DomUtils.querySelectorAll(getElement(), "." + classname);
+      if (current.getLength() > 1)
+      {
+         Debug.logWarning("Multiple controls found with class: " + classname);
+         return null;
+      }
+      if (current.getLength() == 1)
+      {
+         return current.getItem(0);
+      }
+      return null;
    }
 
    private Handle shortcutDisableHandle_;
@@ -633,7 +730,4 @@ public abstract class ModalDialogBase extends DialogBox
    private com.google.gwt.dom.client.Element originallyActiveElement_;
    private Animation currentAnimation_ = null;
    private DialogRole role_;
-   private Button firstControl_;
-   private Button lastControl_;
-   private ThemedButton lastVisibleButton_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -617,7 +617,7 @@ public abstract class ModalDialogBase extends DialogBox
     * Set focus on first keyboard focusable element in dialog, as set by 
     * <code>refreshFocusableElements</code> or <code>setFirstFocusableElement</code>.
     */
-   protected void focusFirstControl()
+   private void focusFirstControl()
    {
       Element first = getByClass(firstFocusClass);
       if (first != null)
@@ -628,7 +628,7 @@ public abstract class ModalDialogBase extends DialogBox
     * Set focus on last keyboard focusable element in dialog, as set by 
     * <code>refreshFocusableElements</code> or <code>setLastFocusableElement</code>.
     */
-   protected void focusLastControl()
+   private void focusLastControl()
    {
       Element last = getByClass(lastFocusClass);
       if (last != null)

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -627,7 +627,8 @@ public abstract class ModalDialogBase extends DialogBox
     /**
     * Set focus on last keyboard focusable element in dialog, as set by 
     * <code>refreshFocusableElements</code> or <code>setLastFocusableElement</code>.
-    */  protected void focusLastControl()
+    */
+   protected void focusLastControl()
    {
       Element last = getByClass(lastFocusClass);
       if (last != null)

--- a/src/gwt/src/org/rstudio/core/client/widget/SlideLabel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SlideLabel.java
@@ -155,7 +155,7 @@ public class SlideLabel extends Composite
          progress_.getStyle().setDisplay(Style.Display.NONE);
       curtain_.setHeight("0px");
 
-      cancel_.setVisible(false);
+      setCancelVisible(false);
       Roles.getPresentationRole().set(border_);
       Roles.getProgressbarRole().set(innerTable_);
       progress_.setAlt("Spinner");
@@ -295,7 +295,7 @@ public class SlideLabel extends Composite
    public void onCancel(final Operation onCancel)
    {
       onCancel_ = onCancel;
-      cancel_.setVisible(onCancel != null);
+      setCancelVisible(onCancel != null);
    }
 
    private void setHeight(double height)
@@ -316,6 +316,17 @@ public class SlideLabel extends Composite
          currentAutoHideTimer_.cancel();
          currentAutoHideTimer_ = null;
       }
+   }
+
+   private void setCancelVisible(boolean visible)
+   {
+      cancel_.setVisible(visible);
+      
+      // also disable so it isn't picked up as potentially focusable via Tab key
+      if (!visible)
+         cancel_.getElement().setAttribute("disabled", "");
+      else
+         cancel_.getElement().removeAttribute("disabled");
    }
 
    @UiField

--- a/src/gwt/src/org/rstudio/core/client/widget/TextEntryModalDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/TextEntryModalDialog.java
@@ -69,7 +69,7 @@ public class TextEntryModalDialog extends ModalDialog<String>
    }
    
    @Override
-   protected void onDialogShown()
+   protected void focusInitialControl()
    {
       textBox_.setFocus(true);
       

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialog.java
@@ -54,17 +54,11 @@ public class AboutDialog extends ModalDialogBase
    {
       return contents_;
    }
-   
-   @Override
-   protected void onDialogShown()
-   {
-      focusOkButton();
-   }
 
    @Override
-   protected void focusFirstControl()
+   protected void focusInitialControl()
    {
-      contents_.focusFirstControl();
+      focusOkButton();
    }
 
    @Inject

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.java
@@ -94,11 +94,6 @@ public class AboutDialogContents extends Composite
          }
       }
    }
-   
-   public void focusFirstControl()
-   {
-      gplLink.setFocus(true);
-   }
 
    public Element getDescriptionElement()
    {

--- a/src/gwt/src/org/rstudio/studio/client/common/rpubs/ui/RPubsUploadDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rpubs/ui/RPubsUploadDialog.java
@@ -257,12 +257,12 @@ public class RPubsUploadDialog extends ModalDialogBase
    }
    
    @Override
-   protected void onDialogShown()
+   protected void focusInitialControl()
    {
-      super.onDialogShown();
-      
       if (hasTitle())
          titleTextBox_.setFocus(true);
+      else
+         super.focusInitialControl();
    }
    
    protected void onUnload()

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/ui/AskSecretDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/ui/AskSecretDialog.java
@@ -191,7 +191,7 @@ public class AskSecretDialog extends ModalDialog<AskSecretDialogResult>
    }
 
    @Override
-   protected void onDialogShown()
+   protected void focusInitialControl()
    {
       textbox_.setFocus(true);
       textbox_.setSelectionRange(0, textbox_.getText().length());

--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/ignore/IgnoreDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/ignore/IgnoreDialog.java
@@ -166,7 +166,7 @@ public class IgnoreDialog extends ModalDialogBase
    }
    
    @Override
-   protected void onDialogShown()
+   protected void focusInitialControl()
    {
       editor_.focus();
    }

--- a/src/gwt/src/org/rstudio/studio/client/notebook/CompileNotebookOptionsDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/notebook/CompileNotebookOptionsDialog.java
@@ -92,7 +92,7 @@ public class CompileNotebookOptionsDialog extends ModalDialog<CompileNotebookOpt
    }
 
    @Override
-   protected void onDialogShown()
+   protected void focusInitialControl()
    {
       txtTitle_.setFocus(true);
       txtTitle_.selectAll();

--- a/src/gwt/src/org/rstudio/studio/client/notebookv2/CompileNotebookv2OptionsDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/notebookv2/CompileNotebookv2OptionsDialog.java
@@ -55,9 +55,8 @@ public class CompileNotebookv2OptionsDialog extends ModalDialog<CompileNotebookv
    }
 
    @Override
-   protected void onDialogShown()
+   protected void focusInitialControl()
    {
-      super.onDialogShown();
       listFormat_.setFocus(true);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ui/ShinyGadgetDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ui/ShinyGadgetDialog.java
@@ -102,9 +102,8 @@ public class ShinyGadgetDialog extends ModalDialogBase
    }
    
    @Override
-   protected void onDialogShown()
+   protected void focusInitialControl()
    {
-      super.onDialogShown();
       frame_.getWindow().focus();
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/ui/CodeSearchDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/ui/CodeSearchDialog.java
@@ -72,7 +72,7 @@ public class CodeSearchDialog extends ModalDialogBase
    }
    
    @Override
-   protected void onDialogShown()
+   protected void focusInitialControl()
    { 
       ((CanFocus)codeSearch_.getSearchWidget()).focus();
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/ExportPlotDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/ExportPlotDialog.java
@@ -98,9 +98,8 @@ public class ExportPlotDialog extends ModalDialogBase
     
   
    @Override
-   protected void onDialogShown()
+   protected void focusInitialControl()
    {
-      super.onDialogShown();
       sizeEditor_.onSizerShown();
    }
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/SavePlotAsImageDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/SavePlotAsImageDialog.java
@@ -82,9 +82,8 @@ public class SavePlotAsImageDialog extends ExportPlotDialog
    }
    
    @Override
-   protected void onDialogShown()
+   protected void focusInitialControl()
    {
-      super.onDialogShown();
       saveAsTarget_.focus();
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/snippets/ui/EditSnippetsDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/snippets/ui/EditSnippetsDialog.java
@@ -164,7 +164,7 @@ public class EditSnippetsDialog extends ModalDialogBase implements TextDisplay
    }
    
    @Override
-   public void onDialogShown()
+   public void focusInitialControl()
    {
       docDisplay_.focus();
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/unsaved/UnsavedChangesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/unsaved/UnsavedChangesDialog.java
@@ -120,7 +120,7 @@ public class UnsavedChangesDialog extends ModalDialog<UnsavedChangesDialog.Resul
    }
    
    @Override
-   protected void onDialogShown()
+   protected void focusInitialControl()
    {
       focusOkButton();
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/edit/ui/EditDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/edit/ui/EditDialog.java
@@ -121,7 +121,7 @@ public class EditDialog extends ModalDialogBase
    }
    
    @Override
-   protected void onDialogShown()
+   protected void focusInitialControl()
    {
       editor_.focus();
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
@@ -196,10 +196,8 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
    }
 
    @Override
-   protected void onDialogShown()
+   protected void focusInitialControl()
    {
-      super.onDialogShown();
-
       txtSearchPattern_.setFocus(true);
       txtSearchPattern_.selectAll();
       updateOkButtonEnabled();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/InstallPackageDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/InstallPackageDialog.java
@@ -252,7 +252,7 @@ public class InstallPackageDialog extends ModalDialog<PackageInstallRequest>
    }
    
    @Override
-   protected void onDialogShown()
+   protected void focusInitialControl()
    {
       if (installFromRepository())
          FocusHelper.setFocusDeferred(packagesSuggestBox_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/export/SavePlotAsPdfDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/export/SavePlotAsPdfDialog.java
@@ -131,7 +131,7 @@ public class SavePlotAsPdfDialog extends ModalDialogBase
    }
    
    @Override 
-   protected void onDialogShown()
+   protected void focusInitialControl()
    {
       fileNameTextBox_.setFocus(true);
       fileNameTextBox_.selectAll();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewPlumberAPI.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewPlumberAPI.java
@@ -222,9 +222,8 @@ public class NewPlumberAPI extends ModalDialog<NewPlumberAPI.Result>
    }
    
    @Override
-   protected void onDialogShown()
+   protected void focusInitialControl()
    {
-      super.onDialogShown();
       apiNameTextBox_.setFocus(true);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewShinyWebApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewShinyWebApplication.java
@@ -261,9 +261,8 @@ public class NewShinyWebApplication extends ModalDialog<NewShinyWebApplication.R
    }
    
    @Override
-   protected void onDialogShown()
+   protected void focusInitialControl()
    {
-      super.onDialogShown();
       appNameTextBox_.setFocus(true);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.java
@@ -268,11 +268,10 @@ public class NewRMarkdownDialog extends ModalDialog<NewRMarkdownDialog.Result>
    }
    
    @Override
-   protected void onDialogShown()
+   protected void focusInitialControl()
    {
       // when dialog is finished booting, focus the title so it's ready to
       // accept input
-      super.onDialogShown();
       txtTitle_.setSelectionRange(0, txtTitle_.getText().length());
       txtTitle_.setFocus(true);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRdDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRdDialog.java
@@ -62,7 +62,7 @@ public class NewRdDialog extends ModalDialog<NewRdDialog.Result>
    }
    
    @Override
-   protected void onDialogShown()
+   protected void focusInitialControl()
    {
       txtName_.setFocus(true);
    }


### PR DESCRIPTION
- replace my initial hack of hidden focusable controls (in ModalDialogBase) with a more automatic approach
- the hidden controls were, themselves, flagged as accessibility violations (allowing hidden controls to get focus); plus they made some screen-readers stutter as focus was bounced from them to visible controls
- now the code makes a reasonable determination of what focusable elements are first and last instead of requiring each dialog subclass to define it and overrides Tab and Shift+Tab to move focus to them
- provides hooks for dialogs to override the default behavior for initial focus, and defining/updating "first" and "last" controls in the dialog, and to refresh the default choices if UI is changed
- probably some individual dialogs will need to use those hooks for best behavior, but overall this makes it just work for most dialogs
- fixes #4729