### PR TITLE
annotate tabs and panes properly for improved screen reader navigation

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -21,19 +21,30 @@ import org.rstudio.core.client.regex.Pattern;
 
 public class ElementIds
 {
-   public static void assignElementId(Element ele, String id)
+   /**
+    * Return a unique ID based on examination of existing elements. Must be assigned
+    * immediately to an element in the DOM to ensure uniqueness.
+    * @param baseId
+    * @return
+    */
+   public static String getUniqueElementId(String baseId)
    {
-      String elementIdBase = ID_PREFIX + id;
+      String elementIdBase = getElementId(baseId);
       String elementId = elementIdBase;
       int counter = 0;
-      
+
       // ensure uniqueness; for example, if multiple modal dialogs are displayed, make sure
       // the OK button instances, etc., are uniquely identified
       while (DomUtils.getElementById(elementId) != null)
       {
          elementId = elementIdBase + "_" + counter++;
       }
-      ele.setId(elementId);
+     return elementId;
+   }
+
+   public static void assignElementId(Element ele, String id)
+   {
+      ele.setId(getUniqueElementId(id));
    }
 
    public static void assignElementId(Widget widget, String id)

--- a/src/gwt/src/org/rstudio/core/client/theme/MinimizedModuleTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/MinimizedModuleTabLayoutPanel.java
@@ -14,13 +14,12 @@
  */
 package org.rstudio.core.client.theme;
 
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.logical.shared.HasSelectionHandlers;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.HorizontalPanel;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 
@@ -52,24 +51,20 @@ public class MinimizedModuleTabLayoutPanel
          ModuleTabLayoutPanel.ModuleTab tab
                = new ModuleTabLayoutPanel.ModuleTab(tabName, styles, false, true /*minimized*/);
          tab.addStyleName("gwt-TabLayoutPanelTab");
+         tab.getElement().setId(ElementIds.getUniqueElementId(tab.getTabId()));
          final Integer thisIndex = i;
-         tab.addClickHandler(new ClickHandler()
+         tab.addClickHandler(event ->
          {
-            public void onClick(ClickEvent event)
-            {
-               event.preventDefault();
-               SelectionEvent.fire(
-                     MinimizedModuleTabLayoutPanel.this,
-                     thisIndex);
-            }
+            event.preventDefault();
+            SelectionEvent.fire(
+                  MinimizedModuleTabLayoutPanel.this,
+                  thisIndex);
          });
-
          horiz.add(tab);
       }
    }
 
-   public HandlerRegistration addSelectionHandler(
-         SelectionHandler<Integer> handler)
+   public HandlerRegistration addSelectionHandler(SelectionHandler<Integer> handler)
    {
       return addHandler(handler, SelectionEvent.getType());
    }

--- a/src/gwt/src/org/rstudio/core/client/theme/ModuleTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ModuleTabLayoutPanel.java
@@ -55,9 +55,9 @@ public class ModuleTabLayoutPanel extends TabLayoutPanel
          if (minimized)
             minimized_id = "_minimized";
 
-         // Assign a unique element ID based on the tab's title
-         ElementIds.assignElementId(layoutPanel.getElement(),
-               ElementIds.WORKBENCH_TAB + minimized_id + "_" + ElementIds.idSafeString(title));
+         // Determine a base element ID based on the tab's title; make available to be
+         // associated with actual tab element when ModuleTab is attached to the tab layout panel
+         tabId_ = ElementIds.WORKBENCH_TAB + minimized_id + "_" + ElementIds.idSafeString(title);
 
          HTML left = new HTML();
          left.setStylePrimaryName(styles.tabLayoutLeft());
@@ -143,8 +143,14 @@ public class ModuleTabLayoutPanel extends TabLayoutPanel
          }
       }
 
+      public String getTabId()
+      {
+         return tabId_;
+      }
+
       private Image closeButton_;
       private ProgressSpinner busySpinner_;
+      private final String tabId_;
    }
 
    public ModuleTabLayoutPanel(final WindowFrame owner, String tabListName)
@@ -196,8 +202,7 @@ public class ModuleTabLayoutPanel extends TabLayoutPanel
       add(child, text, asHtml, null);
    }
 
-   public void add(Widget child, String text, boolean asHtml, 
-                   ClickHandler closeHandler)
+   public void add(Widget child, String text, boolean asHtml, ClickHandler closeHandler)
    {
       add(child, text, asHtml, closeHandler, null);
    }
@@ -210,6 +215,7 @@ public class ModuleTabLayoutPanel extends TabLayoutPanel
 
       ModuleTab tab = new ModuleTab(text, styles_, closeHandler != null, false /*minimized*/);
       super.add(child, tab);
+      setTabId(child, ElementIds.getUniqueElementId(tab.getTabId()));
 
       if (closeHandler != null)
          tab.addCloseButtonClickHandler(closeHandler);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/DelayLoadWorkbenchTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/DelayLoadWorkbenchTab.java
@@ -1,7 +1,7 @@
 /*
  * DelayLoadWorkbenchTab.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.ui;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -24,14 +25,12 @@ import com.google.gwt.user.client.ui.Panel;
 import com.google.gwt.user.client.ui.Widget;
 
 import org.rstudio.core.client.ElementIds;
-import org.rstudio.core.client.SerializedCommandQueue;
 import org.rstudio.core.client.events.EnsureHiddenEvent;
 import org.rstudio.core.client.events.EnsureHiddenHandler;
 import org.rstudio.core.client.events.EnsureHeightEvent;
 import org.rstudio.core.client.events.EnsureHeightHandler;
 import org.rstudio.core.client.events.EnsureVisibleEvent;
 import org.rstudio.core.client.events.EnsureVisibleHandler;
-import org.rstudio.studio.client.RStudioGinjector;
 
 public abstract class DelayLoadWorkbenchTab<T extends IsWidget>
       implements WorkbenchTab
@@ -42,6 +41,13 @@ public abstract class DelayLoadWorkbenchTab<T extends IsWidget>
    {
       title_ = title;
       panel_ = new DockLayoutPanel(Style.Unit.PX);
+      Roles.getTabpanelRole().set(panel_.getElement());
+      Roles.getTabpanelRole().setAriaLabelProperty(panel_.getElement(), title_);
+
+      // Assign a unique ID to the pane based on its title
+      ElementIds.assignElementId(panel_.getElement(),
+            ElementIds.WORKBENCH_PANEL + "_" + ElementIds.idSafeString(title_));
+
       shimmed_ = shimmed;
       shimmed_.setParentTab(this);
    }
@@ -128,79 +134,8 @@ public abstract class DelayLoadWorkbenchTab<T extends IsWidget>
       return handlers_.addHandler(EnsureHeightEvent.TYPE, handler);
    }
 
-   protected void setInternalCallbacks(InternalCallbacks callbacks)
-   {
-      callbacks_ = callbacks;
-   }
-
-   protected interface InternalCallbacks
-   {
-
-      void onBeforeSelected();
-
-      void onSelected();
-
-   }
-
-   protected void initialize(final WorkbenchPane pane, Panel panel)
-   {
-      assert !initialized_;
-
-      initialized_ = true;
-
-      // Assign a unique ID to the pane based on its title
-      ElementIds.assignElementId(pane.getElement(), 
-            ElementIds.WORKBENCH_PANEL + "_" + ElementIds.idSafeString(title_));
-
-      pane.ensureWidget();
-      panel.add(pane);
-      pane.addEnsureVisibleHandler(new EnsureVisibleHandler()
-      {
-         public void onEnsureVisible(EnsureVisibleEvent event)
-         {
-            ensureVisible(event.getActivate());
-         }
-      });
-      pane.addEnsureHiddenHandler(new EnsureHiddenHandler()
-      {
-         @Override
-         public void onEnsureHidden(EnsureHiddenEvent event)
-         {
-            ensureHidden();
-         }
-      });
-
-      setInternalCallbacks(new InternalCallbacks()
-      {
-         public void onBeforeSelected()
-         {
-            pane.onBeforeSelected();
-         }
-
-         public void onSelected()
-         {
-            pane.onSelected();
-         }
-      });
-
-      pane.onBeforeSelected();
-      pane.onSelected();
-   }
-
-   protected void handleCodeLoadFailure(Throwable reason)
-   {
-      RStudioGinjector.INSTANCE.getGlobalDisplay().showErrorMessage(
-            "Code Failed to Load",
-            reason == null ? "(Unknown error)" : reason.getMessage());
-   }
-
    private final HandlerManager handlers_ = new HandlerManager(null);
-   @SuppressWarnings("unused")
-   private SerializedCommandQueue initQueue = new SerializedCommandQueue();
-   private boolean initialized_;
    protected final DockLayoutPanel panel_;
    private final String title_;
-   @SuppressWarnings("unused")
-   private InternalCallbacks callbacks_;
    private DelayLoadTabShim<T, ?> shimmed_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.console;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.IsWidget;
@@ -24,6 +25,7 @@ import com.google.inject.Provider;
 
 import java.util.Stack;
 
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.CanFocus;
 import org.rstudio.core.client.widget.SecondaryToolbar;
@@ -65,6 +67,14 @@ public class ConsolePane extends WorkbenchPane
       // the secondary toolbar can have several possible states that obscure
       // each other; we keep track of the stack here
       mode_ = new Stack<>();
+
+      ElementIds.assignElementId(this, ElementIds.WORKBENCH_PANEL + "_console");
+
+      // technically this is only playing aria-tabpanel role when the console pane
+      // has tabs (e.g. at least one other pane is being shown, such as Terminal), but
+      // having it always marked with that role is fine
+      Roles.getTabpanelRole().set(this.getElement());
+      Roles.getTabpanelRole().setAriaLabelProperty(this.getElement(), "Console");
 
       // console is interacted with immediately so we make sure it
       // is always created during startup


### PR DESCRIPTION
- put id of feature tabs (e.g. Console, Terminal, History, etc) on the actual role=tab element instead of a layout element nested inside it
- fix code that was supposed to give the panes of each feature tab a unique id (workbench_pane_terminal, etc.) but wasn't ever being executed
- give the feature panels the aria tabpanel role since they are controlled by tabs
- provide aria-labels for the tabpanels so they can be identified via screen reader
- delete unreachable code in DelayLoadWorkbenchTab (likely some abandoned approach from early days of the codebase)
- unique id and tabpanel role for the Console pane (special case)