### PR TITLE
Resize and set overflow of ModalDialogBase

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/js/JsWindow.java
+++ b/src/gwt/src/org/rstudio/core/client/js/JsWindow.java
@@ -1,8 +1,0 @@
-package org.rstudio.core.client.js;
-
-public class JsWindow
-{
-   public static native JsObject getProp(String prop) /*-{
-      return $wnd[prop];
-   }-*/;
-}

--- a/src/gwt/src/org/rstudio/core/client/js/JsWindow.java
+++ b/src/gwt/src/org/rstudio/core/client/js/JsWindow.java
@@ -1,0 +1,8 @@
+package org.rstudio.core.client.js;
+
+public class JsWindow
+{
+   public static native JsObject getProp(String prop) /*-{
+      return $wnd[prop];
+   }-*/;
+}

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -39,6 +39,7 @@ import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 
+import elemental.client.Browser;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.Point;
@@ -48,7 +49,6 @@ import org.rstudio.core.client.command.ShortcutManager;
 import org.rstudio.core.client.command.ShortcutManager.Handle;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.NativeWindow;
-import org.rstudio.core.client.js.JsWindow;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.ui.RStudioThemes;
@@ -213,7 +213,7 @@ public abstract class ModalDialogBase extends DialogBox
       Element child = e.getFirstChildElement();
       if (child != null)
       {
-         int windowInnerHeight = Integer.parseInt(JsWindow.getProp("innerHeight").toString());
+         int windowInnerHeight = Browser.getWindow().getInnerHeight();
          if (windowInnerHeight <= 10) return; // degenerate property case
 
          // snap the top of the modal to the top bounds of the window

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -48,6 +48,7 @@ import org.rstudio.core.client.command.ShortcutManager;
 import org.rstudio.core.client.command.ShortcutManager.Handle;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.NativeWindow;
+import org.rstudio.core.client.js.JsWindow;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.ui.RStudioThemes;
@@ -205,6 +206,38 @@ public abstract class ModalDialogBase extends DialogBox
    {
       super.center();
       onCompleted.execute();
+
+      // Force the contents of the modal to be vertically scrollable
+      // if the height of the modal is larger than the app window
+      Element e = this.getElement();
+      Element child = e.getFirstChildElement();
+      if (child != null)
+      {
+         int windowInnerHeight = Integer.parseInt(JsWindow.getProp("innerHeight").toString());
+         if (windowInnerHeight <= 10) return; // degenerate property case
+
+         // snap the top of the modal to the top bounds of the window
+         int eleTop = e.getAbsoluteTop();
+         if (eleTop < 0)
+         {
+            eleTop = 0;
+            e.getStyle().setTop(0, Unit.PX);
+         }
+         int eleHeight = e.getOffsetHeight();
+
+         if (eleHeight + 30 >= windowInnerHeight)
+         {
+            child.getStyle().setProperty("overflowY", "auto");
+
+            // don't override overflowX if it's already set
+            String overflowX = child.getStyle().getProperty("overflowX");
+            if (overflowX == null || overflowX.length() < 1)
+            {
+               child.getStyle().setProperty("overflowX", "hidden");
+            }
+            child.getStyle().setPropertyPx("maxHeight", windowInnerHeight - eleTop - 30);
+         }
+      }
    }
 
    protected void onDialogShown()

--- a/src/gwt/src/org/rstudio/studio/RStudio.gwt.xml
+++ b/src/gwt/src/org/rstudio/studio/RStudio.gwt.xml
@@ -11,7 +11,10 @@
 
    <!-- Gin module dependencies                                    -->
    <inherits name="com.google.gwt.inject.Inject"/>
-    
+
+   <!-- Elemental module dependencies                              -->
+   <inherits name="elemental.Elemental"/>
+
    <!-- Use default GWT style sheet                                -->
    <!--<inherits name='com.google.gwt.user.theme.standard.Standard'/>-->
 


### PR DESCRIPTION
Currently ModalDialogBase objects don't think too much about where and how they're set. Similarly to what was done in PR #5597 this adds logic to a base UI object class to get a little more intelligent about displaying the object.

This fix will apply to a huge number of modals in our application so I spent a lot of time testing making sure it applied as generically and unobtrusively as possible. Some dialogs aren't compatible with it but in the case where it isn't there are no side effects (that I've been able to find). If any bugs fall out of this fixing them will be as easy as special casing it just like the other PR.

Note: Ideally only the central content would scroll and the header and buttons would be pinned but due to how our modals are laid out and differ this isn't generically feasible and this way we get much more generic functionality for much less code.

![iSHHJOq](https://user-images.githubusercontent.com/136863/67987056-ded2c580-fc02-11e9-8bff-27d315f26ae4.png)
![uSO1p1O](https://user-images.githubusercontent.com/136863/67987059-e09c8900-fc02-11e9-8ada-3cde5e472334.png)

fixes #1605 