### PR TITLE
Refine error handling used to get cwd of a pid on mac

### DIFF
--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -44,6 +44,7 @@
 #include <mach-o/dyld.h>
 #include <sys/proc_info.h>
 #include <libproc.h>
+#include <gsl/gsl>
 #endif
 
 #ifndef __APPLE__
@@ -1217,14 +1218,14 @@ FilePath currentWorkingDirMac(PidType pid)
             &info, PROC_PIDVNODEPATHINFO_SIZE);
 
    // check for explicit failure
-   if (size == -1)
+   if (size <= 0)
    {
       LOG_ERROR(systemError(errno, ERROR_LOCATION));
       return FilePath();
    }
 
    // check for failure to write all required bytes
-   if (size != PROC_PIDVNODEPATHINFO_SIZE)
+   if (size < gsl::narrow_cast<int>(PROC_PIDVNODEPATHINFO_SIZE))
    {
       using namespace boost::system::errc;
       LOG_ERROR(systemError(not_enough_memory, ERROR_LOCATION));


### PR DESCRIPTION
On rare occasions, usually when using the rstudio terminal pane in cruel and unusual ways, I see an error logged of the form:

```
21 Oct 2019 19:04:42 [rsession-gary] ERROR system error 12 (Cannot allocate memory); LOGGED FROM: rstudio::core::FilePath rstudio::core::system::currentWorkingDirMac(PidType) /Users/gary/rstudio/src/cpp/core/system/PosixSystem.cpp:1230
```

This always seemed... unlikely, so tweaked the error handling of the proc_pidinfo call to match the pattern used in the open-source code for Mac lsof command. Next time this happens maybe I'll get a more useful error code.

https://opensource.apple.com/source/lsof/lsof-62/lsof/dialects/darwin/libproc/dproc.c.auto.html