### PR TITLE
warn when Xcode license has not been accepted

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -1467,9 +1467,9 @@ void GwtCallback::reloadViewerZoomWindow(QString url)
       pBrowser->webView()->setUrl(url);
 }
 
-bool GwtCallback::isOSXMavericks()
+bool GwtCallback::isMacOS()
 {
-   return desktop::isOSXMavericks();
+   return desktop::isMacOS();
 }
 
 bool GwtCallback::isCentOS()

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -243,7 +243,7 @@ public Q_SLOTS:
 
    QString getScrollingCompensationType();
 
-   bool isOSXMavericks();
+   bool isMacOS();
    bool isCentOS();
 
    void setBusy(bool busy);

--- a/src/cpp/desktop/DesktopUtils.cpp
+++ b/src/cpp/desktop/DesktopUtils.cpp
@@ -90,7 +90,7 @@ double devicePixelRatio(QMainWindow* pMainWindow)
    return 1.0;
 }
 
-bool isOSXMavericks()
+bool isMacOS()
 {
    return false;
 }

--- a/src/cpp/desktop/DesktopUtils.hpp
+++ b/src/cpp/desktop/DesktopUtils.hpp
@@ -43,7 +43,7 @@ rstudio::core::FilePath userWebCachePath();
 double devicePixelRatio(QMainWindow* pMainWindow);
 
 bool isWindows();
-bool isOSXMavericks();
+bool isMacOS();
 bool isCentOS();
 bool isGnomeDesktop();
 

--- a/src/cpp/desktop/DesktopUtilsMac.mm
+++ b/src/cpp/desktop/DesktopUtilsMac.mm
@@ -79,19 +79,9 @@ double devicePixelRatio(QMainWindow* pMainWindow)
    }
 }
 
-bool isOSXMavericks()
+bool isMacOS()
 {
-   NSDictionary *systemVersionDictionary =
-       [NSDictionary dictionaryWithContentsOfFile:
-           @"/System/Library/CoreServices/SystemVersion.plist"];
-
-   NSString *systemVersion =
-       [systemVersionDictionary objectForKey:@"ProductVersion"];
-
-   std::string version(
-         [systemVersion cStringUsingEncoding:NSASCIIStringEncoding]);
-
-   return boost::algorithm::starts_with(version, "10.9");
+   return true;
 }
 
 bool isCentOS()

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -2488,6 +2488,46 @@ in a terminal to accept the Xcode license, and then restart RStudio.
 
 } // end anonymous namespace
 
+bool isMacOS()
+{
+#ifdef __APPLE__
+   return true;
+#else
+   return false;
+#endif
+}
+
+bool hasMacOSDeveloperTools()
+{
+   if (!isMacOS())
+      return false;
+   
+   core::system::ProcessResult result;
+   Error error = core::system::runCommand(
+            "/usr/bin/xcrun --find --show-sdk-path",
+            core::system::ProcessOptions(),
+            &result);
+
+   if (error)
+   {
+      LOG_ERROR(error);
+      return false;
+   }
+
+   if (result.exitStatus == 69)
+      checkXcodeLicense();
+
+   return result.exitStatus == 0;
+}
+
+bool hasMacOSCommandLineTools()
+{
+   if (!isMacOS())
+      return false;
+   
+   return FilePath("/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk").exists();
+}
+
 void checkXcodeLicense()
 {
 #ifdef __APPLE__

--- a/src/cpp/session/SessionModuleContext.mm
+++ b/src/cpp/session/SessionModuleContext.mm
@@ -34,28 +34,6 @@ namespace rstudio {
 namespace session {
 namespace module_context {
 
-bool isMacOS()
-{
-   return true;
-}
-
-bool hasMacOSDeveloperTools()
-{
-   if (isMacOS())
-   {
-      // NOTE: From what I can tell, there isn't a reliable way of
-      // detecting whether command line tools vs. Xcode is installed
-      // on a machine. For that reason, we just check the common
-      // developer tools path, and assume most R users won't adjust it.
-      FilePath devtoolsPath("/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk");
-      return devtoolsPath.exists();
-   }
-   else
-   {
-      return false;
-   }
-}
-
 Error copyImageToCocoaPasteboard(const FilePath& imagePath)
 {
    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];

--- a/src/cpp/session/SessionModuleContext.mm
+++ b/src/cpp/session/SessionModuleContext.mm
@@ -34,38 +34,21 @@ namespace rstudio {
 namespace session {
 namespace module_context {
 
-bool isOSXMavericks()
+bool isMacOS()
 {
-   NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-
-   NSDictionary *systemVersionDictionary =
-       [NSDictionary dictionaryWithContentsOfFile:
-           @"/System/Library/CoreServices/SystemVersion.plist"];
-
-   NSString *systemVersion =
-       [systemVersionDictionary objectForKey:@"ProductVersion"];
-
-   std::string version(
-         [systemVersion cStringUsingEncoding:NSASCIIStringEncoding]);
-
-   [pool release];
-
-   return boost::algorithm::starts_with(version, "10.9") ||
-          boost::algorithm::starts_with(version, "10.10");
+   return true;
 }
 
-bool hasOSXMavericksDeveloperTools()
+bool hasMacOSDeveloperTools()
 {
-   if (isOSXMavericks())
+   if (isMacOS())
    {
-      core::system::ProcessResult result;
-      Error error = core::system::runCommand("xcode-select -p",
-                                             core::system::ProcessOptions(),
-                                             &result);
-      if (!error && (result.exitStatus == EXIT_SUCCESS))
-         return true;
-      else
-         return false;
+      // NOTE: From what I can tell, there isn't a reliable way of
+      // detecting whether command line tools vs. Xcode is installed
+      // on a machine. For that reason, we just check the common
+      // developer tools path, and assume most R users won't adjust it.
+      FilePath devtoolsPath("/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk");
+      return devtoolsPath.exists();
    }
    else
    {

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -485,16 +485,18 @@ bool addRtoolsToPathIfNecessary(std::string* pPath,
 bool addRtoolsToPathIfNecessary(core::system::Options* pEnvironment,
                                 std::string* pWarningMessage);
 
+void checkXcodeLicense();
+
 #ifdef __APPLE__
-bool isOSXMavericks();
-bool hasOSXMavericksDeveloperTools();
+bool isMacOS();
+bool hasMacOSDeveloperTools();
 core::Error copyImageToCocoaPasteboard(const core::FilePath& filePath);
 #else
-inline bool isOSXMavericks()
+inline bool isMacOS()
 {
    return false;
 }
-inline bool hasOSXMavericksDeveloperTools()
+inline bool hasMacOSDeveloperTools()
 {
    return false;
 }

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -485,21 +485,14 @@ bool addRtoolsToPathIfNecessary(std::string* pPath,
 bool addRtoolsToPathIfNecessary(core::system::Options* pEnvironment,
                                 std::string* pWarningMessage);
 
+bool isMacOS();
+bool hasMacOSDeveloperTools();
+bool hasMacOSCommandLineTools();
 void checkXcodeLicense();
 
 #ifdef __APPLE__
-bool isMacOS();
-bool hasMacOSDeveloperTools();
 core::Error copyImageToCocoaPasteboard(const core::FilePath& filePath);
 #else
-inline bool isMacOS()
-{
-   return false;
-}
-inline bool hasMacOSDeveloperTools()
-{
-   return false;
-}
 inline core::Error copyImageToCocoaPasteboard(const core::FilePath& filePath)
 {
    return core::systemError(boost::system::errc::not_supported, ERROR_LOCATION);

--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -533,24 +533,7 @@ FilePath detectedSvnExePath()
       return FilePath();
    }
 #else
-   FilePath svnExeFilePath = whichSvnExe();
-   if (!svnExeFilePath.empty())
-   {
-      // extra check on mavericks to make sure it's not the fake svn
-      if (module_context::isMacOS())
-      {
-         if (module_context::hasMacOSDeveloperTools())
-            return FilePath(svnExeFilePath);
-         else
-            return FilePath();
-      }
-      else
-      {
-         return FilePath(svnExeFilePath);
-      }
-   }
-   else
-      return FilePath();
+   return whichSvnExe();
 #endif
 }
 

--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -229,6 +229,11 @@ Error runSvn(const ShellArgs& args,
    if (pExitCode)
       *pExitCode = result.exitStatus;
 
+#ifdef __APPLE__
+   if (result.exitStatus == 69)
+      module_context::checkXcodeLicense();
+#endif
+   
    return Success();
 }
 
@@ -428,14 +433,6 @@ Error parseXml(const std::string strData,
 
 bool isSvnInstalled()
 {
-   // special check on osx mavericks to make sure we don't run the fake svn
-   if (module_context::isOSXMavericks() &&
-       !module_context::hasOSXMavericksDeveloperTools() &&
-       whichSvnExe().empty())
-   {
-      return false;
-   }
-
    int exitCode;
    Error error = runSvn(ShellArgs() << "help", nullptr, nullptr, &exitCode);
 
@@ -540,9 +537,9 @@ FilePath detectedSvnExePath()
    if (!svnExeFilePath.empty())
    {
       // extra check on mavericks to make sure it's not the fake svn
-      if (module_context::isOSXMavericks())
+      if (module_context::isMacOS())
       {
-         if (module_context::hasOSXMavericksDeveloperTools())
+         if (module_context::hasMacOSDeveloperTools())
             return FilePath(svnExeFilePath);
          else
             return FilePath();

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -2019,17 +2019,15 @@ SEXP rs_installBuildTools()
 
 SEXP rs_installBuildTools()
 {
-   if (module_context::isOSXMavericks())
+   if (module_context::isMacOS())
    {
-      if (!module_context::hasOSXMavericksDeveloperTools())
+      if (!module_context::hasMacOSDeveloperTools())
       {
-         // on mavericks we just need to invoke clang and the user will be
-         // prompted to install the command line tools
          core::system::ProcessResult result;
-         Error error = core::system::runCommand("clang --version",
-                                                "",
-                                                core::system::ProcessOptions(),
-                                                &result);
+         Error error = core::system::runCommand(
+                  "/usr/bin/xcode-select --install",
+                  core::system::ProcessOptions(),
+                  &result);
          if (error)
             LOG_ERROR(error);
       }
@@ -2119,7 +2117,7 @@ void onDeferredInit(bool newSession)
       // to clang if necessary
       using namespace module_context;
       FilePath makevarsPath = userHomePath().childPath(".R/Makevars");
-      if (isOSXMavericks() && !makevarsPath.exists() && !canBuildCpp())
+      if (isMacOS() && !makevarsPath.exists() && !canBuildCpp())
       {
          Error error = makevarsPath.parent().ensureDirectory();
          if (!error)
@@ -2205,9 +2203,9 @@ bool canBuildCpp()
       return true;
    
 #ifdef __APPLE__
-   if (isOSXMavericks() &&
+   if (isMacOS() &&
        usingSystemMake() &&
-       !hasOSXMavericksDeveloperTools())
+       !hasMacOSDeveloperTools())
    {
       return false;
    }
@@ -2253,7 +2251,10 @@ bool canBuildCpp()
    }
 
    if (result.exitStatus != EXIT_SUCCESS)
+   {
+      checkXcodeLicense();
       return false;
+   }
    
    s_canBuildCpp = true;
    return true;

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -2021,7 +2021,7 @@ SEXP rs_installBuildTools()
 {
    if (module_context::isMacOS())
    {
-      if (!module_context::hasMacOSDeveloperTools())
+      if (!module_context::hasMacOSCommandLineTools())
       {
          core::system::ProcessResult result;
          Error error = core::system::runCommand(

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -2201,11 +2201,15 @@ bool canBuildCpp()
 {
    if (s_canBuildCpp)
       return true;
-   
+
 #ifdef __APPLE__
+   // NOTE: on macOS, R normally requests user install and use its own
+   // LLVM toolchain; however, that toolchain still needs to re-use
+   // system headers provided by the default macOS toolchain, and so
+   // we still want to check for macOS command line tools here
    if (isMacOS() &&
        usingSystemMake() &&
-       !hasMacOSDeveloperTools())
+       !hasMacOSCommandLineTools())
    {
       return false;
    }


### PR DESCRIPTION
Closes #5481.

If the Xcode license has not been agreed to, and RStudio attempts to take some action with Git / SVN, then RStudio will print the following warning:

![Screen Shot 2019-10-01 at 4 09 28 PM](https://user-images.githubusercontent.com/1976582/66007376-03eae180-e467-11e9-8597-34a787ac36bb.png)

This should hopefully help users struggling with "where's my Git pane?" after macOS / Xcode updates.

This PR also cleans up some usages of isOSXMavericks that we had from before. Now that we only support macOS 10.12 and above and the old days of `llvm-gcc-4.2` are behind us, we can drop some of the old code and simply check if we're running on macOS.