### PR TITLE
duplicate element IDs in New Project wizard confusing screen readers

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
@@ -66,10 +66,8 @@ public class TextBoxWithButton extends Composite
       textBox_ = new TextBox();
       textBox_.setWidth("100%");
       textBox_.setReadOnly(readOnly);
-      ElementIds.assignElementId(textBox_, ElementIds.TEXTBOXBUTTON_TEXT);
 
       themedButton_ = new ThemedButton(action, handler);
-      ElementIds.assignElementId(themedButton_, ElementIds.TEXTBOXBUTTON_BUTTON);
 
       inner_ = new HorizontalPanel();
       inner_.add(textBox_);
@@ -80,19 +78,19 @@ public class TextBoxWithButton extends Composite
       FlowPanel outer = new FlowPanel();
       if (label != null)
       {
-         FormLabel lblCaption = new FormLabel(label, textBox_, true);
+         lblCaption_ = new FormLabel(label, true);
          if (helpButton != null)
          {
+            helpButton_ = helpButton;
             HorizontalPanel panel = new HorizontalPanel();
-            panel.add(lblCaption);
+            panel.add(lblCaption_);
             helpButton.getElement().getStyle().setMarginLeft(5, Unit.PX);
-            ElementIds.assignElementId(helpButton, ElementIds.TEXTBOXBUTTON_HELP);
             panel.add(helpButton);
             outer.add(panel);
          }
          else
          {
-            outer.add(lblCaption);
+            outer.add(lblCaption_);
          }
       }
       outer.add(inner_);
@@ -185,11 +183,28 @@ public class TextBoxWithButton extends Composite
       textBox_.setFocus(true);
    }
 
+   @Override
+   public void onAttach()
+   {
+      super.onAttach();
+
+      // Some UI scenarios create multiple TextBoxWithButtons before adding them to the
+      // DOM; defer assigning IDs until added to DOM in order to detect and
+      // prevent duplicates.
+      ElementIds.assignElementId(textBox_, ElementIds.TEXTBOXBUTTON_TEXT);
+      ElementIds.assignElementId(themedButton_, ElementIds.TEXTBOXBUTTON_BUTTON);
+      if (helpButton_ != null)
+         ElementIds.assignElementId(helpButton_, ElementIds.TEXTBOXBUTTON_HELP);
+      if (lblCaption_ != null)
+         lblCaption_.setFor(textBox_);
+   }
+
    private HorizontalPanel inner_;
+   private FormLabel lblCaption_;
    private TextBox textBox_;
+   private HelpButton helpButton_;
    private ThemedButton themedButton_;
    private String emptyLabel_;
    private String useDefaultValue_;
    private String text_ = "";
-  
 }

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewDirectoryPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewDirectoryPage.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.projects.ui.newproject;
 
+import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.resources.ImageResource2x;
@@ -86,6 +87,7 @@ public class NewDirectoryPage extends NewProjectWizardPage
       txtProjectName_ = new TextBox();
       txtProjectName_.setWidth("100%");
       DomUtils.disableSpellcheck(txtProjectName_);
+      Roles.getTextboxRole().setAriaRequiredProperty(txtProjectName_.getElement(), true);
 
       // create the dir name label
       dirNameLabel_ = new FormLabel(getDirNameLabel(), txtProjectName_);


### PR DESCRIPTION
- the dialog creates several TextBoxWithButton-based controls, before adding them to the DOM, so the code for detecting duplicate IDs wasn't working (I had added the dup-removal in https://github.com/rstudio/rstudio/pull/5276)
- thus, ended up with a bunch of duplicate IDs causing validation to fail, and VoiceOver on Mac ended up reading all of the labels for a single instance of the control's textbox when you tabbed into it
- small tweak to mark the Project Name text field as required