### PR TITLE
Perform noninteractive signature on Fedora

### DIFF
--- a/docker/jenkins/Dockerfile.fedora28-x86_64
+++ b/docker/jenkins/Dockerfile.fedora28-x86_64
@@ -6,7 +6,6 @@ RUN yum install -y \
     bzip2-devel \
     clang-devel \
     curl \
-    expect \
     fakeroot \
     fuse-libs \
     gcc \
@@ -32,7 +31,6 @@ RUN yum install -y \
     pam-devel \
     pango-devel \
     patchelf \
-    pinentry \
     postgresql-devel \
     procps \
     python \


### PR DESCRIPTION
On RedHat, we currently supply a passphrase for the build signature using `expect` (since the passphrase prompt happens in a plain tty). This does not work on more recent versions of Fedora (since 25), so this change introduces a new mechanism for supplying the passphrase there.

Of course, this new mechanism does not work on CentOS, so we have to keep both. :-) 

Fixes https://github.com/rstudio/rstudio/issues/5169 (again).