### PR TITLE
Accept `/.Rproj.user` in .gitignore

### DIFF
--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -3022,7 +3022,7 @@ Error augmentGitIgnore(const FilePath& gitIgnoreFile)
 
       std::vector<std::string> filesToIgnore;
 
-      if (!regex_utils::search(strIgnore, boost::regex(R"(^\.Rproj\.user/?$)")))
+      if (!regex_utils::search(strIgnore, boost::regex(R"(^/?\.Rproj\.user/?$)")))
          filesToIgnore.push_back(".Rproj.user");
 
       if (session::options().packageOutputInPackageFolder())


### PR DESCRIPTION
If the user is specific in their .gitignore file and uses repo-absolute paths, they’ll add `/.Rproj.user` instead of `.Rproj.user`.

RStudio shouldn’t try to add the latter if the former exists.