### PR TITLE
sudo to provide access to /usr/local/lib/R/site-library

### DIFF
--- a/dependencies/common/install-packages
+++ b/dependencies/common/install-packages
@@ -83,8 +83,14 @@ mv $PACKAGE_ARCHIVE $PACKAGE_ARCHIVE_SHA1
 
 install renv master rstudio
 
+RHOME=$(Rscript -e 'Sys.getenv("R_HOME")')
+if [[ ! -w $RHOME ]]; then
+  echo "$RHOME is not writable. Creating user R library directory."
+  mkdir -p $(Rscript -e 'cat(path.expand(Sys.getenv("R_LIBS_USER")))')
+fi
+
 # Packages needed to run tests
-sudo Rscript -e "if(!require(testthat, quietly = TRUE)) { install.packages('testthat', repos='https://cran.rstudio.com/') }"
+Rscript -e "if(!require(testthat, quietly = TRUE)) { install.packages('testthat', repos='https://cran.rstudio.com/') }"
 
 # back to install-dir
 cd $INSTALL_DIR

--- a/dependencies/common/install-packages
+++ b/dependencies/common/install-packages
@@ -84,7 +84,7 @@ mv $PACKAGE_ARCHIVE $PACKAGE_ARCHIVE_SHA1
 install renv master rstudio
 
 # Packages needed to run tests
-Rscript -e "if(!require(testthat, quietly = TRUE)) { install.packages('testthat', repos='https://cran.rstudio.com/') }"
+sudo Rscript -e "if(!require(testthat, quietly = TRUE)) { install.packages('testthat', repos='https://cran.rstudio.com/') }"
 
 # back to install-dir
 cd $INSTALL_DIR


### PR DESCRIPTION
This should fix an issue I was seeing when trying to install dependencies. Because testthat couldn't be installed, the script exits and the other dependencies afterwards don't get installed.