### PR TITLE
Perform release notarization for RStudio 1.2

### DIFF
--- a/Jenkinsfile.macos
+++ b/Jenkinsfile.macos
@@ -44,7 +44,7 @@ pipeline {
         }
       }
     }
-    stage('upload') {
+    stage('notarize and upload') {
       steps {
         script {
           // extract name of package to publish
@@ -52,6 +52,10 @@ pipeline {
             script: "basename `ls package/osx/build/RStudio-*.dmg`",
             returnStdout: true
           ).trim()
+
+          withCredentials([usernamePassword(credentialsId: 'ide-apple-notarizer', usernameVariable: 'APPLE_ID', passwordVariable: 'APPLE_ID_PASSWORD')]) {
+            sh "docker/jenkins/notarize-release.sh package/osx/build/${packageFile}"
+          }
 
           // this job is going to run on a macOS slave, which cannot use an instance-profile
           withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'jenkins-aws']]) {

--- a/docker/jenkins/notarize-release.sh
+++ b/docker/jenkins/notarize-release.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# RStudio Release Notarization (notarize-release.sh)
+# 
+# Copyright (C) 2009-19 by RStudio, Inc.
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+# Notarizes an RStudio release using the public Apple notary service.
+#
+# Usage: 
+#
+#    notarize-release.sh [path-to-dmg]
+#
+# where path-to-dmg is a relative or absolute path to the DMG file to notarize.
+#
+# Expects the following environment variables to be present:
+#  
+#    APPLE_ID: the ID of the Apple account under which to submit the
+#      notarization request
+#    APPLE_ID_PASSWORD: An app-specific password (NOT the primary password) for
+#      the Apple ID. See details here: https://support.apple.com/en-us/HT204397
+#  
+
+if [[ "$#" -lt 1 ]]; then
+    echo "Usage: notarize-release.sh [path-to-dmg]"
+    exit 1
+fi
+
+# Validate environment vars
+if [ -z "$APPLE_ID" ]; then
+    echo "Please set the environment variable APPLE_ID to the AppleID under which to submit the notarization request."
+    exit 1
+fi
+if [ -z "$APPLE_ID_PASSWORD" ]; then
+    echo "Please set the environment variable APPLE_ID_PASSWORD to the password to the account named in the APPLE_ID environment variable."
+    exit 1
+fi
+
+# Submit the notarization request to Apple
+echo "Submitting notarization request using account $APPLE_ID..."
+XCRUN_RESULT="$(mktemp)"
+xcrun altool --notarize-app \
+    --primary-bundle-id "org.rstudio.RStudio" \
+    --username $APPLE_ID \
+    --password "@env:APPLE_ID_PASSWORD" \
+    --file $1 \
+    --output-format xml \
+    -itc_provider RStudioInc > $XCRUN_RESULT
+
+# Check result
+if [ $? -eq 0 ]; then
+    # Extract the request UUID from the result
+    REQUEST_UUID=$(/usr/libexec/PlistBuddy -c "Print :notarization-upload:RequestUUID" $XCRUN_RESULT)
+    echo "Notarization request with UUID $REQUEST_UUID created."
+else
+    echo "Notarization request submission failed. Server response:"
+    cat $XCRUN_RESULT
+    exit 1
+fi
+
+# Wait for notarization to complete
+echo "Waiting for notarization to complete. This will take several minutes."
+while true; do 
+    sleep 30
+    echo "Checking notarization status..."
+    xcrun altool --notarization-info $REQUEST_UUID --username $APPLE_ID --password "@env:APPLE_ID_PASSWORD" --output-format xml > $XCRUN_RESULT
+    NOTARIZATION_STATUS=$(/usr/libexec/PlistBuddy -c "Print :notarization-info:Status" $XCRUN_RESULT)
+    if [ $? -eq 0 ]; then
+        if [ "$NOTARIZATION_STATUS" != "in progress" ]; then 
+            echo "Notarization ended; result: $NOTARIZATION_STATUS"
+            break
+        fi
+        echo "Notarization still in progress. Waiting 30s to check again."
+    else
+        echo "Could not determine notarization status; giving up. Server response:" 
+        cat $XCRUN_RESULT
+        exit 1
+    fi
+done
+
+# Staple the notarization ticket to the app bundle
+if [ "$NOTARIZATION_STATUS" == "success" ]; then
+    echo "Notarization successful; stapling ticket to app bundle"
+    xcrun stapler staple $1
+else
+    echo "Notarization failed."
+    exit 1
+fi
+

--- a/package/osx/CMakeLists.txt
+++ b/package/osx/CMakeLists.txt
@@ -1,8 +1,29 @@
+#
+# CMakeLists.txt
+#
+# Copyright (C) 2009-19 by RStudio, Inc.
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
 # define package suffix
 set(RSTUDIO_PACKAGE_SUFFIX "-")
 
 # flags to pass to codesign executable
-set(CODESIGN_FLAGS "-s" "8A388E005EF927A09B952C6E71B0E8F2F467AB26" "-i" "org.rstudio.RStudio")
+set(CODESIGN_FLAGS 
+    "--options" "runtime" 
+    "--timestamp" 
+    "--entitlements" "${CMAKE_CURRENT_SOURCE_DIR}/entitlements.plist" 
+    "--deep" 
+    "-s" "8A388E005EF927A09B952C6E71B0E8F2F467AB26" 
+    "-i" "org.rstudio.RStudio")
 
 # include overlay if it exists
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/CMakeOverlay.txt")
@@ -32,7 +53,7 @@ if (RSTUDIO_PACKAGE_BUILD)
      # deep sign all targets
      foreach(CODESIGN_TARGET \${CODESIGN_TARGETS})
          message(\"Signing \${CODESIGN_TARGET}...\")
-         execute_process(COMMAND codesign \"--deep\" ${CODESIGN_FLAGS} \"\${CODESIGN_TARGET}\")
+         execute_process(COMMAND codesign ${CODESIGN_FLAGS} \"\${CODESIGN_TARGET}\")
      endforeach()
      ")
 endif()

--- a/package/osx/entitlements.plist
+++ b/package/osx/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.cs.disable-executable-page-protection</key>
+  <true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+</dict>
+</plist>

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -607,12 +607,13 @@ if(APPLE)
             COMMAND install_name_tool -change ${LIB_DIR}/${LIB_FILE} @executable_path/../Frameworks/${LIB_FILE} ${CMAKE_CURRENT_BINARY_DIR}/rsession)
       endforeach()
 
-      # also rewrite where rsession looks for libR.dylib
-      # (so we don't accidentally load the wrong version of R at launch)
+      # rewrite the libR.dylib path so that it points at the current version
+      # instead of the specific version we linked against. pointing at a
+      # specific version causes that version to always load even if it isn't
+      # the current version (see #2313 for details)
       get_filename_component(LIBR_HOME_REALPATH "${LIBR_HOME}" REALPATH)
       add_custom_command(TARGET rsession POST_BUILD
-         COMMAND install_name_tool -change "${LIBR_HOME_REALPATH}/lib/libR.dylib" "@executable_path/libR.dylib" "${CMAKE_CURRENT_BINARY_DIR}/rsession")
-
+         COMMAND install_name_tool -change "${LIBR_HOME_REALPATH}/lib/libR.dylib" "/Library/Frameworks/R.framework/Versions/Current/Resources/lib/libR.dylib" "${CMAKE_CURRENT_BINARY_DIR}/rsession")
    endif()
 
 endif()


### PR DESCRIPTION
This change ports the changes from PR https://github.com/rstudio/rstudio/pull/5196 to the v1.2-patch branch, so that we can have Apple notarize the 1.2-patch release.