### PR TITLE
Add support for editing sourcehut builds YAML

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1825,6 +1825,10 @@ bool fileListingFilter(const core::FileInfo& fileInfo)
    {
       return true;
    }
+   else if (name == ".build.yml")
+   {
+      return true;
+   }
    else if (prefs::userPrefs().hideObjectFiles() &&
             (ext == ".o" || ext == ".so" || ext == ".dll") &&
             filePath.parent().filename() == "src")


### PR DESCRIPTION
SourceHut provides a Travis (et al)-like CI builder service. If a `.build.yml` file exists in the repo dir the project will be auto-built on commit+push. This PR modifies the same C++ file I modified earlier to support GitLab build YAML files.