### PR TITLE
contrast tweaks, live region for warning bar

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -740,7 +740,7 @@ pre {
 }
 
 .mainMenu .gwt-MenuItem-selected, .mainMenu .subMenuIcon-selected {
-   background-color: #79B7F1;
+   background-color: #1E77BC;
    color: white;
    height: 3px;
 }
@@ -1447,7 +1447,7 @@ body.windows .toolbar {
 }
 
 .toolbarButtonInfoLabel {
-   color: #82868C;
+   color: #636363;
 }
 
 .toolbarButtonLatchable {

--- a/src/gwt/src/org/rstudio/core/client/widget/InfoBar.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/InfoBar.java
@@ -75,6 +75,7 @@ public class InfoBar extends Composite
       
       Roles.getAlertRole().setAriaLiveProperty(live_.getElement(), 
             mode == ERROR ? LiveValue.ASSERTIVE : LiveValue.POLITE);
+      Roles.getAlertRole().setAriaAtomicProperty(live_.getElement(), true);
       dismiss_.addStyleName(ThemeResources.INSTANCE.themeStyles().handCursor());
       
       if (dismissHandler != null)

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.java
@@ -1,7 +1,7 @@
 /*
  * WarningBar.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,6 +14,10 @@
  */
 package org.rstudio.studio.client.application.ui;
 
+import com.google.gwt.aria.client.LiveValue;
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.dom.client.DivElement;
+import com.google.gwt.user.client.Timer;
 import org.rstudio.core.client.theme.res.ThemeResources;
 
 import com.google.gwt.core.client.GWT;
@@ -77,13 +81,26 @@ public class WarningBar extends Composite
       moreButton_.setVisible(false);
       moreButton_.setText("Manage License...");
       moreButton_.addClickHandler(event -> Desktop.getFrame().showLicenseDialog());
+      Roles.getAlertRole().setAriaLiveProperty(live_, LiveValue.ASSERTIVE);
+      Roles.getAlertRole().setAriaAtomicProperty(live_, true);
    }
 
    public void setText(String value)
    {
       label_.setInnerText(value);
+
+      // Give screen reader time to process page to improve chance it will notice the live region
+      Timer liveTimer = new Timer()
+      {
+         @Override
+         public void run()
+         {
+            live_.setInnerText(value);
+         }
+      };
+      liveTimer.schedule(1500);
    }
-   
+
    public void showLicenseButton(boolean show)
    {
       // never show the license button in server mode
@@ -117,6 +134,8 @@ public class WarningBar extends Composite
 
    @UiField
    SpanElement label_;
+   @UiField
+   DivElement live_;
    @UiField
    Button moreButton_;
    @UiField

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.ui.xml
@@ -1,20 +1,22 @@
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
-             xmlns:g='urn:import:com.google.gwt.user.client.ui'>
+             xmlns:g='urn:import:com.google.gwt.user.client.ui'
+             xmlns:rw='urn:import:org.rstudio.core.client.widget'>
 
    <ui:with field="res" type="org.rstudio.studio.client.application.ui.WarningBar.Resources"/>
    <ui:with field="themeRes" type="org.rstudio.core.client.theme.res.ThemeResources"/>
 
    <g:HTMLPanel>
-   <table class="{res.styles.warningBar}"
+   <table class="{res.styles.warningBar}" role="presentation"
           cellpadding="0" cellspacing="0" border="0" width="100%">
       <tr>
          <td class="{res.styles.left}"></td>
          <td class="{res.styles.center}" valign="top">
-            <g:Image resource="{res.warningIconSmall2x}"
+            <rw:DecorativeImage resource="{res.warningIconSmall2x}"
                      width="21"
                      height="17"
                      styleName="{res.styles.warningIcon}"/>
             <span ui:field="label_" class="{res.styles.label}"/>
+            <div ui:field="live_" class="{themeRes.themeStyles.visuallyHidden}"/>
             <g:Button ui:field="moreButton_"/>
          </td>
          <td class="{res.styles.center}" align="right">


### PR DESCRIPTION
WCAG 2.1 AA contrast fixes:
- Selected main menu (server) 
- Session count (pro)

Warning Bar (shown at bottom of IDE):
These warning bars are often shown as the IDE is first loading, during which time the accessibility tree is going through massive updates and giving assistive tech a mild nervous breakdown, so pause before updating the hidden live region, at which point it will be read.

Also marked the warning icon as decorative, and the hidden region in both warning bar and the info bar as atomic (so the entire message is always read). Example screenshot from a Pro-only scenario.

![2019-08-05_10-42-29](https://user-images.githubusercontent.com/10569626/62500050-bff69b80-b799-11e9-8640-1af4f17dcb48.png)

![2019-08-05_10-43-36](https://user-images.githubusercontent.com/10569626/62500059-c553e600-b799-11e9-800b-fe5074c9b65c.png)

![2019-08-05_10-31-43](https://user-images.githubusercontent.com/10569626/62500064-ca189a00-b799-11e9-843c-60c710d1f9f2.png)
