### PR TITLE
adjust scroll speed if device pixel ratio changes

### DIFF
--- a/CMakeCompiler.txt
+++ b/CMakeCompiler.txt
@@ -53,6 +53,11 @@ if(MSVC)
   # these warnings are being triggered in the MSVC-supplied headers and we aren't touching those
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4068")
 
+  # embed debug information into the generated objects
+  # (otherwise we can run into annoying PDB errors during compilation)
+  string(REGEX REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+  string(REGEX REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+
   # ensure that we're using linker flags compatible with
   # the version of Boost that will be linked in
   if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/src/gwt/src/org/rstudio/core/client/dom/WindowEx.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/WindowEx.java
@@ -43,6 +43,10 @@ public class WindowEx extends JavaScriptObject
    protected WindowEx()
    {
    }
+   
+   public final native double getDevicePixelRatio() /*-{
+      return this.devicePixelRatio;
+   }-*/;
 
    public final native void focus() /*-{
       this.focus();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -51,7 +51,9 @@ import com.google.gwt.user.client.ui.ScrollPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.rstudio.core.client.AceSupport;
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.ExternalJavaScriptLoader;
 import org.rstudio.core.client.ExternalJavaScriptLoader.Callback;
@@ -322,6 +324,7 @@ public class AceEditor implements DocDisplay,
    {
       widget_ = new AceEditorWidget();
       snippets_ = new SnippetHelper(this);
+      monitor_ = new AceEditorMonitor(this);
       editorEventListeners_ = new ArrayList<>();
       mixins_ = new AceEditorMixins(this);
       editLines_ = new AceEditorEditLinesHelper(this);
@@ -4020,6 +4023,11 @@ public class AceEditor implements DocDisplay,
    {
       widget_.getEditor().setTextInputAriaLabel(label);
    }
+   
+   public final void setScrollSpeed(double speed)
+   {
+      widget_.getEditor().setScrollSpeed(speed);
+   }
 
    private void fireLineWidgetsChanged()
    {
@@ -4126,6 +4134,7 @@ public class AceEditor implements DocDisplay,
    private final HandlerManager handlers_ = new HandlerManager(this);
    private final AceEditorWidget widget_;
    private final SnippetHelper snippets_;
+   private final AceEditorMonitor monitor_;
    private ScrollAnimator scrollAnimator_;
    private CompletionManager completionManager_;
    private ScopeTreeManager scopes_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorMonitor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorMonitor.java
@@ -1,0 +1,82 @@
+/*
+ * AceEditorMonitor.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text;
+
+import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.dom.WindowEx;
+
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.event.logical.shared.AttachEvent;
+
+public class AceEditorMonitor
+{
+   public AceEditorMonitor(AceEditor editor)
+   {
+      editor_ = editor;
+      init();
+   }
+   
+   private void init()
+   {
+      editor_.addAttachHandler((AttachEvent event) -> {
+         
+         if (event.isAttached())
+         {
+            beginMonitoring();
+         }
+         else
+         {
+            endMonitoring();
+         }
+      });
+   }
+   
+   private boolean monitor()
+   {
+      if (!monitoring_)
+         return false;
+      
+      if (BrowseCap.isWindowsDesktop())
+      {
+         double ratio = WindowEx.get().getDevicePixelRatio();
+         editor_.setScrollSpeed(ACE_EDITOR_DEFAULT_SCROLL_SPEED / ratio);
+      }
+      
+      return true;
+   }
+   
+   private void beginMonitoring()
+   {
+      if (monitoring_)
+         return;
+      
+      monitoring_ = true;
+      Scheduler.get().scheduleFixedDelay(() -> {
+         return monitor();
+      }, 1000);
+   }
+   
+   private void endMonitoring()
+   {
+      monitoring_ = false;
+      editor_ = null;
+   }
+ 
+   private boolean monitoring_ = false;
+   private AceEditor editor_;
+   
+   private static final double ACE_EDITOR_DEFAULT_SCROLL_SPEED = 2.0;
+   
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorMonitor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorMonitor.java
@@ -51,7 +51,11 @@ public class AceEditorMonitor
       if (BrowseCap.isWindowsDesktop())
       {
          double ratio = WindowEx.get().getDevicePixelRatio();
-         editor_.setScrollSpeed(ACE_EDITOR_DEFAULT_SCROLL_SPEED / ratio);
+         if (devicePixelRatio_ != ratio)
+         {
+            devicePixelRatio_ = ratio;
+            editor_.setScrollSpeed(ACE_EDITOR_DEFAULT_SCROLL_SPEED / ratio);
+         }
       }
       
       return true;
@@ -76,6 +80,8 @@ public class AceEditorMonitor
  
    private boolean monitoring_ = false;
    private AceEditor editor_;
+   
+   private double devicePixelRatio_ = 1.0;
    
    private static final double ACE_EDITOR_DEFAULT_SCROLL_SPEED = 2.0;
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -640,6 +640,10 @@ public class AceEditorNative extends JavaScriptObject {
       this.setOption("cursorStyle", style);
    }-*/;
    
+   public final native void setScrollSpeed(double speed) /*-{
+      this.setOption("scrollSpeed", speed);
+   }-*/;
+   
    private static final native void initialize()
    /*-{
       // Remove the 'Return' keybinding associated with Emacs.


### PR DESCRIPTION
On Windows, the Ace editor scroll speed seems to scale with the device pixel ratio, so that systems with higher display scaling (e.g. high DPI displays) will see the editor scroll more lines than expected -- e.g. one might see 12 lines per tick when scrolling with a mousewheel and 300% zoom.

The (simple) solution is to just re-scale Ace's scroll speed based on the device pixel ratio.

Closes https://github.com/rstudio/rstudio/issues/5098.