### PR TITLE
small fix: info and warning bars expose duplicate messages to screen readers

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/InfoBar.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/InfoBar.java
@@ -36,6 +36,7 @@ import com.google.gwt.user.client.ui.Widget;
 
 import java.util.List;
 
+import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
@@ -72,7 +73,8 @@ public class InfoBar extends Composite
      
       labelRight_ = new HorizontalPanel();
       initWidget(binder.createAndBindUi(this));
-      
+
+      A11y.setARIAHidden(label_);
       Roles.getAlertRole().setAriaLiveProperty(live_.getElement(), 
             mode == ERROR ? LiveValue.ASSERTIVE : LiveValue.POLITE);
       Roles.getAlertRole().setAriaAtomicProperty(live_.getElement(), true);

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.java
@@ -18,6 +18,7 @@ import com.google.gwt.aria.client.LiveValue;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.user.client.Timer;
+import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.theme.res.ThemeResources;
 
 import com.google.gwt.core.client.GWT;
@@ -81,6 +82,7 @@ public class WarningBar extends Composite
       moreButton_.setVisible(false);
       moreButton_.setText("Manage License...");
       moreButton_.addClickHandler(event -> Desktop.getFrame().showLicenseDialog());
+      A11y.setARIAHidden(label_);
       Roles.getAlertRole().setAriaLiveProperty(live_, LiveValue.ASSERTIVE);
       Roles.getAlertRole().setAriaAtomicProperty(live_, true);
    }


### PR DESCRIPTION
The Infobar and WarningBar widgets use a visually hidden live region to announce their message; this region contains the same text as the visible label (after a small delay).

This change marks visible labels as aria-hidden, otherwise virtual cursor navigation with screen reader "sees" both, which is redundant.