### PR TITLE
Make Save All command work across satellites

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -1016,7 +1016,8 @@ well as menu structures (for main menu and popup menus).
         label="Save All Source Documents"
         menuLabel="Sa_ve All"
         buttonLabel=""
-        desc="Save all open documents"/>
+        desc="Save all open documents"
+        windowMode="main"/>
         
    <cmd id="saveSourceDocWithEncoding"
         label="Save Current Document with Encoding..."

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -2214,6 +2214,7 @@ public class Source implements InsertSourceHandler,
    @Handler
    public void onSaveAllSourceDocs()
    {
+      // Save all documents in the main window
       cpsExecuteForEachEditor(editors_, new CPSEditingTargetCommand()
       {
          @Override
@@ -2229,6 +2230,9 @@ public class Source implements InsertSourceHandler,
             }
          }
       });
+
+      // Save all documents in satellite windows
+      windowManager_.saveUnsavedDocuments(null, null);
    }
    
    
@@ -3923,7 +3927,15 @@ public class Source implements InsertSourceHandler,
    
    
    private void manageSaveAllCommand()
-   {      
+   {
+      // if source windows are open, managing state of the command becomes
+      // complicated, so leave it enabled
+      if (windowManager_.areSourceWindowsOpen())
+      {
+         commands_.saveAllSourceDocs().setEnabled(true);
+         return;
+      }
+
       // if one document is dirty then we are enabled
       for (EditingTarget target : editors_)
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
@@ -333,6 +333,11 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
       return sourceWindows_.containsKey(windowId);
    }
    
+   public boolean areSourceWindowsOpen()
+   {
+      return !sourceWindows_.isEmpty();
+   }
+   
    public String getWindowIdOfDocPath(String path)
    {
       SourceDocument doc = getDocFromPath(path);
@@ -379,7 +384,6 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
    public void saveUnsavedDocuments(final Set<String> ids,
                                     final Command onCompleted)
    {
-      
       doForAllSourceWindows(new SourceWindowCommand()
       {
          @Override


### PR DESCRIPTION
Currently, the Save All command, somewhat non-intuitively, saves only the files in the current window. This change makes it save all unchanged files in all windows.

We also currently make the Save All command enabled or disabled based on whether or not there are any unsaved targets in the current window. Aggregating this information correctly (and reacting to changes) across all windows is difficult to get right, so we take the conservative approach here of just leaving the command enabled if there are source windows open. 

Fixes https://github.com/rstudio/rstudio/issues/5023.