### PR TITLE
Added recursion depth limits when killing child processes

### DIFF
--- a/src/cpp/core/include/core/system/PosixSystem.hpp
+++ b/src/cpp/core/include/core/system/PosixSystem.hpp
@@ -91,22 +91,6 @@ core::Error systemInformation(SysInfo* pSysInfo);
 
 core::Error pidof(const std::string& process, std::vector<PidType>* pPids);
 
-struct ProcessInfo
-{
-   ProcessInfo() : pid(0), ppid(0), pgrp(0) {}
-   PidType pid;
-   PidType ppid;
-   PidType pgrp;
-   std::string username;
-   std::string exe;
-   std::string state;
-   std::vector<std::string> arguments;
-
-#ifndef __APPLE__
-   core::Error creationTime(boost::posix_time::ptime* pCreationTime) const;
-#endif
-};
-
 typedef boost::function<bool (const ProcessInfo&)> ProcessFilter;
 
 // get process by process name, or all processes if process name is empty


### PR DESCRIPTION
This change adds a recursion depth when killing child processes to ensure we don't blow the stack. 

Also, refactored some of the child process code out of PosixSystem and Win32System and into the base system file for more code re-use.

Closes #5478.