### PR TITLE
cache package information using indexer

### DIFF
--- a/src/cpp/core/include/core/r_util/RPackageInfo.hpp
+++ b/src/cpp/core/include/core/r_util/RPackageInfo.hpp
@@ -20,6 +20,8 @@
 
 #include <core/FilePath.hpp>
 
+#define kPackageType "Package"
+
 namespace rstudio {
 namespace core {
 

--- a/src/cpp/core/r_util/RPackageInfo.cpp
+++ b/src/cpp/core/r_util/RPackageInfo.cpp
@@ -27,8 +27,6 @@ namespace r_util {
 
 namespace {
 
-const char * const kPackageType = "Package";
-
 Error fieldNotFoundError(const FilePath& descFilePath,
                          const std::string& fieldName,
                          const ErrorLocation& location)

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -64,10 +64,7 @@ void onDescriptionChanged()
    std::unique_ptr<r_util::RPackageInfo> pInfo(new r_util::RPackageInfo);
    Error error = pInfo->read(projectContext().directory());
    if (error)
-   {
       LOG_ERROR(error);
-      return;
-   }
 
    pInfo.swap(s_pIndexedPackageInfo);
 }
@@ -79,7 +76,10 @@ void onProjectFilesChanged(const std::vector<core::system::FileChangeEvent>& eve
    {
       auto& info = event.fileInfo();
       if (info.absolutePath() == descPath.absolutePath())
+      {
          onDescriptionChanged();
+         break;
+      }
    }
 }
 


### PR DESCRIPTION
This PR fixes a performance regression in the diagnostics system.

I was surprised to see the indexer taking a long time to run when working with `shiny`:

```
> system.time(.Call("rs_lintRFile", "R/shiny.R"))
   user  system elapsed 
  1.439   0.028   1.468 
```

It turns out this was due to some aggressive calls to `r_util::isPackageProject()`, e.g.

https://github.com/rstudio/rstudio/blob/ad749d1029688931e00034ea0b295822d161258f/src/cpp/session/modules/SessionRParser.cpp#L373

This gets called quite often when the indexer runs, and that check involves re-reading and re-parsing the project DESCRIPTION for each time it's called.

The fix here caches the parsed package information and uses the project file monitor to update that cache as required.

```
> system.time(.Call("rs_lintRFile", "R/shiny.R"))
   user  system elapsed 
  0.371   0.143   0.513 
```