### PR TITLE
Fix help pane fonts on macOS Catalina

### DIFF
--- a/src/cpp/session/resources/R.css
+++ b/src/cpp/session/resources/R.css
@@ -1,7 +1,7 @@
 /*
  * R.css
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,6 +16,15 @@
 body, td {
    font-family: sans-serif;
    font-size: 10pt;
+}
+
+body.macintosh, body.macintosh td {
+   font-family: Helvetica, sans-serif;
+}
+
+body.macintosh code,
+body.macintosh pre{
+   font-family: Courier, monospace;
 }
 
 ::selection {

--- a/src/cpp/session/resources/R.css
+++ b/src/cpp/session/resources/R.css
@@ -19,11 +19,11 @@ body, td {
 }
 
 body.macintosh, body.macintosh td {
-   font-family: Helvetica, sans-serif;
+   font-family: "SF Pro Text", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 body.macintosh code,
-body.macintosh pre{
+body.macintosh pre {
    font-family: Courier, monospace;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/BrowseCap.java
+++ b/src/gwt/src/org/rstudio/core/client/BrowseCap.java
@@ -187,6 +187,11 @@ public class BrowseCap
          return "Unknown";
    }
    
+   public static String operatingSystem()
+   {
+      return OPERATING_SYSTEM;
+   }
+   
    private static native final double getDevicePixelRatio() /*-{
       try
       {

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
@@ -15,6 +15,7 @@
 
 package org.rstudio.core.client.widget;
 
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.ThemeChangedEvent;
@@ -144,6 +145,10 @@ public class RStudioThemedFrame extends RStudioFrame
                document, document.getBody());
             
             body.addClassName("ace_editor_theme");
+            
+            // Add OS tag to the frame so that it can apply OS-specific CSS if
+            // needed.
+            body.addClassName(BrowseCap.operatingSystem());
          }
       }
    }


### PR DESCRIPTION
The Help pane looks terrible in macOS Catalina. Due to what appears to be a bug in QtWebEngine, the generic CSS font classes `serif`, `sans-serif`, `monospace`, etc. all render in some sort of tiny Times New Roman font on MacOS Catalina in the Help pane.

This change works around the problem by specifying the macOS default fonts (Helvetica and Courier) for the limited HTML used by the Help pane, so that the appearance matches that of prior releases. Just to be cautious, we only do this when on macOS. 

Fixes https://github.com/rstudio/rstudio/issues/5066. Candidate for 1.2-patch backport since it's affected, too.