### PR TITLE
support compilation with Boost 1.70+

### DIFF
--- a/src/cpp/core/include/core/http/TcpIpAsyncConnector.hpp
+++ b/src/cpp/core/include/core/http/TcpIpAsyncConnector.hpp
@@ -55,7 +55,8 @@ public:
 public:
    TcpIpAsyncConnector(boost::asio::io_service& ioService,
                        boost::asio::ip::tcp::socket* pSocket)
-     : pSocket_(pSocket),
+     : service_(ioService),
+       pSocket_(pSocket),
        resolver_(ioService),
        isConnected_(false),
        hasFailed_(false)
@@ -78,7 +79,7 @@ public:
       {
          // start a timer that will cancel any outstanding asynchronous operations
          // when it elapses if the connection operation has not succeeded
-         pConnectionTimer_.reset(new boost::asio::deadline_timer(resolver_.get_io_service(), timeout));
+         pConnectionTimer_.reset(new boost::asio::deadline_timer(service_, timeout));
          pConnectionTimer_->async_wait(boost::bind(&TcpIpAsyncConnector::onConnectionTimeout,
                                                    TcpIpAsyncConnector::shared_from_this(),
                                                    boost::asio::placeholders::error));
@@ -233,6 +234,7 @@ private:
    }
 
 private:
+   boost::asio::io_service& service_;
    boost::asio::ip::tcp::socket* pSocket_;
    boost::asio::ip::tcp::resolver resolver_;
    ConnectedHandler connectedHandler_;

--- a/src/cpp/ext/websocketpp/transport/asio/connection.hpp
+++ b/src/cpp/ext/websocketpp/transport/asio/connection.hpp
@@ -296,7 +296,7 @@ public:
      */
     timer_ptr set_timer(long duration, timer_handler callback) {
         timer_ptr new_timer = lib::make_shared<boost::asio::deadline_timer>(
-            lib::ref(*m_io_service),
+            *m_io_service,
             boost::posix_time::milliseconds(duration)
         );
 

--- a/src/cpp/ext/websocketpp/transport/asio/endpoint.hpp
+++ b/src/cpp/ext/websocketpp/transport/asio/endpoint.hpp
@@ -183,8 +183,7 @@ public:
 
         m_io_service = ptr;
         m_external_io_service = true;
-        m_acceptor = lib::make_shared<boost::asio::ip::tcp::acceptor>(
-            lib::ref(*m_io_service));
+        m_acceptor = lib::make_shared<boost::asio::ip::tcp::acceptor>(*m_io_service);
 
         m_state = READY;
         ec = lib::error_code();
@@ -609,9 +608,7 @@ public:
      * @since 0.3.0
      */
     void start_perpetual() {
-        m_work = lib::make_shared<boost::asio::io_service::work>(
-            lib::ref(*m_io_service)
-        );
+        m_work = lib::make_shared<boost::asio::io_service::work>(*m_io_service);
     }
 
     /// Clears the endpoint's perpetual flag, allowing it to exit when empty
@@ -775,8 +772,7 @@ protected:
 
         // Create a resolver
         if (!m_resolver) {
-            m_resolver = lib::make_shared<boost::asio::ip::tcp::resolver>(
-                lib::ref(*m_io_service));
+            m_resolver = lib::make_shared<boost::asio::ip::tcp::resolver>(*m_io_service);
         }
 
         std::string proxy = tcon->get_proxy();

--- a/src/cpp/ext/websocketpp/transport/asio/security/none.hpp
+++ b/src/cpp/ext/websocketpp/transport/asio/security/none.hpp
@@ -166,8 +166,7 @@ protected:
             return socket::make_error_code(socket::error::invalid_state);
         }
 
-        m_socket = lib::make_shared<boost::asio::ip::tcp::socket>(
-            lib::ref(*service));
+        m_socket = lib::make_shared<boost::asio::ip::tcp::socket>(*service);
 
         m_state = READY;
 


### PR DESCRIPTION
This PR patches RStudio + websocketpp to allow compilation with Boost 1.70. (We don't attempt to upgrade Boost explicitly right now; we just want to support compilation for distributions that need it)

Closes https://github.com/rstudio/rstudio/issues/4636.