### PR TITLE
set empty viewport_tag when running on server

### DIFF
--- a/src/cpp/core/gwt/GwtFileHandler.cpp
+++ b/src/cpp/core/gwt/GwtFileHandler.cpp
@@ -135,6 +135,8 @@ void handleFileRequest(const std::string& wwwLocalPath,
 
 #ifndef RSTUDIO_SERVER
       vars["viewport_tag"] = R"(<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />)";
+#else
+      vars["viewport_tag"] = std::string();
 #endif
 
       // read existing CSRF token 


### PR DESCRIPTION
Followup to https://github.com/rstudio/rstudio/pull/5034

Without this you'll see a message on the GWT compilation screen, not sure if there were any other consequences.

![2019-07-01_09-16-30](https://user-images.githubusercontent.com/10569626/60451736-97e7ab80-9be1-11e9-9eee-b0ea865957ae.png)
