### PR TITLE
call cmdlineoptions() to set memory limit

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -566,12 +566,6 @@ assign(envir = .rs.Env, ".rs.hasVar", function(name)
 })
 
 
-.rs.addFunction( "setMemoryLimit", function(limit)
-{
-   suppressWarnings(utils::memory.limit(limit))
-})
-
-
 .rs.addFunction( "libPathsAppend", function(path)
 {
    # remove it if it already exists


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/4986.

This is a pretty dangerous change, but I can't think of any safer way of accomplishing this.

In theory, all we want to do is set `R_max_memory`. Unfortunately, it's not an exported symbol. The exported R function that does allow us to change it, only allows us to raise it -- not lower it. And, by default, R initializes it as R_SIZE_T_MAX:

https://github.com/wch/r-source/commit/24fc04760afdca9edc52afeb4dfb1f5bf50ffd6e

Since `cmdlineoptions()` is the only API we can call that allows us to set the memory limit at R initialization time, the PR sets out to call that with the minimal amount of action taken by R (since we ultimately need to override any of the default startup behaviors with our own startup structs and function pointers).

The definition of `cmdlineoptions()` is here:

https://github.com/wch/r-source/blob/e732fe187ee0d680da79330347c2c5fb0ce1da11/src/gnuwin32/system.c#L880

As far as I can tell, the main negative effect of this PR is that we end up leaking command line arguments in our "dummy" initialization:

https://github.com/wch/r-source/blob/e732fe187ee0d680da79330347c2c5fb0ce1da11/src/main/CommandLineArgs.c#L53-L63

But I think we can live with that.