### PR TITLE
Move open-source NOTICE from About dialog to new dialog

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -3384,11 +3384,21 @@ RapidJSON
 ------------------------------------------------------------------------
 Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip.  All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies
+or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
 
 msinttypes
 ------------------------------------------------------------------------
@@ -3396,13 +3406,27 @@ The msinttypes r29
 Copyright (c) 2006-2013 Alexander Chemeris
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without modification, are
+permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-* Neither the name of  copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+* Redistributions of source code must retain the above copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this list
+  of conditions and the following disclaimer in the documentation and/or other materials
+  provided with the distribution.
+* Neither the name of  copyright holder nor the names of its contributors may be used
+  to endorse or promote products derived from this software without specific prior
+  written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS AND CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND ANY EXPRESS
+OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE REGENTS AND CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 fontawesome
 -----------------------------------------------------------------------
@@ -3484,18 +3508,21 @@ Permission to copy, modify, and distribute this work, with or without modificati
 for any purpose and without fee or royalty is hereby granted, provided that you include
 the following on ALL copies of the work or portions thereof, including modifications:
 
-The full text of this NOTICE in a location viewable to users of the redistributed or derivative work.
+The full text of this NOTICE in a location viewable to users of the redistributed or
+derivative work.
+
 Any pre-existing intellectual property disclaimers, notices, or terms and conditions.
 If none exist, the W3C Software and Document Short Notice should be included.
-Notice of any changes or modifications, through a copyright statement on the new code or document such as
-"This software or document includes material copied from or derived from [title and URI of the W3C document].
-Copyright © [YEAR] W3C® (MIT, ERCIM, Keio, Beihang)."
+
+Notice of any changes or modifications, through a copyright statement on the new code
+or document such as "This software or document includes material copied from or derived
+from [title and URI of the W3C document]. Copyright © [YEAR] W3C® (MIT, ERCIM, Keio, Beihang)."
 
 Disclaimers
 THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY
-PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY THIRD PARTY PATENTS,
-COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY
+THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
 
 COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR
 CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.

--- a/src/cpp/session/modules/SessionAbout.cpp
+++ b/src/cpp/session/modules/SessionAbout.cpp
@@ -41,9 +41,17 @@ Error productInfo(const json::JsonRpcRequest& request,
    result["commit"] = RSTUDIO_GIT_COMMIT;
    result["build"] = RSTUDIO_BUILD_ID;
    result["release_name"] = RSTUDIO_RELEASE_NAME;
-   result["notice"] = module_context::resourceFileAsString("NOTICE");
    result["date"] = RSTUDIO_BUILD_DATE;
    result["copyright_year"] = RSTUDIO_COPYRIGHT_YEAR;
+   pResponse->setResult(result);
+   return Success();
+}
+
+Error productNotice(const json::JsonRpcRequest& request,
+                    json::JsonRpcResponse* pResponse)
+{
+   json::Object result;
+   result["notice"] = module_context::resourceFileAsString("NOTICE");
    pResponse->setResult(result);
    return Success();
 }
@@ -58,6 +66,7 @@ Error initialize()
    ExecBlock initBlock;
    initBlock.addFunctions()
       (bind(registerRpcMethod, "get_product_info", productInfo))
+      (bind(registerRpcMethod, "get_product_notice", productNotice))
    ;
    return initBlock.execute();
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/HyperlinkLabel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/HyperlinkLabel.java
@@ -58,6 +58,7 @@ public class HyperlinkLabel extends Label
    public void setClickHandler(Command clickHandler)
    {
       clickHandler_ = clickHandler;
+      registerClickHandler();
    }
 
    private class MouseHandlers implements MouseOverHandler,
@@ -99,7 +100,12 @@ public class HyperlinkLabel extends Label
    {
       releaseOnUnload_.add(addMouseOverHandler(mouseHandlers_));
       releaseOnUnload_.add(addMouseOutHandler(mouseHandlers_));
-      if (clickHandler_ != null)
+      registerClickHandler();
+   }
+
+   private void registerClickHandler()
+   {
+      if (isAttached() && clickHandler_ != null)
       {
          releaseOnUnload_.add(addClickHandler(event -> click()));
 

--- a/src/gwt/src/org/rstudio/studio/client/application/model/ApplicationServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/model/ApplicationServerOperations.java
@@ -83,7 +83,9 @@ public interface ApplicationServerOperations extends PrefsServerOperations
 
    void getProductInfo(
          ServerRequestCallback<ProductInfo> requestCallback);
-   
+
+   void getProductNotice(ServerRequestCallback<ProductNotice> requestCallback);
+
    void getNewSessionUrl(String hostPageUrl,
          boolean isProject, 
          String directory,

--- a/src/gwt/src/org/rstudio/studio/client/application/model/ProductNotice.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/model/ProductNotice.java
@@ -1,5 +1,5 @@
 /*
- * ProductInfo.java
+ * ProductNotice.java
  *
  * Copyright (C) 2009-19 by RStudio, Inc.
  *
@@ -18,14 +18,9 @@ import jsinterop.annotations.JsType;
 import jsinterop.annotations.JsPackage;
 
 @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
-public class ProductInfo
+public class ProductNotice
 {
-   protected ProductInfo() {}
-   
-   public String version;
-   public String commit;
-   public String build;
-   public String release_name;
-   public String date;
-   public String copyright_year;
+   protected ProductNotice() {}
+
+   public String notice;
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.java
@@ -18,6 +18,9 @@ import com.google.gwt.aria.client.Id;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.Anchor;
+import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.widget.HyperlinkLabel;
+import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.model.ProductEditionInfo;
 import org.rstudio.studio.client.application.model.ProductInfo;
@@ -32,6 +35,9 @@ import com.google.gwt.user.client.ui.InlineLabel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.TextArea;
 import com.google.gwt.user.client.ui.Widget;
+import org.rstudio.studio.client.application.model.ProductNotice;
+import org.rstudio.studio.client.server.ServerError;
+import org.rstudio.studio.client.server.ServerRequestCallback;
 
 public class AboutDialogContents extends Composite
 {
@@ -68,10 +74,27 @@ public class AboutDialogContents extends Composite
       buildLabel.setText(
            "\"" + info.release_name + "\" (" + info.commit.substring(0, 8) + ", " +
            info.date + ")");
-      noticeBox.setValue(info.notice);
       productName.setText(editionInfo.editionName());
       copyrightYearLabel.setText("2009-" + info.copyright_year);
-      
+
+      showNoticelink_.setClickHandler(() ->
+      {
+         RStudioGinjector.INSTANCE.getServer().getProductNotice(new ServerRequestCallback<ProductNotice>()
+         {
+            @Override
+            public void onResponseReceived(ProductNotice notice)
+            {
+               AboutOpenSourceDialog about = new AboutOpenSourceDialog(notice);
+               about.showModal();
+            }
+            @Override
+            public void onError(ServerError error)
+            {
+               Debug.logError(error);
+            }
+         });
+      });
+
       if (editionInfo.proLicense())
       {
          // no need to show GPL notice in pro edition
@@ -80,7 +103,6 @@ public class AboutDialogContents extends Composite
          if (Desktop.hasDesktopFrame())
          {
             // load license status in desktop mode
-            noticeBox.setVisibleLines(9);
             licenseBox.setVisibleLines(3);
             licenseLabel.setVisible(true);
             licenseBox.setVisible(true);
@@ -102,7 +124,7 @@ public class AboutDialogContents extends Composite
    @UiField InlineLabel userAgentLabel;
    @UiField InlineLabel buildLabel;
    @UiField InlineLabel copyrightYearLabel;
-   @UiField TextArea noticeBox;
+   @UiField HyperlinkLabel showNoticelink_;
    @UiField HTMLPanel gplNotice;
    @UiField Label licenseLabel;
    @UiField TextArea licenseBox;

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.ui.xml
@@ -1,6 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
-   xmlns:g="urn:import:com.google.gwt.user.client.ui">
+   xmlns:g="urn:import:com.google.gwt.user.client.ui"
+   xmlns:rw="urn:import:org.rstudio.core.client.widget">
    <ui:with field='res' type='org.rstudio.core.client.theme.res.ThemeResources' />
    <ui:style>
       @eval fixedWidthFont org.rstudio.core.client.theme.ThemeFonts.getFixedWidthFont();
@@ -29,13 +30,14 @@
       .userAgent {
          margin-bottom: 15px;
       }
-      
-      .noticeBox {
-         clear: both;
-         width: 100%;
-         font-family: fixedWidthFont;
+      .notice {
+         text-align: center;
          margin-top: 15px;
          margin-bottom: 15px;
+      }
+      .noticeLink {
+         font-size: 10pt;
+         text-decoration: underline;
       }
       .licenseBox {
          clear: both;
@@ -108,8 +110,12 @@
             <g:InlineLabel ui:field="gplLinkLabel" text="(opens in new window)" styleName="{res.themeStyles.visuallyHidden}"></g:InlineLabel>
          </g:HTMLPanel>
       </g:HTMLPanel>
-      <g:TextArea ui:field="noticeBox" styleName="{style.noticeBox}"
-         visibleLines="15" readOnly="true"></g:TextArea>
+      <g:HTMLPanel styleName="{style.notice}">
+         <rw:HyperlinkLabel
+               text="Open Source Components"
+               addStyleNames="{style.noticeLink} {res.themeStyles.handCursor}"
+               ui:field="showNoticelink_"/>
+      </g:HTMLPanel>
       <g:Label ui:field="licenseLabel" visible="false" text="RStudio Pro License Status" styleName="{style.licenseLabel}"></g:Label>
         <g:TextArea ui:field="licenseBox" styleName="{style.licenseBox}"
            visibleLines="10" visible="false" readOnly="true"></g:TextArea>

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutOpenSourceDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutOpenSourceDialog.java
@@ -1,0 +1,76 @@
+/*
+ * AboutOpenSourceDialog.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.application.ui;
+
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.HasHorizontalAlignment;
+import com.google.gwt.user.client.ui.ScrollPanel;
+import com.google.gwt.user.client.ui.Widget;
+import org.rstudio.core.client.Size;
+import org.rstudio.core.client.dom.DomMetrics;
+import org.rstudio.core.client.widget.FontSizer;
+import org.rstudio.core.client.widget.ModalDialogBase;
+import org.rstudio.core.client.widget.ThemedButton;
+import org.rstudio.studio.client.application.model.ProductNotice;
+
+public class AboutOpenSourceDialog extends ModalDialogBase
+{
+   interface Binder extends UiBinder<Widget, AboutOpenSourceDialog> {}
+
+   public AboutOpenSourceDialog(ProductNotice notice)
+   {
+      super(Roles.getDialogRole());
+      setText("Open Source Components");
+
+      mainWidget_ = GWT.<Binder>create(Binder.class).createAndBindUi(this);
+
+      setButtonAlignment(HasHorizontalAlignment.ALIGN_CENTER);
+      ThemedButton closeButton = new ThemedButton("Close", event -> closeDialog());
+      addOkButton(closeButton);
+
+      noticeHTML_.setHTML("<pre>" + notice.notice + "</pre>");
+      FontSizer.applyNormalFontSize(noticeHTML_);
+      Roles.getDocumentRole().set(noticeHTML_.getElement());
+      Roles.getDocumentRole().setAriaLabelProperty(noticeHTML_.getElement(),
+                                                   "Open Source Components");
+      noticeHTML_.getElement().setTabIndex(0);
+
+      // compute the widget size and set it
+      Size preferredSize = new Size(500, 350);
+      Size minimumSize = new Size(300, 300);
+      preferredSize = DomMetrics.adjustedElementSize(
+            preferredSize,
+            minimumSize,
+            100,   // pad
+            100); // client margin
+      noticeScroll_.setSize(preferredSize.width + "px", preferredSize.height + "px");
+      setWidth("575px");
+   }
+
+   @Override
+   protected Widget createMainWidget()
+   {
+      return mainWidget_;
+   }
+
+   @UiField ScrollPanel noticeScroll_;
+   @UiField HTML noticeHTML_;
+
+   private final Widget mainWidget_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutOpenSourceDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutOpenSourceDialog.ui.xml
@@ -1,0 +1,27 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
+   xmlns:g="urn:import:com.google.gwt.user.client.ui">
+   <ui:with field='res' type='org.rstudio.core.client.theme.res.ThemeResources' />
+   <ui:style>
+      @eval fixedWidthFont org.rstudio.core.client.theme.ThemeFonts.getFixedWidthFont();
+
+      .noticeBox {
+         clear: both;
+         width: 100%;
+         font-family: fixedWidthFont;
+         margin-top: 15px;
+         margin-bottom: 15px;
+         background-color: white;
+         -ms-user-select: text;
+         -moz-user-select: text;
+         -webkit-user-select: text;
+         user-select: text;
+      }
+      .noticeScroll {
+         border: 1px solid #BBB;
+      }
+   </ui:style>
+   <g:ScrollPanel ui:field="noticeScroll_" styleName="{style.noticeScroll}" width="100%" height="100%">
+      <g:HTML ui:field="noticeHTML_" styleName="{style.noticeBox}" text="View Open Source Components" />
+   </g:ScrollPanel>
+</ui:UiBinder>

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4653,7 +4653,15 @@ public class RemoteServer implements Server
             GET_PRODUCT_INFO,
             requestCallback);
    }
-   
+
+   @Override
+   public void getProductNotice(ServerRequestCallback<ProductNotice> requestCallback)
+   {
+      sendRequest(RPC_SCOPE,
+                  GET_PRODUCT_NOTICE,
+                  requestCallback);
+   }
+
    @Override
    public void getRAddins(boolean reindex, 
                           ServerRequestCallback<RAddins> requestCallback)
@@ -6334,7 +6342,8 @@ public class RemoteServer implements Server
 
    private static final String CHECK_FOR_UPDATES = "check_for_updates";
    private static final String GET_PRODUCT_INFO = "get_product_info";
-   
+   private static final String GET_PRODUCT_NOTICE = "get_product_notice";
+
    private static final String GET_R_ADDINS = "get_r_addins";
    private static final String PREPARE_FOR_ADDIN = "prepare_for_addin";
    private static final String EXECUTE_R_ADDIN = "execute_r_addin";


### PR DESCRIPTION
- the 3400+ line NOTICE for open-source components was bogging down
  screen readers when opening the About dialog
- moved into a new dialog, with a link to it from the About dialog
- new dialog puts the text into a `<pre>` instead of a `textarea`; this is much faster and does not slow down screen readers
- marked that area as role="document", and made it able to get focus and be selected / copied
- fixes #5533

![2019-10-10_14-04-53](https://user-images.githubusercontent.com/10569626/66607753-ca525e80-eb69-11e9-8904-ea2a7131553c.png)

![2019-10-10_14-30-14](https://user-images.githubusercontent.com/10569626/66608099-8875e800-eb6a-11e9-8daa-a7a78cfa6513.png)
