### PR TITLE
 Look in correct paths for shiny tests/app for 'compare results'

### DIFF
--- a/src/cpp/session/modules/SessionTests.R
+++ b/src/cpp/session/modules/SessionTests.R
@@ -1,7 +1,7 @@
 #
 # SessionTests.R
 #
-# Copyright (C) 2009-18 by RStudio, Inc.
+# Copyright (C) 2009-19 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -29,15 +29,28 @@
 
 })
 
-.rs.addJsonRpcHandler("has_shinytest_results", function(appPath, testName) {
+.rs.addJsonRpcHandler("has_shinytest_results", function(testFile) {
 
-   result <- dir.exists(
-      file.path(
-         appPath,
-         "tests",
-         paste(testName, "current", sep = "-")
-      )
-   )
+   # The test result is stored in a directory alongside the test file
+   dirExists <- dir.exists(file.path(
+      dirname(testFile), 
+      paste(tools::file_path_sans_ext(basename(testFile)), "current", sep = "-")))
 
-   .rs.scalar(result)
+   # Find the Shiny app directory
+   shinyDir <- dirname(testFile)
+   if (identical(basename(shinyDir), "shinytests")) {
+      # Newer versions of shinytest store tests in a "shinytests" folder
+      shinyDir <- dirname(shinyDir)
+   } 
+   if (identical(basename(shinyDir), "tests")) {
+      # Move up from the tests folder to the app folder
+      shinyDir <- dirname(shinyDir)
+   } else {
+      stop("Could not find Shiny app for test file ", testFile)
+   }
+
+   # Return the discovered application directory, and whether the test exists 
+   list(
+      appDir = .rs.scalar(shinyDir),
+      testDirExists = .rs.scalar(dirExists))
 })

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -131,6 +131,7 @@ import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.shiny.model.ShinyRunCmd;
+import org.rstudio.studio.client.shiny.model.ShinyTestResults;
 import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
 import org.rstudio.studio.client.workbench.codesearch.model.CodeSearchResults;
 import org.rstudio.studio.client.workbench.codesearch.model.ObjectDefinition;
@@ -5893,11 +5894,10 @@ public class RemoteServer implements Server
    }
 
    @Override
-   public void hasShinyTestResults(String shinyApp, String testName, ServerRequestCallback<Boolean> callback)
+   public void hasShinyTestResults(String testFile, ServerRequestCallback<ShinyTestResults> callback)
    {
       JSONArray params = new JSONArray();
-      params.set(0, new JSONString(shinyApp));
-      params.set(1, new JSONString(testName));
+      params.set(0, new JSONString(testFile));
 
       sendRequest(RPC_SCOPE,
                   HAS_SHINYTEST_RESULTS,

--- a/src/gwt/src/org/rstudio/studio/client/shiny/model/ShinyTestResults.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/model/ShinyTestResults.java
@@ -1,0 +1,28 @@
+/*
+ * ShinyTestResults.java
+ *
+ * Copyright (C) 2019 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.shiny.model;
+
+import jsinterop.annotations.JsType;
+import jsinterop.annotations.JsPackage;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class ShinyTestResults
+{
+   // The directory of the application associated with the test
+   public String appDir;
+   
+   // Whether the test directory exists
+   public boolean testDirExists;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -119,6 +119,7 @@ import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.shiny.events.LaunchShinyApplicationEvent;
 import org.rstudio.studio.client.shiny.events.ShinyApplicationStatusEvent;
 import org.rstudio.studio.client.shiny.model.ShinyApplicationParams;
+import org.rstudio.studio.client.shiny.model.ShinyTestResults;
 import org.rstudio.studio.client.workbench.WorkbenchContext;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.Session;
@@ -7359,33 +7360,28 @@ public class TextEditingTarget implements
    @Handler
    void onShinyCompareTest()
    {
-      final String appDir = FilePathUtils.parent(FilePathUtils.dirFromFile(docUpdateSentinel_.getPath()));
-      final String testName = FilePathUtils.fileNameSansExtension(docUpdateSentinel_.getPath());
-
-      server_.hasShinyTestResults(appDir, testName, new ServerRequestCallback<Boolean>() {
+      final String testFile = docUpdateSentinel_.getPath();
+      server_.hasShinyTestResults(testFile, new ServerRequestCallback<ShinyTestResults>() {
          @Override
-         public void onResponseReceived(Boolean hasResults)
+         public void onResponseReceived(ShinyTestResults results)
          {
-            if (!hasResults) {
+            if (!results.testDirExists)
+            {
                globalDisplay_.showMessage(
                   GlobalDisplay.MSG_INFO, 
                   "No Failed Results", 
                   "There are no failed tests to compare."
                );
             }
-            else {
-               checkTestPackageDependencies(
-                  new Command()
-                  {
-                     @Override
-                     public void execute()
-                     {
-                        String code = "shinytest::viewTestDiff(\"" + appDir + "\", \"" + testName + "\")";
-                        events_.fireEvent(new SendToConsoleEvent(code, true));
-                     }
-                  },
-                  false
-               );
+            else
+            {
+               checkTestPackageDependencies(() -> 
+               {
+                  String testName = FilePathUtils.fileNameSansExtension(testFile);
+                  String code = "shinytest::viewTestDiff(\"" + 
+                        results.appDir + "\", \"" + testName + "\")";
+                  events_.fireEvent(new SendToConsoleEvent(code, true));
+               }, false);
             }
          }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/TestServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/TestServerOperations.java
@@ -1,7 +1,7 @@
 /*
  * TestServerOperations.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,6 +16,7 @@ package org.rstudio.studio.client.workbench.views.source.model;
 
 import org.rstudio.studio.client.common.console.ConsoleProcess;
 import org.rstudio.studio.client.server.ServerRequestCallback;
+import org.rstudio.studio.client.shiny.model.ShinyTestResults;
 
 public interface TestServerOperations
 {
@@ -23,5 +24,5 @@ public interface TestServerOperations
    
    void installShinyTestDependencies(ServerRequestCallback<ConsoleProcess> callback);
 
-   void hasShinyTestResults(String shinyApp, String testName, ServerRequestCallback<Boolean> callback);
+   void hasShinyTestResults(String testFile, ServerRequestCallback<ShinyTestResults> callback);
 }


### PR DESCRIPTION
This change fixes a couple more places where we implicitly presumed that (a) test directories were child directories of the Shiny app folder, and (b) the name of the test directory was "tests". Unfortunately both of these are no longer true with the latest version of shinytest, and we need to be compatible with both formulations, so the logic has become more complex.

Fixes https://github.com/rstudio/rstudio/issues/5677. (again)