### PR TITLE
fix issue when generating docker images from developer machine

### DIFF
--- a/docker/jenkins/Dockerfile.bionic-amd64
+++ b/docker/jenkins/Dockerfile.bionic-amd64
@@ -82,7 +82,7 @@ RUN /bin/bash /tmp/install-dependencies
 
 # install common dependencies
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
-COPY dependencies/common/* /opt/rstudio-tools/dependencies/common/
+COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 
 # install Qt SDK

--- a/docker/jenkins/Dockerfile.centos6-x86_64
+++ b/docker/jenkins/Dockerfile.centos6-x86_64
@@ -62,7 +62,7 @@ ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN
 # install common dependencies
 ENV RSTUDIO_DISABLE_CRASHPAD=1
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
-COPY dependencies/common/* /opt/rstudio-tools/dependencies/common/
+COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting

--- a/docker/jenkins/Dockerfile.centos7-x86_64
+++ b/docker/jenkins/Dockerfile.centos7-x86_64
@@ -80,7 +80,7 @@ ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN
 
 # install common dependencies
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
-COPY dependencies/common/* /opt/rstudio-tools/dependencies/common/
+COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 RUN cd /opt/rstudio-tools/dependencies/common && scl enable llvm-toolset-7 "/bin/bash ./install-common"
 
 # install Qt SDK

--- a/docker/jenkins/Dockerfile.debian9-x86_64
+++ b/docker/jenkins/Dockerfile.debian9-x86_64
@@ -72,7 +72,7 @@ ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN
 
 # install common dependencies
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
-COPY dependencies/common/* /opt/rstudio-tools/dependencies/common/
+COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 
 # install Qt SDK

--- a/docker/jenkins/Dockerfile.fedora28-x86_64
+++ b/docker/jenkins/Dockerfile.fedora28-x86_64
@@ -66,7 +66,7 @@ ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN
 
 # install common dependencies
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
-COPY dependencies/common/* /opt/rstudio-tools/dependencies/common/
+COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 
 # install Qt SDK

--- a/docker/jenkins/Dockerfile.opensuse-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse-x86_64
@@ -55,7 +55,7 @@ ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN
 # install common dependencies
 ENV RSTUDIO_DISABLE_CRASHPAD=1
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
-COPY dependencies/common/* /opt/rstudio-tools/dependencies/common/
+COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 
 # install Qt SDK

--- a/docker/jenkins/Dockerfile.opensuse15-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse15-x86_64
@@ -63,7 +63,7 @@ RUN update-alternatives --set java /usr/lib64/jvm/jre-1.8.0-openjdk/bin/java
 
 # install common dependencies
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
-COPY dependencies/common/* /opt/rstudio-tools/dependencies/common/
+COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 
 # install Qt SDK

--- a/docker/jenkins/Dockerfile.xenial-amd64
+++ b/docker/jenkins/Dockerfile.xenial-amd64
@@ -87,7 +87,7 @@ ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN
 
 # install common dependencies
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
-COPY dependencies/common/* /opt/rstudio-tools/dependencies/common/
+COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 
 # install Qt SDK


### PR DESCRIPTION
- when building images using docker-compile.sh, the Dockerfile command to COPY scripts under dependencies/common into the image was pulling in content of subfolders (i.e. dependencies installed on the host machine as part of dev build environment)
- the use of trailing asterisk caused subfolder contents to be flattened into the destination directory instead of preserving the folder structure
- in the case of the renv package dependency, this left files in a state where the installation script would fail, preventing image creation

Fix by not using the trailing asterisk. This will be a no-op in the official builds, since those run against a clean repo where dependencies/common has no subfolders, and on a dev machine, preserves the folder structure of already-installed dependencies.

Discussion of trailing "*" versus not: https://stackoverflow.com/questions/30215830/dockerfile-copy-keep-subdirectory-structure