### PR TITLE
accessibility fixes for radio buttons in a couple more dialogs

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
+++ b/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
@@ -91,4 +91,13 @@ public class A11y
    {
       setARIACurrent(widget.getElement(), value);
    }
+
+   /**
+    * Make a widget hidden to screen readers.
+    * @param widget
+    */
+   public static void setARIAHidden(Widget widget)
+   {
+      widget.getElement().setAttribute("aria-hidden", "true");
+   }
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/FieldSetPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FieldSetPanel.java
@@ -38,6 +38,11 @@ public class FieldSetPanel extends SimplePanel implements HasOneWidget
          legendElement_.setClassName(ThemeStyles.INSTANCE.visuallyHidden());
       }
    }
+   
+   public FieldSetPanel(String legend)
+   {
+      this(legend, false);
+   }
 
    public FieldSetPanel()
    {

--- a/src/gwt/src/org/rstudio/core/client/widget/FieldSetPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FieldSetPanel.java
@@ -18,7 +18,9 @@ package org.rstudio.core.client.widget;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.HasOneWidget;
+import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.SimplePanel;
+import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 
 /**
@@ -49,6 +51,18 @@ public class FieldSetPanel extends SimplePanel implements HasOneWidget
       this("", false);
    }
 
+
+   /**
+    * @param externalLabel existing visual label for the radio buttons; text of that label
+    *                      will be applied to a hidden legend element for accessibility, and
+    *                      the label itself will be marked aria-hidden
+    */
+   public FieldSetPanel(Label externalLabel)
+   {
+      this(externalLabel.getText(), true);
+      A11y.setARIAHidden(externalLabel);
+   }
+   
    public void setLegend(String legend)
    {
       legendElement_.setInnerText(legend);

--- a/src/gwt/src/org/rstudio/core/client/widget/HorizontalRadioPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/HorizontalRadioPanel.java
@@ -17,7 +17,6 @@ package org.rstudio.core.client.widget;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.RadioButton;
-import org.rstudio.core.client.a11y.A11y;
 
 /**
  * A HorizontalPanel containing a group of radio buttons and a legend.
@@ -37,8 +36,8 @@ public class HorizontalRadioPanel extends FieldSetPanel
     */
    public HorizontalRadioPanel(Label externalLabel)
    {
-      this(externalLabel.getText(), true);
-      A11y.setARIAHidden(externalLabel);
+      super(externalLabel);
+      super.add(panel_ = new HorizontalPanel());
    }
 
    public void add(RadioButton w)

--- a/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.css
@@ -92,6 +92,13 @@
 	box-shadow: 0 0 4px #8BF;
 }
 
+fieldset.showChoice {
+   float: left;
+   border: none;
+   padding: 0;
+   margin: 0;
+}
+
 .rstudio-themes-flat .dataGridWidget {
 	background: #FFF;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
@@ -66,6 +66,7 @@ import org.rstudio.core.client.Pair;
 import org.rstudio.core.client.SerializedCommand;
 import org.rstudio.core.client.SerializedCommandQueue;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.command.*;
 import org.rstudio.core.client.command.EditorCommandManager.EditorKeyBinding;
 import org.rstudio.core.client.command.EditorCommandManager.EditorKeyBindings;
@@ -981,10 +982,22 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
       Label radioLabel = new Label("Show:");
       radioLabel.getElement().getStyle().setFloat(Style.Float.LEFT);
       radioLabel.getElement().getStyle().setMarginRight(8, Unit.PX);
+
+      // The fieldset wrapping the radio buttons has a visually hidden legend which
+      // will be "seen" by screen readers, so hide this label to avoid duplication.
+      // Attempts to style the legend to match the current single-line visual layout
+      // proved too frail (browser-specific quirks).
+      A11y.setARIAHidden(radioLabel);
+
       headerPanel.add(radioLabel);
-      headerPanel.add(radioAll_);
+      FieldSetPanel showFieldsetPanel = new FieldSetPanel("Show:", true);
+      showFieldsetPanel.setStyleName(RES.dataGridStyle().showChoice());
+      FlowPanel radioPanel = new FlowPanel();
+      showFieldsetPanel.add(radioPanel);
+      headerPanel.add(showFieldsetPanel);
+      radioPanel.add(radioAll_);
       radioAll_.setValue(true);
-      headerPanel.add(radioCustomized_);
+      radioPanel.add(radioCustomized_);
       
       filterWidget_.getElement().getStyle().setFloat(Style.Float.LEFT);
       filterWidget_.getElement().getStyle().setMarginLeft(10, Unit.PX);
@@ -1474,6 +1487,7 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
       String conflictRow();
       String shortcutInput();
       String icon();
+      String showChoice();
    }
    
    private static final Resources RES = GWT.create(Resources.class);

--- a/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
@@ -66,7 +66,6 @@ import org.rstudio.core.client.Pair;
 import org.rstudio.core.client.SerializedCommand;
 import org.rstudio.core.client.SerializedCommandQueue;
 import org.rstudio.core.client.StringUtil;
-import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.command.*;
 import org.rstudio.core.client.command.EditorCommandManager.EditorKeyBinding;
 import org.rstudio.core.client.command.EditorCommandManager.EditorKeyBindings;
@@ -983,14 +982,8 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
       radioLabel.getElement().getStyle().setFloat(Style.Float.LEFT);
       radioLabel.getElement().getStyle().setMarginRight(8, Unit.PX);
 
-      // The fieldset wrapping the radio buttons has a visually hidden legend which
-      // will be "seen" by screen readers, so hide this label to avoid duplication.
-      // Attempts to style the legend to match the current single-line visual layout
-      // proved too frail (browser-specific quirks).
-      A11y.setARIAHidden(radioLabel);
-
       headerPanel.add(radioLabel);
-      FieldSetPanel showFieldsetPanel = new FieldSetPanel("Show:", true);
+      FieldSetPanel showFieldsetPanel = new FieldSetPanel(radioLabel);
       showFieldsetPanel.setStyleName(RES.dataGridStyle().showChoice());
       FlowPanel radioPanel = new FlowPanel();
       showFieldsetPanel.add(radioPanel);

--- a/src/gwt/src/org/rstudio/core/client/widget/VerticalRadioPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/VerticalRadioPanel.java
@@ -1,5 +1,5 @@
 /*
- * HorizontalRadioPanel.java
+ * VerticalRadioPanel.java
  *
  * Copyright (C) 2009-19 by RStudio, Inc.
  *
@@ -14,28 +14,28 @@
  */
 package org.rstudio.core.client.widget;
 
-import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.RadioButton;
+import com.google.gwt.user.client.ui.VerticalPanel;
 import org.rstudio.core.client.a11y.A11y;
 
 /**
- * A HorizontalPanel containing a group of radio buttons and a legend.
+ * A VerticalPanel containing a group of radio buttons and a legend.
  */
-public class HorizontalRadioPanel extends FieldSetPanel
+public class VerticalRadioPanel extends FieldSetPanel
 {
-   public HorizontalRadioPanel(String legend, boolean visuallyHideLegend)
+   public VerticalRadioPanel(String legend, boolean visuallyHideLegend)
    {
       super(legend, visuallyHideLegend);
-      super.add(panel_ = new HorizontalPanel());
+      super.add(panel_ = new VerticalPanel());
    }
-   
+
    /**
     * @param externalLabel existing visual label for the radio buttons; text of that label
     *                      will be applied to a hidden legend element for accessibility, and
     *                      the label itself will be marked aria-hidden
     */
-   public HorizontalRadioPanel(Label externalLabel)
+   public VerticalRadioPanel(Label externalLabel)
    {
       this(externalLabel.getText(), true);
       A11y.setARIAHidden(externalLabel);
@@ -46,5 +46,5 @@ public class HorizontalRadioPanel extends FieldSetPanel
       panel_.add(w);
    }
 
-   private HorizontalPanel panel_;
+   private VerticalPanel panel_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/VerticalRadioPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/VerticalRadioPanel.java
@@ -17,7 +17,6 @@ package org.rstudio.core.client.widget;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.RadioButton;
 import com.google.gwt.user.client.ui.VerticalPanel;
-import org.rstudio.core.client.a11y.A11y;
 
 /**
  * A VerticalPanel containing a group of radio buttons and a legend.
@@ -37,8 +36,8 @@ public class VerticalRadioPanel extends FieldSetPanel
     */
    public VerticalRadioPanel(Label externalLabel)
    {
-      this(externalLabel.getText(), true);
-      A11y.setARIAHidden(externalLabel);
+      super(externalLabel);
+      super.add(panel_ = new VerticalPanel());
    }
 
    public void add(RadioButton w)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewShinyWebApplication.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewShinyWebApplication.css
@@ -14,7 +14,7 @@
 }
 
 .invalidAppName {
-	background-color: #f2dede;
+   background-color: #f2dede;
 }
 
 .appNameTextBox {
@@ -22,5 +22,11 @@
 }
 
 .textBox, .textBox .gwt-TextBox {
-	padding-left: 4px;
+   padding-left: 4px;
+}
+
+.shinyTypeGroup {
+   border: none;
+   margin: 0;
+   padding: 0;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewShinyWebApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewShinyWebApplication.java
@@ -26,6 +26,7 @@ import org.rstudio.core.client.widget.FormLabel;
 import org.rstudio.core.client.widget.LayoutGrid;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.core.client.widget.VerticalRadioPanel;
 import org.rstudio.core.client.widget.VerticalSpacer;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.GlobalDisplay;
@@ -210,7 +211,8 @@ public class NewShinyWebApplication extends ModalDialog<NewShinyWebApplication.R
       appTypeLabel_.addStyleName(RES.styles().label());
       appTypeLabel_.getElement().getStyle().setMarginTop(2, Unit.PX);
       
-      VerticalPanel radioPanel = new VerticalPanel();
+      VerticalRadioPanel radioPanel = new VerticalRadioPanel(appTypeLabel_);
+      radioPanel.setStylePrimaryName(RES.styles().shinyTypeGroup());
       appTypeSingleFileButton_ = new RadioButton("shiny", "Single File (app.R)");
       appTypeMultipleFileButton_ = new RadioButton("shiny", "Multiple File (ui.R/server.R)");
       radioPanel.add(appTypeSingleFileButton_);
@@ -364,6 +366,7 @@ public class NewShinyWebApplication extends ModalDialog<NewShinyWebApplication.R
       String invalidAppName();
       String appNameTextBox();
       String textBox();
+      String shinyTypeGroup();
    }
 
    public interface Resources extends ClientBundle


### PR DESCRIPTION
- Wrap related radio buttons in a fieldset with a legend
- Make legend visually hidden and and mark existing visible label as aria-hidden to avoid duplicate announcements from screen readers (needed in cases where existing visual layout is tough to replicate using native legend element, e.g. when we are using tables for layout)

![2019-08-07_23-10-49](https://user-images.githubusercontent.com/10569626/62729836-9a54d680-b9d3-11e9-9bb7-1c437169803e.png)

![2019-08-08_11-20-12](https://user-images.githubusercontent.com/10569626/62729848-9fb22100-b9d3-11e9-8db5-d863bcf4e258.png)
