### PR TITLE
added session config option for blacklist of env vars when saving/restoring session

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -82,6 +82,7 @@
 * RStudio Server runtime files are stored in `/var/run`, or another configurable location, instead of `/tmp` (#4666)
 * Errors encountered when attempting to find Rtools installations are handled more gracefully (#5720)
 * Enable copying images to the clipboard from the Plots pane (#3142)
+* Session configuration option to customize environment variables saved when session suspends (#5769)
 
 ### Bugfixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -82,7 +82,6 @@
 * RStudio Server runtime files are stored in `/var/run`, or another configurable location, instead of `/tmp` (#4666)
 * Errors encountered when attempting to find Rtools installations are handled more gracefully (#5720)
 * Enable copying images to the clipboard from the Plots pane (#3142)
-* Session configuration option to customize environment variables saved when session suspends (#5769)
 
 ### Bugfixes
 

--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -1,7 +1,7 @@
 /*
  * RSession.hpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -173,19 +173,25 @@ void reportAndLogWarning(const std::string& warning);
 
 // suspend/resume
 bool isSuspendable(const std::string& prompt);
-bool suspend(bool force, int status = EXIT_SUCCESS);
+bool suspend(bool force, int status, const std::string& envVarSaveBlacklist);
 
 struct RSuspendOptions
 {
    RSuspendOptions(int exitStatus)
-      : status(exitStatus), saveMinimal(false), saveWorkspace(false), 
-        excludePackages(false)
+      : status(exitStatus)
+   {
+   }
+
+   RSuspendOptions(int exitStatus, const std::string& blacklist) 
+      : status(exitStatus),
+        envVarSaveBlacklist(blacklist)
    {
    }
    int status;
-   bool saveMinimal;
-   bool saveWorkspace;
-   bool excludePackages;
+   bool saveMinimal { false };
+   bool saveWorkspace { false };
+   bool excludePackages { false };
+   std::string envVarSaveBlacklist;
 };
 void suspendForRestart(const RSuspendOptions& options);
    

--- a/src/cpp/r/include/r/session/RSessionState.hpp
+++ b/src/cpp/r/include/r/session/RSessionState.hpp
@@ -1,7 +1,7 @@
 /*
  * RSessionState.hpp
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -43,7 +43,8 @@ struct SessionStateInfo
 bool save(const core::FilePath& statePath,
           bool serverMode,
           bool excludePackages,
-          bool disableSaveCompression);
+          bool disableSaveCompression,
+          const std::string& envVarSaveBlacklist);
 
 bool saveMinimal(const core::FilePath& statePath,
                  bool saveGlobalEnvironment);

--- a/src/cpp/r/session/RSuspend.cpp
+++ b/src/cpp/r/session/RSuspend.cpp
@@ -1,7 +1,7 @@
 /*
  * RSuspend.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -69,7 +69,8 @@ bool saveSessionState(const RSuspendOptions& options,
       return r::session::state::save(suspendedSessionPath,
                                      utils::isServerMode(),
                                      options.excludePackages,
-                                     disableSaveCompression);
+                                     disableSaveCompression,
+                                     options.envVarSaveBlacklist);
    }
 }
    
@@ -147,9 +148,9 @@ bool suspend(const RSuspendOptions& options,
    }
 }
 
-bool suspend(bool force, int status)
+bool suspend(bool force, int status, const std::string& envVarSaveBlacklist)
 {
-   return suspend(RSuspendOptions(status),
+   return suspend(RSuspendOptions(status, envVarSaveBlacklist),
                   s_suspendedSessionPath,
                   false,
                   force);

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -257,7 +257,10 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
        "whether to mark cookies as secure")
       ("directory-view-whitelist",
        value<std::string>(&directoryViewWhitelist_)->default_value(""),
-       "list of directories where files can be viewed, separated by :");
+       "list of directories where files can be viewed, separated by :")
+      (kSessionEnvVarSaveBlacklist,
+       value<std::string>(&envVarSaveBlacklist_)->default_value(""),
+       "list of environment variables not saved on session suspend, separated by :");
 
    // allow options
    options_description allow("allow");

--- a/src/cpp/session/SessionSuspend.cpp
+++ b/src/cpp/session/SessionSuspend.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionSuspend.cpp
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -77,7 +77,7 @@ bool suspendSession(bool force, int status)
    r::session::ensureDeserialized();
 
    // perform the suspend (does not return if successful)
-   return r::session::suspend(force, status);
+   return r::session::suspend(force, status, session::options().envVarSaveBlacklist());
 }
 
 void suspendIfRequested(const boost::function<bool()>& allowSuspend)

--- a/src/cpp/session/include/session/SessionConstants.hpp
+++ b/src/cpp/session/include/session/SessionConstants.hpp
@@ -65,7 +65,7 @@
 #define kTimeoutSessionOption             "session-timeout-minutes"
 #define kTimeoutSuspendSessionOption      "session-timeout-suspend"
 #define kDisconnectedTimeoutSessionOption "session-disconnected-timeout-minutes"
-
+#define kSessionEnvVarSaveBlacklist       "session-env-var-save-blacklist"
 #define kVerifySignaturesSessionOption    "verify-signatures"
 #define kStandaloneSessionOption          "standalone"
 #define kWwwAddressSessionOption          "www-address"

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -620,6 +620,11 @@ public:
       return directoryViewWhitelist_;
    }
 
+   std::string envVarSaveBlacklist() const
+   {
+      return envVarSaveBlacklist_;
+   }
+
    static std::string parseReposConfig(core::FilePath reposFile);
 
 private:
@@ -695,6 +700,7 @@ private:
    std::string terminalPort_;
    bool useSecureCookies_;
    std::string directoryViewWhitelist_;
+   std::string envVarSaveBlacklist_;
 
    // r
    std::string coreRSourcePath_;


### PR DESCRIPTION
Use to prevent specific environment variables from being saved (and thus restored) when a session suspends. Specify as a colon-separated list in rsession.conf:

`session-env-var-save-blacklist=FOO:BAR:ETC`

Will add to admin guide once ported over to Pro repo.

Candidate for backporting to 1.2-patch.

Fixes #5769 