### PR TITLE
fix suspend session command showing up in production desktop IDE

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -804,6 +804,9 @@ public class Application implements ApplicationEventHandlers
          removeJobLauncherCommands();
       }
 
+      // only enable suspendSession() in devmode
+      commands_.suspendSession().setVisible(SuperDevMode.isActive());
+
       if (!sessionInfo.getAllowPackageInstallation())
       {
          commands_.installPackage().remove();

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
@@ -106,9 +106,6 @@ public class ApplicationQuit implements SaveActionChangedHandler,
       // bind to commands
       binder.bind(commands, this);
       
-      // only enable suspendSession() in devmode
-      commands.suspendSession().setVisible(SuperDevMode.isActive());
-      
       // subscribe to events
       eventBus.addHandler(SaveActionChangedEvent.TYPE, this);   
       eventBus.addHandler(HandleUnsavedChangesEvent.TYPE, this);


### PR DESCRIPTION
- only supposed to show in SuperDevMode builds
- started happening in build 1.2.243 (Jan 11, 2018)
- fixed by hiding this command in same location other command-hiding takes place
- tested:
   - fixes issue on Desktop build (only tried Mac)
   - command still shows up and works on a dev-server config 

Fixes #5337