### PR TITLE
Use ./shinytests/tests instead of ./tests for newer shinytest

### DIFF
--- a/src/cpp/session/modules/SessionBuild.R
+++ b/src/cpp/session/modules/SessionBuild.R
@@ -83,4 +83,7 @@ options(buildtools.with = .rs.withBuildTools)
    sapply(failures, function(e) e$name)
 })
 
+.rs.addFunction("findShinyTestsDir", function(appDir) {
+   shinytest:::findTestsDir(appDir = appDir, mustExist = FALSE, quiet = TRUE)
+})
 

--- a/src/cpp/session/modules/SessionBuild.R
+++ b/src/cpp/session/modules/SessionBuild.R
@@ -84,6 +84,12 @@ options(buildtools.with = .rs.withBuildTools)
 })
 
 .rs.addFunction("findShinyTestsDir", function(appDir) {
-   shinytest:::findTestsDir(appDir = appDir, mustExist = FALSE, quiet = TRUE)
+   if (exists("findTestsDir", where = asNamespace("shinytest"))) {
+      # Newer versions of shinytest can report their own test directories.
+      shinytest:::findTestsDir(appDir = appDir, mustExist = FALSE, quiet = TRUE)
+   } else {
+      # Older versions require us to know.
+      file.path(appDir, "tests")
+   }
 })
 

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -1197,6 +1197,12 @@ private:
            // Move up from the tests folder to the app folder.
            shinyPath = shinyPath.getParent();
         }
+        else
+        {
+           // If this doesn't look like it's in a tests directory, bail out.
+           terminateWithError("Could not find Shiny app for test in " + 
+              shinyPath.getAbsolutePath());
+        }
       }
 
       // get temp path to store rds results

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -1185,7 +1185,18 @@ private:
       std::string shinyTestName;
       if (type == kTestShinyFile) {
         shinyTestName = shinyPath.getFilename();
-        shinyPath = shinyPath.getParent().getParent();
+        shinyPath = shinyPath.getParent();
+        if (shinyPath.getFilename() == "shinytests")
+        {
+           // In newer versions of shinytest, tests are stored in a "shinytests" folder under the
+           // "tests" folder.
+           shinyPath = shinyPath.getParent();
+        }
+        if (shinyPath.getFilename() == "tests")
+        {
+           // Move up from the tests folder to the app folder.
+           shinyPath = shinyPath.getParent();
+        }
       }
 
       // get temp path to store rds results

--- a/src/cpp/session/modules/build/SessionBuildErrors.cpp
+++ b/src/cpp/session/modules/build/SessionBuildErrors.cpp
@@ -338,10 +338,18 @@ std::vector<module_context::SourceMarker> parseShinyTestErrors(
          std::string column = "0";
          type = "failure";
          message = std::string("Differences detected in " + file + ".");
-         FilePath testFilePath = basePathResolved.completePath("tests").completePath(file + ".R");
+
+         // ask the shinytest package where the tests live (this location varies between versions of
+         // the shinytest package
+         std::string testsDir;
+         r::exec::RFunction findTests(".rs.findShinyTestsDir", 
+               basePathResolved.getAbsolutePath());
+         error = findTests.call(&testsDir);
+         if (error)
+            LOG_ERROR(error);
 
          SourceMarker err(module_context::sourceMarkerTypeFromString(type),
-                          testFilePath,
+                          FilePath(testsDir).completePath(file + ".R"),
                           core::safe_convert::stringTo<int>(line, 1),
                           core::safe_convert::stringTo<int>(column, 1),
                           core::html_utils::HTML(message),


### PR DESCRIPTION
The IDE currently assumes that shinytest scripts live in a folder called `tests`. A recent version of shinytest has changed the location of this folder to `tests/shinytests`, with the result that the IDE can't find the tests from the app, nor the app from the tests.

Unfortunately, we need to be compatible with both layouts, so this change attempts to do so. It's possible to ask shinytest itself to locate the tests folder given the app folder (but not the other way around, so we use a heuristic there). 

Fixes https://github.com/rstudio/rstudio/issues/5703
Fixes https://github.com/rstudio/rstudio/issues/5677
