### PR TITLE
Only emit debug step commands from main window

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -87,6 +87,7 @@
 * Fix issue where calling `install.packages()` without arguments would fail (#5154)
 * Fix issue where C code in packages would incorrectly be diagnosed as C++ (#5418)
 * Fix plot history when plot() called immediately after dev.off() (#3117)
+* Fix debug stopping past breakpoint when source windows are open (#3683)
 * Fix diagnostics error with multibyte characters in R Markdown documents on Windows (#1866)
 * Fix stale processes when invoking child R processes with large command lines (#3414)
 * Fix an issue where help tooltips could become corrupt when using prettycode (#5561)

--- a/src/gwt/src/org/rstudio/studio/client/common/debugging/BreakpointManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/debugging/BreakpointManager.java
@@ -1,7 +1,7 @@
 /*
  * BreakpointManager.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -35,6 +35,7 @@ import org.rstudio.studio.client.common.debugging.model.Breakpoint;
 import org.rstudio.studio.client.common.debugging.model.BreakpointState;
 import org.rstudio.studio.client.common.debugging.model.FunctionState;
 import org.rstudio.studio.client.common.debugging.model.FunctionSteps;
+import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
@@ -389,8 +390,11 @@ public class BreakpointManager
          String functionName = frame.getFunctionName();
          String fileName = frame.getFileName();
          if (functionName == ".doTrace" &&
-             event.isServerInitiated())
+             event.isServerInitiated() && 
+             !Satellite.isCurrentWindowSatellite())
          {
+            // Only perform the step from the main window (otherwise multiple
+            // step commands will be emitted from each satellite)
             events_.fireEvent(new SendToConsoleEvent(
                   DebugCommander.NEXT_COMMAND, true));
          }


### PR DESCRIPTION
Quick fix for a long-standing debug issue. When we hit a breakpoint, we step past it into the user's R code; unfortunately, that step is executed from every RStudio window, so we can wind up stepping more than we meant to.

The fix is to step only from the main window. 

Fixes https://github.com/rstudio/rstudio/issues/3683.