### PR TITLE
always place postback dir on PATH

### DIFF
--- a/src/cpp/core/include/core/system/Environment.hpp
+++ b/src/cpp/core/include/core/system/Environment.hpp
@@ -65,6 +65,10 @@ void unsetenv(Options* pEnvironment,
 
 void getModifiedEnv(const Options& extraVars, Options* pEnv);
 
+// add to the PATH
+void addToPath(const std::string& filePath,
+               bool prepend = false);
+
 // add to the PATH within a string
 void addToPath(std::string* pPath,
                const std::string& filePath,
@@ -74,7 +78,6 @@ void addToPath(std::string* pPath,
 void addToPath(Options* pEnvironment,
                const std::string& filePath,
                bool prepend = false);
-
 
 /****************************************************************
    Utility functions

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -122,6 +122,13 @@ core::system::ProcessOptions procOptions()
    if (!nonPathGitBinDir.empty())
       core::system::addToPath(&childEnv, nonPathGitBinDir);
 
+   // add postback directory to PATH
+   // (note that we also do this on init, but we do this again for
+   // child processes just to ensure any user-initiated PATH munging
+   // doesn't break builtin utilities)
+   FilePath postbackDir = session::options().rpostbackPath().getParent();
+   core::system::addToPath(&childEnv, postbackDir.getAbsolutePath());
+
    options.workingDir = projects::projectContext().directory();
 
 #ifdef _WIN32

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -122,10 +122,6 @@ core::system::ProcessOptions procOptions()
    if (!nonPathGitBinDir.empty())
       core::system::addToPath(&childEnv, nonPathGitBinDir);
 
-   // add postback directory to PATH
-   FilePath postbackDir = session::options().rpostbackPath().getParent();
-   core::system::addToPath(&childEnv, postbackDir.getAbsolutePath());
-
    options.workingDir = projects::projectContext().directory();
 
 #ifdef _WIN32
@@ -3359,6 +3355,10 @@ core::Error initialize()
    {
       core::system::setenv("SSH_ASKPASS", "rpostback-askpass");
    }
+
+   // add postback directory to PATH
+   FilePath postbackDir = session::options().rpostbackPath().getParent();
+   core::system::addToPath(postbackDir.getAbsolutePath());
 
    // add suspend/resume handler
    addSuspendHandler(SuspendHandler(boost::bind(onSuspend, _2), onResume));

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -122,6 +122,10 @@ core::system::ProcessOptions procOptions()
    if (!nonPathGitBinDir.empty())
       core::system::addToPath(&childEnv, nonPathGitBinDir);
 
+   // add postback directory to PATH
+   FilePath postbackDir = session::options().rpostbackPath().getParent();
+   core::system::addToPath(&childEnv, postbackDir.getAbsolutePath());
+
    options.workingDir = projects::projectContext().directory();
 
 #ifdef _WIN32
@@ -3349,13 +3353,11 @@ core::Error initialize()
 
    // setup environment
    BOOST_ASSERT(boost::algorithm::ends_with(sshAskCmd, "rpostback-askpass"));
-   
-   std::string rpostbackPath = session::options().rpostbackPath().getAbsolutePath();
-   core::system::setenv("GIT_ASKPASS", rpostbackPath);
+   core::system::setenv("GIT_ASKPASS", "rpostback-askpass");
 
    if (interceptAskPass)
    {
-      core::system::setenv("SSH_ASKPASS", rpostbackPath);
+      core::system::setenv("SSH_ASKPASS", "rpostback-askpass");
    }
 
    // add suspend/resume handler


### PR DESCRIPTION
From @jcheng5:

> jcheng 6:38 PM
> Maybe that change was there for a reason... I just upgraded to 1.3.565 on my Windows machine, and now I got this when trying to create a new project from a GitHub repo:
> 
> >>> C:/Program Files/Git/bin/git.exe clone --progress git@github.com:jeroen/curl curl
> Cloning into 'curl'...
> ssh_askpass: exec(C:/Program Files/RStudio/bin/postback/rpostback): No such file or directory
> git@github.com: Permission denied (publickey).
> fatal: Could not read from remote repository.
> 
> Please make sure you have the correct access rights
> and the repository exists.
> And sure enough, adding C:/Program Files/RStudio/bin/postback/ to the path and using rpostback-askpass as the GIT_ASKPASS and SSH_ASKPASS fixed it.

So it looks like the PATH munging is required for Git on Windows. The mirrored solution, then, is to make sure the `rpostback` utilities are always on the PATH.