### PR TITLE
Annotate ProgressBar with aria, contrast fixes, misc labelling fixes

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -186,6 +186,14 @@ public class ElementIds
    public final static String BUILD_MORE_MENUBUTTON = "build_more_menubutton";
    public final static String BUILD_BOOKDOWN_MENUBUTTON = "build_bookdown_menubutton";
 
+   // JobLauncherDialog
+   public final static String JOB_LAUNCHER_ENVIRONMENT = "job_launcher_environment";
+   public static String getJobLauncherEnvironment() { return getElementId(JOB_LAUNCHER_ENVIRONMENT); }
+
+   // RmdTemplateOptionsWidget
+   public final static String RMD_TEMPLATE_OPTIONS_OUTPUT_FORMAT = "rmd_template_options_output_format";
+   public static String getRmdTemplateOptionsOutputFormat() { return getElementId(RMD_TEMPLATE_OPTIONS_OUTPUT_FORMAT); }
+
    // Modal Dialogs
    public final static String DIALOG_GLOBAL_PREFS = "dialog_global_prefs";
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/InlineFormLabel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/InlineFormLabel.java
@@ -1,0 +1,30 @@
+/*
+ * InlineFormLabel.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.widget;
+
+import com.google.gwt.uibinder.client.UiConstructor;
+
+public class InlineFormLabel extends FormLabel
+{
+   public @UiConstructor InlineFormLabel(String text, String forId)
+   {
+      super(true, text, forId);
+   }
+
+   public void setFor(String controlId)
+   {
+      super.setFor(controlId);
+   }
+}

--- a/src/gwt/src/org/rstudio/core/client/widget/ProgressBar.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ProgressBar.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.core.client.widget;
 
+import com.google.gwt.aria.client.LiveValue;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
@@ -40,6 +41,7 @@ public class ProgressBar extends Composite
       Roles.getProgressbarRole().setAriaValueminProperty(progress_.getElement(), 0);
       Roles.getProgressbarRole().setAriaValuemaxProperty(progress_.getElement(), 100);
       Roles.getProgressbarRole().setAriaValuenowProperty(progress_.getElement(), 0);
+      Roles.getProgressbarRole().setAriaLiveProperty(progress_.getElement(), LiveValue.POLITE);
       Roles.getPresentationRole().set(bar_.getElement());
    }
 

--- a/src/gwt/src/org/rstudio/core/client/widget/ProgressBar.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ProgressBar.java
@@ -1,7 +1,7 @@
 /*
  * ProgressBar.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,6 +14,7 @@
  */
 package org.rstudio.core.client.widget;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
@@ -34,10 +35,26 @@ public class ProgressBar extends Composite
    {
       initWidget(uiBinder.createAndBindUi(this));
       progress_.addStyleName("rstudio-themes-border");
+
+      Roles.getProgressbarRole().set(progress_.getElement());
+      Roles.getProgressbarRole().setAriaValueminProperty(progress_.getElement(), 0);
+      Roles.getProgressbarRole().setAriaValuemaxProperty(progress_.getElement(), 100);
+      Roles.getProgressbarRole().setAriaValuenowProperty(progress_.getElement(), 0);
+      Roles.getPresentationRole().set(bar_.getElement());
    }
-   
+
+   /**
+    * @param label text label for screen readers
+    */
+   public void setLabel(String label)
+   {
+      if (label != null)
+         Roles.getProgressbarRole().setAriaLabelProperty(progress_.getElement(), label);
+   }
+
    public void setProgress(double percent)
    {
+      Roles.getProgressbarRole().setAriaValuenowProperty(progress_.getElement(), percent);
       bar_.setWidth(percent + "%");
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateOptionsWidget.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateOptionsWidget.ui.xml
@@ -1,6 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
-   xmlns:g="urn:import:com.google.gwt.user.client.ui">
+   xmlns:g="urn:import:com.google.gwt.user.client.ui"
+   xmlns:rw="urn:import:org.rstudio.core.client.widget">
+   <ui:with field="ElementIds" type="org.rstudio.core.client.ElementIds"/>
    <ui:style type="org.rstudio.studio.client.rmarkdown.ui.RmdTemplateOptionsWidget.OptionsStyle">
    @external gwt-TabLayoutPanelTab, gwt-TabLayoutPanelTab-selected;
    @external gwt-TabLayoutPanelContentContainer, gwt-TabLayoutPanelTabs;
@@ -108,12 +110,12 @@
    </ui:style>
    <g:HeaderPanel styleName="{style.root}">
       <g:FlowPanel styleName="{style.formatPanel}">
-         <g:InlineLabel styleName="{style.topLabel}" text="Output Format:"></g:InlineLabel>
-         <g:ListBox ui:field="listFormats_"></g:ListBox>
-         <g:Label styleName="{style.notesLabel}" ui:field="labelFormatNotes_"></g:Label>
-         <g:InlineLabel ui:field="labelFormatName_" visible="false"></g:InlineLabel>
+         <rw:InlineFormLabel forId="{ElementIds.getRmdTemplateOptionsOutputFormat}"
+                             styleName="{style.topLabel}" text="Output Format:"/>
+         <rw:FormListBox elementId="{ElementIds.getRmdTemplateOptionsOutputFormat}" ui:field="listFormats_"/>
+         <g:Label styleName="{style.notesLabel}" ui:field="labelFormatNotes_"/>
+         <g:InlineLabel ui:field="labelFormatName_" visible="false"/>
       </g:FlowPanel>
-      <g:TabLayoutPanel height="100%" barHeight="30" ui:field="optionsTabs_" styleName="{style.optionsTabs}">
-      </g:TabLayoutPanel>
+      <g:TabLayoutPanel height="100%" barHeight="30" ui:field="optionsTabs_" styleName="{style.optionsTabs}"/>
    </g:HeaderPanel>
-</ui:UiBinder> 
+</ui:UiBinder>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.java
@@ -21,6 +21,7 @@ import com.google.inject.Provider;
 import com.google.inject.assistedinject.Assisted;
 import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.ProgressBar;
@@ -125,9 +126,10 @@ public class JobItem extends Composite implements JobItemView
       initWidget(uiBinder.createAndBindUi(this));
       
       name_.setText(job.name);
+      progress_.setLabel(name_.getText());
       spinner_.setResource(new ImageResource2x(RESOURCES.jobSpinner()));
-      spinner_.setAltText("Progress indicator");
-      
+      A11y.setDecorativeImage(spinner_.getElement());
+
       ImageResource2x detailsImage = new ImageResource2x(RESOURCES.jobSelect());
       if (JsArrayUtil.jsArrayStringContains(job.actions, JobConstants.ACTION_INFO))
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.java
@@ -126,7 +126,7 @@ public class JobItem extends Composite implements JobItemView
       initWidget(uiBinder.createAndBindUi(this));
       
       name_.setText(job.name);
-      progress_.setLabel(name_.getText());
+      progress_.setLabel(job.name);
       spinner_.setResource(new ImageResource2x(RESOURCES.jobSpinner()));
       A11y.setDecorativeImage(spinner_.getElement());
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobLauncherControls.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobLauncherControls.ui.xml
@@ -2,6 +2,7 @@
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
    xmlns:g="urn:import:com.google.gwt.user.client.ui"
    xmlns:rw="urn:import:org.rstudio.core.client.widget">
+   <ui:with field="ElementIds" type="org.rstudio.core.client.ElementIds"/>
    <ui:style>
       .spaced, .header {
          margin-bottom: 5px;
@@ -28,8 +29,9 @@
                   text="Run job with copy of global environment" 
                   ui:field="importEnv_"></g:CheckBox>
       <g:HorizontalPanel>
-         <g:InlineLabel text="Copy job results: "></g:InlineLabel>
-         <g:ListBox styleName="{style.check} {style.spaced}" ui:field="exportEnv_"></g:ListBox>
+         <rw:InlineFormLabel forId="{ElementIds.getJobLauncherEnvironment}" text="Copy job results: "/>
+         <rw:FormListBox elementId="{ElementIds.getJobLauncherEnvironment}"
+                         styleName="{style.check} {style.spaced}" ui:field="exportEnv_"/>
       </g:HorizontalPanel>
    </g:VerticalPanel>
-</ui:UiBinder> 
+</ui:UiBinder>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobProgress.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobProgress.java
@@ -53,6 +53,7 @@ public class JobProgress extends Composite
    {
       name_.setText(progress.name());
       progress_.setProgress(progress.units(), progress.max());
+      progress_.setLabel(progress.name());
       jobProgress_ = progress;
    }
    
@@ -60,6 +61,7 @@ public class JobProgress extends Composite
    public void showJob(Job job)
    {
       name_.setText(job.name);
+      progress_.setLabel(job.name);
       String status = JobConstants.stateDescription(job.state);
       if (job.completed > 0)
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobProgress.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobProgress.ui.xml
@@ -13,7 +13,7 @@
    
    .status
    {
-      color: #808080;
+      color: #717171;
    }
    
    .host


### PR DESCRIPTION
- add aria progressbar role and metadata to the ProgressBar widget
- label progressbars in Jobs tab (and Console tab) views with name 
   of the job
- mark the spinner in Jobs tab as cosmetic since the progressbar (or 
   the status text in case of indefinite jobs) gives sufficient feedback 
- create `InlineFormLabel` class to use in UiBinders instead of `InlineLabel`
   in cases where label needs to be associated with another control, and use
   in a couple places that needed it
- tweak contrast of the status text shown after a local job completes to
   meet minimum requirement

<img width="680" alt="2019-10-30_13-43-01" src="https://user-images.githubusercontent.com/10569626/67903346-8e873500-fb28-11e9-9b1d-eebdb760d3e8.png">

<img width="673" alt="2019-10-30_13-43-34" src="https://user-images.githubusercontent.com/10569626/67903355-92b35280-fb28-11e9-95cd-aca737a8c8a0.png">

<img width="678" alt="2019-10-30_13-48-12" src="https://user-images.githubusercontent.com/10569626/67903365-96df7000-fb28-11e9-856f-f3ea66c4ebab.png">

<img width="377" alt="2019-10-30_10-24-05" src="https://user-images.githubusercontent.com/10569626/67902825-50d5dc80-fb27-11e9-8275-f932bc5cb0bf.png">

<img width="472" alt="2019-10-30_13-07-33" src="https://user-images.githubusercontent.com/10569626/67902834-5501fa00-fb27-11e9-8200-b185338e5b1a.png">
