### PR TITLE
avoid IDE hang with excessive console output (#5518)

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -27,6 +27,7 @@ import org.rstudio.core.client.widget.PreWidget;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.debugging.model.UnhandledError;
 import org.rstudio.studio.client.common.debugging.ui.ConsoleError;
+import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.rmarkdown.model.NotebookFrameMetadata;
 import org.rstudio.studio.client.rmarkdown.model.NotebookHtmlMetadata;
 import org.rstudio.studio.client.rmarkdown.model.NotebookPlotMetadata;
@@ -100,6 +101,11 @@ public class ChunkOutputStream extends FlowPanel
    public void showConsoleOutput(JsArray<JsArrayEx> output)
    {
       initializeOutput(RmdChunkOutputUnit.TYPE_TEXT);
+      
+      // track number of newlines in output
+      int newlineCount = 0;
+      int maxCount = Satellite.isCurrentWindowSatellite() ? 10000 : 2000;
+      
       for (int i = 0; i < output.length(); i++)
       {
          // the first element is the output, and the second is the text; if we
@@ -129,6 +135,17 @@ public class ChunkOutputStream extends FlowPanel
             }
 
             vconsole_.submit(outputText, classOfOutput(outputType));
+         }
+         
+         // avoid hanging the IDE by displaying too much output
+         // https://github.com/rstudio/rstudio/issues/5518
+         newlineCount += StringUtil.countMatches(outputText, '\n');
+         if (newlineCount >= maxCount)
+         {
+            vconsole_.submit(
+                  "\n[Output truncated]",
+                  classOfOutput(ChunkConsolePage.CONSOLE_ERROR));
+            break;
          }
       }
    }


### PR DESCRIPTION
This is a bandaid for https://github.com/rstudio/rstudio/issues/5518. We limit the number of CSV lines processed in our console output to 10000 entries, to guard against somewhat pathological cases where the user has printed many lines of console output.