### PR TITLE
fix cheatsheet commands to avoid empty cheatsheet menu items

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -1980,23 +1980,23 @@ well as menu structures (for main menu and popup menus).
           desc="Data transformation with dplyr"
           context="help"/>
           
-    <cmd id="openSpar_klyrCheatSheet"
-         menuLabel="Interfacing Spark with sparklyr"
+    <cmd id="openSparklyrCheatSheet"
+         menuLabel="Interfacing Spar_k with sparklyr"
          desc="Interfacing Apache Spark with sparklyr"
          context="help"/>
 
-    <cmd id="openR_MarkdownCheatSheet"
-         menuLabel="R Markdown Cheat Sheet"
+    <cmd id="openRMarkdownCheatSheet"
+         menuLabel="R _Markdown Cheat Sheet"
          desc="R Markdown cheat sheet"
          context="help"/>
 
-    <cmd id="open_RMarkdownReferenceGuide"
-         menuLabel="R Markdown Reference Guide"
+    <cmd id="openRMarkdownReferenceGuide"
+         menuLabel="R Markdo_wn Reference Guide"
          desc="R Markdown reference guide"
          context="help"/>
 
-    <cmd id="open_ShinyCheatSheet"
-         menuLabel="Web Applications with shiny"
+    <cmd id="openShinyCheatSheet"
+         menuLabel="Web Applications with _shiny"
          desc="Build web applications with Shiny"
          context="help"/>
          


### PR DESCRIPTION
Fix silly mistake. I broke several cheatsheet commands a while back when I was adding hotkeys; put the underscores in the IDs instead of the menuLabels, so on Server the menu displayed as this:

<img width="533" alt="2019-11-26_15-12-36" src="https://user-images.githubusercontent.com/10569626/69681497-24987780-1063-11ea-839a-aea29f5ee2f3.png">

Now back to this:

<img width="496" alt="2019-11-26_15-39-18" src="https://user-images.githubusercontent.com/10569626/69681507-27936800-1063-11ea-844c-5d3c44ee1805.png">
