### PR TITLE
Complete registration of .Rtex files

### DIFF
--- a/src/cpp/desktop/Info.plist.in
+++ b/src/cpp/desktop/Info.plist.in
@@ -110,6 +110,21 @@
       <dict>
          <key>CFBundleTypeExtensions</key>
          <array>
+             <string>Rtex</string>
+             <string>rtex</string>
+         </array>
+         <key>CFBundleTypeIconFile</key>
+         <string>RSweave.icns</string>
+         <key>CFBundleTypeName</key>
+         <string>Sweave File</string>
+         <key>CFBundleTypeRole</key>
+         <string>Editor</string>
+         <key>LSIsAppleDefaultForType</key>
+         <true/>
+      </dict>
+      <dict>
+         <key>CFBundleTypeExtensions</key>
+         <array>
              <string>Rmd</string>
              <string>rmd</string>
              <string>Rmarkdown</string>

--- a/src/cpp/desktop/resources/freedesktop/rstudio.xml
+++ b/src/cpp/desktop/resources/freedesktop/rstudio.xml
@@ -20,6 +20,8 @@
     <comment>R Sweave File</comment>
     <glob pattern="*.Rnw"/>
     <glob pattern="*.rnw"/>
+    <glob pattern="*.Rtex"/>
+    <glob pattern="*.rtex"/>
   </mime-type>
 
   <mime-type type="text/x-r-markdown">

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -909,7 +909,7 @@ private:
       std::string ext = filePath.extensionLowerCase();
       std::string filename = filePath.filename();
       return !filePath.isDirectory() &&
-              (ext == ".r" || ext == ".rnw" ||
+              (ext == ".r" || ext == ".rnw" || ext == ".rtex" ||
                ext == ".rmd" || ext == ".rmarkdown" ||
                ext == ".rhtml" || ext == ".rd" ||
                ext == ".h" || ext == ".hpp" ||

--- a/src/cpp/session/modules/tex/SessionCompilePdf.cpp
+++ b/src/cpp/session/modules/tex/SessionCompilePdf.cpp
@@ -608,7 +608,7 @@ private:
 
       // see if we need to weave
       std::string ext = targetFilePath_.extensionLowerCase();
-      bool isRnw = ext == ".rnw" || ext == ".snw" || ext == ".nw";
+      bool isRnw = ext == ".rnw" || ext == ".snw" || ext == ".nw" || ext == ".rtex";
       if (isRnw)
       {
          // remove existing ancillary files + concordance
@@ -805,7 +805,8 @@ private:
 
    bool isTargetRnw() const
    {
-      return targetFilePath_.extensionLowerCase() == ".rnw";
+      return targetFilePath_.extensionLowerCase() == ".rnw" ||
+             targetFilePath_.extensionLowerCase() == ".rtex";
    }
 
 private:

--- a/src/cpp/session/modules/tex/SessionSynctex.cpp
+++ b/src/cpp/session/modules/tex/SessionSynctex.cpp
@@ -80,7 +80,8 @@ void applyForwardConcordance(const FilePath& mainFile,
                              core::tex::SourceLocation* pLoc)
 {
    // skip if this isn't an Rnw
-   if (pLoc->file().extensionLowerCase() != ".rnw")
+   if (pLoc->file().extensionLowerCase() != ".rnw" && 
+       pLoc->file().extensionLowerCase() != ".rtex")
       return;
 
    // try to read concordance

--- a/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
+++ b/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
@@ -393,6 +393,7 @@ public class FileSystemItem extends JavaScriptObject
       MIME_TYPES.put( "q",     "text/x-r-source");
       MIME_TYPES.put( "rd",    "text/x-r-doc");
       MIME_TYPES.put( "rnw",   "text/x-r-sweave");
+      MIME_TYPES.put( "rtex",  "text/x-r-sweave");
       MIME_TYPES.put( "rmd",   "text/x-r-markdown");
       MIME_TYPES.put( "rhtml", "text/x-r-html");
       MIME_TYPES.put( "rpres", "text/x-r-presentation");


### PR DESCRIPTION
Drive-by change; fixes https://github.com/rstudio/rstudio/issues/5076. Completes the work started in #653. 

Note that `utils::Sweave` does not recognize `.Rtex` files as Sweave, so you will need to use `knitr` as your Sweave engine to be successful with this file extension. 