### PR TITLE
Provide alt-text descriptions for file icons

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/files/FileSystemContext.java
+++ b/src/gwt/src/org/rstudio/core/client/files/FileSystemContext.java
@@ -1,7 +1,7 @@
 /*
  * FileSystemContext.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,6 +17,7 @@ package org.rstudio.core.client.files;
 import com.google.gwt.resources.client.ImageResource;
 import org.rstudio.core.client.MessageDisplay;
 import org.rstudio.core.client.widget.ProgressIndicator;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 
 public interface FileSystemContext
 {
@@ -89,7 +90,7 @@ public interface FileSystemContext
                               boolean onlyIfExists,
                               boolean createAsDirectory);
 
-   ImageResource getIcon(FileSystemItem item);
+   FileIcon getIcon(FileSystemItem item);
 
    boolean isRoot(FileSystemItem item);
    boolean isCloudRoot(FileSystemItem cloud);

--- a/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
+++ b/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
@@ -1,7 +1,7 @@
 /*
  * FileSystemItem.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,12 +19,11 @@ import java.util.HashMap;
 
 import org.rstudio.core.client.regex.Match;
 import org.rstudio.core.client.regex.Pattern;
-import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.common.filetypes.FileIconResources;
 import org.rstudio.studio.client.common.vcs.StatusAndPathInfo;
 
 import com.google.gwt.core.client.JavaScriptObject;
-import com.google.gwt.resources.client.ImageResource;
 
 // NOTE: this class is represented as a native JavaScriptObject for
 // straightforward RPC handling
@@ -193,39 +192,39 @@ public class FileSystemItem extends JavaScriptObject
    }
 
    // RStudio-specific code should use FileTypeRegistry.getIconForFile() instead
-   public final ImageResource getIcon()
+   public final FileIcon getIcon()
    {
       if (isDirectory())
       {
          if (isPublicFolder())
-            return new ImageResource2x(RES.iconPublicFolder2x());
+            return FileIcon.PUBLIC_FOLDER_ICON;
          else
-            return new ImageResource2x(RES.iconFolder2x());
+            return FileIcon.FOLDER_ICON;
       }
 
       Match m = EXT_PATTERN.match(getName(), 0);
       if (m == null)
-         return new ImageResource2x(RES.iconText2x());
+         return FileIcon.TEXT_ICON;
 
       String lowerExt = m.getValue().toLowerCase();
       if (lowerExt.equals(".csv"))
       {
-         return new ImageResource2x(RES.iconCsv2x());
+         return FileIcon.CSV_ICON;
       }
       else if (lowerExt.equals(".pdf"))
       {
-         return new ImageResource2x(RES.iconPdf2x());
+         return FileIcon.PDF_ICON;
       }
       else if (lowerExt.equals(".jpg") || lowerExt.equals(".jpeg") ||
                lowerExt.equals(".gif") || lowerExt.equals(".bmp")  ||
                lowerExt.equals(".tiff")   || lowerExt.equals(".tif") ||
                lowerExt.equals(".png"))
       {
-         return new ImageResource2x(RES.iconPng2x());
+         return FileIcon.IMAGE_ICON;
       }
       else
       {
-         return new ImageResource2x(RES.iconText2x());
+         return FileIcon.TEXT_ICON;
       }
    }
 

--- a/src/gwt/src/org/rstudio/core/client/files/PosixFileSystemContext.java
+++ b/src/gwt/src/org/rstudio/core/client/files/PosixFileSystemContext.java
@@ -1,7 +1,7 @@
 /*
  * PosixFileSystemContext.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/DirectoryContentsWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/DirectoryContentsWidget.java
@@ -1,7 +1,7 @@
 /*
  * DirectoryContentsWidget.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -21,12 +21,10 @@ import com.google.gwt.event.logical.shared.HasSelectionHandlers;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlexTable;
 import com.google.gwt.user.client.ui.HTMLTable;
-import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.impl.FocusImpl;
 
 import org.rstudio.core.client.Point;
@@ -37,12 +35,11 @@ import org.rstudio.core.client.events.SelectionCommitEvent;
 import org.rstudio.core.client.events.SelectionCommitHandler;
 import org.rstudio.core.client.files.FileSystemContext;
 import org.rstudio.core.client.files.FileSystemItem;
-import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.CanFocus;
 import org.rstudio.core.client.widget.DoubleClickState;
 import org.rstudio.core.client.widget.ScrollPanelWithClick;
 import org.rstudio.core.client.widget.SimplePanelWithProgress;
-import org.rstudio.studio.client.common.filetypes.FileIconResources;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -382,7 +379,7 @@ public class DirectoryContentsWidget
       if (parentDirectory != null)
          addItem(parentDirectory,
                  "..",
-                 new ImageResource2x(FileIconResources.INSTANCE.iconUpFolder2x()));
+                 FileIcon.PARENT_FOLDER_ICON);
 
       for (FileSystemItem fsi : contents)
          addItem(fsi, null, null);
@@ -392,7 +389,7 @@ public class DirectoryContentsWidget
 
    private int addItem(FileSystemItem item,
                        String customName,
-                       ImageResource customIcon)
+                       FileIcon customIcon)
    {
       if (customName == null)
          customName = item.getName();
@@ -405,7 +402,7 @@ public class DirectoryContentsWidget
       table_.setWidget(
             newRow,
             COL_ICON,
-            new Image(customIcon));
+            customIcon.getImage());
       table_.setText(newRow, COL_NAME, customName);
 
       table_.getCellFormatter().setStylePrimaryName(newRow,
@@ -499,8 +496,7 @@ public class DirectoryContentsWidget
       setFocus(true);
    }
    
-   private Map<String, FileSystemItem> items_ =
-         new LinkedHashMap<String, FileSystemItem>();
+   private Map<String, FileSystemItem> items_ = new LinkedHashMap<>();
    private final DoubleClickState doubleClick_ = new DoubleClickState();
    private Integer selectedRow_;
    private String selectedValue_;

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarFileLabel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarFileLabel.java
@@ -1,7 +1,7 @@
 /*
  * ToolbarFileLabel.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -20,6 +20,7 @@ import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.studio.client.RStudioGinjector;
 
 import com.google.gwt.user.client.ui.Image;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 
 public class ToolbarFileLabel
 {
@@ -60,8 +61,10 @@ public class ToolbarFileLabel
       }
       else
       {
-         fileImage_.setResource(RStudioGinjector.INSTANCE.getFileTypeRegistry()
-                                                   .getIconForFilename(fileName));
+         FileIcon fileIcon = 
+               RStudioGinjector.INSTANCE.getFileTypeRegistry().getIconForFilename(fileName);
+         fileImage_.setResource(fileIcon.getImageResource());
+         fileImage_.setAltText(fileIcon.getDescription());
          fileImage_.setVisible(true);
          
          String shortFileName = StringUtil.shortPathName(

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/BrowserType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/BrowserType.java
@@ -1,7 +1,7 @@
 /*
  * BrowserType.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -29,5 +29,11 @@ public class BrowserType extends FileType
    public void openFile(FileSystemItem file, EventBus eventBus)
    {
       eventBus.fireEvent(new OpenFileInBrowserEvent(file));
+   }
+
+   @Override
+   protected FileIcon getDefaultFileIcon()
+   {
+      return null;
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/EditableFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/EditableFileType.java
@@ -1,7 +1,7 @@
 /*
  * EditableFileType.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -33,6 +33,12 @@ public abstract class EditableFileType extends FileType
    public ImageResource getDefaultIcon()
    {
       return defaultIcon_;
+   }
+
+   @Override
+   public FileIcon getDefaultFileIcon()
+   {
+      return new FileIcon(defaultIcon_, label_);
    }
 
    private final String label_;

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileIcon.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileIcon.java
@@ -1,0 +1,91 @@
+/*
+ * FileIcon.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.common.filetypes;
+
+import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.user.client.ui.Image;
+import org.rstudio.core.client.resources.ImageResource2x;
+
+public class FileIcon
+{
+   private static final FileIconResources ICONS = FileIconResources.INSTANCE;
+
+   public static final FileIcon PUBLIC_FOLDER_ICON =
+         new FileIcon(new ImageResource2x(ICONS.iconPublicFolder2x()), "Public Folder");
+
+   public static final FileIcon FOLDER_ICON =
+         new FileIcon(new ImageResource2x(ICONS.iconFolder2x()), "Folder");
+
+   public static final FileIcon TEXT_ICON =
+         new FileIcon(new ImageResource2x(ICONS.iconText2x()), "Text file");
+
+   public static final FileIcon CSV_ICON =
+         new FileIcon(new ImageResource2x(ICONS.iconCsv2x()), "CSV");
+
+   public static final FileIcon PDF_ICON =
+         new FileIcon(new ImageResource2x(ICONS.iconPdf2x()), "PDF");
+
+   public static final FileIcon IMAGE_ICON =
+         new FileIcon(new ImageResource2x(ICONS.iconPng2x()), "Image file");
+
+   public static final FileIcon RDATA_ICON =
+         new FileIcon(new ImageResource2x(ICONS.iconRdata2x()), "RData");
+
+   public static final FileIcon RDS_ICON =
+         new FileIcon(new ImageResource2x(ICONS.iconRdata2x()), "RDS");
+
+   public static final FileIcon RPROJECT_ICON =
+         new FileIcon(new ImageResource2x(ICONS.iconRproject2x()), "RProject");
+
+   public static final FileIcon PARENT_FOLDER_ICON =
+         new FileIcon(new ImageResource2x(ICONS.iconUpFolder2x()), "Parent folder");
+
+   public FileIcon(ImageResource imageResource, String description)
+   {
+      imageResource_ = imageResource;
+      description_ = description;
+   }
+
+   public ImageResource getImageResource()
+   {
+      return imageResource_;
+   }
+
+   public void setImageResource(ImageResource imageResource)
+   {
+      imageResource_ = imageResource;
+   }
+
+   public String getDescription()
+   {
+      return description_;
+   }
+
+   public void setDescription(String description)
+   {
+      description_ = description;
+   }
+
+   public Image getImage()
+   {
+      Image icon = new Image(getImageResource());
+      icon.setAltText(getDescription());
+      return icon;
+   }
+
+   private ImageResource imageResource_;
+   private String description_;
+}
+

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileIconRenderer.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileIconRenderer.java
@@ -1,0 +1,56 @@
+/*
+ * FileIconRenderer.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.common.filetypes;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.resources.client.impl.ImageResourcePrototype;
+import com.google.gwt.safehtml.client.SafeHtmlTemplates;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.safehtml.shared.SafeUri;
+import com.google.gwt.text.shared.AbstractSafeHtmlRenderer;
+import com.google.gwt.user.client.ui.AbstractImagePrototype;
+
+/**
+ * Given an {@link FileIcon}, renders an element to show it.
+ */
+public class FileIconRenderer extends AbstractSafeHtmlRenderer<FileIcon>
+{
+   interface Template extends SafeHtmlTemplates
+   {
+      @SafeHtmlTemplates.Template("<img src='{0}' border='0' width='{1}' height='{2}' alt='{3}'>")
+      SafeHtml image(SafeUri imageUri, int width, int height, String altText);
+   }
+
+   private static final Template TEMPLATE = GWT.create(Template.class);
+
+   @Override
+   public SafeHtml render(FileIcon image)
+   {
+      if (image.getImageResource() instanceof ImageResourcePrototype.Bundle)
+      {
+         return AbstractImagePrototype.create(image.getImageResource()).getSafeHtml();
+      } 
+      else
+      {
+         ImageResource imageRez = image.getImageResource();
+         return TEMPLATE.image(
+               imageRez.getSafeUri(), 
+               imageRez.getWidth(), 
+               imageRez.getHeight(),
+               image.getDescription());
+      }
+   }
+}

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileIconResourceCell.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileIconResourceCell.java
@@ -1,5 +1,5 @@
 /*
- * RDSDataType.java
+ * FileIconResourceCell.java
  *
  * Copyright (C) 2009-19 by RStudio, Inc.
  *
@@ -14,26 +14,30 @@
  */
 package org.rstudio.studio.client.common.filetypes;
 
-import org.rstudio.core.client.files.FileSystemItem;
-import org.rstudio.studio.client.application.events.EventBus;
-import org.rstudio.studio.client.common.filetypes.events.OpenDataFileEvent;
+import com.google.gwt.cell.client.AbstractCell;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 
-public class RDSDataType extends FileType
+public class FileIconResourceCell extends AbstractCell<FileIcon>
 {
-   RDSDataType()
+   private static FileIconRenderer renderer;
+
+   /**
+    * Construct a new ImageResourceCell.
+    */
+   public FileIconResourceCell()
    {
-      super("rds_data");
+      if (renderer == null)
+      {
+         renderer = new FileIconRenderer();
+      }
    }
 
    @Override
-   public void openFile(FileSystemItem file, EventBus eventBus)
+   public void render(Context context, FileIcon value, SafeHtmlBuilder sb)
    {
-      eventBus.fireEvent(new OpenDataFileEvent(file));
-   }
-
-   @Override
-   protected FileIcon getDefaultFileIcon()
-   {
-      return FileIcon.RDS_ICON;
+      if (value != null)
+      {
+         sb.append(renderer.render(value));
+      }
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileIconResources.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileIconResources.java
@@ -1,7 +1,7 @@
 /*
  * FileIconResources.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -20,8 +20,7 @@ import com.google.gwt.resources.client.ImageResource;
 
 public interface FileIconResources extends ClientBundle
 {
-   public static final FileIconResources INSTANCE =
-                                           GWT.create(FileIconResources.class);
+   FileIconResources INSTANCE = GWT.create(FileIconResources.class);
 
    @Source("iconCsv_2x.png")
    ImageResource iconCsv2x();

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileType.java
@@ -1,7 +1,7 @@
 /*
  * FileType.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -31,7 +31,7 @@ public abstract class FileType
    public static final String STAN_LANG_MODE = "Stan";
    public static final String PYTHON_LANG_MODE = "Python";
    
-   static ArrayList<FileType> ALL_FILE_TYPES = new ArrayList<FileType>();
+   static ArrayList<FileType> ALL_FILE_TYPES = new ArrayList<>();
 
    protected FileType(String id)
    {
@@ -53,6 +53,7 @@ public abstract class FileType
    }
    
    protected abstract void openFile(FileSystemItem file, EventBus eventBus);
+   protected abstract FileIcon getDefaultFileIcon();
    
    private final String id_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
@@ -1,7 +1,7 @@
 /*
  * FileTypeRegistry.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -43,8 +43,8 @@ public class FileTypeRegistry
    private static final FileIconResources ICONS = FileIconResources.INSTANCE;
 
    public static final TextFileType TEXT =
-         new TextFileType("text", "Text File", EditorLanguage.LANG_PLAIN, "",
-                          new ImageResource2x(ICONS.iconText2x()),
+         new TextFileType("text", FileIcon.TEXT_ICON.getDescription(), EditorLanguage.LANG_PLAIN, "",
+                          FileIcon.TEXT_ICON.getImageResource(),
                           true,
                           false, false, false, false, false, false, false, false, false, true, false, false);
 
@@ -433,18 +433,18 @@ public class FileTypeRegistry
       register("*.snippets", SNIPPETS, new ImageResource2x(icons.iconSnippets2x()));
       register("*.Rprofvis", PROFILER, new ImageResource2x(icons.iconRprofile2x()));
 
-      registerIcon(".jpg", new ImageResource2x(icons.iconPng2x()));
-      registerIcon(".jpeg", new ImageResource2x(icons.iconPng2x()));
-      registerIcon(".gif", new ImageResource2x(icons.iconPng2x()));
-      registerIcon(".bmp", new ImageResource2x(icons.iconPng2x()));
-      registerIcon(".tiff", new ImageResource2x(icons.iconPng2x()));
-      registerIcon(".tif", new ImageResource2x(icons.iconPng2x()));
-      registerIcon(".png", new ImageResource2x(icons.iconPng2x()));
+      registerIcon(".jpg", new FileIcon(new ImageResource2x(icons.iconPng2x()), "JPG"));
+      registerIcon(".jpeg", new FileIcon(new ImageResource2x(icons.iconPng2x()), "JPEG"));
+      registerIcon(".gif", new FileIcon(new ImageResource2x(icons.iconPng2x()), "GIF"));
+      registerIcon(".bmp", new FileIcon(new ImageResource2x(icons.iconPng2x()), "BMP"));
+      registerIcon(".tiff", new FileIcon(new ImageResource2x(icons.iconPng2x()), "TIFF"));
+      registerIcon(".tif", new FileIcon(new ImageResource2x(icons.iconPng2x()), "TIF"));
+      registerIcon(".png", new FileIcon(new ImageResource2x(icons.iconPng2x()), "PNG"));
 
-      registerIcon(".pdf", new ImageResource2x(icons.iconPdf2x()));
-      registerIcon(".csv", new ImageResource2x(icons.iconCsv2x()));
-      registerIcon(".docx", new ImageResource2x(icons.iconWord2x()));
-      registerIcon(".pptx", new ImageResource2x(icons.iconPowerpoint2x()));
+      registerIcon(".pdf", FileIcon.PDF_ICON);
+      registerIcon(".csv", FileIcon.CSV_ICON);
+      registerIcon(".docx", new FileIcon(new ImageResource2x(icons.iconWord2x()), "DOCX"));
+      registerIcon(".pptx", new FileIcon(new ImageResource2x(icons.iconPowerpoint2x()), "PPTX"));
 
       for (FileType fileType : FileType.ALL_FILE_TYPES)
       {
@@ -633,22 +633,22 @@ public class FileTypeRegistry
          return TEXT;
    }
 
-   public ImageResource getIconForFile(FileSystemItem file)
+   public FileIcon getIconForFile(FileSystemItem file)
    {
       if (file.isDirectory())
       {
          if (file.isPublicFolder())
-            return new ImageResource2x(ICONS.iconPublicFolder2x());
+            return FileIcon.PUBLIC_FOLDER_ICON;
          else
-            return new ImageResource2x(ICONS.iconFolder2x());
+            return FileIcon.FOLDER_ICON;
       }
 
       return getIconForFilename(file.getName());
    }
 
-   public ImageResource getIconForFilename(String filename)
+   public FileIcon getIconForFilename(String filename)
    {
-      ImageResource icon = iconsByFilename_.get(filename.toLowerCase());
+      FileIcon icon = iconsByFilename_.get(filename.toLowerCase());
       if (icon != null)
          return icon;
       String ext = FileSystemItem.getExtensionFromPath(filename);
@@ -656,7 +656,7 @@ public class FileTypeRegistry
       if (icon != null)
          return icon;
 
-      return new ImageResource2x(ICONS.iconText2x());
+      return TEXT.getDefaultFileIcon();
    }
 
    private void register(String filespec, FileType fileType, ImageResource icon)
@@ -665,42 +665,50 @@ public class FileTypeRegistry
       {
          String ext = filespec.substring(1).toLowerCase();
          if (ext.equals("."))
+         {
             ext = "";
-         fileTypesByFileExtension_.put(ext,
-                                       fileType);
+         }
+         fileTypesByFileExtension_.put(ext, fileType);
          if (icon != null)
-            iconsByFileExtension_.put(ext, icon);
+         {
+            iconsByFileExtension_.put(
+                  ext,
+                  new FileIcon(icon, fileType.getDefaultFileIcon().getDescription()));
+         }
       }
       else if (filespec.length() == 0)
       {
          fileTypesByFileExtension_.put("", fileType);
          if (icon != null)
-            iconsByFileExtension_.put("", icon);
+         {
+            iconsByFileExtension_.put(
+                  "",
+                  new FileIcon(icon, fileType.getDefaultFileIcon().getDescription()));
+         }
       }
       else
       {
          assert filespec.indexOf("*") < 0 : "Unexpected filespec format";
          fileTypesByFilename_.put(filespec.toLowerCase(), fileType);
          if (icon != null)
-            iconsByFilename_.put(filespec.toLowerCase(), icon);
+         {
+            iconsByFilename_.put(filespec.toLowerCase(),
+                  new FileIcon(icon,
+                        fileType.getDefaultFileIcon().getDescription()));
+         }
       }
    }
 
-   private void registerIcon(String extension, ImageResource icon)
+   private void registerIcon(String extension, FileIcon icon)
    {
       iconsByFileExtension_.put(extension, icon);
    }
 
-   private final HashMap<String, FileType> fileTypesByFileExtension_ =
-         new HashMap<String, FileType>();
-   private final HashMap<String, FileType> fileTypesByFilename_ =
-         new HashMap<String, FileType>();
-   private final HashMap<String, FileType> fileTypesByTypeName_ =
-         new HashMap<String, FileType>();
-   private final HashMap<String, ImageResource> iconsByFileExtension_ =
-         new HashMap<String, ImageResource>();
-   private final HashMap<String, ImageResource> iconsByFilename_ =
-         new HashMap<String, ImageResource>();
+   private final HashMap<String, FileType> fileTypesByFileExtension_ = new HashMap<>();
+   private final HashMap<String, FileType> fileTypesByFilename_ = new HashMap<>();
+   private final HashMap<String, FileType> fileTypesByTypeName_ = new HashMap<>();
+   private final HashMap<String, FileIcon> iconsByFileExtension_ = new HashMap<>();
+   private final HashMap<String, FileIcon> iconsByFilename_ = new HashMap<>();
    private final EventBus eventBus_;
    private final Satellite satellite_;
    private final Session session_;

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/RDataType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/RDataType.java
@@ -30,4 +30,10 @@ public class RDataType extends FileType
    {
       eventBus.fireEvent(new OpenDataFileEvent(file));
    }
+
+   @Override
+   protected FileIcon getDefaultFileIcon()
+   {
+      return FileIcon.RDATA_ICON;
+   }
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/RProjectType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/RProjectType.java
@@ -1,7 +1,7 @@
 /*
  * RProjectType.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -29,5 +29,11 @@ public class RProjectType extends FileType
    public void openFile(FileSystemItem file, EventBus eventBus)
    {
       eventBus.fireEvent(new OpenProjectFileEvent(file));
+   }
+
+   @Override
+   protected FileIcon getDefaultFileIcon()
+   {
+      return FileIcon.RPROJECT_ICON;
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/viewfile/ViewFilePanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/viewfile/ViewFilePanel.java
@@ -30,6 +30,7 @@ import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.FileDialogs;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.GlobalProgressDelayer;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.server.ServerError;
@@ -247,8 +248,10 @@ public class ViewFilePanel extends Composite implements TextDisplay
       // header widget has icon + label
       HorizontalPanel panel = new HorizontalPanel();
      
-      Image imgFile = new Image(fileTypeRegistry_.getIconForFile(file));
+      FileIcon icon = fileTypeRegistry_.getIconForFile(file);
+      Image imgFile = new Image(icon.getImageResource());
       imgFile.addStyleName(styles.fullscreenCaptionIcon());
+      imgFile.setAltText(icon.getDescription());
       panel.add(imgFile);
       
       Label lblCaption = new Label(caption);

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/DirEntryCheckBox.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/DirEntryCheckBox.java
@@ -1,7 +1,7 @@
 /*
  * DirEntryCheckBox.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -43,7 +43,7 @@ public class DirEntryCheckBox extends Composite
       
       // add an icon representing the file
       ImageResource icon = 
-            RStudioGinjector.INSTANCE.getFileTypeRegistry().getIconForFile(fsi);
+            RStudioGinjector.INSTANCE.getFileTypeRegistry().getIconForFile(fsi).getImageResource();
       SafeHtmlBuilder hb = new SafeHtmlBuilder();
       hb.append(AbstractImagePrototype.create(icon).getSafeHtml());
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchSuggestion.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchSuggestion.java
@@ -1,7 +1,7 @@
 /*
  * CodeSearchSuggestion.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -41,7 +41,7 @@ class CodeSearchSuggestion implements Suggestion
             
       // compute display string
       ImageResource image = 
-         fileTypeRegistry_.getIconForFilename(fileItem.getFilename());
+         fileTypeRegistry_.getIconForFilename(fileItem.getFilename()).getImageResource();
    
       displayString_ = createDisplayString(image,
                                            RES.styles().fileImage(),
@@ -126,7 +126,7 @@ class CodeSearchSuggestion implements Suggestion
    public void setFileDisplayString(String file, String displayString)
    {
       // compute display string
-      ImageResource image =  fileTypeRegistry_.getIconForFilename(file);
+      ImageResource image =  fileTypeRegistry_.getIconForFilename(file).getImageResource();
       displayString_ = createDisplayString(image,
                                            RES.styles().fileImage(),
                                            displayString,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/RemoteFileSystemContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/RemoteFileSystemContext.java
@@ -1,7 +1,7 @@
 /*
  * RemoteFileSystemContext.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,13 +15,13 @@
 package org.rstudio.studio.client.workbench.model;
 
 import com.google.gwt.core.client.JsArray;
-import com.google.gwt.resources.client.ImageResource;
 import com.google.inject.Inject;
 import org.rstudio.core.client.MessageDisplay;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.files.PosixFileSystemContext;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
@@ -156,7 +156,7 @@ public class RemoteFileSystemContext extends PosixFileSystemContext
             });
    }
 
-   public ImageResource getIcon(FileSystemItem item)
+   public FileIcon getIcon(FileSystemItem item)
    {
       return fileTypeRegistry_.getIconForFile(item);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -1,7 +1,7 @@
 /*
  * CompletionRequester.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -958,7 +958,7 @@ public class CompletionRequester
       
       private ImageResource getIconForFilename(String name)
       {
-         return FILE_TYPE_REGISTRY.getIconForFilename(name);
+         return FILE_TYPE_REGISTRY.getIconForFilename(name).getImageResource();
       }
 
       public static QualifiedName parseFromText(String val)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilePathToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilePathToolbar.java
@@ -1,7 +1,7 @@
 /*
  * FilePathToolbar.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,7 +17,6 @@ package org.rstudio.studio.client.workbench.views.files.ui;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
-import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.*;
 import org.rstudio.core.client.MessageDisplay;
 import org.rstudio.core.client.StringUtil;
@@ -30,6 +29,7 @@ import org.rstudio.core.client.files.filedialog.PathBreadcrumbWidget;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.workbench.views.files.Files;
 
 import java.util.ArrayList;
@@ -62,7 +62,7 @@ public class FilePathToolbar extends Composite
          throw new UnsupportedOperationException("mkdir not supported");
       }
 
-      public ImageResource getIcon(FileSystemItem item)
+      public FileIcon getIcon(FileSystemItem item)
       {
          throw new UnsupportedOperationException("getIcon not supported");
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesList.java
@@ -1,7 +1,7 @@
 /*
  * FilesList.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -24,17 +24,16 @@ import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.cellview.ColumnSortInfo;
 import org.rstudio.core.client.cellview.LinkColumn;
 import org.rstudio.core.client.files.FileSystemItem;
-import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.RStudioDataGrid;
 import org.rstudio.studio.client.ResizableHeader;
-import org.rstudio.studio.client.common.filetypes.FileIconResources;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
+import org.rstudio.studio.client.common.filetypes.FileIconResourceCell;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.workbench.views.files.Files;
 import org.rstudio.studio.client.workbench.views.files.model.FileChange;
 
 import com.google.gwt.cell.client.CheckboxCell;
-import com.google.gwt.cell.client.ImageResourceCell;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
@@ -42,7 +41,6 @@ import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.dom.client.Style.WhiteSpace;
 import com.google.gwt.event.logical.shared.ResizeEvent;
 import com.google.gwt.event.logical.shared.ResizeHandler;
-import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.DataGrid;
@@ -141,17 +139,17 @@ public class FilesList extends Composite
    }
   
    
-   private Column<FileSystemItem, ImageResource> addIconColumn(
+   private Column<FileSystemItem, FileIcon> addIconColumn(
                               final FileTypeRegistry fileTypeRegistry)
    {
-      Column<FileSystemItem, ImageResource> iconColumn = 
-         new Column<FileSystemItem, ImageResource>(new ImageResourceCell()) {
+      Column<FileSystemItem, FileIcon> iconColumn = 
+         new Column<FileSystemItem, FileIcon>(new FileIconResourceCell()) {
 
             @Override
-            public ImageResource getValue(FileSystemItem object)
+            public FileIcon getValue(FileSystemItem object)
             {
                if (object == parentPath_)
-                  return new ImageResource2x(FileIconResources.INSTANCE.iconUpFolder2x());
+                  return FileIcon.FOLDER_ICON;
                else
                   return fileTypeRegistry.getIconForFile(object);
             }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -624,7 +624,7 @@ public class TextEditingTargetWidget
       ToolbarMenuButton texButton = new ToolbarMenuButton(
                            "Format", 
                            ToolbarButton.NoTitle,
-                           fileTypeRegistry_.getIconForFilename("foo.tex"), 
+                           fileTypeRegistry_.getIconForFilename("foo.tex").getImageResource(),
                            texMenu, 
                            false);
       return texButton;
@@ -1118,8 +1118,8 @@ public class TextEditingTargetWidget
       {
          String ext = extensions.get(i);
          ImageResource img = ext != null ? 
-               fileTypeRegistry_.getIconForFilename("output." + ext) :
-               fileTypeRegistry_.getIconForFilename("Makefile");
+               fileTypeRegistry_.getIconForFilename("output." + ext).getImageResource() :
+               fileTypeRegistry_.getIconForFilename("Makefile").getImageResource();
          final String valueName = values.get(i);
          ScheduledCommand cmd = new ScheduledCommand()
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/CppCompletion.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/CppCompletion.java
@@ -1,7 +1,7 @@
 /*
  * CppCompletion.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -100,7 +100,7 @@ public class CppCompletion extends JavaScriptObject
       case SNIPPET:
          return new ImageResource2x(icons.snippet2x());
       case FILE:
-         return REGISTRY.getIconForFilename(getTypedText());
+         return REGISTRY.getIconForFilename(getTypedText()).getImageResource();
       case DIRECTORY:
          return new ImageResource2x(icons.folder2x());
       default:

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/CommitFilterToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/CommitFilterToolbarButton.java
@@ -123,9 +123,9 @@ public class CommitFilterToolbarButton extends ToolbarMenuButton
          else
          {
             if (value_.isDirectory())
-               setLeftImage(value_.getIcon());
+               setLeftImage(value_.getIcon().getImageResource());
             else
-               setLeftImage(fileTypeRegistry_.getIconForFile(value_));
+               setLeftImage(fileTypeRegistry_.getIconForFile(value_).getImageResource());
             setText(value_.getName());
             setTitle("Filter: " + value_.getPath());
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/CommitTocRow.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/CommitTocRow.java
@@ -1,7 +1,7 @@
 /*
  * CommitTocRow.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -36,9 +36,7 @@ public class CommitTocRow extends Composite implements HasClickHandlers
 
    public CommitTocRow(String filename)
    {
-      icon_ = new Image(
-            RStudioGinjector.INSTANCE.getFileTypeRegistry().getIconForFilename(
-                                                                     filename));
+      icon_ = RStudioGinjector.INSTANCE.getFileTypeRegistry().getIconForFilename(filename).getImage();
       icon_.addStyleName(ThemeStyles.INSTANCE.handCursor());
       anchor_ = new Anchor(filename);
       anchor_.addStyleName(ThemeStyles.INSTANCE.handCursor());
@@ -60,5 +58,5 @@ public class CommitTocRow extends Composite implements HasClickHandlers
    @UiField(provided = true)
    Anchor anchor_;
 
-   private static final MyBinder binder_ = GWT.<MyBinder>create(MyBinder.class);
+   private static final MyBinder binder_ = GWT.create(MyBinder.class);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/DiffFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/DiffFrame.java
@@ -1,7 +1,7 @@
 /*
  * DiffFrame.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -27,6 +27,7 @@ import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.widget.HyperlinkLabel;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.common.filetypes.FileType;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
@@ -73,7 +74,9 @@ public class DiffFrame extends Composite
       FileSystemItem fsItem = FileSystemItem.createFile(filename2 == null ? 
                                                       filename1 : filename2);
       
-      fileIcon_.setResource(fileTypeRegistry.getIconForFile(fsItem));
+      FileIcon fileIcon = fileTypeRegistry.getIconForFile(fsItem);
+      fileIcon_.setResource(fileIcon.getImageResource());
+      fileIcon_.setAltText(fileIcon.getDescription());
      
       headerLabel_.setText(filename1);
      
@@ -112,5 +115,5 @@ public class DiffFrame extends Composite
    @UiField
    HyperlinkLabel viewFileHyperlink_;
    
-   private static final Resources RES = GWT.<Resources>create(Resources.class);
+   private static final Resources RES = GWT.create(Resources.class);
 }


### PR DESCRIPTION
Give file icons alt-text matching their type. This applies to the Files pane, and other locations that use these icons such as the Open File / Folder web-dialogs.

These icons convey useful information (e.g. knowing that something is a folder versus a file, which can't always be known purely from the filename), so opted to plumb in useful alt-text instead of making them decorative.

The key part of this change is building and passing around `FileIcon` objects, which encapsulate both the `ImageResource` and the textual description, where only the `ImageResource` was being passed before.

To test this, either use a screen reader to navigate the File pane's icon column, or examine source and look at the shiny new alt text.

Fixes #4988 
