### PR TITLE
guard against spurious root-changed FS events

### DIFF
--- a/src/cpp/core/system/file_monitor/MacFileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/MacFileMonitor.cpp
@@ -19,6 +19,7 @@
 
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/classification.hpp>
+#include <boost/bind.hpp>
 
 #include <core/Log.hpp>
 #include <core/Error.hpp>
@@ -37,18 +38,70 @@ namespace file_monitor {
 
 namespace {
 
+class DirectoryHandle : boost::noncopyable
+{
+public:
+   DirectoryHandle(const std::string& path)
+      : fd_(-1)
+   {
+      const char* cpath = path.c_str();
+      auto f = [&]() { return ::open(cpath, O_DIRECTORY); };
+      Error error = posixCall<int>(f, ERROR_LOCATION, &fd_);
+      if (error)
+         LOG_ERROR(error);
+   }
+
+   ~DirectoryHandle()
+   {
+      if (fd_ != -1)
+      {
+         auto f = [&]() { return ::close(fd_); };
+         safePosixCall<int>(f, ERROR_LOCATION);
+      }
+   }
+
+   FilePath currentPath()
+   {
+      // read the path associated with the descriptor
+      char path[PATH_MAX];
+      auto f = [&]() { return ::fcntl(fd_, F_GETPATH, path); };
+      Error error = posixCall<int>(f, ERROR_LOCATION);
+      if (error)
+         return FilePath();
+
+      // validate the directory still exists
+      FilePath currPath(path);
+      if (!currPath.isDirectory())
+         return FilePath();
+
+      // okay, return the path
+      return currPath;
+   }
+
+private:
+   int fd_;
+};
+
 class FileEventContext : boost::noncopyable
 {
 public:
-   FileEventContext()
-      : streamRef(nullptr), recursive(false)
+   FileEventContext(const FilePath& rootPath)
+      : rootPath(rootPath),
+        rootHandle(rootPath.absolutePathNative()),
+        streamRef(nullptr),
+        recursive(false)
    {
       handle = Handle((void*)this);
    }
-   virtual ~FileEventContext() {}
+
+   virtual ~FileEventContext()
+   {
+   }
+
    Handle handle;
-   FSEventStreamRef streamRef;
    FilePath rootPath;
+   DirectoryHandle rootHandle;
+   FSEventStreamRef streamRef;
    bool recursive;
    boost::function<bool(const FileInfo&)> filter;
    tree<FileInfo> fileTree;
@@ -71,24 +124,32 @@ void fileEventCallback(ConstFSEventStreamRef streamRef,
    if (!pContext->callbacks.onFilesChanged)
       return;
 
-   char **paths = (char**)eventPaths;
-   for (std::size_t i=0; i<numEvents; i++)
+   // de-register the file monitor if the root path has changed or been
+   // removed
+   //
+   // NOTE: on macOS Catalina, we observed spurious 'RootChanged' events
+   // delivered causing the file monitor to erroneously detach. protect
+   // against this by also double-checking whether the original path
+   // monitored and the path reported by the file handle match up
+   //
+   // https://github.com/rstudio/rstudio/issues/4755
+   if (pContext->rootPath != pContext->rootHandle.currentPath())
    {
-      // check for root changed (unregister)
-      if (eventFlags[i] & kFSEventStreamEventFlagRootChanged)
-      {
-         // propagate error to client
-         Error error = fileNotFoundError(pContext->rootPath.absolutePath(),
-                                         ERROR_LOCATION);
-         pContext->callbacks.onMonitoringError(error);
+      // propagate error to client
+      Error error = fileNotFoundError(pContext->rootPath.absolutePath(),
+                                      ERROR_LOCATION);
+      pContext->callbacks.onMonitoringError(error);
 
-         // unregister this monitor (this is done via postback from the
-         // main file_monitor loop so that the monitor Handle can be tracked)
-         file_monitor::unregisterMonitor(pContext->handle);
+      // unregister this monitor (this is done via postback from the
+      // main file_monitor loop so that the monitor Handle can be tracked)
+      file_monitor::unregisterMonitor(pContext->handle);
 
-         return;
-      }
+      return;
+   }
 
+   char **paths = (char**) eventPaths;
+   for (std::size_t i = 0; i < numEvents; i++)
+   {
       // make a copy of the path and strip off trailing / if necessary
       std::string path(paths[i]);
       boost::algorithm::trim_right_if(path, boost::algorithm::is_any_of("/"));
@@ -195,14 +256,12 @@ Handle registerMonitor(const FilePath& filePath,
    }
    CFRefScope pathsArrayRefScope(pathsArrayRef);
 
-
    // create and allocate FileEventContext (create auto-ptr in case we
    // return early, we'll call release later before returning)
-   FileEventContext* pContext = new FileEventContext();
-   pContext->rootPath = filePath;
+   FileEventContext* pContext = new FileEventContext(filePath);
    pContext->recursive = recursive;
    pContext->filter = filter;
-   std::auto_ptr<FileEventContext> autoPtrContext(pContext);
+   std::unique_ptr<FileEventContext> autoPtrContext(pContext);
    FSEventStreamContext context;
    context.version = 0;
    context.info = (void*) pContext;


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/4755.

This PR takes inspiration from https://developer.apple.com/documentation/coreservices/1455376-fseventstreamcreateflags/kfseventstreamcreateflagwatchroot?language=objc, which suggests:

> If you want to track the current location of a directory, it is best to open the directory before creating the stream so that you have a file descriptor for it and can issue an F_GETPATH fcntl() to find the current path.

One potential worry: this change implies double-checking that the root path hasn't changed and the associated handle is 'valid' every time a filesystem event comes in. While this is cheap, it's still more expensive than the pure event-driven approach.