### PR TITLE
Support the ability to disable tab-based autocompleted in user preferences.

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -95,6 +95,7 @@ namespace prefs {
 #define kInsertSpacesAroundEquals "insert_spaces_around_equals"
 #define kInsertParensAfterFunctionCompletion "insert_parens_after_function_completion"
 #define kTabMultilineCompletion "tab_multiline_completion"
+#define kTabCompletion "tab_completion"
 #define kShowHelpTooltipOnIdle "show_help_tooltip_on_idle"
 #define kSurroundSelection "surround_selection"
 #define kSurroundSelectionNever "never"
@@ -502,6 +503,12 @@ public:
     */
    bool tabMultilineCompletion();
    core::Error setTabMultilineCompletion(bool val);
+
+   /**
+    * Whether to attempt completion of statements when pressing Tab.
+    */
+   bool tabCompletion();
+   core::Error setTabCompletion(bool val);
 
    /**
     * Whether to show help tooltips for functions when the cursor has not been recently moved.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -466,6 +466,19 @@ core::Error UserPrefValues::setTabMultilineCompletion(bool val)
 }
 
 /**
+ * Whether to attempt completion of statements when pressing Tab.
+ */
+bool UserPrefValues::tabCompletion()
+{
+   return readPref<bool>("tab_completion");
+}
+
+core::Error UserPrefValues::setTabCompletion(bool val)
+{
+   return writePref("tab_completion", val);
+}
+
+/**
  * Whether to show help tooltips for functions when the cursor has not been recently moved.
  */
 bool UserPrefValues::showHelpTooltipOnIdle()
@@ -2231,6 +2244,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kInsertSpacesAroundEquals,
       kInsertParensAfterFunctionCompletion,
       kTabMultilineCompletion,
+      kTabCompletion,
       kShowHelpTooltipOnIdle,
       kSurroundSelection,
       kEnableSnippets,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -254,6 +254,11 @@
             "default": false,
             "description": "Whether to attempt completion of multiple-line statements when pressing Tab."
         },
+        "tab_completion": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether to attempt completion of statements when pressing Tab."
+        },
         "show_help_tooltip_on_idle": {
             "type": "boolean",
             "default": false,

--- a/src/gwt/src/org/rstudio/core/rebind/command/ShortcutsEmitter.java
+++ b/src/gwt/src/org/rstudio/core/rebind/command/ShortcutsEmitter.java
@@ -245,6 +245,8 @@ public class ShortcutsEmitter
          return "com.google.gwt.event.dom.client.KeyCodes.KEY_PAGEUP";
       if (val.equalsIgnoreCase("pagedown"))
          return "com.google.gwt.event.dom.client.KeyCodes.KEY_PAGEDOWN";
+      if (val.equalsIgnoreCase("space"))
+         return "32";
       if (val.equalsIgnoreCase("F1"))
          return "112";
       if (val.equalsIgnoreCase("F2"))
@@ -285,6 +287,8 @@ public class ShortcutsEmitter
          return "219";
       if (val.equals("]"))
          return "221";
+
+      logger_.log(Type.WARN, "Returning null from toKeyCode for key " + val);
       return null;
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -794,7 +794,7 @@ well as menu structures (for main menu and popup menus).
       <shortcutgroup name="Other">
          <shortcut value="F1" title="Show Function Help" />
          <shortcut value="F2" title="Go To Function / File"/>
-         <shortcut value="Tab" title="Complete Code" />
+         <shortcut value="Tab|Ctrl+Space" title="Complete Code" />
          <shortcut refid="quitSession" value="Cmd+Q" if="org.rstudio.studio.client.application.Desktop.isDesktop()"/>
          <shortcut refid="restartR" value="Meta+Shift+0" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="restartR" value="Cmd+Shift+F10"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -401,6 +401,14 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Whether to attempt code completion when Tab is pressed.
+    */
+   public PrefValue<Boolean> tabCompletion()
+   {
+      return bool("tab_completion", true);
+   }
+
+   /**
     * Whether to show help tooltips for functions when the cursor has not been recently moved.
     */
    public PrefValue<Boolean> showHelpTooltipOnIdle()
@@ -1635,6 +1643,8 @@ public class UserPrefsAccessor extends Prefs
          insertParensAfterFunctionCompletion().setValue(layer, source.getBool("insert_parens_after_function_completion"));
       if (source.hasKey("tab_multiline_completion"))
          tabMultilineCompletion().setValue(layer, source.getBool("tab_multiline_completion"));
+      if (source.hasKey("tab_completion"))
+         tabCompletion().setValue(layer, source.getBool("tab_completion"));
       if (source.hasKey("show_help_tooltip_on_idle"))
          showHelpTooltipOnIdle().setValue(layer, source.getBool("show_help_tooltip_on_idle"));
       if (source.hasKey("surround_selection"))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -401,7 +401,7 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
-    * Whether to attempt code completion when Tab is pressed.
+    * Whether to attempt completion of statements when pressing Tab.
     */
    public PrefValue<Boolean> tabCompletion()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -359,6 +359,7 @@ public class EditingPreferencesPane extends PreferencesPane
 
       completionPanel.add(checkboxPref("Show help tooltip on cursor idle", prefs.showHelpTooltipOnIdle()));
       completionPanel.add(checkboxPref("Insert spaces around equals for argument completions", prefs.insertSpacesAroundEquals()));
+      completionPanel.add(checkboxPref("Use tab for autocompletions", prefs.tabCompletion()));
       completionPanel.add(checkboxPref("Use tab for multiline autocompletions", prefs.tabMultilineCompletion()));
       
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
@@ -711,6 +711,10 @@ public abstract class CompletionManagerBase
    
    private boolean onTab()
    {
+      // Don't auto complete if tab auto completion was disabled
+      if (!userPrefs_.tabCompletion().getValue())
+         return false;
+
       // if the line is blank, don't request completions unless
       // the user has explicitly opted in
       String line = docDisplay_.getCurrentLineUpToCursor();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1138,6 +1138,12 @@ public class RCompletionManager implements CompletionManager
                                 boolean canAutoInsert)
    {
       suggestTimer_.cancel();
+
+      // Don't auto complete if tab was pressed and tab completion was disabled.
+      if (nativeEvent_ != null &&
+              nativeEvent_.getKeyCode() == KeyCodes.KEY_TAB &&
+              !userPrefs_.tabCompletion().getValue())
+         return false;
       
       if (!input_.isSelectionCollapsed())
          return false ;
@@ -1802,8 +1808,9 @@ public class RCompletionManager implements CompletionManager
                   (nativeEvent_ != null && nativeEvent_.getKeyCode() == KeyCodes.KEY_TAB);
             
             boolean lineIsWhitespace = docDisplay_.getCurrentLine().matches("^\\s*$");
-            
-            if (lastInputWasTab && lineIsWhitespace)
+
+            // Insert tab if tab auto completion was disabled or the line is all whitespace.
+            if (lastInputWasTab && (lineIsWhitespace || !userPrefs_.tabCompletion().getValue()))
             {
                docDisplay_.insertCode("\t");
                return;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -46,7 +46,12 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 
 import org.rstudio.core.client.*;
-import org.rstudio.core.client.command.*;
+import org.rstudio.core.client.command.AppCommand;
+import org.rstudio.core.client.command.Handler;
+import org.rstudio.core.client.command.KeyCombination;
+import org.rstudio.core.client.command.KeyboardShortcut;
+import org.rstudio.core.client.command.KeySequence;
+import org.rstudio.core.client.command.ShortcutManager;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.events.*;
 import org.rstudio.core.client.files.FileSystemItem;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -46,10 +46,7 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 
 import org.rstudio.core.client.*;
-import org.rstudio.core.client.command.AppCommand;
-import org.rstudio.core.client.command.Handler;
-import org.rstudio.core.client.command.KeyboardShortcut;
-import org.rstudio.core.client.command.ShortcutManager;
+import org.rstudio.core.client.command.*;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.events.*;
 import org.rstudio.core.client.files.FileSystemItem;
@@ -398,7 +395,16 @@ public class Source implements InsertSourceHandler,
       // fake shortcuts for commands which we handle at a lower level
       commands.goToHelp().setShortcut(new KeyboardShortcut("F1", KeyCodes.KEY_F1, KeyboardShortcut.NONE));
       commands.goToDefinition().setShortcut(new KeyboardShortcut("F2", KeyCodes.KEY_F2, KeyboardShortcut.NONE));
-      commands.codeCompletion().setShortcut(new KeyboardShortcut("Tab", KeyCodes.KEY_TAB, KeyboardShortcut.NONE));
+
+      // If tab has been disabled for auto complete by the user, set the "shortcut" to ctrl-space instead.
+      if (userPrefs_.tabCompletion().getValue())
+         commands.codeCompletion().setShortcut(new KeyboardShortcut("Tab", KeyCodes.KEY_TAB, KeyboardShortcut.NONE));
+      else
+      {
+         KeySequence sequence = new KeySequence();
+         sequence.add(new KeyCombination("Ctrl+Space", KeyCodes.KEY_SPACE, KeyCodes.KEY_CTRL));
+         commands.codeCompletion().setShortcut(new KeyboardShortcut(sequence));
+      }
       
       events.addHandler(ShowContentEvent.TYPE, this);
       events.addHandler(ShowDataEvent.TYPE, this);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -191,25 +191,29 @@ public class AceEditor implements DocDisplay,
    {
       public boolean shouldComplete(NativeEvent event)
       {
-         // Never complete if there's an active selection
+         // Never complete if there's an active selection.
          Range range = getSession().getSelection().getRange();
          if (!range.isEmpty())
             return false;
 
-         // Don't consider Tab to be a completion if we're at the start of a
-         // line (e.g. only zero or more whitespace characters between the
-         // beginning of the line and the cursor)
+         // If the user explicitly requested an auto-complete by pressing 'ctrl-space' instead of 'tab', always attempt auto-complete.
          if (event != null && event.getKeyCode() != KeyCodes.KEY_TAB)
             return true;
 
-         // Short-circuit if the user has explicitly opted in
+         // Tab was pressed. Don't attempt auto-complete if the user opted out of tab completions.
+         if (!userPrefs_.tabCompletion().getValue())
+            return false;
+
+         // If the user opted in to multi-line tab completion, there is no case where we don't attempt auto-complete.
          if (userPrefs_.tabMultilineCompletion().getValue())
             return true;
 
+         // Otherwise, don't complete if we're at the start of the line...
          int col = range.getStart().getColumn();
          if (col == 0)
             return false;
 
+         // ... or if there is nothing but whitespace between the start of the line and the cursor.
          String line = getSession().getLine(range.getStart().getRow());
          return line.substring(0, col).trim().length() != 0;
 


### PR DESCRIPTION
Some users find our auto-complete a little over-eager and wish they could disable tab-based auto-completion. This PR adds a user preference that lets user disable tab for auto-complete so that pressing tab will always insert a tab character. Unless the user in emacs mode, pressing `ctrl-space` will still initiate auto-completion, and pressing `shift-tab` after the start of a snippet will still initiate snippet completion.

![Screen Shot 2019-10-08 at 3 13 41 PM](https://user-images.githubusercontent.com/37987486/66437416-854df100-e9de-11e9-8bd7-b265770f5fea.png)

Fixes #2766 and part 1 of #5387.