### PR TITLE
add a11y labels to close tab icons, close Find pane icon, text editor double-arrows

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/ModuleTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ModuleTabLayoutPanel.java
@@ -66,6 +66,7 @@ public class ModuleTabLayoutPanel extends TabLayoutPanel
             closeButton_ = new Image(new ImageResource2x(ThemeResources.INSTANCE.closeTab2x()));
             closeButton_.setStylePrimaryName(styles.closeTabButton());
             closeButton_.addStyleName(ThemeStyles.INSTANCE.handCursor());
+            closeButton_.setAltText("Close " + title + " tab");
             center.add(closeButton_);
          }
          layoutPanel_.add(center);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.java
@@ -1,7 +1,7 @@
 /*
  * FindReplaceBar.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.text.findreplace;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.*;
 import com.google.gwt.resources.client.ClientBundle;
@@ -148,6 +149,7 @@ public class FindReplaceBar extends Composite implements Display, RequiresResize
       btnClose_.setStyleName(RES.styles().closeButton());
       btnClose_.addStyleName(ThemeStyles.INSTANCE.closeTabButton());
       btnClose_.addStyleName(ThemeStyles.INSTANCE.handCursor());
+      Roles.getButtonRole().setAriaLabelProperty(btnClose_.getElement(), "Close find and replace");
       btnClose_.getElement().appendChild(
             new Image(new ImageResource2x(ThemeResources.INSTANCE.closeTab2x())).getElement());
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarElementWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarElementWidget.java
@@ -1,7 +1,7 @@
 /*
  * StatusBarElementWidget.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -26,13 +26,13 @@ import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.MenuItem;
 
 import java.util.ArrayList;
 
 import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.core.client.widget.DecorativeImage;
 
 public class StatusBarElementWidget extends FlowPanel
       implements StatusBarElement, HasSelectionHandlers<String>
@@ -114,7 +114,7 @@ public class StatusBarElementWidget extends FlowPanel
          if (showArrows)
          {
             Resources res = GWT.create(Resources.class);
-            arrows_ = new Image(new ImageResource2x(res.upDownArrow2x()));
+            arrows_ = new DecorativeImage(new ImageResource2x(res.upDownArrow2x()));
             arrows_.addStyleName("rstudio-themes-inverts");
             add(arrows_);
          }
@@ -168,7 +168,7 @@ public class StatusBarElementWidget extends FlowPanel
 
    private final ArrayList<String> options_;
    private final Label label_;
-   private Image arrows_;
+   private DecorativeImage arrows_;
    private boolean clicksEnabled_ = true;
    private String popupAlignment_ = POPUP_ALIGNMENT_LEFT;
          


### PR DESCRIPTION
- images without alt-text are flagged by automated a11y tests
- tab close-icons now say, for example, "Close terminal tab" (if you point at them with a screen reader, they are not keyboard accessible otherwise)
- Find pane close says "Close find and replace" (it's a button, so is keyboard accessible, though there are other issues to address in this pane)
- Little arrows on the popup menus at bottom of editor are now marked as cosmetic (empty `alt`)
- this PR doesn't address the "close document tab" icon; doing that separately

![2019-06-27_11-38-32](https://user-images.githubusercontent.com/10569626/60291948-f1459700-98d0-11e9-9cfe-c1c6df42ee3f.png)

![2019-06-27_11-40-58](https://user-images.githubusercontent.com/10569626/60291967-f571b480-98d0-11e9-823d-c88640fe120d.png)
