### PR TITLE
set HOME when using git-bash via tools/shell on Windows

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -1238,19 +1238,17 @@ void GwtCallback::openTerminal(QString terminalPath,
    QStringList args;
    std::string previousHome = core::system::getenv("HOME");
 
-   switch (shellType)
+   if (shellType == GitBash || shellType == WSLBash)
    {
-   case GitBash:
-   case WSLBash:
       args.append(QString::fromUtf8("--login"));
       args.append(QString::fromUtf8("-i"));
-      break;
+   }
 
-   default:
+   if (shellType != WSLBash)
+   {
       // set HOME to USERPROFILE so msys ssh can find our keys
       std::string userProfile = core::system::getenv("USERPROFILE");
       core::system::setenv("HOME", userProfile);
-      break;
    }
 
    QProcess process;


### PR DESCRIPTION
Fixes #3663 

Explicitly set HOME when launching external shell via Tools/Shell on Windows for all types except WSL (which lives in a separate Windows subsystem and takes care of setting home by itself).
