### PR TITLE
Keyboard support for switching preference panes

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBase.java
@@ -15,6 +15,7 @@
 package org.rstudio.core.client.prefs;
 
 
+import com.google.gwt.aria.client.Id;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -89,7 +90,9 @@ public abstract class PreferencesDialogBase<T> extends ModalDialogBase
        
       for (final PreferencesDialogPaneBase<T> pane : panes_)
       {
-         sectionChooser_.addSection(pane.getIcon(), pane.getName());
+         Id sectionTabId = sectionChooser_.addSection(pane.getIcon(), pane.getName());
+         pane.getElement().setId(SectionChooser.getTabPanelId(sectionTabId).getAriaValue());
+         Roles.getTabpanelRole().setAriaLabelledbyProperty(pane.getElement(), sectionTabId);
          pane.setWidth("100%");
          pane.setDialog(this);
          pane.setProgressIndicator(progressIndicator_);

--- a/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogPaneBase.java
+++ b/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogPaneBase.java
@@ -1,7 +1,7 @@
 /*
  * PreferencesDialogPaneBase.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,6 +14,7 @@
  */
 package org.rstudio.core.client.prefs;
 
+import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.events.EnsureVisibleEvent;
 import org.rstudio.core.client.events.EnsureVisibleHandler;
@@ -36,6 +37,12 @@ public abstract class PreferencesDialogPaneBase<T> extends VerticalPanel
 implements HasEnsureVisibleHandlers
 {
    public abstract ImageResource getIcon();
+
+   public PreferencesDialogPaneBase()
+   {
+      super();
+      Roles.getTabpanelRole().set(getElement());
+   }
 
    public boolean validate()
    {

--- a/src/gwt/src/org/rstudio/core/client/prefs/SectionChooser.java
+++ b/src/gwt/src/org/rstudio/core/client/prefs/SectionChooser.java
@@ -14,12 +14,16 @@
  */
 package org.rstudio.core.client.prefs;
 
+import com.google.gwt.aria.client.Id;
 import com.google.gwt.aria.client.Roles;
+import com.google.gwt.aria.client.SelectedValue;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.dom.client.KeyDownEvent;
+import com.google.gwt.event.dom.client.KeyDownHandler;
 import org.rstudio.core.client.ElementIds;
 
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.event.dom.client.HasClickHandlers;
 import com.google.gwt.event.logical.shared.HasSelectionHandlers;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
@@ -33,16 +37,35 @@ import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.widget.DecorativeImage;
 
+/**
+ * Vertical tab control used by Preferences dialogs. Follows the ARIA tab pattern.
+ * 
+ * Each tab:
+ *    role="tab"
+ *    aria-controls=id_of_panel
+ *    aria-selected=true|false
+ *    tabindex=-1 (0 for the currently selected tab only)
+ * 
+ * Each panel controlled by a tab:
+ *    role="tabpanel"
+ *    aria-labelled-by=id_of_tab
+ * 
+ * Navigation between tabs is via up/down arrow keys, with automatic activation of the
+ * tab when it gets focus.
+ */
 class SectionChooser extends SimplePanel implements
                                                 HasSelectionHandlers<Integer>
 {
    private class ClickableVerticalPanel extends VerticalPanel
-      implements HasClickHandlers
    {
-
       public HandlerRegistration addClickHandler(ClickHandler handler)
       {
          return addDomHandler(handler, ClickEvent.getType());
+      }
+
+      public HandlerRegistration addKeyDownHandler(KeyDownHandler handler)
+      {
+         return addDomHandler(handler, KeyDownEvent.getType());
       }
    }
 
@@ -55,7 +78,13 @@ class SectionChooser extends SimplePanel implements
       A11y.setARIATablistOrientation(getElement(), true /*vertical*/);
    }
 
-   public void addSection(ImageResource icon, String name)
+   /**
+    * Add a section (tab) to the chooser.
+    * @param icon
+    * @param name
+    * @return Element ID of the section tab
+    */
+   public Id addSection(ImageResource icon, String name)
    {
       DecorativeImage img = new DecorativeImage(icon.getSafeUri());
       nudgeDown(img);
@@ -71,18 +100,35 @@ class SectionChooser extends SimplePanel implements
       innerPanel.add(nudgeRightPlus(label));
       panel.add(innerPanel);
       panel.setStyleName(res_.styles().section());
-      panel.getElement().setId(ElementIds.idFromLabel(name) + "_options");
+      Id sectionTabId = Id.of(ElementIds.idFromLabel(name) + "_options");
+      panel.getElement().setId(sectionTabId.getAriaValue());
 
-      panel.addClickHandler(new ClickHandler()
-      {
-         public void onClick(ClickEvent event)
+      panel.addClickHandler(event -> select(inner_.getWidgetIndex(panel)));
+      panel.addKeyDownHandler(event -> {
+         switch(event.getNativeKeyCode())
          {
-            select(inner_.getWidgetIndex(panel));
+            case KeyCodes.KEY_UP:
+               selectPreviousSection();
+               break;
+                  
+            case KeyCodes.KEY_DOWN:
+               selectNextSection();
+               break;
+            case KeyCodes.KEY_HOME:
+               selectFirstSection();
+               break;
+            case KeyCodes.KEY_END:
+               selectLastSection();
+               break;
          }
       });
 
       Roles.getTabRole().set(panel.getElement());
+      panel.getElement().setTabIndex(-1);
+      Roles.getTabRole().setAriaSelectedState(panel.getElement(), SelectedValue.FALSE);
+      Roles.getTabRole().setAriaControlsProperty(panel.getElement(), getTabPanelId(sectionTabId));
       inner_.add(panel);
+      return sectionTabId;
    }
 
    public void select(Integer index)
@@ -92,6 +138,7 @@ class SectionChooser extends SimplePanel implements
          Widget prevItem = inner_.getWidget(selectedIndex_);
          prevItem.removeStyleName(res_.styles().activeSection());
          prevItem.getElement().setTabIndex(-1);
+         Roles.getTabRole().setAriaSelectedState(prevItem.getElement(), SelectedValue.FALSE);
       }
 
       selectedIndex_ = index;
@@ -101,6 +148,7 @@ class SectionChooser extends SimplePanel implements
          Widget newItem = inner_.getWidget(index);
          newItem.addStyleName(res_.styles().activeSection());
          newItem.getElement().setTabIndex(0);
+         Roles.getTabRole().setAriaSelectedState(newItem.getElement(), SelectedValue.TRUE);
       }
 
       SelectionEvent.fire(this, index);
@@ -117,6 +165,60 @@ class SectionChooser extends SimplePanel implements
       return addHandler(handler, SelectionEvent.getType());
    }
 
+   private void selectNextSection()
+   {
+      if (selectedIndex_ == null)
+         return;
+      for (int i = selectedIndex_ + 1; i < sectionCount(); i++)
+      {
+         if (inner_.getWidget(i).isVisible())
+         {
+            select(i);
+            return;
+         }
+      }
+      selectFirstSection();
+   }
+
+   private void selectPreviousSection()
+   {
+      if (selectedIndex_ == null)
+         return;
+      for (int i = selectedIndex_ - 1; i >= 0; i--)
+      {
+         if (inner_.getWidget(i).isVisible())
+         {
+            select(i);
+            return;
+         }
+      }
+      selectLastSection();
+   }
+
+   private void selectFirstSection()
+   {
+      for (int i = 0; i < sectionCount(); i++)
+      {
+         if (inner_.getWidget(i).isVisible())
+         {
+            select(i);
+            return;
+         }
+      }
+   }
+
+   private void selectLastSection()
+   {
+      for (int i = sectionCount() - 1; i >= 0; i--)
+      {
+         if (inner_.getWidget(i).isVisible())
+         {
+            select(i);
+            return;
+         }
+      }
+   }
+
    public int getDesiredWidth()
    {
       return 122;
@@ -131,6 +233,15 @@ class SectionChooser extends SimplePanel implements
       }
    }
 
+   /**
+    * @param tabId element id for a tab
+    * @return element id to use for associated tabpanel
+    */
+   public static Id getTabPanelId(Id tabId)
+   {
+      return Id.of(tabId.getAriaValue() + "_panel");
+   }
+
    private Widget nudgeRightPlus(Widget widget)
    {
       widget.addStyleName(res_.styles().nudgeRightPlus());
@@ -141,6 +252,11 @@ class SectionChooser extends SimplePanel implements
    {
       widget.addStyleName(res_.styles().nudgeDown());
       return widget;
+   }
+
+   private int sectionCount()
+   {
+      return inner_.getWidgetCount();
    }
 
    private Integer selectedIndex_;


### PR DESCRIPTION
- implemented as a vertical Tab control per the ARIA pattern
- when selector (left column) of preferences pane or project preferences pane has focus (not currently visually indicated), up and down arrows (plus HOME and END keys) can be used to switch panels
- see https://www.w3.org/TR/wai-aria-practices/#tabpanel for details on this pattern