### PR TITLE
Avoid _R_CHECK_LENGTH_1_LOGIC2_ warning

### DIFF
--- a/src/cpp/session/modules/SessionBreakpoints.R
+++ b/src/cpp/session/modules/SessionBreakpoints.R
@@ -118,7 +118,7 @@
    {
       # if this is a doTrace call, we found a breakpoint; stop recursion here
       if (is.call(funBody[[idx]]) && 
-          as.character(funBody[[idx]][[1]]) == ".doTrace")
+          as.character(funBody[[idx]][[1]])[[1]] == ".doTrace")
       {
          return(idx + 1)
       }


### PR DESCRIPTION
Reprex (interactive, tested on RStudio Desktop):

```r
Sys.setenv("_R_CHECK_LENGTH_1_LOGIC2_" = "verbose")
shiny::runGadget(div(), function(input, output){})
```

What's a good way to hot-patch my RStudio installation to include this? Can't seem to make it work from `.Rprofile`.