### PR TITLE
only attempt to detect DESCRIPTION changes in package project

### DIFF
--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -62,7 +62,7 @@ void onDescriptionChanged()
    s_pIndexedPackageInfo.reset();
 
    std::unique_ptr<r_util::RPackageInfo> pInfo(new r_util::RPackageInfo);
-   Error error = pInfo->read(projectContext().directory());
+   Error error = pInfo->read(projectContext().buildTargetPath());
    if (error)
       LOG_ERROR(error);
 
@@ -71,7 +71,7 @@ void onDescriptionChanged()
 
 void onProjectFilesChanged(const std::vector<core::system::FileChangeEvent>& events)
 {
-   FilePath descPath = projectContext().directory().childPath("DESCRIPTION");
+   FilePath descPath = projectContext().buildTargetPath().childPath("DESCRIPTION");
    for (auto& event : events)
    {
       auto& info = event.fileInfo();
@@ -464,7 +464,8 @@ Error ProjectContext::initialize()
 void ProjectContext::onDeferredInit(bool newSession)
 {
    // update DESCRIPTION file index
-   onDescriptionChanged();
+   if (projectContext().isPackageProject())
+      onDescriptionChanged();
 
    // kickoff file monitoring for this directory
    using boost::bind;


### PR DESCRIPTION
Closes #5092. Also fixes a potential issue where the package directory actually lives as a sub-directory of the project (a practice that is much less common now, but used to be more standard)