### PR TITLE
Fixed a few bugs in the revocation list code

### DIFF
--- a/src/cpp/core/ExponentialBackoff.cpp
+++ b/src/cpp/core/ExponentialBackoff.cpp
@@ -53,7 +53,7 @@ bool ExponentialBackoff::next()
 {
    ExponentialBackoffPtr instance = shared_from_this();
 
-   LOCK_MUTEX(mutex_)
+   RECURSIVE_LOCK_MUTEX(mutex_)
    {
       // we should not continue trying if we've hit the max retries
       if (maxNumRetries_ != 0 &&
@@ -113,7 +113,7 @@ bool ExponentialBackoff::next()
          timer.reset();
 
          // wait has finished - update state and perform the action
-         LOCK_MUTEX(instance->mutex_)
+         RECURSIVE_LOCK_MUTEX(instance->mutex_)
          {
             ++instance->totalNumTries_;
          }

--- a/src/cpp/core/include/core/ExponentialBackoff.hpp
+++ b/src/cpp/core/include/core/ExponentialBackoff.hpp
@@ -61,7 +61,7 @@ private:
    boost::function<void(ExponentialBackoffPtr)> action_;
 
    boost::posix_time::time_duration lastWait_;
-   boost::mutex mutex_;
+   boost::recursive_mutex mutex_;
 };
 
 } // namespace core 


### PR DESCRIPTION
Made Exponential backoff support recursive locking to enable this particular usage, fixed a return bug where we were running code we shouldn't on error, and made it so that the server user becomes the directory owner of the revocation list dir so that file locking works properly when we give up root privilege. 

Fixes #4976