### PR TITLE
two minor visual tweaks

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/BuildToolsRoxygenOptionsDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/BuildToolsRoxygenOptionsDialog.ui.xml
@@ -1,14 +1,17 @@
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
-             xmlns:g='urn:import:com.google.gwt.user.client.ui'
-             xmlns:widget="urn:import:org.rstudio.core.client.widget">
+             xmlns:g='urn:import:com.google.gwt.user.client.ui'>
 
    <ui:style>
       .panel {
          width: 300px;
       }
-      
-      .topParagraph {
-         margin-top: 0px;
+      .panel fieldset {
+         border: none;
+         padding: 0;
+         margin: 0;
+      }
+      .panel legend {
+         padding: 0;
       }
    </ui:style>
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/ExportPlotSizeEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/ExportPlotSizeEditor.java
@@ -179,8 +179,7 @@ public class ExportPlotSizeEditor extends Composite
   
       // lock ratio check box
       keepRatioCheckBox_ = new CheckBox();
-      keepRatioCheckBox_.setStylePrimaryName(
-                           resources.styles().maintainAspectRatioCheckBox());
+      keepRatioCheckBox_.addStyleName(resources.styles().maintainAspectRatioCheckBox());
       keepRatioCheckBox_.setValue(keepRatio);
       keepRatioCheckBox_.setText("Maintain aspect ratio");
       optionsPanel.add(keepRatioCheckBox_);


### PR DESCRIPTION
- remove border around fieldset in BuildToolsRoxygenOptionsDialog
    - make it visually consistent with previous versions despite switch to fieldset in 1.3 (for accessibility)
- fix checkbox styling in ExportPlotSizeEditor widget (long-standing visual glitch)

Before this change:
![2019-08-15_15-50-28](https://user-images.githubusercontent.com/10569626/63134213-5c305780-bf7d-11e9-9118-f01dd5fee572.png)

After this change (matches appearance of 1.2 and earlier)
![2019-08-15_16-49-46](https://user-images.githubusercontent.com/10569626/63134220-618da200-bf7d-11e9-9dac-957d1e08d143.png)

Before (notice checkbox label smooshed against the checkbox):
![2019-08-15_16-28-33](https://user-images.githubusercontent.com/10569626/63134253-808c3400-bf7d-11e9-9083-70c164d1f192.png)

After:
![2019-08-15_16-34-10](https://user-images.githubusercontent.com/10569626/63134274-94d03100-bf7d-11e9-9c7d-a296283402c2.png)

