### PR TITLE
delegate to utils::install.packages() when pkgs not specified

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -123,6 +123,9 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
                                                                 repos = getOption("repos"),
                                                                 ...) 
    {
+      if (missing(pkgs))
+         return(utils::install.packages())
+      
       if (!.Call("rs_canInstallPackages", PACKAGE = "(embedding)"))
       {
         stop("Package installation is disabled in this version of RStudio",


### PR DESCRIPTION
Closes #5154.