### PR TITLE
remove multi-select capability from choose encoding dialog listbox

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/ChooseEncodingDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/ChooseEncodingDialog.java
@@ -18,8 +18,6 @@ import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.dom.client.Style.Display;
 import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.VerticalPanel;
@@ -88,22 +86,19 @@ public class ChooseEncodingDialog extends ModalDialog<String>
    protected Widget createMainWidget()
    {
       listBox_ = new ListBox();
-      listBox_.setMultipleSelect(true);
       listBox_.setVisibleItemCount(15);
       listBox_.setWidth("350px");
+      Roles.getListboxRole().setAriaLabelProperty(listBox_.getElement(), "Encodings");
 
       setEncodings(commonEncodings_, currentEncoding_);
 
       CheckBox showAll = new CheckBox("Show all encodings");
-      showAll.addValueChangeHandler(new ValueChangeHandler<Boolean>()
+      showAll.addValueChangeHandler(valueChangeEvent ->
       {
-         public void onValueChange(ValueChangeEvent<Boolean> e)
-         {
-            if (e.getValue())
-               setEncodings(allEncodings_, currentEncoding_);
-            else
-               setEncodings(commonEncodings_, currentEncoding_);
-         }
+         if (valueChangeEvent.getValue())
+            setEncodings(allEncodings_, currentEncoding_);
+         else
+            setEncodings(commonEncodings_, currentEncoding_);
       });
       setCheckBoxMargins(showAll, 8, 12);
 


### PR DESCRIPTION
- multi-select serves no purpose in this dialog, and the code only looks at first-selected item
- also give listbox an aria-label of "Encodings"

Example of multi-select (after this change only supports single-select):
<img width="373" alt="2019-12-02_15-19-48" src="https://user-images.githubusercontent.com/10569626/70003843-4d17ea00-1519-11ea-920b-f5b381ca3b4a.png">
