### PR TITLE
assorted a11y fixes to contrast and unlabeled controls

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1027,7 +1027,6 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
    display: inline;
    color: black;
    font-size: 11px;
-   font-weight: bold;
    text-shadow: white 0px 1px 0px;
    cursor: default;
 }
@@ -1045,7 +1044,7 @@ body.avoid-move-cursor .gwt-SplitLayoutPanel-VDragger {
 }
 
 .subtitle {
-   color: #999;
+   color: #0c1f30;
    margin-left: 6px;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/widget/CheckBoxHiddenLabel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/CheckBoxHiddenLabel.java
@@ -1,0 +1,39 @@
+/*
+ * CheckBoxHiddenLabel.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.widget;
+
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.ui.CheckBox;
+
+/**
+ * A CheckBox with a label only visible to screen readers. Not recommended, avoid using.
+ */
+public class CheckBoxHiddenLabel extends CheckBox
+{
+   public CheckBoxHiddenLabel(String visuallyHiddenLabel)
+   {
+      super();
+      
+      // CheckBox consists of a span with input (checkbox) element followed
+      // by a label element (empty in this case).
+      Element label = DOM.getChild(getElement(), 1);
+      if (label != null)
+      {
+         Roles.getCheckboxRole().setAriaLabelProperty(label, visuallyHiddenLabel);
+      }
+   }
+}

--- a/src/gwt/src/org/rstudio/core/client/widget/CheckboxLabel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/CheckboxLabel.java
@@ -1,7 +1,7 @@
 /*
  * CheckboxLabel.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,9 +14,11 @@
  */
 package org.rstudio.core.client.widget;
 
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style.Cursor;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Label;
@@ -26,8 +28,16 @@ public class CheckboxLabel implements IsWidget
 {
    public CheckboxLabel(final CheckBox checkbox, String label)
    {
-      label_ = new Label(label);
-
+      // CheckBox consists of a span with input (checkbox) element followed
+      // by a label element, which is blank in this case so we associate our
+      // label with it and disassociate the existing one to avoid confusing 
+      // screen readers
+      label_ = new FormLabel(label, checkbox.getElement().getFirstChildElement());
+      Element blankLabel = DOM.getChild(checkbox.getElement(), 1);
+      if (blankLabel != null)
+      {
+         blankLabel.removeAttribute("for");
+      }
       label_.getElement().getStyle().setCursor(Cursor.DEFAULT);
       label_.addClickHandler(new ClickHandler()
       {
@@ -52,5 +62,5 @@ public class CheckboxLabel implements IsWidget
       return label_;
    }
 
-   private final Label label_;
+   private final FormLabel label_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/FormLabel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FormLabel.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.core.client.widget;
 
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
@@ -77,6 +78,18 @@ public class FormLabel extends Label
    }
 
    /**
+    * Create a label to associate with an existing element
+    * @param text label text
+    * @param el labeled element; if the element does not already have an id attribute,
+    *          one will be generated and assigned to it
+    */
+   public FormLabel(String text, Element el)
+   {
+      super(text, NoForId);
+      setFor(el);
+   }
+
+   /**
     * Associate this label with the given widget. If the widget's element does not
     * have an id attribute, a unique one will be generated and assigned to it.
     * @param widget
@@ -85,11 +98,23 @@ public class FormLabel extends Label
    {
       if (widget == null)
          return;
-      String controlId = widget.getElement().getId();
+      setFor(widget.getElement());
+   }
+
+   /**
+    * Associate this label with the given element. If the element does not
+    * have an id attribute, a unique one will be generated and assigned to it.
+    * @param el
+    */   public void setFor(Element el)
+   {
+      if (el == null)
+         return;
+
+      String controlId = el.getId();
       if (StringUtil.isNullOrEmpty(controlId))
       {
          controlId = DOM.createUniqueId();
-         widget.getElement().setId(controlId);
+         el.setId(controlId);
       }
       setFor(controlId);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.css
@@ -125,7 +125,6 @@
 {
    font-family: proportionalFont;
    font-size: 90%;
-   color: #909090;
 }
 
 .unclickableIcon

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.java
@@ -33,6 +33,8 @@ import com.google.gwt.user.client.ui.*;
 import com.google.gwt.view.client.ListDataProvider;
 
 import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.theme.res.ThemeResources;
+import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.FontSizer;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.studio.client.common.SuperDevMode;
@@ -606,10 +608,12 @@ public class EnvironmentObjects extends ResizeComposite
 
    private Widget buildEmptyGridMessage()
    {
+      ThemeStyles styles = ThemeResources.INSTANCE.themeStyles();
       HTMLPanel messagePanel = new HTMLPanel("");
       messagePanel.setStyleName(style.emptyEnvironmentPanel());
       environmentEmptyMessage_ = new Label(EMPTY_ENVIRONMENT_MESSAGE);
-      environmentEmptyMessage_.setStyleName(style.emptyEnvironmentMessage());
+      environmentEmptyMessage_.setStyleName(styles.subtitle());
+      environmentEmptyMessage_.setStylePrimaryName(style.emptyEnvironmentMessage());
       messagePanel.add(environmentEmptyMessage_);
       return messagePanel;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilePathToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilePathToolbar.java
@@ -27,6 +27,7 @@ import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.files.PosixFileSystemContext;
 import org.rstudio.core.client.files.filedialog.PathBreadcrumbWidget;
 import org.rstudio.core.client.theme.res.ThemeStyles;
+import org.rstudio.core.client.widget.CheckBoxHiddenLabel;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.filetypes.FileIcon;
@@ -115,7 +116,7 @@ public class FilePathToolbar extends Composite
       navigationObserver_ = navigationObserver;
       
       // select all check box
-      CheckBox selectAllCheckBox = new CheckBox();
+      CheckBoxHiddenLabel selectAllCheckBox = new CheckBoxHiddenLabel("Select all files");
       selectAllCheckBox.addStyleDependentName("FilesSelectAll");
       selectAllCheckBox.addValueChangeHandler(new ValueChangeHandler<Boolean>(){
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesList.java
@@ -157,7 +157,7 @@ public class FilesList extends Composite
          };
       iconColumn.setSortable(true);
       filesDataGrid_.addColumn(iconColumn, 
-                                SafeHtmlUtils.fromSafeConstant("<br/>"));
+            SafeHtmlUtils.fromSafeConstant("<span aria-label=\"File Type\"><br/></span>"));
       filesDataGrid_.setColumnWidth(iconColumn, ICON_COLUMN_WIDTH_PIXELS, Unit.PX);
     
       sortHandler_.setComparator(iconColumn, new FilesListComparator() {


### PR DESCRIPTION
- Fix a batch of violations flagged by automated tools on default first-run IDE configuration (plus some others not visible in initial UI configuration)

- the sort-by-file-type column in Files pane had no label, now it has one visible to screen readers
- the select-all-files checkbox in Files pane had no label, now it has one visible to screen readers

![2019-06-26_12-03-02](https://user-images.githubusercontent.com/10569626/60207324-6c904580-980a-11e9-97a7-f56e4ad35b44.png)

- the message "Environment is empty" in background of Environment pane had very low contrast; bumped up contrast and tied color to theme so it remains visible in dark themes

![2019-06-26_10-35-41](https://user-images.githubusercontent.com/10569626/60207357-86ca2380-980a-11e9-92a8-5b1ca0cb7f09.png)

![2019-06-26_12-05-08](https://user-images.githubusercontent.com/10569626/60207408-acefc380-980a-11e9-9819-3eed496e1c38.png)

- the current-directory label in upper-left corner of Console pane had very low contrast; bumped up contrast (only looking at text contrast, not icons)

![2019-06-26_10-38-33](https://user-images.githubusercontent.com/10569626/60207435-c0029380-980a-11e9-9fb4-717259706c15.png)

![2019-06-26_11-09-26](https://user-images.githubusercontent.com/10569626/60207442-c42eb100-980a-11e9-9efd-652c8f8feb0c.png)

- noticed that "CheckboxLabel" class used for multiple checkboxes in editor pane and find/replace sub-pane wasn't associating labels with the checkbox properly, so fixed that

![2019-06-26_11-08-44](https://user-images.githubusercontent.com/10569626/60207523-f7714000-980a-11e9-9bf1-2c288670cc97.png)
