### PR TITLE
use DYLD_INSERT_LIBRARIES to force requested libR

### DIFF
--- a/cmake/modules/FindLibR.cmake
+++ b/cmake/modules/FindLibR.cmake
@@ -21,12 +21,14 @@
 if(APPLE)
 
    find_library(LIBR_LIBRARIES R)
-
+   
    if(LIBR_LIBRARIES MATCHES ".*\\.framework")
-      set(LIBR_HOME "${LIBR_LIBRARIES}/Resources" CACHE PATH "R home directory")
+      set(_LIBR_RESOURCES "${LIBR_LIBRARIES}/Resources")
+      get_filename_component(_LIBR_HOME "${_LIBR_RESOURCES}" REALPATH)
+      set(LIBR_HOME "${_LIBR_HOME}" CACHE PATH "R home directory")
       set(LIBR_INCLUDE_DIRS "${LIBR_HOME}/include" CACHE PATH "R include directory")
       set(LIBR_DOC_DIR "${LIBR_HOME}/doc" CACHE PATH "R doc directory")
-      set(LIBR_EXECUTABLE "${LIBR_HOME}/R" CACHE PATH "R executable")
+      set(LIBR_EXECUTABLE "${LIBR_HOME}/bin/R" CACHE PATH "R executable")
    else()
       get_filename_component(_LIBR_LIBRARIES "${LIBR_LIBRARIES}" REALPATH)
       get_filename_component(_LIBR_LIBRARIES_DIR "${_LIBR_LIBRARIES}" PATH)

--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -54,6 +54,24 @@ void launchProcess(const std::string& absPath,
    QProcess* process = new QProcess();
    process->setProgram(QString::fromStdString(absPath));
    process->setArguments(argList);
+   
+#ifdef Q_OS_DARWIN
+   // on macOS with the hardened runtime, we can no longer rely on dyld
+   // to lazy-load symbols from libR.dylib; to resolve this, we use
+   // DYLD_INSERT_LIBRARIES to inject the library we wish to use on
+   // launch 
+   FilePath rHome = FilePath(core::system::getenv("R_HOME"));
+   FilePath rLib = rHome.childPath("lib/libR.dylib");
+   if (rLib.exists())
+   {
+      QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+      environment.insert(
+               QStringLiteral("DYLD_INSERT_LIBRARIES"),
+               QString::fromStdString(rLib.absolutePathNative()));
+      process->setProcessEnvironment(environment);
+   }
+#endif
+   
    if (options().runDiagnostics())
       process->setProcessChannelMode(QProcess::ForwardedChannels);
 
@@ -369,7 +387,7 @@ Error SessionLauncher::launchSession(const QStringList& argList,
    if (error)
       LOG_ERROR(error);
 
-   return  parent_process_monitor::wrapFork(
+   return parent_process_monitor::wrapFork(
          boost::bind(launchProcess,
                      sessionPath_.absolutePath(),
                      argList,

--- a/src/cpp/r/CMakeLists.txt
+++ b/src/cpp/r/CMakeLists.txt
@@ -92,10 +92,13 @@ include_directories(
 add_library(rstudio-r STATIC ${R_SOURCE_FILES} ${R_HEADER_FILES})
 
 # link dependencies
-target_link_libraries(rstudio-r
-   ${LIBR_LIBRARIES}
-   rstudio-core
-)
+target_link_libraries(rstudio-r rstudio-core)
+
+if(APPLE)
+   target_link_libraries(rstudio-r "-undefined dynamic_lookup")
+else()
+   target_link_libraries(rstudio-r "${LIBR_LIBRARIES}")
+endif()
 
 # install rules
 if (NOT RSTUDIO_SESSION_WIN32)

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -418,9 +418,14 @@ target_link_libraries(rsession
    rstudio-session-workers
    ${SESSION_SYSTEM_LIBRARIES}
    ${CMAKE_DL_LIBS}
-   ${LIBR_LIBRARIES}
    ${CRASHPAD_LIBRARIES}
 )
+
+if(APPLE)
+   target_link_libraries(rsession "-undefined dynamic_lookup")
+else()
+   target_link_libraries(rsession "${LIBR_LIBRARIES}")
+endif()
 
 if (RSTUDIO_SERVER)
    target_link_libraries(rsession
@@ -627,14 +632,6 @@ if(APPLE)
          add_custom_command (TARGET rsession POST_BUILD
             COMMAND install_name_tool -change ${LIB_DIR}/${LIB_FILE} @executable_path/../Frameworks/${LIB_FILE} ${CMAKE_CURRENT_BINARY_DIR}/rsession)
       endforeach()
-
-      # rewrite the libR.dylib path so that it points at the current version
-      # instead of the specific version we linked against. pointing at a
-      # specific version causes that version to always load even if it isn't
-      # the current version (see #2313 for details)
-      get_filename_component(LIBR_HOME_REALPATH "${LIBR_HOME}" REALPATH)
-      add_custom_command(TARGET rsession POST_BUILD
-         COMMAND install_name_tool -change "${LIBR_HOME_REALPATH}/lib/libR.dylib" "/Library/Frameworks/R.framework/Versions/Current/Resources/lib/libR.dylib" "${CMAKE_CURRENT_BINARY_DIR}/rsession")
 
    endif()
 


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/5238.

With this change, `rsession` no longer explicitly links to a particular `libR.dylib`; instead, the RStudio frontend uses `DYLD_INSERT_LIBRARIES` to inject the discovered version of R when RStudio is launched.