### PR TITLE
Enable completion of paths with trailing slashes

### DIFF
--- a/src/cpp/core/FilePathTests.cpp
+++ b/src/cpp/core/FilePathTests.cpp
@@ -64,6 +64,11 @@ TEST_CASE("file paths")
       FilePath cPath("/path/to/foo");
       CHECK(cPath.completeChildPath("../bar") == cPath);
       CHECK(cPath.completeChildPath("/path/to/quux") == cPath);
+
+      // trailing slashes are okay
+      FilePath dPath("/path/to/");
+      FilePath ePath("/path/to/e");
+      CHECK(dPath.completeChildPath("e") == ePath);
    }
 
    SECTION("general path completion")

--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -1029,13 +1029,14 @@ bool FilePath::isWithin(const FilePath& in_scopePath) const
    FilePath parent(in_scopePath.getLexicallyNormalPath());
 
    // Easy test: We can't possibly be in this scope path if it has more components than we do
-   if (parent.m_impl->Path.size() >= child.m_impl->Path.size())
+   if (parent.m_impl->Path.size() > child.m_impl->Path.size())
       return false;
 
-   // Find the first path element that differs
+   // Find the first path element that differs. Stop when we reach the end of the parent
+   // path, or a "." path component, which signifies the end of a directory (/foo/bar/.)
    for (boost::filesystem::path::iterator childIt = child.m_impl->Path.begin(),
                                           parentIt = parent.m_impl->Path.begin();
-        parentIt != parent.m_impl->Path.end();
+        parentIt != parent.m_impl->Path.end() && *parentIt != ".";
         parentIt++, childIt++)
    {
       if (*parentIt != *childIt)


### PR DESCRIPTION
The new security restrictions on `completeChildPath` currently cause child paths not to be completed if the parent path has a trailing slash. This is because:

    /foo/bar/

is lexically normalized to

    /foo/bar/.

and, when comparing path components, we deduce that `/foo/bar/baz` is not within `/foo/bar/.` since `.` != `baz`. 

The fix is to stop comparing path components once we reach a `.`, which signals the end of a lexically normal path.

Fixes https://github.com/rstudio/rstudio/issues/5674.