### PR TITLE
Sanitize and warn about disclosure in diagnostics report

### DIFF
--- a/src/cpp/r/R/Diagnostics.R
+++ b/src/cpp/r/R/Diagnostics.R
@@ -21,6 +21,14 @@ diagnosticsFile <- suppressWarnings(normalizePath("~/rstudio-diagnostics/diagnos
 
 capture.output({
 
+  cat("RStudio Diagnostics Report\n",
+      "-----------------------------------------------------------------------------\n",
+      "Generated ", date(), "\n\n",
+      "WARNING: This report may contain sensitive security information and/or\n",
+      "personally identifiable information. Please audit the below and redact any\n",
+      "sensitive information before submitting your diagnostics report, then remove\n",
+      "this notice.\n\n", sep = "")
+
   # version
   versionFile <- "../VERSION"
   if (file.exists(versionFile)) {
@@ -40,7 +48,14 @@ capture.output({
   print(Sys.info())
   cat("\nR Version:\n")
   print(version)
-  print(as.list(Sys.getenv()))
+
+  # attempt to automatically sanitize environment variables that obviously contain sensitive data
+  envVars <- Sys.getenv()
+  matches <- grepl("KEY|TOKEN|PASSWORD|API|HOST|USER|SECRET|AUTH|GITHUB", 
+                   names(envVars), ignore.case = TRUE)
+  envVars[matches] <- "*** redacted ***"
+
+  print(as.list(envVars))
   print(search())
   
   # locate diagnostics binary and run it
@@ -65,6 +80,7 @@ capture.output({
   
 }, file=diagnosticsFile)
 
-cat("Diagnostics report written to:", diagnosticsFile, "\n")
+cat("Diagnostics report written to:", diagnosticsFile, "\n\n",
+    "Please audit the report and remove any sensitive information before submitting.\n", sep = "")
 
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -622,7 +622,9 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
          if (!diagFile.empty())
          {
             std::cout << "Diagnostics report written to: "
-                      << diagFile << std::endl << std::endl;
+                      << diagFile << std::endl 
+                      << "Please audit the report and remove any sensitive information "
+                      << "before submitting." << std::endl << std::endl;
 
             Error error = rstudio::r::exec::RFunction(".rs.showDiagnostics").call();
             if (error)


### PR DESCRIPTION
This change redacts the content of environment variables that are known to contain sensitive information (such as `AWS_ACCESS_KEY`, `GITHUB_PAT`, etc.) from the diagnostics report.

No such list can be exhaustive, however, so it also does the following:

1. Warns the user after diagnostics report generation that the report might contain sensitive information.
2. Places a warning banner at the very top of the diagnostics report itself, asking users to remove the banner once the report has been audited for sensitive information. (The presence of this banner will therefore tip us off about who's read the warning and actually scrubbed their reports). 

Closes #1840.