### PR TITLE
Update supported browser versions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -82,6 +82,7 @@
 * RStudio Server runtime files are stored in `/var/run`, or another configurable location, instead of `/tmp` (#4666)
 * Errors encountered when attempting to find Rtools installations are handled more gracefully (#5720)
 * Enable copying images to the clipboard from the Plots pane (#3142)
+* Update minimum supported browser versions (#5593)
 
 ### Bugfixes
 

--- a/src/cpp/core/BrowserUtils.cpp
+++ b/src/cpp/core/BrowserUtils.cpp
@@ -132,14 +132,31 @@ bool isTridentOlderThan(const std::string& userAgent, double version)
 
 bool hasRequiredBrowser(const std::string& userAgent)
 {
-   if (isChromeOlderThan(userAgent, 21))
+   if (isChromeOlderThan(userAgent, 71))
+   {
+      // Chrome user agent based on oldest supported Chrome release. See:
+      // https://endoflife.software/applications/browsers/google-chrome
       return false;
-   else if (isFirefoxOlderThan(userAgent, 10))
+   }
+   else if (isFirefoxOlderThan(userAgent, 68))
+   {
+      // Firefox user agent based on oldest ESR release. See:
+      // https://support.mozilla.org/en-US/kb/firefox-esr-release-cycle
       return false;
-   else if (isSafariOlderThan(userAgent, 5.1))
+   }
+   else if (isSafariOlderThan(userAgent, 12.1))
+   {
+      // Safari user agent based on the Safari version on the oldest supported version of macOS.
+      // See:
+      // https://en.wikipedia.org/wiki/Safari_version_history
       return false;
-   else if (isTridentOlderThan(userAgent, 6.0))
+   }
+   else if (isTridentOlderThan(userAgent, 7.0))
+   {
+      // Trident user agent based on IE 11, the last version of IE (and the only one we support
+      // since IE 10 is EOL and no further IE releases based on Trident are expected)
       return false;
+   }
    else
    {
       return isChrome(userAgent) ||

--- a/src/gwt/www/unsupported_browser.htm
+++ b/src/gwt/www/unsupported_browser.htm
@@ -30,11 +30,13 @@ p {
 <ul>
 
 <li><a href="https://www.getfirefox.com/">Firefox 68</a></li>
-<li><a href="https://www.apple.com/safari/">Safari 5.1</a></li>
+<li><a href="https://www.apple.com/safari/">Safari 12.1</a></li>
 <li><a href="https://www.google.com/chrome/">Google Chrome 71</a></li>
 <li><a href="https://www.microsoft.com/en-us/download/internet-explorer.aspx">Internet Explorer 11</a></li>
 
 </ul>
+
+<p>See the <a href="https://rstudio.com/about/platform-support/">RStudio Platform Support</a> page for more information about browser support in RStudio products.</p>
 
 </body>
 

--- a/src/gwt/www/unsupported_browser.htm
+++ b/src/gwt/www/unsupported_browser.htm
@@ -29,10 +29,10 @@ p {
 
 <ul>
 
-<li><a href="http://www.getfirefox.com/">Firefox 10</a></li>
-<li><a href="http://www.apple.com/safari/">Safari 5.1</a></li>
-<li><a href="http://www.google.com/chrome">Google Chrome 21</a></li>
-<li><a href="http://www.microsoft.com/en-us/download/internet-explorer.aspx">Internet Explorer 10</a></li>
+<li><a href="https://www.getfirefox.com/">Firefox 68</a></li>
+<li><a href="https://www.apple.com/safari/">Safari 5.1</a></li>
+<li><a href="https://www.google.com/chrome/">Google Chrome 71</a></li>
+<li><a href="https://www.microsoft.com/en-us/download/internet-explorer.aspx">Internet Explorer 11</a></li>
 
 </ul>
 


### PR DESCRIPTION
This change updates (often dramatically) the minimum browser version for RStudio for each of the four browsers we support. 

The version numbers are not based on the lowest version RStudio works with but rather on the lowest version the browser vendor supports at time of writing, as we could not otherwise feasibly obtain an older version to test with, and customers using older versions are already out of support from the browser vendor. 

Closes https://github.com/rstudio/rstudio/issues/5593.