### PR TITLE
Fix re-entrancy when disabling secure CRAN mirror

### DIFF
--- a/src/cpp/session/modules/SessionPackages.cpp
+++ b/src/cpp/session/modules/SessionPackages.cpp
@@ -184,8 +184,14 @@ private:
 void revertCRANMirrorToHTTP()
 {
    prefs::CRANMirror mirror = prefs::userPrefs().getCRANMirror();
+   std::string previous(mirror.url);
    boost::algorithm::replace_first(mirror.url, "https://", "http://");
-   prefs::userPrefs().setCRANMirror(mirror, true);
+   if (previous != mirror.url)
+   {
+      // Only set the value if it's actually changed (to avoid looping back here when we reconcile
+      // the HTTP type for the new value)
+      prefs::userPrefs().setCRANMirror(mirror, true);
+   }
 }
 
 } // anonymous namespace


### PR DESCRIPTION
When the secure CRAN mirror preference is set to false, we edit the CRAN mirror preference to remove `https` from the URL. This triggers a loop (and stack overflow) since setting the CRAN mirror URL causes us to re-evaluate the aforementioned preference.

The fix is to avoid no-op edits of the preference. 

Fixes https://github.com/rstudio/rstudio/issues/5594.