### PR TITLE
Update to Qt 5.12.6

### DIFF
--- a/dependencies/linux/install-qt-sdk
+++ b/dependencies/linux/install-qt-sdk
@@ -15,13 +15,13 @@
 #
 
 if [ -z "$QT_VERSION" ]; then
-    QT_VERSION=5.12.5
+    QT_VERSION=5.12.6
 fi
 if [ -z "$QT_SDK_BINARY" ]; then
     QT_SDK_BINARY=qt-opensource-linux-x64-${QT_VERSION}.run
 fi
 if [ -z "$QT_PACKAGES" ]; then
-    QT_PACKAGES=qt.qt5.5125.gcc_64,qt.qt5.5125.qtwebengine,qt.qt5.5125.qtwebengine.gcc_64
+    QT_PACKAGES=qt.qt5.5126.gcc_64,qt.qt5.5126.qtwebengine,qt.qt5.5126.qtwebengine.gcc_64
 fi
 if [ -z "$QT_SDK_CUSTOM" ]; then
     echo Using Qt $QT_VERSION

--- a/dependencies/osx/README
+++ b/dependencies/osx/README
@@ -24,11 +24,3 @@ Additional dependencies can be satisfied by running the following script:
 Note that this script includes download, extraction, and compilation of
 boost so can take some time (30-60 minutes) to complete.
 
-Qt SDK and macOS 10.15 Catalina
-=============================================================================
-Installation of the Qt SDK via the dependency scripts may fail due to
-notarization requirements added to macOS Catalina. If so, manually install
-the required version of Qt from the Qt website. Include the macOS and
-QtWebEngine components.
-
-https://www.qt.io/blog/qt-5.12.6-released

--- a/dependencies/osx/README
+++ b/dependencies/osx/README
@@ -24,4 +24,11 @@ Additional dependencies can be satisfied by running the following script:
 Note that this script includes download, extraction, and compilation of
 boost so can take some time (30-60 minutes) to complete.
 
+Qt SDK and macOS 10.15 Catalina
+=============================================================================
+Installation of the Qt SDK via the dependency scripts may fail due to
+notarization requirements added to macOS Catalina. If so, manually install
+the required version of Qt from the Qt website. Include the macOS and
+QtWebEngine components.
 
+https://www.qt.io/blog/qt-5.12.6-released

--- a/dependencies/osx/install-qt-sdk-osx
+++ b/dependencies/osx/install-qt-sdk-osx
@@ -20,11 +20,12 @@
 
 QT_VERSION=5.12.6
 QT_SDK_BINARY_BASE=qt-opensource-mac-x64-${QT_VERSION}
-QT_SDK_BINARY=${QT_SDK_BINARY_BASE}.tar.gz
+QT_SDK_BINARY=${QT_SDK_BINARY_BASE}.dmg
 QT_SDK_INSTALLER=${QT_SDK_BINARY_BASE}.app
-QT_SDK_INSTALLER_BIN=${QT_SDK_INSTALLER}/Contents/MacOS/${QT_SDK_BINARY_BASE}
+QT_SDK_VOLUME=/Volumes/${QT_SDK_BINARY_BASE}
+QT_SDK_INSTALLER_BIN=${QT_SDK_VOLUME}/${QT_SDK_INSTALLER}/Contents/MacOS/${QT_SDK_BINARY_BASE}
 QT_SDK_URL=https://s3.amazonaws.com/rstudio-buildtools/Qt/$QT_SDK_BINARY
-QT_SCRIPT=/tmp/qt-noninteractive-install-osx.qs 
+QT_SCRIPT=/tmp/qt-noninteractive-install-osx.qs
 
 # generate script for automatic Qt installation; customizes the install location via $QT_SDK_DIR
 function write_qt_script() {
@@ -112,21 +113,23 @@ then
    # download and install
    curl -L $QT_SDK_URL > /tmp/$QT_SDK_BINARY
    cd /tmp
-   tar xzf /tmp/$QT_SDK_BINARY
-   write_qt_script   
+   hdiutil attach ${QT_SDK_BINARY}
+   write_qt_script
    
    echo "Installing Qt, this will take a while."
    echo " - Ignore warnings about QtAccount credentials."
    echo " - Do not click on the setup interface, it is controlled by a script."
 
-   ./$QT_SDK_INSTALLER_BIN --script $QT_SCRIPT
+   $QT_SDK_INSTALLER_BIN --script $QT_SCRIPT
 
-   rm -f /tmp/$QT_SDK_BINARY $QT_SCRIPT
-   rm -rf /tmp/$QT_SDK_INSTALLER
    if [ ! -e "$QT_SDK_DIR" ] && [ ! -e "$QT_SDK_DIR2" ] && [ ! -e "$QT_SDK_DIR3" ]; then
-      echo "Error: Unable to install Qt, run script again or install manually." 
+      echo "Error: Unable to install Qt, run script again or install manually."
+      echo "Downloaded installer remains in /tmp and image is still mounted."
       exit 1
    fi
+
+   hdiutil unmount ${QT_SDK_VOLUME}
+   rm -f /tmp/$QT_SDK_BINARY $QT_SCRIPT
 else
    echo "Qt $QT_VERSION SDK already installed"
 fi

--- a/dependencies/osx/install-qt-sdk-osx
+++ b/dependencies/osx/install-qt-sdk-osx
@@ -18,7 +18,7 @@
 # Installs Qt via the online installer at the location in $QT_SDK_DIR.
 # If no location provided, checks against a set of common locations and installs if not found.
 
-QT_VERSION=5.12.5
+QT_VERSION=5.12.6
 QT_SDK_BINARY_BASE=qt-opensource-mac-x64-${QT_VERSION}
 QT_SDK_BINARY=${QT_SDK_BINARY_BASE}.tar.gz
 QT_SDK_INSTALLER=${QT_SDK_BINARY_BASE}.app
@@ -65,10 +65,10 @@ Controller.prototype.TargetDirectoryPageCallback = function()
 Controller.prototype.ComponentSelectionPageCallback = function() {
     var widget = gui.currentPageWidget();
      
-    widget.selectComponent("qt.qt5.5125.clang_64");
-    widget.selectComponent("qt.qt5.5125.qtwebengine");
-    widget.selectComponent("qt.qt5.5125.qtwebengine.clang_64");
-    widget.deselectComponent("qt.qt5.5125.src");
+    widget.selectComponent("qt.qt5.5126.clang_64");
+    widget.selectComponent("qt.qt5.5126.qtwebengine");
+    widget.selectComponent("qt.qt5.5126.qtwebengine.clang_64");
+    widget.deselectComponent("qt.qt5.5126.src");
     gui.clickButton(buttons.NextButton);
 }
 

--- a/dependencies/windows/install-qt-sdk-win.cmd
+++ b/dependencies/windows/install-qt-sdk-win.cmd
@@ -4,7 +4,7 @@ setlocal EnableDelayedExpansion
 
 @rem When updating to a new Qt version, be sure to also update the 
 @rem component versions in qt-noninteractive-install-win.qs
-set QT_VERSION=5.12.5
+set QT_VERSION=5.12.6
 set QT_SDK_BINARY=qt-opensource-windows-x86-%QT_VERSION%.exe
 set QT_SDK_URL=https://s3.amazonaws.com/rstudio-buildtools/Qt/%QT_SDK_BINARY%
 set QT_SCRIPT=qt-noninteractive-install-win.qs

--- a/dependencies/windows/qt-noninteractive-install-win.qs
+++ b/dependencies/windows/qt-noninteractive-install-win.qs
@@ -30,10 +30,10 @@ Controller.prototype.TargetDirectoryPageCallback = function()
 Controller.prototype.ComponentSelectionPageCallback = function() {
     var widget = gui.currentPageWidget();
 
-    widget.selectComponent("qt.qt5.5125.win64_msvc2017_64");
-    widget.selectComponent("qt.qt5.5125.qtwebengine");
-    widget.selectComponent("qt.qt5.5125.qtwebengine.win64_msvc2017_64");
-    widget.deselectComponent("qt.qt5.5125.src");
+    widget.selectComponent("qt.qt5.5126.win64_msvc2017_64");
+    widget.selectComponent("qt.qt5.5126.qtwebengine");
+    widget.selectComponent("qt.qt5.5126.qtwebengine.win64_msvc2017_64");
+    widget.deselectComponent("qt.qt5.5126.src");
     gui.clickButton(buttons.NextButton);
 }
 

--- a/docker/jenkins/Dockerfile.bionic-amd64
+++ b/docker/jenkins/Dockerfile.bionic-amd64
@@ -88,7 +88,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.5 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.6 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/docker/jenkins/Dockerfile.centos7-x86_64
+++ b/docker/jenkins/Dockerfile.centos7-x86_64
@@ -86,7 +86,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && scl enable llvm-toolset-7 "/bin
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.5 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.6 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/docker/jenkins/Dockerfile.centos8-x86_64
+++ b/docker/jenkins/Dockerfile.centos8-x86_64
@@ -73,7 +73,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.5 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.6 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/docker/jenkins/Dockerfile.debian9-x86_64
+++ b/docker/jenkins/Dockerfile.debian9-x86_64
@@ -78,7 +78,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.5 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.6 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/docker/jenkins/Dockerfile.opensuse15-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse15-x86_64
@@ -69,7 +69,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.5 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.6 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -43,9 +43,9 @@ RUN $env:path += ';C:\R\R-3.0.3\bin\i386\' ;`
 
 # install qt (note that we are using the current directory's context)
 RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48; ` 
-  (New-Object System.Net.WebClient).DownloadFile('https://s3.amazonaws.com/rstudio-buildtools/Qt/QtSDK-5.12.5-msvc2017_64.7z', 'c:\QtSDK-5.12.5-msvc2017_64.7z'); `
-  7z x c:\QtSDK-5.12.5-msvc2017_64.7z -oc:\ ; `
-  Remove-Item c:\QtSDK-5.12.5-msvc2017_64.7z -Force
+  (New-Object System.Net.WebClient).DownloadFile('https://s3.amazonaws.com/rstudio-buildtools/Qt/QtSDK-5.12.6-msvc2017_64.7z', 'c:\QtSDK-5.12.6-msvc2017_64.7z'); `
+  7z x c:\QtSDK-5.12.6-msvc2017_64.7z -oc:\ ; `
+  Remove-Item c:\QtSDK-5.12.6-msvc2017_64.7z -Force
     
 # cpack (an alias from chocolatey) and cmake's cpack conflict.
 RUN Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe'

--- a/docker/jenkins/Dockerfile.xenial-amd64
+++ b/docker/jenkins/Dockerfile.xenial-amd64
@@ -93,7 +93,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/linux/install-qt-sdk /tmp/
 RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.5 && \
+    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.6 && \
     export QT_QPA_PLATFORM=minimal && \
     /tmp/install-qt-sdk
 

--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -36,7 +36,7 @@ if(NOT WIN32)
       endif()
          
       if(APPLE)
-         set(QT_CANDIDATES 5.12.6 5.12.1)
+         set(QT_CANDIDATES 5.12.6)
       else()
          set(QT_CANDIDATES 5.12.6 5.10.1)
       endif()

--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -36,9 +36,9 @@ if(NOT WIN32)
       endif()
          
       if(APPLE)
-         set(QT_CANDIDATES 5.12.5 5.12.1)
+         set(QT_CANDIDATES 5.12.6 5.12.1)
       else()
-         set(QT_CANDIDATES 5.12.5 5.10.1)
+         set(QT_CANDIDATES 5.12.6 5.10.1)
       endif()
 
       # find the newest installed Qt version among the versions we build
@@ -72,7 +72,7 @@ if(NOT WIN32)
    endif()
 else()
    # Windows
-   set(QT_VERSION "5.12.5")
+   set(QT_VERSION "5.12.6")
    set(QT_VERSION_SUBDIR "${QT_VERSION}")   
    if(NOT QT_QMAKE_EXECUTABLE)
 


### PR DESCRIPTION
- Debug builds work again on Mac, so removed support for 5.12.1
- switched to downloading and mounting the official dmg on Mac, instead of extracting and repackaging it in a tarball
- offline installers for Mac/Windows/Linux uploaded to S3