### PR TITLE
fix accessibility of Find in Files when custom pattern option is selected

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -172,6 +172,7 @@ public class ElementIds
    // FindInFilesDialog
    public final static String FIND_FILES_TEXT = "find_files_text";
    public static String getFindFilesText() { return getElementId(FIND_FILES_TEXT); }
+   public final static String FIND_FILES_PATTERN_EXAMPLE = "find_files_pattern_example";
 
    // ImportFileSettingsDialog
    public final static String IMPORT_FILE_NAME = "import_file_name";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
@@ -19,6 +19,7 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.dom.client.DivElement;
+import com.google.gwt.dom.client.SpanElement;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
@@ -30,6 +31,7 @@ import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.Widget;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.js.JsUtil;
@@ -103,6 +105,13 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
       mainWidget_ = GWT.<Binder>create(Binder.class).createAndBindUi(this);
       labelFilePatterns_.setFor(listPresetFilePatterns_);
       setOkButtonCaption("Find");
+
+      // give custom pattern textbox a label and extended description using the visible
+      // example shown below it
+      spanPatternExample_.setId(ElementIds.getElementId(ElementIds.FIND_FILES_PATTERN_EXAMPLE));
+      Roles.getTextboxRole().setAriaLabelProperty(txtFilePattern_.getElement(), "Custom Filter Pattern");
+      Roles.getTextboxRole().setAriaDescribedbyProperty(txtFilePattern_.getElement(),
+            ElementIds.getAriaElementId(ElementIds.FIND_FILES_PATTERN_EXAMPLE));
 
       listPresetFilePatterns_.addChangeHandler(new ChangeHandler()
       {
@@ -251,6 +260,9 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
    ListBox listPresetFilePatterns_;
    @UiField
    DivElement divCustomFilter_;
+   @UiField
+   SpanElement spanPatternExample_;
+
    private Widget mainWidget_;
    private GlobalDisplay globalDisplay_ = RStudioGinjector.INSTANCE.getGlobalDisplay();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
@@ -19,7 +19,7 @@
       }
 
       .example {
-         color: #999;
+         color: #696969;
       }
 
       .presetFilePatterns {
@@ -51,7 +51,7 @@
          <div ui:field="divCustomFilter_">
             <g:TextBox ui:field="txtFilePattern_" styleName="{style.filePattern}"/>
             <br/>
-            <span class="{style.example}">Example: *.R, *.r, *.csv. Separate multiple types with commas.</span>
+            <span ui:field="spanPatternExample_" class="{style.example}">Example: *.R, *.r, *.csv. Separate multiple types with commas.</span>
          </div>
       </p>
    </g:HTMLPanel>


### PR DESCRIPTION
On my previous pass through this dialog I missed the controls that are shown when you select "Custom Filter". This fixes issues with those:

- contrast of the text showing examples was too low (bumped up contrast)
- no accessible label for the custom pattern textfield (added `aria-label`)
- example shown below textfield was not associated with the textbox (associated with `aria-description`)
- behavior varies by screen reader, but on VoiceOver/macOS, when you tab to the text field it will now read it's label ("Custom Filter Pattern"), then the contents of the field, then after a brief pause, the description ("Example: *.R, *.r, *.csv...")

<img width="404" alt="2019-12-02_16-04-18" src="https://user-images.githubusercontent.com/10569626/70005775-99662880-151f-11ea-9c8f-1a642b2bd2a9.png">
