### PR TITLE
release handlers when HyperlinkLabel control unloads

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/HandlerRegistrations.java
+++ b/src/gwt/src/org/rstudio/core/client/HandlerRegistrations.java
@@ -1,7 +1,7 @@
 /*
  * HandlerRegistrations.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -37,6 +37,5 @@ public class HandlerRegistrations implements HandlerRegistration
          registrations_.remove(0).removeHandler();
    }
 
-   private final ArrayList<HandlerRegistration> registrations_ =
-         new ArrayList<HandlerRegistration>();
+   private final ArrayList<HandlerRegistration> registrations_ = new ArrayList<>();
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/HyperlinkLabel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/HyperlinkLabel.java
@@ -110,13 +110,20 @@ public class HyperlinkLabel extends Label
       registerClickHandler();
    }
 
+   @Override
+   protected void onUnload()
+   {
+      releaseOnUnload_.removeHandler();
+   }
+
    private void registerClickHandler()
    {
       if (isAttached() && clickHandler_ != null)
       {
          releaseOnUnload_.add(super.addClickHandler(event -> click()));
 
-         releaseOnUnload_.add(addKeyPressHandler(event -> {
+         releaseOnUnload_.add(addKeyPressHandler(event ->
+         {
             char charCode = event.getCharCode();
             if (charCode == KeyCodes.KEY_ENTER || charCode == KeyCodes.KEY_SPACE)
             {
@@ -138,7 +145,7 @@ public class HyperlinkLabel extends Label
       clickHandler_.execute();
    }
 
-   private MouseHandlers mouseHandlers_ = new MouseHandlers();
+   private final MouseHandlers mouseHandlers_ = new MouseHandlers();
    private Command clickHandler_ ;
    private final HandlerRegistrations releaseOnUnload_ = new HandlerRegistrations();
 


### PR DESCRIPTION
- control is used in File pane (breadcrumbs), preferences panes,
  about dialog, handful of other locations, potentially preventing a
  fair amount of JavaScript garbage collection