### PR TITLE
Set the server name indication so we can work with TLS v 1.3.

### DIFF
--- a/src/cpp/core/include/core/http/TcpIpAsyncClientSsl.hpp
+++ b/src/cpp/core/include/core/http/TcpIpAsyncClientSsl.hpp
@@ -34,8 +34,8 @@ class TcpIpAsyncClientSsl
 {
 public:
    TcpIpAsyncClientSsl(boost::asio::io_service& ioService,
-                       std::string address,
-                       std::string port,
+                       const std::string& address,
+                       const std::string& port,
                        bool verify,
                        const std::string& certificateAuthority = std::string(),
                        const boost::posix_time::time_duration& connectionTimeout =
@@ -43,8 +43,8 @@ public:
                        const std::string& hostname = std::string() )
      : AsyncClient<boost::asio::ssl::stream<boost::asio::ip::tcp::socket> >(ioService),
        sslContext_(boost::asio::ssl::context::sslv23_client),
-       address_(std::move(address)),
-       port_(std::move(port)),
+       address_(address),
+       port_(port),
        verify_(verify),
        certificateAuthority_(certificateAuthority),
        connectionTimeout_(connectionTimeout)

--- a/src/cpp/core/include/core/http/TcpIpAsyncClientSsl.hpp
+++ b/src/cpp/core/include/core/http/TcpIpAsyncClientSsl.hpp
@@ -72,7 +72,7 @@ public:
       // the ssl::context (immediately above)
       ptrSslStream_.reset(new boost::asio::ssl::stream<boost::asio::ip::tcp::socket>(ioService, sslContext_));
 
-      // Set the SNI so we still work with TLS v1.3
+      // TLS v1.3 requires that the SNI be set, so set the SNI.
       if (!SSL_set_tlsext_host_name(
             ptrSslStream_->native_handle(),
             (hostname.empty() ? address_.c_str() : hostname.c_str())))


### PR DESCRIPTION
TLS v 1.3 now requires SNI on requests.

This PR needs to be cherry picked to v1.2-patch.