### PR TITLE
A11y: fix focus selectors overriding focus-visible

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/FileDialogStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/FileDialogStyles.css
@@ -236,7 +236,7 @@ body.windows .breadcrumb table.path span {
    margin-top: 0px;
 }
 
-button.browse:focus {
+button.browse:focus:not(.focus-visible) {
    outline:0;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBase.css
+++ b/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBase.css
@@ -62,7 +62,7 @@
    padding: 6px 2px 4px 2px;
 }
 
-.section:focus {
+.section:focus:not(.focus-visible) {
    outline:none;
 }
 
@@ -75,7 +75,7 @@
    background: #D6E9F8;
 }
 
-.activeSection:focus {
+.activeSection:focus:not(.focus-visible) {
    outline:none;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/resources/styles.css
+++ b/src/gwt/src/org/rstudio/core/client/resources/styles.css
@@ -76,7 +76,7 @@
    color: #0000AA;
 }
 
-.rstudio-HyperlinkLabel:focus {
+.rstudio-HyperlinkLabel:focus:not(.focus-visible) {
    outline: none;
 }
 
@@ -92,7 +92,7 @@
    background-color: transparent;
 }
 
-.rstudio-HelpButton:focus {
+.rstudio-HelpButton:focus:not(.focus-visible) {
    outline:none;
 }
 
@@ -103,7 +103,7 @@
    background-color: transparent;
 }
 
-.rstudio-ImageButton:focus {
+.rstudio-ImageButton:focus:not(.focus-visible) {
    outline:none;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1312,7 +1312,7 @@ body.windows .toolbar {
    overflow: hidden;
 }
 
-.toolbarButton:focus {
+.toolbarButton:focus:not(.focus-visible) {
    outline: none;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/widget/ShortcutInfoPanel.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/ShortcutInfoPanel.ui.xml
@@ -34,7 +34,7 @@
      width: 100%;
    }
    
-   .shortcutPanel:focus 
+   .shortcutPanel:focus:not(.focus-visible)
    {
      outline:none
    }

--- a/src/gwt/src/org/rstudio/core/client/widget/WidgetListBox.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/WidgetListBox.css
@@ -29,7 +29,7 @@
    -webkit-box-sizing: border-box;
 }
 
-.outerPanel:focus
+.outerPanel:focus:not(.focus-visible)
 {
    outline: none;
 }
@@ -42,7 +42,7 @@
    width: 100%;
 }
 
-.listPanel:focus
+.listPanel:focus:not(.focus-visible)
 {
    outline: none;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/Wizard.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/Wizard.css
@@ -83,7 +83,7 @@
    background: #DAE7F6;
 }
 
-.wizardPageSelectorItem:focus {
+.wizardPageSelectorItem:focus:not(.focus-visible) {
    outline: none;
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.css
@@ -40,7 +40,7 @@
    cursor: default;
 }
 
-.objectGrid td:focus
+.objectGrid td:focus:not(.focus-visible)
 {
    outline: none;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
@@ -6,7 +6,7 @@
    <ui:style>
       @external .gwt-TextBox;
 
-      .panel input[type=checkbox]{
+      .panel input[type=checkbox] {
          margin-left: 0;
       }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
@@ -6,11 +6,11 @@
    <ui:style>
       @external .gwt-TextBox;
 
-      .panel input[type=checkbox] {
+      .panel input[type=checkbox]{
          margin-left: 0;
       }
 
-      .panel input:focus {
+      .panel input:focus:not(.focus-visible) {
          outline: none;
       }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputGallery.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputGallery.ui.xml
@@ -24,7 +24,7 @@ xmlns:g="urn:import:com.google.gwt.user.client.ui">
    opacity: 1;
 }
 
-.thumbnail:focus {
+.thumbnail:focus:not(.focus-visible) {
    outline: none;
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/xterm.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/xterm.css
@@ -44,7 +44,7 @@
 }
 
 .xterm.focus,
-.xterm:focus {
+.xterm:focus:not(.focus-visible) {
     outline: none;
 }
 

--- a/src/gwt/www/css/focus-visible.css
+++ b/src/gwt/www/css/focus-visible.css
@@ -12,5 +12,5 @@
 
 .js-focus-visible .focus-visible, input[type="checkbox"].focus-visible {
     outline: goldenrod solid 2px;
-    outline-offset: -2px;
+    outline-offset: -1px;
 }


### PR DESCRIPTION
Fixes #5460 

![wqV0zgb](https://user-images.githubusercontent.com/136863/66345942-152c6600-e91f-11e9-8929-a7e03ddd8d3e.png)

![jPJRlNg](https://user-images.githubusercontent.com/136863/66345950-178ec000-e91f-11e9-9b14-843082b7a8d2.png)

@MariaSemple Lmk if I'm doing anything wrong with the CSS here, it seems like doing CSS3 selectors can be a bit tricky with GWT's parser (https://stackoverflow.com/questions/3479636/how-to-get-gwt-cssresource-to-parse-not-selectors/7647867 couldn't get this to work though) so I pared down my changes to things that didn't throw errors.