### PR TITLE
Enable copying plot images to the clipboard from context menu

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -81,6 +81,7 @@
 * Update SumatraPDF to version 3.1.2 (#3155)
 * RStudio Server runtime files are stored in `/var/run`, or another configurable location, instead of `/tmp` (#4666)
 * Errors encountered when attempting to find Rtools installations are handled more gracefully (#5720)
+* Enable copying images to the clipboard from the Plots pane (#3142)
 
 ### Bugfixes
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/Plots.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/Plots.java
@@ -22,7 +22,6 @@ import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.user.client.ui.HasWidgets;
-import com.google.gwt.user.client.ui.Panel;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
@@ -88,7 +87,7 @@ public class Plots extends BasePresenter implements PlotsChangedHandler,
       
       void refresh();
    
-      Panel getPlotsSurface();
+      PlotsSurface getPlotsSurface();
       
       Parent getPlotsParent();
       Size getPlotFrameSize();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/PlotsPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/PlotsPane.java
@@ -21,7 +21,6 @@ import com.google.gwt.event.logical.shared.ResizeEvent;
 import com.google.gwt.event.logical.shared.ResizeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.LayoutPanel;
 import com.google.gwt.user.client.ui.Panel;
 import com.google.gwt.user.client.ui.Widget;
@@ -126,15 +125,12 @@ public class PlotsPane extends WorkbenchPane implements Plots.Display,
       panel_.setWidgetTopBottom(frame_, 0, Unit.PX, 0, Unit.PX);
       panel_.setWidgetLeftRight(frame_, 0, Unit.PX, 0, Unit.PX);
 
-      // Stops mouse events from being routed to the iframe, which would
-      // interfere with dragging the workbench pane sizer. also provide
-      // a widget container where adornments can be added on top fo the
-      // plots panel (e.g. manipulator button)
-      plotsSurface_ = new FlowPanel();
-      plotsSurface_.setSize("100%", "100%");
+      // Provide a widget container where adornments can be added on top of the
+      // plots panel (e.g. manipulator button). Hidden initially so it doens't
+      // block context menu actions such as Copy Image.
+      plotsSurface_ = new PlotsSurface(panel_);
       panel_.add(plotsSurface_);
-      panel_.setWidgetTopBottom(plotsSurface_, 0, Unit.PX, 0, Unit.PX);
-      panel_.setWidgetLeftRight(plotsSurface_, 0, Unit.PX, 0, Unit.PX);
+      plotsSurface_.disableSurface();
       
       // return the panel
       return panel_;
@@ -179,7 +175,7 @@ public class PlotsPane extends WorkbenchPane implements Plots.Display,
          frame_.setImageUrl(plotUrl_);
    }
 
-   public Panel getPlotsSurface()
+   public PlotsSurface getPlotsSurface()
    {
       return plotsSurface_;
    }
@@ -221,7 +217,7 @@ public class PlotsPane extends WorkbenchPane implements Plots.Display,
    private ImageFrame frame_;
    private String plotUrl_;
    private PlotsToolbar plotsToolbar_ = null;
-   private FlowPanel plotsSurface_ = null;
+   private PlotsSurface plotsSurface_ = null;
    private Plots.Parent plotsParent_ = new Plots.Parent() { 
       public void add(Widget w)
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/PlotsSurface.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/PlotsSurface.java
@@ -1,0 +1,45 @@
+/*
+ * PlotsSurface.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.plots;
+
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.LayoutPanel;
+
+public class PlotsSurface extends FlowPanel
+{
+   PlotsSurface(LayoutPanel parent)
+   {
+      parent_ = parent;
+   }
+   
+   public void enableSurface()
+   {
+      setSize("100%", "100%");
+      parent_.setWidgetVisible(this, true);
+      parent_.setWidgetTopBottom(this, 0, Unit.PX, 0, Unit.PX);
+      parent_.setWidgetLeftRight(this, 0, Unit.PX, 0, Unit.PX);
+   }
+   
+   public void disableSurface()
+   {
+      setSize("0%", "0%");
+      parent_.setWidgetVisible(this, false);
+      parent_.setWidgetTopBottom(this, 0, Unit.PX, 100, Unit.PCT);
+      parent_.setWidgetLeftRight(this, 0, Unit.PX, 100, Unit.PCT);
+   }
+   
+   private final LayoutPanel parent_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/manipulator/ManipulatorManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/manipulator/ManipulatorManager.java
@@ -18,6 +18,7 @@ import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.ProgressImage;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.workbench.views.plots.PlotsSurface;
 import org.rstudio.studio.client.workbench.views.plots.model.Manipulator;
 
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -27,7 +28,7 @@ import com.google.gwt.user.client.ui.PopupPanel.PositionCallback;
 
 public class ManipulatorManager
 {
-   public ManipulatorManager(Panel plotsSurface,
+   public ManipulatorManager(PlotsSurface plotsSurface,
                              Commands commands,
                              ManipulatorChangedHandler changedHandler,
                              final ClickHandler plotsClickHandler)
@@ -79,8 +80,6 @@ public class ManipulatorManager
    }
    
    
-   
-   
    public void setManipulator(Manipulator manipulator, boolean show)
    {
       if (isNewManipulatorState(manipulator))
@@ -99,10 +98,14 @@ public class ManipulatorManager
          {
             // show if requested and there are controls
             if (show && manipulator_.hasControls())
+            {
+               plotsSurface_.enableSurface();
                showManipulatorPopup();  
+            }
          }
          else
          {
+            plotsSurface_.disableSurface();
             manipulatorPopup_.hide();
          }
       }
@@ -184,7 +187,7 @@ public class ManipulatorManager
    }
    
    
-   private final Panel plotsSurface_;
+   private final PlotsSurface plotsSurface_;
    private Manipulator manipulator_;
    private ToolbarButton manipulatorButton_;
    private ProgressImage manipulatorProgress_;


### PR DESCRIPTION
It's not currently possible to copy plots to the clipboard using the context menu. This problem exists because there's a layer over the plot we use to draw manipulation UI, and that layer intentionally masks mouse clicks. 

The fix is to disable/hide the plot surface overlay unless we are actually showing a manipulator.

Note that there's a comment that indicates that the plot surface overlay serves a second purpose: keeping mouse events from getting lost during workbench splitter resize. As far as I can tell this is no longer a problem under Chromium, and was probably specific to the older QtWebKit browser. 

Fixes https://github.com/rstudio/rstudio/issues/3142 (which I discovered independently when looking at https://github.com/rstudio/rstudio/issues/5712). 