### PR TITLE
Allow user selection of text in VCS diffs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -96,6 +96,7 @@
 * Fix an issue where Git did not work within projects whose paths contained multibyte characters (#2194)
 * Fix an issue where RStudio would fail to preview self-contained bookdown books (#5371)
 * Fix modal dialog boundaries extending out of the app window in certain cases (#1605)
+* Restore ability to select and copy text in version control diffs (#4734)
 
 ### RStudio Professional
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/LineTableViewCellTableStyle.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/LineTableViewCellTableStyle.css
@@ -7,7 +7,7 @@
    font-family: fixedWidthFont;
    white-space: pre-wrap;
    color: #888;
-   -webkit-user-select: auto;
+   user-select: text;
 }
 .cellTableWidget > tbody > tr > td {
    vertical-align: top;


### PR DESCRIPTION
It is not currently possible to select and copy text from VCS diffs. This is a regression from 1.1 and annoying for people (I certainly don't know any) who copy selectively from VCS diffs to restore snippets of deleted code. 

The fix is to just use a slightly more aggressive CSS rule to make the text selectable. The rule already existed, but stopped working in newer Chromium builds (possibly because it was vendor prefixed). 

Fixes https://github.com/rstudio/rstudio/issues/4734. 