### PR TITLE
prevent popuppanels from going off left of browser window

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.java
@@ -90,8 +90,8 @@ public class ThemedPopupPanel extends DecoratedPopupPanel
    @Override
    public void setPopupPosition(int left, int top)
    {
-      if (autoConstrain_ && left < 0)
-         left = 0;
+      if (autoConstrain_ && left < 10)
+         left = 10;
 
       super.setPopupPosition(left, top);
 

--- a/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.java
@@ -1,7 +1,7 @@
 /*
  * ThemedPopupPanel.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -86,9 +86,13 @@ public class ThemedPopupPanel extends DecoratedPopupPanel
       if (RStudioThemes.usesScrollbars())
          addStyleName("rstudio-themes-scrollbars");
    }
+
    @Override
    public void setPopupPosition(int left, int top)
    {
+      if (autoConstrain_ && left < 0)
+         left = 0;
+
       super.setPopupPosition(left, top);
 
       if (autoConstrain_)


### PR DESCRIPTION
- Fixes #3395
- Keeps build book dropdown in window when build pane is in left column

Before
<img width="351" alt="2019-11-07_09-44-26" src="https://user-images.githubusercontent.com/10569626/68413516-4331df80-0143-11ea-9575-8ac9cce7ebc8.png">

After
<img width="340" alt="2019-11-07_09-39-23" src="https://user-images.githubusercontent.com/10569626/68413395-06fe7f00-0143-11ea-8849-561dc973de72.png">
