### PR TITLE
added early stopping to Jenkins scripts

### DIFF
--- a/docker/docker-compile.sh
+++ b/docker/docker-compile.sh
@@ -156,5 +156,3 @@ fi
 # stop the container
 docker stop "$CONTAINER_ID"
 echo "Container image saved in $CONTAINER_ID."
-
-

--- a/docker/jenkins/publish-daily-binary.sh
+++ b/docker/jenkins/publish-daily-binary.sh
@@ -2,6 +2,9 @@
 
 # publish-daily-binary.sh
 
+# abort on error
+set -e
+
 if [[ "$#" -lt 2 ]]; then
     echo "Usage: publish-daily-binary.sh [https://url/to/binary/rstudio.deb] [identity.pem]"
     exit 1
@@ -32,4 +35,3 @@ scp -o StrictHostKeyChecking=no -i $IDENTITY $HTACCESS www-data@rstudio.org:/srv
 # clean up
 rm -f $HTACCESS
 rm -f $HTACCESS.bak
-

--- a/docker/jenkins/rstudio-version.sh
+++ b/docker/jenkins/rstudio-version.sh
@@ -30,6 +30,9 @@
 # see what the script would do (in this mode debug output is written and no
 # changes are saved to S3).
 
+# abort on error
+set -e
+
 if [[ "$#" -lt 2 ]]; then
     # TODO: add "set" command to move forward 
     echo "Usage: rstudio-version.sh [get|bump] [major.minor] [debug]"
@@ -199,4 +202,3 @@ case "$ACTION" in
         echo "$PRO_VERSION"
     fi
 esac
-

--- a/docker/jenkins/sign-release.sh
+++ b/docker/jenkins/sign-release.sh
@@ -17,6 +17,9 @@
 # the signing key into a private, temporary keyring, uses it to sign the
 # release, and then destroys the keyring.
 
+# abort on error
+set -e
+
 if [[ "$#" -lt 2 ]]; then
     echo "Usage: sign-release.sh [installer-file] [key-file] [passphrase-file]"
     exit 1
@@ -151,5 +154,3 @@ else
     # not a deb or rpm; we don't know how to sign this
     echo "Unknown installer extension $EXT."
 fi
-
-


### PR DESCRIPTION
Hello!

I was looking at your Jenkins setup today to see if there was anything interesting I could learn for my own projects. While doing that, I noticed that several of the scripts in `docker/` do not use `set -e` to ensure early stopping if something breaks.

In this PR, I propose that they _should_. Since these scripts contain imperative code that has side effects (e.g. hitting S3 with `aws s3 cp`), I think it would be valuable to know they'll immediately stop if anything goes wrong.

I've also removed a few unnecessary empty lines at the end of these files. If you prefer that I revert those whitespace-only changes please let me know and I'd be happy to.

Thanks in advance for your time and consideration!