### PR TITLE
Fix crash when reloading preferences

### DIFF
--- a/src/cpp/session/prefs/UserPrefsLayer.cpp
+++ b/src/cpp/session/prefs/UserPrefsLayer.cpp
@@ -58,7 +58,8 @@ void UserPrefsLayer::onPrefsFileChanged()
    }
 
    // Make a copy of the prefs prior to reloading, so we can diff against the old copy
-   const json::Object old = cache_->clone().get_obj();
+   const json::Value oldVal = cache_->clone();
+   const json::Object old = oldVal.get_obj();
 
    // Reload the prefs from the file
    Error error = loadPrefsFromFile(prefsFile_);


### PR DESCRIPTION
This change fixes a subtle JSON value issue that causes a crash when reloading a preference file that has changed on disk.

Fixes https://github.com/rstudio/rstudio/issues/5184.