### PR TITLE
support use of Ctrl+[ as Esc in console on iPadOS (for keyboards lacking Esc key)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,8 @@
 * Show number of characters when entering version control commit messages (#5192)
 * Update embedded Qt to 5.12.5 for Chromium update, stability and bugfixes (#5399)
 * Add preference for changing font size on help pane (#3282)
+* Improved keyboard and touch support for iPadOS 13.1
+* Support Ctrl+[ as Esc key on iPadOS 13.1 keyboards lacking physical Esc key (#4663)
 
 ### Bugfixes
 
@@ -53,4 +55,4 @@
 
 * Logging improvements; log destinations and levels are more configurable and can be changed in real time
 * RStudio Desktop Pro can now function as a client for RStudio Server Pro
-* 
+

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -585,7 +585,8 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
             processCommandEntry();
          }
          else if (
-               (keyCode == KeyCodes.KEY_ESCAPE && modifiers == 0) ||
+               (keyCode == KeyCodes.KEY_ESCAPE &&
+                     (modifiers == 0 || modifiers == KeyboardShortcut.CTRL /*iPadOS 13.1*/)) ||
                (BrowseCap.isMacintoshDesktop() && (
                      modifiers == KeyboardShortcut.CTRL &&
                      keyCode == KeyCodes.KEY_C)))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -140,8 +140,8 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       
       view_.setMaxOutputLines(session.getSessionInfo().getConsoleActionsLimit());
 
-      keyDownPreviewHandlers_ = new ArrayList<KeyDownPreviewHandler>() ;
-      keyPressPreviewHandlers_ = new ArrayList<KeyPressPreviewHandler>() ;
+      keyDownPreviewHandlers_ = new ArrayList<>() ;
+      keyPressPreviewHandlers_ = new ArrayList<>() ;
 
       InputKeyHandler handler = new InputKeyHandler() ;
 
@@ -520,10 +520,11 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
                                                   KeyPressHandler,
                                                   KeyUpHandler
    {
+      @Override
       public void onKeyDown(KeyDownEvent event)
       {
          int keyCode = event.getNativeKeyCode();
-         
+
          // typically we allow all the handlers to process the key; however,
          // this behavior is suppressed when we're incrementally searching the
          // history so we don't stack two kinds of completion popups
@@ -531,7 +532,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
          if (historyCompletion_.getMode() == 
                HistoryCompletionManager.PopupMode.PopupIncremental)
          {
-            handlers = new ArrayList<KeyDownPreviewHandler>();
+            handlers = new ArrayList<>();
             handlers.add(historyCompletion_);
          }
 
@@ -611,7 +612,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
                   eventBus_.fireEvent(new ConsoleInputEvent(null, ""));
                }
             }
-             
+
             input_.clear();
          }
          else
@@ -654,6 +655,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
          }
       }
 
+      @Override
       public void onKeyPress(KeyPressEvent event)
       {
          // typically we allow all the handlers to process the key; however,
@@ -663,7 +665,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
          if (historyCompletion_.getMode() == 
                HistoryCompletionManager.PopupMode.PopupIncremental)
          {
-            handlers = new ArrayList<KeyPressPreviewHandler>();
+            handlers = new ArrayList<>();
             handlers.add(historyCompletion_);
          }
 
@@ -737,7 +739,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    
    private void setHistory(JsArrayString history)
    {
-      ArrayList<String> historyList = new ArrayList<String>(history.length());
+      ArrayList<String> historyList = new ArrayList<>(history.length());
       for (int i = 0; i < history.length(); i++)
          historyList.add(history.get(i));
       historyManager_.setHistory(historyList);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -50,7 +50,6 @@ import org.rstudio.studio.client.common.filetypes.DocumentMode;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
-import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.codesearch.model.DataDefinition;
 import org.rstudio.studio.client.workbench.codesearch.model.FileFunctionDefinition;
 import org.rstudio.studio.client.workbench.codesearch.model.ObjectDefinition;
@@ -279,7 +278,7 @@ public class RCompletionManager implements CompletionManager
 
       server_.getHelpAtCursor(
             linePos.getLine(), linePos.getPosition(),
-            new SimpleRequestCallback<Void>("Help"));
+            new SimpleRequestCallback<>("Help"));
    }
    
    public void goToDefinition()
@@ -431,7 +430,7 @@ public class RCompletionManager implements CompletionManager
       if (isDisabled())
          return false;
       
-      /**
+      /*
        * KEYS THAT MATTER
        *
        * When popup not showing:
@@ -439,6 +438,7 @@ public class RCompletionManager implements CompletionManager
        * 
        * When popup showing:
        * Esc - dismiss popup
+       * Ctrl+Esc - variation of Esc triggered by Ctrl+[ on iPadOS 13.1
        * Enter/Tab - accept current selection
        * Up-arrow/Down-arrow - change selected item
        * [identifier] - narrow suggestions--or if we're lame, just dismiss
@@ -513,6 +513,10 @@ public class RCompletionManager implements CompletionManager
             {
             case KeyCodes.KEY_P: return popup_.selectPrev();
             case KeyCodes.KEY_N: return popup_.selectNext();
+
+            // Typing Ctrl+[ on iPadOS keyboard sends equivalent of Ctrl+Esc, but want to treat
+            // as plain Esc keypress
+            case KeyCodes.KEY_ESCAPE: invalidatePendingRequests(); return true;
             }
          }
          
@@ -1034,9 +1038,9 @@ public class RCompletionManager implements CompletionManager
       public AutocompletionContext()
       {
          token_ = "";
-         assocData_ = new ArrayList<String>();
-         dataType_ = new ArrayList<Integer>();
-         numCommas_ = new ArrayList<Integer>();
+         assocData_ = new ArrayList<>();
+         dataType_ = new ArrayList<>();
+         numCommas_ = new ArrayList<>();
          functionCallString_ = "";
       }
 
@@ -1588,7 +1592,7 @@ public class RCompletionManager implements CompletionManager
       do
       {
          String value = clone.currentValue();
-         if (value.indexOf(",") != -1 || value.equals("("))
+         if (value.contains(",") || value.equals("("))
             break;
          
          if (clone.bwdToMatchingToken())
@@ -1612,7 +1616,7 @@ public class RCompletionManager implements CompletionManager
       while (clone.moveToNextToken())
       {
          String value = clone.currentValue();
-         if (value.indexOf(",") != -1 || value.equals(")"))
+         if (value.contains(",") || value.equals(")"))
          {
             lookupSucceeded = true;
             break;


### PR DESCRIPTION
- in Safari on iPadOS, can now use Ctrl+[ to cancel long-running code, or to get out of continuation mode (e.g. unmatched quotes or parentheses), or dismiss autocomplete popups in console, on an iPad keyboard that doesn't have an Esc key
- the underlying problem is that Ctrl+[ on iPadOS behaves more like pressing Ctrl+Esc
- also some minor gratuitous Java style cleanup
- Fixes #4663
