### PR TITLE
wrap "Default Output Format" radio buttons in New R Markdown dialog in fieldset

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/FieldSetPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FieldSetPanel.java
@@ -30,13 +30,23 @@ public class FieldSetPanel extends SimplePanel implements HasOneWidget
    {
       super(DOM.createFieldSet());
 
-      Element legendElement;
-      getElement().appendChild(legendElement = DOM.createLegend());
-      legendElement.setInnerText(legend);
+      getElement().appendChild(legendElement_ = DOM.createLegend());
+      legendElement_.setInnerText(legend);
 
       if (visuallyHideLegend)
       {
-         legendElement.setClassName(ThemeStyles.INSTANCE.visuallyHidden());
+         legendElement_.setClassName(ThemeStyles.INSTANCE.visuallyHidden());
       }
    }
+
+   public FieldSetPanel()
+   {
+      this("", false);
+   }
+
+   public void setLegend(String legend)
+   {
+      legendElement_.setInnerText(legend);
+   }
+   private Element legendElement_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.java
@@ -24,6 +24,7 @@ import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.core.client.widget.FieldSetPanel;
 import org.rstudio.core.client.widget.FormLabel;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
@@ -392,8 +393,7 @@ public class NewRMarkdownDialog extends ModalDialog<NewRMarkdownDialog.Result>
       else 
       {
          
-         currentTemplate_ = RmdTemplate.getTemplate(templates_,
-                                                    selectedTemplate);
+         currentTemplate_ = RmdTemplate.getTemplate(templates_, selectedTemplate);
          if (currentTemplate_ == null)
             return;
          
@@ -470,12 +470,12 @@ public class NewRMarkdownDialog extends ModalDialog<NewRMarkdownDialog.Result>
    @UiField WidgetListBox<TemplateMenuItem> listTemplates_;
    @UiField NewRmdStyle style;
    @UiField Resources resources;
+   @UiField FieldSetPanel formatFieldSet_;
    @UiField HTMLPanel templateFormatPanel_;
    @UiField HTMLPanel newTemplatePanel_;
    @UiField HTMLPanel existingTemplatePanel_;
    @UiField(provided=true) RmdTemplateChooser templateChooser_;
    @UiField HTMLPanel shinyInfoPanel_;
-   @UiField Label outputFormatLabel_;
 
    private final Widget mainWidget_;
    private List<RadioButton> formatOptions_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.ui.xml
@@ -52,11 +52,22 @@
      margin-right: 20px;
    }
    
-   .defaultOutputLabel
+   .defaultOutputLabel legend
    {
      font-weight: bold;
+     padding: 0;
      margin-bottom: 7px;
-     margin-top: 14px;
+   }
+   
+   fieldset.defaultOutputLabel
+   {
+      border: none;
+      padding: 0;
+      padding-block-end: 0;
+      padding-inline-end: 0;
+      margin-top: 14px;
+      margin-right: 0;
+      margin-left: 0;
    }
    
    .outputFormatChoice
@@ -97,7 +108,7 @@
    
    .shinyInfoHeader
    {
-     margin-top: 25px;
+     margin-top: 15px;
      margin-bottom: 7px;
    }
    
@@ -136,10 +147,10 @@
                            ui:field="txtAuthor_"></g:TextBox></g:customCell>
               </g:row>
            </g:Grid>
-           <g:Label styleName="{style.defaultOutputLabel}" 
-                    text="Default Output Format:"
-                    ui:field="outputFormatLabel_"></g:Label>
-           <g:HTMLPanel ui:field="templateFormatPanel_"></g:HTMLPanel>
+           <rw:FieldSetPanel ui:field="formatFieldSet_" legend="Default Output Format:" 
+                             styleName="{style.defaultOutputLabel}">
+              <g:HTMLPanel ui:field="templateFormatPanel_"></g:HTMLPanel>
+           </rw:FieldSetPanel>
         </g:HTMLPanel>
         <g:HTMLPanel ui:field="existingTemplatePanel_">
           <rmd:RmdTemplateChooser ui:field="templateChooser_">


### PR DESCRIPTION
For accessibility, radio buttons need to be in a fieldset, ideally with a legend as the label (or, if necessary, use ARIA role=radiogroup and then implement keyboard support). In this dialog, was easy to wrap in a `FieldSetPanel`, and use styling to get the original visual appearance.

![2019-08-07_11-47-01](https://user-images.githubusercontent.com/10569626/62658894-ba768e00-b91e-11e9-9510-1457112bc11a.png)

![2019-08-07_11-47-25](https://user-images.githubusercontent.com/10569626/62658898-be0a1500-b91e-11e9-84c7-03524f1be2b0.png)

![2019-08-07_11-47-52](https://user-images.githubusercontent.com/10569626/62658902-c19d9c00-b91e-11e9-81de-b3eb5b5c413f.png)
