### PR TITLE
work around GWT devmode bug involving method references

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/WizardNavigationPage.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/WizardNavigationPage.java
@@ -40,8 +40,7 @@ public class WizardNavigationPage<I,T> extends WizardPage<I,T>
            image,
            largeImage,
            pages,
-           WizardPageSelector::new
-      );
+           pages1 -> new WizardPageSelector<I, T>(pages1));
    }
 
    public WizardNavigationPage(String title,


### PR DESCRIPTION
Using a method reference causes an issue where gwt devmode throws away WizardPageSelector class, so going back to a lambda.

This manifested when I touched WizardPageSelector.java and tried to reload the page and use a wizard. It failed and even reverting the file wouldn't fix it (some order-of-operation thing in the GWT compiler, it appears).

This is the error I saw in the UI, and the warning in the console:

![2019-07-03_10-22-27](https://user-images.githubusercontent.com/10569626/60613272-71f80d80-9d7f-11e9-8156-ebf09dab53a8.png)

```
[WARN] Some stale types ([org.rstudio.core.client.widget.WizardNavigationPage$1]) were not reprocessed as was expected. This is either a compiler bug or a Generator has legitimately stopped creating these types.
```