### PR TITLE
a11y fixes to control labeling in ImportFileSettingsDialog, declarative IDs/labeling

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -130,15 +130,15 @@ public class ElementIds
    public static String getImportFileEncoding() { return getElementId(IMPORT_FILE_ENCODING); }
    public final static String IMPORT_FILE_ROW_NAMES = "import_file_row_names";
    public static String getImportFileRowNames() { return getElementId(IMPORT_FILE_ROW_NAMES); }
-   public final static String IMPORT_FILE_SEPARATOR = "ifs_separator";
+   public final static String IMPORT_FILE_SEPARATOR = "import_file_separator";
    public static String getImportFileSeparator() { return getElementId(IMPORT_FILE_SEPARATOR); }
-   public final static String IMPORT_FILE_DECIMAL = "ifs_decimal";
+   public final static String IMPORT_FILE_DECIMAL = "import_file_decimal";
    public static String getImportFileDecimal() { return getElementId(IMPORT_FILE_DECIMAL); }
-   public final static String IMPORT_FILE_QUOTE = "ifs_quote";
+   public final static String IMPORT_FILE_QUOTE = "import_file_quote";
    public static String getImportFileQuote() { return getElementId(IMPORT_FILE_QUOTE); }
-   public final static String IMPORT_FILE_COMMENT = "ifs_comment";
+   public final static String IMPORT_FILE_COMMENT = "import_file_comment";
    public static String getImportFileComment() { return getElementId(IMPORT_FILE_COMMENT); }
-   public final static String IMPORT_FILE_NA_STRINGS = "ifs_na_strings";
+   public final static String IMPORT_FILE_NA_STRINGS = "import_file_na_strings";
    public static String getImportFileNaStrings() { return getElementId(IMPORT_FILE_NA_STRINGS); }
 
    // NewRMarkdownDialog

--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -114,4 +114,40 @@ public class ElementIds
    
    public final static String PACKAGE_MANAGEMENT_PREFS = "package_management_prefs";
    public final static String PACKAGE_DEVELOPMENT_PREFS = "package_development_prefs";
+
+   // AskSecretDialog
+   public final static String ASK_SECRET_TEXT = "ask_secret_text";
+   public static String getAskSecretText() { return getElementId(ASK_SECRET_TEXT); }
+
+   // FindInFilesDialog
+   public final static String FIND_FILES_TEXT = "find_files_text";
+   public static String getFindFilesText() { return getElementId(FIND_FILES_TEXT); }
+
+   // ImportFileSettingsDialog
+   public final static String IMPORT_FILE_NAME = "import_file_name";
+   public static String getImportFileName() { return getElementId(IMPORT_FILE_NAME); }
+   public final static String IMPORT_FILE_ENCODING = "import_file_encoding";
+   public static String getImportFileEncoding() { return getElementId(IMPORT_FILE_ENCODING); }
+   public final static String IMPORT_FILE_ROW_NAMES = "import_file_row_names";
+   public static String getImportFileRowNames() { return getElementId(IMPORT_FILE_ROW_NAMES); }
+   public final static String IMPORT_FILE_SEPARATOR = "ifs_separator";
+   public static String getImportFileSeparator() { return getElementId(IMPORT_FILE_SEPARATOR); }
+   public final static String IMPORT_FILE_DECIMAL = "ifs_decimal";
+   public static String getImportFileDecimal() { return getElementId(IMPORT_FILE_DECIMAL); }
+   public final static String IMPORT_FILE_QUOTE = "ifs_quote";
+   public static String getImportFileQuote() { return getElementId(IMPORT_FILE_QUOTE); }
+   public final static String IMPORT_FILE_COMMENT = "ifs_comment";
+   public static String getImportFileComment() { return getElementId(IMPORT_FILE_COMMENT); }
+   public final static String IMPORT_FILE_NA_STRINGS = "ifs_na_strings";
+   public static String getImportFileNaStrings() { return getElementId(IMPORT_FILE_NA_STRINGS); }
+
+   // NewRMarkdownDialog
+   public final static String NEW_RMD_TITLE = "new_rmd_title";
+   public static String getNewRmdTitle() { return getElementId(NEW_RMD_TITLE); }
+   public final static String NEW_RMD_AUTHOR = "new_rmd_author";
+   public static String getNewRmdAuthor() { return getElementId(NEW_RMD_AUTHOR); }
+
+   // RmdTemplateChooser
+   public final static String RMD_TEMPLATE_CHOOSER_NAME = "rmd_template_chooser_name";
+   public static String getRmdTemplateChooserName() { return getElementId(RMD_TEMPLATE_CHOOSER_NAME); }
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/CanSetControlId.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/CanSetControlId.java
@@ -1,0 +1,20 @@
+/*
+ * CanSetControlId.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.widget;
+
+public interface CanSetControlId
+{
+   void setElementId(String id);
+}

--- a/src/gwt/src/org/rstudio/core/client/widget/FieldSetPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FieldSetPanel.java
@@ -67,5 +67,14 @@ public class FieldSetPanel extends SimplePanel implements HasOneWidget
    {
       legendElement_.setInnerText(legend);
    }
+
+   public void setLegendHidden(boolean hidden)
+   {
+      if (hidden)
+         legendElement_.setClassName(ThemeStyles.INSTANCE.visuallyHidden());
+      else
+         legendElement_.removeClassName(ThemeStyles.INSTANCE.visuallyHidden());
+   }
+
    private Element legendElement_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/FormLabel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FormLabel.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.core.client.widget;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.Label;
@@ -159,5 +160,10 @@ public class FormLabel extends Label
    public void setDisplay(String display)
    {
       getElement().getStyle().setProperty("display", display);
+   }
+
+   public void setAriaHidden(boolean hidden)
+   {
+      Roles.getTextboxRole().setAriaHiddenState(getElement(), hidden);
    }
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/FormListBox.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FormListBox.java
@@ -1,0 +1,30 @@
+/*
+ * FormListBox.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.widget;
+
+import com.google.gwt.user.client.ui.ListBox;
+
+/**
+ * ListBox with ability to set elementId (e.g. from UiBinder)
+ */
+public class FormListBox extends ListBox
+                         implements CanSetControlId
+{
+   @Override
+   public void setElementId(String id)
+   {
+      getElement().setId(id);
+   }
+}

--- a/src/gwt/src/org/rstudio/core/client/widget/FormPasswordTextBox.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FormPasswordTextBox.java
@@ -1,0 +1,30 @@
+/*
+ * FormPasswordTextBox.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.widget;
+
+import com.google.gwt.user.client.ui.PasswordTextBox;
+
+/**
+ * TextBox with ability to set elementId (e.g. from UiBinder)
+ */
+public class FormPasswordTextBox extends PasswordTextBox
+                                 implements CanSetControlId
+{
+   @Override
+   public void setElementId(String id)
+   {
+      getElement().setId(id);
+   }
+}

--- a/src/gwt/src/org/rstudio/core/client/widget/FormTextBox.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FormTextBox.java
@@ -1,0 +1,30 @@
+/*
+ * FormTextBox.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.widget;
+
+import com.google.gwt.user.client.ui.TextBox;
+
+/**
+ * TextBox with ability to set elementId (e.g. from UiBinder)
+ */
+public class FormTextBox extends TextBox
+                         implements CanSetControlId
+{
+   @Override
+   public void setElementId(String id)
+   {
+      getElement().setId(id);
+   }
+}

--- a/src/gwt/src/org/rstudio/core/client/widget/LabeledTextBox.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/LabeledTextBox.java
@@ -19,6 +19,7 @@ import com.google.gwt.dom.client.Style.Display;
 import com.google.gwt.event.dom.client.HasKeyUpHandlers;
 import com.google.gwt.event.dom.client.KeyUpHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.uibinder.client.UiConstructor;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HasText;
@@ -31,23 +32,18 @@ import org.rstudio.core.client.dom.DomUtils;
 public class LabeledTextBox extends Composite
                             implements HasText, HasKeyUpHandlers
 {
-   public LabeledTextBox()
+   public @UiConstructor LabeledTextBox(String textBoxId)
    {
       FlowPanel flowPanel = new FlowPanel();
       label_ = new FormLabel();
       textBox_ = new TextBox();
+      textBox_.getElement().setId(textBoxId);
       label_.setFor(textBox_);
       setLabelInline(false);
       flowPanel.add(label_);
       flowPanel.add(textBox_);
 
       initWidget(flowPanel);
-   }
-
-   public LabeledTextBox(String label)
-   {
-      this();
-      setLabelText(label);
    }
 
    public void setLabelText(String label)
@@ -129,6 +125,16 @@ public class LabeledTextBox extends Composite
    public void setEnabled(boolean enabled)
    {
       textBox_.setEnabled(enabled);
+   }
+
+   public void setLabelStyleName(String style)
+   {
+      label_.setStyleName(style);
+   }
+
+   public void setTextBoxStyleName(String style)
+   {
+      textBox_.setStyleName(style);
    }
 
    FormLabel label_;

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/ui/AskSecretDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/ui/AskSecretDialog.java
@@ -103,7 +103,6 @@ public class AskSecretDialog extends ModalDialog<AskSecretDialogResult>
       });
 
       label_.setText(prompt);
-      label_.setFor(textbox_);
       Roles.getTextboxRole().setAriaRequiredProperty(textbox_.getElement(), true);
 
       install_.addClickHandler(new ClickHandler() {

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/ui/AskSecretDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/ui/AskSecretDialog.ui.xml
@@ -1,6 +1,7 @@
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
              xmlns:g="urn:import:com.google.gwt.user.client.ui"
-             xmlns:widget="urn:import:org.rstudio.core.client.widget">
+             xmlns:rw="urn:import:org.rstudio.core.client.widget">
+   <ui:with field="ElementIds" type="org.rstudio.core.client.ElementIds"/>
 
    <ui:style>
       .panel {
@@ -33,13 +34,13 @@
       <table>
          <tr>
             <td width="100%">
-               <widget:FormLabel ui:field="label_"/>
+               <rw:FormLabel for="{ElementIds.getAskSecretText}" ui:field="label_"/>
             </td>
          </tr>
          <tr>
             <td width="100%">
-               <g:PasswordTextBox ui:field="textbox_"
-                                  stylePrimaryName="{style.secret}"/>
+               <rw:FormPasswordTextBox elementId="{ElementIds.getAskSecretText}" ui:field="textbox_"
+                                       stylePrimaryName="{style.secret}"/>
             </td>
          </tr>
          <tr>

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateChooser.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateChooser.ui.xml
@@ -2,6 +2,7 @@
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
    xmlns:g="urn:import:com.google.gwt.user.client.ui"
    xmlns:rs="urn:import:org.rstudio.core.client.widget">
+   <ui:with field="ElementIds" type="org.rstudio.core.client.ElementIds"/>
    <ui:style>
      @external .gwt-Label;
      @external .gwt-TextBox;
@@ -76,7 +77,8 @@
         This template contains multiple files. Create a new directory for
         these files:
      </g:HTML>
-     <rs:LabeledTextBox labelText="Name:" styleName="{style.controlLabel} {style.interiorControlLabel}" 
+     <rs:LabeledTextBox textBoxId="{ElementIds.getRmdTemplateChooserName}" labelText="Name:" 
+                        styleName="{style.controlLabel} {style.interiorControlLabel}" 
                         ui:field="txtName_" text="Untitled"></rs:LabeledTextBox>
 
      <rs:DirectoryChooserTextBox width="100%" addStyleNames="{style.directoryChooser} {style.directoryChooserInner}" ui:field="dirLocation_">

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/ImportFileSettingsDialog.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/ImportFileSettingsDialog.css
@@ -44,3 +44,10 @@
    font-family: proportionalFont;
    outline: none;
 }
+.leftPanel fieldset {
+   border: none;
+   padding: 0;
+   padding-block-end: 0;
+   padding-inline-end: 0;
+   margin: 0;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/ImportFileSettingsDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/ImportFileSettingsDialog.java
@@ -33,6 +33,7 @@ import org.rstudio.core.client.Invalidation;
 import org.rstudio.core.client.Invalidation.Token;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.js.JsObject;
+import org.rstudio.core.client.widget.LabeledTextBox;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ProgressIndicator;
@@ -405,7 +406,7 @@ public class ImportFileSettingsDialog extends ModalDialog<ImportFileSettingsDial
    @UiField
    RadioButton headingNo_;
    @UiField
-   TextBox varname_;
+   LabeledTextBox varname_;
    @UiField
    TextBox naStrings_;
    @UiField

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/ImportFileSettingsDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/ImportFileSettingsDialog.ui.xml
@@ -1,7 +1,10 @@
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
-             xmlns:g='urn:import:com.google.gwt.user.client.ui'>
+             xmlns:g='urn:import:com.google.gwt.user.client.ui'
+             xmlns:rw="urn:import:org.rstudio.core.client.widget">
 
    <ui:with field="res" type="org.rstudio.studio.client.workbench.views.environment.dataimport.ImportFileSettingsDialog.Resources"/>
+   <ui:with field="ElementIds" type="org.rstudio.core.client.ElementIds"/>
+   <ui:with field="themeRes" type="org.rstudio.core.client.theme.res.ThemeResources"/>
 
    <g:HTMLPanel>
       <g:HorizontalPanel>
@@ -9,44 +12,55 @@
             <table>
                <tr>
                   <td colspan="2">
-                     <g:Label text="Name" />
-                     <g:TextBox ui:field="varname_" styleName="{res.styles.varname}" />
+                     <rw:LabeledTextBox textBoxId="{ElementIds.getImportFileName}" ui:field="varname_"
+                                        labelText="Name" textBoxStyleName="{res.styles.varname}" />
                   </td>
                </tr>
                <tr>
-                  <td>Encoding</td>
-                  <td><g:ListBox ui:field="encoding_" styleName="{res.styles.list}" /></td>
+                  <td><rw:FormLabel for="{ElementIds.getImportFileEncoding}">Encoding</rw:FormLabel></td>
+                  <td><rw:FormListBox elementId="{ElementIds.getImportFileEncoding}" ui:field="encoding_" 
+                                      styleName="{res.styles.list}" /></td>
                </tr>
                <tr>
-                  <td>Heading</td>
+                  <td><rw:FormLabel ariaHidden="true">Heading</rw:FormLabel></td>
                   <td>
-                     <g:RadioButton ui:field="headingYes_" name="importFileSettingsHeading" text="Yes"/>
-                     <g:RadioButton ui:field="headingNo_" name="importFileSettingsHeading" text="No"/>
+                     <rw:FieldSetPanel legend="Heading" legendHidden="true">
+                        <g:HTMLPanel>
+                           <g:RadioButton ui:field="headingYes_" name="importFileSettingsHeading" text="Yes"/>
+                           <g:RadioButton ui:field="headingNo_" name="importFileSettingsHeading" text="No"/>
+                        </g:HTMLPanel>
+                     </rw:FieldSetPanel>
                   </td>
                </tr>
                <tr>
-                  <td>Row names</td>
-                  <td><g:ListBox ui:field="rowNames_" styleName="{res.styles.list}" /></td>
+                  <td><rw:FormLabel for="{ElementIds.getImportFileRowNames}">Row names</rw:FormLabel></td>
+                  <td><rw:FormListBox elementId="{ElementIds.getImportFileRowNames}" ui:field="rowNames_" 
+                                      styleName="{res.styles.list}" /></td>
                </tr>
                <tr>
-                  <td>Separator</td>
-                  <td><g:ListBox ui:field="separator_" styleName="{res.styles.list}" /></td>
+                  <td><rw:FormLabel for="{ElementIds.getImportFileSeparator}">Separator</rw:FormLabel></td>
+                  <td><rw:FormListBox elementId="{ElementIds.getImportFileSeparator}" ui:field="separator_" 
+                                      styleName="{res.styles.list}" /></td>
                </tr>
                <tr>
-                  <td>Decimal</td>
-                  <td><g:ListBox ui:field="decimal_" styleName="{res.styles.list}" /></td>
+                  <td><rw:FormLabel for="{ElementIds.getImportFileDecimal}">Decimal</rw:FormLabel></td>
+                  <td><rw:FormListBox elementId="{ElementIds.getImportFileDecimal}" ui:field="decimal_" 
+                                      styleName="{res.styles.list}" /></td>
                </tr>
                <tr>
-                  <td>Quote</td>
-                  <td><g:ListBox ui:field="quote_" styleName="{res.styles.list}" /></td>
+                  <td><rw:FormLabel for="{ElementIds.getImportFileQuote}">Quote</rw:FormLabel></td>
+                  <td><rw:FormListBox elementId="{ElementIds.getImportFileQuote}" ui:field="quote_" 
+                                      styleName="{res.styles.list}" /></td>
                </tr>
                <tr>
-                  <td>Comment</td>
-                  <td><g:ListBox ui:field="comment_" styleName="{res.styles.list}" /></td>
+                  <td><rw:FormLabel for="{ElementIds.getImportFileComment}">Comment</rw:FormLabel></td>
+                  <td><rw:FormListBox elementId="{ElementIds.getImportFileComment}" ui:field="comment_" 
+                                      styleName="{res.styles.list}" /></td>
                </tr>
                <tr>
-                  <td>na.strings</td>
-                  <td><g:TextBox ui:field="naStrings_" styleName="{res.styles.nastrings}"></g:TextBox></td>
+                  <td><rw:FormLabel for="{ElementIds.getImportFileNaStrings}">na.strings</rw:FormLabel></td>
+                  <td><rw:FormTextBox elementId="{ElementIds.getImportFileNaStrings}" ui:field="naStrings_" 
+                                      styleName="{res.styles.nastrings}"></rw:FormTextBox></td>
                </tr>
                <tr>
                   <td colspan="2"><g:CheckBox ui:field="stringsAsFactors_" text="Strings as factors"></g:CheckBox></td>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
@@ -1,6 +1,7 @@
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
              xmlns:g='urn:import:com.google.gwt.user.client.ui'
-             xmlns:widget="urn:import:org.rstudio.core.client.widget">
+             xmlns:rw="urn:import:org.rstudio.core.client.widget">
+   <ui:with field="ElementIds" type="org.rstudio.core.client.ElementIds"/>
 
    <ui:style>
       @external .gwt-TextBox;
@@ -28,17 +29,18 @@
 
    <g:HTMLPanel styleName="{style.panel}">
       <p>
-         <widget:LabeledTextBox ui:field="txtSearchPattern_" labelText="Find:" enableSpellcheck="false" styleName="{style.pattern}"/>
+         <rw:LabeledTextBox textBoxId="{ElementIds.getFindFilesText}" ui:field="txtSearchPattern_" 
+                            labelText="Find:" enableSpellcheck="false" styleName="{style.pattern}"/>
          <g:CheckBox ui:field="checkboxCaseSensitive_" text="Case sensitive"/>
          &#x00a0;&#x00a0;&#x00a0;&#x00a0;
          <g:CheckBox ui:field="checkboxRegex_" text="Regular expression"/>
       </p>
 
       <p>
-         <widget:DirectoryChooserTextBox ui:field="dirChooser_"/>
+         <rw:DirectoryChooserTextBox ui:field="dirChooser_"/>
       </p>
 
-      <p><widget:FormLabel ui:field="labelFilePatterns_" text="Search these files:"/>
+      <p><rw:FormLabel ui:field="labelFilePatterns_" text="Search these files:"/>
          <g:ListBox ui:field="listPresetFilePatterns_"
                     styleName="{style.presetFilePatterns}">
             <g:item value="">All Files</g:item>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.java
@@ -24,8 +24,6 @@ import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.resources.ImageResource2x;
-import org.rstudio.core.client.widget.FieldSetPanel;
-import org.rstudio.core.client.widget.FormLabel;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ThemedButton;
@@ -203,9 +201,7 @@ public class NewRMarkdownDialog extends ModalDialog<NewRMarkdownDialog.Result>
       formatOptions_ = new ArrayList<>();
       style.ensureInjected();
       txtAuthor_.setText(author);
-      lblAuthor_.setFor(txtAuthor_);
       txtTitle_.setText("Untitled");
-      lblTitle_.setFor(txtTitle_);
       listTemplates_.addChangeHandler(new ChangeHandler()
       {
          @Override
@@ -463,14 +459,11 @@ public class NewRMarkdownDialog extends ModalDialog<NewRMarkdownDialog.Result>
    }
    
    @UiField Grid formGrid_;
-   @UiField FormLabel lblAuthor_;
    @UiField TextBox txtAuthor_;
-   @UiField FormLabel lblTitle_;
    @UiField TextBox txtTitle_;
    @UiField WidgetListBox<TemplateMenuItem> listTemplates_;
    @UiField NewRmdStyle style;
    @UiField Resources resources;
-   @UiField FieldSetPanel formatFieldSet_;
    @UiField HTMLPanel templateFormatPanel_;
    @UiField HTMLPanel newTemplatePanel_;
    @UiField HTMLPanel existingTemplatePanel_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.ui.xml
@@ -6,6 +6,7 @@
    xmlns:rmd="urn:import:org.rstudio.studio.client.rmarkdown.ui">
 
    <ui:with field="resources" type="org.rstudio.studio.client.workbench.views.source.editors.text.ui.NewRMarkdownDialog.Resources" />
+   <ui:with field="ElementIds" type="org.rstudio.core.client.ElementIds"/>
    <ui:style type="org.rstudio.studio.client.workbench.views.source.editors.text.ui.NewRMarkdownDialog.NewRmdStyle">
    @external .gwt-Label;
    
@@ -133,22 +134,25 @@
         <g:HTMLPanel ui:field="newTemplatePanel_">
            <g:Grid ui:field="formGrid_" width="100%" cellSpacing="0" cellPadding="0">
              <g:row>
-               <g:customCell><rw:FormLabel ui:field="lblTitle_" styleName="{style.topLabel}" 
-                              text="Title:"></rw:FormLabel></g:customCell>
+               <g:customCell>
+                  <rw:FormLabel for="{ElementIds.getNewRmdTitle}" styleName="{style.topLabel}">Title:</rw:FormLabel>
+               </g:customCell>
                <g:customCell styleName="{style.textCol}">
-                 <g:TextBox styleName="{style.textBox}" 
-                            ui:field="txtTitle_"></g:TextBox>
+                 <rw:FormTextBox elementId="{ElementIds.getNewRmdTitle}" styleName="{style.textBox}" 
+                                 ui:field="txtTitle_" />
                </g:customCell>
               </g:row>
               <g:row>
-                <g:customCell><rw:FormLabel ui:field="lblAuthor_" styleName="{style.topLabel}" 
-                         text="Author:"></rw:FormLabel></g:customCell>
-                <g:customCell><g:TextBox styleName="{style.textBox}"
-                           ui:field="txtAuthor_"></g:TextBox></g:customCell>
+                <g:customCell>
+                   <rw:FormLabel for="{ElementIds.getNewRmdAuthor}" styleName="{style.topLabel}">Author:</rw:FormLabel>
+                </g:customCell>
+                <g:customCell>
+                   <rw:FormTextBox elementId="{ElementIds.getNewRmdAuthor}" styleName="{style.textBox}" 
+                                   ui:field="txtAuthor_"/>
+                </g:customCell>
               </g:row>
            </g:Grid>
-           <rw:FieldSetPanel ui:field="formatFieldSet_" legend="Default Output Format:" 
-                             styleName="{style.defaultOutputLabel}">
+           <rw:FieldSetPanel legend="Default Output Format:" styleName="{style.defaultOutputLabel}">
               <g:HTMLPanel ui:field="templateFormatPanel_"></g:HTMLPanel>
            </rw:FieldSetPanel>
         </g:HTMLPanel>


### PR DESCRIPTION
- support declarative setting of control IDs (in UiBinder) and used that technique in this dialog
- switched a few other places over to this technique
- eliminates need to call `setFor` on labels to associate them with their target control
- provides stable IDs for controls, which will be useful in automation
- on the negative side, will result in a gigantic list of IDs in `ElementIds.java`, be nice to come up with a less centralized approach that can still ensure uniqueness

![2019-08-09_17-27-14](https://user-images.githubusercontent.com/10569626/62815166-1716ac00-bacb-11e9-98ab-d5ca0ea5c1eb.png)
