### PR TITLE
associate label with field in About dialog (pro license status)

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -284,4 +284,8 @@ public class ElementIds
    public static String getDataImportCsvGroupingMark() { return getElementId(DATA_IMPORT_CSV_GROUPING_MARK); }
    public final static String DATA_IMPORT_CSV_TZ = "data_import_csv_tz";
    public static String getDataImportCsvTz() { return getElementId(DATA_IMPORT_CSV_TZ); }
+
+   // AboutDialogContents
+   public final static String ABOUT_LICENSE_INFO = "about_license_info";
+   public static String getAboutLicenseInfo() { return getElementId(ABOUT_LICENSE_INFO); }
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/FormTextArea.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FormTextArea.java
@@ -1,0 +1,27 @@
+/*
+ * FormTextArea.java
+ *
+ * Copyright (C) 2019 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.widget;
+
+import com.google.gwt.user.client.ui.TextArea;
+
+public class FormTextArea extends TextArea
+                          implements CanSetControlId
+{
+   @Override
+   public void setElementId(String id)
+   {
+      getElement().setId(id);
+   }
+}

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.java
@@ -126,7 +126,7 @@ public class AboutDialogContents extends Composite
    @UiField InlineLabel copyrightYearLabel;
    @UiField HyperlinkLabel showNoticelink_;
    @UiField HTMLPanel gplNotice;
-   @UiField Label licenseLabel;
+   @UiField HTMLPanel licenseLabel;
    @UiField TextArea licenseBox;
    @UiField Label productName;
    @UiField HTMLPanel productInfo;

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.ui.xml
@@ -3,6 +3,7 @@
    xmlns:g="urn:import:com.google.gwt.user.client.ui"
    xmlns:rw="urn:import:org.rstudio.core.client.widget">
    <ui:with field='res' type='org.rstudio.core.client.theme.res.ThemeResources' />
+   <ui:with field="ElementIds" type="org.rstudio.core.client.ElementIds"/>
    <ui:style>
       @eval fixedWidthFont org.rstudio.core.client.theme.ThemeFonts.getFixedWidthFont();
       .productName {
@@ -116,10 +117,12 @@
                addStyleNames="{style.noticeLink} {res.themeStyles.handCursor}"
                ui:field="showNoticelink_"/>
       </g:HTMLPanel>
-      <g:Label ui:field="licenseLabel" visible="false" text="RStudio Pro License Status" styleName="{style.licenseLabel}"></g:Label>
-        <g:TextArea ui:field="licenseBox" styleName="{style.licenseBox}"
-           visibleLines="10" visible="false" readOnly="true"></g:TextArea>
-
+      <g:HTMLPanel ui:field="licenseLabel" visible="false">
+         <rw:FormLabel text="RStudio Pro License Status" styleName="{style.licenseLabel}"
+            for="{ElementIds.getAboutLicenseInfo}"/>
+      </g:HTMLPanel>
+      <rw:FormTextArea ui:field="licenseBox" styleName="{style.licenseBox}"
+         visibleLines="10" visible="false" readOnly="true" elementId="{ElementIds.getAboutLicenseInfo}"/>
    </g:HTMLPanel>
 </ui:UiBinder> 
 


### PR DESCRIPTION
Associate "RStudio Pro License Status" label with textbox. This is only shown in Pro desktop, but code is identical in Open Source so making the change there.

<img width="602" alt="2019-12-02_21-36-03" src="https://user-images.githubusercontent.com/10569626/70023524-9c2b4280-154c-11ea-80e8-bd10efb4a471.png">
