### PR TITLE
initial work on renv integration

### DIFF
--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -19,8 +19,9 @@
 
 #include <gsl/gsl>
 
-#include <r/RSexp.hpp>
 #include <r/RInternal.hpp>
+#include <r/RJson.hpp>
+#include <r/RSexp.hpp>
 
 #include <core/Algorithm.hpp>
 
@@ -787,6 +788,11 @@ core::Error getNamedListSEXP(SEXP listSEXP,
    }
 }
 
+Error extract(SEXP valueSEXP, core::json::Value* pJson)
+{
+   return r::json::jsonValueFromObject(valueSEXP, pJson);
+}
+
 Error extract(SEXP valueSEXP, int* pInt)
 {
    if (TYPEOF(valueSEXP) != INTSXP)
@@ -904,30 +910,30 @@ SEXP create(SEXP valueSEXP, Protect* pProtect)
    return valueSEXP;
 }
    
-SEXP create(const json::Value& value, Protect* pProtect)
+SEXP create(const core::json::Value& value, Protect* pProtect)
 {
    // call embedded create function based on type
-   if (value.type() == json::StringType)
+   if (value.type() == core::json::StringType)
    {
       return create(value.get_str(), pProtect);
    }
-   else if (value.type() == json::IntegerType)
+   else if (value.type() == core::json::IntegerType)
    {
       return create(value.get_int(), pProtect);
    }
-   else if (value.type() == json::RealType)
+   else if (value.type() == core::json::RealType)
    {
       return create(value.get_real(), pProtect);
    }
-   else if (value.type() == json::BooleanType)
+   else if (value.type() == core::json::BooleanType)
    {
       return create(value.get_bool(), pProtect);
    }
-   else if (value.type() == json::ArrayType)
+   else if (value.type() == core::json::ArrayType)
    {
       return create(value.get_array(), pProtect);
    }
-   else if (value.type() == json::ObjectType)
+   else if (value.type() == core::json::ObjectType)
    {
       return create(value.get_obj(), pProtect);
    }
@@ -978,7 +984,7 @@ SEXP create(bool value, Protect* pProtect)
    return valueSEXP;
 }
 
-SEXP create(const json::Array& value, Protect* pProtect)
+SEXP create(const core::json::Array& value, Protect* pProtect)
 {
    // create the list
    SEXP listSEXP;
@@ -993,7 +999,7 @@ SEXP create(const json::Array& value, Protect* pProtect)
    return listSEXP;
 }
    
-SEXP create(const json::Object& value, Protect* pProtect)
+SEXP create(const core::json::Object& value, Protect* pProtect)
 {
    // create the list
    SEXP listSEXP ;
@@ -1005,7 +1011,7 @@ SEXP create(const json::Object& value, Protect* pProtect)
    
    // add each object field to it
    int index = 0;
-   for (const json::Member& member : value)
+   for (const core::json::Member& member : value)
    {
       // set name
       SET_STRING_ELT(namesSEXP, index, Rf_mkChar(member.name().c_str()));

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -134,7 +134,8 @@ core::Error extract(SEXP valueSEXP, std::string* pString, bool asUtf8 = false);
 core::Error extract(SEXP valueSEXP, std::vector<std::string>* pVector, bool asUtf8 = false);
 core::Error extract(SEXP valueSEXP, std::set<std::string>* pSet, bool asUtf8 = false);
 core::Error extract(SEXP valueSEXP, std::map< std::string, std::set<std::string> >* pMap, bool asUtf8 = false);
-      
+core::Error extract(SEXP valueSEXP, core::json::Value* pJson);
+
 // create SEXP from c++ type
 SEXP create(SEXP valueSEXP, Protect* pProtect);
 SEXP create(const core::json::Value& value, Protect* pProtect);

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -135,6 +135,7 @@ set (SESSION_SOURCE_FILES
    modules/SessionProjectTemplate.cpp
    modules/SessionRAddins.cpp
    modules/SessionRCompletions.cpp
+   modules/SessionRenv.cpp
    modules/SessionReticulate.cpp
    modules/SessionRHooks.cpp
    modules/SessionRParser.cpp

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -144,6 +144,7 @@
 #include "modules/SessionProfiler.hpp"
 #include "modules/SessionRAddins.hpp"
 #include "modules/SessionRCompletions.hpp"
+#include "modules/SessionRenv.hpp"
 #include "modules/SessionRPubs.hpp"
 #include "modules/SessionRHooks.hpp"
 #include "modules/SessionRSConnect.hpp"
@@ -560,6 +561,7 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
       (modules::plumber_viewer::initialize)
       (modules::rsconnect::initialize)
       (modules::packrat::initialize)
+      (modules::renv::initialize)
       (modules::rhooks::initialize)
       (modules::r_packages::initialize)
       (modules::diagnostics::initialize)

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -667,7 +667,7 @@ core::json::Object packratContextAsJson();
 core::json::Object packratOptionsAsJson();
 
 // implemented in SessionRenv.cpp
-core::json::Object renvContextAsJson();
+core::json::Value renvContextAsJson();
 
 // R command invocation -- has two representations, one to be submitted
 // (shellCmd_) and one to show the user (cmdString_)

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -661,10 +661,13 @@ struct PackratContext
 
 bool isRequiredPackratInstalled();
 
+// implemented in SessionPackrat.cpp
 PackratContext packratContext();
 core::json::Object packratContextAsJson();
-
 core::json::Object packratOptionsAsJson();
+
+// implemented in SessionRenv.cpp
+core::json::Object renvContextAsJson();
 
 // R command invocation -- has two representations, one to be submitted
 // (shellCmd_) and one to show the user (cmdString_)

--- a/src/cpp/session/modules/SessionPackages.cpp
+++ b/src/cpp/session/modules/SessionPackages.cpp
@@ -437,6 +437,7 @@ Error getPackageStateJson(json::Object* pJson)
       r::json::jsonValueFromObject(packageList, &packageListJson);
       (*pJson)["package_list"] = packageListJson;
       (*pJson)["packrat_context"] = packrat::contextAsJson(context);
+      (*pJson)["renv_context"] = module_context::renvContextAsJson();
    }
 
    return error;

--- a/src/cpp/session/modules/SessionPackages.cpp
+++ b/src/cpp/session/modules/SessionPackages.cpp
@@ -66,10 +66,10 @@ void insecureReposURLWarning(const std::string& url,
    std::string msg =
          "Your CRAN mirror is set to \"" + url + "\" which "
          "has an insecure (non-HTTPS) URL.";
-   
+
    if (!extraMsg.empty())
       msg += " " + extraMsg;
-   
+
    Error error = r::exec::RFunction(".rs.insecureReposWarning", msg).call();
    if (error)
       LOG_ERROR(error);
@@ -253,7 +253,7 @@ void reconcileSecureDownloadConfiguration()
 
 } // namespace module_context
 
-namespace modules { 
+namespace modules {
 namespace packages {
 
 namespace {
@@ -261,19 +261,19 @@ namespace {
 class AvailablePackagesCache : public boost::noncopyable
 {
 public:
-   
+
    static AvailablePackagesCache& get()
    {
       static AvailablePackagesCache instance;
       return instance;
    }
-   
+
 private:
-   
+
    AvailablePackagesCache()
    {
    }
-   
+
 public:
 
    void insert(const std::string& contribUrl,
@@ -281,7 +281,7 @@ public:
    {
       cache_[contribUrl] = availablePackages;
    }
-   
+
    bool find(const std::string& contribUrl)
    {
       return cache_.find(contribUrl) != cache_.end();
@@ -303,7 +303,7 @@ public:
          return false;
       }
    }
-   
+
    void ensurePopulated(const std::string& contribUrl)
    {
       if (cache_.find(contribUrl) != cache_.end())
@@ -360,7 +360,7 @@ SEXP rs_getCachedAvailablePackages(SEXP contribUrlSEXP)
    r::sexp::Protect protect;
    std::string contribUrl = r::sexp::asString(contribUrlSEXP);
    AvailablePackagesCache& s_availablePackagesCache = AvailablePackagesCache::get();
-   
+
    std::vector<std::string> availablePackages;
    if (s_availablePackagesCache.lookup(contribUrl, &availablePackages))
       return r::sexp::create(availablePackages, &protect);
@@ -409,21 +409,35 @@ Error availablePackages(const core::json::JsonRpcRequest&,
 
 Error getPackageStateJson(json::Object* pJson)
 {
+   using namespace module_context;
+
    Error error = Success();
-   module_context::PackratContext context = module_context::packratContext();
+
+   PackratContext packratContext = module_context::packratContext();
+   core::json::Value renvContext = module_context::renvContextAsJson();
+
    json::Value packageListJson;
    r::sexp::Protect protect;
    SEXP packageList;
 
-   // determine the appropriate package listing method from the current 
+   bool renvActive = renvContext.get_obj()["active"].get_bool();
+
+   // determine the appropriate package listing method from the current
    // packrat mode status
-   if (context.modeOn)
+   if (packratContext.modeOn)
    {
       FilePath projectDir = projects::projectContext().directory();
-      error = r::exec::RFunction(".rs.listPackagesPackrat", 
+      error = r::exec::RFunction(".rs.listPackagesPackrat",
                                  string_utils::utf8ToSystem(
                                     projectDir.absolutePath()))
               .call(&packageList, &protect);
+   }
+   else if (renvActive)
+   {
+      FilePath projectDir = projects::projectContext().directory();
+      error = r::exec::RFunction(".rs.renv.listPackages")
+            .addParam(string_utils::utf8ToSystem(projectDir.absolutePath()))
+            .call(&packageList, &protect);
    }
    else
    {
@@ -435,9 +449,10 @@ Error getPackageStateJson(json::Object* pJson)
    {
       // return the generated package list and the Packrat context
       r::json::jsonValueFromObject(packageList, &packageListJson);
+
       (*pJson)["package_list"] = packageListJson;
-      (*pJson)["packrat_context"] = packrat::contextAsJson(context);
-      (*pJson)["renv_context"] = module_context::renvContextAsJson();
+      (*pJson)["packrat_context"] = packrat::contextAsJson(packratContext);
+      (*pJson)["renv_context"] = renvContext;
    }
 
    return error;
@@ -514,7 +529,7 @@ void onDetectChanges(module_context::ChangeSource source)
    // check for libPaths changes if we're evaluating a change from the REPL at
    // the top-level (i.e. not while debugging, as we don't want to mutate any
    // state that might be under inspection)
-   if (source == module_context::ChangeSourceREPL && 
+   if (source == module_context::ChangeSourceREPL &&
        r::exec::atTopLevelContext())
       detectLibPathsChanges();
 }
@@ -539,7 +554,7 @@ Error getPackageState(const json::JsonRpcRequest& ,
 {
    json::Object result;
    Error error = getPackageStateJson(&result);
-   if (error) 
+   if (error)
       LOG_ERROR(error);
    else
       pResponse->setResult(result);
@@ -575,7 +590,7 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_getCachedAvailablePackages);
    RS_REGISTER_CALL_METHOD(rs_downloadAvailablePackages);
    RS_REGISTER_CALL_METHOD(rs_getCranReposUrl);
-   
+
    using boost::bind;
    using namespace module_context;
    ExecBlock initBlock ;

--- a/src/cpp/session/modules/SessionPackrat.R
+++ b/src/cpp/session/modules/SessionPackrat.R
@@ -75,7 +75,7 @@
 
    projectPath <- paste(normalizePath(dir), "packrat", "lib", "", sep = sep)
    libraryPaths <- normalizePath(as.character(libraryList[,"library"]))
-   libraryList["in.packrat.library"] <- 
+   libraryList["in.project.library"] <- 
       substr(libraryPaths, 1, nchar(projectPath)) == projectPath
 
    # resolve symlinks (use normalizePath rather than Sys.readlink since we want
@@ -104,8 +104,8 @@
    libraryList[,"library"] <- 
       .rs.createAliasedPath(dirname(resolvedLinks))
 
-   packratList <- subset(libraryList, in.packrat.library) 
-   nonPackratList <- subset(libraryList, !in.packrat.library) 
+   packratList <- subset(libraryList, in.project.library) 
+   nonPackratList <- subset(libraryList, !in.project.library) 
 
    # overlay packrat status on the packrat library status
    mergedList <- merge(packratList, 
@@ -116,7 +116,7 @@
                        all.y = TRUE)
 
    # mark all packages in the merged list 
-   mergedList[,"in.packrat.library"] <- rep(TRUE, nrow(mergedList))
+   mergedList[,"in.project.library"] <- rep(TRUE, nrow(mergedList))
 
    # exclude manipulate and rstudio packages 
    mergedList <- subset(mergedList, !(mergedList[,"name"] == "rstudio"))

--- a/src/cpp/session/modules/SessionRenv.R
+++ b/src/cpp/session/modules/SessionRenv.R
@@ -15,19 +15,17 @@
 
 .rs.addFunction("renv.context", function()
 {
-   print("hello!")
-   
    context <- list()
    
    # validate that renv is installed
    location <- find.package("renv", quiet = TRUE)
-   context[["renv_installed"]] <- length(location) != 0
+   context[["installed"]] <- length(location) != 0
    
    # check and see if renv is active
    project <- Sys.getenv("RENV_PROJECT", unset = NA)
-   context[["renv_active"]] <- !is.na(project)
+   context[["active"]] <- !is.na(project)
    
    # return context
-   context
+   lapply(context, .rs.scalar)
    
 })

--- a/src/cpp/session/modules/SessionRenv.R
+++ b/src/cpp/session/modules/SessionRenv.R
@@ -1,0 +1,33 @@
+#
+# SessionRenv.R
+#
+# Copyright (C) 2009-19 by RStudio, Inc.
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+.rs.addFunction("renv.context", function()
+{
+   print("hello!")
+   
+   context <- list()
+   
+   # validate that renv is installed
+   location <- find.package("renv", quiet = TRUE)
+   context[["renv_installed"]] <- length(location) != 0
+   
+   # check and see if renv is active
+   project <- Sys.getenv("RENV_PROJECT", unset = NA)
+   context[["renv_active"]] <- !is.na(project)
+   
+   # return context
+   context
+   
+})

--- a/src/cpp/session/modules/SessionRenv.cpp
+++ b/src/cpp/session/modules/SessionRenv.cpp
@@ -73,6 +73,7 @@ void onConsolePrompt(const std::string& /* prompt */)
       return;
 
    // validate that it matches the project currently open in RStudio
+   // (we could consider relaxing this in the future)
    const FilePath& projDir = projects::projectContext().directory();
    if (!projDir.isEquivalentTo(FilePath(renvProject)))
       return;

--- a/src/cpp/session/modules/SessionRenv.cpp
+++ b/src/cpp/session/modules/SessionRenv.cpp
@@ -30,23 +30,13 @@ namespace rstudio {
 namespace session {
 namespace module_context {
 
-core::json::Object renvContextAsJson()
+core::json::Value renvContextAsJson()
 {
-   SEXP resultSEXP = R_NilValue;
-   r::sexp::Protect protect;
-
+   json::Value resultJson;
    Error error =
          r::exec::RFunction(".rs.renv.context")
-         .call(&resultSEXP, &protect);
+         .call(&resultJson);
 
-   if (error)
-   {
-      LOG_ERROR(error);
-      return json::Object();
-   }
-
-   json::Value resultJson;
-   error = r::json::jsonValueFromObject(resultSEXP, &resultJson);
    if (error)
    {
       LOG_ERROR(error);
@@ -60,7 +50,7 @@ core::json::Object renvContextAsJson()
       return json::Object();
    }
 
-   return resultJson.get_obj();
+   return resultJson;
 }
 
 } // end namespace module_context
@@ -88,7 +78,7 @@ Error initialize()
    using boost::bind;
    ExecBlock initBlock;
    initBlock.addFunctions()
-         (bind(sourceModuleRFile, "SessionPackrat.R"));
+         (bind(sourceModuleRFile, "SessionRenv.R"));
 
    return initBlock.execute();
 }

--- a/src/cpp/session/modules/SessionRenv.cpp
+++ b/src/cpp/session/modules/SessionRenv.cpp
@@ -1,0 +1,54 @@
+/*
+ * SessionRenv.cpp
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "SessionRenv.hpp"
+
+#include <core/Error.hpp>
+#include <core/Exec.hpp>
+
+#include <session/SessionModuleContext.hpp>
+
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace renv {
+
+void afterSessionInitHook(bool newSession)
+{
+   // TODO: initialize if using renv
+}
+
+Error initialize()
+{
+   using namespace module_context;
+
+   // initialize renv after session init (need to make sure
+   // all other RStudio startup code runs first)
+   events().afterSessionInitHook.connect(afterSessionInitHook);
+
+   using boost::bind;
+   ExecBlock initBlock;
+   initBlock.addFunctions()
+         (bind(sourceModuleRFile, "SessionPackrat.R"));
+
+   return initBlock.execute();
+}
+
+} // end namespace renv
+} // end namespace modules
+} // end namespace session
+} // end namespace rstudio

--- a/src/cpp/session/modules/SessionRenv.cpp
+++ b/src/cpp/session/modules/SessionRenv.cpp
@@ -72,6 +72,11 @@ void onConsolePrompt(const std::string& /* prompt */)
    if (renvProject.empty())
       return;
 
+   // validate that it matches the project currently open in RStudio
+   const FilePath& projDir = projects::projectContext().directory();
+   if (!projDir.isEquivalentTo(FilePath(renvProject)))
+      return;
+
    Error error = r::exec::RFunction(".rs.renv.refresh") .call();
    if (error)
       LOG_ERROR(error);

--- a/src/cpp/session/modules/SessionRenv.cpp
+++ b/src/cpp/session/modules/SessionRenv.cpp
@@ -67,23 +67,14 @@ namespace {
 
 void onConsolePrompt(const std::string& /* prompt */)
 {
-   Error error = r::exec::RFunction(".rs.renv.refresh")
-         .call();
-
-   if (error)
-      LOG_ERROR(error);
-}
-
-void afterSessionInitHook(bool /* newSession */)
-{
    // use RENV_PROJECT environment variable to detect if renv active
    std::string renvProject = core::system::getenv("RENV_PROJECT");
    if (renvProject.empty())
       return;
 
-   // renv is active -- initialize other infrastructure
-   using namespace module_context;
-   events().onConsolePrompt.connect(onConsolePrompt);
+   Error error = r::exec::RFunction(".rs.renv.refresh") .call();
+   if (error)
+      LOG_ERROR(error);
 }
 
 } // end anonymous namespace
@@ -94,7 +85,7 @@ Error initialize()
 
    // initialize renv after session init (need to make sure
    // all other RStudio startup code runs first)
-   events().afterSessionInitHook.connect(afterSessionInitHook);
+   events().onConsolePrompt.connect(onConsolePrompt);
 
    using boost::bind;
    ExecBlock initBlock;

--- a/src/cpp/session/modules/SessionRenv.hpp
+++ b/src/cpp/session/modules/SessionRenv.hpp
@@ -1,0 +1,37 @@
+/*
+ * SessionRenv.hpp
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef SESSION_RENV_HPP
+#define SESSION_RENV_HPP
+
+namespace rstudio {
+namespace core {
+class Error;
+}
+}
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace renv {
+
+core::Error initialize();
+
+} // namespace renv
+} // namespace modules
+} // namespace session
+} // namespace rstudio
+
+#endif // SESSION_RENV_HPP

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -512,6 +512,7 @@ Error readProjectOptions(const json::JsonRpcRequest& request,
    optionsJson["build_context"] = projectBuildContextJson();
    optionsJson["packrat_options"] = module_context::packratOptionsAsJson();
    optionsJson["packrat_context"] = module_context::packratContextAsJson();
+   optionsJson["renv_context"] = module_context::renvContextAsJson();
 
    pResponse->setResult(optionsJson);
    return Success();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/projects/ProjectContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/projects/ProjectContext.java
@@ -14,31 +14,41 @@
  */
 package org.rstudio.studio.client.workbench.projects;
 
+import org.rstudio.studio.client.packrat.model.PackratContext;
+
 import com.google.gwt.core.client.JavaScriptObject;
 
 public class ProjectContext extends JavaScriptObject
 {
-   public static enum ProjectType
-   {
-      NONE,
-      PACKRAT,
-      RENV
-   }
-   
    protected ProjectContext()
    {
    }
    
-   public final ProjectType getProjectType()
+   public final boolean isActive()
    {
-      String type = getProjectTypeImpl();
-      return ProjectType.valueOf(type);
+      RenvContext renv = getRenvContext();
+      if (renv.active)
+         return true;
+      
+      PackratContext packrat = getPackratContext();
+      if (packrat.isModeOn())
+         return true;
+      
+      return false;
    }
    
-   private final native String getProjectTypeImpl()
+   public final PackratContext getPackratContext()
+   {
+      PackratContext context = getPackratContextImpl();
+      if (context == null)
+         return PackratContext.empty();
+      return context;
+   }
+   
+   private final native PackratContext getPackratContextImpl()
    /*-{
-      return this.project_type;
+      return this.packrat_context;
    }-*/;
    
-   
+   public final native RenvContext getRenvContext() /*-{ return this.renv_context; }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/projects/ProjectContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/projects/ProjectContext.java
@@ -1,0 +1,44 @@
+/*
+ * ProjectContext.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.projects;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+public class ProjectContext extends JavaScriptObject
+{
+   public static enum ProjectType
+   {
+      NONE,
+      PACKRAT,
+      RENV
+   }
+   
+   protected ProjectContext()
+   {
+   }
+   
+   public final ProjectType getProjectType()
+   {
+      String type = getProjectTypeImpl();
+      return ProjectType.valueOf(type);
+   }
+   
+   private final native String getProjectTypeImpl()
+   /*-{
+      return this.project_type;
+   }-*/;
+   
+   
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/projects/RenvContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/projects/RenvContext.java
@@ -1,0 +1,25 @@
+/*
+ * RenvContext.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.projects;
+
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class RenvContext
+{
+   public boolean installed;
+   public boolean active;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -43,7 +43,6 @@ import org.rstudio.studio.client.common.mirrors.DefaultCRANMirror;
 import org.rstudio.studio.client.packrat.PackratUtil;
 import org.rstudio.studio.client.packrat.model.PackratConflictActions;
 import org.rstudio.studio.client.packrat.model.PackratConflictResolution;
-import org.rstudio.studio.client.packrat.model.PackratContext;
 import org.rstudio.studio.client.packrat.model.PackratPackageAction;
 import org.rstudio.studio.client.packrat.model.PackratServerOperations;
 import org.rstudio.studio.client.packrat.ui.PackratActionDialog;
@@ -59,6 +58,7 @@ import org.rstudio.studio.client.workbench.model.ClientState;
 import org.rstudio.studio.client.workbench.model.RemoteFileSystemContext;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.helper.JSObjectStateValue;
+import org.rstudio.studio.client.workbench.projects.ProjectContext;
 import org.rstudio.studio.client.workbench.views.BasePresenter;
 import org.rstudio.studio.client.workbench.views.console.events.ConsolePromptEvent;
 import org.rstudio.studio.client.workbench.views.console.events.ConsolePromptHandler;
@@ -102,7 +102,7 @@ public class Packages
 
    public interface Display extends WorkbenchView
    {
-      void setPackageState(PackratContext packratContext, 
+      void setPackageState(ProjectContext projectContext, 
                            List<PackageInfo> packagesDS);
       
       void installPackage(PackageInstallContext installContext,
@@ -814,7 +814,7 @@ public class Packages
          packages = allPackages_;
       }
       
-      view_.setPackageState(packratContext_, packages);
+      view_.setPackageState(projectContext_, packages);
    }
    
    private void checkPackageStatusOnNextConsolePrompt(
@@ -1183,7 +1183,7 @@ public class Packages
          }
       }
       
-      packratContext_ = newState.getPackratContext();
+      projectContext_ = newState.getProjectContext();
       view_.setProgress(false);
       setViewPackageList();
    }
@@ -1203,7 +1203,7 @@ public class Packages
    private final PackagesServerOperations server_;
    private final PackratServerOperations packratServer_;
    private ArrayList<PackageInfo> allPackages_ = new ArrayList<PackageInfo>();
-   private PackratContext packratContext_;
+   private ProjectContext projectContext_;
    private String packageFilter_ = new String();
    private HandlerRegistration consolePromptHandlerReg_ = null;
    private final EventBus events_ ;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
@@ -38,6 +38,7 @@ import org.rstudio.studio.client.common.SuperDevMode;
 import org.rstudio.studio.client.packrat.model.PackratContext;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.Session;
+import org.rstudio.studio.client.workbench.projects.ProjectContext;
 import org.rstudio.studio.client.workbench.ui.WorkbenchPane;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageInfo;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageInstallContext;
@@ -101,21 +102,22 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
    }
    
    @Override
-   public void setPackageState(PackratContext packratContext, 
+   public void setPackageState(ProjectContext projectContext, 
                                List<PackageInfo> packages)
    {
-      packratContext_ = packratContext;
+      projectContext_ = projectContext;
       packagesDataProvider_.setList(packages);
       createPackagesTable();
 
       // show the bootstrap button if this state is eligible for Packrat but the
       // project isn't currently under Packrat control
+      PackratContext packratContext = projectContext_.getPackratContext();
       packratBootstrapButton_.setVisible(
-         packratContext_.isApplicable() && 
-         (!packratContext_.isPackified() || !packratContext_.isModeOn()));
+         packratContext.isApplicable() && 
+         (!packratContext.isPackified() || !packratContext.isModeOn()));
       
       // show the toolbar button if Packrat mode is on
-      packratMenuButton_.setVisible(packratContext_.isModeOn());
+      packratMenuButton_.setVisible(packratContext.isModeOn());
       
       // always show the separator before the packrat commands
       prePackratSeparator_.setVisible(true);
@@ -449,11 +451,10 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
       packagesTable_.addColumn(versionColumn, new TextHeader("Version"));
       packagesTable_.setColumnWidth(loadedColumn, 30, Unit.PX);
 
-      // set up Packrat-specific columns
-      if (packratContext_ != null &&
-          packratContext_.isModeOn())
+      // add columns when using project-local library
+      if (projectContext_.isActive())
       {
-         Column<PackageInfo, PackageInfo> packratVersionColumn = 
+         Column<PackageInfo, PackageInfo> lockfileVersionColumn = 
             new Column<PackageInfo, PackageInfo>(new VersionCell(true)) {
 
                @Override
@@ -463,12 +464,12 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
                }
          };
       
-         TextColumn<PackageInfo> packratSourceColumn = 
+         TextColumn<PackageInfo> packageSourceColumn = 
                new TextColumn<PackageInfo>() {
                   @Override
                   public String getValue(PackageInfo pkgInfo)
                   {
-                     if (pkgInfo.getInPackratLibary())
+                     if (pkgInfo.isInProjectLibrary())
                      {
                         String source = pkgInfo.getPackratSource();
                         if (source == "github")
@@ -485,15 +486,15 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
                   }
          };
 
-         packagesTable_.addColumn(packratVersionColumn, new TextHeader("Packrat"));
-         packagesTable_.addColumn(packratSourceColumn, new TextHeader("Source"));
+         packagesTable_.addColumn(lockfileVersionColumn, new TextHeader("Lockfile"));
+         packagesTable_.addColumn(packageSourceColumn, new TextHeader("Source"));
 
          // distribute columns for extended package information
          packagesTable_.setColumnWidth(nameColumn, 20, Unit.PCT);
          packagesTable_.setColumnWidth(descColumn, 40, Unit.PCT);
          packagesTable_.setColumnWidth(versionColumn, 15, Unit.PCT);
-         packagesTable_.setColumnWidth(packratVersionColumn, 15, Unit.PCT);
-         packagesTable_.setColumnWidth(packratSourceColumn, 10, Unit.PCT);
+         packagesTable_.setColumnWidth(lockfileVersionColumn, 15, Unit.PCT);
+         packagesTable_.setColumnWidth(packageSourceColumn, 10, Unit.PCT);
       }
       else
       {
@@ -627,7 +628,7 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
       @Override
       public void buildRowImpl(PackageInfo pkg, int idx)
       {
-         String library = pkg.getInPackratLibary() ? 
+         String library = pkg.isInProjectLibrary() ? 
                pkg.getSourceLibrary() : pkg.getLibrary();
          if (pkg.isFirstInLibrary())
          {
@@ -675,7 +676,7 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
    private Widget prePackratSeparator_;
    private LayoutPanel packagesTableContainer_;
    private int gridRenderRetryCount_;
-   private PackratContext packratContext_ = PackratContext.empty();
+   private ProjectContext projectContext_;
 
    private final Commands commands_;
    private final Session session_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
@@ -109,12 +109,7 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
       packagesDataProvider_.setList(packages);
       createPackagesTable();
 
-      // show the bootstrap button if this state is eligible for Packrat but the
-      // project isn't currently under Packrat control
       PackratContext packratContext = projectContext_.getPackratContext();
-      packratBootstrapButton_.setVisible(
-         packratContext.isApplicable() && 
-         (!packratContext.isPackified() || !packratContext.isModeOn()));
       
       // show the toolbar button if Packrat mode is on
       packratMenuButton_.setVisible(packratContext.isModeOn());
@@ -201,11 +196,6 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
       // packrat (all packrat UI starts out hidden and then appears
       // in response to changes in the packages state)
 
-      // create packrat bootstrap button
-      packratBootstrapButton_ = commands_.packratBootstrap().createToolbarButton(false);
-      toolbar.addLeftWidget(packratBootstrapButton_);
-      packratBootstrapButton_.setVisible(false);
-      
       // create packrat menu + button
       ToolbarPopupMenu packratMenu = new ToolbarPopupMenu();
       packratMenu.addItem(commands_.packratHelp().createMenuItem(false));
@@ -671,7 +661,6 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
    private SearchWidget searchWidget_;
    private PackagesDisplayObserver observer_ ;
    
-   private ToolbarButton packratBootstrapButton_;
    private ToolbarMenuButton packratMenuButton_;
    private Widget prePackratSeparator_;
    private LayoutPanel packagesTableContainer_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageInfo.java
@@ -107,9 +107,9 @@ public class PackageInfo extends JavaScriptObject
       return getPackratBoolField("currently.used");
    }
 
-   public final boolean getInPackratLibary()
+   public final boolean isInProjectLibrary()
    {
-      return getPackratBoolField("in.packrat.library");
+      return getPackratBoolField("in.project.library");
    }
    
    public final String getSourceLibrary()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageState.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageState.java
@@ -14,7 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.packages.model;
 
-import org.rstudio.studio.client.packrat.model.PackratContext;
+import org.rstudio.studio.client.workbench.projects.ProjectContext;
 
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
@@ -29,7 +29,10 @@ public class PackageState extends JavaScriptObject
       return this.package_list;
    }-*/;
    
-   public final native PackratContext getPackratContext() /*-{
-      return this.packrat_context;
+   public final native ProjectContext getProjectContext() /*-{
+      return {
+         "packrat_context": this.packrat_context,
+         "renv_context": this.renv_context
+      };
    }-*/;
 }


### PR DESCRIPTION
This PR brings in the initial bits of `renv` integration -- primarily, just making sure that the Packages pane updates and responds if `renv` is activated for a project.

Fortunately, it was straightforward to reuse the existing codepaths. Because much of the behavior of the packages pane is drawn off of `.rs.listPackagesPackrat()`, we mostly just needed to implement our own facade (`.rs.renv.listPackages()`) to get similar integration set up.