### PR TITLE
Fix tabstop wrapping in preferences dialogs when section selection changes

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBase.java
@@ -92,6 +92,12 @@ public abstract class PreferencesDialogBase<T> extends ModalDialogBase
       {
          Integer index = selectionEvent.getSelectedItem();
 
+         // SectionChooser is first focusable control in the modal dialog, and it
+         // uses a roving tabindex to determine the focused section tab, so notify dialog
+         // when focus leaves or arrives at first tab
+         if ((currentIndex_ != null && currentIndex_ == 0) || index == 0)
+            refreshFocusableElements();
+
          if (currentIndex_ != null)
             setPaneVisibility(panes_[currentIndex_], false);
 


### PR DESCRIPTION
- Fixes #5573
- When a control with a roving tabstop is first (or last) in a modal dialog,
  it must notify the dialog when the selection moves to or from the first
  (or last) tab, otherwise the tab wrapping is broken
- Fixes the two tests marked as xfail in this automation PR: https://github.com/rstudio/rstudio-ide-automation/pull/25