### PR TITLE
support building with Qt 5.12.1 on macOS

### DIFF
--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -38,7 +38,7 @@ if(NOT WIN32)
       if(APPLE)
          set(QT_CANDIDATES 5.12.5 5.12.1)
       else()
-         set(QT_CANDIDATES 5.12.5 5.12.1 5.10.1)
+         set(QT_CANDIDATES 5.12.5 5.10.1)
       endif()
 
       # find the newest installed Qt version among the versions we build

--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -36,9 +36,9 @@ if(NOT WIN32)
       endif()
          
       if(APPLE)
-         set(QT_CANDIDATES 5.12.5)
+         set(QT_CANDIDATES 5.12.5 5.12.1)
       else()
-         set(QT_CANDIDATES 5.12.5 5.10.1)
+         set(QT_CANDIDATES 5.12.5 5.12.1 5.10.1)
       endif()
 
       # find the newest installed Qt version among the versions we build


### PR DESCRIPTION
Necessary if devs want to create and run debug builds on macOS due to Qt 5.12.5 bug: https://bugreports.qt.io/browse/QTBUG-78239

To use this, must not have Qt 5.12.5 installed. Alternatively, can do release builds with debug info.

Any Qt 5.12.5-specific changes need to be conditionally wrapped, see existing examples of QT_VERSION_CHECK in the source code.