### PR TITLE
Fix JS exception when exporting plots

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
@@ -117,11 +117,11 @@ public class UserStateAccessor extends Prefs
    {
       protected ExportPlotOptions() {} 
 
-      public final native Integer getWidth() /*-{
+      public final native int getWidth() /*-{
          return this.width;
       }-*/;
 
-      public final native Integer getHeight() /*-{
+      public final native int getHeight() /*-{
          return this.height;
       }-*/;
 
@@ -155,11 +155,11 @@ public class UserStateAccessor extends Prefs
    {
       protected ExportViewerOptions() {} 
 
-      public final native Integer getWidth() /*-{
+      public final native int getWidth() /*-{
          return this.width;
       }-*/;
 
-      public final native Integer getHeight() /*-{
+      public final native int getHeight() /*-{
          return this.height;
       }-*/;
 
@@ -193,11 +193,11 @@ public class UserStateAccessor extends Prefs
    {
       protected SavePlotAsPdfOptions() {} 
 
-      public final native Integer getWidth() /*-{
+      public final native int getWidth() /*-{
          return this.width;
       }-*/;
 
-      public final native Integer getHeight() /*-{
+      public final native int getHeight() /*-{
          return this.height;
       }-*/;
 

--- a/src/gwt/tools/generate-prefs.R
+++ b/src/gwt/tools/generate-prefs.R
@@ -220,7 +220,7 @@ generate <- function (schemaPath, className) {
             } else if (identical(proptype, "string")) {
                proptype <- "String"
             } else if (identical(proptype, "integer")) {
-               proptype <- "Integer"
+               proptype <- "int"
             }
             java <- paste0(java,
               "      public final native ", proptype, " get",  propname, "() /*-{\n",


### PR DESCRIPTION
This change fixes the integer JSNI type boxing for JavaScript objects in prefs.

Fixes https://github.com/rstudio/rstudio/issues/5194.