### PR TITLE
Fix C++ compiler warning about initialization order

### DIFF
--- a/src/cpp/monitor/MonitorClient.cpp
+++ b/src/cpp/monitor/MonitorClient.cpp
@@ -30,8 +30,8 @@ class MonitorLogDestination : public core::log::ILogDestination
 {
 public:
    MonitorLogDestination(core::log::LogLevel logLevel, const std::string& programIdentity) :
-      programIdentity_(programIdentity),
-      ILogDestination(logLevel)
+      ILogDestination(logLevel),
+      programIdentity_(programIdentity)
    {
    }
 


### PR DESCRIPTION
- On macOS was getting:

```
MonitorClient.cpp:33:7: warning: field 'programIdentity_' will be initialized after base 'rstudio::core::log::ILogDestination' [-Wreorder]
      programIdentity_(programIdentity),
      ^
```