### PR TITLE
fix sans-serif font usage in doc outline

### DIFF
--- a/src/cpp/desktop/DesktopWebPage.cpp
+++ b/src/cpp/desktop/DesktopWebPage.cpp
@@ -156,6 +156,11 @@ void WebPage::init()
    settings()->setAttribute(QWebEngineSettings::JavascriptCanAccessClipboard, true);
    settings()->setAttribute(QWebEngineSettings::LocalStorageEnabled, true);
    settings()->setAttribute(QWebEngineSettings::WebGLEnabled, true);
+   
+#ifdef __APPLE__
+   settings()->setFontFamily(QWebEngineSettings::FixedFont,     QStringLiteral("Courier"));
+   settings()->setFontFamily(QWebEngineSettings::SansSerifFont, QStringLiteral("Helvetica"));
+#endif
 
    defaultSaveDir_ = QDir::home();
    connect(this, SIGNAL(windowCloseRequested()), SLOT(closeRequested()));


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/5525.

Candidate for v1.2-patch backport.