### PR TITLE
keyboard and screenreader support for tab control

### DIFF
--- a/src/gwt/src/com/google/gwt/updatepatches.sh
+++ b/src/gwt/src/com/google/gwt/updatepatches.sh
@@ -20,7 +20,8 @@ jar xvf ${SRCBASE}/../lib/gwt/${GWTVER}/gwt-user.jar \
   com/google/gwt/user/client/ui/MenuBar.java \
   com/google/gwt/user/client/ui/MenuItem.java \
   com/google/gwt/user/client/ui/SplitLayoutPanel.java \
-  com/google/gwt/user/client/ui/SplitPanel.java
+  com/google/gwt/user/client/ui/SplitPanel.java \
+  com/google/gwt/user/client/ui/TabLayoutPanel.java
 
 jar xvf ${SRCBASE}/../lib/gwt/${GWTVER}/gwt-dev.jar \
   com/google/gwt/core/linker/CrossSiteIframeLinker.java \
@@ -43,6 +44,7 @@ updatepatch ${PACKAGE} MenuBar.java
 updatepatch ${PACKAGE} MenuItem.java
 updatepatch ${PACKAGE} SplitLayoutPanel.java
 updatepatch ${PACKAGE} SplitPanel.java
+updatepatch ${PACKAGE} TabLayoutPanel.java
 
 PACKAGE=com/google/gwt/core/ext/linker/impl
 updatepatch ${PACKAGE} installLocationIframe.js

--- a/src/gwt/src/com/google/gwt/updatesources.sh
+++ b/src/gwt/src/com/google/gwt/updatesources.sh
@@ -18,7 +18,8 @@ jar xvf ${SRCBASE}/../lib/gwt/${GWTVER}/gwt-user.jar \
   com/google/gwt/user/client/ui/MenuBar.java \
   com/google/gwt/user/client/ui/MenuItem.java \
   com/google/gwt/user/client/ui/SplitLayoutPanel.java \
-  com/google/gwt/user/client/ui/SplitPanel.java
+  com/google/gwt/user/client/ui/SplitPanel.java \
+  com/google/gwt/user/client/ui/TabLayoutPanel.java
   
 jar xvf ${SRCBASE}/../lib/gwt/${GWTVER}/gwt-dev.jar \
   com/google/gwt/core/linker/CrossSiteIframeLinker.java \
@@ -38,6 +39,7 @@ patch MenuBar.java < MenuBar.java.diff
 patch MenuItem.java < MenuItem.java.diff
 patch SplitLayoutPanel.java < SplitLayoutPanel.java.diff
 patch SplitPanel.java < SplitPanel.java.diff
+patch TabLayoutPanel.java < TabLayoutPanel.java.diff
 
 cd ${SRCBASE}/com/google/gwt/core/ext/linker/impl
 patch installLocationIframe.js < installLocationIframe.js.diff

--- a/src/gwt/src/com/google/gwt/user/client/ui/TabLayoutPanel.java
+++ b/src/gwt/src/com/google/gwt/user/client/ui/TabLayoutPanel.java
@@ -1,0 +1,759 @@
+/*
+ * Copyright 2009 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gwt.user.client.ui;
+
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.logical.shared.BeforeSelectionEvent;
+import com.google.gwt.event.logical.shared.BeforeSelectionHandler;
+import com.google.gwt.event.logical.shared.HasBeforeSelectionHandlers;
+import com.google.gwt.event.logical.shared.HasSelectionHandlers;
+import com.google.gwt.event.logical.shared.SelectionEvent;
+import com.google.gwt.event.logical.shared.SelectionHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.layout.client.Layout.Alignment;
+import com.google.gwt.layout.client.Layout.AnimationCallback;
+import com.google.gwt.resources.client.CommonResources;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.safehtml.shared.annotations.IsSafeHtml;
+import com.google.gwt.safehtml.shared.annotations.SuppressIsSafeHtmlCastCheck;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+/**
+ * A panel that represents a tabbed set of pages, each of which contains another
+ * widget. Its child widgets are shown as the user selects the various tabs
+ * associated with them. The tabs can contain arbitrary text, HTML, or widgets.
+ *
+ * <p>
+ * This widget will <em>only</em> work in standards mode, which requires that
+ * the HTML page in which it is run have an explicit &lt;!DOCTYPE&gt;
+ * declaration.
+ * </p>
+ *
+ * <h3>CSS Style Rules</h3>
+ * <dl>
+ * <dt>.gwt-TabLayoutPanel
+ * <dd>the panel itself
+ * <dt>.gwt-TabLayoutPanel .gwt-TabLayoutPanelTabs
+ * <dd>the tab bar element
+ * <dt>.gwt-TabLayoutPanel .gwt-TabLayoutPanelTab
+ * <dd>an individual tab
+ * <dt>.gwt-TabLayoutPanel .gwt-TabLayoutPanelTabInner
+ * <dd>an element nested in each tab (useful for styling)
+ * <dt>.gwt-TabLayoutPanel .gwt-TabLayoutPanelContent
+ * <dd>applied to all child content widgets
+ * </dl>
+ *
+ * <p>
+ * <h3>Example</h3>
+ * {@example com.google.gwt.examples.TabLayoutPanelExample}
+ *
+ * <h3>Use in UiBinder Templates</h3>
+ * <p>
+ * A TabLayoutPanel element in a {@link com.google.gwt.uibinder.client.UiBinder
+ * UiBinder} template must have a <code>barHeight</code> attribute with a double
+ * value, and may have a <code>barUnit</code> attribute with a
+ * {@link com.google.gwt.dom.client.Style.Unit Style.Unit} value.
+ * <code>barUnit</code> defaults to PX.
+ * <p>
+ * The children of a TabLayoutPanel element are laid out in &lt;g:tab>
+ * elements. Each tab can have one widget child and one of two types of header
+ * elements. A &lt;g:header> element can hold html, or a &lt;g:customHeader>
+ * element can hold a widget. (Note that the tags of the header elements are
+ * not capitalized. This is meant to signal that the head is not a runtime
+ * object, and so cannot have a <code>ui:field</code> attribute.)
+ * <p>
+ * For example:<pre>
+ * &lt;g:TabLayoutPanel barUnit='EM' barHeight='3'>
+ *  &lt;g:tab>
+ *    &lt;g:header size='7'>&lt;b>HTML&lt;/b> header&lt;/g:header>
+ *    &lt;g:Label>able&lt;/g:Label>
+ *  &lt;/g:tab>
+ *  &lt;g:tab>
+ *    &lt;g:customHeader size='7'>
+ *      &lt;g:Label>Custom header&lt;/g:Label>
+ *    &lt;/g:customHeader>
+ *    &lt;g:Label>baker&lt;/g:Label>
+ *  &lt;/g:tab>
+ * &lt;/g:TabLayoutPanel>
+ * </pre>
+ */
+public class TabLayoutPanel extends ResizeComposite implements HasWidgets,
+    ProvidesResize, IndexedPanel.ForIsWidget, AnimatedLayout,
+    HasBeforeSelectionHandlers<Integer>, HasSelectionHandlers<Integer> {
+
+  private class Tab extends SimplePanel {
+    private Element inner;
+    private boolean replacingWidget;
+
+    public Tab(Widget child) {
+      super(Document.get().createDivElement());
+      getElement().appendChild(inner = Document.get().createDivElement());
+
+      setWidget(child);
+      setStyleName(TAB_STYLE);
+      inner.setClassName(TAB_INNER_STYLE);
+
+      getElement().addClassName(CommonResources.getInlineBlockStyle());
+    }
+
+    public HandlerRegistration addClickHandler(ClickHandler handler) {
+      return addDomHandler(handler, ClickEvent.getType());
+    }
+
+    @Override
+    public boolean remove(Widget w) {
+      /*
+       * Removal of items from the TabBar is delegated to the TabLayoutPanel to
+       * ensure consistency.
+       */
+      int index = tabs.indexOf(this);
+      if (replacingWidget || index < 0) {
+        /*
+         * The tab contents are being replaced, or this tab is no longer in the
+         * panel, so just remove the widget.
+         */
+        return super.remove(w);
+      } else {
+        // Delegate to the TabLayoutPanel.
+        return TabLayoutPanel.this.remove(index);
+      }
+    }
+
+    public void setSelected(boolean selected) {
+      if (selected) {
+        addStyleDependentName("selected");
+      } else {
+        removeStyleDependentName("selected");
+      }
+    }
+
+    @Override
+    public void setWidget(Widget w) {
+      replacingWidget = true;
+      super.setWidget(w);
+      replacingWidget = false;
+    }
+
+    @Override
+    protected com.google.gwt.user.client.Element getContainerElement() {
+      return inner.cast();
+    }
+  }
+
+  /**
+   * This extension of DeckLayoutPanel overrides the public mutator methods to
+   * prevent external callers from adding to the state of the DeckPanel.
+   * <p>
+   * Removal of Widgets is supported so that WidgetCollection.WidgetIterator
+   * operates as expected.
+   * </p>
+   * <p>
+   * We ensure that the DeckLayoutPanel cannot become of of sync with its
+   * associated TabBar by delegating all mutations to the TabBar to this
+   * implementation of DeckLayoutPanel.
+   * </p>
+   */
+  private class TabbedDeckLayoutPanel extends DeckLayoutPanel {
+
+    @Override
+    public void add(Widget w) {
+      throw new UnsupportedOperationException(
+          "Use TabLayoutPanel.add() to alter the DeckLayoutPanel");
+    }
+
+    @Override
+    public void clear() {
+      throw new UnsupportedOperationException(
+          "Use TabLayoutPanel.clear() to alter the DeckLayoutPanel");
+    }
+
+    @Override
+    public void insert(Widget w, int beforeIndex) {
+      throw new UnsupportedOperationException(
+          "Use TabLayoutPanel.insert() to alter the DeckLayoutPanel");
+    }
+
+    @Override
+    public boolean remove(Widget w) {
+      /*
+       * Removal of items from the DeckLayoutPanel is delegated to the
+       * TabLayoutPanel to ensure consistency.
+       */
+      return TabLayoutPanel.this.remove(w);
+    }
+
+    protected void insertProtected(Widget w, int beforeIndex) {
+      super.insert(w, beforeIndex);
+    }
+
+    protected void removeProtected(Widget w) {
+      super.remove(w);
+    }
+  }
+
+  private static final String CONTENT_CONTAINER_STYLE = "gwt-TabLayoutPanelContentContainer";
+  private static final String CONTENT_STYLE = "gwt-TabLayoutPanelContent";
+  private static final String TAB_STYLE = "gwt-TabLayoutPanelTab";
+
+  private static final String TAB_INNER_STYLE = "gwt-TabLayoutPanelTabInner";
+
+  private static final int BIG_ENOUGH_TO_NOT_WRAP = 16384;
+
+  private final TabbedDeckLayoutPanel deckPanel = new TabbedDeckLayoutPanel();
+  private final FlowPanel tabBar = new FlowPanel();
+  private final ArrayList<Tab> tabs = new ArrayList<Tab>();
+  private int selectedIndex = -1;
+
+  /**
+   * Creates an empty tab panel.
+   *
+   * @param barHeight the size of the tab bar
+   * @param barUnit the unit in which the tab bar size is specified
+   */
+  public TabLayoutPanel(double barHeight, Unit barUnit) {
+    LayoutPanel panel = new LayoutPanel();
+    initWidget(panel);
+
+    // Add the tab bar to the panel.
+    panel.add(tabBar);
+    panel.setWidgetLeftRight(tabBar, 0, Unit.PX, 0, Unit.PX);
+    panel.setWidgetTopHeight(tabBar, 0, Unit.PX, barHeight, barUnit);
+    panel.setWidgetVerticalPosition(tabBar, Alignment.END);
+
+    // Add the deck panel to the panel.
+    deckPanel.addStyleName(CONTENT_CONTAINER_STYLE);
+    panel.add(deckPanel);
+    panel.setWidgetLeftRight(deckPanel, 0, Unit.PX, 0, Unit.PX);
+    panel.setWidgetTopBottom(deckPanel, barHeight, barUnit, 0, Unit.PX);
+
+    // Make the tab bar extremely wide so that tabs themselves never wrap.
+    // (Its layout container is overflow:hidden)
+    tabBar.getElement().getStyle().setWidth(BIG_ENOUGH_TO_NOT_WRAP, Unit.PX);
+
+    tabBar.setStyleName("gwt-TabLayoutPanelTabs");
+    setStyleName("gwt-TabLayoutPanel");
+  }
+
+  /**
+   * Convenience overload to allow {@link IsWidget} to be used directly.
+   */
+  public void add(IsWidget w) {
+    add(asWidgetOrNull(w));
+  }
+
+  /**
+   * Convenience overload to allow {@link IsWidget} to be used directly.
+   */
+  public void add(IsWidget w, IsWidget tab) {
+    add(asWidgetOrNull(w), asWidgetOrNull(tab));
+  }
+
+  /**
+   * Convenience overload to allow {@link IsWidget} to be used directly.
+   */
+  public void add(IsWidget w, String text) {
+    add(asWidgetOrNull(w), text);
+  }
+
+  /**
+   * Convenience overload to allow {@link IsWidget} to be used directly.
+   */
+  public void add(IsWidget w, @IsSafeHtml String text, boolean asHtml) {
+    add(asWidgetOrNull(w), text, asHtml);
+  }
+
+  public void add(Widget w) {
+    insert(w, getWidgetCount());
+  }
+
+  /**
+   * Adds a widget to the panel. If the Widget is already attached, it will be
+   * moved to the right-most index.
+   *
+   * @param child the widget to be added
+   * @param text the text to be shown on its tab
+   */
+  public void add(Widget child, String text) {
+    insert(child, text, getWidgetCount());
+  }
+
+  /**
+   * Adds a widget to the panel. If the Widget is already attached, it will be
+   * moved to the right-most index.
+   *
+   * @param child the widget to be added
+   * @param html the html to be shown on its tab
+   */
+  public void add(Widget child, SafeHtml html) {
+    add(child, html.asString(), true);
+  }
+
+  /**
+   * Adds a widget to the panel. If the Widget is already attached, it will be
+   * moved to the right-most index.
+   *
+   * @param child the widget to be added
+   * @param text the text to be shown on its tab
+   * @param asHtml <code>true</code> to treat the specified text as HTML
+   */
+  public void add(Widget child, @IsSafeHtml String text, boolean asHtml) {
+    insert(child, text, asHtml, getWidgetCount());
+  }
+
+  /**
+   * Adds a widget to the panel. If the Widget is already attached, it will be
+   * moved to the right-most index.
+   *
+   * @param child the widget to be added
+   * @param tab the widget to be placed in the associated tab
+   */
+  public void add(Widget child, Widget tab) {
+    insert(child, tab, getWidgetCount());
+  }
+
+  public HandlerRegistration addBeforeSelectionHandler(
+      BeforeSelectionHandler<Integer> handler) {
+    return addHandler(handler, BeforeSelectionEvent.getType());
+  }
+
+  public HandlerRegistration addSelectionHandler(
+      SelectionHandler<Integer> handler) {
+    return addHandler(handler, SelectionEvent.getType());
+  }
+
+  public void animate(int duration) {
+    animate(duration, null);
+  }
+
+  public void animate(int duration, AnimationCallback callback) {
+    deckPanel.animate(duration, callback);
+  }
+
+  public void clear() {
+    Iterator<Widget> it = iterator();
+    while (it.hasNext()) {
+      it.next();
+      it.remove();
+    }
+  }
+
+  public void forceLayout() {
+    deckPanel.forceLayout();
+  }
+
+  /**
+   * Get the duration of the animated transition between tabs.
+   * 
+   * @return the duration in milliseconds
+   */
+  public int getAnimationDuration() {
+    return deckPanel.getAnimationDuration();
+  }
+
+  /**
+   * Gets the index of the currently-selected tab.
+   *
+   * @return the selected index, or <code>-1</code> if none is selected.
+   */
+  public int getSelectedIndex() {
+    return selectedIndex;
+  }
+
+  /**
+   * Gets the widget in the tab at the given index.
+   *
+   * @param index the index of the tab to be retrieved
+   * @return the tab's widget
+   */
+  public Widget getTabWidget(int index) {
+    checkIndex(index);
+    return tabs.get(index).getWidget();
+  }
+
+  /**
+   * Convenience overload to allow {@link IsWidget} to be used directly.
+   */
+  public Widget getTabWidget(IsWidget child) {
+    return getTabWidget(asWidgetOrNull(child));
+  }
+
+  /**
+   * Gets the widget in the tab associated with the given child widget.
+   *
+   * @param child the child whose tab is to be retrieved
+   * @return the tab's widget
+   */
+  public Widget getTabWidget(Widget child) {
+    checkChild(child);
+    return getTabWidget(getWidgetIndex(child));
+  }
+
+  /**
+   * Returns the widget at the given index.
+   */
+  public Widget getWidget(int index) {
+    return deckPanel.getWidget(index);
+  }
+
+  /**
+   * Returns the number of tabs and widgets.
+   */
+  public int getWidgetCount() {
+    return deckPanel.getWidgetCount();
+  }
+
+  /**
+   * Convenience overload to allow {@link IsWidget} to be used directly.
+   */
+  public int getWidgetIndex(IsWidget child) {
+    return getWidgetIndex(asWidgetOrNull(child));
+  }
+
+  /**
+   * Returns the index of the given child, or -1 if it is not a child.
+   */
+  public int getWidgetIndex(Widget child) {
+    return deckPanel.getWidgetIndex(child);
+  }
+
+  /**
+   * Convenience overload to allow {@link IsWidget} to be used directly.
+   */
+  public void insert(IsWidget child, int beforeIndex) {
+    insert(asWidgetOrNull(child), beforeIndex);
+  }
+
+  /**
+   * Convenience overload to allow {@link IsWidget} to be used directly.
+   */
+  public void insert(IsWidget child, IsWidget tab, int beforeIndex) {
+    insert(asWidgetOrNull(child), asWidgetOrNull(tab), beforeIndex);
+  }
+
+  /**
+   * Convenience overload to allow {@link IsWidget} to be used directly.
+   */
+  public void insert(IsWidget child, @IsSafeHtml String text, boolean asHtml, int beforeIndex) {
+    insert(asWidgetOrNull(child), text, asHtml, beforeIndex);
+  }
+
+  /**
+   * Convenience overload to allow {@link IsWidget} to be used directly.
+   */
+  public void insert(IsWidget child, String text, int beforeIndex) {
+    insert(asWidgetOrNull(child), text, beforeIndex);
+  }
+
+  /**
+   * Inserts a widget into the panel. If the Widget is already attached, it will
+   * be moved to the requested index.
+   *
+   * @param child the widget to be added
+   * @param beforeIndex the index before which it will be inserted
+   */
+  public void insert(Widget child, int beforeIndex) {
+    insert(child, "", beforeIndex);
+  }
+
+  /**
+   * Inserts a widget into the panel. If the Widget is already attached, it will
+   * be moved to the requested index.
+   *
+   * @param child the widget to be added
+   * @param html the html to be shown on its tab
+   * @param beforeIndex the index before which it will be inserted
+   */
+  public void insert(Widget child, SafeHtml html, int beforeIndex) {
+    insert(child, html.asString(), true, beforeIndex);
+  }
+
+  /**
+   * Inserts a widget into the panel. If the Widget is already attached, it will
+   * be moved to the requested index.
+   *
+   * @param child the widget to be added
+   * @param text the text to be shown on its tab
+   * @param asHtml <code>true</code> to treat the specified text as HTML
+   * @param beforeIndex the index before which it will be inserted
+   */
+  public void insert(Widget child, @IsSafeHtml String text, boolean asHtml, int beforeIndex) {
+    Widget contents;
+    if (asHtml) {
+      contents = new HTML(text);
+    } else {
+      contents = new Label(text);
+    }
+    insert(child, contents, beforeIndex);
+  }
+
+  /**
+   * Inserts a widget into the panel. If the Widget is already attached, it will
+   * be moved to the requested index.
+   *
+   * @param child the widget to be added
+   * @param text the text to be shown on its tab
+   * @param beforeIndex the index before which it will be inserted
+   */
+  @SuppressIsSafeHtmlCastCheck
+  public void insert(Widget child, String text, int beforeIndex) {
+    insert(child, text, false, beforeIndex);
+  }
+
+  /**
+   * Inserts a widget into the panel. If the Widget is already attached, it will
+   * be moved to the requested index.
+   *
+   * @param child the widget to be added
+   * @param tab the widget to be placed in the associated tab
+   * @param beforeIndex the index before which it will be inserted
+   */
+  public void insert(Widget child, Widget tab, int beforeIndex) {
+    insert(child, new Tab(tab), beforeIndex);
+  }
+
+  /**
+   * Check whether or not transitions slide in vertically or horizontally.
+   * Defaults to horizontally.
+   * 
+   * @return true for vertical transitions, false for horizontal
+   */
+  public boolean isAnimationVertical() {
+    return deckPanel.isAnimationVertical();
+  }
+
+  public Iterator<Widget> iterator() {
+    return deckPanel.iterator();
+  }
+
+  public boolean remove(int index) {
+    if ((index < 0) || (index >= getWidgetCount())) {
+      return false;
+    }
+
+    Widget child = getWidget(index);
+    tabBar.remove(index);
+    deckPanel.removeProtected(child);
+    child.removeStyleName(CONTENT_STYLE);
+
+    Tab tab = tabs.remove(index);
+    tab.getWidget().removeFromParent();
+
+    if (index == selectedIndex) {
+      // If the selected tab is being removed, select the first tab (if there
+      // is one).
+      selectedIndex = -1;
+      if (getWidgetCount() > 0) {
+        selectTab(0);
+      }
+    } else if (index < selectedIndex) {
+      // If the selectedIndex is greater than the one being removed, it needs
+      // to be adjusted.
+      --selectedIndex;
+    }
+    return true;
+  }
+
+  public boolean remove(Widget w) {
+    int index = getWidgetIndex(w);
+    if (index == -1) {
+      return false;
+    }
+
+    return remove(index);
+  }
+
+  /**
+   * Programmatically selects the specified tab and fires events.
+   *
+   * @param index the index of the tab to be selected
+   */
+  public void selectTab(int index) {
+    selectTab(index, true);
+  }
+
+  /**
+   * Programmatically selects the specified tab.
+   *
+   * @param index the index of the tab to be selected
+   * @param fireEvents true to fire events, false not to
+   */
+  public void selectTab(int index, boolean fireEvents) {
+    checkIndex(index);
+    if (index == selectedIndex) {
+      return;
+    }
+
+    // Fire the before selection event, giving the recipients a chance to
+    // cancel the selection.
+    if (fireEvents) {
+      BeforeSelectionEvent<Integer> event = BeforeSelectionEvent.fire(this,
+          index);
+      if ((event != null) && event.isCanceled()) {
+        return;
+      }
+    }
+
+    // Update the tabs being selected and unselected.
+    if (selectedIndex != -1) {
+      tabs.get(selectedIndex).setSelected(false);
+    }
+
+    deckPanel.showWidget(index);
+    tabs.get(index).setSelected(true);
+    selectedIndex = index;
+
+    // Fire the selection event.
+    if (fireEvents) {
+      SelectionEvent.fire(this, index);
+    }
+  }
+
+  /**
+   * Convenience overload to allow {@link IsWidget} to be used directly.
+   */
+  public void selectTab(IsWidget child) {
+    selectTab(asWidgetOrNull(child));
+  }
+
+  /**
+   * Convenience overload to allow {@link IsWidget} to be used directly.
+   */
+  public void selectTab(IsWidget child, boolean fireEvents) {
+    selectTab(asWidgetOrNull(child), fireEvents);
+  }
+
+  /**
+   * Programmatically selects the specified tab and fires events.
+   *
+   * @param child the child whose tab is to be selected
+   */
+  public void selectTab(Widget child) {
+    selectTab(getWidgetIndex(child));
+  }
+
+  /**
+   * Programmatically selects the specified tab.
+   *
+   * @param child the child whose tab is to be selected
+   * @param fireEvents true to fire events, false not to
+   */
+  public void selectTab(Widget child, boolean fireEvents) {
+    selectTab(getWidgetIndex(child), fireEvents);
+  }
+
+  /**
+   * Set the duration of the animated transition between tabs.
+   * 
+   * @param duration the duration in milliseconds.
+   */
+  public void setAnimationDuration(int duration) {
+    deckPanel.setAnimationDuration(duration);
+  }
+
+  /**
+   * Set whether or not transitions slide in vertically or horizontally.
+   * 
+   * @param isVertical true for vertical transitions, false for horizontal
+   */
+  public void setAnimationVertical(boolean isVertical) {
+    deckPanel.setAnimationVertical(isVertical);
+  }
+
+  /**
+   * Sets a tab's HTML contents.
+   *
+   * Use care when setting an object's HTML; it is an easy way to expose
+   * script-based security problems. Consider using
+   * {@link #setTabHTML(int, SafeHtml)} or
+   * {@link #setTabText(int, String)} whenever possible.
+   *
+   * @param index the index of the tab whose HTML is to be set
+   * @param html the tab's new HTML contents
+   */
+  public void setTabHTML(int index, @IsSafeHtml String html) {
+    checkIndex(index);
+    tabs.get(index).setWidget(new HTML(html));
+  }
+
+  /**
+   * Sets a tab's HTML contents.
+   *
+   * @param index the index of the tab whose HTML is to be set
+   * @param html the tab's new HTML contents
+   */
+  public void setTabHTML(int index, SafeHtml html) {
+    setTabHTML(index, html.asString());
+  }
+
+  /**
+   * Sets a tab's text contents.
+   *
+   * @param index the index of the tab whose text is to be set
+   * @param text the object's new text
+   */
+  public void setTabText(int index, String text) {
+    checkIndex(index);
+    tabs.get(index).setWidget(new Label(text));
+  }
+
+  private void checkChild(Widget child) {
+    assert getWidgetIndex(child) >= 0 : "Child is not a part of this panel";
+  }
+
+  private void checkIndex(int index) {
+    assert (index >= 0) && (index < getWidgetCount()) : "Index out of bounds";
+  }
+
+  private void insert(final Widget child, Tab tab, int beforeIndex) {
+    assert (beforeIndex >= 0) && (beforeIndex <= getWidgetCount()) : "beforeIndex out of bounds";
+
+    // Check to see if the TabPanel already contains the Widget. If so,
+    // remove it and see if we need to shift the position to the left.
+    int idx = getWidgetIndex(child);
+    if (idx != -1) {
+      remove(child);
+      if (idx < beforeIndex) {
+        beforeIndex--;
+      }
+    }
+
+    deckPanel.insertProtected(child, beforeIndex);
+    tabs.add(beforeIndex, tab);
+
+    tabBar.insert(tab, beforeIndex);
+    tab.addClickHandler(new ClickHandler() {
+      public void onClick(ClickEvent event) {
+        selectTab(child);
+      }
+    });
+
+    child.addStyleName(CONTENT_STYLE);
+
+    if (selectedIndex == -1) {
+      selectTab(0);
+    } else if (selectedIndex >= beforeIndex) {
+      // If we inserted before the currently selected tab, its index has just
+      // increased.
+      selectedIndex++;
+    }
+  }
+}

--- a/src/gwt/src/com/google/gwt/user/client/ui/TabLayoutPanel.java
+++ b/src/gwt/src/com/google/gwt/user/client/ui/TabLayoutPanel.java
@@ -240,8 +240,9 @@ public class TabLayoutPanel extends ResizeComposite implements HasWidgets,
    *
    * @param barHeight the size of the tab bar
    * @param barUnit the unit in which the tab bar size is specified
+   * @param tabListLabel aria-label for the tablist
    */
-  public TabLayoutPanel(double barHeight, Unit barUnit) {
+  public TabLayoutPanel(double barHeight, Unit barUnit, String tabListLabel) {
     LayoutPanel panel = new LayoutPanel();
     initWidget(panel);
 
@@ -263,6 +264,7 @@ public class TabLayoutPanel extends ResizeComposite implements HasWidgets,
 
     tabBar.setStyleName("gwt-TabLayoutPanelTabs");
     Roles.getTablistRole().set(tabBar.getElement());
+    Roles.getTablistRole().setAriaLabelProperty(tabBar.getElement(), tabListLabel);
     setStyleName("gwt-TabLayoutPanel");
   }
 

--- a/src/gwt/src/com/google/gwt/user/client/ui/TabLayoutPanel.java
+++ b/src/gwt/src/com/google/gwt/user/client/ui/TabLayoutPanel.java
@@ -177,6 +177,10 @@ public class TabLayoutPanel extends ResizeComposite implements HasWidgets,
     protected com.google.gwt.user.client.Element getContainerElement() {
       return inner.cast();
     }
+
+    public void setFocus() {
+      getElement().focus();
+    }
   }
 
   /**
@@ -818,6 +822,7 @@ public class TabLayoutPanel extends ResizeComposite implements HasWidgets,
       return;
     }
     selectTab(selectedIndex + 1);
+    focusCurrentTab();
   }
 
   private void selectPreviousTab() {
@@ -828,17 +833,26 @@ public class TabLayoutPanel extends ResizeComposite implements HasWidgets,
       return;
     }
     selectTab(selectedIndex - 1);
+    focusCurrentTab();
   }
 
   private void selectFirstTab() {
     if (getWidgetCount() == 0)
       return;
     selectTab(0);
+    focusCurrentTab();
   }
 
   private void selectLastTab() {
     if (getWidgetCount() == 0)
       return;
     selectTab(getWidgetCount() - 1);
+    focusCurrentTab();
+  }
+
+  private void focusCurrentTab() {
+    if (selectedIndex == -1)
+      return;
+    tabs.get(selectedIndex).setFocus();
   }
 }

--- a/src/gwt/src/com/google/gwt/user/client/ui/TabLayoutPanel.java
+++ b/src/gwt/src/com/google/gwt/user/client/ui/TabLayoutPanel.java
@@ -23,6 +23,9 @@ import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.dom.client.KeyDownEvent;
+import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.event.logical.shared.BeforeSelectionEvent;
 import com.google.gwt.event.logical.shared.BeforeSelectionHandler;
 import com.google.gwt.event.logical.shared.HasBeforeSelectionHandlers;
@@ -125,6 +128,11 @@ public class TabLayoutPanel extends ResizeComposite implements HasWidgets,
 
     public HandlerRegistration addClickHandler(ClickHandler handler) {
       return addDomHandler(handler, ClickEvent.getType());
+    }
+
+    public HandlerRegistration addKeyDownHandler(KeyDownHandler handler)
+    {
+      return addDomHandler(handler, KeyDownEvent.getType());
     }
 
     @Override
@@ -775,7 +783,22 @@ public class TabLayoutPanel extends ResizeComposite implements HasWidgets,
         selectTab(child);
       }
     });
-
+    tab.addKeyDownHandler(event -> {
+      switch(event.getNativeKeyCode()) {
+        case KeyCodes.KEY_LEFT:
+          selectPreviousTab();
+          break;
+        case KeyCodes.KEY_RIGHT:
+          selectNextTab();
+          break;
+        case KeyCodes.KEY_HOME:
+          selectFirstTab();
+          break;
+        case KeyCodes.KEY_END:
+          selectLastTab();
+          break;
+      }
+    });
     child.addStyleName(CONTENT_STYLE);
 
     if (selectedIndex == -1) {
@@ -785,5 +808,37 @@ public class TabLayoutPanel extends ResizeComposite implements HasWidgets,
       // increased.
       selectedIndex++;
     }
+  }
+
+  private void selectNextTab() {
+    if (selectedIndex == -1)
+      return;
+    if (selectedIndex == getWidgetCount() - 1) {
+      selectFirstTab();
+      return;
+    }
+    selectTab(selectedIndex + 1);
+  }
+
+  private void selectPreviousTab() {
+    if (selectedIndex == -1)
+      return;
+    if (selectedIndex == 0) {
+      selectLastTab();
+      return;
+    }
+    selectTab(selectedIndex - 1);
+  }
+
+  private void selectFirstTab() {
+    if (getWidgetCount() == 0)
+      return;
+    selectTab(0);
+  }
+
+  private void selectLastTab() {
+    if (getWidgetCount() == 0)
+      return;
+    selectTab(getWidgetCount() - 1);
   }
 }

--- a/src/gwt/src/com/google/gwt/user/client/ui/TabLayoutPanel.java.diff
+++ b/src/gwt/src/com/google/gwt/user/client/ui/TabLayoutPanel.java.diff
@@ -1,0 +1,53 @@
+17a18,20
+> import com.google.gwt.aria.client.Id;
+> import com.google.gwt.aria.client.Roles;
+> import com.google.gwt.aria.client.SelectedValue;
+35a39
+> import org.rstudio.core.client.dom.DomUtils;
+107c111
+<     public Tab(Widget child) {
+---
+>     public Tab(Widget child, Widget controls) {
+114c118,122
+< 
+---
+>       Roles.getTabRole().set(getElement());
+>       String controlsId = DomUtils.ensureHasId(controls.getElement());
+>       Roles.getTabRole().setAriaControlsProperty(getElement(), Id.of(controlsId));
+>       Roles.getTabRole().setAriaSelectedState(getElement(), SelectedValue.FALSE);
+>       getElement().setTabIndex(-1);
+143a152,153
+>         Roles.getTabRole().setAriaSelectedState(getElement(), SelectedValue.TRUE);
+>         getElement().setTabIndex(0);
+145a156,157
+>         Roles.getTabRole().setAriaSelectedState(getElement(), SelectedValue.FALSE);
+>         getElement().setTabIndex(-1);
+230a243
+>    * @param tabListLabel aria-label for the tablist
+232c245
+<   public TabLayoutPanel(double barHeight, Unit barUnit) {
+---
+>   public TabLayoutPanel(double barHeight, Unit barUnit, String tabListLabel) {
+252a266,267
+>     Roles.getTablistRole().set(tabBar.getElement());
+>     Roles.getTablistRole().setAriaLabelProperty(tabBar.getElement(), tabListLabel);
+410a426,440
+>    * Set elementId on Tab owning given widget
+>    * @param child
+>    * @param id
+>    */
+>   public void setTabId(Widget child, String id)
+>   {
+>     checkChild(child);
+>     Tab tab = tabs.get(getWidgetIndex(child));
+>     if (tab != null)
+>     {
+>       tab.getElement().setId(id);
+>     }
+>   }
+> 
+>   /**
+530c560
+<     insert(child, new Tab(tab), beforeIndex);
+---
+>     insert(child, new Tab(tab, child), beforeIndex);

--- a/src/gwt/src/com/google/gwt/user/client/ui/TabLayoutPanel.java.diff
+++ b/src/gwt/src/com/google/gwt/user/client/ui/TabLayoutPanel.java.diff
@@ -2,13 +2,17 @@
 > import com.google.gwt.aria.client.Id;
 > import com.google.gwt.aria.client.Roles;
 > import com.google.gwt.aria.client.SelectedValue;
-35a39
+22a26,28
+> import com.google.gwt.event.dom.client.KeyCodes;
+> import com.google.gwt.event.dom.client.KeyDownEvent;
+> import com.google.gwt.event.dom.client.KeyDownHandler;
+35a42
 > import org.rstudio.core.client.dom.DomUtils;
-107c111
+107c114
 <     public Tab(Widget child) {
 ---
 >     public Tab(Widget child, Widget controls) {
-114c118,122
+114c121,125
 < 
 ---
 >       Roles.getTabRole().set(getElement());
@@ -16,22 +20,33 @@
 >       Roles.getTabRole().setAriaControlsProperty(getElement(), Id.of(controlsId));
 >       Roles.getTabRole().setAriaSelectedState(getElement(), SelectedValue.FALSE);
 >       getElement().setTabIndex(-1);
-143a152,153
+121a133,137
+>     public HandlerRegistration addKeyDownHandler(KeyDownHandler handler)
+>     {
+>       return addDomHandler(handler, KeyDownEvent.getType());
+>     }
+> 
+143a160,161
 >         Roles.getTabRole().setAriaSelectedState(getElement(), SelectedValue.TRUE);
 >         getElement().setTabIndex(0);
-145a156,157
+145a164,165
 >         Roles.getTabRole().setAriaSelectedState(getElement(), SelectedValue.FALSE);
 >         getElement().setTabIndex(-1);
-230a243
+159a180,183
+> 
+>     public void setFocus() {
+>       getElement().focus();
+>     }
+230a255
 >    * @param tabListLabel aria-label for the tablist
-232c245
+232c257
 <   public TabLayoutPanel(double barHeight, Unit barUnit) {
 ---
 >   public TabLayoutPanel(double barHeight, Unit barUnit, String tabListLabel) {
-252a266,267
+252a278,279
 >     Roles.getTablistRole().set(tabBar.getElement());
 >     Roles.getTablistRole().setAriaLabelProperty(tabBar.getElement(), tabListLabel);
-410a426,440
+410a438,452
 >    * Set elementId on Tab owning given widget
 >    * @param child
 >    * @param id
@@ -47,7 +62,69 @@
 >   }
 > 
 >   /**
-530c560
+530c572
 <     insert(child, new Tab(tab), beforeIndex);
 ---
 >     insert(child, new Tab(tab, child), beforeIndex);
+748c790,805
+< 
+---
+>     tab.addKeyDownHandler(event -> {
+>       switch(event.getNativeKeyCode()) {
+>         case KeyCodes.KEY_LEFT:
+>           selectPreviousTab();
+>           break;
+>         case KeyCodes.KEY_RIGHT:
+>           selectNextTab();
+>           break;
+>         case KeyCodes.KEY_HOME:
+>           selectFirstTab();
+>           break;
+>         case KeyCodes.KEY_END:
+>           selectLastTab();
+>           break;
+>       }
+>     });
+758a816,857
+> 
+>   private void selectNextTab() {
+>     if (selectedIndex == -1)
+>       return;
+>     if (selectedIndex == getWidgetCount() - 1) {
+>       selectFirstTab();
+>       return;
+>     }
+>     selectTab(selectedIndex + 1);
+>     focusCurrentTab();
+>   }
+> 
+>   private void selectPreviousTab() {
+>     if (selectedIndex == -1)
+>       return;
+>     if (selectedIndex == 0) {
+>       selectLastTab();
+>       return;
+>     }
+>     selectTab(selectedIndex - 1);
+>     focusCurrentTab();
+>   }
+> 
+>   private void selectFirstTab() {
+>     if (getWidgetCount() == 0)
+>       return;
+>     selectTab(0);
+>     focusCurrentTab();
+>   }
+> 
+>   private void selectLastTab() {
+>     if (getWidgetCount() == 0)
+>       return;
+>     selectTab(getWidgetCount() - 1);
+>     focusCurrentTab();
+>   }
+> 
+>   private void focusCurrentTab() {
+>     if (selectedIndex == -1)
+>       return;
+>     tabs.get(selectedIndex).setFocus();
+>   }

--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -101,4 +101,16 @@ public class ElementIds
    public final static String ABOUT_MANAGE_LICENSE_BUTTON = "about_manage_license";
    public final static String TEXT_SOURCE_BUTTON = "text_source";
    public final static String TEXT_SOURCE_BUTTON_DROPDOWN = "text_source_dropdown";
+   
+   public final static String EDIT_EDITING_PREFS = "edit_editing_prefs";
+   public final static String EDIT_DISPLAY_PREFS = "edit_display_prefs";
+   public final static String EDIT_SAVING_PREFS = "edit_saving_prefs";
+   public final static String EDIT_COMPLETION_PREFS = "editing_completion_prefs";
+   public final static String EDIT_DIAGNOSTICS_PREFS = "editing_diagnostics_prefs";
+   
+   public final static String GENERAL_BASIC_PREFS = "general_basic_prefs";
+   public final static String GENERAL_ADVANCED_PREFS = "general_advanced_prefs";
+   
+   public final static String PACKAGE_MANAGEMENT_PREFS = "package_management_prefs";
+   public final static String PACKAGE_DEVELOPMENT_PREFS = "package_development_prefs";
 }

--- a/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBase.java
@@ -51,7 +51,7 @@ public abstract class PreferencesDialogBase<T> extends ModalDialogBase
       PreferencesDialogBaseResources res = 
                                    PreferencesDialogBaseResources.INSTANCE;
       
-      sectionChooser_ = new SectionChooser();
+      sectionChooser_ = new SectionChooser(caption);
       
       ThemedButton okButton = new ThemedButton("OK", new ClickHandler() {
          public void onClick(ClickEvent event) 

--- a/src/gwt/src/org/rstudio/core/client/prefs/SectionChooser.java
+++ b/src/gwt/src/org/rstudio/core/client/prefs/SectionChooser.java
@@ -69,13 +69,14 @@ class SectionChooser extends SimplePanel implements
       }
    }
 
-   public SectionChooser()
+   public SectionChooser(String tabListLabel)
    {
       setStyleName(res_.styles().sectionChooser());
       inner_.setStyleName(res_.styles().sectionChooserInner());
       setWidget(inner_);
       Roles.getTablistRole().set(getElement());
       A11y.setARIATablistOrientation(getElement(), true /*vertical*/);
+      Roles.getTablistRole().setAriaLabelProperty(getElement(), tabListLabel);
    }
 
    /**

--- a/src/gwt/src/org/rstudio/core/client/prefs/SectionChooser.java
+++ b/src/gwt/src/org/rstudio/core/client/prefs/SectionChooser.java
@@ -111,7 +111,6 @@ class SectionChooser extends SimplePanel implements
             case KeyCodes.KEY_UP:
                selectPreviousSection();
                break;
-                  
             case KeyCodes.KEY_DOWN:
                selectNextSection();
                break;

--- a/src/gwt/src/org/rstudio/core/client/prefs/SectionChooser.java
+++ b/src/gwt/src/org/rstudio/core/client/prefs/SectionChooser.java
@@ -153,7 +153,16 @@ class SectionChooser extends SimplePanel implements
 
       SelectionEvent.fire(this, index);
    }
-   
+
+   private void focusCurrent()
+   {
+      if (selectedIndex_ == null)
+         return;
+
+      Widget currentItem = inner_.getWidget(selectedIndex_);
+      currentItem.getElement().focus();
+   }
+
    public void hideSection(Integer index)
    {
       if (index != null)
@@ -174,6 +183,7 @@ class SectionChooser extends SimplePanel implements
          if (inner_.getWidget(i).isVisible())
          {
             select(i);
+            focusCurrent();
             return;
          }
       }
@@ -189,6 +199,7 @@ class SectionChooser extends SimplePanel implements
          if (inner_.getWidget(i).isVisible())
          {
             select(i);
+            focusCurrent();
             return;
          }
       }
@@ -202,6 +213,7 @@ class SectionChooser extends SimplePanel implements
          if (inner_.getWidget(i).isVisible())
          {
             select(i);
+            focusCurrent();
             return;
          }
       }
@@ -214,6 +226,7 @@ class SectionChooser extends SimplePanel implements
          if (inner_.getWidget(i).isVisible())
          {
             select(i);
+            focusCurrent();
             return;
          }
       }

--- a/src/gwt/src/org/rstudio/core/client/resources/styles.css
+++ b/src/gwt/src/org/rstudio/core/client/resources/styles.css
@@ -111,3 +111,7 @@
 .rstudio-StatusIndicator .Message-Error {
    background-color: #FF6347;
 }
+
+.gwt-TabLayoutPanelTab, .gwt-TabLayoutPanelTab-selected {
+   outline: none;
+}

--- a/src/gwt/src/org/rstudio/core/client/theme/DialogTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/DialogTabLayoutPanel.java
@@ -26,9 +26,9 @@ import com.google.gwt.user.client.ui.TabLayoutPanel;
 
 public class DialogTabLayoutPanel extends TabLayoutPanel
 {
-   public DialogTabLayoutPanel()
+   public DialogTabLayoutPanel(String tabListLabel)
    {
-      super(14, Unit.PX);
+      super(14, Unit.PX, tabListLabel);
       
       ThemeStyles styles = ThemeResources.INSTANCE.themeStyles();
       addStyleName(styles.dialogTabPanel());

--- a/src/gwt/src/org/rstudio/core/client/theme/DialogTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/DialogTabLayoutPanel.java
@@ -1,7 +1,7 @@
 /*
  * DialogTabLayoutPanel.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,6 +14,8 @@
  */
 package org.rstudio.core.client.theme;
 
+import com.google.gwt.user.client.ui.Widget;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 
@@ -40,4 +42,9 @@ public class DialogTabLayoutPanel extends TabLayoutPanel
       tabInner.getStyle().clearWidth();
    }
 
+   public void add(Widget child, String text, String tabId)
+   {
+      super.add(child, text);
+      setTabId(child, ElementIds.getElementId(VerticalTabPanel.getTabId(tabId)));
+   }
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
@@ -104,7 +104,7 @@ public class DocTabLayoutPanel
                             int padding,
                             int rightMargin)
    {
-      super(BAR_HEIGHT, Style.Unit.PX);
+      super(BAR_HEIGHT, Style.Unit.PX, "Documents");
       closeableTabs_ = closeableTabs;
       padding_ = padding;
       rightMargin_ = rightMargin;

--- a/src/gwt/src/org/rstudio/core/client/theme/ModuleTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ModuleTabLayoutPanel.java
@@ -146,7 +146,7 @@ public class ModuleTabLayoutPanel extends TabLayoutPanel
 
    public ModuleTabLayoutPanel(final WindowFrame owner)
    {
-      super(BAR_HEIGHT, Style.Unit.PX);
+      super(BAR_HEIGHT, Style.Unit.PX, "Pane");
       owner_ = owner;
       styles_ = ThemeResources.INSTANCE.themeStyles();
       addStyleName(styles_.moduleTabPanel());

--- a/src/gwt/src/org/rstudio/core/client/theme/VerticalTabPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/VerticalTabPanel.java
@@ -1,0 +1,53 @@
+/*
+ * VerticalTabPanel.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.theme;
+
+import com.google.gwt.aria.client.Id;
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import org.rstudio.core.client.ElementIds;
+
+/**
+ * A vertical layout panel marked up as an Aria tab panel.
+ */
+public class VerticalTabPanel extends VerticalPanel
+{
+   public VerticalTabPanel(String basePanelId)
+   {
+      basePanelId_ = basePanelId;
+      Roles.getTabpanelRole().set(getElement());
+      Roles.getTabpanelRole().setAriaLabelledbyProperty(getElement(),
+            Id.of(ElementIds.getElementId(getTabId(basePanelId))));
+      ElementIds.assignElementId(getElement(), getTabPanelId(basePanelId));
+   }
+   
+   public String getBasePanelId()
+   {
+      return basePanelId_;
+   }
+
+   public static String getTabPanelId(String basePanelId)
+   {
+      return basePanelId + "_panel";
+   }
+
+   public static String getTabId(String basePanelId)
+   {
+      return basePanelId + "_tab";
+   }
+   
+   /* ID used to generate both tab and panel ids */
+   private String basePanelId_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateOptionsWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateOptionsWidget.java
@@ -1,7 +1,7 @@
 /*
  * RmdTemplateOptionsWidget.java
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.gwt.dom.client.Style;
 import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.theme.res.ThemeResources;
@@ -67,6 +68,7 @@ public class RmdTemplateOptionsWidget extends Composite
 
    public RmdTemplateOptionsWidget(boolean allowFormatChange)
    {
+      optionsTabs_ = new TabLayoutPanel(30, Style.Unit.PX, "R Markdown Options");
       initWidget(uiBinder.createAndBindUi(this));
       style.ensureInjected();
       allowFormatChange_ = allowFormatChange;
@@ -401,6 +403,6 @@ public class RmdTemplateOptionsWidget extends Composite
    @UiField ListBox listFormats_;
    @UiField Label labelFormatNotes_;
    @UiField Label labelFormatName_;
-   @UiField TabLayoutPanel optionsTabs_;
+   @UiField(provided=true) TabLayoutPanel optionsTabs_;
    @UiField OptionsStyle style;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -28,6 +28,7 @@ import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.inject.Inject;
 
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.VirtualConsole;
 import org.rstudio.core.client.command.KeyboardShortcut;
@@ -35,6 +36,7 @@ import org.rstudio.core.client.command.ShortcutManager;
 import org.rstudio.core.client.prefs.PreferencesDialogBaseResources;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.DialogTabLayoutPanel;
+import org.rstudio.core.client.theme.VerticalTabPanel;
 import org.rstudio.core.client.widget.HelpButton;
 import org.rstudio.core.client.widget.ModifyKeyboardShortcutsWidget;
 import org.rstudio.core.client.widget.NumericValueWidget;
@@ -66,7 +68,7 @@ public class EditingPreferencesPane extends PreferencesPane
       server_ = server;
       PreferencesDialogBaseResources baseRes = PreferencesDialogBaseResources.INSTANCE;
       
-      VerticalPanel editingPanel = new VerticalPanel();
+      VerticalTabPanel editingPanel = new VerticalTabPanel(ElementIds.EDIT_EDITING_PREFS);
       editingPanel.add(headerLabel("General"));
       editingPanel.add(tight(spacesForTab_ = checkboxPref("Insert spaces for tab", prefs.useSpacesForTab(), 
             false /*defaultSpace*/)));
@@ -191,7 +193,7 @@ public class EditingPreferencesPane extends PreferencesPane
       editingPanel.add(panel);
       
       
-      VerticalPanel displayPanel = new VerticalPanel();
+      VerticalTabPanel displayPanel = new VerticalTabPanel(ElementIds.EDIT_DISPLAY_PREFS);
       displayPanel.add(headerLabel("General"));
       displayPanel.add(checkboxPref("Highlight selected word", prefs.highlightSelectedWord()));
       displayPanel.add(checkboxPref("Highlight selected line", prefs.highlightSelectedLine()));
@@ -247,7 +249,7 @@ public class EditingPreferencesPane extends PreferencesPane
             false);
       displayPanel.add(consoleColorMode_);
       
-      VerticalPanel savePanel = new VerticalPanel();
+      VerticalTabPanel savePanel = new VerticalTabPanel(ElementIds.EDIT_SAVING_PREFS);
       
       savePanel.add(headerLabel("General"));
       savePanel.add(checkboxPref("Ensure that source files end with newline", prefs_.autoAppendNewline()));
@@ -302,7 +304,7 @@ public class EditingPreferencesPane extends PreferencesPane
       spaced(encoding_);
       setEncoding(prefs.defaultEncoding().getGlobalValue());
       
-      VerticalPanel completionPanel = new VerticalPanel();
+      VerticalTabPanel completionPanel = new VerticalTabPanel(ElementIds.EDIT_COMPLETION_PREFS);
       
       completionPanel.add(headerLabel("R and C/C++"));
      
@@ -399,7 +401,7 @@ public class EditingPreferencesPane extends PreferencesPane
                       prefs.alwaysCompleteDelayMs())));
         
       
-      VerticalPanel diagnosticsPanel = new VerticalPanel();
+      VerticalTabPanel diagnosticsPanel = new VerticalTabPanel(ElementIds.EDIT_DIAGNOSTICS_PREFS);
       diagnosticsPanel.add(headerLabel("R Diagnostics"));
       final CheckBox chkShowRDiagnostics = checkboxPref("Show diagnostics for R", prefs.showDiagnosticsR());
       diagnosticsPanel.add(chkShowRDiagnostics);
@@ -444,11 +446,11 @@ public class EditingPreferencesPane extends PreferencesPane
       
       DialogTabLayoutPanel tabPanel = new DialogTabLayoutPanel();
       tabPanel.setSize("435px", "498px");
-      tabPanel.add(editingPanel, "Editing");
-      tabPanel.add(displayPanel, "Display");
-      tabPanel.add(savePanel, "Saving");
-      tabPanel.add(completionPanel, "Completion");
-      tabPanel.add(diagnosticsPanel, "Diagnostics");
+      tabPanel.add(editingPanel, "Editing", editingPanel.getBasePanelId());
+      tabPanel.add(displayPanel, "Display", displayPanel.getBasePanelId());
+      tabPanel.add(savePanel, "Saving", savePanel.getBasePanelId());
+      tabPanel.add(completionPanel, "Completion", completionPanel.getBasePanelId());
+      tabPanel.add(diagnosticsPanel, "Diagnostics", diagnosticsPanel.getBasePanelId());
       tabPanel.selectTab(0);
       add(tabPanel);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -444,7 +444,7 @@ public class EditingPreferencesPane extends PreferencesPane
       diagnosticsPanel.add(diagnosticsHelpLink);
       
       
-      DialogTabLayoutPanel tabPanel = new DialogTabLayoutPanel();
+      DialogTabLayoutPanel tabPanel = new DialogTabLayoutPanel("Editing");
       tabPanel.setSize("435px", "498px");
       tabPanel.add(editingPanel, "Editing", editingPanel.getBasePanelId());
       tabPanel.add(displayPanel, "Display", displayPanel.getBasePanelId());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -342,7 +342,7 @@ public class GeneralPreferencesPane extends PreferencesPane
       showLastDotValue_.setEnabled(false);
       restoreLastProject_.setEnabled(false);
 
-      DialogTabLayoutPanel tabPanel = new DialogTabLayoutPanel();
+      DialogTabLayoutPanel tabPanel = new DialogTabLayoutPanel("General");
       tabPanel.setSize("435px", "498px");
       tabPanel.add(basic, "Basic", basic.getBasePanelId());
       tabPanel.add(advanced, "Advanced", advanced.getBasePanelId());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -1,7 +1,7 @@
 /*
  * GeneralPreferencesPane.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,11 +17,13 @@ package org.rstudio.studio.client.workbench.prefs.views;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.files.FileSystemContext;
 import org.rstudio.core.client.prefs.PreferencesDialogBaseResources;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.DialogTabLayoutPanel;
+import org.rstudio.core.client.theme.VerticalTabPanel;
 import org.rstudio.core.client.widget.DirectoryChooserTextBox;
 import org.rstudio.core.client.widget.MessageDialog;
 import org.rstudio.core.client.widget.SelectWidget;
@@ -52,7 +54,6 @@ import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.Label;
-import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.inject.Inject;
 
 public class GeneralPreferencesPane extends PreferencesPane
@@ -76,7 +77,7 @@ public class GeneralPreferencesPane extends PreferencesPane
       quit_ = quit;
       
       RVersionsInfo versionsInfo = context.getRVersionsInfo();
-      VerticalPanel basic = new VerticalPanel();
+      VerticalTabPanel basic = new VerticalTabPanel(ElementIds.GENERAL_BASIC_PREFS);
       
       basic.add(headerLabel("R Sessions"));
       if (BrowseCap.isWindowsDesktop())
@@ -197,7 +198,7 @@ public class GeneralPreferencesPane extends PreferencesPane
          basic.add(enableCrashReporting_);
       }
 
-      VerticalPanel advanced = new VerticalPanel();
+      VerticalTabPanel advanced = new VerticalTabPanel(ElementIds.GENERAL_ADVANCED_PREFS);
 
       showServerHomePage_ = new SelectWidget(
             "Show server home page:",
@@ -343,8 +344,8 @@ public class GeneralPreferencesPane extends PreferencesPane
 
       DialogTabLayoutPanel tabPanel = new DialogTabLayoutPanel();
       tabPanel.setSize("435px", "498px");
-      tabPanel.add(basic, "Basic");
-      tabPanel.add(advanced, "Advanced");
+      tabPanel.add(basic, "Basic", basic.getBasePanelId());
+      tabPanel.add(advanced, "Advanced", advanced.getBasePanelId());
       tabPanel.selectTab(0);
       add(tabPanel);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
@@ -227,7 +227,7 @@ public class PackagesPreferencesPane extends PreferencesPane
       useDevtools_.setEnabled(false);
       useSecurePackageDownload_.setEnabled(false);
 
-      DialogTabLayoutPanel tabPanel = new DialogTabLayoutPanel();
+      DialogTabLayoutPanel tabPanel = new DialogTabLayoutPanel("Packages");
       tabPanel.setSize("435px", "498px");
       tabPanel.add(management, "Management", management.getBasePanelId());
       tabPanel.add(development, "Development", development.getBasePanelId());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
@@ -26,15 +26,16 @@ import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Label;
-import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.inject.Inject;
 
 import java.util.ArrayList;
 
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.DialogTabLayoutPanel;
+import org.rstudio.core.client.theme.VerticalTabPanel;
 import org.rstudio.core.client.widget.InfoBar;
 import org.rstudio.core.client.widget.MessageDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
@@ -70,8 +71,8 @@ public class PackagesPreferencesPane extends PreferencesPane
 
       secondaryReposWidget_ = new SecondaryReposWidget();
 
-      VerticalPanel management = new VerticalPanel();
-      VerticalPanel development = new VerticalPanel();
+      VerticalTabPanel management = new VerticalTabPanel(ElementIds.PACKAGE_MANAGEMENT_PREFS);
+      VerticalTabPanel development = new VerticalTabPanel(ElementIds.PACKAGE_DEVELOPMENT_PREFS);
     
       management.add(headerLabel("Package Management"));
 
@@ -228,8 +229,8 @@ public class PackagesPreferencesPane extends PreferencesPane
 
       DialogTabLayoutPanel tabPanel = new DialogTabLayoutPanel();
       tabPanel.setSize("435px", "498px");
-      tabPanel.add(management, "Management");
-      tabPanel.add(development, "Development");
+      tabPanel.add(management, "Management", management.getBasePanelId());
+      tabPanel.add(development, "Development", development.getBasePanelId());
       tabPanel.selectTab(0);
       add(tabPanel);
    }


### PR DESCRIPTION
This is the tab control as used in some preferences panes, the main UI quadrant tabs, editor tabs, and the "Edit R Markdown Document Options" dialog.

This fully hooks up keyboard and screen-reader/ARIA support for the preference pane instances, and keyboard support (and a subset of the screen-reader/ARIA support) for the other instances.

When focus is placed on the active tab, the left/right arrow keys move between the tabs. Home goes to the first, End goes to the last.

The non-preferences uses will have the remaining ARIA attributes hooked up in a subsequent PR. Even with this PR, it makes the tabs reasonably usable via screen-reader (versus unusable before this change).

Also a fix to the previous work on the Pref dialog section chooser; it wasn't setting focus on new tab when selected via keyboard, and wasn't giving the tablist a label.

The ARIA pattern is documented here: https://www.w3.org/TR/wai-aria-practices/#tabpanel

![2019-07-13_19-22-07](https://user-images.githubusercontent.com/10569626/61178570-6806b380-a5a4-11e9-93e5-0730d42a27f9.png)

![2019-07-13_19-22-28](https://user-images.githubusercontent.com/10569626/61178571-6c32d100-a5a4-11e9-8ceb-4cfbfc5db997.png)

![2019-07-13_19-23-25](https://user-images.githubusercontent.com/10569626/61178572-6f2dc180-a5a4-11e9-9114-b618deffb300.png)

![2019-07-13_19-24-39](https://user-images.githubusercontent.com/10569626/61178579-93899e00-a5a4-11e9-8cf4-ddace123afcb.png)
