### PR TITLE
allow for IPC from child processes through rstudioapi

### DIFF
--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -250,6 +250,7 @@ bool AsyncRProcess::onContinue()
       if (error)
       {
          LOG_ERROR(error);
+         ipcRequests_.removeIfExists();
          return false;
       }
    }

--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -46,6 +46,7 @@ void AsyncRProcess::start(const char* rCommand,
    // file paths to be used for IPC (if any) requested by child process
    ipcRequests_ = module_context::tempFile("rstudio-ipc-requests-", "rds");
    ipcResponse_ = module_context::tempFile("rstudio-ipc-response-", "rds");
+   secret_ = core::system::generateUuid();
    
    // R binary
    core::FilePath rProgramPath;
@@ -166,6 +167,7 @@ void AsyncRProcess::start(const char* rCommand,
    // set environment variables used for IPC
    core::system::setenv(&childEnv, "RSTUDIOAPI_IPC_REQUESTS_FILE", ipcRequests_.absolutePath());
    core::system::setenv(&childEnv, "RSTUDIOAPI_IPC_RESPONSE_FILE", ipcResponse_.absolutePath());
+   core::system::setenv(&childEnv, "RSTUDIOAPI_IPC_SHARED_SECRET", sharedSecret_);
    
    // update environment used for child process
    options.environment = childEnv;
@@ -242,6 +244,7 @@ bool AsyncRProcess::onContinue()
       core::Error error = r::exec::RFunction(".rs.rstudioapi.processRequest")
             .addParam(ipcRequests_.absolutePathNative())
             .addParam(ipcResponse_.absolutePathNative())
+            .addParam(sharedSecret_)
             .call();
 
       if (error)

--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -250,7 +250,12 @@ bool AsyncRProcess::onContinue()
       if (error)
       {
          LOG_ERROR(error);
-         ipcRequests_.removeIfExists();
+
+         // remove the requests file so we don't attempt to re-log
+         Error error = ipcRequests_.removeIfExists();
+         if (error)
+            LOG_ERROR(error);
+
          return false;
       }
    }

--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -20,6 +20,8 @@
 #include <core/system/Environment.hpp>
 #include <core/system/Process.hpp>
 
+#include <r/RExec.hpp>
+
 #include <r/session/RSessionUtils.hpp>
 
 #include <session/SessionAsyncRProcess.hpp>
@@ -41,6 +43,10 @@ void AsyncRProcess::start(const char* rCommand,
                           std::vector<core::FilePath> rSourceFiles,
                           const std::string& input)
 {
+   // file paths to be used for IPC (if any) requested by child process
+   ipcRequests_ = module_context::tempFile("rstudio-ipc-requests-", "rds");
+   ipcResponse_ = module_context::tempFile("rstudio-ipc-response-", "rds");
+   
    // R binary
    core::FilePath rProgramPath;
    core::Error error = module_context::rScriptPath(&rProgramPath);
@@ -150,11 +156,18 @@ void AsyncRProcess::start(const char* rCommand,
    {
       core::system::setenv(&childEnv, "R_LIBS", libPaths);
    }
+   
    // forward passed environment variables
    for (const core::system::Option& var : environment)
    {
       core::system::setenv(&childEnv, var.first, var.second);
    }
+   
+   // set environment variables used for IPC
+   core::system::setenv(&childEnv, "RSTUDIOAPI_IPC_REQUESTS_FILE", ipcRequests_.absolutePath());
+   core::system::setenv(&childEnv, "RSTUDIOAPI_IPC_RESPONSE_FILE", ipcResponse_.absolutePath());
+   
+   // update environment used for child process
    options.environment = childEnv;
 
    core::system::ProcessCallbacks cb;
@@ -220,7 +233,25 @@ void AsyncRProcess::onStderr(const std::string& output)
 
 bool AsyncRProcess::onContinue()
 {
-   return !terminationRequested_;
+   if (terminationRequested_)
+      return false;
+   
+   // check for request requiring a response
+   if (ipcRequests_.exists())
+   {
+      core::Error error = r::exec::RFunction(".rs.rstudioapi.processRequest")
+            .addParam(ipcRequests_.absolutePathNative())
+            .addParam(ipcResponse_.absolutePathNative())
+            .call();
+
+      if (error)
+      {
+         LOG_ERROR(error);
+         return false;
+      }
+   }
+   
+   return true;
 }
 
 bool AsyncRProcess::terminationRequested()

--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -265,6 +265,8 @@ bool AsyncRProcess::terminationRequested()
 void AsyncRProcess::onProcessCompleted(int exitStatus)
 {
    markCompleted();
+   ipcRequests_.removeIfExists();
+   ipcResponse_.removeIfExists();
    onCompleted(exitStatus);
 }
 

--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -44,9 +44,9 @@ void AsyncRProcess::start(const char* rCommand,
                           const std::string& input)
 {
    // file paths to be used for IPC (if any) requested by child process
-   ipcRequests_ = module_context::tempFile("rstudio-ipc-requests-", "rds");
-   ipcResponse_ = module_context::tempFile("rstudio-ipc-response-", "rds");
-   secret_ = core::system::generateUuid();
+   ipcRequests_  = module_context::tempFile("rstudio-ipc-requests-", "rds");
+   ipcResponse_  = module_context::tempFile("rstudio-ipc-response-", "rds");
+   sharedSecret_ = core::system::generateUuid();
    
    // R binary
    core::FilePath rProgramPath;
@@ -68,7 +68,7 @@ void AsyncRProcess::start(const char* rCommand,
       const core::FilePath rPath =
             session::options().coreRSourcePath();
       
-      const core::FilePath rTools =  rPath.childPath("Tools.R");
+      const core::FilePath rTools = rPath.childPath("Tools.R");
       
       // insert at begin as Tools.R needs to be sourced first
       rSourceFiles.insert(rSourceFiles.begin(), rTools);

--- a/src/cpp/session/include/session/SessionAsyncRProcess.hpp
+++ b/src/cpp/session/include/session/SessionAsyncRProcess.hpp
@@ -94,6 +94,7 @@ private:
    std::string input_;
    core::FilePath ipcRequests_;
    core::FilePath ipcResponse_;
+   std::string sharedSecret_;
 };
 
 } // namespace async_r

--- a/src/cpp/session/include/session/SessionAsyncRProcess.hpp
+++ b/src/cpp/session/include/session/SessionAsyncRProcess.hpp
@@ -92,6 +92,8 @@ private:
    bool isRunning_;
    bool terminationRequested_;
    std::string input_;
+   core::FilePath ipcRequests_;
+   core::FilePath ipcResponse_;
 };
 
 } // namespace async_r

--- a/src/cpp/session/modules/RStudioAPI.R
+++ b/src/cpp/session/modules/RStudioAPI.R
@@ -1,0 +1,34 @@
+#
+# RStudioAPI.R
+#
+# Copyright (C) 2009-19 by RStudio, Inc.
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+.rs.addFunction("rstudioapi.processRequest", function(requests, response)
+{
+   result <- .rs.tryCatch(.rs.rstudioapi.processRequestImpl(requests, response))
+   
+   unlink(requests)
+   if (inherits(result, "error")) {
+      saveRDS(result, response)
+      return(FALSE)
+   }
+   
+   TRUE
+})
+
+.rs.addFunction("rstudioapi.processRequestImpl", function(requests, response)
+{
+   call <- readRDS(requests)
+   output <- eval(call, envir = baseenv())
+   saveRDS(output, file = response)
+})

--- a/src/cpp/session/modules/RStudioAPI.R
+++ b/src/cpp/session/modules/RStudioAPI.R
@@ -13,9 +13,13 @@
 #
 #
 
-.rs.addFunction("rstudioapi.processRequest", function(requests, response)
+.rs.addFunction("rstudioapi.processRequest", function(requests,
+                                                      response,
+                                                      secret)
 {
-   result <- .rs.tryCatch(.rs.rstudioapi.processRequestImpl(requests, response))
+   result <- .rs.tryCatch(
+      .rs.rstudioapi.processRequestImpl(requests, response, secret)
+   )
    
    unlink(requests)
    if (inherits(result, "error")) {
@@ -26,9 +30,15 @@
    TRUE
 })
 
-.rs.addFunction("rstudioapi.processRequestImpl", function(requests, response)
+.rs.addFunction("rstudioapi.processRequestImpl", function(requests,
+                                                          response,
+                                                          secret)
 {
-   call <- readRDS(requests)
+   data <- readRDS(requests)
+   if (!identical(data$secret, secret))
+      stop("invalid secret in rstudioapi IPC")
+   
+   call <- data$call
    output <- eval(call, envir = baseenv())
    saveRDS(output, file = response)
 })

--- a/src/cpp/session/modules/RStudioAPI.cpp
+++ b/src/cpp/session/modules/RStudioAPI.cpp
@@ -212,8 +212,13 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_showDialog);
    RS_REGISTER_CALL_METHOD(rs_openFileDialog);
    RS_REGISTER_CALL_METHOD(rs_executeAppCommand);
+   
+   using boost::bind;
+   ExecBlock initBlock;
+   initBlock.addFunctions()
+         (bind(sourceModuleRFile, "RStudioAPI.R"));
 
-   return Success();
+   return initBlock.execute();
 }
 
 } // namespace connections

--- a/src/cpp/session/modules/SessionRUtil.cpp
+++ b/src/cpp/session/modules/SessionRUtil.cpp
@@ -220,6 +220,10 @@ protected:
    
    bool onContinue()
    {
+      bool ok = AsyncRProcess::onContinue();
+      if (!ok)
+         return false;
+      
       invokeCallback("continue");
       return true;
    }


### PR DESCRIPTION
Re: https://github.com/rstudio/rstudio/issues/4490. See https://github.com/rstudio/rstudioapi/pull/155 for more discussion.

This PR allows RStudio to read and respond to requests made by child R processes, as made through the `rstudioapi` package.

Note that this PR does potentially open the door to allowing child processes to execute arbitrary R code in the main R session, so we may want to consider if we need to shut that door at all. My gut reaction is that it's fine (the main R session already has that access, so it's fine if it launches a child process that shares that access) but I wanted to raise this in case I might be missing anything.