### PR TITLE
ensure graphics path exists when device requests new page

### DIFF
--- a/src/cpp/r/session/graphics/RGraphicsPlotManager.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsPlotManager.cpp
@@ -729,6 +729,16 @@ void PlotManager::onDeviceNewPage(SEXP previousPageSnapshot)
    if (suppressDeviceEvents_)
       return;
    
+   // make sure the graphics path exists (may have been blown away
+   // by call to dev.off or other call to removeAllPlots)
+   Error error = graphicsPath_.ensureDirectory();
+   if (error)
+   {
+      Error graphicsError(errc::PlotFileError, error, ERROR_LOCATION);
+      logAndReportError(graphicsError, ERROR_LOCATION);
+      return;
+   }
+   
    // if we have a plot with unrendered changes then save the previous snapshot
    if (hasPlot() && hasChanges())
    {


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/3117.

Note that we do something similar here:

https://github.com/rstudio/rstudio/blob/c5ce1c591869e69c7e70d05e50392ffc3b3b2cf8/src/cpp/r/session/graphics/RGraphicsPlotManager.cpp#L449-L457

but `onDeviceNewPage()` is typically called before `render()`, and requires access to the graphics path.