### PR TITLE
Fix assorted accessibility issues with session-loading screens

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
+++ b/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
@@ -14,10 +14,13 @@
  */
 package org.rstudio.core.client.a11y;
 
+import com.google.gwt.aria.client.LiveValue;
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.theme.res.ThemeStyles;
 
 /**
  * Accessibility helpers including newer ARIA stuff not included with GWT
@@ -99,5 +102,71 @@ public class A11y
    public static void setARIAHidden(Element el)
    {
       el.setAttribute("aria-hidden", "true");
+   }
+
+   /**
+    * Mark as widget as an aria-live alert
+    *
+    * @param widget
+    * @param assertive
+    */
+   public static void setAlertRole(Widget widget, boolean assertive)
+   {
+      setAlertRole(widget.getElement(), assertive);
+   }
+
+   /**
+    * Mark an element as an aria-live alert
+    *
+    * @param el
+    * @param assertive
+    */
+   public static void setAlertRole(Element el, boolean assertive)
+   {
+      Roles.getAlertRole().set(el);
+      Roles.getAlertRole().setAriaLiveProperty(el, assertive ? LiveValue.ASSERTIVE : LiveValue.POLITE);
+      Roles.getAlertRole().setAriaAtomicProperty(el, true);
+   }
+
+   /**
+    * Mark a widget as an aria-live status
+    * @param widget
+    * @param assertive
+    */
+   public static void setStatusRole(Widget widget, boolean assertive)
+   {
+      setStatusRole(widget.getElement(), assertive);
+   }
+
+   /**
+    * Mark as widget as an aria-live status
+    * @param el
+    * @param assertive
+    */
+   public static void setStatusRole(Element el, boolean assertive)
+   {
+      Roles.getStatusRole().set(el);
+      Roles.getAlertRole().setAriaLiveProperty(el, assertive ? LiveValue.ASSERTIVE : LiveValue.POLITE);
+      Roles.getAlertRole().setAriaAtomicProperty(el, true);
+   }
+
+   public static void setVisuallyHidden(Widget widget)
+   {
+      setVisuallyHidden(widget.getElement());
+   }
+
+   public static void setVisuallyHidden(Element el)
+   {
+      el.setClassName(ThemeStyles.INSTANCE.visuallyHidden());
+   }
+
+   public static void unsetVisuallyHidden(Widget widget)
+   {
+      setVisuallyHidden(widget.getElement());
+   }
+
+   public static void unsetlVisuallyHidden(Element el)
+   {
+      el.removeClassName(ThemeStyles.INSTANCE.visuallyHidden());
    }
 }

--- a/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
+++ b/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
@@ -162,10 +162,10 @@ public class A11y
 
    public static void unsetVisuallyHidden(Widget widget)
    {
-      setVisuallyHidden(widget.getElement());
+      unsetVisuallyHidden(widget.getElement());
    }
 
-   public static void unsetlVisuallyHidden(Element el)
+   public static void unsetVisuallyHidden(Element el)
    {
       el.removeClassName(ThemeStyles.INSTANCE.visuallyHidden());
    }

--- a/src/gwt/src/org/rstudio/core/client/layout/DelayFadeInHelper.java
+++ b/src/gwt/src/org/rstudio/core/client/layout/DelayFadeInHelper.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.core.client.layout;
 
+import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -26,8 +27,19 @@ public class DelayFadeInHelper
 
    public DelayFadeInHelper(Widget widget, int ms)
    {
+      this(widget, ms, null);
+   }
+
+   /**
+    * @param widget widget to fadein
+    * @param ms animation duration
+    * @param callback optional callback to invoke after fadein complete
+    */
+   public DelayFadeInHelper(Widget widget, int ms, Command callback)
+   {
       widget_ = widget;
       animationMs_ = ms;
+      callback_ = callback;
    }
 
    public void beginShow()
@@ -43,8 +55,7 @@ public class DelayFadeInHelper
          {
             if (nonce_ == nonce)
             {
-               animation_ = new FadeInAnimation(
-                     widget_, 1, null);
+               animation_ = new FadeInAnimation(widget_, 1, callback_);
                animation_.run(animationMs_);
             }
          }
@@ -77,4 +88,5 @@ public class DelayFadeInHelper
 
    private final Widget widget_;
    private final int animationMs_;
+   private final Command callback_;
 }

--- a/src/gwt/src/org/rstudio/core/client/layout/FadeInAnimation.java
+++ b/src/gwt/src/org/rstudio/core/client/layout/FadeInAnimation.java
@@ -1,7 +1,7 @@
 /*
  * FadeInAnimation.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -27,7 +27,7 @@ public class FadeInAnimation extends Animation
                           double targetOpacity,
                           Command callback)
    {
-      this(new ArrayList<Widget>(), targetOpacity, callback);
+      this(new ArrayList<>(), targetOpacity, callback);
       widgets_.add(widget);
    }
 
@@ -61,6 +61,7 @@ public class FadeInAnimation extends Animation
       for (Widget w : widgets_)
       {
          w.getElement().getStyle().setOpacity(targetOpacity_);
+         w.setVisible(true);
       }
       if (callback_ != null)
          callback_.execute();

--- a/src/gwt/src/org/rstudio/core/client/widget/FieldSetPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FieldSetPanel.java
@@ -21,7 +21,6 @@ import com.google.gwt.user.client.ui.HasOneWidget;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.SimplePanel;
 import org.rstudio.core.client.a11y.A11y;
-import org.rstudio.core.client.theme.res.ThemeStyles;
 
 /**
  * Base class for panels containing one widget, wrapped in a Fieldset element.
@@ -37,7 +36,7 @@ public class FieldSetPanel extends SimplePanel implements HasOneWidget
 
       if (visuallyHideLegend)
       {
-         legendElement_.setClassName(ThemeStyles.INSTANCE.visuallyHidden());
+         A11y.setVisuallyHidden(legendElement_);
       }
    }
    
@@ -71,9 +70,9 @@ public class FieldSetPanel extends SimplePanel implements HasOneWidget
    public void setLegendHidden(boolean hidden)
    {
       if (hidden)
-         legendElement_.setClassName(ThemeStyles.INSTANCE.visuallyHidden());
+         A11y.setVisuallyHidden(legendElement_);
       else
-         legendElement_.removeClassName(ThemeStyles.INSTANCE.visuallyHidden());
+         A11y.unsetlVisuallyHidden(legendElement_);
    }
 
    private Element legendElement_;

--- a/src/gwt/src/org/rstudio/core/client/widget/FieldSetPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FieldSetPanel.java
@@ -72,7 +72,7 @@ public class FieldSetPanel extends SimplePanel implements HasOneWidget
       if (hidden)
          A11y.setVisuallyHidden(legendElement_);
       else
-         A11y.unsetlVisuallyHidden(legendElement_);
+         A11y.unsetVisuallyHidden(legendElement_);
    }
 
    private Element legendElement_;

--- a/src/gwt/src/org/rstudio/core/client/widget/ImageButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ImageButton.java
@@ -26,7 +26,7 @@ import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.FocusWidget;
 import com.google.gwt.user.client.ui.Image;
 import org.rstudio.core.client.StringUtil;
-import org.rstudio.core.client.theme.res.ThemeStyles;
+import org.rstudio.core.client.a11y.A11y;
 
 /**
  * An image that behaves like a button.
@@ -53,7 +53,7 @@ public class ImageButton extends FocusWidget implements HasClickHandlers
       button.insertFirst(image_.getElement());
 
       descriptionSpan_ = Document.get().createSpanElement();
-      descriptionSpan_.setClassName(ThemeStyles.INSTANCE.visuallyHidden());
+      A11y.setVisuallyHidden(descriptionSpan_);
       button.appendChild(descriptionSpan_);
       setDescription(description);
 

--- a/src/gwt/src/org/rstudio/core/client/widget/InfoBar.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/InfoBar.java
@@ -14,8 +14,6 @@
  */
 package org.rstudio.core.client.widget;
 
-import com.google.gwt.aria.client.LiveValue;
-import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Style.Cursor;
@@ -75,9 +73,7 @@ public class InfoBar extends Composite
       initWidget(binder.createAndBindUi(this));
 
       A11y.setARIAHidden(label_);
-      Roles.getAlertRole().setAriaLiveProperty(live_.getElement(), 
-            mode == ERROR ? LiveValue.ASSERTIVE : LiveValue.POLITE);
-      Roles.getAlertRole().setAriaAtomicProperty(live_.getElement(), true);
+      A11y.setAlertRole(live_, mode == ERROR);
       dismiss_.addStyleName(ThemeResources.INSTANCE.themeStyles().handCursor());
       
       if (dismissHandler != null)

--- a/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.java
@@ -14,8 +14,6 @@
  */
 package org.rstudio.core.client.widget;
 
-import com.google.gwt.aria.client.LiveValue;
-import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
@@ -228,8 +226,7 @@ public class SearchWidget extends Composite implements SearchDisplay
       
       focusTracker_ = new FocusTracker(suggestBox_);
 
-      Roles.getStatusRole().set(readerResultsLabel_);
-      Roles.getStatusRole().setAriaLiveProperty(readerResultsLabel_, LiveValue.POLITE);
+      A11y.setStatusRole(readerResultsLabel_, false);
    }
    
    public HandlerRegistration addFocusHandler(FocusHandler handler)

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/LauncherSessionStatus.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/LauncherSessionStatus.java
@@ -20,6 +20,7 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
+import org.rstudio.core.client.a11y.A11y;
 
 public class LauncherSessionStatus extends Composite
 {
@@ -34,13 +35,20 @@ public class LauncherSessionStatus extends Composite
    public LauncherSessionStatus()
    {
       initWidget(uiBinder.createAndBindUi(this));
+      A11y.setStatusRole(status_, false);
    }
-   
+
+   public String getMessage()
+   {
+      return message_.getText();
+   }
+
    public void setStatus(String text)
    {
       status_.setVisible(true);
       status_.setText(text);
    }
 
+   @UiField Label message_;
    @UiField Label status_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/LauncherSessionStatus.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/LauncherSessionStatus.ui.xml
@@ -30,7 +30,7 @@
    }
    </ui:style>
    <g:HTMLPanel styleName="{style.host}">
-      <g:Label styleName="{style.waiting}" text="Waiting for session to start..."></g:Label>
+      <g:Label ui:field="message_" styleName="{style.waiting}" text="Waiting for session to start..."></g:Label>
       <g:HTML>
          You may continue waiting here or monitor from
          <a title="Return to RStudio Server Pro Home" 

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RTimeoutOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RTimeoutOptions.java
@@ -43,7 +43,7 @@ public class RTimeoutOptions extends Composite
    public RTimeoutOptions()
    {
       initWidget(uiBinder.createAndBindUi(this));
-      
+
       reload_.addClickHandler((click) ->
       {
          setStatus("Reloading...");
@@ -75,7 +75,12 @@ public class RTimeoutOptions extends Composite
    {
       observer_ = observer;
    }
-   
+
+   public String getMessage()
+   {
+      return visibleMsg_.getText();
+   }
+
    private void setStatus(String status)
    {
       // Disable buttons to prevent attempts to abort these abortive procedures
@@ -94,4 +99,5 @@ public class RTimeoutOptions extends Composite
    @UiField Button safeMode_;
    @UiField Button terminate_;
    @UiField Label status_;
+   @UiField Label visibleMsg_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RTimeoutOptions.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RTimeoutOptions.ui.xml
@@ -9,7 +9,7 @@
    
    .warning
    {
-      font-weight: 300;
+      font-weight: 400;
       margin-top: 10px;
       margin-bottom: 10px;
    }
@@ -21,7 +21,7 @@
       border: none;
       border-radius: 4px;
       color: white;
-      background-color: #a0a0a0;
+      background-color: #767676;
       padding-top: 3px;
       padding-bottom: 3px;
       padding-left: 6px;
@@ -37,7 +37,8 @@
    }
    </ui:style>
    <g:HTMLPanel styleName="{style.host}">
-      <g:Label styleName="{style.warning}" text="R is taking longer to start than usual."></g:Label>
+      <g:Label styleName="{style.warning}" text="R is taking longer to start than usual."
+               ui:field="visibleMsg_"></g:Label>
       <g:VerticalPanel>
          <g:HorizontalPanel>
             <g:Button text="Reload" ui:field="reload_"></g:Button>

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.java
@@ -14,8 +14,6 @@
  */
 package org.rstudio.studio.client.application.ui;
 
-import com.google.gwt.aria.client.LiveValue;
-import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.user.client.Timer;
 import org.rstudio.core.client.a11y.A11y;
@@ -83,8 +81,7 @@ public class WarningBar extends Composite
       moreButton_.setText("Manage License...");
       moreButton_.addClickHandler(event -> Desktop.getFrame().showLicenseDialog());
       A11y.setARIAHidden(label_);
-      Roles.getAlertRole().setAriaLiveProperty(live_, LiveValue.ASSERTIVE);
-      Roles.getAlertRole().setAriaAtomicProperty(live_, true);
+      A11y.setAlertRole(live_, true);
    }
 
    public void setText(String value)

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/serializationprogress/ApplicationSerializationProgressLabel.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/serializationprogress/ApplicationSerializationProgressLabel.java
@@ -14,13 +14,13 @@
  */
 package org.rstudio.studio.client.application.ui.serializationprogress;
 
-import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
+import org.rstudio.core.client.a11y.A11y;
 
 public class ApplicationSerializationProgressLabel extends Composite
 {
@@ -32,7 +32,7 @@ public class ApplicationSerializationProgressLabel extends Composite
    public ApplicationSerializationProgressLabel()
    {
       initWidget(binder.createAndBindUi(this));
-      Roles.getStatusRole().set(label_.getElement());
+      A11y.setStatusRole(label_, false);
    }
 
    public void setText(String text)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
@@ -14,8 +14,6 @@
  */
 package org.rstudio.studio.client.workbench.views.vcs.git.dialog;
 
-import com.google.gwt.aria.client.LiveValue;
-import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
@@ -311,8 +309,7 @@ public class GitReviewPanel extends ResizeComposite implements Display
       A11y.setARIAHidden(lblCharCount_);
       
       // Expose a screen reader-only element with debounced updates
-      Roles.getStatusRole().set(lblReaderCharCount_.getElement());
-      Roles.getStatusRole().setAriaLiveProperty(lblReaderCharCount_.getElement(), LiveValue.POLITE);
+      A11y.setStatusRole(lblReaderCharCount_, false);
 
       unstagedCheckBox_.addValueChangeHandler(new ValueChangeHandler<Boolean>()
       {


### PR DESCRIPTION
- Open-source grey spinner gave screen reader users no idea anything
  was happening; now it says "Loading session" via aria-live after 3
  seconds of waiting
- The spinner image has no alt-text, so would read it's internal name, made it cosmetic via empty `alt`

<img width="284" alt="2019-10-28_10-34-46" src="https://user-images.githubusercontent.com/10569626/67723149-5f41be00-f998-11e9-93e7-d29b49d6c207.png">


- If the 30 second timeout is hit, the "R is taking longer to start than
  usual" message will then be read (previously was saying nothing)

<img width="264" alt="2019-10-28_09-46-00" src="https://user-images.githubusercontent.com/10569626/67723161-69fc5300-f998-11e9-85bf-c58f566fac6c.png">

- Fixed the button and message contrast for that 30-second timeout UI

<img width="307" alt="2019-10-28_15-09-36" src="https://user-images.githubusercontent.com/10569626/67723182-7a143280-f998-11e9-9c24-8c7c576bdbc1.png">

- Fix issue where the button wrapper element was aria-hidden and
  thus buttons were unavailable to screen readers because FadeInAnimation class wasn't
  removing that attribute on completion of fadein
- For launcher sessions (Pro), will read existing "Waiting for session to start",
  after three seconds, and read any intermediate status messages that
  are displayed after that

<img width="428" alt="2019-10-28_16-00-36" src="https://user-images.githubusercontent.com/10569626/67724437-391e1d00-f99c-11e9-80af-672fc06a242d.png">


- created and use A11y helpers for designating aria-live alert and status
  elements, and for visually hiding/unhiding elements
- did testing of aria-live with VoiceOver/Safari and Chrome on mac, NVDA/Chrome on Windows-10