### PR TITLE
fix themed styling of file pane breadcrumb text

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/FileDialogStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/FileDialogStyles.css
@@ -133,9 +133,8 @@ body.windows .gwt-CheckBox-FilesSelectAll {
 .breadcrumb-filepane, .breadcrumb-filepane table, .breadcrumb-filepane td {
    height: 20px;
 }
-.breadcrumb table.path a,
-.breadcrumb table.path span,
-.breadcrumb table.path .rstudio-HyperlinkLabel
+.breadcrumb table.path .rstudio-HyperlinkLabel,
+.breadcrumb table.path span
 {
    float: left;
    text-decoration: none;
@@ -146,23 +145,23 @@ body.windows .gwt-CheckBox-FilesSelectAll {
    background-size: 6px 9px;
 }
 
-.rstudio-themes-flat .breadcrumb table.path a,
+.rstudio-themes-flat .breadcrumb table.path .rstudio-HyperlinkLabel,
 .rstudio-themes-flat .breadcrumb table.path span {
    padding-top: 4px;
 }
 
-body.windows .breadcrumb table.path a,
+body.windows .breadcrumb table.path .rstudio-HyperlinkLabel,
 body.windows .breadcrumb table.path span {
    padding-top: 2px;
 }
 
 
-.breadcrumb table.path a
+.breadcrumb table.path .rstudio-HyperlinkLabel
 {
    color: #0945bf;
 }
 
-.rstudio-themes-flat .rstudio-themes-dark .breadcrumb table.path a
+.rstudio-themes-flat .rstudio-themes-dark .breadcrumb table.path .rstudio-HyperlinkLabel
 {
    color: rgb(191,211,232);
 }


### PR DESCRIPTION
When I switched from Anchor to HyperlinkLabel I didn't update the styling correctly, especially noticeable in dark themes. Also reverts some unintended padding changes.

Fixes #5193 