### PR TITLE
Complete transition of viewer type values from enum to string

### DIFF
--- a/src/cpp/session/modules/SessionPlumberViewer.R
+++ b/src/cpp/session/modules/SessionPlumberViewer.R
@@ -42,9 +42,9 @@
       return("none")
    else if (identical(viewer, TRUE))
       return("browser")
-   else if (is.function(viewer) && is.numeric(attr(viewer, "plumberViewerType")))
+   else if (is.function(viewer) && is.character(attr(viewer, "plumberViewerType")))
       return(attr(viewer, "plumberViewerType"))
-   return(0)
+   return("user")
 })
 
 .rs.addJsonRpcHandler("get_plumber_viewer_type", function() {

--- a/src/cpp/session/modules/SessionPlumberViewer.R
+++ b/src/cpp/session/modules/SessionPlumberViewer.R
@@ -14,15 +14,15 @@
 #
 
 .rs.addFunction("invokePlumberPaneViewer", function(url) {
-   invisible(.Call("rs_plumberviewer", url, getwd(), "pane"))
+   invisible(.Call("rs_plumberviewer", url, getwd(), "pane", PACKAGE = "(embedding)"))
 }, attrs = list(plumberViewerType = "pane"))
 
 .rs.addFunction("invokePlumberWindowViewer", function(url) {
-   invisible(.Call("rs_plumberviewer", url, getwd(), "window"))
+   invisible(.Call("rs_plumberviewer", url, getwd(), "window", PACKAGE = "(embedding)"))
 }, attrs = list(plumberViewerType = "window"))
 
 .rs.addFunction("invokePlumberWindowExternal", function(url) {
-   invisible(.Call("rs_plumberviewer", url, getwd(), "browser"))
+   invisible(.Call("rs_plumberviewer", url, getwd(), "browser", PACKAGE = "(embedding)"))
 }, attrs = list(plumberViewerType = "browser"))
 
 .rs.addFunction("setPlumberViewerType", function(type) {

--- a/src/cpp/session/modules/SessionPlumberViewer.cpp
+++ b/src/cpp/session/modules/SessionPlumberViewer.cpp
@@ -44,7 +44,7 @@ namespace plumber_viewer {
 namespace {
 
 void enqueueStartEvent(const std::string& url, const std::string& path,
-                       int viewerType, int options)
+                       const std::string& viewerType, int options)
 {
    FilePath plumberPath(path);
 
@@ -74,7 +74,7 @@ SEXP rs_plumberviewer(SEXP urlSEXP, SEXP pathSEXP, SEXP viewerSEXP)
          throw r::exec::RErrorException(
             "path must be a single element character vector.");
       }
-      int viewertype = r::sexp::asInteger(viewerSEXP);
+      std::string viewertype = r::sexp::safeAsString(viewerSEXP, kPlumberViewerTypeWindow);
 
       // in desktop mode make sure we have the right version of httpuv
       if (options().programMode() == kSessionProgramModeDesktop)

--- a/src/cpp/session/modules/SessionShinyViewer.R
+++ b/src/cpp/session/modules/SessionShinyViewer.R
@@ -14,15 +14,15 @@
 #
 
 .rs.addFunction("invokeShinyPaneViewer", function(url) {
-   invisible(.Call("rs_shinyviewer", url, getwd(), "pane"))
-}, attrs = list(shinyViewerType = 2))
+   invisible(.Call("rs_shinyviewer", url, getwd(), "pane", PACKAGE = "(embedding)"))
+}, attrs = list(shinyViewerType = "pane"))
 
 .rs.addFunction("invokeShinyWindowViewer", function(url) {
-   invisible(.Call("rs_shinyviewer", url, getwd(), "window"))
+   invisible(.Call("rs_shinyviewer", url, getwd(), "window", PACKAGE = "(embedding)"))
 }, attrs = list(shinyViewerType = "window"))
 
 .rs.addFunction("invokeShinyWindowExternal", function(url) {
-   invisible(.Call("rs_shinyviewer", url, getwd(), "browser"))
+   invisible(.Call("rs_shinyviewer", url, getwd(), "browser", PACKAGE = "(embedding)"))
 }, attrs = list(shinyViewerType = "browser"))
 
 .rs.addFunction("setShinyViewerType", function(type) {
@@ -42,7 +42,7 @@
       return("none")
    else if (identical(viewer, TRUE))
       return("browser")
-   else if (is.function(viewer) && is.numeric(attr(viewer, "shinyViewerType")))
+   else if (is.function(viewer) && is.character(attr(viewer, "shinyViewerType")))
       return(attr(viewer, "shinyViewerType"))
    return("user")
 })

--- a/src/cpp/session/modules/SessionShinyViewer.cpp
+++ b/src/cpp/session/modules/SessionShinyViewer.cpp
@@ -48,7 +48,7 @@ namespace {
 FilePath s_pendingShinyPath;
 
 void enqueueStartEvent(const std::string& url, const std::string& path,
-                     int viewerType, int options)
+                     const std::string& viewerType, int options)
 {
    FilePath shinyPath(path);
    if (module_context::safeCurrentPath() == shinyPath &&
@@ -87,7 +87,7 @@ SEXP rs_shinyviewer(SEXP urlSEXP, SEXP pathSEXP, SEXP viewerSEXP)
          throw r::exec::RErrorException(
             "path must be a single element character vector.");
       }
-      int viewertype = r::sexp::asInteger(viewerSEXP);
+      std::string viewertype = r::sexp::safeAsString(viewerSEXP, kShinyViewerTypeWindow);
 
       // in desktop mode make sure we have the right version of httpuv
       if (options().programMode() == kSessionProgramModeDesktop)
@@ -107,7 +107,7 @@ SEXP rs_shinyviewer(SEXP urlSEXP, SEXP pathSEXP, SEXP viewerSEXP)
       if (path.find("/shinytest/recorder") != std::string::npos ||
           path.find("/shinytest/diffviewerapp") != std::string::npos)
       {
-          viewertype = SHINY_VIEWER_WINDOW;
+          viewertype = kShinyViewerTypeWindow;
           options = SHINY_VIEWER_OPTIONS_NOTOOLS;
       }
       if (path.find("/shinytest/recorder") != std::string::npos)

--- a/src/cpp/session/modules/SessionShinyViewer.hpp
+++ b/src/cpp/session/modules/SessionShinyViewer.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionShinyViewer.hpp
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -26,12 +26,6 @@ namespace rstudio {
 namespace session {
 namespace modules { 
 namespace shiny_viewer {
-
-const int SHINY_VIEWER_USER = 0;
-const int SHINY_VIEWER_NONE = 1;
-const int SHINY_VIEWER_PANE = 2;
-const int SHINY_VIEWER_WINDOW = 3;
-const int SHINY_VIEWER_BROWSER = 4;
 
 const int SHINY_VIEWER_OPTIONS_NONE = 0;
 const int SHINY_VIEWER_OPTIONS_NOTOOLS = 1;


### PR DESCRIPTION
This change fixes a few places that were missed when updating the Shiny and Plumber viewer types from an enum to string values (for ease of use in preference files). 

Fixes https://github.com/rstudio/rstudio-pro/issues/1142.