### PR TITLE
Add view/clear/edit prefs diagnostics commands

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -489,6 +489,7 @@ public class RemoteServer implements Server
                                requestCallback);
    }
 
+   @Override
    public void setUserPrefs(JavaScriptObject userPrefs,
                             ServerRequestCallback<Void> requestCallback)
    {
@@ -498,7 +499,6 @@ public class RemoteServer implements Server
                   requestCallback);
    }
 
-
    @Override
    public void setUserState(JavaScriptObject userState,
                             ServerRequestCallback<Void> requestCallback)
@@ -506,6 +506,30 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE,
                   SET_USER_STATE,
                   userState,
+                  requestCallback);
+   }
+
+   @Override
+   public void editPreferences(ServerRequestCallback<Void> requestCallback)
+   {
+      sendRequest(RPC_SCOPE,
+                  "edit_user_prefs",
+                  requestCallback);
+   }
+
+   @Override
+   public void viewPreferences(ServerRequestCallback<Void> requestCallback)
+   {
+      sendRequest(RPC_SCOPE,
+                  "view_all_prefs",
+                  requestCallback);
+   }
+
+   @Override
+   public void clearPreferences(ServerRequestCallback<String> requestCallback)
+   {
+      sendRequest(RPC_SCOPE,
+                  "clear_user_prefs",
                   requestCallback);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -530,6 +530,10 @@ well as menu structures (for main menu and popup menus).
             <cmd refid="openDeveloperConsole"/>
             <cmd refid="reloadUi"/>
             <separator/>
+            <cmd refid="editUserPrefs"/>
+            <cmd refid="clearUserPrefs"/>
+            <cmd refid="viewAllPrefs"/>
+            <separator/>
             <cmd refid="debugDumpContents"/>
             <cmd refid="debugImportDump"/>
             <cmd refid="toggleEditorTokenInfo"/>
@@ -3455,4 +3459,18 @@ well as menu structures (for main menu and popup menus).
         menuLabel="Show Help Menu"
         windowMode="main"/>
 
+   <cmd id="editUserPrefs"
+        menuLabel="Edit User Prefs File"
+        windowMode="main"
+        rebindable="false"/>
+
+   <cmd id="clearUserPrefs"
+        menuLabel="Clear User Prefs"
+        windowMode="main"
+        rebindable="false"/>
+
+   <cmd id="viewAllPrefs"
+        menuLabel="View All Prefs"
+        windowMode="main"
+        rebindable="false"/>
 </commands>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -448,6 +448,9 @@ public abstract class
    public abstract AppCommand debugImportDump();
    public abstract AppCommand refreshSuperDevMode();
    public abstract AppCommand viewShortcuts();
+   public abstract AppCommand editUserPrefs();
+   public abstract AppCommand viewAllPrefs();
+   public abstract AppCommand clearUserPrefs();
    
    // Viewer
    public abstract AppCommand activateViewer();
@@ -594,9 +597,6 @@ public abstract class
    public abstract AppCommand maximizeConsole();
    public abstract AppCommand toggleEditorTokenInfo();
    
-   public static final String KEYBINDINGS_PATH =
-         "~/.R/keybindings/rstudio_commands.json";
-
    // Main menu (server)
    public abstract AppCommand showFileMenu();
    public abstract AppCommand showEditMenu();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/PrefsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/PrefsServerOperations.java
@@ -26,4 +26,10 @@ public interface PrefsServerOperations
    
    void setUserState(JavaScriptObject userState,
                      ServerRequestCallback<Void> requestCallback);
+   
+   void editPreferences(ServerRequestCallback<Void> requestCallback);
+
+   void clearPreferences(ServerRequestCallback<String> requestCallback);
+   
+   void viewPreferences(ServerRequestCallback<Void> requestCallback);
 }


### PR DESCRIPTION
This change adds a few handy diagnostics commands for working with preferences.

![image](https://user-images.githubusercontent.com/470418/64279630-5a1a4280-cf04-11e9-9e3c-8b360bc4fa21.png)

"Edit" opens a modal editor with the user prefs file loaded, which makes it easy to see what all your raw preference values are.

"View" opens a data viewer tab showing all active preference values and where they came from.

"Clear" deletes user preferences, after making a backup, then restarts R and reloads the UI. 

These commands will ideally never be used in day-to-day practice, which is why they're on the Diagnostics menu. They are inspired by issues like https://github.com/rstudio/rstudio/issues/5296, where the resolution is "go to this deeply nested folder and delete this secret file", and can now be "clear your prefs from the diagnostics menu". 