### PR TITLE
Store rstudioapi prefs separately; enable access to IDE prefs

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -478,11 +478,20 @@
 })
 
 .rs.addApiFunction("writePreference", function(name, value) {
-  .rs.writeUiPref(paste("rstudioapi", name, sep = "_"), value)
+  .rs.writeApiPref(name, value)
 })
 
 .rs.addApiFunction("readPreference", function(name, default = NULL) {
-  value <- .rs.readUiPref(paste("rstudioapi", name, sep = "_"))
+  value <- .rs.readApiPref(name)
+  if (is.null(value)) default else value
+})
+
+.rs.addApiFunction("writeRStudioPreference", function(name, value) {
+  .rs.writeUiPref(name, value)
+})
+
+.rs.addApiFunction("readRStudioPreference", function(name, default = NULL) {
+  value <- .rs.readUiPref(name)
   if (is.null(value)) default else value
 })
 

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -95,6 +95,7 @@ set (SESSION_SOURCE_FILES
    modules/RStudioAPI.cpp
    modules/SessionAbout.cpp
    modules/SessionAgreement.cpp
+   modules/SessionApiPrefs.cpp
    modules/SessionAskPass.cpp
    modules/SessionAskSecret.cpp
    modules/SessionAsyncPackageInformation.cpp

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -282,6 +282,7 @@ namespace prefs {
 #define kDefaultRVersionVersion "version"
 #define kDefaultRVersionRHome "r_home"
 #define kDefaultRVersionLabel "label"
+#define kDataViewerMaxColumns "data_viewer_max_columns"
 
 class UserPrefValues: public Preferences
 {
@@ -1240,6 +1241,12 @@ public:
     */
    core::json::Object defaultRVersion();
    core::Error setDefaultRVersion(core::json::Object val);
+
+   /**
+    * The maximum number of columns to show at once in the data viewer.
+    */
+   int dataViewerMaxColumns();
+   core::Error setDataViewerMaxColumns(int val);
 
 };
 

--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -293,19 +293,35 @@
    .Call("rs_markdownToHTML", content, PACKAGE = "(embedding)")
 })
 
-.rs.addFunction("readUiPref", function(prefName) {
+.rs.addFunction("readPrefInternal", function(method, prefName) {
   if (missing(prefName) || is.null(prefName))
     stop("No preference name supplied")
-  .Call("rs_readUserPref", prefName, PACKAGE = "(embedding)")
+  .Call(method, prefName, PACKAGE = "(embedding)")
 })
-.rs.addFunction("readUserPref", .rs.readUiPref)
 
-.rs.addFunction("writeUiPref", function(prefName, value) {
+.rs.addFunction("writePrefInternal", function(method, prefName, value) {
   if (missing(prefName) || is.null(prefName))
     stop("No preference name supplied")
   if (missing(value))
     stop("No value supplied")
-  invisible(.Call("rs_writeUserPref", prefName, .rs.scalar(value), PACKAGE = "(embedding)"))
+  invisible(.Call(method, prefName, .rs.scalar(value), PACKAGE = "(embedding)"))
+})
+
+.rs.addFunction("readApiPref", function(prefName) {
+  .rs.readPrefInternal("rs_readApiPref", prefName)
+})
+
+.rs.addFunction("writeApiPref", function(prefName, value) {
+  .rs.writePrefInternal("rs_writeApiPref", prefName, value)
+})
+
+.rs.addFunction("readUiPref", function(prefName) {
+  .rs.readPrefInternal("rs_readUserPref", prefName)
+})
+.rs.addFunction("readUserPref", .rs.readUiPref)
+
+.rs.addFunction("writeUiPref", function(prefName, value) {
+  .rs.writerefInternal("rs_writeUserPref", prefName, value)
 })
 .rs.addFunction("writeUserPref", .rs.writeUiPref)
 

--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -321,7 +321,7 @@
 .rs.addFunction("readUserPref", .rs.readUiPref)
 
 .rs.addFunction("writeUiPref", function(prefName, value) {
-  .rs.writerefInternal("rs_writeUserPref", prefName, value)
+  .rs.writePrefInternal("rs_writeUserPref", prefName, value)
 })
 .rs.addFunction("writeUserPref", .rs.writeUiPref)
 

--- a/src/cpp/session/modules/SessionApiPrefs.cpp
+++ b/src/cpp/session/modules/SessionApiPrefs.cpp
@@ -1,0 +1,97 @@
+/*
+ * SessionApiPrefs.cpp
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "SessionApiPrefs.hpp"
+
+#include <core/system/Xdg.hpp>
+
+#include <session/prefs/PrefLayer.hpp>
+
+using namespace rstudio::core;
+using namespace rstudio::session::prefs;
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace prefs {
+namespace {
+
+/**
+ * A preference layer for user-defined preferences from rstudoapi.
+ */
+class ApiPrefLayer: public PrefLayer
+{
+public:
+   ApiPrefLayer():
+      PrefLayer("api")
+   {
+   }
+
+   core::Error readPrefs()
+   {
+      prefsFile_ = core::system::xdg::userConfigDir().complete(kApiPrefsFile);
+      return loadPrefsFromFile(prefsFile_);
+   }
+
+   core::Error writePrefs(const core::json::Object &prefs)
+   {
+      RECURSIVE_LOCK_MUTEX(mutex_)
+      {
+         *cache_ = prefs;
+      }
+      END_LOCK_MUTEX
+
+      return writePrefsToFile(*cache_, prefsFile_);
+   }
+
+   core::Error validatePrefs()
+   {
+      // API prefs are always "valid"
+      return Success();
+   }
+
+private:
+   core::FilePath prefsFile_;
+};
+
+} // anonymous namespace
+
+core::Error ApiPrefs::createLayers()
+{
+   RECURSIVE_LOCK_MUTEX(mutex_)
+   {
+      layers_.push_back(boost::make_shared<ApiPrefLayer>());
+   }
+   END_LOCK_MUTEX
+
+   return Success();
+}
+
+int ApiPrefs::userLayer()
+{
+   // The API prefs have only one layer
+   return 0;
+}
+
+int ApiPrefs::clientChangedEvent()
+{
+   // The client is not currently notified for API prefs changes
+   return 0;
+}
+
+} // namespace prefs
+} // namespace modules
+} // namespace session
+} // namespace rstudio

--- a/src/cpp/session/modules/SessionApiPrefs.hpp
+++ b/src/cpp/session/modules/SessionApiPrefs.hpp
@@ -1,0 +1,52 @@
+/*
+ * SessionApiPrefs.hpp
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef SESSION_MODULE_API_PREFS_HPP
+#define SESSION_MODULE_API_PREFS_HPP
+
+#include <session/prefs/Preferences.hpp>
+
+#define kApiPrefsFile "rstudioapi-prefs.json"
+
+namespace rstudio {
+   namespace core {
+      class Error;
+   }
+}
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace prefs {
+
+/**
+ * This class represents the preferences set from the RStudio API (rstudioapi package). These
+ * preferences don't have a schema; they are arbitrary key/value pairs defined by rstudioapi package
+ * users. API preferences are stored in a separate file from core IDE preferences. 
+ */
+class ApiPrefs: public session::prefs::Preferences
+{
+public:
+   core::Error createLayers();
+   int userLayer();
+   int clientChangedEvent();
+};
+
+} // namespace prefs
+} // namespace modules
+} // namespace session
+} // namespace rstudio
+
+#endif

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -45,6 +45,8 @@
 #include <session/SessionContentUrls.hpp>
 #include <session/SessionSourceDatabase.hpp>
 
+#include <session/prefs/UserPrefs.hpp>
+
 #ifndef _WIN32
 #include <core/system/FileMode.hpp>
 #endif
@@ -353,7 +355,8 @@ json::Value makeDataItem(SEXP dataSEXP,
    dataItem["contentUrl"] = kGridResource "/gridviewer.html?env=" +
       http::util::urlEncode(envName, true) + "&obj=" + 
       http::util::urlEncode(objName, true) + "&cache_key=" +
-      http::util::urlEncode(cacheKey, true);
+      http::util::urlEncode(cacheKey, true) + "&max_cols=" + 
+      safe_convert::numberToString(prefs::userPrefs().dataViewerMaxColumns());
    dataItem["preview"] = preview;
 
    return std::move(dataItem);

--- a/src/cpp/session/prefs/Preferences.cpp
+++ b/src/cpp/session/prefs/Preferences.cpp
@@ -291,6 +291,12 @@ void Preferences::onPrefLayerChanged(const std::string& layerName, const std::st
 
 void Preferences::notifyClient(const std::string &layerName, const std::string &pref)
 {
+   // No work to do unless there's a client event to emit
+   int eventId = clientChangedEvent();
+   if (eventId < 1)
+      return;
+
+   // Loop through layers to find pref at named layer
    bool found = false;
    RECURSIVE_LOCK_MUTEX(mutex_)
    {
@@ -307,7 +313,7 @@ void Preferences::notifyClient(const std::string &layerName, const std::string &
                json::Object dataJson;
                dataJson["name"] = layerName;
                dataJson["values"] = valueJson;
-               ClientEvent event(clientChangedEvent(), dataJson);
+               ClientEvent event(eventId, dataJson);
                module_context::enqueClientEvent(event);
 
                found = true;

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2090,6 +2090,19 @@ core::Error UserPrefValues::setDefaultRVersion(core::json::Object val)
    return writePref("default_r_version", val);
 }
 
+/**
+ * The maximum number of columns to show at once in the data viewer.
+ */
+int UserPrefValues::dataViewerMaxColumns()
+{
+   return readPref<int>("data_viewer_max_columns");
+}
+
+core::Error UserPrefValues::setDataViewerMaxColumns(int val)
+{
+   return writePref("data_viewer_max_columns", val);
+}
+
 std::vector<std::string> UserPrefValues::allKeys()
 {
    return std::vector<std::string>({
@@ -2252,6 +2265,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kClangVerbose,
       kSubmitCrashReports,
       kDefaultRVersion,
+      kDataViewerMaxColumns,
    });
 }
    

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -3,7 +3,7 @@
 /*
  * dtviewer.js
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -939,6 +939,7 @@ var parseLocationUrl = function() {
   var parsedLocation = {};
 
   parsedLocation.env = parsedLocation.obj = parsedLocation.cacheKey = parsedLocation.id = "";
+  parsedLocation.maxCols = defaultMaxColumns;
 
   var query = window.location.search.substring(1);
   var queryVars = query.split("&");
@@ -954,6 +955,8 @@ var parseLocationUrl = function() {
       parsedLocation.dataSource = queryVar[1];
     } else if (queryVar[0] == "id") {
       parsedLocation.id = queryVar[1];
+    } else if (queryVar[0] == "max_cols") {
+      parsedLocation.maxCols = queryVar[1];
     }
   }
 
@@ -1020,6 +1023,7 @@ var initDataTable = function(resCols, data) {
   // look up the query parameters
   var parsedLocation = parseLocationUrl();
   var env = parsedLocation.env, obj = parsedLocation.obj, cacheKey = parsedLocation.cacheKey;
+  maxColumns = defaultMaxColumns = parsedLocation.maxCols;
 
   // keep track of column types for later render
   var typeIndices = {

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -909,6 +909,11 @@
                 }
             },
             "description": "The R version to use by default."
+        },
+        "data_viewer_max_columns": {
+            "type": "integer",
+            "default": 50,
+            "description": "The maximum number of columns to show at once in the data viewer."
         }
     }
 }

--- a/src/cpp/tests/testthat/test-prefs.R
+++ b/src/cpp/tests/testthat/test-prefs.R
@@ -48,3 +48,19 @@ test_that("default values for preferences are respected", {
    }
 })
 
+test_that("rstudio API prefs are separate from IDE prefs", {
+   # read an old value from the RStudio preference
+   oldVal <- .rs.api.readRStudioPreference("code_completion_delay")
+   newVal <- oldVal + 50L
+
+   # save the new value as a regular (non-RStudio) pref
+   .rs.api.writePreference("code_completion_delay", newVal)
+
+   # ensure that the new value was written correctly
+   prefVal <- .rs.api.readPreference("code_completion_delay")
+   expect_equal(prefVal, newVal)
+
+   # ensure that the original RStudio preference is untouched
+   prefVal <- .rs.api.readRStudioPreference("code_completion_delay")
+   expect_equal(prefVal, oldVal)
+})

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1495,6 +1495,14 @@ public class UserPrefsAccessor extends Prefs
 
    }
 
+   /**
+    * The maximum number of columns to show at once in the data viewer.
+    */
+   public PrefValue<Integer> dataViewerMaxColumns()
+   {
+      return integer("data_viewer_max_columns", 50);
+   }
+
    public void syncPrefs(String layer, JsObject source)
    {
       if (source.hasKey("run_rprofile_on_resume"))
@@ -1815,6 +1823,8 @@ public class UserPrefsAccessor extends Prefs
          submitCrashReports().setValue(layer, source.getBool("submit_crash_reports"));
       if (source.hasKey("default_r_version"))
          defaultRVersion().setValue(layer, source.getObject("default_r_version"));
+      if (source.hasKey("data_viewer_max_columns"))
+         dataViewerMaxColumns().setValue(layer, source.getInteger("data_viewer_max_columns"));
    }
    
 


### PR DESCRIPTION
Currently, the rstudioapi package has two preference-related methods, `readPreference` and `writePreference`. These methods, however, do not allow access to any of the IDE's actual preferences. Instead, they are a mechanism for R code to save and load arbitrary key/value pairs into the IDE's preference store under the `rstudioapi` namespace. 

This isn't ideal for a few reasons. The first is that it's useful to access the IDE's preferences from rstudioapi, especially now that they are formalized. The second is that the core preference system is not a great place to store arbitrary values from R code due to different semantics (overriding/defaults, possibility for corruption, etc).

This change does three things:

1. Creates a new mini pref system that stores *only* values from rstudioapi, in a separate file. These prefs are stored in a configurable location that defaults to `rstudioapi-prefs.json`.
2. Adds `.rs.api` methods which enable access to the core RStudio prefs. These will later be used by new rstudioapi methods.
3. As a proof of concept, adds a new pref that controls the default number of columns displayed in the data viewer, with no UI (so it can currently only be set via the API).