### PR TITLE
prevent duplicate IDs in editor, fix couple more unlabeled images

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -17,6 +17,7 @@ package org.rstudio.core.client;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.dom.DomUtils;
+import org.rstudio.core.client.regex.Pattern;
 
 public class ElementIds
 {
@@ -45,6 +46,27 @@ public class ElementIds
       return ID_PREFIX + id;
    }
 
+   public static boolean isInstanceOf(Widget widget, String baseId)
+   {
+      return isInstanceOf(widget.getElement(), baseId);
+   }
+
+   public static boolean isInstanceOf(Element ele, String baseId)
+   {
+      String actualId = ele.getId();
+      String testId = ElementIds.getElementId(baseId);
+      if (actualId == testId)
+         return true;
+
+      // does ID match disambiguation pattern?
+      if (RE_NUMBERED_ELEMENT_ID.test(actualId))
+      {
+         String trimmedId = actualId.substring(0, actualId.lastIndexOf('_'));
+         return trimmedId == testId;
+      }
+      return false;
+   }
+
    public static String idSafeString(String text)
    {
       // replace all non-alphanumerics with underscores
@@ -65,6 +87,8 @@ public class ElementIds
    {
       return ID_PREFIX + "label_" + idSafeString(label);
    }
+
+   private static final Pattern RE_NUMBERED_ELEMENT_ID = Pattern.create("^[a-zA-Z0-9_]+_\\d+$");
 
    public final static String ID_PREFIX = "rstudio_";
 

--- a/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
@@ -71,6 +71,7 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
          parentToolbar_ = getParentToolbar();
 
          super.onAttach();
+         ElementIds.assignElementId(getElement(), "tb_" + ElementIds.idSafeString(getId()));
       }
 
       @Override
@@ -493,7 +494,6 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
                                                              synced);
       if (getTooltip() != null)
          button.setTitle(getTooltip());
-      ElementIds.assignElementId(button.getElement(), "tb_" + ElementIds.idSafeString(getId()));
       return button;
    }
 

--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
@@ -1,7 +1,7 @@
 /*
  * ShortcutManager.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -467,8 +467,7 @@ public class ShortcutManager implements NativePreviewHandler,
             AceEditorNative nativeEditor = AceEditorNative.getEditor(target);
             if (editor != null && nativeEditor != null &&
                   nativeEditor == editor.getWidget().getEditor() &&
-                  editor.getWidget().getElement().getId() ==
-                     ElementIds.getElementId(ElementIds.SOURCE_TEXT_EDITOR))
+                  ElementIds.isInstanceOf(editor.getWidget(), ElementIds.SOURCE_TEXT_EDITOR))
             {
                keyBuffer_.clear();
                commands_.expandToLine().execute();

--- a/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
@@ -205,7 +205,7 @@ public class TextBoxWithButton extends Composite
    }
 
    @Override
-   public void onAttach()
+   protected void onAttach()
    {
       super.onAttach();
 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishButton.java
@@ -111,16 +111,12 @@ public class RSConnectPublishButton extends Composite
                   onPublishButtonClick();
                }
             });
-      
-      publishButton_.getElement().setId(ElementIds.ID_PREFIX + 
-            ElementIds.PUBLISH_ITEM + "_" + host);
+
       panel.add(publishButton_);
       
       // create drop menu of previous deployments/other commands
       publishMenu_ = new DeploymentPopupMenu();
       publishMenuButton_ = new ToolbarMenuButton(ToolbarButton.NoText, "Publish options", publishMenu_, true);
-      publishMenuButton_.getElement().setId(ElementIds.ID_PREFIX + 
-            ElementIds.PUBLISH_SHOW_DEPLOYMENTS + "_" + host);
       panel.add(publishMenuButton_);
       
       // initialize composite widget
@@ -388,8 +384,18 @@ public class RSConnectPublishButton extends Composite
       onPublishButtonClick();
    }
 
+   @Override
+   protected void onAttach()
+   {
+      super.onAttach();
+
+      ElementIds.assignElementId(
+            publishButton_, ElementIds.PUBLISH_ITEM + "_" + host_);
+      ElementIds.assignElementId(
+            publishMenuButton_, ElementIds.PUBLISH_SHOW_DEPLOYMENTS + "_" + host_);
+   }
+
    // Private methods --------------------------------------------------------
-   
 
    private void onPublishButtonClick()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsPane.java
@@ -423,6 +423,7 @@ public class ConnectionsPane extends WorkbenchPane
       connectionIcon_ = new Image();
       connectionIcon_.setWidth("16px");
       connectionIcon_.setHeight("16px");
+      connectionIcon_.setAltText(""); // decorative image
       connectionType_ = new ToolbarLabel();
       connectionType_.getElement().getStyle().setMarginLeft(5, Unit.PX);
       connectionType_.getElement().getStyle().setMarginRight(10, Unit.PX);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ObjectBrowser.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ObjectBrowser.css
@@ -12,7 +12,6 @@
   text-align: center;
   font-style: normal;
   margin-top: 50px;
-  color: #888;
   outline: none;
   cursor: default;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -287,7 +287,8 @@ public class AceEditor implements DocDisplay,
             aceSupportLoader_.addCallback(() ->
                   extLanguageToolsLoader_.addCallback(() ->
                         vimLoader_.addCallback(() ->
-                              emacsLoader_.addCallback(() -> {
+                              emacsLoader_.addCallback(() ->
+                              {
                                  AceSupport.initialize();
 
                                  if (command != null)
@@ -324,7 +325,6 @@ public class AceEditor implements DocDisplay,
       editorEventListeners_ = new ArrayList<>();
       mixins_ = new AceEditorMixins(this);
       editLines_ = new AceEditorEditLinesHelper(this);
-      ElementIds.assignElementId(widget_.getElement(), ElementIds.SOURCE_TEXT_EDITOR);
 
       completionManager_ = new NullCompletionManager();
       diagnosticsBgPopup_ = new DiagnosticsBackgroundPopup(this);
@@ -336,7 +336,8 @@ public class AceEditor implements DocDisplay,
       bgLinkHighlighter_ = new AceEditorBackgroundLinkHighlighter(this);
       bgChunkHighlighter_ = new AceBackgroundHighlighter(this);
       
-      widget_.addValueChangeHandler(evt -> {
+      widget_.addValueChangeHandler(evt ->
+      {
          if (!valueChangeSuppressed_)
          {
             ValueChangeEvent.fire(AceEditor.this, null);
@@ -364,13 +365,15 @@ public class AceEditor implements DocDisplay,
          }
       });
 
-      addPasteHandler(event -> {
+      addPasteHandler(event ->
+      {
          if (completionManager_ != null)
             completionManager_.onPaste(event);
 
          final Position start = getSelectionStart();
 
-         Scheduler.get().scheduleDeferred(() -> {
+         Scheduler.get().scheduleDeferred(() ->
+         {
             Range range = Range.fromPoints(start, getSelectionEnd());
             if (shouldIndentOnPaste())
                indentPastedRange(range);
@@ -378,7 +381,8 @@ public class AceEditor implements DocDisplay,
       });
 
       // handle click events
-      addAceClickHandler(event -> {
+      addAceClickHandler(event ->
+      {
          fixVerticalOffsetBug();
          if (DomUtils.isCommandClick(event.getNativeEvent()))
          {
@@ -398,21 +402,27 @@ public class AceEditor implements DocDisplay,
       });
 
       lastCursorChangedTime_ = 0;
-      addCursorChangedHandler(event -> {
+      addCursorChangedHandler(event ->
+      {
          fixVerticalOffsetBug();
          clearLineHighlight();
          lastCursorChangedTime_ = System.currentTimeMillis();
       });
 
       lastModifiedTime_ = 0;
-      addValueChangeHandler(event -> {
+      addValueChangeHandler(event ->
+      {
          lastModifiedTime_ = System.currentTimeMillis();
          clearDebugLineHighlight();
       });
       
-      widget_.addAttachHandler(event -> {
+      widget_.addAttachHandler(event ->
+      {
          if (event.isAttached())
+         {
             attachToWidget(widget_.getElement(), AceEditor.this);
+            ElementIds.assignElementId(widget_, ElementIds.SOURCE_TEXT_EDITOR);
+         }
          else
             detachFromWidget(widget_.getElement());
 
@@ -435,7 +445,8 @@ public class AceEditor implements DocDisplay,
          }
       });
       
-      widget_.addFocusHandler((FocusEvent event) -> {
+      widget_.addFocusHandler((FocusEvent event) ->
+      {
          String id = AceEditor.this.getWidget().getElement().getId();
          MainWindowObject.lastFocusedEditorId().set(id);
       });
@@ -444,7 +455,8 @@ public class AceEditor implements DocDisplay,
       
       events_.addHandler(
             AceEditorCommandEvent.TYPE,
-            event -> {
+            event ->
+            {
                // skip this if this is only for the actively focused Ace instance
                // (note: in RStudio Server, the Ace Editor instance may become
                // unfocused when e.g. executing commands from the menu, so we
@@ -582,7 +594,8 @@ public class AceEditor implements DocDisplay,
       
       if (Desktop.hasDesktopFrame() && isEmacsModeOn())
       {
-         Desktop.getFrame().getClipboardText((String text) -> {
+         Desktop.getFrame().getClipboardText((String text) ->
+         {
             replaceSelection(text);
             setCursorPosition(getSelectionEnd());
          });
@@ -1055,7 +1068,8 @@ public class AceEditor implements DocDisplay,
                                                      false);
          scrollToY(scrollTop, 0);
          scrollToX(scrollLeft);
-         Scheduler.get().scheduleDeferred(() -> {
+         Scheduler.get().scheduleDeferred(() ->
+         {
             scrollToY(scrollTop, 0);
             scrollToX(scrollLeft);
          });
@@ -1257,7 +1271,8 @@ public class AceEditor implements DocDisplay,
          // Preview". The only thing you could do is close the browser tab.
          // By inserting a 5-minute delay hopefully Firefox would be done with
          // whatever print related operations are important.
-         Scheduler.get().scheduleFixedDelay(() -> {
+         Scheduler.get().scheduleFixedDelay(() ->
+         {
             PrintIFrame.this.removeFromParent();
             return false;
          }, 1000 * 60 * 5);
@@ -1923,7 +1938,8 @@ public class AceEditor implements DocDisplay,
       final AnchoredSelection selection = new AnchoredSelectionImpl(start, end);
       if (hostWidget != null)
       {
-         hostWidget.addAttachHandler(event -> {
+         hostWidget.addAttachHandler(event ->
+         {
             if (!event.isAttached() && selection != null)
                selection.detach();
          });
@@ -2000,7 +2016,8 @@ public class AceEditor implements DocDisplay,
 
    public void onActivate()
    {
-      Scheduler.get().scheduleFinally(() -> {
+      Scheduler.get().scheduleFinally(() ->
+      {
          widget_.onResize();
          widget_.onActivate();
          return false;
@@ -3680,7 +3697,8 @@ public class AceEditor implements DocDisplay,
       if (infoBar_ == null)
       {
          infoBar_ = new AceInfoBar(widget_);
-         widget_.addKeyDownHandler(event -> {
+         widget_.addKeyDownHandler(event ->
+         {
             if (event.getNativeKeyCode() == KeyCodes.KEY_ESCAPE)
                infoBar_.hide();
          });
@@ -4034,7 +4052,8 @@ public class AceEditor implements DocDisplay,
             }
          };
          
-         editor_.addDocumentChangedHandler(event -> {
+         editor_.addDocumentChangedHandler(event ->
+         {
             if (editor_.hasCodeModelScopeTree())
             {
                row_ = event.getEvent().getRange().getStart().getRow();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -404,7 +404,6 @@ public class TextEditingTargetWidget
                   commands_.sourceActiveDocument().execute();
             });
       toolbar.addRightWidget(sourceButton_);
-      ElementIds.assignElementId(sourceButton_.getElement(), ElementIds.TEXT_SOURCE_BUTTON);
 
       previewJsButton_ = commands_.previewJS().createToolbarButton(false);
       toolbar.addRightWidget(previewJsButton_);
@@ -431,7 +430,6 @@ public class TextEditingTargetWidget
          
       sourceMenuButton_ = new ToolbarMenuButton(ToolbarButton.NoText, "Source options", sourceMenu, true);
       toolbar.addRightWidget(sourceMenuButton_);
-      ElementIds.assignElementId(sourceMenuButton_.getElement(), ElementIds.TEXT_SOURCE_BUTTON_DROPDOWN);
 
       //toolbar.addRightSeparator();
      
@@ -1472,7 +1470,16 @@ public class TextEditingTargetWidget
       if (showOutputOptions)
          menu.addItem(commands_.editRmdFormatOptions().createMenuItem(false));
    }
-   
+
+   @Override
+   protected void onAttach()
+   {
+      super.onAttach();
+
+      ElementIds.assignElementId(sourceButton_, ElementIds.TEXT_SOURCE_BUTTON);
+      ElementIds.assignElementId(sourceMenuButton_, ElementIds.TEXT_SOURCE_BUTTON_DROPDOWN);
+   }
+
    private final TextEditingTarget target_;
    private final DocUpdateSentinel docUpdateSentinel_;
    private final Commands commands_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarWidget.java
@@ -140,24 +140,51 @@ public class StatusBarWidget extends Composite
       else
          scopeIcon_.setVisible(true);
 
-           if (type == StatusBar.SCOPE_CLASS)
+      if (type == StatusBar.SCOPE_CLASS)
+      {
          scopeIcon_.setResource(new ImageResource2x(CodeIcons.INSTANCE.clazz2x()));
+         scopeIcon_.setAltText("Class");
+      }
       else if (type == StatusBar.SCOPE_NAMESPACE)
+      {
          scopeIcon_.setResource(new ImageResource2x(CodeIcons.INSTANCE.namespace2x()));
+         scopeIcon_.setAltText("Namespace");
+      }
       else if (type == StatusBar.SCOPE_LAMBDA)
+      {
          scopeIcon_.setResource(new ImageResource2x(StandardIcons.INSTANCE.lambdaLetter2x()));
+         scopeIcon_.setAltText("Lambda");
+      }
       else if (type == StatusBar.SCOPE_ANON)
+      {
          scopeIcon_.setResource(new ImageResource2x(StandardIcons.INSTANCE.functionLetter2x()));
+         scopeIcon_.setAltText("Anonymous");
+      }
       else if (type == StatusBar.SCOPE_FUNCTION)
+      {
          scopeIcon_.setResource(new ImageResource2x(StandardIcons.INSTANCE.functionLetter2x()));
+         scopeIcon_.setAltText("Function");
+      }
       else if (type == StatusBar.SCOPE_CHUNK)
+      {
          scopeIcon_.setResource(new ImageResource2x(RES.chunk2x()));
+         scopeIcon_.setAltText("Chunk");
+      }
       else if (type == StatusBar.SCOPE_SECTION)
+      {
          scopeIcon_.setResource(new ImageResource2x(RES.section2x()));
+         scopeIcon_.setAltText("Section");
+      }
       else if (type == StatusBar.SCOPE_SLIDE)
+      {
          scopeIcon_.setResource(new ImageResource2x(RES.slide2x()));
+         scopeIcon_.setAltText("Slide");
+      }
       else
+      {
          scopeIcon_.setResource(new ImageResource2x(CodeIcons.INSTANCE.function2x()));
+         scopeIcon_.setAltText("Function");
+      }
    }
 
    private void initMessage(String message)

--- a/src/gwt/test/org/rstudio/core/client/ElementIdsTests.java
+++ b/src/gwt/test/org/rstudio/core/client/ElementIdsTests.java
@@ -1,0 +1,69 @@
+/*
+ * ElementIdsTests.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client;
+
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.junit.client.GWTTestCase;
+import com.google.gwt.user.client.DOM;
+
+public class ElementIdsTests extends GWTTestCase
+{
+   @Override
+   public String getModuleName()
+   {
+      return "org.rstudio.studio.RStudioTests";
+   }
+
+   public void testExactMatchElementId()
+   {
+      Element ele = DOM.createDiv();
+      ElementIds.assignElementId(ele, ElementIds.CONSOLE_INPUT);
+      assertTrue(ElementIds.isInstanceOf(ele, ElementIds.CONSOLE_INPUT));
+   }
+
+   public void testMismatchedElementId()
+   {
+      Element ele = DOM.createDiv();
+      ElementIds.assignElementId(ele, ElementIds.CONSOLE_INPUT);
+      assertFalse(ElementIds.isInstanceOf(ele, ElementIds.CONSOLE_OUTPUT));
+   }
+
+   public void testMatchingUndupedElementId()
+   {
+      Element ele = DOM.createDiv();
+      ElementIds.assignElementId(ele, ElementIds.CONSOLE_INPUT + "_123");
+      assertTrue(ElementIds.isInstanceOf(ele, ElementIds.CONSOLE_INPUT));
+   }
+
+   public void testMisMatchedUndupedElementId()
+   {
+      Element ele = DOM.createDiv();
+      assertFalse(ElementIds.isInstanceOf(ele, ElementIds.CONSOLE_OUTPUT));
+   }
+
+   public void testElementIdWithoutStandardPrefix()
+   {
+      Element ele = DOM.createDiv();
+      ele.setId("some-randomID");
+      assertFalse(ElementIds.isInstanceOf(ele, ElementIds.CONSOLE_OUTPUT));
+   }
+
+   public void testElementIdWithoutStandardSuffix()
+   {
+      Element ele = DOM.createDiv();
+      ElementIds.assignElementId(ele, ElementIds.CONSOLE_INPUT + "_123_");
+      assertFalse(ElementIds.isInstanceOf(ele, ElementIds.CONSOLE_OUTPUT));
+   }
+}

--- a/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
+++ b/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
@@ -16,6 +16,7 @@ package org.rstudio.studio.client;
 
 import org.rstudio.core.client.AnsiCodeTests;
 import org.rstudio.core.client.ConsoleOutputWriterTests;
+import org.rstudio.core.client.ElementIdsTests;
 import org.rstudio.core.client.StringUtilTests;
 import org.rstudio.core.client.URIUtilsTests;
 import org.rstudio.core.client.VirtualConsoleTests;
@@ -51,6 +52,7 @@ public class RStudioUnitTestSuite extends GWTTestSuite
       // suite.addTestSuite(RChunkHeaderParserTests.class);
       suite.addTestSuite(SessionScopeTests.class);
       suite.addTestSuite(JobsListTests.class);
+      suite.addTestSuite(ElementIdsTests.class);
       
       // Pro-only tests
       


### PR DESCRIPTION
Assorted element IDs were being duplicated with each document tab opened in the editor so make sure they go through our de-dupping code, and that it happens after the element is added to the DOM.

Added alt-text to images shown in editor context status area (function, lambda, etc).

<img width="457" alt="2019-11-07_14-52-19" src="https://user-images.githubusercontent.com/10569626/68446261-1dcbc280-0191-11ea-9d6c-9d3604edbcf7.png">

Mark image in connections tab as decorative, and fix contrast of the (No Tables) message to match other "no content-ish" labels in various panes.

<img width="441" alt="2019-11-07_14-53-32" src="https://user-images.githubusercontent.com/10569626/68446283-29b78480-0191-11ea-839b-bad1d0d4d936.png">

Some drive-by source reformatting to match our decided-upon lambda brace style