### PR TITLE
Show the auth timeout for users on the home page when using new auth timeout mode to hopefully reduce confusion

### DIFF
--- a/src/cpp/server/ServerPAMAuth.cpp
+++ b/src/cpp/server/ServerPAMAuth.cpp
@@ -91,6 +91,9 @@ const char * const kFormAction = "formAction";
 
 const char * const kStaySignedInDisplay = "staySignedInDisplay";
 
+const char * const kAuthTimeoutMinutes = "authTimeoutMinutes";
+const char * const kAuthTimeoutMinutesDisplay = "authTimeoutMinutesDisplay";
+
 const char * const kLoginPageHtml = "loginPageHtml";
 
 enum ErrorType 
@@ -244,6 +247,9 @@ void signIn(const http::Request& request,
             safe_convert::stringTo<unsigned>(error, kErrorNone)));
    variables[kErrorDisplay] = error.empty() ? "none" : "block";
    variables[kStaySignedInDisplay] = canStaySignedIn() ? "block" : "none";
+   int timeoutMinutes = server::options().authTimeoutMinutes();
+   variables[kAuthTimeoutMinutesDisplay] = timeoutMinutes > 0 ? "block" : "none";
+   variables[kAuthTimeoutMinutes] = safe_convert::numberToString(timeoutMinutes);
    if (server::options().authEncryptPassword())
       variables[kFormAction] = "action=\"javascript:void\" "
                                "onsubmit=\"submitRealForm();return false\"";

--- a/src/gwt/www/templates/encrypted-sign-in.htm
+++ b/src/gwt/www/templates/encrypted-sign-in.htm
@@ -201,8 +201,11 @@ function submitRealForm() {
                 autocomplete='off' /><br />
       </p>
       <p style="display: #staySignedInDisplay#;">
+         <p style="display: #authTimeoutMinutesDisplay#";">
+            <label style="font-size:10px">You will automatically be signed out after #authTimeoutMinutes# minutes of inactivity.</label>
+         </p>
          <input type="checkbox" name="staySignedIn" id="staySignedIn" value="1"/>
-         <label for="staySignedIn">Stay signed in</label>
+         <label for="staySignedIn">Stay signed in when browser closes</label>
       </p>
       </div>
        <input type="hidden" name="appUri" value="#appUri#"/>

--- a/src/gwt/www/templates/encrypted-sign-in.htm
+++ b/src/gwt/www/templates/encrypted-sign-in.htm
@@ -201,8 +201,8 @@ function submitRealForm() {
                 autocomplete='off' /><br />
       </p>
       <p style="display: #staySignedInDisplay#;">
-         <p style="display: #authTimeoutMinutesDisplay#";">
-            <label style="font-size:10px">You will automatically be signed out after #authTimeoutMinutes# minutes of inactivity.</label>
+         <p style="display: #authTimeoutMinutesDisplay#;">
+            <span style="font-size:10px">You will automatically be signed out after #authTimeoutMinutes# minutes of inactivity.</span>
          </p>
          <input type="checkbox" name="staySignedIn" id="staySignedIn" value="1"/>
          <label for="staySignedIn">Stay signed in when browser closes</label>


### PR DESCRIPTION
Closes #5449 

The following screenshot shows the updated visual that users will see when `auth-timeout-minutes` is in effect (greater than 0).

![image](https://user-images.githubusercontent.com/28230621/65617067-ba3f5a00-df81-11e9-8090-c47d6321d397.png)
