### PR TITLE
consolidate setting of textbox placeholder into a helper function, other small tweaks

### DIFF
--- a/src/gwt/src/com/google/gwt/user/client/ui/LabelBase.java
+++ b/src/gwt/src/com/google/gwt/user/client/ui/LabelBase.java
@@ -20,6 +20,7 @@ import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style.WhiteSpace;
 import com.google.gwt.i18n.shared.DirectionEstimator;
 import com.google.gwt.i18n.shared.HasDirectionEstimator;
+import org.rstudio.core.client.StringUtil;
 
 /**
  * Abstract base class for all text display widgets.
@@ -62,7 +63,8 @@ public class LabelBase<T> extends Widget implements HasWordWrap,
     setElement(Document.get().createLabelElement());
     if (!inline)
       getElement().getStyle().setProperty("display", "block");
-    getElement().setAttribute("for", forId);
+    if (!StringUtil.isNullOrEmpty(forId))
+      getElement().setAttribute("for", forId);
     directionalTextHelper = new DirectionalTextHelper(getElement(), inline);
   }
 

--- a/src/gwt/src/com/google/gwt/user/client/ui/LabelBase.java.diff
+++ b/src/gwt/src/com/google/gwt/user/client/ui/LabelBase.java.diff
@@ -1,4 +1,6 @@
-55a56,68
+22a23
+> import org.rstudio.core.client.StringUtil;
+55a57,70
 >   /**
 >    * Create a Label using a <code>label</code> element.
 >    * @param inline
@@ -8,7 +10,8 @@
 >     setElement(Document.get().createLabelElement());
 >     if (!inline)
 >       getElement().getStyle().setProperty("display", "block");
->     getElement().setAttribute("for", forId);
+>     if (!StringUtil.isNullOrEmpty(forId))
+>       getElement().setAttribute("for", forId);
 >     directionalTextHelper = new DirectionalTextHelper(getElement(), inline);
 >   }
 > 

--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -31,6 +31,7 @@ import com.google.gwt.event.dom.client.KeyUpHandler;
 import com.google.gwt.user.client.*;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.RootPanel;
+import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.UIObject;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -1121,6 +1122,32 @@ public class DomUtils
    public static void disableSpellcheck(Widget w)
    {
       disableSpellcheck(w.getElement());
+   }
+
+   /**
+    * Set placeholder attribute on an element (assumed to be a textbox).
+    * This is considered a somewhat dubious technique from an accessibility 
+    * standpoint, especially if the placeholder is serving as the de facto label 
+    * for the textbox. Avoid introducing new uses of placeholder text.
+    * @param ele
+    * @param placeholder
+    */
+   public static void setPlaceholder(Element ele, String placeholder)
+   {
+      ele.setAttribute("placeholder", "Name");
+   }
+
+   /**
+    * Set placeholder attribute on a TextBox widget.
+    * This is considered a somewhat dubious technique from an accessibility 
+    * standpoint, especially if the placeholder is serving as the de facto label 
+    * for the textbox. Avoid introducing new uses of placeholder text.
+    * @param w
+    * @param placeholder
+    */
+   public static void setPlaceholder(TextBox w, String placeholder)
+   {
+      setPlaceholder(w.getElement(), placeholder);
    }
 
    /**

--- a/src/gwt/src/org/rstudio/core/client/widget/FormLabel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FormLabel.java
@@ -17,7 +17,6 @@ package org.rstudio.core.client.widget;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
-import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
 
 /**
@@ -26,6 +25,8 @@ import org.rstudio.core.client.StringUtil;
  */
 public class FormLabel extends Label
 {
+   public static String NoForId = null;
+
    public FormLabel()
    {
       this("");
@@ -37,7 +38,7 @@ public class FormLabel extends Label
     */
    public FormLabel(String text)
    {
-      super(text, "placeholder");
+      super(text, NoForId);
    }
 
   /**
@@ -47,7 +48,7 @@ public class FormLabel extends Label
    */
    public FormLabel(String text, boolean wordWrap)
    {
-      super(text, "placeholder", wordWrap);
+      super(text, NoForId, wordWrap);
    }
 
    /**
@@ -70,17 +71,10 @@ public class FormLabel extends Label
       String controlId = widget.getElement().getId();
       if (StringUtil.isNullOrEmpty(controlId))
       {
-         if (StringUtil.isNullOrEmpty(getText()))
-         {
-            controlId = DOM.createUniqueId();
-         }
-         else
-         {
-            controlId = ElementIds.idFromLabel(getText());
-         }
+         controlId = DOM.createUniqueId();
          widget.getElement().setId(controlId);
       }
-      getElement().setAttribute("for", controlId);
+      setFor(controlId);
    }
 
    /**

--- a/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.java
@@ -337,7 +337,7 @@ public class SearchWidget extends Composite implements SearchDisplay
    
    public void setPlaceholderText(String value)
    {
-      suggestBox_.getElement().setAttribute("placeholder", value);
+      DomUtils.setPlaceholder(suggestBox_.getElement(), value);
    }
    
    public boolean isFocused()

--- a/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithCue.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithCue.java
@@ -50,7 +50,7 @@ public class TextBoxWithCue extends TextBox
    public void setCueText(String cueText)
    {
       cueText_ = cueText;
-      getElement().setAttribute("placeholder", cueText);
+      DomUtils.setPlaceholder(this, cueText);
    }
 
    private String cueText_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
@@ -1,7 +1,7 @@
 /*
  * DataImportOptionsUiXls.java
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client.workbench.views.environment.dataimport;
 
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.studio.client.application.ApplicationUtils;
 import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.workbench.views.environment.dataimport.model.DataImportAssembleResponse;
@@ -50,7 +51,7 @@ public class DataImportOptionsUiXls extends DataImportOptionsUi
       initDefaults();
       initEvents();
 
-      rangeTextBox_.getElement().setPropertyString("placeholder", "A1:D10");
+      DomUtils.setPlaceholder(rangeTextBox_, "A1:D10");
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewPlumberAPI.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewPlumberAPI.java
@@ -195,7 +195,7 @@ public class NewPlumberAPI extends ModalDialog<NewPlumberAPI.Result>
       apiNameTextBox_ = new TextBox();
       DomUtils.disableSpellcheck(apiNameTextBox_);
       apiNameTextBox_.addStyleName(RES.styles().apiNameTextBox());
-      apiNameTextBox_.getElement().setAttribute("placeholder", "Name");
+      DomUtils.setPlaceholder(apiNameTextBox_, "Name");
       addTextFieldValidator(apiNameTextBox_);
       controls_.add(apiNameTextBox_);
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewShinyWebApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewShinyWebApplication.java
@@ -202,7 +202,7 @@ public class NewShinyWebApplication extends ModalDialog<NewShinyWebApplication.R
       DomUtils.disableSpellcheck(appNameTextBox_);
       appNameTextBox_.addStyleName(RES.styles().textBox());
       appNameTextBox_.addStyleName(RES.styles().appNameTextBox());
-      appNameTextBox_.getElement().setAttribute("placeholder", "Name");
+      DomUtils.setPlaceholder(appNameTextBox_, "Name");
       addTextFieldValidator(appNameTextBox_);
       
       appTypeLabel_ = new Label("Application type:");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
@@ -1,7 +1,7 @@
 /*
  * ChunkOptionsPopupPanel.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -408,7 +408,7 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
    private TextBox makeInputBox(final String option, final boolean enquote)
    {
       final TextBox box = new TextBox();
-      box.getElement().setAttribute("placeholder", "Default");
+      DomUtils.setPlaceholder(box, "Default");
       box.setWidth("40px");
       
       DomUtils.addKeyHandlers(box, new NativeEventHandler()


### PR DESCRIPTION
## Description
- create and use `DomUtils.setPlaceholder()` with comment that placeholders are not recommended due to accessibility concerns (additional fixes coming on that in a future PR)
- tweak to FormLabel (and LabelBase) to stop using literal "placeholder" string during construction with target ID not yet known (not related to other "placeholder" fix other than it showed up when I did a search I had meant to fix that previously)
- tweak FormLabel to always create unique IDs instead of using label to create ID (which has high likelihood of creating duplicate HTML ids, another accessibility violation and generally a bad idea)

## More info on placeholders and accessibility
https://www.deque.com/blog/accessible-forms-the-problem-with-placeholders/
https://www.w3.org/WAI/GL/low-vision-a11y-tf/wiki/Placeholder_Research
