### PR TITLE
guard against an occasional null-access exception during terminal start

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -32,6 +32,7 @@ import org.rstudio.studio.client.application.events.SessionSerializationEvent;
 import org.rstudio.studio.client.application.events.SessionSerializationHandler;
 import org.rstudio.studio.client.application.model.SessionSerializationAction;
 import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.common.Timers;
 import org.rstudio.studio.client.common.console.ConsoleProcessInfo;
 import org.rstudio.studio.client.common.console.ServerProcessExitEvent;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
@@ -960,17 +961,11 @@ public class TerminalPane extends WorkbenchPane
                }
                else
                {
-                  new Timer()
+                  Timers.singleShot(200, () ->
                   {
-                     @Override
-                     public void run()
-                     {
-                        if (visibleTerminal.terminalEmulatorLoaded())
-                        {
-                           visibleTerminal.setFocus(true);
-                        }
-                     }
-                  }.schedule(200);
+                     if (visibleTerminal.terminalEmulatorLoaded())
+                        visibleTerminal.setFocus(true);
+                  });
                }
          });
          activeTerminalToolbarButton_.setActiveTerminal(

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -961,8 +961,7 @@ public class TerminalPane extends WorkbenchPane
                }
                else
                {
-                  Timers.singleShot(200, () ->
-                  {
+                  Timers.singleShot(200, () -> {
                      if (visibleTerminal.terminalEmulatorLoaded())
                         visibleTerminal.setFocus(true);
                   });


### PR DESCRIPTION
- seeing this occasionally, haven't been able to nail down the exact timing that results in this happening
- appears benign from user standpoint, but want to avoid and perhaps expose any other (perhaps more helpful) issues lurking after it