### PR TITLE
add aria-label to some instances of Ace editor control

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellDisplay.java
@@ -1,7 +1,7 @@
 /*
  * ShellDisplay.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -49,6 +49,7 @@ public interface ShellDisplay extends ShellOutputWriter,
 
    int getMaxOutputLines();
    void setMaxOutputLines(int maxLines);
+   void setTextInputAriaLabel(String label);
 
    HandlerRegistration addCapturingKeyDownHandler(KeyDownHandler handler);
    HandlerRegistration addCapturingKeyUpHandler(KeyUpHandler handler);

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -766,7 +766,13 @@ public class ShellWidget extends Composite implements ShellDisplay,
    {
       output_.setMaxOutputLines(maxLines);
    }
-   
+
+   @Override
+   public void setTextInputAriaLabel(String label)
+   {
+      input_.setTextInputAriaLabel(label);
+   }
+
    @Override
    public Widget getShellWidget()
    {

--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/ignore/IgnoreDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/ignore/IgnoreDialog.java
@@ -50,6 +50,7 @@ public class IgnoreDialog extends ModalDialogBase
       editor_ = new AceEditor();
       editor_.setUseWrapMode(false);
       editor_.setShowLineNumbers(false);
+      editor_.setTextInputAriaLabel("Ignored files");
       
       ignoresCaption_ = new CaptionWithHelp("Ignore:",
                                              "Specifying ignored files",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
@@ -152,8 +152,9 @@ public class ConsolePane extends WorkbenchPane
       // is entered.
       syncSecondaryToolbar();
 
-      shell_ = consoleProvider_.get() ;
-      return (Widget) shell_.getDisplay() ;
+      shell_ = consoleProvider_.get();
+      shell_.getDisplay().setTextInputAriaLabel("Console");
+      return (Widget) shell_.getDisplay();
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/edit/ui/EditDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/edit/ui/EditDialog.java
@@ -56,6 +56,7 @@ public class EditDialog extends ModalDialogBase
       super(role);
       editor_ = new AceEditor();
       setText(caption);
+      editor_.setTextInputAriaLabel(caption);
       sourceText_ = text;
       isRCode_ = isRCode;
       lineWrapping_ = lineWrapping;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -34,7 +34,6 @@ import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.json.client.JSONString;
 import com.google.gwt.json.client.JSONValue;
-import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Event.NativePreviewEvent;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -4076,7 +4076,16 @@ public class AceEditor implements DocDisplay,
    {
       showChunkOutputInline_ = show;
    }
-   
+
+   /**
+    * Set an aria-label on the input element
+    * @param label
+    */
+   public final void setTextInputAriaLabel(String label)
+   {
+      widget_.getEditor().setTextInputAriaLabel(label);
+   }
+
    private void fireLineWidgetsChanged()
    {
       AceEditor.this.fireEvent(new LineWidgetsChangedEvent());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -454,4 +454,5 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    void goToLineEnd();
    
    void toggleTokenInfo();
+   void setTextInputAriaLabel(String label);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -226,6 +226,8 @@ public class TextEditingTargetWidget
          }
       });
 
+      editor_.setTextInputAriaLabel("Text editor");
+
       initWidget(panel_);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -1,7 +1,7 @@
 /*
  * AceEditorNative.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -201,6 +201,16 @@ public class AceEditorNative extends JavaScriptObject {
    private native Element getTextInputElement() /*-{
       return this.textInput.getElement();
    }-*/;
+
+   /**
+    * Set an aria-label on the input element
+    * @param label
+    */
+   public final void setTextInputAriaLabel(String label)
+   {
+      Element textInput = getTextInputElement();
+      textInput.setAttribute("aria-label", label);
+   }
 
    private native static JavaScriptObject addDomListener(
          Element element,


### PR DESCRIPTION
- added aria-abels to several Ace instances including "console" and "text editor"
- this fixes accessibility violations for unlabled focusable controls
- actual benefit is that when focus goes to, for example, the Console, a screen reader will now say something like "Console Edit Text has keyboard focus" instead of just "Edit text has keyboard focus"
- there remain some unlabeled Ace instances, but those will get caught when I get to evalauting those UI pieces