### PR TITLE
update RStudio 1.3 to Qt 5.12.5

### DIFF
--- a/dependencies/linux/install-qt-sdk
+++ b/dependencies/linux/install-qt-sdk
@@ -15,16 +15,16 @@
 #
 
 if [ -z "$QT_VERSION" ]; then
-    QT_VERSION=5.12.1
+    QT_VERSION=5.12.5
 fi
 if [ -z "$QT_SDK_BINARY" ]; then
     QT_SDK_BINARY=qt-opensource-linux-x64-${QT_VERSION}.run
 fi
 if [ -z "$QT_PACKAGES" ]; then
-    QT_PACKAGES=qt.qt5.5121.gcc_64,qt.qt5.5121.qtwebengine,qt.qt5.5121.qtwebengine.gcc_64
+    QT_PACKAGES=qt.qt5.5125.gcc_64,qt.qt5.5125.qtwebengine,qt.qt5.5125.qtwebengine.gcc_64
 fi
 if [ -z "$QT_SDK_CUSTOM" ]; then
-    echo Using online Qt installer
+    echo Using Qt $QT_VERSION
 else
     echo Using custom Qt package: $QT_SDK_CUSTOM
 fi
@@ -38,7 +38,7 @@ if [ -z "$QT_SDK_DIR" ]; then
    QT_SDK_DIR3=~/Qt/${QT_VERSION}
 fi
 
-QT_SDK_URL=https://s3.amazonaws.com/rstudio-buildtools/$QT_SDK_BINARY
+QT_SDK_URL=https://s3.amazonaws.com/rstudio-buildtools/Qt/$QT_SDK_BINARY
 QT_SCRIPT=/tmp/qt-noninteractive-install-linux.qs
 
 # generate script for automatic Qt installation; customizes the install location via $QT_SDK_DIR
@@ -122,7 +122,7 @@ EOF
 if [ ! -e "$QT_SDK_DIR" ] && [ ! -e "$QT_SDK_DIR2" ] && [ ! -e "$QT_SDK_DIR3" ]
 then
    if [ -z "$QT_SDK_CUSTOM" ]; then
-      # download and install via Qt online installer
+      # download and install via Qt installer package
       wget $QT_SDK_URL -O /tmp/$QT_SDK_BINARY
       chmod u+x /tmp/$QT_SDK_BINARY
       write_qt_script

--- a/dependencies/osx/install-qt-sdk-osx
+++ b/dependencies/osx/install-qt-sdk-osx
@@ -18,12 +18,12 @@
 # Installs Qt via the online installer at the location in $QT_SDK_DIR.
 # If no location provided, checks against a set of common locations and installs if not found.
 
-QT_VERSION=5.12.1
+QT_VERSION=5.12.5
 QT_SDK_BINARY_BASE=qt-opensource-mac-x64-${QT_VERSION}
 QT_SDK_BINARY=${QT_SDK_BINARY_BASE}.tar.gz
 QT_SDK_INSTALLER=${QT_SDK_BINARY_BASE}.app
 QT_SDK_INSTALLER_BIN=${QT_SDK_INSTALLER}/Contents/MacOS/${QT_SDK_BINARY_BASE}
-QT_SDK_URL=https://s3.amazonaws.com/rstudio-buildtools/$QT_SDK_BINARY
+QT_SDK_URL=https://s3.amazonaws.com/rstudio-buildtools/Qt/$QT_SDK_BINARY
 QT_SCRIPT=/tmp/qt-noninteractive-install-osx.qs 
 
 # generate script for automatic Qt installation; customizes the install location via $QT_SDK_DIR
@@ -65,10 +65,10 @@ Controller.prototype.TargetDirectoryPageCallback = function()
 Controller.prototype.ComponentSelectionPageCallback = function() {
     var widget = gui.currentPageWidget();
      
-    widget.selectComponent("qt.qt5.5121.clang_64");
-    widget.selectComponent("qt.qt5.5121.qtwebengine");
-    widget.selectComponent("qt.qt5.5121.qtwebengine.clang_64");
-    widget.deselectComponent("qt.qt5.5121.src");
+    widget.selectComponent("qt.qt5.5125.clang_64");
+    widget.selectComponent("qt.qt5.5125.qtwebengine");
+    widget.selectComponent("qt.qt5.5125.qtwebengine.clang_64");
+    widget.deselectComponent("qt.qt5.5125.src");
     gui.clickButton(buttons.NextButton);
 }
 

--- a/dependencies/windows/install-qt-sdk-win.cmd
+++ b/dependencies/windows/install-qt-sdk-win.cmd
@@ -4,9 +4,9 @@ setlocal EnableDelayedExpansion
 
 @rem When updating to a new Qt version, be sure to also update the 
 @rem component versions in qt-noninteractive-install-win.qs
-set QT_VERSION=5.12.1
+set QT_VERSION=5.12.5
 set QT_SDK_BINARY=qt-opensource-windows-x86-%QT_VERSION%.exe
-set QT_SDK_URL=https://s3.amazonaws.com/rstudio-buildtools/%QT_SDK_BINARY%
+set QT_SDK_URL=https://s3.amazonaws.com/rstudio-buildtools/Qt/%QT_SDK_BINARY%
 set QT_SCRIPT=qt-noninteractive-install-win.qs
 
 call :DetectQt foundQt

--- a/dependencies/windows/qt-noninteractive-install-win.qs
+++ b/dependencies/windows/qt-noninteractive-install-win.qs
@@ -30,10 +30,10 @@ Controller.prototype.TargetDirectoryPageCallback = function()
 Controller.prototype.ComponentSelectionPageCallback = function() {
     var widget = gui.currentPageWidget();
 
-    widget.selectComponent("qt.qt5.5121.win64_msvc2017_64");
-    widget.selectComponent("qt.qt5.5121.qtwebengine");
-    widget.selectComponent("qt.qt5.5121.qtwebengine.win64_msvc2017_64");
-    widget.deselectComponent("qt.qt5.5121.src");
+    widget.selectComponent("qt.qt5.5125.win64_msvc2017_64");
+    widget.selectComponent("qt.qt5.5125.qtwebengine");
+    widget.selectComponent("qt.qt5.5125.qtwebengine.win64_msvc2017_64");
+    widget.deselectComponent("qt.qt5.5125.src");
     gui.clickButton(buttons.NextButton);
 }
 

--- a/docker/jenkins/Dockerfile.bionic-amd64
+++ b/docker/jenkins/Dockerfile.bionic-amd64
@@ -88,7 +88,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.1 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.5 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/docker/jenkins/Dockerfile.centos7-x86_64
+++ b/docker/jenkins/Dockerfile.centos7-x86_64
@@ -86,7 +86,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && scl enable llvm-toolset-7 "/bin
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.1 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.5 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/docker/jenkins/Dockerfile.debian9-x86_64
+++ b/docker/jenkins/Dockerfile.debian9-x86_64
@@ -78,7 +78,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.1 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.5 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/docker/jenkins/Dockerfile.fedora28-x86_64
+++ b/docker/jenkins/Dockerfile.fedora28-x86_64
@@ -72,7 +72,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.1 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.5 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/docker/jenkins/Dockerfile.opensuse15-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse15-x86_64
@@ -69,7 +69,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.1 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.5 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -43,9 +43,9 @@ RUN $env:path += ';C:\R\R-3.0.3\bin\i386\' ;`
 
 # install qt (note that we are using the current directory's context)
 RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48; ` 
-  (New-Object System.Net.WebClient).DownloadFile('https://s3.amazonaws.com/rstudio-buildtools/QtSDK-5.12.1-msvc2017_64.7z', 'c:\QtSDK-5.12.1-msvc2017_64.7z'); `
-  7z x c:\QtSDK-5.12.1-msvc2017_64.7z -oc:\ ; `
-  Remove-Item c:\QtSDK-5.12.1-msvc2017_64.7z -Force
+  (New-Object System.Net.WebClient).DownloadFile('https://s3.amazonaws.com/rstudio-buildtools/Qt/QtSDK-5.12.5-msvc2017_64.7z', 'c:\QtSDK-5.12.5-msvc2017_64.7z'); `
+  7z x c:\QtSDK-5.12.5-msvc2017_64.7z -oc:\ ; `
+  Remove-Item c:\QtSDK-5.12.5-msvc2017_64.7z -Force
     
 # cpack (an alias from chocolatey) and cmake's cpack conflict.
 RUN Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe'

--- a/docker/jenkins/Dockerfile.xenial-amd64
+++ b/docker/jenkins/Dockerfile.xenial-amd64
@@ -93,7 +93,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.1 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.5 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -36,9 +36,9 @@ if(NOT WIN32)
       endif()
          
       if(APPLE)
-         set(QT_CANDIDATES 5.12.1)   
+         set(QT_CANDIDATES 5.12.5)
       else()
-         set(QT_CANDIDATES 5.12.1 5.10.1)
+         set(QT_CANDIDATES 5.12.5 5.10.1)
       endif()
 
       # find the newest installed Qt version among the versions we build
@@ -72,7 +72,7 @@ if(NOT WIN32)
    endif()
 else()
    # Windows
-   set(QT_VERSION "5.12.1")
+   set(QT_VERSION "5.12.5")
    set(QT_VERSION_SUBDIR "${QT_VERSION}")   
    if(NOT QT_QMAKE_EXECUTABLE)
 


### PR DESCRIPTION
- Packages have been uploaded to S3 (`rstudio-buildtools/Qt/`), for all platforms
- Will require the usual Windows image nudge to force rebuild
- Conducted following test builds, installed resulting packages, confirmed they launch
    - Mac desktop
    - Windows desktop
    - Centos7 (via docker)
    - Xenial (via docker)
    - Windows (via docker on my Google Compute setup, in final stages now and looking good)
    - Desktop Pro on Mac Desktop (licensing and RSP integration use a fair bit of Qt UI so wanted to ensure nothing horrible happened)


