### PR TITLE
a11y improvements to SearchWidget and Browser Addins dialog

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
+++ b/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
@@ -98,6 +98,15 @@ public class A11y
     */
    public static void setARIAHidden(Widget widget)
    {
-      widget.getElement().setAttribute("aria-hidden", "true");
+      setARIAHidden(widget.getElement());
+   }
+
+   /**
+    * Make an element hidden to screen readers.
+    * @param el
+    */
+   public static void setARIAHidden(Element el)
+   {
+      el.setAttribute("aria-hidden", "true");
    }
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1652,8 +1652,8 @@ body.windows table.webGlobalToolbar {
 }
 .clearSearch .gwt-Image {
    float: left;
-   width: 10px;
-   height: 10px;
+   width: 11px;
+   height: 11px;
 }
 .searchBoxContainer {
    position: absolute;

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -15,6 +15,7 @@
 @external gwt-DialogBox, gwt-DialogBox-ModalDialog;
 @external gwt-PopupPanelGlass;
 @external gwt-Label;
+@external gwt-Image;
 @external gwt-MenuItem, gwt-MenuItem-selected, subMenuIcon, subMenuIcon-selected, gwt-MenuBarPopup;
 @external gwt-MenuItemSeparator, menuSeparatorInner, menuPopupMiddleCenter;
 @external gwt-MenuBar, gwt-MenuBar-vertical;
@@ -1649,6 +1650,11 @@ body.windows table.webGlobalToolbar {
    width: 11px;
    height: 11px;
 }
+.clearSearch .gwt-Image {
+   float: left;
+   width: 10px;
+   height: 10px;
+}
 .searchBoxContainer {
    position: absolute;
    top: 0;
@@ -2408,14 +2414,6 @@ body.ubuntu_mono .searchBox {
 
 .rstudio-themes-flat.rstudio-themes-dark-menus .search input::placeholder {
    color: #CCC;
-}
-
-.rstudio-themes-flat .searchMagGlass {
-   top: 2px;
-}
-
-.rstudio-themes-flat .clearSearch {
-   top: 3px;
 }
 
 .rstudio-themes-flat .dataGridSortedHeaderAscending img {

--- a/src/gwt/src/org/rstudio/core/client/widget/DecorativeImage.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/DecorativeImage.java
@@ -33,7 +33,7 @@ public class DecorativeImage extends Image
    public DecorativeImage()
    {
       super();
-      A11y.setDecorativeImage(getElement());
+      setDecorative();
    }
 
    /**
@@ -44,8 +44,7 @@ public class DecorativeImage extends Image
    public DecorativeImage(ImageResource resource)
    {
       super(resource);
-      A11y.setDecorativeImage(getElement());
-
+      setDecorative();
    }
 
    /**
@@ -57,7 +56,7 @@ public class DecorativeImage extends Image
    public DecorativeImage(String url)
    {
      super(url);
-      A11y.setDecorativeImage(getElement());
+     setDecorative(); 
    }
 
    /**
@@ -69,7 +68,7 @@ public class DecorativeImage extends Image
    public DecorativeImage(SafeUri url)
    {
       super(url);
-      A11y.setDecorativeImage(getElement());
+      setDecorative();
    }
 
    /**
@@ -93,7 +92,7 @@ public class DecorativeImage extends Image
    public DecorativeImage(String url, int left, int top, int width, int height)
    {
       super(url, left, top, width, height);
-      A11y.setDecorativeImage(getElement());
+      setDecorative();
    }
 
    /**
@@ -117,7 +116,7 @@ public class DecorativeImage extends Image
    public DecorativeImage(SafeUri url, int left, int top, int width, int height)
    {
       super(url, left, top, width, height);
-      A11y.setDecorativeImage(getElement());
+      setDecorative();
    }
 
    /**
@@ -129,7 +128,17 @@ public class DecorativeImage extends Image
    protected DecorativeImage(Element element)
    {
       super(element);
+      setDecorative();
+   }
+
+   private void setDecorative()
+   {
       A11y.setDecorativeImage(getElement());
+
+      // aria-hidden shouldn't be needed, but have seen macOS VoiceOver
+      // putting screen-reader cursor onto the decorative image (and reading nothing) in
+      // some situations, and this prevents it
+      A11y.setARIAHidden(getElement());
    }
 
    /**

--- a/src/gwt/src/org/rstudio/core/client/widget/FilterWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FilterWidget.java
@@ -14,21 +14,15 @@
  */
 package org.rstudio.core.client.widget;
 
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.SuggestOracle;
 
 public abstract class FilterWidget extends Composite
 {
    public abstract void filter(String query);
-   
-   public FilterWidget(String label)
-   {
-      this(label, "Filter...");
-   }
-   
-   public FilterWidget(String label, String placeholder)
+
+   public FilterWidget()
    {
       SuggestOracle oracle = new SuggestOracle()
       {
@@ -37,24 +31,21 @@ public abstract class FilterWidget extends Composite
          {
          }
       };
-      
-      searchWidget_ = new SearchWidget(label, oracle);
-      searchWidget_.setPlaceholderText(placeholder);
-      searchWidget_.addValueChangeHandler(new ValueChangeHandler<String>()
-      {
-         @Override
-         public void onValueChange(ValueChangeEvent<String> event)
-         {
-            filter(event.getValue());
-         }
-      });
+
+      searchWidget_ = new SearchWidget("", oracle);
+      searchWidget_.addValueChangeHandler(event -> filter(event.getValue()));
       initWidget(searchWidget_);
    }
-   
+
    public void focus()
    {
       searchWidget_.focus();
    }
-   
+
+   public Element getInputElement()
+   {
+      return searchWidget_.getInputElement();
+   }
+
    private final SearchWidget searchWidget_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/FormLabel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FormLabel.java
@@ -90,6 +90,21 @@ public class FormLabel extends Label
    }
 
    /**
+    * Creates a label with the specified text, which is associated with
+    * the specified form control.
+    *
+    * @param inline true if inline display, false for block
+    * @param text the new label's text
+    * @param el labeled element; if the element does not already have an id attribute,
+    *           one will be generated and assigned to it
+    */
+   public FormLabel(boolean inline, String text, Element el)
+   {
+      super(inline, text, NoForId);
+      setFor(el);
+   }
+
+   /**
     * Create a label to associate with an existing widget.
     * @param text label text
     * @param w labeled widget; if the widget's element does not already have an id attribute,

--- a/src/gwt/src/org/rstudio/core/client/widget/ImageButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ImageButton.java
@@ -16,6 +16,7 @@ package org.rstudio.core.client.widget;
 
 import com.google.gwt.dom.client.ButtonElement;
 import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.SpanElement;
 import com.google.gwt.dom.client.Style.Cursor;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
@@ -24,21 +25,38 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.FocusWidget;
 import com.google.gwt.user.client.ui.Image;
+import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.theme.res.ThemeStyles;
 
 /**
  * An image that behaves like a button.
  */
 public class ImageButton extends FocusWidget implements HasClickHandlers
 {
-   public ImageButton(String altText, ImageResource image)
+   public ImageButton()
+   {
+      this(null, null);
+   }
+
+   public ImageButton(String description, ImageResource image)
    {
       ButtonElement button = Document.get().createPushButtonElement();
       button.setClassName("rstudio-ImageButton");
-      
-      image_ = new Image(image);
+      button.setAttribute("type", "button");
+
+      if (image != null)
+         image_ = new DecorativeImage(image);
+      else
+         image_ = new DecorativeImage();
+
       image_.getElement().getStyle().setCursor(Cursor.POINTER);
-      image_.setAltText(altText);
       button.insertFirst(image_.getElement());
+
+      descriptionSpan_ = Document.get().createSpanElement();
+      descriptionSpan_.setClassName(ThemeStyles.INSTANCE.visuallyHidden());
+      button.appendChild(descriptionSpan_);
+      setDescription(description);
+
       setElement(button);
    }
 
@@ -50,8 +68,19 @@ public class ImageButton extends FocusWidget implements HasClickHandlers
    public Image getImage()
    {
       return image_;
-      
    }
 
-   private Image image_;
+   public void setDescription(String description)
+   {
+      if (!StringUtil.isNullOrEmpty(description))
+         descriptionSpan_.setInnerText(description);
+   }
+
+   public void setResource(ImageResource resource)
+   {
+      image_.setResource(resource);
+   }
+
+   private SpanElement descriptionSpan_;
+   private DecorativeImage image_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.java
@@ -31,7 +31,6 @@ import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.SuggestBox;
 import com.google.gwt.user.client.ui.SuggestBox.DefaultSuggestionDisplay;
 import com.google.gwt.user.client.ui.SuggestBox.SuggestionDisplay;
@@ -41,6 +40,8 @@ import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.TextBoxBase;
 import com.google.gwt.user.client.ui.ValueBoxBase;
 import com.google.gwt.user.client.ui.Widget;
+import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.events.SelectionCommitEvent;
 import org.rstudio.core.client.events.SelectionCommitHandler;
@@ -130,14 +131,21 @@ public class SearchWidget extends Composite implements SearchDisplay
          suggestBox_ = new FocusSuggestBox(oracle, textBox);
       
       initWidget(uiBinder.createAndBindUi(this));
-      close_.setVisible(false);
-      close_.setAltText("Clear text");
-      hiddenLabel_.setInnerText(label);
-      hiddenLabel_.setHtmlFor(DomUtils.ensureHasId(textBox.getElement()));
+      clearFilter_.setVisible(false);
+      clearFilter_.setDescription("Clear text");
+      if (!StringUtil.isNullOrEmpty(label))
+      {
+         hiddenLabel_.setInnerText(label);
+         hiddenLabel_.setHtmlFor(DomUtils.ensureHasId(textBox.getElement()));
+      }
+      else
+      {
+         A11y.setARIAHidden(hiddenLabel_);
+      }
       ThemeStyles styles = ThemeResources.INSTANCE.themeStyles();
       
       suggestBox_.setStylePrimaryName(styles.searchBox());
-      suggestBox_.setAutoSelectEnabled(false) ;
+      suggestBox_.setAutoSelectEnabled(false);
       addKeyDownHandler(new KeyDownHandler() {
          public void onKeyDown(KeyDownEvent event)
          {
@@ -148,10 +156,10 @@ public class SearchWidget extends Composite implements SearchDisplay
                   public void execute()
                   {
                      SelectionCommitEvent.fire(SearchWidget.this, 
-                                               suggestBox_.getText()) ;
+                                               suggestBox_.getText());
                   }
-               }) ;
-               break ;
+               });
+               break;
             case KeyCodes.KEY_ESCAPE:
                
                event.preventDefault();
@@ -177,10 +185,10 @@ public class SearchWidget extends Composite implements SearchDisplay
                   }   
                });
                    
-               break ;
+               break;
             }
          }
-      }) ;
+      });
 
       if (continuousSearch)
       {
@@ -210,15 +218,10 @@ public class SearchWidget extends Composite implements SearchDisplay
          }
       });
 
-      close_.addMouseDownHandler(new MouseDownHandler()
-      {
-         public void onMouseDown(MouseDownEvent event)
-         {
-            event.preventDefault();
-            
-            suggestBox_.setText("");
-            ValueChangeEvent.fire(suggestBox_, "");
-         }
+      clearFilter_.addClickHandler(event -> {
+         suggestBox_.setText("");
+         ValueChangeEvent.fire(suggestBox_, "");
+         focus();
       });
       
       focusTracker_ = new FocusTracker(suggestBox_);
@@ -243,7 +246,7 @@ public class SearchWidget extends Composite implements SearchDisplay
    public HandlerRegistration addSelectionCommitHandler(
                                        SelectionCommitHandler<String> handler)
    {
-      return addHandler(handler, SelectionCommitEvent.getType()) ;
+      return addHandler(handler, SelectionCommitEvent.getType());
    }
 
    public HandlerRegistration addKeyDownHandler(final KeyDownHandler handler)
@@ -278,12 +281,12 @@ public class SearchWidget extends Composite implements SearchDisplay
    
    public String getText()
    {
-      return suggestBox_.getText() ;
+      return suggestBox_.getText();
    }
 
    public void setText(String text)
    {
-      suggestBox_.setText(text) ;
+      suggestBox_.setText(text);
    }
 
    public void setText(String text, boolean fireEvents)
@@ -322,7 +325,7 @@ public class SearchWidget extends Composite implements SearchDisplay
    public void clear()
    {
       setText("", true);
-      close_.setVisible(false);
+      clearFilter_.setVisible(false);
    }
    
    // NOTE: only works if you are using the default display!
@@ -339,7 +342,7 @@ public class SearchWidget extends Composite implements SearchDisplay
    private void updateLastValue(String value)
    {
       lastValueSent_ = value;
-      close_.setVisible(lastValueSent_.length() > 0);
+      clearFilter_.setVisible(lastValueSent_.length() > 0);
    }
    
    public String getLastValue()
@@ -368,7 +371,7 @@ public class SearchWidget extends Composite implements SearchDisplay
    @UiField(provided=true)
    FocusSuggestBox suggestBox_;
    @UiField
-   Image close_;
+   ImageButton clearFilter_;
    @UiField
    DecorativeImage icon_;
    @UiField

--- a/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.ui.xml
@@ -16,9 +16,9 @@
                <f:SearchWidget.FocusSuggestBox ui:field='suggestBox_'
                           styleName='{res.themeStyles.searchBox}'/>
             </div>
-            <g:Image ui:field='close_'
-                     resource='{res.clearSearch2x}'
-                     styleName='{res.themeStyles.clearSearch}'/>
+            <f:ImageButton ui:field='clearFilter_'
+                           resource='{res.clearSearch2x}'
+                           addStyleNames='{res.themeStyles.clearSearch}'/>
          </div>
          <div class="{res.themeStyles.right}"></div>
       </div>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.css
@@ -17,3 +17,8 @@
 .rstudio-themes-flat .dataGridWidget .dataGridSelectedRow {
    background: #eeeff1
 }
+
+.filterLabel {
+   float: left;
+   padding-right: 4px;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
@@ -45,6 +45,7 @@ import org.rstudio.core.client.js.JsUtil;
 import org.rstudio.core.client.theme.RStudioDataGridResources;
 import org.rstudio.core.client.theme.RStudioDataGridStyle;
 import org.rstudio.core.client.widget.FilterWidget;
+import org.rstudio.core.client.widget.FormLabel;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.ModifyKeyboardShortcutsWidget;
 import org.rstudio.core.client.widget.OperationWithInput;
@@ -71,7 +72,7 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
       
       setOkButtonCaption("Execute");
       
-      filterWidget_ = new FilterWidget("Filter by addin name")
+      filterWidget_ = new FilterWidget()
       {
          @Override
          public void filter(String query)
@@ -142,6 +143,9 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
       }));
       
       FlowPanel headerPanel = new FlowPanel();
+      FormLabel filterLabel = new FormLabel(true, "Filter addins:", filterWidget_.getInputElement());
+      filterLabel.addStyleName(RES.dataGridStyle().filterLabel());
+      headerPanel.add(filterLabel);
       headerPanel.add(filterWidget_);
       headerPanel.add(helpLink_);
       
@@ -368,6 +372,7 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
    
    public interface Styles extends RStudioDataGridStyle
    {
+      String filterLabel();
    }
    
    private static final Resources RES = GWT.create(Resources.class);


### PR DESCRIPTION
- improvements to SearchWidget class
    - make the "clear text" button an actual button that can be tabbed to and used via keyboard/screen reader
    - make the hidden-label optional (for cases where the search control has an actual visible label)
    - set focus back to textbox after invoking the "clear text" button
- put a visible label on the filter control in BrowserAddinsDialog and get rid of the placeholder text
- improvement to DecorativeImage to fix weird cases where macOS VoiceOver would allow selection of images without alt-text via VoiceOver cursor (and would say nothing about it)
- another constructor variation for FormLabel class
- improvements to ImageButton
    - mark underlying button as type="button" to avoid browser variations
    - more setters and no-argument constructor to allow use from UiBinder
    - put descriptive text in a visually hidden span per recommendations
 - delete 2 duplicate styles in themeStyles.css

Before:
![2019-08-12_16-03-41](https://user-images.githubusercontent.com/10569626/62909198-77f2ee00-bd30-11e9-849a-3d35a9fe2eca.png)

After:
![2019-08-12_16-04-28](https://user-images.githubusercontent.com/10569626/62909200-7c1f0b80-bd30-11e9-85f4-5cc146b1813b.png)
