### PR TITLE
mark app serialization toast message as role=status

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/serializationprogress/ApplicationSerializationProgressLabel.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/serializationprogress/ApplicationSerializationProgressLabel.java
@@ -1,7 +1,7 @@
 /*
  * ApplicationSerializationProgressLabel.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.application.ui.serializationprogress;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
@@ -31,6 +32,7 @@ public class ApplicationSerializationProgressLabel extends Composite
    public ApplicationSerializationProgressLabel()
    {
       initWidget(binder.createAndBindUi(this));
+      Roles.getStatusRole().set(label_.getElement());
    }
 
    public void setText(String text)

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/serializationprogress/ApplicationSerializationProgressLabel.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/serializationprogress/ApplicationSerializationProgressLabel.ui.xml
@@ -1,5 +1,6 @@
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
-             xmlns:g='urn:import:com.google.gwt.user.client.ui'>
+             xmlns:g='urn:import:com.google.gwt.user.client.ui'
+             xmlns:rw='urn:import:org.rstudio.core.client.widget'>
 
    <ui:with field="res" type="org.rstudio.studio.client.application.ui.serializationprogress.ApplicationSerializationProgress.Resources"/>
 
@@ -9,7 +10,7 @@
             <td class="{res.styles.left}"></td>
             <td class="{res.styles.center}" valign="top" nowrap="nowrap">
                <nobr>
-                  <g:Image resource="{res.spinnerManilla}" styleName="{res.styles.spinner}"/>
+                  <rw:DecorativeImage resource="{res.spinnerManilla}" styleName="{res.styles.spinner}"/>
                   <g:Label ui:field="label_" styleName="{res.styles.label}" wordWrap="false"/>
                </nobr>
             </td>


### PR DESCRIPTION
Various session actions trigger a toast message; mark it as role=status so it is read by screen readers.

"Loading workspace"
"Saving workspace image"
"Backup up R session..."
"Resuming R session..."

![2019-07-17_09-13-26](https://user-images.githubusercontent.com/10569626/61394125-4bee6500-a877-11e9-9aab-b063becc2502.png)
