### PR TITLE
create LabeledTextBox widget and use in a couple places

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/LabeledTextBox.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/LabeledTextBox.java
@@ -1,0 +1,136 @@
+/*
+ * LabeledTextBox.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.widget;
+
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.dom.client.Style.Display;
+import com.google.gwt.event.dom.client.HasKeyUpHandlers;
+import com.google.gwt.event.dom.client.KeyUpHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.HasText;
+import com.google.gwt.user.client.ui.TextBox;
+import org.rstudio.core.client.dom.DomUtils;
+
+/**
+ * A TextBox with an associated label.
+ */
+public class LabeledTextBox extends Composite
+                            implements HasText, HasKeyUpHandlers
+{
+   public LabeledTextBox()
+   {
+      FlowPanel flowPanel = new FlowPanel();
+      label_ = new FormLabel();
+      textBox_ = new TextBox();
+      label_.setFor(textBox_);
+      setLabelInline(false);
+      flowPanel.add(label_);
+      flowPanel.add(textBox_);
+
+      initWidget(flowPanel);
+   }
+
+   public LabeledTextBox(String label)
+   {
+      this();
+      setLabelText(label);
+   }
+
+   public void setLabelText(String label)
+   {
+      label_.setText(label);
+   }
+
+   @Override
+   public void setText(String text)
+   {
+      textBox_.setText(text);
+   }
+
+   @Override
+   public String getText()
+   {
+      return textBox_.getText();
+   }
+
+   public void setFocus(boolean focused)
+   {
+      textBox_.setFocus(focused);
+   }
+
+   public void selectAll()
+   {
+      textBox_.selectAll();
+   }
+
+   public void setTextRequired(boolean required)
+   {
+      Roles.getTextboxRole().setAriaRequiredProperty(textBox_.getElement(), required);
+   }
+
+   public void disableAutoBehavior()
+   {
+      DomUtils.disableAutoBehavior(textBox_);
+   }
+
+   public void setEnableSpellcheck(boolean enable)
+   {
+      textBox_.getElement().setAttribute("spellcheck", enable ? "true" : "false");
+   }
+
+   /**
+    * @return underlying TextBox control
+    */
+   public TextBox getTextBox()
+   {
+      return textBox_;
+   }
+
+   /**
+    * @return underlying FormLabel control
+    */
+   public FormLabel getLabel()
+   {
+      return label_;
+   }
+
+   /**
+    * @param inline true to have label inline with TextBox
+    */
+   public void setLabelInline(boolean inline)
+   {
+      // by default a label element is inline
+      if (!inline)
+         label_.getElement().getStyle().setDisplay(Display.BLOCK);
+      else
+         label_.getElement().getStyle().clearDisplay();
+   }
+
+   @Override
+   public HandlerRegistration addKeyUpHandler(KeyUpHandler handler)
+   {
+      return textBox_.addKeyUpHandler(handler);
+   }
+
+   public void setEnabled(boolean enabled)
+   {
+      textBox_.setEnabled(enabled);
+   }
+
+   FormLabel label_;
+   TextBox textBox_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateChooser.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateChooser.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import org.rstudio.core.client.resources.CoreResources;
 import org.rstudio.core.client.widget.CaptionWithHelp;
 import org.rstudio.core.client.widget.DirectoryChooserTextBox;
-import org.rstudio.core.client.widget.FormLabel;
+import org.rstudio.core.client.widget.LabeledTextBox;
 import org.rstudio.core.client.widget.SimplePanelWithProgress;
 import org.rstudio.core.client.widget.WidgetListBox;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -40,7 +40,6 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.Image;
-import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.Widget;
 
 public class RmdTemplateChooser extends Composite
@@ -72,7 +71,6 @@ public class RmdTemplateChooser extends Composite
          }
       });
       captionWithHelp_.setFor(listTemplates_);
-      lblName_.setFor(txtName_);
    }
    
    public void populateTemplates()
@@ -218,8 +216,7 @@ public class RmdTemplateChooser extends Composite
    
    @UiField CaptionWithHelp captionWithHelp_;
    @UiField WidgetListBox<RmdDiscoveredTemplateItem> listTemplates_;
-   @UiField FormLabel lblName_;
-   @UiField TextBox txtName_;
+   @UiField LabeledTextBox txtName_;
    @UiField(provided = true) DirectoryChooserTextBox dirLocation_;
    @UiField HTMLPanel noTemplatesFound_;
    @UiField HTMLPanel templateOptionsPanel_;

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateChooser.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateChooser.ui.xml
@@ -4,20 +4,21 @@
    xmlns:rs="urn:import:org.rstudio.core.client.widget">
    <ui:style>
      @external .gwt-Label;
+     @external .gwt-TextBox;
      
-     .controlLabel, .directoryChooser .gwt-Label
+     .controlLabel .gwt-Label, .directoryChooser .gwt-Label
      {
         margin-bottom: 3px;
         font-weight: bold;
         display: block;
      }
      
-     .interiorControlLabel, .directoryChooserInner .gwt-Label
+     .interiorControlLabel .gwt-Label, .directoryChooserInner .gwt-Label
      {
         margin-top: 7px; 
      }
      
-     .textBox, .directoryChooser .textBox
+     .controlLabel .gwt-TextBox
      {
        padding: 2px;
        width: 100%;
@@ -61,8 +62,7 @@
    <rs:CaptionWithHelp ui:field="captionWithHelp_" styleName="{style.help}"></rs:CaptionWithHelp>
    <rs:SimplePanelWithProgress ui:field="progressPanel_" 
                                styleName="{style.templateListArea}">
-      <rs:WidgetListBox width="100%" height="100%"
-                        ui:field="listTemplates_"></rs:WidgetListBox>
+      <rs:WidgetListBox width="100%" height="100%" ui:field="listTemplates_"></rs:WidgetListBox>
    </rs:SimplePanelWithProgress>
    <g:HTMLPanel styleName="{style.templateListArea} {style.noTemplates}" 
                 visible="false" ui:field="noTemplatesFound_">
@@ -76,10 +76,8 @@
         This template contains multiple files. Create a new directory for
         these files:
      </g:HTML>
-     <rs:FormLabel ui:field="lblName_" styleName="{style.controlLabel} {style.interiorControlLabel}" 
-              text="Name:"></rs:FormLabel>
-     <g:TextBox styleName="{style.textBox}" ui:field="txtName_" 
-                text="Untitled"></g:TextBox>
+     <rs:LabeledTextBox labelText="Name:" styleName="{style.controlLabel} {style.interiorControlLabel}" 
+                        ui:field="txtName_" text="Untitled"></rs:LabeledTextBox>
 
      <rs:DirectoryChooserTextBox width="100%" addStyleNames="{style.directoryChooser} {style.directoryChooserInner}" ui:field="dirLocation_">
      </rs:DirectoryChooserTextBox>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
@@ -31,11 +31,11 @@ import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.StringUtil;
-import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.js.JsUtil;
 import org.rstudio.core.client.widget.DirectoryChooserTextBox;
 import org.rstudio.core.client.widget.FormLabel;
+import org.rstudio.core.client.widget.LabeledTextBox;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -101,7 +101,6 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
       dirChooser_ = new DirectoryChooserTextBox("Search in:", null);
       dirChooser_.setText("");
       mainWidget_ = GWT.<Binder>create(Binder.class).createAndBindUi(this);
-      labelSearchPattern_.setFor(txtSearchPattern_);
       labelFilePatterns_.setFor(listPresetFilePatterns_);
       setOkButtonCaption("Find");
 
@@ -114,8 +113,6 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
          }
       });
       manageFilePattern();
-
-      DomUtils.disableSpellcheck(txtSearchPattern_);
 
       txtSearchPattern_.addKeyUpHandler(new KeyUpHandler()
       {
@@ -239,9 +236,7 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
    }
 
    @UiField
-   FormLabel labelSearchPattern_;
-   @UiField
-   TextBox txtSearchPattern_;
+   LabeledTextBox txtSearchPattern_;
    @UiField
    CheckBox checkboxRegex_;
    @UiField

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
@@ -3,6 +3,8 @@
              xmlns:widget="urn:import:org.rstudio.core.client.widget">
 
    <ui:style>
+      @external .gwt-TextBox;
+
       .panel input[type=checkbox] {
          margin-left: 0;
       }
@@ -11,7 +13,7 @@
          outline: none;
       }
 
-      .pattern, .filePattern {
+      .pattern .gwt-TextBox, .filePattern {
          width: 375px;
       }
 
@@ -26,9 +28,7 @@
 
    <g:HTMLPanel styleName="{style.panel}">
       <p>
-         <widget:FormLabel ui:field="labelSearchPattern_" text="Find:"/>
-         <g:TextBox ui:field="txtSearchPattern_" styleName="{style.pattern}"/>
-         <br/>
+         <widget:LabeledTextBox ui:field="txtSearchPattern_" labelText="Find:" enableSpellcheck="false" styleName="{style.pattern}"/>
          <g:CheckBox ui:field="checkboxCaseSensitive_" text="Case sensitive"/>
          &#x00a0;&#x00a0;&#x00a0;&#x00a0;
          <g:CheckBox ui:field="checkboxRegex_" text="Regular expression"/>


### PR DESCRIPTION
Enables declaring a labeled textbox as one component in UiBinder files, instead of having to declare separate `FormLabel` and `TextBox` and then associating them from Java code via `setFor`.