### PR TITLE
Use home dir odbcinst.ini file in linux since users don't need sudo

### DIFF
--- a/src/cpp/session/modules/SessionConnectionsInstaller.R
+++ b/src/cpp/session/modules/SessionConnectionsInstaller.R
@@ -340,7 +340,7 @@
 })
 
 .rs.addFunction("odbcBundleOdbcinstPathUseHome", function() {
-   normalizePath("~/odbcinst.ini", mustWork = FALSE)
+   normalizePath("~/.odbcinst.ini", mustWork = FALSE)
 })
 
 .rs.addFunction("odbcBundleOdbcinstPath", function() {

--- a/src/cpp/session/modules/SessionConnectionsInstaller.R
+++ b/src/cpp/session/modules/SessionConnectionsInstaller.R
@@ -333,10 +333,20 @@
    prereqs()
 })
 
-.rs.addFunction("odbcBundleOdbcinstPath", function() {
+.rs.addFunction("odbcBundleOdbcinstPathDefault", function() {
    config <- system2("odbcinst", "-j", stdout = TRUE)
    odbciniEntry <- config[grepl("odbcinst.ini", config)]
    gsub("^[^/\\\\]*", "", odbciniEntry)
+})
+
+.rs.addFunction("odbcBundleOdbcinstPath", function() {
+   osOdbcinstPath <- list(
+      osx = .rs.odbcBundleOdbcinstPathDefault,
+      windows = .rs.odbcBundleOdbcinstPathDefault,
+      linux = function() normalizePath("~/odbcinst.ini", mustWork = FALSE)
+   )
+
+   osOdbcinstPath[[.rs.odbcBundleOsName()]]()
 })
 
 .rs.addFunction("odbcBundleReadIni", function(odbcinstPath) {

--- a/src/cpp/session/modules/SessionConnectionsInstaller.R
+++ b/src/cpp/session/modules/SessionConnectionsInstaller.R
@@ -333,17 +333,21 @@
    prereqs()
 })
 
-.rs.addFunction("odbcBundleOdbcinstPathDefault", function() {
+.rs.addFunction("odbcBundleOdbcinstPathWithOdbcinst", function() {
    config <- system2("odbcinst", "-j", stdout = TRUE)
    odbciniEntry <- config[grepl("odbcinst.ini", config)]
    gsub("^[^/\\\\]*", "", odbciniEntry)
 })
 
+.rs.addFunction("odbcBundleOdbcinstPathUseHome", function() {
+   normalizePath("~/odbcinst.ini", mustWork = FALSE)
+})
+
 .rs.addFunction("odbcBundleOdbcinstPath", function() {
    osOdbcinstPath <- list(
-      osx = .rs.odbcBundleOdbcinstPathDefault,
-      windows = .rs.odbcBundleOdbcinstPathDefault,
-      linux = function() normalizePath("~/odbcinst.ini", mustWork = FALSE)
+      osx = .rs.odbcBundleOdbcinstPathWithOdbcinst,
+      windows = .rs.odbcBundleOdbcinstPathWithOdbcinst,
+      linux = .rs.odbcBundleOdbcinstPathUseHome
    )
 
    osOdbcinstPath[[.rs.odbcBundleOsName()]]()


### PR DESCRIPTION
When installing ODBC drivers in Linux, seems like a better option to use `~/odbcinst.ini` to avoid permissions issues since it would otherwise require `sudo` to be modified.