### PR TITLE
assign different IDs to minimized tabs vs regular tabs

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/MinimizedModuleTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/MinimizedModuleTabLayoutPanel.java
@@ -1,7 +1,7 @@
 /*
  * MinimizedModuleTabLayoutPanel.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -50,7 +50,7 @@ public class MinimizedModuleTabLayoutPanel
          if (tabName == null)
             continue;
          ModuleTabLayoutPanel.ModuleTab tab
-               = new ModuleTabLayoutPanel.ModuleTab(tabName, styles, false);
+               = new ModuleTabLayoutPanel.ModuleTab(tabName, styles, false, true /*minimized*/);
          tab.addStyleName("gwt-TabLayoutPanelTab");
          final Integer thisIndex = i;
          tab.addClickHandler(new ClickHandler()

--- a/src/gwt/src/org/rstudio/core/client/theme/ModuleTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ModuleTabLayoutPanel.java
@@ -1,7 +1,7 @@
 /*
  * ModuleTabLayoutPanel.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -40,14 +40,18 @@ public class ModuleTabLayoutPanel extends TabLayoutPanel
 {
    public static class ModuleTab extends Composite implements BusyHandler
    {
-      public ModuleTab(String title, ThemeStyles styles, boolean canClose)
+      public ModuleTab(String title, ThemeStyles styles, boolean canClose, boolean minimized)
       {
          layoutPanel_ = new HorizontalPanel();
          layoutPanel_.setStylePrimaryName(styles.tabLayout());
-         
+
+         String minimized_id = "";
+         if (minimized)
+            minimized_id = "_minimized";
+
          // Assign a unique element ID based on the tab's title
          ElementIds.assignElementId(layoutPanel_.getElement(), 
-               ElementIds.WORKBENCH_TAB + "_" + ElementIds.idSafeString(title));
+               ElementIds.WORKBENCH_TAB + minimized_id + "_" + ElementIds.idSafeString(title));
 
          HTML left = new HTML();
          left.setStylePrimaryName(styles.tabLayoutLeft());
@@ -200,7 +204,7 @@ public class ModuleTabLayoutPanel extends TabLayoutPanel
       if (asHtml)
          throw new UnsupportedOperationException("HTML tab names not supported");
 
-      ModuleTab tab = new ModuleTab(text, styles_, closeHandler != null);
+      ModuleTab tab = new ModuleTab(text, styles_, closeHandler != null, false /*minimized*/);
       super.add(child, tab);
 
       if (closeHandler != null)


### PR DESCRIPTION
- basic a11y requirement, no duplicate element IDs on page
- this doesn't fix all of them, just the ones related to the tabs (Environment, Files, and so forth)
- adds "_minimized" to the IDs of minimized tabs, such as "rstudio_workbench_tab_minimized_environment"
- fixes #5011 