### PR TITLE
improve handling of missing expressions in diagnostics engine

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -74,6 +74,7 @@
 * Autocomplete support for Plumber `#*` comment keywords (#2220)
 * Automatically continue Plumber `#*` on successive lines (#2219)
 * Comment / uncomment is now enabled for YAML documents (#3317)
+* The diagnostics system better handles missing expressions. (#5660)
 
 ### Bugfixes
 

--- a/src/cpp/core/include/core/r_util/RTokenizer.hpp
+++ b/src/cpp/core/include/core/r_util/RTokenizer.hpp
@@ -453,7 +453,8 @@ inline bool isValidAsUnaryOperator(const RToken& rToken)
 inline bool canStartExpression(const RToken& rToken)
 {
    return isValidAsUnaryOperator(rToken) ||
-          isValidAsIdentifier(rToken);
+          isValidAsIdentifier(rToken) ||
+          rToken.isType(RToken::LPAREN);
 }
 
 inline bool isExtractionOperator(const RToken& rToken)

--- a/src/cpp/session/modules/SessionDiagnosticsTests.cpp
+++ b/src/cpp/session/modules/SessionDiagnosticsTests.cpp
@@ -279,6 +279,8 @@ test_context("Diagnostics")
       EXPECT_ERRORS("{\nx\n<- 1\n}");
       
       EXPECT_ERRORS("%a\nb%");
+      
+      EXPECT_ERRORS("local({ if (TRUE) })");
    }
    
    lintRStudioRFiles();

--- a/src/cpp/session/modules/SessionRParser.hpp
+++ b/src/cpp/session/modules/SessionRParser.hpp
@@ -1,5 +1,5 @@
 /*
- * RParser.hpp
+ * SessionRParser.hpp
  *
  * Copyright (C) 2009-2019 by RStudio, Inc.
  *
@@ -480,6 +480,20 @@ public:
                "unexpected assignment in argument list; did you mean to use '='?");
    }
    
+   void addLintItem(const RToken& rToken,
+                    LintType type,
+                    const std::string& message)
+   {
+      add(LintItem(rToken, type, message));
+   }
+   
+   void addLintItem(const ParseItem& item,
+                    LintType type,
+                    const std::string& message)
+   {
+      add(LintItem(item, type, message));
+   }
+   
    const std::vector<LintItem>& get() const
    {
       return lintItems_;
@@ -509,20 +523,6 @@ public:
    void dump();
    
 private:
-   
-   void addLintItem(const RToken& rToken,
-                    LintType type,
-                    const std::string& message)
-   {
-      add(LintItem(rToken, type, message));
-   }
-   
-   void addLintItem(const ParseItem& item,
-                    LintType type,
-                    const std::string& message)
-   {
-      add(LintItem(item, type, message));
-   }
    
    void add(const LintItem& item)
    {

--- a/src/cpp/tests/testthat/themes/.gitignore
+++ b/src/cpp/tests/testthat/themes/.gitignore
@@ -1,1 +1,2 @@
-temp
+/temp
+/localInstall


### PR DESCRIPTION
This PR improves how the diagnostics system handles missing expressions in things like:

```
local({
    if (TRUE)
})
```

Previously, the closing bracket `}` was parsed as though it was part of an (invalid) expression for the `if (TRUE)` statement, ultimately leading to a parse state with mismatched parentheses causing a slew of unhelpful diagnostics to be emitted.

The fix, then, it to ensure that the token discovered after the `if (TRUE)` can actually start a new expression, and to handle the cases where it cannot more gracefully.

Closes https://github.com/rstudio/rstudio/issues/5660.