### PR TITLE
restore console pane when activating terminal or jobs panes

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobsPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/JobsPresenter.java
@@ -60,6 +60,7 @@ public class JobsPresenter extends BasePresenter
       display_ = display;
       globalDisplay_ = globalDisplay;
       pJobManager_ = pJobManager;
+      commands_ = commands;
       binder.bind(commands, this);
     }
 
@@ -128,6 +129,8 @@ public class JobsPresenter extends BasePresenter
    @Handler
    public void onActivateJobs()
    {
+      // Ensure that console pane is not minimized
+      commands_.activateConsolePane().execute();
       display_.bringToFront();
    }
   
@@ -136,5 +139,6 @@ public class JobsPresenter extends BasePresenter
    // injected
    private final Display display_;
    private final GlobalDisplay globalDisplay_;
+   private final Commands commands_;
    private final Provider<JobManager> pJobManager_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/LauncherJobsPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/LauncherJobsPresenter.java
@@ -51,6 +51,7 @@ public class LauncherJobsPresenter extends BasePresenter
       jobEventHandler_ = new JobsPresenterEventHandlersImpl(JobConstants.JOB_TYPE_LAUNCHER, display);
       
       display_ = display;
+      commands_ = commands;
       launcherJobManager_ = launcherJobManager;
       binder.bind(commands, this);
     }
@@ -109,6 +110,8 @@ public class LauncherJobsPresenter extends BasePresenter
    @Handler
    public void onActivateLauncherJobs()
    {
+      // Ensure that console pane is not minimized
+      commands_.activateConsolePane().execute();
       display_.bringToFront();
    }
    
@@ -118,5 +121,6 @@ public class LauncherJobsPresenter extends BasePresenter
    
    // injected
    private final Display display_;
+   private final Commands commands_;
    private final LauncherJobManager launcherJobManager_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -268,6 +268,9 @@ public class TerminalPane extends WorkbenchPane
       selectedCallback_ = displaySelected;
       setShowTerminalPref(true);
       closingAll_ = false;
+
+      // Ensure that console pane is not minimized
+      commands_.activateConsolePane().execute();
       bringToFront();
    }
 


### PR DESCRIPTION
Fixes #1599

The terminal scenario had gotten worse with upgrade to xterm3 -- the terminal pane must be visible before xterm3 can be initialized, so without this fix the scenario resulted in an unusable terminal pane.

Also fixed Jobs and Launcher panes so they will also un-minimize the console pane when activated via their respective View commands.