### PR TITLE
Make sure rstudio-server user is added to the rstudio-server group on install

### DIFF
--- a/package/linux/debian-control/postinst.in
+++ b/package/linux/debian-control/postinst.in
@@ -4,8 +4,7 @@
 set +e 
 
 # add rserver user account
-useradd -r rstudio-server
-groupadd -r rstudio-server
+useradd -r -U rstudio-server
 
 # create softlink to admin script in /usr/sbin
 ln -f -s ${CMAKE_INSTALL_PREFIX}/bin/rstudio-server /usr/sbin/rstudio-server

--- a/package/linux/rpm-script/postinst.sh.in
+++ b/package/linux/rpm-script/postinst.sh.in
@@ -4,8 +4,7 @@
 set +e
 
 # add rserver user account
-useradd -r rstudio-server
-groupadd -r rstudio-server
+useradd -r -U rstudio-server
 
 # create softlink to admin script in /usr/sbin
 ln -f -s "${CMAKE_INSTALL_PREFIX}"/bin/rstudio-server /usr/sbin/rstudio-server


### PR DESCRIPTION
Fixes #5464

Accomplished by implicitly creating the `rstudio-server` group in the `useradd` command itself, instead of hoping that the default group policy structure causes this to magically work like it does on some Linux systems.