### PR TITLE
add labels to editor tab icons and unsaved changes file icons

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
@@ -2,7 +2,7 @@
  * 
  * DocTabLayoutPanel.java
  *
- * Copyright (C) 2009-15 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -40,6 +40,7 @@ import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.workbench.views.source.SourceWindowManager;
 import org.rstudio.studio.client.workbench.views.source.events.DocTabDragInitiatedEvent;
@@ -65,7 +66,6 @@ import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.DragStartEvent;
 import com.google.gwt.event.dom.client.DragStartHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Event;
@@ -150,7 +150,7 @@ public class DocTabLayoutPanel
    }
    
    public void add(final Widget child,
-                   ImageResource icon,
+                   FileIcon icon,
                    String docId,
                    final String text,
                    String tooltip,
@@ -1038,7 +1038,7 @@ public class DocTabLayoutPanel
 
    private class DocTab extends Composite
    {
-      private DocTab(ImageResource icon,
+      private DocTab(FileIcon icon,
                      String docId,
                      String title,
                      String tooltip,
@@ -1106,6 +1106,7 @@ public class DocTabLayoutPanel
          Image img = new Image(new ImageResource2x(ThemeResources.INSTANCE.closeTab2x()));
          img.setStylePrimaryName(styles_.closeTabButton());
          img.addStyleName(ThemeStyles.INSTANCE.handCursor());
+         img.setAltText("Close document tab");
          contentPanel_.add(img);
 
          layoutPanel.add(contentPanel_);
@@ -1138,7 +1139,7 @@ public class DocTabLayoutPanel
          contentPanel_.setTitle(tooltip);
       }
 
-      public void replaceIcon(ImageResource icon)
+      public void replaceIcon(FileIcon icon)
       {
          if (contentPanel_.getWidget(0) instanceof Image)
             contentPanel_.remove(0);
@@ -1150,10 +1151,11 @@ public class DocTabLayoutPanel
          return docId_;
       }
       
-      private Image imageForIcon(ImageResource icon)
+      private Image imageForIcon(FileIcon icon)
       {
-         Image image = new Image(icon);
+         Image image = new Image(icon.getImageResource());
          image.setStylePrimaryName(styles_.docTabIcon());
+         image.setAltText(icon.getDescription());
          return image;
       }
 
@@ -1198,7 +1200,7 @@ public class DocTabLayoutPanel
    }
 
    public void replaceDocName(int index,
-                              ImageResource icon,
+                              FileIcon icon,
                               String title,
                               String tooltip)
    {

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
@@ -24,7 +24,6 @@ import org.rstudio.core.client.command.Handler;
 import org.rstudio.core.client.events.BarrierReleasedEvent;
 import org.rstudio.core.client.events.BarrierReleasedHandler;
 import org.rstudio.core.client.files.FileSystemItem;
-import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.MessageDialog;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
@@ -47,7 +46,7 @@ import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.GlobalProgressDelayer;
 import org.rstudio.studio.client.common.SuperDevMode;
 import org.rstudio.studio.client.common.TimedProgressIndicator;
-import org.rstudio.studio.client.common.filetypes.FileIconResources;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
@@ -66,7 +65,6 @@ import org.rstudio.studio.client.workbench.views.source.SourceShim;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalHelper;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Command;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -576,9 +574,9 @@ public class ApplicationQuit implements SaveActionChangedHandler,
       }
 
       @Override
-      public ImageResource getIcon()
+      public FileIcon getIcon()
       {
-         return new ImageResource2x(FileIconResources.INSTANCE.iconRdata2x()); 
+         return FileIcon.RDATA_ICON;
       }
 
       @Override

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileIcon.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileIcon.java
@@ -52,6 +52,15 @@ public class FileIcon
    public static final FileIcon PARENT_FOLDER_ICON =
          new FileIcon(new ImageResource2x(ICONS.iconUpFolder2x()), "Parent folder");
 
+   public static final FileIcon OBJECT_EXPLORER_ICON =
+         new FileIcon(new ImageResource2x(ICONS.iconObjectExplorer2x()), "Explore object");
+
+   public static final FileIcon CODE_BROWSER_ICON =
+         new FileIcon(new ImageResource2x(ICONS.iconSourceViewer2x()), "R source viewer");
+
+   public static final FileIcon PROFILER_ICON =
+         new FileIcon(new ImageResource2x(FileIconResources.INSTANCE.iconProfiler2x()), "Profiler");
+
    public FileIcon(ImageResource imageResource, String description)
    {
       imageResource_ = imageResource;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/UnsavedChangesItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/UnsavedChangesItem.java
@@ -1,7 +1,7 @@
 /*
  * UnsavedChangesItem.java
  *
- * Copyright (C) 2009-15 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,7 +15,7 @@
 package org.rstudio.studio.client.workbench.model;
 
 import com.google.gwt.core.client.JavaScriptObject;
-import com.google.gwt.resources.client.ImageResource;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 
 public class UnsavedChangesItem extends JavaScriptObject
    implements UnsavedChangesTarget
@@ -31,7 +31,7 @@ public class UnsavedChangesItem extends JavaScriptObject
    }
 
    public final native static UnsavedChangesItem create(String id,
-         ImageResource icon, String title, String path) /*-{
+         FileIcon icon, String title, String path) /*-{
       return {
          "id"   : id,
          "icon" : icon,
@@ -46,7 +46,7 @@ public class UnsavedChangesItem extends JavaScriptObject
    }-*/;
 
    @Override
-   public final native ImageResource getIcon() /*-{
+   public final native FileIcon getIcon() /*-{
       return this.icon;
    }-*/;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/UnsavedChangesTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/UnsavedChangesTarget.java
@@ -1,7 +1,7 @@
 /*
  * UnsavedChangesTarget.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,12 +14,12 @@
  */
 package org.rstudio.studio.client.workbench.model;
 
-import com.google.gwt.resources.client.ImageResource;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 
 public interface UnsavedChangesTarget
 {
    String getId();
-   ImageResource getIcon();
+   FileIcon getIcon();
    String getTitle();
    String getPath();
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/unsaved/UnsavedChangesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/unsaved/UnsavedChangesDialog.java
@@ -23,18 +23,18 @@ import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ThemedButton;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
+import org.rstudio.studio.client.common.filetypes.FileIconResourceCell;
 import org.rstudio.studio.client.workbench.model.UnsavedChangesTarget;
 
 import com.google.gwt.cell.client.AbstractCell;
 import com.google.gwt.cell.client.CheckboxCell;
-import com.google.gwt.cell.client.ImageResourceCell;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
-import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.cellview.client.CellTable;
 import com.google.gwt.user.cellview.client.Column;
@@ -205,13 +205,13 @@ public class UnsavedChangesDialog extends ModalDialog<UnsavedChangesDialog.Resul
    }
   
    
-   private Column<UnsavedChangesTarget, ImageResource> addIconColumn()
+   private Column<UnsavedChangesTarget, FileIcon> addIconColumn()
    {
-      Column<UnsavedChangesTarget, ImageResource> iconColumn = 
-         new Column<UnsavedChangesTarget, ImageResource>(new ImageResourceCell()) {
+      Column<UnsavedChangesTarget, FileIcon> iconColumn = 
+         new Column<UnsavedChangesTarget, FileIcon>(new FileIconResourceCell()) {
 
             @Override
-            public ImageResource getValue(UnsavedChangesTarget object)
+            public FileIcon getValue(UnsavedChangesTarget object)
             {
                return object.getIcon();
             }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocsMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocsMenu.java
@@ -1,7 +1,7 @@
 /*
  * DocsMenu.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,7 +15,6 @@
 package org.rstudio.studio.client.workbench.views.source;
 
 import com.google.gwt.dom.client.Style.FontStyle;
-import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.MenuItem;
 import com.google.gwt.user.client.ui.PopupPanel;
@@ -28,6 +27,7 @@ import org.rstudio.core.client.command.DisabledMenuItem;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.workbench.views.source.events.DocTabActivatedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.DocTabsChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.DocTabsChangedHandler;
@@ -78,7 +78,7 @@ public class DocsMenu extends AppMenuBar
       panel_ = panel;
    }
 
-   public void setDocs(String[] ids, ImageResource[] icons, String[] names, String[] paths)
+   public void setDocs(String[] ids, FileIcon[] icons, String[] names, String[] paths)
    {
       clearItems();
       
@@ -98,7 +98,7 @@ public class DocsMenu extends AppMenuBar
 
       for (int i = 0; i < icons.length; i++)
       {
-         String label = AppCommand.formatMenuLabel(icons[i],
+         String label = AppCommand.formatMenuLabel(icons[i].getImageResource(),
                                                    names[i] + "\u00A0\u00A0\u00A0",
                                                    null);
          final int tabIndex = i;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -73,6 +73,7 @@ import org.rstudio.studio.client.common.GlobalProgressDelayer;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.dependencies.DependencyManager;
 import org.rstudio.studio.client.common.filetypes.EditableFileType;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.common.filetypes.FileType;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.filetypes.ObjectExplorerFileType;
@@ -207,7 +208,7 @@ public class Source implements InsertSourceHandler,
                                     HasSelectionHandlers<Integer>
    {
       void addTab(Widget widget,
-                  ImageResource icon,
+                  FileIcon icon,
                   String docId,
                   String name,
                   String tooltip,
@@ -236,7 +237,7 @@ public class Source implements InsertSourceHandler,
       void ensureVisible();
 
       void renameTab(Widget child,
-                     ImageResource icon,
+                     FileIcon icon,
                      String value,
                      String tooltip);
 
@@ -3604,7 +3605,7 @@ public class Source implements InsertSourceHandler,
       syncTabOrder();
 
       String[] ids = new String[editors_.size()];
-      ImageResource[] icons = new ImageResource[editors_.size()];
+      FileIcon[] icons = new FileIcon[editors_.size()];
       String[] names = new String[editors_.size()];
       String[] paths = new String[editors_.size()];
       for (int i = 0; i < ids.length; i++)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourcePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourcePane.java
@@ -1,7 +1,7 @@
 /*
  * SourcePane.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -25,7 +25,6 @@ import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.event.logical.shared.SelectionHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.*;
 import com.google.inject.Inject;
@@ -39,6 +38,7 @@ import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.BeforeShowCallback;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.studio.client.common.AutoGlassAttacher;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.workbench.model.UnsavedChangesTarget;
 import org.rstudio.studio.client.workbench.ui.unsaved.UnsavedChangesDialog;
 import org.rstudio.studio.client.workbench.views.source.Source.Display;
@@ -117,7 +117,7 @@ public class SourcePane extends Composite implements Display,
    }
 
    public void addTab(Widget widget,
-                      ImageResource icon,
+                      FileIcon icon,
                       String docId,
                       String name,
                       String tooltip,
@@ -167,7 +167,7 @@ public class SourcePane extends Composite implements Display,
    }
 
    public void renameTab(Widget child,
-                         ImageResource icon,
+                         FileIcon icon,
                          String value,
                          String tooltip)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceShim.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceShim.java
@@ -1,7 +1,7 @@
 /*
  * SourceShim.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,7 +19,6 @@ import java.util.Set;
 
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.*;
 import com.google.inject.Inject;
@@ -37,6 +36,7 @@ import org.rstudio.core.client.events.HasEnsureVisibleHandlers;
 import org.rstudio.core.client.layout.RequiresVisibilityChanged;
 import org.rstudio.core.client.widget.BeforeShowCallback;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.common.filetypes.events.OpenPresentationSourceFileEvent;
 import org.rstudio.studio.client.common.filetypes.events.OpenPresentationSourceFileHandler;
 import org.rstudio.studio.client.common.filetypes.events.OpenSourceFileEvent;
@@ -226,7 +226,7 @@ public class SourceShim extends Composite
 
       events.fireEvent(new DocTabsChangedEvent(null,
                                                new String[0],
-                                               new ImageResource[0],
+                                               new FileIcon[0],
                                                new String[0],
                                                new String[0]));
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
@@ -1,7 +1,7 @@
 /*
  * EditingTarget.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,7 +15,6 @@
 package org.rstudio.studio.client.workbench.views.source.editors;
 
 import com.google.gwt.event.logical.shared.HasCloseHandlers;
-import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.HasValue;
 import com.google.gwt.user.client.ui.IsWidget;
@@ -26,6 +25,7 @@ import org.rstudio.core.client.events.HasEnsureHeightHandlers;
 import org.rstudio.core.client.events.HasEnsureVisibleHandlers;
 import org.rstudio.core.client.files.FileSystemContext;
 import org.rstudio.studio.client.common.ReadOnlyValue;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.common.filetypes.FileType;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.workbench.model.UnsavedChangesTarget;
@@ -51,7 +51,7 @@ public interface EditingTarget extends IsWidget,
    String getTitle();
    String getPath();
    String getContext();
-   ImageResource getIcon();
+   FileIcon getIcon();
    String getTabTooltip();
    
    FileType getFileType();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
@@ -1,7 +1,7 @@
 /*
  * CodeBrowserEditingTarget.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -23,7 +23,6 @@ import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.GwtEvent;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.HasValue;
 import com.google.gwt.user.client.ui.Widget;
@@ -39,13 +38,12 @@ import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.events.EnsureHeightHandler;
 import org.rstudio.core.client.events.EnsureVisibleHandler;
 import org.rstudio.core.client.files.FileSystemContext;
-import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.ReadOnlyValue;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.Value;
-import org.rstudio.studio.client.common.filetypes.FileIconResources;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.common.filetypes.FileType;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
@@ -405,9 +403,9 @@ public class CodeBrowserEditingTarget implements EditingTarget
    
 
    @Override
-   public ImageResource getIcon()
+   public FileIcon getIcon()
    {
-      return new ImageResource2x(FileIconResources.INSTANCE.iconSourceViewer2x());
+      return FileIcon.CODE_BROWSER_ICON;
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTarget.java
@@ -14,17 +14,15 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.data;
 
-import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
 import org.rstudio.core.client.Debug;
-import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.SimplePanelWithProgress;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
-import org.rstudio.studio.client.common.filetypes.FileIconResources;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
@@ -168,9 +166,9 @@ public class DataEditingTarget extends UrlContentEditingTarget
    }
 
    @Override
-   public ImageResource getIcon()
+   public FileIcon getIcon()
    {
-      return new ImageResource2x(FileIconResources.INSTANCE.iconCsv2x());
+      return FileIcon.CSV_ICON;
    }
 
    private DataItem getDataItem()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/ObjectExplorerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/ObjectExplorerEditingTarget.java
@@ -1,7 +1,7 @@
 /*
  * ObjectExplorerEditingTarget.java
  *
- * Copyright (C) 2009-15 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,15 +14,13 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.explorer;
 
-import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
-import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.SimplePanelWithProgress;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
-import org.rstudio.studio.client.common.filetypes.FileIconResources;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.common.filetypes.FileType;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.workbench.commands.Commands;
@@ -99,9 +97,9 @@ public class ObjectExplorerEditingTarget
    }
 
    @Override
-   public ImageResource getIcon()
+   public FileIcon getIcon()
    {
-      return new ImageResource2x(FileIconResources.INSTANCE.iconObjectExplorer2x());
+      return FileIcon.OBJECT_EXPLORER_ICON;
    }
 
    private ObjectExplorerHandle getHandle()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -21,7 +21,6 @@ import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.event.shared.GwtEvent;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.HasValue;
 import com.google.gwt.user.client.ui.Widget;
@@ -42,7 +41,6 @@ import org.rstudio.core.client.events.HasSelectionCommitHandlers;
 import org.rstudio.core.client.events.SelectionCommitHandler;
 import org.rstudio.core.client.files.FileSystemContext;
 import org.rstudio.core.client.files.FileSystemItem;
-import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ProgressIndicator;
@@ -53,7 +51,7 @@ import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.ReadOnlyValue;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.Value;
-import org.rstudio.studio.client.common.filetypes.FileIconResources;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.common.filetypes.FileType;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.filetypes.ProfilerType;
@@ -160,9 +158,9 @@ public class ProfilerEditingTarget implements EditingTarget,
       return null;
    }
 
-   public ImageResource getIcon()
+   public FileIcon getIcon()
    {
-      return new ImageResource2x(FileIconResources.INSTANCE.iconProfiler2x());
+      return FileIcon.PROFILER_ICON;
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -30,7 +30,6 @@ import com.google.gwt.event.shared.GwtEvent;
 import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.http.client.URL;
-import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Event;
@@ -74,6 +73,7 @@ import org.rstudio.studio.client.common.debugging.events.BreakpointsSavedEvent;
 import org.rstudio.studio.client.common.debugging.model.Breakpoint;
 import org.rstudio.studio.client.common.dependencies.DependencyManager;
 import org.rstudio.studio.client.common.filetypes.DocumentMode;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.common.filetypes.FileType;
 import org.rstudio.studio.client.common.filetypes.FileTypeCommands;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
@@ -2832,9 +2832,9 @@ public class TextEditingTarget implements
       return null;
    }
 
-   public ImageResource getIcon()
+   public FileIcon getIcon()
    {
-      return fileType_.getDefaultIcon();
+      return fileType_.getDefaultFileIcon();
    }
 
    public String getTabTooltip()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
@@ -18,7 +18,6 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.event.shared.GwtEvent;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.HasValue;
 import com.google.gwt.user.client.ui.IsWidget;
@@ -33,12 +32,11 @@ import org.rstudio.core.client.command.Handler;
 import org.rstudio.core.client.events.EnsureHeightHandler;
 import org.rstudio.core.client.events.EnsureVisibleHandler;
 import org.rstudio.core.client.files.FileSystemContext;
-import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.ReadOnlyValue;
 import org.rstudio.studio.client.common.Value;
-import org.rstudio.studio.client.common.filetypes.FileIconResources;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.common.filetypes.FileType;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.server.ServerError;
@@ -118,9 +116,9 @@ public class UrlContentEditingTarget implements EditingTarget
       return null;
    }
 
-   public ImageResource getIcon()
+   public FileIcon getIcon()
    {
-      return new ImageResource2x(FileIconResources.INSTANCE.iconText2x());
+      return FileIcon.TEXT_ICON;
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DocTabsChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DocTabsChangedEvent.java
@@ -1,7 +1,7 @@
 /*
  * DocTabsChangedEvent.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,7 +15,7 @@
 package org.rstudio.studio.client.workbench.views.source.events;
 
 import com.google.gwt.event.shared.GwtEvent;
-import com.google.gwt.resources.client.ImageResource;
+import org.rstudio.studio.client.common.filetypes.FileIcon;
 
 public class DocTabsChangedEvent extends GwtEvent<DocTabsChangedHandler>
 {
@@ -23,7 +23,7 @@ public class DocTabsChangedEvent extends GwtEvent<DocTabsChangedHandler>
 
    public DocTabsChangedEvent(String activeId,
                               String[] ids,
-                              ImageResource[] icons,
+                              FileIcon[] icons,
                               String[] names,
                               String[] paths)
    {
@@ -44,7 +44,7 @@ public class DocTabsChangedEvent extends GwtEvent<DocTabsChangedHandler>
       return ids_;
    }
 
-   public ImageResource[] getIcons()
+   public FileIcon[] getIcons()
    {
       return icons;
    }
@@ -73,7 +73,7 @@ public class DocTabsChangedEvent extends GwtEvent<DocTabsChangedHandler>
 
    private final String activeId_;
    private final String[] ids_;
-   private final ImageResource[] icons;
+   private final FileIcon[] icons;
    private final String[] names;
    private final String[] paths;
 }


### PR DESCRIPTION
Add labels to the file-type icon in editor tab and the unsaved-changes dialog by using FileIcon instead of plain ImageResource in various calls.

Add label to the close icon in editor tab reading "Close document tab".

![2019-06-27_14-25-53](https://user-images.githubusercontent.com/10569626/60302390-aafc3200-98e8-11e9-88d3-566b5ab44b83.png)

![2019-06-27_14-26-30](https://user-images.githubusercontent.com/10569626/60302398-af284f80-98e8-11e9-8803-b6783f372ee7.png)
