### PR TITLE
Import preferences from RStudio 1.2

### DIFF
--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -156,6 +156,7 @@ set (SESSION_SOURCE_FILES
    modules/SessionVCS.cpp
    modules/SessionWorkbench.cpp
    modules/SessionUserPrefs.cpp
+   modules/SessionUserPrefsMigration.cpp
    modules/build/SessionBuild.cpp
    modules/build/SessionBuildEnvironment.cpp
    modules/build/SessionBuildErrors.cpp

--- a/src/cpp/session/include/session/SessionConstants.hpp
+++ b/src/cpp/session/include/session/SessionConstants.hpp
@@ -91,8 +91,6 @@
 #define kListsPath          "lists"
 #define kProjectMruList     "project_mru"
 
-#define kUserSettingsDir       "user-settings"
-#define kUserSettingsFile      kUserSettingsDir
 #define kContextIdentifier     "contextIdentifier"
 
 #define kServerHomeSetting     "showUserHomePage"

--- a/src/cpp/session/modules/SessionUserPrefs.cpp
+++ b/src/cpp/session/modules/SessionUserPrefs.cpp
@@ -248,6 +248,10 @@ SEXP rs_allPrefs()
    return list;
 }
 
+/**
+ * One-time migration of user preferences from the user-settings file used in RStudio 1.2 and below
+ * to the formal preferences system in RStudio 1.3.
+ */
 Error migrateUserPrefs()
 {
    // Check to see whether there's a preferences file at the new location
@@ -289,7 +293,8 @@ core::Error initialize()
    if (error)
       return error;
 
-   // Migrate user preferences from older versions of RStudio. 
+   // Migrate user preferences from older versions of RStudio if they exist (and we don't have prefs
+   // yet)
    error = migrateUserPrefs();
    if (error)
    {

--- a/src/cpp/session/modules/SessionUserPrefs.cpp
+++ b/src/cpp/session/modules/SessionUserPrefs.cpp
@@ -20,6 +20,9 @@
 #include <boost/bind/bind.hpp>
 
 #include <core/Exec.hpp>
+
+#include <core/system/Xdg.hpp>
+
 #include <session/prefs/UserPrefs.hpp>
 #include <session/prefs/UserState.hpp>
 #include <session/SessionModuleContext.hpp>
@@ -256,7 +259,7 @@ Error migrateUserPrefs()
    }
 
    // Check to see whether there's a preferences file at the old location
-   FilePath userSettings = userScratchPath()
+   FilePath userSettings = module_context::userScratchPath()
       .complete(kMonitoredPath)
       .complete("user-settings")
       .complete("user-settings");

--- a/src/cpp/session/modules/SessionUserPrefsMigration.cpp
+++ b/src/cpp/session/modules/SessionUserPrefsMigration.cpp
@@ -85,7 +85,11 @@ void migrateUiPrefs(const json::Object& uiPrefs, json::Object* dest)
                key == kJobsTabVisibility ||
                key == kLauncherJobsSort ||
                key == kBusyDetection ||
-               key == kDocOutlineShow)
+               key == kDocOutlineShow ||
+               key == kRmdViewerType ||
+               key == kShinyViewerType ||
+               key == kPlumberViewerType ||
+               key == kAnsiConsoleMode)
       {
          // These preferences don't migrate
          continue;
@@ -153,7 +157,13 @@ core::Error migratePrefs(const FilePath& src)
       }
       else if (val.type() == json::ObjectType)
       {
-         migrateUiPrefs(val.get_obj(), &destPrefs);
+         // Migrate UI prefs; guard against JSON exceptions (there's a lot of potential for these
+         // due to malformed or invalid prefs files from the wild)
+         try
+         {
+            migrateUiPrefs(val.get_obj(), &destPrefs);
+         }
+         CATCH_UNEXPECTED_EXCEPTION
       }
    }
 

--- a/src/cpp/session/modules/SessionUserPrefsMigration.cpp
+++ b/src/cpp/session/modules/SessionUserPrefsMigration.cpp
@@ -32,6 +32,11 @@ namespace modules {
 namespace prefs {
 namespace {
 
+/**
+ * Migrates the "UI prefs" from RStudio 1.2 (and older) to the RStudio 1.3+. Both are JSON objects,
+ * so most values are just copied as-is, but a number of preferences require special treatment since
+ * they were reworded or reorganized to be more user-friendly in RStudio 1.3.
+ */
 void migrateUiPrefs(const json::Object& uiPrefs, json::Object* dest)
 {
    std::vector<std::string> keys = userPrefs().allKeys();
@@ -134,6 +139,12 @@ void migrateUiPrefs(const json::Object& uiPrefs, json::Object* dest)
 } // anonymous namespace
 
 
+/**
+ * Migrates RStudio 1.2 (or older) preferences from a user-settings file into the new RStudio 1.3+
+ * preferences system. This is a one-time operation, performed only when we detect that no
+ * preferences exist yet. We can remove this code if RStudio 1.2 and below usage ever drops below a
+ * significant threshold.
+ */
 core::Error migratePrefs(const FilePath& src)
 {
    json::Object srcPrefs;
@@ -236,6 +247,7 @@ core::Error migratePrefs(const FilePath& src)
    destPrefs[kCleanTexi2dviOutput] = settings.getBool("cleanTexi2DviOutput", true);
    destPrefs[kUseSecureDownload] = settings.getBool("securePackageDownload", true);
 
+   // Write the accumulated preferences to our user prefs layer
    return userPrefs().writeLayer(PREF_LAYER_USER, destPrefs); 
 }
 

--- a/src/cpp/session/modules/SessionUserPrefsMigration.cpp
+++ b/src/cpp/session/modules/SessionUserPrefsMigration.cpp
@@ -1,0 +1,97 @@
+/*
+ * SessionUserPrefsMigration.cpp
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "SessionUserPrefsMigration.hpp"
+
+#include <core/json/Json.hpp>
+#include <core/Settings.hpp>
+
+using namespace rstudio::core;
+using namespace rstudio::session::prefs;
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace prefs {
+namespace {
+
+void migrateUiPrefs(const json::Object& uiPrefs, json::Object* dest)
+{
+   std::vector<std::string> keys = userPrefs().allKeys();
+   json::Object iterator it;
+   json::Value val;
+   for (const auto &key: keys)
+   {
+      // Migrate pane locations
+      if (key == kPanes)
+      {
+         it = uiPrefs.find("pane_config");
+         if (it != uiPrefs.end())
+         {
+            json::Object old = (*it).value().get_obj();
+            json::Object panes;
+            panes[kPanesQuadrants] = old["panes"];
+            panes[kPanesTabSet1] = old["tabSet1"];
+            panes[kPanesTabSet2] = old["tabSet2"];
+            panes[kPanesConsoleLeftOnTop] = old["consoleLeftOnTop"];
+            panes[kPanesConsoleRightOnTop] = old["consoleRightOnTop"];
+
+            (*dest)[kPanes] = panes;
+         }
+      }
+   }
+}
+
+} // anonymous namespace
+
+
+core::Error migratePrefs(const FilePath& src)
+{
+   json::Object srcPrefs;
+   json::Object destPrefs;
+
+   // Read the old settings file
+   Settings settings; 
+   Error err = settings.initialize(src);
+   if (err)
+      return err;
+
+   // Migrate UI prefs if present.
+   std::string uiPrefs = settings.get("uiPrefs");
+   if (!uiPrefs.empty())
+   {
+      json::Value val;
+      err = json::parse(uiPrefs, ERROR_LOCATION, &val);
+      if (err)
+      {
+         LOG_ERROR(err);
+      }
+      else if (val.type() == json::ObjectType)
+      {
+         migrateUiPrefs(val.get_obj(), &destPrefs);
+      }
+   }
+
+   std::stringstream oss;
+   json::writeFormatted(destPrefs, oss);
+
+   return userPrefs().writeLayer(PREF_LAYER_USER, destPrefs); 
+}
+
+} // namespace prefs
+} // namespace modules
+} // namespace session
+} // namespace rstudio
+

--- a/src/cpp/session/modules/SessionUserPrefsMigration.cpp
+++ b/src/cpp/session/modules/SessionUserPrefsMigration.cpp
@@ -18,6 +18,8 @@
 #include <core/json/Json.hpp>
 #include <core/Settings.hpp>
 
+#include <session/prefs/UserPrefs.hpp>
+
 using namespace rstudio::core;
 using namespace rstudio::session::prefs;
 
@@ -30,14 +32,13 @@ namespace {
 void migrateUiPrefs(const json::Object& uiPrefs, json::Object* dest)
 {
    std::vector<std::string> keys = userPrefs().allKeys();
-   json::Object iterator it;
    json::Value val;
    for (const auto &key: keys)
    {
       // Migrate pane locations
       if (key == kPanes)
       {
-         it = uiPrefs.find("pane_config");
+         json::Object::iterator it = uiPrefs.find("pane_config");
          if (it != uiPrefs.end())
          {
             json::Object old = (*it).value().get_obj();

--- a/src/cpp/session/modules/SessionUserPrefsMigration.hpp
+++ b/src/cpp/session/modules/SessionUserPrefsMigration.hpp
@@ -1,0 +1,40 @@
+/*
+ * SessionUserPrefsMigration.hpp
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef SESSION_MODULE_USER_PREFS_MIGRATION_HPP
+#define SESSION_MODULE_USER_PREFS_MIGRATION_HPP
+
+#include <core/FilePath.hpp>
+
+namespace rstudio {
+   namespace core {
+      class Error;
+   }
+}
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace prefs {
+
+// Migrates preferences from RStudio 1.2 and prior into the new RStudio 1.3 system
+core::Error migratePrefs(const core::FilePath& src, const core::FilePath& dest);
+
+} // namespace prefs
+} // namespace modules
+} // namespace session
+} // namespace rstudio
+
+#endif

--- a/src/cpp/session/modules/SessionUserPrefsMigration.hpp
+++ b/src/cpp/session/modules/SessionUserPrefsMigration.hpp
@@ -30,7 +30,7 @@ namespace modules {
 namespace prefs {
 
 // Migrates preferences from RStudio 1.2 and prior into the new RStudio 1.3 system
-core::Error migratePrefs(const core::FilePath& src, const core::FilePath& dest);
+core::Error migratePrefs(const core::FilePath& src);
 
 } // namespace prefs
 } // namespace modules

--- a/src/cpp/session/prefs/UserPrefsComputedLayer.cpp
+++ b/src/cpp/session/prefs/UserPrefsComputedLayer.cpp
@@ -25,6 +25,8 @@
 #include <core/json/Json.hpp>
 #include <core/CrashHandler.hpp>
 
+#include <r/session/RSession.hpp>
+
 #include "../modules/SessionVCS.hpp"
 #include "../modules/SessionSVN.hpp"
 #include "../modules/SessionSpelling.hpp"
@@ -82,6 +84,18 @@ Error UserPrefsComputedLayer::readPrefs()
    layer["spelling"] =
          session::modules::spelling::spellingPrefsContextAsJson();
 
+   // Other session defaults from rsession.conf -------------------------------
+
+   int saveAction = session::options().saveActionDefault();
+   if (saveAction == r::session::kSaveActionSave)
+      layer[kSaveWorkspace] = kSaveWorkspaceAlways;
+   else if (saveAction == r::session::kSaveActionNoSave)
+      layer[kSaveWorkspace] = kSaveWorkspaceNever;
+   else if (saveAction == r::session::kSaveActionAsk)
+      layer[kSaveWorkspace] = kSaveWorkspaceAsk;
+
+   layer[kRunRprofileOnResume] = session::options().rProfileOnResumeDefault();
+   
    cache_ = boost::make_shared<core::json::Object>(layer);
    return Success();
 }


### PR DESCRIPTION
This change contains the last essential piece of the new prefs work: it migrates user preferences from RStudio 1.2 (and earlier) to the new 1.3 system. It does this by reading the `user-settings` file written by these older versions and translating preferences from the file itself as well as the JSON blob of UI prefs it contains into the new system.

The migration is only done if there are no 1.3 preferences. Since 1.3 preferences are written at the end of the migration, the migration will only be done once unless the 1.3 preferences are removed. 




