### PR TITLE
fix regression in layout of git diff window

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/FormLabel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FormLabel.java
@@ -152,4 +152,12 @@ public class FormLabel extends Label
    {
       getElement().setAttribute("for", controlId);
    }
+
+   /**
+    * @param display directly set display attribute of the label element
+    */
+   public void setDisplay(String display)
+   {
+      getElement().getStyle().setProperty("display", display);
+   }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.ui.xml
@@ -54,7 +54,7 @@
                                     text="Unstaged"
                                     checked="true"
                                     styleName="{res.styles.unstaged}"/>
-                     <rs_widget:FormLabel ui:field="lblContext_" text="Context" styleName="{res.styles.stagedLabel}"/>
+                     <rs_widget:FormLabel ui:field="lblContext_" display="inline" text="Context" styleName="{res.styles.stagedLabel}"/>
                      <g:ListBox ui:field="contextLines_" visibleItemCount="1" selectedIndex="0">
                         <g:item value="5">5 line</g:item>
                         <g:item value="10">10 line</g:item>


### PR DESCRIPTION
Fix a visual layout regression in the Git Diff window, introduced by https://github.com/rstudio/rstudio/commit/f4a95b6b

When I switched from generic Label to FormLabel, it went from display:inline to display:block, so need to set it appropriately in this case.

Broken
![2019-08-08_16-53-43](https://user-images.githubusercontent.com/10569626/62746292-abb5d700-ba03-11e9-9d89-e5d8646278fc.png)

Fixed
![2019-08-08_17-30-07](https://user-images.githubusercontent.com/10569626/62746302-b1132180-ba03-11e9-84b2-5e91efc8133f.png)
