### PR TITLE
Skip invalid preferences during load

### DIFF
--- a/src/cpp/session/include/session/prefs/PrefLayer.hpp
+++ b/src/cpp/session/include/session/prefs/PrefLayer.hpp
@@ -42,7 +42,6 @@ public:
    PrefLayer(const std::string& layerName);
    virtual core::Error readPrefs() = 0;
    virtual core::Error writePrefs(const core::json::Object& prefs);
-   virtual core::Error validatePrefs() = 0;
    virtual ~PrefLayer();
    std::string layerName();
 
@@ -118,7 +117,7 @@ public:
 
 protected:
    // I/O methods
-   core::Error loadPrefsFromFile(const core::FilePath& prefsFile);
+   core::Error loadPrefsFromFile(const core::FilePath& prefsFile, const core::FilePath& schemaFile);
    core::Error loadPrefsFromSchema(const core::FilePath& schemaFile);
    core::Error writePrefsToFile(const core::json::Object& prefs, const core::FilePath& prefsFile);
 

--- a/src/cpp/session/modules/SessionApiPrefs.cpp
+++ b/src/cpp/session/modules/SessionApiPrefs.cpp
@@ -42,7 +42,9 @@ public:
    core::Error readPrefs()
    {
       prefsFile_ = core::system::xdg::userConfigDir().completePath(kApiPrefsFile);
-      return loadPrefsFromFile(prefsFile_);
+
+      // Load prefs; there's no schema for these prefs since API users can write any prefs they like
+      return loadPrefsFromFile(prefsFile_, core::FilePath());
    }
 
    core::Error writePrefs(const core::json::Object &prefs)
@@ -54,12 +56,6 @@ public:
       END_LOCK_MUTEX
 
       return writePrefsToFile(*cache_, prefsFile_);
-   }
-
-   core::Error validatePrefs()
-   {
-      // API prefs are always "valid"
-      return Success();
    }
 
 private:

--- a/src/cpp/session/prefs/Preferences.cpp
+++ b/src/cpp/session/prefs/Preferences.cpp
@@ -83,11 +83,6 @@ Error Preferences::initialize()
    {
       for (auto layer: layers_)
       {
-         // Validate the layer and log errors for violations
-         error = layer->validatePrefs();
-         if (error)
-            LOG_ERROR(error);
-
          // Subscribe for layer change notifications
          layer->onChanged.connect(boost::bind(&Preferences::onPrefLayerChanged, this,
                   layer->layerName(), _1));

--- a/src/cpp/session/prefs/UserPrefsComputedLayer.cpp
+++ b/src/cpp/session/prefs/UserPrefsComputedLayer.cpp
@@ -100,11 +100,6 @@ Error UserPrefsComputedLayer::readPrefs()
    return Success();
 }
 
-core::Error UserPrefsComputedLayer::validatePrefs()
-{
-   return Success();
-}
-
 // Try to detect a terminal on linux desktop
 FilePath UserPrefsComputedLayer::detectedTerminalPath()
 {

--- a/src/cpp/session/prefs/UserPrefsComputedLayer.hpp
+++ b/src/cpp/session/prefs/UserPrefsComputedLayer.hpp
@@ -29,7 +29,6 @@ class UserPrefsComputedLayer: public PrefLayer
 public:
    UserPrefsComputedLayer();
    core::Error readPrefs();
-   core::Error validatePrefs();
 private:
    core::FilePath detectedTerminalPath();
 };

--- a/src/cpp/session/prefs/UserPrefsDefaultLayer.cpp
+++ b/src/cpp/session/prefs/UserPrefsDefaultLayer.cpp
@@ -37,12 +37,6 @@ core::Error UserPrefsDefaultLayer::readPrefs()
       options().rResourcesPath().completePath("schema").completePath(kUserPrefsSchemaFile));
 }
 
-core::Error UserPrefsDefaultLayer::validatePrefs()
-{
-   // No need to validate defaults; they ship in the box and are validated at build time.
-   return Success();
-}
-
 } // namespace prefs
 } // namespace session
 } // namespace rstudio

--- a/src/cpp/session/prefs/UserPrefsDefaultLayer.hpp
+++ b/src/cpp/session/prefs/UserPrefsDefaultLayer.hpp
@@ -27,7 +27,6 @@ class UserPrefsDefaultLayer: public PrefLayer
 public:
    UserPrefsDefaultLayer();
    core::Error readPrefs();
-   core::Error validatePrefs();
 };
 
 } // namespace prefs

--- a/src/cpp/session/prefs/UserPrefsLayer.cpp
+++ b/src/cpp/session/prefs/UserPrefsLayer.cpp
@@ -46,7 +46,8 @@ Error UserPrefsLayer::readPrefs()
    // Mark the last sync time 
    lastSync_ = prefsFile_.getLastWriteTime();
 
-   return loadPrefsFromFile(prefsFile_);
+   return loadPrefsFromFile(prefsFile_,
+       options().rResourcesPath().completePath("schema").completePath(kUserPrefsSchemaFile));
 }
 
 void UserPrefsLayer::onPrefsFileChanged()
@@ -62,7 +63,8 @@ void UserPrefsLayer::onPrefsFileChanged()
    const json::Object old = oldVal.getObject();
 
    // Reload the prefs from the file
-   Error error = loadPrefsFromFile(prefsFile_);
+   Error error = loadPrefsFromFile(prefsFile_,
+       options().rResourcesPath().completePath("schema").completePath(kUserPrefsSchemaFile));
    if (error)
    {
       LOG_ERROR(error);
@@ -108,12 +110,6 @@ Error UserPrefsLayer::writePrefs(const core::json::Object &prefs)
    }
 
    return error;
-}
-
-Error UserPrefsLayer::validatePrefs()
-{
-   return validatePrefsFromSchema(
-      options().rResourcesPath().completePath("schema").completePath(kUserPrefsSchemaFile));
 }
 
 } // namespace prefs

--- a/src/cpp/session/prefs/UserPrefsLayer.hpp
+++ b/src/cpp/session/prefs/UserPrefsLayer.hpp
@@ -29,7 +29,6 @@ public:
    UserPrefsLayer();
    core::Error readPrefs() override;
    core::Error writePrefs(const core::json::Object &prefs) override;
-   core::Error validatePrefs() override;
 
 protected:
    void onPrefsFileChanged() override;

--- a/src/cpp/session/prefs/UserPrefsProjectLayer.cpp
+++ b/src/cpp/session/prefs/UserPrefsProjectLayer.cpp
@@ -65,12 +65,6 @@ core::Error UserPrefsProjectLayer::readPrefs()
    return Success();
 }
 
-core::Error UserPrefsProjectLayer::validatePrefs()
-{
-   // Project level prefs can't be invalid.
-   return Success();
-}
-
 } // namespace prefs
 } // namespace session
 } // namespace rstudio

--- a/src/cpp/session/prefs/UserPrefsProjectLayer.hpp
+++ b/src/cpp/session/prefs/UserPrefsProjectLayer.hpp
@@ -27,7 +27,6 @@ class UserPrefsProjectLayer: public PrefLayer
 public:
    UserPrefsProjectLayer();
    core::Error readPrefs() override;
-   core::Error validatePrefs() override;
 private:
    void onProjectConfigChanged();
 };

--- a/src/cpp/session/prefs/UserPrefsSystemLayer.cpp
+++ b/src/cpp/session/prefs/UserPrefsSystemLayer.cpp
@@ -34,13 +34,9 @@ UserPrefsSystemLayer::UserPrefsSystemLayer():
 core::Error UserPrefsSystemLayer::readPrefs()
 {
    return loadPrefsFromFile(
-      core::system::xdg::systemConfigDir().completePath(kUserPrefsFile));
-}
-
-core::Error UserPrefsSystemLayer::validatePrefs()
-{
-   return validatePrefsFromSchema(
+      core::system::xdg::systemConfigDir().completePath(kUserPrefsFile),
       options().rResourcesPath().completePath("schema").completePath(kUserPrefsSchemaFile));
+      
 }
 
 } // namespace prefs

--- a/src/cpp/session/prefs/UserPrefsSystemLayer.hpp
+++ b/src/cpp/session/prefs/UserPrefsSystemLayer.hpp
@@ -27,7 +27,6 @@ class UserPrefsSystemLayer: public PrefLayer
 public:
    UserPrefsSystemLayer();
    core::Error readPrefs();
-   core::Error validatePrefs();
 };
 
 } // namespace prefs

--- a/src/cpp/session/prefs/UserStateComputedLayer.cpp
+++ b/src/cpp/session/prefs/UserStateComputedLayer.cpp
@@ -46,11 +46,6 @@ Error UserStateComputedLayer::readPrefs()
    return Success();
 }
 
-core::Error UserStateComputedLayer::validatePrefs()
-{
-   return Success();
-}
-
 } // namespace prefs
 } // namespace session
 } // namespace rstudio

--- a/src/cpp/session/prefs/UserStateComputedLayer.hpp
+++ b/src/cpp/session/prefs/UserStateComputedLayer.hpp
@@ -27,7 +27,6 @@ class UserStateComputedLayer: public PrefLayer
 public:
    UserStateComputedLayer();
    core::Error readPrefs();
-   core::Error validatePrefs();
 };
 
 } // namespace prefs

--- a/src/cpp/session/prefs/UserStateDefaultLayer.cpp
+++ b/src/cpp/session/prefs/UserStateDefaultLayer.cpp
@@ -37,12 +37,6 @@ core::Error UserStateDefaultLayer::readPrefs()
       options().rResourcesPath().completePath("schema").completePath(kUserStateSchemaFile));
 }
 
-core::Error UserStateDefaultLayer::validatePrefs()
-{
-   // No need to validate defaults; they ship in the box and are validated at build time.
-   return Success();
-}
-
 } // namespace prefs
 } // namespace session
 } // namespace rstudio

--- a/src/cpp/session/prefs/UserStateDefaultLayer.hpp
+++ b/src/cpp/session/prefs/UserStateDefaultLayer.hpp
@@ -27,7 +27,6 @@ class UserStateDefaultLayer: public PrefLayer
 public:
    UserStateDefaultLayer();
    core::Error readPrefs();
-   core::Error validatePrefs();
 };
 
 } // namespace prefs

--- a/src/cpp/session/prefs/UserStateLayer.cpp
+++ b/src/cpp/session/prefs/UserStateLayer.cpp
@@ -35,7 +35,8 @@ core::Error UserStateLayer::readPrefs()
 {
    prefsFile_ = core::system::xdg::userDataDir().completePath(kUserStateFile);
 
-   return loadPrefsFromFile(prefsFile_);
+   return loadPrefsFromFile(prefsFile_,
+      options().rResourcesPath().completePath("schema").completePath(kUserStateSchemaFile));
 }
 
 core::Error UserStateLayer::writePrefs(const core::json::Object &prefs)
@@ -52,12 +53,6 @@ core::Error UserStateLayer::writePrefs(const core::json::Object &prefs)
    END_LOCK_MUTEX
 
    return writePrefsToFile(*cache_, prefsFile_);
-}
-
-core::Error UserStateLayer::validatePrefs()
-{
-   return validatePrefsFromSchema(
-      options().rResourcesPath().completePath("schema").completePath(kUserStateSchemaFile));
 }
 
 } // namespace prefs

--- a/src/cpp/session/prefs/UserStateLayer.hpp
+++ b/src/cpp/session/prefs/UserStateLayer.hpp
@@ -28,7 +28,6 @@ public:
    UserStateLayer();
    core::Error readPrefs();
    core::Error writePrefs(const core::json::Object &prefs);
-   core::Error validatePrefs();
 private:
    core::FilePath prefsFile_;
 };

--- a/src/cpp/shared_core/include/shared_core/json/Json.hpp
+++ b/src/cpp/shared_core/include/shared_core/json/Json.hpp
@@ -190,6 +190,18 @@ public:
    Value clone() const;
 
    /**
+    * @brief Attempts to coerce a JSON object to conform to the given schema by discarding non-conforming
+    *    properties.
+    *
+    * @param in_schema           The schema to validate this value against.
+    * @param out_propViolations  The names of the properties that did not conform to the schema.
+    *
+    * @return Success if this JSON value matches the schema after coercion; Error otherwise.
+    */
+   Error coerce(const std::string& in_schema,
+                std::vector<std::string>& out_propViolations);
+
+   /**
     * @brief Gets the value as a JSON array. If the call to getType() does not return Type::ARRAY, this method is
     *        invalid.
     *
@@ -391,18 +403,6 @@ public:
     * @return Success if this JSON value matches the schema; the Error that occurred during validation otherwise.
     */
    Error validate(const std::string& in_schema) const;
-
-   /**
-    * @brief Attempts to coerce a JSON object to conform to the given schema by discarding non-conforming
-    *    properties.
-    *
-    * @param in_schema           The schema to validate this value against.
-    * @param out_propViolations  The names of of the properties that did not conform to the schema.
-    *
-    * @return Success if this JSON value matches the schema after coercion; Error otherwise.
-    */
-   Error coerce(const std::string& in_schema,
-                std::vector<std::string>& out_propViolations);
 
    /**
     * @brief Writes this value to a string.

--- a/src/cpp/shared_core/include/shared_core/json/Json.hpp
+++ b/src/cpp/shared_core/include/shared_core/json/Json.hpp
@@ -393,6 +393,18 @@ public:
    Error validate(const std::string& in_schema) const;
 
    /**
+    * @brief Attempts to coerce a JSON object to conform to the given schema by discarding non-conforming
+    *    properties.
+    *
+    * @param in_schema           The schema to validate this value against.
+    * @param out_propViolations  The names of of the properties that did not conform to the schema.
+    *
+    * @return Success if this JSON value matches the schema after coercion; Error otherwise.
+    */
+   Error coerce(const std::string& in_schema,
+                std::vector<std::string>& out_propViolations);
+
+   /**
     * @brief Writes this value to a string.
     *
     * @return The string representation of this value.

--- a/src/cpp/shared_core/json/Json.cpp
+++ b/src/cpp/shared_core/json/Json.cpp
@@ -357,6 +357,63 @@ Value Value::clone() const
    return Value(*this);
 }
 
+Error Value::coerce(const std::string& in_schema,
+                    std::vector<std::string>& out_propViolations)
+{
+   Error error;
+
+   // Parse the schema first.
+   rapidjson::Document sd;
+   rapidjson::ParseResult result = sd.Parse(in_schema.c_str());
+   if (result.IsError())
+   {
+      error = Error(result.Code(), ERROR_LOCATION);
+      error.addProperty("offset", result.Offset());
+      return error;
+   }
+
+   // Validate the input according to the schema.
+   rapidjson::SchemaDocument schemaDoc(sd);
+   rapidjson::SchemaValidator validator(schemaDoc);
+   rapidjson::Pointer lastInvalid;
+   while (!m_impl->Document->Accept(validator))
+   {
+      rapidjson::StringBuffer sb;
+
+      // Find the invalid part of the document
+      rapidjson::Pointer invalid = validator.GetInvalidDocumentPointer();
+
+      if (invalid == lastInvalid)
+      {
+         // If this is the same as the last invalid piece we tried to remove, then removing
+         // it didn't actually fix the problem.
+         error = Error(rapidjson::kParseErrorUnspecificSyntaxError, ERROR_LOCATION);
+         error.addProperty("keyword", validator.GetInvalidSchemaKeyword());
+         invalid.StringifyUriFragment(sb);
+         error.addProperty("document", sb.GetString());
+         return error;
+      }
+
+      // Remember this as the last error we hit, so we can bail if mutating the document
+      // doesn't resolve it
+      lastInvalid = invalid;
+
+      // Accumulate the error for the caller
+      invalid.Stringify(sb);
+      out_propViolations.push_back(sb.GetString());
+
+      // Remove the invalid part of the document
+      JsonPointer pointer(sb.GetString(), &s_allocator);
+      pointer.Erase(*(m_impl->Document));
+
+      // Reset state for re-validation
+      validator.Reset();
+   }
+
+   // The value was successfully coerced, or didn't need to be.
+   return Success();
+}
+
 Array Value::getArray() const
 {
    assert(getType() == Type::ARRAY);
@@ -629,63 +686,6 @@ Error Value::validate(const std::string& in_schema) const
       return error;
    }
 
-   return Success();
-}
-
-Error Value::coerce(const std::string& in_schema,
-                    std::vector<std::string>& out_propViolations)
-{
-   Error error;
-
-   // Parse the schema first.
-   rapidjson::Document sd;
-   rapidjson::ParseResult result = sd.Parse(in_schema.c_str());
-   if (result.IsError())
-   {
-      error = Error(result.Code(), ERROR_LOCATION);
-      error.addProperty("offset", result.Offset());
-      return error;
-   }
-
-   // Validate the input according to the schema.
-   rapidjson::SchemaDocument schemaDoc(sd);
-   rapidjson::SchemaValidator validator(schemaDoc);
-   rapidjson::Pointer lastInvalid;
-   while (!m_impl->Document->Accept(validator))
-   {
-      rapidjson::StringBuffer sb;
-
-      // Find the invalid part of the document
-      rapidjson::Pointer invalid = validator.GetInvalidDocumentPointer();
-
-      if (invalid == lastInvalid)
-      {
-         // If this is the same as the last invalid piece we tried to remove, then removing
-         // it didn't actually fix the problem.
-         error = Error(rapidjson::kParseErrorUnspecificSyntaxError, ERROR_LOCATION);
-         error.addProperty("keyword", validator.GetInvalidSchemaKeyword());
-         invalid.StringifyUriFragment(sb);
-         error.addProperty("document", sb.GetString());
-         return error;
-      }
-
-      // Remember this as the last error we hit, so we can bail if mutating the document
-      // doesn't resolve it
-      lastInvalid = invalid;
-
-      // Accumulate the error for the caller
-      invalid.Stringify(sb);
-      out_propViolations.push_back(sb.GetString());
-
-      // Remove the invalid part of the document
-      JsonPointer pointer(sb.GetString(), &s_allocator);
-      pointer.Erase(*(m_impl->Document));
-
-      // Reset state for re-validation
-      validator.Reset();
-   }
-
-   // The value was succesfully coerced, or didn't need to be.
    return Success();
 }
 


### PR DESCRIPTION
We currently load prefs in two steps:

1. The prefs are loaded from a file.
2. The preferences are validated, and a warning is logged if the prefs don't validate.

However, the invalid prefs are still used in a sort of best-effort way, since we don't want to discard the whole object. This can lead to runtime errors if the type or value of a preference doesn't match the schema expected by the code.

To address this, I've made two changes:

1. There is a new JSON helper function called `coerce`. It takes a schema and attempts to remove parts of an object that are invalid according to the schema. This makes it possible for us to selectively ignore the invalid preference values without throwing prefs away if the object doesn't match the schema as a whole. 
2. We no longer have a second "validate" step for preferences. Instead, we validate as part of the read step. The read step succeeds if the prefs are valid (or can be coerced into valid), and fails otherwise.

Fixes https://github.com/rstudio/rstudio/issues/5606. 