### PR TITLE
add autocomplete support for Plumber keywords

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -70,6 +70,7 @@
 * Add preference for compiling .tex files with tinytex (#2788)
 * Long menus and popups now scroll instead of overflowing (#1760, #1794, #2330)
 * Sort package-installed R Markdown templates alphabetically (#4929)
+* Autocomplete support for Plumber `#*` comment keywords (#2220)
 
 ### Bugfixes
 

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -31,7 +31,8 @@ assign(x = ".rs.acContextTypes",
           ROXYGEN            = 10,
           HELP               = 11,
           ARGUMENT           = 12,
-          PACKAGE            = 13
+          PACKAGE            = 13,
+          PLUMBER            = 14
        )
 )
 
@@ -213,6 +214,72 @@ assign(x = ".rs.acCompletionTypes",
    
    matchingTags <- grep(paste("^", tag, sep = ""), tags, value = TRUE)
    
+   .rs.makeCompletions(tag,
+                       matchingTags,
+                       type = .rs.acCompletionTypes$ROXYGEN,
+                       excludeOtherCompletions = TRUE)
+})
+
+.rs.addFunction("attemptPlumberTagCompletion", function(token, line)
+{
+   emptyCompletions <- .rs.emptyCompletions(excludeOtherCompletions = TRUE)
+
+   # fix up tokenization
+   if (grepl("^\\s*#+\\*\\s*$", line) && token == "*")
+      token <- ""
+
+   # allow the token to be empty only if we're attempting completions
+   # at the start of the line
+   if (token == "")
+   {
+      match <- grepl("^\\s*#+\\*\\s*$", line)
+      if (!match)
+         return(emptyCompletions)
+   }
+   else
+   {
+      match <- grepl("^@[a-zA-Z0-9]*$", token, perl = TRUE)
+      if (!match)
+         return(emptyCompletions)
+   }
+
+   tag <- sub(".*(?=@)", '', token, perl = TRUE)
+
+   # All known Plumber tags, in alphabetical order
+   tags <- c(
+      "@apiBasePath ",
+      "@apiConsumes ",
+      "@apiContact ",
+      "@apiDescription ",
+      "@apiHost ",
+      "@apiLicense ",
+      "@apiProduces ",
+      "@apiSchemes ",
+      "@apiTOS ",
+      "@apiTag ",
+      "@apiTitle ",
+      "@apiVersion ",
+      "@assets ",
+      "@delete ",
+      "@filter ",
+      "@get ",
+      "@head ",
+      "@jpeg ",
+      "@options ",
+      "@param ",
+      "@patch ",
+      "@png ",
+      "@post ",
+      "@preempt ",
+      "@put ",
+      "@response ",
+      "@serializer ",
+      "@tag ",
+      "@use "
+   )
+
+   matchingTags <- grep(paste("^", tag, sep = ""), tags, value = TRUE)
+
    .rs.makeCompletions(tag,
                        matchingTags,
                        type = .rs.acCompletionTypes$ROXYGEN,
@@ -1970,7 +2037,11 @@ assign(x = ".rs.acCompletionTypes",
    # Roxygen
    if (.rs.acContextTypes$ROXYGEN %in% type)
       return(.rs.attemptRoxygenTagCompletion(token, line))
-   
+
+   # Plumber
+   if (.rs.acContextTypes$PLUMBER %in% type)
+      return(.rs.attemptPlumberTagCompletion(token, line))
+
    # install.packages
    if (length(string) && string[[1]] == "install.packages" && numCommas[[1]] == 0)
       return(.rs.getCompletionsInstallPackages(token))


### PR DESCRIPTION
Comments starting with `#*` will provide autocomplete for the Plumber
keywords (extracted these from the latest Plumber sources).

Fixes #2220 