### PR TITLE
pass inferred completion config to precompiledHeaderArgs

### DIFF
--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -307,9 +307,9 @@ void RCompilationDatabase::updateForCurrentPackage()
       return;
 
    // start with base args
-   bool isCpp = false;
+   bool isCpp = true;
    core::r_util::RPackageInfo pkgInfo;
-   std::vector<std::string> args = commonCompilationArgs(&pkgInfo, &isCpp);
+   std::vector<std::string> args = packageCompilationArgs(&pkgInfo, &isCpp);
    if (!args.empty())
    {
       // set the args and build file hash (to avoid recomputation)
@@ -754,8 +754,7 @@ std::vector<std::string> RCompilationDatabase::compileArgsForTranslationUnit(
        (filePath.getExtensionLowerCase() != ".m"))
    {
       // extract any -std= argument
-      std::string stdArg = extractStdArg(args);
-      std::vector<std::string> pchArgs = precompiledHeaderArgs(config.PCH, stdArg);
+      std::vector<std::string> pchArgs = precompiledHeaderArgs(config);
       std::copy(pchArgs.begin(),
                 pchArgs.end(),
                 std::back_inserter(args));
@@ -790,7 +789,7 @@ RCompilationDatabase::CompilationConfig
       return CompilationConfig();
 
    // start with base args
-   std::vector<std::string> args = commonCompilationArgs();
+   std::vector<std::string> args = baseCompilationArgs(true);
 
    // if this is a header file we need to rename it as a temporary .cpp
    // file so that R CMD SHLIB is willing to compile it
@@ -889,7 +888,7 @@ std::vector<std::string> RCompilationDatabase::baseCompilationArgs(bool isCpp)
    return args;
 }
 
-std::vector<std::string> RCompilationDatabase::commonCompilationArgs(
+std::vector<std::string> RCompilationDatabase::packageCompilationArgs(
       core::r_util::RPackageInfo* pPkgInfo,
       bool* pIsCpp)
 {
@@ -1029,13 +1028,13 @@ FilePath precompiledHeaderDir(const std::string& pkgName)
 } // anonymous namespace
 
 std::vector<std::string> RCompilationDatabase::precompiledHeaderArgs(
-                                                  const std::string& pkgName,
-                                                  const std::string& stdArg)
+      const CompilationConfig& config)
 {
    // args to return
    std::vector<std::string> args;
 
    // precompiled header dir
+   std::string pkgName = config.PCH;
    FilePath precompiledDir = precompiledHeaderDir(pkgName);
 
    // further scope to actual path of package (as the locations of the
@@ -1089,6 +1088,7 @@ std::vector<std::string> RCompilationDatabase::precompiledHeaderArgs(
    }
 
    // now create the PCH if we need to
+   std::string stdArg = extractStdArg(config.args);
    FilePath pchPath = platformPath.completeChildPath(pkgName + stdArg + ".pch");
    if (!pchPath.exists())
    {
@@ -1104,8 +1104,8 @@ std::vector<std::string> RCompilationDatabase::precompiledHeaderArgs(
       }
 
       // get common compilation args
-      std::vector<std::string> args = commonCompilationArgs();
-
+      std::vector<std::string> args = config.args;
+      
       // add this package's path to the args
       std::vector<std::string> pkgArgs = includesForLinkingTo(pkgName);
       std::copy(pkgArgs.begin(), pkgArgs.end(), std::back_inserter(args));

--- a/src/cpp/session/modules/clang/RCompilationDatabase.hpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.hpp
@@ -97,14 +97,13 @@ private:
                                              core::FilePath tempSrcFile);
 
    std::vector<std::string> baseCompilationArgs(bool isCppFile) const;
-   std::vector<std::string> commonCompilationArgs(
+   std::vector<std::string> packageCompilationArgs(
          core::r_util::RPackageInfo* pPkgInfo = nullptr,
          bool* pIsCpp = nullptr);
 
    std::vector<std::string> rToolsArgs() const;
    core::system::Options compilationEnvironment() const;
-   std::vector<std::string> precompiledHeaderArgs(const std::string& pkgName,
-                                                  const std::string& stdArg);
+   std::vector<std::string> precompiledHeaderArgs(const CompilationConfig& config);
 
    bool shouldIndexConfig(const CompilationConfig& config);
 


### PR DESCRIPTION
- Rather than recomputing the compilation arguments for precompiled headers, we just pass along all of the arguments that were inferred from the appropriate context.

- `commonCompilationArgs()` is really package-centric; rename it as appropriate and don't use it for `sourceCpp()` configuration.

Closes https://github.com/rstudio/rstudio/issues/5707.