### PR TITLE
avoid deep recursion in hasExternalPtr

### DIFF
--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -63,7 +63,6 @@ typedef std::pair<std::string,SEXP> Variable ;
 void listEnvironment(SEXP env, 
                      bool includeAll,
                      bool includeLastDotValue,
-                     Protect* pProtect,
                      std::vector<Variable>* pVariables);
       
 // object info
@@ -113,7 +112,7 @@ bool fillSetString(SEXP object, std::set<std::string>* pSet);
 SEXP getAttrib(SEXP object, SEXP attrib);
 SEXP getAttrib(SEXP object, const std::string& attrib);
 SEXP setAttrib(SEXP object, const std::string& attrib, SEXP val);
-void listNamedAttributes(SEXP obj, Protect *pProtect, std::vector<Variable>* pVariables);
+void listNamedAttributes(SEXP obj, std::vector<Variable>* pVariables);
 
 // weak/external pointers and finalizers
 bool isExternalPointer(SEXP object);

--- a/src/cpp/session/modules/environment/EnvironmentMonitor.cpp
+++ b/src/cpp/session/modules/environment/EnvironmentMonitor.cpp
@@ -123,12 +123,11 @@ void EnvironmentMonitor::listEnv(std::vector<r::sexp::Variable>* pEnv)
    if (!hasEnvironment())
       return;
 
-   r::sexp::Protect rProtect;
-   r::sexp::listEnvironment(getMonitoredEnvironment(),
-                            false,
-                            prefs::userPrefs().showLastDotValue(),
-                            &rProtect,
-                            pEnv);
+   r::sexp::listEnvironment(
+            getMonitoredEnvironment(),
+            false,
+            prefs::userPrefs().showLastDotValue(),
+            pEnv);
 }
 
 void EnvironmentMonitor::checkForChanges()

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -121,15 +121,15 @@ bool hasExternalPtrImpl(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
 
    // list the contents of this environment
    std::vector<r::sexp::Variable> vars;
-   r::sexp::Protect rProtect;
    if (TYPEOF(obj) == S4SXP)
    {
       // for S4 objects, list the attributes (which correspond to slots)
-      r::sexp::listNamedAttributes(obj, &rProtect, &vars);
+      r::sexp::listNamedAttributes(obj, &vars);
    }
    else
    {
       // not S4, coerce to environment
+      r::sexp::Protect rProtect;
       SEXP envir = R_NilValue;
       if (TYPEOF(obj) == ENVSXP)
       {
@@ -151,7 +151,7 @@ bool hasExternalPtrImpl(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
       r::sexp::listEnvironment(envir,
                                true,  // include all values
                                false, // don't include last dot
-                               &rProtect, &vars);
+                               &vars);
    }
 
    // check for external pointers
@@ -186,7 +186,6 @@ bool hasExternalPtr(SEXP obj,      // environment to search for external pointer
 SEXP rs_hasExternalPointer(SEXP objSEXP, SEXP nullSEXP)
 {
    bool nullPtr = r::sexp::asLogical(nullSEXP);
-   r::sexp::Protect protect;
    bool hasPtr = false;
    if (r::sexp::isExternalPointer(objSEXP))
    {
@@ -198,6 +197,7 @@ SEXP rs_hasExternalPointer(SEXP objSEXP, SEXP nullSEXP)
       // object is an environment; check it for external pointers
       hasPtr = hasExternalPtr(objSEXP, nullPtr);
    }
+   r::sexp::Protect protect;
    return r::sexp::create(hasPtr, &protect);
 }
 
@@ -397,7 +397,6 @@ json::Array environmentListAsJson()
        listEnvironment(env,
                        false,
                        prefs::userPrefs().showLastDotValue(),
-                       &rProtect,
                        &vars);
 
        // get object details and transform to json


### PR DESCRIPTION
Closes #5546.

NOTE: This PR deserves some close scrutiny (it may not be the right approach). It effectively tries to avoid re-protecting an R object that should already be protected by virtue of being referenced by an existing R environment. However, there might be some cases where this cannot be done (e.g. if our API call really did produce a new, unprotected SEXP).