### PR TITLE
add accessible text to several more UI images

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/FullscreenPopupPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FullscreenPopupPanel.java
@@ -1,7 +1,7 @@
 /*
  * FullscreenPopupPanel.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -21,8 +21,6 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.resources.client.ImageResource.ImageOptions;
@@ -86,15 +84,9 @@ public class FullscreenPopupPanel extends ModalPopupPanel
    private void addCloseButton(NineUpBorder border)
    {
       Image closeIcon = new Image(new ImageResource2x(RES.close2x()));
+      closeIcon.setAltText("Close popup");
       closeIcon.getElement().getStyle().setCursor(Style.Cursor.POINTER);
-      closeIcon.addClickHandler(new ClickHandler()
-      {
-         @Override
-         public void onClick(ClickEvent event)
-         {
-            close();
-         }
-      });
+      closeIcon.addClickHandler(event -> close());
 
       LayoutPanel layoutPanel = border.getLayoutPanel();
       layoutPanel.add(closeIcon);
@@ -156,5 +148,5 @@ public class FullscreenPopupPanel extends ModalPopupPanel
    {
    }
    
-   private static final Resources RES = GWT.<Resources>create(Resources.class); 
+   private static final Resources RES = GWT.create(Resources.class);
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenuButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenuButton.java
@@ -29,15 +29,10 @@ import com.google.gwt.user.client.ui.MenuItem;
 public class ToolbarPopupMenuButton extends ToolbarMenuButton
                                     implements HasValueChangeHandlers<String>
 {
-   public ToolbarPopupMenuButton()
-   {
-      this(true, true);
-   }
-
-   public ToolbarPopupMenuButton(boolean showText, boolean rightAlignMenu)
+   public ToolbarPopupMenuButton(String title, boolean showText, boolean rightAlignMenu)
    {
       super(ToolbarButton.NoText,
-            ToolbarButton.NoTitle,
+            title,
             StandardIcons.INSTANCE.empty_command(),
             new ToolbarPopupMenu(),
             rightAlignMenu);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetHost.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetHost.java
@@ -15,7 +15,6 @@
 
 package org.rstudio.studio.client.workbench.views.connections.ui;
 
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -34,6 +33,7 @@ import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.ThemedButton;
+import org.rstudio.core.client.widget.images.MessageDialogImages;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.DelayedProgressRequestCallback;
@@ -121,6 +121,7 @@ public class NewConnectionSnippetHost extends Composite
          warningPanel.addStyleName(RES.styles().warningPanel());
          Image warningImage = new Image(new ImageResource2x(ThemeResources.INSTANCE.warningSmall2x()));
          warningImage.addStyleName(RES.styles().warningImage());
+         warningImage.setAltText(MessageDialogImages.DIALOG_WARNING_TEXT);
          warningPanel.add(warningImage);
          
          Label label = new Label();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.java
@@ -21,7 +21,6 @@ import com.google.inject.Provider;
 import com.google.inject.assistedinject.Assisted;
 import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.StringUtil;
-import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.ProgressBar;
@@ -128,7 +127,6 @@ public class JobItem extends Composite implements JobItemView
       name_.setText(job.name);
       progress_.setLabel(job.name);
       spinner_.setResource(new ImageResource2x(RESOURCES.jobSpinner()));
-      A11y.setDecorativeImage(spinner_.getElement());
 
       ImageResource2x detailsImage = new ImageResource2x(RESOURCES.jobSelect());
       if (JsArrayUtil.jsArrayStringContains(job.actions, JobConstants.ACTION_INFO))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.ui.xml
@@ -156,7 +156,7 @@
                 <g:VerticalPanel styleName="{styles_.item}">
                     <g:HorizontalPanel styleName="{styles_.metadata}">
                         <g:cell horizontalAlignment="ALIGN_LEFT" verticalAlignment="ALIGN_MIDDLE" width="20px">
-                            <g:Image styleName="{styles_.spinner}" ui:field="spinner_"></g:Image>
+                            <rw:DecorativeImage styleName="{styles_.spinner}" ui:field="spinner_"></rw:DecorativeImage>
                         </g:cell>
                         <g:cell horizontalAlignment="ALIGN_LEFT" verticalAlignment="ALIGN_MIDDLE" width="30%">
                             <g:Label ui:field="name_" styleName="{styles_.name}"></g:Label>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourcePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourcePane.java
@@ -15,11 +15,8 @@
 package org.rstudio.studio.client.workbench.views.source;
 
 import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.Style.Cursor;
 import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.logical.shared.BeforeSelectionHandler;
 import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.CloseHandler;
@@ -83,14 +80,9 @@ public class SourcePane extends Composite implements Display,
          }
       });
       chevron_ = new Image(new ImageResource2x(ThemeResources.INSTANCE.chevron2x()));
+      chevron_.setAltText("Switch to tab");
       chevron_.getElement().getStyle().setCursor(Cursor.POINTER);
-      chevron_.addClickHandler(new ClickHandler()
-      {
-         public void onClick(ClickEvent event)
-         {
-            tabOverflowPopup_.showRelativeTo(chevron_);
-         }
-      });
+      chevron_.addClickHandler(event -> tabOverflowPopup_.showRelativeTo(chevron_));
 
       panel_.add(chevron_);
       panel_.setWidgetTopHeight(chevron_,
@@ -107,13 +99,7 @@ public class SourcePane extends Composite implements Display,
    protected void onLoad()
    {
       super.onLoad();
-      Scheduler.get().scheduleDeferred(new ScheduledCommand()
-      {
-         public void execute()
-         {
-            onResize();
-         }
-      });
+      Scheduler.get().scheduleDeferred(() -> onResize());
    }
 
    public void addTab(Widget widget,
@@ -291,7 +277,7 @@ public class SourcePane extends Composite implements Display,
 
    public void onBeforeShow()
    {
-      fireEvent(new BeforeShowEvent());   
+      fireEvent(new BeforeShowEvent());
    }
 
    public HandlerRegistration addBeforeShowHandler(BeforeShowHandler handler)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -331,14 +331,14 @@ public class TextEditingTargetWidget
       }
 
       toolbar.addLeftWidget(compilePdfButton_ = commands_.compilePDF().createToolbarButton());
-      rmdFormatButton_ = new ToolbarPopupMenuButton(false, true);
+      rmdFormatButton_ = new ToolbarPopupMenuButton("Knit options", false, true);
       rmdFormatButton_.getMenu().setAutoOpen(true);
       toolbar.addLeftWidget(rmdFormatButton_);
       
-      runDocumentMenuButton_ = new ToolbarPopupMenuButton(false, true);
+      runDocumentMenuButton_ = new ToolbarPopupMenuButton("Run document options", false, true);
       addClearKnitrCacheMenu(runDocumentMenuButton_);
       runDocumentMenuButton_.addSeparator();
-      runDocumentMenuButton_.addMenuItem(commands_.clearPrerenderedOutput().createMenuItem(false), "");     
+      runDocumentMenuButton_.addMenuItem(commands_.clearPrerenderedOutput().createMenuItem(false), "");
       toolbar.addLeftWidget(runDocumentMenuButton_);
       runDocumentMenuButton_.addSeparator();
       runDocumentMenuButton_.addMenuItem(commands_.shinyRecordTest().createMenuItem(false), "");
@@ -691,7 +691,7 @@ public class TextEditingTargetWidget
          srcOnSaveLabel_.setText("Source on Save");
       codeTransform_.setVisible(
             (canExecuteCode && !isScript && !fileType.canAuthorContent()) ||
-            fileType.isC() || fileType.isStan());   
+            fileType.isC() || fileType.isStan());
      
       previewJsButton_.setVisible(fileType.isJS() && extendedType_.equals(SourceDocument.XT_JS_PREVIEWABLE));
       previewSqlButton_.setVisible(fileType.isSql() && extendedType_.equals(SourceDocument.XT_SQL_PREVIEWABLE));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionSignatureTip.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionSignatureTip.java
@@ -1,7 +1,7 @@
 /*
  * CppCompletionSignatureTip.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 
 import org.rstudio.core.client.Rectangle;
 import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.core.client.widget.DecorativeImage;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay.AnchoredSelection;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
@@ -27,8 +28,6 @@ import org.rstudio.studio.client.workbench.views.source.model.CppCompletion;
 
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Event;
@@ -36,13 +35,11 @@ import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.Event.NativePreviewHandler;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.HorizontalPanel;
-import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Label;
 
 public class CppCompletionSignatureTip extends CppCompletionToolTip
 {
-   public CppCompletionSignatureTip(CppCompletion completion, 
-                                    DocDisplay docDisplay)
+   public CppCompletionSignatureTip(CppCompletion completion, DocDisplay docDisplay)
    {
       // save references
       completion_ = completion;
@@ -80,28 +77,22 @@ public class CppCompletionSignatureTip extends CppCompletionToolTip
       HorizontalPanel panel = new HorizontalPanel();
       panel.setStyleName(RES.styles().pagingWidget());
       
-      Image upImage = new Image(new ImageResource2x(RES.upArrow2x()));
-      upImage.addClickHandler(new ClickHandler() {
-         @Override
-         public void onClick(ClickEvent event)
-         {
-            setTextIndex(currentTextIndex_ - 1);  
-            docDisplay_.setFocus(true);
-         }
+      DecorativeImage upImage = new DecorativeImage(new ImageResource2x(RES.upArrow2x()));
+      upImage.addClickHandler(event ->
+      {
+         setTextIndex(currentTextIndex_ - 1);
+         docDisplay_.setFocus(true);
       });
       panel.add(upImage);
       
       pagingLabel_ = new Label();
       panel.add(pagingLabel_);
       
-      Image downImage = new Image(new ImageResource2x(RES.downArrow2x()));
-      downImage.addClickHandler(new ClickHandler() {
-         @Override
-         public void onClick(ClickEvent event)
-         {
-            setTextIndex(currentTextIndex_ + 1);  
-            docDisplay_.setFocus(true);
-         }
+      DecorativeImage downImage = new DecorativeImage(new ImageResource2x(RES.downArrow2x()));
+      downImage.addClickHandler(event ->
+      {
+         setTextIndex(currentTextIndex_ + 1);
+         docDisplay_.setFocus(true);
       });
       panel.add(downImage);
       panel.add(downImage);
@@ -173,8 +164,7 @@ public class CppCompletionSignatureTip extends CppCompletionToolTip
    {
       // clone so we aren't interacting with the list while we
       // are iterating over it
-      ArrayList<CppCompletionSignatureTip> allTips = 
-                              new ArrayList<CppCompletionSignatureTip>();
+      ArrayList<CppCompletionSignatureTip> allTips = new ArrayList<>();
       allTips.addAll(allTips_);
       for (CppCompletionSignatureTip tip : allTips)
          tip.hide();
@@ -247,9 +237,7 @@ public class CppCompletionSignatureTip extends CppCompletionToolTip
    private final DocDisplay docDisplay_;
    private HandlerRegistration nativePreviewReg_;
    
-   private static ArrayList<CppCompletionSignatureTip> allTips_ = 
-         new ArrayList<CppCompletionSignatureTip>();
+   private static ArrayList<CppCompletionSignatureTip> allTips_ = new ArrayList<>();
    
-   private static final CppCompletionResources RES = 
-                                       CppCompletionResources.INSTANCE;
+   private static final CppCompletionResources RES = CppCompletionResources.INSTANCE;
 }


### PR DESCRIPTION
- Close icon on the FullscreenPopupPanel
- ToolbarPopupMenuButton used in two places in source editor
- Warning icon in connections snippet UI
- Tweaked JobItem spinner to use DecorativeImage instead of adding empty
  alt text to a regular Image
- next/prev arrows shown in C++ signature completion tooltip
- chevron shown in source tabs when they don't all fit

<img width="373" alt="2019-11-08_20-29-50" src="https://user-images.githubusercontent.com/10569626/68538481-f5c39700-0329-11ea-857c-b3a045ec594d.png">
<img width="344" alt="2019-11-09_18-46-53" src="https://user-images.githubusercontent.com/10569626/68538482-f9efb480-0329-11ea-8e2e-487d10db3449.png">
<img width="574" alt="2019-11-09_19-10-50" src="https://user-images.githubusercontent.com/10569626/68538488-ff4cff00-0329-11ea-919b-6045d911adc6.png">
<img width="773" alt="2019-11-09_19-09-02" src="https://user-images.githubusercontent.com/10569626/68538491-04aa4980-032a-11ea-9c63-5bfb0c20197c.png">
<img width="306" alt="2019-11-09_19-15-43" src="https://user-images.githubusercontent.com/10569626/68538492-0a079400-032a-11ea-80c5-b9270483b8ee.png">
