### PR TITLE
Read user commands from XDG folder

### DIFF
--- a/src/cpp/session/modules/SessionUserCommands.R
+++ b/src/cpp/session/modules/SessionUserCommands.R
@@ -1,5 +1,7 @@
 #
-# Copyright (C) 2009-12 by RStudio, Inc.
+# SessionUserCommands.R
+#
+# Copyright (C) 2009-19 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -82,13 +84,20 @@ assign(".rs.userCommands", new.env(parent = emptyenv()), envir = .rs.toolsEnv())
    TRUE
 })
 
-.rs.addFunction("loadUserCommands", function()
+.rs.addFunction("loadUserCommands", function(keybindingPath)
 {
    env <- new.env(parent = globalenv())
    env$registerUserCommand <- .rs.registerUserCommand
    
-   files <- list.files("~/.R/keybindings/R", full.names = TRUE)
-   lapply(files, function(file) {
-      source(file, local = env)
-   })
+   # load user commands from pre-1.3 RStudio folder if present, then from the configured user
+   # command folder
+   paths <- c("~/.R/keybindings", keybindingPath)
+   for (path in paths)
+   {
+      files <- list.files(file.path(path, "R"), full.names = TRUE)
+      lapply(files, function(file)
+      {
+         source(file, local = env)
+      })
+   }
 })

--- a/src/cpp/session/modules/SessionUserCommands.cpp
+++ b/src/cpp/session/modules/SessionUserCommands.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionUserCommands.cpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -23,6 +23,8 @@
 
 #include <core/Error.hpp>
 #include <core/Exec.hpp>
+
+#include <core/system/Xdg.hpp>
 
 #include <r/RExec.hpp>
 #include <r/RSexp.hpp>
@@ -107,6 +109,9 @@ SEXP rs_registerUserCommand(SEXP nameSEXP, SEXP shortcutsSEXP)
 void onDeferredInit(bool newSession)
 {
    r::exec::RFunction loadUserCommands(".rs.loadUserCommands");
+   loadUserCommands.addParam("keybindingPath", 
+         core::system::xdg::userConfigDir().complete("keybindings").absolutePath());
+         
    Error error = loadUserCommands.call();
    if (error)
       LOG_ERROR(error);


### PR DESCRIPTION
RStudio can load user commands from `~/.R/keybindings/R`. This change adds an XDG compliant directory which is also scanned for user commands (so they can be placed in `~/.config/rstudio/keybindings/R`). 