### PR TITLE
use load hook to override matplotlib show

### DIFF
--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -79,6 +79,24 @@
    return(TRUE)
 })
 
+.rs.addFunction("reticulate.initialize", function()
+{
+   # try to default to the tkAgg backend (note that we'll
+   # force a vanilla 'agg' backend when required otherwise)
+   engine <- tolower(Sys.getenv("MPLENGINE"))
+   if (engine %in% c("", "qt5agg"))
+      Sys.setenv(MPLENGINE = "tkAgg")
+   
+   # set up hooks for overriding 'show()' in matplotlib
+   setHook("reticulate::matplotlib.pyplot::load", .rs.reticulate.matplotlib.pyplot.loadHook)
+})
+
+.rs.addFunction("reticulate.matplotlib.pyplot.loadHook", function(plt)
+{
+   .rs.setVar("reticulate.matplotlib.show", plt$show)
+   plt$show <- .rs.reticulate.matplotlib.showHook
+})
+
 .rs.addFunction("reticulate.matplotlib.showHook", function(...)
 {
    # read device size

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -86,9 +86,6 @@
    engine <- tolower(Sys.getenv("MPLENGINE"))
    if (engine %in% c("", "qt5agg"))
       Sys.setenv(MPLENGINE = "tkAgg")
-   
-   # set up hooks for overriding 'show()' in matplotlib
-   setHook("reticulate::matplotlib.pyplot::load", .rs.reticulate.matplotlib.pyplot.loadHook)
 })
 
 .rs.addFunction("reticulate.matplotlib.pyplot.loadHook", function(plt)

--- a/src/cpp/session/modules/SessionReticulate.cpp
+++ b/src/cpp/session/modules/SessionReticulate.cpp
@@ -33,6 +33,16 @@ namespace session {
 namespace modules {
 namespace reticulate {
 
+namespace {
+
+void onDeferredInit(bool)
+{
+   Error error = r::exec::RFunction(".rs.reticulate.initialize").call();
+   if (error)
+      LOG_ERROR(error);
+}
+
+} // end anonymous namespace
 bool isReplActive()
 {
    bool active = false;
@@ -45,6 +55,8 @@ bool isReplActive()
 Error initialize()
 {
    using namespace module_context;
+   
+   events().onDeferredInit.connect(onDeferredInit);
    
    ExecBlock initBlock;
    initBlock.addFunctions()


### PR DESCRIPTION
This PR uses a new mechanism in `reticulate` for adding Python module load hooks, as per https://github.com/rstudio/reticulate/commit/8ff8c3c2c1d8c981d3cb07f74d86384f99e1602e.

The idea is that we can use these load hooks to run code after a Python module is loaded, in case we need to customize some functionality in that module so it can better run within RStudio. This ensures that attempts to generate Python plots directly from `reticulate` can still succeed.

Closes https://github.com/rstudio/rstudio/issues/4182.