### PR TITLE
prevent focus bounce in modal dialogs (was confusing screen readers)

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -209,13 +209,6 @@ public abstract class ModalDialogBase extends DialogBox
    {
       refreshFocusableElements();
       focusInitialControl();
-      
-      // try hard to make sure focus ends up in dialog
-      Element focused = DomUtils.getActiveElement();
-      if (focused == null || !DomUtils.contains(getElement(), focused))
-      {
-        focusFirstControl();
-      }
    }
 
    protected void addOkButton(ThemedButton okButton, String elementId)


### PR DESCRIPTION
- in alert dialogs (e.g. Yes / No dialogs), focus was being put on the first focusable control in the dialog, then being moved to the default button via a deferred setFocus
- if the default button isn't the first control, this rapid-fire change of focus when opening the dialog causes screen readers to often stop reading the dialog's alert text
- remove that secondary just-in-case focus setting; it is doing more harm than good; better off discovering cases where focus isn't being set and fixing them than confusing the screen readers

For example, in this dialog, often all the screen reader would say when the alert displays is "No, button", instead of having the whole dialog read out, especially with VoiceOver on macOS.

![2019-10-07_13-22-52](https://user-images.githubusercontent.com/10569626/66346583-49942800-e907-11e9-943a-5367b5c821bd.png)
