### PR TITLE
use 0.0.0.0 for -bindAddress in devmode

### DIFF
--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -164,7 +164,7 @@
          <arg value="-noserver"/>
          <arg value="-startupUrl"/>
          <arg value="http://localhost:8787"/>
-         <arg line="-bindAddress 127.0.0.1"/>
+         <arg line="-bindAddress 0.0.0.0"/>
          <arg value="-generateJsInteropExports"/>
          <arg value="org.rstudio.studio.RStudioDesktopSuperDevMode"/>
       </java>
@@ -186,7 +186,7 @@
          <arg value="-noserver"/>
          <arg value="-startupUrl"/>
          <arg value="http://localhost:8787"/>
-         <arg line="-bindAddress 127.0.0.1"/>
+         <arg line="-bindAddress 0.0.0.0"/>
          <arg value="-generateJsInteropExports"/>
          <!-- Additional arguments like -logLevel DEBUG -->
          <arg value="org.rstudio.studio.RStudioSuperDevMode"/>

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -30,10 +30,12 @@
 
    <!-- Configure path to GWT SDK -->
    <property name="gwt.sdk" value="${lib.dir}/gwt/gwt-rstudio-1.3"/>
-
    <property name="gwt.extra.args" value=""/>
    <property name="gwt.main.module" value="org.rstudio.studio.RStudio"/>
    <property name="ace.bin" value="${src.dir}/org/rstudio/studio/client/workbench/views/source/editors/text/ace"/>
+
+   <!-- configure code server -->
+   <property name="bind.address" value="127.0.0.1"/>
 
    <path id="project.class.path">
      <pathelement location="${build.dir}"/>
@@ -148,7 +150,20 @@
       </antcall>
    </target>
 
-   <target name="desktop" depends="acesupport,javac" description="Run development mode">
+   <target name="desktop" description="Run desktop development mode">
+      <antcall target="codeserver">
+         <param name="gwt.main.module" value="org.rstudio.studio.RStudioDesktopSuperDevMode"/>
+      </antcall>
+   </target>
+
+   <target name="devmode" description="Run server development mode">
+      <antcall target="codeserver">
+         <param name="gwt.main.module" value="org.rstudio.studio.RStudioSuperDevMode"/>
+      </antcall>
+   </target>
+
+   <target name="codeserver" depends="acesupport,javac" description="Run devmode server">
+
       <java failonerror="true" fork="true" classname="com.google.gwt.dev.DevMode">
          <classpath>
             <pathelement location="${src.dir}"/>
@@ -164,33 +179,11 @@
          <arg value="-noserver"/>
          <arg value="-startupUrl"/>
          <arg value="http://localhost:8787"/>
-         <arg line="-bindAddress 0.0.0.0"/>
+         <arg line="-bindAddress ${bind.address}"/>
          <arg value="-generateJsInteropExports"/>
-         <arg value="org.rstudio.studio.RStudioDesktopSuperDevMode"/>
+         <arg value="${gwt.main.module}"/>
       </java>
-   </target>
 
-   <target name="devmode" depends="acesupport,javac" description="Run development mode">
-      <java failonerror="true" fork="true" classname="com.google.gwt.dev.DevMode">
-         <classpath>
-            <pathelement location="src"/>
-            <path refid="project.class.path"/>
-         </classpath>
-         <jvmarg value="-Xmx2048M"/>
-         <arg value="-style"/>
-         <arg value="PRETTY"/>
-         <arg value="-XmethodNameDisplayMode"/>
-         <arg value="ABBREVIATED"/>
-         <arg value="-war"/>
-         <arg value="${www.dir}"/>
-         <arg value="-noserver"/>
-         <arg value="-startupUrl"/>
-         <arg value="http://localhost:8787"/>
-         <arg line="-bindAddress 0.0.0.0"/>
-         <arg value="-generateJsInteropExports"/>
-         <!-- Additional arguments like -logLevel DEBUG -->
-         <arg value="org.rstudio.studio.RStudioSuperDevMode"/>
-      </java>
    </target>
 
    <target name="build" depends="gwtc" description="Build this project" />

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -162,8 +162,7 @@
       </antcall>
    </target>
 
-   <target name="codeserver" depends="acesupport,javac" description="Run devmode server">
-
+   <target name="codeserver" depends="acesupport,javac" description="Run GWT devmode code server">
       <java failonerror="true" fork="true" classname="com.google.gwt.dev.DevMode">
          <classpath>
             <pathelement location="${src.dir}"/>
@@ -183,7 +182,6 @@
          <arg value="-generateJsInteropExports"/>
          <arg value="${gwt.main.module}"/>
       </java>
-
    </target>
 
    <target name="build" depends="gwtc" description="Build this project" />


### PR DESCRIPTION
This allows one to access a development version of RStudio Server on
machines other than the host machine. This is useful when e.g. you are
running a dev. server locally, but need to connect from (say) a Windows
guest.