### PR TITLE
suppress focus indicator on HelpLinks and HelpButtons

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/resources/styles.css
+++ b/src/gwt/src/org/rstudio/core/client/resources/styles.css
@@ -19,7 +19,6 @@
    font-weight: bold;
 }
 
-
 .gwt-Button-Toolbar {
    height: 19px;
    background-color: transparent;
@@ -29,7 +28,7 @@
 }
 
 .gwt-Button-Toolbar:active {
-  border: 1px inset #ccc;
+   border: 1px inset #ccc;
 }
 
 .gwt-Button-Toolbar:hover {
@@ -40,51 +39,64 @@
 }
 
 .gwt-Button-Toolbar[disabled] {
-  cursor: default;
-  color: #888;
+   cursor: default;
+   color: #888;
 }
 
 .gwt-Button-Toolbar[disabled]:hover {
-  border: 1px outset #ccc;
+   border: 1px outset #ccc;
 }
 
 .gwt-DecoratedPopupPanel-Toolbar .popupMiddleCenter {
-  background: white;
+   background: white;
 }
 
 .gwt-DialogBox-ModalDialog .Caption {
-  font-weight: bold;
-} 
+   font-weight: bold;
+}
 
 .rstudio-DialogBoxProgressPanel {
   height: 25px;
 }
 
 .rstudio-DialogBoxProgressPanel .gwt-Label-ProgressText {
-  color: grey;
-  padding-left: 4px;
+   color: grey;
+   padding-left: 4px;
 }
 
 .rstudio-DialogBoxVerticalInputLabel {
-  margin-bottom: 2px;
+   margin-bottom: 2px;
 }
 
 .rstudio-ModalDialogButtonSpacer {
-  width: 5px;
+   width: 5px;
 }
-
 
 .rstudio-HyperlinkLabel {
    color: #0000AA;
+}
+
+.rstudio-HyperlinkLabel:focus {
+   outline: none;
 }
 
 .rstudio-HyperlinkLabel-Link {
    text-decoration: underline;
 }
 
+.rstudio-HelpButton {
+   display: block;
+   padding: 0;
+   margin: 0;
+   border: none;
+   background-color: transparent;
+}
+
+.rstudio-HelpButton:focus {
+   outline:none;
+}
 
 .rstudio-StatusIndicator {
-   
 }
 
 .rstudio-StatusIndicator .Message {

--- a/src/gwt/src/org/rstudio/core/client/widget/HelpButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/HelpButton.java
@@ -25,7 +25,6 @@ import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.GlobalDisplay;
 
 import com.google.gwt.dom.client.Style;
-import com.google.gwt.dom.client.Style.BorderStyle;
 import com.google.gwt.dom.client.Style.Cursor;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -80,11 +79,7 @@ public class HelpButton extends FocusWidget
                      final String title)
    {
       ButtonElement button = Document.get().createPushButtonElement();
-      button.getStyle().setDisplay(Style.Display.BLOCK);
-      button.getStyle().setPadding(0, Unit.PX);
-      button.getStyle().setMargin(0, Unit.PX);
-      button.getStyle().setBorderStyle(BorderStyle.NONE);
-      button.getStyle().setBackgroundColor("transparent");
+      button.setClassName("rstudio-HelpButton");
 
       Image helpImage = new Image(new ImageResource2x(ThemeResources.INSTANCE.help2x()));
       helpImage.getElement().getStyle().setCursor(Cursor.POINTER);


### PR DESCRIPTION
Now that HelpLinks and HelpButtons accept keyboard focus, they were showing default focus indicators.

We will be doing a UI-wide effort on styling focus indicators tracked by #4982, so suppressing these so they're easier to find later by searching for `outline: none`.

Also moved HelpButton's overall styling from code into css, and made indents consistent in style.css.