### PR TITLE
use absolute path for rpostback-askpass

### DIFF
--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -122,10 +122,6 @@ core::system::ProcessOptions procOptions()
    if (!nonPathGitBinDir.empty())
       core::system::addToPath(&childEnv, nonPathGitBinDir);
 
-   // add postback directory to PATH
-   FilePath postbackDir = session::options().rpostbackPath().getParent();
-   core::system::addToPath(&childEnv, postbackDir.getAbsolutePath());
-
    options.workingDir = projects::projectContext().directory();
 
 #ifdef _WIN32
@@ -3353,11 +3349,13 @@ core::Error initialize()
 
    // setup environment
    BOOST_ASSERT(boost::algorithm::ends_with(sshAskCmd, "rpostback-askpass"));
-   core::system::setenv("GIT_ASKPASS", "rpostback-askpass");
+   
+   std::string rpostbackPath = session::options().rpostbackPath().getAbsolutePath();
+   core::system::setenv("GIT_ASKPASS", rpostbackPath);
 
    if (interceptAskPass)
    {
-      core::system::setenv("SSH_ASKPASS", "rpostback-askpass");
+      core::system::setenv("SSH_ASKPASS", rpostbackPath);
    }
 
    // add suspend/resume handler

--- a/src/cpp/session/postback/CMakeLists.txt
+++ b/src/cpp/session/postback/CMakeLists.txt
@@ -53,6 +53,11 @@ configure_file(rpostback-gitssh ${POSTBACK_SCRIPT_DIR}/rpostback-gitssh)
 configure_file(rpostback-askpass ${POSTBACK_SCRIPT_DIR}/rpostback-askpass)
 configure_file(askpass-passthrough ${POSTBACK_SCRIPT_DIR}/askpass-passthrough)
 
+# put rpostback in a place where it can be found for dev config
+if(NOT RSTUDIO_PACKAGE_BUILD)
+   set_target_properties(rpostback PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${POSTBACK_SCRIPT_DIR})
+endif()
+
 # installation rules
 if(NOT RSTUDIO_SESSION_WIN32)
    install(TARGETS rpostback DESTINATION ${RSTUDIO_INSTALL_BIN})


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/3805.

There is a bit of risk in this PR, as it looks like the original implementation (using the program name + modifying the PATH) was intentional:

https://github.com/rstudio/rstudio/commit/58dd0deacf1ac6b9f9c7173bbfa7d2c70fdcb3fe

However, it's quite possible that things have changed enough in 8 years that we can use full paths for GIT_ASKPASS / SSH_ASKPASS.