### PR TITLE
Update character count when committing

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
@@ -509,7 +509,21 @@ public class GitReviewPanel extends ResizeComposite implements Display
    @Override
    public HasText getCommitMessage()
    {
-      return commitMessage_;
+      return new HasText()
+      {
+         @Override
+         public void setText(String text)
+         {
+            commitMessage_.setText(text);
+            updateCharCount();
+         }
+         
+         @Override
+         public String getText()
+         {
+            return commitMessage_.getText();
+         }
+      };
    }
 
    @Override


### PR DESCRIPTION
This small change ensures that we update the character count when clearing the commit message checkbox during a commit. 

Fixes https://github.com/rstudio/rstudio/issues/5521.