### PR TITLE
Fixes a bug where json::Object and json::Array iterators only take position into account during comparisons. 

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -209,6 +209,8 @@ list(APPEND BOOST_LIBS
    thread
 )
 
+# tell cmake not to look for boost on system paths.
+set(Boost_NO_SYSTEM_PATHS ON)
 # UNIX BOOST
 if(UNIX)
    # prefer static link to our custom built version
@@ -219,7 +221,7 @@ if(UNIX)
       # find headers
       set(Boost_USE_STATIC_LIBS ON)
       set(BOOST_INCLUDEDIR  ${RSTUDIO_TOOLS_BOOST}/include)
-      find_package(Boost ${RSTUDIO_BOOST_REQUESTED_VERSION} REQUIRED)
+      find_package(Boost ${RSTUDIO_BOOST_REQUESTED_VERSION} EXACT REQUIRED)
       if(NOT Boost_VERSION LESS 106900)
          list(REMOVE_ITEM BOOST_LIBS signals)
       endif()
@@ -256,7 +258,7 @@ else()
       set(BOOST_ROOT "${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/boost-1.69.0-win-msvc141-debug-static/boost${BOOST_ARCH}")
    endif()
    set(BOOST_INCLUDEDIR "${BOOST_ROOT}/include/boost-1_69_0")
-   find_package(Boost ${RSTUDIO_BOOST_REQUESTED_VERSION} REQUIRED)
+   find_package(Boost ${RSTUDIO_BOOST_REQUESTED_VERSION} EXACT REQUIRED)
    set(BOOST_LIBRARYDIR "${BOOST_ROOT}/lib")
    foreach(BOOST_LIB ${BOOST_LIBS})
       list(APPEND Boost_LIBRARIES "${BOOST_LIBRARYDIR}/librstudio_boost_${BOOST_LIB}-${BOOST_SUFFIX}")

--- a/src/cpp/core/include/core/json/Json.hpp
+++ b/src/cpp/core/include/core/json/Json.hpp
@@ -486,7 +486,7 @@ public:
 
       bool operator==(iterator other) const
       {
-         return num_ == other.num_;
+         return (parent_ == other.parent_) && (num_ == other.num_);
       }
 
       bool operator!=(iterator other) const
@@ -652,7 +652,7 @@ public:
 
       bool operator==(iterator other) const
       {
-         return num_ == other.num_;
+         return (parent_ == other.parent_) && (num_ == other.num_);
       }
 
       bool operator!=(iterator other) const

--- a/src/cpp/core/json/JsonTests.cpp
+++ b/src/cpp/core/json/JsonTests.cpp
@@ -624,7 +624,7 @@ TEST_CASE("Json")
       REQUIRE(innerC == 3);
    }
 
-   SECTION("Can modify object members via interator")
+   SECTION("Can modify object members via iterator")
    {
       json::Object obj = createObject();
       auto iter = obj.find("c");

--- a/src/cpp/core/json/JsonTests.cpp
+++ b/src/cpp/core/json/JsonTests.cpp
@@ -953,11 +953,11 @@ TEST_CASE("Json")
       REQUIRE(itr1 != obj1.end());     // An itr isn't at the end until it's after the last element.
       REQUIRE(++itr1 == obj1.end());   // Both at the end.
 
-      // Comparing iterators pointing to different objects. They should never be equal, except maybe at the end, but that
-      // doesn't matter too much since iterators really should be compared against the appropriate "end()" result.
+      // Comparing iterators pointing to different objects. They should never be equal.
       itr1 = obj1.begin(), itr2 = obj2.begin();
       REQUIRE(itr1 != itr2);
       REQUIRE(++itr1 != ++itr2);
+      REQUIRE(obj1.end() != obj2.end());
    }
 
    SECTION("Can compare array iterators")
@@ -980,11 +980,11 @@ TEST_CASE("Json")
       REQUIRE(itr1 != arr1.end());     // An itr isn't at the end until it's after the last element.
       REQUIRE(++itr1 == arr1.end());   // Both at the end.
 
-      // Comparing iterators pointing to different objects. They should never be equal, except maybe at the end, but that
-      // doesn't matter too much since iterators really should be compared against the appropriate "end()" result.
+      // Comparing iterators pointing to different objects. They should never be equal.
       itr1 = arr1.begin(), itr2 = arr2.begin();
       REQUIRE(itr1 != itr2);
       REQUIRE(++itr1 != ++itr2);
+      REQUIRE(arr1.end() != arr2.end());
    }
 }
 

--- a/src/cpp/core/json/JsonTests.cpp
+++ b/src/cpp/core/json/JsonTests.cpp
@@ -901,6 +901,64 @@ TEST_CASE("Json")
       REQUIRE(result["first"] == true);   // non-default value
       REQUIRE(result["second"] == "b");   // default value
    }
+
+   SECTION("Can iterate object")
+   {
+      json::Object obj;
+      obj["first"] = 1;
+      obj["second"] = 2;
+      obj["third"] = 3;
+
+      int i = 0;
+      for (auto itr = obj.begin(); itr != obj.end(); ++itr, ++i)
+      {
+         if (i == 0)
+         {
+            REQUIRE((*itr).name() == "first");
+            REQUIRE((*itr).value().get_int() == 1);
+         }
+         else if (i == 1)
+         {
+            REQUIRE((*itr).name() == "second");
+            REQUIRE((*itr).value().get_int() == 2);
+         }
+         else
+         {
+            REQUIRE((*itr).name() == "third");
+            REQUIRE((*itr).value().get_int() == 3);
+         }
+      }
+
+      // Check that we iterated the correct number of times.
+      REQUIRE(i == 3);
+   }
+
+   SECTION("Can compare object iterators")
+   {
+      json::Object obj1, obj2;
+      obj1["first"] = 1;
+      obj1["second"] = 2;
+      obj1["third"] = 3;
+
+      obj2["first"] = 1;
+      obj2["second"] = 2;
+      obj2["third"] = 3;
+
+      // Comparing iterators pointing to the same object.
+      auto itr1 = obj1.begin(), itr2 = obj1.begin();
+      REQUIRE(itr1 == itr2);           // Both at the start.
+      REQUIRE(++itr1 == ++itr2);       // Both at the second element.
+      REQUIRE(itr1 != obj1.begin());   // An itr at the second element is not the same as an itr at the start.
+      REQUIRE(++itr1 != itr2);         // itr1 at the 3rd element, itr2 at the 2nd element.
+      REQUIRE(itr1 != obj1.end());     // An itr isn't at the end until it's after the last element.
+      REQUIRE(++itr1 == obj1.end());   // Both at the end.
+
+      // Comparing iterators pointing to different objects. They should never be equal, except maybe at the end, but that
+      // doesn't matter too much since iterators really should be compared against the appropriate "end()" result.
+      itr1 = obj1.begin(), itr2 = obj2.begin();
+      REQUIRE(itr1 != itr2);
+      REQUIRE(++itr1 != ++itr2);
+   }
 }
 
 } // end namespace tests

--- a/src/cpp/core/json/JsonTests.cpp
+++ b/src/cpp/core/json/JsonTests.cpp
@@ -959,6 +959,33 @@ TEST_CASE("Json")
       REQUIRE(itr1 != itr2);
       REQUIRE(++itr1 != ++itr2);
    }
+
+   SECTION("Can compare array iterators")
+   {
+      json::Array arr1, arr2;
+      arr1.push_back("first");
+      arr1.push_back("second");
+      arr1.push_back("third");
+
+      arr2.push_back("first");
+      arr2.push_back("second");
+      arr2.push_back("third");
+
+      // Comparing iterators pointing to the same object.
+      auto itr1 = arr1.begin(), itr2 = arr1.begin();
+      REQUIRE(itr1 == itr2);           // Both at the start.
+      REQUIRE(++itr1 == ++itr2);       // Both at the second element.
+      REQUIRE(itr1 != arr1.begin());   // An itr at the second element is not the same as an itr at the start.
+      REQUIRE(++itr1 != itr2);         // itr1 at the 3rd element, itr2 at the 2nd element.
+      REQUIRE(itr1 != arr1.end());     // An itr isn't at the end until it's after the last element.
+      REQUIRE(++itr1 == arr1.end());   // Both at the end.
+
+      // Comparing iterators pointing to different objects. They should never be equal, except maybe at the end, but that
+      // doesn't matter too much since iterators really should be compared against the appropriate "end()" result.
+      itr1 = arr1.begin(), itr2 = arr2.begin();
+      REQUIRE(itr1 != itr2);
+      REQUIRE(++itr1 != ++itr2);
+   }
 }
 
 } // end namespace tests


### PR DESCRIPTION
Also try to prevent CMake from using non-RStudio installations of boost.