### PR TITLE
add support for installing tinytex

### DIFF
--- a/src/cpp/core/include/core/system/Xdg.hpp
+++ b/src/cpp/core/include/core/system/Xdg.hpp
@@ -31,16 +31,22 @@ namespace xdg {
  * All of these can be configured with environment variables as described below.
  */
 
-// Returns the RStudio XDG user config directory. On Unix-alikes, this is ~/.config/rstudio, or
-// XDG_CONFIG_HOME.
+// Returns the RStudio XDG user config directory.
+//
+// On Unix-alikes, this is ~/.config/rstudio, or XDG_CONFIG_HOME.
+// On Windows, this is 'FOLDERID_RoamingAppData' (typically 'AppData/Roaming').
 FilePath userConfigDir();
 
-// Returns the RStudio XDG user data directory. On Unix-alikes, this is ~/.local/share/rstudio, or
-// XDG_DATA_HOME
+// Returns the RStudio XDG user data directory.
+//
+// On Unix-alikes, this is ~/.local/share/rstudio, or XDG_DATA_HOME.
+// On Windows, this is 'FOLDERID_LocalAppData' (typically 'AppData/Local').
 FilePath userDataDir();
 
-// Returns the RStudio XDG system config directory. On Unix-alikes, this is /etc/rstudio, or
-// XDG_CONFIG_DIRS
+// Returns the RStudio XDG system config directory.
+//
+// On Unix-alikes, this is /etc/rstudio, XDG_CONFIG_DIRS.
+// On Windows, this is 'FOLDERID_ProgramData' (typically 'C:/ProgramData').
 FilePath systemConfigDir();
 
 } // namespace xdg

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1072,6 +1072,16 @@ FilePath findProgram(const std::string& name)
 
 bool addTinytexToPathIfNecessary()
 {
+   // avoid some pathological cases where e.g. TinyTeX folder
+   // exists but doesn't have the pdflatex binary (don't
+   // attempt to re-add the folder multiple times)
+   static bool s_added = false;
+   if (s_added)
+      return true;
+   
+   if (!module_context::findProgram("pdflatex").empty())
+      return false;
+   
    std::string binDir;
    Error error = r::exec::RFunction(".rs.tinytexBin").call(&binDir);
    if (error)
@@ -1081,6 +1091,7 @@ bool addTinytexToPathIfNecessary()
    if (!binPath.exists())
       return false;
    
+   s_added = true;
    core::system::addToSystemPath(binPath);
    return true;
 }

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1070,6 +1070,25 @@ FilePath findProgram(const std::string& name)
    }
 }
 
+bool addTinytexToPathIfNecessary()
+{
+   if (isPdfLatexInstalled())
+      return false;
+
+   FilePath binPath;
+
+#if defined(_WIN32)
+   FilePath appData(core::system::getenv("APPDATA"));
+   binPath = appData.complete("TinyTeX\\bin\\win32");
+#elif defined(__APPLE__)
+   binPath = resolveAliasedPath("~/Library/TinyTeX/bin/x86_64-darwin");
+#else
+   binPath = resolveAliasedPath("~/bin");
+#endif
+
+   if (binPath.childPath("pdflatex").exists())
+      core::system::addToSystemPath(binPath);
+}
 
 bool isPdfLatexInstalled()
 {

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1072,9 +1072,6 @@ FilePath findProgram(const std::string& name)
 
 bool addTinytexToPathIfNecessary()
 {
-   if (isPdfLatexInstalled())
-      return false;
-   
    std::string binDir;
    Error error = r::exec::RFunction(".rs.tinytexBin").call(&binDir);
    if (error)
@@ -1090,6 +1087,7 @@ bool addTinytexToPathIfNecessary()
 
 bool isPdfLatexInstalled()
 {
+   addTinytexToPathIfNecessary();
    return !module_context::findProgram("pdflatex").empty();
 }
 

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1074,20 +1074,18 @@ bool addTinytexToPathIfNecessary()
 {
    if (isPdfLatexInstalled())
       return false;
-
-   FilePath binPath;
-
-#if defined(_WIN32)
-   FilePath appData(core::system::getenv("APPDATA"));
-   binPath = appData.complete("TinyTeX\\bin\\win32");
-#elif defined(__APPLE__)
-   binPath = resolveAliasedPath("~/Library/TinyTeX/bin/x86_64-darwin");
-#else
-   binPath = resolveAliasedPath("~/bin");
-#endif
-
-   if (binPath.childPath("pdflatex").exists())
-      core::system::addToSystemPath(binPath);
+   
+   std::string binDir;
+   Error error = r::exec::RFunction(".rs.tinytexBin").call(&binDir);
+   if (error)
+      LOG_ERROR(error);
+   
+   FilePath binPath = module_context::resolveAliasedPath(binDir);
+   if (!binPath.exists())
+      return false;
+   
+   core::system::addToSystemPath(binPath);
+   return true;
 }
 
 bool isPdfLatexInstalled()

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -118,6 +118,7 @@ std::string rLibsUser();
 // find out the location of a binary
 core::FilePath findProgram(const std::string& name);
 
+bool addTinytexToPathIfNecessary();
 bool isPdfLatexInstalled();
 
 // is the file a text file

--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -462,17 +462,31 @@
       FALSE
 })
 
+.rs.addFunction("tinytexRoot", function()
+{
+   sysname <- Sys.info()[["sysname"]]
+   if (sysname == "Windows")
+      file.path(Sys.getenv("APPDATA"), "TinyTeX")
+   else if (sysname == "Darwin")
+      "~/Library/TinyTeX"
+   else
+      "~/.TinyTeX"
+})
+
 .rs.addFunction("tinytexBin", function()
 {
-   if (!requireNamespace("tinytex", quietly = TRUE))
+   root <- tryCatch(
+      tinytex:::tinytex_root(),
+      error = function(e) .rs.tinytexRoot()
+   )
+   
+   if (!file.exists(root))
       return(NULL)
    
    # NOTE: binary directory has a single arch-specific subdir;
    # rather than trying to hard-code the architecture we just
    # infer it directly
-   root <- tinytex:::tinytex_root()
    bin <- file.path(root, "bin")
    subbin <- list.files(bin, full.names = TRUE)
-   subbin[[1]]
-   
+   normalizePath(subbin[[1]], mustWork = TRUE)
 })

--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -462,4 +462,17 @@
       FALSE
 })
 
-
+.rs.addFunction("tinytexBin", function()
+{
+   if (!requireNamespace("tinytex", quietly = TRUE))
+      return(NULL)
+   
+   # NOTE: binary directory has a single arch-specific subdir;
+   # rather than trying to hard-code the architecture we just
+   # infer it directly
+   root <- tinytex:::tinytex_root()
+   bin <- file.path(root, "bin")
+   subbin <- list.files(bin, full.names = TRUE)
+   subbin[[1]]
+   
+})

--- a/src/cpp/session/modules/tex/SessionCompilePdf.cpp
+++ b/src/cpp/session/modules/tex/SessionCompilePdf.cpp
@@ -596,6 +596,9 @@ private:
       if (error)
          LOG_ERROR(error);
 
+      // add tinytex to the PATH if appropriate
+      module_context::addTinytexToPathIfNecessary();
+
       // determine tex program path
       std::string userErrMsg;
       if (!pdflatex::latexProgramForFile(magicComments_,

--- a/src/gwt/src/org/rstudio/core/client/widget/InfoBar.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/InfoBar.java
@@ -142,6 +142,14 @@ public class InfoBar extends Composite
       }));
    }
    
+   public void showTexInstallationMissingWarning(String message,
+                                                 Command onInstall)
+   {
+      setText(message);
+      labelRight_.clear();
+      labelRight_.add(label("Install TinyTeX", () -> { onInstall.execute(); }));
+   }
+   
    public void showReadOnlyWarning(List<String> alternatives)
    {
       if (alternatives.size() == 0)

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -484,6 +484,20 @@ public class DependencyManager implements InstallShinyEvent.Handler,
             (Boolean success) -> { if (success) command.execute(); });
    }
    
+   public void withTinyTeX(final String progressCaption,
+                           final String userPrompt,
+                           final Command command)
+   {
+      withDependencies(
+            progressCaption,
+            userPrompt,
+            new Dependency[] {
+                  Dependency.cranPackage("tinytex", "0.16")
+            },
+            true,
+            (Boolean success) -> { if (success) command.execute(); });
+   }
+   
    @Override
    public void onPackageStateChanged(PackageStateChangedEvent event)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.java
@@ -316,6 +316,12 @@ public class CodeBrowserEditingTargetWidget extends ResizeComposite
    }
    
    @Override
+   public void showTexInstallationMissingWarning(String message)
+   {
+      // no-op for code browser targets
+   }
+   
+   @Override
    public void showWarningBar(final String warning)
    {
       showWarningImpl(() -> warningBar_.setText(warning));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1252,6 +1252,24 @@ public class TextEditingTarget implements
       view_.showRequiredPackagesMissingWarning(packages);
    }
    
+   public void showTexInstallationMissingWarning(String message)
+   {
+      view_.showTexInstallationMissingWarning(message);
+   }
+   
+   public void installTinyTeX()
+   {
+      Command onInstall = () -> {
+         String code = "tinytex::install_tinytex()";
+         events_.fireEvent(new SendToConsoleEvent(code, true));
+      };
+      
+      dependencyManager_.withTinyTeX(
+            "Installing tinytex",
+            "Installing TinyTeX",
+            onInstall);
+   }
+   
    private void jumpToPreviousFunction()
    {
       Scope jumpTo = scopeHelper_.getPreviousFunction(

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCompilePdfHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCompilePdfHelper.java
@@ -215,12 +215,12 @@ public class TextEditingTargetCompilePdfHelper
                {
                   String warning;
                   if (Desktop.isDesktop())
-                     warning = "No TeX installation detected. Please install " +
-                               "TeX before compiling.";
+                     warning = "No LaTeX installation detected. Please install " +
+                               "LaTeX before compiling.";
                   else
-                     warning = "This server does not have TeX installed. You " +
+                     warning = "This server does not have LaTeX installed. You " +
                                "may not be able to compile.";
-                  display.showWarningBar(warning);
+                  display.showTexInstallationMissingWarning(warning);
                }
                else if (checkForRnwWeave && 
                         !response.isRnwWeaveAvailable(fRnwWeave))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -959,6 +959,19 @@ public class TextEditingTargetWidget
    }
    
    @Override
+   public void showTexInstallationMissingWarning(String message)
+   {
+      final Command install = () -> {
+         target_.installTinyTeX();
+         hideWarningBar();
+      };
+      
+      showWarningImpl(() -> {
+         warningBar_.showTexInstallationMissingWarning(message, install);
+      });
+   }
+   
+   @Override
    public void showWarningBar(final String warning)
    {
       showWarningImpl(() -> warningBar_.setText(warning));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/WarningBarDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/WarningBarDisplay.java
@@ -22,6 +22,7 @@ public interface WarningBarDisplay extends IsWidget
 {
    void showReadOnlyWarning(List<String> alternatives);
    void showRequiredPackagesMissingWarning(List<String> packages);
+   void showTexInstallationMissingWarning(String message);
    void showWarningBar(String message);
    void hideWarningBar();
 }


### PR DESCRIPTION
Closes #2788.

This PR adds some UI for installing the `tinytex` package, and uses that to call `tinytex::install_tinytex()`.

<img width="450" alt="Screen Shot 2019-09-30 at 4 38 44 PM" src="https://user-images.githubusercontent.com/1976582/65924485-d12ae580-e3a1-11e9-91ec-bd45ed19c262.png">

After running that, documents that need to be compiled to PDF (both `.Rnw` and `.Rmd`) should be able to be compiled successfully.

Some open thoughts:

1. Should we provide a modal dialog before starting the install? It could be a place where we could explain "what is tinytex?" and also provide a help link or similar.

2. We might also want to ensure this warning bar shows up when using an R Markdown document that will be compiled to PDF.