### PR TITLE
Remove 'not' selectors and add important to focus-visible outlines

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/FileDialogStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/FileDialogStyles.css
@@ -236,7 +236,7 @@ body.windows .breadcrumb table.path span {
    margin-top: 0px;
 }
 
-button.browse:focus:not(.focus-visible) {
+button.browse:focus {
    outline:0;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBase.css
+++ b/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBase.css
@@ -62,7 +62,7 @@
    padding: 6px 2px 4px 2px;
 }
 
-.section:focus:not(.focus-visible) {
+.section:focus {
    outline:none;
 }
 
@@ -75,7 +75,7 @@
    background: #D6E9F8;
 }
 
-.activeSection:focus:not(.focus-visible) {
+.activeSection:focus {
    outline:none;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/resources/styles.css
+++ b/src/gwt/src/org/rstudio/core/client/resources/styles.css
@@ -76,7 +76,7 @@
    color: #0000AA;
 }
 
-.rstudio-HyperlinkLabel:focus:not(.focus-visible) {
+.rstudio-HyperlinkLabel:focus {
    outline: none;
 }
 
@@ -92,7 +92,7 @@
    background-color: transparent;
 }
 
-.rstudio-HelpButton:focus:not(.focus-visible) {
+.rstudio-HelpButton:focus {
    outline:none;
 }
 
@@ -103,7 +103,7 @@
    background-color: transparent;
 }
 
-.rstudio-ImageButton:focus:not(.focus-visible) {
+.rstudio-ImageButton:focus {
    outline:none;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1312,7 +1312,7 @@ body.windows .toolbar {
    overflow: hidden;
 }
 
-.toolbarButton:focus:not(.focus-visible) {
+.toolbarButton:focus {
    outline: none;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/widget/ShortcutInfoPanel.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/ShortcutInfoPanel.ui.xml
@@ -34,7 +34,7 @@
      width: 100%;
    }
    
-   .shortcutPanel:focus:not(.focus-visible)
+   .shortcutPanel:focus
    {
      outline:none
    }

--- a/src/gwt/src/org/rstudio/core/client/widget/WidgetListBox.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/WidgetListBox.css
@@ -29,7 +29,7 @@
    -webkit-box-sizing: border-box;
 }
 
-.outerPanel:focus:not(.focus-visible)
+.outerPanel:focus
 {
    outline: none;
 }
@@ -42,7 +42,7 @@
    width: 100%;
 }
 
-.listPanel:focus:not(.focus-visible)
+.listPanel:focus
 {
    outline: none;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/Wizard.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/Wizard.css
@@ -83,7 +83,7 @@
    background: #DAE7F6;
 }
 
-.wizardPageSelectorItem:focus:not(.focus-visible) {
+.wizardPageSelectorItem:focus {
    outline: none;
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.css
@@ -40,7 +40,7 @@
    cursor: default;
 }
 
-.objectGrid td:focus:not(.focus-visible)
+.objectGrid td:focus
 {
    outline: none;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
@@ -10,7 +10,7 @@
          margin-left: 0;
       }
 
-      .panel input:focus:not(.focus-visible) {
+      .panel input:focus {
          outline: none;
       }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputGallery.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputGallery.ui.xml
@@ -24,7 +24,7 @@ xmlns:g="urn:import:com.google.gwt.user.client.ui">
    opacity: 1;
 }
 
-.thumbnail:focus:not(.focus-visible) {
+.thumbnail:focus {
    outline: none;
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/xterm.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/xterm.css
@@ -44,7 +44,7 @@
 }
 
 .xterm.focus,
-.xterm:focus:not(.focus-visible) {
+.xterm:focus {
     outline: none;
 }
 

--- a/src/gwt/www/css/focus-visible.css
+++ b/src/gwt/www/css/focus-visible.css
@@ -11,6 +11,6 @@
 }
 
 .js-focus-visible .focus-visible, input[type="checkbox"].focus-visible {
-    outline: goldenrod solid 2px;
-    outline-offset: -1px;
+    outline: goldenrod solid 2px !important;
+    outline-offset: -1px !important;
 }


### PR DESCRIPTION
The GWT CSS parser is old and glitchy. Its support for CSS3 selectors in particular is very, very shaky. The story can be followed by poor dankurka's adventures trying to get it to work 4 years ago and it seems like they still haven't fixed it: 
https://github.com/gwtproject/gwt/issues/5770

Currently running `ant unittest` will output a barrage of `[WARN] Line 1315 column 25: encountered ".". Was expecting one of: <IDENT> ` errors when trying to parse the `:not` selectors I added yesterday. The CSS worked just fine in the application itself but the unit test harness very much does not like it.

I tried every permutation and suggested workaround in the myriad threads referencing this problem but couldn't think of any other reliable solution.

I'm removing the `not` selectors and proposing the unfortunate, but limited in scope and functional addition of `!important` to the keyboard navigation CSS. The `focus-visible` functionality can be turned off through the library so, worst case, we can add a flag in accessibility that is even off by default if we really don't like how this works in default cases.