### PR TITLE
Some drivers require setup parameter in windows registry

### DIFF
--- a/src/cpp/session/modules/SessionConnectionsInstaller.R
+++ b/src/cpp/session/modules/SessionConnectionsInstaller.R
@@ -472,6 +472,11 @@
          ),
          list(
             path = file.path("SOFTWARE", "ODBC", "ODBCINST.INI", name, fsep = "\\"),
+            key = "Setup",
+            value = driverPath
+         ),
+         list(
+            path = file.path("SOFTWARE", "ODBC", "ODBCINST.INI", name, fsep = "\\"),
             key = "Version",
             value = version
          ),


### PR DESCRIPTION
See https://github.com/rstudio/odbc-install/issues/95, some drivers require setup parameter in windows registry.

CC: @blairj09 

Notice that this PR still requires proper testing in the right environment, with the particular driver, etc. which I'd suggest we do after it's merged and follow up if needed.