### PR TITLE
speak results when filtering addins (dialog-only)

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -1418,7 +1418,8 @@ public class StringUtil
     */
    public static native String spacedString(String str) /*-{
       return str.split('').join(' ');
-   }-*/;   
+   }-*/;
+
    private static final NumberFormat FORMAT = NumberFormat.getFormat("0.#");
    private static final NumberFormat PRETTY_NUMBER_FORMAT = NumberFormat.getFormat("#,##0.#####");
    private static final DateTimeFormat DATE_FORMAT

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -1410,7 +1410,15 @@ public class StringUtil
       
       return str.charAt(pos);
    }
-   
+
+   /**
+    * Convert a string "foo" to "f o o"
+    * @param str
+    * @return
+    */
+   public static native String spacedString(String str) /*-{
+      return str.split('').join(' ');
+   }-*/;   
    private static final NumberFormat FORMAT = NumberFormat.getFormat("0.#");
    private static final NumberFormat PRETTY_NUMBER_FORMAT = NumberFormat.getFormat("#,##0.#####");
    private static final DateTimeFormat DATE_FORMAT

--- a/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
+++ b/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
@@ -24,6 +24,11 @@ import org.rstudio.core.client.StringUtil;
  */
 public class A11y
 {
+   /**
+    * Typing delay before updating related aria-live message
+    */
+   public static int TypingStatusDelayMs = 2000;
+   
    public static void setARIADialogModal(Element element)
    {
       element.setAttribute("aria-modal", "true");

--- a/src/gwt/src/org/rstudio/core/client/widget/FilterWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FilterWidget.java
@@ -47,5 +47,10 @@ public abstract class FilterWidget extends Composite
       return searchWidget_.getInputElement();
    }
 
+   public void speakResult(String message)
+   {
+      searchWidget_.speakResult(message);
+   }
+
    private final SearchWidget searchWidget_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.ui.xml
@@ -6,7 +6,7 @@
 
    <g:HTMLPanel>
       <div class="{res.themeStyles.search}">
-         <div class="{res.themeStyles.left}"></div>
+         <div class="{res.themeStyles.left}"/>
          <div class="{res.themeStyles.rstheme_center}">
             <f:DecorativeImage ui:field='icon_'
                      resource='{res.smallMagGlassIcon2x}'
@@ -20,7 +20,8 @@
                            resource='{res.clearSearch2x}'
                            addStyleNames='{res.themeStyles.clearSearch}'/>
          </div>
-         <div class="{res.themeStyles.right}"></div>
+         <div class="{res.themeStyles.visuallyHidden}" ui:field="readerResultsLabel_"/>
+         <div class="{res.themeStyles.right}"/>
       </div>
    </g:HTMLPanel>
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
@@ -118,14 +118,14 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
       
       addColumns();
       
-      dataProvider_ = new ListDataProvider<RAddin>();
+      dataProvider_ = new ListDataProvider<>();
       dataProvider_.addDataDisplay(table_);
       
-      originalData_ = new ArrayList<RAddin>();
+      originalData_ = new ArrayList<>();
       
       // sync to current addins
       addins_ = addinsCommandManager_.getRAddins();
-      List<RAddin> data = new ArrayList<RAddin>();
+      List<RAddin> data = new ArrayList<>();
       for (String key : JsUtil.asIterable(addins_.keys()))
          data.add(addins_.get(key));
       dataProvider_.setList(data);
@@ -287,6 +287,8 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
          }
       });
       dataProvider_.setList(data);
+      filterWidget_.speakResult("Found " + data.size() + " addins matching " + 
+            StringUtil.spacedString(query));
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
@@ -692,7 +692,7 @@ public class GitReviewPanel extends ResizeComposite implements Display
       // Debounce an update to the accessible character count
       if (updateCharCountTimer_.isRunning())
          updateCharCountTimer_.cancel();
-      updateCharCountTimer_.schedule(2000);
+      updateCharCountTimer_.schedule(A11y.TypingStatusDelayMs);
    }
 
    @UiField(provided = true)


### PR DESCRIPTION
- use live-region to announce results in SearchWidget after a delay to avoid speaking over typing
- created global constant for that delay, also put in GitReviewPanel's character count announcement timer
- hooked up for BrowseAddinsDialog only (for now)
- note that announcement includes the typed query, with letters separated by spaces, so it doesn't try to read the query as a word, and also so the live region trigger an announcement when the query changes, not just when the number of results changes (live regions don't announce unless their text changes from previous value)