### PR TITLE
fix preference pane tab count reported by screen readers with FireFox

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/prefs/SectionChooser.java
+++ b/src/gwt/src/org/rstudio/core/client/prefs/SectionChooser.java
@@ -37,6 +37,9 @@ import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.widget.DecorativeImage;
 
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 /**
  * Vertical tab control used by Preferences dialogs. Follows the ARIA tab pattern.
  * 
@@ -128,6 +131,13 @@ class SectionChooser extends SimplePanel implements
       Roles.getTabRole().setAriaSelectedState(panel.getElement(), SelectedValue.FALSE);
       Roles.getTabRole().setAriaControlsProperty(panel.getElement(), getTabPanelId(sectionTabId));
       inner_.add(panel);
+
+      // FireFox fails to enumerate the tabs when building its accessibility tree, 
+      // perhaps due to the deep nesting of layout tables. Use the aria-owns attribute 
+      // to assist it. https://github.com/rstudio/rstudio/issues/5120
+      tabIds_.add(sectionTabId);
+      Roles.getTablistRole().setAriaOwnsProperty(getElement(), tabIds_.toArray(new Id[0]));
+
       return sectionTabId;
    }
 
@@ -274,6 +284,6 @@ class SectionChooser extends SimplePanel implements
 
    private Integer selectedIndex_;
    private final VerticalPanel inner_ = new VerticalPanel();
-   private static final PreferencesDialogBaseResources res_ = 
-                                    PreferencesDialogBaseResources.INSTANCE;
+   private static final PreferencesDialogBaseResources res_ = PreferencesDialogBaseResources.INSTANCE;
+   private Set<Id> tabIds_ = new LinkedHashSet<>();
 }


### PR DESCRIPTION
Fixes #5120 

Supply the list of tabs controlled by the tablist via the `aria-owns` attribute so FireFox can give correct tab count.

_Shouldn't_ need this because the tabs are nested under the tablist in the DOM, however... an example of needing to test for quirks with multiple browser and screen reader combinations.