### PR TITLE
Make R unit test failures cause rsession-tests to return a non-zero exit code

### DIFF
--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -2,16 +2,14 @@
 
 checkUnitTestFailure() {
    RET_CODE=$?
-   if [ $RET_CODE != 0 ];
-   then
+   if [ $RET_CODE != 0 ]; then
       UNIT_TEST_FAILURE=true
    fi
 }
 
 checkRUnitTestFailure() {
-    FAILURES=$(cat ${CMAKE_CURRENT_BINARY_DIR}/testthat-failures.log)
-    if [[ $FAILURES != 0 ]];
-    then
+    FAILURES=$(cat "${CMAKE_CURRENT_BINARY_DIR}/testthat-failures.log")
+    if [[ $FAILURES != 0 ]]; then
         UNIT_TEST_FAILURE=true
     fi
 }

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -8,6 +8,14 @@ checkUnitTestFailure() {
    fi
 }
 
+checkRUnitTestFailure() {
+    FAILURES=$(cat ${CMAKE_CURRENT_BINARY_DIR}/testthat-failures.log)
+    if [[ $FAILURES != 0 ]];
+    then
+        UNIT_TEST_FAILURE=true
+    fi
+}
+
 TEST_SCOPE=
 if [ "$1" == "--scope" ]; then 
    if [ "$#" == 1 ]; then 
@@ -101,9 +109,9 @@ if [ -z "$TEST_SCOPE" ] || [ "$TEST_SCOPE" == "r" ]; then
     RS_CRASH_HANDLER_PATH="${CMAKE_CURRENT_BINARY_DIR}/server/crash-handler-proxy/crash-handler-proxy" \
        RS_CRASHPAD_HANDLER_PATH="/opt/rstudio-tools/crashpad/crashpad/out/Default/crashpad_handler" \
     "${CMAKE_CURRENT_BINARY_DIR}/session/$RSTUDIO_SESSION_BIN" \
-        --run-script "testthat::test_dir('${CMAKE_CURRENT_SOURCE_DIR}/tests/testthat'$TESTTHAT_FILTER)" \
+        --run-script "source('${CMAKE_CURRENT_SOURCE_DIR}/tests/testthat/run-tests.R'); runAllTests('${CMAKE_CURRENT_SOURCE_DIR}', '${CMAKE_CURRENT_BINARY_DIR}'$TESTTHAT_FILTER)" \
         --config-file="$SESSION_CONF_FILE"
-    checkUnitTestFailure
+    checkRUnitTestFailure
 fi
 
 # return an error exit code if any unit tests failed

--- a/src/cpp/tests/testthat/run-tests.R
+++ b/src/cpp/tests/testthat/run-tests.R
@@ -13,5 +13,5 @@ runAllTests <- function(sourceDir, outputDir, filter = NA)
       tests <- testthat::test_dir(testThatDir)
    }
    
-   cat(sum(as.data.frame(tests)$failed), file = file(file.path(outputDir, "testthat-failures.log")))
+   cat(sum(as.data.frame(tests)$failed), file = file.path(outputDir, "testthat-failures.log"))
 }

--- a/src/cpp/tests/testthat/run-tests.R
+++ b/src/cpp/tests/testthat/run-tests.R
@@ -1,0 +1,18 @@
+library(testthat)
+
+runAllTests <- function(sourceDir, outputDir, filter = NA)
+{
+   testThatDir <- file.path(sourceDir, "tests/testthat")
+   
+   if (!is.na(filter))
+   {
+      tests <- testthat::test_dir(testThatDir, filter = filter)
+   } else
+   {
+      tests <- testthat::test_dir(testThatDir)
+   }
+   
+   resultFile <- file(file.path(outputDir, "testthat-failures.log"), open="w")
+   cat(sum(as.data.frame(tests)$failed), file = resultFile)
+   close(resultFile)
+}

--- a/src/cpp/tests/testthat/run-tests.R
+++ b/src/cpp/tests/testthat/run-tests.R
@@ -7,12 +7,11 @@ runAllTests <- function(sourceDir, outputDir, filter = NA)
    if (!is.na(filter))
    {
       tests <- testthat::test_dir(testThatDir, filter = filter)
-   } else
+   } 
+   else
    {
       tests <- testthat::test_dir(testThatDir)
    }
    
-   resultFile <- file(file.path(outputDir, "testthat-failures.log"), open="w")
-   cat(sum(as.data.frame(tests)$failed), file = resultFile)
-   close(resultFile)
+   cat(sum(as.data.frame(tests)$failed), file = file(file.path(outputDir, "testthat-failures.log")))
 }


### PR DESCRIPTION
Fixes #5472

The `testthat::test_dir` call is wrapped in a script that writes the number of failures to `${CMAKE_CURRENT_BINARY_DIR}/testthat-failures.log`. The unit test script checks the file and returns a non-zero exit code if there were any failures.