### PR TITLE
More general a11y fixes detected by axe

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBase.css
+++ b/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBase.css
@@ -61,6 +61,11 @@
    width: 100%;
    padding: 6px 2px 4px 2px;
 }
+
+.section:focus {
+   outline:none;
+}
+
 .section * {
    cursor: default;
 }
@@ -68,6 +73,10 @@
 
 .activeSection {
    background: #D6E9F8;
+}
+
+.activeSection:focus {
+   outline:none;
 }
 
 .indent {

--- a/src/gwt/src/org/rstudio/core/client/widget/DirectoryChooserTextBox.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/DirectoryChooserTextBox.java
@@ -1,7 +1,7 @@
 /*
  * DirectoryChooserTextBox.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -28,6 +28,11 @@ public class DirectoryChooserTextBox extends TextBoxWithButton
    public DirectoryChooserTextBox()
    {
       this("", "", null);
+   }
+
+   public DirectoryChooserTextBox(String label)
+   {
+      this(label, "", null); 
    }
 
    public DirectoryChooserTextBox(String label, 

--- a/src/gwt/src/org/rstudio/core/client/widget/WidgetListBox.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/WidgetListBox.css
@@ -49,6 +49,6 @@
 
 .emptyMessage
 {
-	color: #c0c0c0;
+	color: #737373;
 	text-align: center;
 }

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdDiscoveredTemplateItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdDiscoveredTemplateItem.java
@@ -30,7 +30,7 @@ public class RmdDiscoveredTemplateItem extends Composite
       panel_ = new HTMLPanel("");
       Label pkg = new Label("{" + template.getPackage() + "}");
       pkg.getElement().getStyle().setFloat(Style.Float.RIGHT);
-      pkg.getElement().getStyle().setColor("#909090");
+      pkg.getElement().getStyle().setColor("#656565");
       panel_.add(pkg);
       Label name = new Label(template.getName());
       name.setTitle(template.getDescription());

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateChooser.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateChooser.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import org.rstudio.core.client.resources.CoreResources;
 import org.rstudio.core.client.widget.CaptionWithHelp;
 import org.rstudio.core.client.widget.DirectoryChooserTextBox;
+import org.rstudio.core.client.widget.FormLabel;
 import org.rstudio.core.client.widget.SimplePanelWithProgress;
 import org.rstudio.core.client.widget.WidgetListBox;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -54,6 +55,7 @@ public class RmdTemplateChooser extends Composite
 
    public RmdTemplateChooser(RMarkdownServerOperations server)
    {
+      dirLocation_ = new DirectoryChooserTextBox("Location:");
       initWidget(uiBinder.createAndBindUi(this));
       server_ = server;
       listTemplates_.setItemPadding(2, Unit.PX);
@@ -70,6 +72,7 @@ public class RmdTemplateChooser extends Composite
          }
       });
       captionWithHelp_.setFor(listTemplates_);
+      lblName_.setFor(txtName_);
    }
    
    public void populateTemplates()
@@ -209,15 +212,15 @@ public class RmdTemplateChooser extends Composite
    }
    
    private int state_;
-   private ArrayList<RmdDocumentTemplate> templates_ = 
-         new ArrayList<RmdDocumentTemplate>();
+   private ArrayList<RmdDocumentTemplate> templates_ = new ArrayList<>();
    
    private final RMarkdownServerOperations server_;
    
    @UiField CaptionWithHelp captionWithHelp_;
    @UiField WidgetListBox<RmdDiscoveredTemplateItem> listTemplates_;
+   @UiField FormLabel lblName_;
    @UiField TextBox txtName_;
-   @UiField DirectoryChooserTextBox dirLocation_;
+   @UiField(provided = true) DirectoryChooserTextBox dirLocation_;
    @UiField HTMLPanel noTemplatesFound_;
    @UiField HTMLPanel templateOptionsPanel_;
    @UiField SimplePanelWithProgress progressPanel_;

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateChooser.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateChooser.ui.xml
@@ -5,19 +5,19 @@
    <ui:style>
      @external .gwt-Label;
      
-     .controlLabel
+     .controlLabel, .directoryChooser .gwt-Label
      {
         margin-bottom: 3px;
         font-weight: bold;
         display: block;
      }
      
-     .interiorControlLabel
+     .interiorControlLabel, .directoryChooserInner .gwt-Label
      {
         margin-top: 7px; 
      }
      
-     .textBox
+     .textBox, .directoryChooser .textBox
      {
        padding: 2px;
        width: 100%;
@@ -43,7 +43,6 @@
      
      .noTemplates
      {
-       color: #909090;
        border: 1px solid #909090;
      }
      
@@ -77,14 +76,12 @@
         This template contains multiple files. Create a new directory for
         these files:
      </g:HTML>
-     <g:Label styleName="{style.controlLabel} {style.interiorControlLabel}" 
-              text="Name:"></g:Label>
+     <rs:FormLabel ui:field="lblName_" styleName="{style.controlLabel} {style.interiorControlLabel}" 
+              text="Name:"></rs:FormLabel>
      <g:TextBox styleName="{style.textBox}" ui:field="txtName_" 
                 text="Untitled"></g:TextBox>
 
-     <g:Label styleName="{style.controlLabel} {style.interiorControlLabel}" 
-              text="Location:"></g:Label>
-     <rs:DirectoryChooserTextBox width="100%" ui:field="dirLocation_">
+     <rs:DirectoryChooserTextBox width="100%" addStyleNames="{style.directoryChooser} {style.directoryChooserInner}" ui:field="dirLocation_">
      </rs:DirectoryChooserTextBox>
    
    </g:HTMLPanel>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewPlumberAPI.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewPlumberAPI.java
@@ -20,7 +20,9 @@ import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.regex.Pattern;
+import org.rstudio.core.client.widget.DecorativeImage;
 import org.rstudio.core.client.widget.DirectoryChooserTextBox;
+import org.rstudio.core.client.widget.FormLabel;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.VerticalSpacer;
@@ -36,16 +38,11 @@ import org.rstudio.studio.client.workbench.model.helper.JSObjectStateValue;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.HasKeyDownHandlers;
-import com.google.gwt.event.dom.client.KeyDownEvent;
-import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.user.client.ui.HorizontalPanel;
-import com.google.gwt.user.client.ui.Image;
-import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
@@ -78,21 +75,7 @@ public class NewPlumberAPI extends ModalDialog<NewPlumberAPI.Result>
    
    private void addTextFieldValidator(HasKeyDownHandlers widget)
    {
-      widget.addKeyDownHandler(new KeyDownHandler()
-      {
-         @Override
-         public void onKeyDown(KeyDownEvent event)
-         {
-            Scheduler.get().scheduleDeferred(new ScheduledCommand()
-            {
-               @Override
-               public void execute()
-               {
-                  validateAPIName();
-               }
-            });
-         }
-      });
+      widget.addKeyDownHandler(event -> Scheduler.get().scheduleDeferred(() -> validateAPIName()));
    }
    
    private boolean isValidAPIName(String apiName)
@@ -188,15 +171,14 @@ public class NewPlumberAPI extends ModalDialog<NewPlumberAPI.Result>
       controls_ = new VerticalPanel();
       
       // Create individual widgets
-      apiNameLabel_ = new Label("API name:");
-      apiNameLabel_.addStyleName(RES.styles().label());
-      controls_.add(apiNameLabel_);
-      
       apiNameTextBox_ = new TextBox();
       DomUtils.disableSpellcheck(apiNameTextBox_);
       apiNameTextBox_.addStyleName(RES.styles().apiNameTextBox());
       DomUtils.setPlaceholder(apiNameTextBox_, "Name");
       addTextFieldValidator(apiNameTextBox_);
+      FormLabel apiNameLabel = new FormLabel("API name:", apiNameTextBox_);
+      apiNameLabel.addStyleName(RES.styles().label());
+      controls_.add(apiNameLabel);
       controls_.add(apiNameTextBox_);
       
       directoryChooserTextBox_ = new DirectoryChooserTextBox("Create within directory:", null);
@@ -208,11 +190,10 @@ public class NewPlumberAPI extends ModalDialog<NewPlumberAPI.Result>
       controls_.add(new VerticalSpacer("20px"));
       
       container_ = new HorizontalPanel();
-      Image image = new Image(NewProjectResources.INSTANCE.plumberAppIcon2x());
+      DecorativeImage image = new DecorativeImage(NewProjectResources.INSTANCE.plumberAppIcon2x());
       image.addStyleName(RES.styles().image());
       container_.add(image);
       container_.add(controls_);
-      
       
       plumberHelpLink_ = new HelpLink(
             "Plumber APIs",
@@ -220,12 +201,6 @@ public class NewPlumberAPI extends ModalDialog<NewPlumberAPI.Result>
             false);
       plumberHelpLink_.getElement().getStyle().setMarginTop(4, Unit.PX);
       addLeftWidget(plumberHelpLink_);
-   }
-   
-   @Override
-   protected void focusInitialControl()
-   {
-      apiNameTextBox_.setFocus(true);
    }
    
    @Override
@@ -279,7 +254,6 @@ public class NewPlumberAPI extends ModalDialog<NewPlumberAPI.Result>
    private HorizontalPanel container_;
    private VerticalPanel controls_;
    
-   private Label   apiNameLabel_;
    private TextBox apiNameTextBox_;
    
    private DirectoryChooserTextBox directoryChooserTextBox_;
@@ -320,5 +294,4 @@ public class NewPlumberAPI extends ModalDialog<NewPlumberAPI.Result>
    static {
       RES.styles().ensureInjected();
    }
-   
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewShinyWebApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewShinyWebApplication.java
@@ -20,7 +20,10 @@ import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.regex.Pattern;
+import org.rstudio.core.client.widget.DecorativeImage;
 import org.rstudio.core.client.widget.DirectoryChooserTextBox;
+import org.rstudio.core.client.widget.FormLabel;
+import org.rstudio.core.client.widget.LayoutGrid;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.VerticalSpacer;
@@ -43,10 +46,8 @@ import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
-import com.google.gwt.user.client.ui.Grid;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.HorizontalPanel;
-import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.RadioButton;
 import com.google.gwt.user.client.ui.TextBox;
@@ -195,16 +196,16 @@ public class NewShinyWebApplication extends ModalDialog<NewShinyWebApplication.R
       controls_ = new VerticalPanel();
       
       // Create individual widgets
-      appNameLabel_ = new Label("Application name:");
-      appNameLabel_.addStyleName(RES.styles().label());
-      
       appNameTextBox_ = new TextBox();
       DomUtils.disableSpellcheck(appNameTextBox_);
       appNameTextBox_.addStyleName(RES.styles().textBox());
       appNameTextBox_.addStyleName(RES.styles().appNameTextBox());
       DomUtils.setPlaceholder(appNameTextBox_, "Name");
       addTextFieldValidator(appNameTextBox_);
-      
+
+      appNameLabel_ = new FormLabel("Application name:", appNameTextBox_);
+      appNameLabel_.addStyleName(RES.styles().label());
+
       appTypeLabel_ = new Label("Application type:");
       appTypeLabel_.addStyleName(RES.styles().label());
       appTypeLabel_.getElement().getStyle().setMarginTop(2, Unit.PX);
@@ -228,7 +229,7 @@ public class NewShinyWebApplication extends ModalDialog<NewShinyWebApplication.R
       directoryChooserTextBox_.addStyleName(RES.styles().textBox());
       
       // Add them to parent
-      Grid appNameTypeGrid = new Grid(3, 2);
+      LayoutGrid appNameTypeGrid = new LayoutGrid(3, 2);
       appNameTypeGrid.addStyleName(RES.styles().grid());
       appNameTypeGrid.setWidget(0, 0, appNameLabel_);
       appNameTypeGrid.setWidget(0, 1, appNameTextBox_);
@@ -247,7 +248,7 @@ public class NewShinyWebApplication extends ModalDialog<NewShinyWebApplication.R
       controls_.add(new VerticalSpacer("20px"));
       
       container_ = new HorizontalPanel();
-      Image image = new Image(NewProjectResources.INSTANCE.shinyAppIcon2x());
+      DecorativeImage image = new DecorativeImage(NewProjectResources.INSTANCE.shinyAppIcon2x());
       image.addStyleName(RES.styles().image());
       container_.add(image);
       container_.add(controls_);
@@ -327,10 +328,10 @@ public class NewShinyWebApplication extends ModalDialog<NewShinyWebApplication.R
    private HorizontalPanel container_;
    private VerticalPanel controls_;
    
-   private Label   appNameLabel_;
-   private TextBox appNameTextBox_;
+   private FormLabel appNameLabel_;
+   private TextBox   appNameTextBox_;
    
-   private Label   appTypeLabel_;
+   private Label appTypeLabel_;
    private RadioButton appTypeSingleFileButton_;
    private RadioButton appTypeMultipleFileButton_;
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.java
@@ -18,9 +18,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.gwt.aria.client.Roles;
+import com.google.gwt.user.client.ui.Grid;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.core.client.widget.FormLabel;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.WidgetListBox;
@@ -193,10 +195,13 @@ public class NewRMarkdownDialog extends ModalDialog<NewRMarkdownDialog.Result>
       templateChooser_ = new RmdTemplateChooser(server_);
 
       mainWidget_ = GWT.<Binder>create(Binder.class).createAndBindUi(this);
-      formatOptions_ = new ArrayList<RadioButton>();
+      Roles.getPresentationRole().set(formGrid_.getElement());
+      formatOptions_ = new ArrayList<>();
       style.ensureInjected();
       txtAuthor_.setText(author);
+      lblAuthor_.setFor(txtAuthor_);
       txtTitle_.setText("Untitled");
+      lblTitle_.setFor(txtTitle_);
       listTemplates_.addChangeHandler(new ChangeHandler()
       {
          @Override
@@ -444,7 +449,10 @@ public class NewRMarkdownDialog extends ModalDialog<NewRMarkdownDialog.Result>
       return formatWrapper;
    }
    
+   @UiField Grid formGrid_;
+   @UiField FormLabel lblAuthor_;
    @UiField TextBox txtAuthor_;
+   @UiField FormLabel lblTitle_;
    @UiField TextBox txtTitle_;
    @UiField WidgetListBox<TemplateMenuItem> listTemplates_;
    @UiField NewRmdStyle style;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.ui.xml
@@ -120,18 +120,18 @@
      <g:HTMLPanel height="100%" width="325px" 
                   styleName="{style.templateDetails}">
         <g:HTMLPanel ui:field="newTemplatePanel_">
-           <g:Grid width="100%" cellSpacing="0" cellPadding="0">
+           <g:Grid ui:field="formGrid_" width="100%" cellSpacing="0" cellPadding="0">
              <g:row>
-               <g:customCell><g:Label styleName="{style.topLabel}" 
-                              text="Title:"></g:Label></g:customCell>
+               <g:customCell><rw:FormLabel ui:field="lblTitle_" styleName="{style.topLabel}" 
+                              text="Title:"></rw:FormLabel></g:customCell>
                <g:customCell styleName="{style.textCol}">
                  <g:TextBox styleName="{style.textBox}" 
                             ui:field="txtTitle_"></g:TextBox>
                </g:customCell>
               </g:row>
               <g:row>
-                <g:customCell><g:Label styleName="{style.topLabel}" 
-                         text="Author:"></g:Label></g:customCell>
+                <g:customCell><rw:FormLabel ui:field="lblAuthor_" styleName="{style.topLabel}" 
+                         text="Author:"></rw:FormLabel></g:customCell>
                 <g:customCell><g:TextBox styleName="{style.textBox}"
                            ui:field="txtAuthor_"></g:TextBox></g:customCell>
               </g:row>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/TemplateMenuItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/TemplateMenuItem.java
@@ -1,7 +1,7 @@
 /*
  * TemplateMenuItem.java
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -20,8 +20,8 @@ import com.google.gwt.dom.client.Style.VerticalAlign;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.InlineLabel;
+import org.rstudio.core.client.widget.DecorativeImage;
 
 public class TemplateMenuItem extends Composite
 {
@@ -36,7 +36,7 @@ public class TemplateMenuItem extends Composite
    
    public void addIcon(ImageResource icon)
    {
-      Image iconImage = new Image(icon);
+      DecorativeImage iconImage = new DecorativeImage(icon);
       wrapper_.insert(iconImage, 0);
       Style imageStyle = iconImage.getElement().getStyle();
       imageStyle.setVerticalAlign(VerticalAlign.MIDDLE);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/CommitDetail.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/CommitDetail.ui.xml
@@ -33,7 +33,7 @@
          margin-top: 80px;
          font-size: 130%;
          font-weight: bold;
-         color: #AAA;
+         color: #6f6f6f;
          text-align: center;
       }
       .progressPanel {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
@@ -271,7 +271,6 @@ public class GitReviewPanel extends ResizeComposite implements Display
       ignoreButton_ = topToolbar_.addLeftWidget(new ToolbarButton(
             "Ignore", ToolbarButton.NoTitle, new ImageResource2x(RES.ignore2x())));
 
-      
       topToolbar_.addRightWidget(commands.vcsPull().createToolbarButton());
 
       topToolbar_.addRightSeparator();
@@ -293,6 +292,9 @@ public class GitReviewPanel extends ResizeComposite implements Display
       unstageAllButton_ = diffToolbar_.addLeftWidget(new ToolbarButton(
             "Unstage All", ToolbarButton.NoTitle, new ImageResource2x(RES.discard2x())));
       unstageAllButton_.setVisible(false);
+
+      lblCommit_.setFor(commitMessage_);
+      lblContext_.setFor(contextLines_);
 
       unstagedCheckBox_.addValueChangeHandler(new ValueChangeHandler<Boolean>()
       {
@@ -664,11 +666,15 @@ public class GitReviewPanel extends ResizeComposite implements Display
    @UiField(provided = true)
    LineTableView lines_;
    @UiField
+   FormLabel lblContext_;
+   @UiField
    ListBox contextLines_;
    @UiField
    Toolbar topToolbar_;
    @UiField
    Toolbar diffToolbar_;
+   @UiField
+   FormLabel lblCommit_;
    @UiField
    TextArea commitMessage_;
    @UiField

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.ui.xml
@@ -19,7 +19,7 @@
                   <g:east size="400">
                      <g:LayoutPanel>
                         <g:layer left="6px" right="6px" top="4px" height="20px">
-                           <g:Label text="Commit message"/>
+                           <rs_widget:FormLabel ui:field="lblCommit_" text="Commit message"/>
                         </g:layer>
                         <g:layer left="6px" right="6px" top="20px" bottom="34px">
                            <g:TextArea ui:field="commitMessage_" styleName="{res.styles.commitMessage}"/>
@@ -54,7 +54,7 @@
                                     text="Unstaged"
                                     checked="true"
                                     styleName="{res.styles.unstaged}"/>
-                     <g:Label text="Context" styleName="{res.styles.stagedLabel}"/>
+                     <rs_widget:FormLabel ui:field="lblContext_" text="Context" styleName="{res.styles.stagedLabel}"/>
                      <g:ListBox ui:field="contextLines_" visibleItemCount="1" selectedIndex="0">
                         <g:item value="5">5 line</g:item>
                         <g:item value="10">10 line</g:item>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/commit/SVNCommitDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/commit/SVNCommitDialog.java
@@ -33,6 +33,7 @@ import com.google.inject.Inject;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
+import org.rstudio.core.client.widget.FormLabel;
 import org.rstudio.core.client.widget.ModalDialogBase;
 import org.rstudio.core.client.widget.SmallButton;
 import org.rstudio.core.client.widget.ThemedButton;
@@ -114,6 +115,8 @@ public class SVNCommitDialog extends ModalDialogBase
                                           HorizontalPanel.ALIGN_TOP);
       topHPanel_.setCellHorizontalAlignment(btnClearSelection_,
                                             HorizontalPanel.ALIGN_RIGHT);
+
+      lblMessage_.setFor(message_);
 
       btnClearSelection_.addClickHandler(new ClickHandler()
       {
@@ -246,6 +249,8 @@ public class SVNCommitDialog extends ModalDialogBase
 
    @UiField(provided = true)
    ChangelistTable changelist_;
+   @UiField
+   FormLabel lblMessage_;
    @UiField
    TextArea message_;
    @UiField

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/commit/SVNCommitDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/commit/SVNCommitDialog.ui.xml
@@ -43,7 +43,7 @@
       </g:center>
       <g:south size="125">
          <g:FlowPanel>
-            <g:Label text="Commit message:" styleName="{style.commitMessageLabel}"/>
+            <rs:FormLabel ui:field="lblMessage_" text="Commit message:" styleName="{style.commitMessageLabel}"/>
             <g:TextArea ui:field="message_" styleName="{style.commitMessage}"/>
          </g:FlowPanel>
       </g:south>


### PR DESCRIPTION
Unlabeled controls, images without alt-text, layout tables not marked as presentation role, and contrast fixes in assorted dialogs/panes. Also added some explicit `outline:nones` to make it easier to track down things needed focus outlines when we get to that. Gets several more dialogs in a clean passing state via axe plugin.

![2019-07-08_10-56-25](https://user-images.githubusercontent.com/10569626/60849178-83398380-a19e-11e9-8647-b1998c0032fb.png)

![2019-07-08_11-10-22](https://user-images.githubusercontent.com/10569626/60849182-8896ce00-a19e-11e9-8e40-215fb667fd93.png)

![2019-07-08_15-18-33](https://user-images.githubusercontent.com/10569626/60849189-8cc2eb80-a19e-11e9-9094-9131846cc5c7.png)

![2019-07-08_15-34-09](https://user-images.githubusercontent.com/10569626/60849196-90ef0900-a19e-11e9-8d1c-f5a1a89cf672.png)

![2019-07-08_16-14-17](https://user-images.githubusercontent.com/10569626/60849200-94829000-a19e-11e9-8bd9-b596809e0d3f.png)

![2019-07-08_16-22-46](https://user-images.githubusercontent.com/10569626/60849206-977d8080-a19e-11e9-9003-4b5222e90410.png)

![2019-07-08_16-31-58](https://user-images.githubusercontent.com/10569626/60849208-9a787100-a19e-11e9-9164-7eff0dc3cf87.png)
