### PR TITLE
remove trailing slashes from HOME / R_USER

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1711,6 +1711,21 @@ int main (int argc, char * const argv[])
       core::system::unsetenv("DYLD_INSERT_LIBRARIES");
 #endif
       
+      // fix up HOME / R_USER environment variables
+      // (some users on Windows report these having trailing
+      // slashes, which confuses a number of RStudio routines)
+      boost::regex reTrailing("[/\\]+$");
+      for (const std::string& envvar : {"HOME", "R_USER"})
+      {
+         std::string oldVal = core::system::getenv(envvar);
+         if (!oldVal.empty())
+         {
+            std::string newVal = boost::regex_replace(oldVal, reTrailing, "");
+            if (oldVal != newVal)
+               core::system::setenv(envvar, newVal);
+         }
+      }
+      
       // read program options
       std::ostringstream osWarnings;
       Options& options = rsession::options();


### PR DESCRIPTION
Re: https://community.rstudio.com/t/mouse-click-return-error-navigating-to/43908

I still don't know why some users are reporting HOME / R_USER with a trailing slash, but the issue is becoming prevalent enough that it's worth working around.