### PR TITLE
Fix some issues with shared_core

### DIFF
--- a/src/cpp/shared_core/FileLogDestination.cpp
+++ b/src/cpp/shared_core/FileLogDestination.cpp
@@ -27,6 +27,7 @@
 
 #include <vector>
 
+#include <shared_core/Error.hpp>
 #include <shared_core/Logger.hpp>
 
 namespace rstudio {
@@ -160,7 +161,6 @@ struct FileLogDestination::Impl
 
       return LogFile.getSize() < maxSize;
    }
-
 
    FileLogOptions LogOptions;
    FilePath LogFile;

--- a/src/cpp/shared_core/include/shared_core/FilePath.hpp
+++ b/src/cpp/shared_core/include/shared_core/FilePath.hpp
@@ -43,8 +43,6 @@
 namespace rstudio {
 namespace core {
 
-class Error;
-
 /**
  * @brief Class which represents a path on the system. May be any type of file (e.g. directory, symlink, regular file,
  *        etc.)

--- a/src/cpp/shared_core/include/shared_core/PImpl.hpp
+++ b/src/cpp/shared_core/include/shared_core/PImpl.hpp
@@ -63,7 +63,7 @@
 
 /**
  * @brief Macro which implements the deleter for the class's private implementation. This macro must be used after the
- *        implentation of the Impl struct in the definition file.
+ *        implementation of the Impl struct in the definition file.
  *
  * @param in_owningClass    The name of the class which owns the private implementation (e.g. Error).
  */

--- a/src/cpp/shared_core/include/shared_core/PImpl.hpp
+++ b/src/cpp/shared_core/include/shared_core/PImpl.hpp
@@ -57,7 +57,7 @@
  *
  * @param in_memeberName    The name of the private implementation member variable (e.g. m_impl).
  */
-#define PRIVATE_IMPL_SHARED(in_memberName) \
+#define PRIVATE_IMPL_SHARED(in_memberName)   \
    PRIVATE_IMPL_START                        \
    std::shared_ptr<Impl> in_memberName;
 

--- a/src/cpp/shared_core/include/shared_core/ReaderWriterMutex.hpp
+++ b/src/cpp/shared_core/include/shared_core/ReaderWriterMutex.hpp
@@ -170,7 +170,8 @@ private:
    catch (...)                                                                               \
    {                                                                                         \
       if (tryLog)                                                                            \
-         log::logErrorMessage("Unknown exception while trying to acquire lock.");            \
+         log::logErrorMessage("Unknown exception while trying to acquire lock.",             \
+                              ERROR_LOCATION);                                               \
    }                                                                                         \
 
 

--- a/src/cpp/shared_core/json/Json.cpp
+++ b/src/cpp/shared_core/json/Json.cpp
@@ -27,14 +27,16 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/regex.hpp>
+#include <boost/system/error_code.hpp>
 
 #include <shared_core/Error.hpp>
-#include <shared_core/json/rapidjson/document.h>
-#include <shared_core/json/rapidjson/stringbuffer.h>
-#include <shared_core/json/rapidjson/prettywriter.h>
-#include <shared_core/json/rapidjson/writer.h>
-#include <shared_core/json/rapidjson/error/en.h>
-#include <shared_core/json/rapidjson/schema.h>
+
+#include "shared_core/json/rapidjson/document.h"
+#include "shared_core/json/rapidjson/stringbuffer.h"
+#include "shared_core/json/rapidjson/prettywriter.h"
+#include "shared_core/json/rapidjson/writer.h"
+#include "shared_core/json/rapidjson/error/en.h"
+#include "shared_core/json/rapidjson/schema.h"
 
 // JSON Boost Error ====================================================================================================
 // Declare rapidjson errors as boost errors.


### PR DESCRIPTION
These are some minor issues I found in shared_core while integrating these classes with the RStudio Launcher Plugin SDK. Mainly whitespacing, spelling, or include issues.