### PR TITLE
give each pane's tablist a unique label

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/ModuleTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ModuleTabLayoutPanel.java
@@ -144,9 +144,9 @@ public class ModuleTabLayoutPanel extends TabLayoutPanel
       private ProgressSpinner busySpinner_;
    }
 
-   public ModuleTabLayoutPanel(final WindowFrame owner)
+   public ModuleTabLayoutPanel(final WindowFrame owner, String tabListName)
    {
-      super(BAR_HEIGHT, Style.Unit.PX, "Pane");
+      super(BAR_HEIGHT, Style.Unit.PX, tabListName);
       owner_ = owner;
       styles_ = ThemeResources.INSTANCE.themeStyles();
       addStyleName(styles_.moduleTabPanel());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
@@ -75,7 +75,7 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
                           WorkbenchTab jobsTab,
                           WorkbenchTab launcherJobsTab)
    {
-      super(owner, parentWindow);
+      super(owner, parentWindow, "ConsoleTabSet");
       owner_ = owner;
       consolePane_ = consolePane;
       compilePdfTab_ = compilePdfTab;
@@ -421,7 +421,8 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
          if (Desktop.hasDesktopFrame())
          {
             // if there are session servers defined, we will show the launcher tab
-            Desktop.getFrame().getSessionServers(servers -> {
+            Desktop.getFrame().getSessionServers(servers ->
+            {
                if (servers.length() > 0)
                {
                   showLauncherTab.execute();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -977,7 +977,7 @@ public class PaneManager
       final MinimizedModuleTabLayoutPanel minimized = new MinimizedModuleTabLayoutPanel();
       final LogicalWindow logicalWindow = new LogicalWindow(frame, minimized);
 
-      final WorkbenchTabPanel tabPanel = new WorkbenchTabPanel(frame, logicalWindow);
+      final WorkbenchTabPanel tabPanel = new WorkbenchTabPanel(frame, logicalWindow, persisterName);
 
       if (persisterName == "TabSet1")
          tabs1_ = tabs;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchTabPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchTabPanel.java
@@ -46,14 +46,14 @@ class WorkbenchTabPanel
                  HasEnsureVisibleHandlers,
                  HasEnsureHeightHandlers
 {
-   public WorkbenchTabPanel(WindowFrame owner, LogicalWindow parentWindow)
+   public WorkbenchTabPanel(WindowFrame owner, LogicalWindow parentWindow, String tabListName)
    {
       final int UTILITY_AREA_SIZE = 52;
       panel_ = new LayoutPanel();
       
       parentWindow_ = parentWindow;
 
-      tabPanel_ = new ModuleTabLayoutPanel(owner);
+      tabPanel_ = new ModuleTabLayoutPanel(owner, tabListName);
       panel_.add(tabPanel_);
       panel_.setWidgetTopBottom(tabPanel_, 0, Unit.PX, 0, Unit.PX);
       panel_.setWidgetLeftRight(tabPanel_, 0, Unit.PX, 0, Unit.PX);


### PR DESCRIPTION
- previously the source pane's tablist had "Documents" label, but the other three were all labeled as "Pane"
- changed so they are now "Documents" (unchanged), "ConsoleTabSet", "TabSet1" and "TabSet2"
- minor accessibility tweak, but also handy when reading the HTML

<img width="797" alt="2019-11-11_20-35-55" src="https://user-images.githubusercontent.com/10569626/68642464-18d57e80-04c3-11ea-9578-8ae22604f2d2.png">
