### PR TITLE
add unique IDs to New Shiny Web App dialog box

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -15,6 +15,7 @@
 package org.rstudio.core.client;
 
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.dom.DomUtils;
 
 public class ElementIds
@@ -33,12 +34,17 @@ public class ElementIds
       }
       ele.setId(elementId);
    }
-   
+
+   public static void assignElementId(Widget widget, String id)
+   {
+      assignElementId(widget.getElement(), id);
+   }
+
    public static String getElementId(String id)
    {
       return ID_PREFIX + id;
    }
-   
+
    public static String idSafeString(String text)
    {
       // replace all non-alphanumerics with underscores
@@ -46,7 +52,7 @@ public class ElementIds
       
       // collapse multiple underscores to a single underscore
       id = id.replaceAll("_+", "_");
-      
+
       // clean up leading/trailing underscores
       id = id.replaceAll("^_+", "");
       id = id.replaceAll("_+$", "");
@@ -54,14 +60,14 @@ public class ElementIds
       // convert to lowercase and return
       return id.toLowerCase();
    }
-   
+
    public static String idFromLabel(String label)
    {
       return ID_PREFIX + "label_" + idSafeString(label);
    }
-   
+
    public final static String ID_PREFIX = "rstudio_";
-   
+
    // global list of specific IDs we assign -- we keep this list centralized in this class as a
    // so that we can be sure an ID is not used elsewhere in the product
    public final static String CONSOLE_INPUT = "console_input";
@@ -102,16 +108,16 @@ public class ElementIds
    public final static String TEXT_SOURCE_BUTTON = "text_source";
    public final static String TEXT_SOURCE_BUTTON_DROPDOWN = "text_source_dropdown";
    public final static String EMPTY_DOC_BUTTON = "empty_doc";
-   
+
    public final static String EDIT_EDITING_PREFS = "edit_editing_prefs";
    public final static String EDIT_DISPLAY_PREFS = "edit_display_prefs";
    public final static String EDIT_SAVING_PREFS = "edit_saving_prefs";
    public final static String EDIT_COMPLETION_PREFS = "editing_completion_prefs";
    public final static String EDIT_DIAGNOSTICS_PREFS = "editing_diagnostics_prefs";
-   
+
    public final static String GENERAL_BASIC_PREFS = "general_basic_prefs";
    public final static String GENERAL_ADVANCED_PREFS = "general_advanced_prefs";
-   
+
    public final static String PACKAGE_MANAGEMENT_PREFS = "package_management_prefs";
    public final static String PACKAGE_DEVELOPMENT_PREFS = "package_development_prefs";
 
@@ -150,4 +156,14 @@ public class ElementIds
    // RmdTemplateChooser
    public final static String RMD_TEMPLATE_CHOOSER_NAME = "rmd_template_chooser_name";
    public static String getRmdTemplateChooserName() { return getElementId(RMD_TEMPLATE_CHOOSER_NAME); }
+
+   // NewShinyWebApplication
+   public final static String NEW_SHINY_APP_NAME = "new_shiny_app_name";
+   public final static String NEW_SHINY_APP_SINGLE_FILE = "new_shiny_app_single_file";
+   public final static String NEW_SHINY_APP_MULTI_FILE = "new_shiny_app_multi_file";
+
+   // TextBoxWithButton
+   public final static String TEXTBOXBUTTON_TEXT = "textboxbutton_text";
+   public final static String TEXTBOXBUTTON_BUTTON = "textboxbutton_button";
+   public final static String TEXTBOXBUTTON_HELP = "textboxbutton_help";
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
@@ -25,6 +25,7 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.TextBox;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.theme.res.ThemeResources;
 
 public class TextBoxWithButton extends Composite
@@ -65,8 +66,10 @@ public class TextBoxWithButton extends Composite
       textBox_ = new TextBox();
       textBox_.setWidth("100%");
       textBox_.setReadOnly(readOnly);
+      ElementIds.assignElementId(textBox_, ElementIds.TEXTBOXBUTTON_TEXT);
 
       themedButton_ = new ThemedButton(action, handler);
+      ElementIds.assignElementId(themedButton_, ElementIds.TEXTBOXBUTTON_BUTTON);
 
       inner_ = new HorizontalPanel();
       inner_.add(textBox_);
@@ -83,6 +86,7 @@ public class TextBoxWithButton extends Composite
             HorizontalPanel panel = new HorizontalPanel();
             panel.add(lblCaption);
             helpButton.getElement().getStyle().setMarginLeft(5, Unit.PX);
+            ElementIds.assignElementId(helpButton, ElementIds.TEXTBOXBUTTON_HELP);
             panel.add(helpButton);
             outer.add(panel);
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewShinyWebApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/NewShinyWebApplication.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.workbench.views.source;
 
 import com.google.gwt.aria.client.Roles;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.RegexUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
@@ -62,12 +63,12 @@ public class NewShinyWebApplication extends ModalDialog<NewShinyWebApplication.R
    public static class Result extends JavaScriptObject
    {
       protected Result() {}
-      
+
       public static final Result create()
       {
          return create("", "", "");
       }
-      
+
       public static final native Result create(String appName,
                                                String appType,
                                                String appDir)
@@ -78,12 +79,12 @@ public class NewShinyWebApplication extends ModalDialog<NewShinyWebApplication.R
             "dir": appDir
          };
       }-*/;
-      
+
       public final native String getAppName() /*-{ return this["name"]; }-*/;
       public final native String getAppType() /*-{ return this["type"]; }-*/;
       public final native String getAppDir() /*-{ return this["dir"]; }-*/;
    }
-   
+
    private void addTextFieldValidator(HasKeyDownHandlers widget)
    {
       widget.addKeyDownHandler(new KeyDownHandler()
@@ -102,12 +103,12 @@ public class NewShinyWebApplication extends ModalDialog<NewShinyWebApplication.R
          }
       });
    }
-   
+
    private boolean isValidAppName(String appName)
    {
       return RE_VALID_APP_NAME.test(appName);
    }
-   
+
    private void validateAppName()
    {
       String appName = appNameTextBox_.getText().trim();
@@ -116,7 +117,7 @@ public class NewShinyWebApplication extends ModalDialog<NewShinyWebApplication.R
       else
          appNameTextBox_.addStyleName(RES.styles().invalidAppName());
    }
-   
+
    private class ShinyWebApplicationClientState extends JSObjectStateValue
    {
       public ShinyWebApplicationClientState()
@@ -145,17 +146,17 @@ public class NewShinyWebApplication extends ModalDialog<NewShinyWebApplication.R
          return result_.cast();
       }
    }
-   
+
    private final void loadAndPersistClientState()
    {
       if (clientStateValue_ == null)
          clientStateValue_ = new ShinyWebApplicationClientState();
    }
-   
+
    private String defaultParentDirectory()
    {
       String dir;
-      
+
       // if we're in a project, use the project directory
       if (context_.isProjectActive())
       {
@@ -169,11 +170,11 @@ public class NewShinyWebApplication extends ModalDialog<NewShinyWebApplication.R
                ? "~"
                : cachedDir;
       }
-      
+
       return dir;
-      
+
    }
-   
+
    @Inject
    private void initialize(Session session,
                            GlobalDisplay globalDisplay,
@@ -183,19 +184,19 @@ public class NewShinyWebApplication extends ModalDialog<NewShinyWebApplication.R
       globalDisplay_ = globalDisplay;
       context_ = context;
    }
-   
+
    public NewShinyWebApplication(String caption, 
                                  OperationWithInput<Result> operation)
    {
       super(caption, Roles.getDialogRole(), operation);
       RStudioGinjector.INSTANCE.injectMembers(this);
-      
+
       setOkButtonCaption("Create");
-      
+
       loadAndPersistClientState();
-        
+
       controls_ = new VerticalPanel();
-      
+
       // Create individual widgets
       appNameTextBox_ = new TextBox();
       DomUtils.disableSpellcheck(appNameTextBox_);
@@ -203,6 +204,7 @@ public class NewShinyWebApplication extends ModalDialog<NewShinyWebApplication.R
       appNameTextBox_.addStyleName(RES.styles().appNameTextBox());
       DomUtils.setPlaceholder(appNameTextBox_, "Name");
       addTextFieldValidator(appNameTextBox_);
+      ElementIds.assignElementId(appNameTextBox_, ElementIds.NEW_SHINY_APP_NAME);
 
       appNameLabel_ = new FormLabel("Application name:", appNameTextBox_);
       appNameLabel_.addStyleName(RES.styles().label());
@@ -210,14 +212,16 @@ public class NewShinyWebApplication extends ModalDialog<NewShinyWebApplication.R
       appTypeLabel_ = new Label("Application type:");
       appTypeLabel_.addStyleName(RES.styles().label());
       appTypeLabel_.getElement().getStyle().setMarginTop(2, Unit.PX);
-      
+
       FieldSetWrapperPanel<VerticalPanel> radioPanel = new FieldSetWrapperPanel<>(new VerticalPanel(), appTypeLabel_);
       radioPanel.setStylePrimaryName(RES.styles().shinyTypeGroup());
       appTypeSingleFileButton_ = new RadioButton("shiny", "Single File (app.R)");
+      ElementIds.assignElementId(appTypeSingleFileButton_, ElementIds.NEW_SHINY_APP_SINGLE_FILE);
       appTypeMultipleFileButton_ = new RadioButton("shiny", "Multiple File (ui.R/server.R)");
+      ElementIds.assignElementId(appTypeMultipleFileButton_, ElementIds.NEW_SHINY_APP_MULTI_FILE);
       radioPanel.add(appTypeSingleFileButton_);
       radioPanel.add(appTypeMultipleFileButton_);
-      
+
       String cachedAppType = result_.getAppType();
       if (TYPE_SINGLE_FILE.equals(cachedAppType))
          appTypeSingleFileButton_.setValue(true);
@@ -379,5 +383,5 @@ public class NewShinyWebApplication extends ModalDialog<NewShinyWebApplication.R
    static {
       RES.styles().ensureInjected();
    }
-   
+
 }


### PR DESCRIPTION
Requested by QA for automation (tracked in a pro issue, which should have been in the open-source repo: https://github.com/rstudio/rstudio-pro/issues/1173)

- Name textbox: `rstudio_new_shiny_app_name`
- Single file radio: `rstudio_new_shiny_app_single_file`
- Multi file radio: `rstudio_new_shiny_app_multi_file`
- Create within directory textbox: `rstudio_textboxbutton_text`
- Browse button: `rstudio_textboxbutton_button`
- Create button: `rstudio_dlg_ok`
- Cancel button: `rstudio_dlg_cancel`

Radio buttons are compound controls. The unique ID is attached to the outer span which contains the input (radio) and label.

The create and cancel buttons already had unique ids, just including here for completeness.

The read-only textfield and browse button are part of a compound control, TextBoxWithButton, used in many places. If multiple instances of this control are simultaneously displayed (e.g. in the same dialog or stacked dialogs) then the IDs will be kept unique by addition of "_##" where ## is an incrementing integer. These IDs would be stable for a given scenario, so still usable for automation.