### PR TITLE
No longer stop processes with ::abort, instead use std::_Exit

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1338,7 +1338,11 @@ void detectParentTermination()
    if (result == ParentTerminationAbnormal)
    {
       LOG_ERROR_MESSAGE("Parent terminated");
-      core::system::abort();
+
+      // we no longer exit with ::abort because it generated unwanted exceptions
+      // ::_Exit should perform the same functionality (not running destructors and exiting process)
+      // without generating an exception
+      std::_Exit(EXIT_FAILURE);
    }
    else if (result == ParentTerminationNormal)
    {

--- a/src/cpp/session/http/SessionHttpConnectionUtils.cpp
+++ b/src/cpp/session/http/SessionHttpConnectionUtils.cpp
@@ -159,8 +159,11 @@ bool checkForAbort(boost::shared_ptr<HttpConnection> ptrConnection,
       // kill child processes before going down
       terminateAllChildProcesses();
 
-      // abort
-      ::abort();
+      // abort the process
+      // we no longer do this with ::abort because it generated unwanted exceptions
+      // ::_Exit should perform the same functionality (not running destructors and exiting process)
+      // without generating an exception
+      std::_Exit(EXIT_SUCCESS);
       return true;
    }
    else


### PR DESCRIPTION
This will perform a similar exit (no destructors run) without generating an exception. 

Fixes IDE-BACKEND-13, Fixes IDE-BACKEND-V, Fixes IDE-BACKEND-3C, Fixes IDE-BACKEND-2W, IDE-BACKEND-1Q, IDE-BACKEND-25