### PR TITLE
use latest cmake on Windows otherwise 32-bit build fails

### DIFF
--- a/dependencies/windows/Install-RStudio-Prereqs.ps1
+++ b/dependencies/windows/Install-RStudio-Prereqs.ps1
@@ -63,7 +63,7 @@ iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/in
 refreshenv
 
 # install some deps via chocolatey
-choco install -y cmake --version 3.12.1 --installargs 'ADD_CMAKE_TO_PATH=""System""' --fail-on-error-output
+choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=""System""' --fail-on-error-output
 refreshenv
 choco install -y jdk8
 choco install -y ant --version 1.10.5

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -14,7 +14,7 @@ RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 
     iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
 # install some deps via chocolatey
-RUN choco install -y cmake --version 3.12.1 --installargs 'ADD_CMAKE_TO_PATH=""System""' --fail-on-error-output; ` 
+RUN choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=""System""' --fail-on-error-output; ` 
   choco install -y jdk8 ; `
   choco install -y ant --version 1.10.5; `
   choco install -y windows-sdk-10.1 --version 10.1.17134.12; `


### PR DESCRIPTION
- we already do this in master, but 1.2-patch dockerfile was still installing an older version
- confirmed on dev machine that 1.2-patch fails in same way that the official build did when I downgrade to that older version of cmake (and works with the newer version)

Requires yet-another dockerfile regen (unless we want to connect and manually upgrade cmake)