### PR TITLE
accessibility fixes for application-ended popup pane

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/appended/ApplicationEndedPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/appended/ApplicationEndedPopupPanel.java
@@ -18,8 +18,6 @@ import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.RunAsyncCallback;
 import com.google.gwt.dom.client.NativeEvent;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
@@ -142,12 +140,7 @@ public class ApplicationEndedPopupPanel extends PopupPanel
       Label captionLabel = new Label();
       captionLabel.setStylePrimaryName(RESOURCES.styles().captionLabel());
       final FancyButton button = new FancyButton();
-      button.addClickHandler(new ClickHandler() {
-         public void onClick(ClickEvent event)
-         {
-            reloadApplication();
-         } 
-      });
+      button.addClickHandler(event -> reloadApplication());
       FocusHelper.setFocusDeferred(button);
       
       switch(mode)
@@ -219,7 +212,7 @@ public class ApplicationEndedPopupPanel extends PopupPanel
                
                nativeEvent.preventDefault();
                nativeEvent.stopPropagation();
-               reloadApplication();    
+               reloadApplication();
                break;
          } 
       }
@@ -255,7 +248,7 @@ public class ApplicationEndedPopupPanel extends PopupPanel
       }
    }
       
-   static interface Styles extends CssResource
+   interface Styles extends CssResource
    {
       String applicationEndedPopupPanel();
       String glass();
@@ -275,7 +268,7 @@ public class ApplicationEndedPopupPanel extends PopupPanel
       String SE();
    }
   
-   static interface Resources extends ClientBundle
+   interface Resources extends ClientBundle
    {
       @Source("ApplicationEndedPopupPanel.css")
       Styles styles();

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/appended/ApplicationEndedPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/appended/ApplicationEndedPopupPanel.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.application.ui.appended;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.RunAsyncCallback;
 import com.google.gwt.dom.client.NativeEvent;
@@ -30,11 +31,19 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.ui.*;
 
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.PopupPanel;
+import com.google.gwt.user.client.ui.SimplePanel;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.CenterPanel;
+import org.rstudio.core.client.widget.DecorativeImage;
 import org.rstudio.core.client.widget.FocusHelper;
+import org.rstudio.core.client.widget.ModalDialogTracker;
 import org.rstudio.studio.client.application.Desktop;
 
 public class ApplicationEndedPopupPanel extends PopupPanel
@@ -121,13 +130,15 @@ public class ApplicationEndedPopupPanel extends PopupPanel
       setStylePrimaryName(RESOURCES.styles().applicationEndedPopupPanel());
       setGlassEnabled(true);
       setGlassStyleName(RESOURCES.styles().glass());
+
+      Roles.getAlertdialogRole().set(getElement());
       
       // main panel
       HorizontalPanel horizontalPanel = new HorizontalPanel();
       horizontalPanel.setSpacing(10);
       
       // create widgets and make mode dependent customizations
-      Image image;
+      DecorativeImage image;
       Label captionLabel = new Label();
       captionLabel.setStylePrimaryName(RESOURCES.styles().captionLabel());
       final FancyButton button = new FancyButton();
@@ -142,31 +153,31 @@ public class ApplicationEndedPopupPanel extends PopupPanel
       switch(mode)
       {
       case QUIT:
-         image = new Image(new ImageResource2x(RESOURCES.applicationQuit2x()));
+         image = new DecorativeImage(new ImageResource2x(RESOURCES.applicationQuit2x()));
          captionLabel.setText("R Session Ended");
          button.setText("Start New Session");
          break;
          
       case SUICIDE:
-         image = new Image(new ImageResource2x(RESOURCES.applicationSuicide2x()));
+         image = new DecorativeImage(new ImageResource2x(RESOURCES.applicationSuicide2x()));
          captionLabel.setText("R Session Aborted");
          button.setText("Start New Session");
          break;
        
       case DISCONNECTED:
-         image = new Image(new ImageResource2x(RESOURCES.applicationDisconnected2x()));
+         image = new DecorativeImage(new ImageResource2x(RESOURCES.applicationDisconnected2x()));
          captionLabel.setText("R Session Disconnected");
          button.setText("Reconnect");
          break;
          
       case OFFLINE:
-         image = new Image(new ImageResource2x(RESOURCES.applicationOffline2x()));
+         image = new DecorativeImage(new ImageResource2x(RESOURCES.applicationOffline2x()));
          captionLabel.setText("RStudio Temporarily Offline");
          button.setText("Reconnect");
          break;
          
       case QUIT_MULTI:
-         image = new Image(new ImageResource2x(RESOURCES.applicationQuit2x()));
+         image = new DecorativeImage(new ImageResource2x(RESOURCES.applicationQuit2x()));
          captionLabel.setText("R Session Ended");
          button.setText("Reconnect");
          break;
@@ -213,7 +224,21 @@ public class ApplicationEndedPopupPanel extends PopupPanel
          } 
       }
    }
-   
+
+   @Override
+   protected void onLoad()
+   {
+      super.onLoad();
+      ModalDialogTracker.onShow(this);
+   }
+
+   @Override
+   protected void onUnload()
+   {
+      super.onUnload();
+      ModalDialogTracker.onHide(this);
+   }
+
    private void reloadApplication()
    {
       if (reloading_)
@@ -285,7 +310,7 @@ public class ApplicationEndedPopupPanel extends PopupPanel
 
    interface MyUiBinder extends UiBinder<Widget, ApplicationEndedPopupPanel> {}
    
-   static Resources RESOURCES = (Resources)GWT.create(Resources.class);
+   static Resources RESOURCES = GWT.create(Resources.class);
    public static void ensureStylesInjected()
    {
       RESOURCES.styles().ensureInjected();

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/appended/ApplicationEndedPopupPanel.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/appended/ApplicationEndedPopupPanel.ui.xml
@@ -4,7 +4,7 @@
    <ui:with field="res" type="org.rstudio.studio.client.application.ui.appended.ApplicationEndedPopupPanel.Resources"/>
 
    <g:HTMLPanel>
-      <table border="0" cellspacing="0" cellpadding="0">
+      <table role="presentation" border="0" cellspacing="0" cellpadding="0">
          <tr>
             <td class="{res.styles.NW}"></td>
             <td class="{res.styles.N}"></td>

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/appended/FancyButton.css
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/appended/FancyButton.css
@@ -1,5 +1,5 @@
 button.fancy {
-  background-color: #75aadb;
+  background-color: #1e77bc;
   border-radius: 4px;
   font-weight: bold;
   font-size: 14px;


### PR DESCRIPTION
Several a11y fixes to application-ended popup pane. Now meets both automated and manual testing requirements.

- Fix button contrast to meet requirements (now using same colors as the login-page's button)
- Mark images as decorative so they don't read their internal names
- Mark popup as an alert dialog so it reads the message when displayed
- Use `ModalDialogTracker` to make rest of UI inert so user can't tab to background controls
- Unlike regular modal dialogs, I'm not preventing Tab from leaving this pane, so hitting Tab or Shift+Tab will send focus to the browser; this seems reasonable in this particular scenario

Examples of this app-ended popup pane (after fixes):

![2019-07-01_16-08-22](https://user-images.githubusercontent.com/10569626/60472208-d189d800-9c1c-11e9-9f64-e720b553850e.png)

![2019-07-01_16-09-17](https://user-images.githubusercontent.com/10569626/60472210-d484c880-9c1c-11e9-8b64-7acb916f60a4.png)
