### PR TITLE
Formalize defaults for export plot options

### DIFF
--- a/src/cpp/session/resources/schema/user-state-schema.json
+++ b/src/cpp/session/resources/schema/user-state-schema.json
@@ -74,7 +74,14 @@
                     "type": "boolean"
                 }
             },
-            "default": {},
+            "default": {
+                "width": 550,
+                "height": 450,
+                "keepRatio": false,
+                "format": "PNG",
+                "viewAfterSave": false,
+                "copyAsMetafile": false
+            },
             "description": "The most recently used plot export options."
         },
         "export_viewer_options": {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/SavePlotAsImageDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/SavePlotAsImageDialog.java
@@ -1,7 +1,7 @@
 /*
  * SavePlotAsImageDialog.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -56,7 +56,7 @@ public class SavePlotAsImageDialog extends ExportPlotDialog
                {
                   onClose.execute(getCurrentOptions(options));
              
-                  closeDialog();   
+                  closeDialog();
                }
             });
          }
@@ -96,7 +96,7 @@ public class SavePlotAsImageDialog extends ExportPlotDialog
                                       sizeEditor.getKeepRatio(),
                                       saveAsTarget_.getFormat(),
                                       viewAfterSaveCheckBox_.getValue(),
-                                      previous.getCopyAsMetafile());    
+                                      previous.getCopyAsMetafile());
    }
    
    private void attemptSavePlot(boolean overwrite,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/model/ExportPlotOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/model/ExportPlotOptions.java
@@ -21,11 +21,6 @@ public class ExportPlotOptions extends UserStateAccessor.ExportPlotOptions
 {
    protected ExportPlotOptions() {}
    
-   public static final ExportPlotOptions createDefault()
-   {
-      return create(550, 450, false, "PNG", false, false);
-   }
-   
    public static final native ExportPlotOptions create(int width, 
                                                        int height,
                                                        boolean keepRatio,
@@ -34,13 +29,13 @@ public class ExportPlotOptions extends UserStateAccessor.ExportPlotOptions
                                                        boolean copyAsMetafile) 
    /*-{
       var options = new Object();
-      options.width = width ;
-      options.height = height ;
+      options.width = width;
+      options.height = height;
       options.format = format;
       options.keepRatio = keepRatio;
       options.viewAfterSave = viewAfterSave;
       options.copyAsMetafile = copyAsMetafile;
-      return options ;
+      return options;
    }-*/;
    
    public static final ExportPlotOptions adaptToSize(ExportPlotOptions options,


### PR DESCRIPTION
Moves the plot export defaults into the schema. This properly populates the default set to avoid missing values that can cause warnings later. 

Fixes https://github.com/rstudio/rstudio/issues/5253.