### PR TITLE
ensure file monitor stopped for all forms of quit

### DIFF
--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -735,13 +735,6 @@ void handleConnection(boost::shared_ptr<HttpConnection> ptrConnection,
             // exit status
             int status = switchToProject.empty() ? EXIT_SUCCESS : EX_CONTINUE;
             
-            // stop file monitor (need to do this explicitly as otherwise we can
-            // run into issues during close where the runtime attempts to clean
-            // up its data structures at same time that monitor wants to exit)
-            //
-            // https://github.com/rstudio/rstudio/issues/5222
-            system::file_monitor::stop();
-
             // acknowledge request & quit session
             json::JsonRpcResponse response;
             response.setResult(true);

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1214,6 +1214,13 @@ void rCleanup(bool terminatedNormally)
       // clean up locks
       FileLock::cleanUp();
 
+      // stop file monitor (need to do this explicitly as otherwise we can
+      // run into issues during close where the runtime attempts to clean
+      // up its data structures at same time that monitor wants to exit)
+      //
+      // https://github.com/rstudio/rstudio/issues/5222
+      system::file_monitor::stop();
+
       // cause graceful exit of clientEventService (ensures delivery
       // of any pending events prior to process termination). wait a
       // very brief interval first to allow the quit or other termination


### PR DESCRIPTION
This PR moves the file monitor thread stopper to the right place, so it properly gets invoked for all types of quits that can be requested.