### PR TITLE
preferences UI for terminal rendering and bell options

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -121,6 +121,9 @@ public class ElementIds
    public final static String PACKAGE_MANAGEMENT_PREFS = "package_management_prefs";
    public final static String PACKAGE_DEVELOPMENT_PREFS = "package_development_prefs";
 
+   public final static String TERMINAL_GENERAL_PREFS = "terminal_general_prefs";
+   public final static String TERMINAL_CLOSING_PREFS = "terminal_closing_prefs";
+
    // AskSecretDialog
    public final static String ASK_SECRET_TEXT = "ask_secret_text";
    public static String getAskSecretText() { return getElementId(ASK_SECRET_TEXT); }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -171,7 +171,10 @@ public class TerminalSession extends XTermWidget
             addHandlerRegistration(eventBus_.addHandler(ThemeChangedEvent.TYPE, TerminalSession.this));
             uiPrefs_.blinkingCursor().bind(arg -> updateBooleanOption("cursorBlink", arg));
             uiPrefs_.terminalBellStyle().bind(arg -> updateStringOption("bellStyle", arg));
-            uiPrefs_.terminalRenderer().bind(arg -> updateStringOption("rendererType", arg));
+            uiPrefs_.terminalRenderer().bind(arg -> {
+               updateStringOption("rendererType", arg);
+               onResize();
+            });
             uiPrefs_.fontSizePoints().bind(arg -> {
                updateDoubleOption("fontSize", XTermTheme.adjustFontSize(arg));
                onResize();


### PR DESCRIPTION
Preferences UI for xterm3 rendering (canvas vs dom) and bell (audible vs none) options.

There are several other new options supported by xterm3, but these are the most critical, imo. The bell will annoy some, and the canvas-based rending (i.e. "Hardware Acceleration") will almost certainly have problems on some systems / browsers.

These options required splitting terminal prefs into two panes (too many options to fit on one).

![2019-08-24_10-53-04](https://user-images.githubusercontent.com/10569626/63641138-421e0580-c65e-11e9-9148-d67b93b524b2.png)

![2019-08-24_10-53-44](https://user-images.githubusercontent.com/10569626/63641141-464a2300-c65e-11e9-947a-fceddfa906a2.png)

