### PR TITLE
avoid sending duplicate dictionary requests (closes #5012)

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/Mutable.java
+++ b/src/gwt/src/org/rstudio/core/client/Mutable.java
@@ -1,7 +1,7 @@
 /*
  * Mutable.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,6 +15,8 @@
 package org.rstudio.core.client;
 
 // A utility class primarily used for creating mutable integers etc.
+// Useful for mutable objects that need to be accessible by anonymous classes,
+// callbacks, and so on.
 public class Mutable<T>
 {
    public Mutable()
@@ -35,6 +37,11 @@ public class Mutable<T>
    public void set(T data)
    {
       data_ = data;
+   }
+   
+   public void clear()
+   {
+      data_ = null;
    }
    
    private T data_;

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RequestLogVisualization.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RequestLogVisualization.java
@@ -202,7 +202,12 @@ public class RequestLogVisualization extends Composite
       HTML html = new HTML();
       html.getElement().getStyle().setOverflow(Overflow.VISIBLE);
       html.getElement().getStyle().setProperty("whiteSpace", "nowrap");
-      html.setText(entry.getRequestMethodName() + (active ? " (active)" : ""));
+      
+      String method = entry.getRequestMethodName();
+      if (method == null)
+         method = entry.getRequestId();
+      
+      html.setText(method + (active ? " (active)" : ""));
       if (active)
          html.getElement().getStyle().setFontWeight(FontWeight.BOLD);
       String color;


### PR DESCRIPTION
On startup, we attempt to load dictionaries once for each document tab that gets opened. If a large number of documents are restored into the user's workspace, a new request for dictionary files will be made for every document that gets opened on startup (since `typoLoaded_` doesn't get flipped to `true` until after a response has been received, and that takes some time).

This PR fixes the issue by keeping track of the 'active' request for dictionary-related files, and avoids making the same request if one is already in flight. It also ensures that the request log entries are updated when a successful response is received.

Closes #5012.