### PR TITLE
Add the ability to stamp arbitrary headers on all server responses

### DIFF
--- a/src/cpp/core/include/core/http/AsyncServerImpl.hpp
+++ b/src/cpp/core/include/core/http/AsyncServerImpl.hpp
@@ -73,11 +73,13 @@ class AsyncServerImpl : public AsyncServer, boost::noncopyable
 public:
    AsyncServerImpl(const std::string& serverName,
                    const std::string& baseUri = std::string(),
-                   bool disableOriginCheck = true)
+                   bool disableOriginCheck = true,
+                   const Headers& additionalResponseHeaders = Headers())
       : abortOnResourceError_(false),
         serverName_(serverName),
         baseUri_(baseUri),
         originCheckDisabled_(disableOriginCheck),
+        additionalResponseHeaders_(additionalResponseHeaders),
         acceptorService_(),
         scheduledCommandInterval_(boost::posix_time::seconds(3)),
         scheduledCommandTimer_(acceptorService_.ioService()),
@@ -530,6 +532,12 @@ private:
       // non-threadsafe std::string implementations)
       pResponse->setHeader("Server", std::string(serverName_.c_str()));
 
+      // set additional headers
+      for (const Header& header : additionalResponseHeaders_)
+      {
+         pResponse->setHeader(header);
+      }
+
       if (responseFilter_)
          responseFilter_(originalUri, pResponse);
    }
@@ -662,6 +670,7 @@ private:
    std::string serverName_;
    std::string baseUri_;
    bool originCheckDisabled_;
+   Headers additionalResponseHeaders_;
    boost::shared_ptr<boost::asio::ssl::context> sslContext_;
    boost::shared_ptr<AsyncConnectionImpl<typename ProtocolType::socket> > ptrNextConnection_;
    AsyncUriHandlers uriHandlers_ ;

--- a/src/cpp/core/include/core/http/TcpIpAsyncServer.hpp
+++ b/src/cpp/core/include/core/http/TcpIpAsyncServer.hpp
@@ -30,8 +30,9 @@ class TcpIpAsyncServer : public AsyncServerImpl<boost::asio::ip::tcp>
 public:
    TcpIpAsyncServer(const std::string& serverName,
                     const std::string& baseUri = std::string(),
-                    bool disableOriginCheck = true)
-      : AsyncServerImpl<boost::asio::ip::tcp>(serverName, baseUri, disableOriginCheck)
+                    bool disableOriginCheck = true,
+                    const Headers& additionalHeaders = Headers())
+      : AsyncServerImpl<boost::asio::ip::tcp>(serverName, baseUri, disableOriginCheck, additionalHeaders)
    {
    }
    

--- a/src/cpp/server/ServerInit.cpp
+++ b/src/cpp/server/ServerInit.cpp
@@ -26,11 +26,12 @@ using namespace rstudio::core;
 namespace rstudio {
 namespace server {
 
-http::AsyncServer* httpServerCreate()
+http::AsyncServer* httpServerCreate(const http::Headers& additionalHeaders)
 {
    return new http::TcpIpAsyncServer("RStudio",
                                      std::string(),
-                                     options().wwwDisableOriginCheck());
+                                     options().wwwDisableOriginCheck(),
+                                     additionalHeaders);
 }
 
 Error httpServerInit(http::AsyncServer* pAsyncServer)

--- a/src/cpp/server/ServerInit.hpp
+++ b/src/cpp/server/ServerInit.hpp
@@ -18,11 +18,14 @@
 
 #include <string>
 
+#include <core/http/Header.hpp>
+
 namespace rstudio {
 namespace core {
    class Error;
    namespace http {
       class AsyncServer;
+
    }
 }
 }
@@ -30,7 +33,7 @@ namespace core {
 namespace rstudio {
 namespace server {
 
-core::http::AsyncServer* httpServerCreate();
+core::http::AsyncServer* httpServerCreate(const core::http::Headers& additionalHeaders);
 core::Error httpServerInit(core::http::AsyncServer* pAsyncServer);
 
 

--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -166,7 +166,8 @@ Error httpServerInit()
          continue;
       }
 
-      additionalHeaders.emplace_back(headerParts[0], headerParts[1]);
+      additionalHeaders.emplace_back(string_utils::trimWhitespace(headerParts[0]),
+                                     string_utils::trimWhitespace(headerParts[1]));
    }
 
    s_pHttpServer.reset(server::httpServerCreate(additionalHeaders));

--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -156,18 +156,16 @@ Error httpServerInit()
    http::Headers additionalHeaders;
    for (const std::string& headerStr : options().serverAddHeaders())
    {
-      std::vector<std::string> headerParts;
-      boost::split(headerParts, headerStr, boost::is_any_of(":"));
-
-      if (headerParts.size() != 2)
+      size_t pos = headerStr.find(':');
+      if (pos == std::string::npos)
       {
          LOG_WARNING_MESSAGE("Invalid header " + headerStr +
                              " will be skipped and not be written to outgoing requests");
          continue;
       }
 
-      additionalHeaders.emplace_back(string_utils::trimWhitespace(headerParts[0]),
-                                     string_utils::trimWhitespace(headerParts[1]));
+      additionalHeaders.emplace_back(string_utils::trimWhitespace(headerStr.substr(0, pos)),
+                                     string_utils::trimWhitespace(headerStr.substr(pos+1)));
    }
 
    s_pHttpServer.reset(server::httpServerCreate(additionalHeaders));

--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -153,7 +153,23 @@ boost::shared_ptr<http::AsyncServer> s_pHttpServer;
 
 Error httpServerInit()
 {
-   s_pHttpServer.reset(server::httpServerCreate());
+   http::Headers additionalHeaders;
+   for (const std::string& headerStr : options().serverAddHeaders())
+   {
+      std::vector<std::string> headerParts;
+      boost::split(headerParts, headerStr, boost::is_any_of(":"));
+
+      if (headerParts.size() != 2)
+      {
+         LOG_WARNING_MESSAGE("Invalid header " + headerStr +
+                             " will be skipped and not be written to outgoing requests");
+         continue;
+      }
+
+      additionalHeaders.emplace_back(headerParts[0], headerParts[1]);
+   }
+
+   s_pHttpServer.reset(server::httpServerCreate(additionalHeaders));
 
    // set server options
    s_pHttpServer->setAbortOnResourceError(true);

--- a/src/cpp/server/ServerOptions.cpp
+++ b/src/cpp/server/ServerOptions.cpp
@@ -32,6 +32,20 @@
 
 using namespace rstudio::core ;
 
+namespace std
+{
+   // needed for boost to compile std::vector<std::string> default value for option
+   std::ostream& operator<<(std::ostream &os, const std::vector<std::string> &vec)
+   {
+      for (auto item : vec)
+      {
+         os << item << " ";
+      }
+
+      return os;
+   }
+}
+
 namespace rstudio {
 namespace server {
 
@@ -210,7 +224,10 @@ ProgramStatus Options::read(int argc,
         "path override for secure cookie key")
       ("server-data-dir",
          value<std::string>(&serverDataDir_)->default_value("/var/run/rstudio-server"),
-         "path to data directory where rstudio server will write run-time state");
+         "path to data directory where rstudio server will write run-time state")
+      ("server-add-header",
+       value<std::vector<std::string>>(&serverAddHeaders_)->default_value(std::vector<std::string>{})->multitoken(),
+         "adds a header to all responses from RStudio Server");
 
    // www - web server options
    options_description www("www") ;

--- a/src/cpp/server/include/server/ServerOptions.hpp
+++ b/src/cpp/server/include/server/ServerOptions.hpp
@@ -87,6 +87,11 @@ public:
       return core::FilePath(serverDataDir_);
    }
 
+   const std::vector<std::string>& serverAddHeaders() const
+   {
+      return serverAddHeaders_;
+   }
+
    // www 
    std::string wwwAddress() const
    { 
@@ -310,6 +315,7 @@ private:
    bool serverSetUmask_;
    bool serverOffline_;
    std::string serverDataDir_;
+   std::vector<std::string> serverAddHeaders_;
    std::string wwwAddress_ ;
    std::string wwwPort_ ;
    std::string wwwLocalPath_ ;


### PR DESCRIPTION
This change gives the user the ability to configure arbitrary headers to add to all rserver responses by using the new multi-option `server-add-header`, giving it the form `HeaderName:HeaderValue`.

This will allow users to easily stamp arbitrary headers on responses without having to mess with a reverse proxy (or in the RSP case, modifying the nginx template).

Fixes https://github.com/rstudio/rstudio-pro/issues/1205.