### PR TITLE
tempdir() path uses UTF-8 encoding internally

### DIFF
--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -559,7 +559,8 @@ FilePath tempDir()
    Error error = r::exec::RFunction("tempdir").call(&tempDir);
    if (error)
       LOG_ERROR(error);
-   FilePath filePath(r::util::fixPath(tempDir));
+
+   FilePath filePath(string_utils::systemToUtf8(r::util::fixPath(tempDir)));
    return filePath;
 }
 


### PR DESCRIPTION
This PR fixes an issue where we would erroneously mis-encode the R `tempdir()` (and hence, files or directories within the R `tempdir()`) when that directory contained non-ASCII characters.

The primary issue is that:

1. We always keep paths encoded as UTF-8 internally;
2. We convert those paths to the system encoding on demand; especially when required by R functions.

Since we were not doing (1) when retrieving `tempdir()`, but were doing (2) in places like this:

https://github.com/rstudio/rstudio/blob/963422a13182ad8f36a2248b7a1e2594ad95fba3/src/cpp/r/session/graphics/RGraphicsDevice.cpp#L646-L647

we were effectively sending mis-encoded paths to R, and then things would fail.

Closes https://github.com/rstudio/rstudio/issues/5576, https://github.com/rstudio/rstudio/issues/2056.

NOTE: This PR should be a big win for Windows users who have accented characters in their user name.