### PR TITLE
Make the new logger implementation threadsafe.

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -4,3 +4,6 @@ CMakeLists.txt.user
 cpp-build*/
 cmake-build-*/
 session32/*
+dbg/*
+rel/*
+rwd/*

--- a/src/cpp/shared_core/CMakeLists.txt
+++ b/src/cpp/shared_core/CMakeLists.txt
@@ -33,6 +33,7 @@ set (SHARED_CORE_SOURCE_FILES
    FileLogDestination.cpp
    FilePath.cpp
    Logger.cpp
+   ReaderWriterMutex.cpp
    StderrLogDestination.cpp
    json/Json.cpp
 )

--- a/src/cpp/shared_core/Logger.cpp
+++ b/src/cpp/shared_core/Logger.cpp
@@ -169,9 +169,10 @@ public:
    /**
     * @brief Writes a pre-formatted message to all registered destinations.
     *
-    * @param in_logLevel    The log level of the message, which is passed to the destination for informational purposes.
-    * @param in_message     The pre-formatted message.
- * @param in_loggedFrom         The location from which the error message was logged.
+    * @param in_logLevel        The log level of the message, which is passed to the destination for informational purposes.
+    * @param in_message         The pre-formatted message.
+    * @param in_section         The section to which to log this message.
+    * @param in_loggedFrom      The location from which the error message was logged.
     */
    void writeMessageToDestinations(
       LogLevel in_logLevel,

--- a/src/cpp/shared_core/ReaderWriterMutex.cpp
+++ b/src/cpp/shared_core/ReaderWriterMutex.cpp
@@ -1,0 +1,164 @@
+/*
+ * ReaderWriterMutex.cpp
+ *
+ * Copyright (C) 2019 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant to the terms of a commercial license agreement
+ * with RStudio, then this program is licensed to you under the following terms:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include <shared_core/ReaderWriterMutex.hpp>
+
+#include <boost/thread/condition_variable.hpp>
+#include <boost/thread/recursive_mutex.hpp>
+
+namespace rstudio {
+namespace core {
+namespace thread {
+
+typedef boost::unique_lock<boost::recursive_mutex> Lock;
+
+// ReaderWriterMutex ===================================================================================================
+struct ReaderWriterMutex::Impl
+{
+   bool IsWriting;
+   unsigned int ReaderCount;
+   boost::recursive_mutex Mutex;
+   // This mutex is used to allow re-entrant lock behaviour on write. On read it's basically already re-entrant.
+   boost::recursive_mutex WriteMutex;
+   boost::condition_variable_any Condition;
+};
+
+PRIVATE_IMPL_DELETER_IMPL(ReaderWriterMutex);
+
+ReaderWriterMutex::ReaderWriterMutex() :
+   m_impl(new Impl())
+{
+   m_impl->IsWriting = false;
+   m_impl->ReaderCount = 0;
+}
+
+ReaderWriterMutex::ReaderWriterMutex(ReaderWriterMutex&& in_other) noexcept :
+   m_impl(std::move(in_other.m_impl))
+{
+}
+
+void ReaderWriterMutex::lockRead()
+{
+   // Acquire the lock.
+   Lock lock(m_impl->Mutex);
+
+   // Wait until writers are finished, unless we can acquire the write lock, because that means the writer is in this
+   // thread.
+   bool haveWriteLock = false;
+   if (m_impl->IsWriting)
+   {
+      haveWriteLock = m_impl->WriteMutex.try_lock();
+      while (!haveWriteLock && m_impl->IsWriting)
+      {
+         m_impl->Condition.wait(lock);
+         haveWriteLock = m_impl->WriteMutex.try_lock();
+      }
+   }
+
+   // Increment the number of readers.
+   ++m_impl->ReaderCount;
+
+   // Safely read. Also unlock the write lock if we locked it before.
+   if (haveWriteLock)
+      m_impl->WriteMutex.unlock();
+}
+
+// This implementation is write-preferring because no more readers can start reading while there is a thread that
+// wishes to obtain the lock for write. Such an implementation is desirable when there would be many read operations and
+// few write operations. In such a case, a read-preferring implementation would result in write operations getting
+// effectively locked out.
+void ReaderWriterMutex::lockWrite()
+{
+   // Acquire the lock.
+   Lock lock(m_impl->Mutex);
+
+   // Wait until we can get access to the write lock.
+   while (!m_impl->WriteMutex.try_lock())
+      m_impl->Condition.wait(lock);
+
+   // Notify other threads that you're waiting to write.
+   m_impl->IsWriting = true;
+
+   // Wait until current readers are finished.
+   while (m_impl->ReaderCount > 0)
+      m_impl->Condition.wait(lock);
+
+   // Safely write.
+}
+
+void ReaderWriterMutex::unlockRead()
+{
+   // Acquire the lock.
+   Lock lock(m_impl->Mutex);
+
+   // If this wasn't erroneously called, decrement the reader count.
+   if (m_impl->ReaderCount > 0)
+   {
+      --m_impl->ReaderCount;
+
+      // If there are no more readers, notify any waiters.
+      if (m_impl->ReaderCount == 0)
+         m_impl->Condition.notify_all();
+   }
+}
+
+void ReaderWriterMutex::unlockWrite()
+{
+   Lock lock(m_impl->Mutex);
+
+   // If this wasn't erroneously called, reset IsWriting and notify any waiters.
+   if (m_impl->IsWriting)
+   {
+      m_impl->WriteMutex.unlock();
+      m_impl->IsWriting = false;
+      m_impl->Condition.notify_all();
+   }
+}
+
+// ReaderLock ==========================================================================================================
+ReaderLock::ReaderLock(ReaderWriterMutex& in_mutex) :
+   m_mutex(in_mutex)
+{
+   m_mutex.lockRead();
+}
+
+ReaderLock::~ReaderLock()
+{
+   m_mutex.unlockRead();
+}
+
+// WriterLock ==========================================================================================================
+WriterLock::WriterLock(ReaderWriterMutex& in_mutex) :
+   m_mutex(in_mutex)
+{
+   m_mutex.lockWrite();
+}
+
+WriterLock::~WriterLock()
+{
+   m_mutex.unlockWrite();
+}
+
+} // namespace thread
+} // namespace rstudio
+} // namespace core

--- a/src/cpp/shared_core/include/shared_core/ReaderWriterMutex.hpp
+++ b/src/cpp/shared_core/include/shared_core/ReaderWriterMutex.hpp
@@ -1,0 +1,177 @@
+/*
+ * ReaderWriterMutex.hpp
+ *
+ * Copyright (C) 2019 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant to the terms of a commercial license agreement
+ * with RStudio, then this program is licensed to you under the following terms:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef SHARED_CORE_READER_WRITER_MUTEX_HPP
+#define SHARED_CORE_READER_WRITER_MUTEX_HPP
+
+#include "PImpl.hpp"
+
+#include <boost/thread/exceptions.hpp>
+
+namespace rstudio {
+namespace core {
+namespace thread {
+
+/**
+ * @brief Reentrant reader-writer mutex implementation. This implementation is write-preferring.
+ */
+class ReaderWriterMutex
+{
+public:
+   /**
+    * @brief Constructor.
+    */
+   ReaderWriterMutex();
+
+   /**
+    * @brief Move constructor.
+    *
+    * @param in_other   The mutex to move to this mutex.
+    */
+   ReaderWriterMutex(ReaderWriterMutex&& in_other) noexcept;
+
+   /**
+    * @brief Deleted copy constructor to prevent copy.
+    */
+   ReaderWriterMutex(const ReaderWriterMutex&) = delete;
+
+   /**
+    * @brief Deleted assignment operator to prevent copy.
+    */
+   ReaderWriterMutex& operator=(const ReaderWriterMutex&) = delete;
+
+   /**
+    * @brief Locks the mutex for read.
+    *
+    * Note: unlockRead() must be called once for each time lockRead() was called.
+    */
+   void lockRead();
+
+   /**
+    * @brief Locks the mutex for write.
+    *
+    * Note: unlockWrite() must be called once for each time lockWrite() was called.
+    */
+   void lockWrite();
+
+   /**
+    * @brief Unlocks the mutex after a read operation.
+    *
+    * Note: unlockRead() must be called once for each time lockRead() was called.
+    */
+   void unlockRead();
+
+   /**
+    * @brief Unlocks the mutex after a write operation.
+    *
+    * Note: unlockWrite() must be called once for each time lockWrite() was called.
+    */
+   void unlockWrite();
+
+private:
+
+   PRIVATE_IMPL(m_impl);
+};
+
+/**
+ * @brief RAII class which allows you to lock a ReaderWriterMutex for read.
+ */
+class ReaderLock
+{
+public:
+   /**
+    * @brief Constructor. Locks the specified mutex for read.
+    *
+    * @param in_mutex    The mutex to lock for read.
+    */
+   explicit ReaderLock(ReaderWriterMutex& in_mutex);
+
+   /**
+    * @brief Destructor.
+    */
+   ~ReaderLock();
+
+private:
+   // The mutex this lock manages.
+   ReaderWriterMutex& m_mutex;
+};
+
+/**
+ * @brief RAII class which allows you to lock a ReaderWriterMutex for write.
+ */
+class WriterLock
+{
+public:
+   /**
+    * @brief Constructor. Locks the specified mutex for write.
+    *
+    * @param in_mutex    The mutex to lock for write.
+    */
+   explicit WriterLock(ReaderWriterMutex& in_mutex);
+
+   /**
+    * @brief Destructor.
+    */
+   ~WriterLock();
+
+private:
+   // The mutex this lock manages.
+   ReaderWriterMutex& m_mutex;
+};
+
+} // namespace thread
+} // namespace core
+} // namespace rstudio
+
+#define READ_LOCK_BEGIN(mutex)                        \
+   try                                                \
+   {                                                  \
+      rstudio::core::thread::ReaderLock lock(mutex);  \
+
+#define WRITE_LOCK_BEGIN(mutex)                       \
+   try                                                \
+   {                                                  \
+      rstudio::core::thread::WriterLock lock(mutex);  \
+
+#define RW_LOCK_END(tryLog)                                                                     \
+   }                                                                                         \
+   catch (const boost::thread_resource_error& e)                                             \
+   {                                                                                         \
+      if (tryLog)                                                                            \
+         log::logErrorMessage("Failed to acquire lock: thread resource error",               \
+                              ERROR_LOCATION);                                               \
+   }                                                                                         \
+   catch (const std::exception& e)                                                           \
+   {                                                                                         \
+      if (tryLog)                                                                            \
+         log::logErrorMessage(std::string("Unexpected exception: ") + e.what(),              \
+                              ERROR_LOCATION);                                               \
+   }                                                                                         \
+   catch (...)                                                                               \
+   {                                                                                         \
+      if (tryLog)                                                                            \
+         log::logErrorMessage("Unknown exception while trying to acquire lock.");            \
+   }                                                                                         \
+
+
+#endif //SHARED_CORE_READER_WRITER_MUTEX_HPP

--- a/src/cpp/shared_core/include/shared_core/ReaderWriterMutex.hpp
+++ b/src/cpp/shared_core/include/shared_core/ReaderWriterMutex.hpp
@@ -153,7 +153,7 @@ private:
    {                                                  \
       rstudio::core::thread::WriterLock lock(mutex);  \
 
-#define RW_LOCK_END(tryLog)                                                                     \
+#define RW_LOCK_END(tryLog)                                                                  \
    }                                                                                         \
    catch (const boost::thread_resource_error& e)                                             \
    {                                                                                         \


### PR DESCRIPTION
Using a reader-writer lock because most of the logging work will be "read" only (writing logs is read only, adding/removing log destinations is write). The R/W lock implementation is write-preferring because writing should happen so much less often than reading. Some cursory profiling on Windows and OSX show there's no appreciable impact on performance by the logging code.

Fixes #5634