### PR TITLE
replace Grid with LayoutGrid in three more locations

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/projects/model/ProjectTemplateWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/ProjectTemplateWidget.java
@@ -22,13 +22,13 @@ import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.widget.FileChooserTextBox;
+import org.rstudio.core.client.widget.LayoutGrid;
 import org.rstudio.core.client.widget.SelectWidget;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.Grid;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.TextBox;
@@ -61,7 +61,7 @@ public class ProjectTemplateWidget extends Composite
    
    public ProjectTemplateWidget(ProjectTemplateDescription description)
    {
-      widgets_ = new ArrayList<ProjectTemplateWidgetItem>();
+      widgets_ = new ArrayList<>();
       
       // initialize widgets
       JsArray<ProjectTemplateWidgetDescription> descriptions = description.getWidgetDescription();
@@ -180,7 +180,7 @@ public class ProjectTemplateWidget extends Composite
       if (!StringUtil.isNullOrEmpty(defaultValue))
          primaryWidget.setText(defaultValue);
       
-      Grid grid = new Grid(1, 2);
+      LayoutGrid grid = new LayoutGrid(1, 2);
       DomUtils.disableSpellcheck(primaryWidget);
       grid.setWidget(0, 0, new Label(ensureEndsWithColon(description.getLabel())));
       grid.setWidget(0, 1, primaryWidget);

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectGeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectGeneralPreferencesPane.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.projects.ui.prefs;
 import org.rstudio.core.client.prefs.PreferencesDialogBaseResources;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.FormLabel;
+import org.rstudio.core.client.widget.LayoutGrid;
 import org.rstudio.studio.client.packrat.model.PackratContext;
 import org.rstudio.studio.client.projects.model.RProjectConfig;
 import org.rstudio.studio.client.projects.model.RProjectOptions;
@@ -26,7 +27,6 @@ import org.rstudio.studio.client.workbench.model.SessionInfo;
 
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.CheckBox;
-import com.google.gwt.user.client.ui.Grid;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.ListBox;
 import com.google.inject.Inject;
@@ -35,10 +35,10 @@ public class ProjectGeneralPreferencesPane extends ProjectPreferencesPane
 {
    @Inject
    public ProjectGeneralPreferencesPane(Session session)
-   {        
+   {
       sessionInfo_ = session.getSessionInfo();
 
-      Grid grid = new Grid(6, 2);
+      LayoutGrid grid = new LayoutGrid(6, 2);
       grid.addStyleName(RESOURCES.styles().workspaceGrid());
       grid.setCellSpacing(8);
 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -69,7 +69,6 @@ import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Anchor;
 import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.Grid;
 import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Image;
@@ -1300,7 +1299,6 @@ public class RSConnectDeploy extends Composite
    @UiField Anchor addAccountAnchor_;
    @UiField Anchor createNewAnchor_;
    @UiField Anchor urlAnchor_;
-   @UiField Grid mainGrid_;
    @UiField HTMLPanel appDetailsPanel_;
    @UiField HTMLPanel appInfoPanel_;
    @UiField HTMLPanel appProgressPanel_;

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
@@ -8,8 +8,8 @@
     <ui:with field="themeRes" type="org.rstudio.core.client.theme.res.ThemeResources" />
     <g:HTMLPanel ui:field="rootPanel_">
     <g:Image ui:field="deployIllustration_"></g:Image>
-    <g:Grid ui:field="mainGrid_"><g:row>
-    <g:customCell styleName="{res.style.rootCell}">
+    <rw:LayoutGrid><rw:row>
+    <rw:customCell styleName="{res.style.rootCell}">
       <g:HTMLPanel>
          <g:VerticalPanel ui:field="filePanel_">
            <g:HTMLPanel>
@@ -41,8 +41,8 @@
             </rw:ThemedButton>
          </g:VerticalPanel>
        </g:HTMLPanel>
-     </g:customCell>
-     <g:customCell styleName="{res.style.rootCell}">
+     </rw:customCell>
+     <rw:customCell styleName="{res.style.rootCell}">
       <g:HTMLPanel>
          <g:HorizontalPanel width="100%" ui:field="publishFromPanel_">
             <g:Label styleName="{res.style.firstControlLabel}" 
@@ -108,7 +108,7 @@
             </g:HTMLPanel>
          </g:HTMLPanel>
       </g:HTMLPanel>
-     </g:customCell>
-   </g:row></g:Grid>
+     </rw:customCell>
+   </rw:row></rw:LayoutGrid>
    </g:HTMLPanel>
 </ui:UiBinder> 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.gwt.aria.client.Roles;
-import com.google.gwt.user.client.ui.Grid;
 
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
@@ -197,7 +196,6 @@ public class NewRMarkdownDialog extends ModalDialog<NewRMarkdownDialog.Result>
       templateChooser_ = new RmdTemplateChooser(server_);
 
       mainWidget_ = GWT.<Binder>create(Binder.class).createAndBindUi(this);
-      Roles.getPresentationRole().set(formGrid_.getElement());
       formatOptions_ = new ArrayList<>();
       style.ensureInjected();
       txtAuthor_.setText(author);
@@ -458,7 +456,6 @@ public class NewRMarkdownDialog extends ModalDialog<NewRMarkdownDialog.Result>
       return formatWrapper;
    }
    
-   @UiField Grid formGrid_;
    @UiField TextBox txtAuthor_;
    @UiField TextBox txtTitle_;
    @UiField WidgetListBox<TemplateMenuItem> listTemplates_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.ui.xml
@@ -132,26 +132,26 @@
      <g:HTMLPanel height="100%" width="325px" 
                   styleName="{style.templateDetails}">
         <g:HTMLPanel ui:field="newTemplatePanel_">
-           <g:Grid ui:field="formGrid_" width="100%" cellSpacing="0" cellPadding="0">
-             <g:row>
-               <g:customCell>
+           <rw:LayoutGrid width="100%" cellSpacing="0" cellPadding="0">
+             <rw:row>
+               <rw:customCell>
                   <rw:FormLabel for="{ElementIds.getNewRmdTitle}" styleName="{style.topLabel}">Title:</rw:FormLabel>
-               </g:customCell>
-               <g:customCell styleName="{style.textCol}">
+               </rw:customCell>
+               <rw:customCell styleName="{style.textCol}">
                  <rw:FormTextBox elementId="{ElementIds.getNewRmdTitle}" styleName="{style.textBox}" 
                                  ui:field="txtTitle_" />
-               </g:customCell>
-              </g:row>
-              <g:row>
-                <g:customCell>
+               </rw:customCell>
+              </rw:row>
+              <rw:row>
+                <rw:customCell>
                    <rw:FormLabel for="{ElementIds.getNewRmdAuthor}" styleName="{style.topLabel}">Author:</rw:FormLabel>
-                </g:customCell>
-                <g:customCell>
+                </rw:customCell>
+                <rw:customCell>
                    <rw:FormTextBox elementId="{ElementIds.getNewRmdAuthor}" styleName="{style.textBox}" 
                                    ui:field="txtAuthor_"/>
-                </g:customCell>
-              </g:row>
-           </g:Grid>
+                </rw:customCell>
+              </rw:row>
+           </rw:LayoutGrid>
            <rw:FieldSetPanel legend="Default Output Format:" styleName="{style.defaultOutputLabel}">
               <g:HTMLPanel ui:field="templateFormatPanel_"></g:HTMLPanel>
            </rw:FieldSetPanel>


### PR DESCRIPTION
- Grid is used for layout here, and thus the resulting tables need to be marked as role=presentation so they aren't read as tabular data
- two cases via UiBinder, showing you can do it declaratively instead of at runtime
- one obscure case for custom project templates where template adds text field(s) to the UI (for an example, see https://github.com/rstudio/ptexamples)

![2019-09-16_16-35-01](https://user-images.githubusercontent.com/10569626/65002407-80e35c00-d8a8-11e9-8a0b-9e5f9faaccb1.png)

![2019-09-16_17-00-08](https://user-images.githubusercontent.com/10569626/65002409-850f7980-d8a8-11e9-862c-33d88f957299.png)

![2019-09-16_17-24-08](https://user-images.githubusercontent.com/10569626/65002412-88a30080-d8a8-11e9-95ea-503f751c1898.png)
