### PR TITLE
use fuzzy matching for help topic search

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -70,6 +70,7 @@
 * Add preference for compiling .tex files with tinytex (#2788)
 * Long menus and popups now scroll instead of overflowing (#1760, #1794, #2330)
 * Sort package-installed R Markdown templates alphabetically (#4929)
+* Allow fuzzy matches in help topic search (#3316)
 
 ### Bugfixes
 

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -92,12 +92,50 @@ options(help_type = "html")
    list(payload, "text/html", character(), 404)
 });
 
-.rs.addJsonRpcHandler("suggest_topics", function(prefix)
+.rs.setVar("topicsEnv", new.env(parent = emptyenv()))
+
+.rs.addJsonRpcHandler("suggest_topics", function(query)
 {
-   if (getRversion() >= "3.0.0")
-      sort(utils:::matchAvailableTopics("", prefix))
-   else
-      sort(utils:::matchAvailableTopics(prefix))
+   pkgpaths <- path.package(quiet = TRUE)
+   
+   # read topics from
+   topics <- lapply(pkgpaths, function(pkgpath) tryCatch({
+      
+      if (exists(pkgpath, envir = .rs.topicsEnv))
+         return(get(pkgpath, envir = .rs.topicsEnv))
+      
+      aliases <- file.path(pkgpath, "help/aliases.rds")
+      index <- file.path(pkgpath, "help/AnIndex")
+      
+      value <- if (file.exists(aliases)) {
+         names(readRDS(aliases))
+      } else if (file.exists(index)) {
+         data <- read.table(index, sep = "\t")
+         data[, 1]
+      }
+      
+      assign(pkgpath, value, envir = .rs.topicsEnv)
+      
+   }, error = function(e) NULL))
+   
+   flat <- unlist(topics, use.names = FALSE)
+   
+   # order matches by subsequence match score
+   scores <- .rs.scoreMatches(tolower(flat), tolower(query))
+   ordered <- flat[order(scores)]
+   matches <- unique(ordered[.rs.isSubsequence(tolower(ordered), tolower(query))])
+   
+   # force first character to match, but allow typos after.
+   # also keep matches with one or more leading '.', so that e.g.
+   # the prefix 'libpaths' can match '.libPaths'
+   if (nzchar(query)) {
+      first <- substring(query, 1, 1)
+      pattern <- sprintf("^[.]*[%s]", first)
+      matches <- grep(pattern, matches, value = TRUE, perl = TRUE)
+   }
+   
+   matches
+   
 })
 
 .rs.addFunction("getHelpFromObject", function(object, envir, name = NULL)


### PR DESCRIPTION
This PR implements fuzzy matching for help topic searches. This effectively allows case-insensitive matching, as well as the omission of some characters in the string during search.

Closes #3316.

![Screen Shot 2019-10-30 at 10 10 28 AM](https://user-images.githubusercontent.com/1976582/67881359-9d0c2700-fafd-11e9-9476-07353094f8b2.png)

![Screen Shot 2019-10-30 at 10 10 40 AM](https://user-images.githubusercontent.com/1976582/67881360-9d0c2700-fafd-11e9-8673-117ac37ca852.png)
