### PR TITLE
accessiblity fixes to Save Plot as PDF dialog

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/FieldSetWrapperPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FieldSetWrapperPanel.java
@@ -1,5 +1,5 @@
 /*
- * VerticalRadioPanel.java
+ * FieldSetWrapperPanel.java
  *
  * Copyright (C) 2009-19 by RStudio, Inc.
  *
@@ -15,18 +15,19 @@
 package org.rstudio.core.client.widget;
 
 import com.google.gwt.user.client.ui.Label;
-import com.google.gwt.user.client.ui.RadioButton;
-import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.gwt.user.client.ui.Panel;
+import com.google.gwt.user.client.ui.Widget;
 
 /**
- * A VerticalPanel containing a group of radio buttons and a legend.
+ * A fieldset element containing a Panel of type T
  */
-public class VerticalRadioPanel extends FieldSetPanel
+public class FieldSetWrapperPanel<T extends Panel> extends FieldSetPanel
 {
-   public VerticalRadioPanel(String legend, boolean visuallyHideLegend)
+   public FieldSetWrapperPanel(T panel, String legend, boolean visuallyHideLegend)
    {
       super(legend, visuallyHideLegend);
-      super.add(panel_ = new VerticalPanel());
+      panel_ = panel;
+      super.add(panel_);
    }
 
    /**
@@ -34,16 +35,22 @@ public class VerticalRadioPanel extends FieldSetPanel
     *                      will be applied to a hidden legend element for accessibility, and
     *                      the label itself will be marked aria-hidden
     */
-   public VerticalRadioPanel(Label externalLabel)
+   public FieldSetWrapperPanel(T panel, Label externalLabel)
    {
       super(externalLabel);
-      super.add(panel_ = new VerticalPanel());
+      panel_ = panel;
+      super.add(panel_);
    }
 
-   public void add(RadioButton w)
+   public void add(Widget w)
    {
       panel_.add(w);
    }
 
-   private VerticalPanel panel_;
+   public T getPanel()
+   {
+      return panel_;
+   }
+
+   private T panel_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/ExportPlot.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/ExportPlot.css
@@ -25,7 +25,6 @@
    width: 250px;
    cursor: default;
 }
-}
 
 .imageOptionLabel {
    margin-right: 5px;
@@ -107,6 +106,14 @@
    margin-bottom: 15px;
 }
 
+.savePdfMainWidget fieldset {
+   border: none;
+   padding: 0;
+   padding-block-end: 0;
+   padding-inline-end: 0;
+   margin: 0;
+}
+
 .savePdfSizeListBox {
    width: 120px;
    margin-right: 10px;
@@ -121,13 +128,9 @@
 }
 
 
-.savePdfFileNameTextBox {
-	margin-left: 10px;
+.savePdfDirectoryTextBox, .savePdfFileNameTextBox {
+   margin-left: 10px;
    width: 280px;
-}
-
-.savePdfDirectoryLabel {
-	margin-left: 10px;
 }
 
 .savePdfViewAfterCheckbox {
@@ -146,5 +149,5 @@
    margin-top: 3px;
    margin-left: 5px;
    margin-right: 5px;
-   color: gray;
+   color: #6F6F6F;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/ExportPlotResources.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/ExportPlotResources.java
@@ -51,7 +51,7 @@ public interface ExportPlotResources extends ClientBundle
       String savePdfMainWidget();
       String savePdfSizeListBox();
       String savePdfSizeLabel();
-      String savePdfDirectoryLabel();
+      String savePdfDirectoryTextBox();
       String savePdfFileNameLabel();
       String savePdfFileNameTextBox();
       String savePdfViewAfterCheckbox();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/export/SavePlotAsPdfDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/export/SavePlotAsPdfDialog.java
@@ -18,10 +18,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.gwt.aria.client.Roles;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.files.FileSystemContext;
 import org.rstudio.core.client.files.FileSystemItem;
+import org.rstudio.core.client.widget.FieldSetWrapperPanel;
+import org.rstudio.core.client.widget.FormLabel;
+import org.rstudio.core.client.widget.LayoutGrid;
 import org.rstudio.core.client.widget.ModalDialogBase;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
@@ -47,7 +51,6 @@ import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.i18n.client.NumberFormat;
 import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.Grid;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.HorizontalPanel;
@@ -143,27 +146,31 @@ public class SavePlotAsPdfDialog extends ModalDialogBase
    {
       ExportPlotResources.Styles styles = ExportPlotResources.INSTANCE.styles();
       
-      Grid grid = new Grid(7, 2);
+      LayoutGrid grid = new LayoutGrid(7, 2);
       grid.setStylePrimaryName(styles.savePdfMainWidget());
       
       // paper size
-      grid.setWidget(0, 0, new Label("PDF Size:"));
+      Label sizeLabel = new Label("PDF Size:");
+      grid.setWidget(0, 0, sizeLabel);
       
       // paper size label
-      paperSizeEditor_ = new PaperSizeEditor();
+      paperSizeEditor_ = new PaperSizeEditor(sizeLabel);
       grid.setWidget(0, 1, paperSizeEditor_);
       
       // orientation
-      grid.setWidget(1, 0, new Label("Orientation:"));
+      Label orientationLabel = new Label("Orientation:");
+      grid.setWidget(1, 0, orientationLabel);
       HorizontalPanel orientationPanel = new HorizontalPanel();
       orientationPanel.setSpacing(kComponentSpacing);
       VerticalPanel orientationGroupPanel = new VerticalPanel();
-      final String kOrientationGroup = new String("Orientation");
+      FieldSetWrapperPanel<VerticalPanel> orientationButtons =
+            new FieldSetWrapperPanel<>(orientationGroupPanel, orientationLabel);
+      final String kOrientationGroup = "Orientation";
       portraitRadioButton_ = new RadioButton(kOrientationGroup, "Portrait");
       orientationGroupPanel.add(portraitRadioButton_);
       landscapeRadioButton_ = new RadioButton(kOrientationGroup, "Landscape");
       orientationGroupPanel.add(landscapeRadioButton_);
-      orientationPanel.add(orientationGroupPanel);
+      orientationPanel.add(orientationButtons);
       grid.setWidget(1, 1, orientationPanel);
       
       boolean haveCairoPdf = sessionInfo_.isCairoPdfAvailable();
@@ -194,7 +201,7 @@ public class SavePlotAsPdfDialog extends ModalDialogBase
             fileDialogs_.chooseFolder(
                "Choose Directory",
                fileSystemContext_,
-               FileSystemItem.createDir(directoryLabel_.getTitle().trim()),
+               FileSystemItem.createDir(directoryTextBox_.getText().trim()),
                new ProgressOperationWithInput<FileSystemItem>() {
 
                  public void execute(FileSystemItem input,
@@ -216,17 +223,19 @@ public class SavePlotAsPdfDialog extends ModalDialogBase
       });
       
       
-      directoryLabel_ = new Label();
+      directoryTextBox_ = new TextBox();
+      directoryTextBox_.setReadOnly(true);
+      Roles.getTextboxRole().setAriaLabelProperty(directoryTextBox_.getElement(), "Selected Directory");
       setDirectory(defaultDirectory_);
-      directoryLabel_.setStylePrimaryName(styles.savePdfDirectoryLabel());
-      grid.setWidget(4, 1, directoryLabel_);
+      directoryTextBox_.setStylePrimaryName(styles.savePdfDirectoryTextBox());
+      grid.setWidget(4, 1, directoryTextBox_);
       
-      Label fileNameLabel = new Label("File name:");
-      fileNameLabel.setStylePrimaryName(styles.savePdfFileNameLabel());
-      grid.setWidget(5, 0, fileNameLabel);
       fileNameTextBox_ = new TextBox();
       fileNameTextBox_.setText(defaultPlotName_);
       fileNameTextBox_.setStylePrimaryName(styles.savePdfFileNameTextBox());
+      FormLabel fileNameLabel = new FormLabel("File name:", fileNameTextBox_);
+      fileNameLabel.setStylePrimaryName(styles.savePdfFileNameLabel());
+      grid.setWidget(5, 0, fileNameLabel);
       grid.setWidget(5, 1, fileNameTextBox_);
       
       
@@ -283,10 +292,7 @@ public class SavePlotAsPdfDialog extends ModalDialogBase
         
       // set label
       String dirLabel = ExportPlotUtils.shortDirectoryName(directory, 250);
-      directoryLabel_.setText(dirLabel);
-      
-      // set tooltip
-      directoryLabel_.setTitle(directory.getPath());
+      directoryTextBox_.setText(dirLabel);
    }
    
    
@@ -360,7 +366,7 @@ public class SavePlotAsPdfDialog extends ModalDialogBase
    
    private class PaperSizeEditor extends Composite
    {
-      public PaperSizeEditor()
+      public PaperSizeEditor(Label visibleLabel)
       {
          ExportPlotResources.Styles styles = 
                                        ExportPlotResources.INSTANCE.styles();
@@ -374,15 +380,17 @@ public class SavePlotAsPdfDialog extends ModalDialogBase
          paperSizes_.add(new PaperSize("5 x 7 in.", 5, 7));
          paperSizes_.add(new PaperSize("6 x 8 in.", 6, 8));
            
-         HorizontalPanel panel = new HorizontalPanel();
-         panel.setVerticalAlignment(HasVerticalAlignment.ALIGN_MIDDLE);   
-         panel.setSpacing(kComponentSpacing);
+         FieldSetWrapperPanel<HorizontalPanel> panel = new FieldSetWrapperPanel<>(
+               new HorizontalPanel(), visibleLabel);
+         panel.getPanel().setVerticalAlignment(HasVerticalAlignment.ALIGN_MIDDLE);   
+         panel.getPanel().setSpacing(kComponentSpacing);
           
          // paper size list box
          int selectedPaperSize = -1;
          paperSizeListBox_ = new ListBox();
          paperSizeListBox_.setStylePrimaryName(styles.savePdfSizeListBox());
-         for (int i=0; i<paperSizes_.size(); i++)
+         Roles.getListboxRole().setAriaLabelProperty(paperSizeListBox_.getElement(), "Size Preset");
+         for (int i = 0; i < paperSizes_.size(); i++)
          {
             PaperSize paperSize = paperSizes_.get(i);
             paperSizeListBox_.addItem(paperSize.getName());
@@ -410,20 +418,23 @@ public class SavePlotAsPdfDialog extends ModalDialogBase
                updateSizeDescription();  
             } 
          });
-         panel.add(paperSizeListBox_);   
+         panel.add(paperSizeListBox_);
          
          HorizontalPanel editPanel = new HorizontalPanel();
          widthTextBox_ = new TextBox();
          widthTextBox_.setStylePrimaryName(styles.savePdfPaperSizeTextBox());
+         Roles.getTextboxRole().setAriaLabelProperty(widthTextBox_.getElement(), "Width");
          widthTextBox_.addChangeHandler(sizeTextBoxChangeHandler_);
          editPanel.add(widthTextBox_);
          
-         Label label = new Label("x");
+         Label label = new Label();
+         label.getElement().setInnerSafeHtml(SafeHtmlUtils.fromSafeConstant("&times;"));
          label.setStylePrimaryName(styles.savePdfPaperSizeX());
          editPanel.add(label);
          
          heightTextBox_ = new TextBox();
          heightTextBox_.setStylePrimaryName(styles.savePdfPaperSizeTextBox());
+         Roles.getTextboxRole().setAriaLabelProperty(heightTextBox_.getElement(), "Height");
          heightTextBox_.addChangeHandler(sizeTextBoxChangeHandler_);
          editPanel.add(heightTextBox_);
          panel.add(editPanel);
@@ -540,7 +551,7 @@ public class SavePlotAsPdfDialog extends ModalDialogBase
    
    private TextBox fileNameTextBox_;
    private FileSystemItem directory_;
-   private Label directoryLabel_;
+   private TextBox directoryTextBox_;
    private PaperSizeEditor paperSizeEditor_ ;
   
    private RadioButton portraitRadioButton_ ;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewShinyWebApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewShinyWebApplication.java
@@ -22,11 +22,11 @@ import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.core.client.widget.DecorativeImage;
 import org.rstudio.core.client.widget.DirectoryChooserTextBox;
+import org.rstudio.core.client.widget.FieldSetWrapperPanel;
 import org.rstudio.core.client.widget.FormLabel;
 import org.rstudio.core.client.widget.LayoutGrid;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
-import org.rstudio.core.client.widget.VerticalRadioPanel;
 import org.rstudio.core.client.widget.VerticalSpacer;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.GlobalDisplay;
@@ -211,7 +211,7 @@ public class NewShinyWebApplication extends ModalDialog<NewShinyWebApplication.R
       appTypeLabel_.addStyleName(RES.styles().label());
       appTypeLabel_.getElement().getStyle().setMarginTop(2, Unit.PX);
       
-      VerticalRadioPanel radioPanel = new VerticalRadioPanel(appTypeLabel_);
+      FieldSetWrapperPanel<VerticalPanel> radioPanel = new FieldSetWrapperPanel<>(new VerticalPanel(), appTypeLabel_);
       radioPanel.setStylePrimaryName(RES.styles().shinyTypeGroup());
       appTypeSingleFileButton_ = new RadioButton("shiny", "Single File (app.R)");
       appTypeMultipleFileButton_ = new RadioButton("shiny", "Multiple File (ui.R/server.R)");


### PR DESCRIPTION
- labeled fieldset around PDF size controls
- labeled fieldset around orientation radio buttons
- fix contrast of "inches"
- use multiplication symbol instead of "x" for dimensions
- use readonly textbox (with aria-label) to show currently selected directory instead of a static label
    - enables tabbing to the control, selection and copy, and is more consistent with other RStudio directory-picker UI
- associate File Name label with textbox
- fix visual layout of the "View plot after saving" checkbox
- created templated fieldset FieldSetWrapperPanel that eliminates need for separate Horizontal/Vertical fieldset classes
- removed the VerticalRadioPanel and switched to FieldSetWrapperPanel
- left HorizontalRadioPanel as-is; that is only used in Pro-only code, so will clean it up there

Before:
![2019-08-10_14-39-20](https://user-images.githubusercontent.com/10569626/62839154-f2d9dd00-bc3a-11e9-8ad3-c8e71888da43.png)

After:
![2019-08-11_13-11-42](https://user-images.githubusercontent.com/10569626/62839155-f79e9100-bc3a-11e9-95fb-4bb46af973b4.png)
