### PR TITLE
refactor: create and use DomUtils.disableSpellcheck()

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -1112,7 +1112,17 @@ public class DomUtils
    {
       disableAutoBehavior(w.getElement());
    }
-   
+
+   public static void disableSpellcheck(Element ele)
+   {
+      ele.setAttribute("spellcheck", "false");
+   }
+
+   public static void disableSpellcheck(Widget w)
+   {
+      disableSpellcheck(w.getElement());
+   }
+
    /**
     * Given any URL, resolves it to an absolute URL (using the current window as
     * the base URL), and returns the result.

--- a/src/gwt/src/org/rstudio/core/client/widget/DataTableColumnWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/DataTableColumnWidget.java
@@ -1,7 +1,22 @@
+/*
+ * DataTableColumnWidget.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
 package org.rstudio.core.client.widget;
 
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.event.dom.client.*;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 
@@ -14,7 +29,7 @@ public class DataTableColumnWidget extends TextBox
       onEnterFunction_ = onEnter;
       ThemeStyles styles = ThemeResources.INSTANCE.themeStyles();
       setStylePrimaryName(styles.dataTableColumnWidget());
-      getElement().setAttribute("spellcheck", "false");
+      DomUtils.disableSpellcheck(this);
 
       init();
    }

--- a/src/gwt/src/org/rstudio/core/client/widget/FixedTextArea.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FixedTextArea.java
@@ -1,12 +1,26 @@
+/*
+ * FixedTextArea.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
 package org.rstudio.core.client.widget;
 
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 
 import com.google.gwt.user.client.ui.TextArea;
 
 public class FixedTextArea extends TextArea
 {
-   
    public FixedTextArea(int numVisibleLines)
    {
       super();
@@ -16,7 +30,6 @@ public class FixedTextArea extends TextArea
    
    private void init() {
       addStyleName(ThemeStyles.INSTANCE.notResizable());
-      getElement().setAttribute("spellcheck", "false");
+      DomUtils.disableSpellcheck(this);
    }
-   
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/MultipleItemSuggestTextBox.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/MultipleItemSuggestTextBox.java
@@ -1,7 +1,7 @@
 /*
  * MultipleItemSuggestTextBox.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,7 +14,6 @@
  */
 package org.rstudio.core.client.widget;
 
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,6 +21,7 @@ import org.rstudio.core.client.StringUtil;
 
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.user.client.ui.TextBoxBase;
+import org.rstudio.core.client.dom.DomUtils;
 
 // TextBox designed for use with SuggestBox that supports the entry
 // of multiple items
@@ -31,7 +31,7 @@ public class MultipleItemSuggestTextBox extends TextBoxBase
    {
       super(Document.get().createTextInputElement());
       setStyleName("gwt-TextBox");
-      getElement().setAttribute("spellcheck", "false");
+      DomUtils.disableSpellcheck(this);
    }
    
    public List<String> getItems()

--- a/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.java
@@ -33,6 +33,7 @@ import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.SuggestBox.DefaultSuggestionDisplay;
 import com.google.gwt.user.client.ui.SuggestBox.SuggestionDisplay;
 
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.events.SelectionCommitEvent;
 import org.rstudio.core.client.events.SelectionCommitHandler;
 import org.rstudio.core.client.theme.res.ThemeResources;
@@ -110,7 +111,7 @@ public class SearchWidget extends Composite implements SearchDisplay
                        SuggestionDisplay suggestDisplay,
                        boolean continuousSearch)
    {
-      textBox.getElement().setAttribute("spellcheck", "false");
+      DomUtils.disableSpellcheck(textBox);
       
       if (suggestDisplay != null)
          suggestBox_ = new FocusSuggestBox(oracle, textBox, suggestDisplay);

--- a/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithCue.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithCue.java
@@ -1,7 +1,7 @@
 /*
  * TextBoxWithCue.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,6 +16,7 @@ package org.rstudio.core.client.widget;
 
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.TextBox;
+import org.rstudio.core.client.dom.DomUtils;
 
 public class TextBoxWithCue extends TextBox
 {
@@ -38,7 +39,7 @@ public class TextBoxWithCue extends TextBox
    private void init(String cueText, Element element)
    {
       setCueText(cueText);
-      element.setAttribute("spellcheck", "false");
+      DomUtils.disableSpellcheck(element);
    }
 
    public String getCueText()

--- a/src/gwt/src/org/rstudio/studio/client/common/rpubs/ui/RPubsUploadDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rpubs/ui/RPubsUploadDialog.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.common.rpubs.ui;
 
 import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.resources.CoreResources;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.FixedTextArea;
@@ -158,7 +159,7 @@ public class RPubsUploadDialog extends ModalDialogBase
          verticalPanel.add(titleLabel);
          titleTextBox_ = new TextBox();
          titleTextBox_.addStyleName(styles.titleTextBox());
-         titleTextBox_.getElement().setAttribute("spellcheck", "false");
+         DomUtils.disableSpellcheck(titleTextBox_);
          verticalPanel.add(titleTextBox_);
          
          Label commentLabel = new Label("Comment (optional):");

--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/ShowPublicKeyDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/ShowPublicKeyDialog.java
@@ -18,6 +18,7 @@ import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.command.KeyCombination;
 import org.rstudio.core.client.command.KeyboardShortcut;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.widget.FocusHelper;
 import org.rstudio.core.client.widget.FontSizer;
 import org.rstudio.core.client.widget.ModalDialogBase;
@@ -73,7 +74,7 @@ public class ShowPublicKeyDialog extends ModalDialogBase
       textArea_.setText(publicKey_);
       textArea_.addStyleName(RES.styles().viewPublicKeyContent());
       textArea_.setSize("400px", "250px");
-      textArea_.getElement().setAttribute("spellcheck", "false");
+      DomUtils.disableSpellcheck(textArea_);
       FontSizer.applyNormalFontSize(textArea_.getElement());
       
       panel.add(textArea_);

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/ProjectTemplateWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/ProjectTemplateWidget.java
@@ -1,7 +1,7 @@
 /*
  * ProjectTemplateWidget.java
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.widget.FileChooserTextBox;
 import org.rstudio.core.client.widget.SelectWidget;
@@ -180,7 +181,7 @@ public class ProjectTemplateWidget extends Composite
          primaryWidget.setText(defaultValue);
       
       Grid grid = new Grid(1, 2);
-      primaryWidget.getElement().setAttribute("spellcheck", "false");
+      DomUtils.disableSpellcheck(primaryWidget);
       grid.setWidget(0, 0, new Label(ensureEndsWithColon(description.getLabel())));
       grid.setWidget(0, 1, primaryWidget);
       

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewDirectoryPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewDirectoryPage.java
@@ -1,7 +1,7 @@
 /*
  * NewDirectoryPage.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.projects.ui.newproject;
 
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.DirectoryChooserTextBox;
@@ -80,7 +81,7 @@ public class NewDirectoryPage extends NewProjectWizardPage
       namePanel.add(dirNameLabel_);
       txtProjectName_ = new TextBox();
       txtProjectName_.setWidth("100%");
-      txtProjectName_.getElement().setAttribute("spellcheck", "false");
+      DomUtils.disableSpellcheck(txtProjectName_);
       namePanel.add(txtProjectName_);
       panel.add(namePanel);
       addWidget(panel);

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/BuildToolsPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/BuildToolsPanel.java
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client.projects.ui.prefs.buildtools;
 
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.ProgressOperationWithInput;
@@ -199,7 +200,7 @@ public abstract class BuildToolsPanel extends VerticalPanel
          panel.add(captionWidget);
          
          textBox_ = new TextBox();
-         textBox_.getElement().setAttribute("spellcheck", "false");
+         DomUtils.disableSpellcheck(textBox_);
          panel.add(textBox_);
    
          initWidget(panel);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/TerminalPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/TerminalPreferencesPane.java
@@ -22,6 +22,7 @@ import com.google.gwt.user.client.ui.HorizontalPanel;
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.FileChooserTextBox;
 import org.rstudio.core.client.widget.SelectWidget;
@@ -107,7 +108,7 @@ public class TerminalPreferencesPane extends PreferencesPane
       customShellOptionsLabel_ = new Label("Custom shell command-line options:");
       add(spacedBefore(customShellOptionsLabel_));
       customShellOptions_ = new TextBox();
-      customShellOptions_.getElement().setAttribute("spellcheck", "false");
+      DomUtils.disableSpellcheck(customShellOptions_);
       customShellOptions_.setWidth(textboxWidth);
       customShellOptions_.setEnabled(false);
       add(customShellOptions_);
@@ -169,7 +170,7 @@ public class TerminalPreferencesPane extends PreferencesPane
          busyWhitelistLabel_ = new Label("Don't ask before killing:");
          add(busyWhitelistLabel_);
          busyWhitelist_ = new TextBox();
-         busyWhitelist_.getElement().setAttribute("spellcheck", "false");
+         DomUtils.disableSpellcheck(busyWhitelist_);
          busyWhitelist_.setWidth(textboxWidth);
          add(busyWhitelist_);
          busyWhitelist_.setEnabled(false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
@@ -31,6 +31,7 @@ import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.js.JsUtil;
 import org.rstudio.core.client.widget.DirectoryChooserTextBox;
@@ -114,8 +115,8 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
       });
       manageFilePattern();
 
-      txtSearchPattern_.getElement().setAttribute("spellcheck", "false");
-      
+      DomUtils.disableSpellcheck(txtSearchPattern_);
+
       txtSearchPattern_.addKeyUpHandler(new KeyUpHandler()
       {
          @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewPlumberAPI.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewPlumberAPI.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.views.source;
 import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.RegexUtil;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.core.client.widget.DirectoryChooserTextBox;
@@ -192,7 +193,7 @@ public class NewPlumberAPI extends ModalDialog<NewPlumberAPI.Result>
       controls_.add(apiNameLabel_);
       
       apiNameTextBox_ = new TextBox();
-      apiNameTextBox_.getElement().setAttribute("spellcheck", "false");
+      DomUtils.disableSpellcheck(apiNameTextBox_);
       apiNameTextBox_.addStyleName(RES.styles().apiNameTextBox());
       apiNameTextBox_.getElement().setAttribute("placeholder", "Name");
       addTextFieldValidator(apiNameTextBox_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewShinyWebApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewShinyWebApplication.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.views.source;
 import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.RegexUtil;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.core.client.widget.DirectoryChooserTextBox;
@@ -198,7 +199,7 @@ public class NewShinyWebApplication extends ModalDialog<NewShinyWebApplication.R
       appNameLabel_.addStyleName(RES.styles().label());
       
       appNameTextBox_ = new TextBox();
-      appNameTextBox_.getElement().setAttribute("spellcheck", "false");
+      DomUtils.disableSpellcheck(appNameTextBox_);
       appNameTextBox_.addStyleName(RES.styles().textBox());
       appNameTextBox_.addStyleName(RES.styles().appNameTextBox());
       appNameTextBox_.getElement().setAttribute("placeholder", "Name");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/AddRemoteDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/AddRemoteDialog.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.views.vcs;
 
 import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.widget.FormLabel;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
@@ -127,7 +128,7 @@ public class AddRemoteDialog extends ModalDialog<AddRemoteDialog.Input>
       TextBox textBox = new TextBox();
       textBox.setWidth("260px");
       textBox.getElement().getStyle().setMarginBottom(6, Unit.PX);
-      textBox.getElement().setAttribute("spellcheck", "false");
+      DomUtils.disableSpellcheck(textBox);
       Roles.getTextboxRole().setAriaRequiredProperty(textBox.getElement(), true);
       return textBox;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchDialog.java
@@ -21,6 +21,7 @@ import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.Functional;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.Functional.Predicate;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.js.JsUtil;
 import org.rstudio.core.client.widget.FormLabel;
 import org.rstudio.core.client.widget.LayoutGrid;
@@ -265,7 +266,7 @@ public class CreateBranchDialog extends ModalDialog<CreateBranchDialog.Input>
    {
       TextBox textBox = new TextBox();
       textBox.getElement().getStyle().setProperty("minWidth", "200px");
-      textBox.getElement().setAttribute("spellcheck", "false");
+      DomUtils.disableSpellcheck(textBox);
       return textBox;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
@@ -315,7 +315,7 @@ public class GitReviewPanel extends ResizeComposite implements Display
          }
       });
       
-      commitMessage_.getElement().setAttribute("spellcheck", "false");
+      DomUtils.disableSpellcheck(commitMessage_);
 
       listBoxAdapter_ = new ListBoxAdapter(contextLines_);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/commit/SVNCommitDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/commit/SVNCommitDialog.java
@@ -31,6 +31,7 @@ import com.google.gwt.user.client.ui.TextArea;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.widget.ModalDialogBase;
 import org.rstudio.core.client.widget.SmallButton;
 import org.rstudio.core.client.widget.ThemedButton;
@@ -122,7 +123,7 @@ public class SVNCommitDialog extends ModalDialogBase
          }
       });
 
-      message_.getElement().setAttribute("spellcheck", "false");
+      DomUtils.disableSpellcheck(message_);
       
       if (!StringUtil.isNullOrEmpty(commitDraft_))
          message_.setText(commitDraft_);


### PR DESCRIPTION
Created DomUtils.disableSpellcheck() and replaced all setAttribute("spellcheck", "false") calls with it. Has both element and widget variations.