### PR TITLE
Check for usage of remotes package-based installation

### DIFF
--- a/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
+++ b/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
@@ -222,7 +222,8 @@ void onConsoleInput(const std::string& input)
       "remove.packages",
       "utils::remove.packages",
       "install_github",
-      "devtools::install_github",
+      "devtools::install_",
+      "remotes::install_",
       "load_all",
       "devtools::load_all",
    };

--- a/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
+++ b/src/cpp/session/modules/SessionPackageProvidedExtension.cpp
@@ -217,15 +217,23 @@ void onConsoleInput(const std::string& input)
       return;
    
    static const char* const commands[] = {
-      "install.packages",
-      "utils::install.packages",
-      "remove.packages",
-      "utils::remove.packages",
-      "install_github",
       "devtools::install_",
-      "remotes::install_",
-      "load_all",
       "devtools::load_all",
+      "install.packages",
+      "install_github",
+      "load_all",
+      "pak::pkg_install",
+      "pak::pkg_remove",
+      "pkg_install",
+      "pkg_remove",
+      "remotes::install_",
+      "remove.packages",
+      "renv::install",
+      "renv::rebuild",
+      "renv::remove",
+      "renv::restore",
+      "utils::install.packages",
+      "utils::remove.packages",
    };
    
    std::string inputTrimmed = boost::algorithm::trim_copy(input);


### PR DESCRIPTION
This change adds installations from the `remotes` package to those watched for to trigger a reindex. It also makes the trigger more broad (to catch both devtools and remotes usages of `install_git`, `install_bitbucket`, `install_gitlab`, etc.)