### PR TITLE
Fixes an issue where neither auto-complete nor tab-insertion is taking place.

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
@@ -730,8 +730,7 @@ public abstract class CompletionManagerBase
             return false;
       }
       
-      beginSuggest(true, true, true);
-      return true;
+      return beginSuggest(true, true, true);
    }
    
    private void showPopupHelp(QualifiedName completion)


### PR DESCRIPTION
In some contexts, `beginSuggest` returns false to indicate that we shouldn't be attempting to auto-complete (such as in the comments of a Stan document) so it doesn't even pop up a `(No matches)` message, but `onTab()` returns true regardless of the result of `beginSuggest`. This PR causes `onTab()` to return the result of `beginSuggest` which correctly allows tabs to be inserted when we shouldn't be auto-completing.

Fixes #5387.