### PR TITLE
use LayoutGrid instead of Grid for proper accessibility annotation

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionCodePanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionCodePanel.java
@@ -1,7 +1,7 @@
 /*
  * ConnectionCodePanel.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,6 +17,7 @@
 package org.rstudio.studio.client.workbench.views.connections.ui;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.widget.FormLabel;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.reditor.EditorLanguage;
 import org.rstudio.studio.client.workbench.views.connections.model.ConnectionOptions;
@@ -33,7 +34,6 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HasHorizontalAlignment;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.HorizontalPanel;
-import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.RequiresResize;
 import com.google.gwt.user.client.ui.VerticalPanel;
@@ -50,19 +50,20 @@ public class ConnectionCodePanel extends Composite implements RequiresResize
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
       container_ = new VerticalPanel();
-      container_.setVerticalAlignment(HasVerticalAlignment.ALIGN_TOP);      
+      container_.setVerticalAlignment(HasVerticalAlignment.ALIGN_TOP);
       HorizontalPanel codeHeaderPanel = new HorizontalPanel();
       codeHeaderPanel.addStyleName(RES.styles().codePanelHeader());
       codeHeaderPanel.setWidth("100%");
-      Label codeLabel = new Label("Connection:");
-      codeHeaderPanel.add(codeLabel);
+      codeLabel_ = new FormLabel("Connection:");
+      codeHeaderPanel.add(codeLabel_);
       codeHeaderPanel.setCellHorizontalAlignment(
-               codeLabel, HasHorizontalAlignment.ALIGN_LEFT);
+               codeLabel_, HasHorizontalAlignment.ALIGN_LEFT);
       HorizontalPanel connectPanel = new HorizontalPanel();
-      Label connectLabel = new Label("Connect from:");
+      FormLabel connectLabel = new FormLabel("Connect from:");
       connectLabel.addStyleName(RES.styles().leftLabel());
       connectPanel.add(connectLabel);
       connectVia_ = new ListBox();
+      connectLabel.setFor(connectVia_);
       updateConnectViaUI_ = new Command() {
          @Override
          public void execute()
@@ -149,6 +150,7 @@ public class ConnectionCodePanel extends Composite implements RequiresResize
       
       // create new code viewer
       codeViewer_ = new AceEditorWidget(false);
+      codeLabel_.setFor(codeViewer_);
       codeViewer_.addStyleName(RES.styles().codeViewer());
       codeViewer_.getEditor().getSession().setEditorMode(
             EditorLanguage.LANG_R.getParserName(), false);
@@ -202,6 +204,7 @@ public class ConnectionCodePanel extends Composite implements RequiresResize
    
    private VerticalPanel container_;
    private ListBox connectVia_;
+   private FormLabel codeLabel_;
    private AceEditorWidget codeViewer_;
    private boolean settingCode_ = false;
    private final Command updateConnectViaUI_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyHost.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionShinyHost.java
@@ -19,6 +19,7 @@ package org.rstudio.studio.client.workbench.views.connections.ui;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
+import org.rstudio.core.client.widget.LayoutGrid;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.RStudioFrame;
@@ -47,7 +48,6 @@ import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.Grid;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
@@ -169,7 +169,7 @@ public class NewConnectionShinyHost extends Composite
       };
       updateCodeCommand.execute();
 
-      Grid codeGrid = new Grid(1, 1);
+      LayoutGrid codeGrid = new LayoutGrid(1, 1);
       codeGrid.addStyleName(RES.styles().codeGrid());
       codeGrid.setCellPadding(0);
       codeGrid.setCellSpacing(0);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetDialog.java
@@ -19,6 +19,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 
 import com.google.gwt.aria.client.Roles;
+import org.rstudio.core.client.widget.FormLabel;
+import org.rstudio.core.client.widget.LayoutGrid;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -30,9 +32,7 @@ import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
-import com.google.gwt.user.client.ui.Grid;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
-import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.Widget;
@@ -85,17 +85,18 @@ public class NewConnectionSnippetDialog extends ModalDialog<HashMap<String, Stri
       SimplePanel wrapper = new SimplePanel();
       wrapper.setStyleName(RES.styles().wrapper());
       
-      Grid connGrid = new Grid(initialConfig_.size(), 2);
+      LayoutGrid connGrid = new LayoutGrid(initialConfig_.size(), 2);
       connGrid.addStyleName(RES.styles().grid());
 
       for (int idxParams = 0; idxParams < initialConfig_.size(); idxParams++) {
          final String key = initialConfig_.get(idxParams).getKey();
-         Label label = new Label(key + ":");
+         FormLabel label = new FormLabel(key + ":");
          label.addStyleName(RES.styles().label());
          connGrid.setWidget(idxParams, 0, label);
          connGrid.getRowFormatter().setVerticalAlign(idxParams, HasVerticalAlignment.ALIGN_TOP);
          
          final TextBox textbox = new TextBox();
+         label.setFor(textbox);
          textbox.setText(initialConfig_.get(idxParams).getValue());
          textbox.addStyleName(RES.styles().textbox());
          connGrid.setWidget(idxParams, 1, textbox);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetHost.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetHost.java
@@ -27,6 +27,8 @@ import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
+import org.rstudio.core.client.widget.FormLabel;
+import org.rstudio.core.client.widget.LayoutGrid;
 import org.rstudio.core.client.widget.MessageDialog;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
@@ -56,7 +58,6 @@ import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.Grid;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.HasAlignment;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
@@ -228,7 +229,7 @@ public class NewConnectionSnippetHost extends Composite
       dlg.showModal();
    }
    
-   private Grid createParameterizedUI(final NewConnectionInfo info, int maxRows)
+   private LayoutGrid createParameterizedUI(final NewConnectionInfo info, int maxRows)
    {
       final ArrayList<NewConnectionSnippetParts> snippetParts = parseSnippet(info.getSnippet());
       int visibleRows = snippetParts.size();
@@ -249,7 +250,7 @@ public class NewConnectionSnippetHost extends Composite
       final ArrayList<NewConnectionSnippetParts> secondarySnippetParts = 
             new ArrayList<NewConnectionSnippetParts>(snippetParts.subList(visibleParams, snippetParts.size()));
 
-      final Grid connGrid = new Grid(visibleRows + 1, 4);
+      final LayoutGrid connGrid = new LayoutGrid(visibleRows + 1, 4);
       connGrid.addStyleName(RES.styles().grid());
 
       if (visibleRows > 0) {
@@ -266,7 +267,7 @@ public class NewConnectionSnippetHost extends Composite
          connGrid.getRowFormatter().setStyleName(idxRow, RES.styles().gridRow());
          
          final String key = snippetParts.get(idxParams).getKey();
-         Label label = new Label(key + ":");
+         FormLabel label = new FormLabel(key + ":");
          label.addStyleName(RES.styles().label());
          connGrid.setWidget(idxRow, 0, label);
          connGrid.getRowFormatter().setVerticalAlign(idxRow, HasVerticalAlignment.ALIGN_TOP);
@@ -295,6 +296,7 @@ public class NewConnectionSnippetHost extends Composite
             textbox.addStyleName(textboxStyle);
             textboxBase = textbox;
          }
+         label.setFor(textboxBase);
          
          connGrid.setWidget(idxRow, 1, textboxBase);
          
@@ -472,13 +474,13 @@ public class NewConnectionSnippetHost extends Composite
       
       parametersPanel_ = new VerticalPanel();
       parametersPanel_.addStyleName(RES.styles().parametersPanel());
-      container.add(parametersPanel_);        
+      container.add(parametersPanel_);
       
-      // add the code panel     
+      // add the code panel
       codePanel_ = new ConnectionCodePanel();
       codePanel_.addStyleName(RES.styles().dialogCodePanel());
 
-      Grid codeGrid = new Grid(1, 1);
+      LayoutGrid codeGrid = new LayoutGrid(1, 1);
       codeGrid.addStyleName(RES.styles().codeGrid());
       codeGrid.setCellPadding(0);
       codeGrid.setCellSpacing(0);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/GridEx.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/GridEx.java
@@ -1,29 +1,46 @@
+/*
+ * GridEx.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
 package org.rstudio.studio.client.workbench.views.console.shell.assist;
 
 import com.google.gwt.dom.client.Element;
-import com.google.gwt.event.dom.client.*;
+import com.google.gwt.event.dom.client.HasMouseMoveHandlers;
+import com.google.gwt.event.dom.client.MouseMoveEvent;
+import com.google.gwt.event.dom.client.MouseMoveHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Event;
-import com.google.gwt.user.client.ui.Grid;
+import org.rstudio.core.client.widget.LayoutGrid;
 
-public class GridEx extends Grid implements HasMouseMoveHandlers
+public class GridEx extends LayoutGrid implements HasMouseMoveHandlers
 {
    public GridEx(int rows, int cols)
    {
-      super(rows, cols) ;
-      sinkEvents(Event.ONMOUSEMOVE) ;
+      super(rows, cols);
+      sinkEvents(Event.ONMOUSEMOVE);
    }
 
    public HandlerRegistration addMouseMoveHandler(MouseMoveHandler handler)
    {
-      return addHandler(handler, MouseMoveEvent.getType()) ;
+      return addHandler(handler, MouseMoveEvent.getType());
    }
 
    public int getRowForEvent(MouseMoveEvent event)
    {
       Element td = getEventTargetCell(Event.as(event.getNativeEvent()));
-      if (td == null) {
+      if (td == null)
+      {
          return -1;
       }
 
@@ -31,7 +48,7 @@ public class GridEx extends Grid implements HasMouseMoveHandlers
       Element body = DOM.getParent(tr);
       int row = DOM.getChildIndex(body, tr);
 
-      return row ;
+      return row;
    }
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
@@ -27,6 +27,7 @@ import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.DomUtils.NativeEventHandler;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.FormLabel;
+import org.rstudio.core.client.widget.LayoutGrid;
 import org.rstudio.core.client.widget.MiniPopupPanel;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.ProgressOperationWithInput;
@@ -160,7 +161,7 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
       });
       
       int gridRows = includeChunkNameUI ? 2 : 1;
-      Grid nameAndOutputGrid = new Grid(gridRows, 2);
+      LayoutGrid nameAndOutputGrid = new LayoutGrid(gridRows, 2);
 
       chunkLabel_ = new FormLabel("Chunk Name:", tbChunkLabel_);
       chunkLabel_.addStyleName(RES.styles().chunkLabel());


### PR DESCRIPTION
- several more instances of Grid replaced with LayoutGrid
- associate labels with controls in Connections dialog

![2019-09-17_17-46-33](https://user-images.githubusercontent.com/10569626/65166934-79ca6400-d9f6-11e9-8f91-b34e9c71ff14.png)
![2019-09-18_08-56-19](https://user-images.githubusercontent.com/10569626/65166948-7df68180-d9f6-11e9-83bb-d744eae2c531.png)
![2019-09-18_09-21-00](https://user-images.githubusercontent.com/10569626/65166957-82229f00-d9f6-11e9-8e2f-cfaee0bfa846.png)
