### PR TITLE
prevent GWT warning message when opening Prefs dialog

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBase.java
@@ -94,8 +94,9 @@ public abstract class PreferencesDialogBase<T> extends ModalDialogBase
 
          // SectionChooser is first focusable control in the modal dialog, and it
          // uses a roving tabindex to determine the focused section tab, so notify dialog
-         // when focus leaves or arrives at first tab
-         if ((currentIndex_ != null && currentIndex_ == 0) || index == 0)
+         // when selected tab changes (except the initial selection, which happens before
+         // the dialog is fully assembled and thus nothing is focusable, yet)
+         if (currentIndex_ != null)
             refreshFocusableElements();
 
          if (currentIndex_ != null)


### PR DESCRIPTION
- Fixes #5609
- Don't refreshFocusableElements when the first selection is made
  because the dialog isn't fully constructed yet and nothing is
  actually focusable at that point
- Fix bug where I was only refreshingFocusableElement when moving from
  or to the first tab; needs to happen with any tabs or the original
  bug that motivated this change still happens!
- Updated Selenium accessibility test to check this case (https://github.com/rstudio/rstudio-ide-automation/pull/27)