### PR TITLE
Only show the session launch failure page when workbench doesn't init

### DIFF
--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -169,6 +169,10 @@ QString MainWindow::getSumatraPdfExePath()
 
 void MainWindow::launchSession(bool reload)
 {
+   // we're about to start another session, so clear the workbench init flag
+   // (will get set again once the new session has initialized the workbench)
+   workbenchInitialized_ = false;
+
    Error error = pSessionLauncher_->launchNextSession(reload);
    if (error)
    {
@@ -210,6 +214,11 @@ void MainWindow::launchRemoteRStudioProject(const QString& projectUrl)
    pAppLauncher_->launchRStudio(args);
 }
 
+bool MainWindow::workbenchInitialized()
+{
+    return workbenchInitialized_;
+}
+
 void MainWindow::onWorkbenchInitialized()
 {
    //QTimer::singleShot(300, this, SLOT(resetMargins()));
@@ -218,6 +227,7 @@ void MainWindow::onWorkbenchInitialized()
    // or reload for a new project context)
    quitConfirmed_ = false;
    geometrySaved_ = false;
+   workbenchInitialized_ = true;
 
    webPage()->runJavaScript(
             QStringLiteral("window.desktopHooks.getActiveProjectDir()"),

--- a/src/cpp/desktop/DesktopMainWindow.hpp
+++ b/src/cpp/desktop/DesktopMainWindow.hpp
@@ -53,6 +53,7 @@ public:
    RemoteDesktopSessionLauncher* getRemoteDesktopSessionLauncher();
    QWebEngineProfile* getPageProfile();
    WebView* getWebView();
+   bool workbenchInitialized();
 
 public Q_SLOTS:
    void quit();
@@ -114,6 +115,7 @@ private:
    bool isRemoteDesktop_;
    bool quitConfirmed_ = false;
    bool geometrySaved_ = false;
+   bool workbenchInitialized_ = false;
    MenuCallback menuCallback_;
    GwtCallback gwtCallback_;
    SessionLauncher* pSessionLauncher_;

--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -340,7 +340,12 @@ void SessionLauncher::onRSessionExited(int, QProcess::ExitStatus)
          // if we haven't loaded the initial session.
       }
 
-      showLaunchErrorPage();
+      if (!pMainWindow_->workbenchInitialized())
+      {
+         // If the R session exited without initializing the workbench, treat it as
+         // a boot failure.
+         showLaunchErrorPage();
+      }
    }
 
    // quit and exit means close the main window


### PR DESCRIPTION
We currently show the "R failed to launch" error screen whenever R barfs (and it wasn't a quit). This is overly aggressive since R may very well have started up fine but then barfed while running.

To distinguish these cases, this change keeps track of whether the workbench was initialized since the most recent session launch. Once the workbench has initialized, we no longer treat an R crash/failure as a launch failure.