### PR TITLE
Update theme API preference names

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -731,9 +731,9 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
 .rs.addApiFunction("getThemeInfo", function() {
    
    # read theme preferences
-   global <- .rs.readUiPref("flat_theme")
+   global <- .rs.readUiPref("global_theme")
 
-   theme <- .rs.readUiPref("rstheme")
+   theme <- .rs.readUserState("theme")
    if (is.null(theme))
       theme <- list("name" = "Textmate (default)", "isDark" = FALSE)
 


### PR DESCRIPTION
These pref names were missed when the prefs system was overhauled; this change switches to the new theme prefs names so that the `getThemeInfo()` API works correctly.

Fixes https://github.com/rstudio/rstudio/issues/3532.