### PR TITLE
Specify dimensions for notebook condition icon

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkConditionBar.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkConditionBar.ui.xml
@@ -10,6 +10,8 @@
   margin-right: 5px;
   margin-left: 2px;
   margin-top: 2px;
+  width: 16px;
+  height: 14px;
 }
 
 .contents


### PR DESCRIPTION
This icon's image file is sized at 2x, but displayed in its native resolution, causing it to be too large and fuzzy on Retina displays (and just plain too large on others).

The fix is to specify the image dimensions.

Fixes https://github.com/rstudio/rstudio/issues/5697.