### PR TITLE
Sort R Markdown templates by package/name

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateChooser.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateChooser.java
@@ -90,8 +90,12 @@ public class RmdTemplateChooser extends Composite
             JsArrayUtil.fillList(templates, templates_);
             templates_.sort((RmdDocumentTemplate a, RmdDocumentTemplate b) ->
             {
-               return (a.getPackage() + a.getName()).compareTo(
-                      (b.getPackage() + b.getName()));
+               int result = a.getPackage().compareTo(b.getPackage());
+               if (result == 0)
+               {
+                  return a.getName().compareTo(b.getName());
+               }
+               return result;
             });
 
             // Add each to the UI

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateChooser.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateChooser.java
@@ -16,6 +16,7 @@ package org.rstudio.studio.client.rmarkdown.ui;
 
 import java.util.ArrayList;
 
+import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.resources.CoreResources;
 import org.rstudio.core.client.widget.CaptionWithHelp;
 import org.rstudio.core.client.widget.DirectoryChooserTextBox;
@@ -85,10 +86,17 @@ public class RmdTemplateChooser extends Composite
          @Override
          public void onResponseReceived(JsArray<RmdDocumentTemplate> templates)
          {
-            for (int i = 0; i < templates.length(); i++)
+            // Sort the list by package, then template name
+            JsArrayUtil.fillList(templates, templates_);
+            templates_.sort((RmdDocumentTemplate a, RmdDocumentTemplate b) ->
             {
-               final RmdDocumentTemplate template = templates.get(i);
+               return (a.getPackage() + a.getName()).compareTo(
+                      (b.getPackage() + b.getName()));
+            });
 
+            // Add each to the UI
+            for (RmdDocumentTemplate template: templates_)
+            {
                String preferredTemplate = RStudioGinjector.INSTANCE.getUserPrefs()
                      .rmdPreferredTemplatePath().getValue();
 
@@ -96,7 +104,6 @@ public class RmdTemplateChooser extends Composite
                // end if it isn't the user's preferred template
                listTemplates_.addItem(new RmdDiscoveredTemplateItem(template), 
                      template.getPath() != preferredTemplate);
-               templates_.add(template);
             }
 
             state_ = STATE_POPULATED;


### PR DESCRIPTION
Drive-by regression fix: currently, R Markdown templates appear in the order we discovered them (which is filesystem-dependent and therefore apparently random). This change sorts them predictably.

Fixes https://github.com/rstudio/rstudio/issues/4929.