### PR TITLE
Include user and system prefs in diagnostics

### DIFF
--- a/src/cpp/diagnostics/DiagnosticsMain.cpp
+++ b/src/cpp/diagnostics/DiagnosticsMain.cpp
@@ -1,7 +1,7 @@
 /*
  * DiagnosticsMain.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -20,6 +20,7 @@
 
 #include <core/Error.hpp>
 #include <core/Log.hpp>
+#include <core/system/Xdg.hpp>
 #include <core/FilePath.hpp>
 #include <core/FileSerializer.hpp>
 #include <core/system/System.hpp>
@@ -47,28 +48,42 @@ FilePath userLogPath()
    return logPath;
 }
 
-void writeLogFile(const std::string& logFileName, std::ostream& ostr)
+void writeFile(const std::string& fileName, const core::FilePath& path, std::ostream& ostr)
 {
-   ostr << "Log file: " << logFileName << std::endl;
+   ostr << fileName << ": " << path << std::endl;
    ostr << "--------------------------------------------------" << std::endl;
    ostr << std::endl;
 
-   FilePath logFilePath = userLogPath().childPath(logFileName);
-   if (logFilePath.exists())
+   if (path.exists())
    {
       std::string contents;
-      Error error = core::readStringFromFile(logFilePath, &contents);
+      Error error = core::readStringFromFile(path, &contents);
       if (error)
          LOG_ERROR(error);
       if (contents.empty())
          ostr << "(Empty)" << std::endl << std::endl;
       else
-         ostr << contents << std::endl;
+         ostr << contents << std::endl << std::endl;
    }
    else
    {
       ostr << "(Not Found)" << std::endl << std::endl;
    }
+}
+
+void writeLogFile(const std::string& logFileName, std::ostream& ostr)
+{
+   writeFile("Log file", userLogPath().childPath(logFileName), ostr);
+}
+
+void writeUserPrefs(std::ostream& ostr)
+{
+   writeFile("User prefs", core::system::xdg::userConfigDir().complete("rstudio-prefs.json"), 
+         ostr);
+   writeFile("System prefs", core::system::xdg::systemConfigDir().complete("rstudio-prefs.json"),
+         ostr);
+   writeFile("User state", core::system::xdg::userDataDir().complete("rstudio-state.json"),
+         ostr);
 }
 
 
@@ -87,6 +102,7 @@ int main(int argc, char** argv)
 
   writeLogFile("rdesktop.log", std::cout);
   writeLogFile("rsession-" + core::system::username() + ".log", std::cout);
+  writeUserPrefs(std::cout);
 
   return EXIT_SUCCESS;
 }

--- a/src/cpp/diagnostics/DiagnosticsMain.cpp
+++ b/src/cpp/diagnostics/DiagnosticsMain.cpp
@@ -48,9 +48,9 @@ FilePath userLogPath()
    return logPath;
 }
 
-void writeFile(const std::string& fileName, const core::FilePath& path, std::ostream& ostr)
+void writeFile(const std::string& description, const core::FilePath& path, std::ostream& ostr)
 {
-   ostr << fileName << ": " << path << std::endl;
+   ostr << description << ": " << path << std::endl;
    ostr << "--------------------------------------------------" << std::endl;
    ostr << std::endl;
 

--- a/src/cpp/r/R/Diagnostics.R
+++ b/src/cpp/r/R/Diagnostics.R
@@ -1,7 +1,7 @@
 #
 # Diagnostics.R
 #
-# Copyright (C) 2009-12 by RStudio, Inc.
+# Copyright (C) 2009-19 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -43,7 +43,7 @@ capture.output({
   print(as.list(Sys.getenv()))
   print(search())
   
-  # locate diagonstics binary and run it
+  # locate diagnostics binary and run it
   sysName <- Sys.info()[['sysname']]
   ext <- ifelse(identical(sysName, "Windows"), ".exe", "")
   


### PR DESCRIPTION
This change includes the user and system preference files (from the new prefs system) in the diagnostics report, with the goal of making it easier to replicate a configuration that's causing problems.