### PR TITLE
add (visually hidden) labels to various search controls, other tweaks

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -42,6 +42,7 @@ import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.Point;
 import org.rstudio.core.client.Rectangle;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.dom.impl.DomUtilsImpl;
 import org.rstudio.core.client.dom.impl.NodeRelativePosition;
@@ -1151,6 +1152,22 @@ public class DomUtils
    }
 
    /**
+    * If an element doesn't already have an id, assign one
+    * @param ele element to operate on
+    * @return id of the element
+    */
+   public static String ensureHasId(Element ele)
+   {
+      String controlId = ele.getId();
+      if (StringUtil.isNullOrEmpty(controlId))
+      {
+         controlId = DOM.createUniqueId();
+         ele.setId(controlId);
+      }
+      return controlId;
+   }
+
+   /**
     * Given any URL, resolves it to an absolute URL (using the current window as
     * the base URL), and returns the result.
     * 
@@ -1212,20 +1229,4 @@ public class DomUtils
    
    public static final int ESTIMATED_SCROLLBAR_WIDTH = 19;
    private static int SCROLLBAR_WIDTH = -1;
-
-   /**
-    * Makes given element visually invisible but still "visible" to assistive technology
-    * such as screen readers.
-    * @param element
-    */
-   public static native void visuallyHide(Element element) /*-{
-      element.style.position = "absolute";
-      element.style.clip = "rect(0 0 0 0)";
-      element.style.border = "0";
-      element.style.width = "1px";
-      element.style.height = "1px";
-      element.style.margin = "-1px";
-      element.style.overflow = "hidden";
-      element.style.padding = "0";
-   }-*/;
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
@@ -1,7 +1,7 @@
 /*
  * ThemeStyles.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -52,6 +52,7 @@ public interface ThemeStyles extends CssResource
 
    String fixedWidthFont();
    
+   String visuallyHidden();
    String tabLayout();
    String tabLayoutLeft();
    String rstheme_tabLayoutCenter();

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -256,6 +256,18 @@ button, input[type="reset"], input[type="button"], input[type="submit"] {
    font-family: fixedWidthFont !important;
 }
 
+/* hide something from sighted users but remain visible to screen readers */
+.visuallyHidden {
+    position: absolute;
+    clip: rect(0 0 0 0);
+    border: 0;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+}
+
 .gwt-Label {
    cursor: default;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/CaptionWithHelp.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/CaptionWithHelp.java
@@ -32,14 +32,15 @@ import com.google.inject.Inject;
 
 public class CaptionWithHelp extends Composite
 {
-   public CaptionWithHelp(String caption, String helpCaption)
+   public CaptionWithHelp(String caption, String helpCaption, Widget forWidget)
    {
-      this(caption, helpCaption, null);
+      this(caption, helpCaption, null, forWidget);
    }
    
    public CaptionWithHelp(String caption, 
                           String helpCaption,
-                          final String rstudioLinkName)
+                          final String rstudioLinkName,
+                          Widget forWidget)
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
       
@@ -47,7 +48,7 @@ public class CaptionWithHelp extends Composite
       
       HorizontalPanel panel = new HorizontalPanel();
       panel.setWidth("100%");
-      captionLabel_ = new FormLabel(caption);
+      captionLabel_ = new FormLabel(caption, forWidget);
       panel.add(captionLabel_);
       helpPanel_ = new HorizontalPanel();
       DecorativeImage helpImage = new DecorativeImage(new ImageResource2x(ThemeResources.INSTANCE.help2x()));
@@ -61,7 +62,7 @@ public class CaptionWithHelp extends Composite
             if (rstudioLinkName_ != null)
                globalDisplay_.openRStudioLink(rstudioLinkName_,
                                               includeVersionInfo_);
-         }  
+         }
       });
       helpPanel_.add(link);
       panel.add(helpPanel_);

--- a/src/gwt/src/org/rstudio/core/client/widget/FilterWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FilterWidget.java
@@ -1,7 +1,7 @@
 /*
  * FilterWidget.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -23,12 +23,12 @@ public abstract class FilterWidget extends Composite
 {
    public abstract void filter(String query);
    
-   public FilterWidget()
+   public FilterWidget(String label)
    {
-      this("Filter...");
+      this(label, "Filter...");
    }
    
-   public FilterWidget(String placeholder)
+   public FilterWidget(String label, String placeholder)
    {
       SuggestOracle oracle = new SuggestOracle()
       {
@@ -38,7 +38,7 @@ public abstract class FilterWidget extends Composite
          }
       };
       
-      searchWidget_ = new SearchWidget(oracle);
+      searchWidget_ = new SearchWidget(label, oracle);
       searchWidget_.setPlaceholderText(placeholder);
       searchWidget_.addValueChangeHandler(new ValueChangeHandler<String>()
       {

--- a/src/gwt/src/org/rstudio/core/client/widget/FormLabel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FormLabel.java
@@ -44,11 +44,14 @@ public class FormLabel extends Label
   /**
    * Creates a label to associate with a form control via <code>setFor</code>
    * @param text the new label's text
+   * @param w labeled widget; if the widget's element does not already have an id attribute,
+   *          one will be generated and assigned to it
    * @param wordWrap <code>false</code> to disable word wrapping
    */
-   public FormLabel(String text, boolean wordWrap)
+   public FormLabel(String text, Widget w, boolean wordWrap)
    {
       super(text, NoForId, wordWrap);
+      setFor(w);
    }
 
    /**
@@ -62,12 +65,26 @@ public class FormLabel extends Label
    }
 
    /**
-    * Associate this label with the given widget. An id will be assigned to the widget
-    * element as part of this.
+    * Create a label to associate with an existing widget.
+    * @param text label text
+    * @param w labeled widget; if the widget's element does not already have an id attribute,
+    *          one will be generated and assigned to it
+    */
+   public FormLabel(String text, Widget w)
+   {
+      super(text, NoForId);
+      setFor(w);
+   }
+
+   /**
+    * Associate this label with the given widget. If the widget's element does not
+    * have an id attribute, a unique one will be generated and assigned to it.
     * @param widget
     */
    public void setFor(Widget widget)
    {
+      if (widget == null)
+         return;
       String controlId = widget.getElement().getId();
       if (StringUtil.isNullOrEmpty(controlId))
       {

--- a/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
@@ -354,7 +354,7 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
          }
       });
       
-      filterWidget_ = new SearchWidget(new SuggestOracle() {
+      filterWidget_ = new SearchWidget("Filter keyboard shortcuts", new SuggestOracle() {
 
          @Override
          public void requestSuggestions(Request request, Callback callback)

--- a/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.java
@@ -18,6 +18,7 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.LabelElement;
 import com.google.gwt.dom.client.NodeList;
 import com.google.gwt.event.dom.client.*;
 import com.google.gwt.event.logical.shared.CloseEvent;
@@ -29,10 +30,17 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
-import com.google.gwt.user.client.ui.*;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.Image;
+import com.google.gwt.user.client.ui.SuggestBox;
 import com.google.gwt.user.client.ui.SuggestBox.DefaultSuggestionDisplay;
 import com.google.gwt.user.client.ui.SuggestBox.SuggestionDisplay;
 
+import com.google.gwt.user.client.ui.SuggestOracle;
+import com.google.gwt.user.client.ui.TextBox;
+import com.google.gwt.user.client.ui.TextBoxBase;
+import com.google.gwt.user.client.ui.ValueBoxBase;
+import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.events.SelectionCommitEvent;
 import org.rstudio.core.client.events.SelectionCommitHandler;
@@ -76,9 +84,9 @@ public class SearchWidget extends Composite implements SearchDisplay
       }
    }
   
-   public SearchWidget()
+   public SearchWidget(String label)
    {
-      this(new SuggestOracle()
+      this(label, new SuggestOracle()
       {
          @Override
          public void requestSuggestions(Request request, Callback callback)
@@ -88,25 +96,28 @@ public class SearchWidget extends Composite implements SearchDisplay
       });
    }
 
-   public SearchWidget(SuggestOracle oracle)
+   public SearchWidget(String label, SuggestOracle oracle)
    {
-      this(oracle, null);
+      this(label, oracle, null);
    }
    
-   public SearchWidget(SuggestOracle oracle, 
+   public SearchWidget(String label,
+                       SuggestOracle oracle,
                        SuggestionDisplay suggestDisplay)
    {
-      this(oracle, new TextBox(), suggestDisplay);
+      this(label, oracle, new TextBox(), suggestDisplay);
    }
    
-   public SearchWidget(SuggestOracle oracle, 
+   public SearchWidget(String label,
+                       SuggestOracle oracle, 
                        TextBoxBase textBox, 
                        SuggestionDisplay suggestDisplay)
    {
-      this(oracle, textBox, suggestDisplay, true);
+      this(label, oracle, textBox, suggestDisplay, true);
    }
 
-   public SearchWidget(SuggestOracle oracle,
+   public SearchWidget(String label,
+                       SuggestOracle oracle,
                        TextBoxBase textBox,
                        SuggestionDisplay suggestDisplay,
                        boolean continuousSearch)
@@ -121,7 +132,8 @@ public class SearchWidget extends Composite implements SearchDisplay
       initWidget(uiBinder.createAndBindUi(this));
       close_.setVisible(false);
       close_.setAltText("Clear text");
-
+      hiddenLabel_.setInnerText(label);
+      hiddenLabel_.setHtmlFor(DomUtils.ensureHasId(textBox.getElement()));
       ThemeStyles styles = ThemeResources.INSTANCE.themeStyles();
       
       suggestBox_.setStylePrimaryName(styles.searchBox());
@@ -359,6 +371,8 @@ public class SearchWidget extends Composite implements SearchDisplay
    Image close_;
    @UiField
    DecorativeImage icon_;
+   @UiField
+   LabelElement hiddenLabel_;
 
    private String lastValueSent_ = null;
    private final FocusTracker focusTracker_;

--- a/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.ui.xml
@@ -12,6 +12,7 @@
                      resource='{res.smallMagGlassIcon2x}'
                      styleName='{res.themeStyles.searchMagGlass}' />
             <div class="{res.themeStyles.searchBoxContainer}">
+               <label ui:field='hiddenLabel_' class="{res.themeStyles.visuallyHidden}"/>
                <f:SearchWidget.FocusSuggestBox ui:field='suggestBox_'
                           styleName='{res.themeStyles.searchBox}'/>
             </div>

--- a/src/gwt/src/org/rstudio/core/client/widget/SelectWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SelectWidget.java
@@ -90,7 +90,7 @@ public class SelectWidget extends Composite
       if (horizontalLayout)
       {
          horizontalPanel_ = new HorizontalPanel();
-         label_ = new FormLabel(label);
+         label_ = new FormLabel(label, listBox_);
          if (listOnLeft)
          {
             horizontalPanel_.add(listBox_);
@@ -109,13 +109,12 @@ public class SelectWidget extends Composite
       }
       else
       {
-         label_ = new FormLabel(label, true);
+         label_ = new FormLabel(label, listBox_, true);
          flowPanel_ = new FlowPanel();
          flowPanel_.add(label_);
          panel = flowPanel_;
          panel.add(listBox_);
       }
-      label_.setFor(listBox_);
       
       initWidget(panel);
       

--- a/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
@@ -77,7 +77,7 @@ public class TextBoxWithButton extends Composite
       FlowPanel outer = new FlowPanel();
       if (label != null)
       {
-         FormLabel lblCaption = new FormLabel(label, true);
+         FormLabel lblCaption = new FormLabel(label, textBox_, true);
          if (helpButton != null)
          {
             HorizontalPanel panel = new HorizontalPanel();
@@ -90,7 +90,6 @@ public class TextBoxWithButton extends Composite
          {
             outer.add(lblCaption);
          }
-         lblCaption.setFor(textBox_);
       }
       outer.add(inner_);
       initWidget(outer);

--- a/src/gwt/src/org/rstudio/core/client/widget/TextEntryModalDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/TextEntryModalDialog.java
@@ -58,8 +58,7 @@ public class TextEntryModalDialog extends ModalDialog<String>
       }
       textBox_.setWidth("100%");
       DomUtils.disableAutoBehavior(textBox_);
-      captionLabel_ = new FormLabel(caption);
-      captionLabel_.setFor(textBox_);
+      captionLabel_ = new FormLabel(caption, textBox_);
 
       extraOption_ = new CheckBox(StringUtil.notNull(extraOptionPrompt));
       extraOption_.setVisible(

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.java
@@ -18,7 +18,6 @@ import com.google.gwt.aria.client.Id;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.Anchor;
-import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.model.ProductEditionInfo;
 import org.rstudio.studio.client.application.model.ProductInfo;
@@ -63,7 +62,6 @@ public class AboutDialogContents extends Composite
       productInfo.getElement().setId("productinfo");
       gplLinkLabel.getElement().setId("gplLinkLabel");
       Roles.getLinkRole().setAriaDescribedbyProperty(gplLink.getElement(), Id.of(gplLinkLabel.getElement()));
-      DomUtils.visuallyHide(gplLinkLabel.getElement());
 
       userAgentLabel.setText(
             Window.Navigator.getUserAgent());

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.ui.xml
@@ -105,7 +105,7 @@
             <g:Anchor ui:field="gplLink" href="http://www.gnu.org/licenses/agpl-3.0.txt"
                text="Affero General Public License."
                target="_blank"></g:Anchor>
-            <g:InlineLabel ui:field="gplLinkLabel" text="(opens in new window)"></g:InlineLabel>
+            <g:InlineLabel ui:field="gplLinkLabel" text="(opens in new window)" styleName="{res.themeStyles.visuallyHidden}"></g:InlineLabel>
          </g:HTMLPanel>
       </g:HTMLPanel>
       <g:TextArea ui:field="noticeBox" styleName="{style.noticeBox}"

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/addins/AddinsToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/addins/AddinsToolbarButton.java
@@ -100,7 +100,7 @@ public class AddinsToolbarButton extends ToolbarMenuButton
          }
       });
       
-      searchWidget_ = new SearchWidget();
+      searchWidget_ = new SearchWidget("Search for addins");
       searchValueChangeTimer_ = new Timer()
       {
          @Override

--- a/src/gwt/src/org/rstudio/studio/client/common/mirrors/ChooseMirrorDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mirrors/ChooseMirrorDialog.java
@@ -159,13 +159,11 @@ public class ChooseMirrorDialog extends ModalDialog<CRANMirror>
    {
       VerticalPanel root = new VerticalPanel();
 
-      FormLabel customLabel = new FormLabel("Custom:");
-      root.add(customLabel);
-
       customTextBox_ = new TextBox();
       customTextBox_.setStylePrimaryName(RESOURCES.styles().customRepo());
+      FormLabel customLabel = new FormLabel("Custom:", customTextBox_);
+      root.add(customLabel);
       root.add(customTextBox_);
-      customLabel.setFor(customTextBox_);
 
       FormLabel mirrorsLabel = new FormLabel("CRAN Mirrors:");
       mirrorsLabel.getElement().getStyle().setMarginTop(8, Unit.PX);
@@ -225,10 +223,9 @@ public class ChooseMirrorDialog extends ModalDialog<CRANMirror>
                @Override
                public void onDoubleClick(DoubleClickEvent event)
                {
-                  clickOkButton();              
+                  clickOkButton();
                }
             });
-            
             
             // if the list box is larger than the space we initially allocated
             // then increase the panel height

--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/CreateKeyDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/CreateKeyDialog.java
@@ -193,21 +193,20 @@ public class CreateKeyDialog extends ModalDialog<CreateKeyOptions>
       namePanel.setWidth("100%");
      
       // path
-      CaptionWithHelp pathCaption = new CaptionWithHelp(
-                                 "The RSA key will be created at:",
-                                 "SSH/RSA key management",
-                                 "rsa_key_help");  
-      pathCaption.setIncludeVersionInfo(false);
-      pathCaption.setWidth("100%");
-      namePanel.add(pathCaption);
-      
       TextBox txtKeyPath = new TextBox();
       txtKeyPath.addStyleName(styles.keyPathTextBox());
       txtKeyPath.setReadOnly(true);
       txtKeyPath.setText(rsaSshKeyPath_.getPath());
       txtKeyPath.setWidth("100%");
+      CaptionWithHelp pathCaption = new CaptionWithHelp(
+                                 "The RSA key will be created at:",
+                                 "SSH/RSA key management",
+                                 "rsa_key_help",
+                                 txtKeyPath);
+      pathCaption.setIncludeVersionInfo(false);
+      pathCaption.setWidth("100%");
+      namePanel.add(pathCaption);
       namePanel.add(txtKeyPath);
-      pathCaption.setFor(txtKeyPath);
       
       panel.add(namePanel);
       
@@ -215,26 +214,24 @@ public class CreateKeyDialog extends ModalDialog<CreateKeyOptions>
       passphrasePanel.addStyleName(styles.newSection());
       
       VerticalPanel passphrasePanel1 = new VerticalPanel();
-      FormLabel passphraseLabel1 = new FormLabel("Passphrase (optional):");
-      passphraseLabel1.addStyleName(styles.entryLabel());
-      passphrasePanel1.add(passphraseLabel1);
       txtPassphrase_ = new PasswordTextBox();
       txtPassphrase_.addStyleName(styles.passphrase());
-      passphraseLabel1.setFor(txtPassphrase_);
+      FormLabel passphraseLabel1 = new FormLabel("Passphrase (optional):", txtPassphrase_);
+      passphraseLabel1.addStyleName(styles.entryLabel());
+      passphrasePanel1.add(passphraseLabel1);
       
       passphrasePanel1.add(txtPassphrase_);
       passphrasePanel.add(passphrasePanel1);
       
       VerticalPanel passphrasePanel2 = new VerticalPanel();
       passphrasePanel2.addStyleName(styles.lastSection());
-      FormLabel passphraseLabel2 = new FormLabel("Confirm:");
-      passphraseLabel2.addStyleName(styles.entryLabel());
-      passphrasePanel2.add(passphraseLabel2);
       txtConfirmPassphrase_ = new PasswordTextBox();
       txtConfirmPassphrase_.addStyleName(styles.passphraseConfirm());
+      FormLabel passphraseLabel2 = new FormLabel("Confirm:", txtConfirmPassphrase_);
+      passphraseLabel2.addStyleName(styles.entryLabel());
+      passphrasePanel2.add(passphraseLabel2);
       passphrasePanel2.add(txtConfirmPassphrase_);
       passphrasePanel.add(passphrasePanel2);
-      passphraseLabel2.setFor(txtConfirmPassphrase_);
       
       panel.add(passphrasePanel);
       

--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/ignore/IgnoreDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/ignore/IgnoreDialog.java
@@ -47,16 +47,15 @@ public class IgnoreDialog extends ModalDialogBase
                                                 null);
       dirChooser_.addStyleName(RES.styles().dirChooser());
       
-      ignoresCaption_ = new CaptionWithHelp("Ignore:",
-                                             "Specifying ignored files");
-      ignoresCaption_.setIncludeVersionInfo(false);
-      ignoresCaption_.addStyleName(RES.styles().ignoresCaption());
-      
       editor_ = new AceEditor();
       editor_.setUseWrapMode(false);
       editor_.setShowLineNumbers(false);
       
-      ignoresCaption_.setFor(editor_.getWidget());
+      ignoresCaption_ = new CaptionWithHelp("Ignore:",
+                                             "Specifying ignored files",
+                                             editor_.getWidget());
+      ignoresCaption_.setIncludeVersionInfo(false);
+      ignoresCaption_.addStyleName(RES.styles().ignoresCaption());
 
       saveButton_ = new ThemedButton("Save", (ClickHandler)null); 
       addButton(saveButton_);

--- a/src/gwt/src/org/rstudio/studio/client/dataviewer/DataTable.java
+++ b/src/gwt/src/org/rstudio/studio/client/dataviewer/DataTable.java
@@ -75,7 +75,7 @@ public class DataTable
       colsSeparator_.setVisible(false);
       addColumnControls(toolbar);
 
-      searchWidget_ = new SearchWidget(new SuggestOracle() {
+      searchWidget_ = new SearchWidget("Search data table", new SuggestOracle() {
          @Override
          public void requestSuggestions(Request request, Callback callback)
          {

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateChooser.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateChooser.java
@@ -145,7 +145,7 @@ public class RmdTemplateChooser extends Composite
    public CaptionWithHelp makeHelpCaption()
    {
       return new CaptionWithHelp("Template:", "Using R Markdown Templates",
-                                 "using_rmarkdown_templates");
+                                 "using_rmarkdown_templates", null);
    }
    
    @UiFactory

--- a/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
@@ -71,7 +71,7 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
       
       setOkButtonCaption("Execute");
       
-      filterWidget_ = new FilterWidget()
+      filterWidget_ = new FilterWidget("Filter by addin name")
       {
          @Override
          public void filter(String query)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/ui/CodeSearchWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/ui/CodeSearchWidget.java
@@ -1,7 +1,7 @@
 /*
  * CodeSearchWidget.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,15 +14,12 @@
  */
 package org.rstudio.studio.client.workbench.codesearch.ui;
 
-
-
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.SearchDisplay;
 import org.rstudio.core.client.widget.SearchWidget;
 import org.rstudio.core.client.widget.TextBoxWithCue;
 import org.rstudio.studio.client.workbench.codesearch.CodeSearch;
 import org.rstudio.studio.client.workbench.codesearch.CodeSearchOracle;
-import org.rstudio.studio.client.workbench.commands.Commands;
 
 import com.google.gwt.user.client.ui.SuggestBox;
 import com.google.inject.Inject;
@@ -32,18 +29,18 @@ public class CodeSearchWidget extends SearchWidget
                               implements CodeSearch.Display
 {
    @Inject
-   public CodeSearchWidget(CodeSearchOracle oracle,
-                           final Commands commands)
+   public CodeSearchWidget(CodeSearchOracle oracle)
    {
-      super(oracle, 
-            new TextBoxWithCue("Go to file/function"), 
+      super("Filter by file or function name",
+            oracle,
+            new TextBoxWithCue("Go to file/function"),
             new SuggestBox.DefaultSuggestionDisplay());
       
       oracle_ = oracle;   
       
       CodeSearchResources res = CodeSearchResources.INSTANCE;
       
-      setIcon(new ImageResource2x(res.gotoFunction2x()));       
+      setIcon(new ImageResource2x(res.gotoFunction2x()));
       
       addStyleName(res.styles().codeSearchWidget());
    }
@@ -67,6 +64,4 @@ public class CodeSearchWidget extends SearchWidget
    }
    
    private final CodeSearchOracle oracle_;
-
-  
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/ExportPlotSizeEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/ExportPlotSizeEditor.java
@@ -113,10 +113,9 @@ public class ExportPlotSizeEditor extends Composite
       }
           
       // image width
-      FormLabel widthLabel = createImageOptionLabel("Width:");
-      widthAndHeightPanel.add(widthLabel);
       widthTextBox_ = createImageSizeTextBox();
-      widthLabel.setFor(widthTextBox_);
+      FormLabel widthLabel = createImageOptionLabel("Width:", widthTextBox_);
+      widthAndHeightPanel.add(widthLabel);
       widthTextBox_.addChangeHandler(new ChangeHandler() {
          @Override
          public void onChange(ChangeEvent event)
@@ -145,10 +144,9 @@ public class ExportPlotSizeEditor extends Composite
      
       // image height
       widthAndHeightPanel.add(new HTML("&nbsp;&nbsp;"));
-      FormLabel heightLabel = createImageOptionLabel("Height:");
-      widthAndHeightPanel.add(heightLabel);
       heightTextBox_ = createImageSizeTextBox();
-      heightLabel.setFor(heightTextBox_);
+      FormLabel heightLabel = createImageOptionLabel("Height:", heightTextBox_);
+      widthAndHeightPanel.add(heightLabel);
       heightTextBox_.addChangeHandler(new ChangeHandler() {
          @Override
          public void onChange(ChangeEvent event)
@@ -474,9 +472,9 @@ public class ExportPlotSizeEditor extends Composite
                       Window.getClientHeight() - 200);
    }
    
-   private FormLabel createImageOptionLabel(String text)
+   private FormLabel createImageOptionLabel(String text, Widget w)
    {
-      FormLabel label = new FormLabel(text);
+      FormLabel label = new FormLabel(text, w);
       label.setStylePrimaryName(
             ExportPlotResources.INSTANCE.styles().imageOptionLabel());
       return label;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/SavePlotAsImageTargetEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/SavePlotAsImageTargetEditor.java
@@ -48,12 +48,11 @@ public class SavePlotAsImageTargetEditor extends Composite implements CanFocus
       LayoutGrid grid = new LayoutGrid(3, 2);
       grid.setCellPadding(0);
     
-      FormLabel imageFormatLabel = new FormLabel("Image format:");
+      imageFormatListBox_ = new ListBox();
+      FormLabel imageFormatLabel = new FormLabel("Image format:", imageFormatListBox_);
       imageFormatLabel.setStylePrimaryName(styles.exportTargetLabel());
           
       grid.setWidget(0, 0, imageFormatLabel);
-      imageFormatListBox_ = new ListBox();
-      imageFormatLabel.setFor(imageFormatListBox_);
       JsArray<SavePlotAsImageFormat> formats = context.getFormats();
       int selectedIndex = 0;
       for (int i=0; i<formats.length(); i++)
@@ -104,13 +103,12 @@ public class SavePlotAsImageTargetEditor extends Composite implements CanFocus
       directoryLabel_.setStylePrimaryName(styles.directoryLabel());
       grid.setWidget(1, 1, directoryLabel_);
       
-      FormLabel fileNameLabel = new FormLabel("File name:");
-      fileNameLabel.setStylePrimaryName(styles.fileNameLabel());
-      grid.setWidget(2, 0, fileNameLabel);
       fileNameTextBox_ = new TextBox();
-      fileNameLabel.setFor(fileNameTextBox_);
       fileNameTextBox_.setText(context.getUniqueFileStem());
       fileNameTextBox_.setStylePrimaryName(styles.fileNameTextBox());
+      FormLabel fileNameLabel = new FormLabel("File name:", fileNameTextBox_);
+      fileNameLabel.setStylePrimaryName(styles.fileNameLabel());
+      grid.setWidget(2, 0, fileNameLabel);
       grid.setWidget(2, 1, fileNameTextBox_);
         
       initWidget(grid);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsPane.java
@@ -337,7 +337,7 @@ public class ConnectionsPane extends WorkbenchPane
    {
       toolbar_ = new Toolbar();
    
-      searchWidget_ = new SearchWidget(new SuggestOracle() {
+      searchWidget_ = new SearchWidget("Filter by connection", new SuggestOracle() {
          @Override
          public void requestSuggestions(Request request, Callback callback)
          {
@@ -348,7 +348,7 @@ public class ConnectionsPane extends WorkbenchPane
          }
       });
 
-      objectSearchWidget_ = new SearchWidget(new SuggestOracle() {
+      objectSearchWidget_ = new SearchWidget("Filter by object", new SuggestOracle() {
          @Override
          public void requestSuggestions(Request request, Callback callback)
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -175,7 +175,7 @@ public class EnvironmentPane extends WorkbenchPane
       ThemeStyles styles = ThemeStyles.INSTANCE;
       toolbar.getWrapper().addStyleName(styles.tallerToolbarWrapper());
       
-      SearchWidget searchWidget = new SearchWidget(new SuggestOracle() {
+      SearchWidget searchWidget = new SearchWidget("Search environment", new SuggestOracle() {
          @Override
          public void requestSuggestions(Request request, Callback callback)
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/search/HelpSearchWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/search/HelpSearchWidget.java
@@ -1,7 +1,7 @@
 /*
  * HelpSearchWidget.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -27,7 +27,7 @@ public class HelpSearchWidget extends SearchWidget
    @Inject
    public HelpSearchWidget(HelpSearchOracle oracle)
    {
-      super(oracle);
+      super("Search help", oracle);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/history/view/HistoryPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/history/view/HistoryPane.java
@@ -1,7 +1,7 @@
 /*
  * HistoryPane.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -564,7 +564,7 @@ public class HistoryPane extends WorkbenchPane
    @Override
    protected Toolbar createMainToolbar()
    {
-      searchWidget_ = new SearchWidget(new SuggestOracle()
+      searchWidget_ = new SearchWidget("Filter command history", new SuggestOracle()
       {
          @Override
          public void requestSuggestions(Request request,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
@@ -214,7 +214,7 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
       toolbar.addLeftWidget(packratMenuButton_);
       packratMenuButton_.setVisible(false);
             
-      searchWidget_ = new SearchWidget(new SuggestOracle() {
+      searchWidget_ = new SearchWidget("Filter by package name", new SuggestOracle() {
          @Override
          public void requestSuggestions(Request request, Callback callback)
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/InstallPackageDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/InstallPackageDialog.java
@@ -130,16 +130,8 @@ public class InstallPackageDialog extends ModalDialog<PackageInstallRequest>
       mainPanel.setStylePrimaryName(RESOURCES.styles().mainWidget());
       
       // source type
-      reposCaption_ = new CaptionWithHelp("Install from:",
-                                          "Configuring Repositories",
-                                          "configuring_repositories");  
-      reposCaption_.setIncludeVersionInfo(false);
-      reposCaption_.setWidth("100%");
-      mainPanel.add(reposCaption_);
-      
       packageSourceListBox_ = new ListBox();
-      packageSourceListBox_.setStylePrimaryName(
-                           RESOURCES.styles().packageSourceListBox());
+      packageSourceListBox_.setStylePrimaryName(RESOURCES.styles().packageSourceListBox());
       packageSourceListBox_.addStyleName(RESOURCES.styles().extraBottomPad());
       JsArrayString repos = installContext_.selectedRepositoryNames();
       if (repos.length() == 1)
@@ -162,8 +154,14 @@ public class InstallPackageDialog extends ModalDialog<PackageInstallRequest>
       packageSourceListBox_.addItem("Package Archive File (" + 
                                     installContext_.packageArchiveExtension() +
                                     ")");
+      reposCaption_ = new CaptionWithHelp("Install from:",
+                                          "Configuring Repositories",
+                                          "configuring_repositories",
+                                          packageSourceListBox_);
+      reposCaption_.setIncludeVersionInfo(false);
+      reposCaption_.setWidth("100%");
+      mainPanel.add(reposCaption_); 
       mainPanel.add(packageSourceListBox_);
-      reposCaption_.setFor(packageSourceListBox_);
       
       // source panel container
       sourcePanel_ = new SimplePanel();
@@ -171,21 +169,19 @@ public class InstallPackageDialog extends ModalDialog<PackageInstallRequest>
       
       // repos source panel
       reposSourcePanel_ = new FlowPanel();
-      FormLabel packagesLabel = new FormLabel(
-                      "Packages (separate multiple with space or comma):");
-      packagesLabel.setStylePrimaryName(RESOURCES.styles().packagesLabel());
-      reposSourcePanel_.add(packagesLabel);
-     
       packagesTextBox_ = new MultipleItemSuggestTextBox();
       packagesSuggestBox_ = new SuggestBox(new PackageOracle(),
                                            packagesTextBox_);
       packagesSuggestBox_.setWidth("100%");
       packagesSuggestBox_.setLimit(20);
       packagesSuggestBox_.addStyleName(RESOURCES.styles().extraBottomPad());
+      FormLabel packagesLabel = new FormLabel(
+                      "Packages (separate multiple with space or comma):", packagesSuggestBox_);
+      packagesLabel.setStylePrimaryName(RESOURCES.styles().packagesLabel());
+      reposSourcePanel_.add(packagesLabel);
       reposSourcePanel_.add(packagesSuggestBox_);
       sourcePanel_.setWidget(reposSourcePanel_);
       mainPanel.add(sourcePanel_);
-      packagesLabel.setFor(packagesSuggestBox_);
          
       // archive source panel
       packageArchiveFile_ = new TextBoxWithButton(
@@ -213,10 +209,6 @@ public class InstallPackageDialog extends ModalDialog<PackageInstallRequest>
          } 
       });
       
-     
-      FormLabel libraryListLabel = new FormLabel("Install to Library:");
-      mainPanel.add(libraryListLabel);
-      
       // library list box
       libraryListBox_ = new ListBox();
       libraryListBox_.setWidth("100%");
@@ -240,8 +232,10 @@ public class InstallPackageDialog extends ModalDialog<PackageInstallRequest>
         
       }
       libraryListBox_.setSelectedIndex(selectedIndex); 
+
+      FormLabel libraryListLabel = new FormLabel("Install to Library:", libraryListBox_);
+      mainPanel.add(libraryListLabel);
       mainPanel.add(libraryListBox_);
-      libraryListLabel.setFor(libraryListBox_);
       
       // install dependencies check box
       installDependenciesCheckBox_.addStyleName(RESOURCES.styles().installDependenciesCheckBox());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/TabOverflowPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/TabOverflowPopupPanel.java
@@ -1,7 +1,7 @@
 /*
  * TabOverflowPopupPanel.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -115,7 +115,7 @@ public class TabOverflowPopupPanel extends ThemedPopupPanel
 
       DockPanel dockPanel = new DockPanel();
 
-      search_ = new SearchWidget(new DocsOracle());
+      search_ = new SearchWidget("Search tabs", new DocsOracle());
       search_.addValueChangeHandler(this);
 
       search_.getElement().getStyle().setMarginRight(0, Unit.PX);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerEditingTargetWidget.java
@@ -74,7 +74,7 @@ public class ObjectExplorerEditingTargetWidget extends Composite
                }
             });
       
-      filterWidget_ = new SearchWidget(new SuggestOracle()
+      filterWidget_ = new SearchWidget("Search objects", new SuggestOracle()
       {
          @Override
          public void requestSuggestions(Request request, Callback callback)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
@@ -26,6 +26,7 @@ import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.DomUtils.NativeEventHandler;
 import org.rstudio.core.client.files.FileSystemItem;
+import org.rstudio.core.client.widget.FormLabel;
 import org.rstudio.core.client.widget.MiniPopupPanel;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.ProgressOperationWithInput;
@@ -161,7 +162,7 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
       int gridRows = includeChunkNameUI ? 2 : 1;
       Grid nameAndOutputGrid = new Grid(gridRows, 2);
 
-      chunkLabel_ = new Label("Name:");
+      chunkLabel_ = new FormLabel("Chunk Name:", tbChunkLabel_);
       chunkLabel_.addStyleName(RES.styles().chunkLabel());
       
       if (includeChunkNameUI)
@@ -660,7 +661,7 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
    
    protected final VerticalPanel panel_;
    protected final Label header_;
-   protected final Label chunkLabel_;
+   protected final FormLabel chunkLabel_;
    protected final TextBoxWithCue tbChunkLabel_;
    protected final ListBox outputComboBox_;
    protected final Grid figureDimensionsPanel_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/DefaultChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/DefaultChunkOptionsPopupPanel.java
@@ -1,3 +1,17 @@
+/*
+ * DefaultChunkOptionsPopupPanel.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
 package org.rstudio.studio.client.workbench.views.source.editors.text.rmd.display;
 
 import com.google.gwt.user.client.Command;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/AddRemoteDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/AddRemoteDialog.java
@@ -66,12 +66,10 @@ public class AddRemoteDialog extends ModalDialog<AddRemoteDialog.Input>
       setOkButtonCaption("Add");
       
       container_ = new VerticalPanel();
-      lblName_ = label("Remote Name:");
-      lblUrl_ = label("Remote URL:");
       tbName_ = textBox();
       tbUrl_ = textBox();
-      lblName_.setFor(tbName_);
-      lblUrl_.setFor(tbUrl_);
+      lblName_ = label("Remote Name:", tbName_);
+      lblUrl_ = label("Remote URL:", tbUrl_);
       
       tbName_.addKeyDownHandler(this);
       tbUrl_.addKeyDownHandler(this);
@@ -133,9 +131,9 @@ public class AddRemoteDialog extends ModalDialog<AddRemoteDialog.Input>
       return textBox;
    }
    
-   private FormLabel label(String text)
+   private FormLabel label(String text, Widget w)
    {
-      FormLabel label = new FormLabel(text);
+      FormLabel label = new FormLabel(text, w);
       label.getElement().getStyle().setMarginBottom(4, Unit.PX);
       return label;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
@@ -155,7 +155,7 @@ public class BranchToolbarButton extends ToolbarMenuButton
          }
       });
       
-      searchWidget_ = new SearchWidget();
+      searchWidget_ = new SearchWidget("Search by branch name");
       
       searchValueChangeTimer_ = new Timer()
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchDialog.java
@@ -173,8 +173,7 @@ public class CreateBranchDialog extends ModalDialog<CreateBranchDialog.Input>
       
       LayoutGrid ctrBranch = new LayoutGrid(1, 2);
       ctrBranch.setWidth("100%");
-      FormLabel branchLabel = new FormLabel("Branch Name:");
-      branchLabel.setFor(tbBranch_);
+      FormLabel branchLabel = new FormLabel("Branch Name:", tbBranch_);
       ctrBranch.setWidget(0, 0, branchLabel);
       ctrBranch.setWidget(0, 1, tbBranch_);
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/HistoryPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/HistoryPanel.java
@@ -123,7 +123,8 @@ public class HistoryPanel extends Composite implements Display
                                  (ClickHandler) null);
       topToolbar_.addLeftWidget(refreshButton_); 
       
-      searchText_ = new SearchWidget(new MultiWordSuggestOracle(),
+      searchText_ = new SearchWidget("Search version control history", 
+                                     new MultiWordSuggestOracle(),
                                      new TextBoxWithCue("Search"),
                                      null);
       topToolbar_.addRightWidget(searchText_);


### PR DESCRIPTION
UI has various search/filter controls, such as on the main toolbar, and in various panes, which rely on an icon and/or placeholder text to identify what they are for, but have no visible labels. This is a basic accessibility violation flagged by automated tools, and makes it harder for screen-reader users to comprehend the UI.

Ideally we'd add visible labels, to also improve the experience for sighted users, but to avoid that degree of UI churn, settling for a visually hidden label which is associated with the search textbox, and will be read by screen readers (and satisfies the automated / WCAG baseline tests).

Also new constructors for FormLabel and CaptionWithHelp to make it a one-step operation to create a label and associate it with another control (at least when creating UI directly in code; still need to provide something similar for declarative .ui.xml approach).