### PR TITLE
fix issue with Tab insertion in Markdown documents

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
@@ -284,8 +284,14 @@ public abstract class CompletionManagerBase
       if (completionCache_.satisfyRequest(line, context_))
          return true;
       
-      getCompletions(line, context_);
-      return true;
+      boolean canComplete = getCompletions(line, context_);
+      
+      // if tab was used to trigger the completion, but no completions
+      // are available in that context, then insert a literal tab
+      if (!canComplete && isTabTriggered)
+         docDisplay_.insertCode("\t");
+      
+      return canComplete;
    }
    
    public Invalidation.Token getInvalidationToken()
@@ -315,7 +321,7 @@ public abstract class CompletionManagerBase
    
    public abstract void goToHelp();
    public abstract void goToDefinition();
-   public abstract void getCompletions(String line, CompletionRequestContext context);
+   public abstract boolean getCompletions(String line, CompletionRequestContext context);
    
    // Subclasses should override this to provide extra (e.g. context) completions.
    protected void addExtraCompletions(String token, List<QualifiedName> completions)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/MarkdownCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/MarkdownCompletionManager.java
@@ -47,11 +47,13 @@ public class MarkdownCompletionManager extends CompletionManagerBase
    }
 
    @Override
-   public void getCompletions(String line, CompletionRequestContext context)
+   public boolean getCompletions(String line, CompletionRequestContext context)
    {
       // check for completion of href
       if (getCompletionsHref(context))
-         return;
+         return true;
+      
+      return false;
    }
    
    private boolean getCompletionsHref(CompletionRequestContext context)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/PythonCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/PythonCompletionManager.java
@@ -96,9 +96,10 @@ public class PythonCompletionManager extends CompletionManagerBase
    }
 
    @Override
-   public void getCompletions(String line, CompletionRequestContext context)
+   public boolean getCompletions(String line, CompletionRequestContext context)
    {
       server_.pythonGetCompletions(buildCompletionLine(), completionContext(), context);
+      return true;
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/SqlCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/SqlCompletionManager.java
@@ -50,11 +50,12 @@ public class SqlCompletionManager extends CompletionManagerBase
    }
    
    @Override
-   public void getCompletions(String line,
-                              CompletionRequestContext context)
+   public boolean getCompletions(String line,
+                                 CompletionRequestContext context)
    {
       String connection = discoverAssociatedConnectionString();
       server_.sqlGetCompletions(line, connection, completionContext(), context);
+      return true;
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/StanCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/StanCompletionManager.java
@@ -79,9 +79,10 @@ public class StanCompletionManager extends CompletionManagerBase
    }
    
    @Override
-   public void getCompletions(String line, CompletionRequestContext context)
+   public boolean getCompletions(String line, CompletionRequestContext context)
    {
       server_.stanGetCompletions(line, context);
+      return true;
    }
    
    @Override


### PR DESCRIPTION
This PR fixes an issue where attempts to insert a literal tab could fail in Markdown documents.

The Markdown completion manager can only provide completions in certain contexts; however, the interface for `getCompletions()` did not allow completion managers to signal when they are unable to complete. That information is necessary for tab-triggered completions, as we then want to insert a literal tab in that case.