### PR TITLE
rebind reflow comment on macOS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -74,6 +74,7 @@
 * Autocomplete support for Plumber `#*` comment keywords (#2220)
 * Automatically continue Plumber `#*` on successive lines (#2219)
 * Comment / uncomment is now enabled for YAML documents (#3317)
+* Reflow comment has been rebound to 'Ctrl + Shift + /' on macOS. (#2443)
 
 ### Bugfixes
 

--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -125,11 +125,6 @@ void GwtCallback::initialize()
 }
 #endif
 
-void GwtCallback::invokeReflowComment()
-{
-   pMainWindow_->invokeCommand(QStringLiteral("reflowComment"));
-}
-
 Synctex& GwtCallback::synctex()
 {
    if (pSynctex_ == nullptr)

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -277,7 +277,6 @@ public Q_SLOTS:
    void signOut();
 
 private:
-   void invokeReflowComment();
    Synctex& synctex();
    void activateAndFocusOwner();
 

--- a/src/cpp/desktop/DesktopGwtCallbackMac.mm
+++ b/src/cpp/desktop/DesktopGwtCallbackMac.mm
@@ -167,25 +167,6 @@ RS_END_NAMESPACE()
 
 void GwtCallback::initialize()
 {
-   [NSEvent addLocalMonitorForEventsMatchingMask: NSKeyDownMask
-                                         handler: ^(NSEvent* event)
-    {
-       // detect attempts to run Command + Shift + /, and let our own
-       // reflow comment code run instead
-       if (event.keyCode == 44 &&
-           (event.modifierFlags & NSEventModifierFlagShift) != 0 &&
-           (event.modifierFlags & NSEventModifierFlagCommand) != 0 &&
-           (event.modifierFlags & NSEventModifierFlagControl) == 0 &&
-           (event.modifierFlags & NSEventModifierFlagOption) == 0 &&
-           (event.modifierFlags & NSEventModifierFlagFunction) == 0)
-       {
-          invokeReflowComment();
-          return (NSEvent*) nil;
-       }
-       
-       return event;
-    }];
-
 }
 
 int GwtCallback::showMessageBox(int type,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -589,8 +589,8 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="blockOutdent" value="Meta+[" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
          <shortcut refid="blockIndent" value="Meta+]" if="org.rstudio.core.client.BrowseCap.isMacintosh()" disableModes="default,vim,emacs"/>
          <shortcut refid="reindent" value="Cmd+I"/>
-         <shortcut refid="reflowComment" value="Cmd+Shift+/" if="!(org.rstudio.core.client.BrowseCap.isMacintosh() &amp;&amp; org.rstudio.core.client.BrowseCap.isChromeServer())"/>
-         <shortcut refid="reflowComment" value="Cmd+Alt+Shift+/" if="org.rstudio.core.client.BrowseCap.isMacintosh() &amp;&amp; org.rstudio.core.client.BrowseCap.isChromeServer()"/>
+         <shortcut refid="reflowComment" value="Ctrl+Shift+/" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="reflowComment" value="Cmd+Shift+/" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="reformatCode" value="Cmd+Shift+A"/>
          <shortcut refid="showDiagnosticsProject" value="Cmd+Shift+Alt+D"/>
          <shortcut refid="fold" value="Alt+L" if="!org.rstudio.core.client.BrowseCap.isMacintosh()" title="Collapse Fold"/>


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/2443.

I think changing the keybinding (and causing some short-term pain for users who are accustomed to this shortcut) is going to be less painful than getting to the bottom of why our custom monitor crashes in certain user configurations.

Let me know if you disagree and we should invest the time to see if we can get the crash under control.