### PR TITLE
Allow a log level to be set per destination.

### DIFF
--- a/src/cpp/core/system/System.cpp
+++ b/src/cpp/core/system/System.cpp
@@ -198,23 +198,19 @@ void initializeLogWriter(const std::string& logSection)
                logLevel,
                s_programIdentity,
                boost::get<FileLogOptions>(options))),
-            LogSection(logSection, s_logOptions->logLevel(logSection)));
+               logSection);
          break;
       }
       case LoggerType::kStdErr:
       {
-         addLogDestination(
-            getStdErrLogDest(logLevel),
-            LogSection(logSection, s_logOptions->logLevel(logSection)));
+         addLogDestination(getStdErrLogDest(logLevel), logSection);
          break;
       }
       case LoggerType::kSysLog:
       default:
       {
 #ifndef _WIN32
-         addLogDestination(
-            getSysLogDest(logLevel),
-            LogSection(logSection, s_logOptions->logLevel(logSection)));
+         addLogDestination(getSysLogDest(logLevel), logSection);
 #endif
       }
    }
@@ -224,7 +220,6 @@ void initializeLogWriters()
 {
    // requires prior synchronization
    log::setProgramId(s_programIdentity);
-   log::setLogLevel(s_logOptions->logLevel());
 
    // Initialize primary log writer
    initializeLogWriter();

--- a/src/cpp/desktop/synctex/rsinverse/RsInverseMain.cpp
+++ b/src/cpp/desktop/synctex/rsinverse/RsInverseMain.cpp
@@ -45,7 +45,6 @@ int main(int argc, char** argv)
    try
    {
       // initialize log
-      core::log::setLogLevel(log::LogLevel::WARN);
       core::log::setProgramId("rsinverse");
       core::system::initializeSystemLog("rsinverse", log::LogLevel::WARN);
 

--- a/src/cpp/desktop/urlopener/UrlOpenerMain.cpp
+++ b/src/cpp/desktop/urlopener/UrlOpenerMain.cpp
@@ -28,7 +28,6 @@ int main(int argc, char** argv)
    try
    {
       // initialize log
-      rstudio::core::log::setLogLevel(rstudio::core::log::LogLevel::WARN);
       rstudio::core::log::setProgramId("urlopener");
       rstudio::core::system::initializeSystemLog("urlopener", rstudio::core::log::LogLevel::WARN);
 

--- a/src/cpp/diagnostics/DiagnosticsMain.cpp
+++ b/src/cpp/diagnostics/DiagnosticsMain.cpp
@@ -93,7 +93,6 @@ void writeUserPrefs(std::ostream& ostr)
 
 int main(int argc, char** argv)
 {
-   core::log::setLogLevel(core::log::LogLevel::WARN);
    core::log::setProgramId("rstudio-diagnostics");
    core::system::initializeStderrLog("rstudio-diagnostics",
                                     core::log::LogLevel::WARN);

--- a/src/cpp/monitor/MonitorClient.cpp
+++ b/src/cpp/monitor/MonitorClient.cpp
@@ -29,8 +29,9 @@ namespace {
 class MonitorLogDestination : public core::log::ILogDestination
 {
 public:
-   MonitorLogDestination(const std::string& programIdentity)
-      : programIdentity_(programIdentity)
+   MonitorLogDestination(core::log::LogLevel logLevel, const std::string& programIdentity) :
+      programIdentity_(programIdentity),
+      ILogDestination(logLevel)
    {
    }
 
@@ -43,6 +44,10 @@ public:
 
    void writeLog(core::log::LogLevel logLevel, const std::string& message) override
    {
+      // Don't log messages which are more detailed than the configured maximum.
+      if (logLevel > m_logLevel)
+         return;
+
       client().logMessage(programIdentity_, logLevel, message);
    }
 
@@ -57,9 +62,10 @@ Client* s_pClient = NULL;
 } // anonymous namespace
 
 std::shared_ptr<core::log::ILogDestination> Client::createLogDestination(
+                                    core::log::LogLevel logLevel,
                                     const std::string& programIdentity)
 {
-   return std::shared_ptr<core::log::ILogDestination>(new MonitorLogDestination(programIdentity));
+   return std::shared_ptr<core::log::ILogDestination>(new MonitorLogDestination(logLevel, programIdentity));
 }
 
 void initializeMonitorClient(const std::string& metricsSocket,

--- a/src/cpp/monitor/include/monitor/MonitorClient.hpp
+++ b/src/cpp/monitor/include/monitor/MonitorClient.hpp
@@ -75,7 +75,8 @@ public:
                            core::log::LogLevel level,
                            const std::string& message) = 0;
 
-   static std::shared_ptr<core::log::ILogDestination> createLogDestination(const std::string& programIdentity);
+   static std::shared_ptr<core::log::ILogDestination> createLogDestination(core::log::LogLevel logLevel,
+                                                                           const std::string& programIdentity);
 
    virtual void sendMetrics(const std::vector<metrics::Metric>& metrics) = 0;
 

--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -613,7 +613,8 @@ int main(int argc, char * const argv[])
       if (!options.verifyInstallation())
       {
          // add a monitor log writer
-         core::log::addLogDestination(monitor::client().createLogDestination(kProgramIdentity));
+         core::log::addLogDestination(
+            monitor::client().createLogDestination(core::log::LogLevel::WARN, kProgramIdentity));
       }
 
       // call overlay initialize

--- a/src/cpp/server/crash-handler-proxy/CrashHandlerProxyMain.cpp
+++ b/src/cpp/server/crash-handler-proxy/CrashHandlerProxyMain.cpp
@@ -41,7 +41,6 @@ int main(int argc, const char* argv[])
 {
    // note: we log all errors and attempt to launch the crashpad handler
    // regardless, as this is a best effort proxy attempt
-   log::setLogLevel(log::LogLevel::WARN);
    log::setProgramId("crash-handler-proxy");
    initializeStderrLog("crash-handler-proxy", log::LogLevel::WARN);
 

--- a/src/cpp/server/pam/PamMain.cpp
+++ b/src/cpp/server/pam/PamMain.cpp
@@ -57,7 +57,6 @@ int main(int argc, char * const argv[])
    try
    { 
       // initialize log
-      core::log::setLogLevel(core::log::LogLevel::WARN);
       core::log::setProgramId("rserver-pam");
       core::system::initializeSystemLog("rserver-pam", core::log::LogLevel::WARN);
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1681,7 +1681,6 @@ int main (int argc, char * const argv[])
       // reading the config file (if we are in desktop mode then the log
       // will get re-initialized below)
       std::string programId = "rsession-" + core::system::username();
-      core::log::setLogLevel(core::log::LogLevel::WARN);
       core::log::setProgramId(programId);
       core::system::initializeSystemLog(programId, core::log::LogLevel::WARN);
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1756,7 +1756,8 @@ int main (int argc, char * const argv[])
 
       // reflect stderr logging
       if (options.logStderr())
-         log::addLogDestination(std::shared_ptr<log::ILogDestination>(new log::StderrLogDestination()));
+         log::addLogDestination(
+            std::shared_ptr<log::ILogDestination>(new log::StderrLogDestination(log::LogLevel::WARN)));
 
       // initialize monitor
       initMonitorClient();
@@ -1764,7 +1765,8 @@ int main (int argc, char * const argv[])
       // register monitor log writer (but not in standalone mode)
       if (!options.standalone())
       {
-         core::log::addLogDestination(monitor::client().createLogDestination(options.programIdentity()));
+         core::log::addLogDestination(
+            monitor::client().createLogDestination(log::LogLevel::WARN, options.programIdentity()));
       }
 
       // initialize file lock config

--- a/src/cpp/session/postback/PostbackMain.cpp
+++ b/src/cpp/session/postback/PostbackMain.cpp
@@ -53,7 +53,6 @@ int main(int argc, char * const argv[])
    try
    {
       // initialize log
-      core::log::setLogLevel(core::log::LogLevel::WARN);
       core::log::setProgramId("rpostback");
       core::system::initializeSystemLog("rpostback", core::log::LogLevel::WARN);
 

--- a/src/cpp/shared_core/FileLogDestination.cpp
+++ b/src/cpp/shared_core/FileLogDestination.cpp
@@ -176,8 +176,8 @@ FileLogDestination::FileLogDestination(
    LogLevel in_logLevel,
    const std::string& in_programId,
    FileLogOptions in_logOptions) :
-      m_impl(new Impl(in_id, in_programId, std::move(in_logOptions))),
-      ILogDestination(in_logLevel)
+      ILogDestination(in_logLevel),
+      m_impl(new Impl(in_id, in_programId, std::move(in_logOptions)))
 {
 }
 

--- a/src/cpp/shared_core/FileLogDestination.cpp
+++ b/src/cpp/shared_core/FileLogDestination.cpp
@@ -173,9 +173,11 @@ struct FileLogDestination::Impl
 
 FileLogDestination::FileLogDestination(
    unsigned int in_id,
+   LogLevel in_logLevel,
    const std::string& in_programId,
    FileLogOptions in_logOptions) :
-      m_impl(new Impl(in_id, in_programId, std::move(in_logOptions)))
+      m_impl(new Impl(in_id, in_programId, std::move(in_logOptions))),
+      ILogDestination(in_logLevel)
 {
 }
 
@@ -190,8 +192,12 @@ unsigned int FileLogDestination::getId() const
    return m_impl->Id;
 }
 
-void FileLogDestination::writeLog(LogLevel, const std::string& in_message)
+void FileLogDestination::writeLog(LogLevel in_logLevel, const std::string& in_message)
 {
+   // Don't write logs that are more detailed than the configured maximum.
+   if (in_logLevel > m_logLevel)
+      return;
+
    // Lock the mutex before attempting to write.
    boost::unique_lock<boost::mutex> lock(m_impl->Mutex);
 

--- a/src/cpp/shared_core/Logger.cpp
+++ b/src/cpp/shared_core/Logger.cpp
@@ -38,7 +38,7 @@ namespace core {
 namespace log {
 
 typedef std::map<unsigned int, std::shared_ptr<ILogDestination> > LogMap;
-typedef std::map<LogSection, LogMap> SectionLogMap;
+typedef std::map<std::string, LogMap> SectionLogMap;
 
 namespace {
 
@@ -123,46 +123,6 @@ std::string formatLogMessage(
 
 } // anonymous namespace
 
-// Log Section =========================================================================================================
-struct LogSection::Impl
-{
-   std::string Name;
-   boost::optional<LogLevel> MaxLogLevel;
-};
-
-LogSection::LogSection(const std::string& in_name) :
-   m_impl(new Impl())
-{
-   m_impl->Name = in_name;
-}
-
-LogSection::LogSection(const std::string& in_name, LogLevel in_logLevel) :
-   m_impl(new Impl())
-{
-   m_impl->Name = in_name;
-   m_impl->MaxLogLevel = in_logLevel;
-}
-
-bool LogSection::operator<(const LogSection& in_other) const
-{
-   return m_impl->Name < in_other.m_impl->Name;
-}
-
-bool LogSection::operator==(const LogSection& in_other) const
-{
-   return m_impl->Name == in_other.m_impl->Name;
-}
-
-LogLevel LogSection::getMaxLogLevel(LogLevel in_defaultLevel) const
-{
-   return boost::get_optional_value_or(m_impl->MaxLogLevel, in_defaultLevel);
-}
-
-const std::string& LogSection::getName() const
-{
-   return m_impl->Name;
-}
-
 // Logger Object =======================================================================================================
 /**
  * @brief Class which logs messages to destinations.
@@ -191,15 +151,11 @@ public:
     */
    Logger() :
       MaxLogLevel(LogLevel::OFF),
-      DefaultLogLevel(LogLevel::OFF),
       ProgramId("")
    { };
 
    // The maximum level of message to write across all log sections.
    LogLevel MaxLogLevel;
-
-   // The default maximum level of message to write.
-   LogLevel DefaultLogLevel;
 
    // The ID of the program fr which to write logs.
    std::string ProgramId;
@@ -225,7 +181,10 @@ void Logger::writeMessageToDestinations(
    const std::string& in_section,
    const ErrorLocation& in_loggedFrom)
 {
-   LogLevel maxLogLevel = DefaultLogLevel;
+   // Don't log this message, it's too detailed for any of the logs.
+   if (in_logLevel > MaxLogLevel)
+      return;
+
    LogMap* logMap = &DefaultLogDestinations;
    if (!in_section.empty())
    {
@@ -234,12 +193,7 @@ void Logger::writeMessageToDestinations(
          return;
       auto logDestIter = SectionedLogDestinations.find(in_section);
       logMap = &logDestIter->second;
-      maxLogLevel = logDestIter->first.getMaxLogLevel(maxLogLevel);
    }
-
-   // Don't log this message, it's too detailed for the configuration.
-   if (in_logLevel > maxLogLevel)
-      return;
 
    // Preformat the message for non-syslog loggers.
    std::string formattedMessage = formatLogMessage(in_logLevel, in_message, ProgramId, in_loggedFrom);
@@ -260,18 +214,15 @@ void setProgramId(const std::string& in_programId)
    logger().ProgramId = in_programId;
 }
 
-void setLogLevel(LogLevel in_logLevel)
-{
-   logger().DefaultLogLevel = in_logLevel;
-   if (in_logLevel > logger().MaxLogLevel)
-      logger().MaxLogLevel = in_logLevel;
-}
-
 void addLogDestination(const std::shared_ptr<ILogDestination>& in_destination)
 {
    LogMap& logMap = logger().DefaultLogDestinations;
    if (logMap.find(in_destination->getId()) == logMap.end())
+   {
       logMap.insert(std::make_pair(in_destination->getId(), in_destination));
+      if (in_destination->getLogLevel() > logger().MaxLogLevel)
+         logger().MaxLogLevel = in_destination->getLogLevel();
+   }
    else {
       logDebugMessage(
          "Attempted to register a log destination that has already been registered with id " +
@@ -279,7 +230,7 @@ void addLogDestination(const std::shared_ptr<ILogDestination>& in_destination)
    }
 }
 
-void addLogDestination(const std::shared_ptr<ILogDestination>& in_destination, const LogSection& in_section)
+void addLogDestination(const std::shared_ptr<ILogDestination>& in_destination, const std::string& in_section)
 {
    Logger& log = logger();
    SectionLogMap& secLogMap =log.SectionedLogDestinations;
@@ -289,18 +240,19 @@ void addLogDestination(const std::shared_ptr<ILogDestination>& in_destination, c
    LogMap& logMap = secLogMap.find(in_section)->second;
 
    if (logMap.find(in_destination->getId()) == logMap.end())
+   {
       logMap.insert(std::make_pair(in_destination->getId(), in_destination));
+      if (log.MaxLogLevel < in_destination->getLogLevel())
+         log.MaxLogLevel = in_destination->getLogLevel();
+   }
    else
    {
       logDebugMessage(
          "Attempted to register a log destination that has already been registered with id " +
          std::to_string(in_destination->getId()) +
          " to section " +
-         in_section.getName());
+         in_section);
    }
-
-   if (in_section.getMaxLogLevel(log.DefaultLogLevel) > log.MaxLogLevel)
-      log.MaxLogLevel = in_section.getMaxLogLevel(log.DefaultLogLevel);
 }
 
 std::string cleanDelimiters(const std::string& in_str)
@@ -312,45 +264,27 @@ std::string cleanDelimiters(const std::string& in_str)
 
 void logError(const Error& in_error)
 {
-   Logger& log = logger();
-   if (log.MaxLogLevel >= LogLevel::ERR)
-   {
-      log.writeMessageToDestinations(LogLevel::ERR, in_error.asString());
-   }
+   logger().writeMessageToDestinations(LogLevel::ERR, in_error.asString());
 }
 
 void logError(const Error& in_error, const ErrorLocation& in_location)
 {
-   Logger& log = logger();
-   if (log.MaxLogLevel >= LogLevel::ERR)
-      log.writeMessageToDestinations(LogLevel::ERR, in_error.asString(), "", in_location);
+   logger().writeMessageToDestinations(LogLevel::ERR, in_error.asString(), "", in_location);
 }
 
 void logErrorAsWarning(const Error& in_error)
 {
-   Logger& log = logger();
-   if (log.MaxLogLevel >= LogLevel::WARN)
-   {
-      log.writeMessageToDestinations(LogLevel::WARN, in_error.asString());
-   }
+   logger().writeMessageToDestinations(LogLevel::WARN, in_error.asString());
 }
 
 void logErrorAsInfo(const Error& in_error)
 {
-   Logger& log = logger();
-   if (log.MaxLogLevel >= LogLevel::INFO)
-   {
-      log.writeMessageToDestinations(LogLevel::INFO, in_error.asString());
-   }
+   logger().writeMessageToDestinations(LogLevel::INFO, in_error.asString());
 }
 
 void logErrorAsDebug(const Error& in_error)
 {
-   Logger& log = logger();
-   if (log.MaxLogLevel >= LogLevel::DEBUG)
-   {
-      log.writeMessageToDestinations(LogLevel::DEBUG, in_error.asString());
-   }
+   logger().writeMessageToDestinations(LogLevel::DEBUG, in_error.asString());
 }
 
 void logErrorMessage(const std::string& in_message, const std::string& in_section)
@@ -399,9 +333,7 @@ void logDebugMessage(const std::string& in_message, const ErrorLocation& in_logg
 
 void logDebugMessage(const std::string& in_message, const std::string& in_section, const ErrorLocation& in_loggedFrom)
 {
-   Logger& log = logger();
-   if (log.MaxLogLevel >= LogLevel::DEBUG)
-      log.writeMessageToDestinations(LogLevel::DEBUG, in_message, in_section, in_loggedFrom);
+   logger().writeMessageToDestinations(LogLevel::DEBUG, in_message, in_section, in_loggedFrom);
 }
 
 void logInfoMessage(const std::string& in_message, const std::string& in_section)
@@ -416,9 +348,7 @@ void logInfoMessage(const std::string& in_message, const ErrorLocation& in_logge
 
 void logInfoMessage(const std::string& in_message, const std::string& in_section, const ErrorLocation& in_loggedFrom)
 {
-   Logger& log = logger();
-   if (log.MaxLogLevel >= LogLevel::INFO)
-      log.writeMessageToDestinations(LogLevel::INFO, in_message, in_section, in_loggedFrom);
+   logger().writeMessageToDestinations(LogLevel::INFO, in_message, in_section, in_loggedFrom);
 }
 
 void removeLogDestination(unsigned int in_destinationId, const std::string& in_section)
@@ -436,7 +366,7 @@ void removeLogDestination(unsigned int in_destinationId, const std::string& in_s
       }
 
       // Remove it from any sections it may have been registered to.
-      std::vector<LogSection> sectionsToRemove;
+      std::vector<std::string> sectionsToRemove;
       for (auto secIter: log.SectionedLogDestinations)
       {
          iter = secIter.second.find(in_destinationId);
@@ -451,7 +381,7 @@ void removeLogDestination(unsigned int in_destinationId, const std::string& in_s
       }
 
       // Clean up any empty sections.
-      for (const LogSection& toRemove: sectionsToRemove)
+      for (const std::string& toRemove: sectionsToRemove)
          log.SectionedLogDestinations.erase(log.SectionedLogDestinations.find(toRemove));
 
       // Log a debug message if this destination wasn't registered.

--- a/src/cpp/shared_core/StderrLogDestination.cpp
+++ b/src/cpp/shared_core/StderrLogDestination.cpp
@@ -29,19 +29,21 @@ namespace rstudio {
 namespace core {
 namespace log {
 
-unsigned int StderrLogDestination::getStderrId()
+StderrLogDestination::StderrLogDestination(LogLevel in_logLevel) :
+   ILogDestination(in_logLevel)
 {
-   return 0;
 }
 
 unsigned int StderrLogDestination::getId() const
 {
-   return getStderrId();
+   return 0;
 }
 
-void StderrLogDestination::writeLog(LogLevel, const std::string& in_message)
+void StderrLogDestination::writeLog(LogLevel in_logLevel, const std::string& in_message)
 {
-   std::cerr << in_message;
+   // Don't write logs that are more detailed than the configured maximum
+   if (in_logLevel <= m_logLevel)
+      std::cerr << in_message;
 }
 
 } // namespace log

--- a/src/cpp/shared_core/include/shared_core/FileLogDestination.hpp
+++ b/src/cpp/shared_core/include/shared_core/FileLogDestination.hpp
@@ -134,13 +134,18 @@ public:
     * @brief Constructor.
     *
     * @param in_id              The ID of this log destination. Must be unique for each file log destination and > 100.
+    * @param in_logLevel        The most detailed level of log to be written to this log file.
     * @param in_programId       The ID of this program.
     * @param in_logOptions      The options for log file creation and management.
     *
     * If the log file cannot be opened, no logs will be written to the file. If there are other log destinations
     * registered an error will be logged regarding the failure.
     */
-   FileLogDestination(unsigned int in_id, const std::string& in_programId, FileLogOptions in_logOptions);
+   FileLogDestination(
+      unsigned int in_id,
+      LogLevel in_logLevel,
+      const std::string& in_programId,
+      FileLogOptions in_logOptions);
 
    /**
     * @brief Destructor.

--- a/src/cpp/shared_core/include/shared_core/ILogDestination.hpp
+++ b/src/cpp/shared_core/include/shared_core/ILogDestination.hpp
@@ -44,6 +44,13 @@ class ILogDestination : boost::noncopyable
 {
 public:
    /**
+    * @brief Constructor.
+    *
+    * @param in_logLevel    The most detailed level of log to be written to this log destination.
+    */
+   explicit ILogDestination(LogLevel in_logLevel) : m_logLevel(in_logLevel) {};
+
+   /**
     * @brief Virtual destructor to allow for inheritance.
     */
    virtual ~ILogDestination() = default;
@@ -56,13 +63,23 @@ public:
    virtual unsigned int getId() const = 0;
 
    /**
+    * @brief Gets the maximum level of logs that will be written to this log destination.
+    *
+    * @return This log destination's maximum log level.
+    */
+   LogLevel getLogLevel() { return m_logLevel; };
+
+   /**
     * @brief Writes a message to this log destination.
     *
-    * @param in_logLevel    The log level of the message to write. Filtering is done prior to this call. This is for
-    *                       informational purposes only.
+    * @param in_logLevel    The log level of the message to write.
     * @param in_message     The message to write to the destination.
     */
    virtual void writeLog(LogLevel in_level, const std::string& in_message) = 0;
+
+protected:
+   // The maximum level of log messages to write for this logger.
+   LogLevel m_logLevel;
 };
 
 } // namespace log

--- a/src/cpp/shared_core/include/shared_core/Logger.hpp
+++ b/src/cpp/shared_core/include/shared_core/Logger.hpp
@@ -74,80 +74,12 @@ enum class LogLevel
 };
 
 /**
- * @brief Class which represents a log section.
- */
-struct LogSection
-{
-   /**
-    * @brief Constructor.
-    *
-    * Intentionally not explicit.
-    *
-    * @param in_name        The name of the section.
-    */
-   LogSection(const std::string& in_name);
-
-   /**
-    * @brief Constructor.
-    *
-    * @param in_name        The name of the section.
-    * @param in_logLevel    The maximum log level for this section.
-    */
-   LogSection(const std::string& in_name, LogLevel in_logLevel);
-
-   /**
-    * @brief Less-than operator. A log section is less than another if its name is alphabetically less than the other.
-    *
-    * @param in_other   The log section to which to compare this log section.
-    *
-    * @return True if this log section is less, alphabetically by name, than in_other; false otherwise.
-    */
-   bool operator<(const LogSection& in_other) const;
-
-   /**
-    * @brief Equality operator. A log section is equal to another if their names are equal.
-    *
-    * @param in_other   The log section to which to compare this log section.
-    *
-    * @return True if the two log sections have the same name; false otherwise.
-    */
-   bool operator==(const LogSection& in_other) const;
-
-   /**
-    * @brief Gets the maximum log level for the section.
-    *
-    * @param in_defaultLevel   The default log level to use if this section does not have a log level configured.
-    *
-    * @return The maximum log level for the section, or the specified default level if this section has no log level
-    *         configured.
-    */
-    LogLevel getMaxLogLevel(LogLevel in_defaultLevel) const;
-
-   /**
-    * @brief Gets the name of the log section.
-    *
-    * @return The name of the log section.
-    */
-   const std::string& getName() const;
-
-private:
-   // Private implementation of LogSection.
-   PRIVATE_IMPL_SHARED(m_impl);
-};
-
-/**
  * @brief Sets the program ID for the logger.
  *
  * @param in_programId       The ID of the program.
  */
 void setProgramId(const std::string& in_programId);
 
-/**
- * @brief Sets the level of detail at which to log messages.
- *
- * @param in_logLevel    The level of detail at which to log messages.
- */
-void setLogLevel(LogLevel in_logLevel);
 /**
  * @brief Adds an un-sectioned log destination to the logger.
  *
@@ -167,7 +99,7 @@ void addLogDestination(const std::shared_ptr<ILogDestination>& in_destination);
  * @param in_destination    The destination to add.
  * @param in_section        The name of the log section to which this logger is assigned.
  */
-void addLogDestination(const std::shared_ptr<ILogDestination>& in_destination, const LogSection& in_section);
+void addLogDestination(const std::shared_ptr<ILogDestination>& in_destination, const std::string& in_section);
 
 /**
  * @brief Replaces logging delimiters with ' ' in the specified string.

--- a/src/cpp/shared_core/include/shared_core/Logger.hpp
+++ b/src/cpp/shared_core/include/shared_core/Logger.hpp
@@ -67,8 +67,8 @@ constexpr char s_delim = ';';
 enum class LogLevel
 {
    OFF = 0,       // No messages will be logged.
-   ERR = 1,     // Error messages will be logged.
-   WARN = 2,   // Warning and error messages will be logged.
+   ERR = 1,       // Error messages will be logged.
+   WARN = 2,      // Warning and error messages will be logged.
    INFO = 3,      // Info, warning, and error messages will be logged.
    DEBUG = 4      // All messages will be logged.
 };

--- a/src/cpp/shared_core/include/shared_core/StderrLogDestination.hpp
+++ b/src/cpp/shared_core/include/shared_core/StderrLogDestination.hpp
@@ -38,12 +38,11 @@ class StderrLogDestination : public ILogDestination
 public:
 
    /**
-    * @brief Gets the unique ID for the stderr destination. There should only be one stderr destination for the whole
-    *        program.
+    * @brief Constructor.
     *
-    * @return The unique ID of the stderr destination.
+    * @param in_logLevel    The most detailed level of logs to be written to stderr.
     */
-   static unsigned int getStderrId();
+   explicit StderrLogDestination(LogLevel in_logLevel);
 
    /**
     * @brief Gets the unique ID of the stderr destination.

--- a/src/cpp/shared_core/include/shared_core/system/SyslogDestination.hpp
+++ b/src/cpp/shared_core/include/shared_core/system/SyslogDestination.hpp
@@ -41,9 +41,10 @@ public:
    /**
     * @brief Constructor.
     *
+    * @param in_logLevel        The most detailed level of log to be written to syslog.
     * @param in_programId       The ID of this program.
     */
-   explicit SyslogDestination(const std::string& in_programId);
+   SyslogDestination(log::LogLevel in_logLevel, const std::string& in_programId);
 
    /**
     * @brief Destructor.

--- a/src/cpp/shared_core/system/SyslogDestination.cpp
+++ b/src/cpp/shared_core/system/SyslogDestination.cpp
@@ -61,7 +61,8 @@ int logLevelToLogPriority(log::LogLevel in_logLevel)
 
 } // anonymous namespace
 
-SyslogDestination::SyslogDestination(const std::string& in_programId)
+SyslogDestination::SyslogDestination(log::LogLevel in_logLevel, const std::string& in_programId) :
+   ILogDestination(in_logLevel)
 {
    // Open the system log. Don't set a mask because filtering is done at a higher level.
    ::openlog(in_programId.c_str(), LOG_CONS | LOG_PID, LOG_USER);
@@ -94,6 +95,10 @@ void SyslogDestination::writeLog(
    log::LogLevel in_logLevel,
    const std::string& in_message)
 {
+   // Don't write logs that are more detailed than the configured maximum.
+   if (in_logLevel > m_logLevel)
+      return;
+
    // Don't allow newlines in syslog messages since they delimit distinct log entries. Strip trailing whitespace first.
    std::string forSyslog = boost::algorithm::trim_right_copy(in_message);
    boost::algorithm::replace_all_copy(forSyslog, "\n", "|||");


### PR DESCRIPTION
This matches behaviour we had before the refactor of logging. There is a branch prepared on the Pro repo which resolves compile issues caused by this change.