### PR TITLE
Feature/close all terminals command

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -62,6 +62,7 @@
 * Support Ctrl+[ as Esc key on iPadOS 13.1 keyboards lacking physical Esc key (#4663)
 * Warn when Xcode license has not been agreed to on macOS when command line tools required (#5481)
 * Improved browser tab names (project name first, complete product name) (Pro #1172)
+* Add 'Close All Terminals' command to Terminal menu (#3564)
 
 ### Bugfixes
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -466,6 +466,8 @@ well as menu structures (for main menu and popup menus).
             <cmd refid="interruptTerminal"/>
             <cmd refid="clearTerminalScrollbackBuffer"/>
             <cmd refid="closeTerminal"/>
+            <separator/>
+            <cmd refid="closeAllTerminals"/>
           </menu>
          <menu label="_Jobs">
             <cmd refid="startJob"/>
@@ -2698,6 +2700,11 @@ well as menu structures (for main menu and popup menus).
         label="Close Terminal"
         menuLabel="Cl_ose Terminal"
         desc="Close current terminal session"/>
+
+   <cmd id="closeAllTerminals"
+        buttonLabel=""
+        label="Close _All Terminals"
+        menuLabel="Close All Terminals"/>
 
    <cmd id="clearTerminalScrollbackBuffer"
         buttonLabel=""

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -417,6 +417,7 @@ public abstract class
    public abstract AppCommand activateTerminal();
    public abstract AppCommand renameTerminal();
    public abstract AppCommand closeTerminal();
+   public abstract AppCommand closeAllTerminals();
    public abstract AppCommand clearTerminalScrollbackBuffer();
    public abstract AppCommand previousTerminal();
    public abstract AppCommand nextTerminal();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -460,9 +460,13 @@ public class TerminalPane extends WorkbenchPane
    }
 
    @Override
-   public void terminateAllTerminals()
+   public void terminateAllTerminals(boolean tabClosing)
    {
-      setShowTerminalPref(false);
+      if (tabClosing)
+      {
+         // don't want terminal tab to show by default next time we startup'
+         setShowTerminalPref(false);
+      }
       closingAll_ = true;
 
       // kill any terminal server processes, and remove them from the server-

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -464,7 +464,7 @@ public class TerminalPane extends WorkbenchPane
    {
       if (tabClosing)
       {
-         // don't want terminal tab to show by default next time we startup'
+         // don't show terminal tab by default at next startup
          setShowTerminalPref(false);
       }
       closingAll_ = true;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
@@ -101,6 +101,8 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
          addItem(commands_.interruptTerminal().createMenuItem(false));
          addItem(commands_.clearTerminalScrollbackBuffer().createMenuItem(false));
          addItem(commands_.closeTerminal().createMenuItem(false));
+         addSeparator();
+         addItem(commands_.closeAllTerminals().createMenuItem(false));
       }
 
       callback.onPopupMenu(this);
@@ -271,10 +273,6 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
          {
             if (StringUtil.equals(activeTerminalHandle_, handle))
             {
-               if (prevHandle == null)
-               {
-                  return null;
-               }
                return prevHandle;
             }
             else
@@ -311,7 +309,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
 
    private ToolbarMenuButton toolbarButton_;
    private String activeTerminalHandle_;
-   private TerminalList terminals_;
+   private final TerminalList terminals_;
 
    // Injected ----
    private Commands commands_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTab.java
@@ -61,6 +61,9 @@ public class TerminalTab extends DelayLoadWorkbenchTab<TerminalTabPresenter>
       public abstract void onCloseTerminal();
 
       @Handler
+      public abstract void onCloseAllTerminals();
+
+      @Handler
       public abstract void onRenameTerminal();
 
       @Handler
@@ -87,7 +90,7 @@ public class TerminalTab extends DelayLoadWorkbenchTab<TerminalTabPresenter>
        */
       abstract void onRepopulateTerminals(ArrayList<ConsoleProcessInfo> procList);
 
-      abstract void confirmClose(Command onConfirmed);
+      abstract void confirmClose(boolean tabClosing, Command onConfirmed);
    }
 
    @Inject
@@ -109,7 +112,8 @@ public class TerminalTab extends DelayLoadWorkbenchTab<TerminalTabPresenter>
       events.addHandler(RemoveTerminalEvent.TYPE, shim_);
       events.addHandler(ActivateNamedTerminalEvent.TYPE, shim_);
 
-      events.addHandler(SessionInitEvent.TYPE, sie -> {
+      events.addHandler(SessionInitEvent.TYPE, sie ->
+      {
          JsArray<ConsoleProcessInfo> procs =
                session.getSessionInfo().getConsoleProcesses();
          final ArrayList<ConsoleProcessInfo> procList = new ArrayList<>();
@@ -136,7 +140,8 @@ public class TerminalTab extends DelayLoadWorkbenchTab<TerminalTabPresenter>
    @Override
    public void confirmClose(Command onConfirmed)
    {
-      shim_.confirmClose(onConfirmed);
+      // closing the entire Terminal pane
+      shim_.confirmClose(true, onConfirmed);
    }
 
    /**
@@ -180,7 +185,7 @@ public class TerminalTab extends DelayLoadWorkbenchTab<TerminalTabPresenter>
       procInfoList.add(procInfo);
    }
 
-   private Shim shim_;
+   private final Shim shim_;
 
    private final Provider<ConsoleProcessFactory> pConsoleProcessFactory_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
@@ -79,7 +79,14 @@ public class TerminalTabPresenter extends BasePresenter
        * process and removes it from the list of known processes. This should
        * only be invoked when the terminal tab itself is being unloaded.
        */
-      void terminateAllTerminals();
+
+      /**
+       * Terminate all terminals, whether busy or not. This kills any server-side
+       * process and removes it from the list of known processes.
+       *
+       * @param tabClosing is the terminal tab itself being closed?
+       */
+      void terminateAllTerminals(boolean tabClosing);
 
       void renameTerminal();
       void clearTerminalScrollbackBuffer(String caption);
@@ -156,6 +163,13 @@ public class TerminalTabPresenter extends BasePresenter
    public void onCloseTerminal()
    {
       view_.terminateCurrentTerminal();
+   }
+
+   @Handler
+   public void onCloseAllTerminals()
+   {
+      // Close all terminals but leave the Terminal tab showing
+      confirmClose(false, null);
    }
 
    @Handler
@@ -238,7 +252,8 @@ public class TerminalTabPresenter extends BasePresenter
    {
       // Request to display the terminal tab and optionally select a specific terminal; if
       // no terminal is specified, then make sure there is an active terminal
-      view_.activateTerminal(() -> {
+      view_.activateTerminal(() ->
+      {
          if (StringUtil.isNullOrEmpty(event.getId()))
             view_.ensureTerminal();
          else
@@ -251,20 +266,23 @@ public class TerminalTabPresenter extends BasePresenter
       view_.repopulateTerminals(procList);
    }
 
-   public void confirmClose(final Command onConfirmed)
+   public void confirmClose(boolean tabClosing, final Command onConfirmed)
    {
-      final String caption = "Close Terminal(s) ";
-      terminalHelper_.warnBusyTerminalBeforeCommand(() -> {
-         shutDownTerminals();
-         onConfirmed.execute();
-      }, caption, "Are you sure you want to close all terminals? Any running jobs " +
-            "will be stopped",
-            userPrefs_.busyDetection().getValue());
+      final String caption = "Close All Terminals";
+      terminalHelper_.warnBusyTerminalBeforeCommand(() ->
+         {
+            shutDownTerminals(tabClosing);
+            if (onConfirmed != null)
+               onConfirmed.execute();
+         },
+         caption, "Are you sure you want to close all terminals? Any running jobs will be stopped",
+         userPrefs_.busyDetection().getValue()
+      );
    }
 
-   private void shutDownTerminals()
+   private void shutDownTerminals(boolean tabClosing)
    {
-      view_.terminateAllTerminals();
+      view_.terminateAllTerminals(tabClosing);
    }
 
    // Injected ---- 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalTabPresenter.java
@@ -268,15 +268,18 @@ public class TerminalTabPresenter extends BasePresenter
 
    public void confirmClose(boolean tabClosing, final Command onConfirmed)
    {
-      final String caption = "Close All Terminals";
-      terminalHelper_.warnBusyTerminalBeforeCommand(() ->
-         {
-            shutDownTerminals(tabClosing);
-            if (onConfirmed != null)
-               onConfirmed.execute();
-         },
-         caption, "Are you sure you want to close all terminals? Any running jobs will be stopped",
-         userPrefs_.busyDetection().getValue()
+      Command command = () ->
+      {
+         shutDownTerminals(tabClosing);
+         if (onConfirmed != null)
+            onConfirmed.execute();
+      };
+
+      terminalHelper_.warnBusyTerminalBeforeCommand(
+            command,
+            "Close All Terminals",
+            "Are you sure you want to close all terminals? Any running jobs will be stopped",
+            userPrefs_.busyDetection().getValue()
       );
    }
 


### PR DESCRIPTION
Easy to implement convenience command for closing all open terminals without having to resort to closing the entire tab, or one-at-a-time.

"Are you sure" prompt if any of the terminals report themselves busy.

Fixes #3564
