### PR TITLE
implement snapshot / restore dialogs for renv

### DIFF
--- a/src/cpp/session/modules/SessionRenv.R
+++ b/src/cpp/session/modules/SessionRenv.R
@@ -81,6 +81,9 @@
    if (is.null(rhs))
       rhs <- default
    
+   if (nrow(lhs) == 0 && nrow(rhs) == 0)
+      return(default)
+   
    names(lhs) <- c("packageName", paste(before.prefix, names(lhs)[-1L], sep = ""))
    names(rhs) <- c("packageName", paste(after.prefix, names(rhs)[-1L], sep = ""))
    

--- a/src/cpp/session/modules/SessionRenv.R
+++ b/src/cpp/session/modules/SessionRenv.R
@@ -88,7 +88,7 @@
 {
    lockpath <- file.path(project, "renv.lock")
    lockfile <- renv:::renv_lockfile_read(lockpath)
-   packages <- lockfile$R$Package
+   packages <- lockfile[["Packages"]]
    filtered <- lapply(packages, `[`, c("Package", "Version", "Source"))
    df <- .rs.rbindList(filtered)
    rownames(df) <- NULL

--- a/src/cpp/session/modules/SessionRenv.R
+++ b/src/cpp/session/modules/SessionRenv.R
@@ -17,8 +17,9 @@
 
 .rs.addJsonRpcHandler("renv_init", function(project)
 {
+   # ask renv not to restart since we'll do it ourselves
    .rs.ensureDirectory(project)
-   renv::init(project = project)
+   renv::init(project = project, restart = FALSE)
 })
 
 .rs.addFunction("renv.context", function()

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -1431,9 +1431,9 @@ public class StringUtil
       String result = fmt;
       for (int i = 0; i < strings.size(); i += 2)
       {
-         String pattern = "{" + strings.get(i) + "}";
+         String target = "{" + strings.get(i) + "}";
          String replacement = strings.get(i + 1);
-         result = result.replaceAll(pattern, replacement);
+         result = result.replace(target, replacement);
       }
       
       return result;

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -1420,6 +1420,25 @@ public class StringUtil
       return str.split('').join(' ');
    }-*/;
 
+   public static String format(String fmt, Object... objects)
+   {
+      List<String> strings = new ArrayList<String>();
+      for (Object object : objects)
+      {
+         strings.add(object.toString());
+      }
+      
+      String result = fmt;
+      for (int i = 0; i < strings.size(); i += 2)
+      {
+         String pattern = "{" + strings.get(i) + "}";
+         String replacement = strings.get(i + 1);
+         result = result.replaceAll(pattern, replacement);
+      }
+      
+      return result;
+   }
+   
    private static final NumberFormat FORMAT = NumberFormat.getFormat("0.#");
    private static final NumberFormat PRETTY_NUMBER_FORMAT = NumberFormat.getFormat("#,##0.#####");
    private static final DateTimeFormat DATE_FORMAT

--- a/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
@@ -283,7 +283,8 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
    public enum Context
    {
       Workbench, Editor, R, Cpp, PackageDevelopment, RMarkdown,
-      Markdown, Sweave, Help, VCS, Packrat, RPresentation, Addin;
+      Markdown, Sweave, Help, VCS, Packrat, Renv, RPresentation,
+      Addin;
       
       @Override
       public String toString()
@@ -325,6 +326,8 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
          context_ = Context.Help;
       else if (lower.equals("packrat"))
          context_ = Context.Packrat;
+      else if (lower.equals("renv"))
+         context_ = Context.Renv;
       else if (lower.equals("presentation"))
          context_ = Context.RPresentation;
       else

--- a/src/gwt/src/org/rstudio/studio/client/renv/model/RenvServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/renv/model/RenvServerOperations.java
@@ -15,11 +15,15 @@
 package org.rstudio.studio.client.renv.model;
 
 import org.rstudio.studio.client.server.ServerRequestCallback;
+import org.rstudio.studio.client.workbench.projects.RenvAction;
 import org.rstudio.studio.client.workbench.views.buildtools.model.BuildServerOperations;
+
+import com.google.gwt.core.client.JsArray;
 
 import org.rstudio.studio.client.server.Void;
 
 public interface RenvServerOperations extends BuildServerOperations
 {
    void renvInit(String projDir, ServerRequestCallback<Void> requestCallback);
+   void renvActions(String action, ServerRequestCallback<JsArray<RenvAction>> requestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/renv/ui/RenvActionDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/renv/ui/RenvActionDialog.java
@@ -1,0 +1,58 @@
+/*
+ * RenvActionDialog.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.renv.ui;
+
+import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.widget.ModalDialog;
+import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.studio.client.workbench.projects.RenvAction;
+
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.user.client.ui.Widget;
+
+public class RenvActionDialog extends ModalDialog<Void>
+{
+   public RenvActionDialog(String action,
+                           JsArray<RenvAction> actions,
+                           final OperationWithInput<Void> operation)
+   {
+      super(
+            action + " Library",
+            Roles.getDialogRole(),
+            operation);
+      
+      widget_ = new RenvActionDialogContents(action, actions);
+      
+      setOkButtonCaption(StringUtil.capitalize(action));
+      setWidth("600px");
+   }
+   
+   @Override
+   protected Widget createMainWidget()
+   {
+      return widget_;
+   }
+   
+   @Override
+   protected Void collectInput()
+   {
+      return null;
+   }
+   
+   
+   private final RenvActionDialogContents widget_;
+
+}

--- a/src/gwt/src/org/rstudio/studio/client/renv/ui/RenvActionDialogContents.css
+++ b/src/gwt/src/org/rstudio/studio/client/renv/ui/RenvActionDialogContents.css
@@ -1,0 +1,1 @@
+@charset "UTF-8";

--- a/src/gwt/src/org/rstudio/studio/client/renv/ui/RenvActionDialogContents.java
+++ b/src/gwt/src/org/rstudio/studio/client/renv/ui/RenvActionDialogContents.java
@@ -1,0 +1,203 @@
+/*
+ * RenvActionDialogContents.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.renv.ui;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.rstudio.core.client.JsArrayUtil;
+import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.theme.RStudioDataGridResources;
+import org.rstudio.core.client.theme.RStudioDataGridStyle;
+import org.rstudio.core.client.widget.RStudioDataGrid;
+import org.rstudio.studio.client.workbench.projects.RenvAction;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.cellview.client.DataGrid;
+import com.google.gwt.user.cellview.client.TextColumn;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.Widget;
+
+public class RenvActionDialogContents extends Composite
+{
+   
+   interface RenvRestoreDialogContentsUiBinder 
+         extends UiBinder<Widget, RenvActionDialogContents> {}
+   
+   public RenvActionDialogContents(String action, JsArray<RenvAction> actions)
+   {
+      action_ = action;
+      actions_ = new ArrayList<RenvAction>();
+      JsArrayUtil.fillList(actions, actions_);
+      
+      table_ = new RStudioDataGrid<RenvAction>(actions.length(), RES);
+      
+      table_.setHeight("500px");
+      table_.setWidth("600px");
+      table_.setRowData(actions_);
+      
+      textColumn("Package",          "15%", (RenvAction entry) -> getPackageName(entry));
+      textColumn("Library Version",  "20%", (RenvAction entry) -> getLibraryVersion(entry));
+      textColumn("Lockfile Version", "20%", (RenvAction entry) -> getLockfileVersion(entry));
+      textColumn("Action",           "45%", (RenvAction entry) -> getAction(entry));
+      
+      
+      if (action == "Snapshot")
+      {
+         headerLabel_ = new Label("The following packages will be updated in the lockfile.");
+      }
+      else if (action == "Restore")
+      {
+         headerLabel_ = new Label("The following changes will be made to the project library.");
+      }
+      
+      initWidget(uiBinder.createAndBindUi(this));
+   }
+   
+   // Helper Functions ----
+   
+   private String getPackageName(RenvAction entry)
+   {
+      return entry.getPackageName();
+   }
+   
+   private String getLibraryVersion(RenvAction entry)
+   {
+      String version = entry.getLibraryVersion();
+      return StringUtil.isNullOrEmpty(version) ? "[Not installed]" : version;
+   }
+   
+   private String getLockfileVersion(RenvAction entry)
+   {
+      String version = entry.getLockfileVersion();
+      return StringUtil.isNullOrEmpty(version) ? "[Not recorded]" : version;
+   }
+   
+   private String getAction(RenvAction entry)
+   {
+      return (action_ == "Snapshot") ? snapshotAction(entry) : restoreAction(entry);
+   }
+   
+   private interface ValueGetter<T>
+   {
+      T getValue(RenvAction action);
+   }
+   
+   private void textColumn(String name, String width, ValueGetter<String> getter)
+   {
+      TextColumn<RenvAction> column = new TextColumn<RenvAction>()
+      {
+         @Override
+         public String getValue(RenvAction action)
+         {
+            return getter.getValue(action);
+         }
+      };
+      
+      table_.addColumn(column, name);
+      table_.setColumnWidth(column, width);
+   }
+   
+   private String snapshotAction(RenvAction entry)
+   {
+      if (entry.getAction() == "install")
+      {
+         return StringUtil.format(
+               "Add '{package}' [{version}] to the lockfile",
+               "package", entry.getPackageName(),
+               "version", entry.getLibraryVersion());
+      }
+      else if (entry.getAction() == "remove")
+      {
+         return StringUtil.format(
+               "Remove '{package}' [{version}] from the lockfile",
+               "package", entry.getPackageName(),
+               "version", entry.getLockfileVersion());
+      }
+      else
+      {
+         return StringUtil.format(
+               "Update '{package}' [{oldVersion} -> {newVersion}] in the lockfile",
+               "package", entry.getPackageName(),
+               "oldVersion", entry.getLockfileVersion(),
+               "newVersion", entry.getLibraryVersion());
+      }
+   }
+   
+   private String restoreAction(RenvAction entry)
+   {
+      if (entry.getAction() == "install")
+      {
+         return StringUtil.format(
+               "Install '{package}' [{version}]",
+               "action",  StringUtil.capitalize(entry.getAction()),
+               "package", entry.getPackageName(),
+               "version", entry.getLockfileVersion());
+      }
+      else if (entry.getAction() == "remove")
+      {
+         return StringUtil.format(
+               "Remove '{package}' [{version}]",
+               "action",  StringUtil.capitalize(entry.getAction()),
+               "package", entry.getPackageName(),
+               "version", entry.getLibraryVersion());
+      }
+      else
+      {
+         return StringUtil.format(
+               "{action} '{package}' [{oldVersion} -> {newVersion}]",
+               "action",     StringUtil.capitalize(entry.getAction()),
+               "package",    entry.getPackageName(),
+               "oldVersion", entry.getLibraryVersion(),
+               "newVersion", entry.getLockfileVersion());
+      }
+   }
+   
+   // UI Fields ----
+   
+   @UiField(provided = true)
+   DataGrid<RenvAction> table_;
+   
+   @UiField(provided = true)
+   Label headerLabel_;
+   
+   // Private Members ----
+   private final String action_;
+   private final List<RenvAction> actions_;
+   
+   private static RenvRestoreDialogContentsUiBinder uiBinder =
+         GWT.create(RenvRestoreDialogContentsUiBinder.class);
+   
+   // Resources, etc ----
+   public interface Resources extends RStudioDataGridResources
+   {
+      @Source({RStudioDataGridStyle.RSTUDIO_DEFAULT_CSS, "RenvActionDialogContents.css"})
+      Styles dataGridStyle();
+   }
+   
+   public interface Styles extends RStudioDataGridStyle
+   {
+   }
+   
+   private static final Resources RES = GWT.create(Resources.class);
+   
+   static { RES.dataGridStyle().ensureInjected(); }
+   
+}

--- a/src/gwt/src/org/rstudio/studio/client/renv/ui/RenvActionDialogContents.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/renv/ui/RenvActionDialogContents.ui.xml
@@ -1,0 +1,35 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+
+<ui:UiBinder
+	xmlns:ui="urn:ui:com.google.gwt.uibinder"
+	xmlns:g="urn:import:com.google.gwt.user.client.ui"
+	xmlns:c="urn:import:com.google.gwt.user.cellview.client">
+
+
+	<ui:style>
+	
+	.headerLabel {
+		margin-bottom: 12px;
+	}
+	
+	.table {
+		width: 500px;
+		height: 400px;
+		border: 1px solid #BBB;
+		background-color: white;
+	}
+	
+	.scrollPanel {
+		
+	}
+	
+	</ui:style>
+
+	<g:VerticalPanel>
+		<g:Label ui:field="headerLabel_" styleName="{style.headerLabel}"></g:Label>
+		<g:ScrollPanel styleName="{style.scrollPanel}">
+			<c:DataGrid ui:field="table_" styleName="{style.table}"/>
+		</g:ScrollPanel>
+	</g:VerticalPanel>
+
+</ui:UiBinder> 

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -146,6 +146,7 @@ import org.rstudio.studio.client.workbench.model.TerminalOptions;
 import org.rstudio.studio.client.workbench.model.TexCapabilities;
 import org.rstudio.studio.client.workbench.model.WorkbenchMetrics;
 import org.rstudio.studio.client.workbench.prefs.model.SpellingPrefsContext;
+import org.rstudio.studio.client.workbench.projects.RenvAction;
 import org.rstudio.studio.client.workbench.snippets.model.SnippetData;
 import org.rstudio.studio.client.workbench.views.buildtools.model.BookdownFormats;
 import org.rstudio.studio.client.workbench.views.connections.model.ConnectionId;
@@ -5351,6 +5352,17 @@ public class RemoteServer implements Server
    }
    
    @Override
+   public void renvActions(String action,
+                           ServerRequestCallback<JsArray<RenvAction>> requestCallback)
+   {
+      JSONArray params = new JSONArrayBuilder()
+            .add(action)
+            .get();
+      
+      sendRequest(RPC_SCOPE, RENV_ACTIONS, params, requestCallback);
+   }
+   
+   @Override
    public void markersTabClosed(ServerRequestCallback<Void> requestCallback)
    {
       sendRequest(RPC_SCOPE, "markers_tab_closed", requestCallback);
@@ -6349,6 +6361,7 @@ public class RemoteServer implements Server
    private static final String GET_PACKRAT_ACTIONS = "get_packrat_actions";
    
    private static final String RENV_INIT = "renv_init";
+   private static final String RENV_ACTIONS = "renv_actions";
    
    private static final String LINT_R_SOURCE_DOCUMENT = "lint_r_source_document";
    private static final String ANALYZE_PROJECT = "analyze_project";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -2583,23 +2583,23 @@ well as menu structures (for main menu and popup menus).
         context="packrat"/>
 
    <cmd id="packratClean"
-         menuLabel="_Clean Unused Packages..."
-         desc="Remove unused packages from your packrat library"
-         rebindable="false"
-         context="packrat"/>
+        menuLabel="_Clean Unused Packages..."
+        desc="Remove unused packages from your packrat library"
+        rebindable="false"
+        context="packrat"/>
 
    <cmd id="packratHelp"
-         menuLabel="Using Packrat"
-         desc="Help on using packrat with R projects"
-         rebindable="false"
-         context="packrat"/>
+        menuLabel="Using Packrat"
+        desc="Help on using packrat with R projects"
+        rebindable="false"
+        context="packrat"/>
          
    <cmd id="packratOptions"
-         buttonLabel="Options"
-         menuLabel="Packrat _Options..."
-         desc="Configure packrat options for this project"
-         rebindable="false"
-         context="packrat"/>
+        buttonLabel="Options"
+        menuLabel="Packrat _Options..."
+        desc="Configure packrat options for this project"
+        rebindable="false"
+        context="packrat"/>
          
    <cmd id="packratBundle"
         buttonLabel="Bundle"
@@ -2609,11 +2609,29 @@ well as menu structures (for main menu and popup menus).
         context="packrat"/>
 
    <cmd id="packratCheckStatus"
-         menuLabel="Check Library _Status..."
-         desc="Check the status of the Packrat library"
-         rebindable="false"
-         context="packrat"/>
-
+        menuLabel="Check Library _Status..."
+        desc="Check the status of the Packrat library"
+        rebindable="false"
+        context="packrat"/>
+         
+   <cmd id="renvHelp"
+        menuLabel="Introduction to renv"
+        desc="Learn how to use renv"
+        rebindable="false"
+        context="renv"/>
+         
+   <cmd id="renvSnapshot"
+        menuLabel="Snapshot Library..."
+        desc="Snapshot the state of your project library"
+        rebindable="false"
+        context="renv"/>
+        
+   <cmd id="renvRestore"
+        menuLabel="Restore Library..."
+        desc="Restore your project library from renv.lock"
+        rebindable="false"
+        context="renv"/>
+         
    <cmd id="versionControlOptions"
         menuLabel="_Options..."
         desc="Configure version control options"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -383,6 +383,11 @@ public abstract class
    public abstract AppCommand packratHelp();
    public abstract AppCommand packratClean();
    public abstract AppCommand packratCheckStatus();
+   
+   // renv
+   public abstract AppCommand renvHelp();
+   public abstract AppCommand renvSnapshot();
+   public abstract AppCommand renvRestore();
 
    // Version control
    public abstract AppCommand versionControlHelp();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/projects/RenvAction.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/projects/RenvAction.java
@@ -1,0 +1,31 @@
+/*
+ * RenvAction.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.projects;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+public class RenvAction extends JavaScriptObject
+{
+   protected RenvAction()
+   {
+   }
+   
+   public final native String getPackageName()     /*-{ return this.packageName;     }-*/;
+   public final native String getLockfileVersion() /*-{ return this.lockfileVersion; }-*/;
+   public final native String getLockfileSource()  /*-{ return this.lockfileSource;  }-*/;
+   public final native String getLibraryVersion()  /*-{ return this.libraryVersion;  }-*/;
+   public final native String getLibrarySource()   /*-{ return this.librarySource;   }-*/;
+   public final native String getAction()          /*-{ return this.action;          }-*/;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -674,7 +674,7 @@ public class Packages
          public void onError(ServerError error)
          {
             Debug.logError(error);
-            indicator.onError(errorMessage);
+            indicator.onError(error.getUserMessage());
          }
       });
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
@@ -41,6 +41,7 @@ import org.rstudio.studio.client.packrat.model.PackratContext;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.projects.ProjectContext;
+import org.rstudio.studio.client.workbench.projects.RenvContext;
 import org.rstudio.studio.client.workbench.ui.WorkbenchPane;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageInfo;
 import org.rstudio.studio.client.workbench.views.packages.model.PackageInstallContext;
@@ -110,13 +111,19 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
       packagesDataProvider_.setList(packages);
       createPackagesTable();
 
+      // manage visibility of Packrat / renv menu buttons
       PackratContext packratContext = projectContext_.getPackratContext();
+      RenvContext renvContext = projectContext_.getRenvContext();
       
-      // show the toolbar button if Packrat mode is on
-      packratMenuButton_.setVisible(packratContext.isModeOn());
+      packratMenuButton_.setVisible(false);
+      renvMenuButton_.setVisible(false);
+      if (packratContext.isModeOn())
+         packratMenuButton_.setVisible(true);
+      else if (renvContext.active)
+         renvMenuButton_.setVisible(true);
       
       // always show the separator before the packrat commands
-      prePackratSeparator_.setVisible(true);
+      projectButtonSeparator_.setVisible(true);
    }
    
    @Override
@@ -192,7 +199,7 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
       
       // update packages
       toolbar.addLeftWidget(commands_.updatePackages().createToolbarButton());
-      prePackratSeparator_ = toolbar.addLeftSeparator();
+      projectButtonSeparator_ = toolbar.addLeftSeparator();
       
       // packrat (all packrat UI starts out hidden and then appears
       // in response to changes in the packages state)
@@ -214,6 +221,21 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
        );
       toolbar.addLeftWidget(packratMenuButton_);
       packratMenuButton_.setVisible(false);
+      
+      // create renv menu + button
+      ToolbarPopupMenu renvMenu = new ToolbarPopupMenu();
+      renvMenu.addItem(commands_.renvHelp().createMenuItem(false));
+      renvMenu.addSeparator();
+      renvMenu.addItem(commands_.renvSnapshot().createMenuItem(false));
+      renvMenu.addItem(commands_.renvRestore().createMenuItem(false));
+      
+      renvMenuButton_ = new ToolbarMenuButton(
+            "renv",
+            ToolbarButton.NoTitle,
+            commands_.packratBootstrap().getImageResource(), // TODO
+            renvMenu);
+      toolbar.addLeftWidget(renvMenuButton_);
+      renvMenuButton_.setVisible(false);
             
       searchWidget_ = new SearchWidget("Filter by package name", new SuggestOracle() {
          @Override
@@ -663,7 +685,9 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
    private PackagesDisplayObserver observer_ ;
    
    private ToolbarMenuButton packratMenuButton_;
-   private Widget prePackratSeparator_;
+   private ToolbarMenuButton renvMenuButton_;
+   private Widget projectButtonSeparator_;
+   
    private LayoutPanel packagesTableContainer_;
    private int gridRenderRetryCount_;
    private ProjectContext projectContext_;


### PR DESCRIPTION
This PR adds dialogs for performing an `renv::snapshot()` / `renv::restore()`.

Note that we deviate from the Packrat behavior a bit here: when using Packrat, we tried to infer if the user desired a snapshot or a restore based on the diff between the lockfile and library state, with this PR, the onus is on the user to understand whether they want to snapshot or restore.

Support for some form of diffing could come in a separate PR.

![Screen Shot 2019-08-13 at 3 57 42 PM](https://user-images.githubusercontent.com/1976582/62983351-e93fa900-bde3-11e9-877b-c429cb37a182.png)
![Screen Shot 2019-08-13 at 3 58 06 PM](https://user-images.githubusercontent.com/1976582/62983353-e93fa900-bde3-11e9-827d-90ccfb78639c.png)
![Screen Shot 2019-08-13 at 4 03 22 PM](https://user-images.githubusercontent.com/1976582/62983354-e93fa900-bde3-11e9-9833-5754f2c4ecad.png)
![Screen Shot 2019-08-13 at 4 03 45 PM](https://user-images.githubusercontent.com/1976582/62983369-f2307a80-bde3-11e9-808e-e39a55cf958a.png)
