### PR TITLE
use common compilation args when generating precompiled headers

### DIFF
--- a/src/cpp/session/modules/SessionClang.R
+++ b/src/cpp/session/modules/SessionClang.R
@@ -15,59 +15,73 @@
 
 
 
-.rs.addFunction( "clangPCHPath", function(pkg, clangVersion) {
-   paste(packageVersion(pkg),
-         R.version$platform,
-         R.version$`svn rev`,
-         clangVersion,
-         sep = "-")
+.rs.addFunction("clangPCHPath", function(pkg, clangVersion)
+{
+  paste(
+    packageVersion(pkg),
+    R.version$platform,
+    R.version$`svn rev`,
+    clangVersion,
+    sep = "-"
+  )
 })
 
-.rs.addFunction( "isClangAvailable", function() {
-   cat("Attemping to load libclang for", R.version$platform, "\n")
-   .Call("rs_isLibClangAvailable")
+.rs.addFunction("isClangAvailable", function() {
+  cat("Attemping to load libclang for", R.version$platform, "\n")
+  .Call("rs_isLibClangAvailable", PACKAGE = "(embedding)")
 })
 
-.rs.addFunction( "setClangDiagnostics", function(level) {
-   if (!is.numeric(level) || (level < 0) || (level > 2))
-      stop("level must be 0, 1, or 2")
-   if (level > 0)
-      .rs.isClangAvailable()
-   .Call("rs_setClangDiagnostics", level)
-   .rs.restartR()
-   invisible(NULL)
+.rs.addFunction("setClangDiagnostics", function(level)
+{
+  if (!is.numeric(level) || (level < 0) || (level > 2))
+    stop("level must be 0, 1, or 2")
+  
+  if (level > 0)
+    .rs.isClangAvailable()
+  
+  .Call("rs_setClangDiagnostics", level, PACKAGE = "(embedding)")
+  
+  .rs.restartR()
+  invisible(NULL)
 })
 
-.rs.addFunction( "packagePCH", function(linkingTo) {
-   linkingTo <- .rs.parseLinkingTo(linkingTo)
-   if ("Rcpp" %in% linkingTo)
-      "Rcpp"
-   else if ("Rcpp11" %in% linkingTo)
-      "Rcpp11"
-   else
-      ""
+.rs.addFunction("packagePCH", function(linkingTo)
+{
+  linkingTo <- .rs.parseLinkingTo(linkingTo)
+  packages <- c("RcppArmadillo", "RcppEigen", "Rcpp11", "Rcpp")
+  for (package in packages)
+    if (package %in% linkingTo)
+      return(package)
+  ""
 })
 
-.rs.addFunction( "includesForLinkingTo", function(linkingTo) {
+.rs.addFunction("includesForLinkingTo", function(linkingTo)
+{
   includes <- character()
+  
   linkingTo <- .rs.parseLinkingTo(linkingTo)
   for (pkg in linkingTo) {
     includeDir <- system.file("include", package = pkg)
     if (file.exists(includeDir)) {
-      includes <- c(includes, 
-                    paste("-I", .rs.asBuildPath(includeDir), sep = ""))
+      includes <- c(
+        includes,
+        paste("-I", .rs.asBuildPath(includeDir), sep = "")
+      )
     }
   }
+  
   includes
 })
 
-.rs.addFunction( "asBuildPath", function(path) {  
+.rs.addFunction("asBuildPath", function(path)
+{
   if (.Platform$OS.type == "windows") {
     path <- normalizePath(path)
-    if (grepl(' ', path, fixed=TRUE))
+    if (grepl(' ', path, fixed = TRUE))
       path <- utils::shortPathName(path)
     path <- gsub("\\\\", "/", path)
   }
+  
   return(path)
 })
 

--- a/src/cpp/session/modules/SessionClang.R
+++ b/src/cpp/session/modules/SessionClang.R
@@ -17,72 +17,72 @@
 
 .rs.addFunction("clangPCHPath", function(pkg, clangVersion)
 {
-  paste(
-    packageVersion(pkg),
-    R.version$platform,
-    R.version$`svn rev`,
-    clangVersion,
-    sep = "-"
-  )
+   paste(
+      packageVersion(pkg),
+      R.version$platform,
+      R.version$`svn rev`,
+      clangVersion,
+      sep = "-"
+   )
 })
 
 .rs.addFunction("isClangAvailable", function() {
-  cat("Attemping to load libclang for", R.version$platform, "\n")
-  .Call("rs_isLibClangAvailable", PACKAGE = "(embedding)")
+   cat("Attemping to load libclang for", R.version$platform, "\n")
+   .Call("rs_isLibClangAvailable", PACKAGE = "(embedding)")
 })
 
 .rs.addFunction("setClangDiagnostics", function(level)
 {
-  if (!is.numeric(level) || (level < 0) || (level > 2))
-    stop("level must be 0, 1, or 2")
-  
-  if (level > 0)
-    .rs.isClangAvailable()
-  
-  .Call("rs_setClangDiagnostics", level, PACKAGE = "(embedding)")
-  
-  .rs.restartR()
-  invisible(NULL)
+   if (!is.numeric(level) || (level < 0) || (level > 2))
+      stop("level must be 0, 1, or 2")
+   
+   if (level > 0)
+      .rs.isClangAvailable()
+   
+   .Call("rs_setClangDiagnostics", level, PACKAGE = "(embedding)")
+   
+   .rs.restartR()
+   invisible(NULL)
 })
 
 .rs.addFunction("packagePCH", function(linkingTo)
 {
-  linkingTo <- .rs.parseLinkingTo(linkingTo)
-  packages <- c("RcppArmadillo", "RcppEigen", "Rcpp11", "Rcpp")
-  for (package in packages)
-    if (package %in% linkingTo)
-      return(package)
-  ""
+   linkingTo <- .rs.parseLinkingTo(linkingTo)
+   packages <- c("RcppArmadillo", "RcppEigen", "Rcpp11", "Rcpp")
+   for (package in packages)
+      if (package %in% linkingTo)
+         return(package)
+   ""
 })
 
 .rs.addFunction("includesForLinkingTo", function(linkingTo)
 {
-  includes <- character()
-  
-  linkingTo <- .rs.parseLinkingTo(linkingTo)
-  for (pkg in linkingTo) {
-    includeDir <- system.file("include", package = pkg)
-    if (file.exists(includeDir)) {
-      includes <- c(
-        includes,
-        paste("-I", .rs.asBuildPath(includeDir), sep = "")
-      )
-    }
-  }
-  
-  includes
+   includes <- character()
+   
+   linkingTo <- .rs.parseLinkingTo(linkingTo)
+   for (pkg in linkingTo) {
+      includeDir <- system.file("include", package = pkg)
+      if (file.exists(includeDir)) {
+         includes <- c(
+            includes,
+            paste("-I", .rs.asBuildPath(includeDir), sep = "")
+         )
+      }
+   }
+   
+   includes
 })
 
 .rs.addFunction("asBuildPath", function(path)
 {
-  if (.Platform$OS.type == "windows") {
-    path <- normalizePath(path)
-    if (grepl(' ', path, fixed = TRUE))
-      path <- utils::shortPathName(path)
-    path <- gsub("\\\\", "/", path)
-  }
-  
-  return(path)
+   if (.Platform$OS.type == "windows") {
+      path <- normalizePath(path)
+      if (grepl(' ', path, fixed = TRUE))
+         path <- utils::shortPathName(path)
+      path <- gsub("\\\\", "/", path)
+   }
+   
+   return(path)
 })
 
 

--- a/src/cpp/session/modules/clang/RCompilationDatabase.hpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.hpp
@@ -33,6 +33,14 @@
 #define kCompilationDbPrefix "clang-compilation-db-"
 
 namespace rstudio {
+namespace core {
+namespace r_util {
+class RPackageInfo;
+} // namespace r_util
+} // namespace core
+} // namespace rstudio
+
+namespace rstudio {
 namespace session {
 namespace modules {      
 namespace clang {
@@ -89,7 +97,10 @@ private:
                                              core::FilePath tempSrcFile);
 
    std::vector<std::string> baseCompilationArgs(bool isCppFile) const;
-   std::vector<std::string> commonCompilationArgs();
+   std::vector<std::string> commonCompilationArgs(
+         core::r_util::RPackageInfo* pPkgInfo = nullptr,
+         bool* pIsCpp = nullptr);
+
    std::vector<std::string> rToolsArgs() const;
    core::system::Options compilationEnvironment() const;
    std::vector<std::string> precompiledHeaderArgs(const std::string& pkgName,

--- a/src/cpp/session/modules/clang/RCompilationDatabase.hpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.hpp
@@ -89,6 +89,7 @@ private:
                                              core::FilePath tempSrcFile);
 
    std::vector<std::string> baseCompilationArgs(bool isCppFile) const;
+   std::vector<std::string> commonCompilationArgs();
    std::vector<std::string> rToolsArgs() const;
    core::system::Options compilationEnvironment() const;
    std::vector<std::string> precompiledHeaderArgs(const std::string& pkgName,


### PR DESCRIPTION
This is necessary as, otherwise, the precompiled headers may effectively
be incompatible with the to-be-compiled translation units used in the
package.

As an example, if the precompiled headers are generated without
'-fopenmp', but C++ files within the package are compiled with
'-fopenmp', then attempts to include precompiled headers will fail and
diagnostics will not work as expected.

Part of #4685.