### PR TITLE
remove leading colon from git-bash reported terminal title

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -485,7 +485,17 @@ public class TerminalSession extends XTermWidget
    @Override
    public void onXTermTitle(XTermTitleEvent event)
    {
-      setTitle(event.getTitle());
+      String title = event.getTitle();
+
+      // On default configuration of git-bash (Windows), the title is reported by the shell
+      // with a leading colon character; this makes sense if $TITLEPREFIX is set, as that
+      // will be put before the colon, such as "MINGW64:/c/Users/foo", but strip the colon
+      // if there's nothing before it
+      if (BrowseCap.isWindows() && !StringUtil.isNullOrEmpty(title) && title.startsWith(":/"))
+      {
+         title = title.substring(1);
+      }
+      setTitle(title);
       eventBus_.fireEvent(new TerminalTitleEvent(this));
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -491,7 +491,7 @@ public class TerminalSession extends XTermWidget
       // with a leading colon character; this makes sense if $TITLEPREFIX is set, as that
       // will be put before the colon, such as "MINGW64:/c/Users/foo", but strip the colon
       // if there's nothing before it
-      if (BrowseCap.isWindows() && !StringUtil.isNullOrEmpty(title) && title.startsWith(":/"))
+      if (BrowseCap.isWindowsDesktop() && !StringUtil.isNullOrEmpty(title) && title.startsWith(":/"))
       {
          title = title.substring(1);
       }


### PR DESCRIPTION
The terminal pane displays whatever title string is reported by the underlying shell (via escape sequences). On git-bash (Windows desktop), the shell title includes a leading colon which only makes sense if there's a $TITLEPREFIX set, which isn't.

So, on Windows, strip the colon if the string starts with ":/", leaving the Cygwin-style path. If user has tweaked things to include something at the start of titles, then leave it alone.

Fixes #3472