### PR TITLE
Allow fullscreen mode in SumatraPDF

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -79,6 +79,7 @@
 * The diagnostics system better handles missing expressions (#5660)
 * Keyboard shortcuts for debugging commands can be customized (#3539)
 * Update SumatraPDF to version 3.1.2 (#3155)
+* Allow previewing PDFs in fullscreen mode in Sumatra PDF (#4301)
 * RStudio Server runtime files are stored in `/var/run`, or another configurable location, instead of `/tmp` (#4666)
 * Errors encountered when attempting to find Rtools installations are handled more gracefully (#5720)
 * Enable copying images to the clipboard from the Plots pane (#3142)

--- a/src/cpp/session/resources/sumatrapdfrestrict.ini
+++ b/src/cpp/session/resources/sumatrapdfrestrict.ini
@@ -20,6 +20,7 @@ InternetAccess = 0
 ; * Launching external PDF viewers, LaTeX source editors or media players
 ; * Displaying Frequently Read page (also requires SavePreferences)
 ; * Reopening recently opened files
+; * Print dialog
 DiskAccess = 1
 
 ; Whether SumatraPDF should save user preferences on exit.
@@ -45,6 +46,11 @@ PrinterAccess = 1
 ; * Select all
 ; * Copying the selection
 CopySelection = 1
+
+; Whether SumatraPDF should be allowed to cover the entire screen.
+; Needed for:
+; * Fullscreen mode and Presentation mode
+FullscreenAccess = 1
 
 ; What protocols for links inside documents should be passed
 ; on to the operating system (e.g. for opening a browser).


### PR DESCRIPTION
Small change to our Sumatra .ini configuration to pick up the ability to preview in fullscreen. I compared the current version of this ini file against the one on Sumatra's Git repo and added one additional comment line.

Fixes #4301. 