### PR TITLE
toggle whether indent occurs on paste with Shift

### DIFF
--- a/src/cpp/desktop/DesktopMenuCallback.cpp
+++ b/src/cpp/desktop/DesktopMenuCallback.cpp
@@ -241,6 +241,10 @@ void MenuCallback::addCommand(QString commandId,
    {
       keySequence = QKeySequence(QKeySequence::Paste);
    }
+   else if (commandId == QStringLiteral("pasteWithIndentDummy"))
+   {
+      keySequence = QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_V);
+   }
    else if (commandId == QStringLiteral("undoDummy"))
    {
       keySequence = QKeySequence(QKeySequence::Undo);

--- a/src/cpp/desktop/DesktopWebView.cpp
+++ b/src/cpp/desktop/DesktopWebView.cpp
@@ -159,23 +159,26 @@ QString WebView::promptForFilename(const QNetworkRequest& request,
 
 void WebView::keyPressEvent(QKeyEvent* pEvent)
 {
+   
 #ifdef Q_OS_MAC
-   if (pEvent->key() == Qt::Key_W &&
-       pEvent->modifiers() == Qt::CTRL)
+   // on macOS, intercept Cmd+W and emit the window close signal
+   if (pEvent->key() == Qt::Key_W && pEvent->modifiers() == Qt::CTRL)
    {
-      // on macOS, intercept Cmd+W and emit the window close signal
       onCloseWindowShortcut();
+      return;
    }
-   else
+#endif
+   
+   // allow Ctrl + Shift + V to act as a paste action
+   if (pEvent->key() == Qt::Key_V && pEvent->modifiers() == Qt::CTRL + Qt::SHIFT)
    {
-      // pass other key events through to WebEngine
-      QWebEngineView::keyPressEvent(pEvent);
+      triggerPageAction(QWebEnginePage::Paste);
+      return;
    }
-#else
-
+   
+   // use default behavior otherwise
    QWebEngineView::keyPressEvent(pEvent);
    
-#endif
 }
 
 void WebView::openFile(QString fileName)

--- a/src/cpp/desktop/DesktopWebView.cpp
+++ b/src/cpp/desktop/DesktopWebView.cpp
@@ -169,13 +169,6 @@ void WebView::keyPressEvent(QKeyEvent* pEvent)
    }
 #endif
    
-   // allow Ctrl + Shift + V to act as a paste action
-   if (pEvent->key() == Qt::Key_V && pEvent->modifiers() == Qt::CTRL + Qt::SHIFT)
-   {
-      triggerPageAction(QWebEnginePage::Paste);
-      return;
-   }
-   
    // use default behavior otherwise
    QWebEngineView::keyPressEvent(pEvent);
    

--- a/src/gwt/src/org/rstudio/core/client/KeyboardTracker.java
+++ b/src/gwt/src/org/rstudio/core/client/KeyboardTracker.java
@@ -1,0 +1,53 @@
+/*
+ * KeyboardTracker.java
+ *
+ * Copyright (C) 2009-17 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client;
+
+import org.rstudio.core.client.command.KeyboardShortcut;
+
+import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.Event.NativePreviewEvent;
+import com.google.gwt.user.client.Event.NativePreviewHandler;
+import com.google.inject.Singleton;
+
+@Singleton
+public class KeyboardTracker
+{
+   public KeyboardTracker()
+   {
+      Event.addNativePreviewHandler(new NativePreviewHandler()
+      {
+         @Override
+         public void onPreviewNativeEvent(NativePreviewEvent preview)
+         {
+            int type = preview.getTypeInt();
+            if ((type & Event.KEYEVENTS) == 0)
+               return;
+            
+            NativeEvent event = preview.getNativeEvent();
+            modifier_ = KeyboardShortcut.getModifierValue(event);
+         }
+            
+      });
+   }
+   
+   public boolean isShiftKeyDown()
+   {
+      return (modifier_ & KeyboardShortcut.SHIFT) != 0;
+   }
+   
+   private int modifier_ = 0;
+   
+}

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -247,6 +247,13 @@ public class DesktopApplicationHeader implements ApplicationHeader,
       fireEditEvent(EditEvent.TYPE_PASTE);
       Desktop.getFrame().clipboardPaste();
    }
+   
+   @Handler
+   void onPasteWithIndentDummy()
+   {
+      fireEditEvent(EditEvent.TYPE_PASTE_WITH_INDENT);
+      Desktop.getFrame().clipboardPaste();
+   }
 
    @Handler
    void onShowLogFiles()

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
@@ -314,12 +314,13 @@ public class WebApplicationHeader extends Composite
    {
       int modifiers = BrowseCap.hasMetaKey() ? KeyboardShortcut.META : KeyboardShortcut.CTRL;
 
-      setCommandShortcut(commands.undoDummy(),  "z", 'Z', modifiers);
-      setCommandShortcut(commands.redoDummy(),  "Z", 'Z', modifiers | KeyboardShortcut.SHIFT);
+      setCommandShortcut(commands.undoDummy(),            "z", 'Z', modifiers);
+      setCommandShortcut(commands.redoDummy(),            "Z", 'Z', modifiers | KeyboardShortcut.SHIFT);
 
-      setCommandShortcut(commands.cutDummy(),   "x", 'X', modifiers);
-      setCommandShortcut(commands.copyDummy(),  "c", 'C', modifiers);
-      setCommandShortcut(commands.pasteDummy(), "v", 'V', modifiers);
+      setCommandShortcut(commands.cutDummy(),             "x", 'X', modifiers);
+      setCommandShortcut(commands.copyDummy(),            "c", 'C', modifiers);
+      setCommandShortcut(commands.pasteDummy(),           "v", 'V', modifiers);
+      setCommandShortcut(commands.pasteWithIndentDummy(), "v", 'V', modifiers | KeyboardShortcut.SHIFT);
       
       CommandHandler useKeyboardNotification = new CommandHandler()
       {
@@ -335,6 +336,7 @@ public class WebApplicationHeader extends Composite
                           makeRow(commands.cutDummy()) +
                           makeRow(commands.copyDummy()) +
                           makeRow(commands.pasteDummy()) +
+                          makeRow(commands.pasteWithIndentDummy()) +
                           "</table>"
                           );
             new WebDialogBuilderFactory().create(
@@ -359,6 +361,7 @@ public class WebApplicationHeader extends Composite
       commands.cutDummy().addHandler(useKeyboardNotification);
       commands.copyDummy().addHandler(useKeyboardNotification);
       commands.pasteDummy().addHandler(useKeyboardNotification);
+      commands.pasteWithIndentDummy().addHandler(useKeyboardNotification);
    }
 
    public int getPreferredHeight()

--- a/src/gwt/src/org/rstudio/studio/client/events/EditEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/events/EditEvent.java
@@ -38,10 +38,11 @@ public class EditEvent extends GwtEvent<EditEvent.Handler>
    private final boolean before_;
    private final int type_;
    
-   public static final int TYPE_NONE  = 0;
-   public static final int TYPE_CUT   = 1;
-   public static final int TYPE_COPY  = 2;
-   public static final int TYPE_PASTE = 4;
+   public static final int TYPE_NONE              = 0;
+   public static final int TYPE_CUT               = 1;
+   public static final int TYPE_COPY              = 2;
+   public static final int TYPE_PASTE             = 4;
+   public static final int TYPE_PASTE_WITH_INDENT = 8;
 
    // Boilerplate ----
    public interface Handler extends EventHandler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -168,6 +168,7 @@ well as menu structures (for main menu and popup menus).
          <cmd refid="cutDummy"/>
          <cmd refid="copyDummy"/>
          <cmd refid="pasteDummy"/>
+         <cmd refid="pasteWithIndentDummy"/>
          <separator/>
          <menu label="_Folding">
             <cmd refid="fold"/>
@@ -562,6 +563,10 @@ well as menu structures (for main menu and popup menus).
       <!-- Use spaces for key sequences, e.g. 'Ctrl+X Ctrl+F' -->
       <!-- Separate shortcuts with '|', e.g. 'Ctrl+X Ctrl+F|Cmd+O' -->
       <shortcutgroup name="Source Editor">
+         <shortcut refid="cutDummy" value="Cmd+X" if="org.rstudio.studio.client.application.Desktop.isDesktop()"/>
+         <shortcut refid="copyDummy" value="Cmd+C" if="org.rstudio.studio.client.application.Desktop.isDesktop()"/>
+         <shortcut refid="pasteDummy" value="Cmd+V" if="org.rstudio.studio.client.application.Desktop.isDesktop()"/>
+         <shortcut refid="pasteWithIndentDummy" value="Cmd+Shift+V" if="org.rstudio.studio.client.application.Desktop.isDesktop()"/>
          <shortcut refid="insertChunk" value="Cmd+Alt+I"/>
          <shortcut refid="insertSection" value="Cmd+Shift+R" disableModes="sublime"/>
          <shortcut refid="insertSection" value="Ctrl+Shift+R" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
@@ -3076,6 +3081,10 @@ well as menu structures (for main menu and popup menus).
         
    <cmd id="pasteDummy"
         menuLabel="_Paste"
+        rebindable="false"/>
+        
+   <cmd id="pasteWithIndentDummy"
+        menuLabel="Paste with Indent"
         rebindable="false"/>
         
    <cmd id="yankBeforeCursor"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -511,6 +511,7 @@ public abstract class
    public abstract AppCommand cutDummy();
    public abstract AppCommand copyDummy();
    public abstract AppCommand pasteDummy();
+   public abstract AppCommand pasteWithIndentDummy();
 
    // Placeholder for most recently used files
    public abstract AppCommand mru0();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -358,6 +358,8 @@ public class AceEditorWidget extends Composite
          unmapForEditImpl("<C-x>", "c-x");
       else if (type == EditEvent.TYPE_PASTE)
          unmapForEditImpl("<C-v>", "c-v");
+      else if (type == EditEvent.TYPE_PASTE_WITH_INDENT)
+         unmapForEditImpl("<C-S-v>", "c-s-v");
    }
    
    private final void remapForEdit(int type)
@@ -368,6 +370,8 @@ public class AceEditorWidget extends Composite
          remapForEditImpl("<C-x>", "c-x");
       else if (type == EditEvent.TYPE_PASTE)
          remapForEditImpl("<C-v>", "c-v");
+      else if (type == EditEvent.TYPE_PASTE_WITH_INDENT)
+         remapForEditImpl("<C-S-v>", "c-s-v");
    }
    
    private static final native void unmapForEditImpl(String vimKeys, String emacsKeys)


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/2409.

This PR makes it possible to control whether code is indented on paste, based on whether the Shift key is held down during the paste event.

The implementation here is a bit odd (using a global event tracker for the keyboard state) but this is somewhat necessitated by the way the browser event is handled and bubbled up by Ace, and the myriad of ways that a paste event can be triggered. It also gives us an implementation that works transparently on both desktop and the browser.

In effect, the Shift key is now used to "reverse" the behavior of the "indent on paste" preference. If the preference is off, then holding the shift key down will re-enable indent on paste, and vice-versa.

We might want to consider adding explicit menu items (Paste, Paste with Indent) but I'm not certain whether browser security restrictions will allow us to do that.