### PR TITLE
Destroy preference layers during session shutdown

### DIFF
--- a/src/cpp/session/include/session/prefs/PrefLayer.hpp
+++ b/src/cpp/session/include/session/prefs/PrefLayer.hpp
@@ -43,6 +43,7 @@ public:
    virtual core::Error readPrefs() = 0;
    virtual core::Error writePrefs(const core::json::Object& prefs);
    virtual ~PrefLayer();
+   virtual void destroy();
    std::string layerName();
 
    template<typename T> boost::optional<T> readPref(const std::string& name)

--- a/src/cpp/session/include/session/prefs/Preferences.hpp
+++ b/src/cpp/session/include/session/prefs/Preferences.hpp
@@ -106,6 +106,7 @@ public:
    virtual core::Error createLayers() = 0;
    virtual int userLayer() = 0;
    virtual int clientChangedEvent() = 0;
+   void destroyLayers();
 
    // Signal emitted when preferences change; includes the layer name and value name
    RSTUDIO_BOOST_SIGNAL<void(const std::string&, const std::string&)> onChanged;

--- a/src/cpp/session/prefs/PrefLayer.cpp
+++ b/src/cpp/session/prefs/PrefLayer.cpp
@@ -81,12 +81,27 @@ PrefLayer::PrefLayer(const std::string& layerName):
 
 PrefLayer::~PrefLayer()
 {
+   destroy();
+}
+
+void PrefLayer::destroy()
+{
    // End file monitoring if not already terminated
    if (handle_)
    {
       core::system::file_monitor::unregisterMonitor(*handle_);
       handle_ = boost::none;
    }
+
+   // Clear prefs cache
+   RECURSIVE_LOCK_MUTEX(mutex_)
+   {
+      if (cache_)
+      {
+         cache_.reset();
+      }
+   }
+   END_LOCK_MUTEX;
 }
 
 core::json::Object PrefLayer::allPrefs()

--- a/src/cpp/session/prefs/Preferences.cpp
+++ b/src/cpp/session/prefs/Preferences.cpp
@@ -96,6 +96,22 @@ Error Preferences::initialize()
    return Success();
 }
 
+void Preferences::destroyLayers()
+{
+   RECURSIVE_LOCK_MUTEX(mutex_)
+   {
+      // Give each layer a chance to destoy itself
+      for (auto layer: layers_)
+      {
+         layer->destroy();
+      }
+
+      // Remove all the destroyed layers
+      layers_.clear();
+   }
+   END_LOCK_MUTEX
+}
+
 core::Error Preferences::writeLayer(int layer, const core::json::Object& prefs)
 {
    Error result;


### PR DESCRIPTION
Currently, the file monitor that watches for user preference changes gets unregistered very late in session shutdown, when the static objects storing the preference layers are freed. This has been observed to create problems, so this change moves preference layer destruction (including freeing and unregistering file monitoring) into code run during a clean session shutdown. 

Fixes https://github.com/rstudio/rstudio/issues/5222. 