### PR TITLE
be more permissive when scanning for rtools

### DIFF
--- a/src/cpp/core/include/core/r_util/RToolsInfo.hpp
+++ b/src/cpp/core/include/core/r_util/RToolsInfo.hpp
@@ -65,7 +65,7 @@ private:
 
 std::ostream& operator<<(std::ostream& os, const RToolsInfo& info);
 
-Error scanForRTools(bool usingMingwGcc49, std::vector<RToolsInfo>* pRTools);
+void scanForRTools(bool usingMingwGcc49, std::vector<RToolsInfo>* pRTools);
 
 template <typename T>
 void prependToSystemPath(const RToolsInfo& toolsInfo, T* pTarget)

--- a/src/cpp/session/modules/build/SessionBuildEnvironment.cpp
+++ b/src/cpp/session/modules/build/SessionBuildEnvironment.cpp
@@ -108,6 +108,7 @@ bool doAddRtoolsToPathIfNecessary(T* pTarget,
     Error error = r::exec::RFunction(".rs.isRtoolsOnPath").call(&rToolsOnPath);
     if (error)
        LOG_ERROR(error);
+
     if (rToolsOnPath)
     {
        // perform an extra check to see if the version on the path is not
@@ -137,12 +138,7 @@ bool doAddRtoolsToPathIfNecessary(T* pTarget,
     // ok so scan for R tools
     bool usingGcc49 = module_context::usingMingwGcc49();
     std::vector<r_util::RToolsInfo> rTools;
-    error = core::r_util::scanForRTools(usingGcc49, &rTools);
-    if (error)
-    {
-       LOG_ERROR(error);
-       return false;
-    }
+    core::r_util::scanForRTools(usingGcc49, &rTools);
 
     // enumerate them to see if we have a compatible version
     // (go in reverse order for most recent first)

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -981,9 +981,7 @@ std::vector<std::string> RCompilationDatabase::rToolsArgs() const
       // scan for Rtools
       bool usingMingwGcc49 = module_context::usingMingwGcc49();
       std::vector<core::r_util::RToolsInfo> rTools;
-      Error error = core::r_util::scanForRTools(usingMingwGcc49, &rTools);
-      if (error)
-         LOG_ERROR(error);
+      core::r_util::scanForRTools(usingMingwGcc49, &rTools);
 
       // enumerate them to see if we have a compatible version
       // (go in reverse order for most recent first)


### PR DESCRIPTION
Previously, an error when attempting to scan the registry for Rtools would inhibit any further discovery of installed copies of Rtools. Now, such failures are logged as appropriate, but further scanning of Rtools will still occur.