### PR TITLE
Install testthat during machine setup

### DIFF
--- a/dependencies/common/install-packages
+++ b/dependencies/common/install-packages
@@ -3,7 +3,7 @@
 #
 # install-packages
 #
-# Copyright (C) 2009-18 by RStudio, Inc.
+# Copyright (C) 2009-19 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -80,6 +80,9 @@ mv $PACKAGE_ARCHIVE $PACKAGE_ARCHIVE_SHA1
 # we often embed these packages but are not currently
 # install rmarkdown master rstudio
 # install rsconnect master rstudio
+
+# Packages needed to run tests
+Rscript -e "if(!require(testthat, quietly = TRUE)) { install.packages('testthat', repos='https://cran.rstudio.com/') }"
 
 # back to install-dir
 cd $INSTALL_DIR


### PR DESCRIPTION
This change installs the `testthat` package when setting up dev/build machines. The `r` unit tests require this package, so installing it during the build is a prerequisite to successfully running those tests at build time.