### PR TITLE
Fix execution of R Markdown chunks on RStudio Server

### DIFF
--- a/src/cpp/core/http/Request.cpp
+++ b/src/cpp/core/http/Request.cpp
@@ -20,6 +20,7 @@
 #include <boost/tokenizer.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/join.hpp>
 
 #include <core/Log.hpp>
 #include <core/Thread.hpp>
@@ -134,6 +135,17 @@ std::string Request::cookieValue(const std::string& name) const
 
    // lookup the cookie
    return util::fieldValue(cookies_, name);
+}
+
+void Request::addCookie(const std::string& name, const std::string& value)
+{
+   cookies_.push_back(std::make_pair(name, value));
+   std::vector<std::string> cookies;
+   for (const auto cookie: cookies_)
+   {
+      cookies.push_back(cookie.first + "=" + cookie.second); 
+   }
+   setHeader("Cookie", boost::algorithm::join(cookies, "; ")); 
 }
 
 std::string Request::cookieValueFromHeader(const std::string& headerName) const

--- a/src/cpp/core/include/core/http/Request.hpp
+++ b/src/cpp/core/include/core/http/Request.hpp
@@ -95,6 +95,7 @@ public:
 
    std::string cookieValue(const std::string& name) const;
    std::string cookieValueFromHeader(const std::string& headerName) const;
+   void addCookie(const std::string& name, const std::string& value);
    
    const Fields& formFields() const;
    std::string formFieldValue(const std::string& name) const;

--- a/src/cpp/session/include/session/http/SessionRequest.hpp
+++ b/src/cpp/session/include/session/http/SessionRequest.hpp
@@ -23,6 +23,7 @@
 
 #include <core/http/TcpIpBlockingClient.hpp>
 #include <core/http/ConnectionRetryProfile.hpp>
+#include <core/http/CSRFToken.hpp>
 
 #ifndef _WIN32
 #include <core/http/LocalStreamBlockingClient.hpp>
@@ -56,6 +57,12 @@ inline core::Error sendSessionRequest(const std::string& uri,
    request.setHeader("Connection", "close");
    request.setHeader("X-Session-Postback", "1");
    request.setHeader(kRStudioUserIdentityDisplay, core::system::username());
+
+   // generate random CSRF token for request
+   std::string token = core::system::generateUuid();
+   request.setHeader(kCSRFTokenHeader, token);
+   request.addCookie(kCSRFTokenCookie, token);
+
    request.setBody(body);
 
    // first, attempt to send a plain old http request

--- a/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
@@ -492,8 +492,20 @@ private:
          core::http::Response response;
          Error error = session::http::sendSessionRequest(
                "/rpc/console_input", input, &response);
+
          if (error)
             LOG_ERROR(error);
+         else
+         {
+            // log warning if the response was not successful
+            if (response.statusCode() != core::http::status::Ok)
+            {
+               std::stringstream oss;
+               oss << "Received unexpected response when submitting console input: "
+                   << response; 
+               LOG_WARNING_MESSAGE(oss.str());
+            }
+         }
       }
    }
 


### PR DESCRIPTION
This change fixes an issue in which R Markdown chunks didn't run on RStudio Server. The problem is that the loopback session-to-session HTTP request which submits chunk code for execution was being rejected due to a missing CSRF token (we added CSRF token validation to all requests for additional security in 1.3).

The fix is to just generate and submit a CSRF token with the request. It'd also be possible to exempt these loopback requests from CSRF requirements in some way, but that would probably require some more complicated trust mechanism (there's no shared secret in this scenario). 

Regression from https://github.com/rstudio/rstudio/commit/e1f76cd905e9603600ee7511b0b45bf914ae31a1; fixes #5041. 