### PR TITLE
Fix an issue where the configured local path is sometimes ignored.

### DIFF
--- a/src/cpp/session/modules/SessionThemes.R
+++ b/src/cpp/session/modules/SessionThemes.R
@@ -778,7 +778,7 @@
    }
    else if (.rs.isLocalTheme(decodedUrl))
    {
-      file.path(.rs.getThemeInstallDir(FALSE), basename(decodedUrl))
+      .Call("rs_getLocalThemePath", basename(decodedUrl), PACKAGE="(embedding)")
    }
    else
    {


### PR DESCRIPTION
### The Problem
There are currently multiple locations in which we check for the existence of a local custom theme, and depending on which one you look at a particular theme may or may not be found. Global themes, custom or default, are working correctly - we only have issues with local custom themes.

In [getAllThemes](https://github.com/rstudio/rstudio/blob/master/src/cpp/session/modules/SessionThemes.cpp#L283-L307) we get:

1. default global themes (the ones we ship with)
2. custom global themes, from either
  a. the default custom location (/etc/rstudio/themes on linux), OR
  b. the env variable custom location (`RS_GLOBAL_THEME_HOME`)
3. the local custom themes, either from:
  a. the current default custom location AND the legacy custom location, OR
  b. the env variable custom location (`RS_LOCAL_THEME_HOME`)

In [handleLocalCustomThemeRequest](https://github.com/rstudio/rstudio/blob/master/src/cpp/session/modules/SessionThemes.cpp#L580-L597) we check:
1. the local custom theme location.
2. the legacy local custom theme location, if the theme was not found in 1.

In [.rs.addTheme](https://github.com/rstudio/rstudio/blob/master/src/cpp/session/modules/SessionThemes.R#L844-L940) we:
1. call getAllThemes to see if the theme has been officially added.
2. call getThemeInstallDir, which calls [rs_getLocalThemeDir](https://github.com/rstudio/rstudio/blob/master/src/cpp/session/modules/SessionThemes.cpp#L643-L647), which just returns the new local custom theme dir.
3. Check whether a file with the same name exists in the location returned by 2, to avoid overwriting a file which is not a valid theme but still has the same name.

### The Solution
For getting installed themes, we want to:
1. Check if there's a configured local theme location (`RS_LOCAL_THEME_HOME`).
a. if yes, check only that location.
b. if no, check first in the new XDG location, then check the legacy location.

For adding a new theme, we only want to be sure there isn't a conflicting file in the new XDG location or the env location, if configured, because we don't want to add files to the legacy location.

This presents a problem with removing a theme - we look up the location of the file the same way as adding a theme, but we want to be able to remove themes that were added to the legacy location. To fix this, I added a new `rs_getLocalThemePath` which takes the filename as a parameter, and looks for the theme file in the same way as we would when we're getting the full list of themes.

