### PR TITLE
Add autoConstrain fuctionality to popup panels

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ScrollableToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ScrollableToolbarPopupMenu.java
@@ -48,28 +48,28 @@ public class ScrollableToolbarPopupMenu extends ToolbarPopupMenu
    
    public HandlerRegistration addSelectionHandler(SelectionHandler<MenuItem> handler)
    {
-      return ((ScrollableToolbarMenuBar)menuBar_).addSelectionHandler(handler);
+      return getMenuBar().addSelectionHandler(handler);
    }
 
    public void ensureSelectedIsVisible()
    {
-      if (menuBar_.getSelectedItem() != null)
+      if (getMenuBar().getSelectedItem() != null)
       {
          DomUtils.ensureVisibleVert(scrollPanel_.getElement(),
-                                    menuBar_.getSelectedItem().getElement(),
+                                    getMenuBar().getSelectedItem().getElement(),
                                     0);
       }
    }
    
    public int getSelectedIndex()
    {
-      return ((ScrollableToolbarMenuBar)menuBar_).getSelectedIndex();
+      return getMenuBar().getSelectedIndex();
    }
 
    @Override
    protected Widget createMainWidget()
    {
-      scrollPanel_ = new ScrollPanel(menuBar_);
+      scrollPanel_ = new ScrollPanel(getMenuBar());
       scrollPanel_.addStyleName(ThemeStyles.INSTANCE.scrollableMenuBar());
       scrollPanel_.getElement().getStyle().setOverflowY(Overflow.AUTO);
       scrollPanel_.getElement().getStyle().setOverflowX(Overflow.HIDDEN);
@@ -109,6 +109,9 @@ public class ScrollableToolbarPopupMenu extends ToolbarPopupMenu
          SelectionEvent.fire(this, item);
       }
    }
+
+   @Override
+   protected ScrollableToolbarMenuBar getMenuBar() { return (ScrollableToolbarMenuBar)menuBar_; }
 
    private ScrollPanel scrollPanel_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ScrollableToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ScrollableToolbarPopupMenu.java
@@ -23,13 +23,18 @@ import com.google.gwt.user.client.ui.*;
 
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.theme.res.ThemeStyles;
-import org.rstudio.core.client.widget.ToolbarPopupMenu;
 
 public class ScrollableToolbarPopupMenu extends ToolbarPopupMenu
 {
    @Override
    protected ToolbarMenuBar createMenuBar()
    {
+      // This class may now be partially/entirely deprecated with the autoContrain
+      // functionality but since ScrollableToolbarPopupMenu touches so many
+      // parts of the app it is best to leave autoConstrain turned
+      // off and defaulting to what exists now until it's thoroughly tested
+      autoConstrain_ = false;
+
       final ScrollableToolbarMenuBar menuBar = new ScrollableToolbarMenuBar(true);
       menuBar.addSelectionHandler(new SelectionHandler<MenuItem>()
       {
@@ -46,7 +51,6 @@ public class ScrollableToolbarPopupMenu extends ToolbarPopupMenu
       return ((ScrollableToolbarMenuBar)menuBar_).addSelectionHandler(handler);
    }
 
-
    public void ensureSelectedIsVisible()
    {
       if (menuBar_.getSelectedItem() != null)
@@ -59,7 +63,7 @@ public class ScrollableToolbarPopupMenu extends ToolbarPopupMenu
    
    public int getSelectedIndex()
    {
-      return menuBar_.getSelectedIndex();
+      return ((ScrollableToolbarMenuBar)menuBar_).getSelectedIndex();
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.java
@@ -14,6 +14,11 @@
  */
 package org.rstudio.core.client.widget;
 
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.NodeList;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.user.client.Window;
+import org.rstudio.core.client.command.BaseMenuBar;
 import org.rstudio.studio.client.application.ui.RStudioThemes;
 
 import com.google.gwt.core.client.GWT;
@@ -76,10 +81,35 @@ public class ThemedPopupPanel extends DecoratedPopupPanel
 
    private void commonInit(Resources res)
    {
+      autoConstrain_ = true;
       addStyleName(res.styles().themedPopupPanel());
 
       if (RStudioThemes.usesScrollbars())
          addStyleName("rstudio-themes-scrollbars");
+   }
+
+   @Override
+   public void setPopupPosition(int left, int top)
+   {
+      super.setPopupPosition(left, top);
+
+      if (autoConstrain_)
+         sizeToWindow(top, Style.Overflow.AUTO);
+   }
+
+   // Size the table to the window
+   private void sizeToWindow(int top, Style.Overflow overflowY)
+   {
+      NodeList<Element> e = this.menuBar_.getElement().getElementsByTagName("table");
+      if (e.getLength() < 1)
+         return;
+
+      Element table = e.getItem(0);
+      int windowHeight = Window.getClientHeight();
+
+      table.getStyle().setOverflowY(overflowY);
+      table.getStyle().setDisplay(Style.Display.BLOCK);
+      table.getStyle().setPropertyPx("maxHeight", windowHeight - top - 30);
    }
 
    private static Resources RES = GWT.create(Resources.class);
@@ -87,4 +117,8 @@ public class ThemedPopupPanel extends DecoratedPopupPanel
    {
       RES.styles().ensureInjected();
    }
+
+   // fit the popup and its overflow inside the app body as best as possible
+   protected boolean autoConstrain_;
+   protected BaseMenuBar menuBar_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.java
@@ -100,7 +100,7 @@ public class ThemedPopupPanel extends DecoratedPopupPanel
    // Size the table to the window
    private void sizeToWindow(int top, Style.Overflow overflowY)
    {
-      NodeList<Element> e = this.menuBar_.getElement().getElementsByTagName("table");
+      NodeList<Element> e = menuBar_.getElement().getElementsByTagName("table");
       if (e.getLength() < 1)
          return;
 
@@ -111,6 +111,8 @@ public class ThemedPopupPanel extends DecoratedPopupPanel
       table.getStyle().setDisplay(Style.Display.BLOCK);
       table.getStyle().setPropertyPx("maxHeight", windowHeight - top - 30);
    }
+
+   protected BaseMenuBar getMenuBar() { return menuBar_; }
 
    private static Resources RES = GWT.create(Resources.class);
    public static void ensureStylesInjected()

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
@@ -82,10 +82,10 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
       super.onUnload();
       menuBar_.selectItem(null);
    }
-   
+
    public void selectFirst()
    {
-      menuBar_.selectFirst();
+      ((ToolbarMenuBar)menuBar_).selectFirst();
    }
 
    public void selectItem(MenuItem menuItem)
@@ -118,7 +118,7 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
       if (command.isEnabled())
          addItem(command.createMenuItem(false), popup);
    }
-   
+
    public void setAutoOpen(boolean autoOpen)
    {
       menuBar_.setAutoOpen(autoOpen);
@@ -172,7 +172,7 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
       return menuBar_.getItemCount() ;
    }
 
-   public List<MenuItem> getMenuItems() { return menuBar_.getMenuItems(); }
+   public List<MenuItem> getMenuItems() { return ((ToolbarMenuBar)menuBar_).getMenuItems(); }
 
    public void focus()
    {
@@ -303,7 +303,7 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
          }
          return -1;
       }
-      
+
       private void moveSelectionFwd(int numElements)
       {
          selectItem(getSelectedIndex() + numElements);
@@ -349,7 +349,6 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
       return tableNode.<Element>cast();
       
    }
-   
-   protected ToolbarMenuBar menuBar_;
+
    private ToolbarPopupMenu parent_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
@@ -73,19 +73,19 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
 
    protected Widget createMainWidget()
    {
-      return menuBar_;
+      return getMenuBar();
    }
    
    @Override
    protected void onUnload()
    {
       super.onUnload();
-      menuBar_.selectItem(null);
+      getMenuBar().selectItem(null);
    }
 
    public void selectFirst()
    {
-      ((ToolbarMenuBar)menuBar_).selectFirst();
+      getMenuBar().selectFirst();
    }
 
    public void selectItem(MenuItem menuItem)
@@ -105,12 +105,12 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
    
    public void addItem(SafeHtml html, MenuBar popup)
    {
-      menuBar_.addItem(html, popup);
+      getMenuBar().addItem(html, popup);
    }
    
    public void addItem(MenuItem menuItem, final ToolbarPopupMenu popup)
    {
-      menuBar_.addItem(SafeHtmlUtils.fromTrustedString(menuItem.getHTML()), popup.menuBar_);
+      getMenuBar().addItem(SafeHtmlUtils.fromTrustedString(menuItem.getHTML()), popup.menuBar_);
    }
    
    public void addItem(AppCommand command, ToolbarPopupMenu popup)
@@ -121,7 +121,7 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
 
    public void setAutoOpen(boolean autoOpen)
    {
-      menuBar_.setAutoOpen(autoOpen);
+      getMenuBar().setAutoOpen(autoOpen);
    }
    
    public void insertItem(MenuItem menuItem, int beforeIndex)
@@ -129,65 +129,66 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
      ScheduledCommand command = menuItem.getScheduledCommand() ;
       if (command != null)
          menuItem.setScheduledCommand(new ToolbarPopupMenuCommand(command));
-      menuBar_.insertItem(menuItem, beforeIndex) ;
+      getMenuBar().insertItem(menuItem, beforeIndex) ;
    }
    
    public void removeItem(MenuItem menuItem)
    {
-      menuBar_.removeItem(menuItem) ;
+      getMenuBar().removeItem(menuItem) ;
    }
    
    public boolean containsItem(MenuItem menuItem)
    {
-      return menuBar_.getItemIndex(menuItem) >= 0 ;
+      return getMenuBar().getItemIndex(menuItem) >= 0 ;
    }
    
    public void clearItems()
    {
-      menuBar_.clearItems() ;
+      getMenuBar().clearItems() ;
    }
    
    public void addSeparator()
    {
-      menuBar_.addSeparator();
+      getMenuBar().addSeparator();
    }
    
    public void addSeparator(MenuItemSeparator separator)
    {
-      menuBar_.addSeparator(separator);
+      getMenuBar().addSeparator(separator);
    }
    
    public void addSeparator(String label)
    {
-      menuBar_.addSeparator(new LabelledMenuSeparator(label));
+      getMenuBar().addSeparator(new LabelledMenuSeparator(label));
    }
    
    public void addSeparator(int minPx)
    {
-      menuBar_.addSeparator(new MinWidthMenuSeparator(minPx));
+      getMenuBar().addSeparator(new MinWidthMenuSeparator(minPx));
    }
    
    public int getItemCount()
    {
-      return menuBar_.getItemCount() ;
+      return getMenuBar().getItemCount() ;
    }
 
-   public List<MenuItem> getMenuItems() { return ((ToolbarMenuBar)menuBar_).getMenuItems(); }
+   public List<MenuItem> getMenuItems() { return getMenuBar().getMenuItems(); }
 
    public void focus()
    {
-      menuBar_.focus();
+      getMenuBar().focus();
    }
    
    public void setAutoHideRedundantSeparators(boolean value)
    {
-      menuBar_.setAutoHideRedundantSeparators(value);
+      getMenuBar().setAutoHideRedundantSeparators(value);
    }
 
    public void getDynamicPopupMenu(DynamicPopupMenuCallback callback)
    {
       callback.onPopupMenu(this);
    }
+
 
    private class ToolbarPopupMenuCommand implements ScheduledCommand
    {
@@ -349,6 +350,9 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
       return tableNode.<Element>cast();
       
    }
+
+   @Override
+   protected ToolbarMenuBar getMenuBar() { return (ToolbarMenuBar)menuBar_; }
 
    private ToolbarPopupMenu parent_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/TabOverflowPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/TabOverflowPopupPanel.java
@@ -60,7 +60,7 @@ public class TabOverflowPopupPanel extends ThemedPopupPanel
    {
       public MenuKeyHandler(BaseMenuBar menu)
       {
-         menu_ = menu;
+         menuBar_ = menu;
       }
 
       public void onKeyDown(KeyDownEvent event)
@@ -72,7 +72,7 @@ public class TabOverflowPopupPanel extends ThemedPopupPanel
                event.preventDefault();
                event.stopPropagation();
 
-               ArrayList<MenuItem> items = menu_.getVisibleItems();
+               ArrayList<MenuItem> items = menuBar_.getVisibleItems();
 
                if (items.size() == 0)
                   return;
@@ -81,24 +81,24 @@ public class TabOverflowPopupPanel extends ThemedPopupPanel
 
                int index = up ? items.size() + 1 : -1;
 
-               MenuItem selectedItem = menu_.getSelectedItem();
+               MenuItem selectedItem = menuBar_.getSelectedItem();
                if (selectedItem != null && items.contains(selectedItem))
                   index = items.indexOf(selectedItem);
 
                index = (index + (up ? -1 : 1) + items.size()) % items.size();
 
-               menu_.selectItem(items.get(index));
+               menuBar_.selectItem(items.get(index));
                break;
             case KeyCodes.KEY_ENTER:
                event.preventDefault();
                event.stopPropagation();
 
-               MenuItem selected = menu_.getSelectedItem();
+               MenuItem selected = menuBar_.getSelectedItem();
                if (selected != null && selected.isVisible())
                   selected.getScheduledCommand().execute();
                else
                {
-                  ArrayList<MenuItem> visibleItems = menu_.getVisibleItems();
+                  ArrayList<MenuItem> visibleItems = menuBar_.getVisibleItems();
                   if (visibleItems.size() == 1)
                      visibleItems.get(0).getScheduledCommand().execute();
                }
@@ -106,7 +106,7 @@ public class TabOverflowPopupPanel extends ThemedPopupPanel
          }
       }
 
-      private final BaseMenuBar menu_;
+      private final BaseMenuBar menuBar_;
    }
 
    public TabOverflowPopupPanel()
@@ -121,15 +121,15 @@ public class TabOverflowPopupPanel extends ThemedPopupPanel
       search_.getElement().getStyle().setMarginRight(0, Unit.PX);
       dockPanel.add(search_, DockPanel.NORTH);
 
-      menu_ = new DocsMenu();
-      menu_.setOwnerPopupPanel(this);
-      menu_.setWidth("100%");
-      dockPanel.add(menu_, DockPanel.CENTER);
+      menuBar_ = new DocsMenu();
+      ((DocsMenu)menuBar_).setOwnerPopupPanel(this);
+      menuBar_.setWidth("100%");
+      dockPanel.add(menuBar_, DockPanel.CENTER);
       setWidget(dockPanel);
 
       setStylePrimaryName(ThemeStyles.INSTANCE.tabOverflowPopup());
 
-      addDomHandler(new MenuKeyHandler(menu_), KeyDownEvent.getType());
+      addDomHandler(new MenuKeyHandler(menuBar_), KeyDownEvent.getType());
       
       addAttachHandler(new AttachEvent.Handler()
       {
@@ -189,8 +189,8 @@ public class TabOverflowPopupPanel extends ThemedPopupPanel
          public void onClose(CloseEvent<PopupPanel> popupPanelCloseEvent)
          {
             search_.setText("", true);
-            menu_.filter(null);
-            menu_.selectItem(null);
+            ((DocsMenu)menuBar_).filter(null);
+            menuBar_.selectItem(null);
          }
       }, CloseEvent.getType());
    }
@@ -198,7 +198,7 @@ public class TabOverflowPopupPanel extends ThemedPopupPanel
    public void onValueChange(ValueChangeEvent<String> event)
    {
       String value = event.getValue();
-      menu_.filter(value);
+      ((DocsMenu)menuBar_).filter(value);
    }
 
    @Override
@@ -214,7 +214,6 @@ public class TabOverflowPopupPanel extends ThemedPopupPanel
       });
    }
 
-   private final DocsMenu menu_;
    private final SearchWidget search_;
    private HandlerRegistration nativePreviewHandler_;
    private Element lastFocusedElement_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/TabOverflowPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/TabOverflowPopupPanel.java
@@ -122,14 +122,14 @@ public class TabOverflowPopupPanel extends ThemedPopupPanel
       dockPanel.add(search_, DockPanel.NORTH);
 
       menuBar_ = new DocsMenu();
-      ((DocsMenu)menuBar_).setOwnerPopupPanel(this);
-      menuBar_.setWidth("100%");
-      dockPanel.add(menuBar_, DockPanel.CENTER);
+      getMenuBar().setOwnerPopupPanel(this);
+      getMenuBar().setWidth("100%");
+      dockPanel.add(getMenuBar(), DockPanel.CENTER);
       setWidget(dockPanel);
 
       setStylePrimaryName(ThemeStyles.INSTANCE.tabOverflowPopup());
 
-      addDomHandler(new MenuKeyHandler(menuBar_), KeyDownEvent.getType());
+      addDomHandler(new MenuKeyHandler(getMenuBar()), KeyDownEvent.getType());
       
       addAttachHandler(new AttachEvent.Handler()
       {
@@ -189,8 +189,8 @@ public class TabOverflowPopupPanel extends ThemedPopupPanel
          public void onClose(CloseEvent<PopupPanel> popupPanelCloseEvent)
          {
             search_.setText("", true);
-            ((DocsMenu)menuBar_).filter(null);
-            menuBar_.selectItem(null);
+            getMenuBar().filter(null);
+            getMenuBar().selectItem(null);
          }
       }, CloseEvent.getType());
    }
@@ -198,7 +198,7 @@ public class TabOverflowPopupPanel extends ThemedPopupPanel
    public void onValueChange(ValueChangeEvent<String> event)
    {
       String value = event.getValue();
-      ((DocsMenu)menuBar_).filter(value);
+      getMenuBar().filter(value);
    }
 
    @Override
@@ -213,6 +213,9 @@ public class TabOverflowPopupPanel extends ThemedPopupPanel
          }
       });
    }
+
+   @Override
+   protected DocsMenu getMenuBar() { return (DocsMenu)menuBar_; }
 
    private final SearchWidget search_;
    private HandlerRegistration nativePreviewHandler_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client.workbench.views.terminal;
 
+import com.google.gwt.dom.client.Style;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
@@ -44,6 +45,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
 {
    public TerminalPopupMenu(TerminalList terminals)
    {
+      super();
       RStudioGinjector.INSTANCE.injectMembers(this);
       terminals_ = terminals;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
@@ -15,7 +15,6 @@
 
 package org.rstudio.studio.client.workbench.views.terminal;
 
-import com.google.gwt.dom.client.Style;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
@@ -45,7 +44,6 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
 {
    public TerminalPopupMenu(TerminalList terminals)
    {
-      super();
       RStudioGinjector.INSTANCE.injectMembers(this);
       terminals_ = terminals;
    }


### PR DESCRIPTION
Added a flag (defaulted to on) to ThemedPopupPanel such that it constrains itself to the app window after a position and size is set. I tried to get it as high as I comfortably could in the hierarchy with an option for subclasses to turn it off so I could reach as many panels as possible that may need this treatment but it's possible I missed something, would want a moderate smoke test by QA after merging to find some possible exceptions.

Tiny laptop users can rejoice!
![WDeYarO](https://user-images.githubusercontent.com/136863/67231941-4e300480-f40e-11e9-8317-4b21d9fcc239.png)
![jRaOUAK](https://user-images.githubusercontent.com/136863/67231948-512af500-f40e-11e9-891b-37fcd94d895c.png)
![oWNkJNM](https://user-images.githubusercontent.com/136863/67231958-56883f80-f40e-11e9-9479-1161852ef359.png)
