### PR TITLE
guard against recursive error pages

### DIFF
--- a/src/cpp/core/include/core/Macros.hpp
+++ b/src/cpp/core/include/core/Macros.hpp
@@ -19,6 +19,14 @@
 #include <iostream>
 #include <iomanip>
 
+#define RS_CALL_ONCE()                                                         \
+   do                                                                          \
+   {                                                                           \
+      static bool s_once = false;                                              \
+      if (s_once) return;                                                      \
+      s_once = true;                                                           \
+   } while (0)
+
 /* Work around Xcode indentation rules */
 #define RS_BEGIN_NAMESPACE(__X__) namespace __X__ {
 #define RS_END_NAMESPACE(__X__) }

--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -21,6 +21,7 @@
 #include <boost/bind.hpp>
 #include <boost/format.hpp>
 
+#include <core/Macros.hpp>
 #include <core/text/TemplateFilter.hpp>
 
 #include "DesktopOptions.hpp"
@@ -522,13 +523,15 @@ void MainWindow::onLoadFinished(bool ok)
    if (ok)
       return;
 
+   RS_CALL_ONCE();
+   
    std::map<std::string,std::string> vars;
    vars["url"] = webView()->url().url().toStdString();
    std::ostringstream oss;
    Error error = text::renderTemplate(options().resourcesPath().complete("html/connect.html"),
                                       vars, oss);
    if (error)
-       LOG_ERROR(error);
+      LOG_ERROR(error);
    else
       loadHtml(QString::fromStdString(oss.str()));
 }

--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -19,6 +19,7 @@
 
 #include <boost/bind.hpp>
 
+#include <core/Macros.hpp>
 #include <core/http/Request.hpp>
 #include <core/http/Response.hpp>
 #include <core/http/TcpIpBlockingClient.hpp>
@@ -267,6 +268,8 @@ Error getRecentSessionLogs(std::string* pLogFile, std::string *pLogContents)
 
 void SessionLauncher::showLaunchErrorPage()
 {
+   RS_CALL_ONCE();
+   
    // String mapping of template codes to diagnostic information
    std::map<std::string,std::string> vars;
 


### PR DESCRIPTION
This avoids an issue where, if an error is shown while attempting to load an error page, a recursive cascade of errors windows will be popped up.

While this doesn't fix the underlying issue, it's still worth guarding against even post-fix.