### PR TITLE
Don't invoke STRING_ELT on non-STRSXP S-expressions

### DIFF
--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -663,7 +663,7 @@ json::Value getData(SEXP dataSEXP, const http::Fields& fields)
       {
          SEXP columnSEXP = VECTOR_ELT(formattedDataSEXP, col);
          if (columnSEXP != nullptr &&
-             TYPEOF(columnSEXP) != NILSXP &&
+             TYPEOF(columnSEXP) == STRSXP &&
              !Rf_isNull(columnSEXP))
          {
             SEXP stringSEXP = STRING_ELT(columnSEXP, row);


### PR DESCRIPTION
Speculative fix for Sentry crash.

Fixes https://github.com/rstudio/rstudio/issues/5220.