### PR TITLE
add unique ids to several toolbar popup menu buttons for automation

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -48,7 +48,7 @@ public class ElementIds
    public static String idSafeString(String text)
    {
       // replace all non-alphanumerics with underscores
-      String id = text.replaceAll("[^a-zA-Z0-0]", "_");
+      String id = text.replaceAll("[^a-zA-Z0-9]", "_");
       
       // collapse multiple underscores to a single underscore
       id = id.replaceAll("_+", "_");
@@ -169,4 +169,18 @@ public class ElementIds
    public final static String TEXTBOXBUTTON_TEXT = "textboxbutton_text";
    public final static String TEXTBOXBUTTON_BUTTON = "textboxbutton_button";
    public final static String TEXTBOXBUTTON_HELP = "textboxbutton_help";
+
+   // TerminalPane
+   public final static String TERMINAL_DROPDOWN_MENUBUTTON = "terminal_dropdown_menubutton";
+
+   // GlobalToolbar
+   public final static String NEW_FILE_MENUBUTTON = "new_file_menubutton";
+   public final static String OPEN_MRU_MENUBUTTON = "open_mru_menubutton";
+   public final static String VCS_MENUBUTTON = "vcs_menubutton";
+   public final static String PANELAYOUT_MENUBUTTON = "panelayout_menubutton";
+   public final static String PROJECT_MENUBUTTON = "project_menubutton";
+
+   // BuildPane
+   public final static String BUILD_MORE_MENUBUTTON = "build_more_menubutton";
+   public final static String BUILD_BOOKDOWN_MENUBUTTON = "build_bookdown_menubutton";
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.application.ui;
 
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.widget.CanFocus;
@@ -78,6 +79,7 @@ public class GlobalToolbar extends Toolbar
                                                           "New File",
                                                           new ImageResource2x(icons.stock_new2x()),
                                                           newMenu_);
+      ElementIds.assignElementId(newButton, ElementIds.NEW_FILE_MENUBUTTON);
       addLeftWidget(newButton);
       addLeftSeparator();
       
@@ -110,10 +112,10 @@ public class GlobalToolbar extends Toolbar
                                                           "Open recent files", 
                                                           mruMenu, 
                                                           false);
+      ElementIds.assignElementId(mruButton, ElementIds.OPEN_MRU_MENUBUTTON);
       addLeftWidget(mruButton);
       addLeftSeparator();
-      
-      
+
       addLeftWidget(commands.saveSourceDoc().createToolbarButton());
       addLeftWidget(commands.saveAllSourceDocs().createToolbarButton());
       addLeftSeparator();
@@ -140,14 +142,7 @@ public class GlobalToolbar extends Toolbar
          @Override
          public void onCompleted()
          {
-            Scheduler.get().scheduleFinally(new ScheduledCommand()
-            {
-               @Override
-               public void execute()
-               {
-                  codeSearchFocusContext_.clear();
-               }
-            });
+            Scheduler.get().scheduleFinally(() -> codeSearchFocusContext_.clear());
          }
          
          @Override
@@ -198,6 +193,7 @@ public class GlobalToolbar extends Toolbar
                "Version control",
                vcsIcon, 
                vcsMenu);
+         ElementIds.assignElementId(vcsButton, ElementIds.VCS_MENUBUTTON);
          addLeftWidget(vcsButton);
       }
       
@@ -233,7 +229,7 @@ public class GlobalToolbar extends Toolbar
             "Workspace Panes",
             paneLayoutIcon,
             paneLayoutMenu);
-      
+      ElementIds.assignElementId(paneLayoutButton, ElementIds.PANELAYOUT_MENUBUTTON);
       addLeftWidget(paneLayoutButton);
       
       // addins menu
@@ -242,8 +238,7 @@ public class GlobalToolbar extends Toolbar
       // project popup menu
       if (sessionInfo.getAllowFullUI())
       {
-         ProjectPopupMenu projectMenu = new ProjectPopupMenu(sessionInfo,
-                                                          commands_);
+         ProjectPopupMenu projectMenu = new ProjectPopupMenu(sessionInfo, commands_);
          addRightWidget(projectMenu.getToolbarButton());
       }
    }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/ProjectPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/ProjectPopupMenu.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.application.ui;
 
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
@@ -87,7 +88,8 @@ public class ProjectPopupMenu extends ToolbarPopupMenu
                 new ImageResource2x(RESOURCES.projectMenu2x()),
                 this, 
                 true);
-          
+         ElementIds.assignElementId(toolbarButton_, ElementIds.PROJECT_MENUBUTTON);
+
          if (activeProjectFile_ != null)
          {
             toolbarButton_.setTitle(activeProjectFile_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPane.java
@@ -24,6 +24,7 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
 import org.rstudio.core.client.CodeNavigationTarget;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.events.HasSelectionCommitHandlers;
 import org.rstudio.core.client.events.SelectionCommitEvent;
 import org.rstudio.core.client.events.SelectionCommitHandler;
@@ -95,6 +96,7 @@ public class BuildPane extends WorkbenchPane
          BookdownBuildPopupMenu buildPopupMenu = new BookdownBuildPopupMenu();
          ToolbarMenuButton buildMenuButton = new ToolbarMenuButton(ToolbarButton.NoText,
                "Build book options", buildPopupMenu, true);
+         ElementIds.assignElementId(buildMenuButton, ElementIds.BUILD_BOOKDOWN_MENUBUTTON);
          toolbar.addLeftWidget(buildMenuButton);
       }
       
@@ -143,6 +145,7 @@ public class BuildPane extends WorkbenchPane
                ToolbarButton.NoTitle,
                new ImageResource2x(StandardIcons.INSTANCE.more_actions2x()),
                moreMenu);
+         ElementIds.assignElementId(moreButton, ElementIds.BUILD_MORE_MENUBUTTON);
          toolbar.addLeftWidget(moreButton);
       }
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
@@ -16,6 +16,7 @@
 package org.rstudio.studio.client.workbench.views.terminal;
 
 import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.widget.ToolbarButton;
@@ -117,6 +118,8 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
                 StandardIcons.INSTANCE.empty_command(),
                 this,
                 false);
+
+         ElementIds.assignElementId(toolbarButton_, ElementIds.TERMINAL_DROPDOWN_MENUBUTTON);
 
          setNoActiveTerminal();
       }


### PR DESCRIPTION
- terminal pane dropdown
- main toolbar, (new file, mru, vcs, pane layout, projects)
- build pane (build bookdown, more...)
- fixed bug in regex for generating unique IDs based on labels; "terminal #" was being stripped of the "#" instead of including it
- fixes #5520