### PR TITLE
Check for filesystem (not string) equivalence

### DIFF
--- a/src/cpp/core/system/file_monitor/MacFileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/MacFileMonitor.cpp
@@ -132,8 +132,12 @@ void fileEventCallback(ConstFSEventStreamRef streamRef,
    // against this by also double-checking whether the original path
    // monitored and the path reported by the file handle match up
    //
+   // We check for filesystem equivalence (not path equivalence) since macOS 
+   // Catalina can issue a RootChanged event for conversion to/from a 
+   // canonicalized /System/Volumes/Data path.
+   //
    // https://github.com/rstudio/rstudio/issues/4755
-   if (pContext->rootPath != pContext->rootHandle.currentPath())
+   if (!pContext->rootPath.isEquivalentTo(pContext->rootHandle.currentPath()))
    {
       // propagate error to client
       Error error = fileNotFoundError(pContext->rootPath.absolutePath(),


### PR DESCRIPTION
This fixes an issue on MacOS Catalina with the file monitor. It's somewhat speculative as the issue is intermittent.

Catalina has a new `/System/Volumes/Data/` root which is, confusingly, the same as `/` in most contexts. Based on error messages, it looks like what's happening is that we're being notified that the root path has changed into or out of this system tree, even though the actual directory we're watching has moved and we don't need to take any action.

The proposed fix is to check to see if the filesystem object is actually referring to the same thing (vs. having the same path). In this case, `/System/Volumes/Data/Users/foo/bar` is really the same path as `/Users/foo/bar`, even though the paths are different strings.

Fixes https://github.com/rstudio/rstudio/issues/4755.