### PR TITLE
Show number of characters when typing a commit message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 * PowerShell Core option in terminal (Windows-only)
 * Custom terminal shell option for Windows desktop (previously only on Mac, Linux, and server)
 * Keyboard shortcuts for main menu items on RStudio Server (e.g. Ctrl+Alt+F for File menu)
+* Show number of characters when entering version control commit messages (#5192)
 
 ### Bugfixes
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.css
@@ -153,3 +153,12 @@
 .ignoreWhitespace label {
 	margin-left: 4px;
 }
+
+.charCountPanel {
+   position: absolute;
+   left: -10000px;
+   top: auto;
+   width: 1px;
+   height: 1px;
+   overflow: hidden;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.css
@@ -153,12 +153,3 @@
 .ignoreWhitespace label {
 	margin-left: 4px;
 }
-
-.charCountPanel {
-   position: absolute;
-   left: -10000px;
-   top: auto;
-   width: 1px;
-   height: 1px;
-   overflow: hidden;
-}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
@@ -676,7 +676,7 @@ public class GitReviewPanel extends ResizeComposite implements Display
       if (length == 0)
          lblCharCount_.setText("");
       else
-         lblCharCount_.setText(commitMessage_.getText().length() + "");
+         lblCharCount_.setText(length + "");
    }
 
    @UiField(provided = true)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.studio.client.workbench.views.vcs.git.dialog;
 
+import com.google.gwt.aria.client.LiveValue;
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
@@ -35,12 +37,14 @@ import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.Event.NativePreviewHandler;
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.PopupPanel.PositionCallback;
 import com.google.inject.Inject;
 
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.WidgetHandlerRegistration;
+import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.dom.DomUtils;
@@ -113,6 +117,8 @@ public class GitReviewPanel extends ResizeComposite implements Display
 
       String splitPanelCommit();
       String ignoreWhitespace();
+      
+      String charCountPanel();
    }
 
    @SuppressWarnings("unused")
@@ -298,6 +304,13 @@ public class GitReviewPanel extends ResizeComposite implements Display
 
       lblCommit_.setFor(commitMessage_);
       lblContext_.setFor(contextLines_);
+      
+      // Hide frequently-updating character count from screen readers
+      A11y.setARIAHidden(lblCharCount_);
+      
+      // Expose a screen reader-only element with debounced updates
+      Roles.getStatusRole().set(lblReaderCharCount_.getElement());
+      Roles.getStatusRole().setAriaLiveProperty(lblReaderCharCount_.getElement(), LiveValue.POLITE);
 
       unstagedCheckBox_.addValueChangeHandler(new ValueChangeHandler<Boolean>()
       {
@@ -676,7 +689,12 @@ public class GitReviewPanel extends ResizeComposite implements Display
       if (length == 0)
          lblCharCount_.setText("");
       else
-         lblCharCount_.setText(length + "");
+         lblCharCount_.setText(length + " characters");
+      
+      // Debounce an update to the accessible character count
+      if (updateCharCountTimer_.isRunning())
+         updateCharCountTimer_.cancel();
+      updateCharCountTimer_.schedule(2000);
    }
 
    @UiField(provided = true)
@@ -706,6 +724,8 @@ public class GitReviewPanel extends ResizeComposite implements Display
    @UiField
    Label lblCharCount_;
    @UiField
+   Label lblReaderCharCount_;
+   @UiField
    TextArea commitMessage_;
    @UiField
    CheckBox commitIsAmend_;
@@ -717,6 +737,8 @@ public class GitReviewPanel extends ResizeComposite implements Display
    HorizontalPanel toolbarWrapper_;
    @UiField
    CheckBox ignoreWhitespaceCheckbox_;
+   @UiField
+   HTMLPanel panelCharCount_;
 
    private ListBoxAdapter listBoxAdapter_;
 
@@ -731,6 +753,22 @@ public class GitReviewPanel extends ResizeComposite implements Display
    private LeftRightToggleButton switchViewButton_;
 
    private SizeWarningWidget overrideSizeWarning_;
+   
+   /**
+    * Timer for updating the accessible character count
+    */
+   private Timer updateCharCountTimer_ = new Timer()
+   {
+      @Override
+      public void run()
+      {
+         int length = commitMessage_.getText().length();
+         if (length == 0)
+            lblReaderCharCount_.setText("");
+         else
+            lblReaderCharCount_.setText(length + " characters in message");
+      }
+   };
 
    private static final Resources RES = GWT.create(Resources.class);
    static {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
@@ -325,6 +325,18 @@ public class GitReviewPanel extends ResizeComposite implements Display
       listBoxAdapter_ = new ListBoxAdapter(contextLines_);
 
       FontSizer.applyNormalFontSize(commitMessage_);
+      commitMessage_.addKeyUpHandler(e ->
+      {
+         // Update commit message whenever keys are pressed
+         updateCharCount();
+      });
+      commitMessage_.addChangeHandler(e ->
+      {
+         // Update commit message whenever the text content changes; catches
+         // e.g. changes on blur after a mouse paste
+         updateCharCount();
+      });
+
       new WidgetHandlerRegistration(this)
       {
          @Override
@@ -654,6 +666,19 @@ public class GitReviewPanel extends ResizeComposite implements Display
       });
    }
 
+   /**
+    * Update the character count for the commit message, or clear it if there
+    * are no longer any characters in the commit message.
+    */
+   private void updateCharCount()
+   {
+      int length = commitMessage_.getText().length();
+      if (length == 0)
+         lblCharCount_.setText("");
+      else
+         lblCharCount_.setText(commitMessage_.getText().length() + "");
+   }
+
    @UiField(provided = true)
    SplitLayoutPanel splitPanel_;
    @UiField(provided = true)
@@ -678,6 +703,8 @@ public class GitReviewPanel extends ResizeComposite implements Display
    Toolbar diffToolbar_;
    @UiField
    FormLabel lblCommit_;
+   @UiField
+   Label lblCharCount_;
    @UiField
    TextArea commitMessage_;
    @UiField

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
@@ -117,8 +117,6 @@ public class GitReviewPanel extends ResizeComposite implements Display
 
       String splitPanelCommit();
       String ignoreWhitespace();
-      
-      String charCountPanel();
    }
 
    @SuppressWarnings("unused")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.ui.xml
@@ -5,6 +5,7 @@
              xmlns:rs_widget='urn:import:org.rstudio.core.client.widget'>
 
    <ui:with field="res" type="org.rstudio.studio.client.workbench.views.vcs.git.dialog.GitReviewPanel.Resources"/>
+   <ui:with field="themeRes" type="org.rstudio.core.client.theme.res.ThemeResources"/>
 
    <g:SplitLayoutPanel ui:field="splitPanel_" styleName="{res.styles.splitPanel}">
       <g:north size="230">
@@ -26,7 +27,7 @@
                              <g:cell horizontalAlignment="ALIGN_RIGHT">
                                <g:HTMLPanel>
                                   <g:Label ui:field="lblCharCount_"/>
-                                  <g:HTMLPanel ui:field="panelCharCount_" styleName="{res.styles.charCountPanel}">
+                                  <g:HTMLPanel ui:field="panelCharCount_" styleName="{themeRes.themeStyles.visuallyHidden}">
                                      <g:Label ui:field="lblReaderCharCount_"/>
                                   </g:HTMLPanel>
                                </g:HTMLPanel>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.ui.xml
@@ -19,7 +19,14 @@
                   <g:east size="400">
                      <g:LayoutPanel>
                         <g:layer left="6px" right="6px" top="4px" height="20px">
-                           <rs_widget:FormLabel ui:field="lblCommit_" text="Commit message"/>
+                           <g:HorizontalPanel width="100%">
+                             <g:cell horizontalAlignment="ALIGN_LEFT">
+                               <rs_widget:FormLabel ui:field="lblCommit_" text="Commit message"/>
+                             </g:cell>
+                             <g:cell horizontalAlignment="ALIGN_RIGHT">
+                               <g:Label ui:field="lblCharCount_"/>
+                             </g:cell>
+                           </g:HorizontalPanel>
                         </g:layer>
                         <g:layer left="6px" right="6px" top="20px" bottom="34px">
                            <g:TextArea ui:field="commitMessage_" styleName="{res.styles.commitMessage}"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.ui.xml
@@ -24,7 +24,12 @@
                                <rs_widget:FormLabel ui:field="lblCommit_" text="Commit message"/>
                              </g:cell>
                              <g:cell horizontalAlignment="ALIGN_RIGHT">
-                               <g:Label ui:field="lblCharCount_"/>
+                               <g:HTMLPanel>
+                                  <g:Label ui:field="lblCharCount_"/>
+                                  <g:HTMLPanel ui:field="panelCharCount_" styleName="{res.styles.charCountPanel}">
+                                     <g:Label ui:field="lblReaderCharCount_"/>
+                                  </g:HTMLPanel>
+                               </g:HTMLPanel>
                              </g:cell>
                            </g:HorizontalPanel>
                         </g:layer>


### PR DESCRIPTION
This change adds a small character counter to the commit message entry box. It is visible only if you've entered a commit message, and intended to help keep commit messages shorter than some limit if desired. 

![image](https://user-images.githubusercontent.com/470418/62812819-440f9280-babc-11e9-82ea-d4cc3d483af0.png)

Closes https://github.com/rstudio/rstudio/issues/5192.