### PR TITLE
Don't attempt to restore connection object expansion state after refresh

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ObjectBrowser.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ObjectBrowser.java
@@ -69,80 +69,21 @@ public class ObjectBrowser extends Composite implements RequiresResize
    
    public void update(Connection connection, String hint)
    { 
-      final Set<DatabaseObject> expandedNodes = new HashSet<DatabaseObject>();
-      
-      // if this update is for the currently visible connection in the model,
-      // cache the set of expanded nodes for replay
-      if (objects_ != null && connection == connection_)
-      {
-         TreeNode rootNode = objects_.getRootTreeNode();
-         if (!objects_.getRootTreeNode().isDestroyed())
-         {
-            for (int i = 0; i < rootNode.getChildCount(); i++)
-            {
-               if (rootNode.isChildOpen(i))
-               {
-                  DatabaseObject node = (DatabaseObject)rootNode.getChildValue(i);
-                  expandedNodes.add(node);
-               }
-            }
-         }
-      }
-      
       // create tables model and widget
       objectsModel_ = new ObjectBrowserModel();
       
-      // capture scroll position
-      final int scrollPosition = scrollPanel_.getVerticalScrollPosition();
-
       // show progress while updating the connection
       hostPanel_.showProgress(50, "Loading objects");
             
       // update the table then restore expanded nodes
       objectsModel_.update(
-         connection,      // connection 
-         expandedNodes,
-         new Command() {   // table update completed, expand nodes
-            @Override
-            public void execute()
-            {
-               // clear progress and show the object tree again
-               hostPanel_.setWidget(scrollPanel_);
-               
-               // restore expanded nodes
-               TreeNode rootNode = objects_.getRootTreeNode();
-               if (!rootNode.isDestroyed())
-               {
-                  for (int i = 0; i < rootNode.getChildCount(); i++)
-                  {
-                     final DatabaseObject nodeVal = 
-                           (DatabaseObject)(rootNode.getChildValue(i));
-                     for (DatabaseObject expanded: expandedNodes)
-                     {
-                        if (expanded.isEqualTo(nodeVal))
-                           rootNode.setChildOpen(i, true, false);
-                     }
-                  }
-               }
-            }
-         },
-         new Command() {   // node expansion completed, restore scroll position
-            @Override
-            public void execute()
-            {
-               // delay 100ms to allow expand animation to complete
-               new Timer() {
-
-                  @Override
-                  public void run()
-                  {
-                     scrollPanel_.setVerticalScrollPosition(scrollPosition); 
-                  }
-                  
-               }.schedule(100);
-              
-            }
-         });
+         connection ,      // connection 
+         null,             // expanded nodes (none for refresh)
+         () -> 
+         {
+            // clear progress and show the object tree again
+            hostPanel_.setWidget(scrollPanel_);
+         }, null);
 
       // create new widget
       objects_ = new CellTree(objectsModel_, null, RES, MESSAGES, 512);


### PR DESCRIPTION
We currently try to restore the exact state of the Connections pane after it's refreshed -- i.e. which objects were open, your scroll position, etc.

This is a nice thing to do, but doesn't work correctly, and after some investigation it'd be difficult to make it do the right thing (as we'd need to hit the server multiple times to refresh each layer individually). A refresh that leaves you looking at exactly the same content might not feel like a refresh, too, so there's some argument to be made for cleaning the slate as a cue that you're looking at fresh data.

Fixes https://github.com/rstudio/rstudio/issues/2136. 