### PR TITLE
Use string-based terminal shell type

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -1223,19 +1223,20 @@ void GwtCallback::openTerminal(QString terminalPath,
    if (terminalPath.length() == 0)
    {
       terminalPath = QString::fromUtf8("cmd.exe");
-      shellType = "win-cmd";
+      shellType = QString::fromUtf8("win-cmd");
    }
 
    QStringList args;
    std::string previousHome = core::system::getenv("HOME");
 
-   if (shellType == "win-git-bash" || shellType == "win-wsl-bash")
+   if (shellType == QString::fromUtf8("win-git-bash") ||
+       shellType == QString::fromUtf8("win-wsl-bash"))
    {
       args.append(QString::fromUtf8("--login"));
       args.append(QString::fromUtf8("-i"));
    }
 
-   if (shellType != "win-wsl-bash")
+   if (shellType != QString::fromUtf8("win-wsl-bash"))
    {
       // set HOME to USERPROFILE so msys ssh can find our keys
       std::string userProfile = core::system::getenv("USERPROFILE");

--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -1196,7 +1196,7 @@ void GwtCallback::openSessionInNewWindow(QString workingDirectoryPath)
 void GwtCallback::openTerminal(QString terminalPath,
                                QString workingDirectory,
                                QString extraPathEntries,
-                               int shellType)
+                               QString shellType)
 {
    // append extra path entries to our path before launching
    std::string path = core::system::getenv("PATH");
@@ -1220,31 +1220,22 @@ void GwtCallback::openTerminal(QString terminalPath,
 
 #elif defined(Q_OS_WIN)
 
-   // keep these shell type constants consistent with SessionTerminalShell.hpp
-   const int GitBash = 1; // Win32: Bash from Windows Git
-   const int WSLBash = 2; // Win32: Windows Services for Linux
-   const int Cmd32 = 3; // Win32: Windows command shell (32-bit)
-   const int Cmd64 = 4; // Win32: Windows command shell (64-bit)
-   const int PS32 = 5; // Win32: PowerShell (32-bit)
-   const int PS64 = 6; // Win32: PowerShell (64-bit)
-   const int PSCore = 10; // Win32: PowerShell Core (v6)
-
    if (terminalPath.length() == 0)
    {
       terminalPath = QString::fromUtf8("cmd.exe");
-      shellType = Cmd32;
+      shellType = "win-cmd";
    }
 
    QStringList args;
    std::string previousHome = core::system::getenv("HOME");
 
-   if (shellType == GitBash || shellType == WSLBash)
+   if (shellType == "win-git-bash" || shellType == "win-wsl-bash")
    {
       args.append(QString::fromUtf8("--login"));
       args.append(QString::fromUtf8("-i"));
    }
 
-   if (shellType != WSLBash)
+   if (shellType != "win-wsl-bash")
    {
       // set HOME to USERPROFILE so msys ssh can find our keys
       std::string userProfile = core::system::getenv("USERPROFILE");

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -180,7 +180,7 @@ public Q_SLOTS:
    void openTerminal(QString terminalPath,
                      QString workingDirectory,
                      QString extraPathEntries,
-                     int shellType);
+                     QString shellType);
 
    QString getFixedWidthFontList();
    QString getFixedWidthFont();

--- a/src/cpp/session/SessionConsoleProcessInfo.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfo.cpp
@@ -207,7 +207,7 @@ core::json::Object ConsoleProcessInfo::toJson(SerializationMode serialMode) cons
    result["allow_restart"] = allowRestart_;
    result["title"] = title_;
    result["child_procs"] = childProcs_;
-   result["shell_type"] = static_cast<int>(shellType_);
+   result["shell_type"] = TerminalShell::getShellId(shellType_); 
    result["channel_mode"] = static_cast<int>(channelMode_);
    result["channel_id"] = channelId_;
    result["alt_buffer"] = altBufferActive_;
@@ -293,11 +293,11 @@ boost::shared_ptr<ConsoleProcessInfo> ConsoleProcessInfo::fromJson(const core::j
    if (error)
       LOG_ERROR(error);
 
-   int shellTypeInt = 0;
-   error = json::getOptionalParam(obj, "shell_type", 0, &shellTypeInt);
+   std::string shellType;
+   error = json::getOptionalParam(obj, "shell_type", std::string("default"), &shellType);
    if (error)
       LOG_ERROR(error);
-   pProc->shellType_ = static_cast<TerminalShell::ShellType>(shellTypeInt);
+   pProc->shellType_ = TerminalShell::shellTypeFromString(shellType);
 
    int channelModeInt = 0;
    error = json::getOptionalParam(obj, "channel_mode", 0, &channelModeInt);

--- a/src/cpp/session/SessionConsoleProcessPersist.cpp
+++ b/src/cpp/session/SessionConsoleProcessPersist.cpp
@@ -51,7 +51,10 @@ namespace console_persist {
 //                Added autoClose, zombie
 // 2017/06/16 - console05 -> console06
 //                Added trackEnv
-#define kConsoleDir "console06"
+// 2019/07/30 - console06 -> console07
+//                Changed shell type from int to string to align with user
+//                preferences
+#define kConsoleDir "console07"
 
 namespace {
 

--- a/src/cpp/session/modules/SessionTerminal.cpp
+++ b/src/cpp/session/modules/SessionTerminal.cpp
@@ -84,7 +84,7 @@ Error getTerminalOptions(const json::JsonRpcRequest& request,
    optionsJson["working_directory"] =
                   module_context::shellWorkingDirectory().absolutePath();
    optionsJson["extra_path_entries"] = extraPathEntries;
-   optionsJson["shell_type"] = console_process::TerminalShell::getShellName(shellType);
+   optionsJson["shell_type"] = console_process::TerminalShell::getShellId(shellType);
    pResponse->setResult(optionsJson);
 
    return Success();

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -150,7 +150,7 @@ public interface DesktopFrame extends JavaScriptPassthrough
    void openTerminal(String terminalPath,
                      String workingDirectory,
                      String extraPathEntries,
-                     int shellType);
+                     String shellType);
 
    void setFixedWidthFont(String font);
    void setZoomLevel(double zoomLevel);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/TerminalOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/TerminalOptions.java
@@ -1,7 +1,7 @@
 /*
  * TerminalOptions.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -32,7 +32,7 @@ public class TerminalOptions extends JavaScriptObject
       return this.extra_path_entries;
    }-*/;
 
-   public native final int getShellType() /*-{
+   public native final String getShellType() /*-{
       return this.shell_type;
    }-*/;
 }


### PR DESCRIPTION
Change #5069 introduced human-readable identifiers for terminal shell types, and removed knowledge of the enum from most parts of the UI. However, there were still a couple of places where the string is supplied but the enum is expected. This change covers those remaining cases.

Note that since one of them is persistent, it also bumps the version of the console persistent storage folder. 

Fixes https://github.com/rstudio/rstudio/issues/5157.