### PR TITLE
you guessed it, more simple a11y fixes

### DIFF
--- a/src/cpp/session/resources/help_resources/index.htm
+++ b/src/cpp/session/resources/help_resources/index.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <title>Home</title>
@@ -26,11 +26,11 @@
    
    li {
       margin-bottom: 6px;
-      color: rgb(45,134,247);
+      color: rgb(39,117,216);
    }
    
    a {
-      color: rgb(45,134,247);
+      color: rgb(39,117,216);
    }
    
    a:link {
@@ -40,7 +40,7 @@
    h3 {
       white-space: nowrap;
       font-weight: normal;
-      color: rgb(50%, 50%, 50%);
+      color: rgb(40%, 40%, 40%);
       margin-top: 12px;
       font-size: 1.3em;
 
@@ -60,8 +60,8 @@
       <tr>
          <td width="50%">
             <h3>
-               <img src="r-2x.png" width="25" height="25"></img> 
-               R Resources       
+               <img src="r-2x.png" width="25" height="25" alt>
+               R Resources
             </h3>
             <ul>
                <li><a href="https://www.rstudio.org/links/r-online-learning">Learning R Online</a></li>
@@ -72,7 +72,7 @@
          </td>
           <td width="50%">
             <h3>
-            <img src="rstudio-2x.png" width="25" height="25"> 
+            <img src="rstudio-2x.png" width="25" height="25" alt>
             RStudio
             </h3>
             <ul>

--- a/src/cpp/session/resources/markdown_help.html
+++ b/src/cpp/session/resources/markdown_help.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
-<html>
+<html lang="en">
 <head>
 <title>Markdown Quick Reference</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/src/cpp/session/resources/roxygen_help.html
+++ b/src/cpp/session/resources/roxygen_help.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
-<html>
+<html lang="en">
 <head>
 <title>Roxygen Quick Reference</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1324,6 +1324,10 @@ body.windows .toolbar {
    overflow: hidden;
 }
 
+.toolbarButton:focus {
+   outline:none;
+}
+
 .toolbarButton.noLabel {
    margin-right: 4px;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/FindTextBox.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FindTextBox.java
@@ -1,7 +1,7 @@
 /*
  * FindTextBox.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,6 +16,7 @@ package org.rstudio.core.client.widget;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.DivElement;
+import com.google.gwt.dom.client.LabelElement;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Position;
 import com.google.gwt.dom.client.Style.Unit;
@@ -30,6 +31,7 @@ import com.google.gwt.user.client.ui.HasValue;
 import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.Widget;
+import org.rstudio.core.client.dom.DomUtils;
 
 public class FindTextBox extends Composite implements HasValue<String>,
                                                       CanFocus
@@ -44,6 +46,9 @@ public class FindTextBox extends Composite implements HasValue<String>,
       initWidget(uiBinder.createAndBindUi(this));
       
       setIconVisible(false);
+
+      hiddenLabel_.setInnerText(cueText);
+      hiddenLabel_.setHtmlFor(DomUtils.ensureHasId(textBox_.getElement()));
 
       Style style = getElement().getStyle();
       style.setPosition(Position.RELATIVE);
@@ -107,6 +112,8 @@ public class FindTextBox extends Composite implements HasValue<String>,
       textBox_.selectAll();
    }
 
+   @UiField
+   LabelElement hiddenLabel_;
    @UiField(provided=true)
    TextBox textBox_;
    @UiField

--- a/src/gwt/src/org/rstudio/core/client/widget/FindTextBox.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/FindTextBox.ui.xml
@@ -1,5 +1,6 @@
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
-             xmlns:g='urn:import:com.google.gwt.user.client.ui'>
+             xmlns:g='urn:import:com.google.gwt.user.client.ui'
+             xmlns:rw='urn:import:org.rstudio.core.client.widget'>
 
    <ui:with field='res' type='org.rstudio.core.client.theme.res.ThemeResources'/>
 
@@ -9,11 +10,12 @@
            style="margin-right: 3px">
          <div class="{res.themeStyles.left}"></div>
          <div class="{res.themeStyles.rstheme_center}">
-            <g:Image ui:field='icon_'
+            <rw:DecorativeImage ui:field='icon_'
                      resource='{res.smallMagGlassIcon2x}'
                      styleName='{res.themeStyles.searchMagGlass}' />
             <div ui:field='textBoxDiv_' 
                  class="{res.themeStyles.searchBoxContainer2}">
+               <label ui:field='hiddenLabel_' class="{res.themeStyles.visuallyHidden}"/>
                <g:TextBox ui:field='textBox_'
                           styleName='{res.themeStyles.searchBox}'/>
             </div>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
@@ -334,7 +334,7 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
    {
       Label label = new Label(caption);
       label.getElement().getStyle().setMarginTop(20, Unit.PX);
-      label.getElement().getStyle().setColor("#888");
+      label.getElement().getStyle().setColor("#656565");
       return label;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -727,9 +727,9 @@ public class HelpPane extends WorkbenchPane
       {
          globalDisplay_.showMessage(MessageDialog.INFO,
                "Find in Topic", 
-               "No occurences found",
+               "No occurrences found",
                findInputSource);
-      }     
+      }
    }
    
    private final native void replaceFrameUrl(JavaScriptObject frame, String url) /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.java
@@ -102,6 +102,7 @@ public class JobItem extends Composite implements JobItemView
       
       name_.setText(job.name);
       spinner_.setResource(new ImageResource2x(RESOURCES.jobSpinner()));
+      spinner_.setAltText("Progress indicator");
       
       ImageResource2x detailsImage = new ImageResource2x(RESOURCES.jobSelect());
       if (JsArrayUtil.jsArrayStringContains(job.actions, JobConstants.ACTION_INFO))
@@ -110,6 +111,7 @@ public class JobItem extends Composite implements JobItemView
       }
       
       select_.setResource(detailsImage);
+      select_.setAltText("Select Job");
 
       ClickHandler selectJob = evt ->
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.ui.xml
@@ -3,6 +3,7 @@
     xmlns:g="urn:import:com.google.gwt.user.client.ui"
     xmlns:rw="urn:import:org.rstudio.core.client.widget">
     <ui:style field="styles_" type="org.rstudio.studio.client.workbench.views.jobs.view.JobItem.Styles">
+    @external rstudio-themes-flat, rstudio-themes-dark;
     .item
     {
         padding-left: 5px;
@@ -31,15 +32,26 @@
     
     .succeeded .state
     {
-        color: #3db057;
+        color: #0c8828;
     }
     
     .cancelled .state,
     .failed .state
     {
-        color: #ee6366;
+        color: #da2c30;
     }
     
+    .rstudio-themes-flat .rstudio-themes-dark .succeeded .state
+    {
+        color: #3db057;
+    }
+    
+    .rstudio-themes-flat .rstudio-themes-dark .cancelled .state,
+    .rstudio-themes-flat .rstudio-themes-dark .failed .state
+    {
+        color: #ee6366;
+    }
+     
     .pending .state
     {
         color: #b8b8b8;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobOutputPanel.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobOutputPanel.ui.xml
@@ -5,7 +5,6 @@
    <ui:style>
    .empty
    {
-      color: #909090;
       text-align: center;
       margin-top: 10%;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsList.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsList.ui.xml
@@ -10,7 +10,6 @@
    
    .empty
    {
-      color: #909090;
       text-align: center;
       margin-top: 10%;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.css
@@ -19,7 +19,7 @@
 }
 
 .functionNamespace {
-   color: #888;
+   color: #717171;
    padding-right: 6px;
 }
 
@@ -37,5 +37,9 @@
 
 .readOnly {
    margin-right: 7px;
-   color: #888;
+   color: #717171;
+}
+
+.rstudio-themes-flat .rstudio-themes-dark .readOnly {
+   color: #DDD;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.java
@@ -28,6 +28,7 @@ import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.CheckboxLabel;
+import org.rstudio.core.client.widget.DecorativeImage;
 import org.rstudio.core.client.widget.FindTextBox;
 import org.rstudio.core.client.widget.SmallButton;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -151,7 +152,7 @@ public class FindReplaceBar extends Composite implements Display, RequiresResize
       btnClose_.addStyleName(ThemeStyles.INSTANCE.handCursor());
       Roles.getButtonRole().setAriaLabelProperty(btnClose_.getElement(), "Close find and replace");
       btnClose_.getElement().appendChild(
-            new Image(new ImageResource2x(ThemeResources.INSTANCE.closeTab2x())).getElement());
+            new DecorativeImage(new ImageResource2x(ThemeResources.INSTANCE.closeTab2x())).getElement());
 
       txtFind_.addKeyDownHandler(new KeyDownHandler()
       {


### PR DESCRIPTION
Assortment of text contrast, image alt-tag, HTML lang, labels, and temporary settings of outline:none (for easier future searching).

![2019-07-09_11-51-53](https://user-images.githubusercontent.com/10569626/60928086-03c0b880-a261-11e9-88e1-1eae33ba5ad1.png)

![2019-07-09_11-20-53](https://user-images.githubusercontent.com/10569626/60928071-ef7cbb80-a260-11e9-9bba-5fca2c65edad.png)

![2019-07-09_11-33-16](https://user-images.githubusercontent.com/10569626/60928076-f5729c80-a260-11e9-9060-11c9a186c150.png)

![2019-07-09_13-46-07](https://user-images.githubusercontent.com/10569626/60928115-1b983c80-a261-11e9-8b8d-c5b4badfd5c7.png)

![2019-07-09_14-14-19](https://user-images.githubusercontent.com/10569626/60928118-1fc45a00-a261-11e9-93f1-7fe094d665cb.png)

![2019-07-09_14-50-50](https://user-images.githubusercontent.com/10569626/60928127-25ba3b00-a261-11e9-8a3f-15edf2d3f9ae.png)

![2019-07-09_14-54-58](https://user-images.githubusercontent.com/10569626/60928137-2e127600-a261-11e9-9e2e-3f3322997581.png)

![2019-07-09_15-10-10](https://user-images.githubusercontent.com/10569626/60928141-310d6680-a261-11e9-9a10-dc26f57fef17.png)

![2019-07-09_15-10-49](https://user-images.githubusercontent.com/10569626/60928145-34085700-a261-11e9-9c4c-629b39fa17c2.png)

![2019-07-09_15-26-27](https://user-images.githubusercontent.com/10569626/60928151-38cd0b00-a261-11e9-960c-7594c47f92e3.png)

![2019-07-09_15-40-29](https://user-images.githubusercontent.com/10569626/60928265-93666700-a261-11e9-8ade-316305e7adf9.png)

![2019-07-09_15-41-15](https://user-images.githubusercontent.com/10569626/60928272-98c3b180-a261-11e9-846e-bb3946b8b660.png)
